### PR TITLE
fix(provider): disable vision tool messages for OpenCode Go

### DIFF
--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -74,6 +74,10 @@ class OpenCodeGoProfile(ProviderProfile):
         top_level: dict[str, Any] = {}
 
         if _is_glm_5_2_model(model):
+            # GLM-5.2 on OpenCode Go uses its native OpenAI-compatible
+            # reasoning_effort knob, which has exactly two enabled levels:
+            # high and max. Map Hermes' richer scale onto those; leave the
+            # server default alone when reasoning is disabled or unset.
             if not isinstance(reasoning_config, dict):
                 return extra_body, top_level
             if reasoning_config.get("enabled") is False:
@@ -85,7 +89,11 @@ class OpenCodeGoProfile(ProviderProfile):
             return extra_body, top_level
 
         if _is_kimi_k2_model(model):
+            # Kimi K2 on OpenCode Go uses Moonshot's native wire shape:
+            # extra_body.thinking (binary toggle) + top-level reasoning_effort
+            # (low|medium|high). Mirrors the KimiProfile (api.moonshot.ai/v1).
             if not isinstance(reasoning_config, dict):
+                # No config → leave server defaults alone.
                 return extra_body, top_level
 
             enabled = reasoning_config.get("enabled") is not False
@@ -99,6 +107,8 @@ class OpenCodeGoProfile(ProviderProfile):
             elif effort in {"low", "medium", "high"}:
                 top_level["reasoning_effort"] = effort
 
+            # Avoid "cannot specify both 'thinking' and 'reasoning_effort'" HTTP 400:
+            # only send extra_body["thinking"] when no reasoning_effort is set.
             if "reasoning_effort" not in top_level:
                 extra_body["thinking"] = {"type": "enabled"}
             return extra_body, top_level
@@ -121,6 +131,8 @@ class OpenCodeGoProfile(ProviderProfile):
             elif effort in {"low", "medium", "high"}:
                 top_level["reasoning_effort"] = effort
 
+        # Avoid "cannot specify both 'thinking' and 'reasoning_effort'" HTTP 400:
+        # only send extra_body["thinking"] when no reasoning_effort is set.
         if "reasoning_effort" not in top_level:
             extra_body["thinking"] = {"type": "enabled"}
 

--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -74,10 +74,6 @@ class OpenCodeGoProfile(ProviderProfile):
         top_level: dict[str, Any] = {}
 
         if _is_glm_5_2_model(model):
-            # GLM-5.2 on OpenCode Go uses its native OpenAI-compatible
-            # reasoning_effort knob, which has exactly two enabled levels:
-            # high and max. Map Hermes' richer scale onto those; leave the
-            # server default alone when reasoning is disabled or unset.
             if not isinstance(reasoning_config, dict):
                 return extra_body, top_level
             if reasoning_config.get("enabled") is False:
@@ -89,11 +85,7 @@ class OpenCodeGoProfile(ProviderProfile):
             return extra_body, top_level
 
         if _is_kimi_k2_model(model):
-            # Kimi K2 on OpenCode Go uses Moonshot's native wire shape:
-            # extra_body.thinking (binary toggle) + top-level reasoning_effort
-            # (low|medium|high). Mirrors the KimiProfile (api.moonshot.ai/v1).
             if not isinstance(reasoning_config, dict):
-                # No config → leave server defaults alone.
                 return extra_body, top_level
 
             enabled = reasoning_config.get("enabled") is not False
@@ -107,8 +99,6 @@ class OpenCodeGoProfile(ProviderProfile):
             elif effort in {"low", "medium", "high"}:
                 top_level["reasoning_effort"] = effort
 
-            # Avoid "cannot specify both 'thinking' and 'reasoning_effort'" HTTP 400:
-            # only send extra_body["thinking"] when no reasoning_effort is set.
             if "reasoning_effort" not in top_level:
                 extra_body["thinking"] = {"type": "enabled"}
             return extra_body, top_level
@@ -131,8 +121,6 @@ class OpenCodeGoProfile(ProviderProfile):
             elif effort in {"low", "medium", "high"}:
                 top_level["reasoning_effort"] = effort
 
-        # Avoid "cannot specify both 'thinking' and 'reasoning_effort'" HTTP 400:
-        # only send extra_body["thinking"] when no reasoning_effort is set.
         if "reasoning_effort" not in top_level:
             extra_body["thinking"] = {"type": "enabled"}
 
@@ -155,6 +143,7 @@ opencode_go = OpenCodeGoProfile(
     base_url="https://opencode.ai/zen/go/v1",
     default_headers=dict(_ATTRIBUTION_HEADERS),
     default_aux_model="glm-5",
+    supports_vision_tool_messages=False,
 )
 
 register_provider(opencode_zen)

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -16,6 +16,11 @@ def opencode_go_profile():
     return profile
 
 
+def test_opencode_go_disables_vision_tool_messages(opencode_go_profile):
+    """OpenCode Go accepts images in user messages, not tool-result messages."""
+    assert opencode_go_profile.supports_vision_tool_messages is False
+
+
 class TestOpenCodeGoKimiReasoning:
     """Kimi K2 models use Moonshot's thinking + reasoning_effort shape on OpenCode Go."""
 


### PR DESCRIPTION
## Summary

OpenCode Go accepts vision images in user messages, but rejects multimodal content inside `tool`-role messages. Mark the provider profile with `supports_vision_tool_messages=False` so Hermes uses its existing text-summary fallback for tool results instead of injecting `image_url` content that makes the proxy return HTTP 500.

This keeps native/user-message vision support intact; only the tool-result transport capability is disabled.

## Related Issue

Fixes #89057

## Changes

- set `supports_vision_tool_messages=False` on the `opencode-go` provider profile
- add a focused regression assertion to the existing OpenCode Go profile tests

## Testing

The change follows the existing provider-profile contract already used by the Xiaomi profile for gateways that reject list-type tool content. The focused test pins the capability flag. I could not run the repository test suite from this connector environment because outbound GitHub/network access from the execution container is unavailable.
