### PR TITLE
fix(computer-use): use desktop route on Wayland

### DIFF
--- a/tests/tools/test_computer_use_cua_backend_linux.py
+++ b/tests/tools/test_computer_use_cua_backend_linux.py
@@ -142,3 +142,316 @@ def test_explicit_app_capture_preserves_filtered_target_order():
     chrome = _normalized_windows(LINUX_LIST_WINDOWS)[1]
 
     assert _select_capture_target([chrome], app_requested=True) == chrome
+
+
+@pytest.mark.linux_only
+def test_wayland_screen_discovers_desktop_tool_before_cold_session_route(monkeypatch):
+    """The first safe call must discover tools before choosing a capture route."""
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    png_b64 = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAADUlEQVR4nG"
+        "NgGAUgAAABCAABgukLHQAAAABJRU5ErkJggg=="
+    )
+    calls = []
+
+    class _ColdWaylandSession:
+        capabilities_discovered = False
+
+        def __init__(self):
+            self.tools = set()
+
+        def _has_tool(self, name):
+            return name in self.tools
+
+        def call_tool(self, name, args, timeout=30.0):
+            calls.append((name, dict(args)))
+            if name == "list_windows":
+                self.tools = {"get_desktop_state", "list_windows"}
+                self.capabilities_discovered = True
+                return {
+                    "data": "",
+                    "images": [],
+                    "structuredContent": {
+                        "windows": [{
+                            "app_name": "xwayland-terminal",
+                            "pid": 4242,
+                            "window_id": 99,
+                            "title": "Terminal",
+                            "is_on_screen": True,
+                            "z_index": 1,
+                        }],
+                    },
+                    "isError": False,
+                }
+            assert name == "get_desktop_state"
+            return {
+                "data": "",
+                "images": [png_b64],
+                "image_mime_types": ["image/png"],
+                "structuredContent": {},
+                "isError": False,
+            }
+
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-1")
+    backend = CuaDriverBackend()
+    backend._session = _ColdWaylandSession()
+
+    capture = backend.capture(mode="vision", app="screen")
+
+    assert capture.png_b64 == png_b64
+    assert capture.app == "screen"
+    assert calls == [
+        (
+            "list_windows",
+            {"on_screen_only": True, "session": backend._session_id},
+        ),
+        ("get_desktop_state", {"session": backend._session_id}),
+    ]
+
+
+@pytest.mark.linux_only
+def test_wayland_empty_windows_uses_desktop_capture_and_input_target(monkeypatch):
+    """Native Wayland can capture and act without an X11 window identity."""
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    png_b64 = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAADUlEQVR4nG"
+        "NgGAUgAAABCAABgukLHQAAAABJRU5ErkJggg=="
+    )
+    calls = []
+
+    class _WaylandSession:
+        capabilities_discovered = True
+
+        def _has_tool(self, name):
+            return name in {"get_desktop_state", "click", "type_text"}
+
+        def supports_input_property(self, tool, prop):
+            return prop == "target" and tool in {"click", "type_text"}
+
+        def supports_capability(self, capability, tool=None):
+            return False
+
+        def _call_tool_via_cli(self, name, args, timeout):
+            assert name == "list_windows"
+            return {
+                "data": "",
+                "images": [],
+                "structuredContent": {"windows": []},
+                "isError": False,
+            }
+
+        def call_tool(self, name, args, timeout=30.0):
+            calls.append((name, dict(args)))
+            if name == "list_windows":
+                return {
+                    "data": "",
+                    "images": [],
+                    "structuredContent": {"windows": []},
+                    "isError": False,
+                }
+            if name == "get_desktop_state":
+                return {
+                    "data": "",
+                    "images": [png_b64],
+                    "image_mime_types": ["image/png"],
+                    "structuredContent": {},
+                    "isError": False,
+                }
+            return {
+                "data": "ok",
+                "images": [],
+                "structuredContent": {},
+                "isError": False,
+            }
+
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-1")
+    backend = CuaDriverBackend()
+    backend._session = _WaylandSession()
+
+    capture = backend.capture(mode="som", app="screen")
+    clicked = backend.click(x=12, y=34)
+    typed = backend.type_text("hello")
+
+    assert capture.png_b64 == png_b64
+    assert (capture.width, capture.height) == (8, 8)
+    assert capture.app == "screen"
+    assert clicked.ok is True
+    assert typed.ok is True
+    assert calls == [
+        ("get_desktop_state", {"session": backend._session_id}),
+        (
+            "click",
+            {
+                "button": "left",
+                "x": 12,
+                "y": 34,
+                "target": {"kind": "desktop", "display_id": "primary"},
+                "session": backend._session_id,
+            },
+        ),
+        (
+            "type_text",
+            {
+                "text": "hello",
+                "target": {"kind": "desktop", "display_id": "primary"},
+                "session": backend._session_id,
+            },
+        ),
+    ]
+
+
+@pytest.mark.linux_only
+def test_wayland_screen_prefers_desktop_capture_with_xwayland_windows(monkeypatch):
+    """A native desktop request must not be captured through an XWayland window."""
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    png_b64 = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAADUlEQVR4nG"
+        "NgGAUgAAABCAABgukLHQAAAABJRU5ErkJggg=="
+    )
+    calls = []
+
+    class _MixedWaylandSession:
+        capabilities_discovered = True
+
+        def _has_tool(self, name):
+            return name == "get_desktop_state"
+
+        def call_tool(self, name, args, timeout=30.0):
+            calls.append((name, dict(args)))
+            if name == "list_windows":
+                return {
+                    "data": "",
+                    "images": [],
+                    "structuredContent": {
+                        "windows": [{
+                            "app_name": "xwayland-terminal",
+                            "pid": 4242,
+                            "window_id": 99,
+                            "title": "Terminal",
+                            "is_on_screen": True,
+                            "z_index": 1,
+                        }],
+                    },
+                    "isError": False,
+                }
+            assert name == "get_desktop_state"
+            return {
+                "data": "",
+                "images": [png_b64],
+                "image_mime_types": ["image/png"],
+                "structuredContent": {},
+                "isError": False,
+            }
+
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-1")
+    backend = CuaDriverBackend()
+    backend._session = _MixedWaylandSession()
+
+    capture = backend.capture(mode="som", app="desktop")
+
+    assert capture.png_b64 == png_b64
+    assert capture.app == "desktop"
+    assert calls == [
+        ("get_desktop_state", {"session": backend._session_id}),
+    ]
+
+
+@pytest.mark.linux_only
+def test_wayland_desktop_routes_double_click_drag_and_scroll(monkeypatch):
+    """Every retained desktop input branch uses the advertised desktop target."""
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    png_b64 = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAADUlEQVR4nG"
+        "NgGAUgAAABCAABgukLHQAAAABJRU5ErkJggg=="
+    )
+    calls = []
+
+    class _WaylandInputSession:
+        capabilities_discovered = True
+
+        def _has_tool(self, name):
+            return name in {"get_desktop_state", "click", "drag", "scroll"}
+
+        def supports_input_property(self, tool, prop):
+            return (tool, prop) in {
+                ("click", "target"),
+                ("click", "count"),
+                ("drag", "target"),
+                ("scroll", "target"),
+                ("scroll", "x"),
+                ("scroll", "y"),
+            }
+
+        def supports_capability(self, capability, tool=None):
+            return False
+
+        def call_tool(self, name, args, timeout=30.0):
+            calls.append((name, dict(args)))
+            if name == "get_desktop_state":
+                return {
+                    "data": "",
+                    "images": [png_b64],
+                    "image_mime_types": ["image/png"],
+                    "structuredContent": {},
+                    "isError": False,
+                }
+            return {
+                "data": "ok",
+                "images": [],
+                "structuredContent": {},
+                "isError": False,
+            }
+
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-1")
+    backend = CuaDriverBackend()
+    backend._session = _WaylandInputSession()
+
+    backend.capture(mode="som", app="screen")
+    double_clicked = backend.click(x=12, y=34, click_count=2)
+    dragged = backend.drag(from_xy=(1, 2), to_xy=(30, 40))
+    scrolled = backend.scroll(direction="down", amount=7, x=50, y=60)
+
+    assert double_clicked.ok is True
+    assert dragged.ok is True
+    assert scrolled.ok is True
+    target = {"kind": "desktop", "display_id": "primary"}
+    assert calls == [
+        ("get_desktop_state", {"session": backend._session_id}),
+        (
+            "click",
+            {
+                "button": "left",
+                "x": 12,
+                "y": 34,
+                "target": target,
+                "count": 2,
+                "session": backend._session_id,
+            },
+        ),
+        (
+            "drag",
+            {
+                "from_x": 1,
+                "from_y": 2,
+                "to_x": 30,
+                "to_y": 40,
+                "target": target,
+                "session": backend._session_id,
+            },
+        ),
+        (
+            "scroll",
+            {
+                "direction": "down",
+                "amount": 7,
+                "target": target,
+                "x": 50,
+                "y": 60,
+                "session": backend._session_id,
+            },
+        ),
+    ]

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -173,16 +173,11 @@ _CUA_DRIVER_ARGS = ["mcp"]  # stdio MCP transport (fallback when the
                             # driver doesn't expose `manifest` — see
                             # `_resolve_mcp_invocation` below)
 
