### PR TITLE
fix(desktop): apply persisted backend skin once it syncs after connect

### DIFF
--- a/apps/desktop/src/themes/context.test.tsx
+++ b/apps/desktop/src/themes/context.test.tsx
@@ -67,4 +67,26 @@ describe('ThemeProvider ← backend skin sync', () => {
     )
     expect(cssVar('--theme-foreground')).toBe('#ff9f0a')
   })
+
+  it('applies a persisted backend skin once its definition syncs after connect', () => {
+    // A prior session selected a backend skin for the default profile, so the
+    // persisted pref names it — but at boot its definition has not synced yet.
+    window.localStorage.setItem('hermes-desktop-theme-v2', 'bloomberg')
+
+    render(
+      <ThemeProvider>
+        <div />
+      </ThemeProvider>
+    )
+
+    // Not resolvable yet → the theme falls back to the default, not the skin.
+    expect(cssVar('--theme-foreground')).not.toBe('#ff9f0a')
+
+    // The gateway connects and SEEDS the skin (apply:false). The persisted pref
+    // must now re-resolve and repaint without a manual profile switch.
+    act(() => ingestBackendSkin(bloomberg('#ff9f0a'), { apply: false }))
+
+    expect(cssVar('--theme-foreground')).toBe('#ff9f0a')
+    expect(cssVar('--theme-background-seed')).toBe('#000000')
+  })
 })

--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -354,6 +354,21 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     setModeState(modePref.resolve(profileKey))
   }, [profileKey])
 
+  // A skin authored in $HERMES_HOME/skins/*.yaml only becomes resolvable once
+  // the gateway syncs it into $backendThemes AFTER connect — i.e. after the
+  // boot-time paint and the initial state init above. If the active profile's
+  // persisted pref points at such a skin, that first normalization silently
+  // fell back to the default (nous), and the connect-time seed (apply:false)
+  // deliberately does not repaint — so the choice was lost until the user
+  // switched profiles. Re-resolve the persisted pref whenever the skin registry
+  // changes, so a now-resolvable backend skin applies on its own at startup.
+  // Same-value sets are React no-ops and the pref is only ever re-read (never
+  // written), so a manual pick already persisted can't be stomped here.
+  useEffect(() => {
+    const live = normalizeProfileKey($activeGatewayProfile.get())
+    setThemeNameState(skinPref.resolve(live))
+  }, [userThemes, backendThemes, registryVersion])
+
   // Appearance is per-profile localStorage, and every desktop window is another
   // renderer on the same origin — so a switch made in the HUD (or any peer
   // window) only ever repainted the window it was made in. `storage` fires in


### PR DESCRIPTION
## Summary

Fixes a startup bug where a custom skin (from `$HERMES_HOME/skins/*.yaml`) selected for a profile did not apply when Hermes Desktop reopened — the app fell back to the default `nous` theme until the user manually switched profiles and back.

## Root cause

Custom skins only become resolvable in the desktop once the gateway syncs them into `$backendThemes` after connect, which happens *after* the boot-time paint and the initial theme-state init. At boot, `normalizeSkin()` could not find the persisted skin name in the still-empty registry, so it silently fell back to `nous`. The connect-time seed is deliberately `apply: false` (so it doesn't stomp a manual pick), which means nothing re-resolved the persisted choice.

## Fix

Re-resolve the active profile's persisted skin pref whenever the skin registry changes (`$userThemes`, `$backendThemes`, contributed themes). A now-resolvable backend skin then applies on its own at startup. The pref is only ever re-read (never written), so a manual pick already persisted can't be stomped, and same-value sets are React no-ops.

## Test plan

- Added a regression test reproducing the boot-time race: a persisted pref names a backend skin → theme falls back to `nous` → `ingestBackendSkin(..., { apply: false })` seeds it → the theme applies without a profile switch.
- `npx vitest run src/themes/` — 67/67 pass.

## Manual verification

On macOS: selected a custom skin, restarted Hermes Desktop, and the skin applied automatically on launch (no profile switch required).
