### PR TITLE
fix(cli): honor final_response_markdown: render while streaming

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3325,6 +3325,178 @@ def _strip_markdown_syntax(text: str) -> str:
     return plain.strip("\n")
 
 
+# ---------------------------------------------------------------------------
+# Line-wise markdown styling for the STREAMING path.
+#
+# Rich's Markdown renderer is a block renderer: it needs the whole document
+# before it can lay out a paragraph, list, or code block.  The streaming
+# emitter publishes one line at a time and can never reflow what it already
+# wrote to scrollback, so it cannot call Rich at all.  That is why
+# `display.final_response_markdown: render` used to be silently ignored while
+# `display.streaming: true` — only the "strip" branch existed, and "render"
+# fell through to the raw path, printing `**markers**` verbatim.
+#
+# This stylizer covers the constructs that are decidable from a single line
+# (headings, bullets, rules, quotes, inline spans) plus fenced code, which
+# needs one bit of carry-over state.  Tables are deliberately untouched: the
+# emitter already buffers and re-aligns them through realign_markdown_tables.
+#
+# Spans close with SGR *off* codes (22/23/24/29) and restore the caller's base
+# color rather than emitting a full reset, so the surrounding response color
+# set by _emit_stream_text survives the span.
+# ---------------------------------------------------------------------------
+
+_STREAM_MD_STYLE_CACHE: dict = {}
+
+_MD_FENCE_RE = re.compile(r"^\s{0,3}(?:```|~~~)")
+_MD_HEADING_RE = re.compile(r"^\s{0,3}(#{1,6})\s+(.*)$")
+_MD_HR_RE = re.compile(r"^\s{0,3}(?:(?:-\s*){3,}|(?:_\s*){3,}|(?:\*\s*){3})$")
+_MD_QUOTE_RE = re.compile(r"^(\s*)>\s?(.*)$")
+_MD_BULLET_RE = re.compile(r"^(\s*)[-*+]\s+(.*)$")
+_MD_ORDERED_RE = re.compile(r"^(\s*)(\d{1,9}[.)])\s+(.*)$")
+
+
+def _ansi_fg(hex_color: str) -> str:
+    """Truecolor SGR prefix for a ``#rrggbb`` string, or "" when unparsable."""
+    try:
+        return (
+            f"\033[38;2;{int(hex_color[1:3], 16)};"
+            f"{int(hex_color[3:5], 16)};{int(hex_color[5:7], 16)}m"
+        )
+    except (ValueError, IndexError, TypeError):
+        return ""
+
+
+def _stream_markdown_styles() -> dict:
+    """ANSI prefixes mirroring the ``markdown.*`` keys of _skin_markdown_theme.
+
+    Kept in lockstep with that theme so a streamed response and a
+    Rich-rendered one read as the same palette.  Falls back to no color
+    (structure only: markers removed, bold/italic still applied) when the
+    skin engine is unavailable.
+    """
+    try:
+        from hermes_cli.skin_engine import get_active_skin
+
+        c = get_active_skin().get_color
+        accent = c("ui_accent") or c("banner_accent") or "#FFBF00"
+        primary = c("ui_primary") or c("banner_title") or accent
+        dim = c("banner_dim") or "#808080"
+        border = c("ui_border") or c("banner_border") or accent
+        code = c("syntax_string") or accent
+        comment = c("syntax_comment") or dim
+    except Exception:
+        accent = primary = dim = border = code = comment = ""
+
+    key = (accent, primary, dim, border, code, comment)
+    cached = _STREAM_MD_STYLE_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    styles = {
+        # Headings: h1/h2 bold like the Rich theme, h4/h5 italic.
+        "h": [
+            "\033[1m" + _ansi_fg(primary),
+            "\033[1m" + _ansi_fg(accent),
+            _ansi_fg(accent),
+            "\033[3m" + _ansi_fg(accent),
+            "\033[3m" + _ansi_fg(dim),
+            "\033[2m" + _ansi_fg(dim),
+        ],
+        "code": "\033[1m" + _ansi_fg(code),
+        "code_block": _ansi_fg(code),
+        "fence": "\033[2m" + _ansi_fg(comment),
+        "quote": _ansi_fg(comment),
+        "hr": _ansi_fg(border),
+        "bullet": "\033[1m" + _ansi_fg(accent),
+        "link": "\033[4m" + _ansi_fg(accent),
+    }
+    _STREAM_MD_STYLE_CACHE[key] = styles
+    return styles
+
+
+def _stylize_markdown_inline(text: str, base: str, styles: dict) -> str:
+    """Apply inline markdown spans (code, bold, italic, strike, links).
+
+    ``base`` is re-emitted after every span so the response body color set by
+    the streaming emitter is restored instead of being reset to the terminal
+    default.
+    """
+
+    def span(open_sgr: str, close_sgr: str, body: str) -> str:
+        return f"{open_sgr}{body}{close_sgr}{base}"
+
+    # Inline code first: its content must not be re-scanned for emphasis.
+    placeholders: list = []
+
+    def _stash_code(m):
+        placeholders.append(span(styles["code"], "\033[39m\033[22m", m.group(1)))
+        return f"\x00{len(placeholders) - 1}\x00"
+
+    text = re.sub(r"`([^`]+)`", _stash_code, text)
+
+    # [label](url) -> underlined label. The URL is dropped: it would blow past
+    # the terminal width mid-stream, and OSC-8 hyperlinks are stripped by the
+    # TUI's ANSI parser anyway (see _OSC_ESCAPE_RE).
+    text = re.sub(
+        r"!?\[([^\]]+)\]\([^)]*\)",
+        lambda m: span(styles["link"], "\033[24m\033[39m", m.group(1)),
+        text,
+    )
+    text = re.sub(r"\*\*\*([^*]+)\*\*\*", lambda m: span("\033[1m\033[3m", "\033[23m\033[22m", m.group(1)), text)
+    text = re.sub(r"\*\*([^*]+)\*\*", lambda m: span("\033[1m", "\033[22m", m.group(1)), text)
+    text = re.sub(r"(?<!\w)__([^_]+)__(?!\w)", lambda m: span("\033[1m", "\033[22m", m.group(1)), text)
+    # Same guard as _strip_markdown_syntax: never touch cron-like "* * * * *".
+    text = re.sub(r"\*([^\s*][^*]*?[^\s*]|[^\s*])\*", lambda m: span("\033[3m", "\033[23m", m.group(1)), text)
+    text = re.sub(r"(?<!\w)_([^_]+)_(?!\w)", lambda m: span("\033[3m", "\033[23m", m.group(1)), text)
+    text = re.sub(r"~~([^~]+)~~", lambda m: span("\033[9m", "\033[29m", m.group(1)), text)
+
+    if placeholders:
+        text = re.sub(r"\x00(\d+)\x00", lambda m: placeholders[int(m.group(1))], text)
+    return text
+
+
+def _stylize_markdown_line(line: str, base: str, in_code: bool) -> tuple:
+    """Return ``(styled_line, in_code)`` for one streamed markdown line."""
+    try:
+        styles = _stream_markdown_styles()
+
+        if _MD_FENCE_RE.match(line):
+            return f"{styles['fence']}{line}\033[22m\033[39m{base}", not in_code
+        if in_code:
+            return f"{styles['code_block']}{line}\033[39m{base}", True
+
+        m = _MD_HEADING_RE.match(line)
+        if m:
+            level = min(len(m.group(1)), 6) - 1
+            body = _stylize_markdown_inline(m.group(2), base, styles)
+            return f"{styles['h'][level]}{body}\033[23m\033[22m\033[39m{base}", False
+
+        if _MD_HR_RE.match(line):
+            width = max(4, _terminal_width_for_streaming())
+            return f"{styles['hr']}{'─' * width}\033[39m{base}", False
+
+        m = _MD_QUOTE_RE.match(line)
+        if m:
+            body = _stylize_markdown_inline(m.group(2), base, styles)
+            return f"{m.group(1)}{styles['quote']}│ \033[39m{base}{body}", False
+
+        m = _MD_BULLET_RE.match(line)
+        if m:
+            body = _stylize_markdown_inline(m.group(2), base, styles)
+            return f"{m.group(1)}{styles['bullet']}•\033[22m\033[39m{base} {body}", False
+
+        m = _MD_ORDERED_RE.match(line)
+        if m:
+            body = _stylize_markdown_inline(m.group(3), base, styles)
+            return f"{m.group(1)}{styles['bullet']}{m.group(2)}\033[22m\033[39m{base} {body}", False
+
+        return _stylize_markdown_inline(line, base, styles), False
+    except Exception:
+        # Display styling must never break the stream: fall back to raw text.
+        return line, in_code
+
+
 _WINDOWS_PATH_WITH_DOT_SEGMENT_RE = re.compile(
     r"(?i)(?:\b[a-z]:\\|\\\\)[^\s`]*\\\.[^\s`]*"
 )
