### PR TITLE
fix(docs): escape ASCII indicator backslash

### DIFF
--- a/website/docs/reference/cli-symbols.md
+++ b/website/docs/reference/cli-symbols.md
@@ -38,7 +38,7 @@ The single line at the bottom of the TUI. Segments appear only when relevant and
 |--------|---------|
 | `⠋⠙⠹…` (braille patterns) | Busy spinner. Thinking and tool phases use different braille animation sets. |
 | `⚕ 🌀 🤔 ✨ 🍵 🔮` | Frames of the `emoji` busy-indicator style (`/indicator emoji`). The default style rotates kaomoji faces instead. |
-| <code>&#124; / - \</code> | Frames of the `ascii` busy-indicator style. |
+| <code>&#124; / - &#92;</code> | Frames of the `ascii` busy-indicator style. |
 | `⏱` | Per-prompt elapsed time while the turn runs, e.g. `⏱ 12s/3m 45s` (turn time / session time). |
 | `⏲` | The same timer, frozen after the turn completes. |
 | `cmp N` | The session has been auto-compressed N times. |


### PR DESCRIPTION
## What does this PR do?

Fixes the Docs Site build after the CLI symbols glossary added an ASCII spinner row containing a raw trailing backslash.

In MDX, that backslash escapes the opening character of `</code>`, so Docusaurus reports an unterminated `<code>` element. Encoding the backslash as `&#92;` preserves the rendered symbol and lets MDX parse the table.

## Related Issue

No tracking issue. The regression was introduced by `acc614e72` and currently affects Docs Site checks for PRs based on that revision.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Encode the ASCII spinner's backslash as `&#92;` inside the existing `<code>` element.

## How to Test

```bash
cd website
npm run build:fast
```

Verified locally with Node 22 and npm 11.17.0: the English Docusaurus client and server bundles compile successfully and static files are generated.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit message follows Conventional Commits
- [x] I searched existing PRs for the same fix
- [x] This PR contains only the one-line MDX fix
- [ ] `pytest tests/ -q` — N/A; no Python code changed
- [x] I've tested the affected Docs Site build

### Documentation & Housekeeping

- [x] No configuration, contributor workflow, platform code, or tool schema changed

## Screenshots / Logs

Before:

```text
Expected a closing tag for `<code>` before the end of `tableData`
```

After: Docusaurus client and server compiled successfully and generated the static site.
