### PR TITLE
fix(voice): serialize audio playback across concurrent speak requests

### DIFF
--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -590,6 +590,56 @@ class TestPlayAudioFile:
         mock_sd_obj.play.assert_called_once()
         mock_sd_obj.stop.assert_called_once()
 
+
+class TestSerialPlayback:
+    """Concurrent play_audio_file calls must queue instead of overlapping.
+
+    Regression test for overlapping audio: concurrent speak requests (CLI
+    voice-mode threads, desktop /api/audio/speak executor threads) used to
+    spawn parallel afplay/ffplay processes, so two replies played at once.
+    The module-level _serial_playback_lock now guarantees one-at-a-time
+    playback, while stop_playback() (barge-in) still works independently
+    through its own short _playback_lock.
+    """
+
+    def test_concurrent_playback_is_serialized(self, monkeypatch):
+        import threading
+
+        import tools.voice_mode as vm
+
+        active = 0
+        max_active = 0
+        state_lock = threading.Lock()
+
+        def _fake_impl(file_path: str) -> bool:
+            nonlocal active, max_active
+            with state_lock:
+                active += 1
+                max_active = max(max_active, active)
+            time.sleep(0.2)  # simulate real playback duration
+            with state_lock:
+                active -= 1
+            return True
+
+        monkeypatch.setattr(vm, "_play_audio_file_impl", _fake_impl)
+        monkeypatch.setattr(vm, "mark_audio_output_active", lambda _active: None)
+
+        results = []
+
+        def worker():
+            results.append(vm.play_audio_file("/tmp/hermes-serial-test.mp3"))
+
+        threads = [threading.Thread(target=worker) for _ in range(3)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert results == [True, True, True]
+        assert max_active == 1, (
+            f"playback overlapped: {max_active} files were playing at once"
+        )
+
 # ============================================================================
 # macOS output policy (no sounddevice for OUTPUT -> avoids TCC prompt)
 # ============================================================================

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -929,6 +929,13 @@ def _split_wav_for_transcription(wav_path: str, *, max_file_size: int) -> List[s
 # ── Audio playback (interruptable) ──
 _active_playback: Optional[subprocess.Popen] = None  # so stop_playback can interrupt it
 _playback_lock = threading.Lock()
+# Serializes ALL audio playback across every caller (CLI voice mode, desktop
+# /api/audio/speak, TUI gateway, streaming consumer). Without it, concurrent
+# speak requests spawn parallel afplay/ffplay processes and the audio
+# overlaps. barge-in (stop_playback) is unaffected: it only takes the short
+# _playback_lock to grab the current process, so it can still cut the
+# playing file while a queued playback waits its turn.
+_serial_playback_lock = threading.Lock()
 
 
 def _set_active_playback(proc) -> None:
@@ -971,12 +978,18 @@ def _wsl_powershell_tts_available() -> bool:
 def play_audio_file(file_path: str) -> bool:
     """Play an audio file; True on success. WAV via ``sounddevice.play()`` when allowed,
     else system players: afplay (macOS), WSL2 PowerShell bridge, ffplay, aplay (Linux).
-    Interruptible via ``stop_playback()``."""
-    mark_audio_output_active(True)  # ref-count real speaker output for the whole call
-    try:
-        return _play_audio_file_impl(file_path)
-    finally:
-        mark_audio_output_active(False)
+    Interruptible via ``stop_playback()``.
+
+    Serialized with every other playback: concurrent callers (multiple desktop
+    speak requests, CLI voice-mode threads) queue up instead of playing over
+    each other. The active-output ref-count stays INSIDE the lock so
+    queued-but-not-yet-playing audio does not count as active."""
+    with _serial_playback_lock:
+        mark_audio_output_active(True)  # ref-count real speaker output for the whole call
+        try:
+            return _play_audio_file_impl(file_path)
+        finally:
+            mark_audio_output_active(False)
 
 
 def _play_wav_via_sounddevice(file_path: str) -> bool:


### PR DESCRIPTION
## Summary

Concurrent TTS playback overlapped: when two speak requests arrived at once (CLI voice-mode threads, desktop `/api/audio/speak` executor threads), each spawned its own `afplay`/`ffplay` subprocess with no mutual exclusion — both replies played through the same output device simultaneously.

**Fix:** a module-level `_serial_playback_lock` in `tools/voice_mode.py`, held for the entire `play_audio_file()` call. Every playback caller now queues one-at-a-time.

## Background & root cause

`play_audio_file()` → `_play_audio_file_impl()` blocks on `proc.wait()` for the system player, but nothing prevented *multiple* callers from being inside that block at once. The existing `_playback_lock` only guards the `_active_playback` reference so `stop_playback()` can interrupt the current process — it does not serialize playback.

Repro: in desktop voice mode, send a second message while the first reply is still being spoken, or trigger two near-simultaneous speaks. Both audio files play on top of each other.

## Fix

```python
_serial_playback_lock = threading.Lock()

def play_audio_file(file_path: str) -> bool:
    with _serial_playback_lock:            # ← serializes every caller
        mark_audio_output_active(True)
        try:
            return _play_audio_file_impl(file_path)
        finally:
            mark_audio_output_active(False)
```

Design decisions:

| Concern | How it's handled |
|---|---|
| Barge-in / `stop_playback()` | Still works — it only takes the short `_playback_lock` to grab and terminate the current process. A queued playback waiting on `_serial_playback_lock` does not block interruption. |
| "Playing now" bookkeeping | `mark_audio_output_active()` moved inside the lock, so queued-but-not-yet-playing audio does not count as active speaker output (thinking-sound loop and barge-in hold logic stay accurate). |
| Scope | Single process, in-process threads → plain `threading.Lock()` matches the existing module concurrency model. |
| No new config / env / surface | Smallest-footprint fix; no schema or API change. |

## Who should enable this

Everyone — no opt-in needed. This is a correctness fix for all audio playback paths (CLI voice mode, desktop speak endpoint, TUI gateway, streaming TTS consumer). If you've ever heard two Hermes voices at once, this is the fix.

## Platform compatibility

| Platform | Playback path | Impact |
|---|---|---|
| macOS | `afplay` subprocess | Serialized (was: overlapping) |
| Linux | `ffplay` / `aplay` | Serialized |
| WSL2 | PowerShell `Media.SoundPlayer` fallback | Serialized |
| Headless (no audio device) | no-op | Unchanged |

## Quick-start guide

1. Update / restart the agent backend (desktop: restart the app; CLI: new session).
2. Send two messages in quick succession in voice mode — the second reply queues until the first finishes speaking.

## Troubleshooting

| Symptom | Cause | Fix |
|---|---|---|
| Replies still overlap after updating | Backend process not restarted; old code still loaded | Restart the desktop app / serve backend |
| Barge-in (speaking over TTS) feels unresponsive | Not related to this change | Check `voice.barge_in` config (default true) |

## Verification

- New regression test `TestSerialPlayback.test_concurrent_playback_is_serialized`: 3 threads call `play_audio_file()` against a slow fake playback; asserts at most one playback is active at any instant. Passes.
- Full `tests/tools/test_voice_mode.py` suite: 57 passed, 5 pre-existing environment-gated failures (macOS sounddevice beep, WSL2 PowerShell fallback, Pulse socket path length) — unchanged by this PR.
- Live check on macOS: 3 concurrent speaks completed at 2.0s / 4.01s / 6.01s (strictly serial, no overlap).