@@ -7802,6 +7974,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
             if self.final_response_markdown == "strip":
                 line = _strip_markdown_syntax(line)
+            elif self.final_response_markdown == "render":
+                line, self._stream_md_in_code = _stylize_markdown_line(
+                    line, _tc, getattr(self, "_stream_md_in_code", False)
+                )
             _emit_one(line)
 
         # Long partial lines are emitted ONLY at real newlines — we no
@@ -7875,6 +8051,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         if self._stream_buf:
             line = _strip_markdown_syntax(self._stream_buf) if self.final_response_markdown == "strip" else self._stream_buf
+            if self.final_response_markdown == "render":
+                line, self._stream_md_in_code = _stylize_markdown_line(
+                    line, _tc, getattr(self, "_stream_md_in_code", False)
+                )
             _cprint(f"{_STREAM_PAD}{_tc}{line}{_RST}" if _tc else f"{_STREAM_PAD}{line}")
             self._stream_buf = ""
 
@@ -7890,6 +8070,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._stream_box_opened = False
         self._stream_text_ansi = ""
         self._stream_prefilt = ""
+        # Fenced-code carry-over for the line-wise markdown stylizer.
+        self._stream_md_in_code = False
         self._in_reasoning_block = False
         self._stream_last_was_newline = True
         self._reasoning_box_opened = False

