### PR TITLE
fix(slack): trim bare command composer padding

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -4234,6 +4234,13 @@ class SlackAdapter(BasePlatformAdapter):
         if command_probe_text != original_text.lstrip():
             original_text = command_probe_text
         is_command_text = command_probe_text.startswith("/")
+        if is_command_text:
+            # Slack can append composer padding to a bare command. Trim that
+            # padding without changing argument bytes for commands that have
+            # an authored argument segment.
+            trimmed_command = command_probe_text.rstrip()
+            if not any(char.isspace() for char in trimmed_command):
+                command_probe_text = trimmed_command
         text = original_text
         # Quoted/forwarded block text is absent from flat ``text``. Skipped for commands: after
         # the ``!``→``/`` rewrite it no longer dedupes and would become bogus arguments.

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1397,6 +1397,17 @@ class TestBangPrefixCommands:
         assert msg_event.text == "/queue  --flag  value  "
         assert msg_event.get_command_args() == "--flag  value  "
 
+    @pytest.mark.asyncio
+    async def test_bare_command_trims_composer_padding(self, adapter):
+        await adapter._handle_slack_message(
+            self._make_event("/restart   ", thread_ts="1111111111.000001")
+        )
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "/restart"
+        assert msg_event.message_type == MessageType.COMMAND
+        assert msg_event.source.thread_id == "1111111111.000001"
+
 
     @pytest.mark.asyncio
     async def test_leading_space_slash_command_is_a_command(self, adapter):


### PR DESCRIPTION
## Summary

Trim trailing Slack composer padding only for bare slash/bang commands so commands such as `/restart   ` route correctly in threads. Preserve exact argument whitespace for commands that include arguments.

## Current-main refresh

- Base: `b0d2148b437decfb060c03c82fc20777bc84aac8`
- Head: `1bb4e33ea823c969eab28b5e124c1239dc1e0f5b`
- Scope: Slack adapter canonicalization and focused regression only

## Verification

- `pytest -q tests/gateway/test_slack.py -k BangPrefixCommands` — 11 passed
- Ruff on adapter/test — passed
- `git diff --check` — passed

Closes #89046
