### PR TITLE
fix(file-safety): read-deny the live Google Workspace token files

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -255,10 +255,11 @@ def get_read_block_error(path: str) -> Optional[str]:
       * Credential / secret stores under HERMES_HOME and the global Hermes
         root: ``auth.json``, ``auth.lock``, ``.anthropic_oauth.json``,
         ``.env``, ``webhook_subscriptions.json``, ``auth/google_oauth.json``,
-        and anything under ``mcp-tokens/``. These hold plaintext provider keys,
-        OAuth tokens, and HMAC secrets that the agent never needs to read
-        directly — provider tools / gateway adapters consume them through
-        internal channels.
+        ``google_token.json``, ``google_oauth_pending.json``,
+        ``cache/bws_cache.json``, and anything under ``mcp-tokens/``. These
+        hold plaintext provider keys, OAuth tokens, and HMAC secrets that the
+        agent never needs to read directly — provider tools / gateway
+        adapters / skill scripts consume them through internal channels.
       * Project-local environment files anywhere on disk: ``.env``,
         ``.env.local``, ``.env.development``, ``.env.production``,
         ``.env.test``, ``.env.staging``, ``.envrc``. These routinely hold
@@ -331,6 +332,15 @@ def get_read_block_error(path: str) -> Optional[str]:
         ".env",
         "webhook_subscriptions.json",
         os.path.join("auth", "google_oauth.json"),
+        # LIVE Google Workspace OAuth stores at the HERMES_HOME root: the
+        # token written by the google-workspace skill's setup.py (refreshed
+        # by google_api.py, consumed by gws_bridge.py) and the in-flight
+        # exchange state (PKCE verifier + session). Only the skill's own
+        # scripts read them, via direct file IO that bypasses this guard.
+        # The skill's sandbox mount keeps working through an explicit
+        # exception in tools.credential_files (_MOUNTABLE_SERVICE_TOKENS).
+        "google_token.json",
+        "google_oauth_pending.json",
         # Bitwarden Secrets Manager disk cache: stores plaintext secret values
         # to avoid re-fetching across back-to-back CLI invocations. The file
         # was introduced by #31968 but not added to this guard.

--- a/tests/agent/test_file_safety_credentials.py
+++ b/tests/agent/test_file_safety_credentials.py
@@ -190,6 +190,46 @@ def test_webhook_subscriptions_blocked(fake_home):
 
 
 
+@pytest.mark.parametrize("name", ["google_token.json", "google_oauth_pending.json"])
+def test_google_workspace_live_stores_blocked(fake_home, name):
+    """The LIVE Google Workspace stores at the HERMES_HOME root are blocked:
+    ``google_token.json`` (OAuth refresh/access token, consumed by the
+    skill's gws_bridge.py/google_api.py) and ``google_oauth_pending.json``
+    (in-flight PKCE exchange state, consumed by setup.py). #38953 closed the
+    write side; before this test the read guard blocked only the unused
+    ``auth/google_oauth.json`` path while the live token stayed readable."""
+    from agent.file_safety import get_read_block_error
+
+    p = _create(fake_home, name)
+    err = get_read_block_error(str(p))
+    assert err is not None
+    assert "credential store" in err
+
+
+@pytest.mark.parametrize("name", ["google_token.json", "google_oauth_pending.json"])
+def test_profile_mode_blocks_root_google_workspace_stores(tmp_path, monkeypatch, name):
+    """Root-level live Google Workspace stores stay blocked while a profile
+    is active (root credentials are inherited by every profile), and the
+    profile-local copies are blocked too."""
+    import agent.file_safety as fs
+
+    root = tmp_path / "hermes"
+    profile = root / "profiles" / "coder"
+    profile.mkdir(parents=True)
+    monkeypatch.setattr(fs, "_hermes_home_path", lambda: profile)
+    monkeypatch.setattr(fs, "_hermes_root_path", lambda: root)
+
+    from agent.file_safety import get_read_block_error
+
+    root_store = root / name
+    root_store.write_text("x")
+    assert "credential store" in (get_read_block_error(str(root_store)) or "")
+
+    profile_store = profile / name
+    profile_store.write_text("x")
+    assert "credential store" in (get_read_block_error(str(profile_store)) or "")
+
+
 def test_identically_named_hermes_files_outside_home_not_blocked(
     fake_home, tmp_path
 ):
