### PR TITLE
fix(update): make desktop update completion durable

### DIFF
--- a/apps/desktop/src/app/settings/about-settings.tsx
+++ b/apps/desktop/src/app/settings/about-settings.tsx
@@ -13,9 +13,9 @@ import {
   $updateChecking,
   $updateStatus,
   checkUpdates,
-  openUpdatesWindow,
+  openUpdateOverlayFor,
   refreshDesktopVersion,
-  startActiveUpdate
+  startUpdateFor
 } from '@/store/updates'
 
 import { ListRow, SectionHeading, SettingsContent } from './primitives'
@@ -173,10 +173,10 @@ export function AboutSettings() {
 
             {updateAvailable && supported && !applying && (
               <>
-                <Button onClick={() => startActiveUpdate()} size="sm">
+                <Button onClick={() => startUpdateFor('client')} size="sm">
                   {a.updateNow}
                 </Button>
-                <Button onClick={() => openUpdatesWindow()} size="sm" variant="textStrong">
+                <Button onClick={() => openUpdateOverlayFor('client')} size="sm" variant="textStrong">
                   {a.seeWhatsNew}
                 </Button>
               </>

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -54,6 +54,7 @@ const {
   $updateOverlayTarget,
   requestActiveUpdate,
   resetUpdateApplyState,
+  startUpdateFor,
   startUpdatePoller,
   stopUpdatePoller,
   $updateStatus
@@ -69,7 +70,11 @@ const status = (over: Partial<DesktopUpdateStatus> = {}): DesktopUpdateStatus =>
   ...over
 })
 
-const lastToast = () => notifySpy.mock.calls.at(-1)?.[0] as { onDismiss: () => void }
+const lastToast = () =>
+  notifySpy.mock.calls.at(-1)?.[0] as {
+    action: { onClick: () => void }
+    onDismiss: () => void
+  }
 
 const setRemote = (on: boolean) =>
   setConnection({
@@ -131,6 +136,15 @@ describe('maybeNotifyUpdateAvailable', () => {
     maybeNotifyUpdateAvailable(status({ behind: null, updateAvailable: true }))
     expect(notifySpy).toHaveBeenCalledTimes(1)
     expect(notifySpy.mock.calls[0]?.[0]).toMatchObject({ message: 'A new update is available.' })
+  })
+
+  it('opens the CLIENT update from a client toast while connected remotely', () => {
+    setRemote(true)
+    maybeNotifyUpdateAvailable(status(), 'client')
+
+    lastToast().action.onClick()
+
+    expect($updateOverlayTarget.get()).toBe('client')
   })
 })
 
@@ -328,6 +342,16 @@ describe('requestActiveUpdate', () => {
 
     expect(applyClientMock).not.toHaveBeenCalled()
     expect($updateOverlayTarget.get()).toBe('backend')
+  })
+
+  it('can explicitly apply the CLIENT update while connected remotely', async () => {
+    setRemote(true)
+
+    startUpdateFor('client')
+    await vi.waitFor(() => expect(applyClientMock).toHaveBeenCalled())
+
+    expect(updateHermesSpy).not.toHaveBeenCalled()
+    expect($updateOverlayTarget.get()).toBe('client')
   })
 
   it('always opens the overlay, so selecting the row is never a silent no-op', () => {

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -204,7 +204,7 @@ export function reportInstallMethodWarning(message: string | undefined): void {
  * (re)starts the cooldown, so a busy upstream branch doesn't re-spam the user
  * on every new commit. The snooze is persisted, so it survives relaunches too.
  */
-export function maybeNotifyUpdateAvailable(status: DesktopUpdateStatus | null) {
+export function maybeNotifyUpdateAvailable(status: DesktopUpdateStatus | null, target: UpdateTarget = 'client') {
   if (!status || status.supported === false || status.error || !status.targetSha) {
     return
   }
@@ -230,7 +230,7 @@ export function maybeNotifyUpdateAvailable(status: DesktopUpdateStatus | null) {
       label: translateNow('notifications.seeWhatsNew'),
       onClick: () => {
         snoozeUpdateToast()
-        openUpdatesWindow()
+        openUpdateOverlayFor(target)
       }
     },
     durationMs: 0,
@@ -257,11 +257,14 @@ export function openUpdatesWindow(): void {
  * Used by the "Update now" affordance on the About panel, which would otherwise
  * only be able to open the changelog overlay.
  */
-export function startActiveUpdate(): void {
-  const target: UpdateTarget = isRemoteMode() ? 'backend' : 'client'
+export function startUpdateFor(target: UpdateTarget): void {
   $updateOverlayTarget.set(target)
   $updateOverlayOpen.set(true)
   void (target === 'backend' ? applyBackendUpdate() : applyUpdates())
+}
+
+export function startActiveUpdate(): void {
+  startUpdateFor(isRemoteMode() ? 'backend' : 'client')
 }
 
 /**
@@ -340,7 +343,7 @@ export async function checkBackendUpdates(): Promise<DesktopUpdateStatus | null>
   try {
     const status = mapBackendCheck(await checkHermesUpdate(true))
     $backendUpdateStatus.set(status)
-    maybeNotifyUpdateAvailable(status)
+    maybeNotifyUpdateAvailable(status, 'backend')
 
     return status
   } catch (error) {
@@ -371,7 +374,7 @@ export async function checkUpdates(): Promise<DesktopUpdateStatus | null> {
   try {
     const status = await bridge.check()
     $updateStatus.set(status)
-    maybeNotifyUpdateAvailable(status)
+    maybeNotifyUpdateAvailable(status, 'client')
     void refreshDesktopVersion()
 
     return status

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -996,6 +996,13 @@ def _print_update_completion(message: str) -> None:
     action_id = os.environ.get("HERMES_ACTION_ID", "")
     if len(action_id) == 32 and all(char in "0123456789abcdef" for char in action_id):
         print(f"=== hermes-update completed {action_id} ===")
+        # The next phase may restart the dashboard systemd unit, terminating
+        # this child before Python's block-buffered action-log stream exits.
+        # Flush the receipt now so the relaunched backend can prove success.
+        try:
+            sys.stdout.flush()
+        except (BrokenPipeError, OSError, ValueError):
+            pass
 
 
 def _read_project_version() -> str | None:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5451,6 +5451,18 @@ async def get_action_status(name: str, lines: int = 200):
         running = False
         exit_code = result.get("exit_code") if result else None
         pid = result.get("pid") if result else None
+        if name == "hermes-update" and result is None:
+            # A successful self-update restarts this dashboard process. That
+            # loses the in-memory Popen/result maps and may close the redirected
+            # action log before the child prints its completion marker. The
+            # updater mirrors every write to update.log, so use that durable
+            # stream when reconciling from the restarted server process.
+            durable_tail = _tail_lines(
+                _ACTION_LOG_DIR / "update.log",
+                min(max(lines, 1), 2000),
+            )
+            if durable_tail:
+                tail = durable_tail
     else:
         exit_code = proc.poll()
         running = exit_code is None

--- a/tests/hermes_cli/test_update_hangup_protection.py
+++ b/tests/hermes_cli/test_update_hangup_protection.py
@@ -48,6 +48,34 @@ def test_update_completion_rejects_untrusted_action_identity(monkeypatch, capsys
     assert capsys.readouterr().out == "✓ Update complete!\n"
 
 
+def test_update_completion_flushes_action_receipt(monkeypatch):
+    """The dashboard may restart its own parent immediately after completion."""
+    monkeypatch.setenv("HERMES_ACTION_ID", "a" * 32)
+    monkeypatch.setattr("hermes_cli.update_cmd._branch_head_suffix", lambda: "")
+    visible = io.StringIO()
+
+    class _BufferedActionLog:
+        def __init__(self):
+            self.pending = ""
+
+        def write(self, data):
+            self.pending += data
+            return len(data)
+
+        def flush(self):
+            visible.write(self.pending)
+            self.pending = ""
+
+    monkeypatch.setattr(sys, "stdout", _BufferedActionLog())
+
+    _print_update_completion("✓ Update complete!")
+
+    assert visible.getvalue().splitlines() == [
+        "✓ Update complete!",
+        f"=== hermes-update completed {'a' * 32} ===",
+    ]
+
+
 # -----------------------------------------------------------------------------
 # _UpdateOutputStream
 # -----------------------------------------------------------------------------

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1274,6 +1274,28 @@ class TestWebServerEndpoints:
         }
 
 
+    def test_update_status_survives_dashboard_restart(self, monkeypatch, tmp_path):
+        """The restarted server must recover the updater's durable result."""
+        import hermes_cli.web_server as web_server
+
+        action_id = "c" * 32
+        (tmp_path / "hermes-update.log").write_text("✓ Code updated!\n")
+        (tmp_path / "update.log").write_text(
+            f"✓ Update complete!\n=== hermes-update completed {action_id} ===\n"
+        )
+        monkeypatch.setattr(web_server, "_ACTION_LOG_DIR", tmp_path)
+        monkeypatch.setattr(web_server, "_ACTION_PROCS", {})
+        monkeypatch.setattr(web_server, "_ACTION_RESULTS", {})
+
+        resp = self.client.get("/api/actions/hermes-update/status?lines=20")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["running"] is False
+        assert data["exit_code"] is None
+        assert f"=== hermes-update completed {action_id} ===" in data["lines"]
+
+
 
 
 


### PR DESCRIPTION
## Summary
- flush the action-specific update completion receipt before a managed dashboard restart can terminate the updater
- recover update completion from the durable updater log after process-local action state is lost
- keep Desktop client and remote backend update targets explicit

## Root cause
A successful update can restart the dashboard process that launched it. That clears the in-memory process/result maps, while the completion receipt may still be buffered. The reconnected Desktop then sees neither a terminal exit code nor its action receipt and reports a successful update as failed. Remote mode also caused local-client update affordances to infer the backend as their target.

## Test plan
- `HERMES_PYTHON=/usr/local/lib/hermes-agent/venv/bin/python scripts/run_tests.sh tests/hermes_cli/test_update_hangup_protection.py tests/hermes_cli/test_web_server.py -q` — 178 passed
- `npx vitest run src/store/updates.test.ts` — 47 passed
- `npm run typecheck` — passed
- `npm run lint -- --quiet` — passed
- `npm run pack` — passed
