### PR TITLE
feat(email): copy sent replies to the Sent folder via IMAP APPEND

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -28,6 +28,7 @@ import socket
 from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
 from agent.secret_scope import get_secret as _scoped_get_secret
 import ssl
+import time
 import uuid
 from email.header import decode_header
 from email.mime.multipart import MIMEMultipart
@@ -550,6 +551,7 @@ class EmailAdapter(BasePlatformAdapter):
         # misleading ``[Errno 8] nodename nor servname`` (an unresolvable name)
         # instead of an obvious "host not set" error.
         extra = config.extra or {}
+        self._config_extra = extra
         self._address = (_get_secret("EMAIL_ADDRESS", "") or extra.get("address", "")).strip()
         self._password = _get_secret("EMAIL_PASSWORD", "")
         self._imap_host = (_get_secret("EMAIL_IMAP_HOST", "") or extra.get("imap_host", "")).strip()
@@ -1155,6 +1157,76 @@ class EmailAdapter(BasePlatformAdapter):
             return self._address.rsplit("@", 1)[-1] or "localhost"
         return "localhost"
 
+    def _sent_folder(self) -> str:
+        """Resolve the mailbox folder used to store sent-message copies.
+
+        Priority: explicit config (``platforms.email.sent_folder`` or the
+        ``EMAIL_SENT_FOLDER`` env var) → auto-detect via IMAP LIST → a small
+        fallback list of common names. Roundcube defaults to ``Sent``, but
+        other servers use ``Sent Items`` / ``Sent Messages``, so we probe.
+        """
+        extra = getattr(self, "_config_extra", {}) or {}
+        explicit = (extra.get("sent_folder") or _get_secret("EMAIL_SENT_FOLDER", "")).strip()
+        if explicit:
+            return explicit
+
+        candidates = ["Sent", "Sent Items", "Sent Messages", "INBOX.Sent"]
+        try:
+            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
+            try:
+                imap.login(self._address, self._password)
+                _send_imap_id(imap)
+                status, data = imap.list()
+                if status == "OK" and data:
+                    folders = []
+                    for item in data:
+                        if not isinstance(item, (bytes, bytearray)):
+                            continue
+                        # LIST returns b'(\\HasNoChildren) "/" "Sent"'
+                        name = item.decode("utf-8", "replace").split('"')[-2] if '"' in item.decode("utf-8", "replace") else ""
+                        if name:
+                            folders.append(name)
+                    for cand in candidates:
+                        if cand in folders:
+                            return cand
+            finally:
+                _close_imap(imap)
+        except Exception as e:
+            logger.debug("[Email] Sent-folder auto-detect failed: %s", e)
+
+        # Fall back to the most common default; APPEND will surface an error
+        # in the log if the folder does not exist on this server.
+        return "Sent"
+
+    def _append_to_sent(self, raw_bytes: bytes) -> None:
+        """Store a copy of a sent message in the Sent folder via IMAP APPEND.
+
+        SMTP only transmits the message; it does not persist a copy in the
+        mailbox, so Roundcube/other IMAP clients show an empty Sent folder
+        even though the mail was delivered. This APPENDs the exact bytes we
+        handed to SMTP (with the ``\\Seen`` flag so it renders as read) so the
+        sent copy is visible in the webmail UI. Best-effort: a failure here
+        must never fail the send itself.
+        """
+        try:
+            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
+            try:
+                imap.login(self._address, self._password)
+                _send_imap_id(imap)
+                folder = self._sent_folder()
+                # Create the folder if it does not exist yet (some servers
+                # only materialize Sent on first use).
+                try:
+                    imap.create(folder)
+                except Exception:
+                    pass
+                imap.append(folder, "\\Seen", imaplib.Time2Internaldate(time.time()), raw_bytes)
+                logger.info("[Email] Appended sent copy to %r", folder)
+            finally:
+                _close_imap(imap)
+        except Exception as e:
+            logger.warning("[Email] Failed to append sent copy to Sent folder: %s", e)
+
     def _send_email(
         self,
         to_addr: str,
@@ -1195,6 +1267,7 @@ class EmailAdapter(BasePlatformAdapter):
             except Exception:
                 smtp.close()
 
+        self._append_to_sent(msg.as_bytes())
         logger.info("[Email] Sent reply to %s (subject: %s)", to_addr, subject)
         return msg_id
 
@@ -1321,6 +1394,7 @@ class EmailAdapter(BasePlatformAdapter):
             except Exception:
                 smtp.close()
 
+        self._append_to_sent(msg.as_bytes())
         logger.info("[Email] Sent multi-attachment email to %s (%d files)", to_addr, len(file_paths))
         return msg_id
 
@@ -1399,6 +1473,7 @@ class EmailAdapter(BasePlatformAdapter):
             except Exception:
                 smtp.close()
 
+        self._append_to_sent(msg.as_bytes())
         return msg_id
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:

--- a/plugins/platforms/email/plugin.yaml
+++ b/plugins/platforms/email/plugin.yaml
@@ -37,3 +37,7 @@ optional_env:
     description: "Default address for cron / notification delivery"
     prompt: "Home address"
     password: false
+  - name: EMAIL_SENT_FOLDER
+    description: "Mailbox folder for sent-message copies (default: auto-detected)"
+    prompt: "Sent folder"
+    password: false

--- a/tests/gateway/test_email_sent_folder.py
+++ b/tests/gateway/test_email_sent_folder.py
@@ -1,0 +1,113 @@
+"""Tests for the Email adapter's sent-folder copy (IMAP APPEND).
+
+The SMTP path only transmits a message; it does not persist a copy in the
+mailbox, so webmail clients (Roundcube, etc.) show an empty Sent folder even
+though the mail was delivered. These tests cover the adapter's best-effort
+IMAP APPEND of the exact bytes handed to SMTP, with the ``\\Seen`` flag so the
+copy renders as read.
+"""
+
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+
+from gateway.config import PlatformConfig
+
+
+class TestSentFolderAppend(unittest.TestCase):
+    """Verify sent replies are copied to the Sent folder via IMAP APPEND."""
+
+    def _make_adapter(self, extra_env=None):
+        env = {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }
+        if extra_env:
+            env.update(extra_env)
+        with patch.dict(os.environ, env):
+            from plugins.platforms.email.adapter import EmailAdapter
+            return EmailAdapter(PlatformConfig(enabled=True))
+
+    def test_send_appends_copy_to_sent_folder(self):
+        """A successful SMTP send is followed by an IMAP APPEND to Sent."""
+        adapter = self._make_adapter()
+        adapter._thread_context["user@test.com"] = {
+            "subject": "Project question",
+            "message_id": "<original@test.com>",
+        }
+
+        mock_imap = MagicMock()
+        mock_imap.list.return_value = ("OK", [b'(\\HasNoChildren) "/" "Sent"'])
+
+        with patch("smtplib.SMTP") as mock_smtp, \
+             patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            adapter._send_email("user@test.com", "Here is the answer.", None)
+
+            # SMTP transmit happened.
+            mock_server.send_message.assert_called_once()
+            # IMAP APPEND happened with the Sent folder and \Seen flag.
+            mock_imap.append.assert_called_once()
+            args, _kwargs = mock_imap.append.call_args
+            self.assertEqual(args[0], "Sent")
+            self.assertEqual(args[1], "\\Seen")
+            self.assertIsInstance(args[3], bytes)
+
+    def test_sent_folder_explicit_env(self):
+        """EMAIL_SENT_FOLDER overrides auto-detection."""
+        adapter = self._make_adapter()
+        # _sent_folder() reads the env var at call time, so keep it set here.
+        with patch.dict(os.environ, {"EMAIL_SENT_FOLDER": "Custom Sent"}):
+            self.assertEqual(adapter._sent_folder(), "Custom Sent")
+
+    def test_sent_folder_explicit_config(self):
+        """platforms.email.sent_folder (config.extra) overrides auto-detection."""
+        from plugins.platforms.email.adapter import EmailAdapter
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }):
+            adapter = EmailAdapter(PlatformConfig(enabled=True, extra={"sent_folder": "Config Sent"}))
+        self.assertEqual(adapter._sent_folder(), "Config Sent")
+
+    def test_sent_folder_autodetect(self):
+        """Auto-detect picks the first matching common folder name."""
+        adapter = self._make_adapter()
+        mock_imap = MagicMock()
+        mock_imap.list.return_value = (
+            "OK",
+            [b'(\\HasNoChildren) "/" "INBOX"', b'(\\HasNoChildren) "/" "Sent Items"'],
+        )
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            self.assertEqual(adapter._sent_folder(), "Sent Items")
+
+    def test_append_failure_does_not_fail_send(self):
+        """A failed APPEND is best-effort and must not raise out of send."""
+        adapter = self._make_adapter()
+        adapter._thread_context["user@test.com"] = {
+            "subject": "Project question",
+            "message_id": "<original@test.com>",
+        }
+
+        mock_imap = MagicMock()
+        mock_imap.list.return_value = ("OK", [b'(\\HasNoChildren) "/" "Sent"'])
+        mock_imap.append.side_effect = Exception("append boom")
+
+        with patch("smtplib.SMTP") as mock_smtp, \
+             patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            # Must not raise even though APPEND failed.
+            adapter._send_email("user@test.com", "Here is the answer.", None)
+            mock_server.send_message.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -122,6 +122,20 @@ Replies are sent via SMTP with proper email threading:
 - **Message-ID** generated with the agent's domain
 - Responses are sent as plain text (UTF-8)
 
