### PR TITLE
fix(gateway): force source.profile override in secondary profile handlers

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15362,7 +15362,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         async def _handler(event):
             try:
-                if getattr(event, "source", None) is not None and not event.source.profile:
+                # The adapter that received the update is authoritative in
+                # multiplex mode.  Telegram DMs to different per-agent bots can
+                # share the same user chat_id (the user's private chat), so a
+                # stale/route-derived source.profile from a previous bot DM must
+                # not win over the credential-owning adapter's profile.
+                if getattr(event, "source", None) is not None:
                     event.source.profile = profile_name
             except Exception:
                 pass
@@ -15377,7 +15382,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Stamp an owning adapter's profile before resolving busy policy."""
         async def _handler(event, _session_key):
             try:
-                if getattr(event, "source", None) is not None and not event.source.profile:
+                if getattr(event, "source", None) is not None:
                     event.source.profile = profile_name
             except Exception:
                 pass
@@ -15428,8 +15433,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             profile_home = None
 
         async def _handler(event, source):
-            if getattr(source, "profile", None) is None:
-                source.profile = profile_name
+            # The secondary adapter that received this platform event owns the
+            # credential/profile. In multiplex mode a stale source.profile from a
+            # previous per-agent bot DM must not leak across bot boundaries;
+            # the owning adapter's profile is authoritative.
+            source.profile = profile_name
             if profile_home is not None:
                 with _profile_runtime_scope(profile_home):
                     return await self._handle_gateway_platform_event(event, source)

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -95,6 +95,79 @@ class TestProfileMessageHandler:
         assert result == "ok"
         assert seen["profile"] == "coder"
 
+    @pytest.mark.asyncio
+    async def test_adapter_owned_profile_overrides_stale_source_profile(self):
+        """Per-agent bot DMs can share a user chat id across adapters.
+
+        The secondary adapter that receives the Telegram update owns the
+        credential/profile, so it must override stale route/session profile
+        data instead of preserving another bot's profile.
+        """
+        runner = GatewayRunner.__new__(GatewayRunner)
+        seen = {}
+
+        async def _fake_handle(event):
+            seen["profile"] = event.source.profile
+            return "ok"
+
+        runner._handle_message = _fake_handle
+        handler = runner._make_profile_message_handler("dev")
+
+        class _Src:
+            profile = "quill"
+
+        class _Evt:
+            source = _Src()
+
+        result = await handler(_Evt())
+        assert result == "ok"
+        assert seen["profile"] == "dev"
+
+
+class TestProfilePlatformEventHandler:
+    @pytest.mark.asyncio
+    async def test_stamps_profile_on_unstamped_source(self):
+        runner = GatewayRunner.__new__(GatewayRunner)
+        seen = {}
+
+        async def _fake_handle(event, source):
+            seen["profile"] = source.profile
+            return "ok"
+
+        runner._handle_gateway_platform_event = _fake_handle
+        handler = runner._make_profile_platform_event_handler("coder")
+
+        class _Src:
+            profile = None
+
+        result = await handler({}, _Src())
+        assert result == "ok"
+        assert seen["profile"] == "coder"
+
+    @pytest.mark.asyncio
+    async def test_adapter_owned_profile_overrides_stale_source_profile(self):
+        """Per-agent bot DMs can share a user chat id across adapters.
+
+        The secondary adapter that receives the platform event owns the
+        credential/profile, so it must override stale route/session profile
+        data instead of preserving another bot's profile.
+        """
+        runner = GatewayRunner.__new__(GatewayRunner)
+        seen = {}
+
+        async def _fake_handle(event, source):
+            seen["profile"] = source.profile
+            return "ok"
+
+        runner._handle_gateway_platform_event = _fake_handle
+        handler = runner._make_profile_platform_event_handler("dev")
+
+        class _Src:
+            profile = "quill"
+
+        result = await handler({}, _Src())
+        assert result == "ok"
+        assert seen["profile"] == "dev"
 
 class TestProfileRuntimeStatus:
     def test_base_adapter_uses_namespaced_platform_key(self, monkeypatch):


### PR DESCRIPTION
In multiplex mode, per-agent bot DMs (e.g. @solovision_dev_bot vs @solovision_quill_bot) can share the same user chat_id. The secondary profile message/busy/platform-event handlers only stamped source.profile when it was empty, allowing stale route/session profile data from a previous bot DM to leak across bot boundaries.

This makes the owning adapter's profile authoritative in all three secondary handlers: source.profile is always overridden to the credential-owning profile, so session keys and profile scope cannot leak from one bot DM to another. Group profile_routes are unaffected (the shared ingress fallback in _handle_message still only resolves when source.profile is unset).

Adds TestProfilePlatformEventHandler and a stale-profile override test for the message handler.