--- a/tests/cli/test_stream_markdown_render.py
+++ b/tests/cli/test_stream_markdown_render.py
@@ -1,0 +1,132 @@
+"""``display.final_response_markdown: render`` must apply while streaming.
+
+The streaming emitter only ever branched on ``strip``, so ``render`` fell
+through to the raw path and printed markdown markers verbatim (upstream
+#83233). Rich's block renderer cannot run line-by-line, so streamed lines
+get a line-wise ANSI stylizer that mirrors the ``markdown.*`` palette of
+``_skin_markdown_theme``.
+"""
+import os
+import re
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(s: str) -> str:
+    return ANSI_RE.sub("", s)
+
+
+@pytest.fixture
+def cli_stub(monkeypatch):
+    from cli import HermesCLI
+    import cli as climod
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.show_reasoning = False
+    cli.final_response_markdown = "render"
+    cli.show_timestamps = False
+    cli._reset_stream_state()
+
+    emitted = []
+    monkeypatch.setattr(climod, "_cprint", lambda s: emitted.append(s))
+    monkeypatch.setattr(climod, "_terminal_width_for_streaming", lambda: 74)
+    return cli, emitted
+
+
+def _run(cli, emitted, text):
+    cli._stream_delta(text)
+    cli._flush_stream()
+    return emitted
+
+
+def _content(emitted, needle):
+    for e in emitted:
+        if needle in _strip_ansi(e):
+            return e
+    raise AssertionError(f"no emitted line containing {needle!r}: {emitted!r}")
+
+
+def test_heading_markers_are_removed_and_styled(cli_stub):
+    cli, emitted = cli_stub
+    _run(cli, emitted, "## Section title\n")
+    line = _content(emitted, "Section title")
+    assert "#" not in _strip_ansi(line)
+    assert "\x1b[1m" in line, "heading should be bold"
+
+
+def test_bold_markers_are_removed_and_styled(cli_stub):
+    cli, emitted = cli_stub
+    _run(cli, emitted, "some **strong** words\n")
+    line = _content(emitted, "strong")
+    assert _strip_ansi(line).strip() == "some strong words"
+    assert "\x1b[1m" in line and "\x1b[22m" in line
+
+
+def test_italic_and_strikethrough_markers_are_removed(cli_stub):
+    cli, emitted = cli_stub
+    _run(cli, emitted, "an *emphasis* and a ~~removal~~\n")
+    line = _content(emitted, "emphasis")
+    assert _strip_ansi(line).strip() == "an emphasis and a removal"
+    assert "\x1b[3m" in line and "\x1b[9m" in line
+
+
+def test_inline_code_markers_are_removed_and_colored(cli_stub):
+    cli, emitted = cli_stub
+    _run(cli, emitted, "call `do_thing()` now\n")
+    line = _content(emitted, "do_thing()")
+    assert "`" not in _strip_ansi(line)
+    assert "\x1b[38;2;" in line, "inline code should carry a truecolor fg"
+
+
+def test_list_bullet_is_normalized(cli_stub):
+    cli, emitted = cli_stub
+    _run(cli, emitted, "- first\n  - nested\n")
+    assert _strip_ansi(_content(emitted, "first")).rstrip() == "• first"
+    assert _strip_ansi(_content(emitted, "nested")).rstrip() == "  • nested"
+
+
+def test_fenced_code_block_content_is_not_inline_processed(cli_stub):
+    cli, emitted = cli_stub
+    _run(cli, emitted, "```python\nx = a ** b  # `note`\n```\nafter\n")
+    line = _content(emitted, "x = a")
+    assert _strip_ansi(line).rstrip() == "x = a ** b  # `note`"
+    # The fence must close: prose after it is styled again.
+    after = _content(emitted, "after")
+    assert _strip_ansi(after).rstrip() == "after"
+
+
+def test_link_text_replaces_the_markdown_target(cli_stub):
+    cli, emitted = cli_stub
+    _run(cli, emitted, "see [the docs](https://example.com) here\n")
+    line = _content(emitted, "the docs")
+    assert _strip_ansi(line).strip() == "see the docs here"
+    assert "\x1b[4m" in line, "link text should be underlined"
+
+
+def test_strip_mode_is_unchanged(cli_stub):
+    cli, emitted = cli_stub
+    cli.final_response_markdown = "strip"
+    _run(cli, emitted, "## Title\nsome **strong** words\n")
+    assert _strip_ansi(_content(emitted, "Title")).strip() == "Title"
+    assert _strip_ansi(_content(emitted, "strong")).strip() == "some strong words"
+
+
+def test_raw_mode_is_unchanged(cli_stub):
+    cli, emitted = cli_stub
+    cli.final_response_markdown = "raw"
+    _run(cli, emitted, "## Title\nsome **strong** words\n")
+    assert _strip_ansi(_content(emitted, "Title")).strip() == "## Title"
+    assert _strip_ansi(_content(emitted, "strong")).strip() == "some **strong** words"
+
+
+def test_trailing_partial_line_is_styled_on_flush(cli_stub):
+    cli, emitted = cli_stub
+    cli._stream_delta("tail **bolded**")
+    cli._flush_stream()
+    line = _content(emitted, "bolded")
+    assert _strip_ansi(line).strip() == "tail bolded"


