### PR TITLE
fix(agent): align empty hidden assistant placeholders on wire to eliminate sanitizer spam (#88955)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3478,7 +3478,8 @@ def repair_empty_non_final_messages(
         return messages
 
     repaired: List[Dict[str, Any]] = []
-    healed = 0
+    healed_corruptions = 0
+    substituted_placeholders = 0
     last_idx = len(messages) - 1
     for idx, msg in enumerate(messages):
         if (
@@ -3493,19 +3494,27 @@ def repair_empty_non_final_messages(
             fixed = dict(msg)
             fixed["content"] = _INTERRUPTED_PLACEHOLDER
             repaired.append(fixed)
-            healed += 1
+            substituted_placeholders += 1
+            # Only count and warn on unexpected corruptions. Intentional hidden
+            # assistant placeholders from active turn redirects or group-chat
+            # member interruptions (#88955) are designed-empty placeholders for
+            # role alternation; substituting [response interrupted] on the wire
+            # prevents provider 400s cleanly without recurring warning spam.
+            if not (msg.get("display_kind") == "hidden" and msg.get("role") == "assistant"):
+                healed_corruptions += 1
         else:
             repaired.append(msg)
 
-    if healed:
+    if healed_corruptions:
         _ra().logger.warning(
             "Pre-call sanitizer: healed %d empty non-final message(s) by "
             "substituting placeholder content — an empty-content turn was in "
             "the transcript and would 400 the request ('messages must have "
             "non-empty content' / INVALID_REQUEST_BODY). Self-recovering the "
             "poisoned transcript in memory; no restart needed.",
-            healed,
+            healed_corruptions,
         )
+    if substituted_placeholders:
         return repaired
     return messages
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2119,6 +2119,19 @@ def run_conversation(
             # outgoing copy.
             _api_content = api_msg.pop("api_content", None)
 
+            from agent.agent_runtime_helpers import _msg_has_payload, _INTERRUPTED_PLACEHOLDER
+
+            # An empty hidden assistant placeholder from active turn redirect /
+            # interruption (#88955): populate placeholder content on the wire copy
+            # so strict providers accept the request without triggering pre-call
+            # sanitizer healing warnings on every turn.
+            if (
+                api_msg.get("role") == "assistant"
+                and api_msg.get("display_kind") == "hidden"
+                and not _msg_has_payload(api_msg)
+            ):
+                api_msg["content"] = _INTERRUPTED_PLACEHOLDER
+
             # Display-only timeline metadata. Never a provider field — strip
             # from every outgoing copy so strict OpenAI-compatible backends
             # don't reject the request after a model switch or resumed typed

--- a/tests/agent/test_interrupted_hidden_placeholder.py
+++ b/tests/agent/test_interrupted_hidden_placeholder.py
@@ -1,0 +1,160 @@
+"""
+Tests for empty display_kind=hidden assistant placeholder handling (#88955).
+
+Ensures that in Bot Mode group chats (and active turn redirects), when a member
+turn is interrupted without visible text, the empty hidden assistant placeholder
+is safely substituted with [response interrupted] on the wire copy without
+repeatedly triggering pre-call sanitizer warning spam on every subsequent turn.
+"""
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+import pytest
+
+from agent.conversation_loop import _apply_active_turn_redirect
+from agent.agent_runtime_helpers import (
+    repair_empty_non_final_messages,
+    _INTERRUPTED_PLACEHOLDER,
+)
+from run_agent import AIAgent
+
+
+def _mock_response(content="Hello", finish_reason="stop", tool_calls=None):
+    msg = SimpleNamespace(
+        content=content,
+        tool_calls=tool_calls,
+        reasoning=None,
+        reasoning_content=None,
+        reasoning_details=None,
+    )
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
+    return SimpleNamespace(
+        choices=[choice],
+        model="test/model",
+        usage=SimpleNamespace(prompt_tokens=10, completion_tokens=10, total_tokens=20),
+    )
+
+
+@pytest.fixture
+def agent():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        return a
+
+
+class TestInterruptedHiddenPlaceholder:
+    def test_apply_active_turn_redirect_creates_hidden_placeholder_when_not_visible(self, agent):
+        """When interrupted with no visible text, active turn redirect creates
+        an empty display_kind=hidden assistant placeholder."""
+        agent._current_streamed_assistant_text = ""
+        messages = [{"role": "user", "content": "Member turn prompt"}]
+
+        _apply_active_turn_redirect(agent, messages, "User interruption")
+
+        assert len(messages) == 3
+        assert messages[1]["role"] == "assistant"
+        assert messages[1]["content"] == ""
+        assert messages[1]["display_kind"] == "hidden"
+        assert messages[2]["role"] == "user"
+        assert messages[2]["content"] == "User interruption"
+
+    def test_repair_empty_non_final_messages_heals_hidden_assistant_without_warning(self, caplog):
+        """repair_empty_non_final_messages substitutes [response interrupted] on
+        display_kind=hidden assistant messages without logging healing warnings (#88955)."""
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "", "display_kind": "hidden"},
+            {"role": "user", "content": "world"},
+            {"role": "assistant", "content": "response"},
+        ]
+
+        with caplog.at_level(logging.WARNING):
+            result = repair_empty_non_final_messages(messages)
+
+        assert len(result) == 4
+        assert result[1]["content"] == _INTERRUPTED_PLACEHOLDER
+        assert "Pre-call sanitizer: healed" not in caplog.text
+
+    def test_repair_empty_non_final_messages_still_heals_unintended_empty_messages(self, caplog):
+        """Non-hidden empty messages (true corruption) are healed with
+        _INTERRUPTED_PLACEHOLDER AND log a warning."""
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": ""},  # No display_kind=hidden
+            {"role": "user", "content": "world"},
+            {"role": "assistant", "content": "response"},
+        ]
+
+        with caplog.at_level(logging.WARNING):
+            result = repair_empty_non_final_messages(messages)
+
+        assert len(result) == 4
+        assert result[1]["content"] == _INTERRUPTED_PLACEHOLDER
+        assert "Pre-call sanitizer: healed" in caplog.text
+
+    def test_group_chat_interruption_does_not_retrigger_sanitizer_on_subsequent_turns(self, agent, caplog):
+        """Regression test for #88955:
+        In a multi-turn conversation with an interrupted turn, subsequent turns
+        must not log pre-call sanitizer warnings.
+        """
+        history = [
+            {"role": "user", "content": "Member turn 1"},
+            {"role": "assistant", "content": "", "display_kind": "hidden"},
+            {
+                "role": "user",
+                "content": "Interruption",
+                "api_content": "[Context from the interrupted assistant response]\nInterruption",
+            },
+        ]
+
+        requests = []
+        def fake_api_call(api_kwargs):
+            requests.append(api_kwargs)
+            return _mock_response(content="Final response", finish_reason="stop")
+
+        with (
+            patch.object(agent, "_interruptible_api_call", side_effect=fake_api_call),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            caplog.at_level(logging.WARNING),
+        ):
+            result = agent.run_conversation("Member turn 2", conversation_history=history)
+
+        assert result["completed"] is True
+        assert len(requests) == 1
+        replayed = requests[0]["messages"]
+
+        # Ensure non-final assistant message has valid placeholder content on wire
+        for m in replayed[:-1]:
+            if m.get("role") == "assistant":
+                assert m.get("content") != "" or m.get("tool_calls")
+
+        # Ensure no recurring sanitizer warning was emitted
+        assert "Pre-call sanitizer: healed" not in caplog.text
+
+    def test_interrupted_turn_with_visible_text_preserved(self, agent):
+        """When an interrupted turn had visible text on screen, it is preserved."""
+        agent._current_streamed_assistant_text = "I am looking up the data..."
+        messages = [{"role": "user", "content": "start"}]
+
+        _apply_active_turn_redirect(agent, messages, "Wait, stop that.")
+
+        assert len(messages) == 3
+        assert messages[1]["role"] == "assistant"
+        assert messages[1]["content"] == "I am looking up the data..."
+        assert "display_kind" not in messages[1]
+        assert messages[2]["role"] == "user"
+        assert messages[2]["content"] == "Wait, stop that."

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -450,6 +450,7 @@ async def test_session_chat_stream_treats_pre_existing_poisoned_row_as_no_model(
                 json={"message": "hi"},
             )
             assert resp.status == 200
+            await resp.text()
 
     _, kwargs = mock_run.call_args
     assert kwargs["session_model"] is None


### PR DESCRIPTION
## Summary

Fixes #88955.

In Bot Mode group chats (and active turn redirects / steering), when a member turn is interrupted before any assistant text has been streamed to the UI, `_apply_active_turn_redirect()` persists an empty role placeholder with `display_kind="hidden"`:

```python
{"role": "assistant", "content": "", "display_kind": "hidden"}
```

This placeholder is intentional and load-bearing in the session history to maintain proper role alternation (`user -> assistant -> user`) without leaking unstreamed reasoning or unfinished content into user-visible transcripts.

However, because this empty placeholder persisted in the session history, the pre-call sanitizer `repair_empty_non_final_messages()` in `agent/agent_runtime_helpers.py` detected it on **every subsequent turn of the session** and repeatedly emitted the following warning:

```
[WARNING] Pre-call sanitizer: healed 1 empty non-final message(s) by substituting placeholder content — an empty-content turn was in the transcript and would 400 the request ('messages must have non-empty content' / INVALID_REQUEST_BODY). Self-recovering the poisoned transcript in memory; no restart needed.
```

In long-running group chat sessions (e.g. 98+ API turns), this warning fired perpetually on every turn, causing log pollution, unnecessary repeated memory-copy healing passes, and false-positive alarm noise.

---

## Root Cause Analysis

1. **Persisted History vs. Wire Messages**:
   The placeholder `{"role": "assistant", "content": "", "display_kind": "hidden"}` is kept in `messages` so that SessionDB, transcripts, and timeline UI renderers can identify the turn as an interrupted redirect without rendering blank speech bubbles.
2. **Wire Stripping Order**:
   When constructing outgoing `api_messages` in `agent/conversation_loop.py`, `api_msg.pop("display_kind", None)` stripped the `display_kind` metadata before `sanitize_api_messages()` was invoked.
3. **Indiscriminate Warning in Sanitizer**:
   `repair_empty_non_final_messages()` received an empty non-final assistant row without the `display_kind="hidden"` context and treated it as unexpected data corruption rather than an intentional alternation placeholder, logging the `[WARNING]` every single turn.

---

## Solution

We implement a clean, two-layer wire alignment:

1. **Wire Substitution in `agent/conversation_loop.py`**:
   When constructing outgoing `api_messages`, before `display_kind` is stripped, empty hidden assistant placeholders are proactively populated with `_INTERRUPTED_PLACEHOLDER` (`"[response interrupted]"`).
   - This ensures strict OpenAI/Anthropic/Bedrock API compliance without 400 errors.
   - The persisted transcript in SessionDB remains byte-stable with `content=""` and `display_kind="hidden"` for clean UI rendering.
2. **Defensive Discrimination in `agent/agent_runtime_helpers.py`**:
   `repair_empty_non_final_messages()` distinguishes between intentional hidden placeholders and true accidental transcript corruption. It substitutes `_INTERRUPTED_PLACEHOLDER` cleanly while only logging warnings for unexpected non-hidden empty turns.

---
## Verification Plan

### Automated Tests
- Added `tests/agent/test_interrupted_hidden_placeholder.py` covering:
  - Active turn redirects creating `display_kind="hidden"` placeholders when no text is visible.
  - Silent healing of hidden placeholders without warning logs.
  - Warning logs preserved for true non-hidden corruptions.
  - Multi-turn conversation regression verification (0 recurring warnings).
  - Preserving streamed visible assistant text during interruptions.
- Ran all existing steer, conversation loop, and runtime helper suites:
  - `pytest tests/agent/test_interrupted_hidden_placeholder.py -v` (5/5 PASSED)
  - `pytest tests/run_agent/test_steer.py -v` (29/29 PASSED)
  - `pytest tests/run_agent/test_run_agent.py -k "scaffold or redirect or display_kind" -v` (5/5 PASSED)
