### PR TITLE
fix(cron): unify inactivity timeout policy

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -7,6 +7,7 @@ from contextvars import ContextVar
 from dataclasses import dataclass, field
 import json
 import logging
+import math
 import shutil
 import tempfile
 import threading
@@ -162,14 +163,61 @@ _ONESHOT_RUN_CLAIM_TTL_HEADROOM = 3
 _DEFAULT_CRON_INACTIVITY_TIMEOUT = 600.0
 
 
-def _oneshot_run_claim_ttl_seconds() -> float:
-    """One-shot running-claim TTL from ``HERMES_CRON_TIMEOUT``: unset/invalid → 600s → 1800s;
-    ``0`` (unlimited) → the fixed floor; positive N → ``max(N * headroom, floor)``."""
+def resolve_cron_inactivity_timeout(config: Optional[dict] = None) -> float:
+    """Resolve the shared cron inactivity budget in seconds.
+
+    ``HERMES_CRON_TIMEOUT`` remains the highest-precedence compatibility
+    override. Otherwise use ``cron.inactivity_timeout_seconds`` from config.
+    Zero disables the watchdog; negative and non-finite values are invalid.
+    """
     raw = cron_env_setting("HERMES_CRON_TIMEOUT").strip()
+    if raw:
+        candidate: Any = raw
+    else:
+        if config is None:
+            try:
+                from hermes_cli.config import load_config
+
+                config = load_config() or {}
+            except Exception:
+                config = {}
+        cron_config = config.get("cron", {}) if isinstance(config, dict) else {}
+        candidate = (
+            cron_config.get(
+                "inactivity_timeout_seconds",
+                _DEFAULT_CRON_INACTIVITY_TIMEOUT,
+            )
+            if isinstance(cron_config, dict)
+            else _DEFAULT_CRON_INACTIVITY_TIMEOUT
+        )
+
     try:
-        timeout = float(raw) if raw else _DEFAULT_CRON_INACTIVITY_TIMEOUT
-    except (ValueError, TypeError):
-        timeout = _DEFAULT_CRON_INACTIVITY_TIMEOUT
+        timeout = float(candidate)
+    except (TypeError, ValueError):
+        timeout = math.nan
+    if not math.isfinite(timeout) or timeout < 0:
+        logger.warning(
+            "Invalid cron inactivity timeout %r; using default %.0fs",
+            candidate,
+            _DEFAULT_CRON_INACTIVITY_TIMEOUT,
+        )
+        return _DEFAULT_CRON_INACTIVITY_TIMEOUT
+    return timeout
+
+
+def _oneshot_run_claim_ttl_seconds(config: Optional[dict] = None) -> float:
+    """Resolve the one-shot running-claim stale-recovery TTL.
+
+    Derived from the shared cron inactivity timeout so the safety valve tracks
+    how long a run is actually allowed to go quiet, instead of a magic constant:
+
+    - unset / invalid → default 600s inactivity limit → TTL = 1800s
+    - ``0`` (unlimited runs) → no finite bound to derive from → fall back to
+      ``ONESHOT_RUN_CLAIM_TTL_SECONDS``
+    - positive N → ``max(N * headroom, ONESHOT_RUN_CLAIM_TTL_SECONDS)`` so a
+      tiny configured timeout can never expire a claim mid-run.
+    """
+    timeout = resolve_cron_inactivity_timeout(config)
     if timeout <= 0:
         return float(ONESHOT_RUN_CLAIM_TTL_SECONDS)
     return max(timeout * _ONESHOT_RUN_CLAIM_TTL_HEADROOM, float(ONESHOT_RUN_CLAIM_TTL_SECONDS))

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -266,15 +266,27 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     # failure). Mirrors the same reordering fix upstream issue #59549 applied for script timeouts vs
     # provider timeouts — check the more specific, deterministic signature first.
     if re.search(r"idle for \d+s\s*\(limit \d+s\)", lower):
+        activity_match = re.search(r"last activity:\s*(.+)", text, re.IGNORECASE)
+        activity_context = ""
+        if activity_match:
+            activity = " ".join(activity_match.group(1).split())
+            if len(activity) > 100:
+                activity = activity[:97].rstrip() + "..."
+            activity_context = f" Last activity: {activity}."
         return (
             f"⚠️ Cron '{job_name}' failed: the job itself stalled — no tool/API "
             "activity for the configured inactivity window. Not a provider or "
             "fallback-chain issue; check what the job was doing when it went "
-            "quiet. Full details saved in cron output."
+            f"quiet.{activity_context} Full details saved in cron output."
         )
 
     if provider_reachable and (
-        "readtimeout" in lower or "timed out" in lower or "timeout" in lower
+        "readtimeout" in lower
+        or "apitimeouterror" in lower
+        or "provider timeout" in lower
+        or "provider timed out" in lower
+        or "upstream timed out" in lower
+        or "request timed out" in lower
     ):
         return (
             f"⚠️ Cron '{job_name}' failed: provider timeout. "
@@ -464,7 +476,7 @@ def _resolve_job_reasoning_config(job: dict, cfg: dict, model: str) -> dict | No
 from cron.jobs import (
     _ensure_cron_dir, advance_next_runs, claim_dispatch, claim_job_for_fire, fire_claim_fence,
     clear_run_claim, get_due_jobs, heartbeat_fire_claim, heartbeat_run_claim, mark_job_run,
-    save_job_output, use_cron_store)
+    resolve_cron_inactivity_timeout, save_job_output, use_cron_store)
 from cron.executions import (
     _TERMINAL_STATES, create_execution, finish_execution, get_execution,
     mark_execution_handoff_pending, mark_execution_running, recover_interrupted_executions)
