### PR TITLE
docs: Docs Site CI compiles again — escape stray backslash in cli-symbols.md

### DIFF
--- a/website/docs/reference/cli-symbols.md
+++ b/website/docs/reference/cli-symbols.md
@@ -38,7 +38,7 @@ The single line at the bottom of the TUI. Segments appear only when relevant and
 |--------|---------|
 | `⠋⠙⠹…` (braille patterns) | Busy spinner. Thinking and tool phases use different braille animation sets. |
 | `⚕ 🌀 🤔 ✨ 🍵 🔮` | Frames of the `emoji` busy-indicator style (`/indicator emoji`). The default style rotates kaomoji faces instead. |
-| <code>&#124; / - \</code> | Frames of the `ascii` busy-indicator style. |
+| <code>&#124; / - &#92;</code> | Frames of the `ascii` busy-indicator style. |
 | `⏱` | Per-prompt elapsed time while the turn runs, e.g. `⏱ 12s/3m 45s` (turn time / session time). |
 | `⏲` | The same timer, frozen after the turn completes. |
 | `cmp N` | The session has been auto-compressed N times. |


### PR DESCRIPTION
## Summary
Docs Site CI compiles again on main and every open PR. The just-merged CLI symbols glossary (acc614e72) put a raw `\` inside a `<code>` span in a table row — MDX treats it as an escape, never finds `</code>`, and `docs-site-checks` fails with "Expected a closing tag for `<code>` (41:3-41:9)". First observed red on PR #89027's run, but the broken file is on main so every branch is affected.

## Changes
- `website/docs/reference/cli-symbols.md`: escape the backslash as `&#92;` in the ascii busy-indicator row (renders identically as `| / - \`)

## Validation
| | Before | After |
|---|---|---|
| `npx docusaurus build` | MDX compile error on cli-symbols.md | clean build (run locally) |

## Infographic

![Docs build restored](https://v3b.fal.media/files/b/0aa6cf80/n94oMOijz82C_YGLcBVt1_4OE0OhjM.png)
