### PR TITLE
fix(tests): plugin-prompt-sections byte-stability test no longer trips on live git output

### DIFF
--- a/tests/agent/test_plugin_prompt_sections.py
+++ b/tests/agent/test_plugin_prompt_sections.py
@@ -42,6 +42,16 @@ def _install_test_section(manager: PluginManager, content) -> None:
 
 
 def test_real_aiagent_builds_section_once_and_keeps_it_out_of_static_prefix(monkeypatch):
+    # Pin the workspace snapshot: build_coding_workspace_block shells out to
+    # live `git status`/`git log` on every build, and a git call failing or
+    # timing out under xdist contention makes the two builds differ in the
+    # Branch/Recent-commits lines — a flake unrelated to what this test
+    # asserts (plugin sections). Byte-stability of the REAL workspace block
+    # is coding_context's contract, covered by its own tests.
+    monkeypatch.setattr(
+        "agent.coding_context.build_coding_workspace_block",
+        lambda cwd=None: "Workspace (snapshot at session start):\n- Root: /pinned",
+    )
     calls = []
 
     def section(session_info):


### PR DESCRIPTION
## Summary
`test_real_aiagent_builds_section_once_and_keeps_it_out_of_static_prefix` no longer fails on unrelated PRs: it now pins the workspace snapshot instead of embedding live `git status`/`git log` output in its byte-equality assertion.

Root cause: the test builds the system prompt twice and asserts byte equality, but the prompt embeds `build_coding_workspace_block()` — live git output. A git call failing between the two builds (xdist contention on CI runners) changes the Branch/Recent-commits lines and the assertion fails on whatever PR happens to be running (first seen on #89027, slice 10: diff showed only `- Branch: (detached HEAD)` + recent-commit lines).

## Changes
- `tests/agent/test_plugin_prompt_sections.py`: monkeypatch `build_coding_workspace_block` to a fixed string in the byte-stability test. The real block's stability is `coding_context`'s own contract; this test asserts plugin-section behavior.

## Validation
| Scenario (coding posture on, cwd = checkout, like CI) | first == rebuilt |
|---|---|
| Unpinned, git call fails on rebuild | **False** (reproduces the CI failure) |
| Pinned, git broken entirely | True |
| Test as committed, local run | pass |

## Infographic

![Byte-stable prompts](https://v3b.fal.media/files/b/0aa6d009/Spz_vF3TEOZyntaKHiimd_M4T7aSat.png)
