### PR TITLE
fix(contributors): make email mappings portable on case-insensitive filesystems

### DIFF
--- a/contributors/emails/agent@Agents-Mac-mini.local
+++ b/contributors/emails/agent@Agents-Mac-mini.local
@@ -1,1 +1,0 @@
-skip-agent

--- a/scripts/add_contributor.py
+++ b/scripts/add_contributor.py
@@ -44,14 +44,45 @@ def read_mapping_file(path: Path) -> str | None:
     return None
 
 
-def _legacy_login(email: str) -> str | None:
-    """Look the email up in the frozen legacy AUTHOR_MAP in release.py."""
+def _nonfile_login(email: str) -> str | None:
+    """Look up mappings stored outside contributors/emails/."""
     try:
         sys.path.insert(0, str(REPO_ROOT / "scripts"))
-        from release import LEGACY_AUTHOR_MAP  # noqa: PLC0415
+        from release import (  # noqa: PLC0415
+            CASEFOLD_COLLISION_AUTHOR_MAP,
+            LEGACY_AUTHOR_MAP,
+        )
 
-        return LEGACY_AUTHOR_MAP.get(email)
+        return CASEFOLD_COLLISION_AUTHOR_MAP.get(
+            email, LEGACY_AUTHOR_MAP.get(email)
+        )
     except Exception:
+        return None
+
+
+def _exact_mapping_path(email: str) -> Path | None:
+    """Return an exact-case mapping path without filesystem aliasing."""
+    try:
+        return next(
+            path
+            for path in EMAILS_DIR.iterdir()
+            if path.is_file() and path.name == email
+        )
+    except (OSError, StopIteration):
+        return None
+
+
+def _casefold_collision(email: str) -> str | None:
+    """Return a differently-cased filename that aliases email, if any."""
+    try:
+        return next(
+            path.name
+            for path in EMAILS_DIR.iterdir()
+            if path.is_file()
+            and path.name != email
+            and path.name.casefold() == email.casefold()
+        )
+    except (OSError, StopIteration):
         return None
 
 
@@ -67,9 +98,10 @@ def add_contributor(email: str, login: str, comment: str = "") -> int:
         return 2
 
     path = EMAILS_DIR / email
-    existing = read_mapping_file(path) if path.is_file() else None
+    exact_path = _exact_mapping_path(email)
+    existing = read_mapping_file(exact_path) if exact_path is not None else None
     if existing is None:
-        existing = _legacy_login(email)
+        existing = _nonfile_login(email)
     if existing is not None:
         if existing == login:
             print("present")
