### PR TITLE
fix(slack): fail closed on incomplete Socket Mode teardown

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -709,7 +709,7 @@ _SOCKET_CLIENT_TASK_ATTRS = (
 _SOCKET_TASK_CANCEL_TIMEOUT_S = 3.0
 
 
-async def _cancel_socket_tasks(tasks: Any) -> None:
+async def _cancel_socket_tasks(tasks: Any) -> set[Any]:
     """Cancel Socket Mode tasks and wait, with a bound, for them to finish.
 
     Cancellation is only a request until the task is awaited, so a caller that
@@ -725,7 +725,7 @@ async def _cancel_socket_tasks(tasks: Any) -> None:
         pending.add(task)
 
     if not pending:
-        return
+        return set()
 
     done, still_running = await asyncio.wait(
         pending, timeout=_SOCKET_TASK_CANCEL_TIMEOUT_S
@@ -743,6 +743,7 @@ async def _cancel_socket_tasks(tasks: Any) -> None:
             len(still_running),
             _SOCKET_TASK_CANCEL_TIMEOUT_S,
         )
+    return still_running
 
 
 _SLACK_PROXY_HOSTS = (
@@ -952,6 +953,10 @@ class SlackAdapter(BasePlatformAdapter):
         # user messages without bot_id/subtype=bot_message markers.
         self._user_is_bot_cache: Dict[Tuple[str, str], bool] = {}
         self._socket_mode_task: Optional[asyncio.Task] = None
+        # Outer tasks intentionally cancelled during teardown may swallow
+        # cancellation and finish later. Keep their done-callback from
+        # scheduling a duplicate reconnect after ownership is restored.
+        self._socket_mode_stopping_tasks: set[asyncio.Task] = set()
         # Multi-workspace support
         self._team_clients: Dict[str, Any] = {}  # team_id → WebClient
         self._team_bot_user_ids: Dict[str, str] = {}  # team_id → bot_user_id
@@ -1240,7 +1245,9 @@ class SlackAdapter(BasePlatformAdapter):
         self._socket_handler_started_monotonic = time.monotonic()
         task.add_done_callback(self._on_socket_mode_task_done)
 
-    async def _stop_socket_mode_handler(self) -> None:
+    async def _stop_socket_mode_handler(
+        self, *, defer_close_if_tasks_running: bool = False
+    ) -> bool:
         """Stop Socket Mode handler and task.
 
         Order matters. ``close_async()`` closes the SocketModeClient's shared
@@ -1256,26 +1263,95 @@ class SlackAdapter(BasePlatformAdapter):
         awaits inside ``close()``. Cancelling from a snapshot taken partway
         through that would race a moving target. See
         slackapi/python-slack-sdk#1913.
+
+        Reconnect callers set ``defer_close_if_tasks_running`` so an owner that
+        resists cancellation keeps its session open and reachable for a later
+        teardown attempt. Full gateway disconnect remains best-effort and
+        always continues through client and platform-lock cleanup.
         """
         handler = self._handler
         task = self._socket_mode_task
+        if task is not None and not task.done():
+            self._socket_mode_stopping_tasks.add(task)
+        # Detach before cancellation so the task done-callback recognizes this
+        # as intentional teardown and cannot queue a second reconnect. Restore
+        # the references below when reconnect teardown must be deferred.
         self._handler = None
         self._socket_mode_task = None
 
         client = getattr(handler, "client", None)
-        await _cancel_socket_tasks(
-            [task] + [getattr(client, attr, None) for attr in _SOCKET_CLIENT_TASK_ATTRS]
-        )
+        captured_owners = [task] + [
+            getattr(client, attr, None) for attr in _SOCKET_CLIENT_TASK_ATTRS
+        ]
+        try:
+            still_running = await _cancel_socket_tasks(captured_owners)
+
+            # An SDK owner can publish a replacement task while responding to
+            # cancellation. Await one bounded late-owner pass so cooperative
+            # replacements settle before full disconnect closes the session.
+            late_owners = []
+            for attr in _SOCKET_CLIENT_TASK_ATTRS:
+                current = getattr(client, attr, None)
+                cancel = getattr(current, "cancel", None)
+                done = getattr(current, "done", None)
+                if (
+                    callable(cancel)
+                    and callable(done)
+                    and not done()
+                    and all(current is not owner for owner in captured_owners)
+                ):
+                    late_owners.append(current)
+
+            if late_owners:
+                still_running.update(await _cancel_socket_tasks(late_owners))
+
+            # Drop owners that settled during the late pass, then make one
+            # final moving-target snapshot. Any task still alive keeps
+            # reconnect fail-closed; full disconnect remains bounded.
+            still_running = {
+                owner
+                for owner in still_running
+                if not callable(getattr(owner, "done", None)) or not owner.done()
+            }
+            for attr in _SOCKET_CLIENT_TASK_ATTRS:
+                current = getattr(client, attr, None)
+                cancel = getattr(current, "cancel", None)
+                done = getattr(current, "done", None)
+                if callable(cancel) and callable(done) and not done():
+                    cancel()
+                    still_running.add(current)
+        except asyncio.CancelledError:
+            # Full disconnect cancels the watchdog before taking the reconnect
+            # lock. Keep ownership reachable so disconnect can close it.
+            self._handler = handler
+            self._socket_mode_task = task
+            raise
+
+        if still_running and defer_close_if_tasks_running:
+            # Anything still alive may enter connect(), so closing the shared
+            # session here would create an unrecoverable closed-session loop.
+            self._handler = handler
+            self._socket_mode_task = task
+            logger.error(
+                "[Slack] Socket Mode reconnect deferred; %d task(s) still running",
+                len(still_running),
+            )
+            return False
 
         if handler is not None:
             try:
                 await handler.close_async()
+            except asyncio.CancelledError:
+                self._handler = handler
+                self._socket_mode_task = task
+                raise
             except Exception as e:  # pragma: no cover - defensive logging
                 logger.warning(
                     "[Slack] Error while closing Socket Mode handler: %s",
                     e,
                     exc_info=True,
                 )
+        return True
 
     async def _socket_transport_connected(self) -> Optional[bool]:
         """Best-effort check of current Socket Mode transport state."""
@@ -1339,7 +1415,11 @@ class SlackAdapter(BasePlatformAdapter):
                 return
 
             logger.warning("[Slack] Socket Mode unhealthy (%s); reconnecting", reason)
-            await self._stop_socket_mode_handler()
+            stopped = await self._stop_socket_mode_handler(
+                defer_close_if_tasks_running=True
+            )
+            if not stopped:
+                return
 
             try:
                 self._start_socket_mode_handler()
@@ -1413,6 +1493,9 @@ class SlackAdapter(BasePlatformAdapter):
             task.add_done_callback(self._on_socket_watchdog_done)
 
     def _on_socket_mode_task_done(self, task: asyncio.Task) -> None:
+        if task in self._socket_mode_stopping_tasks:
+            self._socket_mode_stopping_tasks.discard(task)
+            return
         # Ignore stale tasks from intentional reconnect/shutdown.
         if task is not self._socket_mode_task:
             return
@@ -2318,46 +2401,69 @@ class SlackAdapter(BasePlatformAdapter):
         """Disconnect from Slack."""
         self._running = False
 
-        # Seal any dangling native streams so chats aren't left with a
-        # live-typing indicator across a restart.
-        for chat_id, stream in list(self._active_streams.items()):
-            await self._seal_stream(chat_id, stream)
-        self._active_streams.clear()
-
-        watchdog_task = self._socket_watchdog_task
-        self._socket_watchdog_task = None
-        if watchdog_task is not None and not watchdog_task.done():
-            watchdog_task.cancel()
+        async def _finalize_disconnect() -> None:
             try:
-                await watchdog_task
-            except asyncio.CancelledError:
-                pass
-            except Exception:  # pragma: no cover - defensive logging
-                # Watchdog may have lost the cancellation race and exited with
-                # an unrelated exception. Log and continue so handler cleanup
-                # and lock release still happen.
-                logger.debug(
-                    "[Slack] Watchdog task raised during disconnect", exc_info=True
-                )
+                # Seal dangling native streams so chats are not left with a
+                # live-typing indicator across a restart.
+                for chat_id, stream in list(self._active_streams.items()):
+                    await self._seal_stream(chat_id, stream)
+                self._active_streams.clear()
 
-        # Finalize native streams while workspace clients are still live. The
-        # gateway normally stops each turn's stream first; this is the shutdown
-        # safety net for cancellation/reconnect races.
-        for key, stream in list(self._native_task_card_streams.items()):
-            await self._stop_native_task_card_stream(key, stream)
+                watchdog_task = self._socket_watchdog_task
+                self._socket_watchdog_task = None
+                if watchdog_task is not None and not watchdog_task.done():
+                    watchdog_task.cancel()
+                    try:
+                        await watchdog_task
+                    except asyncio.CancelledError:
+                        pass
+                    except Exception:  # pragma: no cover - defensive logging
+                        logger.debug(
+                            "[Slack] Watchdog task raised during disconnect",
+                            exc_info=True,
+                        )
 
-        await self._stop_socket_mode_handler()
-        await self._close_workspace_clients()
-        self._app = None
-        self._app_token = None
-        self._proxy_url = None
-        self._bot_user_id = None
-        self._team_clients = {}
-        self._team_bot_user_ids = {}
-        self._channel_team = {}
-        self._dm_conversation_cache = {}
+                # Finalize native streams while workspace clients are live.
+                for key, stream in list(self._native_task_card_streams.items()):
+                    await self._stop_native_task_card_stream(key, stream)
+            finally:
+                # A reconnect may have temporarily detached the handler while
+                # cancelling SDK task owners. Serialize final ownership transfer,
+                # and clear state even if a downstream close reports an error.
+                async with self._socket_reconnect_lock:
+                    try:
+                        await self._stop_socket_mode_handler()
+                        await self._close_workspace_clients()
+                    finally:
+                        self._app = None
+                        self._app_token = None
+                        self._proxy_url = None
+                        self._bot_user_id = None
+                        self._team_clients = {}
+                        self._team_bot_user_ids = {}
+                        self._channel_team = {}
+                        self._dm_conversation_cache = {}
 
-        self._release_platform_lock()
+        # Protect the complete teardown sequence, including stream sealing, so
+        # cancellation cannot strand an open handler or retain the exclusivity
+        # lock. Deliver caller cancellation only after bounded cleanup finishes.
+        cleanup_task = asyncio.create_task(_finalize_disconnect())
+        cancel_requested = False
+        try:
+            while True:
+                try:
+                    await asyncio.shield(cleanup_task)
+                    break
+                except asyncio.CancelledError:
+                    cancel_requested = True
+                    if cleanup_task.done():
+                        break
+            cleanup_task.result()
+        finally:
+            self._release_platform_lock()
+
+        if cancel_requested:
+            raise asyncio.CancelledError
 
         logger.info("[Slack] Disconnected")
 

--- a/tests/gateway/test_slack_socket_reconnect_heal.py
+++ b/tests/gateway/test_slack_socket_reconnect_heal.py
@@ -108,9 +108,9 @@ class _FakeSocketModeClient:
         self.aiohttp_client_session = _FakeSession(self)
         self.closed = False
         self.close_should_raise = False
-        self.message_processor = None
-        self.current_session_monitor = None
-        self.message_receiver = None
+        self.message_processor: asyncio.Task | None = None
+        self.current_session_monitor: asyncio.Task | None = None
+        self.message_receiver: asyncio.Task | None = None
 
     def live_task_names(self) -> list:
         return [
@@ -177,6 +177,38 @@ async def _spin() -> None:
         await asyncio.sleep(0.001)
 
 
+async def _resist_cancellation_until(release: asyncio.Event) -> None:
+    """Keep running across cancellation until the test explicitly releases it."""
+    while not release.is_set():
+        try:
+            await asyncio.sleep(0.001)
+        except asyncio.CancelledError:
+            continue
+
+
+async def _replace_client_task_on_cancel(
+    client: _FakeSocketModeClient,
+    release: asyncio.Event,
+) -> None:
+    """Model an SDK owner that replaces its task while cancellation runs."""
+    try:
+        await _spin()
+    except asyncio.CancelledError:
+        client.message_processor = asyncio.create_task(
+            _resist_cancellation_until(release)
+        )
+
+
+async def _replace_client_task_with_cooperative_owner_on_cancel(
+    client: _FakeSocketModeClient,
+) -> None:
+    """Publish a normal cancellable owner while the first snapshot settles."""
+    try:
+        await _spin()
+    except asyncio.CancelledError:
+        client.message_processor = asyncio.create_task(_spin())
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -232,7 +264,6 @@ class TestSocketModeTeardown:
         )
         assert task.done(), "the old socket task outlived teardown"
 
-
     @pytest.mark.asyncio
     async def test_client_tasks_are_dead_before_the_session_closes(self, adapter):
         """Nothing may still be inside connect() when the shared session closes.
@@ -272,7 +303,348 @@ class TestSocketModeTeardown:
 
 
 class TestSocketModeRestart:
+    @pytest.mark.asyncio
+    async def test_restart_defers_close_for_task_created_during_cancellation(
+        self, adapter
+    ):
+        """A post-snapshot SDK task must keep the old session open."""
+        handler = _FakeHandler()
+        client = handler.client
+        release = asyncio.Event()
+        client.message_processor = asyncio.create_task(
+            _replace_client_task_on_cancel(client, release)
+        )
+        _attach(adapter, handler)
+        await asyncio.sleep(0.01)
 
+        started: list[str] = []
+
+        try:
+            with (
+                patch.object(_slack_mod, "_SOCKET_TASK_CANCEL_TIMEOUT_S", 0.01),
+                patch.object(
+                    adapter,
+                    "_start_socket_mode_handler",
+                    side_effect=lambda: started.append("started"),
+                ),
+            ):
+                await adapter._restart_socket_mode("transport disconnected")
+
+                replacement = client.message_processor
+                assert replacement is not None
+                assert replacement.done() is False
+                assert client.aiohttp_client_session.closed is False
+                assert adapter._handler is handler
+                assert started == []
+
+                release.set()
+                await asyncio.wait_for(replacement, timeout=0.1)
+                await adapter._restart_socket_mode("deferred teardown retry")
+
+            assert client.aiohttp_client_session.closed is True
+            assert started == ["started"]
+        finally:
+            release.set()
+            replacement = client.message_processor
+            if replacement is not None and not replacement.done():
+                await asyncio.wait_for(replacement, timeout=0.1)
+
+    @pytest.mark.parametrize(
+        "owner_attr",
+        ["outer", *_FakeSocketModeClient._TASK_ATTRS],
+    )
+    @pytest.mark.asyncio
+    async def test_restart_defers_close_while_owner_resists_cancellation(
+        self, adapter, owner_attr
+    ):
+        """Reconnect must not close a session that an owner can still use."""
+        handler = _FakeHandler()
+        client = handler.client
+        release = asyncio.Event()
+        stubborn_task = asyncio.create_task(_resist_cancellation_until(release))
+        if owner_attr == "outer":
+            adapter._handler = handler
+            adapter._socket_mode_task = stubborn_task
+            old_task = stubborn_task
+        else:
+            setattr(client, owner_attr, stubborn_task)
+            old_task = _attach(adapter, handler)
+        old_task.add_done_callback(adapter._on_socket_mode_task_done)
+        await asyncio.sleep(0.01)
+
+        started: list[str] = []
+
+        try:
+            with (
+                patch.object(_slack_mod, "_SOCKET_TASK_CANCEL_TIMEOUT_S", 0.01),
+                patch.object(
+                    adapter,
+                    "_start_socket_mode_handler",
+                    side_effect=lambda: started.append("started"),
+                ),
+            ):
+                await adapter._restart_socket_mode("transport disconnected")
+
+                session = client.aiohttp_client_session
+                assert session.closed is False
+                assert session.ws_connect_after_close == 0
+                assert adapter._handler is handler
+                assert adapter._socket_mode_task is old_task
+                assert started == []
+
+                release.set()
+                await asyncio.wait_for(stubborn_task, timeout=0.1)
+                await adapter._restart_socket_mode("deferred teardown retry")
+                await asyncio.sleep(0)
+                await asyncio.sleep(0)
+
+            assert session.closed is True
+            assert started == ["started"]
+        finally:
+            release.set()
+            if not stubborn_task.done():
+                await asyncio.wait_for(stubborn_task, timeout=0.1)
+
+    @pytest.mark.asyncio
+    async def test_disconnect_closes_handler_when_watchdog_teardown_is_cancelled(
+        self, adapter
+    ):
+        """Cancelling the watchdog mid-stop must restore ownership for shutdown."""
+        handler = _FakeHandler()
+        _attach(adapter, handler)
+        await asyncio.sleep(0.01)
+
+        entered_cancel = asyncio.Event()
+        original_cancel = _slack_mod._cancel_socket_tasks
+        cancel_calls = 0
+
+        async def _block_first_cancel(tasks):
+            nonlocal cancel_calls
+            cancel_calls += 1
+            if cancel_calls == 1:
+                entered_cancel.set()
+                await asyncio.Event().wait()
+            return await original_cancel(tasks)
+
+        adapter._close_workspace_clients = AsyncMock()
+        adapter._release_platform_lock = MagicMock()
+
+        with (
+            patch.object(_slack_mod, "_cancel_socket_tasks", _block_first_cancel),
+            patch.object(adapter, "_start_socket_mode_handler") as start_handler,
+        ):
+            adapter._socket_watchdog_task = asyncio.create_task(
+                adapter._restart_socket_mode("transport disconnected")
+            )
+            await asyncio.wait_for(entered_cancel.wait(), timeout=0.1)
+            assert adapter._handler is None
+
+            await adapter.disconnect()
+
+        assert handler.client.aiohttp_client_session.closed is True
+        assert adapter._handler is None
+        assert adapter._socket_mode_task is None
+        assert adapter._socket_watchdog_task is None
+        assert adapter._app is None
+        start_handler.assert_not_called()
+        adapter._close_workspace_clients.assert_awaited_once()
+        adapter._release_platform_lock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_cancellation_during_stream_seal_waits_for_cleanup(
+        self, adapter
+    ):
+        """Early stream teardown cancellation must not bypass final cleanup."""
+        handler = _FakeHandler()
+        client = handler.client
+        _attach(adapter, handler)
+        await asyncio.sleep(0.01)
+
+        seal_entered = asyncio.Event()
+        seal_release = asyncio.Event()
+
+        async def _blocked_seal_stream(chat_id, stream) -> None:
+            seal_entered.set()
+            await seal_release.wait()
+
+        adapter._active_streams = {"C123": object()}
+        adapter._seal_stream = _blocked_seal_stream
+        adapter._close_workspace_clients = AsyncMock()
+        adapter._release_platform_lock = MagicMock()
+
+        disconnect_task = asyncio.create_task(adapter.disconnect())
+        await asyncio.wait_for(seal_entered.wait(), timeout=0.1)
+        disconnect_task.cancel()
+        await asyncio.sleep(0)
+        assert disconnect_task.done() is False
+
+        seal_release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await disconnect_task
+
+        assert client.aiohttp_client_session.closed is True
+        assert adapter._active_streams == {}
+        assert adapter._handler is None
+        assert adapter._socket_mode_task is None
+        assert adapter._app is None
+        assert adapter._socket_reconnect_lock.locked() is False
+        adapter._close_workspace_clients.assert_awaited_once()
+        adapter._release_platform_lock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_cancellation_waits_for_final_cleanup(self, adapter):
+        """Caller cancellation must not bypass final close or lock release."""
+        handler = _FakeHandler()
+        client = handler.client
+        _attach(adapter, handler)
+        await asyncio.sleep(0.01)
+
+        close_entered = asyncio.Event()
+        close_release = asyncio.Event()
+
+        async def _blocked_close_async() -> None:
+            close_entered.set()
+            await close_release.wait()
+            await client.close()
+
+        handler.close_async = _blocked_close_async
+        adapter._close_workspace_clients = AsyncMock()
+        adapter._release_platform_lock = MagicMock()
+
+        disconnect_task = asyncio.create_task(adapter.disconnect())
+        await asyncio.wait_for(close_entered.wait(), timeout=0.1)
+        disconnect_task.cancel()
+        await asyncio.sleep(0)
+        assert disconnect_task.done() is False
+
+        close_release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await disconnect_task
+
+        assert client.aiohttp_client_session.closed is True
+        assert adapter._handler is None
+        assert adapter._socket_mode_task is None
+        assert adapter._app is None
+        assert adapter._socket_reconnect_lock.locked() is False
+        adapter._close_workspace_clients.assert_awaited_once()
+        adapter._release_platform_lock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_awaits_task_created_during_cancellation(self, adapter):
+        """Full shutdown must await a cooperative post-snapshot SDK owner."""
+        handler = _FakeHandler()
+        client = handler.client
+        client.message_processor = asyncio.create_task(
+            _replace_client_task_with_cooperative_owner_on_cancel(client)
+        )
+        _attach(adapter, handler)
+        await asyncio.sleep(0.01)
+
+        adapter._close_workspace_clients = AsyncMock()
+        adapter._release_platform_lock = MagicMock()
+
+        await adapter.disconnect()
+
+        replacement = client.message_processor
+        assert replacement is not None
+        assert replacement.done() is True
+        assert client.aiohttp_client_session.live_tasks_at_close == []
+        assert client.aiohttp_client_session.closed is True
+        assert adapter._handler is None
+        adapter._close_workspace_clients.assert_awaited_once()
+        adapter._release_platform_lock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_disconnect_cannot_restore_deferred_handler(self, adapter):
+        """Shutdown must win a race with reconnect teardown and close its handler."""
+        handler = _FakeHandler()
+        release_owner = asyncio.Event()
+        stubborn_task = asyncio.create_task(_resist_cancellation_until(release_owner))
+        handler.client.message_processor = stubborn_task
+        _attach(adapter, handler)
+        await asyncio.sleep(0.01)
+
+        entered_cancel = asyncio.Event()
+        continue_cancel = asyncio.Event()
+        original_cancel = _slack_mod._cancel_socket_tasks
+        cancel_calls = 0
+
+        async def _pause_first_cancel(tasks):
+            nonlocal cancel_calls
+            cancel_calls += 1
+            if cancel_calls == 1:
+                entered_cancel.set()
+                await continue_cancel.wait()
+            return await original_cancel(tasks)
+
+        adapter._close_workspace_clients = AsyncMock()
+        adapter._release_platform_lock = MagicMock()
+
+        try:
+            with (
+                patch.object(_slack_mod, "_SOCKET_TASK_CANCEL_TIMEOUT_S", 0.01),
+                patch.object(_slack_mod, "_cancel_socket_tasks", _pause_first_cancel),
+                patch.object(adapter, "_start_socket_mode_handler") as start_handler,
+            ):
+                reconnect = asyncio.create_task(
+                    adapter._restart_socket_mode("transport disconnected")
+                )
+                await asyncio.wait_for(entered_cancel.wait(), timeout=0.1)
+                assert adapter._handler is None
+
+                shutdown = asyncio.create_task(adapter.disconnect())
+                await asyncio.sleep(0.01)
+                continue_cancel.set()
+                await asyncio.gather(reconnect, shutdown)
+
+            assert handler.client.aiohttp_client_session.closed is True
+            assert adapter._handler is None
+            assert adapter._socket_mode_task is None
+            assert adapter._app is None
+            start_handler.assert_not_called()
+            adapter._close_workspace_clients.assert_awaited_once()
+            adapter._release_platform_lock.assert_called_once()
+        finally:
+            continue_cancel.set()
+            release_owner.set()
+            if not stubborn_task.done():
+                await asyncio.wait_for(stubborn_task, timeout=0.1)
+
+    @pytest.mark.asyncio
+    async def test_full_disconnect_cleans_up_after_cancellation_timeout(self, adapter):
+        """Fail-closed reconnect state must not strand full gateway shutdown."""
+        handler = _FakeHandler()
+        release = asyncio.Event()
+        stubborn_task = asyncio.create_task(_resist_cancellation_until(release))
+        handler.client.message_processor = stubborn_task
+        _attach(adapter, handler)
+        await asyncio.sleep(0.01)
+
+        adapter._close_workspace_clients = AsyncMock()
+        adapter._release_platform_lock = MagicMock()
+
+        try:
+            with (
+                patch.object(_slack_mod, "_SOCKET_TASK_CANCEL_TIMEOUT_S", 0.01),
+                patch.object(adapter, "_start_socket_mode_handler") as start_handler,
+            ):
+                await adapter._restart_socket_mode("transport disconnected")
+                assert handler.client.aiohttp_client_session.closed is False
+                assert adapter._handler is handler
+                start_handler.assert_not_called()
+
+                await adapter.disconnect()
+
+            assert handler.client.aiohttp_client_session.closed is True
+            assert adapter._handler is None
+            assert adapter._socket_mode_task is None
+            assert adapter._app is None
+            adapter._close_workspace_clients.assert_awaited_once()
+            adapter._release_platform_lock.assert_called_once()
+        finally:
+            release.set()
+            if not stubborn_task.done():
+                await asyncio.wait_for(stubborn_task, timeout=0.1)
 
     @pytest.mark.asyncio
     async def test_watchdog_restarts_when_transport_disconnected(self, adapter):


### PR DESCRIPTION
## What does this PR do?

Makes Slack Socket Mode watchdog reconnect fail closed when an SDK-owned task does not settle within the existing cancellation timeout.

The current teardown cancels the outer `start_async()` task and the SDK's `current_session_monitor`, `message_processor`, and `message_receiver`, then waits up to three seconds. If an owner remains alive, teardown currently logs the timeout but still closes the shared aiohttp session and starts a replacement handler. A cancellation-resistant owner can then continue retrying `connect()` against the closed session—the failure mode discussed in #46990 and identified during review of #62196.

This change returns the pending task set from cancellation and defers reconnect teardown when that set is non-empty. The old handler stays reachable, its shared session stays open, and the watchdog can retry teardown on a later pass. Full gateway disconnect intentionally remains best-effort and continues through client, app-state, and platform-lock cleanup, avoiding the shutdown-stranding concern raised on #58658.

## Related Issue

Refs #46990.

Follow-up to the Socket Mode lifecycle fix merged in #69319. Unlike #58658, this does not add persistent teardown state or return early from full disconnect. Unlike open #85660, it does not rebuild `AsyncApp` or workspace clients; it only makes the existing task-cancellation timeout safe.

### Observed impact

In the long-running Linux reproduction documented in #46990, one watchdog reconnect was followed by 1,653 `RuntimeError: Session is closed` failures at an approximately 10-second cadence over 4h35m. Slack inbound connectivity remained unavailable while the gateway and cron ticker continued running, and only a process restart cleared the orphaned retry loop. This PR targets the teardown state that allowed that old retry owner to outlive its handler.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/slack/adapter.py`
  - Return cancellation-resistant Socket Mode owners from the bounded cancellation helper.
  - Re-scan SDK task attributes after cancellation so newly published owners cannot escape teardown.
  - Await a bounded second cancellation pass for cooperative owners published during teardown.
  - Defer reconnect close/replacement while any owner remains alive.
  - Preserve old handler ownership for a later watchdog teardown attempt.
  - Serialize full disconnect with reconnect teardown and restore ownership if watchdog cancellation interrupts a stop.
  - Shield final disconnect cleanup so caller cancellation cannot bypass state clearing or platform-lock release.
  - Start cancellation shielding before stream teardown so no earlier await can bypass final cleanup.
  - Suppress delayed done-callback reconnects from outer tasks intentionally cancelled during teardown.
  - Keep full gateway disconnect best-effort so app/client/lock cleanup always continues.
- `tests/gateway/test_slack_socket_reconnect_heal.py`
  - Reproduce a task that deliberately survives cancellation past the timeout.
  - Assert reconnect does not close the session or start a replacement.
  - Assert a later retry closes the old session and starts exactly one replacement.
  - Cover the outer task and all three SDK task-owner slots, including post-cancel task replacement.
  - Reproduce concurrent disconnect/reconnect teardown and watchdog-cancellation races.
  - Assert post-snapshot owners settle before the shared session closes and disconnect cancellation waits for final cleanup.
  - Cancel disconnect while stream sealing is blocked and assert final cleanup still completes first.
  - Assert full disconnect still completes after entering the deferred-reconnect state.

## How to Test

1. Run the focused Socket Mode regression suite:
   `scripts/run_tests.sh tests/gateway/test_slack_socket_reconnect_heal.py -q`
2. Run the broader focused Slack group:
   `scripts/run_tests.sh tests/gateway/test_slack_socket_reconnect_heal.py tests/gateway/test_slack.py tests/gateway/test_slack_dedup_ttl.py -q`
3. Run static checks:
   `ruff check plugins/platforms/slack/adapter.py tests/gateway/test_slack_socket_reconnect_heal.py`
   `ruff format --check tests/gateway/test_slack_socket_reconnect_heal.py`
   `git diff --check`

Local results:

- Focused Slack group: 181 passed, 0 failed.
- Gateway-wide `-k slack`: 526 passed, 0 failed, 2 platform skips.
- Ruff lint passed; the changed test file is formatted; `git diff --check` passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 13, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; lifecycle docstrings updated in code
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Public incident evidence is documented in [#46990](https://github.com/NousResearch/hermes-agent/issues/46990#issuecomment-5030827500). The regression is deterministic and does not require live Slack credentials.
