### PR TITLE
docs(windows): fix gateway restart troubleshooting advice

### DIFF
--- a/website/docs/user-guide/windows-native.md
+++ b/website/docs/user-guide/windows-native.md
@@ -297,7 +297,18 @@ You hit a shebang-script invocation that bypassed the `.cmd` shim. Hermes resolv
 Your download of `install.ps1` picked up a UTF-8 BOM. The `irm | iex` form strips BOMs automatically; `[scriptblock]::Create((irm ...))` does not. Re-run with the simple `irm | iex` form, or download the script manually and save it without a BOM via `[IO.File]::WriteAllText($path, $text, (New-Object Text.UTF8Encoding $false))`.
 
 **Gateway won't stay running after restart.**
-Check `hermes gateway status` — it merges the schtasks entry, the Startup-folder shortcut (if used), and the live PID. If schtasks is registered but not running, group policy may be blocking `ONLOGON` triggers. Run `schtasks /Query /TN HermesGateway /V /FO LIST` to see the task's failure reason, or fall back to the Startup-folder path by uninstalling and reinstalling with `HERMES_GATEWAY_FORCE_STARTUP=1`.
+Check `hermes gateway status` — it merges the schtasks entry, the Startup-folder login item (if used), and the live PID. If schtasks is registered but not running, group policy may be blocking `ONLOGON` triggers. Run `schtasks /Query /TN HermesGateway /V /FO LIST` to see the task's failure reason. There is **no** `HERMES_GATEWAY_FORCE_STARTUP` env var; older docs referenced it, but the install flow has no such option. The Startup-folder fallback is automatic instead.
+
+Whenever `schtasks /Create` is denied or times out (common on locked-down corporate machines), `hermes gateway install` writes a login item at `%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup\Hermes_Gateway.vbs` and prints `Installed Windows login item`. To pre-answer the install prompts non-interactively, set the two env vars Hermes actually reads, then reinstall. If Windows asks for UAC, decline it, and the Startup-folder fallback is used:
+
+```powershell
+$env:HERMES_GATEWAY_INSTALL_START_ON_LOGIN = "1"   # install a login auto-start
+$env:HERMES_GATEWAY_INSTALL_START_NOW = "1"        # start the gateway right away
+hermes gateway uninstall
+hermes gateway install
+```
+
+Then verify with `hermes gateway status` - the Startup-folder login item is reported even when no Scheduled Task was created.
 
 **`/edit` still does nothing after setting `$env:EDITOR`.**
 You set it in the current process only; close and reopen the shell, or set it at User scope in System Properties → Environment Variables. Verify with `echo $env:EDITOR` in a new PowerShell window.


### PR DESCRIPTION
## What

The Windows Native guide's "Common pitfalls" entry for **Gateway won't stay running after restart** told users to reinstall with `HERMES_GATEWAY_FORCE_STARTUP=1` to force the Startup-folder path. That env var **does not exist** in the codebase (verified against `hermes_cli/gateway_windows.py`), so the advice was a dead end for developers.

## Fix

Replaces the bogus recommendation with the actual mechanism, verified in `hermes_cli/gateway_windows.py`:

- The Startup-folder fallback is **automatic**: whenever `schtasks /Create` is denied or times out (locked-down corporate machines), `hermes gateway install` writes `%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup\Hermes_Gateway.vbs` and prints `Installed Windows login item`.
- The two env vars Hermes actually reads at install time are `HERMES_GATEWAY_INSTALL_START_ON_LOGIN` and `HERMES_GATEWAY_INSTALL_START_NOW` (parsed by `_install_choice_from_env`), which pre-answer the interactive start/login prompts so the fallback runs non-interactively.
- UAC behavior: declining the UAC prompt routes the install to the Startup-folder fallback.

Also renames the misleading `Startup-folder shortcut` wording to `Startup-folder login item` (the launcher is a `.vbs`, not a shortcut).

## Related

Fixes #88077
