### PR TITLE
feat: add SSYCloud(胜算云) LLM provider

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -71,6 +71,7 @@ _AGGREGATOR_PROVIDERS: frozenset[str] = frozenset({
     "nous",
     "ai-gateway",
     "kilocode",
+    "ssycloud",
 })
 
 # Providers that want bare names with dots replaced by hyphens.
@@ -582,4 +583,3 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
 # ---------------------------------------------------------------------------
 # Batch / convenience helpers
 # ---------------------------------------------------------------------------
-

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1408,6 +1408,8 @@ _PROVIDER_ALIASES = {
     "arceeai": "arcee",
     "gmi-cloud": "gmi",
     "gmicloud": "gmi",
+    "shengsuanyun": "ssycloud",
+    "ssy-cloud": "ssycloud",
     "fireworks-ai": "fireworks",
     "fw": "fireworks",
     "actual-computer": "actual",
@@ -3322,7 +3324,7 @@ def _model_in_provider_catalog(name_lower: str, providers: set[str]) -> bool:
 
 
 _AGGREGATOR_PROVIDERS = frozenset(
-    {"nous", "openrouter", "ai-gateway", "copilot", "kilocode"}
+    {"nous", "openrouter", "ai-gateway", "copilot", "kilocode", "ssycloud"}
 )
 
 # Subscription/OAuth providers whose catalogs RE-EXPOSE other vendors' models

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -212,6 +212,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         extra_env_vars=("FIREWORKS_API_KEY",),
         base_url_override="https://api.fireworks.ai/inference/v1",
     ),
