### PR TITLE
fix(desktop): keep HUD dragging aligned across mixed-DPI displays

### DIFF
--- a/apps/desktop/electron/hud-drag.test.ts
+++ b/apps/desktop/electron/hud-drag.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { createHudDragTracker } from './hud-drag'
+
+describe('createHudDragTracker', () => {
+  it('keeps movement in native screen coordinates across a display-scale transition', () => {
+    const tracker = createHudDragTracker()
+
+    tracker.begin({ x: 1900, y: 400 })
+    expect(tracker.move({ x: 1920, y: 400 })).toEqual({ x: 20, y: 0 })
+
+    // The next point is sampled by Electron after the cursor has crossed to a
+    // display with a different scale factor; no renderer CSS conversion is
+    // involved in this delta.
+    expect(tracker.move({ x: 1940, y: 400 })).toEqual({ x: 20, y: 0 })
+  })
+
+  it('does not leak movement into the next drag after ending', () => {
+    const tracker = createHudDragTracker()
+
+    expect(tracker.move({ x: 10, y: 20 })).toBeNull()
+    tracker.begin({ x: 10, y: 20 })
+    expect(tracker.move({ x: 15, y: 27 })).toEqual({ x: 5, y: 7 })
+
+    tracker.end()
+
+    expect(tracker.move({ x: 50, y: 60 })).toBeNull()
+  })
+})

