### PR TITLE
fix(cli): persist model.key_env on /model --global

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10671,6 +10671,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # need (#25106).
             save_config_value("model.base_url", result.base_url or None)
             save_config_value("model.api_mode", result.api_mode or None)
+            # Same lifecycle as base_url: write the destination env-var name
+            # (or None) so a previous provider's key_env cannot 401 the next
+            # request. Never persist result.api_key — that is the resolved
+            # secret (#88989).
+            save_config_value("model.key_env", result.key_env or None)
             _cprint("    Saved to config.yaml (--global)")
         else:
             _cprint("    (session only — add --global to persist)")
@@ -11054,6 +11059,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # must be synced on every global switch (#25106).
             save_config_value("model.base_url", result.base_url or None)
             save_config_value("model.api_mode", result.api_mode or None)
+            save_config_value("model.key_env", result.key_env or None)
             _cprint("    Saved to config.yaml")
         elif one_turn:
             _cprint("    (next turn only — restores after one response)")

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -478,6 +478,79 @@ class ModelSwitchResult:
     capabilities: Optional[ModelCapabilities] = None
     model_info: Optional[ModelInfo] = None
     is_global: bool = False
+    # Env-var name to persist as model.key_env. Empty means "clear the stale
+    # value" — never persist the resolved secret as model.api_key (#88989).
+    key_env: str = ""
+
+
+def _env_ref_name(value: str) -> str:
+    text = str(value or "").strip()
+    if text.startswith("${") and text.endswith("}") and len(text) > 3:
+        return text[2:-1].strip()
+    return ""
+
+
+def resolve_switch_key_env(
+    target_provider: str,
+    user_providers: Optional[dict] = None,
+    custom_providers: Optional[list] = None,
+) -> str:
+    """Env-var name that should land in ``model.key_env`` after a switch.
+
+    Returns ``""`` when the destination has no named env var so callers can
+    clear a stale ``key_env`` left by the previous provider. Does not return
+    or persist the resolved secret.
+    """
+    slug = str(target_provider or "").strip()
+    if not slug:
+        return ""
+    slug_l = slug.lower()
+    candidates = [slug, slug_l]
+    if slug_l.startswith("custom:"):
+        bare = slug[7:]
+        candidates.extend([bare, bare.lower()])
+
+    if isinstance(user_providers, dict):
+        for key in candidates:
+            entry = user_providers.get(key)
+            if not isinstance(entry, dict):
+                continue
+            named = str(entry.get("key_env") or "").strip()
+            if named:
+                return named
+            ref = _env_ref_name(str(entry.get("api_key") or ""))
+            if ref:
+                return ref
+
+    if isinstance(custom_providers, list):
+        for entry in custom_providers:
+            if not isinstance(entry, dict):
+                continue
+            aliases = custom_provider_aliases(
+                str(entry.get("name") or ""),
+                str(entry.get("provider_key") or ""),
+            )
+            if slug_l not in aliases and slug not in aliases:
+                continue
+            named = str(entry.get("key_env") or "").strip()
+            if named:
+                return named
+            ref = _env_ref_name(str(entry.get("api_key") or ""))
+            if ref:
+                return ref
+
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        from hermes_cli.providers import ALIASES
+
+        canonical = ALIASES.get(slug_l, slug_l)
+        pconfig = PROVIDER_REGISTRY.get(canonical)
+        env_vars = tuple(getattr(pconfig, "api_key_env_vars", ()) or ())
+        if env_vars:
+            return str(env_vars[0]).strip()
+    except Exception:
+        pass
+    return ""
 
 
 @dataclass(frozen=True)
@@ -1942,6 +2015,11 @@ def switch_model(
         capabilities=capabilities,
         model_info=model_info,
         is_global=is_global,
+        key_env=resolve_switch_key_env(
+            target_provider,
+            user_providers=user_providers,
+            custom_providers=custom_providers,
+        ),
     )
 
 

--- a/tests/hermes_cli/test_25106_global_switch_persists_base_url_api_mode.py
+++ b/tests/hermes_cli/test_25106_global_switch_persists_base_url_api_mode.py
@@ -137,5 +137,29 @@ def _run_apply(monkeypatch, result, persist_global=True):
     return saved
 
 
+def test_global_switch_persists_key_env(monkeypatch):
+    """#88989: --global must write model.key_env so the previous provider's
+    env-var name cannot stay in config.yaml and 401 the next request."""
+    result = _make_result()
+    result.key_env = "DEEPSEEK_API_KEY"
+    result.target_provider = "deepseek"
+    result.new_model = "deepseek-v4-flash"
+    saved = _run_switch(monkeypatch, result, cmd="/model deepseek-v4-flash --global")
+
+    assert saved["model.key_env"] == "DEEPSEEK_API_KEY"
+    assert "model.api_key" not in saved
+
+
+def test_global_switch_clears_stale_key_env(monkeypatch):
+    saved = _run_switch(monkeypatch, _make_result())
+    assert saved["model.key_env"] is None
+
+
+def test_picker_global_switch_persists_key_env(monkeypatch):
+    result = _make_result()
+    result.key_env = "AGNES_API_KEY"
+    saved = _run_apply(monkeypatch, result, persist_global=True)
+    assert saved["model.key_env"] == "AGNES_API_KEY"
+    assert "model.api_key" not in saved
 
 

