### PR TITLE
fix(desktop): closing main promotes the neighboring session instead of spawning a fresh draft (#88924)

### DIFF
--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -11,6 +11,7 @@ import {
   blankDraftTile,
   focusedSessionNeedsRoute,
   markSelectionRestore,
+  nextSessionTileForWorkspace,
   orderTilesByTree,
   releaseSessionTranscript,
   resetTileRuntimeBindings,
@@ -108,6 +109,47 @@ describe('selectionHomesToWorkspace', () => {
 
   it('skips homing when the selected id is already an open tile', () => {
     expect(selectionHomesToWorkspace('a', tiles)).toBe(false)
+  })
+})
+
+describe('nextSessionTileForWorkspace (⌘W promotion source)', () => {
+  afterEach(() => {
+    $layoutTree.set(null)
+    $sessionTiles.set([])
+  })
+
+  it('prefers a tile stacked WITH the workspace tab (nearest-out)', () => {
+    $layoutTree.set(group(['workspace', tilePane('a'), tilePane('b')], { active: 'workspace', id: 'main' }))
+    $sessionTiles.set([tile('a'), tile('b')])
+
+    expect(nextSessionTileForWorkspace()).toBe('a')
+  })
+
+  it('side-by-side layout: a tile in ANOTHER zone still promotes instead of dropping main to a fresh draft (#88924)', () => {
+    // main zone holds only the workspace; the session tile lives in its own
+    // zone beside it — db's three-pane report shape.
+    $layoutTree.set(
+      split('row', [
+        group(['workspace'], { active: 'workspace', id: 'main' }),
+        group([tilePane('side')], { active: tilePane('side'), id: 'right' })
+      ])
+    )
+    $sessionTiles.set([tile('side')])
+
+    expect(nextSessionTileForWorkspace()).toBe('side')
+  })
+
+  it('returns null when no live tile exists anywhere in the tree', () => {
+    $layoutTree.set(
+      split('row', [
+        group(['workspace'], { active: 'workspace', id: 'main' }),
+        group([tilePane('stale')], { active: tilePane('stale'), id: 'right' })
+      ])
+    )
+    // Pane persisted in the tree but its tile is gone — must not promote a ghost.
+    $sessionTiles.set([])
+
+    expect(nextSessionTileForWorkspace()).toBe(null)
   })
 })
 

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -818,6 +818,17 @@ export function nextSessionTileForWorkspace(): null | string {
     }
   }
 
+  // Nothing stacked WITH main — but a session tile in another zone can still
+  // shift in. Without this, closing main in a side-by-side layout skipped
+  // promotion entirely and dropped to a fresh "New session" draft, which read
+  // as "closing a pane gave me a new session" (#88924). Promoting the tile
+  // also collapses its zone, so Close is how a multi-pane layout shrinks.
+  for (const tile of tiles) {
+    if (tree && findGroupOfPane(tree, `${TILE_PANE_PREFIX}${tile.storedSessionId}`)) {
+      return tile.storedSessionId
+    }
+  }
+
   return null
 }
 


### PR DESCRIPTION
## Summary

Closing the main tab in a side-by-side layout now promotes the neighboring session into main instead of spawning a fresh "New session" draft — and repeated Close is the path from N panes back to 1, no Focus-mode detour. From db's bot-mode feedback thread (Discord, Aug 17), reported as core pane behavior: "tried closing the right-most section and it gave me a new session... not sure how to get the three panes down to just 1."

Root cause: `nextSessionTileForWorkspace()` only walked tabs stacked WITH the workspace tab. With session tiles in their own zones (his three-pane shape), the walk found nothing, `closeWorkspaceTab()` skipped the promotion half, and `requestFreshSession()` dropped main to a new draft.

## Changes

- `store/session-states.ts`: after the same-group walk, a session tile in ANY zone of the tree promotes (its zone collapses via the tile close). Ghost panes whose tile is gone still never promote.
- `store/session-states.test.ts`: +3 tests — stacked-tab preference unchanged, side-by-side promotion (the #88924 shape), ghost-pane null.

## Validation

| | Before | After |
|---|---|---|
| Close main, side-by-side layout | fresh draft in main; side panes stay | side session promotes into main; its zone collapses |
| Close main, tiles stacked with it | next tab shifts in (unchanged) | unchanged |
| `vitest session-states + close-tab` | 30 pass | 33 pass |

Fixes #88924.

## Infographic

![Pane close, fixed](https://v3b.fal.media/files/b/0aa6ceed/CEcC1f3LXLjXJAUaTQmDF_8wHsS4Ln.png)