--- a/apps/desktop/electron/hud-drag.ts
+++ b/apps/desktop/electron/hud-drag.ts
@@ -1,0 +1,42 @@
+export interface HudDragPoint {
+  x: number
+  y: number
+}
+
+export interface HudDragDelta {
+  x: number
+  y: number
+}
+
+export interface HudDragTracker {
+  begin: (point: HudDragPoint) => void
+  move: (point: HudDragPoint) => HudDragDelta | null
+  end: () => void
+}
+
+/** Tracks movement in the native screen coordinate space used by Electron. */
+export function createHudDragTracker(): HudDragTracker {
+  let lastPoint: HudDragPoint | null = null
+
+  return {
+    begin(point) {
+      lastPoint = point
+    },
+    move(point) {
+      const previousPoint = lastPoint
+      lastPoint = point
+
+      if (!previousPoint) {
+        return null
+      }
+
+      return {
+        x: point.x - previousPoint.x,
+        y: point.y - previousPoint.y
+      }
+    },
+    end() {
+      lastPoint = null
+    }
+  }
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -201,6 +201,7 @@ import {
   writeSecretFileAtomic
 } from './hardening'
 import { cursorPointInWindow } from './hud-cursor'
+import { createHudDragTracker } from './hud-drag'
 import { snapHudBounds } from './hud-snap'
 import { createHudSnapShortcut } from './hud-snap-shortcut'
 import { buildHudWindowUrl } from './hud-url'
@@ -10995,6 +10996,7 @@ function closePetOverlay() {
 // lookalike that drifts. Entering HUD mode hides the main window; leaving
 // restores it.
 let hudWindow = null
+const hudDragTracker = createHudDragTracker()
 
 // Whether the main window was visible when HUD mode was entered, so exiting
 // puts the desktop back as it was rather than raising a window the user had
@@ -11301,6 +11303,8 @@ function spawnHudWindow(sessionId, profile) {
   })
 
   win.on('closed', () => {
+    hudDragTracker.end()
+
     if (hudWindow === win) {
       hudWindow = null
     }
@@ -11390,6 +11394,7 @@ function openHudWindow(sessionId, profile) {
 
 function closeHudWindow() {
   hudSnapShortcut.dispose()
+  hudDragTracker.end()
 
   const win = hudWindow
   hudWindow = null
@@ -12171,29 +12176,49 @@ ipcMain.on('hermes:hud:ignore-mouse', (_event, ignore) => {
   }
 })
 
+ipcMain.on('hermes:hud:begin-move', event => {
+  if (hudWindow && !hudWindow.isDestroyed() && event.sender === hudWindow.webContents) {
+    hudDragTracker.begin(screen.getCursorScreenPoint())
+  }
+})
+
+ipcMain.on('hermes:hud:end-move', event => {
+  if (hudWindow && !hudWindow.isDestroyed() && event.sender === hudWindow.webContents) {
+    hudDragTracker.end()
+  }
+})
+
 ipcMain.on('hermes:hud:move-by', (event, delta) => {
   if (!hudWindow || hudWindow.isDestroyed() || event.sender !== hudWindow.webContents) {
     return
   }
 
-  const dx = Number(delta?.x)
-  const dy = Number(delta?.y)
   const width = Number(delta?.width)
   const height = Number(delta?.height)
 
-  if (!Number.isFinite(dx) || !Number.isFinite(dy) || !Number.isFinite(width) || !Number.isFinite(height)) {
+  if (!Number.isFinite(width) || !Number.isFinite(height)) {
+    return
+  }
+
+  const nativeDelta = hudDragTracker.move(screen.getCursorScreenPoint())
+
+  if (!nativeDelta) {
     return
   }
 
   const [x, y] = hudWindow.getPosition()
 
-  // setBounds — NOT setPosition: on Windows, a transparent frameless window
+  // screen.getCursorScreenPoint() and BrowserWindow bounds use Electron's
+  // native device-independent pixel coordinate space. Sampling both sides in
+  // main avoids renderer CSS-pixel drift when the cursor crosses mixed-DPI
+  // displays. setBounds — NOT setPosition: on Windows, a transparent
+  // frameless window
   // silently grows ~1px per setPosition call (worse at >100% DPI). The renderer
   // snapshots outerWidth/outerHeight when the composer drag arms and re-pins
   // to that size on every moveBy (same pattern as the pet overlay drag).
   hudWindow.setBounds({
-    x: Math.round(x + dx),
-    y: Math.round(y + dy),
+    x: Math.round(x + nativeDelta.x),
+    y: Math.round(y + nativeDelta.y),
     width: Math.round(width),
     height: Math.round(height)
   })

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -62,6 +62,8 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     open: request => ipcRenderer.invoke('hermes:hud:open', request),
     close: () => ipcRenderer.invoke('hermes:hud:close'),
     setIgnoreMouse: ignore => ipcRenderer.send('hermes:hud:ignore-mouse', ignore),
+    beginMove: () => ipcRenderer.send('hermes:hud:begin-move'),
+    endMove: () => ipcRenderer.send('hermes:hud:end-move'),
     moveBy: delta => ipcRenderer.send('hermes:hud:move-by', delta),
     setBounds: bounds => ipcRenderer.send('hermes:hud:set-bounds', bounds),
     setVibrancy: on => ipcRenderer.invoke('hermes:hud:vibrancy', on),

--- a/apps/desktop/src/app/hud/composer-drag.test.ts
+++ b/apps/desktop/src/app/hud/composer-drag.test.ts
@@ -9,6 +9,8 @@ const LONG_PRESS_MS = 140
 const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
 const initialHermesDesktop = desktopWindow.hermesDesktop
 
+const beginMove = vi.fn()
+const endMove = vi.fn()
 const moveBy = vi.fn()
 
 function setWindowSize(width: number, height: number) {
@@ -29,9 +31,11 @@ function pressTarget() {
 
 beforeEach(() => {
   vi.useFakeTimers()
+  beginMove.mockClear()
+  endMove.mockClear()
   moveBy.mockClear()
   setWindowSize(620, 320)
-  desktopWindow.hermesDesktop = { hud: { moveBy } } as unknown as Window['hermesDesktop']
+  desktopWindow.hermesDesktop = { hud: { beginMove, endMove, moveBy } } as unknown as Window['hermesDesktop']
 })
 
 afterEach(() => {
@@ -62,14 +66,19 @@ describe('useHudComposerDrag', () => {
     act(() => void vi.advanceTimersByTime(LONG_PRESS_MS))
     act(() => void window.dispatchEvent(new PointerEvent('pointermove', { pointerId: 1, screenX: 110, screenY: 210 })))
 
-    expect(moveBy).toHaveBeenCalledWith({ x: 10, y: 10, width: 620, height: 320 })
+    expect(beginMove).toHaveBeenCalledTimes(1)
+    expect(moveBy).toHaveBeenCalledWith({ width: 620, height: 320 })
 
     // A window that drifted wider mid-drag must not feed its new size back in —
     // that is exactly how the Windows growth compounded.
     setWindowSize(900, 500)
     act(() => void window.dispatchEvent(new PointerEvent('pointermove', { pointerId: 1, screenX: 115, screenY: 215 })))
 
-    expect(moveBy).toHaveBeenLastCalledWith({ x: 5, y: 5, width: 620, height: 320 })
+    expect(moveBy).toHaveBeenLastCalledWith({ width: 620, height: 320 })
+
+    act(() => void window.dispatchEvent(new PointerEvent('pointerup', { pointerId: 1 })))
+
+    expect(endMove).toHaveBeenCalledTimes(1)
   })
 
   it('does not move the window until the hold arms', () => {

--- a/apps/desktop/src/app/hud/composer-drag.ts
+++ b/apps/desktop/src/app/hud/composer-drag.ts
@@ -10,8 +10,6 @@ const MOVE_TOLERANCE = 8
 
 interface PressState {
   armed: boolean
-  lastX: number
-  lastY: number
   originH: number
   originW: number
   pointerId: number
@@ -29,13 +27,14 @@ interface PressState {
  * it decides solidity from, so the window is already transparent by the time
  * the press lands and it falls through to the app behind. See click-through.ts.
  *
- * Deltas are read in SCREEN coordinates. Client coordinates are relative to the
- * window we are moving, so a window that keeps up with the cursor reports the
- * same clientX every frame — zero delta, and the drag dies one pixel in.
+ * The renderer only owns hold detection and the size snapshot. Once armed,
+ * main samples the native cursor position in Electron's DIP coordinate space;
+ * renderer PointerEvent screen coordinates are CSS pixels and must not be
+ * added directly to BrowserWindow positions on mixed-DPI displays.
  *
  * The size is snapshotted at press and sent with every move, so main can pin it
  * (see hermes:hud:move-by — a transparent frameless window drifts wider on
- * Windows otherwise). Same shape as the pet overlay's drag.
+ * Windows otherwise). Movement itself is sampled by main in native coordinates.
  */
 export function useHudComposerDrag(enabled: boolean) {
   const [grabbing, setGrabbing] = useState(false)
@@ -49,6 +48,10 @@ export function useHudComposerDrag(enabled: boolean) {
     }
 
     const state = stateRef.current
+
+    if (state?.armed) {
+      window.hermesDesktop?.hud?.endMove?.()
+    }
 
     if (state?.target.hasPointerCapture(state.pointerId)) {
       state.target.releasePointerCapture(state.pointerId)
@@ -68,8 +71,6 @@ export function useHudComposerDrag(enabled: boolean) {
 
       stateRef.current = {
         armed: false,
-        lastX: event.screenX,
-        lastY: event.screenY,
         originH: window.outerHeight,
         originW: window.outerWidth,
         pointerId: event.pointerId,
@@ -90,6 +91,7 @@ export function useHudComposerDrag(enabled: boolean) {
         }
 
         state.armed = true
+        window.hermesDesktop?.hud?.beginMove?.()
         setGrabbing(true)
         triggerHaptic('selection')
 
@@ -130,15 +132,7 @@ export function useHudComposerDrag(enabled: boolean) {
 
       event.preventDefault()
 
-      const dx = event.screenX - state.lastX
-      const dy = event.screenY - state.lastY
-
-      state.lastX = event.screenX
-      state.lastY = event.screenY
-
       window.hermesDesktop?.hud?.moveBy?.({
-        x: dx,
-        y: dy,
         width: state.originW,
         height: state.originH
       })

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -94,7 +94,9 @@ declare global {
         open: (request?: { sessionId?: null | string; profile?: null | string }) => Promise<{ ok: boolean }>
         close: () => Promise<{ ok: boolean }>
         setIgnoreMouse: (ignore: boolean) => void
-        moveBy: (delta: { x: number; y: number; width: number; height: number }) => void
+        beginMove: () => void
+        endMove: () => void
+        moveBy: (delta: { width: number; height: number }) => void
         setBounds: (bounds: { x: number; y: number; width: number; height: number }) => void
         setVibrancy: (on: boolean) => Promise<{ ok: boolean }>
         setSession: (sessionId: null | string) => void


### PR DESCRIPTION
## Summary
- Keep HUD composer dragging in Electron's native screen coordinate space.
- Preserve the existing press-time size pin so transparent HUD windows do not grow during drag.

## Root cause
Renderer `PointerEvent.screenX`/`screenY` deltas are CSS-pixel values, while Electron's screen/window geometry is expressed in device-independent pixels (DIP). The main process previously added renderer deltas directly to `BrowserWindow` bounds, so crossing monitors with different scale factors accumulated an offset.

## Fix
- Add a small native HUD drag tracker with explicit begin/end lifecycle.
- Have the renderer send only the snapshotted width/height after the long press arms.
- Sample `screen.getCursorScreenPoint()` in the main process for each move and apply that native delta to `setBounds()`.
- Reset the tracker on pointer end and HUD window close.

## Testing
- PASS: focused UI regression, `vitest run --project ui src/app/hud/composer-drag.test.ts` (2/2 tests).
- PASS: focused Electron regression, `vitest run --project electron electron/hud-drag.test.ts` (2/2 tests).
- PASS: `npm run typecheck --workspace apps/desktop`.
- PASS: targeted ESLint and Prettier checks for all seven changed files.
- PASS: full desktop lint (0 errors; 123 existing warnings in unrelated files).
- ENVIRONMENT-LIMITED: full UI suite, 4 failed / 4,716 tests; failures are existing billing, locale-formatting, and tool-payload expectations outside HUD.
- ENVIRONMENT-LIMITED: full Electron suite, 27 failed / 1,412 tests; failures are existing Windows/POSIX file-mode, symlink, SSH, WSL, and path assumptions outside HUD.
- Manual two-monitor mixed-DPI reproduction was not available in this environment.

## Issue
Fixes #88951