### PR TITLE
fix(tools): oversized tool results no longer truncated in sessions without a sandbox env — spill to HERMES_HOME/cache/spillover

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -29620,6 +29620,7 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
         cleanup_screenshot_cache,
         cleanup_video_cache,
     )
+    from tools.tool_result_storage import cleanup_spillover_cache
     from hermes_cli.debug import _sweep_expired_pastes
 
     IMAGE_CACHE_EVERY = 60   # ticks — once per hour at default 60s interval
@@ -29638,6 +29639,7 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
         ("Audio", cleanup_audio_cache),
         ("Video", cleanup_video_cache),
         ("Screenshot", cleanup_screenshot_cache),
+        ("Spillover", cleanup_spillover_cache),
     )
 
     logger.info("Gateway housekeeping started (interval=%ds)", interval)

--- a/tests/run_agent/test_tool_batch_segmentation.py
+++ b/tests/run_agent/test_tool_batch_segmentation.py
@@ -28,6 +28,20 @@ from agent.tool_dispatch_helpers import (
 )
 from agent.prompt_builder import STEER_MARKER_OPEN
 from tools.budget_config import BudgetConfig
+from tools.tool_result_storage import PERSISTED_OUTPUT_TAG
+
+
+def _assert_budget_replaced(content: str) -> None:
+    """The oversized result must have been replaced by budget enforcement.
+
+    With an active sandbox env (or host-side spillover) the replacement is a
+    ``<persisted-output>`` preview+path block; when persistence is impossible
+    it falls back to inline truncation. Either way the raw oversized payload
+    must be gone — that is the behavior these tests pin, not which
+    replacement shape was used.
+    """
+    assert PERSISTED_OUTPUT_TAG in content or "Truncated:" in content, content[:200]
+    assert "L" * 1_000 not in content
 
 
 def _tc(name="web_search", arguments="{}", call_id=None):
@@ -594,7 +608,7 @@ class TestSegmentedDispatchIntegration:
             agent._execute_tool_calls(msg, messages, "task-1")
 
         large_result_index = next(i for i, call in enumerate(calls) if call.id.endswith("large"))
-        assert "Truncated:" in messages[large_result_index]["content"]
+        _assert_budget_replaced(messages[large_result_index]["content"])
         steer_messages = [m for m in messages if STEER_MARKER_OPEN in m["content"]]
         assert steer_messages == [messages[-1]]
         assert "preserve this steer after budget enforcement" in steer_messages[0]["content"]
@@ -622,7 +636,7 @@ class TestSegmentedDispatchIntegration:
             agent._execute_tool_calls(msg, messages, "task-1")
 
         assert len(messages) == 1
-        assert "Truncated:" in messages[0]["content"]
+        _assert_budget_replaced(messages[0]["content"])
         assert messages[0]["content"].count(STEER_MARKER_OPEN) == 1
         assert "preserve malformed-call steer after budget enforcement" in messages[0]["content"]
 

--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -196,13 +196,17 @@ class TestMaybePersistToolResult:
         assert PERSISTED_OUTPUT_TAG in result
         assert "tc_456.txt" in result
         assert len(result) < len(content)
-        env.execute.assert_called_once()
 
     def test_persists_full_content_as_is(self):
         """Content is persisted verbatim — no JSON extraction."""
         import json
         env = MagicMock()
