### PR TITLE
fix(delegate): preserve named custom provider pools

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1005,6 +1005,181 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
         result = _resolve_child_credential_pool("openrouter", parent)
         self.assertIs(result, mock_pool)
 
+    def test_named_custom_child_uses_requested_provider_pool_when_endpoints_are_shared(self):
+        parent = _make_mock_parent()
+        parent.provider = "custom"
+        parent.requested_provider = "open-ai"
+        parent.base_url = "https://shared.example/v1"
+        parent._credential_pool = None
+
+        wrong_pool = MagicMock(name="wrong_pool")
+        wrong_pool.has_credentials.return_value = True
+        correct_pool = MagicMock(name="correct_pool")
+        correct_pool.has_credentials.return_value = True
+
+        def load_pool(provider):
+            return {
+                "custom:claude-ai": wrong_pool,
+                "custom:open-ai": correct_pool,
+            }.get(provider)
+
+        with (
+            patch(
+                "agent.credential_pool.get_custom_provider_pool_key",
+                side_effect=lambda _url, provider_name=None: (
+                    f"custom:{provider_name}" if provider_name else "custom:claude-ai"
+                ),
+            ),
+            patch("agent.credential_pool.load_pool", side_effect=load_pool),
+        ):
+            result = _resolve_child_credential_pool(
+                "custom",
+                parent,
+                parent.base_url,
+                effective_requested_provider="open-ai",
+            )
+
+        self.assertIs(result, correct_pool)
+
+    def test_named_custom_child_resolves_shared_endpoint_from_real_config(self):
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hermes_home = Path(tmpdir)
+            (hermes_home / "config.yaml").write_text(
+                "providers:\n"
+                "  claude-ai:\n"
+                "    api: https://shared.example/v1\n"
+                "    api_key: claude-key\n"
+                "  open-ai:\n"
+                "    api: https://shared.example/v1\n"
+                "    api_key: openai-key\n",
+                encoding="utf-8",
+            )
+
+            parent = _make_mock_parent()
+            parent.provider = "custom"
+            parent.requested_provider = "open-ai"
+            parent.base_url = "https://shared.example/v1"
+            parent._credential_pool = None
+
+            correct_pool = MagicMock(name="correct_pool")
+            correct_pool.has_credentials.return_value = True
+
+            with (
+                patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+                patch(
+                    "agent.credential_pool.load_pool",
+                    side_effect=lambda provider: (
+                        correct_pool if provider == "custom:open-ai" else None
+                    ),
+                ),
+            ):
+                result = _resolve_child_credential_pool(
+                    "custom",
+                    parent,
+                    parent.base_url,
+                    effective_requested_provider="open-ai",
+                )
+
+        self.assertIs(result, correct_pool)
+
+    def test_named_custom_parent_pool_sharing_uses_requested_provider_not_endpoint_order(self):
+        parent = _make_mock_parent()
+        parent.provider = "custom"
+        parent.requested_provider = "open-ai"
+        parent.base_url = "https://shared.example/v1"
+        parent_pool = MagicMock(name="parent_open_ai_pool")
+        parent._credential_pool = parent_pool
+
+        with patch(
+            "agent.credential_pool.get_custom_provider_pool_key",
+            side_effect=lambda _url, provider_name=None: (
+                f"custom:{provider_name}" if provider_name else "custom:claude-ai"
+            ),
+        ):
+            result = _resolve_child_credential_pool(
+                "custom",
+                parent,
+                parent.base_url,
+                effective_requested_provider="open-ai",
+            )
+
+        self.assertIs(result, parent_pool)
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_build_child_inherits_requested_provider_identity(self, _mock_cfg):
+        parent = _make_mock_parent()
+        parent.provider = "custom"
+        parent.requested_provider = "open-ai"
+        parent.base_url = "https://shared.example/v1"
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="Preserve named provider identity",
+                context=None,
+                toolsets=[],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        self.assertEqual(MockAgent.call_args.kwargs["requested_provider"], "open-ai")
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_build_child_explicit_provider_overrides_parent_requested_provider(self, _mock_cfg):
+        parent = _make_mock_parent()
+        parent.provider = "custom"
+        parent.requested_provider = "open-ai"
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="Use explicit provider",
+                context=None,
+                toolsets=[],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                override_provider="anthropic",
+            )
+
+        self.assertEqual(MockAgent.call_args.kwargs["requested_provider"], "anthropic")
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_build_child_raw_base_url_does_not_inherit_named_provider_identity(self, _mock_cfg):
+        parent = _make_mock_parent()
+        parent.provider = "custom"
+        parent.requested_provider = "open-ai"
+        parent.base_url = "https://shared.example/v1"
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="Use raw endpoint",
+                context=None,
+                toolsets=[],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                override_provider="custom",
+                override_base_url="https://raw.example/v1",
+            )
+
+        self.assertEqual(MockAgent.call_args.kwargs["requested_provider"], "custom")
+
     # --- Custom-endpoint identity resolution (issue #7833) ---
 
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1757,6 +1757,15 @@ def _build_child_agent(
     effective_base_url = override_base_url or parent_agent.base_url
     if not override_base_url:
         effective_base_url = _inherit_parent_base_url(parent_agent, effective_base_url)
+    effective_requested_provider = (
+        override_provider
+        or (
+            effective_provider
+            if override_base_url
+            else getattr(parent_agent, "requested_provider", None)
+        )
+        or effective_provider
+    )
     effective_api_key = override_api_key or parent_api_key
     # Bug #20558 / PR #20563: api_mode must NOT be inherited when the child uses a
     # different provider than the parent — each provider has its own API surface
@@ -1939,6 +1948,7 @@ def _build_child_agent(
                 api_key=effective_api_key,
                 model=effective_model,
                 provider=effective_provider,
+                requested_provider=effective_requested_provider,
                 api_mode=effective_api_mode,
                 acp_command=effective_acp_command,
                 acp_args=effective_acp_args,
@@ -2026,7 +2036,10 @@ def _build_child_agent(
     # Share a credential pool with the child when possible so subagents can
     # rotate credentials on rate limits instead of getting pinned to one key.
     child_pool = _resolve_child_credential_pool(
-        effective_provider, parent_agent, effective_base_url
+        effective_provider,
+        parent_agent,
+        effective_base_url,
+        effective_requested_provider=effective_requested_provider,
     )
     if child_pool is not None:
         child._credential_pool = child_pool
@@ -4333,6 +4346,7 @@ def _resolve_child_credential_pool(
     effective_provider: Optional[str],
     parent_agent,
     effective_base_url: Optional[str] = None,
+    effective_requested_provider: Optional[str] = None,
 ):
     """Resolve a credential pool for the child agent.
 
@@ -4351,6 +4365,11 @@ def _resolve_child_credential_pool(
     We therefore resolve custom runtimes by endpoint identity (the
     ``custom:<name>`` pool key derived from the base_url) and only share the
     parent's pool when both resolve to the *same* custom endpoint.
+
+    Named custom providers may intentionally share a gateway URL while using
+    different credentials or account groups.  In that case the inherited
+    ``requested_provider`` identity takes precedence over URL-only matching so
+    the child cannot lease the first pool registered for the shared endpoint.
     """
     if not effective_provider:
         return getattr(parent_agent, "_credential_pool", None)
@@ -4365,7 +4384,10 @@ def _resolve_child_credential_pool(
         try:
             from agent.credential_pool import get_custom_provider_pool_key, load_pool
 
-            child_key = get_custom_provider_pool_key(effective_base_url)
+            child_key = get_custom_provider_pool_key(
+                effective_base_url,
+                provider_name=effective_requested_provider,
+            )
             if child_key is None:
                 # Unregistered endpoint (raw delegation.base_url with no
                 # matching custom_providers entry) -> no shared pool exists.
@@ -4375,7 +4397,8 @@ def _resolve_child_credential_pool(
 
             # Reuse the parent's pool only when it is the same custom endpoint.
             parent_key = get_custom_provider_pool_key(
-                getattr(parent_agent, "base_url", None)
+                getattr(parent_agent, "base_url", None),
+                provider_name=getattr(parent_agent, "requested_provider", None),
             )
             if (
                 parent_pool is not None


### PR DESCRIPTION
## Summary
- Preserve the effective named custom provider identity when `delegate_task` builds child agents.
- Resolve delegated child credential pools with `provider_name` so same-endpoint named providers do not share the wrong account group.
- Add regression coverage for inherited `requested_provider`, explicit `delegation.provider` override, raw `delegation.base_url`, and parent/child pool sharing.

## Background
This is the remaining current-main delegate call-path fix for NousResearch/hermes-agent#45763. It is based on latest upstream `main` and does not stack on Kewe63/hermes-agent#3 or the closed duplicate upstream PR #77530.

Attribution: Kewe63/hermes-agent#3 identified the follow-up problem around delegated named custom providers. Current upstream already has `AIAgent.requested_provider` and `get_custom_provider_pool_key(..., provider_name=...)`; this PR applies that existing upstream machinery at the child-agent construction and credential-pool resolution path only.

## Changes
- Forward `effective_requested_provider` into child `AIAgent` construction.
- Pass the same identity into `_resolve_child_credential_pool` for custom provider pool keys.
- Preserve precedence: explicit `delegation.provider` > inherited parent `requested_provider`; explicit raw `delegation.base_url` uses the raw custom identity rather than inheriting the parent's named provider.
- Keep the fix focused to `tools/delegate_tool.py` plus behavior tests in `tests/tools/test_delegate.py`.

## Verification
- `scripts/run_tests.sh tests/tools/test_delegate.py -q` — passed 75/75 after final rebase.
- `scripts/run_tests.sh tests/agent/test_credential_pool_provider_boundary.py tests/agent/test_credential_pool.py -q` — passed 62/62.
- `uv run --extra dev ruff check tools/delegate_tool.py tests/tools/test_delegate.py` — passed.
- `python3 -m compileall -q tools/delegate_tool.py tests/tools/test_delegate.py` — passed.
- `git diff --check` — passed.
- Added-line security grep for hardcoded secrets, shell injection, eval/exec, pickle, and SQL-format patterns — no findings.
- Sabotage check from the implementation run: reverting the production fix made the new named-provider/requested-provider/raw-base-url regressions fail as expected.

## Risk
Low. This only threads an already-resolved provider identity through delegate child setup and credential-pool selection. Existing raw `delegation.base_url` behavior is intentionally preserved so raw endpoints do not accidentally inherit a parent named provider identity.
