### PR TITLE
fix: restore production hotfixes for lifecycle guard and OpenRouter

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -41,6 +41,8 @@ import re
 import shlex
 import stat
 from pathlib import Path
+
+from tools.shell_heredoc import strip_inert_heredoc_bodies
 from typing import Callable, Iterator, Optional
 
 logger = logging.getLogger(__name__)
@@ -375,6 +377,7 @@ def _iter_referenced_shell_scripts(
     cwd: Optional[str] = None,
 ) -> Iterator[Path]:
     """Yield scripts executed directly or through a POSIX shell."""
+    command = strip_inert_heredoc_bodies(command)
     for segment in _iter_command_segments(command):
         index = _command_token_index(segment)
         if index is None:
@@ -429,6 +432,7 @@ def _iter_referenced_shell_scripts(
 
 def _iter_shell_command_payloads(command: str) -> Iterator[str]:
     """Yield code passed through ``sh|bash|... -c`` for recursive scanning."""
+    command = strip_inert_heredoc_bodies(command)
     for segment in _iter_command_segments(command):
         index = _command_token_index(segment)
         if index is None or Path(segment[index]).name not in _SHELL_EXECUTABLES:

--- a/plugins/model-providers/openrouter/__init__.py
+++ b/plugins/model-providers/openrouter/__init__.py
@@ -134,7 +134,13 @@ class OpenRouterProfile(ProviderProfile):
         # also stays stable for installs that opt out of the default
         # ``compression.in_place: true`` and across delegate-subagent trees.
         sticky_key = _cache_scope_from_session_id(get_conversation_context() or session_id)
-        if sticky_key:
+        # Only OpenRouter understands the top-level session_id sticky key. When
+        # this profile fronts a custom OpenAI-compatible endpoint (e.g. a local
+        # router like OmniRoute), the field is forwarded to strict upstreams
+        # (OpenAI, NVIDIA) which reject the whole request with 400 "Unknown
+        # parameter: session_id".
+        base_url = str(context.get("base_url") or "")
+        if sticky_key and (not base_url or "openrouter.ai" in base_url):
             body["session_id"] = sticky_key
         prefs = context.get("provider_preferences")
         if prefs:

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -695,6 +695,30 @@ class TestLifecycleGuardModule:
         )
         assert result is False
 
+    def test_python_heredoc_with_css_paths_not_blocked(self):
+        """Quoted python heredoc bodies with path-like CSS/text must not trip
+        the referenced-script walk (#hermes-cloud production hotfix)."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        cmd = """python3 << 'PY'
+import paramiko
+css = '''
+.ssp-review { font-family: "Source Sans 3", system-ui, sans-serif; max-width: 760px; }
+</style>
+'''
+print('/')
+print('/tmp')
+ssh.exec_command('cat /tmp/a.php > /tmp/b.php')
+PY"""
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(
+                cmd, cwd="/home/deploy"
+            )
+            is False
+        )
+
     def test_nul_byte_in_path_token_does_not_crash_guard(self):
         """Residual #76762 class: when a NUL byte survives into the *path
         token itself* (tokenized binary-adjacent command text), ``os.open``

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -60,6 +60,30 @@ class TestOpenRouterProfile:
         assert first["session_id"] == "cron_job42"
         assert first["session_id"] == second["session_id"]
 
+    def test_sticky_session_id_omitted_for_custom_openai_compatible_base_url(self):
+        """OpenRouter profile must not leak session_id to strict local routers."""
+        p = get_provider_profile("openrouter")
+        body = p.build_extra_body(
+            session_id="sess123",
+            base_url="http://localhost:20128/v1",
+            model="z-ai/glm-5.2",
+        )
+        assert "session_id" not in body
+
+    def test_sticky_session_id_sent_for_openrouter_base_url(self):
+        p = get_provider_profile("openrouter")
+        body = p.build_extra_body(
+            session_id="sess123",
+            base_url="https://openrouter.ai/api/v1",
+            model="z-ai/glm-5.2",
+        )
+        assert body["session_id"] == "sess123"
+
+    def test_sticky_session_id_sent_when_base_url_unset(self):
+        p = get_provider_profile("openrouter")
+        body = p.build_extra_body(session_id="sess123", model="z-ai/glm-5.2")
+        assert body["session_id"] == "sess123"
+
 
 
 


### PR DESCRIPTION
## Summary
- Gate OpenRouter `session_id` sticky routing to real `openrouter.ai` endpoints so local OpenAI-compatible routers (OmniRoute) are not rejected with HTTP 400.
- Mask inert heredoc bodies before lifecycle referenced-script discovery to prevent false gateway blocks on Cloudways/paramiko write commands.

## Test plan
- [x] `pytest tests/providers/test_provider_profiles.py::TestOpenRouterProfile::test_sticky_session_id_omitted_for_custom_openai_compatible_base_url`
- [x] `pytest tests/providers/test_provider_profiles.py::TestOpenRouterProfile::test_sticky_session_id_sent_for_openrouter_base_url`
- [x] `pytest tests/providers/test_provider_profiles.py::TestOpenRouterProfile::test_sticky_session_id_sent_when_base_url_unset`
- [x] `pytest tests/hermes_cli/test_gateway_restart_loop.py::TestLifecycleGuardModule::test_python_heredoc_with_css_paths_not_blocked`

Made with [Cursor](https://cursor.com)