### PR TITLE
feat(sessions): opt-in Markdown auto-export on session finalize

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -41,6 +41,19 @@ DEFAULT_CONFIG = {
         # most-recent one. Set false to restore the old latest-session
         # behavior everywhere.
         "terminal_continue": True,
+        # Write every finished session to Markdown automatically, so a transcript
+        # reaches a notes vault (Obsidian, Logseq, ...) without anyone
+        # remembering to run `hermes sessions export`. Off by default:
+        # persisting full conversations to disk is a privacy-relevant side
+        # effect that has to be opted into, never inherited.
+        "auto_export": False,
+        # Destination for auto_export. Empty means $HERMES_HOME/session-exports
+        # — the same directory `hermes sessions export` writes to by default,
+        # so manual and automatic exports share one manifest instead of
+        # drifting into two half-complete sets.
+        "auto_export_dir": "",
+        # "md" or "qmd" — the formats `hermes sessions export` accepts.
+        "auto_export_format": "md",
     },
     "agent": {
         "max_turns": 500,

--- a/hermes_cli/lifecycle.py
+++ b/hermes_cli/lifecycle.py
@@ -58,6 +58,17 @@ def finalize_session(**kwargs: Any) -> List[Any]:
         except Exception:
             logger.warning("Core Relay session finalization failed", exc_info=True)
 
+        # Opt-in Markdown export of the finished conversation. Runs after the
+        # Relay close so a slow disk write can never delay releasing the
+        # conversation, and swallows its own errors: a failed export must not
+        # turn into a failed shutdown.
+        try:
+            from hermes_cli.session_auto_export import export_finalized_session
+
+            export_finalized_session(session_id)
+        except Exception:
+            logger.warning("Session auto-export failed", exc_info=True)
+
     from hermes_cli import plugins
 
     return plugins.invoke_hook("on_session_finalize", **kwargs)

--- a/hermes_cli/session_auto_export.py
+++ b/hermes_cli/session_auto_export.py
@@ -1,0 +1,135 @@
+"""Export a finished session to Markdown when ``session.auto_export`` is on.
+
+``hermes sessions export`` already renders Markdown/QMD, redacts secrets and
+appends a manifest entry — but it has to be run by hand. People who keep a
+notes vault (Obsidian, Logseq, ...) end up with only the conversations they
+remembered to export, which is precisely the wrong subset: the transcript you
+want later is the one you did not think was worth keeping at the time.
+
+This module is the unattended counterpart. Same renderer, same manifest, same
+redaction — driven from the session-finalize hook instead of argv.
+
+It stays off by default. Writing full transcripts to disk on every exit is a
+privacy-relevant side effect, and a user who has not asked for it should never
+discover their conversations already on disk.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_FORMAT = "md"
+SUPPORTED_FORMATS = ("md", "qmd")
+
+
+def resolve_settings(config: Optional[dict[str, Any]] = None) -> tuple[bool, Path, str]:
+    """Return ``(enabled, output_dir, fmt)`` for auto-export.
+
+    Reads ``session.auto_export*``. An unset ``auto_export_dir`` resolves to
+    ``$HERMES_HOME/session-exports`` — the same default ``hermes sessions
+    export`` uses, so manual and automatic exports land in one directory
+    sharing one manifest rather than drifting into two half-complete sets.
+    """
+    if config is None:
+        from hermes_cli.config import load_config_readonly
+
+        config = load_config_readonly()
+
+    session_cfg = config.get("session") if isinstance(config, dict) else None
+    if not isinstance(session_cfg, dict):
+        session_cfg = {}
+
+    enabled = bool(session_cfg.get("auto_export", False))
+
+    raw_dir = str(session_cfg.get("auto_export_dir") or "").strip()
+    if raw_dir:
+        output_dir = Path(raw_dir).expanduser()
+    else:
+        from hermes_constants import get_hermes_home
+
+        output_dir = get_hermes_home() / "session-exports"
+
+    fmt = str(session_cfg.get("auto_export_format") or DEFAULT_FORMAT).strip().lower()
+    if fmt not in SUPPORTED_FORMATS:
+        # Don't fail the export over a typo in the config — a transcript in the
+        # wrong-but-valid format beats no transcript at shutdown, where nobody
+        # is watching for an error message.
+        logger.warning(
+            "Unknown session.auto_export_format %r; falling back to %r",
+            fmt,
+            DEFAULT_FORMAT,
+        )
+        fmt = DEFAULT_FORMAT
+
+    return enabled, output_dir, fmt
+
+
+def export_finalized_session(
+    session_id: str,
+    *,
+    config: Optional[dict[str, Any]] = None,
+    db: Any = None,
+) -> Optional[Path]:
+    """Export one finalized session, or return ``None`` if nothing was written.
+
+    ``None`` covers every "not applicable" case — auto-export disabled, unknown
+    session, empty transcript — so the caller cannot tell a skip from a failure
+    and does not need to: failures raise, and the finalize hook swallows them.
+
+    ``db`` is injectable for tests; when omitted a short-lived ``SessionDB`` is
+    opened and closed here.
+    """
+    session_id = str(session_id or "").strip()
+    if not session_id:
+        return None
+
+    enabled, output_dir, fmt = resolve_settings(config)
+    if not enabled:
+        return None
+
+    owns_db = db is None
+    if owns_db:
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+
+    try:
+        data = db.export_session(session_id)
+        if not data:
+            return None
+
+        from hermes_cli.session_export_md import (
+            append_manifest_entry,
+            redact_session_data,
+            write_session_markdown,
+        )
+
+        # A `hermes` invocation that never produced a turn is not a
+        # conversation. Exporting it would bury the real transcripts under
+        # empty files nobody asked for. (``export_session`` returns a flat
+        # dict — only ``export_session_lineage`` builds ``segments`` — so a
+        # plain message count is the whole story here.)
+        if not (data.get("messages") or []):
+            return None
+
+        # Always redact. The manual command makes this a flag because the
+        # operator is right there to judge; an unattended write into a synced
+        # notes vault has no such supervision, so it takes the safe branch.
+        data = redact_session_data(data)
+
+        # force=True: a resumed session finalizes again with a longer
+        # transcript, and the newer file is a superset of the older one.
+        # Refusing to overwrite would freeze the export at the first exit.
+        path = write_session_markdown(data, output_dir, fmt=fmt, force=True)
+        append_manifest_entry(output_dir, data, path, fmt=fmt)
+        return path
+    finally:
+        if owns_db:
+            try:
+                db.close()
+            except Exception:
+                logger.debug("Auto-export session DB close failed", exc_info=True)

--- a/tests/hermes_cli/test_session_auto_export.py
+++ b/tests/hermes_cli/test_session_auto_export.py
@@ -1,0 +1,266 @@
+"""Auto-export writes a finished session to Markdown only when asked to."""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from agent import relay_runtime
+from hermes_cli import lifecycle, observability, plugins, session_auto_export
+
+
+def _session(session_id="sess-1", *, title="Nightly run", messages=None):
+    if messages is None:
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+    return {
+        "id": session_id,
+        "title": title,
+        "messages": messages,
+    }
+
+
+def _db(data):
+    """Minimal SessionDB stand-in: export_session + close."""
+    closed = []
+    return (
+        SimpleNamespace(
+            export_session=lambda sid: data if data and data.get("id") == sid else None,
+            close=lambda: closed.append(True),
+        ),
+        closed,
+    )
+
+
+def _config(**session_overrides):
+    return {"session": {**session_overrides}}
+
+
+def _exports(directory):
+    """Export artifacts in a directory (the shared conftest drops its own
+    scratch dirs into tmp_path, so a bare iterdir() is never empty)."""
+    return sorted(
+        p.name
+        for p in directory.iterdir()
+        if p.suffix in {".md", ".qmd"} or p.name == "manifest.jsonl"
+    )
+
+
+# ── resolve_settings ────────────────────────────────────────────────────────
+
+
+def test_disabled_by_default():
+    enabled, _, _ = session_auto_export.resolve_settings({"session": {}})
+    assert enabled is False
+
+
+def test_missing_session_section_is_not_an_error():
+    enabled, _, fmt = session_auto_export.resolve_settings({})
+    assert enabled is False
+    assert fmt == "md"
+
+
+def test_explicit_dir_is_expanded(monkeypatch):
+    monkeypatch.setenv("HOME", "/home/tester")
+    _, output_dir, _ = session_auto_export.resolve_settings(
+        _config(auto_export=True, auto_export_dir="~/vault/hermes")
+    )
+    assert output_dir == Path("/home/tester/vault/hermes")
+
+
+def test_empty_dir_falls_back_to_hermes_home(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "hermes_constants.get_hermes_home", lambda: tmp_path, raising=False
+    )
+    _, output_dir, _ = session_auto_export.resolve_settings(
+        _config(auto_export=True, auto_export_dir="")
+    )
+    # Shares the directory `hermes sessions export` uses, so both paths
+    # contribute to one manifest.
+    assert output_dir == tmp_path / "session-exports"
+
+
+def test_unknown_format_falls_back_to_md():
+    _, _, fmt = session_auto_export.resolve_settings(
+        _config(auto_export=True, auto_export_format="pdf")
+    )
+    assert fmt == "md"
+
+
+def test_qmd_format_is_honored():
+    _, _, fmt = session_auto_export.resolve_settings(
+        _config(auto_export=True, auto_export_format="QMD")
+    )
+    assert fmt == "qmd"
+
+
+# ── export_finalized_session ────────────────────────────────────────────────
+
+
+def test_writes_nothing_when_disabled(tmp_path):
+    db, _ = _db(_session())
+    path = session_auto_export.export_finalized_session(
+        "sess-1", config=_config(auto_export=False, auto_export_dir=str(tmp_path)), db=db
+    )
+    assert path is None
+    assert _exports(tmp_path) == []
+
+
+def test_writes_markdown_and_manifest_when_enabled(tmp_path):
+    db, _ = _db(_session())
+    path = session_auto_export.export_finalized_session(
+        "sess-1", config=_config(auto_export=True, auto_export_dir=str(tmp_path)), db=db
+    )
+
+    assert path is not None and path.exists()
+    assert path.suffix == ".md"
+    text = path.read_text(encoding="utf-8")
+    assert "hello" in text and "hi" in text
+
+    manifest = tmp_path / "manifest.jsonl"
+    entry = json.loads(manifest.read_text(encoding="utf-8").strip())
+    assert entry["session_id"] == "sess-1"
+    assert entry["format"] == "md"
+    assert entry["path"] == str(path)
+
+
+def test_empty_transcript_is_skipped(tmp_path):
+    db, _ = _db(_session(messages=[]))
+    path = session_auto_export.export_finalized_session(
+        "sess-1", config=_config(auto_export=True, auto_export_dir=str(tmp_path)), db=db
+    )
+    # A `hermes` run that produced no turn must not litter the vault.
+    assert path is None
+    assert _exports(tmp_path) == []
+
+
+def test_unknown_session_is_skipped(tmp_path):
+    db, _ = _db(_session())
+    path = session_auto_export.export_finalized_session(
+        "nope", config=_config(auto_export=True, auto_export_dir=str(tmp_path)), db=db
+    )
+    assert path is None
+
+
+def test_blank_session_id_is_skipped(tmp_path):
+    db, _ = _db(_session())
+    path = session_auto_export.export_finalized_session(
+        "  ", config=_config(auto_export=True, auto_export_dir=str(tmp_path)), db=db
+    )
+    assert path is None
+
+
+def test_second_finalize_overwrites_with_longer_transcript(tmp_path):
+    """A resumed session finalizes again; the newer transcript is a superset."""
+    cfg = _config(auto_export=True, auto_export_dir=str(tmp_path))
+
+    db, _ = _db(_session())
+    first = session_auto_export.export_finalized_session("sess-1", config=cfg, db=db)
+
+    longer = _session(
+        messages=[
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+            {"role": "user", "content": "and one more thing"},
+        ]
+    )
+    db2, _ = _db(longer)
+    second = session_auto_export.export_finalized_session("sess-1", config=cfg, db=db2)
+
+    assert second == first
+    assert "and one more thing" in second.read_text(encoding="utf-8")
+
+
+def test_secrets_are_redacted(tmp_path):
+    secret = "sk-ant-api03-" + "A" * 40
+    db, _ = _db(
+        _session(messages=[{"role": "user", "content": f"key is {secret}"}])
+    )
+    path = session_auto_export.export_finalized_session(
+        "sess-1", config=_config(auto_export=True, auto_export_dir=str(tmp_path)), db=db
+    )
+    # Unattended writes into a synced vault get redaction unconditionally —
+    # there is no operator present to pass --redact.
+    assert secret not in path.read_text(encoding="utf-8")
+
+
+def test_owned_db_is_closed(tmp_path, monkeypatch):
+    data = _session()
+    db, closed = _db(data)
+    monkeypatch.setattr(
+        "hermes_state.SessionDB", lambda *a, **k: db, raising=False
+    )
+    session_auto_export.export_finalized_session(
+        "sess-1", config=_config(auto_export=True, auto_export_dir=str(tmp_path))
+    )
+    assert closed == [True]
+
+
+def test_injected_db_is_not_closed(tmp_path):
+    db, closed = _db(_session())
+    session_auto_export.export_finalized_session(
+        "sess-1", config=_config(auto_export=True, auto_export_dir=str(tmp_path)), db=db
+    )
+    assert closed == []
+
+
+# ── finalize_session wiring ─────────────────────────────────────────────────
+
+
+def _stub_finalize_deps(monkeypatch, calls):
+    monkeypatch.setattr(
+        observability, "observe_lifecycle", lambda name, **kw: calls.append("builtin")
+    )
+    monkeypatch.setattr(plugins, "invoke_hook", lambda name, **kw: calls.append("plugin") or [])
+    monkeypatch.setattr(
+        relay_runtime,
+        "SESSION_COORDINATOR",
+        SimpleNamespace(finalize_conversation=lambda **kw: calls.append("core")),
+    )
+    monkeypatch.setattr(relay_runtime, "current_profile_key", lambda: "profile-1")
+
+
+def test_finalize_session_triggers_export(monkeypatch):
+    calls = []
+    _stub_finalize_deps(monkeypatch, calls)
+    monkeypatch.setattr(
+        session_auto_export,
+        "export_finalized_session",
+        lambda sid: calls.append(("export", sid)),
+    )
+
+    lifecycle.finalize_session(session_id="sess-1", platform="cli")
+
+    assert ("export", "sess-1") in calls
+    # After the Relay close, before plugin dispatch.
+    assert calls.index("core") < calls.index(("export", "sess-1")) < calls.index("plugin")
+
+
+def test_export_failure_does_not_break_finalize(monkeypatch):
+    calls = []
+    _stub_finalize_deps(monkeypatch, calls)
+
+    def _boom(session_id):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(session_auto_export, "export_finalized_session", _boom)
+
+    # Shutdown must survive a broken export.
+    lifecycle.finalize_session(session_id="sess-1", platform="cli")
+
+    assert "plugin" in calls
+
+
+def test_finalize_without_session_id_skips_export(monkeypatch):
+    calls = []
+    _stub_finalize_deps(monkeypatch, calls)
+    monkeypatch.setattr(
+        session_auto_export,
+        "export_finalized_session",
+        lambda sid: calls.append("export"),
+    )
+
+    lifecycle.finalize_session(session_id="", platform="cli")
+
+    assert "export" not in calls


### PR DESCRIPTION
## Problem

`hermes sessions export` renders Markdown/QMD, redacts secrets and appends a manifest entry — but only when someone runs it. People who keep a notes vault (Obsidian, Logseq, ...) end up with only the conversations they remembered to export, which is the wrong subset: the transcript you want months later is usually the one that didn't seem worth keeping at the time.

## Change

Add `session.auto_export` (default **off**) which runs that same pipeline from the session-finalize hook.

No second exporter — this calls the existing `write_session_markdown()`, `append_manifest_entry()` and `redact_session_data()` from `hermes_cli/session_export_md.py`. Net diff is +425 lines, 0 lines of existing code removed or rewritten.

```yaml
session:
  auto_export: true
  auto_export_dir: "~/ObsidianVault/Hermes"   # empty -> $HERMES_HOME/session-exports
  auto_export_format: "md"                    # or "qmd"
```

## Design notes

- **Off by default.** Writing full transcripts to disk on every exit is a privacy-relevant side effect; nobody should discover their conversations already on disk.
- **`auto_export_dir` defaults to `$HERMES_HOME/session-exports`** — the directory `hermes sessions export` already writes to, so manual and automatic exports share one manifest instead of drifting into two half-complete sets.
- **Redaction is unconditional.** The manual command makes it a flag because an operator is present to judge; an unattended write into a synced vault has no such supervision.
- **`force=True`.** A resumed session finalizes again with a longer transcript, and the newer file is a superset — refusing to overwrite would freeze the export at the first exit.
- **Empty sessions are skipped**, so a `hermes` run that produced no turn doesn't bury real transcripts under empty files.
- **The hook swallows its own errors.** A failed export must never become a failed shutdown. It also runs after the Relay close, so a slow disk write can't delay releasing the conversation.

## Testing

```
tests/hermes_cli/test_session_auto_export.py            18 passed
lifecycle / session_export_md / session_export_html /
config_validation / nemo_relay_plugin  (regression)     46 passed, 0 failed
ruff check                                              All checks passed
ty check                                                All checks passed
```

Tests cover: default-off, config resolution (explicit dir, `~` expansion, empty-dir fallback, unknown-format fallback, `qmd`), disabled/empty/unknown/blank-session skips, manifest contents, re-finalize overwrite, redaction, DB ownership (owned DB closed, injected DB left alone), and the `finalize_session` wiring including the error-swallowing path.

## Context

This replaces #14608, which I'm closing. That PR predated upstream's own projects subsystem (`hermes_cli/projects_db.py`) and `session_export_md.py`, and its status-bar and export halves are both superseded. Automatic export on session end is the one idea in it that upstream doesn't already have, so this PR carries only that, built on the existing exporter instead of a second one.