### PR TITLE
fix(desktop): keep completion notification body off the session title

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -23,6 +23,7 @@ import {
   stripGeneratedImageEchoes
 } from '@/lib/generated-images'
 import { parseTodos } from '@/lib/todos'
+import { turnDoneNotificationBody } from '@/lib/turn-done-notification-body'
 import { dispatchNativeNotification } from '@/store/native-notifications'
 import { isDiskFullErrorMessage, notifyError } from '@/store/notifications'
 import { broadcastSessionsChanged } from '@/store/session-sync'
@@ -770,7 +771,7 @@ export function useMessageStream({
       }
 
       dispatchNativeNotification({
-        body: text.slice(0, 140) || translateNow('notifications.native.turnDoneBody'),
+        body: turnDoneNotificationBody(text, translateNow('notifications.native.turnDoneBody')),
         kind: 'turnDone',
         sessionId,
         title: translateNow('notifications.native.turnDoneTitle')

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -161,7 +161,7 @@ export const ar = defineLocale({
       inputTitle: 'مطلوب إدخال',
       inputBody: 'ينتظر Hermes ردّك.',
       turnDoneTitle: 'أنهى Hermes',
-      turnDoneBody: '',
+      turnDoneBody: 'اكتملت الرسالة.',
       turnErrorTitle: 'فشلت الجولة',
       backgroundDoneTitle: 'انتهت المهمة في الخلفية',
       backgroundFailedTitle: 'فشلت المهمة في الخلفية'

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -178,7 +178,7 @@ export const en: Translations = {
       inputTitle: 'Input needed',
       inputBody: 'Hermes is waiting for your response.',
       turnDoneTitle: 'Hermes finished',
-      turnDoneBody: '',
+      turnDoneBody: 'Message complete.',
       turnErrorTitle: 'Turn failed',
       backgroundDoneTitle: 'Background task finished',
       backgroundFailedTitle: 'Background task failed',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -179,7 +179,7 @@ export const ja = defineLocale({
       inputTitle: '入力が必要です',
       inputBody: 'Hermes が応答を待っています。',
       turnDoneTitle: 'Hermes が完了しました',
-      turnDoneBody: '',
+      turnDoneBody: 'メッセージが完了しました。',
       turnErrorTitle: 'ターンが失敗しました',
       backgroundDoneTitle: 'バックグラウンドタスクが完了しました',
       backgroundFailedTitle: 'バックグラウンドタスクが失敗しました',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -174,7 +174,7 @@ export const zhHant = defineLocale({
       inputTitle: '需要輸入',
       inputBody: 'Hermes 正在等待你的回應。',
       turnDoneTitle: 'Hermes 已完成',
-      turnDoneBody: '',
+      turnDoneBody: '訊息已完成。',
       turnErrorTitle: '本輪失敗',
       backgroundDoneTitle: '背景工作已完成',
       backgroundFailedTitle: '背景工作失敗',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -174,7 +174,7 @@ export const zh: Translations = {
       inputTitle: '需要输入',
       inputBody: 'Hermes 正在等待你的回应。',
       turnDoneTitle: 'Hermes 已完成',
-      turnDoneBody: '',
+      turnDoneBody: '消息已完成。',
       turnErrorTitle: '本轮失败',
       backgroundDoneTitle: '后台任务已完成',
       backgroundFailedTitle: '后台任务失败',

--- a/apps/desktop/src/lib/turn-done-notification-body.test.ts
+++ b/apps/desktop/src/lib/turn-done-notification-body.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  TURN_DONE_BODY_FALLBACK,
+  TURN_DONE_BODY_MAX,
+  turnDoneNotificationBody
+} from './turn-done-notification-body'
+
+// Mirrors the minified Studio helper from #88488:
+//   Xn(n?.content || e.title || "Message complete.", 140)
+function legacyStudioBody(sessionTitle: string, assistantContent?: string): string {
+  const raw = assistantContent || sessionTitle || TURN_DONE_BODY_FALLBACK
+  return raw.length <= TURN_DONE_BODY_MAX ? raw : raw.slice(0, TURN_DONE_BODY_MAX)
+}
+
+describe('turnDoneNotificationBody', () => {
+  it('uses the assistant reply when present', () => {
+    expect(turnDoneNotificationBody('The build is green.')).toBe('The build is green.')
+  })
+
+  it('truncates long replies to 140 characters', () => {
+    const reply = 'a'.repeat(200)
+    expect(turnDoneNotificationBody(reply)).toBe('a'.repeat(TURN_DONE_BODY_MAX))
+    expect(turnDoneNotificationBody(reply).length).toBe(TURN_DONE_BODY_MAX)
+  })
+
+  it('falls back to a generic phrase when content is missing, not the session title (#88488)', () => {
+    const sessionTitle = "what's the weather in Seoul?"
+
+    expect(legacyStudioBody(sessionTitle, undefined)).toBe(sessionTitle)
+    expect(legacyStudioBody(sessionTitle, '')).toBe(sessionTitle)
+
+    expect(turnDoneNotificationBody(undefined)).toBe(TURN_DONE_BODY_FALLBACK)
+    expect(turnDoneNotificationBody('')).toBe(TURN_DONE_BODY_FALLBACK)
+    expect(turnDoneNotificationBody('   ')).toBe(TURN_DONE_BODY_FALLBACK)
+    expect(turnDoneNotificationBody(undefined, TURN_DONE_BODY_FALLBACK)).toBe(TURN_DONE_BODY_FALLBACK)
+    expect(turnDoneNotificationBody('', TURN_DONE_BODY_FALLBACK)).not.toBe(sessionTitle)
+  })
+
+  it('ignores a blank i18n fallback and still avoids an empty body', () => {
+    expect(turnDoneNotificationBody('', '')).toBe(TURN_DONE_BODY_FALLBACK)
+    expect(turnDoneNotificationBody(null, '   ')).toBe(TURN_DONE_BODY_FALLBACK)
+  })
+})

--- a/apps/desktop/src/lib/turn-done-notification-body.ts
+++ b/apps/desktop/src/lib/turn-done-notification-body.ts
@@ -1,0 +1,18 @@
+// Native turn-done notification body (#88488).
+// Prefer the assistant reply. If that text is missing, use a generic
+// completion phrase — never the session title (usually the user's first
+// message). The minified Studio builder was `content || session.title ||
+// "Message complete."`; title in that chain made the OS toast repeat the
+// question instead of the answer.
+
+export const TURN_DONE_BODY_MAX = 140
+export const TURN_DONE_BODY_FALLBACK = 'Message complete.'
+
+export function turnDoneNotificationBody(
+  content: string | null | undefined,
+  fallback: string = TURN_DONE_BODY_FALLBACK
+): string {
+  const reply = (content ?? '').trim()
+  const source = reply || fallback.trim() || TURN_DONE_BODY_FALLBACK
+  return source.length <= TURN_DONE_BODY_MAX ? source : source.slice(0, TURN_DONE_BODY_MAX)
+}


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Fixes the desktop completion notification showing the session title (the user's first message) in its body instead of the final assistant reply.

The issue's quoted minified snippet (`content || session.title || "Message complete."`) is from the Vue Studio build and is not in the current React source tree. The real culprit: `notifications.native.turnDoneBody` was an empty string, so when the assistant reply was empty, the notification body fell through to `''`. Electron then handed the OS an empty body, and Linux (GNOME) toasts fill an empty body with the session/window title — reproducing the reported symptom.

This also means the defect is cross-platform: the empty-body fallback happens on every OS; only Linux toasts render it as the session title.

The fix extracts a small, tested helper that prefers the assistant reply and otherwise falls back to a generic phrase — never an empty body, and never the title.


## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #88488

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `apps/desktop/src/lib/turn-done-notification-body.ts` (new) — `turnDoneNotificationBody(content, fallback)` helper: reply first, then fallback, then `'Message complete.'`, capped at 140 chars.
- `apps/desktop/src/app/session/hooks/use-message-stream/index.ts` — call site now uses the helper.
- `apps/desktop/src/i18n/en.ts`, `ar.ts`, `ja.ts`, `zh.ts`, `zh-hant.ts` — fill `turnDoneBody` with a localized phrase (was empty).
- `apps/desktop/src/lib/turn-done-notification-body.test.ts` (new) — unit coverage for the helper.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Full `npm run test:ui` on Windows 11 (Node v24.19.0): **506 files / 4692 tests — all passing**.
2. Targeted run on Ubuntu 24.04 (WSL2): the new test file passes **4/4**.
3. This is a desktop-only change, so the Python `pytest` suite is N/A.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the desktop test suite (`npm run test:ui`) — new test passes 4/4 (Python pytest is N/A for this desktop-only change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2) <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (N/A)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (N/A)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (N/A)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (the empty-body fallback was already cross-platform; the fix preserves identical behavior on all OSes)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (N/A)

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

Run:
```
npm run install:desktop
cd apps/desktop && npm run test:ui
```
<img width="1086" height="510" alt="image" src="https://github.com/user-attachments/assets/d38e79eb-44ce-4e19-b847-9057115db457" />