### PR DESCRIPTION
## What does this PR do?

`display.final_response_markdown: render` is silently ignored whenever `display.streaming: true`. Streamed responses print raw markdown source — `**bold**`, `## heading`, visible backticks — while the exact same response rendered correctly with streaming off.

**Root cause.** Markdown rendering and streaming are disjoint paths in `cli.py`. Only the non-streamed path calls `_render_final_assistant_content(response, mode=self.final_response_markdown)` → `rich.markdown.Markdown`, and it is explicitly skipped once a stream has run:

```python
already_streamed = self._stream_started and self._stream_box_opened and not is_error_response
...
elif already_streamed:
    # _flush_stream() already closed the box. Skip Rich Panel.
```

The token emitter, meanwhile, only ever branched on `"strip"`:

```python
if self.final_response_markdown == "strip":
    line = _strip_markdown_syntax(line)
_emit_one(line)
```

so `"render"` fell through to the raw path.

**Why not just call Rich.** `rich.markdown.Markdown` is a *block* renderer: it needs the whole document before it can lay out a paragraph, list, or code block. The streaming emitter publishes one line at a time and can never reflow what it already wrote to scrollback, so Rich cannot be invoked there at all.

This PR therefore adds a **line-wise** stylizer, `_stylize_markdown_line`, wired into the two emission points, with a palette (`_stream_markdown_styles`) mirroring the `markdown.*` theme keys used by the Rich path so streamed and non-streamed output read as the same palette.