-# Whole-screen / desktop capture. cua-driver is a window-oriented driver —
-# its `get_window_state` / `screenshot` tools capture a single window (by
-# pid + window_id), and there is no MCP tool that captures the entire virtual
-# desktop or an arbitrary monitor as one image. But the OS shell surfaces
-# themselves (the desktop backdrop and the taskbar/menu-bar) are real windows
-# that show up in `list_windows`, so "show me my screen" / "click the taskbar"
-# is reachable by targeting those windows. When `app` is one of these
-# sentinels, capture() resolves to the desktop/shell window instead of an
-# application window.
+# Whole-screen / desktop capture. Current cua-driver builds advertise
+# `get_desktop_state`; older builds remain window-oriented and resolve these
+# sentinels to a desktop/shell window from `list_windows` instead.
 _SCREEN_CAPTURE_SENTINELS = {"screen", "desktop", "fullscreen", "full screen", "all"}
+_PRIMARY_DESKTOP_TARGET = {"kind": "desktop", "display_id": "primary"}
 
 # Known shell/desktop window identifiers across platforms. Matched
 # case-insensitively as a substring against both the window's app_name and
@@ -2200,6 +2195,7 @@ class _CuaDriverSession:
     # out of this set because a lost response does not prove they failed.
     _TRANSPORT_REPLAY_SAFE_TOOLS = frozenset({
         "get_cursor_position",
+        "get_desktop_state",
         "get_displays",
         "get_screen_size",
         "get_window_state",
@@ -2541,6 +2537,7 @@ class CuaDriverBackend(ComputerUseBackend):
         # Sticky context — updated by capture(), used by action tools.
         self._active_pid: Optional[int] = None
         self._active_window_id: Optional[int] = None
+        self._active_desktop_display_id: Optional[str] = None
         self._last_app: Optional[str] = None  # last app name targeted via capture/focus_app
         # Exact identity for capture_after. App names may be generic on Linux
         # (for example, multiple unrelated Qt windows can say Qt6Application).
@@ -2704,6 +2701,7 @@ class CuaDriverBackend(ComputerUseBackend):
         """Forget a capture/focus target so a failed lookup cannot misroute input."""
         self._active_pid = None
         self._active_window_id = None
+        self._active_desktop_display_id = None
         self._last_app = None
         self._last_target = None
         self._snapshot_tokens = {}
@@ -2720,6 +2718,94 @@ class CuaDriverBackend(ComputerUseBackend):
             app="",
             window_title=message,
             png_bytes_len=0,
+        )
+
+    def _wayland_desktop_capture_available(self, app: Optional[str]) -> bool:
+        """Whether a screen sentinel should use cua-driver's desktop route."""
+        is_wayland_screen = bool(
+            sys.platform == "linux"
+            and os.environ.get("WAYLAND_DISPLAY")
+            and isinstance(app, str)
+            and app.strip().lower() in _SCREEN_CAPTURE_SENTINELS
+        )
+        if not is_wayland_screen:
+            return False
+
+        # A backend may be used before start(), leaving tools/list undiscovered.
+        # Make one legacy-safe, read-only call to start the lazy MCP session;
+        # session startup populates capabilities before dispatching the call.
+        # If startup/discovery fails, retain the existing window/shell route.
+        if not self._session.capabilities_discovered:
+            try:
+                self._call_capture_tool(
+                    "list_windows",
+                    {"on_screen_only": True, "session": self._session_id},
+                )
+            except Exception as exc:
+                logger.debug(
+                    "cua-driver Wayland desktop capability preflight failed: %s",
+                    exc,
+                )
+                return False
+
+        return self._session._has_tool("get_desktop_state")
+
+    def _capture_wayland_desktop(self, mode: str, app: str) -> CaptureResult:
+        """Capture the primary display and arm its coordinate input target."""
+        out = self._call_capture_tool(
+            "get_desktop_state",
+            {"session": self._session_id},
+        )
+        png_b64, image_mime_type = _image_from_tool_result(out)
+        if not png_b64:
+            return self._failed_capture(
+                mode,
+                "<cua-driver get_desktop_state returned no screenshot>",
+            )
+
+        width = height = 0
+        try:
+            raw = base64.b64decode(png_b64, validate=False)
+            png_bytes_len = len(raw)
+            width, height = _image_dimensions_from_bytes(raw)
+        except Exception:
+            png_bytes_len = len(png_b64) * 3 // 4
+
+        self._active_pid = None
+        self._active_window_id = None
+        self._active_desktop_display_id = _PRIMARY_DESKTOP_TARGET["display_id"]
+        self._last_app = app
+        self._last_target = None
+        self._snapshot_tokens = {}
+        return CaptureResult(
+            mode=mode,
+            width=width,
+            height=height,
+            png_b64=png_b64,
+            elements=[],
+            app=app,
+            window_title="Desktop (primary)",
+            png_bytes_len=png_bytes_len,
+            image_mime_type=image_mime_type,
+        )
+
+    def _desktop_input_target(self, tool: str) -> Optional[Dict[str, str]]:
+        """Return the advertised sticky desktop target for an input tool."""
+        display_id = getattr(self, "_active_desktop_display_id", None)
+        if not display_id or not self._session.supports_input_property(tool, "target"):
+            return None
+        return {"kind": "desktop", "display_id": display_id}
+
+    @staticmethod
+    def _desktop_input_unsupported(action: str) -> ActionResult:
+        return ActionResult(
+            ok=False,
+            action=action,
+            code="desktop_target_unsupported",
+            message=(
+                f"The connected cua-driver {action} schema does not advertise "
+                "desktop targets. Capture and act through a window instead."
+            ),
         )
 
     def _call_capture_tool(self, name: str, args: Dict[str, Any]) -> Dict[str, Any]:
@@ -2907,6 +2993,8 @@ class CuaDriverBackend(ComputerUseBackend):
                 "z_index": 0,
             }]
         else:
