### PR TITLE
fix(desktop): bind approvals to source authority

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -216,6 +216,11 @@ import {
   resolveReadinessProbeAuth
 } from './native-auth-decisions'
 import {
+  nativeNotificationDedupeKey,
+  sendNativeNotificationAction,
+  sendNativeNotificationFocus
+} from './native-notification-action'
+import {
   nativeRefreshUrl,
   type NativeTokenSet,
   parseTokenResponse,
@@ -13447,7 +13452,7 @@ const claimedAmbientCue = createEventDeduper()
 // The first caller within the window gets true; peers get false and stay quiet.
 ipcMain.handle('hermes:ambient:claim', (_event, key) => !claimedAmbientCue(String(key ?? '')))
 
-ipcMain.handle('hermes:notify', (_event, payload) => {
+ipcMain.handle('hermes:notify', (event, payload) => {
   if (!Notification.isSupported()) {
     return false
   }
@@ -13456,7 +13461,7 @@ ipcMain.handle('hermes:notify', (_event, payload) => {
   // kind+session can arrive here twice. Collapse it at this single choke point.
   // Return true (not false): a notification for the event IS being shown by the
   // first caller, so the settings "send test" success probe stays honest.
-  if (isDuplicateNotification(`${payload?.kind ?? ''}:${payload?.sessionId ?? payload?.tag ?? ''}`)) {
+  if (isDuplicateNotification(nativeNotificationDedupeKey(payload ?? {}))) {
     return true
   }
 
@@ -13472,26 +13477,16 @@ ipcMain.handle('hermes:notify', (_event, payload) => {
   })
 
   notification.on('click', () => {
-    if (!mainWindow || mainWindow.isDestroyed()) {
-      return
+    const sourceWindow = BrowserWindow.fromWebContents(event.sender)
+
+    if (sourceWindow && !sourceWindow.isDestroyed()) {
+      focusWindow(sourceWindow)
     }
 
-    focusWindow(mainWindow)
-
-    if (payload?.sessionId) {
-      mainWindow.webContents.send('hermes:focus-session', payload.sessionId)
-    }
+    sendNativeNotificationFocus(event.sender, payload ?? {})
   })
   notification.on('action', (_actionEvent, index) => {
-    if (!mainWindow || mainWindow.isDestroyed()) {
-      return
-    }
-
-    const action = actions[index]
-
-    if (action?.id) {
-      mainWindow.webContents.send('hermes:notification-action', { sessionId: payload?.sessionId, actionId: action.id })
-    }
+    sendNativeNotificationAction(event.sender, payload ?? {}, actions, index)
   })
   notification.show()
 

--- a/apps/desktop/electron/native-notification-action.test.ts
+++ b/apps/desktop/electron/native-notification-action.test.ts
@@ -1,0 +1,166 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  nativeNotificationDedupeKey,
+  sendNativeNotificationAction,
+  sendNativeNotificationFocus
+} from './native-notification-action'
+
+describe('sendNativeNotificationAction', () => {
+  it('wires the Electron notification action to its IPC event sender', () => {
+    const main = fs.readFileSync(path.join(path.dirname(fileURLToPath(import.meta.url)), 'main.ts'), 'utf8')
+    const handlerStart = main.indexOf("ipcMain.handle('hermes:notify'")
+    const handler = main.slice(handlerStart, main.indexOf('notification.show()', handlerStart))
+
+    expect(handler).toContain('sendNativeNotificationAction(event.sender, payload ?? {}, actions, index)')
+  })
+
+  it('returns the action to the originating renderer with exact approval authority', () => {
+    const send = vi.fn()
+    const sender = { isDestroyed: () => false, send }
+
+    sendNativeNotificationAction(
+      sender,
+      {
+        approvalConnectionId: 'remote-a',
+        approvalProfile: 'research',
+        approvalRequestId: 'request-a',
+        sessionId: 'session-a'
+      },
+      [{ id: 'approve', text: 'Run' }],
+      0
+    )
+
+    expect(send).toHaveBeenCalledWith('hermes:notification-action', {
+      actionId: 'approve',
+      connectionId: 'remote-a',
+      profile: 'research',
+      requestId: 'request-a',
+      sessionId: 'session-a'
+    })
+  })
+
+  it('does not send through a destroyed originating renderer', () => {
+    const send = vi.fn()
+
+    sendNativeNotificationAction(
+      { isDestroyed: () => true, send },
+      { approvalRequestId: 'request-a', sessionId: 'session-a' },
+      [{ id: 'approve', text: 'Run' }],
+      0
+    )
+
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('ignores an action index without an opaque action id', () => {
+    const send = vi.fn()
+
+    sendNativeNotificationAction(
+      { isDestroyed: () => false, send },
+      { approvalRequestId: 'request-a', sessionId: 'session-a' },
+      [{ id: '', text: 'Run' }],
+      0
+    )
+
+    expect(send).not.toHaveBeenCalled()
+  })
+})
+
+describe('nativeNotificationDedupeKey', () => {
+  it('keeps same-session approvals distinct by source and request authority', () => {
+    const sourceA = nativeNotificationDedupeKey({
+      approvalConnectionId: 'remote-a',
+      approvalProfile: 'research',
+      approvalRequestId: 'request-a',
+      kind: 'approval',
+      sessionId: 'shared'
+    })
+
+    const sourceB = nativeNotificationDedupeKey({
+      approvalConnectionId: 'remote-b',
+      approvalProfile: 'research',
+      approvalRequestId: 'request-b',
+      kind: 'approval',
+      sessionId: 'shared'
+    })
+
+    expect(sourceA).not.toBe(sourceB)
+  })
+
+  it('is used at the real Electron notification composition seam', () => {
+    const main = fs.readFileSync(path.join(path.dirname(fileURLToPath(import.meta.url)), 'main.ts'), 'utf8')
+    const handlerStart = main.indexOf("ipcMain.handle('hermes:notify'")
+    const handler = main.slice(handlerStart, main.indexOf('notification.show()', handlerStart))
+
+    expect(handler).toContain('isDuplicateNotification(nativeNotificationDedupeKey(payload ?? {}))')
+  })
+})
+
+describe('sendNativeNotificationFocus', () => {
+  it('returns complete source authority to the renderer that created the notification', () => {
+    const send = vi.fn()
+
+    sendNativeNotificationFocus(
+      { isDestroyed: () => false, send },
+      {
+        approvalConnectionId: 'remote-a',
+        approvalProfile: 'research',
+        approvalRequestId: 'request-a',
+        sessionId: 'shared'
+      }
+    )
+
+    expect(send).toHaveBeenCalledWith('hermes:focus-session', {
+      connectionId: 'remote-a',
+      profile: 'research',
+      requestId: 'request-a',
+      sessionId: 'shared'
+    })
+  })
+
+  it('is called at the real Electron notification click seam with the original sender', () => {
+    const main = fs.readFileSync(path.join(path.dirname(fileURLToPath(import.meta.url)), 'main.ts'), 'utf8')
+    const clickStart = main.indexOf("notification.on('click'")
+    const clickHandler = main.slice(clickStart, main.indexOf("notification.on('action'", clickStart))
+
+    expect(clickHandler).toContain('BrowserWindow.fromWebContents(event.sender)')
+    expect(clickHandler).toContain('sendNativeNotificationFocus(event.sender, payload ?? {})')
+    expect(clickHandler).not.toContain('mainWindow.webContents.send')
+  })
+})
+
+describe('approval source composition', () => {
+  const desktopRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+  it('uses the active-source selector at inline and grouped fallback seams', () => {
+    const approval = fs.readFileSync(
+      path.join(desktopRoot, 'src/components/assistant-ui/tool/approval.tsx'),
+      'utf8'
+    )
+
+    const fallback = fs.readFileSync(
+      path.join(desktopRoot, 'src/components/assistant-ui/tool/fallback.tsx'),
+      'utf8'
+    )
+
+    expect(approval.match(/activeSessionApprovalRequest\(sessionId\)/g)).toHaveLength(2)
+    expect(fallback).toContain('activeSessionApprovalRequest(sessionId)')
+  })
+
+  it('uses source-scoped prompt cleanup at both interrupt seams', () => {
+    const tileActions = fs.readFileSync(path.join(desktopRoot, 'src/app/chat/session-tile-actions.ts'), 'utf8')
+
+    const primaryActions = fs.readFileSync(
+      path.join(desktopRoot, 'src/app/session/hooks/use-prompt-actions/index.ts'),
+      'utf8'
+    )
+
+    expect(tileActions).toContain('clearAllPromptsForActiveSource(sessionId)')
+    expect(primaryActions).toContain('clearAllPromptsForActiveSource(sessionId)')
+  })
+})

--- a/apps/desktop/electron/native-notification-action.ts
+++ b/apps/desktop/electron/native-notification-action.ts
@@ -1,0 +1,75 @@
+export interface NativeNotificationAction {
+  id?: string
+  text?: string
+}
+
+export interface NativeNotificationAuthority {
+  approvalConnectionId?: null | string
+  approvalProfile?: string
+  approvalRequestId?: string
+  sessionId?: string
+  kind?: string
+  tag?: string
+}
+
+export function nativeNotificationDedupeKey(payload: NativeNotificationAuthority): string {
+  if (payload.kind === 'approval') {
+    return JSON.stringify([
+      payload.kind,
+      payload.sessionId ?? null,
+      payload.approvalConnectionId ?? null,
+      payload.approvalProfile ?? null,
+      payload.approvalRequestId ?? null
+    ])
+  }
+
+  return `${payload.kind ?? ''}:${payload.sessionId ?? payload.tag ?? ''}`
+}
+
+export interface NativeNotificationActionSender {
+  isDestroyed: () => boolean
+  send: (channel: string, payload: Record<string, unknown>) => void
+}
+
+/** Return a body click to the renderer/source that created its notification. */
+export function sendNativeNotificationFocus(
+  sender: NativeNotificationActionSender,
+  payload: NativeNotificationAuthority
+): void {
+  if (sender.isDestroyed() || !payload.sessionId) {
+    return
+  }
+
+  sender.send('hermes:focus-session', {
+    connectionId: payload.approvalConnectionId,
+    profile: payload.approvalProfile,
+    requestId: payload.approvalRequestId,
+    sessionId: payload.sessionId
+  })
+}
+
+/** Return one native action to the renderer that created its notification. */
+export function sendNativeNotificationAction(
+  sender: NativeNotificationActionSender,
+  payload: NativeNotificationAuthority,
+  actions: NativeNotificationAction[],
+  index: number
+): void {
+  if (sender.isDestroyed()) {
+    return
+  }
+
+  const action = actions[index]
+
+  if (!action?.id) {
+    return
+  }
+
+  sender.send('hermes:notification-action', {
+    actionId: action.id,
+    connectionId: payload.approvalConnectionId,
+    profile: payload.approvalProfile,
+    requestId: payload.approvalRequestId,
+    sessionId: payload.sessionId
+  })
+}

--- a/apps/desktop/src/app/chat/session-tile-actions.test.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.test.ts
@@ -2,6 +2,8 @@ import { renderHook } from '@testing-library/react'
 import { act } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { clearAllPrompts, sessionApprovalRequest, setApprovalRequest } from '@/store/prompts'
+
 import { MAIN_COMPOSER_SCOPE } from './composer/scope'
 
 const requestGatewayMock = vi.hoisted(() => vi.fn())
@@ -58,6 +60,7 @@ describe('useSessionTileActions sleep/wake session recovery', () => {
   })
 
   afterEach(() => {
+    clearAllPrompts()
     requestGatewayMock.mockReset()
     vi.restoreAllMocks()
   })
@@ -97,6 +100,30 @@ describe('useSessionTileActions sleep/wake session recovery', () => {
     expect(calls[0]?.params).toEqual({ session_id: RUNTIME_SESSION_ID })
     expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID, source: 'desktop', omit_messages: true })
     expect(calls[2]?.params).toEqual({ session_id: RECOVERED_SESSION_ID })
+  })
+
+  it('interrupt cleanup preserves a foreign-source approval with the same session id', async () => {
+    requestGatewayMock.mockResolvedValue({})
+    setApprovalRequest({ command: '', description: 'active', requestId: 'active-request', sessionId: RUNTIME_SESSION_ID })
+    setApprovalRequest({
+      command: '',
+      connectionId: 'remote-b',
+      description: 'foreign',
+      profile: 'research',
+      requestId: 'foreign-request',
+      sessionId: RUNTIME_SESSION_ID
+    })
+
+    const { result } = renderTileActions()
+
+    await act(async () => {
+      await result.current.cancelRun()
+    })
+
+    expect(sessionApprovalRequest(RUNTIME_SESSION_ID, { connectionId: null, profile: 'default' }).get()).toBeNull()
+    expect(
+      sessionApprovalRequest(RUNTIME_SESSION_ID, { connectionId: 'remote-b', profile: 'research' }).get()?.requestId
+    ).toBe('foreign-request')
   })
 
   it('resumes the stored session and retries once when session.redirect (steer) reports "session not found"', async () => {

--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -22,7 +22,7 @@ import type { ComposerAttachment } from '@/store/composer'
 import { resetSessionBackground } from '@/store/composer-status'
 import { notifyError } from '@/store/notifications'
 import { clearPreviewArtifacts } from '@/store/preview-status'
-import { clearAllPrompts } from '@/store/prompts'
+import { clearAllPromptsForActiveSource } from '@/store/prompts'
 import { $connection, $sessions, sessionMatchesStoredId } from '@/store/session'
 import { $sessionStates, sessionTileDelegate } from '@/store/session-states'
 import { broadcastSessionsChanged } from '@/store/session-sync'
@@ -298,7 +298,7 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
     clearSessionSubagents(sessionId)
     resetSessionBackground(sessionId)
     setSessionDraftingTool(sessionId, '')
-    clearAllPrompts(sessionId)
+    clearAllPromptsForActiveSource(sessionId)
     clearClarifyRequest(undefined, sessionId)
 
     try {

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
@@ -1,6 +1,8 @@
-import { renderHook } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type * as GatewayStore from '@/store/gateway'
+import type * as NativeNotifications from '@/store/native-notifications'
 import { _resetLegacyDiscardForTests } from '@/store/session'
 import type * as WindowsStore from '@/store/windows'
 import type { SessionInfo } from '@/types/hermes'
@@ -10,7 +12,23 @@ import { useDesktopIntegrations } from './use-desktop-integrations'
 // Mutable HUD-window flag so the restore tests can flip the window kind the
 // hook believes it runs in. Default false keeps the pre-existing restore
 // coverage exercising the real main-window path.
-const { hudWindowMock } = vi.hoisted(() => ({ hudWindowMock: vi.fn(() => false) }))
+const { ensureGatewayForAgentMock, hudWindowMock, respondToApprovalActionMock } = vi.hoisted(() => ({
+  ensureGatewayForAgentMock: vi.fn(async () => true),
+  hudWindowMock: vi.fn(() => false),
+  respondToApprovalActionMock: vi.fn()
+}))
+
+vi.mock('@/store/gateway', async importOriginal => {
+  const actual = await importOriginal<typeof GatewayStore>()
+
+  return { ...actual, ensureGatewayForAgent: ensureGatewayForAgentMock }
+})
+
+vi.mock('@/store/native-notifications', async importOriginal => {
+  const actual = await importOriginal<typeof NativeNotifications>()
+
+  return { ...actual, respondToApprovalAction: respondToApprovalActionMock }
+})
 
 vi.mock('@/store/windows', async importOriginal => {
   const actual = await importOriginal<typeof WindowsStore>()
@@ -53,10 +71,33 @@ const session = (over: Partial<SessionInfo> = {}): SessionInfo => ({
 describe('useDesktopIntegrations', () => {
   let navigate: ReturnType<typeof vi.fn<(...args: unknown[]) => void>>
 
+  let notificationActionCallback:
+    | ((payload: {
+        actionId: string
+        connectionId?: null | string
+        profile?: string
+        requestId?: string
+        sessionId?: string
+      }) => void)
+    | undefined
+
+  let focusSessionCallback:
+    | ((payload: {
+        connectionId?: null | string
+        profile?: string
+        requestId?: string
+        sessionId?: string
+      }) => void)
+    | undefined
+
   beforeEach(() => {
     window.localStorage.clear()
     _resetLegacyDiscardForTests()
     navigate = vi.fn()
+    notificationActionCallback = undefined
+    focusSessionCallback = undefined
+    ensureGatewayForAgentMock.mockClear()
+    respondToApprovalActionMock.mockReset()
     // Every test starts as a main window; only the HUD describe flips this.
     hudWindowMock.mockReturnValue(false)
 
@@ -66,8 +107,16 @@ describe('useDesktopIntegrations', () => {
     desktopWindow.hermesDesktop = {
       setPreviewShortcutActive: vi.fn(),
       onOpenUpdatesRequested: vi.fn(),
-      onFocusSession: vi.fn(),
-      onNotificationAction: vi.fn(),
+      onFocusSession: vi.fn(callback => {
+        focusSessionCallback = callback
+
+        return vi.fn()
+      }),
+      onNotificationAction: vi.fn(callback => {
+        notificationActionCallback = callback
+
+        return vi.fn()
+      }),
       onDeepLink: vi.fn(),
       signalDeepLinkReady: vi.fn(),
       onClosePreviewRequested: vi.fn(),
@@ -132,6 +181,58 @@ describe('useDesktopIntegrations', () => {
       }
     )
   }
+
+  it('forwards complete native approval authority into the response handler', () => {
+    render()
+
+    act(() =>
+      notificationActionCallback?.({
+        actionId: 'approve',
+        connectionId: 'remote-a',
+        profile: 'research',
+        requestId: 'request-a',
+        sessionId: 'session-a'
+      })
+    )
+
+    expect(respondToApprovalActionMock).toHaveBeenCalledWith('session-a', 'request-a', 'approve', {
+      connectionId: 'remote-a',
+      profile: 'research'
+    })
+  })
+
+  it('activates the captured notification source before opening its session', async () => {
+    render()
+
+    act(() =>
+      focusSessionCallback?.({
+        connectionId: 'remote-a',
+        profile: 'research',
+        requestId: 'request-a',
+        sessionId: 'session-a'
+      })
+    )
+
+    await waitFor(() => expect(ensureGatewayForAgentMock).toHaveBeenCalledWith('remote-a', 'research'))
+    expect(navigate).toHaveBeenCalled()
+  })
+
+  it('does not navigate when the captured notification source cannot be activated', async () => {
+    ensureGatewayForAgentMock.mockResolvedValueOnce(false)
+    render()
+
+    act(() =>
+      focusSessionCallback?.({
+        connectionId: 'remote-a',
+        profile: 'research',
+        requestId: 'request-a',
+        sessionId: 'session-a'
+      })
+    )
+
+    await waitFor(() => expect(ensureGatewayForAgentMock).toHaveBeenCalledWith('remote-a', 'research'))
+    expect(navigate).not.toHaveBeenCalled()
+  })
 
   describe('profile-ready gate', () => {
     it('does NOT restore before profileReady is true', () => {

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'react'
 import { closeActiveTab } from '@/app/chat/close-tab'
 import { openSession } from '@/app/open-session'
 import { storedSessionIdForNotification } from '@/lib/session-ids'
+import { ensureGatewayForAgent } from '@/store/gateway'
 import { requestMcpInstallFromDeepLink } from '@/store/mcp-deeplink-install'
 import { startMcpHealthChecker, stopMcpHealthChecker } from '@/store/mcp-health'
 import { respondToApprovalAction } from '@/store/native-notifications'
@@ -176,19 +177,43 @@ export function useDesktopIntegrations({
   // on screen. Runtime id is translated to the stored id the chat route is
   // keyed by; action buttons resolve in place.
   useEffect(() => {
-    const unsubscribe = window.hermesDesktop?.onFocusSession?.(sessionId => {
-      if (sessionId) {
-        openSession(storedSessionIdForNotification(sessionId, runtimeIdByStoredSessionId.current), navigate, 'stack')
+    const unsubscribe = window.hermesDesktop?.onFocusSession?.(rawPayload => {
+      const payload = typeof rawPayload === 'string' ? { sessionId: rawPayload } : rawPayload
+
+      const sessionId = payload.sessionId
+
+      if (!sessionId) {
+        return
       }
+      void (async () => {
+        if (payload.profile) {
+          const activated = await ensureGatewayForAgent(payload.connectionId ?? null, payload.profile)
+
+          if (!activated) {
+            return
+          }
+        }
+
+        openSession(
+          storedSessionIdForNotification(sessionId, runtimeIdByStoredSessionId.current),
+          navigate,
+          'stack'
+        )
+      })()
     })
 
     return () => unsubscribe?.()
   }, [navigate, runtimeIdByStoredSessionId])
 
   useEffect(() => {
-    const unsubscribe = window.hermesDesktop?.onNotificationAction?.(({ actionId, sessionId }) => {
-      void respondToApprovalAction(sessionId ?? null, actionId)
-    })
+    const unsubscribe = window.hermesDesktop?.onNotificationAction?.(
+      ({ actionId, connectionId, profile, requestId, sessionId }) => {
+        void respondToApprovalAction(sessionId ?? null, requestId ?? '', actionId, {
+          connectionId: connectionId ?? null,
+          profile: profile ?? ''
+        })
+      }
+    )
 
     return () => unsubscribe?.()
   }, [])

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -2,10 +2,11 @@ import { act, cleanup, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $desktopBoot } from '@/store/boot'
-import { closeSecondaryGateways, isActivePrimary } from '@/store/gateway'
+import { closeSecondaryGateways, emitLocalGatewayEvent, isActivePrimary } from '@/store/gateway'
 import { reconnectGateway } from '@/store/gateway-reconnect'
 import { $activeGatewayProfile, $profiles, ensureGatewayProfile } from '@/store/profile'
 import { $connection, $currentCwd, $gatewayState } from '@/store/session'
+import { clearAllSessionStates, recordSessionEventScope } from '@/store/session-states'
 
 import { takeGatewaySurvivor } from './gateway-hmr-survivor'
 import { useGatewayBoot } from './use-gateway-boot'
@@ -161,6 +162,7 @@ beforeEach(() => {
   }
 
   closeSecondaryGateways()
+  clearAllSessionStates()
   $activeGatewayProfile.set('default')
   $connection.set(null)
   $profiles.set([])
@@ -199,6 +201,7 @@ afterEach(() => {
   }
 
   closeSecondaryGateways()
+  clearAllSessionStates()
   $activeGatewayProfile.set('default')
   $connection.set(null)
   $profiles.set([])
@@ -226,6 +229,30 @@ async function advanceBackoff() {
 }
 
 describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => {
+  it('forwards registry events without pre-claiming their runtime scope', async () => {
+    render(<Harness />)
+    await flushAsync()
+
+    act(() =>
+      emitLocalGatewayEvent({
+        connectionId: 'remote-b',
+        profile: 'research',
+        session_id: 'colliding-runtime-id',
+        type: 'message.complete'
+      })
+    )
+
+    // The central message handler owns source registration. If the registry
+    // fan-in records first, this independent source claim is rejected.
+    expect(
+      recordSessionEventScope({
+        connectionId: 'remote-a',
+        profile: 'default',
+        session_id: 'colliding-runtime-id'
+      })
+    ).toBe(true)
+  })
+
   it('INITIAL boot against a dead VPS: getConnection hangs (waitForHermes) → app sits in the connecting combo, then fails', async () => {
     // The report's actual path: a fresh launch pointed at an unreachable VPS.
     // startHermes()'s remote branch awaits waitForHermes() for 45s before it

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -52,7 +52,6 @@ import {
   $attentionSessionIds,
   $workingSessionIds,
   liveSessionScopes,
-  recordSessionEventScope,
   resetTileRuntimeBindings
 } from '@/store/session-states'
 import { windowProfileOverride } from '@/store/windows'
@@ -467,15 +466,11 @@ export function useGatewayBoot({
     callbacksRef.current.onGatewayReady(gateway)
     setPrimaryGateway(gateway, survivor?.profile ?? normalizeProfileKey($activeGatewayProfile.get()))
     // Secondary (background-profile) sockets funnel into the same handler.
-    // Record each event's source scope first: registry-tagged events feed the
-    // (connectionId, profile) keep-set so two sources exposing the same
-    // profile name (every source has a 'default') can't collide.
+    // The handler records source scope only after it has protected active
+    // runtime ownership, so a foreign first event cannot poison a colliding id.
     configureGatewayRegistry({
       onActiveConnectionChanged: publish,
-      onEvent: event => {
-        recordSessionEventScope(event)
-        callbacksRef.current.handleGatewayEvent(event)
-      },
+      onEvent: event => callbacksRef.current.handleGatewayEvent(event),
       onActiveConnectionInvalidated: (fallbackProfile, invalidationEpoch) => {
         $activeGatewayProfile.set(fallbackProfile)
         void desktop

--- a/apps/desktop/src/app/session/hooks/use-message-stream/approval-request-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/approval-request-event.test.tsx
@@ -1,0 +1,440 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import * as gatewayStore from '@/store/gateway'
+import { dispatchNativeNotification } from '@/store/native-notifications'
+import { $activeGatewayProfile } from '@/store/profile'
+import { clearAllPrompts, sessionApprovalRequest } from '@/store/prompts'
+import { sessionProviderWait, setSessionProviderWait } from '@/store/provider-wait'
+import { $activeSessionId } from '@/store/session'
+import { clearAllSessionStates, recordSessionEventScope } from '@/store/session-states'
+import { sessionDraftingTool, setSessionDraftingTool } from '@/store/tool-drafting'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './index'
+
+vi.mock('@/store/native-notifications', () => ({ dispatchNativeNotification: vi.fn() }))
+
+const ACTIVE_SID = 'session-active'
+
+const sourceAApproval = () =>
+  sessionApprovalRequest(ACTIVE_SID, { connectionId: 'remote-a', profile: 'research' }).get()
+
+let handleEvent: ((event: RpcEvent) => void) | null = null
+let stateBySession: Map<string, ClientSessionState> | null = null
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(ACTIVE_SID)
+  const sessionStateByRuntimeIdRef = useRef(new Map<string, ClientSessionState>())
+  stateBySession = sessionStateByRuntimeIdRef.current
+  const queryClientRef = useRef(new QueryClient())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater) => {
+      const current = sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState()
+      const next = updater(current)
+      sessionStateByRuntimeIdRef.current.set(sessionId, next)
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    handleEvent = stream.handleGatewayEvent
+  }, [stream.handleGatewayEvent])
+
+  return null
+}
+
+describe('approval.request event', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    handleEvent = null
+    stateBySession = null
+    clearAllSessionStates()
+    clearAllPrompts()
+    $activeGatewayProfile.set('default')
+    $activeSessionId.set(ACTIVE_SID)
+    gatewayStore.$gateway.set(null)
+    render(<Harness />)
+    await waitFor(() => expect(handleEvent).not.toBeNull())
+  })
+
+  afterEach(() => {
+    cleanup()
+    clearAllSessionStates()
+    clearAllPrompts()
+    $activeSessionId.set(null)
+    gatewayStore.$gateway.set(null)
+    vi.restoreAllMocks()
+  })
+
+  it('binds the parked prompt, receipt ack and notification to the emitting source', async () => {
+    const activeRequest = vi.fn()
+    const routedRequest = vi.spyOn(gatewayStore, 'requestGatewayForAgent').mockResolvedValue({} as never)
+    gatewayStore.$gateway.set({ request: activeRequest } as never)
+
+    act(() =>
+      handleEvent!({
+        payload: {
+          choices: ['once', 'deny'],
+          description: 'redacted',
+          request_id: 'test-request-id'
+        },
+        connectionId: 'remote-a',
+        profile: 'research',
+        session_id: ACTIVE_SID,
+        type: 'approval.request'
+      })
+    )
+
+    expect(sourceAApproval()).toMatchObject({
+      connectionId: 'remote-a',
+      description: 'redacted',
+      profile: 'research',
+      requestId: 'test-request-id',
+      sessionId: ACTIVE_SID
+    })
+    expect(stateBySession?.get(ACTIVE_SID)?.needsInput).not.toBe(true)
+    expect(dispatchNativeNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        approvalConnectionId: 'remote-a',
+        approvalProfile: 'research',
+        approvalRequestId: 'test-request-id',
+        sessionId: ACTIVE_SID
+      })
+    )
+    await waitFor(() =>
+      expect(routedRequest).toHaveBeenCalledWith('remote-a', 'research', 'approval.received', {
+        request_id: 'test-request-id',
+        session_id: ACTIVE_SID
+      })
+    )
+    expect(activeRequest).not.toHaveBeenCalled()
+  })
+
+  it('marks needsInput only for an approval from the active source', () => {
+    act(() =>
+      handleEvent!({
+        payload: { description: 'active approval', request_id: 'active-request' },
+        profile: 'default',
+        session_id: ACTIVE_SID,
+        type: 'approval.request'
+      })
+    )
+
+    expect(stateBySession?.get(ACTIVE_SID)?.needsInput).toBe(true)
+  })
+
+  it('keeps legacy ID-free approvals inline and omits unsafe native response actions', async () => {
+    const routedRequest = vi.spyOn(gatewayStore, 'requestGatewayForAgent').mockResolvedValue({} as never)
+
+    act(() =>
+      handleEvent!({
+        connectionId: 'remote-a',
+        payload: { description: 'legacy approval' },
+        profile: 'research',
+        session_id: ACTIVE_SID,
+        type: 'approval.request'
+      })
+    )
+
+    expect(sourceAApproval()).toMatchObject({
+      connectionId: 'remote-a',
+      description: 'legacy approval',
+      profile: 'research',
+      requestId: undefined,
+      sessionId: ACTIVE_SID
+    })
+    expect(dispatchNativeNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actions: undefined,
+        approvalConnectionId: 'remote-a',
+        approvalProfile: 'research',
+        approvalRequestId: undefined,
+        sessionId: ACTIVE_SID
+      })
+    )
+    expect(routedRequest).not.toHaveBeenCalled()
+  })
+
+  it('keeps a foreign connection from claiming the active runtime when the profile matches', () => {
+    const before = { ...createClientSessionState(), busy: true, needsInput: true }
+    stateBySession?.set(ACTIVE_SID, before)
+
+    act(() =>
+      handleEvent!({
+        connectionId: 'remote-b',
+        payload: { text: 'foreign completion' },
+        profile: 'default',
+        session_id: ACTIVE_SID,
+        type: 'message.complete'
+      })
+    )
+
+    expect(stateBySession?.get(ACTIVE_SID)).toEqual(before)
+  })
+
+  it('keeps a foreign profile from claiming the active runtime when the connection matches', () => {
+    const before = { ...createClientSessionState(), busy: true, needsInput: true }
+    stateBySession?.set(ACTIVE_SID, before)
+
+    act(() =>
+      handleEvent!({
+        payload: { text: 'foreign completion' },
+        profile: 'research',
+        session_id: ACTIVE_SID,
+        type: 'message.complete'
+      })
+    )
+
+    expect(stateBySession?.get(ACTIVE_SID)).toEqual(before)
+  })
+
+  it('keeps a foreign message.start from composing into the active runtime', () => {
+    const before = { ...createClientSessionState(), needsInput: true }
+    stateBySession?.set(ACTIVE_SID, before)
+
+    act(() =>
+      handleEvent!({
+        connectionId: 'remote-b',
+        payload: { message_id: 'foreign-message' },
+        profile: 'default',
+        session_id: ACTIVE_SID,
+        type: 'message.start'
+      })
+    )
+
+    expect(stateBySession?.get(ACTIVE_SID)).toEqual(before)
+  })
+
+  it('does not clear an approval when another source completes the same session id', async () => {
+    vi.spyOn(gatewayStore, 'requestGatewayForAgent').mockResolvedValue({} as never)
+
+    act(() =>
+      handleEvent!({
+        connectionId: 'remote-a',
+        payload: { description: 'source A', request_id: 'source-a-request' },
+        profile: 'research',
+        session_id: ACTIVE_SID,
+        type: 'approval.request'
+      })
+    )
+
+    await waitFor(() => expect(sourceAApproval()?.requestId).toBe('source-a-request'))
+
+    act(() =>
+      handleEvent!({
+        connectionId: 'remote-b',
+        payload: { text: 'source B completed' },
+        profile: 'research',
+        session_id: ACTIVE_SID,
+        type: 'message.complete'
+      })
+    )
+
+    expect(sourceAApproval()?.requestId).toBe('source-a-request')
+
+    act(() =>
+      handleEvent!({
+        connectionId: 'remote-a',
+        payload: { text: 'source A completed' },
+        profile: 'research',
+        session_id: ACTIVE_SID,
+        type: 'message.complete'
+      })
+    )
+
+    expect(sourceAApproval()).toBeNull()
+  })
+
+  it('does not settle active runtime state when another source completes the same session id', () => {
+    // Model the production registry fan-in that used to let the first foreign
+    // event claim the shared runtime id before the active handler saw it.
+    recordSessionEventScope({ connectionId: 'remote-b', profile: 'research', session_id: ACTIVE_SID })
+
+    act(() =>
+      handleEvent!({
+        payload: { description: 'active approval', request_id: 'active-request' },
+        profile: 'default',
+        session_id: ACTIVE_SID,
+        type: 'approval.request'
+      })
+    )
+
+    const before = stateBySession?.get(ACTIVE_SID)
+
+    expect(before?.needsInput).toBe(true)
+    setSessionProviderWait(ACTIVE_SID, 'waiting on provider')
+    setSessionDraftingTool(ACTIVE_SID, 'write_file')
+
+    act(() =>
+      handleEvent!({
+        connectionId: 'remote-b',
+        payload: { text: 'foreign completion' },
+        profile: 'research',
+        session_id: ACTIVE_SID,
+        type: 'message.complete'
+      })
+    )
+
+    expect(stateBySession?.get(ACTIVE_SID)).toEqual(before)
+    expect(sessionProviderWait(ACTIVE_SID).get()).toBe('waiting on provider')
+    expect(sessionDraftingTool(ACTIVE_SID).get()?.name).toBe('write_file')
+  })
+
+  it('does not clear an approval when another source errors for the same session id', async () => {
+    vi.spyOn(gatewayStore, 'requestGatewayForAgent').mockResolvedValue({} as never)
+
+    act(() =>
+      handleEvent!({
+        connectionId: 'remote-a',
+        payload: { description: 'source A', request_id: 'source-a-request' },
+        profile: 'research',
+        session_id: ACTIVE_SID,
+        type: 'approval.request'
+      })
+    )
+
+    await waitFor(() => expect(sourceAApproval()?.requestId).toBe('source-a-request'))
+
+    act(() =>
+      handleEvent!({
+        connectionId: 'remote-b',
+        payload: { message: 'source B errored' },
+        profile: 'research',
+        session_id: ACTIVE_SID,
+        type: 'error'
+      })
+    )
+
+    expect(sourceAApproval()?.requestId).toBe('source-a-request')
+
+    act(() =>
+      handleEvent!({
+        connectionId: 'remote-a',
+        payload: { message: 'source A errored' },
+        profile: 'research',
+        session_id: ACTIVE_SID,
+        type: 'error'
+      })
+    )
+
+    expect(sourceAApproval()).toBeNull()
+  })
+
+  it('does not fail active runtime state when another source errors for the same session id', () => {
+    act(() =>
+      handleEvent!({
+        payload: { description: 'active approval', request_id: 'active-request' },
+        profile: 'default',
+        session_id: ACTIVE_SID,
+        type: 'approval.request'
+      })
+    )
+
+    const before = stateBySession?.get(ACTIVE_SID)
+
+    expect(before?.needsInput).toBe(true)
+    setSessionProviderWait(ACTIVE_SID, 'waiting on provider')
+    setSessionDraftingTool(ACTIVE_SID, 'write_file')
+
+    act(() =>
+      handleEvent!({
+        connectionId: 'remote-b',
+        payload: { message: 'foreign error' },
+        profile: 'research',
+        session_id: ACTIVE_SID,
+        type: 'error'
+      })
+    )
+
+    expect(stateBySession?.get(ACTIVE_SID)).toEqual(before)
+    expect(sessionProviderWait(ACTIVE_SID).get()).toBe('waiting on provider')
+    expect(sessionDraftingTool(ACTIVE_SID).get()?.name).toBe('write_file')
+  })
+
+  it('does not apply session.info from another source sharing the active runtime id', () => {
+    act(() =>
+      handleEvent!({
+        payload: { description: 'active approval', request_id: 'active-request' },
+        profile: 'default',
+        session_id: ACTIVE_SID,
+        type: 'approval.request'
+      })
+    )
+
+    const before = stateBySession?.get(ACTIVE_SID)
+
+    expect(before?.needsInput).toBe(true)
+
+    act(() =>
+      handleEvent!({
+        connectionId: 'remote-b',
+        payload: { cwd: '/foreign', model: 'foreign-model', running: true },
+        profile: 'research',
+        session_id: ACTIVE_SID,
+        type: 'session.info'
+      })
+    )
+
+    expect(stateBySession?.get(ACTIVE_SID)).toEqual(before)
+  })
+
+  it('replays a pending approval through the gateway.ready or session.info source', async () => {
+    const activeRequest = vi.fn()
+
+    const routedRequest = vi.spyOn(gatewayStore, 'requestGatewayForAgent').mockImplementation(
+      async (_connectionId, _profile, method) => {
+        if (method === 'approval.pending') {
+          return {
+            approvals: [{ description: 'replayed', request_id: 'replayed-request-id' }]
+          } as never
+        }
+
+        return { acknowledged: true } as never
+      }
+    )
+
+    gatewayStore.$gateway.set({ request: activeRequest } as never)
+
+    act(() =>
+      handleEvent!({
+        connectionId: 'remote-a',
+        payload: { running: true },
+        profile: 'research',
+        session_id: ACTIVE_SID,
+        type: 'session.info'
+      })
+    )
+
+    await waitFor(() =>
+      expect(routedRequest).toHaveBeenNthCalledWith(1, 'remote-a', 'research', 'approval.pending', {
+        session_id: ACTIVE_SID
+      })
+    )
+    await waitFor(() =>
+      expect(sourceAApproval()).toMatchObject({
+        connectionId: 'remote-a',
+        profile: 'research',
+        requestId: 'replayed-request-id',
+        sessionId: ACTIVE_SID
+      })
+    )
+    expect(routedRequest).toHaveBeenNthCalledWith(2, 'remote-a', 'research', 'approval.received', {
+      request_id: 'replayed-request-id',
+      session_id: ACTIVE_SID
+    })
+    expect(activeRequest).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -28,7 +28,7 @@ import { billingCtaLabel, clearBillingBlock, runBillingRecovery, setBillingBlock
 import { clearClarifyRequest, normalizeChoices, setClarifyRequest, warnDroppedChoices } from '@/store/clarify'
 import { setSessionCompacting } from '@/store/compaction'
 import { refreshBackgroundProcesses } from '@/store/composer-status'
-import { $gateway, activeGatewayConnectionId } from '@/store/gateway'
+import { $gateway, activeGatewayConnectionId, requestGatewayForAgent } from '@/store/gateway'
 import { applyGoalStatusText } from '@/store/goals'
 import {
   notifyCronChanged,
@@ -77,7 +77,12 @@ import {
   setWorkspaceCwdOwner,
   setYoloActive
 } from '@/store/session'
-import { dropSessionState, unbindTileRuntime } from '@/store/session-states'
+import {
+  claimActiveSessionEventScope,
+  dropSessionState,
+  recordSessionEventScope,
+  unbindTileRuntime
+} from '@/store/session-states'
 import { pruneDelegateFallbackSubagents, pruneFinishedSessionSubagents, upsertSubagent } from '@/store/subagents'
 import { reportMcpToolResult } from '@/store/suggestion-providers/repair'
 import { invalidateSkillSuggestionIndex } from '@/store/suggestion-providers/skill'
@@ -375,6 +380,24 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
 
       const sessionId = route.sessionId
 
+      // A foreign source may legitimately park an approval whose runtime id
+      // collides with the visible session. Claim the active runtime for the
+      // active gateway before examining the event so that source-qualified
+      // prompt handling cannot transfer ownership of shared transcript state.
+      if (sessionId && sessionId === activeSessionIdRef.current) {
+        claimActiveSessionEventScope({
+          connectionId: activeGatewayConnectionId(),
+          profile: normalizeProfileKey($activeGatewayProfile.get()),
+          session_id: sessionId
+        })
+      }
+
+      const isSessionSourceEvent = recordSessionEventScope({
+        connectionId: event.connectionId ?? null,
+        profile: event.profile,
+        session_id: sessionId ?? undefined
+      })
+
       // Late stragglers: an unscoped stream event attributed via the
       // active-session fallback (no pin) to a session that has no live turn
       // belongs to a turn that already ended elsewhere. Dropping it keeps the
@@ -402,10 +425,40 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
 
       const isActiveEvent = !!sessionId && sessionId === activeSessionIdRef.current
 
+      const isActiveSourceEvent =
+        (event.connectionId ?? null) === activeGatewayConnectionId() &&
+        normalizeProfileKey(event.profile ?? $activeGatewayProfile.get()) ===
+          normalizeProfileKey($activeGatewayProfile.get())
+
       const replaySessionId = approvalReplaySessionId(event.type, activeSessionIdRef.current, sessionId)
 
       if (replaySessionId) {
-        void replayPendingApproval($gateway.get(), replaySessionId).catch(() => undefined)
+        const replaySource = {
+          connectionId: event.connectionId ?? null,
+          profile: normalizeProfileKey(event.profile ?? $activeGatewayProfile.get())
+        }
+
+        const replayGateway = {
+          request: (method: string, params: Record<string, unknown>) =>
+            requestGatewayForAgent(replaySource.connectionId, replaySource.profile, method, params)
+        }
+
+        void replayPendingApproval(replayGateway, replaySessionId, replaySource).catch(() => undefined)
+      }
+
+      if (
+        sessionId &&
+        !isSessionSourceEvent &&
+        event.type !== 'approval.request' &&
+        event.type !== 'message.complete' &&
+        event.type !== 'error' &&
+        event.type !== 'session.info'
+      ) {
+        // Only events with their own exact-source handling may cross a runtime
+        // authority mismatch. Ordinary stream/tool/status events compose into
+        // session-keyed runtime, transcript and composer state, so a colliding
+        // backend must stop before any of those shared sinks.
+        return
       }
 
       // Mid-turn compaction does not emit another message.start. The first
@@ -416,11 +469,11 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         setSessionCompacting(sessionId, false)
       }
 
-      if (sessionId && DRAFT_SUPERSEDING_EVENT_TYPES.has(event.type)) {
+      if (sessionId && isSessionSourceEvent && DRAFT_SUPERSEDING_EVENT_TYPES.has(event.type)) {
         setSessionDraftingTool(sessionId, '')
       }
 
-      if (sessionId && PROVIDER_WAIT_SUPERSEDING_EVENT_TYPES.has(event.type)) {
+      if (sessionId && isSessionSourceEvent && PROVIDER_WAIT_SUPERSEDING_EVENT_TYPES.has(event.type)) {
         setSessionProviderWait(sessionId, '')
       }
 
@@ -495,6 +548,13 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
 
         return
       } else if (event.type === 'session.info') {
+        // Explicit session state belongs to the authority that first claimed
+        // this runtime id. A colliding backend must not mutate the active view,
+        // transcript/runtime cache, composer metadata, or turn lifecycle.
+        if (explicitSid && !isSessionSourceEvent) {
+          return
+        }
+
         // Apply session-scoped fields when the event targets the active
         // session, OR when it's a global broadcast and we have no session.
         const apply = explicitSid ? isActiveEvent : !activeSessionIdRef.current
@@ -972,7 +1032,15 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         // (e.g. interrupted, or the approval already resolved). Scoped to the
         // session so a background turn finishing can't wipe the active chat's
         // prompt, and vice versa.
-        clearAllPrompts(sessionId)
+        clearAllPrompts(sessionId, {
+          connectionId: event.connectionId ?? null,
+          profile: normalizeProfileKey(event.profile ?? $activeGatewayProfile.get())
+        })
+
+        if (!isSessionSourceEvent) {
+          return
+        }
+
         clearClarifyRequest(undefined, sessionId)
         // Turn ended without a final `todo` update — drop a still-unfinished
         // list so "Tasks N/M" doesn't stay pinned above the composer with the
@@ -1258,29 +1326,45 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         // surfaces once the user focuses that chat.
         const command = typeof payload?.command === 'string' ? payload.command : ''
         const description = typeof payload?.description === 'string' ? payload.description : 'dangerous command'
+        const requestId = typeof payload?.request_id === 'string' && payload.request_id ? payload.request_id : undefined
+        const approvalProfile = normalizeProfileKey(event.profile ?? $activeGatewayProfile.get())
 
-        void receiveApprovalRequest($gateway.get(), {
+        const approvalConnectionId = event.connectionId ?? null
+
+        const approvalGateway = {
+          request: (method: string, params: Record<string, unknown>) =>
+            requestGatewayForAgent(approvalConnectionId, approvalProfile, method, params)
+        }
+
+        void receiveApprovalRequest(approvalGateway, {
           // false only when a tirith warning forbids it; backend omits the field otherwise.
           allowPermanent: payload?.allow_permanent !== false,
           choices: Array.isArray(payload?.choices)
             ? payload.choices.filter(choice => typeof choice === 'string')
             : undefined,
           command,
+          connectionId: approvalConnectionId,
           description,
-          requestId: typeof payload?.request_id === 'string' ? payload.request_id : undefined,
+          profile: approvalProfile,
+          requestId,
           sessionId: sessionId ?? null,
           smartDenied: payload?.smart_denied === true
         }).catch(() => undefined)
 
-        if (sessionId) {
+        if (sessionId && isActiveSourceEvent) {
           updateSessionState(sessionId, state => ({ ...state, needsInput: true }))
         }
 
         dispatchNativeNotification({
-          actions: [
-            { id: 'approve', text: translateNow('notifications.native.approveAction') },
-            { id: 'reject', text: translateNow('notifications.native.rejectAction') }
-          ],
+          actions: requestId
+            ? [
+                { id: 'approve', text: translateNow('notifications.native.approveAction') },
+                { id: 'reject', text: translateNow('notifications.native.rejectAction') }
+              ]
+            : undefined,
+          approvalConnectionId,
+          approvalProfile,
+          approvalRequestId: requestId,
           body: command || description,
           kind: 'approval',
           sessionId,
@@ -1531,7 +1615,15 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         // for this session so an approval/sudo/secret overlay can't linger past
         // the failed turn (same intent as the message.complete clear).
         if (sessionId) {
-          clearAllPrompts(sessionId)
+          clearAllPrompts(sessionId, {
+            connectionId: event.connectionId ?? null,
+            profile: normalizeProfileKey(event.profile ?? $activeGatewayProfile.get())
+          })
+
+          if (!isSessionSourceEvent) {
+            return
+          }
+
           clearClarifyRequest(undefined, sessionId)
           clearActiveSessionTodos(sessionId)
           setSessionCompacting(sessionId, false)

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -11,6 +11,7 @@ import { $composerAttachments, $composerDraft, type ComposerAttachment, setCompo
 import { $queuedPromptsBySession, getQueuedPrompts } from '@/store/composer-queue'
 import { $hudMode } from '@/store/hud'
 import { $notifications, clearNotifications } from '@/store/notifications'
+import { clearAllPrompts, sessionApprovalRequest, setApprovalRequest } from '@/store/prompts'
 import {
   $busy,
   $connection,
@@ -3503,6 +3504,37 @@ describe('usePromptActions sleep/wake session recovery', () => {
       interrupted: true,
       turnStartedAt: null
     })
+  })
+
+  it('interrupt cleanup preserves a foreign-source approval with the same session id', async () => {
+    clearAllPrompts()
+    setApprovalRequest({ command: '', description: 'active', requestId: 'active-request', sessionId: RUNTIME_SESSION_ID })
+    setApprovalRequest({
+      command: '',
+      connectionId: 'remote-b',
+      description: 'foreign',
+      profile: 'research',
+      requestId: 'foreign-request',
+      sessionId: RUNTIME_SESSION_ID
+    })
+
+    const requestGateway = vi.fn(async () => ({}) as never)
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.cancelRun()
+
+    expect(sessionApprovalRequest(RUNTIME_SESSION_ID, { connectionId: null, profile: 'default' }).get()).toBeNull()
+    expect(
+      sessionApprovalRequest(RUNTIME_SESSION_ID, { connectionId: 'remote-b', profile: 'research' }).get()?.requestId
+    ).toBe('foreign-request')
+    clearAllPrompts()
   })
 
   it('surfaces the original error (no resume) when the failure is not "session not found"', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -23,7 +23,7 @@ import {
 import { resetSessionBackground } from '@/store/composer-status'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { clearPreviewArtifacts } from '@/store/preview-status'
-import { clearAllPrompts } from '@/store/prompts'
+import { clearAllPromptsForActiveSource } from '@/store/prompts'
 import {
   $busy,
   $connection,
@@ -691,7 +691,7 @@ export function usePromptActions({
     // raised. Drop this session's pending clarify / approval / sudo / secret so
     // a dead panel (and the sidebar "needs input" dot) can't linger and accept
     // an answer the backend will reject.
-    clearAllPrompts(sessionId)
+    clearAllPromptsForActiveSource(sessionId)
     clearClarifyRequest(undefined, sessionId)
 
     try {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -17,6 +17,7 @@ import { createClientSessionState } from '@/lib/chat-runtime'
 import { clearSessionDraft, stashSessionDraft, takeSessionDraft } from '@/store/composer'
 import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile } from '@/store/profile'
 import { $projectScope, $projectTree, ALL_PROJECTS } from '@/store/projects'
+import { clearAllPrompts, sessionApprovalRequest } from '@/store/prompts'
 import {
   $activeSessionId,
   $activeSessionStoredIdRotation,
@@ -1700,6 +1701,8 @@ describe('resumeSession warm-cache mapping integrity', () => {
     setResumeFailedSessionId(null)
     setMessages([])
     setSessions([])
+    clearAllPrompts()
+    $activeGatewayProfile.set('default')
     vi.restoreAllMocks()
   })
 
@@ -1863,6 +1866,93 @@ describe('resumeSession warm-cache mapping integrity', () => {
       expect.objectContaining({ omit_messages: true, session_id: 'rt-A' })
     )
     expect(runtimeIdByStoredSessionIdRef.current.get('stored-A')).toBe('rt-A')
+  })
+
+  it('parks a session.resume approval under the resumed profile authority', async () => {
+    $activeGatewayProfile.set('research')
+    setSessions([storedSession({ id: 'stored-A', profile: 'research' })])
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({ messages: [], session_id: 'stored-A' } as never)
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.resume') {
+        return {
+          info: {},
+          message_count: 0,
+          messages: [],
+          pending_approval: {
+            description: 'cold resumed approval',
+            request_id: 'cold-resume-request'
+          },
+          resumed: 'stored-A',
+          running: false,
+          session_id: 'rt-A'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+    render(<ResumeHarness onReady={value => (resume = value)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(resume).not.toBeNull())
+    await resume!('stored-A', true)
+
+    expect(sessionApprovalRequest('rt-A', { connectionId: null, profile: 'research' }).get()).toMatchObject({
+      description: 'cold resumed approval',
+      requestId: 'cold-resume-request'
+    })
+  })
+
+  it('parks a session.activate approval under the resumed profile authority', async () => {
+    $activeGatewayProfile.set('research')
+    setSessions([storedSession({ id: 'stored-A', profile: 'research' })])
+
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([['stored-A', 'rt-A']])
+    }
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([['rt-A', clientState('stored-A')]])
+    }
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.activate') {
+        return {
+          info: {},
+          message_count: 0,
+          messages: [],
+          pending_approval: {
+            description: 'resumed approval',
+            request_id: 'resume-request'
+          },
+          resumed: 'stored-A',
+          running: false,
+          session_id: 'rt-A',
+          session_key: 'stored-A'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({ messages: [], session_id: 'stored-A' } as never)
+
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+    render(
+      <ResumeHarness
+        onReady={value => (resume = value)}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+    await resume!('stored-A', true)
+
+    expect(sessionApprovalRequest('rt-A', { connectionId: null, profile: 'research' }).get()).toMatchObject({
+      description: 'resumed approval',
+      requestId: 'resume-request'
+    })
   })
 
   it('preserves cached image attachments through an idle persisted transcript refresh', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -13,6 +13,7 @@ import { setSessionYolo } from '@/lib/yolo-session'
 import { normalizeChoices, setClarifyRequest } from '@/store/clarify'
 import { migrateSessionDraft } from '@/store/composer'
 import { clearQueuedPrompts, migrateQueuedPrompts } from '@/store/composer-queue'
+import { activeGatewayConnectionId } from '@/store/gateway'
 import { $gatewaySwitching } from '@/store/gateway-switch'
 import { $pinnedSessionIds } from '@/store/layout'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
@@ -30,7 +31,7 @@ import {
   tombstoneSessions,
   untombstoneSessions
 } from '@/store/projects'
-import { setApprovalRequest } from '@/store/prompts'
+import { type PromptSource, setApprovalRequest } from '@/store/prompts'
 import {
   $activeSessionStoredIdRotation,
   $currentCwd,
@@ -219,7 +220,7 @@ interface FreshSessionDraftOptions {
   workspaceTarget?: NewChatWorkspaceTarget
 }
 
-function restorePendingApproval(response: SessionResumeResponse, sessionId: string): boolean {
+function restorePendingApproval(response: SessionResumeResponse, sessionId: string, source: PromptSource): boolean {
   const pending = response.pending_approval
 
   if (!pending) {
@@ -230,7 +231,9 @@ function restorePendingApproval(response: SessionResumeResponse, sessionId: stri
     allowPermanent: pending.allow_permanent !== false,
     choices: pending.choices,
     command: pending.command ?? '',
+    connectionId: source.connectionId,
     description: pending.description ?? 'dangerous command',
+    profile: source.profile,
     requestId: typeof pending.request_id === 'string' ? pending.request_id : undefined,
     sessionId,
     smartDenied: pending.smart_denied === true
@@ -736,6 +739,11 @@ export function useSessionActions({
 
       await ensureGatewayProfile(sessionProfile)
 
+      const resumeSource = {
+        connectionId: activeGatewayConnectionId(),
+        profile: normalizeProfileKey($activeGatewayProfile.get())
+      }
+
       // Re-check after the profile-resolve / gateway-swap awaits above: the
       // cache may have changed, and takeWarmCache re-validates belongs-to and
       // purges a cross-wired mapping before we trust the fast-path.
@@ -841,7 +849,7 @@ export function useSessionActions({
               sessionStateByRuntimeIdRef.current.delete(cachedRuntimeId)
               dropSessionState(cachedRuntimeId)
             } else {
-              const pendingApproval = restorePendingApproval(activated, cachedRuntimeId)
+              const pendingApproval = restorePendingApproval(activated, cachedRuntimeId, resumeSource)
               const pendingClarify = restorePendingClarify(activated, cachedRuntimeId)
               const runtimeInfo = applyRuntimeInfo(activated.info)
 
@@ -1223,7 +1231,7 @@ export function useSessionActions({
 
         setActiveSessionId(resumed.session_id)
         activeSessionIdRef.current = resumed.session_id
-        const pendingApproval = restorePendingApproval(resumed, resumed.session_id)
+        const pendingApproval = restorePendingApproval(resumed, resumed.session_id, resumeSource)
         const pendingClarify = restorePendingClarify(resumed, resumed.session_id)
         const runtimeInfo = applyRuntimeInfo(resumed.info)
 

--- a/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
@@ -1,9 +1,12 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { atom } from 'nanostores'
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
+import { type SessionView, SessionViewProvider } from '@/app/chat/session-view'
 import type { HermesGateway } from '@/hermes'
-import { $gateway } from '@/store/gateway'
-import { $approvalRequest, clearAllPrompts, setApprovalRequest } from '@/store/prompts'
+import * as gatewayStore from '@/store/gateway'
+import { $activeGatewayProfile } from '@/store/profile'
+import { $approvalRequest, clearAllPrompts, sessionApprovalRequest, setApprovalRequest } from '@/store/prompts'
 import { $activeSessionId } from '@/store/session'
 
 import { PendingApprovalFallback, PendingToolApproval } from './approval'
@@ -33,15 +36,21 @@ function part(toolName: string): ToolPart {
 function setRequest(
   command = 'rm -rf /tmp/x',
   allowPermanent?: boolean,
-  extra: { choices?: string[]; smartDenied?: boolean } = {}
+  extra: {
+    choices?: string[]
+    connectionId?: null | string
+    profile?: string
+    requestId?: string
+    smartDenied?: boolean
+  } = {}
 ) {
   $activeSessionId.set('sess-1')
   setApprovalRequest({ allowPermanent, command, description: 'dangerous command', sessionId: 'sess-1', ...extra })
 }
 
 function mockGateway() {
-  const request = vi.fn().mockResolvedValue({ resolved: true })
-  $gateway.set({ request } as unknown as HermesGateway)
+  const request = vi.fn().mockResolvedValue({ resolved: 1 })
+  gatewayStore.$gateway.set({ request } as unknown as HermesGateway)
 
   return request
 }
@@ -50,7 +59,9 @@ afterEach(() => {
   cleanup()
   clearAllPrompts()
   $activeSessionId.set(null)
-  $gateway.set(null)
+  $activeGatewayProfile.set('default')
+  gatewayStore.$gateway.set(null)
+  vi.restoreAllMocks()
 })
 
 describe('PendingToolApproval', () => {
@@ -75,17 +86,151 @@ describe('PendingToolApproval', () => {
     expect(screen.getByRole('button', { name: /Reject/ })).toBeTruthy()
   })
 
-  it('sends approval.respond {choice: "once"} and clears the request on Run', async () => {
+  it('keeps the active-source approval actionable when another source shares its session id', async () => {
+    mockGateway()
+
+    const routedRequest = vi.spyOn(gatewayStore, 'requestGatewayForAgent').mockImplementation(
+      async (_connectionId, _profile, method) =>
+        method === 'approval.respond' ? ({ resolved: 1 } as never) : ({ approvals: [] } as never)
+    )
+
+    setRequest('', undefined, { connectionId: null, profile: 'default', requestId: 'request-a' })
+    setApprovalRequest({
+      command: '',
+      connectionId: 'remote-b',
+      description: 'source B',
+      profile: 'research',
+      requestId: 'request-b',
+      sessionId: 'sess-1'
+    })
+    $activeSessionId.set('primary-session')
+
+    const tileView: SessionView = {
+      ...({} as SessionView),
+      $runtimeId: atom<null | string>('sess-1'),
+      kind: 'tile'
+    }
+
+    render(
+      <SessionViewProvider value={tileView}>
+        <PendingToolApproval part={part('terminal')} />
+      </SessionViewProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /Run/ }))
+
+    await waitFor(() =>
+      expect(routedRequest).toHaveBeenCalledWith(null, 'default', 'approval.respond', {
+        choice: 'once',
+        request_id: 'request-a',
+        session_id: 'sess-1'
+      })
+    )
+  })
+
+  it('sends the stored opaque request id with approval on Run', async () => {
     const request = mockGateway()
-    setRequest()
+    setRequest('', undefined, { requestId: 'test-request-id' })
     render(<PendingToolApproval part={part('terminal')} />)
 
     fireEvent.click(screen.getByRole('button', { name: /Run/ }))
 
     await waitFor(() => {
-      expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'once', session_id: 'sess-1' })
+      expect(request).toHaveBeenCalledWith('approval.respond', {
+        choice: 'once',
+        request_id: 'test-request-id',
+        session_id: 'sess-1'
+      })
     })
     expect($approvalRequest.get()).toBeNull()
+  })
+
+  it('responds and replays through the parked request source, not the active gateway', async () => {
+    const activeRequest = mockGateway()
+    let resolveResponse: ((value: { resolved: number }) => void) | undefined
+
+    const response = new Promise<{ resolved: number }>(resolve => {
+      resolveResponse = resolve
+    })
+
+    const routedRequest = vi.spyOn(gatewayStore, 'requestGatewayForAgent').mockImplementation(
+      async (_connectionId, _profile, method) =>
+        method === 'approval.respond'
+          ? (response as never)
+          : ({ approvals: [{ description: 'next approval', request_id: 'next-request-id' }] } as never)
+    )
+
+    $activeGatewayProfile.set('research')
+    setRequest('', undefined, {
+      connectionId: null,
+      profile: 'research',
+      requestId: 'test-request-id'
+    })
+    render(<PendingToolApproval part={part('terminal')} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Run/ }))
+
+    await waitFor(() =>
+      expect(routedRequest).toHaveBeenNthCalledWith(1, null, 'research', 'approval.respond', {
+        choice: 'once',
+        request_id: 'test-request-id',
+        session_id: 'sess-1'
+      })
+    )
+
+    // The response can resolve after the user switches profile. Replay must
+    // retain the request's captured source rather than consulting mutable UI.
+    $activeGatewayProfile.set('default')
+    resolveResponse?.({ resolved: 1 })
+
+    await waitFor(() =>
+      expect(routedRequest).toHaveBeenNthCalledWith(2, null, 'research', 'approval.pending', {
+        session_id: 'sess-1'
+      })
+    )
+    expect(sessionApprovalRequest('sess-1', { connectionId: null, profile: 'research' }).get()?.requestId).toBe(
+      'next-request-id'
+    )
+    expect(sessionApprovalRequest('sess-1', { connectionId: null, profile: 'default' }).get()).toBeNull()
+    expect(activeRequest).not.toHaveBeenCalled()
+  })
+
+  it('keeps legacy ID-free FIFO responses bound to the parked request source', async () => {
+    const activeRequest = mockGateway()
+
+    const routedRequest = vi.spyOn(gatewayStore, 'requestGatewayForAgent').mockImplementation(
+      async (_connectionId, _profile, method) =>
+        method === 'approval.respond' ? ({ resolved: 1 } as never) : ({ approvals: [] } as never)
+    )
+
+    setRequest('', undefined, { connectionId: null, profile: 'default' })
+    render(<PendingToolApproval part={part('terminal')} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Run/ }))
+
+    await waitFor(() =>
+      expect(routedRequest).toHaveBeenNthCalledWith(1, null, 'default', 'approval.respond', {
+        choice: 'once',
+        request_id: undefined,
+        session_id: 'sess-1'
+      })
+    )
+    expect(routedRequest).toHaveBeenNthCalledWith(2, null, 'default', 'approval.pending', {
+      session_id: 'sess-1'
+    })
+    expect(activeRequest).not.toHaveBeenCalled()
+  })
+
+  it('keeps the prompt parked when the backend resolves no matching request', async () => {
+    const request = mockGateway()
+    request.mockResolvedValueOnce({ resolved: 0 })
+    setRequest('', undefined, { requestId: 'test-request-id' })
+    render(<PendingToolApproval part={part('terminal')} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Run/ }))
+
+    await waitFor(() => expect(request).toHaveBeenCalled())
+    expect($approvalRequest.get()?.requestId).toBe('test-request-id')
   })
 
   it('reveals the full command inline when the Command toggle is clicked', () => {
@@ -101,15 +246,19 @@ describe('PendingToolApproval', () => {
     expect(screen.getByText(longCommand)).toBeTruthy()
   })
 
-  it('sends choice "deny" on Reject', async () => {
+  it('sends the stored opaque request id with denial on Reject', async () => {
     const request = mockGateway()
-    setRequest()
+    setRequest('', undefined, { requestId: 'test-request-id' })
     render(<PendingToolApproval part={part('terminal')} />)
 
     fireEvent.click(screen.getByRole('button', { name: /Reject/ }))
 
     await waitFor(() => {
-      expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'deny', session_id: 'sess-1' })
+      expect(request).toHaveBeenCalledWith('approval.respond', {
+        choice: 'deny',
+        request_id: 'test-request-id',
+        session_id: 'sess-1'
+      })
     })
   })
 

--- a/apps/desktop/src/components/assistant-ui/tool/approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.tsx
@@ -18,9 +18,10 @@ import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { AlertCircle, ChevronDown, Loader2 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
-import { $gateway } from '@/store/gateway'
+import { $gateway, requestGatewayForAgent } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
 import {
+  activeSessionApprovalRequest,
   type ApprovalRequest,
   clearApprovalRequest,
   registerApprovalInlineAnchor,
@@ -53,7 +54,7 @@ export const PendingToolApproval: FC<{ part: ToolPart }> = ({ part }) => {
   // The tool row lives in whichever session's transcript rendered it — read
   // THAT session's approval (works for the primary and every tile).
   const sessionId = useStore(useSessionView().$runtimeId)
-  const $request = useMemo(() => sessionApprovalRequest(sessionId), [sessionId])
+  const $request = useMemo(() => activeSessionApprovalRequest(sessionId), [sessionId])
   const request = useStore($request)
 
   if (!request || !APPROVAL_TOOLS.has(part.toolName)) {
@@ -72,7 +73,7 @@ const InlineApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
 export const PendingApprovalFallback: FC = () => {
   const { t } = useI18n()
   const sessionId = useStore(useSessionView().$runtimeId)
-  const $request = useMemo(() => sessionApprovalRequest(sessionId), [sessionId])
+  const $request = useMemo(() => activeSessionApprovalRequest(sessionId), [sessionId])
   const $inlineVisible = useMemo(() => sessionApprovalInlineVisible(sessionId), [sessionId])
   const request = useStore($request)
   const inlineVisible = useStore($inlineVisible)
@@ -127,14 +128,29 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
 
   const respond = useCallback(
     async (choice: ApprovalChoice) => {
+      const source = request.profile
+        ? { connectionId: request.connectionId ?? null, profile: request.profile }
+        : undefined
+
       // Another bar (or the keyboard path) may have already resolved this
       // approval; the map is the single source of truth, so bail if this
       // session's request is gone.
-      if (busy || !sessionApprovalRequest(request.sessionId).get()) {
+      const currentRequest = source
+        ? sessionApprovalRequest(request.sessionId, source).get()
+        : activeSessionApprovalRequest(request.sessionId).get()
+
+      if (busy || !currentRequest) {
         return
       }
 
-      if (!gateway) {
+      const approvalGateway = source
+        ? {
+            request: <T,>(method: string, params: Record<string, unknown>) =>
+              requestGatewayForAgent<T>(source.connectionId, source.profile, method, params)
+          }
+        : gateway
+
+      if (!approvalGateway) {
         notifyError(new Error(copy.gatewayDisconnected), copy.sendFailed)
 
         return
@@ -143,20 +159,36 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
       setSubmitting(choice)
 
       try {
-        await gateway.request<{ resolved?: boolean }>('approval.respond', {
+        const result = await approvalGateway.request<{ resolved?: number }>('approval.respond', {
           choice,
           request_id: request.requestId,
           session_id: request.sessionId ?? undefined
         })
+
+        if (result?.resolved !== 1) {
+          setSubmitting(null)
+
+          return
+        }
+
         triggerHaptic(choice === 'deny' ? 'cancel' : 'submit')
-        clearApprovalRequest(request.sessionId, request.requestId)
-        void replayPendingApproval(gateway, request.sessionId).catch(() => undefined)
+        clearApprovalRequest(request.sessionId, request.requestId, source)
+        void replayPendingApproval(approvalGateway, request.sessionId, source).catch(() => undefined)
       } catch (error) {
         notifyError(error, copy.sendFailed)
         setSubmitting(null)
       }
     },
-    [busy, copy.gatewayDisconnected, copy.sendFailed, gateway, request.requestId, request.sessionId]
+    [
+      busy,
+      copy.gatewayDisconnected,
+      copy.sendFailed,
+      gateway,
+      request.connectionId,
+      request.profile,
+      request.requestId,
+      request.sessionId
+    ]
   )
 
   // ⌘/Ctrl+Enter → Run, Esc → Reject.

--- a/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
@@ -42,7 +42,7 @@ import { normalize } from '@/lib/text'
 import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
 import { recordPreviewArtifact } from '@/store/preview-status'
-import { sessionApprovalRequest } from '@/store/prompts'
+import { activeSessionApprovalRequest } from '@/store/prompts'
 import { $toolInlineDiff } from '@/store/tool-diffs'
 import { $toolRowDismissed, dismissToolRow } from '@/store/tool-dismiss'
 import { $anyToolDisclosureOpen, $toolDisclosureOpen, $toolViewMode, setToolDisclosureOpen } from '@/store/tool-view'
@@ -930,7 +930,7 @@ const ToolRun: FC<PropsWithChildren<{ endIndex: number; startIndex: number }>> =
   )
 
   const sessionId = useStore(useSessionView().$runtimeId)
-  const approval = useStore(useMemo(() => sessionApprovalRequest(sessionId), [sessionId]))
+  const approval = useStore(useMemo(() => activeSessionApprovalRequest(sessionId), [sessionId]))
   const disclosureId = `tool-run:${key}`
   const persistedOpen = useStore($toolDisclosureOpen(disclosureId))
   const rowOpen = useStore(useMemo(() => $anyToolDisclosureOpen(entryIds), [entryIds]))

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -358,8 +358,27 @@ declare global {
       ) => () => void
       signalDeepLinkReady?: () => Promise<{ ok: boolean }>
       onWindowStateChanged?: (callback: (payload: HermesWindowState) => void) => () => void
-      onFocusSession?: (callback: (sessionId: string) => void) => () => void
-      onNotificationAction?: (callback: (payload: { actionId: string; sessionId?: string }) => void) => () => void
+      onFocusSession?: (
+        callback: (
+          payload:
+            | string
+            | {
+                connectionId?: null | string
+                profile?: string
+                requestId?: string
+                sessionId?: string
+              }
+        ) => void
+      ) => () => void
+      onNotificationAction?: (
+        callback: (payload: {
+          actionId: string
+          connectionId?: null | string
+          profile?: string
+          requestId?: string
+          sessionId?: string
+        }) => void
+      ) => () => void
       onPreviewFileChanged: (callback: (payload: HermesPreviewFileChanged) => void) => () => void
       onBackendExit: (callback: (payload: BackendExit) => void) => () => void
       // Soft gateway-mode apply: primary backend was torn down without a window
@@ -1051,6 +1070,11 @@ export interface HermesNotification {
   /** Dedupe discriminator for session-less notifications (e.g. plugin id). */
   tag?: string
   actions?: { id: string; text: string }[]
+  /** Opaque approval request authority echoed only with a native action. */
+  approvalRequestId?: string
+  /** Immutable backend source paired with approvalRequestId. */
+  approvalConnectionId?: null | string
+  approvalProfile?: string
 }
 
 export interface HermesPreviewTarget {

--- a/apps/desktop/src/store/native-notifications.test.ts
+++ b/apps/desktop/src/store/native-notifications.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { $gateway } from './gateway'
+vi.mock('./gateway', async () => {
+  const { atom } = await import('nanostores')
+
+  return { $gateway: atom(null), activeGatewayConnectionId: vi.fn(() => null), requestGatewayForAgent: vi.fn() }
+})
+
+import { requestGatewayForAgent } from './gateway'
 import {
   dispatchNativeNotification,
   dispatchPluginNativeNotification,
@@ -11,7 +17,8 @@ import {
   setNativeNotifyKind
 } from './native-notifications'
 import { __resetNativeNotifyBaselineForTests, markNativeNotifyBaseline } from './notify-baseline'
-import { $approvalRequest, setApprovalRequest } from './prompts'
+import { $activeGatewayProfile } from './profile'
+import { clearAllPrompts, sessionApprovalRequest, setApprovalRequest } from './prompts'
 import { $activeSessionId, setActiveSessionId } from './session'
 
 const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
@@ -100,6 +107,23 @@ describe('dispatchNativeNotification focus gating', () => {
     expect(notify).not.toHaveBeenCalled()
   })
 
+  it('fires a foreign-source approval sharing the focused active session id', () => {
+    setWindowState({ focused: true, hidden: false })
+    setActiveSessionId('shared-session')
+    $activeGatewayProfile.set('default')
+
+    dispatchNativeNotification({
+      approvalConnectionId: 'remote-b',
+      approvalProfile: 'research',
+      approvalRequestId: 'request-b',
+      kind: 'approval',
+      sessionId: 'shared-session',
+      title: 'approve'
+    })
+
+    expect(notify).toHaveBeenCalledTimes(1)
+  })
+
   it('fires a global completion notification while away with no active session (pet gen)', () => {
     setActiveSessionId(null)
     dispatchNativeNotification({ global: true, kind: 'backgroundDone', title: 'Your pet hatched' })
@@ -138,6 +162,26 @@ describe('dispatchNativeNotification preferences', () => {
     dispatchNativeNotification({ body: 'hi', kind: 'turnError', sessionId: 'abc', title: 'boom' })
     expect(notify).toHaveBeenCalledWith(
       expect.objectContaining({ body: 'hi', kind: 'turnError', sessionId: 'abc', title: 'boom' })
+    )
+  })
+
+  it('forwards the opaque approval request id to the native action context', () => {
+    const background = freshSession()
+    setActiveSessionId('foreground')
+    dispatchNativeNotification({
+      approvalConnectionId: 'remote-a',
+      approvalProfile: 'research',
+      approvalRequestId: 'request-a',
+      kind: 'approval',
+      sessionId: background,
+      title: 'approve'
+    })
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        approvalConnectionId: 'remote-a',
+        approvalProfile: 'research',
+        approvalRequestId: 'request-a'
+      })
     )
   })
 })
@@ -207,6 +251,30 @@ describe('dispatchNativeNotification throttle', () => {
     dispatchNativeNotification({ kind: 'turnDone', sessionId, title: 'done again' })
     expect(notify).toHaveBeenCalledTimes(1)
   })
+
+  it('does not collapse approvals from distinct source authorities sharing a session id', () => {
+    const sessionId = freshSession()
+    setActiveSessionId('another-session')
+
+    dispatchNativeNotification({
+      approvalConnectionId: 'remote-a',
+      approvalProfile: 'research',
+      approvalRequestId: 'request-a',
+      kind: 'approval',
+      sessionId,
+      title: 'A'
+    })
+    dispatchNativeNotification({
+      approvalConnectionId: 'remote-b',
+      approvalProfile: 'research',
+      approvalRequestId: 'request-b',
+      kind: 'approval',
+      sessionId,
+      title: 'B'
+    })
+
+    expect(notify).toHaveBeenCalledTimes(2)
+  })
 })
 
 describe('sendTestNativeNotification', () => {
@@ -226,40 +294,100 @@ describe('$activeSessionId wiring', () => {
 })
 
 describe('respondToApprovalAction', () => {
-  const request = vi.fn().mockResolvedValue({ resolved: true })
+  const routedRequest = vi.mocked(requestGatewayForAgent)
+  const source = { connectionId: 'remote-a', profile: 'research' }
 
   beforeEach(() => {
-    request.mockClear()
-    $gateway.set({ request } as unknown as ReturnType<typeof $gateway.get>)
-  })
-
-  afterEach(() => {
-    $gateway.set(null)
-  })
-
-  it('approves via approval.respond {choice: "once"} and clears the prompt', async () => {
+    clearAllPrompts()
+    routedRequest.mockReset()
+    routedRequest.mockImplementation(async (_connectionId, _profile, method) =>
+      method === 'approval.respond' ? ({ resolved: 1 } as never) : ({ approvals: [] } as never)
+    )
     setActiveSessionId('bg')
-    setApprovalRequest({ command: 'rm -rf /', description: 'dangerous', sessionId: 'bg' })
-
-    await respondToApprovalAction('bg', 'approve')
-
-    expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'once', session_id: 'bg' })
-    expect($approvalRequest.get()).toBeNull()
   })
 
-  it('rejects via approval.respond {choice: "deny"}', async () => {
-    await respondToApprovalAction('bg', 'reject')
-    expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'deny', session_id: 'bg' })
+  it('approves the exact notification request id and clears only that prompt', async () => {
+    setActiveSessionId('bg')
+    setApprovalRequest({ ...source, command: '', description: 'redacted', requestId: 'test-request-id', sessionId: 'bg' })
+
+    await respondToApprovalAction('bg', 'test-request-id', 'approve', source)
+
+    expect(routedRequest).toHaveBeenNthCalledWith(1, 'remote-a', 'research', 'approval.respond', {
+      choice: 'once',
+      request_id: 'test-request-id',
+      session_id: 'bg'
+    })
+    expect(routedRequest).toHaveBeenNthCalledWith(2, 'remote-a', 'research', 'approval.pending', {
+      session_id: 'bg'
+    })
+    expect(sessionApprovalRequest('bg', source).get()).toBeNull()
+  })
+
+  it('parks the replayed approval under the original notification source', async () => {
+    const sessionId = freshSession()
+
+    $activeGatewayProfile.set('default')
+    routedRequest.mockImplementation(async (_connectionId, _profile, method) => {
+      if (method === 'approval.respond') {
+        return { resolved: 1 } as never
+      }
+
+      return {
+        approvals: [{ description: 'next approval', request_id: 'next-request-id' }]
+      } as never
+    })
+    setApprovalRequest({ ...source, command: '', description: 'current', requestId: 'current-request-id', sessionId })
+
+    await respondToApprovalAction(sessionId, 'current-request-id', 'approve', source)
+
+    expect(sessionApprovalRequest(sessionId, source).get()?.requestId).toBe('next-request-id')
+    expect(sessionApprovalRequest(sessionId, { connectionId: null, profile: 'default' }).get()).toBeNull()
+  })
+
+  it('does not let a stale notification action clear a newer prompt', async () => {
+    setApprovalRequest({ ...source, command: '', description: 'newer', requestId: 'new-request-id', sessionId: 'bg' })
+
+    await respondToApprovalAction('bg', 'old-request-id', 'approve', source)
+
+    expect(routedRequest).toHaveBeenNthCalledWith(1, 'remote-a', 'research', 'approval.respond', {
+      choice: 'once',
+      request_id: 'old-request-id',
+      session_id: 'bg'
+    })
+    expect(sessionApprovalRequest('bg', source).get()?.requestId).toBe('new-request-id')
+  })
+
+  it('keeps the exact prompt parked when the backend resolves nothing', async () => {
+    routedRequest.mockResolvedValueOnce({ resolved: 0 } as never)
+    setApprovalRequest({ ...source, command: '', description: 'redacted', requestId: 'test-request-id', sessionId: 'bg' })
+
+    await respondToApprovalAction('bg', 'test-request-id', 'reject', source)
+
+    expect(sessionApprovalRequest('bg', source).get()?.requestId).toBe('test-request-id')
+    expect(routedRequest).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects with the exact notification request id', async () => {
+    await respondToApprovalAction('bg', 'test-request-id', 'reject', source)
+
+    expect(routedRequest).toHaveBeenNthCalledWith(1, 'remote-a', 'research', 'approval.respond', {
+      choice: 'deny',
+      request_id: 'test-request-id',
+      session_id: 'bg'
+    })
   })
 
   it('ignores unknown action ids', async () => {
-    await respondToApprovalAction('bg', 'snooze')
-    expect(request).not.toHaveBeenCalled()
+    await respondToApprovalAction('bg', 'test-request-id', 'snooze', source)
+    expect(routedRequest).not.toHaveBeenCalled()
   })
 
-  it('no-ops without a gateway', async () => {
-    $gateway.set(null)
-    await respondToApprovalAction('bg', 'approve')
-    expect(request).not.toHaveBeenCalled()
+  it('leaves the prompt parked when the source-scoped gateway rejects', async () => {
+    routedRequest.mockRejectedValueOnce(new Error('source unavailable'))
+    setApprovalRequest({ ...source, command: '', description: 'redacted', requestId: 'test-request-id', sessionId: 'bg' })
+
+    await respondToApprovalAction('bg', 'test-request-id', 'approve', source)
+
+    expect(sessionApprovalRequest('bg', source).get()?.requestId).toBe('test-request-id')
   })
 })

--- a/apps/desktop/src/store/native-notifications.ts
+++ b/apps/desktop/src/store/native-notifications.ts
@@ -2,9 +2,10 @@ import { atom } from 'nanostores'
 
 import { persistString, storedString } from '@/lib/storage'
 
-import { $gateway } from './gateway'
+import { activeGatewayConnectionId, requestGatewayForAgent } from './gateway'
 import { withinNativeNotifyBaseline } from './notify-baseline'
-import { clearApprovalRequest } from './prompts'
+import { $activeGatewayProfile, normalizeProfileKey } from './profile'
+import { clearApprovalRequest, replayPendingApproval } from './prompts'
 import { $activeSessionId } from './session'
 
 // Native OS notifications (Electron `Notification`), separate from the in-app
@@ -125,7 +126,13 @@ function isBackgrounded(): boolean {
   return typeof document.hasFocus === 'function' && !document.hasFocus()
 }
 
-function shouldFire(kind: NativeNotificationKind, sessionId?: null | string, global = false): boolean {
+function shouldFire(
+  kind: NativeNotificationKind,
+  sessionId?: null | string,
+  global = false,
+  approvalConnectionId?: null | string,
+  approvalProfile?: string
+): boolean {
   // Global notifications aren't tied to a chat session (e.g. pet generation,
   // which runs from the command center with no active conversation). They fire
   // whenever the user is away, with no session-match requirement — otherwise a
@@ -136,7 +143,15 @@ function shouldFire(kind: NativeNotificationKind, sessionId?: null | string, glo
 
   // Attention kinds break through for an off-screen session even while focused.
   if (ATTENTION_KINDS.has(kind)) {
-    return isBackgrounded() || (Boolean(sessionId) && sessionId !== $activeSessionId.get())
+    const activeSessionMatches = Boolean(sessionId) && sessionId === $activeSessionId.get()
+
+    const activeSourceMatches =
+      kind !== 'approval' ||
+      ((approvalConnectionId ?? null) === activeGatewayConnectionId() &&
+        normalizeProfileKey(approvalProfile ?? $activeGatewayProfile.get()) ===
+          normalizeProfileKey($activeGatewayProfile.get()))
+
+    return isBackgrounded() || !activeSessionMatches || !activeSourceMatches
   }
 
   // Completion kinds: only the active session, only while away — so a busy
@@ -162,6 +177,11 @@ export interface NativeNotificationInput {
   global?: boolean
   silent?: boolean
   actions?: NativeNotificationAction[]
+  /** Opaque backend authority captured when an approval notification is created. */
+  approvalRequestId?: string
+  /** Backend source captured with the opaque approval authority. */
+  approvalConnectionId?: null | string
+  approvalProfile?: string
   /**
    * Extra throttle/dedupe discriminator for session-less notifications (e.g.
    * the plugin id), so unrelated emitters of the same kind don't collapse
@@ -181,16 +201,38 @@ export function dispatchNativeNotification(input: NativeNotificationInput): void
     return
   }
 
-  if (!shouldFire(input.kind, input.sessionId, input.global)) {
+  if (
+    !shouldFire(
+      input.kind,
+      input.sessionId,
+      input.global,
+      input.approvalConnectionId,
+      input.approvalProfile
+    )
+  ) {
     return
   }
 
-  if (throttled(`${input.kind}:${input.sessionId ?? input.tag ?? (input.global ? 'global' : '')}`, Date.now())) {
+  const throttleKey =
+    input.kind === 'approval'
+      ? JSON.stringify([
+          input.kind,
+          input.sessionId ?? null,
+          input.approvalConnectionId ?? null,
+          input.approvalProfile ?? null,
+          input.approvalRequestId ?? null
+        ])
+      : `${input.kind}:${input.sessionId ?? input.tag ?? (input.global ? 'global' : '')}`
+
+  if (throttled(throttleKey, Date.now())) {
     return
   }
 
   void window.hermesDesktop?.notify({
     actions: input.actions,
+    approvalConnectionId: input.approvalConnectionId,
+    approvalProfile: input.approvalProfile,
+    approvalRequestId: input.approvalRequestId,
     body: input.body,
     kind: input.kind,
     sessionId: input.sessionId ?? undefined,
@@ -217,24 +259,43 @@ export function dispatchPluginNativeNotification(pluginId: string, input: Plugin
   dispatchNativeNotification({ ...input, global: true, kind: 'plugin', tag: pluginId })
 }
 
-// Resolve a pending approval from a notification button, mirroring the in-app
-// Run/Reject bar. Keyed by session id — a background approval has no local guard.
-export async function respondToApprovalAction(sessionId: null | string, actionId: string): Promise<void> {
+// Resolve the exact approval captured by this notification, mirroring the
+// in-app Run/Reject bar. Never re-read mutable session prompt state here: an old
+// OS notification can outlive the request that replaced it in the renderer.
+export async function respondToApprovalAction(
+  sessionId: null | string,
+  requestId: string,
+  actionId: string,
+  source: { connectionId: null | string; profile: string }
+): Promise<void> {
   const choice = actionId === 'approve' ? 'once' : actionId === 'reject' ? 'deny' : null
 
   if (!choice) {
     return
   }
 
-  const gateway = $gateway.get()
+  if (!source.profile) {
+    return
+  }
 
-  if (!gateway) {
+  if (!requestId) {
     return
   }
 
   try {
-    await gateway.request('approval.respond', { choice, session_id: sessionId ?? undefined })
-    clearApprovalRequest(sessionId)
+    const request = <T>(method: string, params: Record<string, unknown>) =>
+      requestGatewayForAgent<T>(source.connectionId, source.profile, method, params)
+
+    const result = await request<{ resolved?: number }>('approval.respond', {
+      choice,
+      request_id: requestId,
+      session_id: sessionId ?? undefined
+    })
+
+    if (result?.resolved === 1) {
+      clearApprovalRequest(sessionId, requestId, source)
+      await replayPendingApproval({ request }, sessionId, source)
+    }
   } catch {
     // Leave the prompt parked so the user can still resolve it in-app.
   }

--- a/apps/desktop/src/store/prompts.test.ts
+++ b/apps/desktop/src/store/prompts.test.ts
@@ -6,12 +6,18 @@ import {
   $approvalRequest,
   $secretRequest,
   $sudoRequest,
+  activeSessionApprovalRequest,
   clearAllPrompts,
+  clearAllPromptsForActiveSource,
   clearApprovalRequest,
   clearSecretRequest,
   clearSudoRequest,
+  hasBlockingPromptRequest,
   receiveApprovalRequest,
   replayPendingApproval,
+  sessionApprovalRequest,
+  sessionAwaitingInput,
+  sessionBlockingPrompt,
   setApprovalRequest,
   setSecretRequest,
   setSudoRequest
@@ -31,12 +37,13 @@ afterEach(() => {
 })
 
 describe('approval prompt store', () => {
-  it('holds the active session-keyed approval request', () => {
-    setApprovalRequest({ command: 'rm -rf /tmp/x', description: 'recursive delete', sessionId: 's1' })
+  it('holds an opaque request id with the active session-keyed approval request', () => {
+    setApprovalRequest({ command: '', description: 'redacted', requestId: 'test-request-id', sessionId: 's1' })
 
     expect($approvalRequest.get()).toEqual({
-      command: 'rm -rf /tmp/x',
-      description: 'recursive delete',
+      command: '',
+      description: 'redacted',
+      requestId: 'test-request-id',
       sessionId: 's1'
     })
   })
@@ -50,6 +57,38 @@ describe('approval prompt store', () => {
     // … but surfaces once the user switches to the session that raised it.
     $activeSessionId.set('s2')
     expect($approvalRequest.get()?.sessionId).toBe('s2')
+  })
+
+  it('selects a background tile approval from the active backend source', () => {
+    setApprovalRequest({
+      command: 'dangerous',
+      connectionId: null,
+      description: 'tile approval',
+      profile: 'default',
+      requestId: 'tile-request',
+      sessionId: 'tile-session'
+    })
+
+    expect($activeSessionId.get()).toBe('s1')
+    expect(activeSessionApprovalRequest('tile-session').get()?.requestId).toBe('tile-request')
+  })
+
+  it('does not surface a lone foreign-source approval in the active source', () => {
+    setApprovalRequest({
+      command: 'remote only',
+      connectionId: 'remote-b',
+      description: 'foreign approval',
+      profile: 'research',
+      requestId: 'remote-request',
+      sessionId: 's1'
+    })
+
+    expect(activeSessionApprovalRequest('s1').get()).toBeNull()
+    expect($approvalRequest.get()).toBeNull()
+    expect($activeSessionAwaitingInput.get()).toBe(false)
+    expect(hasBlockingPromptRequest('s1')).toBe(false)
+    expect(sessionBlockingPrompt('s1').get()).toBe(false)
+    expect(sessionAwaitingInput('s1').get()).toBe(false)
   })
 
   it('clears the active session prompt', () => {
@@ -77,6 +116,40 @@ describe('approval prompt store', () => {
     expect($approvalRequest.get()?.requestId).toBe('r1')
     clearApprovalRequest('s1', 'r1')
     expect($approvalRequest.get()).toBeNull()
+  })
+
+  it('keys identical session ids by connection and profile authority', () => {
+    const sourceA = { connectionId: 'remote-a', profile: 'research' }
+    const sourceB = { connectionId: 'remote-b', profile: 'research' }
+
+    setApprovalRequest({ ...sourceA, command: 'a', description: 'A', requestId: 'r-a', sessionId: 's1' })
+    setApprovalRequest({ ...sourceB, command: 'b', description: 'B', requestId: 'r-b', sessionId: 's1' })
+
+    expect(sessionApprovalRequest('s1', sourceA).get()?.requestId).toBe('r-a')
+    expect(sessionApprovalRequest('s1', sourceB).get()?.requestId).toBe('r-b')
+
+    clearApprovalRequest('s1', undefined, sourceB)
+
+    expect(sessionApprovalRequest('s1', sourceA).get()?.requestId).toBe('r-a')
+    expect(sessionApprovalRequest('s1', sourceB).get()).toBeNull()
+  })
+
+  it('active-source interrupt cleanup preserves another source with the same session id', () => {
+    const sourceB = { connectionId: 'remote-b', profile: 'research' }
+
+    setApprovalRequest({ command: '', description: 'local A', requestId: 'request-a', sessionId: 's1' })
+    setApprovalRequest({
+      ...sourceB,
+      command: '',
+      description: 'remote B',
+      requestId: 'request-b',
+      sessionId: 's1'
+    })
+
+    clearAllPromptsForActiveSource('s1')
+
+    expect(sessionApprovalRequest('s1', { connectionId: null, profile: 'default' }).get()).toBeNull()
+    expect(sessionApprovalRequest('s1', sourceB).get()?.requestId).toBe('request-b')
   })
 
   it('acknowledges an approval only after parking it', async () => {
@@ -121,9 +194,16 @@ describe('approval prompt store', () => {
       }
     }
 
-    await replayPendingApproval(gateway, 's1')
+    await replayPendingApproval(gateway, 's1', { connectionId: 'remote-a', profile: 'research' })
 
-    expect($approvalRequest.get()?.requestId).toBe('r1')
+    expect(
+      sessionApprovalRequest('s1', { connectionId: 'remote-a', profile: 'research' }).get()
+    ).toMatchObject({
+      connectionId: 'remote-a',
+      profile: 'research',
+      requestId: 'r1'
+    })
+    expect($approvalRequest.get()).toBeNull()
     expect(calls).toEqual([
       ['approval.pending', { session_id: 's1' }],
       ['approval.received', { request_id: 'r1', session_id: 's1' }]

--- a/apps/desktop/src/store/prompts.ts
+++ b/apps/desktop/src/store/prompts.ts
@@ -1,6 +1,9 @@
+import { registryBackendScopeKey } from '@hermes/shared'
 import { atom, computed, type ReadableAtom } from 'nanostores'
 
 import { $clarifyRequest, $clarifyRequests } from './clarify'
+import { $gateway, activeGatewayConnectionId } from './gateway'
+import { $activeGatewayProfile, normalizeProfileKey } from './profile'
 import { $activeSessionId } from './session'
 
 // Blocking interactive prompts the gateway raises mid-turn. Each maps to a
@@ -16,6 +19,11 @@ import { $activeSessionId } from './session'
 // prompt never hijacks the foreground.
 
 const keyFor = (sessionId: string | null | undefined): string => sessionId ?? ''
+
+export interface PromptSource {
+  connectionId: null | string
+  profile: string
+}
 
 interface KeyedPrompt {
   sessionId: string | null
@@ -67,15 +75,17 @@ function keyedPromptStore<T extends KeyedPrompt>(): PromptStore<T> {
   }
 }
 
-// Approval is session-keyed on the backend and correlated by `request_id` when
-// available (legacy ID-free responses remain FIFO-compatible). Resolved via
-// approval.respond {choice, request_id, session_id}.
+// Approval is session-keyed on the backend. Desktop requests preserve the
+// gateway queue's opaque `request_id` so responses resolve exactly; legacy
+// backends without IDs retain their existing FIFO fallback.
 export interface ApprovalRequest extends KeyedPrompt {
   // false when the backend won't honor a permanent allow (tirith warning) → hide "Always allow".
   allowPermanent?: boolean
   choices?: string[]
   command: string
+  connectionId?: null | string
   description: string
+  profile?: string
   requestId?: string
   smartDenied?: boolean
 }
@@ -103,7 +113,89 @@ export interface SecretRequest extends KeyedPrompt {
   requestId: string
 }
 
-const approval = keyedPromptStore<ApprovalRequest>()
+const approvalSourceKey = (
+  sessionId: string | null | undefined,
+  source: { connectionId?: null | string; profile?: string }
+): string =>
+  `${registryBackendScopeKey(source.connectionId ?? null, normalizeProfileKey(source.profile))}\u0000${keyFor(sessionId)}`
+
+const approvalsForSession = (all: Record<string, ApprovalRequest>, sessionId: string | null | undefined) =>
+  Object.values(all).filter(request => request.sessionId === (sessionId ?? null))
+
+const approvalForSession = (
+  all: Record<string, ApprovalRequest>,
+  sessionId: string | null | undefined,
+  source?: PromptSource,
+  strictSource = false
+): ApprovalRequest | null => {
+  if (source) {
+    const exact = all[approvalSourceKey(sessionId, source)]
+
+    if (exact || strictSource) {
+      return exact ?? null
+    }
+  }
+
+  const matches = approvalsForSession(all, sessionId)
+
+  return matches.length === 1 ? matches[0] : null
+}
+
+// Approval identity includes the complete backend authority. Session ids are
+// only runtime-local and may collide across configured gateway connections.
+const $approvalRequests = atom<Record<string, ApprovalRequest>>({})
+
+const approval = {
+  $active: computed(
+    [$approvalRequests, $activeSessionId, $activeGatewayProfile, $gateway],
+    (all, sessionId, profile) =>
+      approvalForSession(
+        all,
+        sessionId,
+        {
+          connectionId: activeGatewayConnectionId(),
+          profile: normalizeProfileKey(profile)
+        },
+        true
+      )
+  ),
+  $all: $approvalRequests,
+  clear(sessionId?: string | null, requestId?: string, source?: PromptSource) {
+    const all = $approvalRequests.get()
+
+    const keys =
+      sessionId === undefined
+        ? Object.keys(all)
+        : source
+          ? [approvalSourceKey(sessionId, source)]
+          : Object.entries(all)
+              .filter(([, request]) => request.sessionId === sessionId)
+              .map(([key]) => key)
+
+    const next = { ...all }
+    let changed = false
+
+    for (const key of keys) {
+      const current = next[key]
+
+      if (current && !(requestId && current.requestId !== requestId)) {
+        delete next[key]
+        changed = true
+      }
+    }
+
+    if (changed) {
+      $approvalRequests.set(next)
+    }
+  },
+  reset: () => $approvalRequests.set({}),
+  set: (request: ApprovalRequest) =>
+    $approvalRequests.set({
+      ...$approvalRequests.get(),
+      [approvalSourceKey(request.sessionId, request)]: request
+    })
+}
+
 const sudo = keyedPromptStore<SudoRequest>()
 const secret = keyedPromptStore<SecretRequest>()
 
@@ -126,7 +218,11 @@ export async function receiveApprovalRequest(gateway: ApprovalGateway | null, re
   }
 }
 
-export async function replayPendingApproval(gateway: ApprovalGateway | null, sessionId: string | null): Promise<void> {
+export async function replayPendingApproval(
+  gateway: ApprovalGateway | null,
+  sessionId: string | null,
+  source?: { connectionId: null | string; profile: string }
+): Promise<void> {
   if (!gateway || !sessionId) {
     return
   }
@@ -148,7 +244,9 @@ export async function replayPendingApproval(gateway: ApprovalGateway | null, ses
     allowPermanent: pending.allow_permanent !== false,
     choices: Array.isArray(pending.choices) ? pending.choices.filter(choice => typeof choice === 'string') : undefined,
     command: typeof pending.command === 'string' ? pending.command : '',
+    connectionId: source?.connectionId,
     description: typeof pending.description === 'string' ? pending.description : 'dangerous command',
+    profile: source?.profile,
     requestId: pending.request_id,
     sessionId,
     smartDenied: pending.smart_denied === true
@@ -157,8 +255,20 @@ export async function replayPendingApproval(gateway: ApprovalGateway | null, ses
 
 /** The prompt request for one specific session — the tile counterpart of the
  *  active-session `$*Request` views (same map, fixed key). */
-export const sessionApprovalRequest = (sessionId: string | null) =>
-  computed(approval.$all, all => all[keyFor(sessionId)] ?? null)
+export const sessionApprovalRequest = (sessionId: string | null, source?: PromptSource) =>
+  computed(approval.$all, all => approvalForSession(all, sessionId, source, Boolean(source)))
+export const activeSessionApprovalRequest = (sessionId: string | null) =>
+  computed([$approvalRequests, $activeGatewayProfile, $gateway], (all, profile) =>
+    approvalForSession(
+      all,
+      sessionId,
+      {
+        connectionId: activeGatewayConnectionId(),
+        profile: normalizeProfileKey(profile)
+      },
+      true
+    )
+  )
 export const sessionSudoRequest = (sessionId: string | null) =>
   computed(sudo.$all, all => all[keyFor(sessionId)] ?? null)
 export const sessionSecretRequest = (sessionId: string | null) =>
@@ -210,33 +320,66 @@ export const $activeSessionAwaitingInput = computed(
 export const hasBlockingPromptRequest = (sessionId: string | null | undefined): boolean => {
   const key = keyFor(sessionId)
 
-  return Boolean(approval.$all.get()[key] || sudo.$all.get()[key] || secret.$all.get()[key])
+  const approvalRequest = approvalForSession(
+    approval.$all.get(),
+    sessionId,
+    {
+      connectionId: activeGatewayConnectionId(),
+      profile: normalizeProfileKey($activeGatewayProfile.get())
+    },
+    true
+  )
+
+  return Boolean(approvalRequest || sudo.$all.get()[key] || secret.$all.get()[key])
 }
 
 /** Reactive twin of `hasBlockingPromptRequest`, for the composer's busy-action
  *  affordance (the primary button must advertise queue, not steer, while the
  *  turn is parked on a prompt Enter can't answer). */
 export const sessionBlockingPrompt = (sessionId: string | null) =>
-  computed([approval.$all, sudo.$all, secret.$all], (approvals, sudos, secrets) => {
+  computed([approval.$all, sudo.$all, secret.$all, $activeGatewayProfile, $gateway], (approvals, sudos, secrets, profile) => {
     const key = keyFor(sessionId)
 
-    return Boolean(approvals[key] || sudos[key] || secrets[key])
+    const approvalRequest = approvalForSession(
+      approvals,
+      sessionId,
+      {
+        connectionId: activeGatewayConnectionId(),
+        profile: normalizeProfileKey(profile)
+      },
+      true
+    )
+
+    return Boolean(approvalRequest || sudos[key] || secrets[key])
   })
 
 /** Per-session `awaitingInput` — the tile composer's counterpart of
  *  `$activeSessionAwaitingInput` (same sources, fixed session instead of the
  *  active one). */
 export function sessionAwaitingInput(sessionId: string | null) {
-  return computed([$clarifyRequests, approval.$all, sudo.$all, secret.$all], (clarify, approvals, sudos, secrets) => {
-    const key = keyFor(sessionId)
+  return computed(
+    [$clarifyRequests, approval.$all, sudo.$all, secret.$all, $activeGatewayProfile, $gateway],
+    (clarify, approvals, sudos, secrets, profile) => {
+      const key = keyFor(sessionId)
 
-    return Boolean(clarify[key] || approvals[key] || sudos[key] || secrets[key])
-  })
+      const approvalRequest = approvalForSession(
+        approvals,
+        sessionId,
+        {
+          connectionId: activeGatewayConnectionId(),
+          profile: normalizeProfileKey(profile)
+        },
+        true
+      )
+
+      return Boolean(clarify[key] || approvalRequest || sudos[key] || secrets[key])
+    }
+  )
 }
 
 // Drop in-flight prompts for `sessionId` (a turn ended) across all three kinds —
 // or every parked prompt when no session is given (global reset / tests).
-export function clearAllPrompts(sessionId?: string | null): void {
+export function clearAllPrompts(sessionId?: string | null, source?: PromptSource): void {
   if (sessionId === undefined) {
     approval.reset()
     sudo.reset()
@@ -246,7 +389,14 @@ export function clearAllPrompts(sessionId?: string | null): void {
     return
   }
 
-  approval.clear(sessionId)
+  approval.clear(sessionId, undefined, source)
   sudo.clear(sessionId)
   secret.clear(sessionId)
+}
+
+export function clearAllPromptsForActiveSource(sessionId: string | null): void {
+  clearAllPrompts(sessionId, {
+    connectionId: activeGatewayConnectionId(),
+    profile: normalizeProfileKey($activeGatewayProfile.get())
+  })
 }

--- a/apps/desktop/src/store/session-states-scopes.test.ts
+++ b/apps/desktop/src/store/session-states-scopes.test.ts
@@ -70,6 +70,15 @@ describe('liveSessionScopes', () => {
     expect(liveSessionScopes()).toEqual(new Set(['conn:homelab::default', 'conn:spark::default']))
   })
 
+  it("does not overwrite a live runtime id's original source scope", () => {
+    recordSessionEventScope({ connectionId: 'remote-a', profile: 'research', session_id: 'shared' })
+    publishSessionState('shared', state({ busy: false, needsInput: true }))
+
+    recordSessionEventScope({ connectionId: 'remote-b', profile: 'research', session_id: 'shared' })
+
+    expect(liveSessionScopes()).toEqual(new Set(['conn:remote-a::research']))
+  })
+
   it('forgets a dropped runtime session', () => {
     recordSessionEventScope({ connectionId: 'homelab', profile: 'default', session_id: 'rt-1' })
     publishSessionState('rt-1', state({ busy: true }))

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -62,16 +62,55 @@ export const $sessionStates = atom<Record<string, ClientSessionState>>({})
 // connected gateways can both expose a 'default' profile, so the gateway
 // keep-set (pruneSecondaryGateways) must key live work by the composite
 // (connectionId, profile) scope, not the bare profile name. Recorded at
-// event fan-in (use-gateway-boot); local/primary events carry no connectionId
-// and record nothing, so single-source behavior is untouched.
+// event fan-in. Local/primary authority is recorded too so a remote source
+// cannot claim a colliding runtime id, but only registry-backed authorities
+// contribute to the gateway keep-set below.
 // ---------------------------------------------------------------------------
 
-const sessionScopeByRuntimeId = new Map<string, string>()
+interface SessionEventAuthority {
+  connectionId: null | string
+  profile: string
+}
 
-export function recordSessionEventScope(event: { connectionId?: string; profile?: string; session_id?: string }): void {
-  if (event.session_id && event.connectionId) {
-    sessionScopeByRuntimeId.set(event.session_id, registryBackendScopeKey(event.connectionId, event.profile))
+const sessionScopeByRuntimeId = new Map<string, SessionEventAuthority>()
+
+export function claimActiveSessionEventScope(event: {
+  connectionId?: null | string
+  profile?: string
+  session_id: string
+}): void {
+  sessionScopeByRuntimeId.set(event.session_id, {
+    connectionId: event.connectionId ?? null,
+    profile: normalizeProfileKey(event.profile ?? $activeGatewayProfile.get())
+  })
+}
+
+export function recordSessionEventScope(event: {
+  connectionId?: null | string
+  profile?: string
+  session_id?: string
+}): boolean {
+  if (!event.session_id) {
+    return true
   }
+
+  const authority = {
+    connectionId: event.connectionId ?? null,
+    profile: normalizeProfileKey(event.profile ?? $activeGatewayProfile.get())
+  }
+
+  const current = sessionScopeByRuntimeId.get(event.session_id)
+
+  if (
+    current &&
+    (current.connectionId !== authority.connectionId || normalizeProfileKey(current.profile) !== authority.profile)
+  ) {
+    return false
+  }
+
+  sessionScopeByRuntimeId.set(event.session_id, authority)
+
+  return true
 }
 
 /** Composite scopes of registry-sourced sessions that are live (busy or
@@ -85,10 +124,10 @@ export function liveSessionScopes(): Set<string> {
       continue
     }
 
-    const scope = sessionScopeByRuntimeId.get(runtimeId)
+    const authority = sessionScopeByRuntimeId.get(runtimeId)
 
-    if (scope) {
-      scopes.add(scope)
+    if (authority?.connectionId) {
+      scopes.add(registryBackendScopeKey(authority.connectionId, authority.profile))
     }
   }
 


### PR DESCRIPTION
## Summary

- bind desktop approval prompts to the gateway connection, normalized profile, runtime session, and opaque request ID that emitted them
- preserve source authority across replay, native actions, session activation/resume, interrupt cleanup, and notification focus
- prevent colliding session IDs from composing foreign gateway events into the active runtime, transcript, or composer state
- retain source-bound FIFO behavior for legacy ID-free approvals while omitting unsafe native response actions

## Verification

- desktop test suite: 6,166 passed, 2 skipped
- focused approval authority suite: 313 passed
- gateway protocol suite: 54 passed
- approval replay contract: passed
- renderer, Electron, and E2E type checks: passed
- ESLint: 0 errors
- desktop production build: passed
- independent security/correctness review: PASS/NO BLOCKERS
- independent mutation review: all 18 authority seams detected by committed tests