+### Sent Folder Copy
+
+SMTP only transmits a message — it does not store a copy in the mailbox, so
+webmail clients (Roundcube, etc.) would otherwise show an empty Sent folder
+even though the mail was delivered. After each successful send, the adapter
+APPENDs a copy of the exact bytes it handed to SMTP to the Sent folder via
+IMAP, flagged `\Seen` so it renders as read.
+
+- The Sent folder is auto-detected from the mailbox (tries `Sent`,
+  `Sent Items`, `Sent Messages`, `INBOX.Sent`) and created if missing.
+- Override the folder with `EMAIL_SENT_FOLDER` (or `platforms.email.sent_folder`
+  in `config.yaml`) if your server uses a non-standard name.
+- The copy is best-effort: a failed APPEND is logged but never fails the send.
+
 ### File Attachments
 
 The agent can send file attachments in replies. Include `MEDIA:/path/to/file` in the response and the file is attached to the outgoing email.
@@ -196,3 +210,4 @@ Email access is stricter by default than chat-style platforms:
 | `EMAIL_ALLOWED_USERS` | No | — | Comma-separated allowed sender addresses |
 | `EMAIL_HOME_ADDRESS` | No | — | Default delivery target for cron jobs |
 | `EMAIL_ALLOW_ALL_USERS` | No | `false` | Allow all senders (not recommended) |
