### PR TITLE
fix(dashboard): reap action subprocesses without status polling

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -519,6 +519,13 @@ async def _lifespan(app: "FastAPI"):
     # Reap idle/dead keep-alive PTY sessions in the background (30-min TTL).
     pty_reaper_task = asyncio.create_task(run_reaper(PTY_REGISTRY))
 
+    # Reap finished dashboard action subprocesses unconditionally, so headless
+    # (``--no-open``) deployments don't accumulate ``<defunct>`` zombies. The
+    # ``/api/actions/{name}/status`` endpoint's ``poll()`` used to be the only
+    # reap path; without a browser polling it, exited children are never
+    # ``wait()``ed. See ``run_action_reaper`` for details.
+    action_reaper_task = asyncio.create_task(run_action_reaper())
+
     # Periodic authenticated self-test (feeds the ``dashboard`` component on
     # /api/status).  The loop exits immediately when httpx is unavailable.
     selftest_task = asyncio.create_task(_dashboard_selftest_loop())
@@ -560,6 +567,7 @@ async def _lifespan(app: "FastAPI"):
         pty_reaper_task.cancel()
         selftest_task.cancel()
         auto_archive_task.cancel()
+        action_reaper_task.cancel()
         await PTY_REGISTRY.close_all()
         # Stop the managed llama-server with its parent — a supervisor-less
         # orphan would keep VRAM pinned after the app closes.
