### PR TITLE
fix(session): scale the compute-host /compress wait to the compression budget

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -108,7 +108,9 @@ def test_session_slot_is_claimed_on_first_turn_not_on_create(monkeypatch, tmp_pa
         server._cfg_path = None
         _clear_server_sessions()
         monkeypatch.setattr(server, "_start_agent_build", lambda *args, **kwargs: None)
-        monkeypatch.setattr(server, "_completion_cwd", lambda params=None: str(tmp_path))
+        monkeypatch.setattr(
+            server, "_completion_cwd", lambda params=None: str(tmp_path)
+        )
 
         # Opening a chat must NOT take a slot. Every tile paint and every
         # background reconnect-resume calls session.create, and an unprompted
@@ -134,7 +136,9 @@ def test_session_slot_is_claimed_on_first_turn_not_on_create(monkeypatch, tmp_pa
         assert closed["result"]["closed"] is True
         assert active_session_registry_snapshot() == []
 
-        assert server._ensure_active_session_slot(other, server._sessions[other]) is None
+        assert (
+            server._ensure_active_session_slot(other, server._sessions[other]) is None
+        )
     finally:
         _clear_server_sessions()
         server._cfg_cache = None
@@ -200,13 +204,19 @@ def test_handoff_fail_marks_only_inflight_rows(monkeypatch):
     try:
         pending = FakeDb("pending")
         monkeypatch.setattr(server, "_session_db", lambda _session: DbContext(pending))
-        result = server._methods["handoff.fail"]("r1", {"session_id": sid, "error": "timed out"})
+        result = server._methods["handoff.fail"](
+            "r1", {"session_id": sid, "error": "timed out"}
+        )
         assert result["result"] == {"failed": True, "state": "failed"}
         assert pending.failed_with == "timed out"
 
         completed = FakeDb("completed")
-        monkeypatch.setattr(server, "_session_db", lambda _session: DbContext(completed))
-        result = server._methods["handoff.fail"]("r2", {"session_id": sid, "error": "late timeout"})
+        monkeypatch.setattr(
+            server, "_session_db", lambda _session: DbContext(completed)
+        )
+        result = server._methods["handoff.fail"](
+            "r2", {"session_id": sid, "error": "late timeout"}
+        )
         assert result["result"] == {"failed": False, "state": "completed"}
         assert completed.failed_with is None
     finally:
@@ -256,7 +266,9 @@ def test_default_config_seeds_dashboard_process_isolation_keys():
     assert dashboard["compute_host_respawn_max"] == 3
 
 
-def test_prompt_submit_dispatches_to_compute_host_when_turn_isolation_enabled(monkeypatch):
+def test_prompt_submit_dispatches_to_compute_host_when_turn_isolation_enabled(
+    monkeypatch,
+):
     class FakeSupervisor:
         def __init__(self):
             self.frames = []
@@ -292,16 +304,16 @@ def test_prompt_submit_dispatches_to_compute_host_when_turn_isolation_enabled(mo
             "persist_seed", parent_writes["persist_seed"] + 1
         ),
     )
-    monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda _cfg=None: fake_supervisor)
+    monkeypatch.setattr(
+        server, "_get_compute_host_supervisor", lambda _cfg=None: fake_supervisor
+    )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "submit",
-                "method": "prompt.submit",
-                "params": {"session_id": "iso-sid", "text": "hello"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "submit",
+            "method": "prompt.submit",
+            "params": {"session_id": "iso-sid", "text": "hello"},
+        })
         assert resp["result"] == {"status": "streaming", "turn_isolation": True}
         assert fake_supervisor.frames[0]["type"] == "turn.start"
         assert fake_supervisor.frames[0]["sid"] == "iso-sid"
@@ -311,14 +323,12 @@ def test_prompt_submit_dispatches_to_compute_host_when_turn_isolation_enabled(mo
         assert parent_writes == {"ensure_session": 0, "persist_seed": 0}
         assert server._sessions["iso-sid"]["running"] is True
 
-        fake_supervisor.callback(
-            {
-                "type": "turn.end",
-                "sid": "iso-sid",
-                "request_id": "submit",
-                "history_version": 1,
-            }
-        )
+        fake_supervisor.callback({
+            "type": "turn.end",
+            "sid": "iso-sid",
+            "request_id": "submit",
+            "history_version": 1,
+        })
         assert server._sessions["iso-sid"]["running"] is False
         assert server._sessions["iso-sid"]["history_version"] == 1
     finally:
@@ -331,7 +341,9 @@ def test_compute_host_explicit_images_do_not_clear_later_attachment(monkeypatch)
             session["attached_images"].append("/tmp/c.png")
 
     session = _session(attached_images=[])
-    monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda _cfg=None: _Supervisor())
+    monkeypatch.setattr(
+        server, "_get_compute_host_supervisor", lambda _cfg=None: _Supervisor()
+    )
 
     response = server._submit_prompt_to_compute_host(
         "r1", "sid", session, "B", image_paths=["/tmp/b.png"]
@@ -345,14 +357,12 @@ def test_prompt_submit_fails_open_inline_when_compute_host_dispatch_breaks(monke
     class _BrokenSupervisor:
         def submit_turn(self, frame, *, on_complete=None):
             if on_complete is not None:
-                on_complete(
-                    {
-                        "type": "turn.error",
-                        "request_id": frame["request_id"],
-                        "reason": "send_failed",
-                        "message": "broken pipe",
-                    }
-                )
+                on_complete({
+                    "type": "turn.error",
+                    "request_id": frame["request_id"],
+                    "reason": "send_failed",
+                    "message": "broken pipe",
+                })
             raise BrokenPipeError("broken pipe")
 
     class _ImmediateThread:
@@ -366,29 +376,37 @@ def test_prompt_submit_fails_open_inline_when_compute_host_dispatch_breaks(monke
     session = _session(agent=None, agent_ready=threading.Event())
     server._sessions["iso-fallback"] = session
     inline_calls = []
-    monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}})
-    monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda _cfg=None: _BrokenSupervisor())
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}}
+    )
+    monkeypatch.setattr(
+        server, "_get_compute_host_supervisor", lambda _cfg=None: _BrokenSupervisor()
+    )
     monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
     monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
     monkeypatch.setattr(server, "_start_agent_build", lambda _sid, _session: None)
     monkeypatch.setattr(server, "_wait_agent", lambda _session, _rid: None)
     # The deferred inline-fallback thread now waits via the patient variant.
-    monkeypatch.setattr(server, "_wait_agent_for_prompt", lambda _session, _rid, _sid: None)
+    monkeypatch.setattr(
+        server, "_wait_agent_for_prompt", lambda _session, _rid, _sid: None
+    )
     monkeypatch.setattr(
         server,
         "_run_prompt_submit",
-        lambda rid, sid, _session, text, **_kwargs: inline_calls.append((rid, sid, text)),
+        lambda rid, sid, _session, text, **_kwargs: inline_calls.append((
+            rid,
+            sid,
+            text,
+        )),
     )
     monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "fallback-turn",
-                "method": "prompt.submit",
-                "params": {"session_id": "iso-fallback", "text": "hello"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "fallback-turn",
+            "method": "prompt.submit",
+            "params": {"session_id": "iso-fallback", "text": "hello"},
+        })
     finally:
         server._sessions.pop("iso-fallback", None)
 
@@ -417,7 +435,11 @@ def test_compute_host_turn_end_updates_metadata_mirror(monkeypatch):
     )
     server._sessions["iso-sid"] = session
     emitted = []
-    monkeypatch.setattr(server, "_emit", lambda event, sid, payload=None: emitted.append((event, sid, payload)))
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, payload=None: emitted.append((event, sid, payload)),
+    )
 
     try:
         server._on_compute_host_turn_done(
@@ -484,22 +506,34 @@ def test_slash_exec_compress_flag_on_applies_host_control_mirror(monkeypatch):
             }
 
     fake = _FakeSupervisor()
-    session = _session(agent=None, agent_ready=threading.Event(), _compute_host_active=True)
+    session = _session(
+        agent=None, agent_ready=threading.Event(), _compute_host_active=True
+    )
     server._sessions["sid"] = session
-    monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}})
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}}
+    )
     monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda _cfg=None: fake)
     monkeypatch.setattr(server, "_SlashWorker", _ExplodingWorker)
-    monkeypatch.setattr(server, "_compress_session_history", lambda *a, **k: (_ for _ in ()).throw(AssertionError("parent compressed")))
-    monkeypatch.setattr(server, "_sync_session_key_after_compress", lambda *a, **k: (_ for _ in ()).throw(AssertionError("parent identity guard ran")))
+    monkeypatch.setattr(
+        server,
+        "_compress_session_history",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("parent compressed")),
+    )
+    monkeypatch.setattr(
+        server,
+        "_sync_session_key_after_compress",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("parent identity guard ran")
+        ),
+    )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "slash.exec",
-                "params": {"command": "compress focus", "session_id": "sid"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "slash.exec",
+            "params": {"command": "compress focus", "session_id": "sid"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -535,7 +569,9 @@ def test_prompt_submit_golden_transcript_matches_flag_off_and_on(monkeypatch):
         def clear_interrupt(self):
             return None
 
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             if stream_callback is not None:
                 stream_callback("hi")
             return {
@@ -546,12 +582,18 @@ def test_prompt_submit_golden_transcript_matches_flag_off_and_on(monkeypatch):
                 ],
             }
 
-    fixed_info = {"model": "gold-model", "provider": "gold-provider", "usage": {"total": 15}}
+    fixed_info = {
+        "model": "gold-model",
+        "provider": "gold-provider",
+        "usage": {"total": 15},
+    }
     usage = server._get_usage(_Agent())
     monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
     monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
     monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
-    monkeypatch.setattr(server, "_session_info", lambda _agent, _session=None: dict(fixed_info))
+    monkeypatch.setattr(
+        server, "_session_info", lambda _agent, _session=None: dict(fixed_info)
+    )
     monkeypatch.setattr(server, "make_stream_renderer", lambda _cols: None)
     monkeypatch.setattr(server, "render_message", lambda _raw, _cols: None)
     fake_title = types.ModuleType("agent.title_generator")
@@ -560,15 +602,24 @@ def test_prompt_submit_golden_transcript_matches_flag_off_and_on(monkeypatch):
 
     def run_flag_off():
         events = []
-        monkeypatch.setattr(server, "_emit", lambda event, sid, payload=None: events.append((event, sid, payload)))
-        monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": False}})
+        monkeypatch.setattr(
+            server,
+            "_emit",
+            lambda event, sid, payload=None: events.append((event, sid, payload)),
+        )
+        monkeypatch.setattr(
+            server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": False}}
+        )
         server._sessions["sid"] = _session(
-            agent=_Agent(), model_override={"model": "gold-model", "provider": "gold-provider"}
+            agent=_Agent(),
+            model_override={"model": "gold-model", "provider": "gold-provider"},
         )
         try:
-            response = server.handle_request(
-                {"id": "turn-1", "method": "prompt.submit", "params": {"session_id": "sid", "text": "hello"}}
-            )
+            response = server.handle_request({
+                "id": "turn-1",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid", "text": "hello"},
+            })
             assert response["result"]["status"] == "streaming"
             return events
         finally:
@@ -576,32 +627,42 @@ def test_prompt_submit_golden_transcript_matches_flag_off_and_on(monkeypatch):
 
     def run_flag_on():
         events = []
-        monkeypatch.setattr(server, "_emit", lambda event, sid, payload=None: events.append((event, sid, payload)))
-        monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}})
+        monkeypatch.setattr(
+            server,
+            "_emit",
+            lambda event, sid, payload=None: events.append((event, sid, payload)),
+        )
+        monkeypatch.setattr(
+            server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}}
+        )
 
         class _FakeSupervisor:
             def submit_turn(self, frame, *, on_complete=None):
                 sid = frame["sid"]
                 server._emit("message.start", sid)
                 server._emit("message.delta", sid, {"text": "hi"})
-                server._emit("message.complete", sid, {"text": "hi", "usage": usage, "status": "complete"})
+                server._emit(
+                    "message.complete",
+                    sid,
+                    {"text": "hi", "usage": usage, "status": "complete"},
+                )
                 server._emit("session.info", sid, dict(fixed_info))
                 if on_complete is not None:
-                    on_complete(
-                        {
-                            "type": "turn.end",
-                            "sid": sid,
-                            "request_id": frame["request_id"],
-                            "session_key": "session-key",
-                            "history_version": 1,
-                            "message_count": 2,
-                            "session_info": dict(fixed_info),
-                            "session_info_emitted": True,
-                        }
-                    )
+                    on_complete({
+                        "type": "turn.end",
+                        "sid": sid,
+                        "request_id": frame["request_id"],
+                        "session_key": "session-key",
+                        "history_version": 1,
+                        "message_count": 2,
+                        "session_info": dict(fixed_info),
+                        "session_info_emitted": True,
+                    })
                 return frame["request_id"]
 
-        monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda _cfg=None: _FakeSupervisor())
+        monkeypatch.setattr(
+            server, "_get_compute_host_supervisor", lambda _cfg=None: _FakeSupervisor()
+        )
         session = _session(
             agent=None,
             agent_ready=threading.Event(),
@@ -611,9 +672,11 @@ def test_prompt_submit_golden_transcript_matches_flag_off_and_on(monkeypatch):
         session["agent"] = None
         server._sessions["sid"] = session
         try:
-            response = server.handle_request(
-                {"id": "turn-1", "method": "prompt.submit", "params": {"session_id": "sid", "text": "hello"}}
-            )
+            response = server.handle_request({
+                "id": "turn-1",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid", "text": "hello"},
+            })
             assert response["result"]["status"] == "streaming"
             return events
         finally:
@@ -662,9 +725,7 @@ def test_profile_scoped_mcp_discovery_uses_target_home(monkeypatch, tmp_path):
     profile_home.mkdir(parents=True)
 
     (profile_home / "config.yaml").write_text(
-        "mcp_servers:\n"
-        "  bluesky_sheepyr:\n"
-        "    command: test-command\n",
+        "mcp_servers:\n  bluesky_sheepyr:\n    command: test-command\n",
         encoding="utf-8",
     )
 
@@ -717,8 +778,7 @@ def test_profile_scoped_agent_build_starts_mcp_discovery_in_profile_home(
     monkeypatch.setattr(
         server,
         "_make_agent",
-        lambda *args, **kwargs: built.set()
-        or type("Agent", (), {"model": "test"})(),
+        lambda *args, **kwargs: built.set() or type("Agent", (), {"model": "test"})(),
     )
     monkeypatch.setattr(
         "tui_gateway.entry.ensure_mcp_discovery_started",
@@ -768,9 +828,7 @@ def test_profile_scoped_agent_build_installs_secret_scope(monkeypatch, tmp_path)
 
     profile_home = tmp_path / "profiles" / "grace"
     profile_home.mkdir(parents=True)
-    (profile_home / ".env").write_text(
-        "PROXMOX_TOKEN=grace-secret\n", encoding="utf-8"
-    )
+    (profile_home / ".env").write_text("PROXMOX_TOKEN=grace-secret\n", encoding="utf-8")
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "default"))
 
@@ -784,9 +842,7 @@ def test_profile_scoped_agent_build_installs_secret_scope(monkeypatch, tmp_path)
         return type("Agent", (), {"model": "test"})()
 
     monkeypatch.setattr(server, "_make_agent", _fake_make_agent)
-    monkeypatch.setattr(
-        "tui_gateway.entry.ensure_mcp_discovery_started", lambda: None
-    )
+    monkeypatch.setattr("tui_gateway.entry.ensure_mcp_discovery_started", lambda: None)
     monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
     monkeypatch.setattr(server, "_SlashWorker", lambda *args: None)
     monkeypatch.setattr(server, "_attach_worker", lambda *args: None)
@@ -868,7 +924,9 @@ def test_completion_cwd_prefers_launch_config_over_stale_env(monkeypatch, tmp_pa
     stale.mkdir()
 
     monkeypatch.setenv("TERMINAL_CWD", str(stale))
-    monkeypatch.setattr(server, "_load_cfg", lambda: {"terminal": {"cwd": str(configured)}})
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"terminal": {"cwd": str(configured)}}
+    )
     monkeypatch.setattr(server, "_profile_home", lambda _name: None)
 
     assert server._completion_cwd({}) == str(configured)
@@ -884,7 +942,9 @@ def test_default_session_cwd_prefers_launch_config(monkeypatch, tmp_path):
     stale.mkdir()
 
     monkeypatch.setenv("TERMINAL_CWD", str(stale))
-    monkeypatch.setattr(server, "_load_cfg", lambda: {"terminal": {"cwd": str(configured)}})
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"terminal": {"cwd": str(configured)}}
+    )
 
     assert server._default_session_cwd() == str(configured)
 
@@ -1043,11 +1103,14 @@ def test_write_json_drops_detached_ws_frames(monkeypatch):
     monkeypatch.setattr(server, "_real_stdout", out)
     server._sessions["detached-sid"] = {"transport": server._detached_ws_transport}
     try:
-        assert server.write_json({
-            "jsonrpc": "2.0",
-            "method": "event",
-            "params": {"session_id": "detached-sid", "type": "message.delta"},
-        }) is False
+        assert (
+            server.write_json({
+                "jsonrpc": "2.0",
+                "method": "event",
+                "params": {"session_id": "detached-sid", "type": "message.delta"},
+            })
+            is False
+        )
         assert out.parts == []
     finally:
         server._sessions.pop("detached-sid", None)
@@ -1060,7 +1123,9 @@ def test_usage_ticker_emits_wrapped_usage_payload(monkeypatch):
     # …) silently drops every live tick on the client side.
     events: list[tuple[str, str, dict]] = []
     monkeypatch.setattr(
-        server, "_emit", lambda event_type, sid, payload: events.append((event_type, sid, payload))
+        server,
+        "_emit",
+        lambda event_type, sid, payload: events.append((event_type, sid, payload)),
     )
     snapshot = {"input": 1200, "total": 1280}
     monkeypatch.setattr(server, "_get_usage", lambda agent: dict(snapshot))
@@ -1237,13 +1302,11 @@ def test_run_prompt_submit_never_ticks_after_message_complete(monkeypatch):
 
     server._sessions["sid"] = _session(agent=_Agent())
     try:
-        server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid", "text": "hello"},
-            }
-        )
+        server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "hello"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -1346,13 +1409,11 @@ def test_run_prompt_submit_joins_ticker_without_timeout(monkeypatch):
 
     server._sessions["sid"] = _session(agent=_Agent())
     try:
-        server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid", "text": "hello"},
-            }
-        )
+        server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "hello"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -1409,7 +1470,9 @@ def test_tui_verbose_tool_events_omit_details_when_redaction_fails(monkeypatch):
 
     events: list[tuple[str, str, dict]] = []
     monkeypatch.setattr(
-        server, "_emit", lambda event_type, sid, payload: events.append((event_type, sid, payload))
+        server,
+        "_emit",
+        lambda event_type, sid, payload: events.append((event_type, sid, payload)),
     )
     monkeypatch.setitem(
         server._sessions,
@@ -1418,7 +1481,9 @@ def test_tui_verbose_tool_events_omit_details_when_redaction_fails(monkeypatch):
     )
 
     server._on_tool_start("redaction-test", "tool-1", "terminal", {"command": "pwd"})
-    server._on_tool_complete("redaction-test", "tool-1", "terminal", {"command": "pwd"}, "done")
+    server._on_tool_complete(
+        "redaction-test", "tool-1", "terminal", {"command": "pwd"}, "done"
+    )
 
     assert events[0][0] == "tool.start"
     assert events[1][0] == "tool.complete"
@@ -1429,7 +1494,9 @@ def test_tui_verbose_tool_events_omit_details_when_redaction_fails(monkeypatch):
 def test_tui_tool_output_risk_event_exposes_metadata_without_raw_output(monkeypatch):
     events: list[tuple[str, str, dict]] = []
     monkeypatch.setattr(
-        server, "_emit", lambda event_type, sid, payload: events.append((event_type, sid, payload))
+        server,
+        "_emit",
+        lambda event_type, sid, payload: events.append((event_type, sid, payload)),
     )
     monkeypatch.setitem(
         server._sessions,
@@ -1449,24 +1516,28 @@ def test_tui_tool_output_risk_event_exposes_metadata_without_raw_output(monkeypa
         },
     )
 
-    assert events == [(
-        "tool.output_risk",
-        "risk-test",
-        {
-            "tool_id": "tool-1",
-            "name": "web_extract",
-            "risk": "high",
-            "findings": ["prompt_injection"],
-            "redacted": False,
-        },
-    )]
+    assert events == [
+        (
+            "tool.output_risk",
+            "risk-test",
+            {
+                "tool_id": "tool-1",
+                "name": "web_extract",
+                "risk": "high",
+                "findings": ["prompt_injection"],
+                "redacted": False,
+            },
+        )
+    ]
     assert "result" not in events[0][2]
 
 
 def test_tui_clarify_lifecycle_events_emit_when_tool_progress_off(monkeypatch):
     events: list[tuple[str, str, dict]] = []
     monkeypatch.setattr(
-        server, "_emit", lambda event_type, sid, payload: events.append((event_type, sid, payload))
+        server,
+        "_emit",
+        lambda event_type, sid, payload: events.append((event_type, sid, payload)),
     )
     monkeypatch.setitem(
         server._sessions,
@@ -1478,7 +1549,9 @@ def test_tui_clarify_lifecycle_events_emit_when_tool_progress_off(monkeypatch):
     result = '{"question":"Pick one","choices_offered":["A","B"],"user_response":"A"}'
 
     server._on_tool_start("clarify-off-test", "tool-clarify", "clarify", args)
-    server._on_tool_complete("clarify-off-test", "tool-clarify", "clarify", args, result)
+    server._on_tool_complete(
+        "clarify-off-test", "tool-clarify", "clarify", args, result
+    )
 
     assert [event[0] for event in events] == ["tool.start", "tool.complete"]
     assert events[0][2]["name"] == "clarify"
@@ -1486,10 +1559,14 @@ def test_tui_clarify_lifecycle_events_emit_when_tool_progress_off(monkeypatch):
     assert events[1][2]["result"]["user_response"] == "A"
 
 
-def test_tui_non_interactive_tool_lifecycle_stays_hidden_when_tool_progress_off(monkeypatch):
+def test_tui_non_interactive_tool_lifecycle_stays_hidden_when_tool_progress_off(
+    monkeypatch,
+):
     events: list[tuple[str, str, dict]] = []
     monkeypatch.setattr(
-        server, "_emit", lambda event_type, sid, payload: events.append((event_type, sid, payload))
+        server,
+        "_emit",
+        lambda event_type, sid, payload: events.append((event_type, sid, payload)),
     )
     monkeypatch.setitem(
         server._sessions,
@@ -1498,7 +1575,9 @@ def test_tui_non_interactive_tool_lifecycle_stays_hidden_when_tool_progress_off(
     )
 
     server._on_tool_start("terminal-off-test", "tool-1", "terminal", {"command": "pwd"})
-    server._on_tool_complete("terminal-off-test", "tool-1", "terminal", {"command": "pwd"}, "done")
+    server._on_tool_complete(
+        "terminal-off-test", "tool-1", "terminal", {"command": "pwd"}, "done"
+    )
 
     assert events == []
 
@@ -1568,9 +1647,11 @@ def test_config_set_battery_toggles_and_persists(monkeypatch):
         server, "_write_config_key", lambda k, v: writes.__setitem__(k, v)
     )
 
-    resp = server.dispatch(
-        {"id": "c1", "method": "config.set", "params": {"key": "battery", "value": ""}}
-    )
+    resp = server.dispatch({
+        "id": "c1",
+        "method": "config.set",
+        "params": {"key": "battery", "value": ""},
+    })
 
     assert resp["result"] == {"key": "battery", "value": "on"}
     assert writes == {"display.battery": True}
@@ -1583,13 +1664,11 @@ def test_config_set_battery_explicit_off(monkeypatch):
         server, "_write_config_key", lambda k, v: writes.__setitem__(k, v)
     )
 
-    resp = server.dispatch(
-        {
-            "id": "c2",
-            "method": "config.set",
-            "params": {"key": "battery", "value": "off"},
-        }
-    )
+    resp = server.dispatch({
+        "id": "c2",
+        "method": "config.set",
+        "params": {"key": "battery", "value": "off"},
+    })
 
     assert resp["result"] == {"key": "battery", "value": "off"}
     assert writes == {"display.battery": False}
@@ -1615,12 +1694,16 @@ def test_voice_toggle_returns_configured_record_key(monkeypatch):
     # review on #19835).
     monkeypatch.setenv("HERMES_VOICE", "0")
 
-    on_resp = _dispatch_sync(
-        {"id": "voice-on", "method": "voice.toggle", "params": {"action": "on"}}
-    )
-    status_resp = _dispatch_sync(
-        {"id": "voice-status", "method": "voice.toggle", "params": {"action": "status"}}
-    )
+    on_resp = _dispatch_sync({
+        "id": "voice-on",
+        "method": "voice.toggle",
+        "params": {"action": "on"},
+    })
+    status_resp = _dispatch_sync({
+        "id": "voice-status",
+        "method": "voice.toggle",
+        "params": {"action": "status"},
+    })
 
     assert on_resp["result"]["record_key"] == "ctrl+o"
     assert status_resp["result"]["record_key"] == "ctrl+o"
@@ -1641,9 +1724,11 @@ def test_voice_toggle_on_carries_stop_hint(monkeypatch):
     )
     monkeypatch.setenv("HERMES_VOICE", "0")
 
-    on_resp = _dispatch_sync(
-        {"id": "voice-on", "method": "voice.toggle", "params": {"action": "on"}}
-    )
+    on_resp = _dispatch_sync({
+        "id": "voice-on",
+        "method": "voice.toggle",
+        "params": {"action": "on"},
+    })
     assert on_resp["result"]["stop_hint"] == 'Say "halt" to end the voice chat.'
 
     # Disabled stop phrases → empty hint, clients show nothing.
@@ -1655,15 +1740,19 @@ def test_voice_toggle_on_carries_stop_hint(monkeypatch):
             voice_stop_hint=lambda: "",
         ),
     )
-    on_resp = _dispatch_sync(
-        {"id": "voice-on2", "method": "voice.toggle", "params": {"action": "on"}}
-    )
+    on_resp = _dispatch_sync({
+        "id": "voice-on2",
+        "method": "voice.toggle",
+        "params": {"action": "on"},
+    })
     assert on_resp["result"]["stop_hint"] == ""
 
     # off carries no hint text (mode is ending).
-    off_resp = _dispatch_sync(
-        {"id": "voice-off", "method": "voice.toggle", "params": {"action": "off"}}
-    )
+    off_resp = _dispatch_sync({
+        "id": "voice-off",
+        "method": "voice.toggle",
+        "params": {"action": "off"},
+    })
     assert off_resp["result"]["stop_hint"] == ""
 
 
@@ -1687,17 +1776,15 @@ def test_voice_toggle_handles_non_dict_voice_cfg(monkeypatch):
     for bad in (True, "cmd+b", None, 42, ["ctrl+b"]):
         monkeypatch.setattr(server, "_load_cfg", lambda b=bad: {"voice": b})
 
-        status_resp = _dispatch_sync(
-            {
-                "id": "voice-status",
-                "method": "voice.toggle",
-                "params": {"action": "status"},
-            }
-        )
+        status_resp = _dispatch_sync({
+            "id": "voice-status",
+            "method": "voice.toggle",
+            "params": {"action": "status"},
+        })
 
-        assert (
-            status_resp["result"]["record_key"] == "ctrl+b"
-        ), f"voice.record_key fell back to default for voice={bad!r}"
+        assert status_resp["result"]["record_key"] == "ctrl+b", (
+            f"voice.record_key fell back to default for voice={bad!r}"
+        )
 
     # Round-4 follow-up: the YAML root itself may be a non-dict. A
     # hand-edit that collapses config.yaml to a scalar / list would
@@ -1706,17 +1793,15 @@ def test_voice_toggle_handles_non_dict_voice_cfg(monkeypatch):
     for bad_root in (True, None, [], "ctrl+b", 42):
         monkeypatch.setattr(server, "_load_cfg", lambda r=bad_root: r)
 
-        status_resp = _dispatch_sync(
-            {
-                "id": "voice-status-root",
-                "method": "voice.toggle",
-                "params": {"action": "status"},
-            }
-        )
+        status_resp = _dispatch_sync({
+            "id": "voice-status-root",
+            "method": "voice.toggle",
+            "params": {"action": "status"},
+        })
 
-        assert (
-            status_resp["result"]["record_key"] == "ctrl+b"
-        ), f"voice.record_key fell back to default for root={bad_root!r}"
+        assert status_resp["result"]["record_key"] == "ctrl+b", (
+            f"voice.record_key fell back to default for root={bad_root!r}"
+        )
 
 
 def test_voice_record_start_handles_non_dict_voice_cfg(monkeypatch):
@@ -1747,22 +1832,19 @@ def test_voice_record_start_handles_non_dict_voice_cfg(monkeypatch):
         captured.clear()
         monkeypatch.setattr(server, "_load_cfg", lambda b=bad: {"voice": b})
 
-        resp = _dispatch_sync(
-            {
-                "id": "voice-record",
-                "method": "voice.record",
-                "params": {"action": "start"},
-            }
-        )
+        resp = _dispatch_sync({
+            "id": "voice-record",
+            "method": "voice.record",
+            "params": {"action": "start"},
+        })
 
-        assert (
-            "result" in resp
-        ), f"voice.record raised for voice={bad!r}: {resp.get('error')}"
+        assert "result" in resp, (
+            f"voice.record raised for voice={bad!r}: {resp.get('error')}"
+        )
         assert resp["result"]["status"] == "recording"
         assert captured["silence_threshold"] == 200
         assert captured["silence_duration"] == 3.0
         assert captured["auto_restart"] is False
-
 
     # Round-12 Copilot review regression on #19835: ``bool`` is a subclass
     # of ``int``, so the naive ``isinstance(threshold, (int, float))``
@@ -1776,21 +1858,19 @@ def test_voice_record_start_handles_non_dict_voice_cfg(monkeypatch):
         captured.clear()
         monkeypatch.setattr(server, "_load_cfg", lambda c=bad_bool_cfg: {"voice": c})
 
-        resp = _dispatch_sync(
-            {
-                "id": "voice-record-bool",
-                "method": "voice.record",
-                "params": {"action": "start"},
-            }
-        )
+        resp = _dispatch_sync({
+            "id": "voice-record-bool",
+            "method": "voice.record",
+            "params": {"action": "start"},
+        })
 
         assert "result" in resp, f"voice.record raised for bool cfg={bad_bool_cfg!r}"
-        assert (
-            captured["silence_threshold"] == 200
-        ), f"bool silence_threshold leaked through for {bad_bool_cfg!r}"
-        assert (
-            captured["silence_duration"] == 3.0
-        ), f"bool silence_duration leaked through for {bad_bool_cfg!r}"
+        assert captured["silence_threshold"] == 200, (
+            f"bool silence_threshold leaked through for {bad_bool_cfg!r}"
+        )
+        assert captured["silence_duration"] == 3.0, (
+            f"bool silence_duration leaked through for {bad_bool_cfg!r}"
+        )
         assert captured["auto_restart"] is False
 
 
@@ -1802,7 +1882,9 @@ def test_prompt_submit_typed_stop_phrase_ends_voice_chat(monkeypatch):
     calls = {"stop_continuous": 0}
     emitted = []
     monkeypatch.setattr(
-        server, "_emit", lambda event, sid, payload=None: emitted.append((event, payload))
+        server,
+        "_emit",
+        lambda event, sid, payload=None: emitted.append((event, payload)),
     )
     monkeypatch.setitem(
         sys.modules,
@@ -1824,13 +1906,11 @@ def test_prompt_submit_typed_stop_phrase_ends_voice_chat(monkeypatch):
     monkeypatch.setenv("HERMES_VOICE", "1")
     monkeypatch.setenv("HERMES_VOICE_TTS", "1")
 
-    resp = server.dispatch(
-        {
-            "id": "typed-stop",
-            "method": "prompt.submit",
-            "params": {"session_id": "any-sid", "text": "Stop."},
-        }
-    )
+    resp = server.dispatch({
+        "id": "typed-stop",
+        "method": "prompt.submit",
+        "params": {"session_id": "any-sid", "text": "Stop."},
+    })
 
     assert resp["result"] == {"voice_stopped": True}
     assert os.environ["HERMES_VOICE"] == "0"
@@ -1853,13 +1933,11 @@ def test_prompt_submit_typed_stop_passes_through_when_voice_off(monkeypatch):
     )
     monkeypatch.setenv("HERMES_VOICE", "0")
 
-    resp = server.dispatch(
-        {
-            "id": "typed-stop-off",
-            "method": "prompt.submit",
-            "params": {"session_id": "missing-sid", "text": "stop"},
-        }
-    )
+    resp = server.dispatch({
+        "id": "typed-stop-off",
+        "method": "prompt.submit",
+        "params": {"session_id": "missing-sid", "text": "stop"},
+    })
 
     # The submit proceeds into normal handling (here: unknown session error),
     # NOT the voice_stopped consumption path.
@@ -1867,7 +1945,7 @@ def test_prompt_submit_typed_stop_passes_through_when_voice_off(monkeypatch):
 
 
 def test_prompt_submit_longer_text_not_consumed_in_voice_mode(monkeypatch):
-    """"stop the build" while voice is on must reach the agent path."""
+    """ "stop the build" while voice is on must reach the agent path."""
     monkeypatch.setitem(
         sys.modules,
         "tools.voice_mode",
@@ -1877,13 +1955,11 @@ def test_prompt_submit_longer_text_not_consumed_in_voice_mode(monkeypatch):
     )
     monkeypatch.setenv("HERMES_VOICE", "1")
 
-    resp = server.dispatch(
-        {
-            "id": "typed-long",
-            "method": "prompt.submit",
-            "params": {"session_id": "missing-sid", "text": "stop the build"},
-        }
-    )
+    resp = server.dispatch({
+        "id": "typed-long",
+        "method": "prompt.submit",
+        "params": {"session_id": "missing-sid", "text": "stop the build"},
+    })
 
     assert resp.get("result") != {"voice_stopped": True}
 
@@ -1926,22 +2002,32 @@ def test_wake_owner_is_sticky_and_routes_detection_to_first_transport(monkeypatc
         voice_callbacks.update(callbacks)
         return True
 
-    monkeypatch.setattr(wake_word, "load_wake_word_config", lambda: {
-        "enabled": True,
-        "phrase": "hey hermes",
-        "surface": "auto",
-        "start_new_session": True,
-    })
-    monkeypatch.setattr(wake_word, "check_wake_word_requirements", lambda _cfg: {
-        "available": True,
-        "phrase": "hey hermes",
-        "provider": "test",
-        "hint": "",
-    })
+    monkeypatch.setattr(
+        wake_word,
+        "load_wake_word_config",
+        lambda: {
+            "enabled": True,
+            "phrase": "hey hermes",
+            "surface": "auto",
+            "start_new_session": True,
+        },
+    )
+    monkeypatch.setattr(
+        wake_word,
+        "check_wake_word_requirements",
+        lambda _cfg: {
+            "available": True,
+            "phrase": "hey hermes",
+            "provider": "test",
+            "hint": "",
+        },
+    )
     monkeypatch.setattr(wake_word, "start_listening", start_listening)
     monkeypatch.setattr(wake_word, "pause_listening", pause_listening)
     monkeypatch.setattr(wake_word, "stop_listening", stop_listening)
-    monkeypatch.setattr(wake_word, "owns_listener", lambda owner: state["owner"] is owner)
+    monkeypatch.setattr(
+        wake_word, "owns_listener", lambda owner: state["owner"] is owner
+    )
     monkeypatch.setattr(
         wake_word,
         "is_listening",
@@ -1968,33 +2054,48 @@ def test_wake_owner_is_sticky_and_routes_detection_to_first_transport(monkeypatc
     monkeypatch.setattr(
         server,
         "_emit",
-        lambda event, sid, payload: emitted.append(
-            (event, sid, payload, server.current_transport())
-        ),
+        lambda event, sid, payload: emitted.append((
+            event,
+            sid,
+            payload,
+            server.current_transport(),
+        )),
     )
     server._wake_owner_transport = None
     server._wake_owner_surface = ""
     try:
-        started = _dispatch_sync({
-            "id": "wake-1",
-            "method": "wake.start",
-            "params": {"surface": "gui", "session_id": "first-session"},
-        }, transport=first)
-        denied = _dispatch_sync({
-            "id": "wake-2",
-            "method": "wake.start",
-            "params": {"surface": "tui", "session_id": "second-session"},
-        }, transport=second)
-        denied_stop = server.dispatch({
-            "id": "wake-stop-2",
-            "method": "wake.stop",
-            "params": {},
-        }, transport=second)
-        denied_voice_stop = _dispatch_sync({
-            "id": "voice-stop-2",
-            "method": "voice.record",
-            "params": {"action": "stop"},
-        }, transport=second)
+        started = _dispatch_sync(
+            {
+                "id": "wake-1",
+                "method": "wake.start",
+                "params": {"surface": "gui", "session_id": "first-session"},
+            },
+            transport=first,
+        )
+        denied = _dispatch_sync(
+            {
+                "id": "wake-2",
+                "method": "wake.start",
+                "params": {"surface": "tui", "session_id": "second-session"},
+            },
+            transport=second,
+        )
+        denied_stop = server.dispatch(
+            {
+                "id": "wake-stop-2",
+                "method": "wake.stop",
+                "params": {},
+            },
+            transport=second,
+        )
+        denied_voice_stop = _dispatch_sync(
+            {
+                "id": "voice-stop-2",
+                "method": "voice.record",
+                "params": {"action": "stop"},
+            },
+            transport=second,
+        )
 
         assert started["result"]["started"] is True
         assert denied["result"] == {
@@ -2013,39 +2114,50 @@ def test_wake_owner_is_sticky_and_routes_detection_to_first_transport(monkeypatc
         }
 
         state["callback"]()
-        assert emitted == [(
-            "wake.detected",
-            "first-session",
-            {"phrase": "hey hermes", "profile": None, "start_new_session": True},
-            first,
-        )]
+        assert emitted == [
+            (
+                "wake.detected",
+                "first-session",
+                {"phrase": "hey hermes", "profile": None, "start_new_session": True},
+                first,
+            )
+        ]
         assert state["paused"] is True
 
-        voice_started = _dispatch_sync({
-            "id": "voice-start-1",
-            "method": "voice.record",
-            "params": {"action": "start", "session_id": "first-session"},
-        }, transport=first)
+        voice_started = _dispatch_sync(
+            {
+                "id": "voice-start-1",
+                "method": "voice.record",
+                "params": {"action": "start", "session_id": "first-session"},
+            },
+            transport=first,
+        )
         assert voice_started["result"]["status"] == "recording"
         voice_callbacks["on_status"]("idle")
         assert state["paused"] is False
 
-        stopped = server.dispatch({
-            "id": "wake-stop-1",
-            "method": "wake.stop",
-            "params": {},
-        }, transport=first)
+        stopped = server.dispatch(
+            {
+                "id": "wake-stop-1",
+                "method": "wake.stop",
+                "params": {},
+            },
+            transport=first,
+        )
         assert stopped["result"] == {
             "stopped": True,
             "reason": None,
             "disabled_persisted": False,
         }
 
-        reclaimed = _dispatch_sync({
-            "id": "wake-reclaim-2",
-            "method": "wake.start",
-            "params": {"surface": "tui", "session_id": "second-session"},
-        }, transport=second)
+        reclaimed = _dispatch_sync(
+            {
+                "id": "wake-reclaim-2",
+                "method": "wake.start",
+                "params": {"surface": "tui", "session_id": "second-session"},
+            },
+            transport=second,
+        )
         assert reclaimed["result"]["started"] is True
         assert state["owner"] is second
 
@@ -2057,11 +2169,14 @@ def test_wake_owner_is_sticky_and_routes_detection_to_first_transport(monkeypatc
             second,
         )
 
-        stopped_again = server.dispatch({
-            "id": "wake-stop-2-after-reclaim",
-            "method": "wake.stop",
-            "params": {},
-        }, transport=second)
+        stopped_again = server.dispatch(
+            {
+                "id": "wake-stop-2-after-reclaim",
+                "method": "wake.stop",
+                "params": {},
+            },
+            transport=second,
+        )
         assert stopped_again["result"] == {
             "stopped": True,
             "reason": None,
@@ -2076,8 +2191,12 @@ def test_wake_toggle_persists_enabled_flag_only_on_explicit_gesture(monkeypatch)
     """The ear toggle / /wake on|off write wake_word.enabled; auto-arm never does."""
     from tools import wake_word
 
-    config = {"enabled": False, "phrase": "hey hermes", "surface": "auto",
-              "start_new_session": True}
+    config = {
+        "enabled": False,
+        "phrase": "hey hermes",
+        "surface": "auto",
+        "start_new_session": True,
+    }
     persisted = []
 
     def fake_persist(enabled):
@@ -2087,65 +2206,85 @@ def test_wake_toggle_persists_enabled_flag_only_on_explicit_gesture(monkeypatch)
 
     monkeypatch.setattr(server, "_persist_wake_enabled", fake_persist)
     monkeypatch.setattr(wake_word, "load_wake_word_config", lambda: dict(config))
-    monkeypatch.setattr(wake_word, "check_wake_word_requirements", lambda _cfg: {
-        "available": True,
-        "phrase": "hey hermes",
-        "provider": "test",
-        "hint": "",
-    })
+    monkeypatch.setattr(
+        wake_word,
+        "check_wake_word_requirements",
+        lambda _cfg: {
+            "available": True,
+            "phrase": "hey hermes",
+            "provider": "test",
+            "hint": "",
+        },
+    )
     listener = {"owner": None}
     monkeypatch.setattr(
-        wake_word, "start_listening",
+        wake_word,
+        "start_listening",
         lambda callback, *, owner, config, external_audio=False: listener.update(
             owner=owner, external_audio=bool(external_audio)
         ),
     )
     monkeypatch.setattr(
-        wake_word, "stop_listening",
+        wake_word,
+        "stop_listening",
         lambda *, owner: listener["owner"] is owner and not listener.update(owner=None),
     )
-    monkeypatch.setattr(wake_word, "owns_listener", lambda owner: listener["owner"] is owner)
+    monkeypatch.setattr(
+        wake_word, "owns_listener", lambda owner: listener["owner"] is owner
+    )
 
     transport = types.SimpleNamespace(_closed=False)
     server._wake_owner_transport = None
     server._wake_owner_surface = ""
     try:
         # Passive auto-arm (no persist): refused, config untouched.
-        passive = _dispatch_sync({
-            "id": "wake-passive",
-            "method": "wake.start",
-            "params": {"surface": "gui"},
-        }, transport=transport)
+        passive = _dispatch_sync(
+            {
+                "id": "wake-passive",
+                "method": "wake.start",
+                "params": {"surface": "gui"},
+            },
+            transport=transport,
+        )
         assert passive["result"] == {"started": False, "reason": "disabled"}
         assert persisted == []
 
         # Explicit gesture: enables in config AND arms.
-        clicked = _dispatch_sync({
-            "id": "wake-click",
-            "method": "wake.start",
-            "params": {"surface": "gui", "persist": True},
-        }, transport=transport)
+        clicked = _dispatch_sync(
+            {
+                "id": "wake-click",
+                "method": "wake.start",
+                "params": {"surface": "gui", "persist": True},
+            },
+            transport=transport,
+        )
         assert clicked["result"]["started"] is True
         assert clicked["result"]["enabled_persisted"] is True
         assert persisted == [True]
 
         # Explicit stop: disables in config.
-        stopped = server.dispatch({
-            "id": "wake-click-off",
-            "method": "wake.stop",
-            "params": {"persist": True},
-        }, transport=transport)
+        stopped = server.dispatch(
+            {
+                "id": "wake-click-off",
+                "method": "wake.stop",
+                "params": {"persist": True},
+            },
+            transport=transport,
+        )
         assert stopped["result"]["stopped"] is True
         assert stopped["result"]["disabled_persisted"] is True
         assert persisted == [True, False]
 
         # persist does NOT override an explicit surface scoping.
         config.update(enabled=True, surface="tui")
-        scoped = _dispatch_sync({
-            "id": "wake-scoped",
-            "method": "wake.start",
-            "params": {"surface": "gui", "persist": True},
-        }, transport=transport)
+        scoped = _dispatch_sync(
+            {
+                "id": "wake-scoped",
+                "method": "wake.start",
+                "params": {"surface": "gui", "persist": True},
+            },
+            transport=transport,
+        )
         assert scoped["result"] == {"started": False, "reason": "disabled_for_surface"}
         assert persisted == [True, False]
     finally:
@@ -2153,7 +2292,9 @@ def test_wake_toggle_persists_enabled_flag_only_on_explicit_gesture(monkeypatch)
         server._wake_owner_surface = ""
 
 
-def test_wake_status_reports_configured_input_device_and_windows_silence_hint(monkeypatch):
+def test_wake_status_reports_configured_input_device_and_windows_silence_hint(
+    monkeypatch,
+):
     from tools import wake_word
 
     config = {
@@ -2234,29 +2375,29 @@ def test_voice_record_start_forwards_max_recording_seconds(monkeypatch):
     monkeypatch.setenv("HERMES_VOICE", "1")
 
     for cfg, expected in (
-        ({"max_recording_seconds": 45}, 45),        # explicit cap forwarded as-is
-        ({"max_recording_seconds": 0}, 0.0),        # explicit 0 = disabled
-        ({"max_recording_seconds": -5}, 0.0),       # negative = disabled
-        ({}, 120.0),                                # missing = documented default
-        ({"max_recording_seconds": True}, 120.0),   # bool must not become 1s cap
-        ({"max_recording_seconds": "long"}, 120.0), # garbage = documented default
+        ({"max_recording_seconds": 45}, 45),  # explicit cap forwarded as-is
+        ({"max_recording_seconds": 0}, 0.0),  # explicit 0 = disabled
+        ({"max_recording_seconds": -5}, 0.0),  # negative = disabled
+        ({}, 120.0),  # missing = documented default
+        ({"max_recording_seconds": True}, 120.0),  # bool must not become 1s cap
+        ({"max_recording_seconds": "long"}, 120.0),  # garbage = documented default
     ):
         captured.clear()
         monkeypatch.setattr(server, "_load_cfg", lambda c=cfg: {"voice": c})
 
-        resp = _dispatch_sync(
-            {
-                "id": "voice-record-cap",
-                "method": "voice.record",
-                "params": {"action": "start"},
-            }
-        )
+        resp = _dispatch_sync({
+            "id": "voice-record-cap",
+            "method": "voice.record",
+            "params": {"action": "start"},
+        })
 
-        assert "result" in resp, f"voice.record raised for cfg={cfg!r}: {resp.get('error')}"
+        assert "result" in resp, (
+            f"voice.record raised for cfg={cfg!r}: {resp.get('error')}"
+        )
         assert resp["result"]["status"] == "recording"
-        assert (
-            captured["max_recording_seconds"] == expected
-        ), f"cfg={cfg!r} forwarded {captured.get('max_recording_seconds')!r}, expected {expected!r}"
+        assert captured["max_recording_seconds"] == expected, (
+            f"cfg={cfg!r} forwarded {captured.get('max_recording_seconds')!r}, expected {expected!r}"
+        )
 
 
 def test_voice_record_stop_forces_transcription(monkeypatch):
@@ -2274,13 +2415,11 @@ def test_voice_record_stop_forces_transcription(monkeypatch):
         ),
     )
 
-    resp = _dispatch_sync(
-        {
-            "id": "voice-record-stop",
-            "method": "voice.record",
-            "params": {"action": "stop"},
-        }
-    )
+    resp = _dispatch_sync({
+        "id": "voice-record-stop",
+        "method": "voice.record",
+        "params": {"action": "stop"},
+    })
 
     assert resp["result"]["status"] == "stopped"
     assert captured["force_transcribe"] is True
@@ -2297,13 +2436,11 @@ def test_voice_record_stop_updates_event_session_id(monkeypatch):
     )
     monkeypatch.setattr(server, "_voice_event_sid", "old-session")
 
-    resp = _dispatch_sync(
-        {
-            "id": "voice-record-stop-session",
-            "method": "voice.record",
-            "params": {"action": "stop", "session_id": "new-session"},
-        }
-    )
+    resp = _dispatch_sync({
+        "id": "voice-record-stop-session",
+        "method": "voice.record",
+        "params": {"action": "stop", "session_id": "new-session"},
+    })
 
     assert resp["result"]["status"] == "stopped"
     assert server._voice_event_sid == "new-session"
@@ -2321,13 +2458,11 @@ def test_voice_record_start_reports_busy_when_stop_is_in_progress(monkeypatch):
     monkeypatch.setenv("HERMES_VOICE", "1")
     monkeypatch.setattr(server, "_load_cfg", lambda: {"voice": {}})
 
-    resp = _dispatch_sync(
-        {
-            "id": "voice-record-busy",
-            "method": "voice.record",
-            "params": {"action": "start"},
-        }
-    )
+    resp = _dispatch_sync({
+        "id": "voice-record-busy",
+        "method": "voice.record",
+        "params": {"action": "start"},
+    })
 
     assert resp["result"]["status"] == "busy"
 
@@ -2359,9 +2494,11 @@ def test_voice_toggle_tts_branch_also_carries_record_key(monkeypatch):
     # later test in the file (which now spins up the streaming TTS pipeline).
     monkeypatch.setenv("HERMES_VOICE_TTS", "0")
 
-    tts_resp = _dispatch_sync(
-        {"id": "voice-tts", "method": "voice.toggle", "params": {"action": "tts"}}
-    )
+    tts_resp = _dispatch_sync({
+        "id": "voice-tts",
+        "method": "voice.toggle",
+        "params": {"action": "tts"},
+    })
 
     assert tts_resp["result"]["record_key"] == "ctrl+space"
     assert tts_resp["result"]["tts"] is True
@@ -2612,9 +2749,9 @@ def test_history_to_messages_ships_full_tool_args():
     assert rows[1]["context"]
 
     # A tool row with no recorded args keeps the old small shape.
-    argless = server._history_to_messages(
-        [{"role": "tool", "content": "{}", "tool_call_id": "missing"}]
-    )
+    argless = server._history_to_messages([
+        {"role": "tool", "content": "{}", "tool_call_id": "missing"}
+    ])
     assert "args" not in argless[0]
 
 
@@ -2625,7 +2762,9 @@ def test_tool_start_ships_full_args(monkeypatch):
     # every client, so tool.start does too. There is no per-client gate.
     events: list[tuple[str, str, dict]] = []
     monkeypatch.setattr(
-        server, "_emit", lambda event_type, sid, payload: events.append((event_type, sid, payload))
+        server,
+        "_emit",
+        lambda event_type, sid, payload: events.append((event_type, sid, payload)),
     )
     long_command = "echo " + "y" * 200
     monkeypatch.setitem(
@@ -2647,11 +2786,16 @@ def test_tool_ctx_sends_an_arg_preview_not_a_phrased_label():
     # `Terminal("<ctx>")` and the desktop prepends "Running"/"Ran". Sending a
     # pre-phrased label made both stutter ("Ran Running sleep 70 + 2 commands")
     # and stood in for the real command in the desktop's `$` transcript.
-    assert server._tool_ctx("terminal", {"command": 'sleep 70; echo "a"; echo "b"'}) == (
-        "sleep 70 + 2 commands"
+    assert server._tool_ctx(
+        "terminal", {"command": 'sleep 70; echo "a"; echo "b"'}
+    ) == ("sleep 70 + 2 commands")
+    assert (
+        server._tool_ctx("read_file", {"path": "/tmp/demo/package.json"})
+        == "package.json"
     )
-    assert server._tool_ctx("read_file", {"path": "/tmp/demo/package.json"}) == "package.json"
-    assert server._tool_ctx("web_search", {"query": "weather in NYC"}) == "weather in NYC"
+    assert (
+        server._tool_ctx("web_search", {"query": "weather in NYC"}) == "weather in NYC"
+    )
 
 
 def test_history_to_messages_keeps_reasoning_only_assistant_turn():
@@ -2699,7 +2843,10 @@ def test_history_to_messages_renders_multimodal_content():
             "role": "user",
             "content": [
                 {"type": "text", "text": "look here"},
-                {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,abc"},
+                },
             ],
         },
         {"role": "assistant", "content": "saw it"},
@@ -2937,9 +3084,11 @@ def test_session_resume_uses_parent_lineage_for_display(monkeypatch, omit_messag
             include_row_ids=False,
             **_kwargs,
         ):
-            captured.setdefault("history_calls", []).append(
-                (target, include_ancestors, include_row_ids)
-            )
+            captured.setdefault("history_calls", []).append((
+                target,
+                include_ancestors,
+                include_row_ids,
+            ))
             return (
                 [
                     {"role": "user", "content": "root prompt"},
@@ -2964,7 +3113,9 @@ def test_session_resume_uses_parent_lineage_for_display(monkeypatch, omit_messag
         lambda agent, *a: {"model": "test", "tools": {}, "skills": {}},
     )
     monkeypatch.setattr(
-        server, "_init_session", lambda sid, key, agent, history, cols=80, **_kwargs: None
+        server,
+        "_init_session",
+        lambda sid, key, agent, history, cols=80, **_kwargs: None,
     )
     # The deferred pre-warm timer is neutered module-wide by the autouse
     # _neuter_agent_prewarm_timer fixture; this test only asserts the
@@ -2973,21 +3124,31 @@ def test_session_resume_uses_parent_lineage_for_display(monkeypatch, omit_messag
     params = {"session_id": target}
     if omit_messages:
         params["omit_messages"] = True
-    resp = server.handle_request(
-        {"id": "1", "method": "session.resume", "params": params}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.resume",
+        "params": params,
+    })
 
-    expected = [] if omit_messages else [
-        {"role": "user", "text": "root prompt"},
-        {"role": "assistant", "text": "root answer"},
-    ]
+    expected = (
+        []
+        if omit_messages
+        else [
+            {"role": "user", "text": "root prompt"},
+            {"role": "assistant", "text": "root answer"},
+        ]
+    )
     assert resp["result"]["messages"] == expected
     assert resp["result"]["message_count"] == (1 if omit_messages else 2)
     assert resp["result"]["messages_omitted"] is omit_messages
-    expected_calls = [(target, False, True)] if omit_messages else [
-        (target, False, False),
-        (target, True, False),
-    ]
+    expected_calls = (
+        [(target, False, True)]
+        if omit_messages
+        else [
+            (target, False, False),
+            (target, True, False),
+        ]
+    )
     assert captured["history_calls"] == expected_calls
 
 
@@ -3011,8 +3172,11 @@ def test_live_visible_history_prefers_db_display_with_candidate():
     # Persisted display lineage: the candidate (substantive answer) survives.
     display_with_candidate = [
         {"role": "user", "content": "do the thing"},
-        {"role": "assistant", "content": "long substantive answer",
-         "finish_reason": "verification_required"},
+        {
+            "role": "assistant",
+            "content": "long substantive answer",
+            "finish_reason": "verification_required",
+        },
         {"role": "assistant", "content": "terse verified reply"},
     ]
 
@@ -3031,11 +3195,15 @@ def test_live_visible_history_prefers_db_display_with_candidate():
 def test_live_visible_history_falls_back_without_db_or_key():
     in_memory = [{"role": "user", "content": "hi"}]
     # No DB handle available.
-    assert server._live_visible_history({"session_key": "s"}, None, in_memory) == in_memory
+    assert (
+        server._live_visible_history({"session_key": "s"}, None, in_memory) == in_memory
+    )
 
     # DB available but the session has no persist key yet.
     class DB:
-        def get_messages_as_conversation(self, *a, **k):  # pragma: no cover - not reached
+        def get_messages_as_conversation(
+            self, *a, **k
+        ):  # pragma: no cover - not reached
             raise AssertionError("must not query without a session_key")
 
     assert server._live_visible_history({}, DB(), in_memory) == in_memory
@@ -3050,17 +3218,26 @@ def test_live_visible_history_falls_back_when_db_empty():
         def get_messages_as_conversation(self, *a, **k):
             return []
 
-    assert server._live_visible_history({"session_key": "s"}, EmptyDB(), in_memory) == in_memory
+    assert (
+        server._live_visible_history({"session_key": "s"}, EmptyDB(), in_memory)
+        == in_memory
+    )
 
 
 def test_live_visible_history_falls_back_when_db_raises():
-    in_memory = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "yo"}]
+    in_memory = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "yo"},
+    ]
 
     class BrokenDB:
         def get_messages_as_conversation(self, *a, **k):
             raise RuntimeError("db exploded")
 
-    assert server._live_visible_history({"session_key": "s"}, BrokenDB(), in_memory) == in_memory
+    assert (
+        server._live_visible_history({"session_key": "s"}, BrokenDB(), in_memory)
+        == in_memory
+    )
 
 
 def test_live_visible_history_keeps_candidate_and_fresh_tail():
@@ -3069,8 +3246,11 @@ def test_live_visible_history_keeps_candidate_and_fresh_tail():
     # Persisted display: has the verification candidate, lags the newest turn.
     db_display = [
         {"role": "user", "content": "turn 1"},
-        {"role": "assistant", "content": "long substantive answer",
-         "finish_reason": "verification_required"},
+        {
+            "role": "assistant",
+            "content": "long substantive answer",
+            "finish_reason": "verification_required",
+        },
         {"role": "assistant", "content": "terse verified reply"},
     ]
     # In-memory model history: candidate collapsed out, but has a fresh turn 2.
@@ -3082,14 +3262,19 @@ def test_live_visible_history_keeps_candidate_and_fresh_tail():
     ]
 
     class DB:
-        def get_messages_as_conversation(self, key, include_ancestors=False, repair_alternation=False, **_kwargs):
+        def get_messages_as_conversation(
+            self, key, include_ancestors=False, repair_alternation=False, **_kwargs
+        ):
             return list(db_display)
 
     result = server._live_visible_history({"session_key": "s1"}, DB(), in_memory)
     assert result == [
         {"role": "user", "content": "turn 1"},
-        {"role": "assistant", "content": "long substantive answer",
-         "finish_reason": "verification_required"},
+        {
+            "role": "assistant",
+            "content": "long substantive answer",
+            "finish_reason": "verification_required",
+        },
         {"role": "assistant", "content": "terse verified reply"},
         {"role": "user", "content": "turn 2 not flushed"},
         {"role": "assistant", "content": "turn 2 reply not flushed"},
@@ -3125,24 +3310,33 @@ def test_live_visible_history_matches_eager_resume_with_real_db(tmp_path):
     db.create_session("s1", source="tui")
     db.append_message("s1", role="user", content="do the thing")
     db.append_message(
-        "s1", role="assistant", content="long substantive answer",
+        "s1",
+        role="assistant",
+        content="long substantive answer",
         finish_reason="verification_required",
     )
     db.append_message(
-        "s1", role="assistant", content="terse verified reply", finish_reason="stop",
+        "s1",
+        role="assistant",
+        content="terse verified reply",
+        finish_reason="stop",
     )
 
     model_history, display_history = db.get_resume_conversations("s1")
 
     # The divergence #65919 introduced: candidate absent from the model
     # projection, present in the display projection.
-    assert not any("long substantive" in (m.get("content") or "") for m in model_history)
+    assert not any(
+        "long substantive" in (m.get("content") or "") for m in model_history
+    )
     assert any("long substantive" in (m.get("content") or "") for m in display_history)
 
     # Eager session.resume serves the display projection.
     eager_messages = server._history_to_messages(display_history)
     # Warm/live reuse: in-memory history is the collapsed model projection.
-    live_history = server._live_visible_history({"session_key": "s1"}, db, list(model_history))
+    live_history = server._live_visible_history(
+        {"session_key": "s1"}, db, list(model_history)
+    )
     # They must agree — the candidate survives the warm switch.
     assert server._history_to_messages(live_history) == eager_messages
     assert any(m.get("text") == "long substantive answer" for m in eager_messages)
@@ -3157,15 +3351,23 @@ def test_live_visible_history_keeps_candidate_and_new_flushed_turn_real_db(tmp_p
     db.create_session("s1", source="tui")
     db.append_message("s1", role="user", content="turn 1")
     db.append_message(
-        "s1", role="assistant", content="candidate answer",
+        "s1",
+        role="assistant",
+        content="candidate answer",
         finish_reason="verification_required",
     )
-    db.append_message("s1", role="assistant", content="verified reply", finish_reason="stop")
+    db.append_message(
+        "s1", role="assistant", content="verified reply", finish_reason="stop"
+    )
     db.append_message("s1", role="user", content="turn 2")
-    db.append_message("s1", role="assistant", content="turn 2 reply", finish_reason="stop")
+    db.append_message(
+        "s1", role="assistant", content="turn 2 reply", finish_reason="stop"
+    )
 
     model_history, display_history = db.get_resume_conversations("s1")
-    live_history = server._live_visible_history({"session_key": "s1"}, db, list(model_history))
+    live_history = server._live_visible_history(
+        {"session_key": "s1"}, db, list(model_history)
+    )
     texts = [m.get("text") for m in server._history_to_messages(live_history)]
 
     assert texts == [
@@ -3211,7 +3413,9 @@ def test_live_session_payload_reads_profile_db_not_launch_db(monkeypatch, tmp_pa
         finish_reason="stop",
     )
     model_history, display_history = profile_db.get_resume_conversations("s-profile")
-    assert not any("long substantive" in (m.get("content") or "") for m in model_history)
+    assert not any(
+        "long substantive" in (m.get("content") or "") for m in model_history
+    )
     assert any("long substantive" in (m.get("content") or "") for m in display_history)
 
     session = {
@@ -3233,10 +3437,14 @@ def test_live_session_payload_reads_profile_db_not_launch_db(monkeypatch, tmp_pa
     texts = [m.get("text") for m in payload.get("messages") or []]
 
     assert "long substantive answer" in texts
-    assert texts == [m.get("text") for m in server._history_to_messages(display_history)]
+    assert texts == [
+        m.get("text") for m in server._history_to_messages(display_history)
+    ]
 
 
-def test_lazy_child_watch_resume_serves_candidate_inclusive_display(monkeypatch, tmp_path):
+def test_lazy_child_watch_resume_serves_candidate_inclusive_display(
+    monkeypatch, tmp_path
+):
     """The delegated-child watch-window cold resume (lazy=True) must serve the
     verbatim display projection so a persisted verification candidate is not
     collapsed out of the watch window (#65919 sibling of the warm-payload fix).
@@ -3247,11 +3455,16 @@ def test_lazy_child_watch_resume_serves_candidate_inclusive_display(monkeypatch,
     db.create_session("child1", source="tui")
     db.append_message("child1", role="user", content="child prompt")
     db.append_message(
-        "child1", role="assistant", content="child substantive answer",
+        "child1",
+        role="assistant",
+        content="child substantive answer",
         finish_reason="verification_required",
     )
     db.append_message(
-        "child1", role="assistant", content="child terse reply", finish_reason="stop",
+        "child1",
+        role="assistant",
+        content="child terse reply",
+        finish_reason="stop",
     )
 
     lease = types.SimpleNamespace(session_id="child1", release=lambda: None)
@@ -3266,15 +3479,15 @@ def test_lazy_child_watch_resume_serves_candidate_inclusive_display(monkeypatch,
     )
     monkeypatch.setattr(server, "_claim_or_reuse_live", lambda *a, **k: None)
     monkeypatch.setattr(server, "_child_run_active", lambda *a, **k: False)
-    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda *a, **k: None)
-
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "session.resume",
-            "params": {"session_id": "child1", "lazy": True},
-        }
+    monkeypatch.setattr(
+        server, "_schedule_session_cap_enforcement", lambda *a, **k: None
     )
+
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.resume",
+        "params": {"session_id": "child1", "lazy": True},
+    })
 
     assert "error" not in resp, resp
     texts = [m.get("text") for m in resp["result"]["messages"]]
@@ -3322,9 +3535,11 @@ def test_session_resume_deferred_history_acknowledges_and_reuses(monkeypatch):
     monkeypatch.setattr(
         server,
         "_maybe_schedule_auto_continue",
-        lambda sid, session, stored_id: auto_continue_calls.append(
-            (sid, session, stored_id)
-        ),
+        lambda sid, session, stored_id: auto_continue_calls.append((
+            sid,
+            session,
+            stored_id,
+        )),
     )
 
     try:
@@ -3513,13 +3728,17 @@ def test_session_resume_follows_compression_tip(monkeypatch, tmp_path):
     base = int(time.time()) - 10_000
     db.create_session("parent_root", source="tui")
     db.append_message(
-        "parent_root", role="user", content="pre-compression turn",
+        "parent_root",
+        role="user",
+        content="pre-compression turn",
         timestamp=base + 10,
     )
     db.end_session("parent_root", "compression")
     db.create_session("cont_tip", source="tui", parent_session_id="parent_root")
     db.append_message(
-        "cont_tip", role="assistant", content="post-compression reply",
+        "cont_tip",
+        role="assistant",
+        content="post-compression reply",
         timestamp=base + 110,
     )
     conn = db._conn
@@ -3528,7 +3747,9 @@ def test_session_resume_follows_compression_tip(monkeypatch, tmp_path):
         "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = 'parent_root'",
         (base, base + 50),
     )
-    conn.execute("UPDATE sessions SET started_at = ? WHERE id = 'cont_tip'", (base + 100,))
+    conn.execute(
+        "UPDATE sessions SET started_at = ? WHERE id = 'cont_tip'", (base + 100,)
+    )
     conn.commit()
 
     captured = {}
@@ -3546,19 +3767,25 @@ def test_session_resume_follows_compression_tip(monkeypatch, tmp_path):
     monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
     monkeypatch.setattr(server, "_make_agent", fake_make_agent)
     monkeypatch.setattr(
-        server, "_session_info", lambda agent, *a: {"model": "test", "tools": {}, "skills": {}}
+        server,
+        "_session_info",
+        lambda agent, *a: {"model": "test", "tools": {}, "skills": {}},
     )
     monkeypatch.setattr(
-        server, "_init_session", lambda sid, key, agent, history, cols=80, **_kwargs: None
+        server,
+        "_init_session",
+        lambda sid, key, agent, history, cols=80, **_kwargs: None,
     )
 
     try:
         # eager_build: this asserts the synchronously-built agent binds to the
         # resolved tip (captured["agent_session_id"]); the compression-tip
         # resolution itself runs before the build and is mode-agnostic.
-        resp = server.handle_request(
-            {"id": "1", "method": "session.resume", "params": {"session_id": "parent_root", "eager_build": True}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.resume",
+            "params": {"session_id": "parent_root", "eager_build": True},
+        })
     finally:
         db.close()
 
@@ -3594,7 +3821,9 @@ def test_session_resume_passes_stored_runtime_to_agent(monkeypatch):
         def get_ancestor_display_prefix(self, _sid):
             return []
 
-        def get_messages_as_conversation(self, target, include_ancestors=False, repair_alternation=False, **_kwargs):
+        def get_messages_as_conversation(
+            self, target, include_ancestors=False, repair_alternation=False, **_kwargs
+        ):
             return [{"role": "user", "content": "hello"}]
 
     def fake_make_agent(sid, key, session_id=None, session_db=None, **kwargs):
@@ -3606,7 +3835,11 @@ def test_session_resume_passes_stored_runtime_to_agent(monkeypatch):
     monkeypatch.setattr(server, "_set_session_context", lambda target: [])
     monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
     monkeypatch.setattr(server, "_make_agent", fake_make_agent)
-    monkeypatch.setattr(server, "_session_info", lambda agent, *a: {"model": agent.model, "provider": agent.provider})
+    monkeypatch.setattr(
+        server,
+        "_session_info",
+        lambda agent, *a: {"model": agent.model, "provider": agent.provider},
+    )
 
     def fake_init_session(sid, key, agent, history, cols=80, **_kwargs):
         server._sessions[sid] = {"agent": agent, "session_key": key}
@@ -3616,9 +3849,11 @@ def test_session_resume_passes_stored_runtime_to_agent(monkeypatch):
     # eager_build: this asserts the synchronous build contract (stored runtime
     # overrides reach _make_agent, info comes from _session_info). The deferred
     # default restores the same overrides via _start_agent_build off-thread.
-    resp = server.handle_request(
-        {"id": "1", "method": "session.resume", "params": {"session_id": "stored-session", "eager_build": True}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.resume",
+        "params": {"session_id": "stored-session", "eager_build": True},
+    })
 
     assert resp["result"]["info"] == {"model": "gpt-5.4", "provider": "openai-codex"}
     assert captured["model_override"] == {
@@ -3663,7 +3898,9 @@ def test_session_resume_profile_uses_profile_db_cwd(monkeypatch, tmp_path):
         def get_ancestor_display_prefix(self, _sid):
             return []
 
-        def get_messages_as_conversation(self, _target, include_ancestors=False, repair_alternation=False, **_kwargs):
+        def get_messages_as_conversation(
+            self, _target, include_ancestors=False, repair_alternation=False, **_kwargs
+        ):
             return [{"role": "user", "content": "hello"}]
 
         def update_session_cwd(self, *_args):
@@ -3715,13 +3952,11 @@ def test_session_resume_profile_uses_profile_db_cwd(monkeypatch, tmp_path):
     try:
         # eager_build: asserts the synchronous build receives the profile's db
         # (the deferred default builds with the same db via _start_agent_build).
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.resume",
-                "params": {"session_id": target, "profile": "worker", "eager_build": True},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.resume",
+            "params": {"session_id": target, "profile": "worker", "eager_build": True},
+        })
 
         assert "error" not in resp
         sid = resp["result"]["session_id"]
@@ -3742,7 +3977,9 @@ def test_session_cwd_set_profile_session_updates_profile_db(monkeypatch, tmp_pat
     captured = {}
 
     class ProfileDB:
-        def update_session_cwd(self, session_id, cwd, git_branch=None, git_repo_root=None):
+        def update_session_cwd(
+            self, session_id, cwd, git_branch=None, git_repo_root=None
+        ):
             captured["profile_update"] = (session_id, cwd)
 
         def close(self):
@@ -3779,34 +4016,43 @@ def test_stored_session_runtime_overrides_skips_bare_billing_provider():
     `model_config.provider`, is still restored.
     """
     # Bare "custom" bucket, no explicit model_config.provider: no provider override restored.
-    ov = server._stored_session_runtime_overrides({"model": "my-model", "billing_provider": "custom"})
+    ov = server._stored_session_runtime_overrides({
+        "model": "my-model",
+        "billing_provider": "custom",
+    })
     assert "provider_override" not in ov
     assert ov["model_override"]["provider"] is None
 
     for bare in ("auto", "custom"):
-        ov = server._stored_session_runtime_overrides({"model": "m", "billing_provider": bare})
+        ov = server._stored_session_runtime_overrides({
+            "model": "m",
+            "billing_provider": bare,
+        })
         assert "provider_override" not in ov
 
     # A real provider in billing_provider is still restored.
-    ov = server._stored_session_runtime_overrides({"model": "m", "billing_provider": "anthropic"})
+    ov = server._stored_session_runtime_overrides({
+        "model": "m",
+        "billing_provider": "anthropic",
+    })
     assert ov["provider_override"] == "anthropic"
     assert ov["model_override"]["provider"] == "anthropic"
 
     # An explicit routable provider in model_config wins over the bare billing bucket.
-    ov = server._stored_session_runtime_overrides(
-        {"model": "m", "billing_provider": "custom", "model_config": {"provider": "custom:myendpoint"}}
-    )
+    ov = server._stored_session_runtime_overrides({
+        "model": "m",
+        "billing_provider": "custom",
+        "model_config": {"provider": "custom:myendpoint"},
+    })
     assert ov["provider_override"] == "custom:myendpoint"
     assert ov["model_override"]["provider"] == "custom:myendpoint"
 
 
 def test_stored_session_runtime_overrides_restores_explicit_normal_tier():
-    overrides = server._stored_session_runtime_overrides(
-        {
-            "model": "gpt-5.4",
-            "model_config": {"service_tier": "normal"},
-        }
-    )
+    overrides = server._stored_session_runtime_overrides({
+        "model": "gpt-5.4",
+        "model_config": {"service_tier": "normal"},
+    })
 
     assert "service_tier_override" in overrides
     assert overrides["service_tier_override"] == ""
@@ -3820,22 +4066,24 @@ def test_openrouter_session_resume_restores_provider():
     # OpenRouter session with no explicit model_config.provider (the common case
     # for sessions that never used /model): billing_provider="openrouter" should
     # be restored as the provider override.
-    ov = server._stored_session_runtime_overrides(
-        {"model": "anthropic/claude-opus-4.8", "billing_provider": "openrouter"}
-    )
+    ov = server._stored_session_runtime_overrides({
+        "model": "anthropic/claude-opus-4.8",
+        "billing_provider": "openrouter",
+    })
     assert ov["provider_override"] == "openrouter"
     assert ov["model_override"]["provider"] == "openrouter"
     assert ov["model_override"]["model"] == "anthropic/claude-opus-4.8"
 
     # When an explicit model_config.provider exists, it takes precedence over
     # billing_provider (this path was already correct).
-    ov = server._stored_session_runtime_overrides(
-        {
-            "model": "anthropic/claude-opus-4.8",
-            "billing_provider": "openrouter",
-            "model_config": {"provider": "openrouter", "base_url": "https://openrouter.ai/api/v1"},
-        }
-    )
+    ov = server._stored_session_runtime_overrides({
+        "model": "anthropic/claude-opus-4.8",
+        "billing_provider": "openrouter",
+        "model_config": {
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+        },
+    })
     assert ov["provider_override"] == "openrouter"
 
 
@@ -3860,7 +4108,10 @@ def test_persist_live_session_runtime_preserves_resume_metadata(monkeypatch):
         _session_db=FakeDB(),
     )
 
-    server._persist_live_session_runtime({"agent": agent, "session_key": "stored-session"})
+    server._persist_live_session_runtime({
+        "agent": agent,
+        "session_key": "stored-session",
+    })
 
     assert "model" not in updates
     assert updates["meta"] == (
@@ -3898,13 +4149,11 @@ def test_persist_live_session_runtime_preserves_explicit_normal_tier():
         _session_db=FakeDB(),
     )
 
-    server._persist_live_session_runtime(
-        {
-            "agent": agent,
-            "session_key": "stored-session",
-            "create_service_tier_override": "",
-        }
-    )
+    server._persist_live_session_runtime({
+        "agent": agent,
+        "session_key": "stored-session",
+        "create_service_tier_override": "",
+    })
 
     assert updates["config"]["service_tier"] == "normal"
 
@@ -4093,7 +4342,9 @@ def test_config_sync_config_wins_over_env_seed(monkeypatch):
     # the per-turn sync must follow config.yaml edits, not stay pinned to it.
     monkeypatch.setenv("HERMES_INFERENCE_MODEL", "seed/model")
     monkeypatch.delenv("HERMES_MODEL", raising=False)
-    monkeypatch.setattr(server, "_load_cfg", lambda: {"model": {"default": "new/model"}})
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"model": {"default": "new/model"}}
+    )
     session = _sync_test_session(config_model_seen=("seed/model", ""))
     calls = []
     monkeypatch.setattr(
@@ -4155,15 +4406,14 @@ def test_apply_model_switch_persist_override_false_never_persists(monkeypatch):
         model_info=None,
         error_message="",
     )
-    monkeypatch.setattr(
-        "hermes_cli.model_switch.switch_model", lambda **kw: result
-    )
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", lambda **kw: result)
     monkeypatch.setattr(
         "hermes_cli.model_switch.resolve_persist_behavior",
         lambda *a: pytest.fail("persist_override must bypass resolve_persist_behavior"),
     )
     monkeypatch.setattr(
-        server, "_persist_model_switch",
+        server,
+        "_persist_model_switch",
         lambda _r: pytest.fail("persist_override=False must not persist"),
     )
     monkeypatch.setattr(
@@ -4401,9 +4651,11 @@ def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
     )
 
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.close", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.close",
+            "params": {"session_id": "sid"},
+        })
         assert resp["result"]["closed"] is True
         assert calls["history"] == [{"role": "user", "content": "hello"}]
         assert ("on_session_finalize", "session-key") in calls["hooks"]
@@ -4427,13 +4679,11 @@ def test_session_close_releases_resume_lock_before_slow_teardown(monkeypatch):
 
     def _close():
         response.update(
-            server.handle_request(
-                {
-                    "id": "close",
-                    "method": "session.close",
-                    "params": {"session_id": "slow-close"},
-                }
-            )
+            server.handle_request({
+                "id": "close",
+                "method": "session.close",
+                "params": {"session_id": "slow-close"},
+            })
         )
 
     thread = threading.Thread(target=_close)
@@ -4475,19 +4725,15 @@ def test_session_close_settles_active_turn_before_teardown(monkeypatch):
     session["_run_thread"] = run_thread
     server._sessions["settle-close"] = session
     monkeypatch.setattr(server, "_teardown_session", _teardown)
-    monkeypatch.setattr(
-        server, "_TURN_SETTLE_BEFORE_CLOSE_SECONDS", 1.0, raising=False
-    )
+    monkeypatch.setattr(server, "_TURN_SETTLE_BEFORE_CLOSE_SECONDS", 1.0, raising=False)
 
     close_thread = threading.Thread(
         target=lambda: response.update(
-            server.handle_request(
-                {
-                    "id": "close",
-                    "method": "session.close",
-                    "params": {"session_id": "settle-close"},
-                }
-            )
+            server.handle_request({
+                "id": "close",
+                "method": "session.close",
+                "params": {"session_id": "settle-close"},
+            })
         )
     )
     run_thread.start()
@@ -4603,9 +4849,10 @@ def test_ws_orphan_reap_waits_for_active_delegation_then_reaps(monkeypatch):
     monkeypatch.setattr(
         server,
         "_teardown_session",
-        lambda session, *, end_reason="tui_close": torn_down.append(
-            (session, end_reason)
-        ),
+        lambda session, *, end_reason="tui_close": torn_down.append((
+            session,
+            end_reason,
+        )),
     )
     server._sessions["delegating-sid"] = _session(
         transport=server._detached_ws_transport,
@@ -4657,15 +4904,14 @@ def test_ws_orphan_reap_retries_when_delegation_lookup_fails(monkeypatch):
 
     monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0.01)
     monkeypatch.setattr(server.threading, "Timer", _Timer)
-    monkeypatch.setattr(
-        async_delegation, "has_live_for_session", _raise_lookup_error
-    )
+    monkeypatch.setattr(async_delegation, "has_live_for_session", _raise_lookup_error)
     monkeypatch.setattr(
         server,
         "_teardown_session",
-        lambda session, *, end_reason="tui_close": torn_down.append(
-            (session, end_reason)
-        ),
+        lambda session, *, end_reason="tui_close": torn_down.append((
+            session,
+            end_reason,
+        )),
     )
     server._sessions["lookup-error-sid"] = _session(
         transport=server._detached_ws_transport,
@@ -4738,7 +4984,9 @@ def test_ws_orphan_reap_spares_reattached_session(monkeypatch):
     assert server._ws_session_is_orphaned(done) is False
 
 
-def test_ws_orphan_reap_spares_detached_session_with_running_async_delegation(monkeypatch):
+def test_ws_orphan_reap_spares_detached_session_with_running_async_delegation(
+    monkeypatch,
+):
     """A detached desktop session with live background delegation is parked.
 
     Regression for Desktop session switches / transient WS detaches: the parent
@@ -4768,7 +5016,9 @@ def test_ws_orphan_reap_spares_detached_session_with_running_async_delegation(mo
         server,
         "_teardown_popped_session",
         lambda session, *, end_reason="tui_close": (
-            closed.append((session["_sid"], end_reason)) if session is not None else None
+            closed.append((session["_sid"], end_reason))
+            if session is not None
+            else None
         ),
     )
 
@@ -4917,13 +5167,11 @@ def test_session_title_creates_row_and_sets_immediately_when_not_ready(monkeypat
     monkeypatch.setattr(server, "_ensure_session_db_row", _fake_ensure_row)
     monkeypatch.setattr(server, "_session_db", _fake_session_db)
     try:
-        set_resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.title",
-                "params": {"session_id": "sid", "title": "my-custom-name"},
-            }
-        )
+        set_resp = server.handle_request({
+            "id": "1",
+            "method": "session.title",
+            "params": {"session_id": "sid", "title": "my-custom-name"},
+        })
 
         # No longer queued — the row is created and the title set immediately.
         assert set_resp["result"]["pending"] is False
@@ -4933,9 +5181,11 @@ def test_session_title_creates_row_and_sets_immediately_when_not_ready(monkeypat
         assert server._sessions["sid"]["pending_title"] is None
 
         # A subsequent read reflects the persisted title.
-        get_resp = server.handle_request(
-            {"id": "2", "method": "session.title", "params": {"session_id": "sid"}}
-        )
+        get_resp = server.handle_request({
+            "id": "2",
+            "method": "session.title",
+            "params": {"session_id": "sid"},
+        })
         assert get_resp["result"]["title"] == "my-custom-name"
     finally:
         server._sessions.pop("sid", None)
@@ -4976,21 +5226,21 @@ def test_session_title_falls_back_to_queue_when_row_create_fails(monkeypatch):
     monkeypatch.setattr(server, "_ensure_session_db_row", _fake_ensure_row)
     monkeypatch.setattr(server, "_session_db", _fake_session_db)
     try:
-        set_resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.title",
-                "params": {"session_id": "sid", "title": "queued title"},
-            }
-        )
+        set_resp = server.handle_request({
+            "id": "1",
+            "method": "session.title",
+            "params": {"session_id": "sid", "title": "queued title"},
+        })
 
         assert set_resp["result"]["pending"] is True
         assert set_resp["result"]["title"] == "queued title"
         assert server._sessions["sid"]["pending_title"] == "queued title"
 
-        get_resp = server.handle_request(
-            {"id": "2", "method": "session.title", "params": {"session_id": "sid"}}
-        )
+        get_resp = server.handle_request({
+            "id": "2",
+            "method": "session.title",
+            "params": {"session_id": "sid"},
+        })
         assert get_resp["result"]["title"] == "queued title"
     finally:
         server._sessions.pop("sid", None)
@@ -5003,14 +5253,30 @@ def test_notification_event_routing_by_session_key(monkeypatch):
     monkeypatch.setattr(server, "_sessions", {"a": mine, "b": other})
 
     # My own event → handle it.
-    assert server._notification_event_belongs_elsewhere("a", mine, {"session_key": "mine"}) is False
+    assert (
+        server._notification_event_belongs_elsewhere("a", mine, {"session_key": "mine"})
+        is False
+    )
     # Global/system event with no owner → handle it.
-    assert server._notification_event_belongs_elsewhere("a", mine, {"session_key": ""}) is False
+    assert (
+        server._notification_event_belongs_elsewhere("a", mine, {"session_key": ""})
+        is False
+    )
     assert server._notification_event_belongs_elsewhere("a", mine, {}) is False
     # Owned by another *live* session → defer to that session's poller.
-    assert server._notification_event_belongs_elsewhere("a", mine, {"session_key": "other"}) is True
+    assert (
+        server._notification_event_belongs_elsewhere(
+            "a", mine, {"session_key": "other"}
+        )
+        is True
+    )
     # Owner is gone (not in _sessions) → handle as fallback so it isn't lost.
-    assert server._notification_event_belongs_elsewhere("a", mine, {"session_key": "ghost"}) is False
+    assert (
+        server._notification_event_belongs_elsewhere(
+            "a", mine, {"session_key": "ghost"}
+        )
+        is False
+    )
 
 
 def test_async_delegation_event_prefers_origin_ui_session(monkeypatch):
@@ -5031,14 +5297,18 @@ def test_async_delegation_event_prefers_origin_ui_session(monkeypatch):
     }
 
     assert server._notification_event_belongs_elsewhere("other-sid", other, evt) is True
-    assert server._notification_event_belongs_elsewhere("origin-sid", mine, evt) is False
+    assert (
+        server._notification_event_belongs_elsewhere("origin-sid", mine, evt) is False
+    )
 
 
 def test_notification_event_follows_compression_continuation(monkeypatch):
     """Events keyed to a compressed parent route to the live continuation."""
     old_parent = _session(session_key="old-parent")
     live_tip = _session(session_key="new-tip")
-    monkeypatch.setattr(server, "_sessions", {"old-sid": old_parent, "tip-sid": live_tip})
+    monkeypatch.setattr(
+        server, "_sessions", {"old-sid": old_parent, "tip-sid": live_tip}
+    )
 
     class _DB:
         def resolve_resume_session_id(self, session_id):
@@ -5047,8 +5317,12 @@ def test_notification_event_follows_compression_continuation(monkeypatch):
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
     evt = {"type": "async_delegation", "session_key": "old-parent"}
 
-    assert server._notification_event_belongs_elsewhere("old-sid", old_parent, evt) is True
-    assert server._notification_event_belongs_elsewhere("tip-sid", live_tip, evt) is False
+    assert (
+        server._notification_event_belongs_elsewhere("old-sid", old_parent, evt) is True
+    )
+    assert (
+        server._notification_event_belongs_elsewhere("tip-sid", live_tip, evt) is False
+    )
     # A third session must leave it alone for the continuation's poller.
     third = _session(session_key="third")
     monkeypatch.setattr(
@@ -5080,8 +5354,15 @@ def test_finalized_origin_ui_session_falls_back_to_live_continuation(monkeypatch
         "origin_ui_session_id": "origin-sid",
     }
 
-    assert server._notification_event_belongs_elsewhere("origin-sid", finalized_origin, evt) is True
-    assert server._notification_event_belongs_elsewhere("tip-sid", live_tip, evt) is False
+    assert (
+        server._notification_event_belongs_elsewhere(
+            "origin-sid", finalized_origin, evt
+        )
+        is True
+    )
+    assert (
+        server._notification_event_belongs_elsewhere("tip-sid", live_tip, evt) is False
+    )
 
 
 def test_prompt_submit_rejects_negative_truncate_ordinal(monkeypatch):
@@ -5097,7 +5378,9 @@ def test_prompt_submit_rejects_negative_truncate_ordinal(monkeypatch):
     replaced = []
 
     class _FakeDB:
-        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+        def replace_messages(
+            self, key, messages, active_only=False, archive_dropped=False
+        ):
             replaced.append((key, list(messages)))
 
     history = [
@@ -5111,25 +5394,27 @@ def test_prompt_submit_rejects_negative_truncate_ordinal(monkeypatch):
     # If the guard ever lets a negative ordinal through, these would run and the
     # session would be marked busy; failing here makes that regression loud.
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_inflight_turn",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "trunc-sid",
-                    "text": "next",
-                    "truncate_before_user_ordinal": -1,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "trunc-sid",
+                "text": "next",
+                "truncate_before_user_ordinal": -1,
+                "confirm_truncate": True,
+            },
+        })
         assert resp["error"]["code"] == 4018
         # History and the DB are left exactly as they were — no silent loss.
         assert server._sessions["trunc-sid"]["history"] == history
@@ -5155,25 +5440,27 @@ def test_prompt_submit_refuses_boolean_ordinal(monkeypatch):
     ]
     server._sessions["bool-trunc-sid"] = _session(history=list(history))
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_inflight_turn",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "bool-trunc-sid",
-                    "text": "new turn",
-                    "truncate_before_user_ordinal": True,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "bool-trunc-sid",
+                "text": "new turn",
+                "truncate_before_user_ordinal": True,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is not None
         assert resp["error"]["code"] == 4004
         assert "must be an integer" in resp["error"]["message"]
@@ -5196,24 +5483,26 @@ def test_prompt_submit_refuses_confirm_truncate_without_target(monkeypatch):
     ]
     server._sessions["bare-confirm-sid"] = _session(history=list(history))
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_inflight_turn",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "bare-confirm-sid",
-                    "text": "new turn",
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "bare-confirm-sid",
+                "text": "new turn",
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is not None
         assert resp["error"]["code"] == 4004
         assert "confirm_truncate requires" in resp["error"]["message"]
@@ -5234,7 +5523,9 @@ def test_prompt_submit_refuses_unconfirmed_nonempty_truncation(monkeypatch):
     replaced = []
 
     class _FakeDB:
-        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+        def replace_messages(
+            self, key, messages, active_only=False, archive_dropped=False
+        ):
             replaced.append((key, list(messages)))
 
     history = [
@@ -5248,25 +5539,27 @@ def test_prompt_submit_refuses_unconfirmed_nonempty_truncation(monkeypatch):
     server._sessions["unconfirmed-trunc-sid"] = _session(history=list(history))
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_inflight_turn",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     def _submit(**extra):
-        return server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "unconfirmed-trunc-sid",
-                    "text": "an ordinary typed message",
-                    "truncate_before_user_ordinal": 2,
-                    **extra,
-                },
-            }
-        )
+        return server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "unconfirmed-trunc-sid",
+                "text": "an ordinary typed message",
+                "truncate_before_user_ordinal": 2,
+                **extra,
+            },
+        })
 
     try:
         resp = _submit()
@@ -5292,7 +5585,9 @@ def test_prompt_submit_truncates_by_message_id(monkeypatch):
     replaced = []
 
     class _FakeDB:
-        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+        def replace_messages(
+            self, key, messages, active_only=False, archive_dropped=False
+        ):
             replaced.append((key, list(messages)))
 
     history = [
@@ -5303,26 +5598,20 @@ def test_prompt_submit_truncates_by_message_id(monkeypatch):
     ]
     server._sessions["msg-id-trunc-sid"] = _session(history=list(history))
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
-    monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: None
-    )
-    monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: None
-    )
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_start_inflight_turn", lambda *a, **k: None)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "msg-id-trunc-sid",
-                    "text": "new turn",
-                    "truncate_before_message_id": "msg-2",
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "msg-id-trunc-sid",
+                "text": "new turn",
+                "truncate_before_message_id": "msg-2",
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("result") is not None
         assert len(replaced) == 1
         assert replaced[0][1] == history[:2]
@@ -5342,7 +5631,9 @@ def test_prompt_submit_truncation_falls_back_to_sid_when_session_key_null(monkey
     replaced = []
 
     class _FakeDB:
-        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+        def replace_messages(
+            self, key, messages, active_only=False, archive_dropped=False
+        ):
             replaced.append((key, list(messages)))
 
     history = [
@@ -5359,19 +5650,17 @@ def test_prompt_submit_truncation_falls_back_to_sid_when_session_key_null(monkey
     monkeypatch.setattr(server, "_start_inflight_turn", lambda *a, **k: None)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "null-key-trunc-sid",
-                    "text": "new turn",
-                    "truncate_before_row_id": 103,
-                    "truncate_before_user_ordinal": 1,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "null-key-trunc-sid",
+                "text": "new turn",
+                "truncate_before_row_id": 103,
+                "truncate_before_user_ordinal": 1,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("result") is not None
         assert len(replaced) == 1
         # Keyed by the session id, never None (the FK-violating value).
@@ -5391,26 +5680,28 @@ def test_prompt_submit_refuses_ordinal_and_message_id_mismatch(monkeypatch):
     ]
     server._sessions["mismatch-trunc-sid"] = _session(history=list(history))
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_inflight_turn",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "mismatch-trunc-sid",
-                    "text": "new turn",
-                    "truncate_before_message_id": "msg-2",  # ordinal index 1
-                    "truncate_before_user_ordinal": 0,      # mismatch (stale 0)
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "mismatch-trunc-sid",
+                "text": "new turn",
+                "truncate_before_message_id": "msg-2",  # ordinal index 1
+                "truncate_before_user_ordinal": 0,  # mismatch (stale 0)
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is not None
         assert resp["error"]["code"] == 4030
         assert "does not match" in resp["error"]["message"]
@@ -5423,7 +5714,9 @@ def test_prompt_submit_refuses_ordinal_only_when_history_has_row_ids(monkeypatch
     replaced = []
 
     class _FakeDB:
-        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+        def replace_messages(
+            self, key, messages, active_only=False, archive_dropped=False
+        ):
             replaced.append((key, list(messages)))
 
     history = [
@@ -5435,25 +5728,27 @@ def test_prompt_submit_refuses_ordinal_only_when_history_has_row_ids(monkeypatch
     server._sessions["ordinal-only-durable-sid"] = _session(history=list(history))
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_inflight_turn",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "ordinal-only-durable-sid",
-                    "text": "retry",
-                    "truncate_before_user_ordinal": 1,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "ordinal-only-durable-sid",
+                "text": "retry",
+                "truncate_before_user_ordinal": 1,
+                "confirm_truncate": True,
+            },
+        })
 
         assert resp["error"]["code"] == 4004
         assert "truncate_before_row_id" in resp["error"]["message"]
@@ -5464,7 +5759,9 @@ def test_prompt_submit_refuses_ordinal_only_when_history_has_row_ids(monkeypatch
         server._sessions.pop("ordinal-only-durable-sid", None)
 
 
-def test_prompt_submit_refuses_ordinal_only_when_durable_history_is_unstamped(monkeypatch):
+def test_prompt_submit_refuses_ordinal_only_when_durable_history_is_unstamped(
+    monkeypatch,
+):
     """Durability comes from state.db, not optional stamps on the live copy."""
     replaced = []
     history = [
@@ -5478,33 +5775,40 @@ def test_prompt_submit_refuses_ordinal_only_when_durable_history_is_unstamped(mo
         def get_messages_as_conversation(self, key, **kwargs):
             assert key == "session-key"
             assert kwargs["include_row_ids"] is True
-            return [dict(message, _row_id=100 + index) for index, message in enumerate(history)]
+            return [
+                dict(message, _row_id=100 + index)
+                for index, message in enumerate(history)
+            ]
 
-        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+        def replace_messages(
+            self, key, messages, active_only=False, archive_dropped=False
+        ):
             replaced.append((key, list(messages)))
 
     server._sessions["unstamped-durable-sid"] = _session(history=list(history))
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_inflight_turn",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "unstamped-durable-sid",
-                    "text": "retry",
-                    "truncate_before_user_ordinal": 1,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "unstamped-durable-sid",
+                "text": "retry",
+                "truncate_before_user_ordinal": 1,
+                "confirm_truncate": True,
+            },
+        })
 
         assert resp["error"]["code"] == 4004
         assert "truncate_before_row_id" in resp["error"]["message"]
@@ -5519,7 +5823,9 @@ def test_prompt_submit_truncates_by_row_id(monkeypatch):
     replaced = []
 
     class _FakeDB:
-        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+        def replace_messages(
+            self, key, messages, active_only=False, archive_dropped=False
+        ):
             replaced.append((key, list(messages)))
 
     history = [
@@ -5532,24 +5838,20 @@ def test_prompt_submit_truncates_by_row_id(monkeypatch):
     server._sessions["row-id-trunc-sid"] = sess
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     started = []
-    monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: started.append(k)
-    )
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: started.append(k))
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "row-id-trunc-sid",
-                    "text": "new turn",
-                    "truncate_before_row_id": 103,
-                    "truncate_before_user_ordinal": 1,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "row-id-trunc-sid",
+                "text": "new turn",
+                "truncate_before_row_id": 103,
+                "truncate_before_user_ordinal": 1,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is None
         assert len(sess["history"]) == 2
         assert sess["history"][-1]["content"] == "reply 1"
@@ -5564,7 +5866,9 @@ def test_prompt_submit_truncates_by_string_row_id(monkeypatch):
     replaced = []
 
     class _FakeDB:
-        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+        def replace_messages(
+            self, key, messages, active_only=False, archive_dropped=False
+        ):
             replaced.append((key, list(messages)))
 
     history = [
@@ -5579,18 +5883,16 @@ def test_prompt_submit_truncates_by_string_row_id(monkeypatch):
     monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "str-row-id-trunc-sid",
-                    "text": "new turn",
-                    "truncate_before_row_id": 103,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "str-row-id-trunc-sid",
+                "text": "new turn",
+                "truncate_before_row_id": 103,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is None
         assert len(sess["history"]) == 2
     finally:
@@ -5607,23 +5909,23 @@ def test_prompt_submit_refuses_ordinal_and_row_id_mismatch(monkeypatch):
     ]
     server._sessions["row-mismatch-sid"] = _session(history=list(history))
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "row-mismatch-sid",
-                    "text": "new turn",
-                    "truncate_before_row_id": 203,  # user turn ordinal 1
-                    "truncate_before_user_ordinal": 0,  # mismatch (stale 0)
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "row-mismatch-sid",
+                "text": "new turn",
+                "truncate_before_row_id": 203,  # user turn ordinal 1
+                "truncate_before_user_ordinal": 0,  # mismatch (stale 0)
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is not None
         assert resp["error"]["code"] == 4030
         assert "does not match" in resp["error"]["message"]
@@ -5639,18 +5941,16 @@ def test_prompt_submit_refuses_boolean_row_id(monkeypatch):
     ]
     server._sessions["bool-row-sid"] = _session(history=list(history))
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "bool-row-sid",
-                    "text": "new turn",
-                    "truncate_before_row_id": True,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "bool-row-sid",
+                "text": "new turn",
+                "truncate_before_row_id": True,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is not None
         assert resp["error"]["code"] == 4004
         assert "must be an integer" in resp["error"]["message"]
@@ -5665,18 +5965,16 @@ def test_prompt_submit_row_id_not_found(monkeypatch):
     ]
     server._sessions["missing-row-sid"] = _session(history=list(history))
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "missing-row-sid",
-                    "text": "new turn",
-                    "truncate_before_row_id": 999,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "missing-row-sid",
+                "text": "new turn",
+                "truncate_before_row_id": 999,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is not None
         assert resp["error"]["code"] == 4018
         assert "no longer in session history" in resp["error"]["message"]
@@ -5700,7 +5998,7 @@ def test_prompt_submit_row_id_ignores_platform_id_fallback(monkeypatch):
                 "text": "new turn",
                 "truncate_before_row_id": 999,
                 "confirm_truncate": True,
-            }
+            },
         })
         assert resp.get("error") is not None
         assert resp["error"]["code"] == 4018
@@ -5718,7 +6016,9 @@ def test_prompt_submit_refuses_empty_truncation_without_confirm(monkeypatch):
     replaced = []
 
     class _FakeDB:
-        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+        def replace_messages(
+            self, key, messages, active_only=False, archive_dropped=False
+        ):
             replaced.append((key, list(messages)))
 
     history = [
@@ -5730,16 +6030,34 @@ def test_prompt_submit_refuses_empty_truncation_without_confirm(monkeypatch):
     server._sessions["empty-trunc-sid"] = _session(history=list(history))
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_inflight_turn",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     try:
         # Missing confirm → refuse.
-        resp = server.handle_request(
-            {
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "empty-trunc-sid",
+                "text": "fresh typed message",
+                "truncate_before_row_id": 101,
+                "truncate_before_user_ordinal": 0,
+                "confirm_truncate": True,
+            },
+        })
+        assert resp["error"]["code"] == 4028
+        assert "confirm_empty_truncate" in resp["error"]["message"]
+        # Explicit falsey values must not satisfy the opt-in either.
+        for falsey in (False, 0, "", "false", "no"):
+            resp = server.handle_request({
                 "id": "1",
                 "method": "prompt.submit",
                 "params": {
@@ -5748,27 +6066,9 @@ def test_prompt_submit_refuses_empty_truncation_without_confirm(monkeypatch):
                     "truncate_before_row_id": 101,
                     "truncate_before_user_ordinal": 0,
                     "confirm_truncate": True,
+                    "confirm_empty_truncate": falsey,
                 },
-            }
-        )
-        assert resp["error"]["code"] == 4028
-        assert "confirm_empty_truncate" in resp["error"]["message"]
-        # Explicit falsey values must not satisfy the opt-in either.
-        for falsey in (False, 0, "", "false", "no"):
-            resp = server.handle_request(
-                {
-                    "id": "1",
-                    "method": "prompt.submit",
-                    "params": {
-                        "session_id": "empty-trunc-sid",
-                        "text": "fresh typed message",
-                        "truncate_before_row_id": 101,
-                        "truncate_before_user_ordinal": 0,
-                        "confirm_truncate": True,
-                        "confirm_empty_truncate": falsey,
-                    },
-                }
-            )
+            })
             assert resp["error"]["code"] == 4028, falsey
         assert server._sessions["empty-trunc-sid"]["history"] == history
         assert server._sessions["empty-trunc-sid"]["running"] is False
@@ -5807,7 +6107,9 @@ def test_prompt_submit_empty_truncation_allowed_with_confirm(monkeypatch):
             self._target()
 
     class _FakeDB:
-        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+        def replace_messages(
+            self, key, messages, active_only=False, archive_dropped=False
+        ):
             replaced.append((key, list(messages)))
 
     history = [
@@ -5827,20 +6129,18 @@ def test_prompt_submit_empty_truncation_allowed_with_confirm(monkeypatch):
         monkeypatch.setattr(server, "_emit", lambda *a: None)
         monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
 
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "confirm-empty-sid",
-                    "text": "first",
-                    "truncate_before_row_id": 101,
-                    "truncate_before_user_ordinal": 0,
-                    "confirm_truncate": True,
-                    "confirm_empty_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "confirm-empty-sid",
+                "text": "first",
+                "truncate_before_row_id": 101,
+                "truncate_before_user_ordinal": 0,
+                "confirm_truncate": True,
+                "confirm_empty_truncate": True,
+            },
+        })
         assert resp.get("result"), f"got error: {resp.get('error')}"
         assert seen["prompt"] == "first"
         assert seen["history"] == []
@@ -5893,12 +6193,10 @@ def test_notification_poller_live_loop_requeues_foreign_completion_for_owner(
         session["running"] = False
 
     monkeypatch.setattr(server, "_run_prompt_submit", _deliver)
-    server._sessions.update(
-        {
-            "sid-a-live-handoff": session_a,
-            "sid-b-live-handoff": session_b,
-        }
-    )
+    server._sessions.update({
+        "sid-a-live-handoff": session_a,
+        "sid-b-live-handoff": session_b,
+    })
     process_registry._completion_consumed.discard(event["session_id"])
 
     try:
@@ -5970,9 +6268,7 @@ def test_completion_ownership_lineage_lookup_failure_fails_closed(monkeypatch):
         {"origin_ui_session_id": "missing-owner-sid"},
     ],
 )
-def test_notification_poller_live_loop_drops_addressed_orphan(
-    monkeypatch, routing
-):
+def test_notification_poller_live_loop_drops_addressed_orphan(monkeypatch, routing):
     """A live poll never injects an addressed event whose owner is gone."""
     import queue as _queue_mod
 
@@ -6045,16 +6341,14 @@ def test_notification_poller_drops_orphaned_events(monkeypatch, routing):
     isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
     monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
     process_registry._completion_consumed.discard("proc_ghost")
-    isolated_queue.put(
-        {
-            "type": "completion",
-            "session_id": "proc_ghost",
-            "command": "echo from ghost",
-            "exit_code": 0,
-            "output": "ghost output",
-            **routing,
-        }
-    )
+    isolated_queue.put({
+        "type": "completion",
+        "session_id": "proc_ghost",
+        "command": "echo from ghost",
+        "exit_code": 0,
+        "output": "ghost output",
+        **routing,
+    })
 
     stop = threading.Event()
     stop.set()
@@ -6084,9 +6378,7 @@ def test_notification_poller_drops_orphaned_events(monkeypatch, routing):
         ({"session_key": "old-parent-key"}, "session-a"),
     ],
 )
-def test_notification_poller_delivers_owned_events(
-    monkeypatch, routing, resolved_key
-):
+def test_notification_poller_delivers_owned_events(monkeypatch, routing, resolved_key):
     """Direct, UI-origin, and compression-lineage owners are delivered."""
     import queue as _queue_mod
 
@@ -6111,16 +6403,14 @@ def test_notification_poller_delivers_owned_events(
     isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
     monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
     process_registry._completion_consumed.discard("proc_mine")
-    isolated_queue.put(
-        {
-            "type": "completion",
-            "session_id": "proc_mine",
-            "command": "echo mine",
-            "exit_code": 0,
-            "output": "mine",
-            **routing,
-        }
-    )
+    isolated_queue.put({
+        "type": "completion",
+        "session_id": "proc_mine",
+        "command": "echo mine",
+        "exit_code": 0,
+        "output": "mine",
+        **routing,
+    })
 
     stop = threading.Event()
     stop.set()
@@ -6139,9 +6429,7 @@ def test_notification_poller_delivers_owned_events(
             process_registry.completion_queue.get_nowait()
 
 
-def _configure_immediate_prompt_run(
-    monkeypatch, tmp_path, *, immediate_threads=True
-):
+def _configure_immediate_prompt_run(monkeypatch, tmp_path, *, immediate_threads=True):
     class _ImmediateThread:
         def __init__(self, target=None, daemon=None, **_kwargs):
             self._target = target
@@ -6236,7 +6524,9 @@ class _RecordingAgent:
     def clear_interrupt(self):
         return None
 
-    def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+    def run_conversation(
+        self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+    ):
         self._turns.append(prompt)
         return {"final_response": "", "messages": []}
 
@@ -6380,9 +6670,7 @@ def test_run_prompt_submit_requeues_all_unstarted_notifications_with_real_thread
 
     from tools.process_registry import process_registry
 
-    _configure_immediate_prompt_run(
-        monkeypatch, tmp_path, immediate_threads=False
-    )
+    _configure_immediate_prompt_run(monkeypatch, tmp_path, immediate_threads=False)
     real_thread_class = threading.Thread
     threads = []
     nested_started = threading.Event()
@@ -6395,7 +6683,9 @@ def test_run_prompt_submit_requeues_all_unstarted_notifications_with_real_thread
         return thread
 
     class _BlockingNotificationAgent(_RecordingAgent):
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             turns.append(prompt)
             if "proc_batch_1" in prompt:
                 nested_started.set()
@@ -6567,8 +6857,6 @@ def test_run_prompt_submit_prefers_origin_ui_session_id(monkeypatch, tmp_path):
         server._sessions.pop("sid_b", None)
         process_registry._completion_consumed.discard(event["session_id"])
 
-
-
     """session.create must NOT eagerly write a DB row.
 
     Every TUI/desktop launch opens a session here just to paint the composer;
@@ -6589,9 +6877,11 @@ def test_run_prompt_submit_prefers_origin_ui_session_id(monkeypatch, tmp_path):
         lambda *a, **k: types.SimpleNamespace(daemon=False, start=lambda: None),
     )
 
-    resp = server.handle_request(
-        {"id": "1", "method": "session.create", "params": {"cols": 80}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.create",
+        "params": {"cols": 80},
+    })
     sid = resp["result"]["session_id"]
     try:
         assert resp["result"]["stored_session_id"]
@@ -6605,20 +6895,43 @@ def test_ensure_session_db_row_persists_explicit_cwd(monkeypatch, tmp_path):
     created = []
 
     class _FakeDB:
-        def create_session(self, key, source=None, model=None, model_config=None, parent_session_id=None, cwd=None, profile_name=None):
-            created.append(
-                {"key": key, "source": source, "model": model, "model_config": model_config, "cwd": cwd}
-            )
+        def create_session(
+            self,
+            key,
+            source=None,
+            model=None,
+            model_config=None,
+            parent_session_id=None,
+            cwd=None,
+            profile_name=None,
+        ):
+            created.append({
+                "key": key,
+                "source": source,
+                "model": model,
+                "model_config": model_config,
+                "cwd": cwd,
+            })
 
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
     monkeypatch.delenv("HERMES_DESKTOP", raising=False)
     monkeypatch.delenv("HERMES_DESKTOP_TERMINAL", raising=False)
 
-    server._ensure_session_db_row({"session_key": "k1", "cwd": str(tmp_path), "explicit_cwd": True})
+    server._ensure_session_db_row({
+        "session_key": "k1",
+        "cwd": str(tmp_path),
+        "explicit_cwd": True,
+    })
 
     assert created == [
-        {"key": "k1", "source": "tui", "model": "test-model", "model_config": None, "cwd": str(tmp_path)}
+        {
+            "key": "k1",
+            "source": "tui",
+            "model": "test-model",
+            "model_config": None,
+            "cwd": str(tmp_path),
+        }
     ]
 
 
@@ -6626,10 +6939,23 @@ def test_ensure_session_db_row_persists_session_source(monkeypatch):
     created = []
 
     class _FakeDB:
-        def create_session(self, key, source=None, model=None, model_config=None, parent_session_id=None, cwd=None, profile_name=None):
-            created.append(
-                {"key": key, "source": source, "model": model, "model_config": model_config, "cwd": cwd}
-            )
+        def create_session(
+            self,
+            key,
+            source=None,
+            model=None,
+            model_config=None,
+            parent_session_id=None,
+            cwd=None,
+            profile_name=None,
+        ):
+            created.append({
+                "key": key,
+                "source": source,
+                "model": model,
+                "model_config": model_config,
+                "cwd": cwd,
+            })
 
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
@@ -6637,7 +6963,13 @@ def test_ensure_session_db_row_persists_session_source(monkeypatch):
     server._ensure_session_db_row({"session_key": "k1", "source": "tool"})
 
     assert created == [
-        {"key": "k1", "source": "tool", "model": "test-model", "model_config": None, "cwd": None}
+        {
+            "key": "k1",
+            "source": "tool",
+            "model": "test-model",
+            "model_config": None,
+            "cwd": None,
+        }
     ]
 
 
@@ -6651,10 +6983,23 @@ def test_ensure_session_db_row_records_a_terminal_workspace(monkeypatch, tmp_pat
     created = []
 
     class _FakeDB:
-        def create_session(self, key, source=None, model=None, model_config=None, parent_session_id=None, cwd=None, profile_name=None):
-            created.append(
-                {"key": key, "source": source, "model": model, "model_config": model_config, "cwd": cwd}
-            )
+        def create_session(
+            self,
+            key,
+            source=None,
+            model=None,
+            model_config=None,
+            parent_session_id=None,
+            cwd=None,
+            profile_name=None,
+        ):
+            created.append({
+                "key": key,
+                "source": source,
+                "model": model,
+                "model_config": model_config,
+                "cwd": cwd,
+            })
 
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
@@ -6664,7 +7009,13 @@ def test_ensure_session_db_row_records_a_terminal_workspace(monkeypatch, tmp_pat
     server._ensure_session_db_row({"session_key": "k1", "cwd": str(tmp_path)})
 
     assert created == [
-        {"key": "k1", "source": "tui", "model": "test-model", "model_config": None, "cwd": str(tmp_path)}
+        {
+            "key": "k1",
+            "source": "tui",
+            "model": "test-model",
+            "model_config": None,
+            "cwd": str(tmp_path),
+        }
     ]
 
 
@@ -6674,18 +7025,41 @@ def test_ensure_session_db_row_defaults_desktop_to_no_workspace(monkeypatch, tmp
     created = []
 
     class _FakeDB:
-        def create_session(self, key, source=None, model=None, model_config=None, parent_session_id=None, cwd=None, profile_name=None):
-            created.append(
-                {"key": key, "source": source, "model": model, "model_config": model_config, "cwd": cwd}
-            )
+        def create_session(
+            self,
+            key,
+            source=None,
+            model=None,
+            model_config=None,
+            parent_session_id=None,
+            cwd=None,
+            profile_name=None,
+        ):
+            created.append({
+                "key": key,
+                "source": source,
+                "model": model,
+                "model_config": model_config,
+                "cwd": cwd,
+            })
 
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
 
-    server._ensure_session_db_row({"session_key": "k1", "source": "desktop", "cwd": str(tmp_path)})
+    server._ensure_session_db_row({
+        "session_key": "k1",
+        "source": "desktop",
+        "cwd": str(tmp_path),
+    })
 
     assert created == [
-        {"key": "k1", "source": "desktop", "model": "test-model", "model_config": None, "cwd": None}
+        {
+            "key": "k1",
+            "source": "desktop",
+            "model": "test-model",
+            "model_config": None,
+            "cwd": None,
+        }
     ]
 
 
@@ -6701,22 +7075,32 @@ def test_ensure_session_db_row_persists_session_model_override(monkeypatch):
     created = []
 
     class _FakeDB:
-        def create_session(self, key, source=None, model=None, model_config=None, parent_session_id=None, cwd=None, profile_name=None):
-            created.append(
-                {"key": key, "model": model, "model_config": model_config, "cwd": cwd}
-            )
+        def create_session(
+            self,
+            key,
+            source=None,
+            model=None,
+            model_config=None,
+            parent_session_id=None,
+            cwd=None,
+            profile_name=None,
+        ):
+            created.append({
+                "key": key,
+                "model": model,
+                "model_config": model_config,
+                "cwd": cwd,
+            })
 
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "global/default")
 
-    server._ensure_session_db_row(
-        {
-            "session_key": "k1",
-            "model_override": {"model": "openai/gpt-5.5", "provider": "openrouter"},
-            "create_reasoning_override": {"effort": "high"},
-            "create_service_tier_override": "priority",
-        }
-    )
+    server._ensure_session_db_row({
+        "session_key": "k1",
+        "model_override": {"model": "openai/gpt-5.5", "provider": "openrouter"},
+        "create_reasoning_override": {"effort": "high"},
+        "create_service_tier_override": "priority",
+    })
 
     assert len(created) == 1
     row = created[0]
@@ -6733,7 +7117,16 @@ def test_ensure_session_db_row_no_override_uses_global(monkeypatch):
     created = []
 
     class _FakeDB:
-        def create_session(self, key, source=None, model=None, model_config=None, parent_session_id=None, cwd=None, profile_name=None):
+        def create_session(
+            self,
+            key,
+            source=None,
+            model=None,
+            model_config=None,
+            parent_session_id=None,
+            cwd=None,
+            profile_name=None,
+        ):
             created.append({"model": model, "model_config": model_config})
 
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
@@ -6765,9 +7158,10 @@ def test_ensure_session_db_row_stamps_profile_name(monkeypatch, tmp_path):
     monkeypatch.setattr("hermes_state.SessionDB", _ProfileDB)
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
 
-    server._ensure_session_db_row(
-        {"session_key": "k1", "profile_home": str(profile_home)}
-    )
+    server._ensure_session_db_row({
+        "session_key": "k1",
+        "profile_home": str(profile_home),
+    })
 
     assert created and created[0]["key"] == "k1"
     assert created[0]["profile_name"] == "mlperf"
@@ -6795,13 +7189,11 @@ def test_session_title_clears_pending_after_persist(monkeypatch):
     monkeypatch.setattr(server, "_get_db", lambda: db)
     monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.title",
-                "params": {"session_id": "sid", "title": "fresh"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.title",
+            "params": {"session_id": "sid", "title": "fresh"},
+        })
 
         assert resp["result"]["pending"] is False
         assert resp["result"]["title"] == "fresh"
@@ -6830,13 +7222,11 @@ def test_session_title_does_not_queue_noop_when_row_exists(monkeypatch):
     server._sessions["sid"] = _session(pending_title="stale")
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.title",
-                "params": {"session_id": "sid", "title": "same title"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.title",
+            "params": {"session_id": "sid", "title": "same title"},
+        })
 
         assert resp["result"]["pending"] is False
         assert resp["result"]["title"] == "same title"
@@ -6853,9 +7243,11 @@ def test_session_title_get_falls_back_to_pending_when_db_read_throws(monkeypatch
     server._sessions["sid"] = _session(pending_title="queued title")
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.title", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.title",
+            "params": {"session_id": "sid"},
+        })
         assert resp["result"]["title"] == "queued title"
     finally:
         server._sessions.pop("sid", None)
@@ -6880,9 +7272,11 @@ def test_session_title_get_retries_persist_for_pending_title(monkeypatch):
     server._sessions["sid"] = _session(pending_title="queued title")
     monkeypatch.setattr(server, "_get_db", lambda: db)
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.title", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.title",
+            "params": {"session_id": "sid"},
+        })
         assert resp["result"]["title"] == "queued title"
         assert server._sessions["sid"]["pending_title"] is None
     finally:
@@ -6908,9 +7302,11 @@ def test_session_title_get_retries_pending_even_when_db_has_title(monkeypatch):
     server._sessions["sid"] = _session(pending_title="queued title")
     monkeypatch.setattr(server, "_get_db", lambda: db)
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.title", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.title",
+            "params": {"session_id": "sid"},
+        })
         assert resp["result"]["title"] == "queued title"
         assert server._sessions["sid"]["pending_title"] is None
     finally:
@@ -6925,13 +7321,11 @@ def test_session_title_rejects_empty_title_with_specific_error_code(monkeypatch)
     server._sessions["sid"] = _session()
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.title",
-                "params": {"session_id": "sid", "title": "   "},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.title",
+            "params": {"session_id": "sid", "title": "   "},
+        })
         assert "error" in resp
         assert resp["error"]["code"] == 4021
     finally:
@@ -6952,13 +7346,11 @@ def test_session_title_set_maps_valueerror_to_user_error(monkeypatch):
     server._sessions["sid"] = _session()
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.title",
-                "params": {"session_id": "sid", "title": "dup"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.title",
+            "params": {"session_id": "sid", "title": "dup"},
+        })
         assert "error" in resp
         assert resp["error"]["code"] == 4022
         assert "already in use" in resp["error"]["message"]
@@ -6980,13 +7372,11 @@ def test_session_title_set_errors_when_row_lookup_fails_after_noop(monkeypatch):
     server._sessions["sid"] = _session()
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.title",
-                "params": {"session_id": "sid", "title": "fresh"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.title",
+            "params": {"session_id": "sid", "title": "fresh"},
+        })
         assert "error" in resp
         assert resp["error"]["code"] == 5007
         assert "row lookup failed" in resp["error"]["message"]
@@ -7053,9 +7443,11 @@ def test_session_create_drops_pending_title_on_valueerror(monkeypatch):
     monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
 
     try:
-        server.handle_request(
-            {"id": "1", "method": "prompt.submit", "params": {"session_id": "sid", "text": "hello"}}
-        )
+        server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "hello"},
+        })
         assert session["pending_title"] is None
     finally:
         server._sessions.pop("sid", None)
@@ -7066,23 +7458,19 @@ def test_config_set_yolo_toggles_session_scope():
 
     server._sessions["sid"] = _session()
     try:
-        resp_on = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {"session_id": "sid", "key": "yolo"},
-            }
-        )
+        resp_on = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "yolo"},
+        })
         assert resp_on["result"]["value"] == "1"
         assert is_session_yolo_enabled("session-key") is True
 
-        resp_off = server.handle_request(
-            {
-                "id": "2",
-                "method": "config.set",
-                "params": {"session_id": "sid", "key": "yolo"},
-            }
-        )
+        resp_off = server.handle_request({
+            "id": "2",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "yolo"},
+        })
         assert resp_off["result"]["value"] == "0"
         assert is_session_yolo_enabled("session-key") is False
     finally:
@@ -7098,24 +7486,20 @@ def test_config_set_yolo_global_scope_writes_approvals_mode(tmp_path, monkeypatc
     cfg_path.write_text(yaml.safe_dump({"approvals": {"mode": "manual"}}))
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
 
-    resp_on = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"key": "yolo", "scope": "global"},
-        }
-    )
+    resp_on = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"key": "yolo", "scope": "global"},
+    })
     assert resp_on["result"]["value"] == "1"
     assert resp_on["result"]["scope"] == "global"
     assert yaml.safe_load(cfg_path.read_text())["approvals"]["mode"] == "off"
 
-    resp_off = server.handle_request(
-        {
-            "id": "2",
-            "method": "config.set",
-            "params": {"key": "yolo", "scope": "global"},
-        }
-    )
+    resp_off = server.handle_request({
+        "id": "2",
+        "method": "config.set",
+        "params": {"key": "yolo", "scope": "global"},
+    })
     assert resp_off["result"]["value"] == "0"
     assert yaml.safe_load(cfg_path.read_text())["approvals"]["mode"] == "manual"
 
@@ -7134,9 +7518,11 @@ def test_config_get_approval_mode_uses_smart_default_when_key_is_missing(
         yaml.safe_dump({"approvals": {"timeout": 15}})
     )
 
-    response = server.handle_request(
-        {"id": "1", "method": "config.get", "params": {"key": "approvals.mode"}}
-    )
+    response = server.handle_request({
+        "id": "1",
+        "method": "config.get",
+        "params": {"key": "approvals.mode"},
+    })
     assert response["result"]["value"] == "smart"
 
 
@@ -7155,9 +7541,11 @@ def test_config_get_approval_mode_fails_safe_to_manual_for_invalid_explicit_valu
         yaml.safe_dump({"approvals": {"mode": "sometimes"}})
     )
 
-    response = server.handle_request(
-        {"id": "1", "method": "config.get", "params": {"key": "approvals.mode"}}
-    )
+    response = server.handle_request({
+        "id": "1",
+        "method": "config.get",
+        "params": {"key": "approvals.mode"},
+    })
     assert response["result"]["value"] == "manual"
 
 
@@ -7172,9 +7560,11 @@ def test_config_get_approval_mode_normalizes_yaml_off(tmp_path, monkeypatch):
         yaml.safe_dump({"approvals": {"mode": False}})
     )
 
-    response = server.handle_request(
-        {"id": "1", "method": "config.get", "params": {"key": "approvals.mode"}}
-    )
+    response = server.handle_request({
+        "id": "1",
+        "method": "config.get",
+        "params": {"key": "approvals.mode"},
+    })
     assert response["result"]["value"] == "off"
 
 
@@ -7193,18 +7583,19 @@ def test_config_set_approval_mode_persists_three_way_value_and_emits_live_status
     server._sessions["sid"] = {"agent": object(), "session_key": "profile-session"}
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {"key": "approvals.mode", "value": "manual"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {"key": "approvals.mode", "value": "manual"},
+        })
     finally:
         server._sessions.clear()
 
     assert resp["result"] == {"key": "approvals.mode", "value": "manual"}
-    assert yaml.safe_load((tmp_path / "config.yaml").read_text())["approvals"]["mode"] == "manual"
+    assert (
+        yaml.safe_load((tmp_path / "config.yaml").read_text())["approvals"]["mode"]
+        == "manual"
+    )
     assert emitted and emitted[0][0:2] == ("session.info", "sid")
     assert emitted[0][2]["approval_mode"] == "manual"
 
@@ -7224,9 +7615,7 @@ def test_pet_gallery_quoted_false_enabled_reports_disabled(tmp_path, monkeypatch
         yaml.safe_dump({"display": {"pet": {"enabled": "false"}}})
     )
 
-    response = server.handle_request(
-        {"id": "1", "method": "pet.gallery", "params": {}}
-    )
+    response = server.handle_request({"id": "1", "method": "pet.gallery", "params": {}})
     assert response["result"]["enabled"] is False
 
 
@@ -7255,22 +7644,30 @@ def test_pet_info_known_revision_elides_spritesheet(monkeypatch):
         "scale": 0.33,
     }
 
-    monkeypatch.setattr(server, "_pet_active_selection", lambda: (True, _FakePet(), 0.33))
-    monkeypatch.setattr(server, "_pet_sprite_payload", lambda pet, *, scale: dict(payload))
+    monkeypatch.setattr(
+        server, "_pet_active_selection", lambda: (True, _FakePet(), 0.33)
+    )
+    monkeypatch.setattr(
+        server, "_pet_sprite_payload", lambda pet, *, scale: dict(payload)
+    )
 
     # Matching revision: bytes elided, unchanged marker set.
-    resp = server.handle_request(
-        {"id": "1", "method": "pet.info", "params": {"knownRevision": "123:456"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "pet.info",
+        "params": {"knownRevision": "123:456"},
+    })
     assert resp["result"]["enabled"] is True
     assert "spritesheetBase64" not in resp["result"]
     assert resp["result"]["spritesheetUnchanged"] is True
     assert resp["result"]["spritesheetRevision"] == "123:456"
 
     # Stale revision: full payload still flows.
-    resp = server.handle_request(
-        {"id": "2", "method": "pet.info", "params": {"knownRevision": "999:999"}}
-    )
+    resp = server.handle_request({
+        "id": "2",
+        "method": "pet.info",
+        "params": {"knownRevision": "999:999"},
+    })
     assert resp["result"]["spritesheetBase64"] == "A" * 1024
     assert "spritesheetUnchanged" not in resp["result"]
 
@@ -7284,13 +7681,11 @@ def test_desktop_contract_includes_approval_mode_rpc():
 
 
 def test_config_set_approval_mode_rejects_unknown_value():
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"key": "approvals.mode", "value": "sometimes"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"key": "approvals.mode", "value": "sometimes"},
+    })
 
     assert resp["error"]["code"] == 4002
 
@@ -7303,24 +7698,20 @@ def test_config_set_yolo_global_scope_honors_explicit_value(tmp_path, monkeypatc
     cfg_path.write_text(yaml.safe_dump({"approvals": {"mode": "manual"}}))
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"key": "yolo", "scope": "global", "value": "1"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"key": "yolo", "scope": "global", "value": "1"},
+    })
     assert resp["result"]["value"] == "1"
     assert yaml.safe_load(cfg_path.read_text())["approvals"]["mode"] == "off"
 
     # Setting it on again is idempotent — stays off.
-    resp_again = server.handle_request(
-        {
-            "id": "2",
-            "method": "config.set",
-            "params": {"key": "yolo", "scope": "global", "value": "1"},
-        }
-    )
+    resp_again = server.handle_request({
+        "id": "2",
+        "method": "config.set",
+        "params": {"key": "yolo", "scope": "global", "value": "1"},
+    })
     assert resp_again["result"]["value"] == "1"
     assert yaml.safe_load(cfg_path.read_text())["approvals"]["mode"] == "off"
 
@@ -7352,13 +7743,11 @@ def test_config_set_fast_updates_live_agent_session_scoped(monkeypatch):
     )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {"session_id": "sid", "key": "fast", "value": "fast"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "fast", "value": "fast"},
+        })
         assert resp["result"]["value"] == "fast"
         assert agent.service_tier == "priority"
         assert agent.request_overrides == {
@@ -7369,13 +7758,11 @@ def test_config_set_fast_updates_live_agent_session_scoped(monkeypatch):
         assert writes == []
         assert ("session.info", "sid", {"model": "x"}) in emits
 
-        resp_normal = server.handle_request(
-            {
-                "id": "2",
-                "method": "config.set",
-                "params": {"session_id": "sid", "key": "fast", "value": "normal"},
-            }
-        )
+        resp_normal = server.handle_request({
+            "id": "2",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "fast", "value": "normal"},
+        })
         assert resp_normal["result"]["value"] == "normal"
         assert agent.service_tier is None
         assert agent.request_overrides == {"foo": "bar"}
@@ -7399,13 +7786,11 @@ def test_config_set_fast_status_is_non_mutating(monkeypatch):
     monkeypatch.setattr(server, "_emit", lambda *args: emits.append(args))
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {"session_id": "sid", "key": "fast", "value": "status"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "fast", "value": "status"},
+        })
         assert resp["result"]["value"] == "fast"
         assert writes == []
         assert emits == []
@@ -7431,13 +7816,11 @@ def test_config_set_fast_rejects_unsupported_model(monkeypatch):
     )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {"session_id": "sid", "key": "fast", "value": "fast"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "fast", "value": "fast"},
+        })
         assert resp["error"]["code"] == 4002
         assert "not available" in resp["error"]["message"]
         assert agent.service_tier is None
@@ -7461,13 +7844,11 @@ def test_config_set_fast_rejects_missing_model(monkeypatch):
     )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {"session_id": "sid", "key": "fast", "value": "fast"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "fast", "value": "fast"},
+        })
         assert resp["error"]["code"] == 4002
         assert "without a selected model" in resp["error"]["message"]
         assert agent.service_tier is None
@@ -7489,18 +7870,18 @@ def test_config_busy_get_and_set(monkeypatch):
         server, "_write_config_key", lambda path, value: writes.append((path, value))
     )
 
-    get_resp = server.handle_request(
-        {"id": "1", "method": "config.get", "params": {"key": "busy"}}
-    )
+    get_resp = server.handle_request({
+        "id": "1",
+        "method": "config.get",
+        "params": {"key": "busy"},
+    })
     assert get_resp["result"]["value"] == "steer"
 
-    set_resp = server.handle_request(
-        {
-            "id": "2",
-            "method": "config.set",
-            "params": {"key": "busy", "value": "interrupt"},
-        }
-    )
+    set_resp = server.handle_request({
+        "id": "2",
+        "method": "config.set",
+        "params": {"key": "busy", "value": "interrupt"},
+    })
     assert set_resp["result"]["value"] == "interrupt"
     assert ("display.busy_input_mode", "interrupt") in writes
 
@@ -7508,13 +7889,11 @@ def test_config_busy_get_and_set(monkeypatch):
 def test_config_set_yolo_process_scope_treats_false_like_env_as_disabled(monkeypatch):
     monkeypatch.setenv("HERMES_YOLO_MODE", "false")
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"key": "yolo"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"key": "yolo"},
+    })
 
     assert resp["result"]["value"] == "1"
     assert os.environ.get("HERMES_YOLO_MODE") == "1"
@@ -7523,9 +7902,11 @@ def test_config_set_yolo_process_scope_treats_false_like_env_as_disabled(monkeyp
 def test_config_get_statusbar_survives_non_dict_display(monkeypatch):
     monkeypatch.setattr(server, "_load_cfg", lambda: {"display": "broken"})
 
-    resp = server.handle_request(
-        {"id": "1", "method": "config.get", "params": {"key": "statusbar"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.get",
+        "params": {"key": "statusbar"},
+    })
 
     assert resp["result"]["value"] == "top"
 
@@ -7533,9 +7914,11 @@ def test_config_get_statusbar_survives_non_dict_display(monkeypatch):
 def test_config_get_busy_survives_non_dict_display(monkeypatch):
     monkeypatch.setattr(server, "_load_cfg", lambda: {"display": "broken"})
 
-    resp = server.handle_request(
-        {"id": "1", "method": "config.get", "params": {"key": "busy"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.get",
+        "params": {"key": "busy"},
+    })
 
     assert resp["result"]["value"] == "interrupt"
 
@@ -7547,13 +7930,11 @@ def test_config_set_statusbar_survives_non_dict_display(tmp_path, monkeypatch):
     cfg_path.write_text(yaml.safe_dump({"display": "broken"}))
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"key": "statusbar", "value": "bottom"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"key": "statusbar", "value": "bottom"},
+    })
 
     assert resp["result"]["value"] == "bottom"
     saved = yaml.safe_load(cfg_path.read_text())
@@ -7565,19 +7946,17 @@ def test_config_set_details_mode_pins_all_sections(tmp_path, monkeypatch):
 
     cfg_path = tmp_path / "config.yaml"
     cfg_path.write_text(
-        yaml.safe_dump(
-            {"display": {"sections": {"tools": "expanded", "activity": "hidden"}}}
-        )
+        yaml.safe_dump({
+            "display": {"sections": {"tools": "expanded", "activity": "hidden"}}
+        })
     )
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"key": "details_mode", "value": "collapsed"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"key": "details_mode", "value": "collapsed"},
+    })
 
     assert resp["result"] == {"key": "details_mode", "value": "collapsed"}
     saved = yaml.safe_load(cfg_path.read_text())
@@ -7596,13 +7975,11 @@ def test_config_set_section_writes_per_section_override(tmp_path, monkeypatch):
     cfg_path = tmp_path / "config.yaml"
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"key": "details_mode.activity", "value": "hidden"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"key": "details_mode.activity", "value": "hidden"},
+    })
 
     assert resp["result"] == {"key": "details_mode.activity", "value": "hidden"}
     saved = yaml.safe_load(cfg_path.read_text())
@@ -7614,19 +7991,17 @@ def test_config_set_section_clears_override_on_empty_value(tmp_path, monkeypatch
 
     cfg_path = tmp_path / "config.yaml"
     cfg_path.write_text(
-        yaml.safe_dump(
-            {"display": {"sections": {"activity": "hidden", "tools": "expanded"}}}
-        )
+        yaml.safe_dump({
+            "display": {"sections": {"activity": "hidden", "tools": "expanded"}}
+        })
     )
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"key": "details_mode.activity", "value": ""},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"key": "details_mode.activity", "value": ""},
+    })
 
     assert resp["result"] == {"key": "details_mode.activity", "value": ""}
     saved = yaml.safe_load(cfg_path.read_text())
@@ -7636,22 +8011,18 @@ def test_config_set_section_clears_override_on_empty_value(tmp_path, monkeypatch
 def test_config_set_section_rejects_unknown_section_or_mode(tmp_path, monkeypatch):
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
 
-    bad_section = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"key": "details_mode.bogus", "value": "hidden"},
-        }
-    )
+    bad_section = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"key": "details_mode.bogus", "value": "hidden"},
+    })
     assert bad_section["error"]["code"] == 4002
 
-    bad_mode = server.handle_request(
-        {
-            "id": "2",
-            "method": "config.set",
-            "params": {"key": "details_mode.tools", "value": "maximised"},
-        }
-    )
+    bad_mode = server.handle_request({
+        "id": "2",
+        "method": "config.set",
+        "params": {"key": "details_mode.tools", "value": "maximised"},
+    })
     assert bad_mode["error"]["code"] == 4002
 
 
@@ -7664,29 +8035,37 @@ def test_config_mouse_uses_documented_key_with_legacy_fallback(monkeypatch):
         server, "_write_config_key", lambda path, value: writes.append((path, value))
     )
 
-    get_legacy = server.handle_request(
-        {"id": "1", "method": "config.get", "params": {"key": "mouse"}}
-    )
+    get_legacy = server.handle_request({
+        "id": "1",
+        "method": "config.get",
+        "params": {"key": "mouse"},
+    })
     assert get_legacy["result"]["value"] == "off"
 
-    set_toggle = server.handle_request(
-        {"id": "2", "method": "config.set", "params": {"key": "mouse"}}
-    )
+    set_toggle = server.handle_request({
+        "id": "2",
+        "method": "config.set",
+        "params": {"key": "mouse"},
+    })
     # /mouse (no arg) toggles between 'all' and 'off'. Starting from
     # tui_mouse: False (→ 'off'), the toggle flips to 'all'.
     assert set_toggle["result"] == {"key": "mouse", "value": "all"}
     assert writes == [("display.mouse_tracking", "all")]
 
     cfg["display"] = {"mouse_tracking": 0, "tui_mouse": True}
-    get_canonical = server.handle_request(
-        {"id": "3", "method": "config.get", "params": {"key": "mouse"}}
-    )
+    get_canonical = server.handle_request({
+        "id": "3",
+        "method": "config.get",
+        "params": {"key": "mouse"},
+    })
     assert get_canonical["result"]["value"] == "off"
 
     cfg["display"] = {"mouse_tracking": None, "tui_mouse": False}
-    get_null = server.handle_request(
-        {"id": "4", "method": "config.get", "params": {"key": "mouse"}}
-    )
+    get_null = server.handle_request({
+        "id": "4",
+        "method": "config.get",
+        "params": {"key": "mouse"},
+    })
     # mouse_tracking present-but-None defers neither to tui_mouse nor to
     # the legacy off bucket: it falls through to the 'all' default.
     assert get_null["result"]["value"] == "all"
@@ -7702,35 +8081,29 @@ def test_config_mouse_accepts_preset_strings_and_aliases(monkeypatch):
     )
 
     # Direct preset.
-    set_wheel = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"key": "mouse", "value": "wheel"},
-        }
-    )
+    set_wheel = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"key": "mouse", "value": "wheel"},
+    })
     assert set_wheel["result"] == {"key": "mouse", "value": "wheel"}
     assert writes[-1] == ("display.mouse_tracking", "wheel")
 
     # Alias for buttons.
-    set_click = server.handle_request(
-        {
-            "id": "2",
-            "method": "config.set",
-            "params": {"key": "mouse", "value": "click"},
-        }
-    )
+    set_click = server.handle_request({
+        "id": "2",
+        "method": "config.set",
+        "params": {"key": "mouse", "value": "click"},
+    })
     assert set_click["result"] == {"key": "mouse", "value": "buttons"}
     assert writes[-1] == ("display.mouse_tracking", "buttons")
 
     # Unknown value → 4002.
-    bad = server.handle_request(
-        {
-            "id": "3",
-            "method": "config.set",
-            "params": {"key": "mouse", "value": "rainbows"},
-        }
-    )
+    bad = server.handle_request({
+        "id": "3",
+        "method": "config.set",
+        "params": {"key": "mouse", "value": "rainbows"},
+    })
     assert bad["error"]["code"] == 4002
 
 
@@ -7779,7 +8152,11 @@ def test_setup_runtime_check_rejects_empty_runtime_key(monkeypatch):
         },
     )
 
-    resp = server.handle_request({"id": "1", "method": "setup.runtime_check", "params": {}})
+    resp = server.handle_request({
+        "id": "1",
+        "method": "setup.runtime_check",
+        "params": {},
+    })
 
     assert resp["result"] == {
         "ok": False,
@@ -7801,7 +8178,11 @@ def test_setup_runtime_check_allows_no_key_custom_runtime(monkeypatch):
         },
     )
 
-    resp = server.handle_request({"id": "1", "method": "setup.runtime_check", "params": {}})
+    resp = server.handle_request({
+        "id": "1",
+        "method": "setup.runtime_check",
+        "params": {},
+    })
 
     assert resp["result"]["ok"] is True
     assert resp["result"]["provider"] == "custom"
@@ -7818,7 +8199,11 @@ def test_setup_runtime_check_rejects_implicit_bedrock_when_unconfigured(monkeypa
         },
     )
 
-    resp = server.handle_request({"id": "1", "method": "setup.runtime_check", "params": {}})
+    resp = server.handle_request({
+        "id": "1",
+        "method": "setup.runtime_check",
+        "params": {},
+    })
 
     assert resp["result"]["ok"] is False
     assert resp["result"]["provider"] == "bedrock"
@@ -7846,13 +8231,19 @@ def test_setup_runtime_check_honors_requested_provider(monkeypatch):
         fake_resolve,
     )
 
-    scoped = server.handle_request(
-        {"id": "1", "method": "setup.runtime_check", "params": {"provider": "nous"}}
-    )
+    scoped = server.handle_request({
+        "id": "1",
+        "method": "setup.runtime_check",
+        "params": {"provider": "nous"},
+    })
     assert scoped["result"]["ok"] is True
     assert scoped["result"]["provider"] == "nous"
 
-    default = server.handle_request({"id": "1", "method": "setup.runtime_check", "params": {}})
+    default = server.handle_request({
+        "id": "1",
+        "method": "setup.runtime_check",
+        "params": {},
+    })
     assert default["result"]["ok"] is False
     assert default["result"]["provider"] == "anthropic"
 
@@ -7860,16 +8251,20 @@ def test_setup_runtime_check_honors_requested_provider(monkeypatch):
 def test_complete_slash_drops_removed_provider_alias():
     # `/provider` was folded into a single `/model` command, so autocomplete
     # must no longer offer the dead alias...
-    resp = server.handle_request(
-        {"id": "1", "method": "complete.slash", "params": {"text": "/pro"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "complete.slash",
+        "params": {"text": "/pro"},
+    })
 
     assert not any(item["text"] == "provider" for item in resp["result"]["items"])
 
     # ...while `/model` stays the canonical command.
-    resp_model = server.handle_request(
-        {"id": "2", "method": "complete.slash", "params": {"text": "/mod"}}
-    )
+    resp_model = server.handle_request({
+        "id": "2",
+        "method": "complete.slash",
+        "params": {"text": "/mod"},
+    })
 
     assert any(item["text"] == "model" for item in resp_model["result"]["items"])
 
@@ -7879,9 +8274,11 @@ def test_complete_slash_returns_plain_string_fields():
     # display/display_meta; the TUI's CompletionItem contract is plain
     # strings, and shipping the raw list trips Ink's row layout into
     # 1-char truncation of the next column (/goal → /goa).
-    resp = server.handle_request(
-        {"id": "1", "method": "complete.slash", "params": {"text": "/g"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "complete.slash",
+        "params": {"text": "/g"},
+    })
 
     items = resp["result"]["items"]
     goal = next((it for it in items if it["text"] == "goal"), None)
@@ -7895,35 +8292,41 @@ def test_complete_slash_returns_plain_string_fields():
 
 
 def test_complete_slash_includes_tui_details_command():
-    resp = server.handle_request(
-        {"id": "1", "method": "complete.slash", "params": {"text": "/det"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "complete.slash",
+        "params": {"text": "/det"},
+    })
 
     assert any(item["text"] == "/details" for item in resp["result"]["items"])
 
 
 def test_complete_slash_includes_tui_mouse_command():
-    resp = server.handle_request(
-        {"id": "1", "method": "complete.slash", "params": {"text": "/mou"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "complete.slash",
+        "params": {"text": "/mou"},
+    })
 
     assert any(item["text"] == "/mouse" for item in resp["result"]["items"])
 
 
 def test_complete_slash_details_args():
-    resp_root = server.handle_request(
-        {"id": "0", "method": "complete.slash", "params": {"text": "/details"}}
-    )
-    resp_section = server.handle_request(
-        {"id": "1", "method": "complete.slash", "params": {"text": "/details t"}}
-    )
-    resp_mode = server.handle_request(
-        {
-            "id": "2",
-            "method": "complete.slash",
-            "params": {"text": "/details thinking e"},
-        }
-    )
+    resp_root = server.handle_request({
+        "id": "0",
+        "method": "complete.slash",
+        "params": {"text": "/details"},
+    })
+    resp_section = server.handle_request({
+        "id": "1",
+        "method": "complete.slash",
+        "params": {"text": "/details t"},
+    })
+    resp_mode = server.handle_request({
+        "id": "2",
+        "method": "complete.slash",
+        "params": {"text": "/details thinking e"},
+    })
 
     assert resp_root["result"]["replace_from"] == len("/details")
     assert any(item["text"] == " thinking" for item in resp_root["result"]["items"])
@@ -7932,9 +8335,11 @@ def test_complete_slash_details_args():
 
 
 def test_complete_slash_reasoning_includes_current_efforts_and_global_scope():
-    resp = server.handle_request(
-        {"id": "1", "method": "complete.slash", "params": {"text": "/reasoning "}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "complete.slash",
+        "params": {"text": "/reasoning "},
+    })
 
     values = {item["text"] for item in resp["result"]["items"]}
     assert {"max", "ultra", "--global"} <= values
@@ -7970,9 +8375,11 @@ def _slash_skill_fixtures(monkeypatch):
 
 
 def _slash_completions(text: str) -> list[dict]:
-    resp = server.handle_request(
-        {"id": "1", "method": "complete.slash", "params": {"text": text}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "complete.slash",
+        "params": {"text": text},
+    })
     return resp["result"]["items"]
 
 
@@ -7994,7 +8401,9 @@ def test_complete_slash_ranks_skills_by_recorded_usage(monkeypatch):
     _slash_skill_fixtures(monkeypatch)
 
     skills = [
-        item["text"].strip() for item in _slash_completions("/") if item["kind"] == "skill"
+        item["text"].strip()
+        for item in _slash_completions("/")
+        if item["kind"] == "skill"
     ]
 
     assert skills[:3] == ["work", "research", "clean"]
@@ -8030,69 +8439,66 @@ def test_complete_slash_leaves_argument_stages_alone(monkeypatch):
 
 def test_config_set_reasoning_updates_live_session_and_agent(tmp_path, monkeypatch):
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
-    (tmp_path / "config.yaml").write_text("agent:\n  reasoning_effort: medium\n", encoding="utf-8")
+    (tmp_path / "config.yaml").write_text(
+        "agent:\n  reasoning_effort: medium\n", encoding="utf-8"
+    )
     agent = types.SimpleNamespace(reasoning_config=None)
     server._sessions["sid"] = _session(agent=agent)
 
-    resp_effort = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {
-                "session_id": "sid",
-                "key": "reasoning",
-                "value": "low",
-            },
-        }
-    )
+    resp_effort = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {
+            "session_id": "sid",
+            "key": "reasoning",
+            "value": "low",
+        },
+    })
     assert resp_effort["result"]["value"] == "low"
     assert agent.reasoning_config == {"enabled": True, "effort": "low"}
-    assert server._sessions["sid"]["create_reasoning_override"] == {"enabled": True, "effort": "low"}
+    assert server._sessions["sid"]["create_reasoning_override"] == {
+        "enabled": True,
+        "effort": "low",
+    }
     assert server._load_cfg()["agent"]["reasoning_effort"] == "medium"
 
-    resp_status = server.handle_request(
-        {
-            "id": "5",
-            "method": "config.get",
-            "params": {"session_id": "sid", "key": "reasoning"},
-        }
-    )
+    resp_status = server.handle_request({
+        "id": "5",
+        "method": "config.get",
+        "params": {"session_id": "sid", "key": "reasoning"},
+    })
     assert resp_status["result"]["value"] == "low"
 
-    resp_global_status = server.handle_request(
-        {"id": "6", "method": "config.get", "params": {"key": "reasoning"}}
-    )
+    resp_global_status = server.handle_request({
+        "id": "6",
+        "method": "config.get",
+        "params": {"key": "reasoning"},
+    })
     assert resp_global_status["result"]["value"] == "medium"
 
     del server._sessions["sid"]["create_reasoning_override"]
     agent.reasoning_config = {"enabled": True, "effort": "high"}
-    resp_agent_status = server.handle_request(
-        {
-            "id": "7",
-            "method": "config.get",
-            "params": {"session_id": "sid", "key": "reasoning"},
-        }
-    )
+    resp_agent_status = server.handle_request({
+        "id": "7",
+        "method": "config.get",
+        "params": {"session_id": "sid", "key": "reasoning"},
+    })
     assert resp_agent_status["result"]["value"] == "high"
 
-    resp_show = server.handle_request(
-        {
-            "id": "2",
-            "method": "config.set",
-            "params": {"session_id": "sid", "key": "reasoning", "value": "show"},
-        }
-    )
+    resp_show = server.handle_request({
+        "id": "2",
+        "method": "config.set",
+        "params": {"session_id": "sid", "key": "reasoning", "value": "show"},
+    })
     assert resp_show["result"]["value"] == "show"
     assert server._sessions["sid"]["show_reasoning"] is True
     assert server._load_cfg()["display"]["sections"]["thinking"] == "expanded"
 
-    resp_hide = server.handle_request(
-        {
-            "id": "3",
-            "method": "config.set",
-            "params": {"session_id": "sid", "key": "reasoning", "value": "hide"},
-        }
-    )
+    resp_hide = server.handle_request({
+        "id": "3",
+        "method": "config.set",
+        "params": {"session_id": "sid", "key": "reasoning", "value": "hide"},
+    })
     assert resp_hide["result"]["value"] == "hide"
     assert server._sessions["sid"]["show_reasoning"] is False
     assert server._load_cfg()["display"]["sections"]["thinking"] == "hidden"
@@ -8100,58 +8506,61 @@ def test_config_set_reasoning_updates_live_session_and_agent(tmp_path, monkeypat
     # /reasoning full | clamp — parity with the classic CLI reasoning_full
     # toggle. In the TUI these map to the thinking section's expand/collapse
     # rendering (no fixed 10-line recap exists here).
-    resp_full = server.handle_request(
-        {
-            "id": "4",
-            "method": "config.set",
-            "params": {"session_id": "sid", "key": "reasoning", "value": "full"},
-        }
-    )
+    resp_full = server.handle_request({
+        "id": "4",
+        "method": "config.set",
+        "params": {"session_id": "sid", "key": "reasoning", "value": "full"},
+    })
     assert resp_full["result"]["value"] == "full"
     cfg_full = server._load_cfg()
     assert cfg_full["display"]["reasoning_full"] is True
     assert cfg_full["display"]["sections"]["thinking"] == "expanded"
 
-    resp_clamp = server.handle_request(
-        {
-            "id": "5",
-            "method": "config.set",
-            "params": {"session_id": "sid", "key": "reasoning", "value": "clamp"},
-        }
-    )
+    resp_clamp = server.handle_request({
+        "id": "5",
+        "method": "config.set",
+        "params": {"session_id": "sid", "key": "reasoning", "value": "clamp"},
+    })
     assert resp_clamp["result"]["value"] == "clamp"
     cfg_clamp = server._load_cfg()
     assert cfg_clamp["display"]["reasoning_full"] is False
     assert cfg_clamp["display"]["sections"]["thinking"] == "collapsed"
 
 
-def test_config_set_reasoning_global_scope_clears_session_override(tmp_path, monkeypatch):
+def test_config_set_reasoning_global_scope_clears_session_override(
+    tmp_path, monkeypatch
+):
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
-    (tmp_path / "config.yaml").write_text("agent:\n  reasoning_effort: medium\n", encoding="utf-8")
+    (tmp_path / "config.yaml").write_text(
+        "agent:\n  reasoning_effort: medium\n", encoding="utf-8"
+    )
     agent = types.SimpleNamespace(reasoning_config=None)
     server._sessions["sid"] = _session(agent=agent)
-    server._sessions["sid"]["create_reasoning_override"] = {"enabled": True, "effort": "low"}
+    server._sessions["sid"]["create_reasoning_override"] = {
+        "enabled": True,
+        "effort": "low",
+    }
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {
-                "session_id": "sid",
-                "key": "reasoning",
-                "value": "high",
-                "scope": "global",
-            },
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {
+            "session_id": "sid",
+            "key": "reasoning",
+            "value": "high",
+            "scope": "global",
+        },
+    })
 
     assert resp["result"]["value"] == "high"
     assert server._load_cfg()["agent"]["reasoning_effort"] == "high"
     assert "create_reasoning_override" not in server._sessions["sid"]
 
-    status = server.handle_request(
-        {"id": "2", "method": "config.get", "params": {"session_id": "sid", "key": "reasoning"}}
-    )
+    status = server.handle_request({
+        "id": "2",
+        "method": "config.get",
+        "params": {"session_id": "sid", "key": "reasoning"},
+    })
     assert status["result"]["value"] == "high"
 
 
@@ -8160,18 +8569,15 @@ def test_config_set_verbose_updates_session_mode_and_agent(tmp_path, monkeypatch
     agent = types.SimpleNamespace(verbose_logging=False)
     server._sessions["sid"] = _session(agent=agent)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"session_id": "sid", "key": "verbose", "value": "cycle"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"session_id": "sid", "key": "verbose", "value": "cycle"},
+    })
 
     assert resp["result"]["value"] == "verbose"
     assert server._sessions["sid"]["tool_progress_mode"] == "verbose"
     assert agent.verbose_logging is True
-
 
 
 def test_config_set_model_waits_for_lazy_agent_before_switch(monkeypatch):
@@ -8202,18 +8608,17 @@ def test_config_set_model_waits_for_lazy_agent_before_switch(monkeypatch):
     monkeypatch.setattr(server, "_apply_model_switch", fake_apply)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {"session_id": "sid", "key": "model", "value": "new/model"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "model", "value": "new/model"},
+        })
 
         assert resp["result"]["value"] == "new/model"
         assert calls == [("start", "sid"), ("apply", "sid", agent, "new/model")]
     finally:
         server._sessions.pop("sid", None)
+
 
 def test_config_set_model_uses_live_switch_path(monkeypatch):
     server._sessions["sid"] = _session()
@@ -8224,13 +8629,11 @@ def test_config_set_model_uses_live_switch_path(monkeypatch):
         return {"value": "new/model", "warning": "catalog unreachable"}
 
     monkeypatch.setattr(server, "_apply_model_switch", _fake_apply)
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"session_id": "sid", "key": "model", "value": "new/model"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"session_id": "sid", "key": "model", "value": "new/model"},
+    })
 
     assert resp["result"]["value"] == "new/model"
     assert resp["result"]["warning"] == "catalog unreachable"
@@ -8271,34 +8674,30 @@ def test_config_set_model_requires_confirmation_for_expensive_model(monkeypatch)
     monkeypatch.setattr(server, "_restart_slash_worker", lambda sid, session: None)
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {
-                "session_id": "sid",
-                "key": "model",
-                "value": "openai/gpt-5.5-pro --provider openrouter",
-            },
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {
+            "session_id": "sid",
+            "key": "model",
+            "value": "openai/gpt-5.5-pro --provider openrouter",
+        },
+    })
 
     assert resp["result"]["confirm_required"] is True
     assert "did you mean to select openai/gpt-5.5?" in resp["result"]["confirm_message"]
     assert agent.switched is False
 
-    confirmed = server.handle_request(
-        {
-            "id": "2",
-            "method": "config.set",
-            "params": {
-                "session_id": "sid",
-                "key": "model",
-                "value": "openai/gpt-5.5-pro --provider openrouter",
-                "confirm_expensive_model": True,
-            },
-        }
-    )
+    confirmed = server.handle_request({
+        "id": "2",
+        "method": "config.set",
+        "params": {
+            "session_id": "sid",
+            "key": "model",
+            "value": "openai/gpt-5.5-pro --provider openrouter",
+            "confirm_expensive_model": True,
+        },
+    })
 
     assert confirmed["result"]["confirm_required"] is False
     assert confirmed["result"]["value"] == "openai/gpt-5.5-pro"
@@ -8337,19 +8736,20 @@ def test_config_set_model_global_persists(monkeypatch):
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
     # _persist_model_switch uses targeted save_config_value writes (#48305) so it
     # preserves sibling model.* keys instead of rewriting the whole block.
-    monkeypatch.setattr("cli.save_config_value", lambda key, value: saved_values.__setitem__(key, value) or True)
-
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {
-                "session_id": "sid",
-                "key": "model",
-                "value": "anthropic/claude-sonnet-4.6 --global",
-            },
-        }
+    monkeypatch.setattr(
+        "cli.save_config_value",
+        lambda key, value: saved_values.__setitem__(key, value) or True,
     )
+
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {
+            "session_id": "sid",
+            "key": "model",
+            "value": "anthropic/claude-sonnet-4.6 --global",
+        },
+    })
 
     assert resp["result"]["value"] == "anthropic/claude-sonnet-4.6"
     assert seen["is_global"] is True
@@ -8363,9 +8763,19 @@ def test_config_set_model_explicit_provider_skips_broken_default_init(monkeypatc
     session = _session()
     session["agent"] = None
     server._sessions["sid"] = session
-    monkeypatch.setattr(server, "_load_cfg", lambda: {"model": {"default": "broken/model", "provider": "openrouter"}})
-    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: seen.__setitem__("build", seen["build"] + 1))
-    monkeypatch.setattr(server, "_wait_agent", lambda *_args: seen.__setitem__("wait", seen["wait"] + 1))
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"model": {"default": "broken/model", "provider": "openrouter"}},
+    )
+    monkeypatch.setattr(
+        server,
+        "_start_agent_build",
+        lambda *_args: seen.__setitem__("build", seen["build"] + 1),
+    )
+    monkeypatch.setattr(
+        server, "_wait_agent", lambda *_args: seen.__setitem__("wait", seen["wait"] + 1)
+    )
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
     monkeypatch.setattr(server, "_restart_slash_worker", lambda *args, **kwargs: None)
 
@@ -8381,20 +8791,20 @@ def test_config_set_model_explicit_provider_skips_broken_default_init(monkeypatc
             }
         raise RuntimeError(f"unexpected provider {requested}")
 
-    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", fake_runtime_provider)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", fake_runtime_provider
+    )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {
-                    "session_id": "sid",
-                    "key": "model",
-                    "value": "claude-sonnet-4.6 --provider anthropic",
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {
+                "session_id": "sid",
+                "key": "model",
+                "value": "claude-sonnet-4.6 --provider anthropic",
+            },
+        })
 
         assert resp["result"]["value"] == "claude-sonnet-4-6"
         assert seen["build"] == 0
@@ -8406,14 +8816,26 @@ def test_config_set_model_explicit_provider_skips_broken_default_init(monkeypatc
         server._sessions.pop("sid", None)
 
 
-def test_config_set_model_explicit_provider_surfaces_selected_provider_errors(monkeypatch):
+def test_config_set_model_explicit_provider_surfaces_selected_provider_errors(
+    monkeypatch,
+):
     seen = {"build": 0, "wait": 0}
     session = _session()
     session["agent"] = None
     server._sessions["sid"] = session
-    monkeypatch.setattr(server, "_load_cfg", lambda: {"model": {"default": "broken/model", "provider": "openrouter"}})
-    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: seen.__setitem__("build", seen["build"] + 1))
-    monkeypatch.setattr(server, "_wait_agent", lambda *_args: seen.__setitem__("wait", seen["wait"] + 1))
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"model": {"default": "broken/model", "provider": "openrouter"}},
+    )
+    monkeypatch.setattr(
+        server,
+        "_start_agent_build",
+        lambda *_args: seen.__setitem__("build", seen["build"] + 1),
+    )
+    monkeypatch.setattr(
+        server, "_wait_agent", lambda *_args: seen.__setitem__("wait", seen["wait"] + 1)
+    )
 
     def fake_runtime_provider(*, requested=None, **_kwargs):
         if requested is None:
@@ -8422,20 +8844,20 @@ def test_config_set_model_explicit_provider_surfaces_selected_provider_errors(mo
             raise RuntimeError("missing anthropic API key")
         raise RuntimeError(f"unexpected provider {requested}")
 
-    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", fake_runtime_provider)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", fake_runtime_provider
+    )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {
-                    "session_id": "sid",
-                    "key": "model",
-                    "value": "claude-sonnet-4.6 --provider anthropic",
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {
+                "session_id": "sid",
+                "key": "model",
+                "value": "claude-sonnet-4.6 --provider anthropic",
+            },
+        })
 
         assert resp["error"]["code"] == 5001
         assert "anthropic" in resp["error"]["message"].lower()
@@ -8486,17 +8908,15 @@ def test_config_set_model_does_not_leak_inference_provider_env(monkeypatch):
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
 
     try:
-        server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {
-                    "session_id": "sid",
-                    "key": "model",
-                    "value": "claude-sonnet-4.6 --provider anthropic",
-                },
-            }
-        )
+        server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {
+                "session_id": "sid",
+                "key": "model",
+                "value": "claude-sonnet-4.6 --provider anthropic",
+            },
+        })
 
         # Shared process env is UNCHANGED (the contamination vector is gone).
         assert os.environ["HERMES_INFERENCE_PROVIDER"] == "openrouter"
@@ -8547,17 +8967,15 @@ def test_config_set_model_records_per_session_override_not_env(monkeypatch):
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
 
     try:
-        server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {
-                    "session_id": "sid",
-                    "key": "model",
-                    "value": "deepseek-v4-pro --provider custom:xuanji",
-                },
-            }
-        )
+        server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {
+                "session_id": "sid",
+                "key": "model",
+                "value": "deepseek-v4-pro --provider custom:xuanji",
+            },
+        })
 
         # No process-global env mutation.
         assert "HERMES_TUI_PROVIDER" not in os.environ
@@ -8613,9 +9031,11 @@ def test_config_set_model_switches_agent_without_touching_env(monkeypatch):
             self.system_prompt = system_prompt
 
         def append_message(self, session_id, role, content=None, **_kwargs):
-            self.messages.append(
-                {"session_id": session_id, "role": role, "content": content}
-            )
+            self.messages.append({
+                "session_id": session_id,
+                "role": role,
+                "content": content,
+            })
 
     agent = Agent()
     db = SessionDB()
@@ -8642,17 +9062,15 @@ def test_config_set_model_switches_agent_without_touching_env(monkeypatch):
     monkeypatch.setattr("hermes_cli.model_switch.switch_model", fake_switch_model)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {
-                    "session_id": "sid",
-                    "key": "model",
-                    "value": "anthropic/claude-sonnet-4.6 --provider anthropic",
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {
+                "session_id": "sid",
+                "key": "model",
+                "value": "anthropic/claude-sonnet-4.6 --provider anthropic",
+            },
+        })
 
         assert resp["result"]["value"] == "anthropic/claude-sonnet-4.6"
         # Agent switched in place...
@@ -8670,7 +9088,10 @@ def test_config_set_model_switches_agent_without_touching_env(monkeypatch):
         )
         assert agent._cached_system_prompt == db.system_prompt
         assert session["history"][-1]["role"] == "user"
-        assert "changed to anthropic/claude-sonnet-4.6" in session["history"][-1]["content"]
+        assert (
+            "changed to anthropic/claude-sonnet-4.6"
+            in session["history"][-1]["content"]
+        )
         assert db.messages[-1] == {
             "session_id": "session-key",
             "role": "user",
@@ -8722,17 +9143,15 @@ def test_config_set_model_once_keeps_env_and_records_restore(monkeypatch):
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {
-                    "session_id": "sid",
-                    "key": "model",
-                    "value": "claude-sonnet-4.6 --provider anthropic --once",
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {
+                "session_id": "sid",
+                "key": "model",
+                "value": "claude-sonnet-4.6 --provider anthropic --once",
+            },
+        })
 
         assert resp["result"]["scope"] == "once"
         assert seen["is_global"] is False
@@ -8750,16 +9169,14 @@ def test_config_set_model_once_requires_live_session(monkeypatch):
         lambda **_: (_ for _ in ()).throw(AssertionError("switch should not run")),
     )
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {
-                "key": "model",
-                "value": "claude-sonnet-4.6 --provider anthropic --once",
-            },
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {
+            "key": "model",
+            "value": "claude-sonnet-4.6 --provider anthropic --once",
+        },
+    })
 
     assert resp["error"]["code"] == 5001
     assert "/model --once requires a live session" in resp["error"]["message"]
@@ -8792,22 +9209,22 @@ def test_config_set_model_session_switch_clears_pending_once_restore(monkeypatch
     session = _session(agent=Agent())
     session["one_turn_model_restore"] = {"model": "old/model"}
     server._sessions["sid"] = session
-    monkeypatch.setattr("hermes_cli.model_switch.switch_model", lambda **_kwargs: result)
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model", lambda **_kwargs: result
+    )
     monkeypatch.setattr(server, "_restart_slash_worker", lambda *args, **kwargs: None)
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {
-                    "session_id": "sid",
-                    "key": "model",
-                    "value": "new/model --provider openrouter --session",
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {
+                "session_id": "sid",
+                "key": "model",
+                "value": "new/model --provider openrouter --session",
+            },
+        })
 
         assert resp["result"]["scope"] == "session"
         assert "one_turn_model_restore" not in session
@@ -8854,13 +9271,11 @@ def test_config_set_personality_rejects_unknown_name(monkeypatch):
         "_available_personalities",
         lambda cfg=None: {"helpful": "You are helpful."},
     )
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"key": "personality", "value": "bogus"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"key": "personality", "value": "bogus"},
+    })
 
     assert "error" in resp
     assert "Unknown personality" in resp["error"]["message"]
@@ -8885,7 +9300,9 @@ def test_config_set_personality_preserves_history_and_returns_info(monkeypatch):
         lambda cfg=None: {"helpful": "You are helpful."},
     )
     monkeypatch.setattr(
-        server, "_session_info", lambda agent, *a: {"model": getattr(agent, "model", "?")}
+        server,
+        "_session_info",
+        lambda agent, *a: {"model": getattr(agent, "model", "?")},
     )
     monkeypatch.setattr(server, "_emit", lambda *args: emits.append(args))
     # Persistence now flows through the single owner (hermes_cli.personality),
@@ -8903,13 +9320,11 @@ def test_config_set_personality_preserves_history_and_returns_info(monkeypatch):
         lambda path, value: writes.append((path, value)),
     )
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"session_id": "sid", "key": "personality", "value": "helpful"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"session_id": "sid", "key": "personality", "value": "helpful"},
+    })
 
     assert resp["result"]["history_reset"] is False
     assert resp["result"]["info"] == {"model": "?"}
@@ -9003,9 +9418,11 @@ def test_session_compress_uses_compress_helper(monkeypatch):
     monkeypatch.setattr(server, "_session_info", lambda _agent, *a: {"model": "x"})
 
     with patch("tui_gateway.server._emit") as emit:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.compress", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.compress",
+            "params": {"session_id": "sid"},
+        })
 
     assert resp["result"]["removed"] == 2
     assert resp["result"]["usage"]["total"] == 42
@@ -9023,21 +9440,32 @@ def test_session_compress_normalizes_messages_for_desktop_transcript(monkeypatch
             "tool_calls": [
                 {
                     "id": "call-1",
-                    "function": {"name": "read_file", "arguments": '{"path":"secret.txt"}'},
+                    "function": {
+                        "name": "read_file",
+                        "arguments": '{"path":"secret.txt"}',
+                    },
                 }
             ],
         },
-        {"role": "tool", "tool_call_id": "call-1", "content": "very sensitive tool output"},
+        {
+            "role": "tool",
+            "tool_call_id": "call-1",
+            "content": "very sensitive tool output",
+        },
     ]
     agent = types.SimpleNamespace()
     server._sessions["sid"] = _session(agent=agent, history=history)
-    monkeypatch.setattr(server, "_compress_session_history", lambda *_args, **_kwargs: (0, {}))
+    monkeypatch.setattr(
+        server, "_compress_session_history", lambda *_args, **_kwargs: (0, {})
+    )
     monkeypatch.setattr(server, "_session_info", lambda *_args: {})
 
     try:
-        response = server.handle_request(
-            {"id": "1", "method": "session.compress", "params": {"session_id": "sid"}}
-        )
+        response = server.handle_request({
+            "id": "1",
+            "method": "session.compress",
+            "params": {"session_id": "sid"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -9055,12 +9483,16 @@ def test_session_compress_returns_compute_host_history(monkeypatch):
         "session_info": {"usage": {"total": 42}},
     }
     monkeypatch.setattr(server, "_session_uses_compute_host", lambda _session: True)
-    monkeypatch.setattr(server, "_send_compute_host_control", lambda *args, **kwargs: ack)
+    monkeypatch.setattr(
+        server, "_send_compute_host_control", lambda *args, **kwargs: ack
+    )
 
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.compress", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.compress",
+            "params": {"session_id": "sid"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -9074,7 +9506,11 @@ def test_session_compress_returns_compute_host_history(monkeypatch):
     }
 
 
-def test_session_compress_forwards_120_second_budget_to_compute_host(monkeypatch):
+def test_session_compress_forwards_compression_budget_to_compute_host(monkeypatch):
+    """#88988: the host wait must be the compression budget (per-attempt
+    timeout x retries + 30s grace), not the old fixed 120s."""
+    import hermes_cli.config as hc_config
+
     session = _session(agent=None, _compute_host_active=True)
     server._sessions["sid"] = session
     calls = []
@@ -9093,11 +9529,21 @@ def test_session_compress_forwards_120_second_budget_to_compute_host(monkeypatch
 
     monkeypatch.setattr(server, "_session_uses_compute_host", lambda _session: True)
     monkeypatch.setattr(server, "_send_compute_host_control", send_control)
+    monkeypatch.setattr(
+        hc_config,
+        "load_config",
+        lambda: {
+            "auxiliary": {"compression": {"timeout": 60}},
+            "compression": {"max_attempts": 2},
+        },
+    )
 
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.compress", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.compress",
+            "params": {"session_id": "sid"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -9109,7 +9555,7 @@ def test_session_compress_forwards_120_second_budget_to_compute_host(monkeypatch
                 "route_name": "session.compress",
                 "command": "/compress",
                 "wait": True,
-                "timeout": 120.0,
+                "timeout": 150.0,
             },
         )
     ]
@@ -9143,9 +9589,11 @@ def test_session_compress_preserves_compute_host_aborted_summary(monkeypatch):
     )
 
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.compress", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.compress",
+            "params": {"session_id": "sid"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -9181,13 +9629,11 @@ def test_session_compress_reports_aborted_summary_without_success(monkeypatch):
 
     try:
         with patch("tui_gateway.server._emit"):
-            resp = server.handle_request(
-                {
-                    "id": "1",
-                    "method": "session.compress",
-                    "params": {"session_id": "sid"},
-                }
-            )
+            resp = server.handle_request({
+                "id": "1",
+                "method": "session.compress",
+                "params": {"session_id": "sid"},
+            })
 
         result = resp["result"]
         assert result["status"] == "aborted"
@@ -9238,13 +9684,11 @@ def test_session_compress_syncs_session_key_after_rotation(monkeypatch):
 
     try:
         with patch("tui_gateway.server._emit"):
-            server.handle_request(
-                {
-                    "id": "1",
-                    "method": "session.compress",
-                    "params": {"session_id": "sid"},
-                }
-            )
+            server.handle_request({
+                "id": "1",
+                "method": "session.compress",
+                "params": {"session_id": "sid"},
+            })
 
         assert server._sessions["sid"]["session_key"] == "rotated-id"
         assert server._sessions["sid"]["pending_title"] is None
@@ -9286,13 +9730,11 @@ def test_session_compress_sync_failure_discards_lcm_notification(monkeypatch):
 
     try:
         with patch("tui_gateway.server._emit"):
-            resp = server.handle_request(
-                {
-                    "id": "1",
-                    "method": "session.compress",
-                    "params": {"session_id": "sid"},
-                }
-            )
+            resp = server.handle_request({
+                "id": "1",
+                "method": "session.compress",
+                "params": {"session_id": "sid"},
+            })
         assert resp["error"]["code"] == 5005
         assert events == []
     finally:
@@ -9302,7 +9744,9 @@ def test_session_compress_sync_failure_discards_lcm_notification(monkeypatch):
 def test_slash_exec_r7_read_commands_use_metadata_mirror_flag_on(monkeypatch):
     class _ExplodingWorker:
         def __init__(self, *args, **kwargs):
-            raise AssertionError("slash worker should not run for isolated read commands")
+            raise AssertionError(
+                "slash worker should not run for isolated read commands"
+            )
 
     history_from_db = [
         {"role": "user", "content": "live question from state db"},
@@ -9328,7 +9772,9 @@ def test_slash_exec_r7_read_commands_use_metadata_mirror_flag_on(monkeypatch):
         def get_ancestor_display_prefix(self, _sid):
             return []
 
-        def get_messages_as_conversation(self, key, include_ancestors=True, repair_alternation=False, **_kwargs):
+        def get_messages_as_conversation(
+            self, key, include_ancestors=True, repair_alternation=False, **_kwargs
+        ):
             assert key == "session-key"
             assert include_ancestors is True
             return list(history_from_db)
@@ -9361,7 +9807,9 @@ def test_slash_exec_r7_read_commands_use_metadata_mirror_flag_on(monkeypatch):
     )
     monkeypatch.setattr(server, "_SlashWorker", _ExplodingWorker)
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
-    monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}})
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}}
+    )
 
     cases = {
         "usage": "Total tokens:                 140",
@@ -9375,13 +9823,11 @@ def test_slash_exec_r7_read_commands_use_metadata_mirror_flag_on(monkeypatch):
 
     try:
         for command, expected in cases.items():
-            resp = server.handle_request(
-                {
-                    "id": command,
-                    "method": "slash.exec",
-                    "params": {"command": command, "session_id": "sid"},
-                }
-            )
+            resp = server.handle_request({
+                "id": command,
+                "method": "slash.exec",
+                "params": {"command": command, "session_id": "sid"},
+            })
             assert "result" in resp, (command, resp)
             assert expected in resp["result"]["output"]
             assert "stale parent mirror" not in resp["result"]["output"]
@@ -9396,7 +9842,9 @@ def test_prompt_submit_sets_approval_session_key(monkeypatch):
     captured = {}
 
     class _Agent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             captured["session_key"] = get_current_session_key(default="")
             return {
                 "final_response": "ok",
@@ -9416,13 +9864,11 @@ def test_prompt_submit_sets_approval_session_key(monkeypatch):
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "prompt.submit",
-            "params": {"session_id": "sid", "text": "ping"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "prompt.submit",
+        "params": {"session_id": "sid", "text": "ping"},
+    })
 
     assert resp["result"]["status"] == "streaming"
     assert captured["session_key"] == "session-key"
@@ -9436,7 +9882,9 @@ def test_prompt_submit_expands_context_refs(monkeypatch):
         base_url = ""
         api_key = ""
 
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             captured["prompt"] = prompt
             return {
                 "final_response": "ok",
@@ -9451,8 +9899,8 @@ def test_prompt_submit_expands_context_refs(monkeypatch):
             self._target()
 
     fake_ctx = types.ModuleType("agent.context_references")
-    fake_ctx.preprocess_context_references = (
-        lambda message, **kwargs: types.SimpleNamespace(
+    fake_ctx.preprocess_context_references = lambda message, **kwargs: (
+        types.SimpleNamespace(
             blocked=False,
             message="expanded prompt",
             warnings=[],
@@ -9471,13 +9919,11 @@ def test_prompt_submit_expands_context_refs(monkeypatch):
     monkeypatch.setitem(sys.modules, "agent.context_references", fake_ctx)
     monkeypatch.setitem(sys.modules, "agent.model_metadata", fake_meta)
 
-    server.handle_request(
-        {
-            "id": "1",
-            "method": "prompt.submit",
-            "params": {"session_id": "sid", "text": "@diff"},
-        }
-    )
+    server.handle_request({
+        "id": "1",
+        "method": "prompt.submit",
+        "params": {"session_id": "sid", "text": "@diff"},
+    })
 
     assert captured["prompt"] == "expanded prompt"
 
@@ -9496,13 +9942,11 @@ def test_image_attach_appends_local_image(monkeypatch):
     server._sessions["sid"] = _session()
     monkeypatch.setitem(sys.modules, "cli", fake_cli)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "image.attach",
-            "params": {"session_id": "sid", "path": "/tmp/cat.png"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "image.attach",
+        "params": {"session_id": "sid", "path": "/tmp/cat.png"},
+    })
 
     assert resp["result"]["attached"] is True
     assert resp["result"]["name"] == "cat.png"
@@ -9527,13 +9971,11 @@ def test_image_attach_accepts_unquoted_screenshot_path_with_spaces(monkeypatch):
     server._sessions["sid"] = _session()
     monkeypatch.setitem(sys.modules, "cli", fake_cli)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "image.attach",
-            "params": {"session_id": "sid", "path": str(screenshot)},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "image.attach",
+        "params": {"session_id": "sid", "path": str(screenshot)},
+    })
 
     assert resp["result"]["attached"] is True
     assert resp["result"]["path"] == str(screenshot)
@@ -9559,18 +10001,16 @@ def test_file_attach_uploads_remote_file_into_session_workspace(monkeypatch, tmp
     monkeypatch.setitem(sys.modules, "cli", fake_cli)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "file.attach",
-                "params": {
-                    "session_id": "sid",
-                    "path": "/Users/alice/Downloads/report.txt",
-                    "name": "report.txt",
-                    "data_url": "data:text/plain;base64,aGVsbG8gd29ybGQ=",
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "file.attach",
+            "params": {
+                "session_id": "sid",
+                "path": "/Users/alice/Downloads/report.txt",
+                "name": "report.txt",
+                "data_url": "data:text/plain;base64,aGVsbG8gd29ybGQ=",
+            },
+        })
 
         stored = home / "attachments" / "report.txt"
         assert resp["result"]["attached"] is True
@@ -9582,7 +10022,9 @@ def test_file_attach_uploads_remote_file_into_session_workspace(monkeypatch, tmp
         server._sessions.pop("sid", None)
 
 
-def test_file_attach_copies_gateway_visible_file_outside_workspace(monkeypatch, tmp_path):
+def test_file_attach_copies_gateway_visible_file_outside_workspace(
+    monkeypatch, tmp_path
+):
     """Local case: gateway can see the file but it's outside the workspace → copy in."""
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -9598,13 +10040,11 @@ def test_file_attach_copies_gateway_visible_file_outside_workspace(monkeypatch, 
     monkeypatch.setitem(sys.modules, "cli", fake_cli)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "file.attach",
-                "params": {"session_id": "sid", "path": str(source)},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "file.attach",
+            "params": {"session_id": "sid", "path": str(source)},
+        })
 
         stored = home / "attachments" / "outside.txt"
         assert resp["result"]["attached"] is True
@@ -9630,13 +10070,11 @@ def test_file_attach_uses_in_workspace_file_without_copying(monkeypatch, tmp_pat
     monkeypatch.setitem(sys.modules, "cli", fake_cli)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "file.attach",
-                "params": {"session_id": "sid", "path": str(source)},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "file.attach",
+            "params": {"session_id": "sid", "path": str(source)},
+        })
 
         assert resp["result"]["attached"] is True
         assert resp["result"]["uploaded"] is False
@@ -9662,13 +10100,11 @@ def test_file_attach_errors_when_unresolvable_and_no_bytes(monkeypatch, tmp_path
     monkeypatch.setitem(sys.modules, "cli", fake_cli)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "file.attach",
-                "params": {"session_id": "sid", "path": "/Users/alice/missing.txt"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "file.attach",
+            "params": {"session_id": "sid", "path": "/Users/alice/missing.txt"},
+        })
 
         assert "error" in resp
         assert "no data_url" in resp["error"]["message"]
@@ -9685,21 +10121,21 @@ def test_file_attach_quotes_ref_with_spaces(monkeypatch, tmp_path):
     fake_cli._split_path_input = lambda raw: (raw, "")
     fake_cli._resolve_attachment_path = lambda raw: None
 
-    server._sessions["sid"] = _session(cwd=str(workspace), profile_home=str(tmp_path / "home"))
+    server._sessions["sid"] = _session(
+        cwd=str(workspace), profile_home=str(tmp_path / "home")
+    )
     monkeypatch.setitem(sys.modules, "cli", fake_cli)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "file.attach",
-                "params": {
-                    "session_id": "sid",
-                    "name": "my exam schedule.csv",
-                    "data_url": "data:text/csv;base64,YSxiCg==",
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "file.attach",
+            "params": {
+                "session_id": "sid",
+                "name": "my exam schedule.csv",
+                "data_url": "data:text/csv;base64,YSxiCg==",
+            },
+        })
 
         stored = tmp_path / "home" / "attachments" / "my exam schedule.csv"
         assert resp["result"]["attached"] is True
@@ -9726,9 +10162,11 @@ def test_commands_catalog_surfaces_quick_commands(monkeypatch):
         },
     )
 
-    resp = server.handle_request(
-        {"id": "1", "method": "commands.catalog", "params": {}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "commands.catalog",
+        "params": {},
+    })
 
     pairs = dict(resp["result"]["pairs"])
     assert "npm run build" in pairs["/build"]
@@ -9771,9 +10209,11 @@ def test_commands_catalog_ranks_skill_commands_by_recorded_usage(monkeypatch):
         },
     )
 
-    resp = server.handle_request(
-        {"id": "1", "method": "commands.catalog", "params": {}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "commands.catalog",
+        "params": {},
+    })
 
     skills = resp["result"]["skills"]
     assert skills["/work"] == {"usage": 172, "origin": "local"}
@@ -9794,9 +10234,11 @@ def test_commands_catalog_survives_an_unreadable_usage_sidecar(monkeypatch):
         lambda: (_ for _ in ()).throw(OSError("sidecar is gone")),
     )
 
-    resp = server.handle_request(
-        {"id": "1", "method": "commands.catalog", "params": {}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "commands.catalog",
+        "params": {},
+    })
 
     assert "error" not in resp
     assert all(
@@ -9806,9 +10248,11 @@ def test_commands_catalog_survives_an_unreadable_usage_sidecar(monkeypatch):
 
 
 def test_commands_catalog_includes_tui_mouse_command():
-    resp = server.handle_request(
-        {"id": "1", "method": "commands.catalog", "params": {}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "commands.catalog",
+        "params": {},
+    })
 
     pairs = dict(resp["result"]["pairs"])
     tui_cat = next(c for c in resp["result"]["categories"] if c["name"] == "TUI")
@@ -9823,29 +10267,29 @@ def test_commands_catalog_has_no_duplicate_or_alias_colliding_names():
     shadow an alias of a different command (e.g. the historical /compact
     collision where the registry aliased compact -> compress while the TUI
     also registered its own /compact display toggle; see #57133)."""
-    resp = server.handle_request(
-        {"id": "1", "method": "commands.catalog", "params": {}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "commands.catalog",
+        "params": {},
+    })
 
     names = [name for name, _ in resp["result"]["pairs"]]
     dupes = {n for n in names if names.count(n) > 1}
     assert not dupes, f"duplicate commands advertised in catalog: {sorted(dupes)}"
 
     canon = resp["result"]["canon"]
-    colliding = {
-        name
-        for name in names
-        if canon.get(name.lower(), name) != name
-    }
+    colliding = {name for name in names if canon.get(name.lower(), name) != name}
     assert not colliding, (
         f"catalog commands shadow aliases of other commands: {sorted(colliding)}"
     )
 
 
 def test_commands_catalog_filters_gateway_only_commands_and_keeps_status_visible():
-    resp = server.handle_request(
-        {"id": "1", "method": "commands.catalog", "params": {}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "commands.catalog",
+        "params": {},
+    })
 
     pairs = dict(resp["result"]["pairs"])
     canon = resp["result"]["canon"]
@@ -9888,9 +10332,11 @@ def test_session_status_reads_live_gateway_agent(monkeypatch):
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.status", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.status",
+            "params": {"session_id": "sid"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -9930,24 +10376,20 @@ def test_skills_reload_runs_in_gateway_process(monkeypatch):
 def test_snapshot_restore_is_blocked_from_tui_worker():
     server._sessions["sid"] = _session()
     try:
-        worker_resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "slash.exec",
-                "params": {"command": "snapshot restore latest", "session_id": "sid"},
-            }
-        )
-        dispatch_resp = server.handle_request(
-            {
-                "id": "2",
-                "method": "command.dispatch",
-                "params": {
-                    "arg": "restore latest",
-                    "name": "snapshot",
-                    "session_id": "sid",
-                },
-            }
-        )
+        worker_resp = server.handle_request({
+            "id": "1",
+            "method": "slash.exec",
+            "params": {"command": "snapshot restore latest", "session_id": "sid"},
+        })
+        dispatch_resp = server.handle_request({
+            "id": "2",
+            "method": "command.dispatch",
+            "params": {
+                "arg": "restore latest",
+                "name": "snapshot",
+                "session_id": "sid",
+            },
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -9975,9 +10417,11 @@ def test_command_dispatch_exec_nonzero_surfaces_error(monkeypatch):
         ),
     )
 
-    resp = server.handle_request(
-        {"id": "1", "method": "command.dispatch", "params": {"name": "boom"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "command.dispatch",
+        "params": {"name": "boom"},
+    })
 
     assert "error" in resp
     assert "failed" in resp["error"]["message"]
@@ -9985,9 +10429,11 @@ def test_command_dispatch_exec_nonzero_surfaces_error(monkeypatch):
 
 def test_plugins_list_surfaces_loader_error(monkeypatch):
     with patch("hermes_cli.plugins.get_plugin_manager", side_effect=Exception("boom")):
-        resp = server.handle_request(
-            {"id": "1", "method": "plugins.list", "params": {}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "plugins.list",
+            "params": {},
+        })
 
     assert "error" in resp
     assert "boom" in resp["error"]["message"]
@@ -9998,9 +10444,11 @@ def test_complete_slash_surfaces_completer_error(monkeypatch):
         "hermes_cli.commands.SlashCommandCompleter",
         side_effect=Exception("no completer"),
     ):
-        resp = server.handle_request(
-            {"id": "1", "method": "complete.slash", "params": {"text": "/mo"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "complete.slash",
+            "params": {"text": "/mo"},
+        })
 
     assert "error" in resp
     assert "no completer" in resp["error"]["message"]
@@ -10017,13 +10465,11 @@ def test_input_detect_drop_attaches_image(monkeypatch):
     server._sessions["sid"] = _session()
     monkeypatch.setitem(sys.modules, "cli", fake_cli)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "input.detect_drop",
-            "params": {"session_id": "sid", "text": "/tmp/cat.png"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "input.detect_drop",
+        "params": {"session_id": "sid", "text": "/tmp/cat.png"},
+    })
 
     assert resp["result"]["matched"] is True
     assert resp["result"]["is_image"] is True
@@ -10038,13 +10484,11 @@ def test_input_detect_drop_path_with_spaces(tmp_path):
 
     server._sessions["sid"] = _session()
 
-    resp = server.handle_request(
-        {
-            "id": "2",
-            "method": "input.detect_drop",
-            "params": {"session_id": "sid", "text": str(img)},
-        }
-    )
+    resp = server.handle_request({
+        "id": "2",
+        "method": "input.detect_drop",
+        "params": {"session_id": "sid", "text": str(img)},
+    })
 
     assert resp["result"]["matched"] is True
     assert resp["result"]["is_image"] is True
@@ -10063,13 +10507,11 @@ def test_input_detect_drop_path_with_spaces_and_remainder(tmp_path):
     server._sessions["sid"] = _session()
 
     user_input = f"{img} describe this image"
-    resp = server.handle_request(
-        {
-            "id": "3",
-            "method": "input.detect_drop",
-            "params": {"session_id": "sid", "text": user_input},
-        }
-    )
+    resp = server.handle_request({
+        "id": "3",
+        "method": "input.detect_drop",
+        "params": {"session_id": "sid", "text": user_input},
+    })
 
     assert resp["result"]["matched"] is True
     assert resp["result"]["is_image"] is True
@@ -10095,13 +10537,11 @@ def test_rollback_restore_resolves_number_and_file_path():
     server._sessions["sid"] = _session(
         agent=types.SimpleNamespace(_checkpoint_mgr=_Mgr()), history=[]
     )
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "rollback.restore",
-            "params": {"session_id": "sid", "hash": "2", "file_path": "src/app.tsx"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "rollback.restore",
+        "params": {"session_id": "sid", "hash": "2", "file_path": "src/app.tsx"},
+    })
 
     assert resp["result"]["success"] is True
     assert calls["args"][1] == "bbb222"
@@ -10139,13 +10579,11 @@ def test_rollback_restore_truncates_from_real_user_turn_not_marker(monkeypatch):
         history=list(history),
     )
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "rollback.restore",
-                "params": {"session_id": "sid", "hash": "abc123"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "rollback.restore",
+            "params": {"session_id": "sid", "hash": "abc123"},
+        })
 
         assert resp["result"]["success"] is True
         assert resp["result"]["history_removed"] == 3  # q2 + a2 + marker
@@ -10199,13 +10637,11 @@ def test_rollback_restore_skips_legacy_compaction_handoff(monkeypatch):
         history=list(history),
     )
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "rollback.restore",
-                "params": {"session_id": "sid", "hash": "abc123"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "rollback.restore",
+            "params": {"session_id": "sid", "hash": "abc123"},
+        })
 
         assert resp["result"]["success"] is True
         # Truncation lands on "second question", not the handoff row.
@@ -10235,13 +10671,11 @@ def test_session_steer_calls_agent_steer_when_agent_supports_it():
 
     server._sessions["sid"] = _session(agent=_Agent())
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.steer",
-                "params": {"session_id": "sid", "text": "also check auth.log"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.steer",
+            "params": {"session_id": "sid", "text": "also check auth.log"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -10257,13 +10691,11 @@ def test_session_steer_rejects_empty_text():
         agent=types.SimpleNamespace(steer=lambda t: True)
     )
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.steer",
-                "params": {"session_id": "sid", "text": "   "},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.steer",
+            "params": {"session_id": "sid", "text": "   "},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -10274,13 +10706,11 @@ def test_session_steer_rejects_empty_text():
 def test_session_steer_errors_when_agent_has_no_steer_method():
     server._sessions["sid"] = _session(agent=types.SimpleNamespace())  # no steer()
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.steer",
-                "params": {"session_id": "sid", "text": "hi"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.steer",
+            "params": {"session_id": "sid", "text": "hi"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -10295,17 +10725,18 @@ def test_session_redirect_calls_capable_core_agent(monkeypatch):
         redirect=lambda text: calls.append(text) or True,
     )
     session = _session(agent=agent)
-    session["inflight_turn"] = {"user": "original request", "assistant": "partial reply"}
+    session["inflight_turn"] = {
+        "user": "original request",
+        "assistant": "partial reply",
+    }
     server._sessions["sid"] = session
     try:
         before = session.get("last_active")
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.redirect",
-                "params": {"session_id": "sid", "text": "use Postgres"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.redirect",
+            "params": {"session_id": "sid", "text": "use Postgres"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -10350,16 +10781,14 @@ def test_session_redirect_rpc_drops_queued_duplicate_of_inflight_user():
     ]
     server._sessions["sid"] = session
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.redirect",
-                "params": {
-                    "session_id": "sid",
-                    "text": "what about the pricing instead?",
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.redirect",
+            "params": {
+                "session_id": "sid",
+                "text": "what about the pricing instead?",
+            },
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -10390,13 +10819,11 @@ def test_session_redirect_build_window_scrubs_stale_p_when_queuing_q():
     session["queued_prompt"] = {"text": original, "transport": "ws-1"}
     server._sessions["sid"] = session
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.redirect",
-                "params": {"session_id": "sid", "text": "correction Q"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.redirect",
+            "params": {"session_id": "sid", "text": "correction Q"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -10496,13 +10923,11 @@ def test_session_redirect_queues_during_agent_build_window(monkeypatch):
     session["agent"] = None
     server._sessions["sid"] = session
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.redirect",
-                "params": {"session_id": "sid", "text": "wait, use SQLite"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.redirect",
+            "params": {"session_id": "sid", "text": "wait, use SQLite"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -10517,13 +10942,11 @@ def test_session_redirect_rejects_when_idle_without_agent(monkeypatch):
     session["agent"] = None
     server._sessions["sid"] = session
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.redirect",
-                "params": {"session_id": "sid", "text": "hi"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.redirect",
+            "params": {"session_id": "sid", "text": "hi"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -10541,7 +10964,9 @@ def test_session_info_includes_mcp_servers(monkeypatch):
     fake_mod.get_mcp_status = lambda: fake_status
     monkeypatch.setitem(sys.modules, "tools.mcp_tool", fake_mod)
 
-    info = server._session_info(types.SimpleNamespace(tools=[], model="", provider="openai-codex"))
+    info = server._session_info(
+        types.SimpleNamespace(tools=[], model="", provider="openai-codex")
+    )
 
     assert info["provider"] == "openai-codex"
     assert info["mcp_servers"] == fake_status
@@ -10622,9 +11047,11 @@ def test_session_undo_rejects_while_running():
         ],
     )
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.undo", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.undo",
+            "params": {"session_id": "sid"},
+        })
         assert resp.get("error"), "session.undo should reject while running"
         assert resp["error"]["code"] == 4009
         assert "session busy" in resp["error"]["message"]
@@ -10644,9 +11071,11 @@ def test_session_undo_allowed_when_idle():
         ],
     )
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.undo", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.undo",
+            "params": {"session_id": "sid"},
+        })
         assert resp.get("result"), f"got error: {resp.get('error')}"
         assert resp["result"]["removed"] == 2
         assert server._sessions["sid"]["history"] == []
@@ -10657,9 +11086,11 @@ def test_session_undo_allowed_when_idle():
 def test_session_compress_rejects_while_running(monkeypatch):
     server._sessions["sid"] = _session(running=True)
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.compress", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.compress",
+            "params": {"session_id": "sid"},
+        })
         assert resp.get("error")
         assert resp["error"]["code"] == 4009
     finally:
@@ -10670,13 +11101,11 @@ def test_rollback_restore_rejects_full_history_while_running(monkeypatch):
     """Full-history rollback must reject; file-scoped rollback still allowed."""
     server._sessions["sid"] = _session(running=True)
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "rollback.restore",
-                "params": {"session_id": "sid", "hash": "abc"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "rollback.restore",
+            "params": {"session_id": "sid", "hash": "abc"},
+        })
         assert resp.get("error"), "full-history rollback should reject while running"
         assert resp["error"]["code"] == 4009
     finally:
@@ -10693,7 +11122,9 @@ def test_prompt_submit_history_version_mismatch_surfaces_warning(monkeypatch):
     session_ref = {"s": None}
 
     class _RacyAgent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             # Simulate: something external bumped history_version
             # while we were running.
             with session_ref["s"]["history_lock"]:
@@ -10719,13 +11150,11 @@ def test_prompt_submit_history_version_mismatch_surfaces_warning(monkeypatch):
         monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
         monkeypatch.setattr(server, "_emit", lambda *a: emits.append(a))
 
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid", "text": "hi"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "hi"},
+        })
         assert resp.get("result"), f"got error: {resp.get('error')}"
 
         # History should NOT contain the agent's output (version mismatch)
@@ -10776,7 +11205,9 @@ def test_prompt_submit_merges_on_model_switch_marker(monkeypatch):
         def __init__(self, new_history_state: list):
             self._new_history_state = new_history_state
 
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             # Simulate _append_model_switch_marker: strip prior markers, append new one.
             with session_ref["s"]["history_lock"]:
                 hist = session_ref["s"]["history"]
@@ -10786,7 +11217,8 @@ def test_prompt_submit_merges_on_model_switch_marker(monkeypatch):
             # result["messages"] = conversation_history + user msg + assistant reply
             return {
                 "final_response": "agent reply",
-                "messages": list(conversation_history) + [
+                "messages": list(conversation_history)
+                + [
                     {"role": "user", "content": "hi"},
                     {"role": "assistant", "content": "agent reply"},
                 ],
@@ -10794,6 +11226,7 @@ def test_prompt_submit_merges_on_model_switch_marker(monkeypatch):
 
     def _is_marker(entry) -> bool:
         from tui_gateway.server import _is_model_switch_marker
+
         return _is_model_switch_marker(entry)
 
     class _ImmediateThread:
@@ -10806,11 +11239,14 @@ def test_prompt_submit_merges_on_model_switch_marker(monkeypatch):
     # Test both: no prior marker, and prior marker present
     for label, prior_history in [
         ("no prior marker", [{"role": "user", "content": "hello"}]),
-        ("with prior marker", [
-            {"role": "user", "content": "hello"},
-            _make_marker("old-model"),
-            {"role": "assistant", "content": "hi there"},
-        ]),
+        (
+            "with prior marker",
+            [
+                {"role": "user", "content": "hello"},
+                _make_marker("old-model"),
+                {"role": "assistant", "content": "hi there"},
+            ],
+        ),
     ]:
         server._sessions["sid"] = _session(
             agent=_MarkerAgent([]),
@@ -10824,21 +11260,21 @@ def test_prompt_submit_merges_on_model_switch_marker(monkeypatch):
             monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
             monkeypatch.setattr(server, "_emit", lambda *a: emits.append(a))
 
-            resp = server.handle_request(
-                {
-                    "id": "1",
-                    "method": "prompt.submit",
-                    "params": {"session_id": "sid", "text": "hi"},
-                }
-            )
+            resp = server.handle_request({
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid", "text": "hi"},
+            })
             assert resp.get("result"), f"[{label}] got error: {resp.get('error')}"
 
             final_history = server._sessions["sid"]["history"]
 
             # The agent's new messages must be present in the persisted history.
             assistant_msgs = [
-                e for e in final_history
-                if isinstance(e, dict) and e.get("role") == "assistant"
+                e
+                for e in final_history
+                if isinstance(e, dict)
+                and e.get("role") == "assistant"
                 and e.get("content") == "agent reply"
             ]
             assert len(assistant_msgs) == 1, (
@@ -10915,13 +11351,11 @@ def test_prompt_submit_merges_on_personality_pivot_marker(monkeypatch):
         monkeypatch.setattr(server, "_session_info", lambda *a, **k: {})
         monkeypatch.setattr(server, "_emit", lambda *a: emits.append(a))
 
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid", "text": "hi"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "hi"},
+        })
         assert resp.get("result"), f"got error: {resp.get('error')}"
 
         final_history = server._sessions["sid"]["history"]
@@ -10958,7 +11392,9 @@ def test_prompt_submit_sanitizes_bracketed_paste_before_agent(monkeypatch):
     captured: dict[str, str] = {}
 
     class _Agent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             captured["prompt"] = prompt
             return {
                 "final_response": "ok",
@@ -10983,13 +11419,11 @@ def test_prompt_submit_sanitizes_bracketed_paste_before_agent(monkeypatch):
         monkeypatch.setattr(server, "_ensure_session_db_row", lambda *a, **k: None)
         monkeypatch.setattr(server, "_persist_branch_seed", lambda *a, **k: None)
 
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid", "text": corrupted},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": corrupted},
+        })
         assert resp.get("result"), f"got error: {resp.get('error')}"
         assert captured["prompt"] == "hello"
     finally:
@@ -11000,7 +11434,9 @@ def test_prompt_submit_history_version_match_persists_normally(monkeypatch):
     """Regression guard: the backstop does not affect the happy path."""
 
     class _Agent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             return {
                 "final_response": "reply",
                 "messages": [{"role": "assistant", "content": "reply"}],
@@ -11021,13 +11457,11 @@ def test_prompt_submit_history_version_match_persists_normally(monkeypatch):
         monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
         monkeypatch.setattr(server, "_emit", lambda *a: emits.append(a))
 
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid", "text": "hi"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "hi"},
+        })
         assert resp.get("result")
 
         # History was written
@@ -11084,13 +11518,16 @@ def test_prompt_submit_snapshots_history_after_pending_model_switch(monkeypatch)
         monkeypatch.setattr(server, "render_message", lambda *_a: "")
         monkeypatch.setattr(server, "_emit", lambda *a: emits.append(a))
 
-        server.handle_request(
-            {"id": "1", "method": "prompt.submit", "params": {"session_id": "sid", "text": "hi"}}
-        )
+        server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "hi"},
+        })
 
         assert seen["history"] == [marker]
         assert server._sessions["sid"]["history"][-1] == {
-            "role": "assistant", "content": "reply"
+            "role": "assistant",
+            "content": "reply",
         }
         complete = [a for a in emits if a[0] == "message.complete"]
         assert "warning" not in complete[0][2]
@@ -11104,7 +11541,9 @@ def test_prompt_submit_can_truncate_before_user_ordinal(monkeypatch):
     seen = {}
 
     class _Agent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             seen["prompt"] = prompt
             seen["history"] = conversation_history
             return {
@@ -11138,7 +11577,9 @@ def test_prompt_submit_can_truncate_before_user_ordinal(monkeypatch):
         def get_messages_as_conversation(self, *_args, **_kwargs):
             return []
 
-        def replace_messages(self, session_id, messages, active_only=False, archive_dropped=False):
+        def replace_messages(
+            self, session_id, messages, active_only=False, archive_dropped=False
+        ):
             self.replaced.append((session_id, list(messages)))
 
     stub_db = _StubDb()
@@ -11150,18 +11591,16 @@ def test_prompt_submit_can_truncate_before_user_ordinal(monkeypatch):
         monkeypatch.setattr(server, "_emit", lambda *a: None)
         monkeypatch.setattr(server, "_get_db", lambda: stub_db)
 
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "sid",
-                    "text": "edited second",
-                    "truncate_before_user_ordinal": 1,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "sid",
+                "text": "edited second",
+                "truncate_before_user_ordinal": 1,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("result"), f"got error: {resp.get('error')}"
 
         assert seen["prompt"] == "edited second"
@@ -11198,33 +11637,40 @@ def test_prompt_submit_refuses_turn_when_truncate_persist_fails(monkeypatch):
         def get_messages_as_conversation(self, *_args, **_kwargs):
             return []
 
-        def replace_messages(self, session_id, messages, active_only=False, archive_dropped=False):
+        def replace_messages(
+            self, session_id, messages, active_only=False, archive_dropped=False
+        ):
             raise OSError("disk full")
 
     monkeypatch.setattr(server, "_get_db", lambda: _FailDb())
     monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_inflight_turn",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "trunc-fail-sid",
-                    "text": "edited second",
-                    "truncate_before_user_ordinal": 1,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "trunc-fail-sid",
+                "text": "edited second",
+                "truncate_before_user_ordinal": 1,
+                "confirm_truncate": True,
+            },
+        })
         assert "error" in resp
         assert resp["error"]["code"] == 5008
-        assert "truncat" in resp["error"]["message"].lower() or "persist" in resp["error"]["message"].lower()
+        assert (
+            "truncat" in resp["error"]["message"].lower()
+            or "persist" in resp["error"]["message"].lower()
+        )
         # Memory left intact — same list contents as before the refused cut.
         assert sess["history"] == original_history
         assert sess["history_version"] == 0
@@ -11254,7 +11700,9 @@ def test_prompt_submit_truncate_ordinal_skips_display_kind_rows(monkeypatch):
     seen = {}
 
     class _Agent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             seen["prompt"] = prompt
             seen["history"] = conversation_history
             return {
@@ -11293,7 +11741,9 @@ def test_prompt_submit_truncate_ordinal_skips_display_kind_rows(monkeypatch):
         def get_messages_as_conversation(self, *_args, **_kwargs):
             return []
 
-        def replace_messages(self, session_id, messages, active_only=False, archive_dropped=False):
+        def replace_messages(
+            self, session_id, messages, active_only=False, archive_dropped=False
+        ):
             self.replaced.append((session_id, list(messages)))
 
     stub_db = _StubDb()
@@ -11307,18 +11757,16 @@ def test_prompt_submit_truncate_ordinal_skips_display_kind_rows(monkeypatch):
 
         # ordinal=1 means "truncate before the 2nd-from-last real user turn"
         # which is "first". The display_kind marker must NOT shift the ordinal.
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "sid",
-                    "text": "edited first",
-                    "truncate_before_user_ordinal": 1,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "sid",
+                "text": "edited first",
+                "truncate_before_user_ordinal": 1,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("result"), f"got error: {resp.get('error')}"
 
         # With display_kind filter: user_indices = [0, 2] (indices of "first" and "second").
@@ -11347,7 +11795,9 @@ def test_prompt_submit_truncate_translates_display_prefix_ordinal(monkeypatch):
     seen = {}
 
     class _Agent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             seen["prompt"] = prompt
             seen["history"] = conversation_history
             return {
@@ -11396,7 +11846,9 @@ def test_prompt_submit_truncate_translates_display_prefix_ordinal(monkeypatch):
             # may take the ordinal-only path past the durability gate.
             return []
 
-        def replace_messages(self, session_id, messages, active_only=False, archive_dropped=False):
+        def replace_messages(
+            self, session_id, messages, active_only=False, archive_dropped=False
+        ):
             self.replaced.append((session_id, list(messages)))
 
     stub_db = _StubDb()
@@ -11408,18 +11860,16 @@ def test_prompt_submit_truncate_translates_display_prefix_ordinal(monkeypatch):
         monkeypatch.setattr(server, "_emit", lambda *a: None)
         monkeypatch.setattr(server, "_get_db", lambda: stub_db)
 
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "sid",
-                    "text": "edited post B",
-                    "truncate_before_user_ordinal": desktop_ordinal_for_post_b,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "sid",
+                "text": "edited post B",
+                "truncate_before_user_ordinal": desktop_ordinal_for_post_b,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("result"), f"got error: {resp.get('error')}"
         assert seen["prompt"] == "edited post B"
         assert seen["history"] == tip_history[:2]
@@ -11447,20 +11897,20 @@ def test_prompt_submit_truncate_oor_includes_structured_user_turn_count(monkeypa
 
     try:
         monkeypatch.setattr(
-            server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+            server,
+            "_start_inflight_turn",
+            lambda *a, **k: pytest.fail("must not start a turn"),
         )
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "sid",
-                    "text": "edit ancestor",
-                    "truncate_before_user_ordinal": 0,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "sid",
+                "text": "edit ancestor",
+                "truncate_before_user_ordinal": 0,
+                "confirm_truncate": True,
+            },
+        })
         err = resp.get("error") or {}
         assert err.get("code") == 4018
         assert "no longer in session history" in (err.get("message") or "")
@@ -11497,7 +11947,9 @@ def test_prompt_submit_row_id_accepts_full_lineage_ordinal(monkeypatch):
     replaced = []
 
     class _FakeDB:
-        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+        def replace_messages(
+            self, key, messages, active_only=False, archive_dropped=False
+        ):
             replaced.append((key, list(messages)))
 
     sess = _session(history=list(tip_history), display_history_prefix=display_prefix)
@@ -11506,21 +11958,19 @@ def test_prompt_submit_row_id_accepts_full_lineage_ordinal(monkeypatch):
     monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "lineage-row-sid",
-                    "text": "edited post B",
-                    # Row id resolves to tip ordinal 1; the client counted the
-                    # 2 ancestor user turns, so its lineage ordinal is 3.
-                    "truncate_before_row_id": 503,
-                    "truncate_before_user_ordinal": 3,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "lineage-row-sid",
+                "text": "edited post B",
+                # Row id resolves to tip ordinal 1; the client counted the
+                # 2 ancestor user turns, so its lineage ordinal is 3.
+                "truncate_before_row_id": 503,
+                "truncate_before_user_ordinal": 3,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is None, f"got error: {resp.get('error')}"
         assert sess["history"] == tip_history[:2]
     finally:
@@ -11531,22 +11981,22 @@ def test_prompt_submit_row_id_accepts_full_lineage_ordinal(monkeypatch):
     sess2 = _session(history=list(tip_history), display_history_prefix=display_prefix)
     server._sessions["lineage-row-sid-2"] = sess2
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     try:
-        resp = server.handle_request(
-            {
-                "id": "2",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "lineage-row-sid-2",
-                    "text": "edited post B",
-                    "truncate_before_row_id": 503,
-                    "truncate_before_user_ordinal": 2,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "2",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "lineage-row-sid-2",
+                "text": "edited post B",
+                "truncate_before_row_id": 503,
+                "truncate_before_user_ordinal": 2,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is not None
         assert resp["error"]["code"] == 4030
     finally:
@@ -11584,13 +12034,11 @@ def test_interrupt_only_clears_own_session_pending():
         server._answers.clear()
 
         # Interrupt session A.
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.interrupt",
-                "params": {"session_id": "sid_a"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.interrupt",
+            "params": {"session_id": "sid_a"},
+        })
         assert resp.get("result"), f"got error: {resp.get('error')}"
 
         # Session A's pending must be released to empty.
@@ -11627,9 +12075,11 @@ def test_interrupt_clears_multiple_own_pending():
         server._pending["r1"] = ("sid", ev1)
         server._pending["r2"] = ("sid", ev2)
 
-        resp = server.handle_request(
-            {"id": "1", "method": "session.interrupt", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.interrupt",
+            "params": {"session_id": "sid"},
+        })
         assert resp.get("result")
         assert ev1.is_set() and ev2.is_set()
         assert server._answers.get("r1") == "" and server._answers.get("r2") == ""
@@ -11674,9 +12124,11 @@ def test_run_prompt_submit_registers_turn_thread_for_interrupt(monkeypatch):
         server._run_prompt_submit("1", "sid", session, "hello")
 
         assert session.get("_run_thread") is not None
-        resp = server.handle_request(
-            {"id": "2", "method": "session.interrupt", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "2",
+            "method": "session.interrupt",
+            "params": {"session_id": "sid"},
+        })
 
         assert resp.get("result"), f"got error: {resp.get('error')}"
         assert calls["interrupted"] is True
@@ -11698,15 +12150,23 @@ def test_interrupt_drops_queued_prompt_for_session():
         ),
         running=True,
         queued_prompt={"text": "next prompt", "transport": None},
-        queued_prompts=[{"text": "later prompt", "image_paths": ["/tmp/later.png"], "transport": None}],
+        queued_prompts=[
+            {
+                "text": "later prompt",
+                "image_paths": ["/tmp/later.png"],
+                "transport": None,
+            }
+        ],
         _run_thread=_LiveThread(),
     )
     server._sessions["sid"] = session
 
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.interrupt", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.interrupt",
+            "params": {"session_id": "sid"},
+        })
 
         assert resp.get("result"), f"got error: {resp.get('error')}"
         assert calls["interrupted"] is True
@@ -11751,20 +12211,20 @@ def test_interrupt_before_agent_ready_prevents_late_turn_start(monkeypatch):
             ),
         )
 
-        submit = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid", "text": "hello"},
-            }
-        )
+        submit = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "hello"},
+        })
         assert submit.get("result"), f"got error: {submit.get('error')}"
         assert session["running"] is True
         assert len(threads) == 1
 
-        stop = server.handle_request(
-            {"id": "2", "method": "session.interrupt", "params": {"session_id": "sid"}}
-        )
+        stop = server.handle_request({
+            "id": "2",
+            "method": "session.interrupt",
+            "params": {"session_id": "sid"},
+        })
         assert stop.get("result"), f"got error: {stop.get('error')}"
 
         threads[0].target()
@@ -11808,7 +12268,9 @@ def test_cancelled_turn_before_agent_ready_emits_error_event(monkeypatch):
 
     try:
         monkeypatch.setattr(server.threading, "Thread", _FakeThread)
-        monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: emitted.append(args))
+        monkeypatch.setattr(
+            server, "_emit", lambda *args, **kwargs: emitted.append(args)
+        )
         monkeypatch.setattr(server, "_ensure_session_db_row", lambda session: None)
         monkeypatch.setattr(server, "_persist_branch_seed", lambda session: None)
         monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
@@ -11821,20 +12283,20 @@ def test_cancelled_turn_before_agent_ready_emits_error_event(monkeypatch):
             ),
         )
 
-        submit = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid", "text": "hello"},
-            }
-        )
+        submit = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "hello"},
+        })
         assert submit.get("result"), f"got error: {submit.get('error')}"
         assert session["running"] is True
 
         # User hits Stop while the agent is still building.
-        stop = server.handle_request(
-            {"id": "2", "method": "session.interrupt", "params": {"session_id": "sid"}}
-        )
+        stop = server.handle_request({
+            "id": "2",
+            "method": "session.interrupt",
+            "params": {"session_id": "sid"},
+        })
         assert stop.get("result"), f"got error: {stop.get('error')}"
         assert session.get("_turn_cancel_requested") is True
 
@@ -11846,7 +12308,11 @@ def test_cancelled_turn_before_agent_ready_emits_error_event(monkeypatch):
         assert session["running"] is False
         assert session.get("inflight_turn") is None
         # Exactly one error event addressed to this session.
-        error_events = [e for e in emitted if e and len(e) >= 2 and e[0] == "error" and e[1] == "sid"]
+        error_events = [
+            e
+            for e in emitted
+            if e and len(e) >= 2 and e[0] == "error" and e[1] == "sid"
+        ]
         assert len(error_events) == 1, f"expected one error event, got: {emitted}"
         msg = error_events[0][2].get("message", "")
         assert "cancelled" in msg.lower(), f"unexpected message: {msg}"
@@ -11880,7 +12346,9 @@ def test_session_not_running_before_agent_ready_emits_error_event(monkeypatch):
 
     try:
         monkeypatch.setattr(server.threading, "Thread", _FakeThread)
-        monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: emitted.append(args))
+        monkeypatch.setattr(
+            server, "_emit", lambda *args, **kwargs: emitted.append(args)
+        )
         monkeypatch.setattr(server, "_ensure_session_db_row", lambda session: None)
         monkeypatch.setattr(server, "_persist_branch_seed", lambda session: None)
         monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
@@ -11893,13 +12361,11 @@ def test_session_not_running_before_agent_ready_emits_error_event(monkeypatch):
             ),
         )
 
-        submit = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid", "text": "hello"},
-            }
-        )
+        submit = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "hello"},
+        })
         assert submit.get("result"), f"got error: {submit.get('error')}"
         assert session["running"] is True
 
@@ -11912,7 +12378,11 @@ def test_session_not_running_before_agent_ready_emits_error_event(monkeypatch):
 
         assert calls["run_prompt"] == 0
         assert session.get("inflight_turn") is None
-        error_events = [e for e in emitted if e and len(e) >= 2 and e[0] == "error" and e[1] == "sid"]
+        error_events = [
+            e
+            for e in emitted
+            if e and len(e) >= 2 and e[0] == "error" and e[1] == "sid"
+        ]
         assert len(error_events) == 1, f"expected one error event, got: {emitted}"
         msg = error_events[0][2].get("message", "")
         assert "no longer running" in msg.lower(), f"unexpected message: {msg}"
@@ -11966,7 +12436,9 @@ def test_slow_agent_build_delivers_prompt_instead_of_timing_out(monkeypatch):
 
     try:
         monkeypatch.setattr(server.threading, "Thread", _FakeThread)
-        monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: emitted.append(args))
+        monkeypatch.setattr(
+            server, "_emit", lambda *args, **kwargs: emitted.append(args)
+        )
         monkeypatch.setattr(server, "_ensure_session_db_row", lambda session: None)
         monkeypatch.setattr(server, "_persist_branch_seed", lambda session: None)
         monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
@@ -11978,13 +12450,11 @@ def test_slow_agent_build_delivers_prompt_instead_of_timing_out(monkeypatch):
             ),
         )
 
-        submit = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid", "text": "first message"},
-            }
-        )
+        submit = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "first message"},
+        })
         assert submit.get("result"), f"got error: {submit.get('error')}"
 
         threads[0].target()
@@ -12041,7 +12511,9 @@ def test_slow_agent_build_emits_keyed_progress_notice(monkeypatch):
         monkeypatch.setattr(server.threading, "Thread", _FakeThread)
         # Every wait slice lands past the slow threshold.
         monkeypatch.setattr(server, "_AGENT_BUILD_SLOW_NOTICE_AFTER", 0.0)
-        monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: emitted.append(args))
+        monkeypatch.setattr(
+            server, "_emit", lambda *args, **kwargs: emitted.append(args)
+        )
         monkeypatch.setattr(server, "_ensure_session_db_row", lambda session: None)
         monkeypatch.setattr(server, "_persist_branch_seed", lambda session: None)
         monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
@@ -12053,24 +12525,29 @@ def test_slow_agent_build_emits_keyed_progress_notice(monkeypatch):
             ),
         )
 
-        submit = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid", "text": "first message"},
-            }
-        )
+        submit = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "first message"},
+        })
         assert submit.get("result"), f"got error: {submit.get('error')}"
 
         threads[0].target()
 
         assert calls["run_prompt"] == 1
-        shows = [e for e in emitted if e and e[0] == "notification.show" and e[1] == "sid"]
-        clears = [e for e in emitted if e and e[0] == "notification.clear" and e[1] == "sid"]
+        shows = [
+            e for e in emitted if e and e[0] == "notification.show" and e[1] == "sid"
+        ]
+        clears = [
+            e for e in emitted if e and e[0] == "notification.clear" and e[1] == "sid"
+        ]
         # Exactly one keyed notice, replaced-in-place semantics, then cleared.
         assert len(shows) == 1, f"expected one slow-build notice, got: {shows}"
         assert shows[0][2].get("key") == server._AGENT_BUILD_SLOW_NOTICE_KEY
-        assert len(clears) == 1 and clears[0][2].get("key") == server._AGENT_BUILD_SLOW_NOTICE_KEY
+        assert (
+            len(clears) == 1
+            and clears[0][2].get("key") == server._AGENT_BUILD_SLOW_NOTICE_KEY
+        )
     finally:
         server._sessions.pop("sid", None)
 
@@ -12103,7 +12580,9 @@ def test_agent_build_failure_surfaces_error_and_drops_turn(monkeypatch):
 
     try:
         monkeypatch.setattr(server.threading, "Thread", _FakeThread)
-        monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: emitted.append(args))
+        monkeypatch.setattr(
+            server, "_emit", lambda *args, **kwargs: emitted.append(args)
+        )
         monkeypatch.setattr(server, "_ensure_session_db_row", lambda session: None)
         monkeypatch.setattr(server, "_persist_branch_seed", lambda session: None)
         monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
@@ -12115,13 +12594,11 @@ def test_agent_build_failure_surfaces_error_and_drops_turn(monkeypatch):
             ),
         )
 
-        submit = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid", "text": "first message"},
-            }
-        )
+        submit = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "first message"},
+        })
         assert submit.get("result"), f"got error: {submit.get('error')}"
 
         threads[0].target()
@@ -12145,7 +12622,9 @@ def test_agent_build_failure_surfaces_error_and_drops_turn(monkeypatch):
                 or "No LLM provider configured" in str(e[2].get("text", ""))
             )
         ]
-        assert len(failure_frames) == 1, f"expected one visible failure frame, got: {emitted}"
+        assert len(failure_frames) == 1, (
+            f"expected one visible failure frame, got: {emitted}"
+        )
         frame = failure_frames[0]
         if frame[0] == "message.complete":
             assert frame[2].get("status") == "error"
@@ -12172,7 +12651,9 @@ def test_dead_build_thread_fails_fast_not_full_cap(monkeypatch):
     server._sessions["sid"] = session
 
     try:
-        monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: emitted.append(args))
+        monkeypatch.setattr(
+            server, "_emit", lambda *args, **kwargs: emitted.append(args)
+        )
         # Short slices so the test is fast; the dead-thread check fires on the
         # first empty slice, far below the cap.
         monkeypatch.setattr(server, "_AGENT_BUILD_WAIT_SLICE", 0.01)
@@ -12221,22 +12702,29 @@ def test_wait_agent_for_prompt_honors_cancel_mid_wait(monkeypatch):
 def test_agent_build_wait_cap_config_override(monkeypatch):
     """agent.build_wait_timeout in config.yaml overrides the default cap;
     invalid/absent values fall back to 600s."""
-    monkeypatch.setattr(server, "_load_cfg", lambda: {"agent": {"build_wait_timeout": 90}})
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"agent": {"build_wait_timeout": 90}}
+    )
     assert server._agent_build_wait_cap() == 90.0
 
     monkeypatch.setattr(server, "_load_cfg", lambda: {"agent": {}})
     assert server._agent_build_wait_cap() == 600.0
 
-    monkeypatch.setattr(server, "_load_cfg", lambda: {"agent": {"build_wait_timeout": 0}})
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"agent": {"build_wait_timeout": 0}}
+    )
     assert server._agent_build_wait_cap() == 600.0
 
-    monkeypatch.setattr(server, "_load_cfg", lambda: {"agent": {"build_wait_timeout": "nonsense"}})
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"agent": {"build_wait_timeout": "nonsense"}}
+    )
     assert server._agent_build_wait_cap() == 600.0
 
 
 def test_wait_agent_for_prompt_expires_at_cap(monkeypatch):
     """A genuinely hung build (thread alive, never ready) still fails at the
     bounded cap with a message that tells the user their text was not sent."""
+
     class _AliveThread:
         def is_alive(self):
             return True
@@ -12282,13 +12770,11 @@ def test_respond_unpacks_sid_tuple_correctly():
     ev = threading.Event()
     server._pending["rid-x"] = ("sid_x", ev)
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "clarify.respond",
-                "params": {"request_id": "rid-x", "answer": "the answer"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "clarify.respond",
+            "params": {"request_id": "rid-x", "answer": "the answer"},
+        })
         assert resp.get("result")
         assert ev.is_set()
         assert server._answers.get("rid-x") == "the answer"
@@ -12321,17 +12807,15 @@ def test_config_set_model_defers_while_running(monkeypatch):
 
     server._sessions["sid"] = _session(running=True)
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {
-                    "session_id": "sid",
-                    "key": "model",
-                    "value": "anthropic/claude-sonnet-4.6",
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {
+                "session_id": "sid",
+                "key": "model",
+                "value": "anthropic/claude-sonnet-4.6",
+            },
+        })
         assert not resp.get("error")
         result = resp["result"]
         assert result["deferred"] is True
@@ -12385,13 +12869,11 @@ def test_config_set_model_allowed_when_idle(monkeypatch):
 
     server._sessions["sid"] = _session(running=False)
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {"session_id": "sid", "key": "model", "value": "newmodel"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "model", "value": "newmodel"},
+        })
         assert resp.get("result")
         assert resp["result"]["value"] == "newmodel"
         assert seen["called"]
@@ -12429,9 +12911,9 @@ def test_mirror_slash_side_effects_rejects_mutating_commands_while_running(monke
         ("/compress", "compress"),
     ]:
         warning = server._mirror_slash_side_effects("sid", session, cmd)
-        assert (
-            "session busy" in warning
-        ), f"{cmd} should have returned busy warning, got: {warning!r}"
+        assert "session busy" in warning, (
+            f"{cmd} should have returned busy warning, got: {warning!r}"
+        )
         assert f"/{expected_name}" in warning
 
     # None of the mutating side-effect helpers should have fired.
@@ -12486,10 +12968,10 @@ def test_mirror_slash_compress_does_not_prelock_history(monkeypatch):
     monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
 
     session = _session(running=False)
-    session["history"] = [
-        {"role": "user", "content": f"m{i}"} for i in range(6)
-    ]
-    session["agent"] = types.SimpleNamespace(model="x", _cached_system_prompt="", tools=None)
+    session["history"] = [{"role": "user", "content": f"m{i}"} for i in range(6)]
+    session["agent"] = types.SimpleNamespace(
+        model="x", _cached_system_prompt="", tools=None
+    )
 
     warning = server._mirror_slash_side_effects("sid", session, "/compress")
 
@@ -12611,17 +13093,17 @@ def test_session_compress_rpc_honors_here_argument(monkeypatch):
     server._sessions["sid"] = session
 
     monkeypatch.setattr(server, "_session_info", lambda *_a, **_kw: {"model": "x"})
-    monkeypatch.setattr(server, "_sync_session_key_after_compress", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        server, "_sync_session_key_after_compress", lambda *a, **kw: None
+    )
     monkeypatch.setattr(server, "_emit", lambda *args: None)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.compress",
-                "params": {"session_id": "sid", "focus_topic": "here 1"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.compress",
+            "params": {"session_id": "sid", "focus_topic": "here 1"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -12643,17 +13125,17 @@ def test_command_dispatch_compress_honors_here_argument(monkeypatch):
 
     monkeypatch.setattr(server, "_session_uses_compute_host", lambda *_a, **_kw: False)
     monkeypatch.setattr(server, "_session_info", lambda *_a, **_kw: {"model": "x"})
-    monkeypatch.setattr(server, "_sync_session_key_after_compress", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        server, "_sync_session_key_after_compress", lambda *a, **kw: None
+    )
     monkeypatch.setattr(server, "_emit", lambda *args: None)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "command.dispatch",
-                "params": {"session_id": "sid", "name": "compress", "arg": "here 1"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "command.dispatch",
+            "params": {"session_id": "sid", "name": "compress", "arg": "here 1"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -12673,7 +13155,9 @@ def test_mirror_slash_compress_honors_here_argument(monkeypatch):
     session["history"] = list(_PARTIAL_FAKE_HISTORY)
 
     monkeypatch.setattr(server, "_session_info", lambda *_a, **_kw: {"model": "x"})
-    monkeypatch.setattr(server, "_sync_session_key_after_compress", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        server, "_sync_session_key_after_compress", lambda *a, **kw: None
+    )
     monkeypatch.setattr(server, "_emit", lambda *args: None)
 
     warning = server._mirror_slash_side_effects("sid", session, "/compress here 1")
@@ -12767,13 +13251,11 @@ def test_session_create_close_race_does_not_orphan_worker(monkeypatch):
     monkeypatch.setattr(_approval, "load_permanent_allowlist", lambda: None)
 
     # Start: session.create spawns _build thread, returns synchronously
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "session.create",
-            "params": {"cols": 80},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.create",
+        "params": {"cols": 80},
+    })
     assert resp.get("result"), f"got error: {resp.get('error')}"
     sid = resp["result"]["session_id"]
     own_key = resp["result"]["stored_session_id"]
@@ -12788,13 +13270,11 @@ def test_session_create_close_race_does_not_orphan_worker(monkeypatch):
     # Build thread is blocked in _slow_make_agent.  Close the session
     # NOW — this pops _sessions[sid] before _build can install the
     # worker/notify.
-    close_resp = server.handle_request(
-        {
-            "id": "2",
-            "method": "session.close",
-            "params": {"session_id": sid},
-        }
-    )
+    close_resp = server.handle_request({
+        "id": "2",
+        "method": "session.close",
+        "params": {"session_id": sid},
+    })
     assert close_resp.get("result", {}).get("closed") is True
 
     # At this point session.close saw slash_worker=None (never eagerly
@@ -12851,7 +13331,9 @@ def test_session_create_no_race_keeps_worker_alive(monkeypatch):
             self.base_url = ""
             self.api_key = ""
 
-    monkeypatch.setattr(server, "_make_agent", lambda sid, key, session_db=None, **_kwargs: _FakeAgent())
+    monkeypatch.setattr(
+        server, "_make_agent", lambda sid, key, session_db=None, **_kwargs: _FakeAgent()
+    )
     monkeypatch.setattr(server, "_SlashWorker", _FakeWorker)
     monkeypatch.setattr(
         server,
@@ -12883,13 +13365,11 @@ def test_session_create_no_race_keeps_worker_alive(monkeypatch):
     server._sessions.clear()
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.create",
-                "params": {"cols": 80},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.create",
+            "params": {"cols": 80},
+        })
         sid = resp["result"]["session_id"]
 
         # Wait for the build to finish (ready event inside session dict).
@@ -12909,12 +13389,12 @@ def test_session_create_no_race_keeps_worker_alive(monkeypatch):
         own_key = session["session_key"]
         own_closed = [k for k in closed_workers if k == own_key]
         own_unregistered = [k for k in unregistered_keys if k == own_key]
-        assert (
-            own_closed == []
-        ), f"build thread closed its own worker despite no race: {own_closed}"
-        assert (
-            own_unregistered == []
-        ), f"build thread unregistered its own notify despite no race: {own_unregistered}"
+        assert own_closed == [], (
+            f"build thread closed its own worker despite no race: {own_closed}"
+        )
+        assert own_unregistered == [], (
+            f"build thread unregistered its own notify despite no race: {own_unregistered}"
+        )
 
         # No pre-warmed worker: slash.exec spawns on demand, so a fresh
         # session that hasn't run a worker-routed command carries None.
@@ -12959,7 +13439,9 @@ def test_session_create_continues_when_state_db_is_unavailable(monkeypatch):
 
     emits = []
 
-    monkeypatch.setattr(server, "_make_agent", lambda sid, key, session_db=None, **_kwargs: _FakeAgent())
+    monkeypatch.setattr(
+        server, "_make_agent", lambda sid, key, session_db=None, **_kwargs: _FakeAgent()
+    )
     monkeypatch.setattr(server, "_SlashWorker", _FakeWorker)
     monkeypatch.setattr(server, "_get_db", lambda: None)
     monkeypatch.setattr(server, "_session_info", lambda _a, *a2: {"model": "x"})
@@ -12972,9 +13454,11 @@ def test_session_create_continues_when_state_db_is_unavailable(monkeypatch):
     monkeypatch.setattr(_approval, "register_gateway_notify", lambda key, cb: None)
     monkeypatch.setattr(_approval, "load_permanent_allowlist", lambda: None)
 
-    resp = server.handle_request(
-        {"id": "1", "method": "session.create", "params": {"cols": 80}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.create",
+        "params": {"cols": 80},
+    })
     sid = resp["result"]["session_id"]
     session = server._sessions[sid]
     session["agent_ready"].wait(timeout=2.0)
@@ -13003,9 +13487,11 @@ def test_session_create_lazy_info_reports_desktop_contract(monkeypatch):
     monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
     monkeypatch.setattr(server, "_start_agent_build", lambda *a, **kw: None)
 
-    resp = server.handle_request(
-        {"id": "1", "method": "session.create", "params": {"cols": 80}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.create",
+        "params": {"cols": 80},
+    })
     info = resp["result"]["info"]
 
     assert info["desktop_contract"] == server.DESKTOP_BACKEND_CONTRACT
@@ -13034,13 +13520,11 @@ def test_session_activate_lazy_info_reports_desktop_contract():
         "transport": server._stdio_transport,
     }
     try:
-        resp = server.handle_request(
-            {
-                "id": "activate-lazy",
-                "method": "session.activate",
-                "params": {"session_id": sid},
-            }
-        )
+        resp = server.handle_request({
+            "id": "activate-lazy",
+            "method": "session.activate",
+            "params": {"session_id": sid},
+        })
         info = resp["result"]["info"]
         assert info["lazy"] is True
         assert info["desktop_contract"] == server.DESKTOP_BACKEND_CONTRACT
@@ -13084,9 +13568,11 @@ def test_session_delete_returns_db_unavailable_when_no_db(monkeypatch):
     monkeypatch.setattr(server, "_get_db", lambda: None)
     monkeypatch.setattr(server, "_db_error", "locked")
 
-    resp = server.handle_request(
-        {"id": "1", "method": "session.delete", "params": {"session_id": "abc"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.delete",
+        "params": {"session_id": "abc"},
+    })
 
     assert "error" in resp
     assert resp["error"]["code"] == 5036
@@ -13105,13 +13591,11 @@ def test_session_delete_refuses_active_session(monkeypatch):
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
     monkeypatch.setitem(server._sessions, "live", {"session_key": "key-live"})
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.delete",
-                "params": {"session_id": "key-live"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.delete",
+            "params": {"session_id": "key-live"},
+        })
     finally:
         server._sessions.pop("live", None)
 
@@ -13138,9 +13622,11 @@ def test_session_delete_fails_closed_when_active_snapshot_raises(monkeypatch):
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
     monkeypatch.setattr(server, "_sessions", _ExplodingDict())
 
-    resp = server.handle_request(
-        {"id": "1", "method": "session.delete", "params": {"session_id": "x"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.delete",
+        "params": {"session_id": "x"},
+    })
 
     assert "error" in resp
     assert resp["error"]["code"] == 5036
@@ -13154,9 +13640,11 @@ def test_session_delete_returns_4007_when_missing(monkeypatch):
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
 
-    resp = server.handle_request(
-        {"id": "1", "method": "session.delete", "params": {"session_id": "ghost"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.delete",
+        "params": {"session_id": "ghost"},
+    })
 
     assert "error" in resp
     assert resp["error"]["code"] == 4007
@@ -13169,9 +13657,11 @@ def test_session_delete_propagates_db_exception(monkeypatch):
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
 
-    resp = server.handle_request(
-        {"id": "1", "method": "session.delete", "params": {"session_id": "x"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.delete",
+        "params": {"session_id": "x"},
+    })
 
     assert "error" in resp
     assert resp["error"]["code"] == 5036
@@ -13192,9 +13682,11 @@ def test_session_delete_success_returns_deleted_id(monkeypatch):
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
 
-    resp = server.handle_request(
-        {"id": "1", "method": "session.delete", "params": {"session_id": "old-1"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.delete",
+        "params": {"session_id": "old-1"},
+    })
 
     assert "result" in resp, resp
     assert resp["result"] == {"deleted": "old-1"}
@@ -13205,8 +13697,6 @@ def test_session_delete_success_returns_deleted_id(monkeypatch):
     # /sessions to it.
     assert captured["sessions_dir"] is not None
     assert str(captured["sessions_dir"]).endswith("sessions")
-
-
 
 
 # --------------------------------------------------------------------------
@@ -13246,17 +13736,17 @@ def test_session_list_honors_params_profile_opens_profile_db(monkeypatch, tmp_pa
         def close(self):
             seen["closed"] = True
 
-    monkeypatch.setattr(server, "_profile_home", lambda p: profile_home if p == "mlperf" else None)
+    monkeypatch.setattr(
+        server, "_profile_home", lambda p: profile_home if p == "mlperf" else None
+    )
     monkeypatch.setattr(server, "_get_db", lambda: LaunchDB())
     monkeypatch.setattr("hermes_state.SessionDB", ProfileDB)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "session.list",
-            "params": {"profile": "mlperf", "limit": 5},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.list",
+        "params": {"profile": "mlperf", "limit": 5},
+    })
     assert "result" in resp, resp
     assert resp["result"]["sessions"][0]["id"] == "ml-1"
     assert seen.get("profile") is True
@@ -13272,7 +13762,9 @@ def test_session_most_recent_honors_params_profile(monkeypatch, tmp_path):
 
     class LaunchDB:
         def list_sessions_rich(self, **kwargs):
-            return [{"id": "launch-tip", "source": "tui", "title": "L", "started_at": 9}]
+            return [
+                {"id": "launch-tip", "source": "tui", "title": "L", "started_at": 9}
+            ]
 
     class ProfileDB2:
         def __init__(self, db_path=None):
@@ -13287,17 +13779,17 @@ def test_session_most_recent_honors_params_profile(monkeypatch, tmp_path):
         def close(self):
             pass
 
-    monkeypatch.setattr(server, "_profile_home", lambda p: profile_home if p == "mlperf" else None)
+    monkeypatch.setattr(
+        server, "_profile_home", lambda p: profile_home if p == "mlperf" else None
+    )
     monkeypatch.setattr(server, "_get_db", lambda: LaunchDB())
     monkeypatch.setattr("hermes_state.SessionDB", ProfileDB2)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "session.most_recent",
-            "params": {"profile": "mlperf"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.most_recent",
+        "params": {"profile": "mlperf"},
+    })
     assert resp["result"]["session_id"] == "ml-tip"
 
 
@@ -13313,14 +13805,22 @@ def test_session_create_reports_requested_profile_name(monkeypatch, tmp_path):
 
     monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
     monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
-    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda *a, **k: None)
+    monkeypatch.setattr(
+        server, "_schedule_session_cap_enforcement", lambda *a, **k: None
+    )
     monkeypatch.setattr(server, "_completion_cwd", lambda params=None: str(tmp_path))
-    monkeypatch.setattr(server, "_profile_home", lambda p: profile_home if p == "mlperf" else None)
+    monkeypatch.setattr(
+        server, "_profile_home", lambda p: profile_home if p == "mlperf" else None
+    )
     monkeypatch.setattr(server, "_current_profile_name", lambda: "default")
-    monkeypatch.setattr(server, "_claim_active_session_slot", lambda *a, **k: (None, None))
+    monkeypatch.setattr(
+        server, "_claim_active_session_slot", lambda *a, **k: (None, None)
+    )
     _clear()
     try:
-        resp = server._methods["session.create"]("r1", {"profile": "mlperf", "cols": 80})
+        resp = server._methods["session.create"](
+            "r1", {"profile": "mlperf", "cols": 80}
+        )
         assert "result" in resp, resp
         assert resp["result"]["info"]["profile_name"] == "mlperf"
         sid = resp["result"]["session_id"]
@@ -13347,17 +13847,17 @@ def test_session_delete_honors_params_profile_sessions_dir(monkeypatch, tmp_path
         def close(self):
             captured["closed"] = True
 
-    monkeypatch.setattr(server, "_profile_home", lambda p: profile_home if p == "mlperf" else None)
+    monkeypatch.setattr(
+        server, "_profile_home", lambda p: profile_home if p == "mlperf" else None
+    )
     monkeypatch.setattr(server, "_get_db", lambda: None)
     monkeypatch.setattr("hermes_state.SessionDB", ProfileDB)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "session.delete",
-            "params": {"session_id": "old-ml", "profile": "mlperf"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.delete",
+        "params": {"session_id": "old-ml", "profile": "mlperf"},
+    })
     assert "result" in resp, resp
     assert resp["result"] == {"deleted": "old-ml"}
     assert str(captured["db_path"]).endswith("state.db")
@@ -13418,22 +13918,22 @@ def test_session_title_uses_session_profile_db_not_launch(monkeypatch, tmp_path)
     monkeypatch.setattr(server, "_get_db", lambda: LaunchDB())
     monkeypatch.setattr("hermes_state.SessionDB", ProfileDB)
     try:
-        set_resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.title",
-                "params": {"session_id": "sid", "title": "profile-title"},
-            }
-        )
+        set_resp = server.handle_request({
+            "id": "1",
+            "method": "session.title",
+            "params": {"session_id": "sid", "title": "profile-title"},
+        })
         assert "result" in set_resp, set_resp
         assert set_resp["result"]["title"] == "profile-title"
         assert seen.get("profile_write") is True
         assert seen.get("launch_write") is None
         assert str(seen.get("db_path")).endswith("state.db")
 
-        get_resp = server.handle_request(
-            {"id": "2", "method": "session.title", "params": {"session_id": "sid"}}
-        )
+        get_resp = server.handle_request({
+            "id": "2",
+            "method": "session.title",
+            "params": {"session_id": "sid"},
+        })
         assert get_resp["result"]["title"] == "profile-title"
         assert seen.get("launch_read") is None
     finally:
@@ -13475,9 +13975,11 @@ def test_session_history_uses_session_profile_db(monkeypatch, tmp_path):
     monkeypatch.setattr(server, "_get_db", lambda: LaunchDB())
     monkeypatch.setattr("hermes_state.SessionDB", ProfileDB)
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.history", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.history",
+            "params": {"session_id": "sid"},
+        })
         assert "result" in resp, resp
         assert seen.get("profile") is True
         assert seen.get("launch") is None
@@ -13497,7 +13999,9 @@ def test_session_history_ships_durable_row_ids(monkeypatch):
     seen: dict = {}
 
     class _Db:
-        def get_messages_as_conversation(self, _key, include_ancestors=False, include_row_ids=False, **_kwargs):
+        def get_messages_as_conversation(
+            self, _key, include_ancestors=False, include_row_ids=False, **_kwargs
+        ):
             seen["include_row_ids"] = include_row_ids
 
             return [
@@ -13516,9 +14020,11 @@ def test_session_history_ships_durable_row_ids(monkeypatch):
     }
     monkeypatch.setattr(server, "_get_db", lambda: _Db())
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.history", "params": {"session_id": "rowid-hist-sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.history",
+            "params": {"session_id": "rowid-hist-sid"},
+        })
         assert "result" in resp, resp
         assert seen.get("include_row_ids") is True
         user_rows = [m for m in resp["result"]["messages"] if m.get("role") == "user"]
@@ -13562,9 +14068,11 @@ def test_session_status_uses_session_profile_db(monkeypatch, tmp_path):
     monkeypatch.setattr(server, "_get_db", lambda: LaunchDB())
     monkeypatch.setattr("hermes_state.SessionDB", ProfileDB)
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.status", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.status",
+            "params": {"session_id": "sid"},
+        })
         assert "result" in resp, resp
         assert "profile-title" in resp["result"]["output"]
         assert seen.get("profile") is True
@@ -13696,7 +14204,9 @@ def test_session_branch_writes_to_parent_profile_db(monkeypatch, tmp_path):
     server._sessions["parent"] = parent
     monkeypatch.setattr(server, "_get_db", lambda: LaunchDB())
     monkeypatch.setattr("hermes_state.SessionDB", ProfileDB)
-    monkeypatch.setattr(server, "_claim_active_session_slot", lambda *a, **k: (None, None))
+    monkeypatch.setattr(
+        server, "_claim_active_session_slot", lambda *a, **k: (None, None)
+    )
 
     def _fake_make_agent(*a, **k):
         seen["agent_session_db"] = k.get("session_db")
@@ -13710,13 +14220,11 @@ def test_session_branch_writes_to_parent_profile_db(monkeypatch, tmp_path):
     monkeypatch.setattr(server, "_register_session_cwd", lambda *a, **k: None)
     monkeypatch.setattr(server, "_attach_worker", lambda *a, **k: None)
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.branch",
-                "params": {"session_id": "parent", "name": "forked"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.branch",
+            "params": {"session_id": "parent", "name": "forked"},
+        })
         assert "result" in resp, resp
         assert seen.get("created")
         assert seen.get("parent") == "parent-key"
@@ -13812,7 +14320,9 @@ def test_session_branch_installs_parent_profile_secret_scope(monkeypatch, tmp_pa
     server._sessions["parent"] = parent
     monkeypatch.setattr(server, "_get_db", lambda: ProfileDB())
     monkeypatch.setattr("hermes_state.SessionDB", ProfileDB)
-    monkeypatch.setattr(server, "_claim_active_session_slot", lambda *a, **k: (None, None))
+    monkeypatch.setattr(
+        server, "_claim_active_session_slot", lambda *a, **k: (None, None)
+    )
 
     def _fake_make_agent(*a, **k):
         scope = current_secret_scope()
@@ -13827,13 +14337,11 @@ def test_session_branch_installs_parent_profile_secret_scope(monkeypatch, tmp_pa
     monkeypatch.setattr(server, "_register_session_cwd", lambda *a, **k: None)
     monkeypatch.setattr(server, "_attach_worker", lambda *a, **k: None)
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.branch",
-                "params": {"session_id": "parent", "name": "forked"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.branch",
+            "params": {"session_id": "parent", "name": "forked"},
+        })
         assert "result" in resp, resp
         assert seen.get("scope") == {"PROXMOX_TOKEN": "mlperf-secret"}
     finally:
@@ -13841,7 +14349,9 @@ def test_session_branch_installs_parent_profile_secret_scope(monkeypatch, tmp_pa
             server._sessions.pop(k, None)
 
 
-def test_session_branch_uses_persisted_display_history_after_compaction(monkeypatch, tmp_path):
+def test_session_branch_uses_persisted_display_history_after_compaction(
+    monkeypatch, tmp_path
+):
     """A live branch must copy the complete visible transcript, not the compacted model tail."""
     profile_home = tmp_path / "profiles" / "mlperf"
     profile_home.mkdir(parents=True)
@@ -13929,7 +14439,9 @@ def test_session_branch_uses_persisted_display_history_after_compaction(monkeypa
     server._sessions["parent"] = parent
     monkeypatch.setattr(server, "_get_db", lambda: LaunchDB())
     monkeypatch.setattr("hermes_state.SessionDB", ProfileDB)
-    monkeypatch.setattr(server, "_claim_active_session_slot", lambda *args, **kwargs: (None, None))
+    monkeypatch.setattr(
+        server, "_claim_active_session_slot", lambda *args, **kwargs: (None, None)
+    )
     monkeypatch.setattr(server, "_make_agent", lambda *args, **kwargs: FakeAgent())
     monkeypatch.setattr(server, "_set_session_context", lambda *args, **kwargs: {})
     monkeypatch.setattr(server, "_clear_session_context", lambda *args, **kwargs: None)
@@ -13939,13 +14451,11 @@ def test_session_branch_uses_persisted_display_history_after_compaction(monkeypa
     monkeypatch.setattr(server, "_attach_worker", lambda *args, **kwargs: None)
 
     try:
-        response = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.branch",
-                "params": {"session_id": "parent", "count": 4},
-            }
-        )
+        response = server.handle_request({
+            "id": "1",
+            "method": "session.branch",
+            "params": {"session_id": "parent", "count": 4},
+        })
 
         assert "result" in response, response
         assert [message["content"] for message in seen["msgs"]] == [
@@ -14179,8 +14689,12 @@ def test_model_options_preserves_canonical_custom_row_after_agent_init(monkeypat
         "hermes_cli.auth.is_provider_explicitly_configured",
         lambda _slug: False,
     )
-    monkeypatch.setattr("hermes_cli.inventory._apply_pricing", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr("hermes_cli.inventory._apply_capabilities", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        "hermes_cli.inventory._apply_pricing", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        "hermes_cli.inventory._apply_capabilities", lambda *_args, **_kwargs: None
+    )
 
     resp = server._methods["model.options"](
         102,
@@ -14303,7 +14817,9 @@ def test_prompt_submit_wires_live_title_rename_callback(monkeypatch):
         api_key = object()
         api_mode = "codex_responses"
 
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             return {
                 "final_response": "Rome was founded in 753 BC.",
                 "messages": [
@@ -14317,19 +14833,19 @@ def test_prompt_submit_wires_live_title_rename_callback(monkeypatch):
     emitted = []
     monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
     monkeypatch.setattr(
-        server, "_emit", lambda kind, sid, payload=None, **kw: emitted.append((kind, payload))
+        server,
+        "_emit",
+        lambda kind, sid, payload=None, **kw: emitted.append((kind, payload)),
     )
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
     monkeypatch.setattr(server, "_get_db", lambda: None)
 
-    server.handle_request(
-        {
-            "id": "1",
-            "method": "prompt.submit",
-            "params": {"session_id": "sid", "text": "Tell me about Rome"},
-        }
-    )
+    server.handle_request({
+        "id": "1",
+        "method": "prompt.submit",
+        "params": {"session_id": "sid", "text": "Tell me about Rome"},
+    })
 
     hook = getattr(agent, "_on_session_title", None)
     assert callable(hook), "gateway did not install a live title-rename hook"
@@ -14338,7 +14854,9 @@ def test_prompt_submit_wires_live_title_rename_callback(monkeypatch):
     # the lanes that spend a rate-limited remote rename filter by stage.
     hook("tell me about rome", "derived")
     hook("Founding of Rome", "llm")
-    assert [payload["title"] for kind, payload in emitted if kind == "session.title"] == [
+    assert [
+        payload["title"] for kind, payload in emitted if kind == "session.title"
+    ] == [
         "tell me about rome",
         "Founding of Rome",
     ]
@@ -14354,7 +14872,9 @@ def test_prompt_submit_surfaces_backend_error_as_visible_text(monkeypatch):
     instead of emitting a blank message.complete turn."""
 
     class _Agent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             return {
                 "final_response": None,
                 "messages": [],
@@ -14377,13 +14897,11 @@ def test_prompt_submit_surfaces_backend_error_as_visible_text(monkeypatch):
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
     monkeypatch.setattr(server, "_get_db", lambda: None)
 
-    server.handle_request(
-        {
-            "id": "1",
-            "method": "prompt.submit",
-            "params": {"session_id": "sid", "text": "hello"},
-        }
-    )
+    server.handle_request({
+        "id": "1",
+        "method": "prompt.submit",
+        "params": {"session_id": "sid", "text": "hello"},
+    })
 
     complete_events = [e for e in emitted if e[0] == "message.complete"]
     assert complete_events, "expected message.complete to be emitted"
@@ -14399,7 +14917,9 @@ def test_prompt_submit_preserves_empty_response_without_error(monkeypatch):
     semantics owned by downstream handlers."""
 
     class _Agent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             return {
                 "final_response": None,
                 "messages": [],
@@ -14420,13 +14940,11 @@ def test_prompt_submit_preserves_empty_response_without_error(monkeypatch):
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
     monkeypatch.setattr(server, "_get_db", lambda: None)
 
-    server.handle_request(
-        {
-            "id": "1",
-            "method": "prompt.submit",
-            "params": {"session_id": "sid", "text": "hello"},
-        }
-    )
+    server.handle_request({
+        "id": "1",
+        "method": "prompt.submit",
+        "params": {"session_id": "sid", "text": "hello"},
+    })
 
     complete_events = [e for e in emitted if e[0] == "message.complete"]
     assert complete_events, "expected message.complete to be emitted"
@@ -14465,13 +14983,11 @@ def test_session_active_list_reports_live_sessions(monkeypatch):
         last_active=30.0,
     )
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.active_list",
-                "params": {"current_session_id": "sid-b"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.active_list",
+            "params": {"current_session_id": "sid-b"},
+        })
     finally:
         server._sessions.clear()
         server._sessions.update(previous_sessions)
@@ -14508,6 +15024,7 @@ def test_session_active_list_excludes_finalized_sessions(monkeypatch):
     until a gateway restart. A live session on the real stdio transport (the
     standalone ``hermes --tui`` case) must still be reported.
     """
+
     class _DB:
         def get_session_title(self, key):
             return {"key-live": "Live", "key-dead": "Dead"}.get(key, "")
@@ -14532,20 +15049,17 @@ def test_session_active_list_excludes_finalized_sessions(monkeypatch):
     dead["_finalized"] = True
     server._sessions["sid-dead"] = dead
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.active_list",
-                "params": {},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.active_list",
+            "params": {},
+        })
     finally:
         server._sessions.clear()
         server._sessions.update(previous_sessions)
 
     session_rows = resp["result"]["sessions"]
     assert [row["id"] for row in session_rows] == ["sid-live"]
-
 
 
 def test_session_activate_returns_inflight_stream_before_completion(monkeypatch):
@@ -14562,7 +15076,9 @@ def test_session_activate_returns_inflight_stream_before_completion(monkeypatch)
     class _Agent:
         model = "model-live"
 
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             assert prompt == "write a long answer"
             assert conversation_history == []
             stream_callback("partial ")
@@ -14590,23 +15106,19 @@ def test_session_activate_returns_inflight_stream_before_completion(monkeypatch)
     monkeypatch.setattr(server, "_emit", _emit)
 
     try:
-        submit = server.handle_request(
-            {
-                "id": "submit",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid-live", "text": "write a long answer"},
-            }
-        )
+        submit = server.handle_request({
+            "id": "submit",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid-live", "text": "write a long answer"},
+        })
         assert submit["result"]["status"] == "streaming"
         assert started.wait(2), "fake model did not stream before activation"
 
-        resp = server.handle_request(
-            {
-                "id": "activate",
-                "method": "session.activate",
-                "params": {"session_id": "sid-live"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "activate",
+            "method": "session.activate",
+            "params": {"session_id": "sid-live"},
+        })
 
         inflight = resp["result"].get("inflight")
         assert inflight == {
@@ -14615,19 +15127,20 @@ def test_session_activate_returns_inflight_stream_before_completion(monkeypatch)
             "user": "write a long answer",
         }
         turn_started_at = resp["result"]["turn_started_at"]
-        assert turn_started_at == server._sessions["sid-live"]["inflight_turn"]["started_at"]
+        assert (
+            turn_started_at
+            == server._sessions["sid-live"]["inflight_turn"]["started_at"]
+        )
         assert turn_started_at > 0
         assert resp["result"]["messages"] == []
 
         release.set()
         assert done.wait(2), "fake model turn did not complete"
-        completed = server.handle_request(
-            {
-                "id": "activate-done",
-                "method": "session.activate",
-                "params": {"session_id": "sid-live"},
-            }
-        )
+        completed = server.handle_request({
+            "id": "activate-done",
+            "method": "session.activate",
+            "params": {"session_id": "sid-live"},
+        })
         assert completed["result"].get("inflight") is None
         assert completed["result"]["turn_started_at"] is None
         assert completed["result"]["messages"] == [
@@ -14666,13 +15179,11 @@ def test_session_activate_returns_prompt_queued_during_busy_turn(monkeypatch):
         )
         assert queued["result"]["status"] == "queued"
 
-        activated = server.handle_request(
-            {
-                "id": "activate",
-                "method": "session.activate",
-                "params": {"session_id": "sid-live"},
-            }
-        )
+        activated = server.handle_request({
+            "id": "activate",
+            "method": "session.activate",
+            "params": {"session_id": "sid-live"},
+        })
 
         assert activated["result"]["queued"] == {"user": "newest prompt"}
         assert "transport" not in activated["result"]["queued"]
@@ -14697,9 +15208,11 @@ def test_session_activate_switches_live_session_without_closing_siblings(monkeyp
         session_key="key-b",
     )
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.activate", "params": {"session_id": "sid-b"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.activate",
+            "params": {"session_id": "sid-b"},
+        })
 
         assert "sid-a" in server._sessions
         assert "sid-b" in server._sessions
@@ -14728,13 +15241,11 @@ def test_session_activate_can_omit_duplicate_desktop_transcript(monkeypatch):
         session_key="key-large",
     )
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.activate",
-                "params": {"session_id": "sid-large", "omit_messages": True},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.activate",
+            "params": {"session_id": "sid-large", "omit_messages": True},
+        })
 
         assert resp["result"]["messages"] == []
         assert resp["result"]["message_count"] == 2
@@ -14751,7 +15262,14 @@ def test_session_most_recent_returns_first_non_denied(monkeypatch):
     """Drops `tool` rows like session.list does, returns the first hit."""
 
     class _DB:
-        def list_sessions_rich(self, *, source=None, limit=200, order_by_last_active=False, compact_rows=False):
+        def list_sessions_rich(
+            self,
+            *,
+            source=None,
+            limit=200,
+            order_by_last_active=False,
+            compact_rows=False,
+        ):
             return [
                 {"id": "tool-1", "source": "tool", "title": "noise", "started_at": 100},
                 {"id": "tui-1", "source": "tui", "title": "real", "started_at": 99},
@@ -14759,9 +15277,11 @@ def test_session_most_recent_returns_first_non_denied(monkeypatch):
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
 
-    resp = server.handle_request(
-        {"id": "1", "method": "session.most_recent", "params": {}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.most_recent",
+        "params": {},
+    })
 
     assert resp["result"]["session_id"] == "tui-1"
     assert resp["result"]["title"] == "real"
@@ -14770,14 +15290,23 @@ def test_session_most_recent_returns_first_non_denied(monkeypatch):
 
 def test_session_most_recent_returns_null_when_only_tool_rows(monkeypatch):
     class _DB:
-        def list_sessions_rich(self, *, source=None, limit=200, order_by_last_active=False, compact_rows=False):
+        def list_sessions_rich(
+            self,
+            *,
+            source=None,
+            limit=200,
+            order_by_last_active=False,
+            compact_rows=False,
+        ):
             return [{"id": "tool-1", "source": "tool", "started_at": 1}]
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
 
-    resp = server.handle_request(
-        {"id": "1", "method": "session.most_recent", "params": {}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.most_recent",
+        "params": {},
+    })
 
     assert resp["result"]["session_id"] is None
 
@@ -14788,14 +15317,23 @@ def test_session_most_recent_folds_db_exception_into_null_result(monkeypatch):
     'no answer' (Copilot review on #17130)."""
 
     class _BrokenDB:
-        def list_sessions_rich(self, *, source=None, limit=200, order_by_last_active=False, compact_rows=False):
+        def list_sessions_rich(
+            self,
+            *,
+            source=None,
+            limit=200,
+            order_by_last_active=False,
+            compact_rows=False,
+        ):
             raise RuntimeError("db locked")
 
     monkeypatch.setattr(server, "_get_db", lambda: _BrokenDB())
 
-    resp = server.handle_request(
-        {"id": "1", "method": "session.most_recent", "params": {}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.most_recent",
+        "params": {},
+    })
 
     assert "error" not in resp
     assert resp["result"]["session_id"] is None
@@ -14804,9 +15342,11 @@ def test_session_most_recent_folds_db_exception_into_null_result(monkeypatch):
 def test_session_most_recent_handles_db_unavailable(monkeypatch):
     monkeypatch.setattr(server, "_get_db", lambda: None)
 
-    resp = server.handle_request(
-        {"id": "1", "method": "session.most_recent", "params": {}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.most_recent",
+        "params": {},
+    })
 
     assert resp["result"]["session_id"] is None
 
@@ -14817,7 +15357,9 @@ def test_session_most_recent_handles_db_unavailable(monkeypatch):
 def test_verification_status_returns_recorded_evidence(tmp_path, monkeypatch):
     profile_home = tmp_path / "profiles" / "verify"
     profile_home.mkdir(parents=True)
-    monkeypatch.setattr(server, "_profile_home", lambda p: profile_home if p == "verify" else None)
+    monkeypatch.setattr(
+        server, "_profile_home", lambda p: profile_home if p == "verify" else None
+    )
     token = set_hermes_home_override(profile_home)
     project = tmp_path / "project"
     project.mkdir()
@@ -14838,13 +15380,11 @@ def test_verification_status_returns_recorded_evidence(tmp_path, monkeypatch):
             output="green",
         )
 
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "verification.status",
-                "params": {"cwd": str(project), "session_id": "sid", "profile": "verify"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "verification.status",
+            "params": {"cwd": str(project), "session_id": "sid", "profile": "verify"},
+        })
     finally:
         reset_hermes_home_override(token)
 
@@ -14869,13 +15409,11 @@ def test_verification_status_outside_workspace_is_not_applicable(monkeypatch, tm
     home.mkdir()
     token = set_hermes_home_override(home)
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "verification.status",
-                "params": {"cwd": str(tmp_path), "session_id": "sid"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "verification.status",
+            "params": {"cwd": str(tmp_path), "session_id": "sid"},
+        })
     finally:
         reset_hermes_home_override(token)
 
@@ -14935,9 +15473,11 @@ def test_browser_manage_status_reads_env_var(monkeypatch):
     """Status returns the env var verbatim (no network I/O)."""
     monkeypatch.setenv("BROWSER_CDP_URL", "http://127.0.0.1:9222")
 
-    resp = server.handle_request(
-        {"id": "1", "method": "browser.manage", "params": {"action": "status"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "browser.manage",
+        "params": {"action": "status"},
+    })
 
     assert resp["result"]["connected"] is True
     assert resp["result"]["url"] == "http://127.0.0.1:9222"
@@ -14952,9 +15492,11 @@ def test_browser_manage_status_falls_back_to_config_cdp_url(monkeypatch):
         read_raw_config=lambda: {"browser": {"cdp_url": "http://lan:9222"}}
     )
     with patch.dict(sys.modules, {"hermes_cli.config": fake_cfg}):
-        resp = server.handle_request(
-            {"id": "1", "method": "browser.manage", "params": {"action": "status"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "browser.manage",
+            "params": {"action": "status"},
+        })
 
     assert resp["result"] == {"connected": True, "url": "http://lan:9222"}
 
@@ -14971,9 +15513,11 @@ def test_browser_manage_status_does_not_call_get_cdp_override(monkeypatch):
         )
     )
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
-        resp = server.handle_request(
-            {"id": "1", "method": "browser.manage", "params": {"action": "status"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "browser.manage",
+            "params": {"action": "status"},
+        })
 
     assert resp["result"]["connected"] is True
 
@@ -14995,13 +15539,11 @@ def test_browser_manage_connect_sets_env_and_cleans_twice(monkeypatch):
     )
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
         _stub_urlopen(monkeypatch, ok=True)
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "browser.manage",
-                "params": {"action": "connect", "url": "http://127.0.0.1:9222"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "browser.manage",
+            "params": {"action": "connect", "url": "http://127.0.0.1:9222"},
+        })
 
     assert resp["result"]["connected"] is True
     assert resp["result"]["url"] == "http://127.0.0.1:9222"
@@ -15021,9 +15563,11 @@ def test_browser_manage_connect_defaults_to_loopback(monkeypatch):
     )
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
         urls = _stub_urlopen_capture(monkeypatch, ok=True)
-        resp = server.handle_request(
-            {"id": "1", "method": "browser.manage", "params": {"action": "connect"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "browser.manage",
+            "params": {"action": "connect"},
+        })
 
     assert resp["result"]["connected"] is True
     assert resp["result"]["url"] == "http://127.0.0.1:9222"
@@ -15057,23 +15601,24 @@ def test_browser_manage_connect_default_local_reports_launch_hint(monkeypatch):
                 return_value=ChromeDebugLaunch(),
             ),
             patch("hermes_cli.browser_connect.local_port_in_use", return_value=False),
-            patch("hermes_cli.browser_connect.manual_chrome_debug_command", return_value=None),
+            patch(
+                "hermes_cli.browser_connect.manual_chrome_debug_command",
+                return_value=None,
+            ),
             patch(
                 "hermes_cli.browser_connect.get_chrome_debug_candidates",
                 return_value=[],
             ),
         ):
-            resp = server.handle_request(
-                {
-                    "id": "1",
-                    "method": "browser.manage",
-                    "params": {
-                        "action": "connect",
-                        "session_id": "sess-1",
-                        "url": "http://localhost:9222",
-                    },
-                }
-            )
+            resp = server.handle_request({
+                "id": "1",
+                "method": "browser.manage",
+                "params": {
+                    "action": "connect",
+                    "session_id": "sess-1",
+                    "url": "http://localhost:9222",
+                },
+            })
 
     assert resp["result"]["connected"] is False
     assert resp["result"]["url"] == "http://127.0.0.1:9222"
@@ -15115,19 +15660,20 @@ def test_browser_manage_connect_no_session_skips_progress_events(monkeypatch):
                 "hermes_cli.browser_connect.launch_chrome_debug",
                 return_value=ChromeDebugLaunch(),
             ),
-            patch("hermes_cli.browser_connect.manual_chrome_debug_command", return_value=None),
+            patch(
+                "hermes_cli.browser_connect.manual_chrome_debug_command",
+                return_value=None,
+            ),
             patch(
                 "hermes_cli.browser_connect.get_chrome_debug_candidates",
                 return_value=[],
             ),
         ):
-            resp = server.handle_request(
-                {
-                    "id": "1",
-                    "method": "browser.manage",
-                    "params": {"action": "connect", "url": "http://localhost:9222"},
-                }
-            )
+            resp = server.handle_request({
+                "id": "1",
+                "method": "browser.manage",
+                "params": {"action": "connect", "url": "http://localhost:9222"},
+            })
 
     assert resp["result"]["connected"] is False
     assert resp["result"]["messages"]  # bundled list still populated
@@ -15145,13 +15691,11 @@ def test_browser_manage_connect_handles_null_url(monkeypatch):
     )
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
         _stub_urlopen(monkeypatch, ok=True)
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "browser.manage",
-                "params": {"action": "connect", "url": None},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "browser.manage",
+            "params": {"action": "connect", "url": None},
+        })
 
     assert resp["result"]["connected"] is True
     assert resp["result"]["url"] == "http://127.0.0.1:9222"
@@ -15159,13 +15703,11 @@ def test_browser_manage_connect_handles_null_url(monkeypatch):
 
 def test_browser_manage_connect_rejects_non_string_url(monkeypatch):
     monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "browser.manage",
-            "params": {"action": "connect", "url": 9222},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "browser.manage",
+        "params": {"action": "connect", "url": 9222},
+    })
 
     assert resp["error"]["code"] == 4015
     assert "must be a string" in resp["error"]["message"]
@@ -15213,9 +15755,11 @@ def test_browser_manage_connect_default_local_retries_after_launch(monkeypatch):
             ),
             patch("hermes_cli.browser_connect.local_port_in_use", return_value=False),
         ):
-            resp = server.handle_request(
-                {"id": "1", "method": "browser.manage", "params": {"action": "connect"}}
-            )
+            resp = server.handle_request({
+                "id": "1",
+                "method": "browser.manage",
+                "params": {"action": "connect"},
+            })
 
     assert resp["result"]["connected"] is True
     assert resp["result"]["url"] == "http://127.0.0.1:9222"
@@ -15254,9 +15798,11 @@ def test_browser_manage_connect_finds_ipv6_only_browser(monkeypatch):
 
     monkeypatch.setattr(urllib.request, "urlopen", _opener)
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
-        resp = server.handle_request(
-            {"id": "1", "method": "browser.manage", "params": {"action": "connect"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "browser.manage",
+            "params": {"action": "connect"},
+        })
 
     assert resp["result"]["connected"] is True
     assert resp["result"]["url"] == "http://[::1]:9222"
@@ -15299,19 +15845,25 @@ def test_browser_manage_connect_squatted_port_launches_on_alternate(monkeypatch)
 
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
         with (
-            patch("hermes_cli.browser_connect.launch_chrome_debug", side_effect=_launch),
+            patch(
+                "hermes_cli.browser_connect.launch_chrome_debug", side_effect=_launch
+            ),
             patch("hermes_cli.browser_connect.local_port_in_use", return_value=True),
             patch("hermes_cli.browser_connect.find_free_debug_port", return_value=9223),
         ):
-            resp = server.handle_request(
-                {"id": "1", "method": "browser.manage", "params": {"action": "connect"}}
-            )
+            resp = server.handle_request({
+                "id": "1",
+                "method": "browser.manage",
+                "params": {"action": "connect"},
+            })
 
     assert launch_ports == [9223]
     assert resp["result"]["connected"] is True
     assert resp["result"]["url"] == "http://127.0.0.1:9223"
     assert os.environ["BROWSER_CDP_URL"] == "http://127.0.0.1:9223"
-    assert any("occupied by another application" in m for m in resp["result"]["messages"])
+    assert any(
+        "occupied by another application" in m for m in resp["result"]["messages"]
+    )
 
 
 def test_browser_manage_connect_rejects_unreachable_endpoint(monkeypatch):
@@ -15326,13 +15878,11 @@ def test_browser_manage_connect_rejects_unreachable_endpoint(monkeypatch):
     )
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
         _stub_urlopen(monkeypatch, ok=False)
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "browser.manage",
-                "params": {"action": "connect", "url": "http://unreachable:9222"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "browser.manage",
+            "params": {"action": "connect", "url": "http://unreachable:9222"},
+        })
 
     assert "error" in resp
     # Env preserved; nothing reaped.
@@ -15351,13 +15901,11 @@ def test_browser_manage_connect_normalizes_bare_host_port(monkeypatch):
     )
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
         _stub_urlopen(monkeypatch, ok=True)
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "browser.manage",
-                "params": {"action": "connect", "url": "127.0.0.1:9222"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "browser.manage",
+            "params": {"action": "connect", "url": "127.0.0.1:9222"},
+        })
 
     assert resp["result"]["connected"] is True
     # Bare host:port got promoted to a full URL with explicit scheme.
@@ -15377,13 +15925,11 @@ def test_browser_manage_connect_strips_discovery_path(monkeypatch):
     )
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
         _stub_urlopen(monkeypatch, ok=True)
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "browser.manage",
-                "params": {"action": "connect", "url": "http://127.0.0.1:9222/json"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "browser.manage",
+            "params": {"action": "connect", "url": "http://127.0.0.1:9222/json"},
+        })
 
     assert resp["result"]["connected"] is True
     assert resp["result"]["url"] == "http://127.0.0.1:9222"
@@ -15415,13 +15961,11 @@ def test_browser_manage_connect_preserves_devtools_browser_endpoint(monkeypatch)
             "urllib.request.urlopen", side_effect=AssertionError("urlopen called")
         ):
             with patch("socket.create_connection", return_value=_OkSocket()):
-                resp = server.handle_request(
-                    {
-                        "id": "1",
-                        "method": "browser.manage",
-                        "params": {"action": "connect", "url": concrete},
-                    }
-                )
+                resp = server.handle_request({
+                    "id": "1",
+                    "method": "browser.manage",
+                    "params": {"action": "connect", "url": concrete},
+                })
 
     assert resp["result"]["connected"] is True
     assert resp["result"]["url"] == concrete
@@ -15448,13 +15992,11 @@ def test_browser_manage_connect_local_devtools_ws_preserves_path(monkeypatch):
 
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
         with patch("socket.create_connection", return_value=_OkSocket()):
-            resp = server.handle_request(
-                {
-                    "id": "1",
-                    "method": "browser.manage",
-                    "params": {"action": "connect", "url": concrete},
-                }
-            )
+            resp = server.handle_request({
+                "id": "1",
+                "method": "browser.manage",
+                "params": {"action": "connect", "url": concrete},
+            })
 
     assert resp["result"]["connected"] is True
     assert resp["result"]["url"] == concrete
@@ -15463,13 +16005,11 @@ def test_browser_manage_connect_local_devtools_ws_preserves_path(monkeypatch):
 
 def test_browser_manage_connect_rejects_invalid_port(monkeypatch):
     monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "browser.manage",
-            "params": {"action": "connect", "url": "http://localhost:abc"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "browser.manage",
+        "params": {"action": "connect", "url": "http://localhost:abc"},
+    })
 
     assert resp["error"]["code"] == 4015
     assert "invalid port" in resp["error"]["message"]
@@ -15478,13 +16018,11 @@ def test_browser_manage_connect_rejects_invalid_port(monkeypatch):
 
 def test_browser_manage_connect_rejects_missing_host(monkeypatch):
     monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "browser.manage",
-            "params": {"action": "connect", "url": "http://:9222"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "browser.manage",
+        "params": {"action": "connect", "url": "http://:9222"},
+    })
 
     assert resp["error"]["code"] == 4015
     assert "missing host" in resp["error"]["message"]
@@ -15522,13 +16060,11 @@ def test_browser_manage_connect_concrete_ws_skips_http_probe(monkeypatch):
             "urllib.request.urlopen", side_effect=AssertionError("urlopen called")
         ):
             with patch("socket.create_connection", side_effect=_fake_create_connection):
-                resp = server.handle_request(
-                    {
-                        "id": "1",
-                        "method": "browser.manage",
-                        "params": {"action": "connect", "url": concrete},
-                    }
-                )
+                resp = server.handle_request({
+                    "id": "1",
+                    "method": "browser.manage",
+                    "params": {"action": "connect", "url": concrete},
+                })
 
     assert resp["result"] == {"connected": True, "url": concrete}
     # wss → port 443, host preserved verbatim.
@@ -15548,13 +16084,11 @@ def test_browser_manage_connect_concrete_ws_tcp_unreachable(monkeypatch):
 
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
         with patch("socket.create_connection", side_effect=OSError("ECONNREFUSED")):
-            resp = server.handle_request(
-                {
-                    "id": "1",
-                    "method": "browser.manage",
-                    "params": {"action": "connect", "url": concrete},
-                }
-            )
+            resp = server.handle_request({
+                "id": "1",
+                "method": "browser.manage",
+                "params": {"action": "connect", "url": concrete},
+            })
 
     assert "error" in resp
     assert resp["error"]["code"] == 5031
@@ -15570,9 +16104,11 @@ def test_browser_manage_disconnect_drops_env_and_cleans(monkeypatch):
         _get_cdp_override=lambda: os.environ.get("BROWSER_CDP_URL", ""),
     )
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
-        resp = server.handle_request(
-            {"id": "1", "method": "browser.manage", "params": {"action": "disconnect"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "browser.manage",
+            "params": {"action": "disconnect"},
+        })
 
     assert resp["result"] == {"connected": False}
     assert "BROWSER_CDP_URL" not in os.environ
@@ -15587,9 +16123,11 @@ def test_config_get_indicator_returns_known_value_verbatim(monkeypatch):
     monkeypatch.setattr(
         server, "_load_cfg", lambda: {"display": {"tui_status_indicator": "emoji"}}
     )
-    resp = server.handle_request(
-        {"id": "1", "method": "config.get", "params": {"key": "indicator"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.get",
+        "params": {"key": "indicator"},
+    })
     assert resp["result"] == {"value": "emoji"}
 
 
@@ -15602,9 +16140,11 @@ def test_config_get_indicator_normalizes_casing_and_whitespace(monkeypatch):
     monkeypatch.setattr(
         server, "_load_cfg", lambda: {"display": {"tui_status_indicator": " EMOJI "}}
     )
-    resp = server.handle_request(
-        {"id": "1", "method": "config.get", "params": {"key": "indicator"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.get",
+        "params": {"key": "indicator"},
+    })
     assert resp["result"] == {"value": "emoji"}
 
 
@@ -15614,17 +16154,21 @@ def test_config_get_indicator_falls_back_to_default_for_unknown(monkeypatch):
     monkeypatch.setattr(
         server, "_load_cfg", lambda: {"display": {"tui_status_indicator": "rainbow"}}
     )
-    resp = server.handle_request(
-        {"id": "1", "method": "config.get", "params": {"key": "indicator"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.get",
+        "params": {"key": "indicator"},
+    })
     assert resp["result"] == {"value": "kaomoji"}
 
 
 def test_config_get_indicator_falls_back_when_unset(monkeypatch):
     monkeypatch.setattr(server, "_load_cfg", lambda: {"display": {}})
-    resp = server.handle_request(
-        {"id": "1", "method": "config.get", "params": {"key": "indicator"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.get",
+        "params": {"key": "indicator"},
+    })
     assert resp["result"] == {"value": "kaomoji"}
 
 
@@ -15638,13 +16182,11 @@ def test_config_set_indicator_accepts_known_value(monkeypatch):
         "_write_config_key",
         lambda k, v: written.update({k: v}),
     )
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"key": "indicator", "value": "EMOJI"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"key": "indicator", "value": "EMOJI"},
+    })
     assert resp["result"] == {"key": "indicator", "value": "emoji"}
     assert written == {"display.tui_status_indicator": "emoji"}
 
@@ -15656,13 +16198,11 @@ def test_config_set_indicator_falsy_non_string_surfaces_in_error(monkeypatch):
     monkeypatch.setattr(server, "_write_config_key", lambda *a, **k: None)
 
     for bad in (0, False, []):
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {"key": "indicator", "value": bad},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {"key": "indicator", "value": bad},
+        })
         assert "error" in resp
         msg = resp["error"]["message"]
         assert "unknown indicator" in msg
@@ -15675,13 +16215,11 @@ def test_config_set_indicator_falsy_non_string_surfaces_in_error(monkeypatch):
 def test_config_set_indicator_none_keeps_blank_repr(monkeypatch):
     """`None` is the genuine 'no value' case — empty raw is acceptable."""
     monkeypatch.setattr(server, "_write_config_key", lambda *a, **k: None)
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"key": "indicator", "value": None},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"key": "indicator", "value": None},
+    })
     assert "error" in resp
     assert "unknown indicator: ''" in resp["error"]["message"]
 
@@ -15828,7 +16366,10 @@ def test_make_agent_uses_session_runtime_overrides(monkeypatch):
     assert resolved == {"requested": "openai-codex", "target_model": "gpt-5.4"}
     assert mock_agent.call_args.kwargs["model"] == "gpt-5.4"
     assert mock_agent.call_args.kwargs["provider"] == "openai-codex"
-    assert mock_agent.call_args.kwargs["reasoning_config"] == {"enabled": True, "effort": "high"}
+    assert mock_agent.call_args.kwargs["reasoning_config"] == {
+        "enabled": True,
+        "effort": "high",
+    }
     assert mock_agent.call_args.kwargs["service_tier"] == "priority"
 
 
@@ -15922,7 +16463,9 @@ def test_notification_poller_delivers_completion(monkeypatch):
     emitted = []
 
     class _Agent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             turns.append(prompt)
             return {
                 "final_response": "ok",
@@ -15932,6 +16475,7 @@ def test_notification_poller_delivers_completion(monkeypatch):
     class _ImmediateThread:
         def __init__(self, target=None, daemon=None):
             self._target = target
+
         def start(self):
             self._target()
 
@@ -15977,7 +16521,10 @@ def test_notification_poller_delivers_completion(monkeypatch):
 
         # Should have triggered an agent turn
         assert len(turns) == 1
-        assert "[IMPORTANT: Background process proc_poller_test completed normally" in turns[0]
+        assert (
+            "[IMPORTANT: Background process proc_poller_test completed normally"
+            in turns[0]
+        )
     finally:
         server._sessions.pop("sid_poll", None)
         while not process_registry.completion_queue.empty():
@@ -15993,13 +16540,16 @@ def test_notification_poller_skips_consumed(monkeypatch):
     turns = []
 
     class _Agent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             turns.append(prompt)
             return {"final_response": "ok", "messages": []}
 
     class _ImmediateThread:
         def __init__(self, target=None, daemon=None):
             self._target = target
+
         def start(self):
             self._target()
 
@@ -16089,7 +16639,9 @@ def test_notification_poller_requeues_when_busy(monkeypatch):
             process_registry.completion_queue.get_nowait()
 
 
-def test_session_save_writes_under_hermes_home_with_system_prompt(monkeypatch, tmp_path):
+def test_session_save_writes_under_hermes_home_with_system_prompt(
+    monkeypatch, tmp_path
+):
     """TUI /save (session.save RPC) must snapshot under the Hermes profile
     home — not the project/workspace CWD — and include the system prompt,
     mirroring the classic CLI /save and the dashboard save export.
@@ -16258,9 +16810,9 @@ def test_notification_event_dedup_key_keeps_completions_one_shot():
         "output": "different output should not change completion key",
     }
 
-    assert server._notification_event_dedup_key(first) == server._notification_event_dedup_key(
-        replay
-    )
+    assert server._notification_event_dedup_key(
+        first
+    ) == server._notification_event_dedup_key(replay)
 
 
 # --- image.attach_bytes / pdf.attach (remote-client byte upload) -------------
@@ -16284,17 +16836,15 @@ def test_image_attach_bytes_writes_to_gateway_dir(monkeypatch, tmp_path):
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
     server._sessions["abx"] = _session()
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "image.attach_bytes",
-            "params": {
-                "session_id": "abx",
-                "content_base64": _PNG_1X1_B64,
-                "filename": "shot.png",
-            },
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "image.attach_bytes",
+        "params": {
+            "session_id": "abx",
+            "content_base64": _PNG_1X1_B64,
+            "filename": "shot.png",
+        },
+    })
 
     res = resp["result"]
     assert res["attached"] is True
@@ -16311,16 +16861,14 @@ def test_image_attach_bytes_accepts_data_url_prefix(monkeypatch, tmp_path):
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
     server._sessions["abx2"] = _session()
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "image.attach_bytes",
-            "params": {
-                "session_id": "abx2",
-                "content_base64": f"data:image/png;base64,{_PNG_1X1_B64}",
-            },
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "image.attach_bytes",
+        "params": {
+            "session_id": "abx2",
+            "content_base64": f"data:image/png;base64,{_PNG_1X1_B64}",
+        },
+    })
     assert resp["result"]["attached"] is True
 
 
@@ -16330,13 +16878,11 @@ def test_image_attach_bytes_data_alias_and_magic_sniff(monkeypatch, tmp_path):
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
     server._sessions["abx3"] = _session()
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "image.attach_bytes",
-            "params": {"session_id": "abx3", "data": _PNG_1X1_B64},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "image.attach_bytes",
+        "params": {"session_id": "abx3", "data": _PNG_1X1_B64},
+    })
     res = resp["result"]
     assert res["attached"] is True
     assert Path(res["path"]).suffix == ".png"  # sniffed from magic bytes
@@ -16347,13 +16893,11 @@ def test_image_attach_bytes_rejects_invalid_base64(monkeypatch, tmp_path):
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
     server._sessions["abx4"] = _session()
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "image.attach_bytes",
-            "params": {"session_id": "abx4", "content_base64": "!!!not base64!!!"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "image.attach_bytes",
+        "params": {"session_id": "abx4", "content_base64": "!!!not base64!!!"},
+    })
     assert "error" in resp
     assert resp["error"]["code"] == 4017
 
@@ -16367,13 +16911,11 @@ def test_image_attach_bytes_rejects_oversize(monkeypatch, tmp_path):
     server._sessions["abx5"] = _session()
 
     big = _b64.b64encode(b"\x89PNG\r\n\x1a\n" + b"0" * 100).decode("ascii")
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "image.attach_bytes",
-            "params": {"session_id": "abx5", "content_base64": big},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "image.attach_bytes",
+        "params": {"session_id": "abx5", "content_base64": big},
+    })
     assert "error" in resp
     assert resp["error"]["code"] == 4018
 
@@ -16384,17 +16926,15 @@ def test_image_attach_bytes_rejects_unsupported_extension(monkeypatch, tmp_path)
     server._sessions["abx6"] = _session()
 
     # filename hint forces a non-image extension; magic sniff is bypassed by hint
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "image.attach_bytes",
-            "params": {
-                "session_id": "abx6",
-                "content_base64": _PNG_1X1_B64,
-                "filename": "evil.exe",
-            },
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "image.attach_bytes",
+        "params": {
+            "session_id": "abx6",
+            "content_base64": _PNG_1X1_B64,
+            "filename": "evil.exe",
+        },
+    })
     assert "error" in resp
     assert resp["error"]["code"] == 4016
 
@@ -16406,13 +16946,11 @@ def test_pdf_attach_requires_poppler(monkeypatch, tmp_path):
     monkeypatch.setattr("shutil.which", lambda _name: None)
     server._sessions["pdf1"] = _session()
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "pdf.attach",
-            "params": {"session_id": "pdf1", "content_base64": "JVBERi0xLjQK"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "pdf.attach",
+        "params": {"session_id": "pdf1", "content_base64": "JVBERi0xLjQK"},
+    })
     assert "error" in resp
     assert resp["error"]["code"] == 5028
 
@@ -16426,13 +16964,11 @@ def test_pdf_attach_rejects_non_pdf_bytes(monkeypatch, tmp_path):
     server._sessions["pdf2"] = _session()
 
     not_pdf = _b64.b64encode(b"this is not a pdf").decode("ascii")
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "pdf.attach",
-            "params": {"session_id": "pdf2", "content_base64": not_pdf},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "pdf.attach",
+        "params": {"session_id": "pdf2", "content_base64": not_pdf},
+    })
     assert "error" in resp
     assert resp["error"]["code"] == 4017
 
@@ -16443,9 +16979,11 @@ def test_pdf_attach_requires_path_or_bytes(monkeypatch, tmp_path):
     monkeypatch.setattr("shutil.which", lambda _name: "/usr/bin/pdftoppm")
     server._sessions["pdf3"] = _session()
 
-    resp = server.handle_request(
-        {"id": "1", "method": "pdf.attach", "params": {"session_id": "pdf3"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "pdf.attach",
+        "params": {"session_id": "pdf3"},
+    })
     assert "error" in resp
     assert resp["error"]["code"] == 4015
 
@@ -16456,11 +16994,16 @@ def test_decode_attach_base64_helper():
     raw = _b64.b64encode(b"hello").decode("ascii")
     assert server._decode_attach_base64(raw, mime_prefix="image/") == b"hello"
     assert (
-        server._decode_attach_base64(f"data:image/png;base64,{raw}", mime_prefix="image/")
+        server._decode_attach_base64(
+            f"data:image/png;base64,{raw}", mime_prefix="image/"
+        )
         == b"hello"
     )
     # whitespace inside payload is tolerated
-    assert server._decode_attach_base64(raw[:4] + "\n" + raw[4:], mime_prefix="image/") == b"hello"
+    assert (
+        server._decode_attach_base64(raw[:4] + "\n" + raw[4:], mime_prefix="image/")
+        == b"hello"
+    )
     assert server._decode_attach_base64("@@@", mime_prefix="image/") is None
 
 
@@ -16538,7 +17081,8 @@ def test_close_session_by_id_is_idempotent_and_full(monkeypatch):
     monkeypatch.setattr(server, "_finalize_session", _fake_finalize)
     monkeypatch.setattr(
         "tools.approval.unregister_gateway_notify",
-        lambda key: calls.__setitem__("unreg", calls["unreg"] + 1), raising=False,
+        lambda key: calls.__setitem__("unreg", calls["unreg"] + 1),
+        raising=False,
     )
     server._sessions["sid-1"] = {"session_key": "k1", "agent": A(), "slash_worker": W()}
 
@@ -16679,13 +17223,11 @@ def test_slash_exec_concurrent_first_use_spawns_single_worker(monkeypatch):
 
     def _exec(n):
         barrier.wait()
-        resp = server.handle_request(
-            {
-                "id": str(n),
-                "method": "slash.exec",
-                "params": {"command": "/context", "session_id": "race-spawn"},
-            }
-        )
+        resp = server.handle_request({
+            "id": str(n),
+            "method": "slash.exec",
+            "params": {"command": "/context", "session_id": "race-spawn"},
+        })
         results.append(resp)
 
     try:
@@ -16707,15 +17249,19 @@ def test_slash_exec_concurrent_first_use_spawns_single_worker(monkeypatch):
 def test_session_close_rpc_claims_then_tears_down(monkeypatch):
     seen = []
     claimed = {"session_key": "k"}
-    monkeypatch.setattr(server, "_pop_session_by_id", lambda sid: seen.append(sid) or claimed)
+    monkeypatch.setattr(
+        server, "_pop_session_by_id", lambda sid: seen.append(sid) or claimed
+    )
     monkeypatch.setattr(
         server,
         "_teardown_popped_session",
         lambda session, *, end_reason: seen.append((session, end_reason)) or True,
     )
-    resp = server.handle_request(
-        {"id": "1", "method": "session.close", "params": {"session_id": "s9"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.close",
+        "params": {"session_id": "s9"},
+    })
     assert resp["result"] == {"closed": True}
     assert seen == ["s9", (claimed, "tui_close")]
 
@@ -16723,7 +17269,8 @@ def test_session_close_rpc_claims_then_tears_down(monkeypatch):
 def test_close_sessions_for_transport_closes_flagged_repoints_rest(monkeypatch):
     seen = []
     monkeypatch.setattr(
-        server, "_close_session_by_id",
+        server,
+        "_close_session_by_id",
         lambda sid, *, end_reason: bool(seen.append((sid, end_reason))) or True,
     )
     # Detached session "b" would schedule a real grace-reap threading.Timer that
@@ -16736,7 +17283,9 @@ def test_close_sessions_for_transport_closes_flagged_repoints_rest(monkeypatch):
     try:
         server._close_sessions_for_transport(transport, end_reason="ws_disconnect")
         assert seen == [("a", "ws_disconnect")]  # only the flagged one closed
-        assert server._sessions["b"]["transport"] is server._detached_ws_transport  # re-pointed
+        assert (
+            server._sessions["b"]["transport"] is server._detached_ws_transport
+        )  # re-pointed
     finally:
         server._sessions.clear()
 
@@ -16745,12 +17294,16 @@ def test_session_create_records_close_on_disconnect_flag(monkeypatch):
     monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
     server._sessions.clear()
     try:
-        on = server.handle_request(
-            {"id": "1", "method": "session.create", "params": {"close_on_disconnect": True}}
-        )["result"]["session_id"]
-        off = server.handle_request(
-            {"id": "2", "method": "session.create", "params": {}}
-        )["result"]["session_id"]
+        on = server.handle_request({
+            "id": "1",
+            "method": "session.create",
+            "params": {"close_on_disconnect": True},
+        })["result"]["session_id"]
+        off = server.handle_request({
+            "id": "2",
+            "method": "session.create",
+            "params": {},
+        })["result"]["session_id"]
         assert server._sessions[on]["close_on_disconnect"]
         assert not server._sessions[off]["close_on_disconnect"]
     finally:
@@ -16761,9 +17314,11 @@ def test_session_create_records_source(monkeypatch):
     monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
     server._sessions.clear()
     try:
-        sid = server.handle_request(
-            {"id": "1", "method": "session.create", "params": {"source": "tool"}}
-        )["result"]["session_id"]
+        sid = server.handle_request({
+            "id": "1",
+            "method": "session.create",
+            "params": {"source": "tool"},
+        })["result"]["session_id"]
         assert server._sessions[sid]["source"] == "tool"
     finally:
         server._sessions.clear()
@@ -16772,7 +17327,8 @@ def test_session_create_records_source(monkeypatch):
 def test_shutdown_sessions_closes_every_session_via_helper(monkeypatch):
     seen = []
     monkeypatch.setattr(
-        server, "_close_session_by_id",
+        server,
+        "_close_session_by_id",
         lambda sid, *, end_reason: seen.append((sid, end_reason)),
     )
     server._sessions.clear()
@@ -16836,7 +17392,8 @@ def test_reap_idle_sessions_closes_only_evictable(monkeypatch):
     closed = []
     monkeypatch.setattr(server, "_session_pending_kind", lambda sid: "")
     monkeypatch.setattr(
-        server, "_close_session_by_id",
+        server,
+        "_close_session_by_id",
         lambda sid, *, end_reason, predicate=None: closed.append((sid, end_reason)),
     )
     now = time.time()
@@ -16863,7 +17420,8 @@ def test_reap_idle_sessions_calls_periodic_trim(monkeypatch):
     import hermes_cli.mem_trim as mem_trim
 
     monkeypatch.setattr(
-        mem_trim, "trim_memory",
+        mem_trim,
+        "trim_memory",
         lambda **kw: trim_calls.append(kw.get("reason", "")) or True,
     )
 
@@ -16883,7 +17441,11 @@ def test_reap_idle_sessions_logs_trim_failure(monkeypatch, caplog):
     monkeypatch.setattr(server, "_reclaim_orphaned_leases", lambda: None)
     import hermes_cli.mem_trim as mem_trim
 
-    monkeypatch.setattr(mem_trim, "trim_memory", lambda **_kw: (_ for _ in ()).throw(RuntimeError("boom")))
+    monkeypatch.setattr(
+        mem_trim,
+        "trim_memory",
+        lambda **_kw: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
     server._sessions.clear()
     try:
         with caplog.at_level("DEBUG", logger="tui_gateway.server"):
@@ -17006,11 +17568,16 @@ def test_lru_reaper_revalidates_and_tries_next_candidate(monkeypatch):
 
     def _reattach_oldest_after_scan(sid, session):
         evictable = original_is_evictable(sid, session)
-        if sid == "lru-race" and session.get("transport") is server._detached_ws_transport:
+        if (
+            sid == "lru-race"
+            and session.get("transport") is server._detached_ws_transport
+        ):
             session["transport"] = live_transport
         return evictable
 
-    monkeypatch.setattr(server, "_session_is_lru_evictable", _reattach_oldest_after_scan)
+    monkeypatch.setattr(
+        server, "_session_is_lru_evictable", _reattach_oldest_after_scan
+    )
     now = time.time()
     server._sessions.clear()
     server._sessions["lru-race"] = _idle_evictable_session(now) | {
@@ -17049,7 +17616,10 @@ def test_session_create_records_ui_model_as_session_override(monkeypatch):
         )
         sid = resp["result"]["session_id"]
         sess = server._sessions[sid]
-        assert sess["model_override"] == {"model": "claude-sonnet-4.6", "provider": "anthropic"}
+        assert sess["model_override"] == {
+            "model": "claude-sonnet-4.6",
+            "provider": "anthropic",
+        }
         assert sess["create_reasoning_override"] is not None
         assert sess["create_service_tier_override"] == "priority"
         # The immediate response reflects the override (not the global default) so
@@ -17059,9 +17629,7 @@ def test_session_create_records_ui_model_as_session_override(monkeypatch):
 
         # Explicit false is not the same as omission: it must suppress a Fast
         # profile default for this session's first request.
-        normal = server._methods["session.create"](
-            "r2", {"cols": 80, "fast": False}
-        )
+        normal = server._methods["session.create"]("r2", {"cols": 80, "fast": False})
         normal_sess = server._sessions[normal["result"]["session_id"]]
         assert normal_sess["create_service_tier_override"] == ""
 
@@ -17245,12 +17813,12 @@ class _BillingHeaders:
         (429, "rate_limited", None),
     ],
 )
-def test_billing_error_serialization_preserves_server_code(
-    status, error, retry_after
-):
+def test_billing_error_serialization_preserves_server_code(status, error, retry_after):
     import hermes_cli.nous_billing as nb
 
-    headers = _BillingHeaders({"Retry-After": str(retry_after)}) if retry_after else None
+    headers = (
+        _BillingHeaders({"Retry-After": str(retry_after)}) if retry_after else None
+    )
     with pytest.raises(nb.BillingTransient) as ei:
         nb._raise_for_error(status, {"error": error}, headers)
 
@@ -17277,7 +17845,9 @@ def test_billing_rate_limit_without_error_defaults_wire_code():
 def _sub_rpc(method, params):
     # These RPCs are in _LONG_HANDLERS (pool-routed → dispatch returns None and the
     # worker writes via the transport), so drive the inline handler directly.
-    return server.handle_request({"id": "1", "method": method, "params": params})["result"]
+    return server.handle_request({"id": "1", "method": method, "params": params})[
+        "result"
+    ]
 
 
 def test_subscription_preview_serializes_quote(monkeypatch):
@@ -17332,7 +17902,11 @@ def test_subscription_change_cancellation(monkeypatch):
     def _put(*, subscription_type_id=None, cancel=False):
         seen["tier"] = subscription_type_id
         seen["cancel"] = cancel
-        return {"rail": "stripe", "cancelAtPeriodEnd": True, "message": "Scheduled to cancel."}
+        return {
+            "rail": "stripe",
+            "cancelAtPeriodEnd": True,
+            "message": "Scheduled to cancel.",
+        }
 
     monkeypatch.setattr(nb, "put_subscription_pending_change", _put)
     res = _sub_rpc("subscription.change", {"cancel": True})
@@ -17349,7 +17923,12 @@ def test_subscription_change_tier_downgrade(monkeypatch):
     def _put(*, subscription_type_id=None, cancel=False):
         seen["tier"] = subscription_type_id
         seen["cancel"] = cancel
-        return {"rail": "stripe", "changeType": "downgrade", "targetTierName": "Plus", "message": "Scheduled."}
+        return {
+            "rail": "stripe",
+            "changeType": "downgrade",
+            "targetTierName": "Plus",
+            "message": "Scheduled.",
+        }
 
     monkeypatch.setattr(nb, "put_subscription_pending_change", _put)
     res = _sub_rpc("subscription.change", {"subscription_type_id": "plus"})
@@ -17383,10 +17962,17 @@ def test_subscription_upgrade_echoes_status_and_idempotency(monkeypatch):
 
     def _upgrade(*, subscription_type_id, idempotency_key):
         seen["key"] = idempotency_key
-        return {"status": "upgraded", "targetTierId": "ultra", "targetTierName": "Ultra"}
+        return {
+            "status": "upgraded",
+            "targetTierId": "ultra",
+            "targetTierName": "Ultra",
+        }
 
     monkeypatch.setattr(nb, "post_subscription_upgrade", _upgrade)
-    res = _sub_rpc("subscription.upgrade", {"subscription_type_id": "ultra", "idempotency_key": "k-1"})
+    res = _sub_rpc(
+        "subscription.upgrade",
+        {"subscription_type_id": "ultra", "idempotency_key": "k-1"},
+    )
     assert res["ok"] is True
     assert res["status"] == "upgraded"
     assert res["target_tier_name"] == "Ultra"
@@ -17412,6 +17998,8 @@ def test_subscription_upgrade_requires_action_surfaces_recovery(monkeypatch):
     assert res["status"] == "requires_action"
     assert res["recovery_url"].startswith("https://portal.example")
     assert res["idempotency_key"]  # minted when the caller omits one
+
+
 # ── _get_usage active_subagents (TUI status-bar ⛓ indicator) ──────────────
 # Mirrors the classic CLI status bar: _get_usage embeds a live count of
 # background/async subagents from tools.async_delegation.active_count() so the
@@ -17428,6 +18016,7 @@ class _BareAgent:
 
 def test_get_usage_includes_active_subagents(monkeypatch):
     import tools.async_delegation as ad_mod
+
     monkeypatch.setattr(ad_mod, "active_count", lambda: 4)
     usage = server._get_usage(_BareAgent())
     assert usage["active_subagents"] == 4
@@ -17435,6 +18024,7 @@ def test_get_usage_includes_active_subagents(monkeypatch):
 
 def test_get_usage_active_subagents_zero(monkeypatch):
     import tools.async_delegation as ad_mod
+
     monkeypatch.setattr(ad_mod, "active_count", lambda: 0)
     usage = server._get_usage(_BareAgent())
     assert usage["active_subagents"] == 0
@@ -17529,6 +18119,7 @@ def test_persist_model_switch_clears_stale_base_url(tmp_path, monkeypatch):
 # _resolve_runtime_with_fallback — init-time provider fallback
 # ---------------------------------------------------------------------------
 
+
 class TestResolveRuntimeWithFallback:
     """Tests for _resolve_runtime_with_fallback(): init-time provider
     fallback when the primary provider raises AuthError."""
@@ -17540,9 +18131,7 @@ class TestResolveRuntimeWithFallback:
             "hermes_cli.runtime_provider.resolve_runtime_provider",
             lambda **kw: expected,
         )
-        resolution = server._resolve_runtime_with_fallback(
-            {"requested": "openai"}
-        )
+        resolution = server._resolve_runtime_with_fallback({"requested": "openai"})
         assert resolution.runtime == expected
         assert resolution.selected_model is None
         assert resolution.used_fallback is False
@@ -17600,9 +18189,9 @@ class TestResolveRuntimeWithFallback:
             ],
         )
 
-        resolution = server._resolve_runtime_with_fallback(
-            {"requested": "openai-codex"}
-        )
+        resolution = server._resolve_runtime_with_fallback({
+            "requested": "openai-codex"
+        })
 
         assert requested == ["openai-codex", "openrouter"]
         assert resolution.runtime == fallback_runtime
@@ -17639,9 +18228,9 @@ class TestResolveRuntimeWithFallback:
                 }
             ],
         )
-        resolution = server._resolve_runtime_with_fallback(
-            {"requested": "openai-codex"}
-        )
+        resolution = server._resolve_runtime_with_fallback({
+            "requested": "openai-codex"
+        })
         assert resolution.used_fallback is True
         assert captured.get("explicit_api_key") == "env-resolved-key"
 
@@ -17739,7 +18328,9 @@ class TestResolveRuntimeWithFallback:
             fake_resolve,
         )
         monkeypatch.setattr("run_agent.AIAgent", fake_agent)
-        monkeypatch.setattr(server, "_load_enabled_toolsets", lambda *_a, **_kw: ["file"])
+        monkeypatch.setattr(
+            server, "_load_enabled_toolsets", lambda *_a, **_kw: ["file"]
+        )
         monkeypatch.setattr(server, "_get_db", lambda: None)
 
         agent = server._make_agent(
@@ -17821,7 +18412,10 @@ def test_get_usage_clamps_post_compression_sentinel():
 # Streaming TTS — per-turn pipeline + barge-in
 # ---------------------------------------------------------------------------
 
-def _fake_tts_modules(monkeypatch, *, requirements=True, playback_stops=None, listen=None, transcribe=None):
+
+def _fake_tts_modules(
+    monkeypatch, *, requirements=True, playback_stops=None, listen=None, transcribe=None
+):
     """Install lightweight tools.tts_tool / tools.voice_mode fakes."""
     started = {}
 
@@ -17851,11 +18445,14 @@ def _fake_tts_modules(monkeypatch, *, requirements=True, playback_stops=None, li
         sys.modules,
         "tools.voice_mode",
         types.SimpleNamespace(
-            stop_playback=lambda: (playback_stops.append(True) if playback_stops is not None else None),
+            stop_playback=lambda: (
+                playback_stops.append(True) if playback_stops is not None else None
+            ),
             listen_for_speech=listen or default_listen,
             full_duplex_listen=listen or default_fd_listen,
             is_audio_output_active=lambda: False,
-            transcribe_recording=transcribe or (lambda path, model=None: {"success": True, "transcript": ""}),
+            transcribe_recording=transcribe
+            or (lambda path, model=None: {"success": True, "transcript": ""}),
         ),
     )
     # Fresh listener slot per test — the arm is idempotent per process.
@@ -17945,7 +18542,9 @@ def test_tts_stream_stop_after_natural_finish_does_not_latch(monkeypatch):
     assert ts.take_speech_interrupted() is False
 
 
-def test_tts_stream_vad_barge_in_cuts_pipeline_and_submits_capture(monkeypatch, tmp_path):
+def test_tts_stream_vad_barge_in_cuts_pipeline_and_submits_capture(
+    monkeypatch, tmp_path
+):
     """User speech during playback cuts TTS at the moment of detection
     (voice.interrupted), then the captured interruption is transcribed and
     emitted as voice.transcript so the TUI submits it — complete from its
@@ -17959,7 +18558,9 @@ def test_tts_stream_vad_barge_in_cuts_pipeline_and_submits_capture(monkeypatch, 
     monkeypatch.setattr(server, "_load_cfg", lambda: {"voice": {"barge_in": True}})
     events: list = []
     monkeypatch.setattr(
-        server, "_voice_emit", lambda event, payload=None: events.append((event, payload))
+        server,
+        "_voice_emit",
+        lambda event, payload=None: events.append((event, payload)),
     )
 
     wav = tmp_path / "barge.wav"
@@ -17972,7 +18573,10 @@ def test_tts_stream_vad_barge_in_cuts_pipeline_and_submits_capture(monkeypatch, 
     _fake_tts_modules(
         monkeypatch,
         listen=fake_listen,
-        transcribe=lambda path, model=None: {"success": True, "transcript": "stop, actually—"},
+        transcribe=lambda path, model=None: {
+            "success": True,
+            "transcript": "stop, actually—",
+        },
     )
 
     server._tts_stream_begin()
@@ -17999,7 +18603,9 @@ def test_full_duplex_generation_phase_interrupts_running_turn(monkeypatch, tmp_p
     monkeypatch.setattr(server, "_load_cfg", lambda: {"voice": {"barge_in": True}})
     events: list = []
     monkeypatch.setattr(
-        server, "_voice_emit", lambda event, payload=None: events.append((event, payload))
+        server,
+        "_voice_emit",
+        lambda event, payload=None: events.append((event, payload)),
     )
 
     wav = tmp_path / "interject.wav"
@@ -18018,7 +18624,10 @@ def test_full_duplex_generation_phase_interrupts_running_turn(monkeypatch, tmp_p
     _fake_tts_modules(
         monkeypatch,
         listen=fake_listen,
-        transcribe=lambda path, model=None: {"success": True, "transcript": "wait, try another way"},
+        transcribe=lambda path, model=None: {
+            "success": True,
+            "transcript": "wait, try another way",
+        },
     )
 
     server._arm_full_duplex_listener()
@@ -18039,7 +18648,9 @@ def test_full_duplex_stop_phrase_mid_generation_ends_voice_chat(monkeypatch, tmp
     monkeypatch.setattr(server, "_load_cfg", lambda: {"voice": {"barge_in": True}})
     events: list = []
     monkeypatch.setattr(
-        server, "_voice_emit", lambda event, payload=None: events.append((event, payload))
+        server,
+        "_voice_emit",
+        lambda event, payload=None: events.append((event, payload)),
     )
 
     wav = tmp_path / "stop.wav"
@@ -18061,13 +18672,15 @@ def test_full_duplex_stop_phrase_mid_generation_ends_voice_chat(monkeypatch, tmp
         transcribe=lambda path, model=None: {"success": True, "transcript": "stop"},
     )
     # is_voice_stop_phrase lives in the faked tools.voice_mode namespace.
-    sys.modules["tools.voice_mode"].is_voice_stop_phrase = (
-        lambda text: text.strip().lower() == "stop"
+    sys.modules["tools.voice_mode"].is_voice_stop_phrase = lambda text: (
+        text.strip().lower() == "stop"
     )
     monkeypatch.setitem(
         sys.modules,
         "hermes_cli.voice",
-        types.SimpleNamespace(stop_continuous=lambda **_kw: None, speak_text=lambda *a, **k: None),
+        types.SimpleNamespace(
+            stop_continuous=lambda **_kw: None, speak_text=lambda *a, **k: None
+        ),
     )
 
     server._arm_full_duplex_listener()
@@ -18098,7 +18711,9 @@ def test_speak_text_with_barge_arms_monitor_and_cuts_playback(monkeypatch, tmp_p
     )
     events: list = []
     monkeypatch.setattr(
-        server, "_voice_emit", lambda event, payload=None: events.append((event, payload))
+        server,
+        "_voice_emit",
+        lambda event, payload=None: events.append((event, payload)),
     )
 
     wav = tmp_path / "barge.wav"
@@ -18134,7 +18749,10 @@ def test_speak_text_with_barge_arms_monitor_and_cuts_playback(monkeypatch, tmp_p
     server._speak_text_with_barge("a long spoken reply")
 
     deadline = time.monotonic() + 5.0
-    while time.monotonic() < deadline and ("voice.transcript", {"text": "hang on"}) not in events:
+    while (
+        time.monotonic() < deadline
+        and ("voice.transcript", {"text": "hang on"}) not in events
+    ):
         time.sleep(0.01)
     release_speak.set()
 
@@ -18225,7 +18843,9 @@ def test_clarify_callback_multi_select_hint(monkeypatch):
     ("configured", "expected"),
     [(0, None), (-1, None), (42, 42)],
 )
-def test_clarify_timeout_seconds_maps_non_positive_to_unlimited(monkeypatch, configured, expected):
+def test_clarify_timeout_seconds_maps_non_positive_to_unlimited(
+    monkeypatch, configured, expected
+):
     """A ``<= 0`` clarify timeout means unlimited and reaches _block as None
     (ev.wait(None) waits forever) rather than an immediate ev.wait(0) skip."""
     monkeypatch.setattr("tools.clarify_gateway.get_clarify_timeout", lambda: configured)
@@ -18236,18 +18856,25 @@ def test_clarify_timeout_seconds_maps_non_positive_to_unlimited(monkeypatch, con
 def test_build_persist_message_with_image_refs_without_images_returns_text(monkeypatch):
     """#70720: when no images are attached the persisted message is the raw
     prompt — no @image directive prefix is introduced."""
-    assert server._build_persist_message_with_image_refs("what is this?", []) == "what is this?"
+    assert (
+        server._build_persist_message_with_image_refs("what is this?", [])
+        == "what is this?"
+    )
     assert server._build_persist_message_with_image_refs("", []) == ""
 
 
-def test_build_persist_message_with_image_refs_appends_existing_paths(monkeypatch, tmp_path):
+def test_build_persist_message_with_image_refs_appends_existing_paths(
+    monkeypatch, tmp_path
+):
     """Attached images that still exist on disk are persisted as trailing
     ``@image:<path>`` directive lines so the desktop renders them after a
     restart (instead of the vision-only enrichment that silently breaks)."""
     img = tmp_path / "cat.png"
     img.write_bytes(b"\x89PNG")
 
-    result = server._build_persist_message_with_image_refs("what is in this photo?", [str(img)])
+    result = server._build_persist_message_with_image_refs(
+        "what is in this photo?", [str(img)]
+    )
 
     assert result == f"what is in this photo?\n@image:{img}"
 
@@ -18259,30 +18886,40 @@ def test_build_persist_message_keeps_the_caption_on_the_first_line(tmp_path):
     img = tmp_path / "cat.png"
     img.write_bytes(b"png")
 
-    result = server._build_persist_message_with_image_refs("what is in this photo?", [str(img)])
+    result = server._build_persist_message_with_image_refs(
+        "what is in this photo?", [str(img)]
+    )
 
     assert result.split("\n", 1)[0] == "what is in this photo?"
 
 
-def test_build_persist_message_with_image_refs_skips_missing_paths(monkeypatch, tmp_path):
+def test_build_persist_message_with_image_refs_skips_missing_paths(
+    monkeypatch, tmp_path
+):
     """Only paths that still exist are persisted; a missing file must not
     inject a dangling @image ref into the transcript."""
     existing = tmp_path / "a.png"
     existing.write_bytes(b"png")
     missing = str(tmp_path / "gone.png")
 
-    result = server._build_persist_message_with_image_refs("compare them", [str(existing), missing])
+    result = server._build_persist_message_with_image_refs(
+        "compare them", [str(existing), missing]
+    )
 
     assert result == f"compare them\n@image:{existing}"
 
 
-def test_build_persist_message_with_image_refs_without_text_is_refs_only(monkeypatch, tmp_path):
+def test_build_persist_message_with_image_refs_without_text_is_refs_only(
+    monkeypatch, tmp_path
+):
     """A stand-alone attachment (no caption) persists as just the directive
     line, so a bare image survives in history and is not dropped as empty."""
     img = tmp_path / "only.png"
     img.write_bytes(b"png")
 
-    assert server._build_persist_message_with_image_refs("", [str(img)]) == f"@image:{img}"
+    assert (
+        server._build_persist_message_with_image_refs("", [str(img)]) == f"@image:{img}"
+    )
 
 
 def test_build_persist_message_quotes_paths_containing_spaces(tmp_path):
@@ -18307,12 +18944,20 @@ def test_persist_user_message_mirrors_the_shape_sent_to_the_model(tmp_path):
     silently dropped and the attachment never reaches history."""
     img = tmp_path / "cat.png"
     img.write_bytes(b"png")
-    image_part = {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}
+    image_part = {
+        "type": "image_url",
+        "image_url": {"url": "data:image/png;base64,AAAA"},
+    }
     native_parts = [{"type": "text", "text": "api-only text"}, image_part]
 
-    override = server._build_persist_user_message("what is this?", [str(img)], native_parts)
+    override = server._build_persist_user_message(
+        "what is this?", [str(img)], native_parts
+    )
 
-    assert override == [{"type": "text", "text": f"what is this?\n@image:{img}"}, image_part]
+    assert override == [
+        {"type": "text", "text": f"what is this?\n@image:{img}"},
+        image_part,
+    ]
 
 
 def test_persist_user_message_stays_a_string_for_text_mode(tmp_path):
@@ -18321,7 +18966,9 @@ def test_persist_user_message_stays_a_string_for_text_mode(tmp_path):
     img = tmp_path / "cat.png"
     img.write_bytes(b"png")
 
-    override = server._build_persist_user_message("what is this?", [str(img)], "enriched api-only text")
+    override = server._build_persist_user_message(
+        "what is this?", [str(img)], "enriched api-only text"
+    )
 
     assert override == f"what is this?\n@image:{img}"
 
@@ -18345,7 +18992,9 @@ def test_native_vision_turn_persists_a_renderable_image_ref(tmp_path):
             "0557bfabd40000000049454e44ae426082"
         )
     )
-    native_parts, skipped = build_native_content_parts("what is in this photo?", [str(img)])
+    native_parts, skipped = build_native_content_parts(
+        "what is in this photo?", [str(img)]
+    )
     assert not skipped
 
     agent = AIAgent.__new__(AIAgent)
@@ -18365,11 +19014,15 @@ def test_native_vision_turn_persists_a_renderable_image_ref(tmp_path):
 
     agent._flush_messages_to_session_db([{"role": "user", "content": native_parts}], [])
 
-    written = agent._session_db.append_messages_batch.call_args.kwargs["messages"][0]["content"]
+    written = agent._session_db.append_messages_batch.call_args.kwargs["messages"][0][
+        "content"
+    ]
     assert f"@image:`{img}`" in written
     assert "what is in this photo?" in written
     # The model keeps the pixels for the rest of the session.
-    assert any(part.get("type") == "image_url" for part in agent._persist_user_message_override)
+    assert any(
+        part.get("type") == "image_url" for part in agent._persist_user_message_override
+    )
 
 
 def test_prompt_submit_passes_persist_user_message_to_agent(monkeypatch):
@@ -18379,7 +19032,9 @@ def test_prompt_submit_passes_persist_user_message_to_agent(monkeypatch):
     captured = {}
 
     class _Agent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             captured["persist_user_message"] = _kwargs.get("persist_user_message")
             return {
                 "final_response": "reply",
@@ -18400,13 +19055,11 @@ def test_prompt_submit_passes_persist_user_message_to_agent(monkeypatch):
         monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
         monkeypatch.setattr(server, "_emit", lambda *a: None)
 
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid", "text": "hi"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "hi"},
+        })
         assert resp.get("result")
 
         # Without attachments the persist form equals the raw prompt.
@@ -18472,13 +19125,11 @@ def test_prompt_submit_releases_old_history_before_heap_trim(monkeypatch):
         )
         monkeypatch.setattr("hermes_cli.mem_trim.trim_memory", _inspect_trim_frame)
 
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid_trim", "text": "hi"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid_trim", "text": "hi"},
+        })
 
         assert resp is not None and resp.get("result")
         assert not observed["history"]
@@ -18647,9 +19298,11 @@ def test_session_branch_keeps_reasoning_fields(monkeypatch, tmp_path):
         )
         monkeypatch.setattr(server, "_init_session", lambda *args, **kwargs: None)
 
-        resp = server.handle_request(
-            {"id": "1", "method": "session.branch", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.branch",
+            "params": {"session_id": "sid"},
+        })
 
         assert resp.get("result"), f"got error: {resp.get('error')}"
         assistant = _branched_assistant(db, "branch-key")
@@ -18693,12 +19346,10 @@ def test_save_cfg_preserves_user_comments(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
 
-    server._save_cfg(
-        {
-            "model": {"default": "claude-opus-4-7"},
-            "display": {"skin": "mono"},
-        }
-    )
+    server._save_cfg({
+        "model": {"default": "claude-opus-4-7"},
+        "display": {"skin": "mono"},
+    })
 
     text = cfg_path.read_text(encoding="utf-8")
     assert "# top of file note" in text
@@ -18730,20 +19381,20 @@ def test_save_cfg_preserves_top_level_key_order(tmp_path, monkeypatch):
 
     # Caller's dict iteration order is intentionally alphabetical to confirm
     # the helper consults disk order, not caller order.
-    server._save_cfg(
-        {
-            "agent": {"max_turns": 90},
-            "display": {"skin": "mono"},
-            "model": {"default": "claude-opus-4-7"},
-            "toolsets": ["hermes-cli"],
-        }
-    )
+    server._save_cfg({
+        "agent": {"max_turns": 90},
+        "display": {"skin": "mono"},
+        "model": {"default": "claude-opus-4-7"},
+        "toolsets": ["hermes-cli"],
+    })
 
     text = cfg_path.read_text(encoding="utf-8")
     top_keys = [
         line.split(":", 1)[0]
         for line in text.splitlines()
-        if line and not line.startswith(" ") and not line.startswith("-")
+        if line
+        and not line.startswith(" ")
+        and not line.startswith("-")
         and not line.startswith("#")
     ]
     assert top_keys == ["model", "toolsets", "agent", "display"]
@@ -18756,7 +19407,7 @@ def test_save_cfg_keeps_unicode_personalities_readable(tmp_path, monkeypatch):
     cfg_path.write_text(
         "agent:\n"
         "  personalities:\n"
-        "    catgirl: \"nya (=^･ω･^=) 你好\"\n"
+        '    catgirl: "nya (=^･ω･^=) 你好"\n'
         "display:\n"
         "  skin: default\n",
         encoding="utf-8",
@@ -18765,12 +19416,10 @@ def test_save_cfg_keeps_unicode_personalities_readable(tmp_path, monkeypatch):
 
     # Simulate an unrelated /skin write — must not corrupt the catgirl
     # personality string sitting in agent.personalities.
-    server._save_cfg(
-        {
-            "agent": {"personalities": {"catgirl": "nya (=^･ω･^=) 你好"}},
-            "display": {"skin": "mono"},
-        }
-    )
+    server._save_cfg({
+        "agent": {"personalities": {"catgirl": "nya (=^･ω･^=) 你好"}},
+        "display": {"skin": "mono"},
+    })
 
     text = cfg_path.read_text(encoding="utf-8")
     assert "你好" in text
@@ -18795,7 +19444,9 @@ def test_personality_marker_does_not_shift_truncate_ordinal(monkeypatch):
     """
 
     class _Agent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             return {
                 "final_response": "reply",
                 "messages": [
@@ -18819,7 +19470,9 @@ def test_personality_marker_does_not_shift_truncate_ordinal(monkeypatch):
         def get_messages_as_conversation(self, *_args, **_kwargs):
             return []
 
-        def replace_messages(self, session_id, messages, active_only=False, archive_dropped=False):
+        def replace_messages(
+            self, session_id, messages, active_only=False, archive_dropped=False
+        ):
             self.replaced.append((session_id, list(messages)))
 
     session = _session(
@@ -18842,17 +19495,17 @@ def test_personality_marker_does_not_shift_truncate_ordinal(monkeypatch):
         )
 
         marker = session["history"][-1]
-        assert marker["role"] == "user", "provider compatibility: pivot rides as a user turn"
+        assert marker["role"] == "user", (
+            "provider compatibility: pivot rides as a user turn"
+        )
 
         # Two more real turns land after the personality change.
-        session["history"].extend(
-            [
-                {"role": "user", "content": "second"},
-                {"role": "assistant", "content": "second reply"},
-                {"role": "user", "content": "third"},
-                {"role": "assistant", "content": "third reply"},
-            ]
-        )
+        session["history"].extend([
+            {"role": "user", "content": "second"},
+            {"role": "assistant", "content": "second reply"},
+            {"role": "user", "content": "third"},
+            {"role": "assistant", "content": "third reply"},
+        ])
         history_before = list(session["history"])
         third_index = history_before.index({"role": "user", "content": "third"})
 
@@ -18863,18 +19516,16 @@ def test_personality_marker_does_not_shift_truncate_ordinal(monkeypatch):
 
         # The client counts three user bubbles (first=0, second=1, third=2) —
         # it never sees the pivot. Rewinding to "third" must cut exactly there.
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "personality-ordinal-sid",
-                    "text": "third, reworded",
-                    "truncate_before_user_ordinal": 2,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "personality-ordinal-sid",
+                "text": "third, reworded",
+                "truncate_before_user_ordinal": 2,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("result"), f"got error: {resp.get('error')}"
 
         expected = history_before[:third_index]
@@ -18908,7 +19559,9 @@ def test_prompt_submit_truncation_archives_instead_of_deleting(monkeypatch):
     captured = {}
 
     class _Agent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             return {
                 "final_response": "reply",
                 "messages": [
@@ -18953,18 +19606,16 @@ def test_prompt_submit_truncation_archives_instead_of_deleting(monkeypatch):
         monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
         monkeypatch.setattr(server, "_get_db", lambda: _StubDb())
 
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "archive-trunc-sid",
-                    "text": "second, reworded",
-                    "truncate_before_user_ordinal": 1,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "archive-trunc-sid",
+                "text": "second, reworded",
+                "truncate_before_user_ordinal": 1,
+                "confirm_truncate": True,
+            },
+        })
 
         assert resp.get("result"), f"got error: {resp.get('error')}"
         assert captured.get("archive_dropped") is True, (
@@ -18979,6 +19630,7 @@ def test_prompt_submit_truncation_archives_instead_of_deleting(monkeypatch):
 def test_insert_message_rows_sets_row_id_on_fresh_dicts(tmp_path):
     """#82959: _insert_message_rows must assign _row_id on freshly inserted message dicts."""
     from hermes_state import SessionDB
+
     db = SessionDB(db_path=tmp_path / "state.db")
     db.create_session("fresh-msg-row-id-sid", "cli")
     msg = {"role": "user", "content": "fresh turn without pre-existing _row_id"}
@@ -18993,7 +19645,9 @@ def test_prompt_submit_unmatched_row_id_refuses_even_with_ordinal(monkeypatch):
     replaced = []
 
     class _FakeDB:
-        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+        def replace_messages(
+            self, key, messages, active_only=False, archive_dropped=False
+        ):
             replaced.append((key, list(messages)))
 
     history = [
@@ -19006,24 +19660,24 @@ def test_prompt_submit_unmatched_row_id_refuses_even_with_ordinal(monkeypatch):
     server._sessions["fallback-row-id-sid"] = sess
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     try:
         # Stale row_id 999 not in history — even with a valid ordinal, refuse.
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "fallback-row-id-sid",
-                    "text": "new turn",
-                    "truncate_before_row_id": 999,
-                    "truncate_before_user_ordinal": 1,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "fallback-row-id-sid",
+                "text": "new turn",
+                "truncate_before_row_id": 999,
+                "truncate_before_user_ordinal": 1,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is not None
         assert resp["error"]["code"] == 4018
         assert replaced == []
@@ -19037,7 +19691,9 @@ def test_prompt_submit_unmatched_message_id_refuses_even_with_ordinal(monkeypatc
     replaced = []
 
     class _FakeDB:
-        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+        def replace_messages(
+            self, key, messages, active_only=False, archive_dropped=False
+        ):
             replaced.append((key, list(messages)))
 
     # Production-shaped history: no renderer "id" keys on user dicts.
@@ -19051,24 +19707,24 @@ def test_prompt_submit_unmatched_message_id_refuses_even_with_ordinal(monkeypatc
     server._sessions["synthetic-msg-id-sid"] = sess
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "synthetic-msg-id-sid",
-                    "text": "fresh start",
-                    "truncate_before_message_id": "user-1723456789-0",
-                    "truncate_before_user_ordinal": 0,
-                    "confirm_truncate": True,
-                    "confirm_empty_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "synthetic-msg-id-sid",
+                "text": "fresh start",
+                "truncate_before_message_id": "user-1723456789-0",
+                "truncate_before_user_ordinal": 0,
+                "confirm_truncate": True,
+                "confirm_empty_truncate": True,
+            },
+        })
         assert resp.get("error") is not None
         assert resp["error"]["code"] == 4018
         assert replaced == []
@@ -19095,10 +19751,14 @@ def test_prompt_submit_row_id_resolves_via_db_when_memory_lacks_stamps(monkeypat
     ]
 
     class _FakeDB:
-        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+        def replace_messages(
+            self, key, messages, active_only=False, archive_dropped=False
+        ):
             replaced.append((key, list(messages)))
 
-        def get_messages_as_conversation(self, key, repair_alternation=False, include_row_ids=False):
+        def get_messages_as_conversation(
+            self, key, repair_alternation=False, include_row_ids=False
+        ):
             assert include_row_ids is True
             return list(durable_history)
 
@@ -19108,18 +19768,16 @@ def test_prompt_submit_row_id_resolves_via_db_when_memory_lacks_stamps(monkeypat
     monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "db-row-resolve-sid",
-                    "text": "new turn",
-                    "truncate_before_row_id": 503,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "db-row-resolve-sid",
+                "text": "new turn",
+                "truncate_before_row_id": 503,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is None, resp
         assert len(sess["history"]) == 2
         assert sess["history"][-1]["content"] == "reply 1"
@@ -19172,19 +19830,17 @@ def test_prompt_submit_row_id_real_sessiondb_resolve_without_memory_stamps(
 
     try:
         # Cut before second user turn (row_ids[2]) — leave first exchange only.
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": sid,
-                    "text": "rewound second",
-                    "truncate_before_row_id": row_ids[2],
-                    "truncate_before_user_ordinal": 1,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": sid,
+                "text": "rewound second",
+                "truncate_before_row_id": row_ids[2],
+                "truncate_before_user_ordinal": 1,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is None, resp
         assert len(sess["history"]) == 2
         assert sess["history"][0]["content"] == "first"
@@ -19228,28 +19884,30 @@ def test_prompt_submit_row_id_real_sessiondb_unknown_refuses_despite_ordinal(
     server._sessions[sid] = sess
     monkeypatch.setattr(server, "_get_db", lambda: db)
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_inflight_turn",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     n_before = len(db.get_messages_as_conversation(session_key))
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": sid,
-                    "text": "stale durable id",
-                    "truncate_before_row_id": 999_999_999,
-                    "truncate_before_user_ordinal": 0,
-                    "confirm_truncate": True,
-                    "confirm_empty_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": sid,
+                "text": "stale durable id",
+                "truncate_before_row_id": 999_999_999,
+                "truncate_before_user_ordinal": 0,
+                "confirm_truncate": True,
+                "confirm_empty_truncate": True,
+            },
+        })
         assert resp.get("error") is not None
         assert resp["error"]["code"] == 4018
         assert len(sess["history"]) == 4
@@ -19295,26 +19953,28 @@ def test_prompt_submit_row_id_misaligned_memory_refuses_content_swap(
     server._sessions[sid] = sess
     monkeypatch.setattr(server, "_get_db", lambda: db)
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_inflight_turn",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     n_before = len(db.get_messages_as_conversation(session_key))
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": sid,
-                    "text": "rewind B",
-                    "truncate_before_row_id": rid_b,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": sid,
+                "text": "rewind B",
+                "truncate_before_row_id": rid_b,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is not None
         assert resp["error"]["code"] == 4018
         # Fail-closed: nothing stamped onto the misaligned dicts, nothing cut.
@@ -19364,18 +20024,16 @@ def test_prompt_submit_row_id_misaligned_memory_role_shift_targets_real_turn(
     monkeypatch.setattr(server, "_start_inflight_turn", lambda *a, **k: None)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": sid,
-                    "text": "rewind B",
-                    "truncate_before_row_id": rid_b,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": sid,
+                "text": "rewind B",
+                "truncate_before_row_id": rid_b,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is None, resp
         # The addressed turn ("B") is dropped exactly; earlier live turns
         # survive untouched. Before the guard, a positional zip-stamp put a
@@ -19421,10 +20079,14 @@ def test_prompt_submit_row_id_db_fallback_ordinal_mapping_verifies_content(
     ]
 
     class _FakeDB:
-        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+        def replace_messages(
+            self, key, messages, active_only=False, archive_dropped=False
+        ):
             replaced.append((key, list(messages)))
 
-        def get_messages_as_conversation(self, key, repair_alternation=False, include_row_ids=False):
+        def get_messages_as_conversation(
+            self, key, repair_alternation=False, include_row_ids=False
+        ):
             return [dict(m) for m in durable_history]
 
     sess = _session(history=list(live_history), session_key="db-fallback-verify-key")
@@ -19432,25 +20094,27 @@ def test_prompt_submit_row_id_db_fallback_ordinal_mapping_verifies_content(
     server._sessions[sid] = sess
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_inflight_turn",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": sid,
-                    "text": "rewind to second",
-                    "truncate_before_row_id": 604,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": sid,
+                "text": "rewind to second",
+                "truncate_before_row_id": 604,
+                "confirm_truncate": True,
+            },
+        })
         # Mapped live turn ("follow-up") does not match durable target
         # ("second") — refuse instead of cutting the wrong turn.
         assert resp.get("error") is not None
@@ -19497,19 +20161,17 @@ def test_prompt_submit_consecutive_rewinds_with_returned_survivor_row_ids(
     try:
         # Rewind 1: cut before "third" (last user turn). Survivors: turns
         # "first" + "second" (+ assistant replies) — re-inserted as NEW rows.
-        resp1 = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": sid,
-                    "text": "rewound third",
-                    "truncate_before_row_id": original_row_ids[4],
-                    "truncate_before_user_ordinal": 2,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp1 = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": sid,
+                "text": "rewound third",
+                "truncate_before_row_id": original_row_ids[4],
+                "truncate_before_user_ordinal": 2,
+                "confirm_truncate": True,
+            },
+        })
         assert resp1.get("error") is None, resp1
         survivors = resp1["result"].get("survivor_user_row_ids")
         # Fresh ids for the two surviving user turns, in visible-user order.
@@ -19520,37 +20182,33 @@ def test_prompt_submit_consecutive_rewinds_with_returned_survivor_row_ids(
         sess["running"] = False
 
         # Rewind 2a: the STALE pre-rewind id for "second" must fail closed.
-        stale_resp = server.handle_request(
-            {
-                "id": "2",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": sid,
-                    "text": "rewound second (stale id)",
-                    "truncate_before_row_id": original_row_ids[2],
-                    "truncate_before_user_ordinal": 1,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        stale_resp = server.handle_request({
+            "id": "2",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": sid,
+                "text": "rewound second (stale id)",
+                "truncate_before_row_id": original_row_ids[2],
+                "truncate_before_user_ordinal": 1,
+                "confirm_truncate": True,
+            },
+        })
         assert stale_resp.get("error") is not None
         assert stale_resp["error"]["code"] == 4018
         assert len(sess["history"]) == 4  # nothing cut
 
         # Rewind 2b: the RETURNED survivor id for "second" must succeed.
-        resp2 = server.handle_request(
-            {
-                "id": "3",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": sid,
-                    "text": "rewound second (fresh id)",
-                    "truncate_before_row_id": survivors[1],
-                    "truncate_before_user_ordinal": 1,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp2 = server.handle_request({
+            "id": "3",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": sid,
+                "text": "rewound second (fresh id)",
+                "truncate_before_row_id": survivors[1],
+                "truncate_before_user_ordinal": 1,
+                "confirm_truncate": True,
+            },
+        })
         assert resp2.get("error") is None, resp2
         assert len(sess["history"]) == 2
         assert sess["history"][0]["content"] == "first"
@@ -19593,47 +20251,45 @@ def test_prompt_submit_unconfirmed_truncation_refuses_before_target_resolution(
     server._sessions[sid] = sess
     monkeypatch.setattr(server, "_get_db", lambda: _SpyDB())
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_inflight_turn",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     try:
         # Unconfirmed row_id: 4029, no DB read, no heal stamps on history.
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": sid, "text": "x", "truncate_before_row_id": 3},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": sid, "text": "x", "truncate_before_row_id": 3},
+        })
         assert (resp.get("error") or {}).get("code") == 4029, resp
         assert db_reads == []
         assert all("_row_id" not in m for m in sess["history"])
 
         # Malformed param still beats consent: bool row_id is 4004.
-        resp = server.handle_request(
-            {
-                "id": "2",
-                "method": "prompt.submit",
-                "params": {"session_id": sid, "text": "x", "truncate_before_row_id": True},
-            }
-        )
+        resp = server.handle_request({
+            "id": "2",
+            "method": "prompt.submit",
+            "params": {"session_id": sid, "text": "x", "truncate_before_row_id": True},
+        })
         assert (resp.get("error") or {}).get("code") == 4004, resp
 
         # Unconfirmed out-of-range ordinal: 4029 (consent), not 4018 (range).
-        resp = server.handle_request(
-            {
-                "id": "3",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": sid,
-                    "text": "x",
-                    "truncate_before_user_ordinal": 99,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "3",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": sid,
+                "text": "x",
+                "truncate_before_user_ordinal": 99,
+            },
+        })
         assert (resp.get("error") or {}).get("code") == 4029, resp
         assert len(sess["history"]) == 4
     finally:
@@ -19662,6 +20318,7 @@ def test_persist_live_session_system_prompt_uses_profile_home(monkeypatch, tmp_p
 
         def _build_system_prompt(self, system_message=None):
             from hermes_constants import get_hermes_home
+
             home = get_hermes_home()
             built_homes.append(str(home))
             soul = (
@@ -19695,12 +20352,14 @@ def test_persist_live_session_system_prompt_uses_profile_home(monkeypatch, tmp_p
 
     # The override must have been reset after the call.
     from hermes_constants import get_hermes_home_override
+
     assert get_hermes_home_override() is None
 
 
 def test_persist_live_session_system_prompt_no_profile_is_unchanged(monkeypatch):
     """Sessions without a profile_home must not set/clear any override —
     the function should behave identically to before the fix."""
+
     class FakeAgent:
         model = "test"
         _cached_system_prompt = None
@@ -19751,6 +20410,7 @@ def test_persist_live_session_system_prompt_restores_pre_existing_override(tmp_p
 
         def _build_system_prompt(self, system_message=None):
             from hermes_constants import get_hermes_home
+
             built_homes.append(str(get_hermes_home()))
             return "inner prompt"
 
@@ -19793,7 +20453,9 @@ def test_workspace_move_rehomes_running_session(monkeypatch, tmp_path):
         def get_session(self, session_id):
             return {"id": session_id}
 
-        def update_session_cwd(self, session_id, cwd, branch=None, root=None, replace_git_meta=True):
+        def update_session_cwd(
+            self, session_id, cwd, branch=None, root=None, replace_git_meta=True
+        ):
             captured["row_update"] = (session_id, cwd)
 
         def close(self):
@@ -19817,7 +20479,11 @@ def test_workspace_move_rehomes_running_session(monkeypatch, tmp_path):
         lambda cwd: str(new_cwd),
     )
 
-    live = {"session_key": target, "running": True, "cwd": str(tmp_path / "old-project")}
+    live = {
+        "session_key": target,
+        "running": True,
+        "cwd": str(tmp_path / "old-project"),
+    }
     server._sessions["live-sid"] = live
     monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
 

--- a/tests/tui_gateway/test_session_hidden_rpc.py
+++ b/tests/tui_gateway/test_session_hidden_rpc.py
@@ -69,3 +69,31 @@ def test_session_list_include_hidden(db):
 
     all_rows = _call("session.list", {"include_hidden": True})["result"]["sessions"]
     assert {s["id"] for s in all_rows} == {"plain-chat", "bot-chat"}
+
+
+def test_compute_host_compress_wait_budget_resolution(monkeypatch):
+    """#88988: the /compress host wait must scale with the compression
+    timeout + retry rounds instead of the fixed 120s that failed the RPC
+    while the host finished at ~134s."""
+    from tui_gateway import methods_session as ms
+
+    import hermes_cli.config as hc_config
+
+    # Shipped defaults: 120s per attempt x 3 rounds + 30s grace = 390s.
+    monkeypatch.setattr(hc_config, "load_config", lambda: {})
+    assert ms._compute_host_compress_wait_s() == 390.0
+
+    # Config-driven: 60s per attempt x 2 rounds + 30s grace = 150s.
+    monkeypatch.setattr(
+        hc_config,
+        "load_config",
+        lambda: {
+            "auxiliary": {"compression": {"timeout": 60}},
+            "compression": {"max_attempts": 2},
+        },
+    )
+    assert ms._compute_host_compress_wait_s() == 150.0
+
+    # Broken config fails open to the default.
+    monkeypatch.setattr(hc_config, "load_config", lambda: {"auxiliary": "nonsense"})
+    assert ms._compute_host_compress_wait_s() == 390.0

--- a/tests/tui_gateway/test_session_hidden_rpc.py
+++ b/tests/tui_gateway/test_session_hidden_rpc.py
@@ -81,13 +81,16 @@ def test_compute_host_compress_wait_budget_resolution(monkeypatch):
     """#88988: the /compress host wait must scale with the compression
     timeout + retry rounds instead of the fixed 120s that failed the RPC
     while the host finished at ~134s."""
-    from tui_gateway import methods_session as ms
+    # The helper lives in tui_gateway.server: register() rebuilds every
+    # methods_* handler with server's globals, so module helpers referenced
+    # from those handlers must resolve there.
+    from tui_gateway import server
 
     import hermes_cli.config as hc_config
 
     # Shipped defaults: 120s per attempt x 3 rounds + 30s grace = 390s.
     monkeypatch.setattr(hc_config, "load_config", lambda: {})
-    assert ms._compute_host_compress_wait_s() == 390.0
+    assert server._compute_host_compress_wait_s() == 390.0
 
     # Config-driven: 60s per attempt x 2 rounds + 30s grace = 150s.
     monkeypatch.setattr(
@@ -98,8 +101,8 @@ def test_compute_host_compress_wait_budget_resolution(monkeypatch):
             "compression": {"max_attempts": 2},
         },
     )
-    assert ms._compute_host_compress_wait_s() == 150.0
+    assert server._compute_host_compress_wait_s() == 150.0
 
     # Broken config fails open to the default.
     monkeypatch.setattr(hc_config, "load_config", lambda: {"auxiliary": "nonsense"})
-    assert ms._compute_host_compress_wait_s() == 390.0
+    assert server._compute_host_compress_wait_s() == 390.0

--- a/tests/tui_gateway/test_session_hidden_rpc.py
+++ b/tests/tui_gateway/test_session_hidden_rpc.py
@@ -43,19 +43,25 @@ def test_set_hidden_resolves_stored_id_without_live_session(db):
     _seed(db, "stored-chat")
     assert srv._find_live_session_by_key("stored-chat") is None
 
-    envelope = _call("session.set_hidden", {"session_id": "stored-chat", "hidden": True})
+    envelope = _call(
+        "session.set_hidden", {"session_id": "stored-chat", "hidden": True}
+    )
     assert "error" not in envelope, envelope
     assert envelope["result"]["hidden"] is True
     assert db.get_session("stored-chat")["hidden"] == 1
 
     # And back — unhide through the same durable path.
-    envelope = _call("session.set_hidden", {"session_id": "stored-chat", "hidden": False})
+    envelope = _call(
+        "session.set_hidden", {"session_id": "stored-chat", "hidden": False}
+    )
     assert "error" not in envelope, envelope
     assert db.get_session("stored-chat")["hidden"] == 0
 
 
 def test_set_hidden_unknown_id_still_errors(db):
-    envelope = _call("session.set_hidden", {"session_id": "no-such-session", "hidden": True})
+    envelope = _call(
+        "session.set_hidden", {"session_id": "no-such-session", "hidden": True}
+    )
     assert envelope.get("error"), envelope
 
 

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -28,7 +28,9 @@ def _(rid, params: dict) -> dict:
     # workspace" instead of whatever folder the desktop launched in.
     raw_cwd = str(params.get("cwd") or "").strip()
     try:
-        explicit_cwd = bool(raw_cwd) and os.path.isdir(os.path.abspath(os.path.expanduser(raw_cwd)))
+        explicit_cwd = bool(raw_cwd) and os.path.isdir(
+            os.path.abspath(os.path.expanduser(raw_cwd))
+        )
     except Exception:
         explicit_cwd = False
     resolved_cwd = _completion_cwd(params)
@@ -49,7 +51,10 @@ def _(rid, params: dict) -> dict:
     # (resolved at build).
     create_model = str(params.get("model") or "").strip()
     session_model_override = (
-        {"model": create_model, "provider": str(params.get("provider") or "").strip() or None}
+        {
+            "model": create_model,
+            "provider": str(params.get("provider") or "").strip() or None,
+        }
         if create_model
         else None
     )
@@ -80,7 +85,9 @@ def _(rid, params: dict) -> dict:
             "agent_error": None,
             "agent_ready": ready,
             "attached_images": [],
-            "close_on_disconnect": is_truthy_value(params.get("close_on_disconnect", False)),
+            "close_on_disconnect": is_truthy_value(
+                params.get("close_on_disconnect", False)
+            ),
             "active_session_lease": lease,
             "cols": cols,
             "created_at": now,
@@ -350,7 +357,9 @@ def _(rid, params: dict) -> dict:
             found = db.get_session_by_title(target)
             if found:
                 target = found["id"]
-            elif is_truthy_value(params.get("lazy", False)) and _child_run_active(target):
+            elif is_truthy_value(params.get("lazy", False)) and _child_run_active(
+                target
+            ):
                 # Race: a watch window opened on a freshly-spawned subagent. The
                 # child relays `subagent.start` (which carries child_session_id and
                 # triggers the window) BEFORE its first run_conversation() flushes
@@ -414,12 +423,13 @@ def _(rid, params: dict) -> dict:
             # to lose access to a session. Only a genuine over-limit blocks.
             logger.warning(
                 "resume safety check failed for %s (proceeding without guard): %s",
-                target, exc,
+                target,
+                exc,
             )
 
-        profile_resume_cwd = str(found.get("cwd") or "").strip() or _profile_configured_cwd(
-            profile_home
-        )
+        profile_resume_cwd = str(
+            found.get("cwd") or ""
+        ).strip() or _profile_configured_cwd(profile_home)
 
         def _reuse_live_payload(sid: str, session: dict) -> dict:
             payload = _live_session_payload(
@@ -460,8 +470,12 @@ def _(rid, params: dict) -> dict:
         # (resume_session_id keeps the upgrade on the stored conversation).
         if is_truthy_value(params.get("lazy", False)):
             sid = uuid.uuid4().hex[:8]
-            source = _resolve_session_source(str(params.get("source") or "").strip() or None)
-            lease = None  # claimed lazily on the first turn (_ensure_active_session_slot)
+            source = _resolve_session_source(
+                str(params.get("source") or "").strip() or None
+            )
+            lease = (
+                None  # claimed lazily on the first turn (_ensure_active_session_slot)
+            )
             try:
                 db.reopen_session(target)
                 # The child's OWN conversation only — include_ancestors would prepend
@@ -485,7 +499,9 @@ def _(rid, params: dict) -> dict:
                 history=history,
                 lease=lease,
                 source=source,
-                close_on_disconnect=is_truthy_value(params.get("close_on_disconnect", False)),
+                close_on_disconnect=is_truthy_value(
+                    params.get("close_on_disconnect", False)
+                ),
                 profile_home=profile_home,
                 lazy=True,
             )
@@ -505,7 +521,9 @@ def _(rid, params: dict) -> dict:
                     target, repair_alternation=False, include_row_ids=True
                 )
             except Exception:
-                logger.debug("child-watch display projection read failed", exc_info=True)
+                logger.debug(
+                    "child-watch display projection read failed", exc_info=True
+                )
                 display_history = history
             messages = [] if omit_messages else _history_to_messages(display_history)
             return _ok(
@@ -513,7 +531,9 @@ def _(rid, params: dict) -> dict:
                 {
                     "session_id": sid,
                     "resumed": target,
-                    "message_count": len(display_history) if omit_messages else len(messages),
+                    "message_count": len(display_history)
+                    if omit_messages
+                    else len(messages),
                     "messages": messages,
                     "messages_omitted": omit_messages,
                     "info": _lazy_resume_info(cwd, profile=profile),
@@ -539,8 +559,12 @@ def _(rid, params: dict) -> dict:
         # governs the response shape of the non-deferred paths.
         if defer_history and not is_truthy_value(params.get("eager_build", False)):
             sid = uuid.uuid4().hex[:8]
-            source = _resolve_session_source(str(params.get("source") or "").strip() or None)
-            lease = None  # claimed lazily on the first turn (_ensure_active_session_slot)
+            source = _resolve_session_source(
+                str(params.get("source") or "").strip() or None
+            )
+            lease = (
+                None  # claimed lazily on the first turn (_ensure_active_session_slot)
+            )
             _enable_gateway_prompts()
             overrides = _stored_session_runtime_overrides(found) or {}
             model_override = overrides.get("model_override") or {}
@@ -552,7 +576,9 @@ def _(rid, params: dict) -> dict:
                 history=[],
                 lease=lease,
                 source=source,
-                close_on_disconnect=is_truthy_value(params.get("close_on_disconnect", False)),
+                close_on_disconnect=is_truthy_value(
+                    params.get("close_on_disconnect", False)
+                ),
                 profile_home=profile_home,
                 model_override=overrides.get("model_override"),
                 resume_runtime_overrides=overrides or None,
@@ -606,8 +632,12 @@ def _(rid, params: dict) -> dict:
         # session's persisted runtime identity, and is a real (upgradable) session.
         if not is_truthy_value(params.get("eager_build", False)):
             sid = uuid.uuid4().hex[:8]
-            source = _resolve_session_source(str(params.get("source") or "").strip() or None)
-            lease = None  # claimed lazily on the first turn (_ensure_active_session_slot)
+            source = _resolve_session_source(
+                str(params.get("source") or "").strip() or None
+            )
+            lease = (
+                None  # claimed lazily on the first turn (_ensure_active_session_slot)
+            )
             # Interactive resume routes approvals/clarify through gateway prompts;
             # the deferred build wires the remaining per-session callbacks.
             _enable_gateway_prompts()
@@ -647,7 +677,9 @@ def _(rid, params: dict) -> dict:
                 history=history,
                 lease=lease,
                 source=source,
-                close_on_disconnect=is_truthy_value(params.get("close_on_disconnect", False)),
+                close_on_disconnect=is_truthy_value(
+                    params.get("close_on_disconnect", False)
+                ),
                 display_history_prefix=prefix,
                 profile_home=profile_home,
                 model_override=overrides.get("model_override"),
@@ -688,11 +720,15 @@ def _(rid, params: dict) -> dict:
         # _session_resume_lock across it would stall session.close on the main
         # dispatch thread (it's not a _LONG_HANDLER), blocking fast-path RPCs.
         sid = uuid.uuid4().hex[:8]
-        source = _resolve_session_source(str(params.get("source") or "").strip() or None)
+        source = _resolve_session_source(
+            str(params.get("source") or "").strip() or None
+        )
         lease = None  # claimed lazily on the first turn (_ensure_active_session_slot)
         _enable_gateway_prompts()
         home_token = (
-            set_hermes_home_override(str(profile_home)) if profile_home is not None else None
+            set_hermes_home_override(str(profile_home))
+            if profile_home is not None
+            else None
         )
         secret_token = (
             set_secret_scope(build_profile_secret_scope(Path(str(profile_home))))
@@ -782,7 +818,9 @@ def _(rid, params: dict) -> dict:
                     else None
                 )
                 init_secret_token = (
-                    set_secret_scope(build_profile_secret_scope(Path(str(profile_home))))
+                    set_secret_scope(
+                        build_profile_secret_scope(Path(str(profile_home)))
+                    )
                     if profile_home is not None
                     else None
                 )
@@ -904,12 +942,16 @@ def _(rid, params: dict) -> dict:
     except ValueError as e:
         return _err(rid, 4017, str(e))
     agent = session.get("agent")
-    info = _session_info(agent, session) if agent is not None else {
-        "cwd": cwd,
-        "branch": _git_branch_for_cwd(cwd),
-        "project": _project_info_for_cwd(cwd),
-        "lazy": True,
-    }
+    info = (
+        _session_info(agent, session)
+        if agent is not None
+        else {
+            "cwd": cwd,
+            "branch": _git_branch_for_cwd(cwd),
+            "project": _project_info_for_cwd(cwd),
+            "lazy": True,
+        }
+    )
     _emit("session.info", params.get("session_id", ""), info)
     return _ok(rid, info)
 
@@ -978,12 +1020,16 @@ def _(rid, params: dict) -> dict:
         except ValueError as e:
             return _err(rid, 4017, str(e))
         agent = live.get("agent")
-        info = _session_info(agent, live) if agent is not None else {
-            "cwd": resolved,
-            "branch": branch,
-            "project": _project_info_for_cwd(resolved),
-            "lazy": True,
-        }
+        info = (
+            _session_info(agent, live)
+            if agent is not None
+            else {
+                "cwd": resolved,
+                "branch": branch,
+                "project": _project_info_for_cwd(resolved),
+                "lazy": True,
+            }
+        )
         _emit("session.info", live_sid, info)
 
     return _ok(rid, {"cwd": resolved, "branch": branch, "git_repo_root": root})
@@ -1121,7 +1167,9 @@ def _(rid, params: dict) -> dict:
                         resolved_title = fallback
                     else:
                         existing_row = db.get_session(key)
-                        existing_title = ((existing_row or {}).get("title") or "").strip()
+                        existing_title = (
+                            (existing_row or {}).get("title") or ""
+                        ).strip()
                         if existing_title == fallback:
                             session["pending_title"] = None
                             resolved_title = fallback
@@ -1173,7 +1221,9 @@ def _(rid, params: dict) -> dict:
             with _session_db(session) as scoped_db:
                 if scoped_db is not None and scoped_db.set_session_title(key, title):
                     session["pending_title"] = None
-                    _emit_session_info_for_session(params.get("session_id", ""), session)
+                    _emit_session_info_for_session(
+                        params.get("session_id", ""), session
+                    )
                     return _ok(rid, {"pending": False, "title": title})
             # Row creation didn't take (DB unavailable, or a concurrent writer) —
             # fall back to queuing so the post-turn apply block can still recover.
@@ -1229,7 +1279,11 @@ def _(rid, params: dict) -> dict:
         if db is None:
             return _db_unavailable_error(rid, code=5007)
         try:
-            resolved = db.resolve_session_id(target) if hasattr(db, "resolve_session_id") else target
+            resolved = (
+                db.resolve_session_id(target)
+                if hasattr(db, "resolve_session_id")
+                else target
+            )
             if not resolved:
                 return err
             db.set_session_hidden(resolved, hidden)
@@ -1305,7 +1359,9 @@ def _(rid, params: dict) -> dict:
     template = (params.get("template") or "").strip() or None
     instructions = params.get("instructions") or ""
     user_input = params.get("input") or ""
-    variables = params.get("variables") if isinstance(params.get("variables"), dict) else {}
+    variables = (
+        params.get("variables") if isinstance(params.get("variables"), dict) else {}
+    )
     task = (params.get("task") or "title_generation").strip() or "title_generation"
 
     try:
@@ -1528,7 +1584,9 @@ def _(rid, params: dict) -> dict:
                 "context_max": usage.get("context_max", 0) or 0,
                 "context_percent": usage.get("context_percent", 0) or 0,
                 "context_used": usage.get("context_used", 0) or 0,
-                "estimated_total": usage.get("context_used", 0) or usage.get("total", 0) or 0,
+                "estimated_total": usage.get("context_used", 0)
+                or usage.get("total", 0)
+                or 0,
                 "model": _metadata_mirror(session).get("model", ""),
             },
         )
@@ -1622,8 +1680,12 @@ def _(rid, params: dict) -> dict:
             from hermes_cli.config import load_config
 
             cfg = load_config()
-            display = cfg.get("display", {}) if isinstance(cfg.get("display"), dict) else {}
-            pet_cfg = display.get("pet", {}) if isinstance(display.get("pet"), dict) else {}
+            display = (
+                cfg.get("display", {}) if isinstance(cfg.get("display"), dict) else {}
+            )
+            pet_cfg = (
+                display.get("pet", {}) if isinstance(display.get("pet"), dict) else {}
+            )
         except Exception:
             pet_cfg = {}
 
@@ -1635,8 +1697,12 @@ def _(rid, params: dict) -> dict:
             return _ok(rid, {"enabled": False})
 
         state = str(params.get("state") or constants.PetState.IDLE.value)
-        scale = float(pet_cfg.get("scale", constants.DEFAULT_SCALE) or constants.DEFAULT_SCALE)
-        cols = int(params.get("cols") or 0) or constants.resolve_cols(scale, pet_cfg.get("unicode_cols", 0))
+        scale = float(
+            pet_cfg.get("scale", constants.DEFAULT_SCALE) or constants.DEFAULT_SCALE
+        )
+        cols = int(params.get("cols") or 0) or constants.resolve_cols(
+            scale, pet_cfg.get("unicode_cols", 0)
+        )
 
         # Graphics path: when the TUI is attached to a real TTY (``graphics``)
         # and the terminal speaks the kitty protocol, return a Unicode-
@@ -1647,7 +1713,11 @@ def _(rid, params: dict) -> dict:
         # kitty is grid-safe in Ink — iTerm/sixel stay on the fallback.
         if params.get("graphics"):
             configured = str(pet_cfg.get("render_mode", "auto") or "auto").lower()
-            gmode = render.detect_terminal_graphics() if configured in ("", "auto") else configured
+            gmode = (
+                render.detect_terminal_graphics()
+                if configured in ("", "auto")
+                else configured
+            )
             if gmode == "kitty":
                 image_id = render.kitty_image_id(pet.slug)
                 # kitty sizes from scaled pixels (_cell_box), so unicode_cols is moot here.
@@ -1685,9 +1755,7 @@ def _(rid, params: dict) -> dict:
         frames = []
         for i in range(count):
             grid = renderer.cells(state, i, cols=cols)
-            frames.append(
-                [[[*top, *bottom] for (top, bottom) in row] for row in grid]
-            )
+            frames.append([[[*top, *bottom] for (top, bottom) in row] for row in grid])
 
         return _ok(
             rid,
@@ -1729,8 +1797,12 @@ def _(rid, params: dict) -> dict:
             from hermes_cli.config import load_config
 
             cfg = load_config()
-            display = cfg.get("display", {}) if isinstance(cfg.get("display"), dict) else {}
-            pet_cfg = display.get("pet", {}) if isinstance(display.get("pet"), dict) else {}
+            display = (
+                cfg.get("display", {}) if isinstance(cfg.get("display"), dict) else {}
+            )
+            pet_cfg = (
+                display.get("pet", {}) if isinstance(display.get("pet"), dict) else {}
+            )
         except Exception:
             pet_cfg = {}
 
@@ -1748,34 +1820,31 @@ def _(rid, params: dict) -> dict:
 
             for entry in [] if local_only else fetch_manifest():
                 seen.add(entry.slug)
-                gallery.append(
-                    {
-                        "slug": entry.slug,
-                        "displayName": entry.display_name,
-                        "installed": entry.slug in installed,
-                        "spritesheetUrl": entry.spritesheet_url,
-                        # petdex exposes no popularity metric; "curated" (its
-                        # hand-picked/official set, identified by the asset path)
-                        # is the closest signal, so the picker can surface it first.
-                        "curated": "/curated/" in entry.spritesheet_url,
-                        "generated": entry.slug in installed and installed[entry.slug].generated,
-                    }
-                )
+                gallery.append({
+                    "slug": entry.slug,
+                    "displayName": entry.display_name,
+                    "installed": entry.slug in installed,
+                    "spritesheetUrl": entry.spritesheet_url,
+                    # petdex exposes no popularity metric; "curated" (its
+                    # hand-picked/official set, identified by the asset path)
+                    # is the closest signal, so the picker can surface it first.
+                    "curated": "/curated/" in entry.spritesheet_url,
+                    "generated": entry.slug in installed
+                    and installed[entry.slug].generated,
+                })
         except Exception as exc:  # noqa: BLE001 - offline: fall back to installed
             logger.debug("pet.gallery manifest fetch failed: %s", exc)
 
         # Always include locally-installed pets even if the gallery is unreachable.
         for slug, pet in installed.items():
             if slug not in seen:
-                gallery.append(
-                    {
-                        "slug": slug,
-                        "displayName": pet.display_name,
-                        "installed": True,
-                        "spritesheetUrl": "",
-                        "generated": pet.generated,
-                    }
-                )
+                gallery.append({
+                    "slug": slug,
+                    "displayName": pet.display_name,
+                    "installed": True,
+                    "spritesheetUrl": "",
+                    "generated": pet.generated,
+                })
 
         return _ok(
             rid,
@@ -1867,7 +1936,11 @@ def _(rid, params: dict) -> dict:
         filename, data = store.export_pet(slug)
         return _ok(
             rid,
-            {"ok": True, "filename": filename, "zipBase64": base64.standard_b64encode(data).decode("ascii")},
+            {
+                "ok": True,
+                "filename": filename,
+                "zipBase64": base64.standard_b64encode(data).decode("ascii"),
+            },
         )
     except Exception as exc:  # noqa: BLE001
         logger.debug("pet.export failed: %s", exc)
@@ -1939,7 +2012,8 @@ def _(rid, params: dict) -> dict:
             {
                 "ok": True,
                 "slug": slug,
-                "dataUri": "data:image/png;base64," + base64.standard_b64encode(data).decode("ascii"),
+                "dataUri": "data:image/png;base64,"
+                + base64.standard_b64encode(data).decode("ascii"),
             },
         )
     except Exception as exc:  # noqa: BLE001
@@ -2078,7 +2152,9 @@ def _(rid, params: dict) -> dict:
         sprite = None
         if provider_name:
             try:
-                sprite = resolve_provider(require_references=bool(reference_images), prefer=provider_name)
+                sprite = resolve_provider(
+                    require_references=bool(reference_images), prefer=provider_name
+                )
             except GenerationError as exc:
                 _pet_cancel_release(token)
                 return _err(rid, 5031, str(exc))
@@ -2108,7 +2184,12 @@ def _(rid, params: dict) -> dict:
                 _emit(
                     "pet.generate.progress",
                     "",
-                    {"token": token, "index": index, "dataUri": data_uri, "count": count},
+                    {
+                        "token": token,
+                        "index": index,
+                        "dataUri": data_uri,
+                        "count": count,
+                    },
                 )
             except Exception as exc:  # noqa: BLE001
                 logger.debug("pet.generate progress emit failed: %s", exc)
@@ -2252,7 +2333,10 @@ def _(rid, params: dict) -> dict:
         state = build_billing_state()
         return _ok(rid, _serialize_billing_state(state))
     except Exception:
-        return _ok(rid, {"ok": True, "logged_in": False, "error": "could not load billing state"})
+        return _ok(
+            rid,
+            {"ok": True, "logged_in": False, "error": "could not load billing state"},
+        )
 
 
 @method("usage.bars")
@@ -2283,7 +2367,14 @@ def _(rid, params: dict) -> dict:
         state = build_subscription_state()
         return _ok(rid, _serialize_subscription_state(state))
     except Exception:
-        return _ok(rid, {"ok": True, "logged_in": False, "error": "could not load subscription state"})
+        return _ok(
+            rid,
+            {
+                "ok": True,
+                "logged_in": False,
+                "error": "could not load subscription state",
+            },
+        )
 
 
 @method("subscription.preview")
@@ -2299,7 +2390,14 @@ def _(rid, params: dict) -> dict:
 
     tier_id = params.get("subscription_type_id")
     if not tier_id:
-        return _ok(rid, {"ok": False, "error": "invalid_request", "message": "subscription_type_id is required"})
+        return _ok(
+            rid,
+            {
+                "ok": False,
+                "error": "invalid_request",
+                "message": "subscription_type_id is required",
+            },
+        )
     try:
         preview = subscription_change_preview_from_payload(
             post_subscription_preview(subscription_type_id=tier_id)
@@ -2324,10 +2422,21 @@ def _(rid, params: dict) -> dict:
     cancel = bool(params.get("cancel"))
     tier_id = params.get("subscription_type_id")
     if not cancel and not tier_id:
-        return _ok(rid, {"ok": False, "error": "invalid_request", "message": "subscription_type_id or cancel is required"})
+        return _ok(
+            rid,
+            {
+                "ok": False,
+                "error": "invalid_request",
+                "message": "subscription_type_id or cancel is required",
+            },
+        )
     try:
-        result = put_subscription_pending_change(subscription_type_id=tier_id, cancel=cancel)
-        return _ok(rid, {"ok": True, "message": result.get("message"), "payload": result})
+        result = put_subscription_pending_change(
+            subscription_type_id=tier_id, cancel=cancel
+        )
+        return _ok(
+            rid, {"ok": True, "message": result.get("message"), "payload": result}
+        )
     except BillingError as exc:
         return _ok(rid, _serialize_billing_error(exc))
     except Exception as exc:
@@ -2345,7 +2454,9 @@ def _(rid, params: dict) -> dict:
 
     try:
         result = delete_subscription_pending_change()
-        return _ok(rid, {"ok": True, "message": result.get("message"), "payload": result})
+        return _ok(
+            rid, {"ok": True, "message": result.get("message"), "payload": result}
+        )
     except BillingError as exc:
         return _ok(rid, _serialize_billing_error(exc))
     except Exception as exc:
@@ -2367,10 +2478,19 @@ def _(rid, params: dict) -> dict:
 
     tier_id = params.get("subscription_type_id")
     if not tier_id:
-        return _ok(rid, {"ok": False, "error": "invalid_request", "message": "subscription_type_id is required"})
+        return _ok(
+            rid,
+            {
+                "ok": False,
+                "error": "invalid_request",
+                "message": "subscription_type_id is required",
+            },
+        )
     key = params.get("idempotency_key") or new_idempotency_key()
     try:
-        result = post_subscription_upgrade(subscription_type_id=tier_id, idempotency_key=key)
+        result = post_subscription_upgrade(
+            subscription_type_id=tier_id, idempotency_key=key
+        )
         return _ok(
             rid,
             {
@@ -2387,7 +2507,15 @@ def _(rid, params: dict) -> dict:
         env["idempotency_key"] = key  # so the TUI can reuse on retry
         return _ok(rid, env)
     except Exception as exc:
-        return _ok(rid, {"ok": False, "error": "error", "message": str(exc), "idempotency_key": key})
+        return _ok(
+            rid,
+            {
+                "ok": False,
+                "error": "error",
+                "message": str(exc),
+                "idempotency_key": key,
+            },
+        )
 
 
 @method("billing.charge")
@@ -2403,17 +2531,35 @@ def _(rid, params: dict) -> dict:
 
     amount = params.get("amount_usd")
     if amount is None:
-        return _ok(rid, {"ok": False, "error": "invalid_request", "message": "amount_usd is required"})
+        return _ok(
+            rid,
+            {
+                "ok": False,
+                "error": "invalid_request",
+                "message": "amount_usd is required",
+            },
+        )
     key = params.get("idempotency_key") or new_idempotency_key()
     try:
         result = post_charge(amount_usd=amount, idempotency_key=key)
-        return _ok(rid, {"ok": True, "charge_id": result.get("chargeId"), "idempotency_key": key})
+        return _ok(
+            rid,
+            {"ok": True, "charge_id": result.get("chargeId"), "idempotency_key": key},
+        )
     except BillingError as exc:
         env = _serialize_billing_error(exc)
         env["idempotency_key"] = key  # so the TUI can reuse on retry
         return _ok(rid, env)
     except Exception as exc:
-        return _ok(rid, {"ok": False, "error": "error", "message": str(exc), "idempotency_key": key})
+        return _ok(
+            rid,
+            {
+                "ok": False,
+                "error": "error",
+                "message": str(exc),
+                "idempotency_key": key,
+            },
+        )
 
 
 @method("billing.charge_status")
@@ -2426,7 +2572,14 @@ def _(rid, params: dict) -> dict:
 
     charge_id = params.get("charge_id")
     if not charge_id:
-        return _ok(rid, {"ok": False, "error": "invalid_charge_id", "message": "charge_id is required"})
+        return _ok(
+            rid,
+            {
+                "ok": False,
+                "error": "invalid_charge_id",
+                "message": "charge_id is required",
+            },
+        )
     try:
         result = get_charge_status(charge_id)
         return _ok(
@@ -2458,8 +2611,17 @@ def _(rid, params: dict) -> dict:
         threshold = params.get("threshold")
         top_up_amount = params.get("top_up_amount")
         if threshold is None or top_up_amount is None:
-            return _ok(rid, {"ok": False, "error": "invalid_request", "message": "threshold and top_up_amount are required"})
-        patch_auto_top_up(enabled=enabled, threshold=threshold, top_up_amount=top_up_amount)
+            return _ok(
+                rid,
+                {
+                    "ok": False,
+                    "error": "invalid_request",
+                    "message": "threshold and top_up_amount are required",
+                },
+            )
+        patch_auto_top_up(
+            enabled=enabled, threshold=threshold, top_up_amount=top_up_amount
+        )
         return _ok(rid, {"ok": True})
     except BillingError as exc:
         return _ok(rid, _serialize_billing_error(exc))
@@ -2505,7 +2667,9 @@ def _(rid, params: dict) -> dict:
         env["granted"] = False
         return _ok(rid, env)
     except Exception as exc:
-        return _ok(rid, {"ok": False, "error": "error", "message": str(exc), "granted": False})
+        return _ok(
+            rid, {"ok": False, "error": "error", "message": str(exc), "granted": False}
+        )
 
 
 @method("session.status")
@@ -2572,15 +2736,13 @@ def _(rid, params: dict) -> dict:
     title = (meta.get("title") or "").strip()
     if title:
         lines.append(f"Title: {title}")
-    lines.extend(
-        [
-            f"Model: {model} ({provider})",
-            f"Created: {created.strftime('%Y-%m-%d %H:%M')}",
-            f"Last Activity: {updated.strftime('%Y-%m-%d %H:%M')}",
-            f"Tokens: {int(usage.get('total') or 0):,}",
-            f"Agent Running: {'Yes' if session.get('running') else 'No'}",
-        ]
-    )
+    lines.extend([
+        f"Model: {model} ({provider})",
+        f"Created: {created.strftime('%Y-%m-%d %H:%M')}",
+        f"Last Activity: {updated.strftime('%Y-%m-%d %H:%M')}",
+        f"Tokens: {int(usage.get('total') or 0):,}",
+        f"Agent Running: {'Yes' if session.get('running') else 'No'}",
+    ])
     return _ok(rid, {"output": "\n".join(lines)})
 
 
@@ -2669,8 +2831,16 @@ def _compute_host_compress_wait_s() -> float:
 
         cfg = load_config() or {}
         aux = cfg.get("auxiliary", {}) if isinstance(cfg.get("auxiliary"), dict) else {}
-        comp_cfg = aux.get("compression", {}) if isinstance(aux.get("compression"), dict) else {}
-        root_comp = cfg.get("compression", {}) if isinstance(cfg.get("compression"), dict) else {}
+        comp_cfg = (
+            aux.get("compression", {})
+            if isinstance(aux.get("compression"), dict)
+            else {}
+        )
+        root_comp = (
+            cfg.get("compression", {})
+            if isinstance(cfg.get("compression"), dict)
+            else {}
+        )
         per_attempt = float(comp_cfg.get("timeout") or 120)
         attempts = int(root_comp.get("max_attempts") or 3)
         return max(per_attempt, per_attempt * attempts + 30.0)
@@ -2699,7 +2869,9 @@ def _(rid, params: dict) -> dict:
         except Exception as exc:
             return _err(rid, 5019, f"compute-host compress failed: {exc}")
         if ack.get("type") in {"control.error", "error"}:
-            return _err(rid, 4009, str(ack.get("message") or "compute-host compress failed"))
+            return _err(
+                rid, 4009, str(ack.get("message") or "compute-host compress failed")
+            )
         _apply_compute_host_metadata_mirror(session, ack)
         host_result = ack.get("result")
         if isinstance(host_result, dict):
@@ -2709,8 +2881,14 @@ def _(rid, params: dict) -> dict:
             # old text-only acknowledgement made Desktop show aborted work as a
             # success toast.
             return _ok(rid, {**host_result, "turn_isolation": True})
-        host_info = ack.get("session_info") if isinstance(ack.get("session_info"), dict) else {}
-        host_messages = _history_to_messages(ack.get("messages")) if isinstance(ack.get("messages"), list) else []
+        host_info = (
+            ack.get("session_info") if isinstance(ack.get("session_info"), dict) else {}
+        )
+        host_messages = (
+            _history_to_messages(ack.get("messages"))
+            if isinstance(ack.get("messages"), list)
+            else []
+        )
         # `messages` is returned at top level for the desktop transcript
         # replacement. Keep the host acknowledgement metadata, but do not send
         # the same (potentially large) transcript a second time inside it.
@@ -2723,7 +2901,9 @@ def _(rid, params: dict) -> dict:
                 "host_ack": host_ack,
                 "info": host_info,
                 "messages": host_messages,
-                "usage": host_info.get("usage") if isinstance(host_info.get("usage"), dict) else {},
+                "usage": host_info.get("usage")
+                if isinstance(host_info.get("usage"), dict)
+                else {},
             },
         )
     session, err = _sess(params, rid)
@@ -2837,11 +3017,15 @@ def _(rid, params: dict) -> dict:
         from agent.manual_compression_feedback import (
             describe_compression_lock_skip,
         )
-        return _ok(rid, {
-            "compressed": False,
-            "lock_held": True,
-            "message": describe_compression_lock_skip(e.holder),
-        })
+
+        return _ok(
+            rid,
+            {
+                "compressed": False,
+                "lock_held": True,
+                "message": describe_compression_lock_skip(e.holder),
+            },
+        )
     except Exception as e:
         finalize_context_engine_compression_notification(
             session["agent"],
@@ -2867,10 +3051,14 @@ def _(rid, params: dict) -> dict:
         except Exception as exc:
             return _err(rid, 5011, f"compute-host session save failed: {exc}")
         if ack.get("type") in {"control.error", "error"}:
-            return _err(rid, 5011, str(ack.get("message") or "compute-host session save failed"))
+            return _err(
+                rid, 5011, str(ack.get("message") or "compute-host session save failed")
+            )
         result = ack.get("result")
         if not isinstance(result, dict):
-            return _err(rid, 5011, "compute-host session save returned an invalid response")
+            return _err(
+                rid, 5011, "compute-host session save returned an invalid response"
+            )
         return _ok(rid, result)
 
     agent = session["agent"]
@@ -2948,14 +3136,18 @@ def _(rid, params: dict) -> dict:
         with session["history_lock"]:
             in_memory_history = [
                 dict(msg)
-                for msg in list(session.get("display_history_prefix") or []) + list(session.get("history", []))
+                for msg in list(session.get("display_history_prefix") or [])
+                + list(session.get("history", []))
                 if isinstance(msg, dict)
             ]
 
         def _visible_branch_history(messages):
             visible = []
             for message in messages or []:
-                if not isinstance(message, dict) or message.get("role") not in {"user", "assistant"}:
+                if not isinstance(message, dict) or message.get("role") not in {
+                    "user",
+                    "assistant",
+                }:
                     continue
                 if not _coerce_message_text(message.get("content")).strip():
                     continue
@@ -2975,7 +3167,9 @@ def _(rid, params: dict) -> dict:
         if callable(get_resume_conversations):
             try:
                 _, display_history = get_resume_conversations(old_key)
-                display_history = _reconcile_display_with_live(display_history, in_memory_history)
+                display_history = _reconcile_display_with_live(
+                    display_history, in_memory_history
+                )
                 history = _visible_branch_history(display_history)
             except Exception:
                 logger.debug("branch display projection read failed", exc_info=True)
@@ -3077,9 +3271,7 @@ def _(rid, params: dict) -> dict:
             # _init_session raising, both leave here without that transfer.
             branch_db = SessionDB(db_path=Path(parent_home) / "state.db")
             branch_owns_db = True
-        home_token = (
-            set_hermes_home_override(parent_home) if parent_home else None
-        )
+        home_token = set_hermes_home_override(parent_home) if parent_home else None
         # The home override alone only moves config/skills/memory; credentials
         # resolve through get_secret(), which without a scope falls through to
         # process os.environ — the LAUNCH profile's .env. Install the parent's
@@ -3162,14 +3354,18 @@ def _(rid, params: dict) -> dict:
         sid = str(params.get("session_id") or "")
         if session.get("running"):
             try:
-                _get_compute_host_supervisor().interrupt(sid, request_id=f"interrupt-{rid}")
+                _get_compute_host_supervisor().interrupt(
+                    sid, request_id=f"interrupt-{rid}"
+                )
             except Exception as exc:
                 return _err(rid, 5019, f"compute-host interrupt failed: {exc}")
         with session["history_lock"]:
             session["_turn_cancel_requested"] = True
             session["queued_prompt"] = None
             session.pop("queued_prompts", None)
-            session["_queued_prompt_generation"] = int(session.get("_queued_prompt_generation", 0)) + 1
+            session["_queued_prompt_generation"] = (
+                int(session.get("_queued_prompt_generation", 0)) + 1
+            )
         _clear_pending(sid)
         try:
             from tools.approval import resolve_gateway_approval
@@ -3195,7 +3391,9 @@ def _(rid, params: dict) -> dict:
         session["_turn_cancel_requested"] = True
         session["queued_prompt"] = None
         session.pop("queued_prompts", None)
-        session["_queued_prompt_generation"] = int(session.get("_queued_prompt_generation", 0)) + 1
+        session["_queued_prompt_generation"] = (
+            int(session.get("_queued_prompt_generation", 0)) + 1
+        )
     if should_interrupt:
         from agent.interrupt_compat import request_hard_interrupt
 
@@ -3386,16 +3584,14 @@ def _(rid, params: dict) -> dict:
                 except Exception:
                     raw = {}
                 subagents = raw.get("subagents") or []
-                entries.append(
-                    {
-                        "path": str(p),
-                        "session_id": raw.get("session_id") or d.name,
-                        "finished_at": raw.get("finished_at") or stat.st_mtime,
-                        "started_at": raw.get("started_at"),
-                        "label": raw.get("label") or "",
-                        "count": len(subagents) if isinstance(subagents, list) else 0,
-                    }
-                )
+                entries.append({
+                    "path": str(p),
+                    "session_id": raw.get("session_id") or d.name,
+                    "finished_at": raw.get("finished_at") or stat.st_mtime,
+                    "started_at": raw.get("started_at"),
+                    "label": raw.get("label") or "",
+                    "count": len(subagents) if isinstance(subagents, list) else 0,
+                })
             except OSError:
                 continue
 

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2654,6 +2654,30 @@ def _(rid, params: dict) -> dict:
     return _ok(rid, {"removed": removed})
 
 
+def _compute_host_compress_wait_s() -> float:
+    """Wait budget for the remote compute-host /compress acknowledgement.
+
+    Compression of a large session legitimately exceeds the old fixed 120s
+    wait — the host reported success at ~134s (#88988) AFTER the desktop had
+    already failed the RPC. Budget = per-attempt compression timeout x
+    retry rounds + a 30s completion grace (shipped defaults: 120 x 3 + 30 =
+    390s). Reads auxiliary.compression.timeout and compression.max_attempts
+    the same way the compression paths do; fails open to the 390s default.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        aux = cfg.get("auxiliary", {}) if isinstance(cfg.get("auxiliary"), dict) else {}
+        comp_cfg = aux.get("compression", {}) if isinstance(aux.get("compression"), dict) else {}
+        root_comp = cfg.get("compression", {}) if isinstance(cfg.get("compression"), dict) else {}
+        per_attempt = float(comp_cfg.get("timeout") or 120)
+        attempts = int(root_comp.get("max_attempts") or 3)
+        return max(per_attempt, per_attempt * attempts + 30.0)
+    except Exception:
+        return 390.0
+
+
 @method("session.compress")
 def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)
@@ -2670,7 +2694,7 @@ def _(rid, params: dict) -> dict:
                 route_name="session.compress",
                 command=command,
                 wait=True,
-                timeout=120.0,
+                timeout=_compute_host_compress_wait_s(),
             )
         except Exception as exc:
             return _err(rid, 5019, f"compute-host compress failed: {exc}")

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2816,38 +2816,6 @@ def _(rid, params: dict) -> dict:
     return _ok(rid, {"removed": removed})
 
 
-def _compute_host_compress_wait_s() -> float:
-    """Wait budget for the remote compute-host /compress acknowledgement.
-
-    Compression of a large session legitimately exceeds the old fixed 120s
-    wait — the host reported success at ~134s (#88988) AFTER the desktop had
-    already failed the RPC. Budget = per-attempt compression timeout x
-    retry rounds + a 30s completion grace (shipped defaults: 120 x 3 + 30 =
-    390s). Reads auxiliary.compression.timeout and compression.max_attempts
-    the same way the compression paths do; fails open to the 390s default.
-    """
-    try:
-        from hermes_cli.config import load_config
-
-        cfg = load_config() or {}
-        aux = cfg.get("auxiliary", {}) if isinstance(cfg.get("auxiliary"), dict) else {}
-        comp_cfg = (
-            aux.get("compression", {})
-            if isinstance(aux.get("compression"), dict)
-            else {}
-        )
-        root_comp = (
-            cfg.get("compression", {})
-            if isinstance(cfg.get("compression"), dict)
-            else {}
-        )
-        per_attempt = float(comp_cfg.get("timeout") or 120)
-        attempts = int(root_comp.get("max_attempts") or 3)
-        return max(per_attempt, per_attempt * attempts + 30.0)
-    except Exception:
-        return 390.0
-
-
 @method("session.compress")
 def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -149,7 +149,9 @@ _db = None
 _db_error: str | None = None
 _stdout_lock = threading.Lock()
 _cfg_lock = threading.Lock()
-_sessions_lock = threading.RLock()  # reentrant: _close_session_by_id may run under callers that already hold it
+_sessions_lock = (
+    threading.RLock()
+)  # reentrant: _close_session_by_id may run under callers that already hold it
 _prompt_lock = threading.Lock()
 _cfg_cache: dict | None = None
 _cfg_mtime: float | None = None
@@ -191,137 +193,135 @@ _DETAIL_MODES = frozenset({"hidden", "collapsed", "expanded"})
 # everything else stays on the main thread so ordering stays sane for the
 # fast path.  write_json is already _stdout_lock-guarded, so concurrent
 # response writes are safe.
-_LONG_HANDLERS = frozenset(
-    {
-        # Billing/usage reads each do a blocking portal HTTP fetch (state + usage
-        # is two serial round-trips); keep them off the main stdin loop so a slow
-        # portal can't stall approval.respond / session.interrupt / other RPCs.
-        "billing.state",
-        "subscription.state",
-        # Subscription change (V3): preview + the pending-change mutations + upgrade
-        # each do a blocking portal round-trip (preview + upgrade also hit Stripe,
-        # which can take seconds) — keep them off the main stdin loop.
-        "subscription.preview",
-        "subscription.change",
-        "subscription.resume",
-        "subscription.upgrade",
-        "usage.bars",
-        "session.usage",
-        "billing.step_up",
-        "browser.manage",
-        "cli.exec",
-        # Completion RPCs run inline on the reader thread by default, but both
-        # can block it for seconds: complete.path spawns `git ls-files` and
-        # fuzzy-ranks the whole repo (slow on large repos / WSL2 mounts), and
-        # complete.slash does first-call prompt_toolkit imports + a skill-dir
-        # scan. While either runs inline, prompt.submit / session.interrupt sit
-        # unread in the stdin pipe — the TUI appears frozen until the 120s RPC
-        # timeout fires (#21123). Routing them to the pool keeps the fast path
-        # responsive; completion is read-only and write_json is lock-guarded.
-        "complete.path",
-        "complete.slash",
-        "llm.oneshot",
-        # model.options builds the full picker payload — per-provider credential
-        # pool checks, pricing fetch, Nous tier check, optional custom-provider
-        # probe — measured seconds inline. While it runs on the reader thread,
-        # prompt.submit / session.interrupt sit unread (same class as #21123),
-        # and the Desktop model pill / picker block on it every open.
-        "model.options",
-        # Pet RPCs hit the network (manifest fetch / spritesheet download) or do
-        # per-frame PNG decode/encode (pet.cells): inline they serialize on the
-        # reader thread, so picker previews trickle in one at a time and the
-        # animation poll stutters. On the pool they run concurrently.
-        "pet.cells",
-        "pet.gallery",
-        # Generation is the heaviest pet path by far — multiple image-model
-        # round-trips per call — so it must never block the reader thread.
-        "pet.generate",
-        "pet.hatch",
-        "pet.info",
-        "pet.select",
-        "pet.thumb",
-        "learning.frames",
-        "plugins.manage",
-        # reload.mcp shuts down and rediscovers every MCP server — with a
-        # flapping server (retry loops, connect timeouts up to 120s) that can
-        # block for minutes. Inline it froze the reader thread: config.set,
-        # complete.slash, prompt.submit all sat unread and the TUI appeared
-        # dead after a few skin switches. The handler serializes concurrent
-        # reloads via _mcp_reload_lock.
-        "reload.mcp",
-        # MCP server test/OAuth RPCs block on network: a probe spawns a stdio
-        # server (cold `npx` cold start = many seconds) or connects to a remote
-        # endpoint; oauth.start blocks up to ~30s waiting for the provider to
-        # publish an authorization URL. Keep them off the reader thread.
-        "mcp.servers.test",
-        "mcp.servers.oauth.start",
-        "process.list",
-        # profiles.list runs list_profiles() (recursive skill-tree walk per
-        # profile) and opens each profile's state.db for the last-session
-        # preview; profiles.create copies skill bundles. Both are seconds-
-        # scale on cold disks — keep them off the WS reader thread.
-        "profiles.configure",
-        "profiles.create",
-        "profiles.describe",
-        "profiles.get_asset",
-        "profiles.list",
-        "profiles.set_asset",
-        # image.generate is a multi-second remote API round-trip.
-        "image.generate",
-        "projects.discover_repos",
-        "projects.record_repos",
-        "projects.for_cwd",
-        "projects.tree",
-        "projects.project_sessions",
-        # Setup readiness RPCs are polled by the Desktop frontend on connect
-        # and periodically (use-status-snapshot → evaluateRuntimeReadiness).
-        # setup.runtime_check calls resolve_runtime_provider() which reads
-        # config, checks auth state, and may probe the provider endpoint;
-        # setup.status calls _has_any_provider_configured() which scans
-        # provider config + credential files. Under GIL pressure from
-        # concurrent agent turns, either can take seconds inline, blocking
-        # the WS read loop and causing false "needs setup" (#50005 family).
-        "setup.runtime_check",
-        "setup.status",
-        # Voice RPCs can trigger check_voice_requirements() → STT provider
-        # auto-detect → a SYNCHRONOUS faster-whisper lazy install (uv/pip
-        # subprocess with a 300s timeout). Inline they stall the WS reader
-        # loop (handle_ws awaits dispatch before reading the next frame), so
-        # prompt.submit / session.list queued behind a voice.toggle sit
-        # unread and the desktop "send message" appears dead for minutes
-        # (reproduced: voice.toggle → session.list 40s+ timeout). Route them
-        # to the pool so a slow lazy install can't block message handling.
-        "voice.toggle",
-        "voice.record",
-        "voice.tts",
-        # wake.start calls check_wake_word_requirements() → _stt_ready() →
-        # _get_provider() → _try_lazy_install_stt() → ensure("stt.faster_whisper")
-        # (same synchronous subprocess install chain as the voice RPCs above).
-        # It also calls start_listening() → _build_engine() whose constructors
-        # call lazy_deps.ensure("wake.openwakeword" / "wake.sherpa" / …).
-        # wake.status calls check_wake_word_requirements() too and is polled
-        # by the desktop on every gateway-ready, so it can re-trigger the
-        # same block on a fresh launch. Same bug class as #21123 / #50005.
-        "wake.start",
-        "wake.status",
-        # Desktop also polls the in-memory live-session registry every 15s.
-        # The handler is normally cheap, but under heavy agent GIL pressure it
-        # can still stall for tens of seconds. Keep it off the WS reader thread
-        # so a delayed status rehydrate cannot block runtime readiness, prompt
-        # submission, or interrupts queued behind it on the same socket.
-        "session.active_list",
-        "session.branch",
-        "session.compress",
-        "session.list",
-        "session.resume",
-        # Workspace re-home runs git branch/root subprocess probes against an
-        # arbitrary folder — inline they'd stall the reader on a slow mount.
-        "session.workspace.move",
-        "shell.exec",
-        "skills.manage",
-        "slash.exec",
-    }
-)
+_LONG_HANDLERS = frozenset({
+    # Billing/usage reads each do a blocking portal HTTP fetch (state + usage
+    # is two serial round-trips); keep them off the main stdin loop so a slow
+    # portal can't stall approval.respond / session.interrupt / other RPCs.
+    "billing.state",
+    "subscription.state",
+    # Subscription change (V3): preview + the pending-change mutations + upgrade
+    # each do a blocking portal round-trip (preview + upgrade also hit Stripe,
+    # which can take seconds) — keep them off the main stdin loop.
+    "subscription.preview",
+    "subscription.change",
+    "subscription.resume",
+    "subscription.upgrade",
+    "usage.bars",
+    "session.usage",
+    "billing.step_up",
+    "browser.manage",
+    "cli.exec",
+    # Completion RPCs run inline on the reader thread by default, but both
+    # can block it for seconds: complete.path spawns `git ls-files` and
+    # fuzzy-ranks the whole repo (slow on large repos / WSL2 mounts), and
+    # complete.slash does first-call prompt_toolkit imports + a skill-dir
+    # scan. While either runs inline, prompt.submit / session.interrupt sit
+    # unread in the stdin pipe — the TUI appears frozen until the 120s RPC
+    # timeout fires (#21123). Routing them to the pool keeps the fast path
+    # responsive; completion is read-only and write_json is lock-guarded.
+    "complete.path",
+    "complete.slash",
+    "llm.oneshot",
+    # model.options builds the full picker payload — per-provider credential
+    # pool checks, pricing fetch, Nous tier check, optional custom-provider
+    # probe — measured seconds inline. While it runs on the reader thread,
+    # prompt.submit / session.interrupt sit unread (same class as #21123),
+    # and the Desktop model pill / picker block on it every open.
+    "model.options",
+    # Pet RPCs hit the network (manifest fetch / spritesheet download) or do
+    # per-frame PNG decode/encode (pet.cells): inline they serialize on the
+    # reader thread, so picker previews trickle in one at a time and the
+    # animation poll stutters. On the pool they run concurrently.
+    "pet.cells",
+    "pet.gallery",
+    # Generation is the heaviest pet path by far — multiple image-model
+    # round-trips per call — so it must never block the reader thread.
+    "pet.generate",
+    "pet.hatch",
+    "pet.info",
+    "pet.select",
+    "pet.thumb",
+    "learning.frames",
+    "plugins.manage",
+    # reload.mcp shuts down and rediscovers every MCP server — with a
+    # flapping server (retry loops, connect timeouts up to 120s) that can
+    # block for minutes. Inline it froze the reader thread: config.set,
+    # complete.slash, prompt.submit all sat unread and the TUI appeared
+    # dead after a few skin switches. The handler serializes concurrent
+    # reloads via _mcp_reload_lock.
+    "reload.mcp",
+    # MCP server test/OAuth RPCs block on network: a probe spawns a stdio
+    # server (cold `npx` cold start = many seconds) or connects to a remote
+    # endpoint; oauth.start blocks up to ~30s waiting for the provider to
+    # publish an authorization URL. Keep them off the reader thread.
+    "mcp.servers.test",
+    "mcp.servers.oauth.start",
+    "process.list",
+    # profiles.list runs list_profiles() (recursive skill-tree walk per
+    # profile) and opens each profile's state.db for the last-session
+    # preview; profiles.create copies skill bundles. Both are seconds-
+    # scale on cold disks — keep them off the WS reader thread.
+    "profiles.configure",
+    "profiles.create",
+    "profiles.describe",
+    "profiles.get_asset",
+    "profiles.list",
+    "profiles.set_asset",
+    # image.generate is a multi-second remote API round-trip.
+    "image.generate",
+    "projects.discover_repos",
+    "projects.record_repos",
+    "projects.for_cwd",
+    "projects.tree",
+    "projects.project_sessions",
+    # Setup readiness RPCs are polled by the Desktop frontend on connect
+    # and periodically (use-status-snapshot → evaluateRuntimeReadiness).
+    # setup.runtime_check calls resolve_runtime_provider() which reads
+    # config, checks auth state, and may probe the provider endpoint;
+    # setup.status calls _has_any_provider_configured() which scans
+    # provider config + credential files. Under GIL pressure from
+    # concurrent agent turns, either can take seconds inline, blocking
+    # the WS read loop and causing false "needs setup" (#50005 family).
+    "setup.runtime_check",
+    "setup.status",
+    # Voice RPCs can trigger check_voice_requirements() → STT provider
+    # auto-detect → a SYNCHRONOUS faster-whisper lazy install (uv/pip
+    # subprocess with a 300s timeout). Inline they stall the WS reader
+    # loop (handle_ws awaits dispatch before reading the next frame), so
+    # prompt.submit / session.list queued behind a voice.toggle sit
+    # unread and the desktop "send message" appears dead for minutes
+    # (reproduced: voice.toggle → session.list 40s+ timeout). Route them
+    # to the pool so a slow lazy install can't block message handling.
+    "voice.toggle",
+    "voice.record",
+    "voice.tts",
+    # wake.start calls check_wake_word_requirements() → _stt_ready() →
+    # _get_provider() → _try_lazy_install_stt() → ensure("stt.faster_whisper")
+    # (same synchronous subprocess install chain as the voice RPCs above).
+    # It also calls start_listening() → _build_engine() whose constructors
+    # call lazy_deps.ensure("wake.openwakeword" / "wake.sherpa" / …).
+    # wake.status calls check_wake_word_requirements() too and is polled
+    # by the desktop on every gateway-ready, so it can re-trigger the
+    # same block on a fresh launch. Same bug class as #21123 / #50005.
+    "wake.start",
+    "wake.status",
+    # Desktop also polls the in-memory live-session registry every 15s.
+    # The handler is normally cheap, but under heavy agent GIL pressure it
+    # can still stall for tens of seconds. Keep it off the WS reader thread
+    # so a delayed status rehydrate cannot block runtime readiness, prompt
+    # submission, or interrupts queued behind it on the same socket.
+    "session.active_list",
+    "session.branch",
+    "session.compress",
+    "session.list",
+    "session.resume",
+    # Workspace re-home runs git branch/root subprocess probes against an
+    # arbitrary folder — inline they'd stall the reader on a slow mount.
+    "session.workspace.move",
+    "shell.exec",
+    "skills.manage",
+    "slash.exec",
+})
 
 try:
     _rpc_pool_workers = max(
@@ -383,7 +383,9 @@ def _prepend_tool_paths(env: dict[str, str]) -> dict[str, str]:
         managed_bin = str(Path(get_hermes_home()) / "bin")
     except Exception:
         pass
-    venv_bin = str(Path(sys.executable).parent)  # <venv>/bin (POSIX) or <venv>/Scripts (Windows)
+    venv_bin = str(
+        Path(sys.executable).parent
+    )  # <venv>/bin (POSIX) or <venv>/Scripts (Windows)
     user_bin = str(Path.home() / ".local" / "bin")
     existing = env.get("PATH") or ""
     env["PATH"] = os.pathsep.join(
@@ -423,6 +425,7 @@ class _SlashWorker:
         # build_subprocess_env factory's `extra` (applied last, always wins)
         # instead of a hand-rolled env["HERMES_HOME"] assignment.
         from tools.environments.local import build_subprocess_env
+
         env = build_subprocess_env(
             hermes_subprocess_env(inherit_credentials=True),
             scrub_secrets=False,
@@ -676,7 +679,9 @@ def _transfer_active_session_slot(
             try:
                 old_lease.release()
             except Exception:
-                logger.debug("Failed to release stale active session slot", exc_info=True)
+                logger.debug(
+                    "Failed to release stale active session slot", exc_info=True
+                )
         session["active_session_lease"] = new_lease
         return True
     # Reserve failed — retain the existing lease rather than dropping it.
@@ -698,8 +703,20 @@ def _transfer_active_session_slot(
 # TUI backend itself creates ("tui", plus whatever a client passes as its
 # own ``source``) and the CLI's own sessions are NOT gateway-owned.
 _NON_GATEWAY_SOURCES = frozenset({
-    "", "tui", "cli", "webui", "desktop", "cron", "kanban", "subagent", "test",
-    "local", "acp", "webhook", "api_server", "msgraph_webhook",
+    "",
+    "tui",
+    "cli",
+    "webui",
+    "desktop",
+    "cron",
+    "kanban",
+    "subagent",
+    "test",
+    "local",
+    "acp",
+    "webhook",
+    "api_server",
+    "msgraph_webhook",
 })
 
 
@@ -805,7 +822,9 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
 
     session_key = session.get("session_key")
     session_id = getattr(agent, "session_id", None) or session_key
-    _notify_session_boundary("on_session_finalize", session_id, _session_source(session))
+    _notify_session_boundary(
+        "on_session_finalize", session_id, _session_source(session)
+    )
 
     # Mark session ended in DB so it doesn't linger as a ghost row in /resume.
     # Use session_id (from agent.session_id) not session_key — after compression,
@@ -1083,7 +1102,9 @@ def _session_async_delegation_selectors(
     agent = session.get("agent")
     session_key = str(session.get("session_key") or "")
     session_id = getattr(agent, "session_id", None) or session_key
-    owned_session_key = session_key if _session_owns_durable_lifecycle(session_id) else ""
+    owned_session_key = (
+        session_key if _session_owns_durable_lifecycle(session_id) else ""
+    )
     return own_sid, owned_session_key
 
 
@@ -1180,7 +1201,9 @@ def _close_sessions_for_transport(
 
     Returns ``(reaped, detached)`` counts for disconnect-path observability."""
     with _sessions_lock:
-        owned = [(sid, s) for sid, s in _sessions.items() if s.get("transport") is transport]
+        owned = [
+            (sid, s) for sid, s in _sessions.items() if s.get("transport") is transport
+        ]
     reaped = 0
     detached = 0
     for sid, session in owned:
@@ -1252,7 +1275,9 @@ def _session_is_evictable(sid: str, session: dict, now: float) -> bool:
 def _reap_idle_sessions() -> None:
     now = time.time()
     with _sessions_lock:
-        victims = [sid for sid, s in _sessions.items() if _session_is_evictable(sid, s, now)]
+        victims = [
+            sid for sid, s in _sessions.items() if _session_is_evictable(sid, s, now)
+        ]
     for sid in victims:
         _close_session_by_id(
             sid,
@@ -1275,9 +1300,7 @@ def _reap_idle_sessions() -> None:
     except Exception as exc:
         # debug, not warning — persistent failure would repeat every reaper
         # scan (300s) forever; sibling failure branches log at debug.
-        logger.debug(
-            "idle reaper memory trim failed: %s: %s", type(exc).__name__, exc
-        )
+        logger.debug("idle reaper memory trim failed: %s: %s", type(exc).__name__, exc)
 
 
 def _reclaim_orphaned_leases() -> None:
@@ -1345,7 +1368,9 @@ def _enforce_session_cap() -> None:
         if total <= cap:
             return
         evictable = [
-            (sid, s) for sid, s in _sessions.items() if _session_is_lru_evictable(sid, s)
+            (sid, s)
+            for sid, s in _sessions.items()
+            if _session_is_lru_evictable(sid, s)
         ]
     # Oldest-touched first; only evict down to the cap (live/focused sessions on
     # a live transport are never eligible, so we may stop short of the cap).
@@ -1540,7 +1565,9 @@ def _profile_scoped(handler):
     """
 
     def wrapper(rid, params):
-        home = _profile_home(params.get("profile") if isinstance(params, dict) else None)
+        home = _profile_home(
+            params.get("profile") if isinstance(params, dict) else None
+        )
         if home is None:
             return handler(rid, params)
         token = set_hermes_home_override(home)
@@ -1709,7 +1736,9 @@ def _broadcast_global_event(event: str, payload: dict | None = None) -> None:
         except Exception:
             # One wedged peer must not stall the rest; disconnect teardown
             # unregisters it.
-            logger.debug("global-event broadcast write failed type=%s", event, exc_info=True)
+            logger.debug(
+                "global-event broadcast write failed type=%s", event, exc_info=True
+            )
 
 
 _compute_host_supervisor = None
@@ -1747,7 +1776,9 @@ def _get_compute_host_supervisor(cfg: dict | None = None):
 
             _compute_host_supervisor = HostSupervisor(
                 rpc_sink=write_json,
-                heartbeat_secs=int(isolation_cfg.get("compute_host_heartbeat_secs") or 15),
+                heartbeat_secs=int(
+                    isolation_cfg.get("compute_host_heartbeat_secs") or 15
+                ),
                 respawn_max=int(isolation_cfg.get("compute_host_respawn_max") or 3),
             )
         return _compute_host_supervisor
@@ -1818,7 +1849,9 @@ def _apply_compute_host_metadata_mirror(session: dict, frame: dict | None) -> No
                 pass
         if frame.get("message_count") is not None:
             try:
-                session["_metadata_message_count"] = int(frame.get("message_count") or 0)
+                session["_metadata_message_count"] = int(
+                    frame.get("message_count") or 0
+                )
             except Exception:
                 pass
     info = frame.get("session_info")
@@ -1963,7 +1996,9 @@ def _pending_approval_request_payload(session_key: str) -> dict | None:
 
         approval = get_pending_gateway_approval(session_key)
     except Exception:
-        logger.debug("failed to read pending approval for %s", session_key, exc_info=True)
+        logger.debug(
+            "failed to read pending approval for %s", session_key, exc_info=True
+        )
         return None
     return _approval_request_payload(approval) if approval else None
 
@@ -2325,9 +2360,14 @@ def _start_agent_build(sid: str, session: dict) -> None:
             if profile_home:
                 home_token = set_hermes_home_override(profile_home)
                 try:
-                    from agent.secret_scope import build_profile_secret_scope, set_secret_scope
+                    from agent.secret_scope import (
+                        build_profile_secret_scope,
+                        set_secret_scope,
+                    )
 
-                    secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
+                    secret_token = set_secret_scope(
+                        build_profile_secret_scope(Path(profile_home))
+                    )
                 except Exception:
                     pass
                 try:
@@ -2371,9 +2411,13 @@ def _start_agent_build(sid: str, session: dict) -> None:
                     # them directly (no global config, no build-then-switch).
                     if override := current.get("model_override"):
                         kw["model_override"] = override
-                    if (reasoning := current.get("create_reasoning_override")) is not None:
+                    if (
+                        reasoning := current.get("create_reasoning_override")
+                    ) is not None:
                         kw["reasoning_config_override"] = reasoning
-                    if (tier := current.get("create_service_tier_override")) is not None:
+                    if (
+                        tier := current.get("create_service_tier_override")
+                    ) is not None:
                         kw["service_tier_override"] = tier
                 agent = _make_agent(sid, key, **kw)
             finally:
@@ -2443,7 +2487,9 @@ def _start_agent_build(sid: str, session: dict) -> None:
                 pass
             with _sessions_lock:
                 if sid in _sessions:
-                    _sessions[sid]["_notif_stop"] = _start_notification_poller(sid, _sessions[sid])
+                    _sessions[sid]["_notif_stop"] = _start_notification_poller(
+                        sid, _sessions[sid]
+                    )
             _notify_session_boundary("on_session_reset", key, _session_source(current))
 
             info = _session_info(agent, current)
@@ -3151,7 +3197,10 @@ def _persist_session_git_meta(session: dict, cwd: str, generation: int) -> None:
         return
     # Snapshot the routing fields now; the live session dict may be gone by the
     # time the thread runs. `_session_db` reopens the profile-correct db inside.
-    db_session = {"session_key": session_key, "profile_home": session.get("profile_home")}
+    db_session = {
+        "session_key": session_key,
+        "profile_home": session.get("profile_home"),
+    }
 
     def _run() -> None:
         try:
@@ -3183,9 +3232,7 @@ def _persist_session_cwd_and_schedule_git_meta(
     """Claim a DB-backed probe generation, then start Git enrichment."""
     try:
         if db is not None:
-            generation = db.update_session_cwd(
-                session.get("session_key", ""), cwd
-            )
+            generation = db.update_session_cwd(session.get("session_key", ""), cwd)
         else:
             with _session_db(session) as owner_db:
                 if owner_db is None:
@@ -3305,6 +3352,7 @@ def _load_cfg_raw() -> dict:
                 return copy.deepcopy(_cfg_cache)
         if p.exists():
             from hermes_cli.config import read_user_config_raw
+
             data = read_user_config_raw(p)
         else:
             data = {}
@@ -3499,15 +3547,20 @@ def _block(event: str, sid: str, payload: dict, timeout: float | None = 300) -> 
     # slow renderer (or a reconnect that dropped tool.complete) can still answer
     # afterward. Without this the late `*.respond` would hit the generic 4009
     # "no pending request" error and clients would surface a raw JSON-RPC string.
-    if not answered and not answer_present and event in {
-        "secret.request",
-        "sudo.request",
-        "clarify.request",
-        "terminal.read.request",
-        "preview.read.request",
-        "window.read.request",
-        "mcp.setup.request",
-    }:
+    if (
+        not answered
+        and not answer_present
+        and event
+        in {
+            "secret.request",
+            "sudo.request",
+            "clarify.request",
+            "terminal.read.request",
+            "preview.read.request",
+            "window.read.request",
+            "mcp.setup.request",
+        }
+    ):
         _emit(
             f"{event.removesuffix('.request')}.expire",
             sid,
@@ -3523,6 +3576,7 @@ def _clarify_timeout_seconds() -> float | None:
     means unlimited and is returned as ``None`` (never auto-skip)."""
     try:
         from tools.clarify_gateway import get_clarify_timeout
+
         timeout = get_clarify_timeout()
         return timeout if timeout > 0 else None
     except Exception:
@@ -4028,9 +4082,7 @@ def _stored_session_runtime_overrides(row: dict | None) -> dict:
                 base_url=base_url or None, model=model or None
             )
         except Exception:
-            logger.debug(
-                "custom provider identity recovery failed", exc_info=True
-            )
+            logger.debug("custom provider identity recovery failed", exc_info=True)
         provider = healed or ("" if not base_url else provider)
 
     if model:
@@ -4090,15 +4142,11 @@ def _runtime_model_config(agent, existing: dict | None = None) -> dict:
                 )
 
                 provider = (
-                    canonical_custom_identity(
-                        base_url=base_url, model=model or None
-                    )
+                    canonical_custom_identity(base_url=base_url, model=model or None)
                     or provider
                 )
             except Exception:
-                logger.debug(
-                    "custom provider identity lookup failed", exc_info=True
-                )
+                logger.debug("custom provider identity lookup failed", exc_info=True)
         config["provider"] = provider
     if base_url:
         config["base_url"] = base_url
@@ -4178,13 +4226,13 @@ def _persist_live_session_system_prompt(session: dict | None) -> None:
     # override and the rebuilt prompt silently uses the root profile's
     # SOUL.md and skills.  See issue #50233.
     profile_home = session.get("profile_home")
-    home_token = (
-        set_hermes_home_override(profile_home) if profile_home else None
-    )
+    home_token = set_hermes_home_override(profile_home) if profile_home else None
     try:
         prompt = agent._build_system_prompt(None)
         agent._cached_system_prompt = prompt
-        db.update_system_prompt(getattr(agent, "session_id", None) or session_key, prompt)
+        db.update_system_prompt(
+            getattr(agent, "session_id", None) or session_key, prompt
+        )
     except Exception:
         logger.warning(
             "failed to persist live session system prompt for session %s",
@@ -4225,7 +4273,9 @@ def _is_pivot_marker(entry: Any) -> bool:
     return isinstance(entry, dict) and entry.get("display_kind") == "personality_switch"
 
 
-def _append_model_switch_marker(session: dict | None, *, model: str, provider: str) -> None:
+def _append_model_switch_marker(
+    session: dict | None, *, model: str, provider: str
+) -> None:
     """Record a real system-history pivot after a live model switch.
 
     Only the most recent marker is kept: each new switch first strips any
@@ -4729,7 +4779,9 @@ def _restore_agent_model_runtime(agent, snapshot: dict | None) -> None:
             if agent._restore_primary_runtime():
                 return
         except Exception:
-            logger.debug("TUI one-turn model restore via primary runtime failed", exc_info=True)
+            logger.debug(
+                "TUI one-turn model restore via primary runtime failed", exc_info=True
+            )
     if hasattr(agent, "switch_model"):
         agent.switch_model(
             new_model=snapshot.get("model", ""),
@@ -4768,7 +4820,9 @@ def _apply_model_switch(
         is_session = parsed_flags.is_session
         one_turn = parsed_flags.is_once
     else:
-        model_input, explicit_provider, is_global_flag, _force_refresh, is_session = parsed_flags
+        model_input, explicit_provider, is_global_flag, _force_refresh, is_session = (
+            parsed_flags
+        )
         one_turn = False
     # Conflict validation delegates to the shared single-owner parser; the
     # TUI surfaces it as a raised ValueError (its historical behavior)
@@ -4844,11 +4898,15 @@ def _apply_model_switch(
     if not result.success:
         raise ValueError(result.error_message or "model switch failed")
 
-    restore_snapshot = _snapshot_agent_model_runtime(agent) if (one_turn and agent) else None
+    restore_snapshot = (
+        _snapshot_agent_model_runtime(agent) if (one_turn and agent) else None
+    )
 
     if agent:
         try:
-            from hermes_cli.context_switch_guard import merge_preflight_compression_warning
+            from hermes_cli.context_switch_guard import (
+                merge_preflight_compression_warning,
+            )
 
             _cfg_ctx = None
             if isinstance(cfg, dict):
@@ -4974,7 +5032,9 @@ def _sync_bot_capabilities(sid: str, session: dict) -> None:
         if not title:
             db = getattr(agent, "_session_db", None)
             key = session.get("session_key") or ""
-            title = str((db.get_session_title(key) if (db and key) else None) or "").strip()
+            title = str(
+                (db.get_session_title(key) if (db and key) else None) or ""
+            ).strip()
         if title != "Bot Chat":
             return
         from tools.bot_mode_probe import capability_fingerprint
@@ -5010,7 +5070,9 @@ def _sync_bot_capabilities(sid: str, session: dict) -> None:
         _emit(
             "notice",
             sid,
-            {"message": "Capabilities updated — this bot's tools and prompt were refreshed."},
+            {
+                "message": "Capabilities updated — this bot's tools and prompt were refreshed."
+            },
         )
     except Exception as e:
         logger.warning("Bot capability sync failed for %s: %s", sid, e)
@@ -5091,7 +5153,11 @@ def _apply_pending_model_switch(sid: str, session: dict) -> None:
             _emit(
                 "error",
                 sid,
-                {"message": result.get("confirm_message") or result.get("warning") or ""},
+                {
+                    "message": result.get("confirm_message")
+                    or result.get("warning")
+                    or ""
+                },
             )
     except Exception as e:
         _emit(
@@ -5104,9 +5170,46 @@ def _apply_pending_model_switch(sid: str, session: dict) -> None:
 class CompressionLockHeld(Exception):
     """Raised by _compress_session_history when compression skipped due
     to a concurrent lock on the session's compression_locks row."""
+
     def __init__(self, holder: str | None = None):
         self.holder = holder
         super().__init__(f"Compression lock held: {holder or 'unknown'}")
+
+
+def _compute_host_compress_wait_s() -> float:
+    """Wait budget for the remote compute-host /compress acknowledgement.
+
+    Compression of a large session legitimately exceeds the old fixed 120s
+    wait — the host reported success at ~134s (#88988) AFTER the desktop had
+    already failed the RPC. Budget = per-attempt compression timeout x
+    retry rounds + a 30s completion grace (shipped defaults: 120 x 3 + 30 =
+    390s). Reads auxiliary.compression.timeout and compression.max_attempts
+    the same way the compression paths do; fails open to the 390s default.
+
+    Defined HERE (not in methods_session) because register() rebuilds every
+    handler with this module's globals — module helpers referenced from a
+    methods_* handler resolve here.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        aux = cfg.get("auxiliary", {}) if isinstance(cfg.get("auxiliary"), dict) else {}
+        comp_cfg = (
+            aux.get("compression", {})
+            if isinstance(aux.get("compression"), dict)
+            else {}
+        )
+        root_comp = (
+            cfg.get("compression", {})
+            if isinstance(cfg.get("compression"), dict)
+            else {}
+        )
+        per_attempt = float(comp_cfg.get("timeout") or 120)
+        attempts = int(root_comp.get("max_attempts") or 3)
+        return max(per_attempt, per_attempt * attempts + 30.0)
+    except Exception:
+        return 390.0
 
 
 def _compress_session_history(
@@ -5323,9 +5426,9 @@ def _sync_session_key_after_compress(
     # claimed envelope is restored to the queue (see ``_drain_queued_prompt``)
     # so legitimate follow-ups still survive. Complements self-duplicate
     # scrubbing on redirect.
-    session["_queued_prompt_generation"] = int(
-        session.get("_queued_prompt_generation", 0)
-    ) + 1
+    session["_queued_prompt_generation"] = (
+        int(session.get("_queued_prompt_generation", 0)) + 1
+    )
 
     if clear_pending_title:
         session["pending_title"] = None
@@ -5374,13 +5477,16 @@ def _get_usage(agent) -> dict:
         if ctx_max and last_prompt:
             usage["context_used"] = last_prompt
             usage["context_max"] = ctx_max
-            usage["context_percent"] = max(0, min(100, round(last_prompt / ctx_max * 100)))
+            usage["context_percent"] = max(
+                0, min(100, round(last_prompt / ctx_max * 100))
+            )
         usage["compressions"] = getattr(comp, "compression_count", 0) or 0
     # Live count of background/async subagents still running (delegate_task
     # batches + background single delegations). Mirrors the classic CLI status
     # bar's ⛓ indicator; sourced from the same async_delegation registry.
     try:
         from tools.async_delegation import active_count as _async_active_count
+
         usage["active_subagents"] = _async_active_count()
     except Exception:
         pass
@@ -5520,7 +5626,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
     session_key = str(
         (session or {}).get("session_key") or getattr(agent, "session_id", "") or ""
     )
-    cfg_personality = ((_load_cfg().get("display") or {}).get("personality") or "")
+    cfg_personality = (_load_cfg().get("display") or {}).get("personality") or ""
     personality = (session or {}).get("personality", cfg_personality)
     reasoning_config = getattr(agent, "reasoning_config", None)
     reasoning_effort = ""
@@ -5533,7 +5639,9 @@ def _session_info(agent, session: dict | None = None) -> dict:
             reasoning_effort = "none"
         else:
             reasoning_effort = str(reasoning_config.get("effort", "") or "")
-    service_tier = getattr(agent, "service_tier", None) or mirror.get("service_tier") or ""
+    service_tier = (
+        getattr(agent, "service_tier", None) or mirror.get("service_tier") or ""
+    )
     # Effective approval-bypass state — the same three sources that
     # check_all_command_guards() ORs together: persistent config
     # (approvals.mode=off), the process-scoped --yolo env, and the
@@ -5579,8 +5687,12 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "fast": service_tier == "priority",
         "yolo": yolo,
         "approval_mode": approval_mode,
-        "tools": dict(mirror.get("tools") or {}) if isinstance(mirror.get("tools"), dict) else {},
-        "skills": dict(mirror.get("skills") or {}) if isinstance(mirror.get("skills"), dict) else {},
+        "tools": dict(mirror.get("tools") or {})
+        if isinstance(mirror.get("tools"), dict)
+        else {},
+        "skills": dict(mirror.get("skills") or {})
+        if isinstance(mirror.get("skills"), dict)
+        else {},
         "cwd": cwd,
         "branch": _git_branch_for_cwd(cwd),
         "project": _project_info_for_cwd(cwd),
@@ -5618,9 +5730,9 @@ def _session_info(agent, session: dict | None = None) -> dict:
             info["tools"] = {}
             for t in getattr(agent, "tools", []) or []:
                 name = t["function"]["name"]
-                info["tools"].setdefault(get_toolset_for_tool(name) or "other", []).append(
-                    name
-                )
+                info["tools"].setdefault(
+                    get_toolset_for_tool(name) or "other", []
+                ).append(name)
         except Exception:
             pass
         try:
@@ -5887,7 +5999,11 @@ def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result
             payload["inline_diff"] = "\n".join(rendered)
     except Exception:
         pass
-    if _tool_progress_enabled(sid) or payload.get("inline_diff") or _tool_lifecycle_required_for_ui(name):
+    if (
+        _tool_progress_enabled(sid)
+        or payload.get("inline_diff")
+        or _tool_lifecycle_required_for_ui(name)
+    ):
         _emit("tool.complete", sid, payload)
 
 
@@ -6094,7 +6210,9 @@ def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
         return
     csid = live[0]
     with _child_mirrors_lock:
-        st = _child_mirrors.setdefault(child_key, {"seq": 0, "open_tool": None, "started": False})
+        st = _child_mirrors.setdefault(
+            child_key, {"seq": 0, "open_tool": None, "started": False}
+        )
         if not st["started"]:
             st["started"] = True
             _emit("message.start", csid)
@@ -6141,11 +6259,13 @@ def _agent_cbs(sid: str) -> dict:
         "tool_complete_callback": lambda tc_id, name, args, result: _on_tool_complete(
             sid, tc_id, name, args, result
         ),
-        "tool_progress_callback": lambda event_type, name=None, preview=None, args=None, **kwargs: _on_tool_progress(
-            sid, event_type, name, preview, args, **kwargs
+        "tool_progress_callback": lambda event_type, name=None, preview=None, args=None, **kwargs: (
+            _on_tool_progress(sid, event_type, name, preview, args, **kwargs)
         ),
-        "tool_gen_callback": lambda name: _tool_progress_enabled(sid)
-        and _emit("tool.generating", sid, {"name": name}),
+        "tool_gen_callback": lambda name: (
+            _tool_progress_enabled(sid)
+            and _emit("tool.generating", sid, {"name": name})
+        ),
         "thinking_callback": lambda text: _emit("thinking.delta", sid, {"text": text}),
         # Affection reaction (ily / <3 / good bot) → hearts. Core-detected, so
         # the TUI heart and desktop floating hearts share one signal.
@@ -6268,7 +6388,10 @@ def _apply_project_workspace(task_id: str, path: str, _name: str = "") -> None:
             sid, session = key, _sessions[key]
         else:
             for cand_sid, cand in _sessions.items():
-                if cand.get("session_key") == key or getattr(cand.get("agent"), "session_id", None) == key:
+                if (
+                    cand.get("session_key") == key
+                    or getattr(cand.get("agent"), "session_id", None) == key
+                ):
                     sid, session = cand_sid, cand
                     break
 
@@ -6301,7 +6424,9 @@ def _apply_project_workspace(task_id: str, path: str, _name: str = "") -> None:
         )
         _emit("session.info", sid, info)
     except Exception:
-        logger.debug("failed to emit session.info after project workspace move", exc_info=True)
+        logger.debug(
+            "failed to emit session.info after project workspace move", exc_info=True
+        )
 
 
 def _wire_callbacks(sid: str):
@@ -6429,9 +6554,11 @@ def _apply_personality_to_session(
         # every later rewind resolves one turn too early and `replace_messages`
         # hard-deletes the difference (#82756).
         with session["history_lock"]:
-            session["history"].append(
-                {"role": "user", "content": marker, "display_kind": "personality_switch"}
-            )
+            session["history"].append({
+                "role": "user",
+                "content": marker,
+                "display_kind": "personality_switch",
+            })
             session["history_version"] = int(session.get("history_version", 0)) + 1
         info = _session_info(agent)
         _emit("session.info", sid, info)
@@ -6515,7 +6642,9 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
             agent, "provider_require_parameters", False
         ),
         "provider_data_collection": getattr(agent, "provider_data_collection", None),
-        "openrouter_min_coding_score": getattr(agent, "openrouter_min_coding_score", None),
+        "openrouter_min_coding_score": getattr(
+            agent, "openrouter_min_coding_score", None
+        ),
         "session_id": task_id,
         "reasoning_config": getattr(agent, "reasoning_config", None)
         or _load_reasoning_config(str(getattr(agent, "model", "") or "")),
@@ -6529,17 +6658,17 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
 
 def _ephemeral_preview_agent_kwargs(agent, task_id: str) -> dict:
     kwargs = _background_agent_kwargs(agent, task_id)
-    kwargs.update(
-        {
-            "enabled_toolsets": ["terminal", "file"],
-            "session_db": None,
-            "skip_memory": True,
-        }
-    )
+    kwargs.update({
+        "enabled_toolsets": ["terminal", "file"],
+        "session_db": None,
+        "skip_memory": True,
+    })
     return kwargs
 
 
-def _preview_restart_history(session: dict, max_messages: int = 24, max_tool_chars: int = 1200) -> list[dict]:
+def _preview_restart_history(
+    session: dict, max_messages: int = 24, max_tool_chars: int = 1200
+) -> list[dict]:
     """Distill the parent session's recent history into a context the
     ephemeral preview-restart agent can actually use.
 
@@ -6626,7 +6755,11 @@ def _preview_restart_callbacks(parent: str, task_id: str) -> dict:
     def progress(message: str, level: str = "info") -> None:
         text = str(message or "").strip()
         if text:
-            _emit("preview.restart.progress", parent, {"task_id": task_id, "level": level, "text": text})
+            _emit(
+                "preview.restart.progress",
+                parent,
+                {"task_id": task_id, "level": level, "text": text},
+            )
 
     def tool_start(tool_call_id: str, name: str, args: dict) -> None:
         started_at[tool_call_id] = time.time()
@@ -6635,11 +6768,16 @@ def _preview_restart_callbacks(parent: str, task_id: str) -> dict:
 
     def tool_complete(tool_call_id: str, name: str, _args: dict, result: str) -> None:
         duration_s = time.time() - started_at.get(tool_call_id, time.time())
-        summary = _tool_summary(name, result, duration_s) or f"Finished {name}{f' in {_fmt_tool_duration(duration_s)}' if duration_s else ''}"
+        summary = (
+            _tool_summary(name, result, duration_s)
+            or f"Finished {name}{f' in {_fmt_tool_duration(duration_s)}' if duration_s else ''}"
+        )
         output = _preview_tool_result_preview(name, result)
         progress(summary + (f"\n{output}" if output else ""))
 
-    def tool_progress(event_type: str, name: str | None = None, preview: str | None = None, **_kwargs) -> None:
+    def tool_progress(
+        event_type: str, name: str | None = None, preview: str | None = None, **_kwargs
+    ) -> None:
         if preview:
             progress(str(preview))
         elif name:
@@ -6650,7 +6788,9 @@ def _preview_restart_callbacks(parent: str, task_id: str) -> dict:
         "tool_complete_callback": tool_complete,
         "tool_progress_callback": tool_progress,
         "tool_gen_callback": lambda name: progress(f"Preparing {name}"),
-        "status_callback": lambda kind, text=None: progress(text if text is not None else kind),
+        "status_callback": lambda kind, text=None: progress(
+            text if text is not None else kind
+        ),
     }
 
 
@@ -6681,7 +6821,9 @@ def _reset_session_agent(sid: str, session: dict) -> dict:
     session["attached_images"] = []
     session["queued_prompt"] = None
     session.pop("queued_prompts", None)
-    session["_queued_prompt_generation"] = int(session.get("_queued_prompt_generation", 0)) + 1
+    session["_queued_prompt_generation"] = (
+        int(session.get("_queued_prompt_generation", 0)) + 1
+    )
     session["edit_snapshots"] = {}
     session["image_counter"] = 0
     session["running"] = False
@@ -6764,6 +6906,7 @@ def _schedule_mcp_late_refresh(sid: str, agent) -> None:
             info = _session_info(agent, session)
         # Emit outside the lock — write_json must not block under _sessions_lock.
         _emit("session.info", sid, info)
+
     threading.Thread(
         target=_wait_then_refresh,
         name=f"tui-mcp-late-refresh-{sid}",
@@ -6998,7 +7141,9 @@ def _make_agent(
             if service_tier_override is not None
             else _load_service_tier()
         ),
-        enabled_toolsets=_load_enabled_toolsets(_resolve_agent_platform(platform_override)),
+        enabled_toolsets=_load_enabled_toolsets(
+            _resolve_agent_platform(platform_override)
+        ),
         # OpenRouter provider-routing prefs (config.yaml `provider_routing`).
         # Mirrors the messaging gateway + CLI so the desktop/TUI honors the same
         # routing instead of letting OpenRouter pick providers at random.
@@ -7094,9 +7239,7 @@ def _init_session(
                             _sessions[sid], _cwd, db=db
                         )
                 except Exception:
-                    logger.debug(
-                        "failed to persist resumed session cwd", exc_info=True
-                    )
+                    logger.debug("failed to persist resumed session cwd", exc_info=True)
     finally:
         if _init_owns_db and db is not None:
             try:
@@ -7135,8 +7278,12 @@ def _init_session(
     _wire_callbacks(sid)
     with _sessions_lock:
         if sid in _sessions:
-            _sessions[sid]["_notif_stop"] = _start_notification_poller(sid, _sessions[sid])
-    _notify_session_boundary("on_session_reset", key, _session_source(_sessions.get(sid, {})))
+            _sessions[sid]["_notif_stop"] = _start_notification_poller(
+                sid, _sessions[sid]
+            )
+    _notify_session_boundary(
+        "on_session_reset", key, _session_source(_sessions.get(sid, {}))
+    )
     _emit("session.info", sid, _session_info(agent, _sessions.get(sid, {})))
     _schedule_mcp_late_refresh(sid, agent)
 
@@ -7205,7 +7352,9 @@ def _build_image_ref_message(user_text: str, image_paths: list[str]) -> str:
     return text or "What do you see in this image?"
 
 
-def _build_persist_message_with_image_refs(user_text: str, image_paths: list[str]) -> str:
+def _build_persist_message_with_image_refs(
+    user_text: str, image_paths: list[str]
+) -> str:
     """Build the clean, UI-recognizable version of the user's message for
     persisting to session history. Uses ``@image:<path>`` directives — the
     format the desktop client (directive-text.tsx / HERMES_DIRECTIVE_RE)
@@ -7224,13 +7373,17 @@ def _build_persist_message_with_image_refs(user_text: str, image_paths: list[str
     from agent.context_references import format_reference_value
 
     text = user_text or ""
-    refs = "\n".join(f"@image:{format_reference_value(p)}" for p in image_paths if Path(p).exists())
+    refs = "\n".join(
+        f"@image:{format_reference_value(p)}" for p in image_paths if Path(p).exists()
+    )
     if not refs:
         return text
     return f"{text}\n{refs}" if text else refs
 
 
-def _build_persist_user_message(user_text: str, image_paths: list[str], run_message: Any) -> Any:
+def _build_persist_user_message(
+    user_text: str, image_paths: list[str], run_message: Any
+) -> Any:
     """Shape the persisted user turn to match what was sent to the model.
 
     Native-vision turns send ``content`` as a parts list, and
@@ -7244,7 +7397,9 @@ def _build_persist_user_message(user_text: str, image_paths: list[str], run_mess
     persist_text = _build_persist_message_with_image_refs(user_text, image_paths)
     if not isinstance(run_message, list):
         return persist_text
-    image_parts = [p for p in run_message if not (isinstance(p, dict) and p.get("type") == "text")]
+    image_parts = [
+        p for p in run_message if not (isinstance(p, dict) and p.get("type") == "text")
+    ]
     return [{"type": "text", "text": persist_text}, *image_parts]
 
 
@@ -7448,7 +7603,10 @@ def _expand_skill_invocation_for_replay(text: str, task_id: str) -> str:
         if cmd_key is None:
             return text
 
-        return build_skill_invocation_message(cmd_key, arg.strip(), task_id=task_id) or text
+        return (
+            build_skill_invocation_message(cmd_key, arg.strip(), task_id=task_id)
+            or text
+        )
     except Exception:
         # A skill that no longer resolves (renamed, disabled, external dir
         # gone) must not break the rewind — replay the text as typed.
@@ -7711,7 +7869,11 @@ def _fail_inflight_turn(session: dict, error: Any) -> None:
 
     Caller must hold ``session["history_lock"]``.
     """
-    message = str(error) if not isinstance(error, BaseException) else (str(error) or type(error).__name__)
+    message = (
+        str(error)
+        if not isinstance(error, BaseException)
+        else (str(error) or type(error).__name__)
+    )
     now = time.time()
     turn = session.get("inflight_turn")
     if not isinstance(turn, dict):
@@ -7750,7 +7912,9 @@ def _auto_continue_config() -> tuple[bool, float, int]:
     if not isinstance(cfg, dict):
         cfg = {}
     try:
-        minutes = float(cfg.get("freshness_minutes", _AUTO_CONTINUE_FRESHNESS_MINUTES_DEFAULT))
+        minutes = float(
+            cfg.get("freshness_minutes", _AUTO_CONTINUE_FRESHNESS_MINUTES_DEFAULT)
+        )
     except (TypeError, ValueError):
         minutes = float(_AUTO_CONTINUE_FRESHNESS_MINUTES_DEFAULT)
     return (
@@ -7798,7 +7962,9 @@ def _auto_continue_note(prompt: str) -> str:
     )
 
 
-def _maybe_schedule_auto_continue(sid: str, session: dict, session_key: str) -> dict | None:
+def _maybe_schedule_auto_continue(
+    sid: str, session: dict, session_key: str
+) -> dict | None:
     """Kick off a continuation turn for a crash-interrupted session.
 
     Called from session.resume's cold paths after the live record is
@@ -7831,14 +7997,20 @@ def _maybe_schedule_auto_continue(sid: str, session: dict, session_key: str) -> 
             _start_agent_build(sid, session)
             err = _wait_agent(session, rid, timeout=120.0)
         except Exception:
-            logger.warning("auto-continue agent build failed for %s", sid, exc_info=True)
+            logger.warning(
+                "auto-continue agent build failed for %s", sid, exc_info=True
+            )
             err = {"error": {"message": "agent build failed"}}
         if err:
             # Leave the marker: the next resume retries (bounded by attempts).
             session["_auto_continue_scheduled"] = False
             return
         with session["history_lock"]:
-            if session.get("running") or session.get("_turn_cancel_requested") or session.get("_finalized"):
+            if (
+                session.get("running")
+                or session.get("_turn_cancel_requested")
+                or session.get("_finalized")
+            ):
                 # A real user prompt beat us to it — their turn wins, and its
                 # own conclusion clears the marker.
                 session["_auto_continue_scheduled"] = False
@@ -7905,9 +8077,7 @@ def _enqueue_prompt(
     # the same user turn as a fresh agent invocation.
     if not image_paths and isinstance(text, str):
         turn = session.get("inflight_turn")
-        original = (
-            str(turn.get("user") or "").strip() if isinstance(turn, dict) else ""
-        )
+        original = str(turn.get("user") or "").strip() if isinstance(turn, dict) else ""
         if original and text.strip() == original:
             return
     queued = {"text": text, "transport": transport}
@@ -7931,9 +8101,7 @@ def _enqueue_prompt(
     session["queued_prompt"] = queued
 
 
-def _sanitize_queued_entry_vs_inflight_user(
-    entry: Any, original: str
-) -> dict | None:
+def _sanitize_queued_entry_vs_inflight_user(entry: Any, original: str) -> dict | None:
     """Drop or rewrite a queue envelope that re-carries the live user text.
 
     Returns ``None`` to drop the envelope, or a (possibly rewritten) dict to
@@ -8039,7 +8207,9 @@ def _interrupt_busy_session(sid: str, session: dict, agent: Any) -> None:
             with session["history_lock"]:
                 session["_busy_interrupt_pending"] = False
 
-    threading.Thread(target=interrupt, daemon=True, name=f"busy-interrupt-{sid}").start()
+    threading.Thread(
+        target=interrupt, daemon=True, name=f"busy-interrupt-{sid}"
+    ).start()
 
 
 def _handle_busy_submit(
@@ -8081,7 +8251,13 @@ def _handle_busy_submit(
             session["attached_images"] = []
     text_only = not image_paths and _is_text_only_busy_payload(text)
     plain_text = _coerce_message_text(text).strip() if text_only else ""
-    if mode == "steer" and text_only and plain_text and agent is not None and hasattr(agent, "steer"):
+    if (
+        mode == "steer"
+        and text_only
+        and plain_text
+        and agent is not None
+        and hasattr(agent, "steer")
+    ):
         try:
             if agent.steer(plain_text):
                 with session["history_lock"]:
@@ -8119,7 +8295,9 @@ def _handle_busy_submit(
     with session["history_lock"]:
         if not session.get("running"):
             if image_paths:
-                session["attached_images"] = image_paths + list(session.get("attached_images", []))
+                session["attached_images"] = image_paths + list(
+                    session.get("attached_images", [])
+                )
             return None
         _enqueue_prompt(session, text, transport, image_paths=image_paths)
         session["last_active"] = time.time()
@@ -8195,10 +8373,16 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
                 )
             else:
                 resp = _submit_prompt_to_compute_host(
-                    rid, sid, session, queued["text"], queued_prompt_generation=queue_generation
+                    rid,
+                    sid,
+                    session,
+                    queued["text"],
+                    queued_prompt_generation=queue_generation,
                 )
             if resp.get("error"):
-                message = str(((resp.get("error") or {}).get("message")) or "queued prompt failed")
+                message = str(
+                    ((resp.get("error") or {}).get("message")) or "queued prompt failed"
+                )
                 with session["history_lock"]:
                     session["running"] = False
                     _clear_inflight_turn(session)
@@ -8224,8 +8408,7 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
                 )
     except Exception as exc:
         print(
-            f"[tui_gateway] queued prompt dispatch failed: "
-            f"{type(exc).__name__}: {exc}",
+            f"[tui_gateway] queued prompt dispatch failed: {type(exc).__name__}: {exc}",
             file=sys.stderr,
         )
         with session["history_lock"]:
@@ -8271,8 +8454,12 @@ def _inflight_snapshot(session: dict) -> dict | None:
         # Only sent when every correction has one, so clients can trust the
         # pairing; older in-memory turns without offsets omit the field and
         # clients fall back to placing corrections after the assistant dump.
-        if all(isinstance(offset, int) and offset >= 0 for _, offset in correction_pairs):
-            snapshot["correction_offsets"] = [int(offset) for _, offset in correction_pairs]  # type: ignore[arg-type]
+        if all(
+            isinstance(offset, int) and offset >= 0 for _, offset in correction_pairs
+        ):
+            snapshot["correction_offsets"] = [
+                int(offset) for _, offset in correction_pairs
+            ]  # type: ignore[arg-type]
     if error:
         # Retained failed turn (see _fail_inflight_turn): carry the error
         # semantics so a resuming client can rebuild the failed-turn bubble
@@ -8519,7 +8706,9 @@ def _schedule_resume_hydration(
             )
             _emit("error", sid, {"message": message})
             with _sessions_lock:
-                discarded = _sessions.pop(sid, None) if _sessions.get(sid) is session else None
+                discarded = (
+                    _sessions.pop(sid, None) if _sessions.get(sid) is session else None
+                )
             lease = (discarded or {}).get("active_session_lease")
             if lease is not None:
                 lease.release()
@@ -8592,7 +8781,9 @@ def _session_live_item(sid: str, session: dict, current_sid: str = "") -> dict:
     return {
         "current": sid == current_sid,
         "id": sid,
-        "last_active": float(session.get("last_active") or session.get("created_at") or now),
+        "last_active": float(
+            session.get("last_active") or session.get("created_at") or now
+        ),
         "message_count": len(history),
         "model": str(getattr(agent, "model", "") or _resolve_model()),
         "preview": preview,
@@ -8695,7 +8886,9 @@ def _reconcile_display_with_live(
     return list(db_display) + list(in_memory[last_shared + 1 :])
 
 
-def _live_visible_history(session: dict, db, in_memory_fallback: list[dict]) -> list[dict]:
+def _live_visible_history(
+    session: dict, db, in_memory_fallback: list[dict]
+) -> list[dict]:
     """Return the user-visible DISPLAY projection for a live/warm session.
 
     Serving the raw in-memory *model* history for the user-visible payload
@@ -8715,7 +8908,9 @@ def _live_visible_history(session: dict, db, in_memory_fallback: list[dict]) -> 
     key = session.get("session_key")
     if db is not None and key:
         try:
-            display = db.get_messages_as_conversation(key, include_ancestors=True, include_row_ids=True)
+            display = db.get_messages_as_conversation(
+                key, include_ancestors=True, include_row_ids=True
+            )
             return _reconcile_display_with_live(display, in_memory_fallback)
         except Exception:
             logger.debug("live display projection read failed", exc_info=True)
@@ -8779,7 +8974,9 @@ def _live_session_payload(
         payload["inflight"] = inflight
     if queued:
         payload["queued"] = queued
-    if approval := _pending_approval_request_payload(str(session.get("session_key") or "")):
+    if approval := _pending_approval_request_payload(
+        str(session.get("session_key") or "")
+    ):
         payload["pending_approval"] = approval
     if clarify := _pending_clarify_request_payload(sid):
         payload["pending_clarify"] = clarify
@@ -8878,7 +9075,12 @@ def _pet_row_frame_counts(spritesheet) -> dict:
             count = 0
             for col in range(cols):
                 left = col * constants.FRAME_W
-                frame = image.crop((left, top, left + constants.FRAME_W, top + constants.FRAME_H))
+                frame = image.crop((
+                    left,
+                    top,
+                    left + constants.FRAME_W,
+                    top + constants.FRAME_H,
+                ))
                 if render._frame_is_blank(frame):
                     break
                 count += 1
@@ -8898,7 +9100,9 @@ def _pet_config_scale() -> float:
         cfg = load_config()
         display = cfg.get("display", {}) if isinstance(cfg.get("display"), dict) else {}
         pet_cfg = display.get("pet", {}) if isinstance(display.get("pet"), dict) else {}
-        return float(pet_cfg.get("scale", constants.DEFAULT_SCALE) or constants.DEFAULT_SCALE)
+        return float(
+            pet_cfg.get("scale", constants.DEFAULT_SCALE) or constants.DEFAULT_SCALE
+        )
     except Exception:  # noqa: BLE001
         return constants.DEFAULT_SCALE
 
@@ -8962,7 +9166,9 @@ def _pet_active_selection():
     enabled = is_truthy_value(pet_cfg.get("enabled"), default=False)
     configured_slug = str(pet_cfg.get("slug", "") or "")
     pet = store.resolve_active_pet(configured_slug) if enabled else None
-    scale = float(pet_cfg.get("scale", constants.DEFAULT_SCALE) or constants.DEFAULT_SCALE)
+    scale = float(
+        pet_cfg.get("scale", constants.DEFAULT_SCALE) or constants.DEFAULT_SCALE
+    )
     return enabled, pet, scale
 
 
@@ -9022,7 +9228,9 @@ def _pet_png_data_uri(path, *, max_px: int = 160) -> str:
     img.thumbnail((max_px, max_px), Image.LANCZOS)
     buf = io.BytesIO()
     img.save(buf, format="PNG")
-    return "data:image/png;base64," + base64.standard_b64encode(buf.getvalue()).decode("ascii")
+    return "data:image/png;base64," + base64.standard_b64encode(buf.getvalue()).decode(
+        "ascii"
+    )
 
 
 # Cooperative cancellation for the heavy pet generation paths. The client's Stop
@@ -9053,7 +9261,9 @@ def _pet_reference_images_from_data_url(ref_raw: str, stage) -> list:
     import binascii
     import re as _re
 
-    match = _re.match(r"^data:image/([a-zA-Z0-9.+-]+);base64,(.*)$", ref_raw, _re.DOTALL)
+    match = _re.match(
+        r"^data:image/([a-zA-Z0-9.+-]+);base64,(.*)$", ref_raw, _re.DOTALL
+    )
     if not match:
         raise ValueError("invalid reference image format")
 
@@ -9306,15 +9516,22 @@ def _serialize_usage_model(model) -> dict:
         "status": model.status,
         "plan_name": model.plan_name,
         "renews_at": model.renews_at,
-        "renews_display": getattr(model, "renews_display", None) or format_renews(model.renews_at),
+        "renews_display": getattr(model, "renews_display", None)
+        or format_renews(model.renews_at),
         "subscription_remaining_display": (
-            None if model.subscription_remaining_usd is None else _fmt_usd(model.subscription_remaining_usd)
+            None
+            if model.subscription_remaining_usd is None
+            else _fmt_usd(model.subscription_remaining_usd)
         ),
         "topup_remaining_display": (
-            None if model.topup_remaining_usd is None else _fmt_usd(model.topup_remaining_usd)
+            None
+            if model.topup_remaining_usd is None
+            else _fmt_usd(model.topup_remaining_usd)
         ),
         "total_spendable_display": (
-            None if model.total_spendable_usd is None else _fmt_usd(model.total_spendable_usd)
+            None
+            if model.total_spendable_usd is None
+            else _fmt_usd(model.total_spendable_usd)
         ),
         "has_topup": model.has_topup,
         "plan_bar": _serialize_usage_bar(model.plan_bar),
@@ -9344,7 +9561,9 @@ def _serialize_subscription_state(state) -> dict:
             "pending_downgrade_display": format_renews(c.pending_downgrade_at),
             "cancel_at_period_end": c.cancel_at_period_end,
             "cancellation_effective_at": c.cancellation_effective_at,
-            "cancellation_effective_display": format_renews(c.cancellation_effective_at),
+            "cancellation_effective_display": format_renews(
+                c.cancellation_effective_at
+            ),
         }
     # Selectable catalog for the in-terminal tier picker; price is pre-formatted
     # ($X / $X.YY) so the TUI renders it directly.
@@ -9487,7 +9706,9 @@ def _notification_event_belongs_elsewhere(sid: str, session: dict, evt: dict) ->
             return False
         try:
             with _sessions_lock:
-                owner_live = evt_ui_sid in _sessions and not _sessions[evt_ui_sid].get("_finalized")
+                owner_live = evt_ui_sid in _sessions and not _sessions[evt_ui_sid].get(
+                    "_finalized"
+                )
         except Exception:
             owner_live = False
         if owner_live:
@@ -9597,8 +9818,7 @@ def _session_owns_notification_event(sid: str, session: dict, evt: dict) -> bool
 def _notification_event_requires_owner(evt: dict) -> bool:
     """Whether ``evt`` must be positively claimed before TUI delivery."""
     return evt.get("type") == "async_delegation" or bool(
-        str(evt.get("origin_ui_session_id") or "")
-        or str(evt.get("session_key") or "")
+        str(evt.get("origin_ui_session_id") or "") or str(evt.get("session_key") or "")
     )
 
 
@@ -9643,8 +9863,14 @@ def _notification_event_dedup_key(evt: dict) -> tuple:
 # the cursor advances past them and they can't wedge a later completed/blocked
 # event behind an unclaimed row.
 _KANBAN_NOTIFY_KINDS = (
-    "completed", "blocked", "gave_up", "crashed", "timed_out",
-    "status", "archived", "unblocked",
+    "completed",
+    "blocked",
+    "gave_up",
+    "crashed",
+    "timed_out",
+    "status",
+    "archived",
+    "unblocked",
 )
 _KANBAN_SILENT_KINDS = frozenset({"archived", "unblocked"})
 _KANBAN_POLL_SECONDS = 5.0
@@ -9727,14 +9953,15 @@ def _maybe_fire_tui_loop_tick(sid: str, session: dict) -> None:
                 pass
             decision = mgr.complete_tick("")
             if decision.get("message"):
-                _emit("status.update", sid, {"kind": "loop", "text": decision["message"]})
+                _emit(
+                    "status.update", sid, {"kind": "loop", "text": decision["message"]}
+                )
             return
         _emit("message.start", sid)
         _run_prompt_submit(rid, sid, session, wakeup)
     except Exception as exc:
         print(
-            f"[tui_gateway] loop wakeup dispatch failed: "
-            f"{type(exc).__name__}: {exc}",
+            f"[tui_gateway] loop wakeup dispatch failed: {type(exc).__name__}: {exc}",
             file=sys.stderr,
         )
         with session["history_lock"]:
@@ -9772,7 +9999,9 @@ def _format_kanban_event_text(sub: dict, task, ev, board_slug: str) -> Optional[
             handoff = f"\n{lines[0][:160]}" if lines else ""
         return f"✔ {board_tag}{tag}Kanban {task_id} done — {title}{handoff}"
     if kind == "blocked":
-        reason = f": {str(payload.get('reason'))[:160]}" if payload.get("reason") else ""
+        reason = (
+            f": {str(payload.get('reason'))[:160]}" if payload.get("reason") else ""
+        )
         return f"⏸ {board_tag}{tag}Kanban {task_id} blocked{reason}"
     if kind == "gave_up":
         err = f"\n{str(payload.get('error'))[:200]}" if payload.get("error") else ""
@@ -9830,7 +10059,8 @@ def _collect_kanban_notifications(session: dict) -> list:
         try:
             resolved = (
                 str(Path(db_path).expanduser().resolve())
-                if db_path else str(_kb.kanban_db_path(slug).resolve())
+                if db_path
+                else str(_kb.kanban_db_path(slug).resolve())
             )
         except Exception:
             resolved = f"slug:{slug}"
@@ -9841,11 +10071,14 @@ def _collect_kanban_notifications(session: dict) -> list:
         # writable unless it has a subscription owned by this exact session;
         # subscriptions for gateways or other sessions are not actionable here.
         try:
-            if _kb.count_notify_subs(
-                board=slug,
-                platform="tui",
-                chat_id=session_key,
-            ) == 0:
+            if (
+                _kb.count_notify_subs(
+                    board=slug,
+                    platform="tui",
+                    chat_id=session_key,
+                )
+                == 0
+            ):
                 continue
         except Exception:
             # Preserve delivery if the read-only probe cannot inspect a
@@ -10015,7 +10248,9 @@ def _notification_poller_loop(
             continue
 
         _evt_sid = evt.get("session_id", "")
-        if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):
+        if evt.get("type") == "completion" and process_registry.is_completion_consumed(
+            _evt_sid
+        ):
             continue
 
         text = format_process_notification(evt)
@@ -10047,8 +10282,11 @@ def _notification_poller_loop(
 
         rid = f"__notif__{int(time.time() * 1000)}"
         from tools.async_delegation import (
-            claim_event_delivery, complete_event_delivery, release_event_delivery,
+            claim_event_delivery,
+            complete_event_delivery,
+            release_event_delivery,
         )
+
         _claim = claim_event_delivery(evt, "tui-poller")
         if _claim is None:
             continue
@@ -10106,7 +10344,9 @@ def _notification_poller_loop(
                 )
             continue
         _evt_sid = evt.get("session_id", "")
-        if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):
+        if evt.get("type") == "completion" and process_registry.is_completion_consumed(
+            _evt_sid
+        ):
             continue
         text = format_process_notification(evt)
         if not text:
@@ -10125,8 +10365,11 @@ def _notification_poller_loop(
 
         rid = f"__notif__{int(time.time() * 1000)}"
         from tools.async_delegation import (
-            claim_event_delivery, complete_event_delivery, release_event_delivery,
+            claim_event_delivery,
+            complete_event_delivery,
+            release_event_delivery,
         )
+
         _claim = claim_event_delivery(evt, "tui-poller")
         if _claim is None:
             continue
@@ -10162,17 +10405,17 @@ def _notification_poller_loop(
 def _async_delegation_display_metadata(evt: dict) -> dict:
     """Build display-only metadata before the completion event is formatted."""
     raw_results = evt.get("results")
-    results: list[dict] = [
-        result for result in raw_results if isinstance(result, dict)
-    ] if isinstance(raw_results, list) else []
+    results: list[dict] = (
+        [result for result in raw_results if isinstance(result, dict)]
+        if isinstance(raw_results, list)
+        else []
+    )
     task_count = len(results) or 1
     completed_count = sum(
-        1 for result in results
-        if result.get("status") in {"completed", "success"}
+        1 for result in results if result.get("status") in {"completed", "success"}
     )
     failed_count = sum(
-        1 for result in results
-        if result.get("status") in {"failed", "error"}
+        1 for result in results if result.get("status") in {"failed", "error"}
     )
     metadata = {
         "delegation_id": str(evt.get("delegation_id") or ""),
@@ -10487,7 +10730,8 @@ def _run_prompt_submit(
             return False
         if (
             queued_prompt_generation is not None
-            and int(session.get("_queued_prompt_generation", 0)) != queued_prompt_generation
+            and int(session.get("_queued_prompt_generation", 0))
+            != queued_prompt_generation
         ):
             session["running"] = False
             return False
@@ -10562,7 +10806,9 @@ def _run_prompt_submit(
         marker_attempt = int(session.pop("_auto_continue_attempt", 0) or 0)
         marker_text = session.pop("_auto_continue_prompt", None) or text
         if isinstance(marker_text, str) and marker_text.strip():
-            record_turn_start(marker_home, marker_key, marker_text, attempts=marker_attempt)
+            record_turn_start(
+                marker_home, marker_key, marker_text, attempts=marker_attempt
+            )
         try:
             from tools.approval import (
                 reset_current_session_key,
@@ -10577,7 +10823,9 @@ def _run_prompt_submit(
             _profile_home_str = session.get("profile_home")
             if _profile_home_str:
                 home_token = set_hermes_home_override(_profile_home_str)
-                secret_token = set_secret_scope(build_profile_secret_scope(Path(_profile_home_str)))
+                secret_token = set_secret_scope(
+                    build_profile_secret_scope(Path(_profile_home_str))
+                )
             # The sudo password callback is thread-local (tools.terminal_tool
             # _callback_tls), so wiring it on the build thread doesn't reach this
             # turn thread — terminal sudo prompts would fall through to /dev/tty
@@ -10668,9 +10916,7 @@ def _run_prompt_submit(
                         _provider,
                         _model,
                         _cfg,
-                        requested_provider=getattr(
-                            agent, "requested_provider", ""
-                        ),
+                        requested_provider=getattr(agent, "requested_provider", ""),
                     )
                     if getattr(agent, "api_mode", "") == "codex_app_server":
                         _mode = "text"
@@ -10752,7 +10998,10 @@ def _run_prompt_submit(
             # Barged mid-speech? Tell the model (API-message note, same
             # enrichment channel as attached images) so it can react
             # ("rude!") instead of being oblivious to its own interruption.
-            from tools.tts_streaming import SPEECH_INTERRUPTED_NOTE, take_speech_interrupted
+            from tools.tts_streaming import (
+                SPEECH_INTERRUPTED_NOTE,
+                take_speech_interrupted,
+            )
 
             if take_speech_interrupted():
                 run_message = _prepend_note(run_message, SPEECH_INTERRUPTED_NOTE)
@@ -10780,11 +11029,18 @@ def _run_prompt_submit(
             # losing it when message.complete replaces the streaming buffer.
             # Gated on display.interim_assistant_messages (default true).
             if _load_interim_assistant_messages():
-                def _interim_assistant_cb(text: str, *, already_streamed: bool = False) -> None:
-                    _emit("message.interim", sid, {
-                        "text": text,
-                        "already_streamed": already_streamed,
-                    })
+
+                def _interim_assistant_cb(
+                    text: str, *, already_streamed: bool = False
+                ) -> None:
+                    _emit(
+                        "message.interim",
+                        sid,
+                        {
+                            "text": text,
+                            "already_streamed": already_streamed,
+                        },
+                    )
 
                 agent.interim_assistant_callback = _interim_assistant_cb
             else:
@@ -10794,7 +11050,9 @@ def _run_prompt_submit(
                 "conversation_history": list(history),
                 "stream_callback": _stream,
                 "persist_user_message": (
-                    _build_persist_user_message(prompt, images, run_message) if images else prompt
+                    _build_persist_user_message(prompt, images, run_message)
+                    if images
+                    else prompt
                 ),
             }
             # Type a synthesized turn at turn START so the crash persist writes
@@ -10837,7 +11095,9 @@ def _run_prompt_submit(
                 _usage_thread.join()
             if display_kind and isinstance(text, str):
                 db = getattr(agent, "_session_db", None)
-                current_session_id = getattr(agent, "session_id", None) or session.get("session_key")
+                current_session_id = getattr(agent, "session_id", None) or session.get(
+                    "session_key"
+                )
                 if db is not None:
                     try:
                         db.set_latest_matching_message_display_kind(
@@ -10848,10 +11108,17 @@ def _run_prompt_submit(
                             display_metadata=display_metadata,
                         )
                     except Exception:
-                        logger.debug("failed to stamp synthetic display kind", exc_info=True)
-                if isinstance(result, dict) and isinstance(result.get("messages"), list):
+                        logger.debug(
+                            "failed to stamp synthetic display kind", exc_info=True
+                        )
+                if isinstance(result, dict) and isinstance(
+                    result.get("messages"), list
+                ):
                     for message in reversed(result["messages"]):
-                        if message.get("role") == "user" and message.get("content") == text:
+                        if (
+                            message.get("role") == "user"
+                            and message.get("content") == text
+                        ):
                             message["display_kind"] = display_kind
                             if display_metadata:
                                 message["display_metadata"] = display_metadata
@@ -10932,10 +11199,7 @@ def _run_prompt_submit(
                             ]
                             pivot_only = (
                                 current_no_markers == history_no_markers
-                                and any(
-                                    _is_pivot_marker(e)
-                                    for e in current_history
-                                )
+                                and any(_is_pivot_marker(e) for e in current_history)
                             )
                             if pivot_only:
                                 # The agent's new messages start after the
@@ -10943,7 +11207,7 @@ def _run_prompt_submit(
                                 # auto-compression making result["messages"]
                                 # shorter than history (#77274 review).
                                 if len(result["messages"]) > len(history):
-                                    new_messages = result["messages"][len(history):]
+                                    new_messages = result["messages"][len(history) :]
                                 else:
                                     # Compression rebound the messages list —
                                     # use the full result as the base.
@@ -10974,14 +11238,19 @@ def _run_prompt_submit(
                 # worker-backed commands (/title etc.) target the live session.
                 # Fix for #20001.
                 _sync_session_key_after_compress(
-                    sid, session, clear_pending_title=False, restart_slash_worker=True,
+                    sid,
+                    session,
+                    clear_pending_title=False,
+                    restart_slash_worker=True,
                 )
 
                 raw = result.get("final_response", "")
                 status = (
                     "interrupted"
                     if result.get("interrupted")
-                    else "error" if result.get("error") else "complete"
+                    else "error"
+                    if result.get("error")
+                    else "complete"
                 )
                 # When the backend produced no visible response AND reported a
                 # real error (e.g. invalid model slug → provider 4xx), surface
@@ -10991,8 +11260,10 @@ def _run_prompt_submit(
                 # Leaves the None-with-no-error path untouched: an empty
                 # successful turn still renders as empty, and the existing
                 # "(empty)" sentinel handling stays in its own lane.
-                if (not raw) and result.get("error") and (
-                    result.get("failed") or result.get("partial")
+                if (
+                    (not raw)
+                    and result.get("error")
+                    and (result.get("failed") or result.get("partial"))
                 ):
                     raw = f"Error: {result.get('error')}"
                 # "Operation interrupted: waiting for model response (…)" is
@@ -11000,8 +11271,10 @@ def _run_prompt_submit(
                 # and the ACP adapter already suppress this sentinel; without
                 # this the desktop paints it as the agent's reply whenever a
                 # stop/steer lands mid-request (#7921).
-                if status == "interrupted" and isinstance(raw, str) and raw.strip().startswith(
-                    INTERRUPT_WAITING_FOR_MODEL_PREFIX
+                if (
+                    status == "interrupted"
+                    and isinstance(raw, str)
+                    and raw.strip().startswith(INTERRUPT_WAITING_FOR_MODEL_PREFIX)
                 ):
                     raw = ""
                 lr = result.get("last_reasoning")
@@ -11021,7 +11294,9 @@ def _run_prompt_submit(
             # Forward the structured billing-wall descriptor (provider,
             # billing_url, is_nous, message) so the TUI/desktop render a
             # billing-specific recovery surface instead of re-parsing text.
-            _billing_block = result.get("billing_block") if isinstance(result, dict) else None
+            _billing_block = (
+                result.get("billing_block") if isinstance(result, dict) else None
+            )
             if _billing_block:
                 payload["billing"] = _billing_block
                 payload["failure_reason"] = result.get("failure_reason")
@@ -11103,7 +11378,10 @@ def _run_prompt_submit(
                         )
                         if goal_mgr.is_active():
                             try:
-                                from hermes_cli.goals import gather_background_processes as _gather_bg
+                                from hermes_cli.goals import (
+                                    gather_background_processes as _gather_bg,
+                                )
+
                                 _bg_procs = _gather_bg()
                             except Exception:
                                 _bg_procs = None
@@ -11175,7 +11453,8 @@ def _run_prompt_submit(
                     session["pending_title"] = None
                     logger.info(
                         "Dropping pending title for session %s: %s",
-                        _session_key, exc,
+                        _session_key,
+                        exc,
                     )
                 except Exception:
                     # Transient DB failure — keep pending_title for retry.
@@ -11338,7 +11617,9 @@ def _run_prompt_submit(
         # so it isn't silently dropped — same rule as cli.py and gateway/run.py.
         # A real queued prompt still wins: the merge in _enqueue_prompt keeps
         # both texts.
-        _leftover_steer = result.get("pending_steer") if isinstance(result, dict) else None
+        _leftover_steer = (
+            result.get("pending_steer") if isinstance(result, dict) else None
+        )
         if isinstance(_leftover_steer, str) and _leftover_steer.strip():
             with session["history_lock"]:
                 _enqueue_prompt(session, _leftover_steer, session.get("transport"))
@@ -11399,8 +11680,11 @@ def _run_prompt_submit(
                         break
                     session["running"] = True
                 from tools.async_delegation import (
-                    claim_event_delivery, complete_event_delivery, release_event_delivery,
+                    claim_event_delivery,
+                    complete_event_delivery,
+                    release_event_delivery,
                 )
+
                 _claim = claim_event_delivery(_evt, "tui-post-turn")
                 if _claim is None:
                     continue
@@ -11427,9 +11711,8 @@ def _run_prompt_submit(
     run_thread = threading.Thread(target=run, daemon=True)
     with _sessions_lock:
         registered = _sessions.get(sid)
-        can_start = (
-            not session.get("_closing")
-            and (registered is None or registered is session)
+        can_start = not session.get("_closing") and (
+            registered is None or registered is session
         )
         if can_start:
             session["_run_thread"] = run_thread
@@ -11528,7 +11811,9 @@ def _session_images_dir(session: dict) -> Path:
     return base / "images"
 
 
-def _queue_attached_image(session: dict, img_bytes: bytes, ext: str, *, prefix: str) -> Path:
+def _queue_attached_image(
+    session: dict, img_bytes: bytes, ext: str, *, prefix: str
+) -> Path:
     """Write image bytes into the gateway's images dir and queue them.
 
     Mirrors what ``image.attach`` does for a local path: appends to
@@ -11654,7 +11939,9 @@ def _decode_attachment_data_url(data_url: str) -> bytes:
     import re as _re
 
     cleaned = (data_url or "").strip()
-    m = _re.match(r"^data:[^;,]*(?:;[^;,=]+=[^;,]+)*;base64,(.*)$", cleaned, _re.DOTALL | _re.I)
+    m = _re.match(
+        r"^data:[^;,]*(?:;[^;,=]+=[^;,]+)*;base64,(.*)$", cleaned, _re.DOTALL | _re.I
+    )
     if m:
         cleaned = m.group(1)
     cleaned = _re.sub(r"\s+", "", cleaned)
@@ -11830,7 +12117,10 @@ def _(rid, params: dict) -> dict:
         agent = session.get("agent") if session else None
         if agent is not None:
             current_fast = getattr(agent, "service_tier", None) == "priority"
-        elif session is not None and session.get("create_service_tier_override") is not None:
+        elif (
+            session is not None
+            and session.get("create_service_tier_override") is not None
+        ):
             # Pre-build session with a pinned tier (desktop draft pick or an
             # earlier session-scoped toggle) — report/toggle from the pin, not
             # the global default.
@@ -11892,9 +12182,7 @@ def _(rid, params: dict) -> dict:
             # build ("switch one session, switches everywhere"). Pin the
             # create override so lazily-built sessions and rebuilds (/new,
             # deferred resume) keep the choice; "" pins normal explicitly.
-            session["create_service_tier_override"] = (
-                "priority" if nv == "fast" else ""
-            )
+            session["create_service_tier_override"] = "priority" if nv == "fast" else ""
         else:
             _write_config_key("agent.service_tier", nv)
         if agent is not None:
@@ -12311,7 +12599,9 @@ def _(rid, params: dict) -> dict:
         # auto-detection (xterm.js hosts misreport OSC 11); 'auto' trusts it.
         raw = str(value or "").strip().lower()
         if raw not in {"auto", "light", "dark"}:
-            return _err(rid, 4002, f"unknown theme value: {value} (use auto|light|dark)")
+            return _err(
+                rid, 4002, f"unknown theme value: {value} (use auto|light|dark)"
+            )
         _write_config_key("display.tui_theme", raw)
         return _ok(rid, {"key": key, "value": raw})
 
@@ -12379,7 +12669,12 @@ def _(rid, params: dict) -> dict:
         os.environ["TERMINAL_CWD"] = cwd
         return _ok(
             rid,
-            {"key": "terminal.cwd", "value": cwd, "cwd": cwd, "branch": _git_branch_for_cwd(cwd)},
+            {
+                "key": "terminal.cwd",
+                "value": cwd,
+                "cwd": cwd,
+                "branch": _git_branch_for_cwd(cwd),
+            },
         )
 
     if key in {"prompt", "personality", "skin"}:
@@ -12446,7 +12741,9 @@ def _projects_payload(conn) -> dict:
     from hermes_cli import projects_db as pdb
 
     return {
-        "projects": [p.to_dict() for p in pdb.list_projects(conn, include_archived=True)],
+        "projects": [
+            p.to_dict() for p in pdb.list_projects(conn, include_archived=True)
+        ],
         "active_id": pdb.get_active_id(conn),
     }
 
@@ -12561,7 +12858,9 @@ def _(rid, params, pdb, conn) -> dict:
 @_projects_method("projects.archive")
 def _(rid, params, pdb, conn) -> dict:
     proj = _require_project(pdb, conn, params)
-    (pdb.restore_project if params.get("restore") else pdb.archive_project)(conn, proj.id)
+    (pdb.restore_project if params.get("restore") else pdb.archive_project)(
+        conn, proj.id
+    )
     return _ok(rid, _projects_payload(conn))
 
 
@@ -12574,15 +12873,26 @@ def _(rid, params, pdb, conn) -> dict:
 
 @_projects_method("projects.set_active")
 def _(rid, params, pdb, conn) -> dict:
-    pdb.set_active(conn, _require_project(pdb, conn, params).id if params.get("id") else None)
+    pdb.set_active(
+        conn, _require_project(pdb, conn, params).id if params.get("id") else None
+    )
     return _ok(rid, {"active_id": pdb.get_active_id(conn)})
 
 
 @_projects_method("projects.for_cwd")
 def _(rid, params, pdb, conn) -> dict:
-    cwd = _completion_cwd({"cwd": str(params.get("cwd") or "").strip()} if params.get("cwd") else {})
+    cwd = _completion_cwd(
+        {"cwd": str(params.get("cwd") or "").strip()} if params.get("cwd") else {}
+    )
     proj = pdb.project_for_path(conn, cwd)
-    return _ok(rid, {"project": proj.to_dict() if proj else None, "cwd": cwd, "branch": _git_branch_for_cwd(cwd)})
+    return _ok(
+        rid,
+        {
+            "project": proj.to_dict() if proj else None,
+            "cwd": cwd,
+            "branch": _git_branch_for_cwd(cwd),
+        },
+    )
 
 
 def _non_workspace_dirs() -> set[str]:
@@ -12650,16 +12960,24 @@ def _repo_discovery_policy(raw: dict | None = None) -> dict:
     if not isinstance(source, dict):
         source = {}
 
-    enabled = source.get("enabled", source.get("repo_scan_enabled", defaults["repo_scan_enabled"]))
-    roots = source.get("roots", source.get("repo_scan_roots", defaults["repo_scan_roots"]))
+    enabled = source.get(
+        "enabled", source.get("repo_scan_enabled", defaults["repo_scan_enabled"])
+    )
+    roots = source.get(
+        "roots", source.get("repo_scan_roots", defaults["repo_scan_roots"])
+    )
     excludes = source.get(
         "exclude_paths",
         source.get("repo_scan_exclude_paths", defaults["repo_scan_exclude_paths"]),
     )
 
     return {
-        "enabled": enabled if isinstance(enabled, bool) else defaults["repo_scan_enabled"],
-        "roots": [value.strip() for value in roots if isinstance(value, str) and value.strip()]
+        "enabled": enabled
+        if isinstance(enabled, bool)
+        else defaults["repo_scan_enabled"],
+        "roots": [
+            value.strip() for value in roots if isinstance(value, str) and value.strip()
+        ]
         if isinstance(roots, list)
         else list(defaults["repo_scan_roots"]),
         "exclude_paths": [
@@ -12718,7 +13036,9 @@ def _discover_repos_payload(
     repos: dict[str, dict] = {}
 
     def _agg(root: str) -> dict:
-        return repos.setdefault(root, {"root": root, "label": "", "sessions": 0, "last_active": 0.0})
+        return repos.setdefault(
+            root, {"root": root, "label": "", "sessions": 0, "last_active": 0.0}
+        )
 
     # Session-derived roots (common repo root, folding worktrees; cached) +
     # backfill the column so persisted git_repo_root matches the tree grouping.
@@ -12785,7 +13105,9 @@ def _discover_repos_payload(
 
     out = sorted(repos.values(), key=lambda r: r["last_active"], reverse=True)
     for r in out:
-        r["label"] = r["label"] or os.path.basename(r["root"].rstrip("/\\")) or r["root"]
+        r["label"] = (
+            r["label"] or os.path.basename(r["root"].rstrip("/\\")) or r["root"]
+        )
     return out
 
 
@@ -12913,7 +13235,12 @@ def _dir_exists_cached(path: str) -> bool:
 
 
 def _build_project_tree(
-    db, *, preview_limit: int, hydrate: bool, session_limit: int, include_discovered: bool
+    db,
+    *,
+    preview_limit: int,
+    hydrate: bool,
+    session_limit: int,
+    include_discovered: bool,
 ) -> tuple[dict, str | None]:
     """Gather inputs and run the one authoritative builder. Returns (tree, active_id)."""
     from tui_gateway import project_tree
@@ -12999,7 +13326,11 @@ def _compute_mcp_rev() -> str:
         # /reload-mcp. `mcp` (settings) and `tools` (enable/disable) round
         # out the MCP-relevant surface.
         rev_src = json.dumps(
-            {"mcp": cfg.get("mcp"), "mcp_servers": cfg.get("mcp_servers"), "tools": cfg.get("tools")},
+            {
+                "mcp": cfg.get("mcp"),
+                "mcp_servers": cfg.get("mcp_servers"),
+                "tools": cfg.get("tools"),
+            },
             sort_keys=True,
             default=str,
         )
@@ -13026,15 +13357,13 @@ def _finish_reload(rid, params: dict, *, coalesced: bool) -> dict:
     return _ok(rid, payload)
 
 
-_TUI_HIDDEN: frozenset[str] = frozenset(
-    {
-        "sethome",
-        "set-home",
-        "commands",
-        "approve",
-        "deny",
-    }
-)
+_TUI_HIDDEN: frozenset[str] = frozenset({
+    "sethome",
+    "set-home",
+    "commands",
+    "approve",
+    "deny",
+})
 
 _TUI_EXTRA: list[tuple[str, str, str]] = [
     ("/density", "Toggle compact display mode", "TUI"),
@@ -13052,24 +13381,22 @@ _TUI_EXTRA: list[tuple[str, str, str]] = [
 # so slash.exec routes them to command.dispatch internally (which handles
 # them and returns a structured payload) instead of erroring out and
 # relying on a client-side fallback. See #48848.
-_PENDING_INPUT_COMMANDS: frozenset[str] = frozenset(
-    {
-        "retry",
-        "queue",
-        "q",
-        "steer",
-        "plan",
-        "goal",
-        "loop",
-        "proactive",
-        "moa",
-        "undo",
-        "learn",
-        "init",
-        "compress",
-        "compact",
-    }
-)
+_PENDING_INPUT_COMMANDS: frozenset[str] = frozenset({
+    "retry",
+    "queue",
+    "q",
+    "steer",
+    "plan",
+    "goal",
+    "loop",
+    "proactive",
+    "moa",
+    "undo",
+    "learn",
+    "init",
+    "compress",
+    "compact",
+})
 
 _WORKER_BLOCKED_COMMANDS: frozenset[str] = frozenset({"snapshot", "snap"})
 
@@ -13211,25 +13538,23 @@ _paste_counter = 0
 
 _FUZZY_CACHE_TTL_S = 5.0
 _FUZZY_CACHE_MAX_FILES = 20000
-_FUZZY_FALLBACK_EXCLUDES = frozenset(
-    {
-        ".git",
-        ".hg",
-        ".svn",
-        ".next",
-        ".cache",
-        ".venv",
-        "venv",
-        "node_modules",
-        "__pycache__",
-        "dist",
-        "build",
-        "target",
-        ".mypy_cache",
-        ".pytest_cache",
-        ".ruff_cache",
-    }
-)
+_FUZZY_FALLBACK_EXCLUDES = frozenset({
+    ".git",
+    ".hg",
+    ".svn",
+    ".next",
+    ".cache",
+    ".venv",
+    "venv",
+    "node_modules",
+    "__pycache__",
+    "dist",
+    "build",
+    "target",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+})
 _fuzzy_cache_lock = threading.Lock()
 _fuzzy_cache: dict[str, tuple[float, list[str]]] = {}
 
@@ -13466,7 +13791,9 @@ def _details_completions(text: str) -> list[dict] | None:
                 (
                     "section override"
                     if candidate in sections
-                    else "cycle global mode" if candidate == "cycle" else "global mode"
+                    else "cycle global mode"
+                    if candidate == "cycle"
+                    else "global mode"
                 ),
             )
             for candidate in candidates
@@ -13515,8 +13842,7 @@ def _model_picker_context(agent):
                 canonical_custom_identity(
                     base_url=base_url or None,
                     config_provider=ctx.current_provider,
-                    model=(getattr(agent, "model", "") if agent else "")
-                    or None,
+                    model=(getattr(agent, "model", "") if agent else "") or None,
                 )
                 or provider
             )
@@ -13537,19 +13863,17 @@ def _model_picker_context(agent):
 # ── Methods: slash.exec ──────────────────────────────────────────────
 
 
-_LIVE_SESSION_DIRECT_COMMANDS = frozenset(
-    {
-        "clear",
-        "compress",
-        "effort",
-        "history",
-        "models",
-        "prompt",
-        "rename",
-        "status",
-        "usage",
-    }
-)
+_LIVE_SESSION_DIRECT_COMMANDS = frozenset({
+    "clear",
+    "compress",
+    "effort",
+    "history",
+    "models",
+    "prompt",
+    "rename",
+    "status",
+    "usage",
+})
 
 _ISOLATED_SESSION_READ_COMMANDS = frozenset({"context", "tools", "help"})
 
@@ -13574,14 +13898,12 @@ def _format_live_usage_output(session: dict) -> str:
     reasoning = int(usage.get("reasoning") or 0)
     if reasoning:
         lines.append(f"Reasoning tokens:             {reasoning:,}")
-    lines.extend(
-        [
-            f"Prompt tokens:                {int(usage.get('prompt') or 0):,}",
-            f"Completion tokens:            {int(usage.get('completion') or 0):,}",
-            f"Total tokens:                 {int(usage.get('total') or 0):,}",
-            f"API calls:                    {int(usage.get('calls') or 0):,}",
-        ]
-    )
+    lines.extend([
+        f"Prompt tokens:                {int(usage.get('prompt') or 0):,}",
+        f"Completion tokens:            {int(usage.get('completion') or 0):,}",
+        f"Total tokens:                 {int(usage.get('total') or 0):,}",
+        f"API calls:                    {int(usage.get('calls') or 0):,}",
+    ])
     if usage.get("context_max"):
         lines.append(
             "Current context:              "
@@ -13589,12 +13911,10 @@ def _format_live_usage_output(session: dict) -> str:
             f"{int(usage.get('context_max') or 0):,} "
             f"({int(usage.get('context_percent') or 0)}%)"
         )
-    lines.extend(
-        [
-            f"Messages:                     {message_count:,}",
-            f"Compressions:                 {int(usage.get('compressions') or 0):,}",
-        ]
-    )
+    lines.extend([
+        f"Messages:                     {message_count:,}",
+        f"Compressions:                 {int(usage.get('compressions') or 0):,}",
+    ])
     return "\n".join(lines)
 
 
@@ -13615,7 +13935,13 @@ def _format_live_history_output(session: dict) -> str:
     lines = ["Conversation History", "────────────────────────────────────────"]
     for idx, message in enumerate(messages, start=1):
         role = str(message.get("role") or "unknown")
-        label = "You" if role == "user" else "Hermes" if role == "assistant" else role.title()
+        label = (
+            "You"
+            if role == "user"
+            else "Hermes"
+            if role == "assistant"
+            else role.title()
+        )
         text = str(message.get("text") or message.get("context") or "").strip()
         if len(text) > 400:
             text = f"{text[:400]}..."
@@ -13657,7 +13983,9 @@ def _format_live_context_output(session: dict) -> str:
     usage = _session_usage_snapshot(session)
     mirror = _metadata_mirror(session)
     lines = [
-        f"Conversation: {len(messages)} messages" if messages else "Conversation is empty (no messages yet)."
+        f"Conversation: {len(messages)} messages"
+        if messages
+        else "Conversation is empty (no messages yet)."
     ]
     roles: dict[str, int] = {}
     for msg in messages:
@@ -13729,7 +14057,9 @@ def _format_live_model_output(session: dict) -> str:
     return "Current model: (unknown)"
 
 
-def _live_slash_command_output(sid: str, session: Optional[dict], name: str, arg: str) -> Optional[str]:
+def _live_slash_command_output(
+    sid: str, session: Optional[dict], name: str, arg: str
+) -> Optional[str]:
     name = (name or "").lstrip("/").lower()
     arg = arg or ""
     if name == "model" and not arg.strip():
@@ -13786,7 +14116,6 @@ def _live_slash_command_output(sid: str, session: Optional[dict], name: str, arg
     if name == "effort":
         return "Use /reasoning <effort> to change reasoning effort."
     return None
-
 
 
 def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
@@ -13884,12 +14213,15 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
                 from agent.manual_compression_feedback import (
                     describe_compression_lock_skip,
                 )
+
                 return describe_compression_lock_skip(e.holder)
             _sync_session_key_after_compress(sid, session)
 
             with session["history_lock"]:
                 _after_messages = list(session.get("history", []))
-            _sys_prompt_after = getattr(agent, "_cached_system_prompt", "") or _sys_prompt
+            _sys_prompt_after = (
+                getattr(agent, "_cached_system_prompt", "") or _sys_prompt
+            )
             _tools_after = getattr(agent, "tools", None) or _tools
             _after_tokens = (
                 estimate_request_tokens_rough(
@@ -14055,6 +14387,7 @@ def _tts_stream_stop(user_barge: bool = True) -> None:
         return
     if user_barge and not state["done"].is_set():
         import traceback as _tb
+
         logger.debug(
             "TTS CUT: _tts_stream_stop(user_barge=True) — new turn or "
             "interrupt cutting in-flight TTS\n%s",
@@ -14176,9 +14509,7 @@ def _full_duplex_listener() -> None:
             tripped.set()
             mark_speech_interrupted()
             if phase == "playback":
-                logger.debug(
-                    "TTS CUT: full-duplex listener tripped during playback"
-                )
+                logger.debug("TTS CUT: full-duplex listener tripped during playback")
                 _cut_all_tts()
             else:
                 logger.debug(
@@ -14191,9 +14522,7 @@ def _full_duplex_listener() -> None:
                 # process-global, and the same seam session.interrupt uses.
                 try:
                     with _sessions_lock:
-                        running = [
-                            s for s in _sessions.values() if s.get("running")
-                        ]
+                        running = [s for s in _sessions.values() if s.get("running")]
                     for s in running:
                         agent = s.get("agent")
                         if agent is not None and hasattr(agent, "interrupt"):
@@ -14216,13 +14545,18 @@ def _full_duplex_listener() -> None:
             return
         try:
             result = transcribe_recording(wav_path)
-            text = (result.get("transcript") or "").strip() if result.get("success") else ""
+            text = (
+                (result.get("transcript") or "").strip()
+                if result.get("success")
+                else ""
+            )
             if text:
                 # Stop-check must never break transcript delivery — if the
                 # helper is unavailable (stubbed voice_mode in tests, partial
                 # installs), treat as not-a-stop-phrase.
                 try:
                     from tools.voice_mode import is_voice_stop_phrase
+
                     _is_stop = is_voice_stop_phrase(text)
                 except Exception:
                     _is_stop = False
@@ -14353,8 +14687,9 @@ _wake_resume_retry_lock = threading.Lock()
 _wake_resume_retry_active = False
 
 
-def _wake_resume_if_owner(owner: "Transport", *, retry_seconds: float = 15.0,
-                          retry_interval: float = 1.0) -> bool:
+def _wake_resume_if_owner(
+    owner: "Transport", *, retry_seconds: float = 15.0, retry_interval: float = 1.0
+) -> bool:
     """Resume the wake detector for ``owner``; self-heal a busy microphone.
 
     Reopening the mic right after a voice turn can fail while the capture
@@ -14467,12 +14802,15 @@ def _(rid, params: dict) -> dict:
     reqs = check_wake_word_requirements(probe_cfg)
     if not reqs["available"]:
         logger.warning("wake.start(%s): not available — %s", surface, reqs.get("hint"))
-        return _ok(rid, {
-            "started": False,
-            "reason": "unavailable",
-            "hint": reqs.get("hint") or "",
-            "capture": capture_mode,
-        })
+        return _ok(
+            rid,
+            {
+                "started": False,
+                "reason": "unavailable",
+                "hint": reqs.get("hint") or "",
+                "capture": capture_mode,
+            },
+        )
     enabled_persisted = False
     if persist and not cfg.get("enabled"):
         enabled_persisted = _persist_wake_enabled(True)
@@ -14485,8 +14823,13 @@ def _(rid, params: dict) -> dict:
         # disabled_for_surface — respects an explicit wake_word.surface choice,
         # which persist does NOT override).
         reason = "disabled" if not cfg.get("enabled") else "disabled_for_surface"
-        logger.info("wake.start(%s): %s (enabled=%s, surface=%s)",
-                    surface, reason, cfg.get("enabled"), cfg.get("surface"))
+        logger.info(
+            "wake.start(%s): %s (enabled=%s, surface=%s)",
+            surface,
+            reason,
+            cfg.get("enabled"),
+            cfg.get("surface"),
+        )
         return _ok(rid, {"started": False, "reason": reason})
 
     existing_owner, existing_surface = _wake_owner_snapshot()
@@ -14497,11 +14840,14 @@ def _(rid, params: dict) -> dict:
         existing_owner = None
         existing_surface = ""
     if existing_owner is not None and existing_owner is not transport:
-        return _ok(rid, {
-            "started": False,
-            "reason": "owned",
-            "owner_surface": existing_surface,
-        })
+        return _ok(
+            rid,
+            {
+                "started": False,
+                "reason": "owned",
+                "owner_surface": existing_surface,
+            },
+        )
 
     sid = str(params.get("session_id") or "")
     phrase = wake_phrase(cfg)
@@ -14522,15 +14868,23 @@ def _(rid, params: dict) -> dict:
         # back to the owner's configured phrase / no profile for
         # single-phrase engines.
         matched_phrase, matched_profile = get_last_match() or (phrase, "")
-        logger.info("wake.detected: emitting to sid=%r (transport=%s, profile=%r)",
-                    sid, type(transport).__name__, matched_profile)
+        logger.info(
+            "wake.detected: emitting to sid=%r (transport=%s, profile=%r)",
+            sid,
+            type(transport).__name__,
+            matched_profile,
+        )
         token = bind_transport(transport)
         try:
-            _emit("wake.detected", sid, {
-                "phrase": matched_phrase or phrase,
-                "profile": matched_profile or None,
-                "start_new_session": new_session,
-            })
+            _emit(
+                "wake.detected",
+                sid,
+                {
+                    "phrase": matched_phrase or phrase,
+                    "profile": matched_profile or None,
+                    "start_new_session": new_session,
+                },
+            )
         finally:
             reset_transport(token)
 
@@ -14542,11 +14896,14 @@ def _(rid, params: dict) -> dict:
             external_audio=external_audio,
         )
     except WakeWordInUse:
-        return _ok(rid, {
-            "started": False,
-            "reason": "owned",
-            "owner_surface": existing_surface or None,
-        })
+        return _ok(
+            rid,
+            {
+                "started": False,
+                "reason": "owned",
+                "owner_surface": existing_surface or None,
+            },
+        )
     except Exception as e:
         logger.warning("wake.start(%s): failed to start listener: %s", surface, e)
         return _err(rid, 5026, str(e))
@@ -14557,18 +14914,25 @@ def _(rid, params: dict) -> dict:
     frame = detector_frame_info()
     logger.info(
         "wake.start(%s): listening for %r (%s) capture=%s frame=%s",
-        surface, reqs["phrase"], reqs["provider"], capture_mode, frame.get("frame_length"),
+        surface,
+        reqs["phrase"],
+        reqs["provider"],
+        capture_mode,
+        frame.get("frame_length"),
     )
-    return _ok(rid, {
-        "started": True,
-        "phrase": reqs["phrase"],
-        "provider": reqs["provider"],
-        "owner_surface": surface,
-        "enabled_persisted": enabled_persisted,
-        "capture": capture_mode,
-        "sample_rate": frame.get("sample_rate", 16000),
-        "frame_length": frame.get("frame_length", 1280),
-    })
+    return _ok(
+        rid,
+        {
+            "started": True,
+            "phrase": reqs["phrase"],
+            "provider": reqs["provider"],
+            "owner_surface": surface,
+            "enabled_persisted": enabled_persisted,
+            "capture": capture_mode,
+            "sample_rate": frame.get("sample_rate", 16000),
+            "frame_length": frame.get("frame_length", 1280),
+        },
+    )
 
 
 @method("wake.stop")
@@ -14591,11 +14955,14 @@ def _(rid, params: dict) -> dict:
             currently_enabled = True
         if currently_enabled:
             disabled_persisted = _persist_wake_enabled(False)
-    return _ok(rid, {
-        "stopped": stopped,
-        "reason": None if stopped else "not_owner",
-        "disabled_persisted": disabled_persisted,
-    })
+    return _ok(
+        rid,
+        {
+            "stopped": stopped,
+            "reason": None if stopped else "not_owner",
+            "disabled_persisted": disabled_persisted,
+        },
+    )
 
 
 @method("wake.pause")
@@ -14610,10 +14977,13 @@ def _(rid, params: dict) -> dict:
     except Exception as e:
         logger.debug("wake.pause failed: %s", e)
         paused = False
-    return _ok(rid, {
-        "paused": paused,
-        "reason": None if paused else "not_owner",
-    })
+    return _ok(
+        rid,
+        {
+            "paused": paused,
+            "reason": None if paused else "not_owner",
+        },
+    )
 
 
 @method("wake.resume")
@@ -14622,10 +14992,13 @@ def _(rid, params: dict) -> dict:
     transport = current_transport() or _stdio_transport
     resumed = _wake_resume_if_owner(transport)
     logger.info("wake.resume: detector resumed=%s", resumed)
-    return _ok(rid, {
-        "resumed": resumed,
-        "reason": None if resumed else "not_owner",
-    })
+    return _ok(
+        rid,
+        {
+            "resumed": resumed,
+            "reason": None if resumed else "not_owner",
+        },
+    )
 
 
 @method("wake.status")
@@ -14642,6 +15015,7 @@ def _(rid, params: dict) -> dict:
             resolve_capture_mode,
             silent_audio_hint,
         )
+
         cfg = load_wake_word_config()
         # Prefer client when the GUI asks (desktop remote re-arm / status).
         prefer_client = bool(params.get("client_capture")) or str(
@@ -14658,7 +15032,9 @@ def _(rid, params: dict) -> dict:
         input_device = get_input_device_status(cfg)
         hint = reqs.get("hint", "")
         if input_device.get("error") and not hint:
-            hint = f"Wake-word input device could not be resolved: {input_device['error']}"
+            hint = (
+                f"Wake-word input device could not be resolved: {input_device['error']}"
+            )
         if silent and not hint:
             hint = silent_audio_hint(input_device)
         # Effective capture: prefer the *armed* detector over config/auto.
@@ -14671,29 +15047,34 @@ def _(rid, params: dict) -> dict:
         elif owned_by_caller and listening:
             capture = "local"
         else:
-            capture = probe_cfg.get("capture") or reqs.get("capture") or str(
-                cfg.get("capture") or "auto"
+            capture = (
+                probe_cfg.get("capture")
+                or reqs.get("capture")
+                or str(cfg.get("capture") or "auto")
             )
-        return _ok(rid, {
-            "listening": listening,
-            "owned_by_caller": owned_by_caller,
-            "owner_surface": owner_surface if owner is not None else None,
-            "phrase": reqs["phrase"],
-            "provider": reqs["provider"],
-            "configured_surface": str(cfg.get("surface") or "auto"),
-            "input_device": input_device,
-            "available": reqs["available"],
-            "hint": hint,
-            # Config truth: clients use this to re-arm after a voice turn
-            # ("permanent on") without guessing from runtime listener state.
-            "enabled": bool(cfg.get("enabled")),
-            # Armed but deaf despite an open stream; see platform-specific hint.
-            "audio_silent": silent,
-            "capture": capture,
-            "local_input_available": bool(reqs.get("local_input_available")),
-            "sample_rate": frame.get("sample_rate", 16000),
-            "frame_length": frame.get("frame_length", 1280),
-        })
+        return _ok(
+            rid,
+            {
+                "listening": listening,
+                "owned_by_caller": owned_by_caller,
+                "owner_surface": owner_surface if owner is not None else None,
+                "phrase": reqs["phrase"],
+                "provider": reqs["provider"],
+                "configured_surface": str(cfg.get("surface") or "auto"),
+                "input_device": input_device,
+                "available": reqs["available"],
+                "hint": hint,
+                # Config truth: clients use this to re-arm after a voice turn
+                # ("permanent on") without guessing from runtime listener state.
+                "enabled": bool(cfg.get("enabled")),
+                # Armed but deaf despite an open stream; see platform-specific hint.
+                "audio_silent": silent,
+                "capture": capture,
+                "local_input_available": bool(reqs.get("local_input_available")),
+                "sample_rate": frame.get("sample_rate", 16000),
+                "frame_length": frame.get("frame_length", 1280),
+            },
+        )
     except Exception as e:
         return _err(rid, 5026, str(e))
 
@@ -14717,6 +15098,7 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 4001, "wake.feed requires base64 pcm")
     try:
         import base64
+
         pcm = base64.b64decode(raw_b64, validate=False)
     except Exception as e:
         return _err(rid, 4001, f"invalid base64 pcm: {e}")
@@ -14730,6 +15112,7 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 4001, "wake.feed only accepts 16 kHz PCM")
     try:
         from tools.wake_word import feed_audio
+
         ok = feed_audio(owner=transport, pcm_int16=pcm)
     except Exception as e:
         logger.debug("wake.feed failed: %s", e)
@@ -15119,7 +15502,10 @@ def _failure_messages(url: str, port: int, system: str) -> list[str]:
 
     command = manual_chrome_debug_command(port, system)
     hint = (
-        ["Start a Chromium-family browser with remote debugging, then retry /browser connect:", command]
+        [
+            "Start a Chromium-family browser with remote debugging, then retry /browser connect:",
+            command,
+        ]
         if command
         else [
             "No supported Chromium-family browser executable was found in this environment.",
@@ -15246,7 +15632,9 @@ def _browser_connect(rid, params: dict) -> dict:
                         rid, {"connected": False, "url": url, "messages": messages}
                     )
             else:
-                announce(f"Chromium-family browser is already listening at {discovered}")
+                announce(
+                    f"Chromium-family browser is already listening at {discovered}"
+                )
 
             # Adopt whatever loopback/port actually answered (may be
             # [::1] and/or an alternate port when 9222 was squatted).
@@ -15291,8 +15679,6 @@ def _browser_disconnect(rid) -> dict:
     os.environ.pop("BROWSER_CDP_URL", None)
     reap()
     return _ok(rid, {"connected": False})
-
-
 
 
 # Per-profile MCP lifecycle helpers (mcp.servers.* handlers). Defined on THIS


### PR DESCRIPTION
## Summary

Fixes #88988: `/compress` on a large session (~293K tokens) reported `request timed out after 120s: session.compress` — while the compression actually completed at ~134s and committed the summary. The compute-host control wait was a fixed 120s.

## Fix

`_compute_host_compress_wait_s()`: the wait is now the per-attempt compression timeout × retry rounds + a 30s completion grace — shipped defaults resolve to 390s (120 × 3 + 30). Reads `auxiliary.compression.timeout` and `compression.max_attempts` (the same keys the compression paths use), fails open to the default on broken config. Users who tuned the compression timeout for slow local models automatically get a matching host wait.

## Validation

- New tests: defaults → 390s; config-driven 60s×2 → 150s; broken config → fail-open default.
- `tests/tui_gateway/test_session_hidden_rpc.py`: 4 passed. ruff check + format clean.
- Atomic commits: fix → tests → style.