@@ -77,6 +109,16 @@ def add_contributor(email: str, login: str, comment: str = "") -> int:
         print(
             f"error: {email} already maps to {existing!r} (asked for {login!r}) — "
             "resolve manually",
+            file=sys.stderr,
+        )
+        return 1
+
+    collision = _casefold_collision(email)
+    if collision is not None:
+        print(
+            f"error: {email} cannot be stored beside {collision} on "
+            "case-insensitive filesystems — add the exact mapping to "
+            "CASEFOLD_COLLISION_AUTHOR_MAP in scripts/release.py",
             file=sys.stderr,
         )
         return 1

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -2078,6 +2078,14 @@ LEGACY_AUTHOR_MAP = {
 # ──────────────────────────────────────────────────────────────────────
 CONTRIBUTORS_EMAILS_DIR = REPO_ROOT / "contributors" / "emails"
 
+# Exact-case mappings that cannot coexist as filenames on the default
+# case-insensitive filesystems used by macOS and Windows. Keep this table
+# limited to real collisions; ordinary additions still belong in
+# contributors/emails/ so parallel contribution branches remain conflict-free.
+CASEFOLD_COLLISION_AUTHOR_MAP = {
+    "agent@Agents-Mac-mini.local": "skip-agent",
+}
+
 
 def _load_contributor_dir(directory: "Path | None" = None) -> dict:
     """Load one-file-per-email mappings from contributors/emails/.
@@ -2104,8 +2112,13 @@ def _load_contributor_dir(directory: "Path | None" = None) -> dict:
     return mapping
 
 
-# Effective map: frozen legacy dict + directory entries (directory wins).
-AUTHOR_MAP = {**LEGACY_AUTHOR_MAP, **_load_contributor_dir()}
+# Effective map: frozen legacy dict + portable exact-case exceptions +
+# directory entries (directory wins).
+AUTHOR_MAP = {
+    **LEGACY_AUTHOR_MAP,
+    **CASEFOLD_COLLISION_AUTHOR_MAP,
+    **_load_contributor_dir(),
+}
 
 
 def git(*args, cwd=None):

--- a/tests/scripts/test_contributor_map.py
+++ b/tests/scripts/test_contributor_map.py
@@ -46,6 +46,17 @@ def test_effective_map_merges_legacy_and_directory():
         assert release.AUTHOR_MAP[email] == login
 
 
+def test_mapping_filenames_are_portable_to_case_insensitive_filesystems():
+    names = [path.name for path in release.CONTRIBUTORS_EMAILS_DIR.iterdir()]
+    folded = [name.casefold() for name in names]
+    assert len(folded) == len(set(folded))
+
+
+def test_casefold_collision_mappings_preserve_exact_authorship():
+    assert release.AUTHOR_MAP["agent@Agents-Mac-mini.local"] == "skip-agent"
+    assert release.AUTHOR_MAP["agent@agents-Mac-mini.local"] == "momomojo"
+
+
 
 
 # ── add_contributor.py CLI behavior ───────────────────────────────────
@@ -77,6 +88,19 @@ def test_add_refuses_login_conflicting_with_legacy_map(emails_dir):
     email, login = next(iter(release.LEGACY_AUTHOR_MAP.items()))
     assert add_contributor(email, login + "x") == 1
     assert not (emails_dir / email).exists()
+
+
+def test_add_accepts_existing_casefold_collision_mapping(emails_dir):
+    assert add_contributor("agent@Agents-Mac-mini.local", "skip-agent") == 0
+    assert not (emails_dir / "agent@Agents-Mac-mini.local").exists()
+
+
+def test_add_refuses_new_casefold_filename_collision(emails_dir, capsys):
+    (emails_dir / "Alice@example.com").parent.mkdir(parents=True)
+    (emails_dir / "Alice@example.com").write_text("alice\n", encoding="utf-8")
+
+    assert add_contributor("alice@example.com", "different") == 1
+    assert "CASEFOLD_COLLISION_AUTHOR_MAP" in capsys.readouterr().err
 
 
 


### PR DESCRIPTION
## What changed

- move the exact-case `agent@Agents-Mac-mini.local -> skip-agent` mapping out of the filename-backed directory into a small case-fold collision table
- keep `agent@agents-Mac-mini.local -> momomojo` in the normal one-file-per-email directory
- make `add_contributor.py` resolve exact-case filenames and reject new filename aliases with an actionable error
- add regression coverage for portable filenames and both preserved author mappings

## Why

`main` tracks two `contributors/emails/` paths that differ only by the case of `Agents` and map to different GitHub users. Default macOS APFS and Windows filesystems cannot represent both paths at once, so a clean checkout immediately reports one mapping as modified. That also makes local build stamps report a dirty source tree.

The mappings cannot be collapsed without losing contributor attribution. This keeps both exact email keys while restoring a clean checkout on case-insensitive filesystems.

## Validation

- `python -m pytest tests/scripts/test_contributor_map.py -q` — 11 passed
- `python -m ruff check scripts/add_contributor.py scripts/release.py tests/scripts/test_contributor_map.py`
- `git diff --check HEAD^ HEAD`
- case-folded `git ls-tree` duplicate scan — no duplicates
