### PR TITLE
fix(desktop): layout reset clears session tiles in every profile

### DIFF
--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -49,6 +49,7 @@ import {
 import {
   $sessionStates,
   $sessionTiles,
+  clearInactiveProfileTiles,
   closeSessionTile,
   discardSessionTile,
   patchSessionTile,
@@ -455,6 +456,11 @@ export function SessionTileCloseConfirm() {
  *  workspace group as a tab (append). The main group id is re-read each pass
  *  because appending returns a new tree. */
 export function stackSessionTilesIntoMain(): void {
+  // Reset restores the whole window: the other profiles' persisted tiles would
+  // otherwise re-adopt at their saved edges on the next gateway swap, silently
+  // undoing the reset one profile switch later.
+  clearInactiveProfileTiles()
+
   for (const tile of $sessionTiles.get()) {
     const tree = $layoutTree.get()
     const mainGroup = tree ? findGroupOfPane(tree, 'workspace')?.id : null

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -900,6 +900,37 @@ export function reuseBlankDraftTile(storedSessionId: string): boolean {
   return true
 }
 
+/** Drop the STORED tiles of every profile that isn't live right now.
+ *
+ *  Tiles persist per profile, so a layout reset only ever reached the active
+ *  one: the other profiles' tiles stayed on disk and re-adopted at their saved
+ *  edges the moment the gateway swapped (the profile rail, or opening a session
+ *  owned by another profile) — a reset that visibly undid itself one profile
+ *  later. Reset restores the whole window, so the inactive sets are cleared
+ *  here while the active profile's tiles go through the normal reset handler
+ *  (stacked into main as tabs).
+ *
+ *  The live atom is untouched — this only prunes the persisted map. */
+export function clearInactiveProfileTiles() {
+  if (isSecondaryWindow()) {
+    return
+  }
+
+  const active = profileKey()
+  let changed = false
+
+  for (const key of Object.keys(tilesByProfile)) {
+    if (key !== active) {
+      delete tilesByProfile[key]
+      changed = true
+    }
+  }
+
+  if (changed) {
+    persistTiles()
+  }
+}
+
 // Closed-tab stack for ⌘⇧T reopen (in-memory) — keyed PER PROFILE like the
 // tiles themselves, so ⌘⇧T after a profile switch never resurrects the other
 // profile's session. The tile's placement is remembered so it returns in place.

--- a/apps/desktop/src/store/session-tiles-profile-reset.test.ts
+++ b/apps/desktop/src/store/session-tiles-profile-reset.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Regression: a layout reset must clear EVERY profile's persisted session
+ * tiles, not just the live one.
+ *
+ * Tiles are stored per profile (`hermes.desktop.sessionTiles.v2` is a map keyed
+ * by profile). Before `clearInactiveProfileTiles`, a reset only emptied the
+ * active profile's entry, so the moment the gateway swapped — a bot click, the
+ * profile rail — the other profile's saved tiles re-adopted at their stored
+ * edges and the window went back to the pre-reset split. The reset visibly
+ * undid itself one profile later.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type * as ProfileStore from '@/store/profile'
+
+const TILES_KEY = 'hermes.desktop.sessionTiles.v2'
+
+describe('layout reset clears tiles across profiles', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.resetModules()
+  })
+
+  async function loadWithProfile(active: string) {
+    vi.doMock('@/store/profile', async () => {
+      const actual = await vi.importActual<typeof ProfileStore>('@/store/profile')
+      const { atom } = await import('nanostores')
+
+      return { ...actual, $activeGatewayProfile: atom(active) }
+    })
+
+    return import('@/store/session-states')
+  }
+
+  it('drops inactive profiles from storage while leaving the live one alone', async () => {
+    window.localStorage.setItem(
+      TILES_KEY,
+      JSON.stringify({
+        curolab: [{ dir: 'right', storedSessionId: 'curolab-1' }],
+        ops: [{ dir: 'right', storedSessionId: 'ops-1' }],
+        plan: [{ dir: 'right', storedSessionId: 'plan-1' }, { dir: 'bottom', storedSessionId: 'plan-2' }]
+      })
+    )
+
+    const states = await loadWithProfile('ops')
+
+    // The live profile hydrates its own tiles; the others sit in storage.
+    expect(states.$sessionTiles.get().map(t => t.storedSessionId)).toEqual(['ops-1'])
+
+    states.clearInactiveProfileTiles()
+
+    const stored = JSON.parse(window.localStorage.getItem(TILES_KEY) ?? '{}')
+
+    expect(Object.keys(stored)).toEqual(['ops'])
+    expect(stored.plan).toBeUndefined()
+    expect(stored.curolab).toBeUndefined()
+    // The live atom is untouched — the normal reset handler stacks these.
+    expect(states.$sessionTiles.get().map(t => t.storedSessionId)).toEqual(['ops-1'])
+  })
+
+  it('a profile swap after the clear surfaces nothing (the reset actually held)', async () => {
+    window.localStorage.setItem(
+      TILES_KEY,
+      JSON.stringify({
+        ops: [{ dir: 'right', storedSessionId: 'ops-1' }],
+        plan: [{ dir: 'right', storedSessionId: 'plan-1' }]
+      })
+    )
+
+    const opsStates = await loadWithProfile('ops')
+    opsStates.clearInactiveProfileTiles()
+
+    // Re-import as if the gateway swapped to `plan` (a bot click).
+    vi.resetModules()
+    const planStates = await loadWithProfile('plan')
+
+    expect(planStates.$sessionTiles.get()).toEqual([])
+  })
+})


### PR DESCRIPTION
## Problem

With more than one profile, a layout reset does not stick. Reset the layout, switch profiles (rail, or open a session owned by another profile), and the window snaps back to the split that was just cleared. From the user's side the reset "undoes itself".

## Cause

Session tiles are persisted **per profile** — `hermes.desktop.sessionTiles.v2` is a map keyed by profile, each entry carrying the tile's `dir` / `anchor` / `before` placement. The reset handler only walks the live profile's tiles:

```ts
export function stackSessionTilesIntoMain(): void {
  for (const tile of $sessionTiles.get()) {   // ← active profile only
```

So the other profiles' entries survive the reset on disk, and `$activeGatewayProfile.subscribe` rehydrates them at their saved edges on the next swap.

## Fix

`clearInactiveProfileTiles()` prunes the persisted tiles of every profile that isn't live; the reset handler calls it before stacking the active profile's tiles into main.

This follows the contract reset already has elsewhere — it reopens every bound side, clears dismissed panes and user placement — so stored tiles from other profiles should not outlive it either. The live atom is untouched; only the persisted map is pruned, and the active profile's tiles still go through the normal stack-into-main path.

## Testing

New `apps/desktop/src/store/session-tiles-profile-reset.test.ts`:

1. inactive profiles are dropped from storage, the live entry and atom are preserved;
2. after the clear, loading with a different active profile surfaces no tiles — i.e. the reset actually held across a swap.

**Negative check:** removing the `clearInactiveProfileTiles()` call makes test 2 fail with the other profile's tile (`plan-1`) resurrected — the exact reported symptom, so the test is pinned to the bug rather than to the implementation.

- `vitest run --project ui src/store/session-tiles-profile-reset.test.ts src/store/session-states.test.ts` → **24 passing**
- `tsc -p . --noEmit` clean, `eslint` clean on all touched files

## Reproduction

1. Have ≥2 profiles, each with a session tile split beside the main chat.
2. In profile A: `⌘⇧\` → Reset. Layout collapses correctly.
3. Switch to profile B.

**Before:** B's old tiles re-adopt at their saved edges; the window is split again.
**After:** the reset holds across profiles.

## Notes

Found while running six profiles. Two profiles are enough to reproduce; the count only affects how often it fires.

Related: #89031 (same "profile switch restores state the user just cleared" class, different store).
