### PR TITLE
fix(cli): stop doctor reporting an API key that is not configured

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -4,12 +4,15 @@ Doctor command for hermes CLI.
 Diagnoses issues with Hermes Agent setup.
 """
 
+import io
 import os
 import sys
 import subprocess
 import shutil
 import importlib.util
 from pathlib import Path
+
+from dotenv import dotenv_values
 
 from hermes_cli.config import (
     detect_install_method,
@@ -260,9 +263,39 @@ def _termux_install_all_fallback_notes() -> list[str]:
     ]
 
 
+def _provider_env_config_source(content: str) -> str | None:
+    """Return where a usable provider credential came from, or None.
+
+    ``content`` is the raw text of ``~/.hermes/.env``.  Returns ``"env-file"``
+    when the file itself assigns a usable value to a known provider key,
+    ``"environment"`` when only the process environment carries one (a shell
+    export, or an external secret source such as Bitwarden), and ``None`` when
+    neither does.
+
+    The file is parsed instead of substring-searched.  ``.env.example`` ships
+    commented-out samples such as ``# OPENROUTER_API_KEY=``, so a raw ``in``
+    test reports a key on every fresh install that has none.  Parsing also
+    rejects empty values, placeholders, and unrelated keys that merely contain
+    a hint name (``STT_OPENAI_BASE_URL`` contains ``OPENAI_BASE_URL``).
+    """
+    # Imported lazily: every other hermes_cli.auth use in this module is
+    # function-local, and doctor runs on startup paths where auth is heavy.
+    from hermes_cli.auth import has_usable_secret
+
+    parsed = dotenv_values(stream=io.StringIO(content))
+    if any(has_usable_secret(parsed.get(key)) for key in _PROVIDER_ENV_HINTS):
+        return "env-file"
+    # A key supplied by a shell export or an external secret source is
+    # legitimate and never appears in .env — checking os.environ keeps this
+    # check from turning a false positive into a false negative.
+    if any(has_usable_secret(os.environ.get(key)) for key in _PROVIDER_ENV_HINTS):
+        return "environment"
+    return None
+
+
 def _has_provider_env_config(content: str) -> bool:
-    """Return True when ~/.hermes/.env contains provider auth/base URL settings."""
-    return any(key in content for key in _PROVIDER_ENV_HINTS)
+    """Return True when a usable provider credential is configured."""
+    return _provider_env_config_source(content) is not None
 
 
 def _honcho_is_configured_for_doctor() -> bool:
@@ -1149,10 +1182,16 @@ def run_doctor(args):
             content = env_path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             content = env_path.read_text(encoding="latin-1")
-        if _has_provider_env_config(content):
-            check_ok("API key or custom endpoint configured")
+        env_config_source = _provider_env_config_source(content)
+        if env_config_source == "env-file":
+            check_ok(f"API key configured in {_DHH}/.env")
+        elif env_config_source == "environment":
+            check_ok("API key found in environment", "(shell export or secret source)")
         else:
-            check_warn(f"No API key found in {_DHH}/.env")
+            check_warn(
+                f"No usable API key in {_DHH}/.env",
+                "(only commented-out or placeholder entries)",
+            )
             issues.append("Run 'hermes setup' to configure API keys")
     else:
         # Also check project root as fallback

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -13,7 +13,7 @@ import pytest
 import hermes_cli.doctor as doctor
 import hermes_cli.gateway as gateway_cli
 from hermes_cli import doctor as doctor_mod
-from hermes_cli.doctor import _has_provider_env_config
+from hermes_cli.doctor import _has_provider_env_config, _provider_env_config_source
 
 
 class TestDoctorPlatformHints:
@@ -55,6 +55,12 @@ class TestDoctorPlatformHints:
 
 
 class TestProviderEnvDetection:
+    @pytest.fixture(autouse=True)
+    def _clear_provider_env(self, monkeypatch):
+        """Detection falls back to os.environ, so pin it for deterministic runs."""
+        for env_name in doctor._PROVIDER_ENV_HINTS:
+            monkeypatch.delenv(env_name, raising=False)
+
     def test_detects_openai_api_key(self):
         content = "OPENAI_BASE_URL=http://localhost:1234/v1\nOPENAI_API_KEY=***"
         assert _has_provider_env_config(content)
@@ -63,6 +69,40 @@ class TestProviderEnvDetection:
     def test_returns_false_when_no_provider_settings(self):
         content = "TERMINAL_ENV=local\n"
         assert not _has_provider_env_config(content)
+
+    def test_commented_out_key_is_not_configured(self):
+        """.env.example ships `# OPENROUTER_API_KEY=`, so every fresh install hit this."""
+        content = (
+            "# Get your key at: https://openrouter.ai/keys\n"
+            "# OPENROUTER_API_KEY=\n"
+            "# ANTHROPIC_API_KEY=sk-ant-...\n"
+        )
+        assert not _has_provider_env_config(content)
+
+    def test_empty_value_is_not_configured(self):
+        assert not _has_provider_env_config("OPENROUTER_API_KEY=\n")
+
+    def test_placeholder_value_is_not_configured(self):
+        assert not _has_provider_env_config("ANTHROPIC_API_KEY=your_api_key_here\n")
+
+    def test_unrelated_key_containing_a_hint_name_is_not_configured(self):
+        """STT_OPENAI_BASE_URL contains the hint OPENAI_BASE_URL but is unrelated."""
+        assert not _has_provider_env_config("STT_OPENAI_BASE_URL=https://api.example/v1\n")
+
+    def test_export_prefixed_assignment_is_configured(self):
+        assert _has_provider_env_config("export ANTHROPIC_TOKEN=sk-ant-abcdef123456\n")
+
+    def test_source_is_env_file_when_key_lives_in_the_file(self):
+        content = "ANTHROPIC_API_KEY=sk-ant-abcdef123456\n"
+        assert _provider_env_config_source(content) == "env-file"
+
+    def test_source_is_environment_for_shell_exported_key(self, monkeypatch):
+        """A shell export or secret source never appears in .env — do not report it missing."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-abcdef123456")
+        assert _provider_env_config_source("# ANTHROPIC_API_KEY=\n") == "environment"
+
+    def test_source_is_none_when_nothing_is_configured(self):
+        assert _provider_env_config_source("# ANTHROPIC_API_KEY=\n") is None
 
 
 class TestDoctorToolAvailabilitySummary:
