### PR TITLE
fix(desktop): honor default remote SSH profile

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -69,6 +69,7 @@ test('resolveRemoteSshDashboardProfile never sends a conn: pool key to the remot
   assert.equal(resolveRemoteSshDashboardProfile('', 'bob'), 'bob')
   assert.equal(resolveRemoteSshDashboardProfile('', 'default'), '')
   assert.equal(resolveRemoteSshDashboardProfile('writer', 'conn:mac-mini::default'), 'writer')
+  assert.equal(resolveRemoteSshDashboardProfile('default', 'mac-mini'), '')
 })
 
 test('normAuthMode coerces to token unless explicitly oauth', () => {

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -221,8 +221,8 @@ function connectionScopeKey(profile) {
 function resolveRemoteSshDashboardProfile(configuredRemoteProfile, poolOrProfileKey) {
   const configured = String(configuredRemoteProfile || '').trim()
 
-  if (configured && configured !== 'default') {
-    return configured
+  if (configured) {
+    return configured === 'default' ? '' : configured
   }
 
   const key = String(poolOrProfileKey || '').trim()


### PR DESCRIPTION
## Summary

- preserve an explicitly configured SSH `remoteProfile` even when it is `default`
- map explicit `default` to the remote root profile instead of falling back to the local profile name
- add a regression for local profile `mac-mini` → remote profile `default`

Closes #88994

## Root cause

`resolveRemoteSshDashboardProfile()` only treated a configured remote profile as authoritative when it was not `default`. With `remoteProfile: default`, it fell through to the local routing key. A local profile named `mac-mini` was therefore sent to the remote as `--profile mac-mini`, even though the remote mapping explicitly selected its default/root profile.

The resolver now distinguishes an absent mapping from an explicit `default`: absence keeps the historical same-name fallback, while explicit `default` resolves to the remote root profile (`''`).

## Verification

- `npm exec --workspace=apps/desktop vitest -- run --project electron electron/connection-config.test.ts` — 105 passed
- `npm run typecheck --workspace=apps/desktop`
- `npm run lint --workspace=apps/desktop -- --quiet`
- `git diff --check`
