### PR TITLE
fix(desktop): honor explicit SSH default remote profile

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -68,6 +68,7 @@ test('resolveRemoteSshDashboardProfile never sends a conn: pool key to the remot
   assert.equal(resolveRemoteSshDashboardProfile('', 'conn:mac-mini::dixie'), 'dixie')
   assert.equal(resolveRemoteSshDashboardProfile('', 'bob'), 'bob')
   assert.equal(resolveRemoteSshDashboardProfile('', 'default'), '')
+  assert.equal(resolveRemoteSshDashboardProfile('default', 'mac-mini'), '')
   assert.equal(resolveRemoteSshDashboardProfile('writer', 'conn:mac-mini::default'), 'writer')
 })
 

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -221,8 +221,8 @@ function connectionScopeKey(profile) {
 function resolveRemoteSshDashboardProfile(configuredRemoteProfile, poolOrProfileKey) {
   const configured = String(configuredRemoteProfile || '').trim()
 
-  if (configured && configured !== 'default') {
-    return configured
+  if (configured) {
+    return configured === 'default' ? '' : configured
   }
 
   const key = String(poolOrProfileKey || '').trim()


### PR DESCRIPTION
## Summary
Honor an explicitly configured SSH `remoteProfile: "default"` in the desktop bootstrap.

## Root cause
The SSH remote-profile resolver skipped the configured value `"default"` and then fell back to the local Desktop profile name. For a local profile such as `mac-mini`, the remote dashboard was therefore spawned with `--profile mac-mini` instead of the remote root/default profile.

## Fix
Treat any non-empty configured `remoteProfile` as authoritative and normalize `"default"` to the existing remote-root representation `""`. Existing pool-key cleanup and named remote-profile behavior remain unchanged.

## Testing
- Reproduced the pre-fix resolver behavior with Node: `("default", "mac-mini")` produced `"mac-mini"`.
- Evaluated the committed resolver cases: `("default", "mac-mini") -> ""`, `("","conn:mac-mini::default") -> ""`, `("","conn:mac-mini::dixie") -> "dixie"`, and explicit `"writer"` remains `"writer"`.
- The focused Vitest/desktop checks are left for GitHub Actions because the local sandbox could not materialize a Git checkout.

## Issue
Fixes #88994