+            if self._wayland_desktop_capture_available(app):
+                return self._capture_wayland_desktop(mode, app or "screen")
             try:
                 windows = self._load_windows()
             except Exception:
@@ -2983,6 +3071,7 @@ class CuaDriverBackend(ComputerUseBackend):
         )
         self._active_pid = target["pid"]
         self._active_window_id = target["window_id"]
+        self._active_desktop_display_id = None
         # Tokens belong to the prior window snapshot. Disarm them before any
         # capture call so an exception cannot pair old tokens with this target.
         self._snapshot_tokens = {}
@@ -3308,9 +3397,42 @@ class CuaDriverBackend(ComputerUseBackend):
         bring_to_front: bool = False,
     ) -> ActionResult:
         pid = self._active_pid
+        desktop_active = bool(getattr(self, "_active_desktop_display_id", None))
         if pid is None:
-            return ActionResult(ok=False, action="click",
-                                message="No active window — call capture() first.")
+            if not desktop_active:
+                return ActionResult(ok=False, action="click",
+                                    message="No active window — call capture() first.")
+
+            button_norm = (button or "left").lower()
+            if button_norm not in {"left", "right", "middle"}:
+                return ActionResult(ok=False, action="click",
+                                    message=f"unknown button {button!r} — expected left, right, middle.")
+            if element is not None:
+                return ActionResult(
+                    ok=False, action="click",
+                    message="Desktop capture has no element indices; use x/y coordinates.",
+                )
+            if x is None or y is None:
+                return ActionResult(ok=False, action="click",
+                                    message="click requires x/y after desktop capture.")
+            target = self._desktop_input_target("click")
+            if target is None:
+                return self._desktop_input_unsupported("click")
+            args: Dict[str, Any] = {
+                "button": button_norm,
+                "x": x,
+                "y": y,
+                "target": target,
+            }
+            if click_count == 2:
+                if not self._session.supports_input_property("click", "count"):
+                    return self._desktop_input_unsupported("double_click")
+                args["count"] = 2
+            if modifiers:
+                args["modifier"] = modifiers
+            return self._run_input_action(
+                "click", args, delivery_mode, bring_to_front,
+            )
 
         # Choose tool by click_count only — single-vs-double — and pass the
         # button through to `click`'s `button` enum (Surface 5 of
