### PR TITLE
fix(slack): keep clarify choices readable on mobile

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -77,6 +77,55 @@ except Exception:
 _HERMES_SLACK_USER_AGENT_PREFIX = f"HermesAgent/{_HERMES_VERSION}"
 
 _SLACK_ERROR_BODY_LIMIT_BYTES = 8 * 1024
+_SLACK_SECTION_TEXT_LIMIT = 3000
+
+
+def _escape_slack_mrkdwn_text(value: Any) -> str:
+    """Escape user-authored text before embedding it in Slack mrkdwn."""
+    text = "" if value is None else str(value)
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def _clarify_section_text(question: str, choices: list) -> str:
+    """Render a bounded question plus numbered choices for a Slack section.
+
+    Slack mobile truncates button labels aggressively, so the section is the
+    authoritative readable copy of every option. If pathological input would
+    exceed Slack's 3000-character limit, divide the available text budget
+    fairly across the question and choices. Short entries donate their unused
+    budget to long entries, and every numbered choice remains visible.
+    """
+    segments = [f"❓ {_escape_slack_mrkdwn_text(question)}"]
+    segments.extend(
+        f"{idx}. {_escape_slack_mrkdwn_text(choice)}"
+        for idx, choice in enumerate(choices, start=1)
+    )
+    separator_size = 2 + max(len(choices) - 1, 0)  # blank line, then list newlines
+    available = _SLACK_SECTION_TEXT_LIMIT - separator_size
+    caps = [0] * len(segments)
+    remaining = list(range(len(segments)))
+
+    while remaining:
+        share = available // len(remaining)
+        completed = [idx for idx in remaining if len(segments[idx]) <= share]
+        if not completed:
+            for offset, idx in enumerate(remaining):
+                caps[idx] = share + (1 if offset < available % len(remaining) else 0)
+            break
+        for idx in completed:
+            caps[idx] = len(segments[idx])
+            available -= caps[idx]
+        remaining = [idx for idx in remaining if idx not in completed]
+
+    def _bounded(text: str, cap: int) -> str:
+        if len(text) <= cap:
+            return text
+        if cap <= 3:
+            return text[:cap]
+        return text[: cap - 3] + "..."
+
+    fitted = [_bounded(text, caps[idx]) for idx, text in enumerate(segments)]
+    return fitted[0] + "\n\n" + "\n".join(fitted[1:])
 
 
 async def _read_error_text_limited(
@@ -7062,9 +7111,10 @@ class SlackAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Render a clarify prompt as Block Kit interactive buttons.
 
-        Multi-choice mode (``choices`` non-empty): one button per option
-        (unique ``hermes_clarify_choice_<idx>`` action_id, ``value`` packs
-        ``clarify_id|idx``) plus a final "✏️ Other…" button
+        Multi-choice mode (``choices`` non-empty): numbered option text in the
+        message body, one compact index button per option (unique
+        ``hermes_clarify_choice_<idx>`` action_id, ``value`` packs
+        ``clarify_id|idx``), plus a final "✏️ Other…" button
         (``hermes_clarify_other``).  A choice click resolves the clarify
         primitive directly; the "Other" button flips the entry into
         text-capture mode so the gateway's platform-agnostic text-intercept
@@ -7096,27 +7146,20 @@ class SlackAdapter(BasePlatformAdapter):
         try:
             thread_ts = self._resolve_thread_ts(None, metadata)
 
-            # Escape the Slack mrkdwn control chars (&, <, >) so a question
-            # containing them renders literally instead of as markup/mentions.
-            # Section text caps at 3000 chars — budget the question so the
-            # wrapper never pushes the block over the limit (overflow →
-            # invalid_blocks → no buttons).
-            q = (question or "").replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-            body = f"❓ {q}"
-            budget = 3000 - len("...")
-            if len(body) > budget:
-                body = body[:budget] + "..."
+            # Slack mobile truncates long button labels before their essential
+            # text becomes visible. Keep the full numbered choices in the
+            # section and make the buttons compact index selectors instead.
+            body = _clarify_section_text(question, choices)
 
             # One button per choice + a free-text "Other" button.  Slack caps
             # an actions block at 5 elements; the clarify tool caps choices at
             # 4 (+ Other = 5) so this is normally one block, but chunk anyway
             # so a larger choice list degrades gracefully instead of 400ing.
             elements = []
-            for idx, choice in enumerate(choices):
-                label = str(choice).strip() or f"Option {idx + 1}"
+            for idx in range(len(choices)):
                 elements.append({
                     "type": "button",
-                    "text": {"type": "plain_text", "text": label[:75], "emoji": True},
+                    "text": {"type": "plain_text", "text": str(idx + 1)},
                     "action_id": f"hermes_clarify_choice_{idx}",
                     "value": f"{clarify_id}|{idx}",
                 })

--- a/tests/gateway/test_slack_clarify_buttons.py
+++ b/tests/gateway/test_slack_clarify_buttons.py
@@ -124,7 +124,11 @@ class TestSlackSendClarify:
         assert elements[0]["value"] == "cid1|0"
         assert elements[1]["action_id"] == "hermes_clarify_choice_1"
         assert elements[1]["value"] == "cid1|1"
-        assert elements[0]["text"]["text"] == "staging"
+        assert blocks[0]["text"]["text"] == (
+            "❓ Which environment?\n\n1. staging\n2. production"
+        )
+        assert elements[0]["text"]["text"] == "1"
+        assert elements[1]["text"]["text"] == "2"
         # Final button is the free-text "Other"
         assert elements[2]["action_id"] == "hermes_clarify_other"
         assert elements[2]["value"] == "cid1|other"
@@ -143,7 +147,7 @@ class TestSlackSendClarify:
         await adapter.send_clarify(
             chat_id="C1",
             question="Use <A> & <B>?",
-            choices=["yes"],
+            choices=["Use <prod> & wait"],
             clarify_id="cid2",
             session_key="sk2",
         )
@@ -151,6 +155,56 @@ class TestSlackSendClarify:
         assert "<A>" not in section_text
         assert "&lt;A&gt;" in section_text
         assert "&amp;" in section_text
+        assert "1. Use &lt;prod&gt; &amp; wait" in section_text
+
+    @pytest.mark.asyncio
+    async def test_long_mobile_choices_are_readable_in_numbered_body(self):
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "1.2"})
+        choices = [
+            "Deploy the shared prefix to staging after the smoke test completes",
+            "Deploy the shared prefix to production after approval is recorded",
+        ]
+
+        await adapter.send_clarify(
+            chat_id="C1",
+            question="Which deployment path?",
+            choices=choices,
+            clarify_id="cid-mobile",
+            session_key="sk-mobile",
+        )
+
+        blocks = mock_client.chat_postMessage.call_args[1]["blocks"]
+        section_text = blocks[0]["text"]["text"]
+        assert f"1. {choices[0]}" in section_text
+        assert f"2. {choices[1]}" in section_text
+        buttons = [element for block in blocks[1:] for element in block["elements"]]
+        assert [button["text"]["text"] for button in buttons] == ["1", "2", "✏️ Other…"]
+        assert [button["value"] for button in buttons] == [
+            "cid-mobile|0",
+            "cid-mobile|1",
+            "cid-mobile|other",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_oversized_prompt_keeps_every_choice_within_section_limit(self):
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "1.3"})
+
+        await adapter.send_clarify(
+            chat_id="C1",
+            question="q" * 4000,
+            choices=[f"choice-{idx}-" + ("x" * 4000) for idx in range(1, 5)],
+            clarify_id="cid-limit",
+            session_key="sk-limit",
+        )
+
+        section_text = mock_client.chat_postMessage.call_args[1]["blocks"][0]["text"]["text"]
+        assert len(section_text) <= 3000
+        for idx in range(1, 5):
+            assert f"{idx}. choice-{idx}-" in section_text
 
 
 # ===========================================================================


