### PR TITLE
feat(desktop): double-click a composer reference chip to edit it in place

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-url-dialog.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-url-dialog.test.tsx
@@ -5,10 +5,19 @@ import { useComposerUrlDialog } from './use-composer-url-dialog'
 
 vi.mock('@/lib/haptics', () => ({ triggerHaptic: () => {} }))
 
+// The dialog engine always gets a chip-edit path wired in, even when a given
+// surface only uses the attach path — supply inert defaults so the options
+// object is complete.
+const noopOptions = {
+  applyChipEdit: () => true,
+  recordChipEditUndo: () => {},
+  syncEditorToDraft: () => {}
+}
+
 describe('useComposerUrlDialog', () => {
   it('drops an @url: directive into the draft when there is no host onAddUrl', () => {
     const insertText = vi.fn()
-    const { result } = renderHook(() => useComposerUrlDialog({ insertText }))
+    const { result } = renderHook(() => useComposerUrlDialog({ ...noopOptions, insertText }))
 
     act(() => result.current.setUrlValue('  https://example.dev  '))
     act(() => result.current.submitUrl())
@@ -20,7 +29,7 @@ describe('useComposerUrlDialog', () => {
   it('prefers the host onAddUrl handler, then clears + closes the dialog', () => {
     const insertText = vi.fn()
     const onAddUrl = vi.fn()
-    const { result } = renderHook(() => useComposerUrlDialog({ insertText, onAddUrl }))
+    const { result } = renderHook(() => useComposerUrlDialog({ ...noopOptions, insertText, onAddUrl }))
 
     act(() => {
       result.current.openUrlDialog()
@@ -37,12 +46,82 @@ describe('useComposerUrlDialog', () => {
   it('no-ops on an empty / whitespace-only URL', () => {
     const insertText = vi.fn()
     const onAddUrl = vi.fn()
-    const { result } = renderHook(() => useComposerUrlDialog({ insertText, onAddUrl }))
+    const { result } = renderHook(() => useComposerUrlDialog({ ...noopOptions, insertText, onAddUrl }))
 
     act(() => result.current.setUrlValue('   '))
     act(() => result.current.submitUrl())
 
     expect(insertText).not.toHaveBeenCalled()
     expect(onAddUrl).not.toHaveBeenCalled()
+  })
+
+  it('rewrites the chip in place on a chip-edit submit, banking undo first', () => {
+    const applyChipEdit = vi.fn(() => true)
+    const recordChipEditUndo = vi.fn()
+    const syncEditorToDraft = vi.fn()
+    const insertText = vi.fn()
+    const chip = { dataset: {} } as HTMLElement
+
+    const { result } = renderHook(() =>
+      useComposerUrlDialog({
+        ...noopOptions,
+        applyChipEdit,
+        insertText,
+        recordChipEditUndo,
+        syncEditorToDraft
+      })
+    )
+
+    act(() => result.current.beginChipEdit(chip, 'https://example.dev/a'))
+    act(() => result.current.setUrlValue('https://example.dev/b'))
+    act(() => result.current.submitUrl())
+
+    expect(recordChipEditUndo).toHaveBeenCalled()
+    expect(applyChipEdit).toHaveBeenCalledWith(chip, 'https://example.dev/b')
+    expect(syncEditorToDraft).toHaveBeenCalled()
+    // Editing never inserts a new directive.
+    expect(insertText).not.toHaveBeenCalled()
+    expect(result.current.urlOpen).toBe(false)
+    expect(result.current.chipEdit).toBeNull()
+  })
+
+  it('keeps the dialog open when the chip is gone before the edit lands', () => {
+    const applyChipEdit = vi.fn(() => false)
+    const recordChipEditUndo = vi.fn()
+    const syncEditorToDraft = vi.fn()
+    const insertText = vi.fn()
+    const chip = { dataset: {} } as HTMLElement
+
+    const { result } = renderHook(() =>
+      useComposerUrlDialog({
+        ...noopOptions,
+        applyChipEdit,
+        insertText,
+        recordChipEditUndo,
+        syncEditorToDraft
+      })
+    )
+
+    act(() => result.current.beginChipEdit(chip, 'https://example.dev/a'))
+    act(() => result.current.setUrlValue('https://example.dev/b'))
+    act(() => result.current.submitUrl())
+
+    expect(applyChipEdit).toHaveBeenCalledWith(chip, 'https://example.dev/b')
+    // The value survives so the user can attach it or retry, and the dialog stays up.
+    expect(result.current.urlOpen).toBe(true)
+    expect(result.current.urlValue).toBe('https://example.dev/b')
+    expect(syncEditorToDraft).not.toHaveBeenCalled()
+  })
+
+  it('does not stack a second chip edit while a dialog is already open', () => {
+    const chipA = { dataset: {} } as HTMLElement
+    const chipB = { dataset: {} } as HTMLElement
+    const { result } = renderHook(() => useComposerUrlDialog({ ...noopOptions, insertText: vi.fn() }))
+
+    act(() => result.current.beginChipEdit(chipA, 'https://example.dev/a'))
+    act(() => result.current.beginChipEdit(chipB, 'https://example.dev/b'))
+
+    // The first edit wins; the second is a no-op.
+    expect(result.current.chipEdit).toEqual({ chip: chipA, value: 'https://example.dev/a' })
   })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-url-dialog.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-url-dialog.ts
@@ -3,19 +3,47 @@ import { useEffect, useRef, useState } from 'react'
 import { triggerHaptic } from '@/lib/haptics'
 
 interface UseComposerUrlDialogOptions {
+  /** Insert a new `@url:` directive into the draft (attach mode submit). */
   insertText: (text: string) => void
   onAddUrl?: (url: string) => void
+  /** Rewrite a reference chip in place. Returns false when the chip vanished
+   *  (deleted/undone) before the edit landed — the caller keeps the dialog
+   *  open so the user can retry or cancel. */
+  applyChipEdit: (chip: HTMLElement, value: string) => boolean
+  /** Bank the pre-edit state on the composer's undo stack before a chip edit. */
+  recordChipEditUndo: () => void
+  /** Push the live editor text back into draft + composer state after an edit. */
+  syncEditorToDraft: () => void
+}
+
+interface ChipEdit {
+  chip: HTMLElement
+  value: string
 }
 
 /**
- * "Add URL" dialog engine: open/value state, autofocus-on-open, and submit. On
- * submit it prefers the host's `onAddUrl` (which may fetch/title the link) and
- * otherwise drops an `@url:` directive into the draft.
+ * The URL dialog engine: open/value state, autofocus-on-open, and submit.
+ *
+ * Two modes share the one dialog:
+ *  - **attach** (the "Add URL" action) — submit prefers the host's `onAddUrl`
+ *    (which may fetch/title the link) and otherwise drops an `@url:` directive
+ *    into the draft.
+ *  - **chip edit** (double-clicking a reference chip) — the field is pre-filled
+ *    with the chip's current value and submit rewrites that chip in place,
+ *    which is the only way a `contenteditable="false"` chip can be corrected
+ *    mid-draft (it is atomic: the caret cannot enter it).
  */
-export function useComposerUrlDialog({ insertText, onAddUrl }: UseComposerUrlDialogOptions) {
+export function useComposerUrlDialog({
+  applyChipEdit,
+  insertText,
+  onAddUrl,
+  recordChipEditUndo,
+  syncEditorToDraft
+}: UseComposerUrlDialogOptions) {
   const urlInputRef = useRef<HTMLInputElement | null>(null)
   const [urlOpen, setUrlOpen] = useState(false)
   const [urlValue, setUrlValue] = useState('')
+  const [chipEdit, setChipEdit] = useState<ChipEdit | null>(null)
 
   useEffect(() => {
     if (urlOpen) {
@@ -25,13 +53,59 @@ export function useComposerUrlDialog({ insertText, onAddUrl }: UseComposerUrlDia
 
   const openUrlDialog = () => {
     triggerHaptic('open')
+    setChipEdit(null)
+    setUrlValue('')
     setUrlOpen(true)
+  }
+
+  /** Double-click a reference chip: open the dialog pre-filled with its value,
+   *  in edit mode. */
+  const beginChipEdit = (chip: HTMLElement, value: string) => {
+    if (urlOpen) {
+      // A dialog is already open (attach or a prior edit) — don't stack a
+      // second one on it.
+      return
+    }
+
+    triggerHaptic('open')
+    setChipEdit({ chip, value })
+    setUrlValue(value)
+    setUrlOpen(true)
+  }
+
+  const closeUrlDialog = () => {
+    setChipEdit(null)
+    setUrlOpen(false)
   }
 
   const submitUrl = () => {
     const url = urlValue.trim()
 
     if (!url) {
+      return
+    }
+
+    if (chipEdit) {
+      // Editing an existing chip: bank the pre-edit state, rewrite in place,
+      // and pull the live DOM text back into draft + composer state so the
+      // submit button and queue reflect the corrected reference.
+      recordChipEditUndo()
+
+      if (!applyChipEdit(chipEdit.chip, url)) {
+        // The chip is gone (deleted/undone while the dialog was open) — keep
+        // the dialog open on the value so the user can attach it instead or
+        // cancel; closing would silently discard their edit.
+        triggerHaptic('selection')
+
+        return
+      }
+
+      syncEditorToDraft()
+      triggerHaptic('success')
+      setChipEdit(null)
+      setUrlValue('')
+      setUrlOpen(false)
+
       return
     }
 
@@ -46,5 +120,16 @@ export function useComposerUrlDialog({ insertText, onAddUrl }: UseComposerUrlDia
     setUrlOpen(false)
   }
 
-  return { openUrlDialog, setUrlOpen, setUrlValue, submitUrl, urlInputRef, urlOpen, urlValue }
+  return {
+    beginChipEdit,
+    chipEdit,
+    closeUrlDialog,
+    openUrlDialog,
+    setUrlOpen: closeUrlDialog,
+    setUrlValue,
+    submitUrl,
+    urlInputRef,
+    urlOpen,
+    urlValue
+  }
 }

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -1,6 +1,6 @@
 import { ComposerPrimitive } from '@assistant-ui/react'
 import { useStore } from '@nanostores/react'
-import { type ClipboardEvent, type FormEvent, type KeyboardEvent, useCallback, useEffect, useMemo, useRef } from 'react'
+import { type ClipboardEvent, type FormEvent, type KeyboardEvent, type MouseEvent, useCallback, useEffect, useMemo, useRef } from 'react'
 
 import { useHudComposerDrag } from '@/app/hud/composer-drag'
 import { composerFill, composerFloatingStrip, composerSurfaceGlass } from '@/components/chat/composer-dock'
@@ -68,7 +68,10 @@ import {
   deleteSelectionInEditor,
   insertComposerContentsAtCaret,
   normalizeComposerEditorDom,
-  RICH_INPUT_SLOT
+  replaceRefChipValue,
+  replaceSlashChipValue,
+  RICH_INPUT_SLOT,
+  unquoteRef
 } from './rich-editor'
 import { useComposerScope } from './scope'
 import { ComposerStatusStack } from './status-stack'
@@ -269,11 +272,26 @@ export function ChatBar({
   }, [activeQueueSessionKey, resetUndoHistory])
 
   // "Add URL" dialog — open/value state, autofocus, and submit (host onAddUrl or
-  // an @url: directive into the draft).
-  const { openUrlDialog, setUrlOpen, setUrlValue, submitUrl, urlInputRef, urlOpen, urlValue } = useComposerUrlDialog({
-    insertText,
-    onAddUrl
-  })
+  // an @url: directive into the draft). The same dialog also edits an existing
+  // reference chip in place (double-click): the field opens pre-filled with the
+  // chip's value and submit rewrites that chip rather than inserting a new one.
+  const applyChipEdit = (chip: HTMLElement, value: string) =>
+    chip.dataset.slashKind ? replaceSlashChipValue(chip, value) : replaceRefChipValue(chip, value)
+
+  const { beginChipEdit, chipEdit, openUrlDialog, setUrlOpen, setUrlValue, submitUrl, urlInputRef, urlOpen, urlValue } =
+    useComposerUrlDialog({
+      applyChipEdit,
+      insertText,
+      onAddUrl,
+      recordChipEditUndo: () => recordUndoPoint(),
+      syncEditorToDraft: () => {
+        const editor = editorRef.current
+
+        if (editor) {
+          flushEditorToDraft(editor)
+        }
+      }
+    })
 
   // The queue engine — queued turns, in-place editing, the shared drain lock,
   // and bounded auto-drain. Consumes the draft API and writes `queueEditRef`.
@@ -548,6 +566,29 @@ export function ChatBar({
     recordUndoPoint()
     insertComposerContentsAtCaret(event.currentTarget, pathifyRefs(linkifyUrls(pastedText)), scope)
     scheduleFlushEditorToDraft(event.currentTarget)
+  }
+
+  // Double-click a reference chip to edit its value. Chips are atomic
+  // (`contenteditable="false"`), so the caret cannot enter one — the dialog is
+  // the only way to correct a reference mid-draft. `data-ref-text` holds the
+  // serialized form (`@url:`https://…`` or a bare `/clean`); strip the
+  // `@kind:` prefix and any quoting to open the dialog on the raw value.
+  const handleEditorDoubleClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (inputDisabled) {
+      return
+    }
+
+    const chip = event.target instanceof Element ? event.target.closest<HTMLElement>('[data-ref-text]') : null
+    const editor = event.currentTarget
+
+    if (!chip || !editor.contains(chip) || !chip.dataset.refText) {
+      return
+    }
+
+    const serialized = chip.dataset.refText
+    const raw = serialized.startsWith('@') ? serialized.replace(/^@[\w-]+:/, '') : serialized
+
+    beginChipEdit(chip, unquoteRef(raw))
   }
 
   const handleEditorKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
@@ -1053,6 +1094,7 @@ export function ChatBar({
           // hint would sit behind the preedit text the whole time (#75960).
           beginComposerComposition(event.currentTarget)
         }}
+        onDoubleClick={handleEditorDoubleClick}
         onDragOver={handleInputDragOver}
         onDrop={handleInputDrop}
         onFocus={() => markActiveComposer(scope.target)}
@@ -1357,6 +1399,7 @@ export function ChatBar({
       </ComposerPrimitive.Unstable_TriggerPopoverRoot>
 
       <UrlDialog
+        chipEdit={chipEdit}
         inputRef={urlInputRef}
         onChange={setUrlValue}
         onOpenChange={setUrlOpen}

--- a/apps/desktop/src/app/chat/composer/rich-editor.test.ts
+++ b/apps/desktop/src/app/chat/composer/rich-editor.test.ts
@@ -9,7 +9,10 @@ import {
   refChipElement,
   renderComposerContents,
   replaceBeforeCaret,
-  RICH_INPUT_SLOT
+  replaceRefChipValue,
+  replaceSlashChipValue,
+  RICH_INPUT_SLOT,
+  slashChipElement
 } from './rich-editor'
 
 const caretIn = (editor: HTMLElement) => {
@@ -376,6 +379,113 @@ describe('deleteSelectionInEditor', () => {
     expect(composerPlainText(editor)).toBe('')
     expect(selection.getRangeAt(0).collapsed).toBe(true)
     expect(deleteSelectionInEditor(editor)).toBe(false)
+
+    editor.remove()
+  })
+})
+
+describe('replaceRefChipValue', () => {
+  it('rewrites a url chip value in place, re-deriving the display label', () => {
+    const editor = document.createElement('div')
+    editor.dataset.slot = RICH_INPUT_SLOT
+    const chip = refChipElement('url', 'https://project.samokat.ru/browse/ACC-77201')
+    editor.append(chip)
+    document.body.append(editor)
+
+    expect(replaceRefChipValue(chip, 'https://project.samokat.ru/browse/ACC-77202')).toBe(true)
+    expect(chip.dataset.refId).toBe('https://project.samokat.ru/browse/ACC-77202')
+    expect(chip.dataset.refText).toBe('@url:`https://project.samokat.ru/browse/ACC-77202`')
+    expect(chip.title).toBe('https://project.samokat.ru/browse/ACC-77202')
+    // The pill now reads as the same reference with the corrected value.
+    expect(composerPlainText(editor)).toBe('@url:`https://project.samokat.ru/browse/ACC-77202`')
+    // The node survived the edit — no flicker into a rebuilt chip.
+    expect(editor.querySelector('[data-ref-kind="url"]')).toBe(chip)
+
+    editor.remove()
+  })
+
+  it('re-quotes a value that gains a space', () => {
+    const editor = document.createElement('div')
+    editor.dataset.slot = RICH_INPUT_SLOT
+    const chip = refChipElement('file', 'a.ts')
+    editor.append(chip)
+    document.body.append(editor)
+
+    expect(replaceRefChipValue(chip, 'src/main file.ts')).toBe(true)
+    expect(chip.dataset.refText).toBe('@file:`src/main file.ts`')
+    expect(chip.title).toBe('src/main file.ts')
+    expect(composerPlainText(editor)).toBe('@file:`src/main file.ts`')
+
+    editor.remove()
+  })
+
+  it('refuses to blank out a reference value', () => {
+    const editor = document.createElement('div')
+    editor.dataset.slot = RICH_INPUT_SLOT
+    const chip = refChipElement('url', 'https://example.com')
+    editor.append(chip)
+    document.body.append(editor)
+
+    expect(replaceRefChipValue(chip, '   ')).toBe(false)
+    // A blanked value is a delete, not an edit — the chip stays put.
+    expect(chip.dataset.refId).toBe('https://example.com')
+    expect(composerPlainText(editor)).toBe('@url:`https://example.com`')
+
+    editor.remove()
+  })
+
+  it('does not touch a slash command chip', () => {
+    const editor = document.createElement('div')
+    editor.dataset.slot = RICH_INPUT_SLOT
+    const chip = slashChipElement('/clean', 'command')
+    editor.append(chip)
+    document.body.append(editor)
+
+    expect(replaceRefChipValue(chip, '/other')).toBe(false)
+    expect(chip.dataset.refText).toBe('/clean')
+
+    editor.remove()
+  })
+})
+
+describe('replaceSlashChipValue', () => {
+  it('rewrites a slash chip value in place, tracking it as the label', () => {
+    const editor = document.createElement('div')
+    editor.dataset.slot = RICH_INPUT_SLOT
+    const chip = slashChipElement('/clean', 'command')
+    editor.append(chip)
+    document.body.append(editor)
+
+    expect(replaceSlashChipValue(chip, '/goal ship it')).toBe(true)
+    expect(chip.dataset.refText).toBe('/goal ship it')
+    expect(composerPlainText(editor)).toBe('/goal ship it')
+    expect(editor.querySelector('[data-slash-kind]')).toBe(chip)
+
+    editor.remove()
+  })
+
+  it('refuses to blank out a slash command', () => {
+    const editor = document.createElement('div')
+    editor.dataset.slot = RICH_INPUT_SLOT
+    const chip = slashChipElement('/clean', 'command')
+    editor.append(chip)
+    document.body.append(editor)
+
+    expect(replaceSlashChipValue(chip, '  ')).toBe(false)
+    expect(chip.dataset.refText).toBe('/clean')
+
+    editor.remove()
+  })
+
+  it('does not touch a reference chip', () => {
+    const editor = document.createElement('div')
+    editor.dataset.slot = RICH_INPUT_SLOT
+    const chip = refChipElement('url', 'https://example.com')
+    editor.append(chip)
+    document.body.append(editor)
+
+    expect(replaceSlashChipValue(chip, '/x')).toBe(false)
+    expect(chip.dataset.refText).toBe('@url:`https://example.com`')
 
     editor.remove()
   })

--- a/apps/desktop/src/app/chat/composer/rich-editor.ts
+++ b/apps/desktop/src/app/chat/composer/rich-editor.ts
@@ -525,6 +525,70 @@ export function deleteSelectionInEditor(editor: HTMLElement) {
   return true
 }
 
+/** Set the visible label (the chip's trailing text node) to `label`. A chip's
+ *  first child is its glyph (an `<svg>`), so only the text nodes carry the
+ *  label — and they can be several after Chromium fragments them, so rewrite
+ *  every one rather than assuming a single node. */
+function setChipLabel(chip: HTMLElement, label: string) {
+  for (const node of Array.from(chip.childNodes)) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      node.textContent = label
+    }
+  }
+}
+
+/** Rewrite an existing reference chip's value in place (double-click edit).
+ *  The chip node and its glyph stay — only the serialized value (`data-ref-
+ *  text`), the resolved id, the `title`, and the visible label change, so the
+ *  pill reads as the same reference with a corrected value instead of
+ *  flickering into a rebuilt node. Returns false when `chip` is not a
+ *  `@kind:` reference (a slash command, or a blanked value).
+ *
+ *  `newValue` is the raw, unquoted value; quoting and the display label are
+ *  re-derived exactly as `refChipElement` would, so the edited chip is
+ *  byte-identical to one freshly committed with the same value. */
+export function replaceRefChipValue(chip: HTMLElement, newValue: string): boolean {
+  const kind = chip.dataset.refKind
+
+  if (!kind || chip.dataset.slashKind) {
+    return false
+  }
+
+  const id = newValue.trim()
+
+  if (!id) {
+    return false
+  }
+
+  chip.dataset.refId = id
+  chip.dataset.refText = `@${kind}:${quoteRefValue(id)}`
+  chip.title = id
+  setChipLabel(chip, refChipLabel(kind, id))
+
+  return true
+}
+
+/** Rewrite an existing slash command chip's value in place. The command is the
+ *  whole `data-ref-text` (a no-arg `/skill`, or a committed `/cmd arg`), so the
+ *  edited text replaces it verbatim and the visible label tracks it. Returns
+ *  false when `chip` is not a slash chip or the value blanks out. */
+export function replaceSlashChipValue(chip: HTMLElement, newValue: string): boolean {
+  if (!chip.dataset.slashKind) {
+    return false
+  }
+
+  const command = newValue.trim()
+
+  if (!command) {
+    return false
+  }
+
+  chip.dataset.refText = command
+  setChipLabel(chip, command)
+
+  return true
+}
+
 /** Serialize a draft string into chip-HTML for the contenteditable surface. */
 export function composerHtml(text: string) {
   let cursor = 0

--- a/apps/desktop/src/app/chat/composer/url-dialog.tsx
+++ b/apps/desktop/src/app/chat/composer/url-dialog.tsx
@@ -11,11 +11,29 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { useI18n } from '@/i18n'
-import { Globe } from '@/lib/icons'
+import { Globe, Pencil } from '@/lib/icons'
 
 const URL_HINT = /^https?:\/\//i
 
+/** A value that will serialize as an `@kind:` reference or a slash chip —
+ *  non-empty after trimming. Edit mode applies to any reference kind, so this
+ *  is intentionally looser than attach mode's URL check. */
+function isUsableValue(value: string, editMode: boolean): boolean {
+  const trimmed = value.trim()
+
+  if (trimmed.length === 0) {
+    return false
+  }
+
+  if (editMode) {
+    return true
+  }
+
+  return URL_HINT.test(trimmed)
+}
+
 export function UrlDialog({
+  chipEdit,
   inputRef,
   onChange,
   onOpenChange,
@@ -23,6 +41,7 @@ export function UrlDialog({
   open,
   value
 }: {
+  chipEdit: { chip: HTMLElement; value: string } | null
   inputRef: React.RefObject<HTMLInputElement | null>
   onChange: (value: string) => void
   onOpenChange: (open: boolean) => void
@@ -32,15 +51,19 @@ export function UrlDialog({
 }) {
   const { t } = useI18n()
   const c = t.composer
+  const editMode = chipEdit !== null
   const trimmed = value.trim()
   const looksLikeUrl = trimmed.length > 0 && URL_HINT.test(trimmed)
+  const usable = isUsableValue(value, editMode)
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
       <DialogContent bodyClassName="gap-5" className="max-w-md">
         <DialogHeader>
-          <DialogTitle icon={Globe}>{c.attachUrlTitle}</DialogTitle>
-          <DialogDescription>{c.attachUrlDesc}</DialogDescription>
+          <DialogTitle icon={editMode ? Pencil : Globe}>
+            {editMode ? c.editRefTitle : c.attachUrlTitle}
+          </DialogTitle>
+          <DialogDescription>{editMode ? c.editRefDesc : c.attachUrlDesc}</DialogDescription>
         </DialogHeader>
         <form
           className="grid gap-4"
@@ -53,14 +76,14 @@ export function UrlDialog({
             <Input
               autoComplete="off"
               autoCorrect="off"
-              inputMode="url"
+              inputMode={editMode ? 'text' : 'url'}
               onChange={e => onChange(e.target.value)}
-              placeholder={c.urlPlaceholder}
+              placeholder={editMode ? (chipEdit?.value ?? '') : c.urlPlaceholder}
               ref={inputRef}
               spellCheck={false}
               value={value}
             />
-            {trimmed.length > 0 && !looksLikeUrl && (
+            {!editMode && trimmed.length > 0 && !looksLikeUrl && (
               <p className="text-xs text-muted-foreground/85">
                 {c.urlHintPre}
                 <span className="font-mono">https://…</span>
@@ -71,8 +94,8 @@ export function UrlDialog({
             <Button onClick={() => onOpenChange(false)} type="button" variant="ghost">
               {t.common.cancel}
             </Button>
-            <Button disabled={!looksLikeUrl} type="submit">
-              {c.attach}
+            <Button disabled={!usable} type="submit">
+              {editMode ? t.common.save : c.attach}
             </Button>
           </DialogFooter>
         </form>

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1768,6 +1768,8 @@ export const ar = defineLocale({
     urlPlaceholder: 'https://example.com',
     urlHintPre: 'سيقرأ Hermes الرابط ضمن السياق.',
     attach: 'إرفاق',
+    editRefTitle: 'تعديل المرجع',
+    editRefDesc: 'تم النقر المزدوج على مرجع — عدّل قيمته في مكانها.',
     queued: count => `${count} في الطابور`,
     attachmentOnly: 'إرفاق فقط',
     emptyTurn: 'اكتب رسالة أو أرفق ملفا.',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2212,6 +2212,8 @@ export const en: Translations = {
     urlPlaceholder: 'https://example.com/post',
     urlHintPre: 'Include the full URL, e.g. ',
     attach: 'Attach',
+    editRefTitle: 'Edit reference',
+    editRefDesc: 'Double-clicked a reference — change its value in place.',
     queued: count => `${count} Queued`,
     queuedPaused: count => `${count} Queued — paused`,
     attachmentOnly: 'Attachment-only turn',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1961,6 +1961,8 @@ export const ja = defineLocale({
     urlPlaceholder: 'https://example.com/post',
     urlHintPre: '完全な URL を入力してください。例: ',
     attach: '添付',
+    editRefTitle: '参照を編集',
+    editRefDesc: '参照をダブルクリックしました — その値をその場で変更します。',
     queued: count => `${count} 件キュー済み`,
     queuedPaused: count => `${count} 件キュー済み — 一時停止中`,
     attachmentOnly: '添付のみのターン',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1858,6 +1858,8 @@ export interface Translations {
     urlPlaceholder: string
     urlHintPre: string
     attach: string
+    editRefTitle: string
+    editRefDesc: string
     queued: (count: number) => string
     queuedPaused: (count: number) => string
     attachmentOnly: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1898,6 +1898,8 @@ export const zhHant = defineLocale({
     urlPlaceholder: 'https://example.com/post',
     urlHintPre: '請輸入完整 URL，例如 ',
     attach: '附加',
+    editRefTitle: '編輯引用',
+    editRefDesc: '雙擊了引用——就地修改其值。',
     queued: count => `${count} 個排隊中`,
     queuedPaused: count => `${count} 個排隊中 — 已暫停`,
     attachmentOnly: '僅附件回合',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2397,6 +2397,8 @@ export const zh: Translations = {
     urlPlaceholder: 'https://example.com/post',
     urlHintPre: '请包含完整 URL，例如 ',
     attach: '附加',
+    editRefTitle: '编辑引用',
+    editRefDesc: '双击了引用——就地修改其值。',
     queued: count => `${count} 条排队`,
     queuedPaused: count => `${count} 条排队 — 已暂停`,
     attachmentOnly: '仅附件回合',


### PR DESCRIPTION
## Summary

Fixes #89079.

Reference chips in the chat composer are atomic `contenteditable="false"` spans — the cursor can only sit before or after them. That made a pasted-but-typo'd URL uncorrectable: the only way out was deleting the whole chip and retyping the entire value.

This PR lets you **double-click a chip** to edit it: the existing URL dialog opens in an *edit* mode, prefilled with the chip's current value; **Save** rewrites the chip **in place** (serialized value, id, title, display label — node, icon and position preserved) and records an undo point so ⌘Z reverts the edit.

## What changed

| File | Change |
|---|---|
| `composer/rich-editor.ts` | `replaceRefChipValue` / `replaceSlashChipValue` DOM helpers — rewrite the chip's value/label like a fresh insert; empty value refused (no accidental delete) |
| `composer/hooks/use-composer-url-dialog.ts` | chip-edit mode alongside attach mode (prefilled field, edit-aware submit) |
| `composer/url-dialog.tsx` | mode-aware title, icon, button label, validation (Save + non-empty) |
| `composer/index.tsx` | `onDoubleClick` handler: extracts value from `data-ref-text` (kind prefix stripped, unquoted) and wires dialog + undo stack + draft flush |
| `i18n/types.ts` + en/zh/zh-hant/ja/ar | `editRefTitle` / `editRefDesc` |

## Behavior

- Double-click any reference chip (URL / `@file:` / `@folder:` / `/command`) → dialog opens prefilled.
- Edit + **Save** → chip rewrites in place; `@url:`-quoting re-derived so the serialized draft is correct.
- Empty value in the dialog → chip is **not** deleted (the old value stays).
- ⌘Z / Ctrl+Z after an edit → previous chip value restored.
- If the chip is removed while the dialog is open, the dialog stays open with your value so you can re-attach or cancel.

## Test plan

- [x] `npm run typecheck` (renderer, electron, e2e tsconfigs) — clean
- [x] `npx eslint` on all touched files — 0 findings
- [x] `npx vitest run src/i18n/ src/app/chat/composer/` — 393/393 (adds 10 new cases: in-place rewrite, re-quoting, empty refusal, slash-chip variant, hook edit mode, dialog mode-awareness)
- [ ] Manual: paste a URL into the composer, double-click the chip, edit the middle of the value, Save, ⌘Z

## Draft?

Draft — built against `main` locally, happy to adjust to reviewer preferences (e.g. dialog copy, whether edit should also cover chips originating from slash-commands).