@@ -3362,8 +3484,32 @@ class CuaDriverBackend(ComputerUseBackend):
     ) -> ActionResult:
         pid = self._active_pid
         if pid is None:
-            return ActionResult(ok=False, action="drag",
-                                message="No active window — call capture() first.")
+            if not getattr(self, "_active_desktop_display_id", None):
+                return ActionResult(ok=False, action="drag",
+                                    message="No active window — call capture() first.")
+            if from_element is not None or to_element is not None:
+                return ActionResult(
+                    ok=False, action="drag",
+                    message="Desktop capture has no element indices; use coordinates.",
+                )
+            if from_xy is None or to_xy is None:
+                return ActionResult(
+                    ok=False, action="drag",
+                    message="drag requires coordinate pairs after desktop capture.",
+                )
+            target = self._desktop_input_target("drag")
+            if target is None:
+                return self._desktop_input_unsupported("drag")
+            args: Dict[str, Any] = {
+                "from_x": int(from_xy[0]),
+                "from_y": int(from_xy[1]),
+                "to_x": int(to_xy[0]),
+                "to_y": int(to_xy[1]),
+                "target": target,
+            }
+            return self._run_input_action(
+                "drag", args, delivery_mode, bring_to_front,
+            )
         args: Dict[str, Any] = {"pid": pid}
         if from_element is not None and to_element is not None:
             if self._active_window_id is None:
@@ -3398,8 +3544,33 @@ class CuaDriverBackend(ComputerUseBackend):
     ) -> ActionResult:
         pid = self._active_pid
         if pid is None:
-            return ActionResult(ok=False, action="scroll",
-                                message="No active window — call capture() first.")
+            if not getattr(self, "_active_desktop_display_id", None):
+                return ActionResult(ok=False, action="scroll",
+                                    message="No active window — call capture() first.")
+            if element is not None:
+                return ActionResult(
+                    ok=False, action="scroll",
+                    message="Desktop capture has no element indices; use coordinates.",
+                )
+            target = self._desktop_input_target("scroll")
+            if target is None:
+                return self._desktop_input_unsupported("scroll")
+            args: Dict[str, Any] = {
+                "direction": direction,
+                "amount": max(1, min(50, amount)),
+                "target": target,
+            }
+            if x is not None and y is not None:
+                if not (
+                    self._session.supports_input_property("scroll", "x")
+                    and self._session.supports_input_property("scroll", "y")
+                ):
+                    return self._desktop_input_unsupported("scroll")
+                args["x"] = x
+                args["y"] = y
+            return self._run_input_action(
+                "scroll", args, delivery_mode, bring_to_front,
+            )
         args: Dict[str, Any] = {
             "pid": pid,
             "direction": direction,
@@ -3432,6 +3603,16 @@ class CuaDriverBackend(ComputerUseBackend):
         pid = self._active_pid
         window_id = self._active_window_id
         if pid is None or window_id is None:
+            if getattr(self, "_active_desktop_display_id", None):
+                target = self._desktop_input_target("type_text")
+                if target is None:
+                    return self._desktop_input_unsupported("type_text")
+                return self._run_input_action(
+                    "type_text",
+                    {"text": text, "target": target},
+                    delivery_mode,
+                    bring_to_front,
+                )
             return ActionResult(ok=False, action="type_text",
                                 message="No active window — call capture() first.")
         args: Dict[str, Any] = {"pid": pid, "window_id": window_id, "text": text}
@@ -3547,6 +3728,7 @@ class CuaDriverBackend(ComputerUseBackend):
         if target:
             self._active_pid = target["pid"]
             self._active_window_id = target["window_id"]
+            self._active_desktop_display_id = None
             self._snapshot_tokens = {}
             self._last_app = target["app_name"] or app  # retained for back-compat diagnostics
             self._last_target = {


### PR DESCRIPTION
## Summary
- Use cua-driver’s advertised `get_desktop_state` route for `capture(app="screen")` on native Wayland.
- Preserve the existing X11/shell fallback when that desktop API is unavailable.
- Route coordinate-based desktop input through `{kind: "desktop", display_id: "primary"}`.

## Why
On Omarchy/Hyprland, cua-driver health reports native Wayland capture and input as available, but Hermes first requires X11 `list_windows`. Native windows therefore cannot be captured even though the driver can capture the desktop.

## Validation
- `python -m pytest tests/tools/test_computer_use_cua_backend_linux.py -q` → 9 passed
- `python -m pytest tests/tools/test_computer_use*.py -q` → 294 passed
- Live Omarchy/Wayland smoke through the patched adapter → `capture_ok width=1920 height=1080`

## Scope
This enables the desktop screenshot + coordinate route. Native Wayland app-specific semantic capture (`capture(app="chromium")`) remains a separate limitation until cua-driver exposes a native window identity for it.