### PR DESCRIPTION
## What does this PR do?

Makes Slack clarify choices readable on mobile. Slack mobile truncates long Block Kit button labels early, so choices with a shared prefix can become indistinguishable.

The message section is now the authoritative numbered list, while the buttons are compact numeric selectors. Choice action IDs and values are unchanged, so a click still resolves the original option by index.

The section renderer escapes Slack mrkdwn control characters and enforces Slack's 3000-character section limit. On oversized input it shares the available budget across the question and every choice, reclaiming unused space from short entries, so each numbered option remains visible instead of later choices disappearing behind a naive tail truncation.

## Related Issue

Fixes #88579

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- plugins/platforms/slack/adapter.py
  - render complete numbered choices in the section body
  - use short numeric button labels without changing action values
  - escape choice text as well as the question
  - bound pathological input to 3000 characters while preserving every option
- tests/gateway/test_slack_clarify_buttons.py
  - cover numbered body rendering and index mapping
  - cover long shared-prefix choices
  - cover mrkdwn escaping
  - cover oversized questions and four oversized choices

## How to Test

1. Run: scripts/run_tests.sh tests/gateway/test_slack_clarify_buttons.py -q
2. Run the Slack neighbor suites listed below.
3. In Slack mobile, send a clarify prompt whose choices share a long prefix; the full choices appear in the numbered body and the buttons read 1, 2, and Other.

Observed automated results:

- Focused clarify suite: 7 passed
- Slack adapter, clarify, Block Kit, and approval suites: 208 passed
- Ruff on both changed files: clean
- Python byte compilation: clean
- git diff --check: clean

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing issues and open PRs for duplicates
- [x] My PR contains only changes related to this fix
- [ ] I've run the complete pytest tests/ -q suite
- [x] I've added tests for the bug fix
- [x] I've tested on Windows 11 with WSL2 (automated adapter tests; no live Slack workspace)

### Documentation & Housekeeping

- [x] Documentation update: N/A; the adapter docstring documents the rendering contract
- [x] cli-config.yaml.example update: N/A; no config keys changed
- [x] CONTRIBUTING.md or AGENTS.md update: N/A; no architecture or workflow change
- [x] Cross-platform impact considered: pure payload construction, no OS-specific behavior
- [x] Tool descriptions/schemas update: N/A; clarify semantics are unchanged

## Notes

This PR was prepared with Codex assistance. The final diff, duplicate search, focused tests, neighboring Slack suites, lint, compilation, and whitespace checks were verified before publication.