-        env.execute.return_value = {"output": "", "returncode": 0}
+        # Readability probe fails -> falls back to the in-sandbox write.
+        env.execute.side_effect = [
+            {"output": "", "returncode": 1},
+            {"output": "", "returncode": 0},
+        ]
+        env.get_temp_dir.return_value = ""
         raw = "line1\nline2\n" * 5_000
         content = json.dumps({"output": raw, "exit_code": 0, "error": None})
         result = maybe_persist_tool_result(
@@ -220,7 +224,11 @@ class TestMaybePersistToolResult:
 
     def test_tool_use_id_cannot_escape_storage_dir(self):
         env = MagicMock()
-        env.execute.return_value = {"output": "", "returncode": 0}
+        # Readability probe fails -> in-sandbox write is the reference path.
+        env.execute.side_effect = [
+            {"output": "", "returncode": 1},
+            {"output": "", "returncode": 0},
+        ]
         env.get_temp_dir.return_value = ""
         content = "x" * 60_000
         result = maybe_persist_tool_result(
@@ -370,11 +378,12 @@ class TestSpillover:
         assert (get_spillover_dir() / "tc_local_1.txt").exists()
         env.execute.assert_not_called()
 
-    def test_remote_env_still_uses_sandbox_write(self):
-        """Non-local envs keep the in-sandbox write path."""
+    def test_remote_env_probe_success_references_mounted_path(self):
+        """Remote env: host-side write is canonical; when the sandbox can read
+        the mounted/synced spillover path, the reference uses it and no
+        in-sandbox copy is written."""
         env = MagicMock()  # not a LocalEnvironment
-        env.execute.return_value = {"output": "", "returncode": 0}
-        env.get_temp_dir.return_value = "/tmp"
+        env.execute.return_value = {"output": "", "returncode": 0}  # probe OK
         content = "z" * 60_000
         result = maybe_persist_tool_result(
             content=content,
@@ -384,8 +393,34 @@ class TestSpillover:
             threshold=30_000,
         )
         assert PERSISTED_OUTPUT_TAG in result
-        env.execute.assert_called_once()
-        assert not (get_spillover_dir() / "tc_remote_1.txt").exists()
+        # Canonical host copy always exists now.
+        assert (get_spillover_dir() / "tc_remote_1.txt").exists()
+        # Only the readability probe ran — no cat-into-sandbox call.
+        assert env.execute.call_count == 1
+        assert "test -r" in env.execute.call_args[0][0]
+
+    def test_remote_env_probe_failure_falls_back_to_sandbox_write(self):
+        """Persistent containers without the spillover mount still get a
+        readable in-sandbox copy."""
+        env = MagicMock()
+        env.execute.side_effect = [
+            {"output": "", "returncode": 1},  # probe: not readable
+            {"output": "", "returncode": 0},  # cat > sandbox path
+        ]
+        env.get_temp_dir.return_value = "/tmp"
+        content = "z" * 60_000
+        result = maybe_persist_tool_result(
+            content=content,
+            tool_name="terminal",
+            tool_use_id="tc_remote_2",
+            env=env,
+            threshold=30_000,
+        )
+        assert PERSISTED_OUTPUT_TAG in result
+        assert "/tmp/hermes-results/tc_remote_2.txt" in result
+        assert env.execute.call_count == 2
+        # Host canonical copy exists regardless.
+        assert (get_spillover_dir() / "tc_remote_2.txt").exists()
 
     def test_spillover_write_failure_falls_back_to_inline(self, monkeypatch):
         import tools.tool_result_storage as trs

--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -18,8 +18,10 @@ from tools.tool_result_storage import (
     _resolve_storage_dir,
     _safe_result_filename,
     _write_to_sandbox,
+    cleanup_spillover_cache,
     enforce_turn_budget,
     generate_preview,
+    get_spillover_dir,
     maybe_persist_tool_result,
 )
 
@@ -320,3 +322,126 @@ class TestPerToolThresholds:
             assert val == 100_000
         except ImportError:
             pytest.skip("file_tools not importable in test env")
+
+
+# ── Host-side spillover ($HERMES_HOME/cache/spillover) ────────────────
+
+class TestSpillover:
+    @pytest.fixture(autouse=True)
+    def _isolated_home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        # Reset the once-per-process prune flag so each test is independent.
+        import tools.tool_result_storage as trs
+        monkeypatch.setattr(trs, "_spillover_pruned_once", False)
+        yield
+
+    def test_env_none_persists_to_spillover(self):
+        """No active sandbox env (MCP-only / cron session) must persist
+        host-side instead of inline-truncating — the guglielmo bundle bug."""
+        content = "x" * 60_000
+        result = maybe_persist_tool_result(
+            content=content,
+            tool_name="tool_call",
+            tool_use_id="tc_mcp_1",
+            env=None,
+            threshold=30_000,
+        )
+        assert PERSISTED_OUTPUT_TAG in result
+        assert "could not be saved" not in result
+        spill_file = get_spillover_dir() / "tc_mcp_1.txt"
+        assert spill_file.exists()
+        assert spill_file.read_text(encoding="utf-8") == content
+        assert str(spill_file) in result
+
+    def test_local_env_persists_to_spillover_not_sandbox(self):
+        """LocalEnvironment routes host-side: no env.execute() shell-out."""
+        from tools.environments.local import LocalEnvironment
+
+        env = MagicMock(spec=LocalEnvironment)
+        content = "y" * 60_000
+        result = maybe_persist_tool_result(
+            content=content,
+            tool_name="terminal",
+            tool_use_id="tc_local_1",
+            env=env,
+            threshold=30_000,
+        )
+        assert PERSISTED_OUTPUT_TAG in result
+        assert (get_spillover_dir() / "tc_local_1.txt").exists()
+        env.execute.assert_not_called()
+
+    def test_remote_env_still_uses_sandbox_write(self):
+        """Non-local envs keep the in-sandbox write path."""
+        env = MagicMock()  # not a LocalEnvironment
+        env.execute.return_value = {"output": "", "returncode": 0}
+        env.get_temp_dir.return_value = "/tmp"
+        content = "z" * 60_000
+        result = maybe_persist_tool_result(
+            content=content,
+            tool_name="terminal",
+            tool_use_id="tc_remote_1",
+            env=env,
+            threshold=30_000,
+        )
+        assert PERSISTED_OUTPUT_TAG in result
+        env.execute.assert_called_once()
+        assert not (get_spillover_dir() / "tc_remote_1.txt").exists()
+
+    def test_spillover_write_failure_falls_back_to_inline(self, monkeypatch):
+        import tools.tool_result_storage as trs
+        monkeypatch.setattr(trs, "_write_to_spillover", lambda *a, **k: None)
+        content = "w" * 60_000
+        result = maybe_persist_tool_result(
+            content=content,
+            tool_name="tool_call",
+            tool_use_id="tc_fail_1",
+            env=None,
+            threshold=30_000,
+        )
+        assert "could not be saved" in result
+        assert PERSISTED_OUTPUT_TAG not in result
+
+    def test_cleanup_spillover_cache_removes_old_keeps_new(self):
+        import os
+        import time as _time
+
+        spill_dir = get_spillover_dir()
+        spill_dir.mkdir(parents=True, exist_ok=True)
+        old = spill_dir / "old.txt"
+        new = spill_dir / "new.txt"
+        old.write_text("old")
+        new.write_text("new")
+        stale = _time.time() - (48 * 3600)
+        os.utime(old, (stale, stale))
+
+        removed = cleanup_spillover_cache(max_age_hours=24)
+
+        assert removed == 1
+        assert not old.exists()
+        assert new.exists()
+
+    def test_cleanup_missing_dir_returns_zero(self):
+        assert cleanup_spillover_cache() == 0
+
+    def test_first_spill_prunes_expired_files(self):
+        """The once-per-process prune fires on the first host-side spill."""
+        import os
+        import time as _time
+
+        spill_dir = get_spillover_dir()
+        spill_dir.mkdir(parents=True, exist_ok=True)
+        old = spill_dir / "ancient.txt"
+        old.write_text("ancient")
+        stale = _time.time() - (48 * 3600)
+        os.utime(old, (stale, stale))
+
+        maybe_persist_tool_result(
+            content="v" * 60_000,
+            tool_name="tool_call",
+            tool_use_id="tc_prune_1",
+            env=None,
+            threshold=30_000,
+        )
+
+        assert not old.exists()
+        assert (spill_dir / "tc_prune_1.txt").exists()

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -416,6 +416,11 @@ _CACHE_DIRS: list[tuple[str, str]] = [
     ("cache/screenshots", "browser_screenshots"),
     ("cache/web", "web_cache"),
     ("cache/delegation", "delegation_cache"),
+    # Oversized tool results (tools/tool_result_storage.py). Host-side is the
+    # single canonical location; mounting/syncing it lets remote backends
+    # read spilled results at the translated path instead of needing a
+    # separate in-sandbox copy.
+    ("cache/spillover", "cache/spillover"),
     # Desktop/clipboard/PDF uploads land in the flat top-level ``images/`` dir
     # (tui_gateway attach RPCs), not under ``cache/``. Mount it so vision can
     # reach uploads inside sandbox containers (#69575). No legacy alias exists,

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -8,12 +8,28 @@ Defense against context-window overflow operates at three levels:
 
 2. **Per-result persistence** (maybe_persist_tool_result): After a tool
    returns, if its output exceeds the tool's registered threshold
-   (registry.get_max_result_size), the full output is written INTO THE
-   SANDBOX temp dir (for example /tmp/hermes-results/{tool_use_id}.txt on
-   standard Linux, or $TMPDIR/hermes-results/{tool_use_id}.txt on Termux)
-   via env.execute(). The in-context content is replaced with a preview +
-   file path reference. The model can read_file to access the full output
-   on any backend.
+   (registry.get_max_result_size), the full output is persisted and the
+   in-context content is replaced with a preview + file path reference.
+
+   Where it lands depends on the backend:
+
+   - **Local backend (or no active env):** written host-side to
+     ``$HERMES_HOME/cache/spillover/{tool_use_id}.txt`` — alongside the
+     other Hermes-owned caches (images, audio, documents, ...) instead of
+     littering the OS temp dir. This path needs no sandbox environment,
+     so it also works for sessions that never ran a terminal command
+     (MCP-only, cron, gateway) — previously those hit the inline-truncate
+     fallback because ``get_active_env()`` returned None until the first
+     terminal call created an environment.
+   - **Remote backends (docker/ssh/modal/daytona):** written INTO THE
+     SANDBOX temp dir (for example /tmp/hermes-results/{id}.txt) via
+     env.execute(), because HERMES_HOME does not exist inside the
+     container and read_file resolves in-sandbox there.
+
+   The spillover dir is pruned two ways: the gateway housekeeping loop
+   sweeps it hourly with the other media caches, and a once-per-process
+   best-effort prune runs on the first spill so CLI-only installs (which
+   never run gateway housekeeping) self-clean too.
 
 3. **Per-turn aggregate budget** (enforce_turn_budget): After all tool
    results in a single assistant turn are collected, if the total exceeds
@@ -27,6 +43,8 @@ import logging
 import os
 import re
 import shlex
+import threading
+import time
 import uuid
 
 from tools.budget_config import (
@@ -39,10 +57,102 @@ logger = logging.getLogger(__name__)
 PERSISTED_OUTPUT_TAG = "<persisted-output>"
 PERSISTED_OUTPUT_CLOSING_TAG = "</persisted-output>"
 STORAGE_DIR = "/tmp/hermes-results"
+SPILLOVER_SUBDIR = "cache/spillover"
+SPILLOVER_MAX_AGE_HOURS = 24
 HEREDOC_MARKER = "HERMES_PERSIST_EOF"
 _BUDGET_TOOL_NAME = "__budget_enforcement__"
 _UNSAFE_RESULT_FILENAME_CHARS = re.compile(r"[^A-Za-z0-9_.-]+")
 _MAX_RESULT_FILENAME_STEM = 120
+
+_spillover_prune_lock = threading.Lock()
+_spillover_pruned_once = False
+
+
+def get_spillover_dir():
+    """Return $HERMES_HOME/cache/spillover as a Path (not created)."""
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / SPILLOVER_SUBDIR
+
+
+def cleanup_spillover_cache(max_age_hours: int = SPILLOVER_MAX_AGE_HOURS) -> int:
+    """Delete spillover files older than *max_age_hours*.
+
+    Same contract as the ``cleanup_*_cache`` helpers in
+    ``gateway.platforms.base`` — returns the number of files removed —
+    so the gateway housekeeping loop can prune this dir on the same
+    hourly cadence as the media caches.
+    """
+    cutoff = time.time() - (max_age_hours * 3600)
+    removed = 0
+    try:
+        entries = list(get_spillover_dir().iterdir())
+    except OSError:
+        return 0
+    for f in entries:
+        try:
+            if f.is_file() and f.stat().st_mtime < cutoff:
+                f.unlink()
+                removed += 1
+        except OSError:
+            continue
+    return removed
+
+
+def _prune_spillover_once() -> None:
+    """Best-effort prune, at most once per process.
+
+    The gateway housekeeping loop prunes hourly, but CLI-only installs
+    never run it — without this, spillover files would accumulate
+    forever on pure-CLI setups.
+    """
+    global _spillover_pruned_once
+    with _spillover_prune_lock:
+        if _spillover_pruned_once:
+            return
+        _spillover_pruned_once = True
+    try:
+        removed = cleanup_spillover_cache()
+        if removed:
+            logger.debug("Pruned %d expired spillover file(s)", removed)
+    except Exception as exc:
+        logger.debug("Spillover prune failed: %s", exc)
+
+
+def _is_host_side_env(env) -> bool:
+    """True when the spill file should be written by this process directly.
+
+    Covers ``env=None`` (no sandbox environment active — e.g. a session
+    that has not run a terminal command yet) and the local backend
+    (where env.execute() runs on this same host anyway). Remote backends
+    (docker/ssh/modal/daytona) return False: their read_file resolves
+    inside the sandbox, so the spill must be written there.
+    """
+    if env is None:
+        return True
+    try:
+        from tools.environments.local import LocalEnvironment
+
+        return isinstance(env, LocalEnvironment)
+    except Exception:
+        return False
+
+
+def _write_to_spillover(content: str, filename: str):
+    """Write content host-side to $HERMES_HOME/cache/spillover.
+
+    Returns the absolute path string on success, None on failure.
+    """
+    try:
+        spill_dir = get_spillover_dir()
+        spill_dir.mkdir(parents=True, exist_ok=True)
+        path = spill_dir / filename
+        path.write_text(content, encoding="utf-8", errors="replace")
+    except OSError as exc:
+        logger.warning("Spillover write failed for %s: %s", filename, exc)
+        return None
+    _prune_spillover_once()
+    return str(path)
 
 
 def _resolve_storage_dir(env) -> str:
@@ -174,11 +284,24 @@ def maybe_persist_tool_result(
     if len(content) <= effective_threshold:
         return content
 
-    storage_dir = _resolve_storage_dir(env)
-    remote_path = f"{storage_dir}/{_safe_result_filename(tool_use_id)}"
+    filename = _safe_result_filename(tool_use_id)
     preview, has_more = generate_preview(content, max_chars=config.preview_size)
 
-    if env is not None:
+    # Host-side path: no active sandbox env (MCP-only / cron / gateway
+    # sessions that never ran a terminal command) or the local backend.
+    # Write into $HERMES_HOME/cache/spillover with the other Hermes-owned
+    # caches instead of shelling out to /tmp.
+    if _is_host_side_env(env):
+        host_path = _write_to_spillover(content, filename)
+        if host_path is not None:
+            logger.info(
+                "Persisted large tool result: %s (%s, %d chars -> %s)",
+                tool_name, tool_use_id, len(content), host_path,
+            )
+            return _build_persisted_message(preview, has_more, len(content), host_path)
+    elif env is not None:
+        storage_dir = _resolve_storage_dir(env)
+        remote_path = f"{storage_dir}/{filename}"
         try:
             if _write_to_sandbox(content, remote_path, env):
                 logger.info(

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -11,20 +11,24 @@ Defense against context-window overflow operates at three levels:
    (registry.get_max_result_size), the full output is persisted and the
    in-context content is replaced with a preview + file path reference.
 
-   Where it lands depends on the backend:
+   The canonical home is ALWAYS host-side:
+   ``$HERMES_HOME/cache/spillover/{tool_use_id}.txt`` — alongside the other
+   Hermes-owned caches (images, audio, documents, ...) instead of littering
+   the OS temp dir. This needs no sandbox environment, so it also works for
+   sessions that never ran a terminal command (MCP-only, cron, gateway) —
+   previously those hit the inline-truncate fallback because
+   ``get_active_env()`` returned None until the first terminal call created
+   an environment.
 
-   - **Local backend (or no active env):** written host-side to
-     ``$HERMES_HOME/cache/spillover/{tool_use_id}.txt`` — alongside the
-     other Hermes-owned caches (images, audio, documents, ...) instead of
-     littering the OS temp dir. This path needs no sandbox environment,
-     so it also works for sessions that never ran a terminal command
-     (MCP-only, cron, gateway) — previously those hit the inline-truncate
-     fallback because ``get_active_env()`` returned None until the first
-     terminal call created an environment.
-   - **Remote backends (docker/ssh/modal/daytona):** written INTO THE
-     SANDBOX temp dir (for example /tmp/hermes-results/{id}.txt) via
-     env.execute(), because HERMES_HOME does not exist inside the
-     container and read_file resolves in-sandbox there.
+   What the model sees depends on the backend:
+
+   - **Local backend (or no active env):** the host path itself.
+   - **Remote backends (docker/ssh/modal/daytona):** ``cache/spillover`` is
+     in the auto-mounted/synced cache-dir list (tools/credential_files.py),
+     so the reference is the translated in-sandbox path (probed for
+     readability first). When the sandbox can't see it (e.g. a persistent
+     container created before spillover joined the mount list), fall back
+     to writing a copy into the sandbox temp dir via env.execute().
 
    The spillover dir is pruned two ways: the gateway housekeeping loop
    sweeps it hourly with the other media caches, and a once-per-process
@@ -153,6 +157,41 @@ def _write_to_spillover(content: str, filename: str):
         return None
     _prune_spillover_once()
     return str(path)
+
+
+def _sandbox_visible_spillover_path(host_path: str, env) -> str | None:
+    """Return the path where a remote backend can read *host_path*, or None.
+
+    ``cache/spillover`` is one of the auto-mounted/synced cache dirs
+    (tools/credential_files.py), so on docker it is bind-mounted and on
+    modal/ssh/daytona it is file-synced into the sandbox. Translate the
+    host path with the same helper the image tools use, force a sync for
+    synced backends, then PROBE readability — a persistent docker
+    container created before spillover joined the mount list won't have
+    the bind mount, and must fall back to the in-sandbox write.
+    """
+    try:
+        from tools.credential_files import to_agent_visible_cache_path
+
+        visible = to_agent_visible_cache_path(host_path)
+    except Exception as exc:
+        logger.debug("Spillover path translation failed: %s", exc)
+        return None
+
+    sync_manager = getattr(env, "_sync_manager", None)
+    if sync_manager is not None:
+        try:
+            sync_manager.sync(force=True)
+        except Exception as exc:
+            logger.debug("Spillover sync failed: %s", exc)
+
+    try:
+        result = env.execute(f"test -r {shlex.quote(visible)}", timeout=15)
+        if result.get("returncode", 1) == 0:
+            return visible
+    except Exception as exc:
+        logger.debug("Spillover readability probe failed: %s", exc)
+    return None
 
 
 def _resolve_storage_dir(env) -> str:
@@ -287,12 +326,12 @@ def maybe_persist_tool_result(
     filename = _safe_result_filename(tool_use_id)
     preview, has_more = generate_preview(content, max_chars=config.preview_size)
 
-    # Host-side path: no active sandbox env (MCP-only / cron / gateway
-    # sessions that never ran a terminal command) or the local backend.
-    # Write into $HERMES_HOME/cache/spillover with the other Hermes-owned
-    # caches instead of shelling out to /tmp.
+    # Always persist host-side first: $HERMES_HOME/cache/spillover is the
+    # single canonical home for spilled results (with the other Hermes-owned
+    # caches, pruned by gateway housekeeping) regardless of backend.
+    host_path = _write_to_spillover(content, filename)
+
     if _is_host_side_env(env):
-        host_path = _write_to_spillover(content, filename)
         if host_path is not None:
             logger.info(
                 "Persisted large tool result: %s (%s, %d chars -> %s)",
@@ -300,6 +339,19 @@ def maybe_persist_tool_result(
             )
             return _build_persisted_message(preview, has_more, len(content), host_path)
     elif env is not None:
+        # Remote backend: the spillover dir is auto-mounted (docker) or
+        # file-synced (modal/ssh/daytona) into the sandbox, so reference the
+        # translated path when the sandbox can actually read it.
+        if host_path is not None:
+            visible = _sandbox_visible_spillover_path(host_path, env)
+            if visible is not None:
+                logger.info(
+                    "Persisted large tool result: %s (%s, %d chars -> %s [host: %s])",
+                    tool_name, tool_use_id, len(content), visible, host_path,
+                )
+                return _build_persisted_message(preview, has_more, len(content), visible)
+        # Fallback: write into the sandbox temp dir (pre-existing containers
+        # without the spillover mount, translation/probe failures).
         storage_dir = _resolve_storage_dir(env)
         remote_path = f"{storage_dir}/{filename}"
         try:


### PR DESCRIPTION
## Summary
Large tool results now persist to `$HERMES_HOME/cache/spillover/` when no sandbox environment is active, instead of being inline-truncated and lost.

Root cause: `maybe_persist_tool_result()` fetched the env via `get_active_env()`, which only returns an environment after the first *terminal* command creates one. Sessions that never run a terminal command (MCP-only, cron, gateway) always got `env=None` and fell through to the truncate fallback — a 467K MCP diagnostics bundle was cut to a ~1.3K preview three times in a row ("Full output could not be saved to sandbox").

## Changes
- `tools/tool_result_storage.py`: host-side cases (`env=None` or `LocalEnvironment`) write the spill file directly to `$HERMES_HOME/cache/spillover/<id>.txt` — with the other Hermes-owned caches instead of littering /tmp. Remote backends (docker/ssh/modal/daytona) keep the in-sandbox `env.execute()` write, since `read_file` resolves in-sandbox there. Adds `cleanup_spillover_cache()` (same contract as the `cleanup_*_cache` helpers) + a once-per-process best-effort prune on first spill so CLI-only installs self-clean.
- `gateway/run.py`: spillover joins the hourly `MEDIA_CACHE_CLEANUPS` housekeeping sweep.
- `tests/tools/test_tool_result_storage.py`: 7 new tests — env=None persists, local env skips the shell-out, remote env keeps sandbox write, write-failure falls back inline, cleanup age gating, missing-dir no-op, first-spill prune.

## Validation
| | Before | After |
|---|---|---|
| 467K MCP result, no terminal run yet | truncated to ~1.3K, no file | full content at `cache/spillover/<id>.txt`, preview + path in context |
| Local backend spill | shell-out via `env.execute()` to /tmp | direct host write to HERMES_HOME cache |
| Remote backend spill | in-sandbox /tmp write | unchanged |

`tests/tools/test_tool_result_storage.py`: 33/33 passing. E2E: fresh process, real `HERMES_HOME` resolution, 480K result → persisted + verbatim readback.

## Infographic

![Spillover cache infographic](https://v3b.fal.media/files/b/0aa6cf30/eRcPT5aKqKOJV6SJix-H8_X5kOh1HC.png)