@@ -4682,6 +4690,88 @@ _UPDATE_ACTION_COMPLETED_RE = re.compile(
 # without spawning a subprocess (for example, unsupported Docker updates).
 _ACTION_RESULTS: Dict[str, Dict[str, Any]] = {}
 
+# Handles that have lost their ``_ACTION_PROCS`` slot (overwritten by a newer
+# same-name action) but may not have exited yet.  They must be tracked
+# separately: ``_spawn_hermes_action`` overwrites ``_ACTION_PROCS[name]``, and
+# a subprocess is only reaped when its own ``Popen`` handle is ``wait()``ed.
+# Without this list, an overwritten handle is dropped on the floor and its
+# child lingers as a ``<defunct>`` zombie forever.
+_ACTION_ORPHANS: List[subprocess.Popen] = []
+_ACTION_ORPHANS_LOCK = threading.Lock()
+
+
+def _try_reap_action(proc: subprocess.Popen) -> bool:
+    """Non-blocking reap of one action child. True = reaped or nothing to do."""
+    try:
+        if proc.poll() is None:
+            return False           # still running; retry next tick
+        proc.wait(timeout=0)       # exited: releases the ``task_struct``
+        return True
+    except Exception:
+        # Already reaped elsewhere (ECHILD) or bad handle — nothing to track.
+        return True
+
+
+def _retire_action_proc(proc: Optional[subprocess.Popen]) -> None:
+    """Hand a ``Popen`` handle about to lose its reference to the reaper."""
+    if proc is None:
+        return
+    if _try_reap_action(proc):
+        return                     # already exited, reaped on the spot
+    with _ACTION_ORPHANS_LOCK:     # still running: let the reaper poll it
+        _ACTION_ORPHANS.append(proc)
+
+
+async def run_action_reaper(interval: float = 60.0) -> None:
+    """Periodically reap finished dashboard action subprocesses.
+
+    Action children (``gateway restart``/``start``/``stop``, ``doctor``,
+    ``backup``, ``update``, …) are spawned detached and, until this loop was
+    added, were only reaped when the UI polled
+    ``GET /api/actions/{name}/status``.  A headless dashboard (``--no-open``)
+    has no browser to poll that endpoint, so finished children are never
+    ``wait()``ed and accumulate as ``<defunct>`` zombies.
+    ``start_new_session=True`` only detaches the controlling terminal; it
+    does not reparent to init, so the kernel keeps the zombie until this
+    process reaps it.  This loop reaps unconditionally.
+
+    Design choices:
+
+    * Non-blocking poll (``poll()`` + ``wait(timeout=0)``) rather than
+      ``SIGCHLD``: asyncio installs its own child watcher on Unix, and a
+      module-level signal handler would conflict with it in surprising ways.
+    * Preserve the ``exit_code`` in ``_ACTION_RESULTS`` when reaping an
+      in-registry handle, so the ``/api/actions/{name}/status`` endpoint
+      keeps reporting exit codes exactly as before — only the timing of the
+      reap changes, never the observable result.
+    * Runs on the same event loop as the rest of the dashboard, so it is
+      naturally cancelled when the lifespan exits.
+    """
+    while True:
+        try:
+            await asyncio.sleep(interval)
+            # In-registry handles: reap on exit, preserve exit_code so
+            # ``/api/actions/{name}/status`` can still report it.
+            for name, proc in list(_ACTION_PROCS.items()):
+                code = proc.poll()
+                if code is None:
+                    continue
+                if _try_reap_action(proc):
+                    _ACTION_RESULTS[name] = {"exit_code": code, "pid": proc.pid}
+                    _ACTION_PROCS.pop(name, None)
+                    _ACTION_COMMANDS.pop(name, None)
+                    _ACTION_IDS.pop(name, None)
+            # Orphaned handles (overwritten by a newer same-name spawn, or
+            # retired via _retire_action_proc).
+            with _ACTION_ORPHANS_LOCK:
+                _ACTION_ORPHANS[:] = [
+                    p for p in _ACTION_ORPHANS if not _try_reap_action(p)
+                ]
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # pragma: no cover - defensive: never let the loop die
+            _log.exception("action reaper tick failed")
+
 
 def _terminate_desktop_managed_gateway() -> None:
     """Stop a live gateway restart child when its Desktop backend shuts down."""
@@ -4708,7 +4798,7 @@ def _record_completed_action(name: str, message: str, exit_code: int = 1) -> Non
         log_file.write(message.encode("utf-8", errors="replace"))
         if not message.endswith("\n"):
             log_file.write(b"\n")
-    _ACTION_PROCS.pop(name, None)
+    _retire_action_proc(_ACTION_PROCS.pop(name, None))
     _ACTION_COMMANDS.pop(name, None)
     _ACTION_IDS.pop(name, None)
     _ACTION_RESULTS[name] = {"exit_code": exit_code, "pid": None}
@@ -4810,6 +4900,10 @@ def _spawn_hermes_action(
     log_file.close()
     _ACTION_RESULTS.pop(name, None)
     _ACTION_COMMANDS[name] = tuple(subcommand)
+    # The previous same-name handle is about to lose its ``_ACTION_PROCS``
+    # slot; hand it to the reaper first so its child can never linger
+    # unreaped as a zombie.
+    _retire_action_proc(_ACTION_PROCS.get(name))
     _ACTION_PROCS[name] = proc
     action_id = (env_overrides or {}).get("HERMES_ACTION_ID")
     if action_id:

--- a/tests/hermes_cli/test_dashboard_action_reaper.py
+++ b/tests/hermes_cli/test_dashboard_action_reaper.py
@@ -1,0 +1,164 @@
+"""Tests for the background dashboard-action reaper (#89060).
+
+Action children are spawned detached and, before this loop existed, were only
+``wait()``ed when the UI polled ``GET /api/actions/{name}/status``. A headless
+dashboard has no browser to poll it, so finished children stayed ``<defunct>``.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, cast
+from unittest.mock import patch
+
+import pytest
+
+
+class _FinishedProc:
+    def __init__(self, pid: int, code: int = 0):
+        self.pid = pid
+        self._code = code
+        self.wait_calls = 0
+
+    def poll(self):
+        return self._code
+
+    def wait(self, timeout=None):
+        assert timeout == 0
+        self.wait_calls += 1
+        return self._code
+
+
+class _RunningThenFinishedProc(_FinishedProc):
+    def __init__(self, pid: int, code: int = 0):
+        super().__init__(pid, code)
+        self._running = True
+
+    def poll(self):
+        if self._running:
+            return None
+        return self._code
+
+    def finish(self):
+        self._running = False
+
+
+class _NeverExitsProc(_FinishedProc):
+    def poll(self):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_action_reaper_reaps_completed_registered_action():
+    from hermes_cli import web_server
+
+    proc = _FinishedProc(pid=1234, code=7)
+    web_server._ACTION_PROCS["unit-action"] = cast(Any, proc)
+    web_server._ACTION_COMMANDS["unit-action"] = ("doctor",)
+    web_server._ACTION_IDS["unit-action"] = "deadbeef"
+    web_server._ACTION_RESULTS.pop("unit-action", None)
+
+    task = asyncio.create_task(web_server.run_action_reaper(interval=0.001))
+    try:
+        for _ in range(20):
+            await asyncio.sleep(0.01)
+            if "unit-action" not in web_server._ACTION_PROCS:
+                break
+        assert "unit-action" not in web_server._ACTION_PROCS
+        assert "unit-action" not in web_server._ACTION_COMMANDS
+        # Every other retirement path (_record_completed_action, the status
+        # endpoint) drops the action id with the handle; so does this one.
+        assert "unit-action" not in web_server._ACTION_IDS
+        assert web_server._ACTION_RESULTS["unit-action"] == {"exit_code": 7, "pid": 1234}
+        assert proc.wait_calls == 1
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        web_server._ACTION_PROCS.pop("unit-action", None)
+        web_server._ACTION_COMMANDS.pop("unit-action", None)
+        web_server._ACTION_IDS.pop("unit-action", None)
+        web_server._ACTION_RESULTS.pop("unit-action", None)
+
+
+@pytest.mark.asyncio
+async def test_action_reaper_leaves_a_live_registered_action_alone():
+    """A running child keeps its registry slot — reaping it would break status."""
+    from hermes_cli import web_server
+
+    proc = _NeverExitsProc(pid=4321)
+    web_server._ACTION_PROCS["unit-live"] = cast(Any, proc)
+    web_server._ACTION_COMMANDS["unit-live"] = ("gateway", "restart")
+    web_server._ACTION_RESULTS.pop("unit-live", None)
+
+    task = asyncio.create_task(web_server.run_action_reaper(interval=0.001))
+    try:
+        await asyncio.sleep(0.05)
+        assert web_server._ACTION_PROCS.get("unit-live") is proc
+        assert "unit-live" in web_server._ACTION_COMMANDS
+        assert "unit-live" not in web_server._ACTION_RESULTS
+        assert proc.wait_calls == 0
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        web_server._ACTION_PROCS.pop("unit-live", None)
+        web_server._ACTION_COMMANDS.pop("unit-live", None)
+        web_server._ACTION_RESULTS.pop("unit-live", None)
+
+
+@pytest.mark.asyncio
+async def test_action_reaper_drains_retired_same_name_orphan():
+    from hermes_cli import web_server
+
+    proc = _RunningThenFinishedProc(pid=5678)
+    with web_server._ACTION_ORPHANS_LOCK:
+        web_server._ACTION_ORPHANS.clear()
+
+    web_server._retire_action_proc(cast(Any, proc))
+    with web_server._ACTION_ORPHANS_LOCK:
+        assert web_server._ACTION_ORPHANS == [proc]
+
+    proc.finish()
+    task = asyncio.create_task(web_server.run_action_reaper(interval=0.001))
+    try:
+        for _ in range(20):
+            await asyncio.sleep(0.01)
+            with web_server._ACTION_ORPHANS_LOCK:
+                if not web_server._ACTION_ORPHANS:
+                    break
+        with web_server._ACTION_ORPHANS_LOCK:
+            assert web_server._ACTION_ORPHANS == []
+        assert proc.wait_calls == 1
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        with web_server._ACTION_ORPHANS_LOCK:
+            web_server._ACTION_ORPHANS.clear()
+
+
+def test_lifespan_starts_the_action_reaper():
+    """Without this, dropping the ``create_task`` line leaves every unit test green.
+
+    Scoped to startup on purpose: the loop's own teardown cancels a pending
+    task regardless, so a shutdown-cancellation assertion here would pass even
+    with ``action_reaper_task.cancel()`` deleted.
+    """
+    from fastapi.testclient import TestClient
+
+    from hermes_cli import web_server
+
+    state: dict[str, Any] = {"task": None}
+
+    async def _stub_reaper():
+        state["task"] = asyncio.current_task()
+        await asyncio.sleep(3600)
+
+    with patch.object(web_server, "run_action_reaper", _stub_reaper):
+        with TestClient(web_server.app, raise_server_exceptions=False):
+            for _ in range(200):
+                if state["task"] is not None:
+                    break
+                time.sleep(0.01)
+            assert state["task"] is not None, "_lifespan never started run_action_reaper"


### PR DESCRIPTION
## Summary

A headless dashboard leaks a `<defunct>` process for every action it runs.

Root cause: dashboard action children (`gateway restart`/`start`/`stop`, `doctor`, `backup`, `update`, …) are spawned detached and their `Popen` handles are parked in `_ACTION_PROCS`. The only code that ever calls `poll()`/`wait()` on them is `GET /api/actions/{name}/status`, so the reap is driven entirely by a browser polling the endpoint. With `--no-open`, or any deployment where nobody has the dashboard open, an exited child is never `wait()`ed and the kernel keeps its `task_struct` forever. `start_new_session=True` does not help — it detaches the controlling terminal, not the parent, so the zombie is ours to reap. A second leak sits alongside it: `_spawn_hermes_action` overwrites `_ACTION_PROCS[name]`, and the displaced handle is the only thing that could have reaped that child, so it is dropped on the floor while still running.

This adds a background reaper on the dashboard's own event loop, next to the existing `run_reaper(PTY_REGISTRY)` task and on the same 60s interval.

Verified against a real process rather than argued from the docs — a `Popen` whose handle is held but never polled sits in `Z <defunct>`, and creating another `Popen` does not clear it (CPython's `subprocess._cleanup` only sees handles that were garbage-collected while running):

```
child pid 11253 ps -> '11253 Z    <defunct>'
after another Popen -> '11253 Z'
```

## Changes

- **`hermes_cli/web_server.py`**
  - `run_action_reaper(interval=60.0)`: every tick, reap exited in-registry handles (recording `exit_code`/`pid` into `_ACTION_RESULTS` first, so `/api/actions/{name}/status` reports exactly what it reported before — only the reap *timing* changes), then drain `_ACTION_ORPHANS`. Never dies: `CancelledError` propagates, anything else is logged and the loop continues.
  - `_ACTION_ORPHANS` + `_ACTION_ORPHANS_LOCK`: handles that lost their `_ACTION_PROCS` slot but may still be running. `_retire_action_proc()` reaps one on the spot if it has already exited, otherwise hands it to the list.
  - `_try_reap_action()`: non-blocking `poll()` + `wait(timeout=0)`. Deliberately not `SIGCHLD` — asyncio installs its own child watcher on Unix and a module-level handler conflicts with it.
  - Retire the displaced handle at both sites that drop one: `_record_completed_action` and the `_ACTION_PROCS[name] = proc` overwrite in `_spawn_hermes_action`.
  - `_lifespan`: start the task next to `pty_reaper_task`, cancel it in the same `finally`.
  - The reaper drops `_ACTION_IDS[name]` with the handle, matching the other two retirement paths (`_record_completed_action`, the status endpoint). Not observable today — the sole reader guards on a live `_ACTION_PROCS` entry and the next spawn overwrites the id — but leaving one of three paths out of step is how it stops being unobservable.
- **`tests/hermes_cli/test_dashboard_action_reaper.py`** (new): 4 tests. Kept out of `test_spawn_gateway_restart_reap.py` on purpose — that file is scoped to the `#77276` orphan-gateway guard inside `_spawn_gateway_restart`, and this is a process-wide action reaper.

## Validation

`scripts/run_tests.sh` on every test file that references `_ACTION_PROCS`, `_ACTION_IDS`, `_ACTION_COMMANDS`, `_record_completed_action`, `_spawn_hermes_action` or `_lifespan` — 10 files, **291 passed, 0 failed**. No pre-existing failures in that set.

`ruff check .` clean. `ty` reports 19 diagnostics in `hermes_cli/web_server.py`, byte-for-byte the same 19 as `origin/main` and none inside the changed hunks (`522-528`, `570`, `4693-4773`, `4800`, `4902-4905`); the new test file is clean. **0 new diagnostics.**

Mutation-checked — every test fails when the behavior it names is reverted:

| Mutation | Failures |
|---|---|
| drop `proc.wait(timeout=0)` from `_try_reap_action` | 2 |
| reaper stops draining `_ACTION_ORPHANS` | 1 |
| reaper stops popping `_ACTION_COMMANDS` | 1 |
| reaper stops popping `_ACTION_IDS` | 1 |
| `_retire_action_proc` drops a live handle instead of tracking it | 1 |
| both live-child guards removed (reaper's `continue` + `_try_reap_action`'s) | 2 |
| `_lifespan` never starts the reaper | 1 |

The last row is the one that mattered most to add: before `test_lifespan_starts_the_action_reaper` existed, replacing `asyncio.create_task(run_action_reaper())` with `asyncio.create_task(asyncio.sleep(0))` made the whole feature inert **with every test still green**. It drives the real `_lifespan` through `TestClient(web_server.app)`, the seam `test_web_server_boot_handshake.py` already uses.

Two guards are mutually redundant by design and only fall together (hence the combined row): the reaper's `if code is None: continue` and `_try_reap_action`'s own `poll()` check. Removing either alone is behaviour-preserving, so neither is claimed as independently covered.

**Not verified:** no end-to-end run of a long-lived headless dashboard accumulating and then shedding zombies over the real 60s interval — the tests drive `run_action_reaper(interval=0.001)` directly. The zombie premise itself is verified above against a real process.

## Related

Follow-up to #38049 / #38032, which made the status endpoint reap on poll. This covers the two paths that endpoint can never reach: nobody polling it, and a handle displaced before anyone polls.