@@ -840,7 +880,7 @@ def test_run_doctor_kimi_cn_env_is_detected_and_probe_is_null_safe(monkeypatch, 
         doctor_mod.run_doctor(Namespace(fix=False))
     out = buf.getvalue()
 
-    assert "API key or custom endpoint configured" in out
+    assert "API key configured in" in out
     assert "Kimi / Moonshot (China)" in out
     assert "str expected, not NoneType" not in out
     assert any(url == "https://api.moonshot.cn/v1/models" for url, _, _ in calls)

--- a/tests/hermes_cli/test_fireworks_provider.py
+++ b/tests/hermes_cli/test_fireworks_provider.py
@@ -19,6 +19,9 @@ import pytest
 if "dotenv" not in sys.modules:
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    # doctor parses ~/.hermes/.env to tell a real key from a commented-out
+    # sample; this stub only has to mirror the API surface, not parse.
+    fake_dotenv.dotenv_values = lambda *args, **kwargs: {}
     sys.modules["dotenv"] = fake_dotenv
 
 from hermes_cli.auth import resolve_api_key_provider_credentials

--- a/tests/hermes_cli/test_gmi_provider.py
+++ b/tests/hermes_cli/test_gmi_provider.py
@@ -14,6 +14,9 @@ import pytest
 if "dotenv" not in sys.modules:
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    # doctor parses ~/.hermes/.env to tell a real key from a commented-out
+    # sample; this stub only has to mirror the API surface, not parse.
+    fake_dotenv.dotenv_values = lambda *args, **kwargs: {}
     sys.modules["dotenv"] = fake_dotenv
 
 from hermes_cli.auth import resolve_provider
@@ -198,7 +201,7 @@ class TestGmiDoctor:
             doctor_mod.run_doctor(Namespace(fix=False))
         out = buf.getvalue()
 
-        assert "API key or custom endpoint configured" in out
+        assert "API key found in environment" in out
         assert "GMI Cloud" in out
         assert any(url == "https://api.gmi-serving.com/v1/models" for url, _, _ in calls)
 


### PR DESCRIPTION
## What

`hermes doctor` reports `✓ API key or custom endpoint configured` on installs that have **no API key at all**, and silently skips the `Run 'hermes setup' to configure API keys` remediation that should have fired.

## Why it affects every fresh install

`.env.example` ships a commented-out sample at line 17:

```
# OPENROUTER_API_KEY=
```

`~/.hermes/.env` is seeded from that file, and the check is a raw substring search over the file's text (`hermes_cli/doctor.py`):

```python
def _has_provider_env_config(content: str) -> bool:
    return any(key in content for key in _PROVIDER_ENV_HINTS)
```

The string `OPENROUTER_API_KEY` is present, so the check passes. A new user sees a green diagnostic, then hits an opaque failure on their first message.

### Reproduction

```sh
# On a fresh install with no key configured:
grep -c '^[^#]*_API_KEY=' ~/.hermes/.env     # → 0
hermes doctor | grep -i 'api key'            # → ✓ API key or custom endpoint configured
```

Verified on macOS 26.5.2 (Darwin 25.5.0), Hermes 0.19.1, Python 3.11 — an install whose `.env` contains only `TERMINAL_*`, `BROWSER*` and `*_DEBUG` entries.

### Four families of false positive

| Case | Example | Reported | Correct |
|---|---|---|---|
| Commented-out line | `# ANTHROPIC_API_KEY=sk-ant-...` | configured | not configured |
| Empty value | `OPENROUTER_API_KEY=` | configured | not configured |
| Placeholder | `ANTHROPIC_API_KEY=your_api_key_here` | configured | not configured |
| Substring collision | `STT_OPENAI_BASE_URL=…` matches hint `OPENAI_BASE_URL` | configured | not configured |

## How

Parse the file instead of searching its text, and reuse what already exists rather than adding new logic:

- **`dotenv_values()`** (`python-dotenv`, already a pinned core dependency) — drops comments, handles the `export ` prefix, and surfaces empty values so they can be filtered.
- **Exact key matching** against `_PROVIDER_ENV_HINTS` — kills the `STT_OPENAI_BASE_URL` collision.
- **`has_usable_secret()`** from `hermes_cli/auth.py` — already rejects empty, too-short, and placeholder values via `_PLACEHOLDER_SECRET_VALUES`. No new placeholder list.

### Not trading a false positive for a false negative

A credential can legitimately never appear in `.env` — a shell export (which `env_loader.py` documents as a supported path) or an external secret source such as Bitwarden. Tightening the `.env` check alone would regress those users from a wrong ✓ to a wrong ⚠.

So detection falls back to `os.environ`, and the three outcomes are reported separately:

| Situation | Output |
|---|---|
| Usable key in the file | `✓ API key configured in ~/.hermes/.env` |
| Only in the environment | `✓ API key found in environment (shell export or secret source)` |
| Nothing usable | `⚠ No usable API key in ~/.hermes/.env (only commented-out or placeholder entries)` |

The third case restores the `Run 'hermes setup'` remediation. Naming *why* nothing was found is the point — "commented-out or placeholder" is exactly the state users get stuck in.

## Tests

Added to `TestProviderEnvDetection`, covering each false-positive family plus both source labels and the `export ` prefix. All four cases return `True` (wrong) against the previous implementation and `False` (correct) after the change.

The class gains an autouse fixture clearing `_PROVIDER_ENV_HINTS` from `os.environ`, since detection now consults it and results would otherwise depend on the developer's shell.

Two existing assertions were updated for the new messages. Both tests turn out to already exercise the environment fallback — they write a placeholder (`***`) to `.env` and the real key to `os.environ`.

The `dotenv` stubs in `test_gmi_provider.py` and `test_fireworks_provider.py` gain `dotenv_values`, mirroring the API surface the code under test now uses. They are the only two of the sixteen stubbing files that import `doctor`.

```
scripts/run_tests.sh tests/hermes_cli/test_doctor.py \
  tests/hermes_cli/test_gmi_provider.py \
  tests/hermes_cli/test_fireworks_provider.py
→ 3 files, 99 tests passed, 0 failed
```

`scripts/run_tests.sh tests/hermes_cli/` shows 2 failures in `test_service_manager.py` and `test_kanban_review_surfaces.py`; both reproduce identically on an unmodified checkout (macOS directory-mode assertions) and are unrelated to this change. `ruff check` is clean on all four files.

**Platforms tested:** macOS 26.5.2 (arm64), Python 3.11.15.

## Related

#45155 reports a neighbouring problem — doctor reporting Anthropic as OK while a real invocation fails on billing. That is a different root cause (a key that exists but cannot be used) and needs live-invocation verification, so it is deliberately out of scope here.
