### PR TITLE
fix(gateway): preserve authorization denial outcomes

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -438,7 +438,12 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.helpers import fence_state_after
-from gateway.platforms.event import MessageEvent, MessageType, ProcessingOutcome
+from gateway.platforms.event import (
+    PROCESSING_OUTCOME_METADATA_KEY,
+    MessageEvent,
+    MessageType,
+    ProcessingOutcome,
+)
 from gateway.session import SessionSource, build_session_key
 from gateway.session_transcript import TranscriptReadError
 from hermes_constants import get_default_hermes_root, get_hermes_dir, get_hermes_home
@@ -4036,13 +4041,18 @@ class BasePlatformAdapter(ABC):
                     anything_sent=delivery_attempted or _tts_caption_delivered,
                     record_delivery=_record_delivery)
             processing_ok = delivery_succeeded if delivery_attempted else not bool(response)
+            explicit_outcome = event.metadata.get(PROCESSING_OUTCOME_METADATA_KEY)
+            outcome = (
+                explicit_outcome
+                if isinstance(explicit_outcome, ProcessingOutcome)
+                else ProcessingOutcome.SUCCESS if processing_ok else ProcessingOutcome.FAILURE
+            )
             # Clean up the per-turn streaming-TTS flag.
             self._streaming_tts_completed_turns.discard(self._streaming_tts_turn_key(
                 session_key, getattr(interrupt_event, "_hermes_run_generation", None),
                 event=event) or "")
             await self._run_processing_hook(
-                "on_processing_complete", event,
-                ProcessingOutcome.SUCCESS if processing_ok else ProcessingOutcome.FAILURE)
+                "on_processing_complete", event, outcome)
             # Force-flush an unfired debounce timer so this task hands off to a fresh drain task.
             # Clear the Event BEFORE the stop-typing await so concurrent inbound sees a live guard.
             await self._flush_text_debounce_now(session_key)

--- a/gateway/platforms/event.py
+++ b/gateway/platforms/event.py
@@ -32,6 +32,10 @@ class ProcessingOutcome(Enum):
     CANCELLED = "cancelled"
 
 
+# Per-event override for the adapter's processing-complete lifecycle hook.
+PROCESSING_OUTCOME_METADATA_KEY = "_hermes_processing_outcome"
+
+
 @dataclass
 class MessageEvent:
     """Incoming message from a platform — the normalized shape all adapters produce."""

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -19,7 +19,12 @@ import time
 from contextlib import suppress
 from gateway.config import Platform
 from gateway.platforms.base import EphemeralReply
-from gateway.platforms.event import MessageEvent, MessageType
+from gateway.platforms.event import (
+    PROCESSING_OUTCOME_METADATA_KEY,
+    MessageEvent,
+    MessageType,
+    ProcessingOutcome,
+)
 from gateway.run_common import _UNSET
 from gateway.session import (
     SessionSource, is_shared_multi_user_session, neutralize_untrusted_inline_text
@@ -189,6 +194,9 @@ class GatewayInboundMixin:
         source = event.source
 
         if not self._is_user_authorized_for_source(source):
+            # Empty handler responses are normally successful no-ops. Policy
+            # denials must still complete platform lifecycle hooks as failures.
+            event.metadata[PROCESSING_OUTCOME_METADATA_KEY] = ProcessingOutcome.FAILURE
             if source.user_id is None:
                 # No user identity (Telegram service messages, channel forwards, anonymous admin
                 # posts, sender_chat): can't be paired but may be authorized via a chat allowlist.

--- a/tests/gateway/test_base_topic_sessions.py
+++ b/tests/gateway/test_base_topic_sessions.py
@@ -9,7 +9,12 @@ import pytest
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter, SendResult
-from gateway.platforms.event import MessageEvent, MessageType, ProcessingOutcome
+from gateway.platforms.event import (
+    PROCESSING_OUTCOME_METADATA_KEY,
+    MessageEvent,
+    MessageType,
+    ProcessingOutcome,
+)
 from gateway.session import SessionSource, build_session_key
 
 
@@ -134,6 +139,46 @@ class TestBasePlatformTopicSessions:
         assert adapter.processing_hooks == [
             ("start", "1"),
             ("complete", "1", ProcessingOutcome.SUCCESS),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_process_message_empty_response_is_successful_noop(self):
+        adapter = DummyTelegramAdapter()
+
+        async def hold_typing(_chat_id, interval=2.0, metadata=None):
+            await asyncio.Event().wait()
+
+        adapter.set_message_handler(lambda _event: asyncio.sleep(0, result=None))
+        adapter._keep_typing = hold_typing
+
+        event = _make_event("-1001", "17585")
+        await adapter._process_message_background(event, build_session_key(event.source))
+
+        assert adapter.processing_hooks == [
+            ("start", "1"),
+            ("complete", "1", ProcessingOutcome.SUCCESS),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_process_message_honors_explicit_empty_response_failure(self):
+        adapter = DummyTelegramAdapter()
+
+        async def denied_handler(event):
+            event.metadata[PROCESSING_OUTCOME_METADATA_KEY] = ProcessingOutcome.FAILURE
+            return None
+
+        async def hold_typing(_chat_id, interval=2.0, metadata=None):
+            await asyncio.Event().wait()
+
+        adapter.set_message_handler(denied_handler)
+        adapter._keep_typing = hold_typing
+
+        event = _make_event("-1001", "17585")
+        await adapter._process_message_background(event, build_session_key(event.source))
+
+        assert adapter.processing_hooks == [
+            ("start", "1"),
+            ("complete", "1", ProcessingOutcome.FAILURE),
         ]
 
 

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -4,7 +4,11 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
-from gateway.platforms.event import MessageEvent
+from gateway.platforms.event import (
+    PROCESSING_OUTCOME_METADATA_KEY,
+    MessageEvent,
+    ProcessingOutcome,
+)
 from gateway.session import SessionSource
 
 
@@ -81,6 +85,19 @@ def _make_runner(platform: Platform, config: GatewayConfig):
     runner.hooks = SimpleNamespace(dispatch=AsyncMock(return_value=None))
     runner._sessions = {}
     return runner, adapter
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_event_marks_processing_failure(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "U_ALLOWED")
+    config = GatewayConfig(platforms={Platform.SLACK: PlatformConfig(enabled=True)})
+    runner, _adapter = _make_runner(Platform.SLACK, config)
+    event = _make_event(Platform.SLACK, "U_DENIED", "D_DENIED")
+
+    await runner._handle_message(event)
+
+    assert event.metadata[PROCESSING_OUTCOME_METADATA_KEY] is ProcessingOutcome.FAILURE
 
 
 def test_whatsapp_lid_user_matches_phone_allowlist_via_modern_session_mapping(


### PR DESCRIPTION
## Summary

Preserve an explicit authorization-denial processing outcome through the gateway completion hook. Unauthorized empty responses are reported as failure rather than successful no-ops, while ordinary empty/no-op handlers retain the existing success behavior.

The current-main refresh uses a shared event metadata key instead of duplicating a magic attribute contract.

## Current-main refresh

- Base: `b0d2148b437decfb060c03c82fc20777bc84aac8`
- Head: `57bc7009b83ecb088ac24f32810298f5b3aef0c5`

## Verification

- `pytest -q tests/gateway/test_base_topic_sessions.py tests/gateway/test_unauthorized_dm_behavior.py` — 19 passed
- Ruff on implementation/tests — passed
- `git diff --check` — passed

Closes #89039
