### PR TITLE
fix(desktop): honor explicit SSH remoteProfile default

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -71,6 +71,14 @@ test('resolveRemoteSshDashboardProfile never sends a conn: pool key to the remot
   assert.equal(resolveRemoteSshDashboardProfile('writer', 'conn:mac-mini::default'), 'writer')
 })
 
+test('resolveRemoteSshDashboardProfile honors explicit default and does not leak a local profile name', () => {
+  // Per-profile SSH with remoteProfile: "default" used to skip that value and
+  // send the local Desktop profile name (mac-mini) as --profile.
+  assert.equal(resolveRemoteSshDashboardProfile('default', 'mac-mini'), '')
+  assert.equal(resolveRemoteSshDashboardProfile('default', 'conn:mac-mini::writer'), '')
+  assert.equal(resolveRemoteSshDashboardProfile('default', 'default'), '')
+})
+
 test('normAuthMode coerces to token unless explicitly oauth', () => {
   assert.equal(normAuthMode('oauth'), 'oauth')
   assert.equal(normAuthMode('token'), 'token')

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -225,6 +225,15 @@ function resolveRemoteSshDashboardProfile(configuredRemoteProfile, poolOrProfile
     return configured
   }
 
+  // Explicit remoteProfile: "default" means the remote root home. The second
+  // argument at the SSH bootstrap call site is often the *local* Desktop
+  // profile name (e.g. mac-mini) — a routing label, not a remote profile.
+  // Treating "default" as unset leaked that local name into
+  // `hermes --profile <local>` and the remote exited immediately (#88994).
+  if (configured === 'default') {
+    return ''
+  }
+
   const key = String(poolOrProfileKey || '').trim()
   const requested = key.startsWith('conn:') ? key.split('::').pop() || '' : key
 


### PR DESCRIPTION
## What does this PR do?

SSH bootstrap calls `resolveRemoteSshDashboardProfile(sshConfig.remoteProfile, profile)`. When `remoteProfile` is the explicit string `"default"`, the helper treated it as unset and used the second argument. That argument is often the *local* Desktop profile name (`mac-mini`), so the remote was spawned as `hermes --profile mac-mini` and exited with `Profile 'mac-mini' does not exist`.

An explicit `"default"` now maps to the remote root home (`''`). Unset `remoteProfile` plus a `conn:` pool key is unchanged.

## Related Issue

Fixes #88994

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/connection-config.ts`: honor explicit `remoteProfile: "default"`
- `connection-config.test.ts`: regression for local name leak

#88978 also touches `connection-config.ts` (URL-remote `remoteProfile` mapping). This helper is SSH-only; land either first and rebase the other if they collide.

## How to Test

```text
cd apps/desktop
vitest run --project electron electron/connection-config.test.ts
# 106 passed
```

Not runtime-tested against a live SSH remote.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A (no UI change)
