### PR TITLE
fix(tests): gateway SSE and goal-verdict tests stop flaking under CI load (#88975)

### DIFF
--- a/tests/gateway/test_goal_verdict_send.py
+++ b/tests/gateway/test_goal_verdict_send.py
@@ -96,6 +96,18 @@ def _make_runner_with_adapter(session_id: str = None):
     return runner, adapter, session_entry, src
 
 
+async def _drain_until(condition, timeout=5.0):
+    """Yield to the event loop until ``condition()`` is truthy (bounded).
+
+    The goal-continuation path finishes its sends/enqueues on spawned tasks;
+    a fixed 0.05s sleep raced them on loaded CI runners (#88975). Returns as
+    soon as the condition holds — the asserts after the call stay exact.
+    """
+    deadline = asyncio.get_event_loop().time() + timeout
+    while not condition() and asyncio.get_event_loop().time() < deadline:
+        await asyncio.sleep(0.01)
+
+
 @pytest.mark.asyncio
 async def test_goal_verdict_continue_enqueues_continuation(hermes_home):
     """When the judge says continue, both the 'continuing' status and the
@@ -115,7 +127,7 @@ async def test_goal_verdict_continue_enqueues_continuation(hermes_home):
             source=src,
             final_response="here's a partial edit",
         )
-        await asyncio.sleep(0.05)
+        await _drain_until(lambda: adapter.sends and adapter._pending_messages)
 
     # Status line sent back
     assert len(adapter.sends) == 1
@@ -143,7 +155,7 @@ async def test_goal_verdict_budget_exhausted_sends_pause(hermes_home):
             source=src,
             final_response="still partial",
         )
-        await asyncio.sleep(0.05)
+        await _drain_until(lambda: adapter.sends)
 
     assert len(adapter.sends) == 1
     content = adapter.sends[0]["content"]

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -450,6 +450,10 @@ async def test_session_chat_stream_treats_pre_existing_poisoned_row_as_no_model(
                 json={"message": "hi"},
             )
             assert resp.status == 200
+            # Drain the SSE body: the 200 lands before the streaming task
+            # invokes _run_agent, so asserting on call_args without reading
+            # the body races the handler (flaked on loaded CI runners).
+            await resp.text()
 
     _, kwargs = mock_run.call_args
     assert kwargs["session_model"] is None


### PR DESCRIPTION
## Summary

Three gateway tests that red-flagged unrelated main pushes and PR runs on Aug 18 (#88975) no longer race the tasks they assert on.

Root cause, SSE test: `_handle_session_chat_stream` runs `_run_agent` inside `asyncio.create_task(_run_and_signal())` and `response.prepare()` returns the 200 before that task necessarily starts — asserting `mock_run.call_args` right after the status check found `None` on loaded runners (`TypeError: cannot unpack non-iterable NoneType object`). The goal-verdict pair asserted on spawned-task output after a fixed `asyncio.sleep(0.05)`.

## Changes

- `tests/gateway/test_session_api.py`: the poisoned-row stream test drains the SSE body (`await resp.text()`), which joins the stream end and guarantees the runner task completed before `call_args` is read
- `tests/gateway/test_goal_verdict_send.py`: fixed sleeps replaced with a bounded `_drain_until()` poll (5s cap, returns the moment the condition holds) — asserts stay exact

## Validation

| | Before | After |
|---|---|---|
| Red main runs (Aug 18) | 32099139396, 32101135100, 32106224479 + PR run 32101070064 | mechanism removed |
| `pytest tests/gateway/test_session_api.py tests/gateway/test_goal_verdict_send.py` | 22 passed (flaky under CI load) | 22 passed, load-independent |

Fixes #88975.

## Infographic

![Gateway test races neutralized](https://v3b.fal.media/files/b/0aa6cead/kfcxU83eSZPokI9127GnB_aBFccjG2.png)