@@ -213,6 +253,10 @@ def test_identically_named_hermes_files_outside_home_not_blocked(
     google_oauth.parent.mkdir()
     google_oauth.write_text("not really a token", encoding="utf-8")
     assert get_read_block_error(str(google_oauth)) is None
+
+    google_token = project / "google_token.json"
+    google_token.write_text("not really a token", encoding="utf-8")
+    assert get_read_block_error(str(google_token)) is None
 
     tokens = project / "mcp-tokens"
     tokens.mkdir()

--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -528,7 +528,10 @@ class TestMasterCredentialStoresAreNeverMountable:
 
     The bar is the canonical read deny-list: whatever the agent is forbidden to
     ``read_file`` must not be mountable either, so the mount surface can't
-    grant what the read surface denies.
+    grant what the read surface denies. One carve-out: skill-scoped service
+    tokens (``_MOUNTABLE_SERVICE_TOKENS``, today only ``google_token.json``)
+    are read-denied to the agent but stay mountable, because the skill's own
+    sandboxed scripts are their intended consumer.
     """
 
     @staticmethod
@@ -566,7 +569,13 @@ class TestMasterCredentialStoresAreNeverMountable:
             assert get_credential_file_mounts() == []
 
     def test_per_service_token_still_mounts(self, tmp_path):
-        """The module's legitimate purpose must keep working."""
+        """The module's legitimate purpose must keep working.
+
+        Doubles as the regression test for the ``_MOUNTABLE_SERVICE_TOKENS``
+        carve-out: ``google_token.json`` is read-denied by
+        ``get_read_block_error()``, so without the carve-out this mount
+        would be refused and the google-workspace skill would lose its
+        token inside Docker/Modal sandboxes."""
         home = self._home(tmp_path)
         with patch.dict(os.environ, {"HERMES_HOME": str(home)}):
             assert register_credential_file("google_token.json") is True
@@ -574,6 +583,29 @@ class TestMasterCredentialStoresAreNeverMountable:
         assert [m["container_path"] for m in mounts] == [
             "/root/.hermes/google_token.json"
         ]
+
+    def test_pending_oauth_state_is_refused(self, tmp_path):
+        """``google_oauth_pending.json`` is read-denied and NOT in the
+        service-token carve-out: no skill declares it, and the in-flight
+        PKCE verifier has no business inside a sandbox."""
+        home = self._home(tmp_path)
+        (home / "google_oauth_pending.json").write_text("{}")
+        with patch.dict(os.environ, {"HERMES_HOME": str(home)}):
+            assert register_credential_file("google_oauth_pending.json") is False
+            assert get_credential_file_mounts() == []
+
+    def test_carve_out_is_exact_path_not_basename(self, tmp_path):
+        """A nested file that merely shares the carve-out basename gets no
+        special treatment: it is not read-denied (per-location gate), so it
+        mounts on its own merits, while the carve-out never widens to paths
+        outside HERMES_HOME root."""
+        from tools.credential_files import _is_mountable_service_token
+
+        home = self._home(tmp_path)
+        nested = home / "skills" / "g" / "google_token.json"
+        nested.parent.mkdir(parents=True)
+        nested.write_text("{}")
+        assert _is_mountable_service_token(nested.resolve(), home) is False
 
     def test_refused_entry_does_not_block_the_rest_of_the_batch(self, tmp_path):
         home = self._home(tmp_path)

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -35,6 +35,18 @@ except ImportError:  # noqa: F401 - sentinel consumed in register_credential_fil
 
 logger = logging.getLogger(__name__)
 
+# Per-service tokens that skills may mount into their own sandboxes even
+# though the model-facing read surface denies them. The mount gate below
+# reuses the canonical read deny-list, but read-denied and mountable are not
+# the same judgement for a service token: google_token.json must not be
+# read_file'd by the agent on the host (a prompt-injected read exfiltrates a
+# live refresh token), yet the google-workspace skill's own scripts need it
+# bind-mounted to run inside Docker/Modal sandboxes. Exact filenames relative
+# to HERMES_HOME; keep this to skill-declared service tokens only — master
+# stores (.env, auth.json, mcp-tokens/, ...) must never appear here. See
+# #89064 for folding these per-surface judgements into one registry.
+_MOUNTABLE_SERVICE_TOKENS = frozenset({"google_token.json"})
+
 # Session-scoped list of credential files to mount.
 # Backed by ContextVar to prevent cross-session data bleed in the gateway pipeline.
 _registered_files_var: ContextVar[Dict[str, str]] = ContextVar("_registered_files")
@@ -59,6 +71,19 @@ def _resolve_hermes_home() -> Path:
     return get_hermes_home()
 
 
+def _is_mountable_service_token(resolved: Path, hermes_home: Path) -> bool:
+    """Return True when *resolved* is exactly a ``_MOUNTABLE_SERVICE_TOKENS``
+    entry under the active HERMES_HOME. Path-resolved comparison so spellings
+    like ``./google_token.json`` neither dodge nor widen the carve-out."""
+    for name in _MOUNTABLE_SERVICE_TOKENS:
+        try:
+            if resolved == (hermes_home / name).resolve():
+                return True
+        except OSError:
+            continue
+    return False
+
+
 def register_credential_file(
     relative_path: str,
     container_base: str = "/root/.hermes",
@@ -80,7 +105,10 @@ def register_credential_file(
     ``mcp-tokens/`` or the Bitwarden plaintext cache. Those are refused via
     the canonical read deny-list (``agent.file_safety.get_read_block_error``)
     — the same guard that stops the agent reading them with ``read_file``, so
-    the mount surface cannot hand a skill what the read surface denies it.
+    the mount surface cannot hand a skill what the read surface denies it,
+    with one carve-out: the read guard also denies skill-scoped service
+    tokens (``_MOUNTABLE_SERVICE_TOKENS``), which stay mountable because the
+    skill's own sandboxed scripts are their intended consumer.
     """
     hermes_home = _resolve_hermes_home()
 
@@ -133,7 +161,7 @@ def register_credential_file(
             "credential_files: refusing %r — read guard raised", relative_path
         )
         return False
-    if denied:
+    if denied and not _is_mountable_service_token(resolved, hermes_home):
         logger.warning(
             "credential_files: refused %r — it is a credential store the agent "
             "is denied from reading; a skill may mount its own service token, "


### PR DESCRIPTION
## What does this PR do?

Follow-up to #38953 (write side) — noted there by @egilewski's review and tracked in the drift history of #89064.

`get_read_block_error()` blocks reads of the legacy `auth/google_oauth.json` path, but not the stores the Google Workspace skill actually uses: `HERMES_HOME/google_token.json` (live OAuth refresh/access token) and `HERMES_HOME/google_oauth_pending.json` (in-flight PKCE exchange state). A prompt-injected `read_file` can exfiltrate a live Google refresh token. The other credential surfaces already deny both (`_ROOT_CREDENTIAL_FILES` on delivery, `_SENSITIVE_MANAGED_FILE_BASENAMES` on the dashboard, and `build_write_denied_paths()` for writes once #38953 lands); the read guard was the last open one.

**The subtlety:** the sandbox mount gate in `tools/credential_files.py` deliberately reuses the read deny-list ("the mount surface cannot hand a skill what the read surface denies"), and the google-workspace skill declares `google_token.json` in `required_credential_files` — its own docstring cites that file as the canonical *legitimately mountable* service token. A blanket read-deny would therefore silently break the skill inside Docker/Modal sandboxes (`register_credential_file` would refuse the mount and the token would never reach the container).

So the fix is two-sided:

- read-deny both files (under the active profile home **and** the Hermes root, since profiles inherit root credentials);
- add a narrow, exact-path carve-out in the mount gate (`_MOUNTABLE_SERVICE_TOKENS = {"google_token.json"}`) so skill-declared service tokens stay mountable while master stores remain refused. `google_oauth_pending.json` gets no carve-out: nothing mounts it, and the in-flight PKCE verifier has no business inside a sandbox.

**Why the carve-out only resolves against `HERMES_HOME`, while the read deny-list covers both `HERMES_HOME` and the Hermes root:** it cannot be reached from anywhere else. `register_credential_file()` builds its host path as `hermes_home / relative_path` and then runs `validate_within_dir(host_path, hermes_home)`, so by the time the deny-list is consulted the resolved path is always inside the active `HERMES_HOME`. Matching the deny-list's two-location shape here would widen the carve-out to a location the gate can never see, which is the opposite of what a carve-out should do. `test_carve_out_is_exact_path_not_basename` pins the narrowness from the other side: a nested file that merely shares the basename gets no special treatment.

Trusted consumers are unaffected: `setup.py`, `google_api.py`, and `gws_bridge.py` read/write the token via direct file IO in their own processes, which never routes through the model-facing guard.

## Related Issue

Discussed in the #38953 review thread; part of the four-list drift documented in #89064.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/file_safety.py`: added `google_token.json` and `google_oauth_pending.json` to `credential_file_names` in `get_read_block_error()`; updated the docstring enumeration (which was also missing the already-blocked `cache/bws_cache.json`).
- `tools/credential_files.py`: new `_MOUNTABLE_SERVICE_TOKENS` frozenset and `_is_mountable_service_token()` helper (path-resolved exact match, so `./google_token.json` spellings neither dodge nor widen the carve-out); the refusal in `register_credential_file()` now exempts carve-out entries. Docstrings updated to state the carve-out explicitly.
- `tests/agent/test_file_safety_credentials.py`: parametrized read-deny tests for both filenames under the active `HERMES_HOME` and at `<root>/` + `<profile>/` while a profile is active; plus a negative case pinning that `google_token.json` *outside* HERMES_HOME stays readable (per-location gate, not per-basename).
- `tests/tools/test_credential_files.py`: `test_per_service_token_still_mounts` docstring now marks it as the carve-out regression test; new `test_pending_oauth_state_is_refused` (no carve-out for the pending file) and `test_carve_out_is_exact_path_not_basename`.

## How to Test

```bash
uv run --extra dev pytest tests/agent/test_file_safety.py tests/agent/test_file_safety_credentials.py tests/agent/test_file_safety_cross_profile.py tests/tools/test_credential_files.py tests/skills/test_google_workspace_credential_files.py tests/tools/test_write_deny.py -q
```

Without the `agent/file_safety.py` change, the 4 new read-deny cases and `test_pending_oauth_state_is_refused` fail; without the carve-out, `test_per_service_token_still_mounts` and the google-workspace skill mount tests fail. All pass with both.

(Note: 3 pre-existing symlink tests in `tests/tools/test_credential_files.py` fail on Windows without Developer Mode — `os.symlink` needs elevation, WinError 1314. They fail identically on unpatched `main`, so they are unrelated to this change.)

This branch is based directly on `main`, not on #38953, and the two apply cleanly together: this PR touches `get_read_block_error()`, #38953 touches `build_write_denied_paths()`. Merging in either order works.

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the six suites listed above (97 passed in total) — not the full `pytest tests/ -q`. I also ran the two blocking lint jobs in full on this head: repo-wide `ruff check .` ("All checks passed") and `python scripts/check-windows-footguns.py --all` (clean, 1003 files scanned)
- [x] Rebased onto current `main` (`14c59f0b`); single commit, no merge commit
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings updated in both changed modules
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — exact-path matching via `Path.resolve()`, consistent with the surrounding entries
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A



