### PR TITLE
fix(desktop): render math and missing markdown elements in .md file preview

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-file.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.test.tsx
@@ -1,0 +1,53 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { MarkdownPreview } from './preview-file'
+
+// Behavior tests for the .md file preview renderer: input markdown goes
+// through preprocessMarkdown -> Streamdown (+ KaTeX math plugin) and must
+// come out as real rendered elements, matching what the chat transcript
+// renderer produces. Guards the regression where the preview was a bare
+// Streamdown pass with no math plugin and no table/img/a components.
+describe('MarkdownPreview', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders block and inline math through KaTeX', () => {
+    // KaTeX marks its output; raw "$" delimiters must be gone.
+    const { container } = render(
+      <MarkdownPreview
+        text={'Formula:\n\n$$\nx = \\frac{-b \\pm \\sqrt{b^2-4ac}}{2a}\n$$\n\nInline $a^2 + b^2 = c^2$ too.'}
+      />
+    )
+
+    expect(container.querySelector('.katex')).not.toBeNull()
+    expect(screen.queryByText(/\$\$/)).toBeNull()
+  })
+
+  it('renders GFM tables with header and body cells', () => {
+    const { container } = render(<MarkdownPreview text={'| h1 | h2 |\n| --- | --- |\n| a | b |'} />)
+
+    const table = container.querySelector('table')
+    expect(table).not.toBeNull()
+    expect(table?.querySelector('thead th')?.textContent).toBe('h1')
+    expect(table?.querySelector('tbody td')?.textContent).toBe('a')
+  })
+
+  it('renders images with alt text', () => {
+    const { container } = render(<MarkdownPreview text={'![a chart](https://example.com/chart.png)'} />)
+
+    const img = container.querySelector('img')
+    expect(img?.getAttribute('alt')).toBe('a chart')
+    expect(img?.getAttribute('src')).toBe('https://example.com/chart.png')
+  })
+
+  it('renders external links to open in a new tab safely', () => {
+    const { container } = render(<MarkdownPreview text={'[docs](https://example.com/docs)'} />)
+
+    const anchor = container.querySelector('a')
+    expect(anchor?.getAttribute('href')).toBe('https://example.com/docs')
+    expect(anchor?.getAttribute('target')).toBe('_blank')
+    expect(anchor?.getAttribute('rel')).toBe('noopener noreferrer')
+  })
+})

--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -10,6 +10,8 @@ import type {
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Streamdown } from 'streamdown'
 
+import { createMemoizedMathPlugin } from '@/lib/katex-memo'
+import { preprocessMarkdown } from '@/lib/markdown-preprocess'
 import { requestComposerFocus, requestComposerInsertRefs } from '@/app/chat/composer/focus'
 import { droppedFileInlineRef } from '@/app/chat/composer/inline-refs'
 import { HERMES_PATHS_MIME } from '@/app/chat/hooks/use-composer-actions'
@@ -300,7 +302,11 @@ const MD_TAG_CLASSES = {
   ol: 'mb-4 list-decimal pl-6 marker:text-muted-foreground/70 last:mb-0',
   li: 'mt-1 leading-relaxed',
   blockquote: 'mb-4 border-l-2 border-border pl-3 text-muted-foreground italic last:mb-0',
-  pre: 'mb-4 overflow-hidden rounded-lg border border-border bg-card font-mono text-xs leading-relaxed last:mb-0 [&_pre]:m-0 [&_pre]:overflow-x-auto [&_pre]:bg-transparent! [&_pre]:p-3 [&_pre]:font-mono'
+  pre: 'mb-4 overflow-hidden rounded-lg border border-border bg-card font-mono text-xs leading-relaxed last:mb-0 [&_pre]:m-0 [&_pre]:overflow-x-auto [&_pre]:bg-transparent! [&_pre]:p-3 [&_pre]:font-mono',
+  hr: 'my-6 border-border',
+  th: 'px-3 py-2 text-left text-sm font-semibold text-foreground',
+  td: 'px-3 py-2 align-top text-sm leading-relaxed',
+  thead: 'bg-muted/35 text-muted-foreground'
 } as const
 
 function tagged<T extends keyof typeof MD_TAG_CLASSES>(Tag: T) {
@@ -355,6 +361,47 @@ function MarkdownCode({ className, children, ...props }: ComponentProps<'code'>)
   return <RichCodeBlock code={code} fallback={highlighted} language={language} />
 }
 
