### PR TITLE
fix(desktop): dedupe profile mention completions

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-at-completions-contrib.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-at-completions-contrib.test.tsx
@@ -25,11 +25,9 @@ function addSource(id: string, provide: ComposerAtCompletionSource['provide']) {
   )
 }
 
-function gatewayStub() {
+function gatewayStub(items = [{ text: '@file:src/research-notes.md', display: 'research-notes.md', meta: 'file' }]) {
   return {
-    request: vi.fn(async () => ({
-      items: [{ text: '@file:src/research-notes.md', display: 'research-notes.md', meta: 'file' }]
-    }))
+    request: vi.fn(async () => ({ items }))
   }
 }
 
@@ -73,6 +71,24 @@ describe('contributed @ completion sources', () => {
     const rows = await searchAndRead(result, 'rese')
     expect(rows[0]).toBe('@researcher')
     expect(rows.some(l => l.includes('research-notes.md'))).toBe(true)
+  })
+
+  it('deduplicates contributed and core profile handles without collapsing distinct references', async () => {
+    vi.useFakeTimers()
+    addSource('bots', q => ('researcher'.startsWith(q) ? [{ insert: '@Researcher', meta: 'Bot · Researcher' }] : []))
+
+    const gateway = gatewayStub([
+      { text: '@researcher', display: '@researcher', meta: 'Research and intelligence analyst' },
+      { text: '@researcher-homelab', display: '@researcher-homelab', meta: 'agent profile' },
+      { text: '@file:src/researcher.md', display: 'researcher.md', meta: 'file' }
+    ])
+
+    const { result } = renderHook(() => useAtCompletions({ gateway: gateway as never, sessionId: 's1', cwd: '/repo' }))
+
+    const rows = await searchAndRead(result, 'rese')
+    expect(rows.filter(label => label.toLowerCase() === '@researcher')).toEqual(['@Researcher'])
+    expect(rows).toContain('@researcher-homelab')
+    expect(rows.some(label => label.includes('researcher.md'))).toBe(true)
   })
 
   it('drops rows when the query does not match the source filter', async () => {

--- a/apps/desktop/src/app/chat/composer/hooks/use-at-completions.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-at-completions.ts
@@ -15,6 +15,8 @@ import { useLiveCompletionAdapter } from './use-live-completion-adapter'
 
 const KIND_RE = /^@(file|folder|url|image|tool|git):(.*)$/
 const REF_STARTERS = new Set(['file', 'folder', 'url', 'image', 'tool', 'git'])
+// These bare tokens are context actions, not profile handles.
+const SIMPLE_CONTEXT_REFS = new Set(['@diff', '@staged'])
 
 const STARTER_META: Record<string, string> = {
   file: 'Attach a file reference',
@@ -35,6 +37,26 @@ function starterEntries(query: string): CompletionEntry[] {
     display: `@${kind}:`,
     meta: STARTER_META[kind] || ''
   }))
+}
+
+function mergeCompletionEntries(preferred: CompletionEntry[], fallback: CompletionEntry[]): CompletionEntry[] {
+  const seenHandles = new Set<string>()
+
+  return [...preferred, ...fallback].filter(entry => {
+    const key = normalize(entry.text)
+
+    if (!/^@[^:\s]+$/.test(key) || SIMPLE_CONTEXT_REFS.has(key)) {
+      return true
+    }
+
+    if (seenHandles.has(key)) {
+      return false
+    }
+
+    seenHandles.add(key)
+
+    return true
+  })
 }
 
 interface AtItemMetadata extends Record<string, string> {
@@ -147,7 +169,7 @@ export function useAtCompletions(options: {
       const extras = contributedEntries(query)
 
       if (!gateway) {
-        return { items: [...extras, ...starters], query }
+        return { items: mergeCompletionEntries(extras, starters), query }
       }
 
       const word = REF_STARTERS.has(query) ? `@${query}:` : `@${query}`
@@ -174,9 +196,9 @@ export function useAtCompletions(options: {
         const items = result.items ?? []
         const base = items.length > 0 ? items : starters
 
-        return { items: [...extras, ...base], query }
+        return { items: mergeCompletionEntries(extras, base), query }
       } catch {
-        return { items: [...extras, ...starters], query }
+        return { items: mergeCompletionEntries(extras, starters), query }
       }
     },
     [cacheKey, contributedEntries, gateway, sessionId, cwd]


### PR DESCRIPTION
## What / Why

Fixes #88915.

When Bot Mode is active, a profile can be offered twice in the Desktop `@` autocomplete: once by the synchronous Bot plugin contribution and once by the gateway's core profile completion. Both rows insert the same mention, so the duplicate is not a distinct choice.

## Product impact path

1. A user types `@` in the main Desktop composer or the edit-message composer.
2. Both consumers call `useAtCompletions`.
3. Bot Mode contributes the roster handle through `composer.atCompletions`.
4. `complete.path` independently returns the same active profile handle.
5. The hook previously concatenated both arrays, and the adapter assigned index-distinct IDs.
6. The popover therefore rendered two selectable rows that insert the same `@handle`.

## Root cause and scope

`useAtCompletions` had no identity reconciliation at the only merge seam between contributed and core completion rows.

This patch deduplicates case-insensitive bare `@handle` overlaps while preserving contribution order, so the richer Bot row wins. It deliberately does not collapse typed references such as `@file:...`, distinct multi-source handles such as `@researcher-homelab`, or the simple context actions `@diff` / `@staged`. The same merge is used for gateway success, no-gateway fallback, and request-error fallback.

Non-goals: changing backend profile enumeration, Bot roster/group behavior, path-reference formatting, databases, Langfuse, security behavior, or unrelated completion sources.

## Commits

- Base (`NousResearch/hermes-agent:main`): `e624e9fde561e1add9388384012b295fde669ade`
- Head: `b6b494493853006525a60939dfcedc6779044de3`
- History: one commit by `zhongwater123`; two files changed; no commits from another PR.

## Main / head comparison and mutation proof

Regression command:

```text
node ../../node_modules/vitest/vitest.mjs run --project ui src/app/chat/composer/hooks/use-at-completions-contrib.test.tsx
```

- Latest base behavior plus the new regression test, with the production fix absent: **failed**, 1 failed / 3 passed. The popover returned `['@Researcher', '@researcher']`; expected `['@Researcher']`.
- PR head: **passed**, 4 / 4.
- Mutation proof: temporarily removed only the production merge fix from the PR head while retaining the regression test; the same assertion failed again, 1 failed / 3 passed. Restored the fix and reconfirmed 4 / 4 with a clean worktree.

## Validation

Passed on the final head:

- Focused regression: 4 / 4.
- `vitest run --project ui src/app/chat/composer/hooks`: 87 / 87 across 14 files.
- `node --test src/plugins/*/tests/*.test.mjs`: 254 / 254.
- `npm run typecheck`: renderer, Electron, and E2E TypeScript configs passed.
- `npm run build`: production renderer (15,033 modules), Electron main/preload bundles, native dependency staging, and `assert-dist-built` passed.
- `npm run lint`: exit 0, 0 errors; 123 warnings are in unmodified repository files. The two touched files separately pass ESLint with `--max-warnings=0`.
- Prettier check for both touched files passed.
- `python scripts/check-windows-footguns.py --all`: passed, 983 files scanned.
- `git diff --check`: passed.

Checks that did not pass or could not run:

- `npm run test:ui` did not pass in this Windows environment. The captured run timed out in four unrelated files: `src/app/skills/index.test.tsx`, `src/app/messaging/index.test.tsx`, `src/store/session-unread-tile.test.ts`, and `src/app/settings/gateway-settings.test.tsx`. A single-worker rerun of exactly those files also failed 12 / 20 (mostly 15-second timeouts plus existing DOM/`act()` isolation symptoms). None imports or exercises the changed hook.
- `HERMES_PYTHON=D:\python312\python.exe scripts/run_tests.sh tests/gateway/test_complete_path_at_filter.py` reached pytest collection but could not collect because `concurrent_log_handler` is not installed. No Python production code is changed.

## Platform

- Windows 11, case-sensitive NTFS checkout
- Node.js 24.19.0; npm 10.9.3
- Python 3.12.2 for the attempted backend test

## Overlap audit

No open PR references #88915 or its exact symptom at publication time. #86814 touches the Bot plugin but is a stale/conflicting alternate feature implementation and does not reconcile contributed/core completion rows.

Prepared with Codex assistance; evidence verified against the stated commits.
