### PR TITLE
fix(desktop): bot navigation no longer forces the all-profiles sidebar on

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -2932,7 +2932,7 @@ function createCanonicalChat(name) {
 
     if (sid && typeof host.openSession === 'function') {
       try {
-        await host.openSession(sid, { profile: name })
+        await host.openSession(sid, { keepAllProfilesScope: false, profile: name })
         opened = true
       } catch {
         // The stored row may not exist until the kickoff persists it. Retry
@@ -2947,7 +2947,7 @@ function createCanonicalChat(name) {
         await host.request('prompt.submit', { session_id: runtime, text: 'Hey, tell me about yourself!' })
 
         if (!opened && sid && typeof host.openSession === 'function') {
-          await host.openSession(sid, { profile: name })
+          await host.openSession(sid, { keepAllProfilesScope: false, profile: name })
         }
       } catch {
         // The chat already exists. Keep the pin so the next click
@@ -2982,7 +2982,7 @@ async function openBotCanonicalChat(name, pinned, history) {
     const adoptId = history?.id
     if (adoptId && typeof host.openSession === 'function') {
       try {
-        await host.openSession(adoptId, { profile: name })
+        await host.openSession(adoptId, { keepAllProfilesScope: false, profile: name })
         saveBotMeta(name, { chat: adoptId })
         return adoptId
       } catch {
@@ -3015,7 +3015,7 @@ async function openBotCanonicalChat(name, pinned, history) {
     // Transient gateway state (or an older backend): the pin is innocent
     // until proven guilty — try it as-is, and only a rejected open clears.
     try {
-      await host.openSession(pinned, { profile: name })
+      await host.openSession(pinned, { keepAllProfilesScope: false, profile: name })
       return pinned
     } catch {
       saveBotMeta(name, { chat: null })
@@ -3025,7 +3025,7 @@ async function openBotCanonicalChat(name, pinned, history) {
 
   if (preferred) {
     try {
-      await host.openSession(preferred.resolved_id || preferred.id, { profile: name })
+      await host.openSession(preferred.resolved_id || preferred.id, { keepAllProfilesScope: false, profile: name })
       return pinned
     } catch (error) {
       // The precise lookup JUST confirmed this session exists, so a failed
@@ -3042,7 +3042,7 @@ async function openBotCanonicalChat(name, pinned, history) {
   const recoveryId = history?.id
   if (recoveryId && typeof host.openSession === 'function') {
     try {
-      await host.openSession(recoveryId, { profile: name })
+      await host.openSession(recoveryId, { keepAllProfilesScope: false, profile: name })
       saveBotMeta(name, { chat: recoveryId })
       return recoveryId
     } catch {
@@ -7143,7 +7143,7 @@ async function openProfileSession(botName, storedId, gatewayGeneration) {
   if (typeof host.openSession !== 'function') {
     throw new Error('This Hermes Desktop version cannot open stored sessions')
   }
-  await host.openSession(id, { profile })
+  await host.openSession(id, { keepAllProfilesScope: false, profile })
   if (gatewayGeneration !== $sessionsGatewayGeneration.get()) return
   $botSelectedSessions.set({ ...$botSelectedSessions.get(), [profile]: id })
 }

--- a/apps/desktop/src/plugins/hermes-bots/tests/session-workspace.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/session-workspace.test.mjs
@@ -89,7 +89,9 @@ test('sessions workspace: filtering searches title, preview, and source without 
 test('sessions workspace: opening a stored row uses profile-aware navigation and records selection', async () => {
   const runtime = load({ profile: 'default' })
   await runtime.__sessions.openProfileSession('ops', 'stored-123', 0)
-  assert.deepEqual(plain(runtime.calls), [['openSession', 'stored-123', { profile: 'ops' }]])
+  assert.deepEqual(plain(runtime.calls), [
+    ['openSession', 'stored-123', { keepAllProfilesScope: false, profile: 'ops' }]
+  ])
   assert.equal(runtime.__sessions.$botSelectedSessions.get().ops, 'stored-123')
 })
 


### PR DESCRIPTION
## Problem

With more than one profile, the Sessions sidebar profile filter cannot be kept: narrowing Sessions to a single profile works, but clicking **any other bot** re-enables the unified all-profiles list.

Clicking the *same* bot again is fine — no profile change, so nothing resets. That asymmetry makes it read as flaky UI rather than a bug.

## Cause

`sdk/index.ts` turns the all-profiles view back on whenever `openSession` crosses a profile boundary, unless the caller opts out:

```ts
if (profile && profile !== $activeGatewayProfile.get()) {
  await ensureGatewayProfile(profile)

  if (options.keepAllProfilesScope !== false) {
    setShowAllProfiles(true)   // ← default path
  }
}
```

The Bot Mode plugin never passes `keepAllProfilesScope`, so all seven of its `host.openSession` calls take that default.

That default is right for its original caller — the all-profiles browse list, where switching scope would throw away the view the user is in. It is wrong for bot navigation, which is an explicit *context switch into that bot's profile*: the user is leaving the unified view, not browsing it.

## Fix

Pass `keepAllProfilesScope: false` at all seven call sites — canonical chat open, adopt, pinned/preferred, recovery, and the Sessions workspace row.

No new API: the option already exists and is documented in the SDK; the plugin simply was not using it.

## Testing

- `node --test apps/desktop/src/plugins/hermes-bots/tests/*.test.mjs` → **254 passing**
- `session-workspace.test.mjs` asserts the exact options object, so its expectation is updated in the same commit.

## Reproduction

1. Have ≥2 profiles.
2. Sidebar → filter menu → narrow Sessions to one profile.
3. Click a different bot in the Bots panel.

**Before:** the filter is discarded and every profile's sessions return.
**After:** the filter holds; the sidebar follows the profile you switched into.

## Notes

Found while running six profiles (one bot per brand). The profile count only changes how often it fires — two profiles are enough to reproduce.
