### PR TITLE
fix(auth): honor earliest key_cmd token expiry

### DIFF
--- a/agent/command_token_source.py
+++ b/agent/command_token_source.py
@@ -24,8 +24,9 @@ fresh. It is cached until shortly before expiry, so the command runs about
 once per token lifetime rather than once per request.
 
 Output contract: print ONLY the token on stdout, either bare or as JSON with
-an ``access_token`` field (``expires_in`` is honoured when present) — the
-shape OAuth 2.0 token endpoints and the helpers above already emit.
+an ``access_token`` field. ``expires_in`` and absolute deadlines (``expiry`` /
+``expiresOn``) are honoured when present — the shape OAuth 2.0 token endpoints
+and the helpers above already emit.
 
 Precedence: an explicit ``--api-key`` still wins (the one-off recovery escape
 hatch); otherwise ``key_cmd`` is preferred over a static ``api_key`` /
@@ -115,9 +116,10 @@ def _mint(command: str, label: str) -> tuple[str, Optional[float]]:
                     f"key_cmd for provider {label!r} returned JSON without an "
                     "'access_token' field"
                 )
+            ttl_candidates: list[float] = []
             ttl = payload.get("expires_in")
             if isinstance(ttl, (int, float)) and ttl > 0:
-                return token, float(ttl)
+                ttl_candidates.append(float(ttl))
             # A relative lifetime is the OAuth 2.0 field, but CLI token helpers
             # commonly print an absolute ISO 8601 deadline instead. Treating
             # that as "no TTL advertised" caches the token for the life of the
@@ -130,8 +132,10 @@ def _mint(command: str, label: str) -> tuple[str, Optional[float]]:
                 deadline = _parse_iso_timestamp(payload.get(field))
                 if deadline is not None:
                     remaining = deadline - time.time()
-                    if remaining > 0:
-                        return token, remaining
+                    if remaining > 0 or ttl_candidates:
+                        ttl_candidates.append(max(remaining, 0.0))
+            if ttl_candidates:
+                return token, min(ttl_candidates)
             return token, None
 
     # Bare token. The contract every comparable helper documents is "stdout
@@ -167,7 +171,7 @@ class CommandTokenSource:
             self._token = token
             self._expires_at = (
                 time.monotonic() + max(ttl - _TOKEN_REFRESH_LEEWAY_SECONDS, 5.0)
-                if ttl
+                if ttl is not None
                 # No advertised TTL: bounded cache (see _NO_TTL_REFRESH_SECONDS)
                 # — there is no 401-driven re-mint hook to fall back on.
                 else time.monotonic() + _NO_TTL_REFRESH_SECONDS

--- a/tests/agent/test_command_token_source.py
+++ b/tests/agent/test_command_token_source.py
@@ -258,14 +258,23 @@ class TestAbsoluteExpiry:
         _, ttl = _mint(f"printf '%s' '{{\"access_token\":\"t\",\"expiresOn\":\"{deadline}\"}}'", "p")
         assert ttl is not None and 1700 < ttl <= 1800
 
-    def test_expires_in_still_wins_when_both_present(self):
-        """The RFC 6749 field is authoritative where a helper sends both."""
+    def test_shorter_expires_in_wins_when_both_present(self):
+        """The cache must honour the soonest advertised deadline."""
         deadline = self._iso(3600)
         _, ttl = _mint(
             f"printf '%s' '{{\"access_token\":\"t\",\"expires_in\":120,\"expiry\":\"{deadline}\"}}'",
             "p",
         )
         assert ttl == 120.0
+
+    def test_earlier_absolute_expiry_wins_when_both_present(self):
+        """Helpers may keep expires_in at full lifetime while expiry counts down."""
+        deadline = self._iso(90)
+        _, ttl = _mint(
+            f"printf '%s' '{{\"access_token\":\"t\",\"expires_in\":3600,\"expiry\":\"{deadline}\"}}'",
+            "p",
+        )
+        assert ttl is not None and 0 < ttl <= 90
 
     def test_unparseable_expiry_is_not_a_ttl(self):
         """Junk must fall back to refresh-on-401, never to a guessed deadline."""


### PR DESCRIPTION
## Summary
- consider both expires_in and absolute expiry/expiresOn deadlines from key_cmd JSON output
- cache key_cmd tokens only until the earliest advertised deadline
- keep the existing no-TTL behavior for payloads that only carry an already-expired absolute deadline

Fixes #88535

## Tests
- .venv/bin/python -m pytest tests/agent/test_command_token_source.py::TestAbsoluteExpiry -q
- .venv/bin/python -m pytest tests/agent/test_command_token_source.py::TestAbsoluteExpiry::test_earlier_absolute_expiry_wins_when_both_present tests/agent/test_command_token_source.py::TestAbsoluteExpiry::test_shorter_expires_in_wins_when_both_present -q
- .venv/bin/python -m ruff check agent/command_token_source.py tests/agent/test_command_token_source.py
- git diff --check

## Local note
- scripts/run_tests.sh tests/agent/test_command_token_source.py -q reached 29 passing tests and 1 unrelated local ImportError because the optional anthropic package is not installed in this environment.