+    "ssycloud": HermesOverlay(
+        transport="openai_chat",
+        is_aggregator=True,
+        extra_env_vars=("SSYCLOUD_API_KEY",),
+        base_url_override="https://router.shengsuanyun.com/api/v1",
+    ),
     "actual": HermesOverlay(
         transport="codex_responses",
         extra_env_vars=("ACTUAL_API_KEY", "ACTUAL_BASE_URL"),
@@ -397,6 +403,10 @@ ALIASES: Dict[str, str] = {
     "fireworks-ai": "fireworks",
     "fw": "fireworks",
 
+    # SSYCloud / 胜算云
+    "shengsuanyun": "ssycloud",
+    "ssy-cloud": "ssycloud",
+
     # upstage
     "solar": "upstage",
 
@@ -429,6 +439,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",
     "gmi": "GMI Cloud",
+    "ssycloud": "SSYCloud (胜算云)",
     "upstage": "Upstage Solar",
     "actual": "Actual Computer",
     "tencent-tokenhub": "Tencent TokenHub",

--- a/plugins/model-providers/ssycloud/__init__.py
+++ b/plugins/model-providers/ssycloud/__init__.py
@@ -1,0 +1,28 @@
+"""SSYCloud (ShengSuanYun / 胜算云) provider profile.
+
+SSYCloud exposes a multi-vendor catalog through an OpenAI-compatible
+Chat Completions API.  Native model IDs keep their vendor prefix, for example
+``deepseek/deepseek-v4-flash``.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+ssycloud = ProviderProfile(
+    name="ssycloud",
+    aliases=("shengsuanyun", "ssy-cloud"),
+    display_name="SSYCloud (胜算云)",
+    description="SSYCloud — 300+ LLM and multimodel API router",
+    signup_url="https://console.shengsuanyun.com/user/keys",
+    env_vars=("SSYCLOUD_API_KEY",),
+    base_url="https://router.shengsuanyun.com/api/v1",
+    api_mode="chat_completions",
+    auth_type="api_key",
+    # Official docs use this agentic, tool-capable model as the default.
+    # The live /v1/models catalog remains authoritative when reachable.
+    fallback_models=("deepseek/deepseek-v4-flash",),
+    default_aux_model="deepseek/deepseek-v4-flash",
+)
+
+register_provider(ssycloud)

--- a/plugins/model-providers/ssycloud/plugin.yaml
+++ b/plugins/model-providers/ssycloud/plugin.yaml
@@ -1,0 +1,5 @@
+name: ssycloud-provider
+kind: model-provider
+version: 1.0.0
+description: SSYCloud (胜算云) — 300+ LLM and multimodel API router
+author: Hermes Agent contributors

--- a/tests/plugins/model_providers/test_ssycloud_profile.py
+++ b/tests/plugins/model_providers/test_ssycloud_profile.py
@@ -1,0 +1,89 @@
+"""Tests for the SSYCloud (胜算云) model-provider plugin."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_user_config(tmp_path, monkeypatch):
+    """Keep developer credentials and user plugins out of these tests."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("SSYCLOUD_API_KEY", raising=False)
+
+
+@pytest.fixture
+def ssycloud_profile():
+    """Resolve SSYCloud through the real provider discovery path."""
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("ssycloud")
+    assert profile is not None, "SSYCloud provider profile must be registered"
+    return profile
+
+
+class TestSSYCloudProfile:
+    def test_identity_endpoint_and_auth(self, ssycloud_profile):
+        assert ssycloud_profile.name == "ssycloud"
+        assert ssycloud_profile.api_mode == "chat_completions"
+        assert ssycloud_profile.auth_type == "api_key"
+        assert ssycloud_profile.base_url == "https://router.shengsuanyun.com/api/v1"
+        assert ssycloud_profile.get_hostname() == "router.shengsuanyun.com"
+        assert ssycloud_profile.env_vars == ("SSYCLOUD_API_KEY",)
+
+    @pytest.mark.parametrize("alias", ["shengsuanyun", "ssy-cloud"])
+    def test_aliases_resolve(self, ssycloud_profile, alias):
+        import providers
+
+        assert providers.get_provider_profile(alias) is ssycloud_profile
+
+    def test_fallback_models_keep_native_vendor_prefix(self, ssycloud_profile):
+        assert ssycloud_profile.fallback_models
+        assert all("/" in model for model in ssycloud_profile.fallback_models)
+
+
+class TestSSYCloudAutoWiring:
+    def test_auth_registry_and_credentials(self, monkeypatch):
+        monkeypatch.setenv("SSYCLOUD_API_KEY", "ssy-test-key")
+
+        from hermes_cli.auth import (
+            PROVIDER_REGISTRY,
+            resolve_api_key_provider_credentials,
+        )
+
+        config = PROVIDER_REGISTRY["ssycloud"]
+        assert config.api_key_env_vars == ("SSYCLOUD_API_KEY",)
+        assert config.base_url_env_var == ""
+
+        credentials = resolve_api_key_provider_credentials("ssycloud")
+        assert credentials["api_key"] == "ssy-test-key"
+        assert credentials["base_url"] == "https://router.shengsuanyun.com/api/v1"
+
+    def test_catalog_and_overlay_treat_ssycloud_as_aggregator(self):
+        from hermes_cli.models import (
+            CANONICAL_PROVIDERS,
+            _AGGREGATOR_PROVIDERS,
+            normalize_provider as normalize_model_provider,
+        )
+        from hermes_cli.providers import (
+            HERMES_OVERLAYS,
+            is_aggregator,
+            normalize_provider as normalize_runtime_provider,
+        )
+
+        assert "ssycloud" in {entry.slug for entry in CANONICAL_PROVIDERS}
+        assert "ssycloud" in _AGGREGATOR_PROVIDERS
+        assert HERMES_OVERLAYS["ssycloud"].is_aggregator is True
+        assert is_aggregator("ssycloud") is True
+        assert normalize_model_provider("shengsuanyun") == "ssycloud"
+        assert normalize_runtime_provider("shengsuanyun") == "ssycloud"
+
+    def test_model_normalization_preserves_router_slug(self):
+        from hermes_cli.model_normalize import normalize_model_for_provider
+
+        assert normalize_model_for_provider(
+            "deepseek/deepseek-v4-flash", "ssycloud"
+        ) == "deepseek/deepseek-v4-flash"

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -28,6 +28,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Kimi / Moonshot (China)** | `KIMI_CN_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding-cn`; aliases: `kimi-cn`, `moonshot-cn`) |
 | **Arcee AI** | `ARCEEAI_API_KEY` in `~/.hermes/.env` (provider: `arcee`; aliases: `arcee-ai`, `arceeai`) |
 | **GMI Cloud** | `GMI_API_KEY` in `~/.hermes/.env` (provider: `gmi`; aliases: `gmi-cloud`, `gmicloud`) |
+| **SSYCloud (胜算云)** | `SSYCLOUD_API_KEY` in `~/.hermes/.env` (provider: `ssycloud`; aliases: `shengsuanyun`, `ssy-cloud`) |
 | **Actual Computer** | `ACTUAL_API_KEY` in `~/.hermes/.env` for the hosted relay, or `ACTUAL_BASE_URL=http://127.0.0.1:8080` for the local daemon — no key needed on loopback (provider: `actual`; aliases: `actual-computer`, `actualcomputer`, `aci`) |
 | **MiniMax** | `MINIMAX_API_KEY` in `~/.hermes/.env` (provider: `minimax`) |
 | **MiniMax China** | `MINIMAX_CN_API_KEY` in `~/.hermes/.env` (provider: `minimax-cn`) |
@@ -297,6 +298,10 @@ hermes chat --provider meta-ai --model muse-spark-1.2
 # Use the exact model ID returned by GMI's /v1/models endpoint.
 hermes chat --provider gmi --model zai-org/GLM-5.1-FP8
 # Requires: GMI_API_KEY in ~/.hermes/.env
+
+# SSYCloud (胜算云)
+hermes chat --provider ssycloud --model deepseek/deepseek-v4-flash
+# Requires: SSYCLOUD_API_KEY in ~/.hermes/.env
 ```
 
 Fireworks uses its native slash-form catalog IDs, such as `accounts/fireworks/models/kimi-k2p6`. Run `hermes model`, choose **Fireworks AI**, and select from the live catalog or enter another Fireworks model ID. The default endpoint is `https://api.fireworks.ai/inference/v1`; configure a different endpoint through `model.base_url` in `config.yaml`, not `.env`.
@@ -313,6 +318,15 @@ Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_U
 :::note Meta contributor tier
 `muse-spark-1.2-contributor` is Meta's discounted tier — Meta may train on your prompts and completions, so [interactive model selection asks for confirmation](../user-guide/configuring-models.md) before using it. Use `muse-spark-1.2` (standard pricing, no training) for confidential work.
 :::
+
+SSYCloud accepts standard OpenAI-compatible requests at `https://router.shengsuanyun.com/api/v1`. Override that endpoint through `model.base_url` in `config.yaml`, not an environment variable. If your SSYCloud integration expects an application title, opt in explicitly in the same section:
+
+```yaml
+model:
+  base_url: https://router.shengsuanyun.com/api/v1
+  default_headers:
+    X-Title: hermes-agent
+```
 
 :::note Z.AI Endpoint Auto-Detection
 When using the Z.AI / GLM provider, Hermes automatically probes multiple endpoints (global, China, coding variants) to find one that accepts your API key. You don't need to set `GLM_BASE_URL` manually — the working endpoint is detected and cached automatically.
@@ -1585,7 +1599,7 @@ fallback_model:
 
 When activated, the fallback swaps the model and provider mid-session without losing your conversation. The chain is tried entry-by-entry; activation is one-shot per session.
 
-Supported providers: `openrouter`, `nous`, `novita`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `qwen-oauth`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `xai-oauth`, `ollama-cloud`, `bedrock`, `ai-gateway`, `azure-foundry`, `opencode-zen`, `opencode-go`, `commandcode`, `commandcode-anthropic`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `actual`, `stepfun`, `lmstudio`, `alibaba`, `alibaba-coding-plan`, `tencent-tokenhub`, `custom`.
+Supported providers: `openrouter`, `nous`, `novita`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `qwen-oauth`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `xai-oauth`, `ollama-cloud`, `bedrock`, `ai-gateway`, `azure-foundry`, `opencode-zen`, `opencode-go`, `commandcode`, `commandcode-anthropic`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `ssycloud`, `actual`, `stepfun`, `lmstudio`, `alibaba`, `alibaba-coding-plan`, `tencent-tokenhub`, `custom`.
 
 :::tip
 Fallback is configured exclusively through `config.yaml` — or interactively via `hermes fallback`. For full details on when it triggers, how the chain advances, and how it interacts with auxiliary tasks and delegation, see [Fallback Providers](/user-guide/features/fallback-providers).

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -45,6 +45,7 @@ Hermes reads environment variables from the process environment and, for user-ma
 | `ARCEE_BASE_URL` | Override Arcee base URL (default: `https://api.arcee.ai/api/v1`) |
 | `GMI_API_KEY` | GMI Cloud API key ([gmicloud.ai](https://www.gmicloud.ai/)) |
 | `GMI_BASE_URL` | Override GMI Cloud base URL (default: `https://api.gmi-serving.com/v1`) |
+| `SSYCLOUD_API_KEY` | SSYCloud (胜算云) API key ([console.shengsuanyun.com](https://console.shengsuanyun.com/user/keys)) |
 | `ACTUAL_API_KEY` | Actual Computer inference key (`ac_...`, [actual.inc/user/keys](https://actual.inc/user/keys)). Not needed for the local daemon. |
 | `ACTUAL_BASE_URL` | Override Actual Computer base URL (default: `https://api.actual.inc/v1`). Set to `http://127.0.0.1:8080` for the local offline daemon — loopback hosts need no API key. |
 | `MINIMAX_API_KEY` | MiniMax API key — global endpoint ([minimax.io](https://www.minimax.io)). **Not used by `minimax-oauth`** (OAuth path uses browser login instead). |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/integrations/providers.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/integrations/providers.md
@@ -27,6 +27,7 @@ sidebar_position: 1
 | **Kimi / Moonshot（中国）** | `~/.hermes/.env` 中的 `KIMI_CN_API_KEY`（provider: `kimi-coding-cn`；别名：`kimi-cn`、`moonshot-cn`） |
 | **Arcee AI** | `~/.hermes/.env` 中的 `ARCEEAI_API_KEY`（provider: `arcee`；别名：`arcee-ai`、`arceeai`） |
 | **GMI Cloud** | `~/.hermes/.env` 中的 `GMI_API_KEY`（provider: `gmi`；别名：`gmi-cloud`、`gmicloud`） |
+| **SSYCloud（胜算云）** | `~/.hermes/.env` 中的 `SSYCLOUD_API_KEY`（provider: `ssycloud`；别名：`shengsuanyun`、`ssy-cloud`） |
 | **MiniMax** | `~/.hermes/.env` 中的 `MINIMAX_API_KEY`（provider: `minimax`） |
 | **MiniMax 中国** | `~/.hermes/.env` 中的 `MINIMAX_CN_API_KEY`（provider: `minimax-cn`） |
 | **xAI（Grok）— Responses API** | `~/.hermes/.env` 中的 `XAI_API_KEY`（provider: `xai`） |
@@ -466,6 +467,24 @@ model:
 ```
 
 基础 URL 可通过 `GMI_BASE_URL` 覆盖（默认：`https://api.gmi-serving.com/v1`）。
+
+### SSYCloud（胜算云）
+
+通过[胜算云](https://lean.shengsuanyun.com/openai-api)使用多供应商模型——OpenAI 兼容 API，API key 认证，并保留 `vendor/model` 形式的模型 ID。
+
+```bash
+hermes chat --provider ssycloud --model deepseek/deepseek-v4-flash
+# 需要：~/.hermes/.env 中的 SSYCLOUD_API_KEY
+```
+
+默认基础 URL 为 `https://router.shengsuanyun.com/api/v1`。如需覆盖，请使用 `config.yaml` 中的 `model.base_url`，不要新增环境变量。如果你的胜算云集成需要应用标题，可在同一配置节中显式启用：
+
+```yaml
+model:
+  base_url: https://router.shengsuanyun.com/api/v1
+  default_headers:
+    X-Title: hermes-agent
+```
 
 ### StepFun
 
@@ -1404,7 +1423,7 @@ fallback_model:
 
 激活时，故障转移在不丢失对话的情况下中途切换模型和提供商。链按条目逐一尝试；每个会话激活一次。
 
-支持的提供商：`openrouter`、`nous`、`openai-codex`、`copilot`、`copilot-acp`、`anthropic`、`gemini`、`qwen-oauth`、`huggingface`、`zai`、`kimi-coding`、`kimi-coding-cn`、`minimax`、`minimax-cn`、`minimax-oauth`、`deepseek`、`nvidia`、`xai`、`xai-oauth`、`ollama-cloud`、`bedrock`、`azure-foundry`、`opencode-zen`、`opencode-go`、`kilocode`、`xiaomi`、`arcee`、`gmi`、`stepfun`、`lmstudio`、`alibaba`、`alibaba-coding-plan`、`tencent-tokenhub`、`custom`。
+支持的提供商：`openrouter`、`nous`、`openai-codex`、`copilot`、`copilot-acp`、`anthropic`、`gemini`、`qwen-oauth`、`huggingface`、`zai`、`kimi-coding`、`kimi-coding-cn`、`minimax`、`minimax-cn`、`minimax-oauth`、`deepseek`、`nvidia`、`xai`、`xai-oauth`、`ollama-cloud`、`bedrock`、`azure-foundry`、`opencode-zen`、`opencode-go`、`kilocode`、`xiaomi`、`arcee`、`gmi`、`ssycloud`、`stepfun`、`lmstudio`、`alibaba`、`alibaba-coding-plan`、`tencent-tokenhub`、`custom`。
 
 :::tip
 故障转移仅通过 `config.yaml` 配置——或通过 `hermes fallback` 交互式配置。有关触发时机、链推进方式以及与辅助任务和委托的交互，参见[故障转移提供商](/user-guide/features/fallback-providers)。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
@@ -40,6 +40,7 @@ description: "Hermes Agent 使用的所有环境变量完整参考"
 | `ARCEE_BASE_URL` | 覆盖 Arcee base URL（默认：`https://api.arcee.ai/api/v1`） |
 | `GMI_API_KEY` | GMI Cloud API 密钥（[gmicloud.ai](https://www.gmicloud.ai/)） |
 | `GMI_BASE_URL` | 覆盖 GMI Cloud base URL（默认：`https://api.gmi-serving.com/v1`） |
+| `SSYCLOUD_API_KEY` | SSYCloud（胜算云）API 密钥（[console.shengsuanyun.com](https://console.shengsuanyun.com/user/keys)） |
 | `MINIMAX_API_KEY` | MiniMax API 密钥——全球端点（[minimax.io](https://www.minimax.io)）。**`minimax-oauth` 不使用此变量**（OAuth 路径通过浏览器登录）。 |
 | `MINIMAX_BASE_URL` | 覆盖 MiniMax base URL（默认：`https://api.minimax.io/anthropic`——Hermes 使用 MiniMax 的 Anthropic Messages 兼容端点）。**`minimax-oauth` 不使用此变量**。 |
 | `MINIMAX_CN_API_KEY` | MiniMax API 密钥——中国区端点（[minimaxi.com](https://www.minimaxi.com)）。**`minimax-oauth` 不使用此变量**（OAuth 路径通过浏览器登录）。 |


### PR DESCRIPTION
# feat: add SSYCloud(胜算云) LLM provider

## Summary

- Add SSYCloud (胜算云) as a built-in OpenAI-compatible LLM provider
- Provider ID: `ssycloud`
- Provider aliases: `shengsuanyun`, `ssy-cloud`
- Description: `SSYCloud — 300+ LLM and multimodel API router`
- Base URL: `https://router.shengsuanyun.com/api/v1`
- Authentication: Bearer API key through `SSYCLOUD_API_KEY`
- Use the existing OpenAI-compatible Chat Completions transport
- Discover available models dynamically through `GET {base_url}/models`
- Use `deepseek/deepseek-v4-flash` as the fallback and auxiliary model
- Preserve native `vendor/model` identifiers by treating SSYCloud as an aggregator
- Support an optional `X-Title: hermes-agent` header through `model.default_headers`
- Add English and Simplified Chinese documentation
- No breaking changes to existing providers

## How to Use

- Register and obtain an SSYCloud API key: <https://www.shengsuanyun.com/?from=CH_JWSPH12M>

- Add the API key to `~/.hermes/.env`:

  ```dotenv
  SSYCLOUD_API_KEY=<your-api-key>
  ```

- Start Hermes with SSYCloud:

  ```bash
  hermes chat --provider ssycloud --model deepseek/deepseek-v4-flash
  ```

- The `shengsuanyun` alias can also be used:

  ```bash
  hermes chat --provider shengsuanyun --model deepseek/deepseek-v4-flash
  ```

- To explicitly send the application title header, add the following to `~/.hermes/config.yaml`:

  ```yaml
  model:
    default_headers:
      X-Title: hermes-agent
  ```

## Files Changed

- `plugins/model-providers/ssycloud/__init__.py`
- `plugins/model-providers/ssycloud/plugin.yaml`
- `hermes_cli/model_normalize.py`
- `hermes_cli/models.py`
- `hermes_cli/providers.py`
- `tests/plugins/model_providers/test_ssycloud_profile.py`
- `website/docs/integrations/providers.md`
- `website/docs/reference/environment-variables.md`
- `website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/integrations/providers.md`
- `website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md`

## Test Plan

Run the focused provider tests:

```bash
export HERMES_PYTHON="$VIRTUAL_ENV/bin/python"

scripts/run_tests.sh \
  tests/plugins/model_providers/test_ssycloud_profile.py \
  tests/providers/test_plugin_discovery.py \
  tests/hermes_cli/test_provider_catalog.py \
  -v --tb=short
```

- [x] Verify all 14 focused tests pass
- [x] Verify `ssycloud` is discovered through the bundled plugin system
- [x] Verify `shengsuanyun` and `ssy-cloud` resolve to `ssycloud`
- [x] Verify `SSYCLOUD_API_KEY` is resolved through the API-key credential path
- [x] Verify the runtime transport resolves to `openai_chat`
- [x] Verify SSYCloud is treated as an aggregator
- [x] Verify `deepseek/deepseek-v4-flash` retains its vendor prefix
- [x] Verify existing provider discovery regression tests pass
- [x] Verify existing provider catalog regression tests pass
- [x] Run `git diff --check`
- [x] Verify live model discovery with a valid SSYCloud API key
- [x] Send a live Chat Completions request
- [x] Verify tool calling with a supported SSYCloud model
- [x] Confirm the optional `X-Title: hermes-agent` header in a live request

## Notes
- Channel tracking: https://www.shengsuanyun.com/?from=CH_JWSPH12M
- Docs: https://lean.shengsuanyun.com/apidocs
- Test quota exchange code: H200DFW30425S (console → avatar → redeem quota)
- Support/Business: zhouyang1@shengsuanyun.cn · WeChat 18010814593
  We're happy to discuss sponsorship / revenue-share arrangements and explore
  deeper product cooperation.