+| `EMAIL_SENT_FOLDER` | No | auto-detected | Mailbox folder for sent-message copies (e.g., `Sent`) |


### PR DESCRIPTION
## Problem

The Email gateway adapter sends replies over SMTP only. SMTP transmits a message but does **not** persist a copy in the mailbox, so webmail clients (Roundcube, cPanel webmail, etc.) show an **empty Sent folder** even though the mail was delivered. Users checking the agent's mailbox in webmail see no record of what the agent sent.

## Fix

After each successful SMTP send, the adapter APPENDs the exact bytes it handed to SMTP to the Sent folder via IMAP, flagged `\Seen` so the copy renders as read (no unread noise).

- **Auto-detect** the Sent folder from the mailbox (`Sent`, `Sent Items`, `Sent Messages`, `INBOX.Sent`) and create it if missing.
- **Override** via `EMAIL_SENT_FOLDER` env var or `platforms.email.sent_folder` in `config.yaml` for non-standard folder names.
- **Best-effort**: a failed APPEND is logged but never fails the send itself.

## Changes

- `plugins/platforms/email/adapter.py` — add `_sent_folder()` (resolve folder) and `_append_to_sent()` (IMAP APPEND), wired into all three send paths (`_send_email`, `_send_email_with_attachments`, `_send_email_with_attachment`).
- `plugins/platforms/email/plugin.yaml` — register the optional `EMAIL_SENT_FOLDER` env var.
- `tests/gateway/test_email_sent_folder.py` — new tests: APPEND on send, explicit env/config override, auto-detect, and APPEND-failure-does-not-fail-send.
- `website/docs/user-guide/messaging/email.md` — document the Sent Folder Copy behavior and the new env var.

## Testing

- New: `tests/gateway/test_email_sent_folder.py` — 5 passed.
- Existing email suite (`test_email.py`, `test_email_robustness.py`, `test_email_charset_fallback.py`, `test_email_secret_scope.py`) — 62 passed, no regressions.
- Manually verified against a live cPanel/Roundcube mailbox: sent replies now appear in the webmail Sent folder.
