### PR TITLE
fix: validate POSIX Python fallback versions

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -261,6 +261,7 @@ import {
   fetchRemoteProfileSessions,
   mergeProfileSessionWindow
 } from './profile-session-routing'
+import { findSupportedPythonOnPath, readPythonVersion } from './python-runtime'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
 import * as remoteLifecycle from './remote-lifecycle'
@@ -2265,6 +2266,12 @@ function findPythonForRoot(root) {
   const override = process.env.HERMES_DESKTOP_PYTHON
 
   if (override && fileExists(override)) {
+    if (!IS_WINDOWS) {
+      const version = readPythonVersion(override)
+
+      rememberLog(`[backend] Using explicit Python${version ? ` ${version}` : ''} at ${override}`)
+    }
+
     return override
   }
 
@@ -2276,8 +2283,28 @@ function findPythonForRoot(root) {
     const candidate = path.join(root, relativePath)
 
     if (fileExists(candidate)) {
+      if (!IS_WINDOWS) {
+        const version = readPythonVersion(candidate)
+
+        rememberLog(`[backend] Using repo-local Python${version ? ` ${version}` : ''} at ${candidate}`)
+      }
+
       return candidate
     }
+  }
+
+  if (!IS_WINDOWS) {
+    const selection = findSupportedPythonOnPath(['python3', 'python'], findOnPath)
+
+    if (selection) {
+      rememberLog(`[backend] Selected Python ${selection.version} at ${selection.path} from PATH`)
+
+      return selection.path
+    }
+
+    rememberLog('[backend] No supported Python (>=3.11,<3.14) found on PATH')
+
+    return null
   }
 
   return findSystemPython()

--- a/apps/desktop/electron/python-runtime.test.ts
+++ b/apps/desktop/electron/python-runtime.test.ts
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+
+import { test } from 'vitest'
+
+import {
+  findSupportedPythonOnPath,
+  isSupportedPythonVersion,
+  readPythonVersion,
+  selectSupportedPythonCandidate
+} from './python-runtime'
+
+const mainSource = fs.readFileSync(new URL('./main.ts', import.meta.url), 'utf8')
+
+function extractMainFunction(startMarker: string, endMarker: string): string {
+  const start = mainSource.indexOf(startMarker)
+  const end = mainSource.indexOf(endMarker, start)
+
+  assert.notEqual(start, -1, `missing start marker: ${startMarker}`)
+  assert.notEqual(end, -1, `missing end marker: ${endMarker}`)
+
+  return mainSource.slice(start, end)
+}
+
+test('skips an unsupported Python 3.9 candidate and selects a later supported interpreter', () => {
+  const versions = new Map([
+    ['/usr/bin/python3', '3.9.6'],
+    ['/opt/hermes/venv/bin/python', '3.11.15']
+  ])
+
+  const selected = selectSupportedPythonCandidate(
+    ['/usr/bin/python3', '/opt/hermes/venv/bin/python'],
+    candidate => versions.get(candidate) ?? null
+  )
+
+  assert.deepEqual(selected, {
+    path: '/opt/hermes/venv/bin/python',
+    version: '3.11.15'
+  })
+})
+
+test('matches the project Python range of 3.11 through 3.13', () => {
+  assert.equal(isSupportedPythonVersion('3.10.14'), false)
+  assert.equal(isSupportedPythonVersion('3.11.0'), true)
+  assert.equal(isSupportedPythonVersion('3.12.9'), true)
+  assert.equal(isSupportedPythonVersion('3.13.2'), true)
+  assert.equal(isSupportedPythonVersion('3.14.0'), false)
+  assert.equal(isSupportedPythonVersion('not-a-version'), false)
+})
+
+test('reads the interpreter version with a bounded no-shell probe', () => {
+  let invocation = null
+
+  const version = readPythonVersion('/opt/python', (command, args, options) => {
+    invocation = { command, args, options }
+
+    return '3.12.7\n'
+  })
+
+  assert.deepEqual(invocation, {
+    command: '/opt/python',
+    args: ['-c', 'import sys; print(".".join(map(str, sys.version_info[:3])))'],
+    options: {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5_000,
+      windowsHide: true
+    }
+  })
+  assert.equal(version, '3.12.7')
+})
+
+test('treats an interpreter probe failure as unavailable', () => {
+  assert.equal(
+    readPythonVersion('/broken/python', () => {
+      throw new Error('cannot execute')
+    }),
+    null
+  )
+})
+
+test('continues from an unsupported python3 command to a supported python command on PATH', () => {
+  const paths = new Map([
+    ['python3', '/usr/bin/python3'],
+    ['python', '/opt/hermes/venv/bin/python']
+  ])
+
+  const versions = new Map([
+    ['/usr/bin/python3', '3.9.6'],
+    ['/opt/hermes/venv/bin/python', '3.11.15']
+  ])
+
+  const selected = findSupportedPythonOnPath(
+    ['python3', 'python'],
+    command => paths.get(command) ?? null,
+    candidate => versions.get(candidate) ?? null
+  )
+
+  assert.deepEqual(selected, {
+    path: '/opt/hermes/venv/bin/python',
+    version: '3.11.15'
+  })
+})
+
+test('returns null when no PATH candidate is runnable and supported', () => {
+  assert.equal(
+    findSupportedPythonOnPath(
+      ['python3', 'python'],
+      command => `/usr/bin/${command}`,
+      candidate => (candidate.endsWith('python3') ? '3.9.6' : null)
+    ),
+    null
+  )
+})
+
+test('applies the supported-version gate only to the source resolver fallback', () => {
+  const sourceResolver = extractMainFunction('function findPythonForRoot(root) {', '\nfunction findSystemPython() {')
+  const sharedSystemResolver = extractMainFunction('function findSystemPython() {', '\n// findGitBash')
+
+  assert.match(sourceResolver, /if \(!IS_WINDOWS\)[\s\S]*findSupportedPythonOnPath/)
+  assert.doesNotMatch(sharedSystemResolver, /findSupportedPythonOnPath/)
+  assert.match(sharedSystemResolver, /for \(const command of \['python3', 'python'\]\)/)
+})

--- a/apps/desktop/electron/python-runtime.ts
+++ b/apps/desktop/electron/python-runtime.ts
@@ -1,0 +1,88 @@
+import { execFileSync } from 'node:child_process'
+
+interface PythonSelection {
+  path: string
+  version: string
+}
+
+type ReadPythonVersion = (candidate: string) => string | null
+type FindOnPath = (command: string) => string | null
+type ExecVersionProbe = (
+  command: string,
+  args: string[],
+  options: {
+    encoding: 'utf8'
+    stdio: ['ignore', 'pipe', 'ignore']
+    timeout: number
+    windowsHide: boolean
+  }
+) => string | Buffer
+
+const PYTHON_VERSION_SNIPPET = 'import sys; print(".".join(map(str, sys.version_info[:3])))'
+const PYTHON_VERSION_PROBE_TIMEOUT_MS = 5_000
+
+function readPythonVersion(
+  candidate: string,
+  exec: ExecVersionProbe = execFileSync as ExecVersionProbe
+): string | null {
+  try {
+    const output = exec(candidate, ['-c', PYTHON_VERSION_SNIPPET], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: PYTHON_VERSION_PROBE_TIMEOUT_MS,
+      windowsHide: true
+    })
+
+    const version = String(output).trim()
+
+    return version || null
+  } catch {
+    return null
+  }
+}
+
+function isSupportedPythonVersion(version: string): boolean {
+  const match = String(version).trim().match(/^(\d+)\.(\d+)(?:\.\d+)?$/)
+
+  if (!match) {
+    return false
+  }
+
+  const major = Number(match[1])
+  const minor = Number(match[2])
+
+  return major === 3 && minor >= 11 && minor < 14
+}
+
+function selectSupportedPythonCandidate(
+  candidates: string[],
+  readVersion: ReadPythonVersion
+): PythonSelection | null {
+  for (const candidate of candidates) {
+    const version = readVersion(candidate)
+
+    if (version && isSupportedPythonVersion(version)) {
+      return { path: candidate, version }
+    }
+  }
+
+  return null
+}
+
+function findSupportedPythonOnPath(
+  commands: string[],
+  findOnPath: FindOnPath,
+  readVersion: ReadPythonVersion = readPythonVersion
+): PythonSelection | null {
+  const candidates = commands.map(findOnPath).filter((candidate): candidate is string => Boolean(candidate))
+
+  return selectSupportedPythonCandidate(candidates, readVersion)
+}
+
+export {
+  findSupportedPythonOnPath,
+  isSupportedPythonVersion,
+  readPythonVersion,
+  selectSupportedPythonCandidate
+}
+export type { ExecVersionProbe, FindOnPath, PythonSelection, ReadPythonVersion }


### PR DESCRIPTION
## Summary
- probe POSIX source-mode PATH candidates before selecting them
- accept only Python >=3.11,<3.14, matching pyproject.toml
- continue from an unsupported or broken python3 to a later supported python
- log the selected interpreter path/version and actionable no-match state
- preserve explicit HERMES_DESKTOP_PYTHON, repo-local venv, Windows, managed runtime, and uninstall semantics

## Regression covered
On macOS, source mode could select /usr/bin/python3 (Python 3.9.6) and stop before a later PATH python (Python 3.11.15), causing the backend to fail during import.

## Test plan
- npx vitest run --project electron electron/python-runtime.test.ts (7/7)
- npm run test:desktop:platforms (1415 passed, 2 skipped)
- npm run typecheck
- npm run lint -- --quiet
- npm run build
- git diff --check origin/main...HEAD
- real npm run dev:mock without override: skipped Python 3.9.6, selected Python 3.11.15, backend ready, GUI mock reply received
- explicit HERMES_DESKTOP_PYTHON: Python 3.11.15 logged and backend ready

## Scope
Production managed-runtime Python hardening is intentionally deferred to a separate follow-up.