--- a/tests/hermes_cli/test_resolve_switch_key_env.py
+++ b/tests/hermes_cli/test_resolve_switch_key_env.py
@@ -1,0 +1,56 @@
+"""#88989: resolve the env-var name to persist as model.key_env."""
+
+from hermes_cli.model_switch import resolve_switch_key_env
+
+
+def test_builtin_deepseek_uses_registry_env_var():
+    assert resolve_switch_key_env("deepseek") == "DEEPSEEK_API_KEY"
+
+
+def test_named_providers_dict_key_env_wins():
+    assert (
+        resolve_switch_key_env(
+            "sensenova",
+            user_providers={
+                "sensenova": {
+                    "base_url": "https://api.sensenova.cn/v1",
+                    "key_env": "AGNES_API_KEY",
+                }
+            },
+        )
+        == "AGNES_API_KEY"
+    )
+
+
+def test_named_providers_dict_expands_env_ref():
+    assert (
+        resolve_switch_key_env(
+            "custom:neuralwatt",
+            user_providers={
+                "neuralwatt": {"api_key": "${NEURALWATT_API_KEY}"},
+            },
+        )
+        == "NEURALWATT_API_KEY"
+    )
+
+
+def test_custom_providers_list_key_env():
+    assert (
+        resolve_switch_key_env(
+            "custom:agnes",
+            custom_providers=[
+                {
+                    "name": "agnes",
+                    "provider_key": "agnes",
+                    "base_url": "https://example.test/v1",
+                    "key_env": "AGNES_API_KEY",
+                }
+            ],
+        )
+        == "AGNES_API_KEY"
+    )
+
+
+def test_unknown_provider_clears():
+    assert resolve_switch_key_env("not-a-real-provider") == ""
+    assert resolve_switch_key_env("") == ""

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -17525,6 +17525,38 @@ def test_persist_model_switch_clears_stale_base_url(tmp_path, monkeypatch):
     assert not saved["model"].get("base_url"), saved["model"].get("base_url")
 
 
+def test_persist_model_switch_syncs_key_env(tmp_path, monkeypatch):
+    """#88989: TUI persist must replace a stale model.key_env, not leave the
+    previous provider's env-var name on disk."""
+    import types
+    import yaml
+    import cli
+
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        "model:\n"
+        "  default: old-model\n"
+        "  provider: custom\n"
+        "  key_env: AGNES_API_KEY\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(cli, "_hermes_home", tmp_path)
+
+    result = types.SimpleNamespace(
+        new_model="deepseek-v4-flash",
+        target_provider="deepseek",
+        base_url="https://api.deepseek.com",
+        key_env="DEEPSEEK_API_KEY",
+    )
+    server._persist_model_switch(result)
+    saved = yaml.safe_load(cfg_path.read_text())
+
+    assert saved["model"]["default"] == "deepseek-v4-flash"
+    assert saved["model"]["provider"] == "deepseek"
+    assert saved["model"]["key_env"] == "DEEPSEEK_API_KEY"
+    assert "api_key" not in saved["model"]
+
+
 # ---------------------------------------------------------------------------
 # _resolve_runtime_with_fallback — init-time provider fallback
 # ---------------------------------------------------------------------------

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4702,6 +4702,8 @@ def _persist_model_switch(result) -> None:
         # removal without needing a key-delete. Leaving the old value would
         # route the new model at the previous custom host (#48305).
         save_config_value("model.base_url", None)
+    # Clear or replace stale model.key_env the same way as base_url (#88989).
+    save_config_value("model.key_env", getattr(result, "key_env", None) or None)
 
 
 def _snapshot_agent_model_runtime(agent) -> dict:


### PR DESCRIPTION
## What does this PR do?

`/model … --global` (and the TUI persist twin) already writes `model.default`, `model.provider`, `model.base_url`, and `model.api_mode`. It never touched `model.key_env`. After switching away from a custom provider the old env-var name stayed in `config.yaml` and later requests could 401.

`ModelSwitchResult` now carries the destination `key_env` (named provider entry, `${ENV}` reference, or the built-in registry's first env var). Persist writes that name, or `None` to clear a stale one. The resolved secret is not written to `config.yaml`.

## Related Issue

Fixes #88989

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/model_switch.py`: `resolve_switch_key_env()` + `ModelSwitchResult.key_env`
- `cli.py`: persist `model.key_env` on both `--global` paths
- `tui_gateway/server.py`: same write in `_persist_model_switch`
- Tests for the resolver, CLI persist, and TUI persist

## How to Test

```text
uv run --extra dev python -m pytest \
  tests/hermes_cli/test_resolve_switch_key_env.py \
  tests/hermes_cli/test_25106_global_switch_persists_base_url_api_mode.py \
  tests/test_tui_gateway_server.py::test_persist_model_switch_syncs_key_env \
  tests/test_tui_gateway_server.py::test_persist_model_switch_clears_stale_base_url \
  tests/test_tui_gateway_server.py::test_persist_model_switch_preserves_sibling_model_keys \
  -q
# 13 passed
```

`uv run --extra dev ruff check` on the touched Python files: clean.

Not runtime-tested against a live DeepSeek/custom tenant.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A (no UI change)