## Related Issue

Fixes #83233

### Note on prior art — please read before triaging

I'm aware of #1986, closed with the reasoning that a 537-line hand-rolled SGR renderer carries more maintenance surface than the Rich-based path in #12836, and that #12836 is the intended direction. This PR is deliberately **not** a competing full renderer:

- It touches **only** the streaming path. The non-streamed path keeps going through `_render_final_assistant_content` exactly as today — none of the redundancy that reason (1) of that closure called out.
- 182 lines, one self-contained function plus a palette helper, no new module, no runtime toggle, no LLM-side hint.
- It is a stopgap for a P2 config key that currently does nothing. #12836 has been open and unchanged since 2026-07-12; until it lands, `render` + `streaming` is silently broken for every user.

If #12836 lands, this becomes redundant and I'll close it myself — happy to port any surviving edge cases on top instead.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py` — new `_ansi_fg`, `_stream_markdown_styles`, `_stylize_markdown_inline`, `_stylize_markdown_line` (placed next to `_strip_markdown_syntax`, their non-streaming counterpart).
- `cli.py` — `_emit_stream_text`: added the `render` branch alongside the existing `strip` branch.
- `cli.py` — `_flush_stream`: same, for the trailing partial line.
- `cli.py` — `_reset_stream_state`: initialise `_stream_md_in_code`, the fenced-code carry-over bit.
- `tests/cli/test_stream_markdown_render.py` — 10 tests.

**Covered:** headings (`#`…`######`), bold / italic / strikethrough, inline code, links, bullet and ordered lists, blockquotes, horizontal rules, fenced code blocks.

**Deliberately not covered:** tables, which the emitter already buffers and re-aligns through `realign_markdown_tables` — left untouched. Link URLs are dropped from the display: they would blow past the terminal width mid-stream, and OSC-8 hyperlinks are stripped by the TUI's ANSI parser anyway (`_OSC_ESCAPE_RE`).

**Two details worth reviewing:**

- Spans close with SGR *off* codes (`22`/`23`/`24`/`29`) and re-emit the caller's base color, never a full `\033[0m` reset — otherwise the response body color set by `_emit_stream_text` dies at the first `**bold**`.
- Inline code is stashed behind placeholders before emphasis processing, so `` `a ** b` `` is not re-scanned as bold. The `*emphasis*` regex keeps the same non-whitespace guard as `_strip_markdown_syntax`, so cron expressions like `* * * * *` survive.
- `_stylize_markdown_line` is wrapped in a bare `except` that returns the raw line: display styling must never be able to break a stream.

## How to Test

1. Set `display.streaming: true` and `display.final_response_markdown: render`.
2. Ask for a response containing headings, bold, inline code, a list and a fenced code block.
3. Before: raw markdown source scrolls by. After: styled output, still token-by-token, in the active skin's palette.

Automated:

```
pytest tests/cli/test_stream_markdown_render.py -q     # 10 passed
```

`strip` and `raw` behavior is pinned by two dedicated regression tests in that file.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate — see the prior-art note above (#1986, #12836, #4513, #5084)
- [x] My PR contains **only** changes related to this fix
- [x] I've run the CLI suite: `1222 passed, 10 failed`. The 10 failures are pre-existing on unpatched `main` at `7cae03b8c` (`test_quick_commands`, `test_personality_none`, `test_resume_quiet_stderr` — missing `pytest-asyncio` plus test-ordering pollution); baseline without this patch is `1215 passed, 17 failed`.
- [x] I've added tests
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Terminal.app, truecolor

### Documentation & Housekeeping

- [x] Documentation — N/A (no user-facing config change; an existing key simply starts working)
- [x] `cli-config.yaml.example` — N/A (no new keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered: output is truecolor SGR only, the same escapes `_emit_stream_text` already emits for the response body color; no new terminal assumptions. Falls back to uncolored (structure-only) output when the skin engine is unavailable.
- [x] Tool descriptions/schemas — N/A