@@ -933,18 +945,13 @@ def _inactivity_watchdog_loop(
     return False
 
 
-def _cron_inactivity_seconds() -> float:
-    """Parse HERMES_CRON_TIMEOUT (seconds). 0 = unlimited; bad input = 600. Shared by the
-    inactivity monitor and the cwd-lock bound so they can't drift: the lock bound must stay >= the
-    inactivity limit or waiters fail while a healthy holder runs."""
-    raw = cron_env_setting("HERMES_CRON_TIMEOUT").strip()
-    if not raw:
-        return 600.0
-    try:
-        return float(raw)
-    except (ValueError, TypeError):
-        logger.warning("Invalid HERMES_CRON_TIMEOUT=%r; using default 600s", raw)
-        return 600.0
+def _cron_inactivity_seconds(config: Optional[dict] = None) -> float:
+    """Resolve cron inactivity seconds. 0 = unlimited; bad input = 600.
+
+    Shared with the one-shot claim TTL calculation so the scheduler watchdog
+    and stale-claim recovery horizon cannot drift apart.
+    """
+    return resolve_cron_inactivity_timeout(config)
 
 
 def _get_parallel_pool(max_workers: Optional[int]) -> concurrent.futures.ThreadPoolExecutor:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1691,6 +1691,10 @@ DEFAULT_CONFIG = {
         # Max due jobs run in parallel per tick. None/0 = unbounded (thread count only); 1 = serial.
         # Env override: HERMES_CRON_MAX_PARALLEL.
         "max_parallel_jobs": None,
+        # Stop an agent cron run after this many seconds with no model or tool
+        # activity. Active jobs may run indefinitely. 0 disables the watchdog.
+        # HERMES_CRON_TIMEOUT remains a backward-compatible env override.
+        "inactivity_timeout_seconds": 600,
         # save_job_output keeps the N most recent .md files per job; 0 or negative disables pruning
         # (for externally managed cleanup).
         "output_retention": 50,

--- a/tests/cron/test_cron_failure_alert_remediation_hint.py
+++ b/tests/cron/test_cron_failure_alert_remediation_hint.py
@@ -45,3 +45,26 @@ def test_rate_limit_empty_chain_also_carries_the_hint(monkeypatch):
     msg = _summarize_cron_failure_for_delivery(job, "HTTP 429: rate limit exceeded")
     assert "No fallback chain configured" in msg
     assert "hermes fallback add" in msg
+
+
+def test_inactivity_timeout_preserves_stalled_wording_and_activity():
+    msg = _summarize_cron_failure_for_delivery(
+        {"name": "daily-review"},
+        "TimeoutError: Cron job 'daily-review' idle for 601s (limit 600s) "
+        "— last activity: executing tool: terminal",
+    )
+
+    assert "the job itself stalled" in msg
+    assert "Last activity: executing tool: terminal" in msg
+    assert "Not a provider or fallback-chain issue" in msg
+
+
+def test_unclassified_timeout_is_not_reported_as_provider_failure():
+    msg = _summarize_cron_failure_for_delivery(
+        {"name": "daily-review"},
+        "TimeoutError: local subprocess exceeded its deadline",
+    )
+
+    assert "local subprocess exceeded its deadline" in msg
+    assert "provider timeout" not in msg
+    assert "Fallback chain" not in msg

--- a/tests/cron/test_cron_inactivity_timeout.py
+++ b/tests/cron/test_cron_inactivity_timeout.py
@@ -9,11 +9,12 @@ Tests cover:
 """
 
 import concurrent.futures
-import os
 import sys
 import threading
 import time
 from pathlib import Path
+
+import pytest
 
 
 # Ensure project root is importable
@@ -167,24 +168,57 @@ class TestInactivityTimeout:
 
         assert result["final_response"] == "Done"
 
-    def _parse_cron_timeout(self, raw_value):
-        """Mirror the defensive parsing logic from cron/scheduler.py run_job()."""
-        if raw_value:
-            try:
-                return float(raw_value)
-            except (ValueError, TypeError):
-                return 600.0
-        return 600.0
-
     def test_timeout_env_var_parsing(self, monkeypatch):
         """HERMES_CRON_TIMEOUT env var is respected."""
+        from cron.jobs import resolve_cron_inactivity_timeout
+
         monkeypatch.setenv("HERMES_CRON_TIMEOUT", "1200")
-        raw = os.getenv("HERMES_CRON_TIMEOUT", "").strip()
-        _cron_timeout = self._parse_cron_timeout(raw)
+        _cron_timeout = resolve_cron_inactivity_timeout(
+            {"cron": {"inactivity_timeout_seconds": 3600}}
+        )
         assert _cron_timeout == 1200.0
 
         _cron_inactivity_limit = _cron_timeout if _cron_timeout > 0 else None
         assert _cron_inactivity_limit == 1200.0
+
+    def test_config_drives_scheduler_and_claim_ttl(self, monkeypatch):
+        from cron import jobs, scheduler
+
+        monkeypatch.delenv("HERMES_CRON_TIMEOUT", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"cron": {"inactivity_timeout_seconds": 3600}},
+        )
+
+        assert scheduler._cron_inactivity_seconds() == 3600.0
+        assert jobs._oneshot_run_claim_ttl_seconds() == 10800.0
+
+    def test_zero_means_unlimited_with_bounded_claim_fallback(self, monkeypatch):
+        from cron import jobs, scheduler
+
+        monkeypatch.setenv("HERMES_CRON_TIMEOUT", "0")
+
+        assert scheduler._cron_inactivity_seconds() == 0.0
+        assert jobs._oneshot_run_claim_ttl_seconds() == 1800.0
+
+    @pytest.mark.parametrize("value", [-1, "nan", "inf", "-inf", object()])
+    def test_invalid_values_use_default(self, monkeypatch, value):
+        from cron import jobs, scheduler
+
+        monkeypatch.delenv("HERMES_CRON_TIMEOUT", raising=False)
+        config = {"cron": {"inactivity_timeout_seconds": value}}
+
+        assert scheduler._cron_inactivity_seconds(config) == 600.0
+        assert jobs._oneshot_run_claim_ttl_seconds(config) == 1800.0
+
+    @pytest.mark.parametrize("value", ["-1", "nan", "inf", "-inf"])
+    def test_invalid_env_override_uses_default(self, monkeypatch, value):
+        from cron import jobs, scheduler
+
+        monkeypatch.setenv("HERMES_CRON_TIMEOUT", value)
+
+        assert scheduler._cron_inactivity_seconds() == 600.0
+        assert jobs._oneshot_run_claim_ttl_seconds() == 1800.0
 
 
     def test_agent_without_activity_summary_uses_wallclock_fallback(self):

--- a/website/docs/guides/cron-troubleshooting.md
+++ b/website/docs/guides/cron-troubleshooting.md
@@ -167,7 +167,14 @@ The skill must be installed on the machine running the scheduler. If you move be
 Likely a delivery target issue (see Delivery Failures above), no output, or a response containing the cron quiet marker `[SILENT]`.
 
 **Job hangs or times out**
-The scheduler uses an inactivity-based timeout (default 600s, configurable via `HERMES_CRON_TIMEOUT` env var, `0` for unlimited). The agent can run as long as it's actively calling tools — the timer only fires after sustained inactivity. Long-running jobs should use scripts to handle data collection and deliver only the result.
+The scheduler uses an inactivity-based timeout. The agent can run as long as it's actively calling tools — the timer only fires after sustained inactivity. Configure the timeout in `config.yaml` (`0` means unlimited):
+
+```yaml
+cron:
+  inactivity_timeout_seconds: 600
+```
+
+The legacy `HERMES_CRON_TIMEOUT` environment variable, when set, overrides the config value. Long-running jobs should use scripts to handle data collection and deliver only the result.
 
 ### Check 3: Lock contention
 


### PR DESCRIPTION
## Summary

- Add `cron.inactivity_timeout_seconds` as the durable YAML setting while retaining `HERMES_CRON_TIMEOUT` as the compatibility override.
- Resolve scheduler watchdog, cwd-lock, and one-shot claim TTL horizons through one helper.
- Preserve scheduler last-activity detail in failure delivery.
- Classify only provider-specific timeout signatures as provider/fallback failures.
- Deliver unrelated timeout errors verbatim instead of suggesting provider remediation.

Fixes #89035.

## Current-main refresh

- Base: `b6f42c667a59469b477220254fec6e2486e30e51`
- Head: `25af947fbfef5d909a81c02262f6d922d3be3bc7`

## Validation

- `python -m pytest -q -o 'addopts=' tests/cron/test_cron_failure_alert_remediation_hint.py tests/cron/test_cron_inactivity_timeout.py` → **25 passed**
- Ruff on changed files → passed
- `git diff --check origin/main...HEAD` → passed

## Negative controls

- Provider timeout signatures still receive provider/fallback remediation.
- Local subprocess timeout text does not.
- `HERMES_CRON_TIMEOUT` still overrides YAML.
- Invalid values fall back to the existing 600-second default.