+function MarkdownTable({ className, ...rest }: ComponentProps<'table'>) {
+  return (
+    <div className="mb-4 w-full overflow-x-auto rounded-lg border border-border last:mb-0">
+      <table
+        className={cn(
+          'm-0 w-full min-w-[18rem] border-collapse [&_tr]:border-b [&_tr]:border-border last:[&_tr]:border-0',
+          className
+        )}
+        {...rest}
+      />
+    </div>
+  )
+}
+
+function MarkdownImage({ alt, src, ...rest }: ComponentProps<'img'>) {
+  return (
+    <img
+      alt={alt ?? ''}
+      className="my-3 max-h-96 w-auto max-w-full rounded-lg border border-border object-contain shadow-sm"
+      src={src}
+      {...rest}
+    />
+  )
+}
+
+function MarkdownLink({ children, className, href, ...rest }: ComponentProps<'a'>) {
+  const isExternal = /^https?:\/\//i.test(href || '')
+
+  return (
+    <a
+      className={cn('text-foreground underline underline-offset-2 hover:text-primary', className)}
+      href={href}
+      rel={isExternal ? 'noopener noreferrer' : undefined}
+      target={isExternal ? '_blank' : undefined}
+      {...rest}
+    >
+      {children}
+    </a>
+  )
+}
+
 const MARKDOWN_COMPONENTS = {
   h1: tagged('h1'),
   h2: tagged('h2'),
@@ -366,14 +413,37 @@ const MARKDOWN_COMPONENTS = {
   li: tagged('li'),
   blockquote: tagged('blockquote'),
   pre: tagged('pre'),
-  code: MarkdownCode
+  code: MarkdownCode,
+  hr: tagged('hr'),
+  table: MarkdownTable,
+  th: tagged('th'),
+  td: tagged('td'),
+  thead: tagged('thead'),
+  img: MarkdownImage,
+  a: MarkdownLink
 }
 
+const mathPlugin = createMemoizedMathPlugin({ singleDollarTextMath: true })
+
 function MarkdownPreview({ text }: { text: string }) {
+  const processed = useMemo(() => {
+    try {
+      return preprocessMarkdown(text)
+    } catch {
+      return text
+    }
+  }, [text])
+
   return (
     <div className="preview-markdown mx-auto max-w-3xl px-4 py-3 text-sm text-foreground" data-selectable-text="true">
-      <Streamdown components={MARKDOWN_COMPONENTS} controls={false} mode="static" parseIncompleteMarkdown={false}>
-        {text}
+      <Streamdown
+        components={MARKDOWN_COMPONENTS}
+        controls={false}
+        mode="static"
+        parseIncompleteMarkdown={false}
+        plugins={{ math: mathPlugin }}
+      >
+        {processed}
       </Streamdown>
     </div>
   )

--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -10,8 +10,6 @@ import type {
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Streamdown } from 'streamdown'
 
-import { createMemoizedMathPlugin } from '@/lib/katex-memo'
-import { preprocessMarkdown } from '@/lib/markdown-preprocess'
 import { requestComposerFocus, requestComposerInsertRefs } from '@/app/chat/composer/focus'
 import { droppedFileInlineRef } from '@/app/chat/composer/inline-refs'
 import { HERMES_PATHS_MIME } from '@/app/chat/hooks/use-composer-actions'
@@ -33,7 +31,9 @@ import {
   writeDesktopFileText
 } from '@/lib/desktop-fs'
 import { Check, Pencil, X } from '@/lib/icons'
+import { createMemoizedMathPlugin } from '@/lib/katex-memo'
 import { shikiLanguageForFilename } from '@/lib/markdown-code'
+import { preprocessMarkdown } from '@/lib/markdown-preprocess'
 import { cn } from '@/lib/utils'
 import type { PreviewTarget } from '@/store/preview'
 import { setPreviewDirty } from '@/store/preview-edit'
@@ -423,9 +423,14 @@ const MARKDOWN_COMPONENTS = {
   a: MarkdownLink
 }
 
+// KaTeX math plugin, same setup as the chat renderer (markdown-text.tsx):
+// created once at module scope - the plugin is stateless beyond its LRU
+// cache - and memoized so only equations whose source changed re-render.
+// `singleDollarTextMath: true` enables `$x^2$` inline math (de-facto LLM
+// convention) alongside `$$...$$` blocks.
 const mathPlugin = createMemoizedMathPlugin({ singleDollarTextMath: true })
 
-function MarkdownPreview({ text }: { text: string }) {
+export function MarkdownPreview({ text }: { text: string }) {
   const processed = useMemo(() => {
     try {
       return preprocessMarkdown(text)

--- a/contributors/emails/46404230+peetteerr@users.noreply.github.com
+++ b/contributors/emails/46404230+peetteerr@users.noreply.github.com
@@ -1,0 +1,1 @@
+peetteerr


### PR DESCRIPTION
## Problem

The .md file preview renderer in the desktop app (`MarkdownPreview` in `preview-file.tsx`) was a bare Streamdown pass that lacked key capabilities present in the chat transcript renderer:

- Math formulas (`$x^2$` inline and `$$...$$` block) rendered as raw text without KaTeX
- GFM tables, images, external links, and horizontal rules lacked dedicated components/styling
- The `preprocessMarkdown` normalization pipeline was bypassed

## Fix

Brings the .md file preview renderer to parity with the chat transcript renderer in `apps/desktop/src/app/chat/right-rail/preview-file.tsx`:

- Wire the memoized KaTeX plugin (`createMemoizedMathPlugin({ singleDollarTextMath: true })`) into Streamdown
- Add `MarkdownTable` (with horizontal scroll container), `MarkdownImage`, `MarkdownLink`, and `hr`/`th`/`td`/`thead` tags
- Run content through `preprocessMarkdown`
- Zero new runtime dependencies; reuses existing internal utilities

## Verification

- Added behavior tests in `preview-file.test.tsx` verifying KaTeX output, GFM tables, images, and secure external links
- `npx eslint src/app/chat/right-rail/preview-file.tsx src/app/chat/right-rail/preview-file.test.tsx` passes cleanly (0 errors, 0 warnings)
- `npx prettier --check` passes
- `npx tsc --noEmit -p tsconfig.json` passes
- `npx vitest run src/app/chat/right-rail/preview-file.test.tsx` passes (4/4 tests)