### PR TITLE
fix(agent): guard repeated successful tool calls

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -77,6 +77,8 @@ class ToolCallGuardrailConfig:
     same_tool_failure_halt_after: int = 8
     no_progress_warn_after: int = 2
     no_progress_block_after: int = 5
+    repeated_success_warn_after: int = 2
+    repeated_success_block_after: int = 5
     idempotent_tools: frozenset[str] = field(default_factory=lambda: IDEMPOTENT_TOOL_NAMES)
     mutating_tools: frozenset[str] = field(default_factory=lambda: MUTATING_TOOL_NAMES)
     loop_caps: "LoopCapConfig" = field(default_factory=lambda: LoopCapConfig())
@@ -110,6 +112,12 @@ class ToolCallGuardrailConfig:
                 warn_after.get("idempotent_no_progress", data.get("no_progress_warn_after")),
                 defaults.no_progress_warn_after,
             ),
+            repeated_success_warn_after=_positive_int(
+                warn_after.get(
+                    "repeated_success", data.get("repeated_success_warn_after")
+                ),
+                defaults.repeated_success_warn_after,
+            ),
             exact_failure_block_after=_positive_int(
                 hard_stop_after.get("exact_failure", data.get("exact_failure_block_after")),
                 defaults.exact_failure_block_after,
@@ -121,6 +129,12 @@ class ToolCallGuardrailConfig:
             no_progress_block_after=_positive_int(
                 hard_stop_after.get("idempotent_no_progress", data.get("no_progress_block_after")),
                 defaults.no_progress_block_after,
+            ),
+            repeated_success_block_after=_positive_int(
+                hard_stop_after.get(
+                    "repeated_success", data.get("repeated_success_block_after")
+                ),
+                defaults.repeated_success_block_after,
             ),
             loop_caps=LoopCapConfig.from_mapping(data.get("loop_caps")),
         )
@@ -280,7 +294,7 @@ class ToolCallGuardrailController:
     def reset_for_turn(self) -> None:
         self._exact_failure_counts: dict[ToolCallSignature, int] = {}
         self._same_tool_failure_counts: dict[str, int] = {}
-        self._no_progress: dict[ToolCallSignature, tuple[str, int]] = {}
+        self._successful_results: dict[ToolCallSignature, tuple[str, int]] = {}
         self._halt_decision: ToolGuardrailDecision | None = None
         # Per-turn runaway-loop cap counters. Reset every turn (this method
         # runs at the start of each run_conversation), so the caps bound a
@@ -325,25 +339,41 @@ class ToolCallGuardrailController:
             self._halt_decision = decision
             return decision
 
-        if self._is_idempotent(tool_name):
-            record = self._no_progress.get(signature)
-            if record is not None:
-                _result_hash, repeat_count = record
-                if repeat_count >= self.config.no_progress_block_after:
-                    decision = ToolGuardrailDecision(
-                        action="block",
-                        code="idempotent_no_progress_block",
-                        message=(
-                            f"Blocked {tool_name}: this read-only call returned the same "
-                            f"result {repeat_count} times. Stop repeating it unchanged; "
-                            "use the result already provided or try a different query."
-                        ),
-                        tool_name=tool_name,
-                        count=repeat_count,
-                        signature=signature,
+        record = self._successful_results.get(signature)
+        if record is not None:
+            _result_hash_value, repeat_count = record
+            is_idempotent = self._is_idempotent(tool_name)
+            block_after = (
+                self.config.no_progress_block_after
+                if is_idempotent
+                else self.config.repeated_success_block_after
+            )
+            if repeat_count >= block_after:
+                if is_idempotent:
+                    code = "idempotent_no_progress_block"
+                    message = (
+                        f"Blocked {tool_name}: this read-only call returned the same "
+                        f"result {repeat_count} times. Stop repeating it unchanged; "
+                        "use the result already provided or try a different query."
                     )
-                    self._halt_decision = decision
-                    return decision
+                else:
+                    code = "repeated_success_block"
+                    message = (
+                        f"Blocked {tool_name}: this successful call returned the same "
+                        f"result {repeat_count} times with identical arguments. Stop "
+                        "repeating it unchanged; use the successful result already "
+                        "provided or change strategy."
+                    )
+                decision = ToolGuardrailDecision(
+                    action="block",
+                    code=code,
+                    message=message,
+                    tool_name=tool_name,
+                    count=repeat_count,
+                    signature=signature,
+                )
+                self._halt_decision = decision
+                return decision
 
         return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 
@@ -363,7 +393,7 @@ class ToolCallGuardrailController:
         if failed:
             exact_count = self._exact_failure_counts.get(signature, 0) + 1
             self._exact_failure_counts[signature] = exact_count
-            self._no_progress.pop(signature, None)
+            self._successful_results.pop(signature, None)
 
             same_count = self._same_tool_failure_counts.get(tool_name, 0) + 1
             self._same_tool_failure_counts[tool_name] = same_count
@@ -412,26 +442,45 @@ class ToolCallGuardrailController:
         self._exact_failure_counts.pop(signature, None)
         self._same_tool_failure_counts.pop(tool_name, None)
 
-        if not self._is_idempotent(tool_name):
-            self._no_progress.pop(signature, None)
+        # Multimodal results use structured content that warning guidance cannot
+        # safely append to. Keep the existing textual guardrail boundary.
+        if result is not None and not isinstance(result, str):
+            self._successful_results.pop(signature, None)
             return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 
         result_hash = _result_hash(result)
-        previous = self._no_progress.get(signature)
+        previous = self._successful_results.get(signature)
         repeat_count = 1
         if previous is not None and previous[0] == result_hash:
             repeat_count = previous[1] + 1
-        self._no_progress[signature] = (result_hash, repeat_count)
+        self._successful_results[signature] = (result_hash, repeat_count)
 
-        if self.config.warnings_enabled and repeat_count >= self.config.no_progress_warn_after:
-            return ToolGuardrailDecision(
-                action="warn",
-                code="idempotent_no_progress_warning",
-                message=(
+        is_idempotent = self._is_idempotent(tool_name)
+        warn_after = (
+            self.config.no_progress_warn_after
+            if is_idempotent
+            else self.config.repeated_success_warn_after
+        )
+        if self.config.warnings_enabled and repeat_count >= warn_after:
+            if is_idempotent:
+                code = "idempotent_no_progress_warning"
+                message = (
                     f"{tool_name} returned the same result {repeat_count} times. "
                     "Use the result already provided or change the query instead of "
                     "repeating it unchanged."
-                ),
+                )
+            else:
+                code = "repeated_success_warning"
+                message = (
+                    f"{tool_name} succeeded with identical arguments and the same "
+                    f"result {repeat_count} times. This looks like a loop; use the "
+                    "successful result already provided. Repeat only if external "
+                    "state is expected to change, otherwise change strategy."
+                )
+            return ToolGuardrailDecision(
+                action="warn",
+                code=code,
+                message=message,
                 tool_name=tool_name,
                 count=repeat_count,
                 signature=signature,

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -503,10 +503,12 @@ tool_loop_guardrails:
     exact_failure: 2
     same_tool_failure: 3
     idempotent_no_progress: 2
+    repeated_success: 2
   hard_stop_after:
     exact_failure: 5
     same_tool_failure: 8
     idempotent_no_progress: 5
+    repeated_success: 5
 
 # =============================================================================
 # Context Compression (Auto-shrinks long conversations)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -637,11 +637,13 @@ DEFAULT_CONFIG = {
             "exact_failure": 2,
             "same_tool_failure": 3,
             "idempotent_no_progress": 2,
+            "repeated_success": 2,
         },
         "hard_stop_after": {
             "exact_failure": 5,
             "same_tool_failure": 8,
             "idempotent_no_progress": 5,
+            "repeated_success": 5,
         },
         # Per-turn runaway-loop caps (inspired by Claude Code v2.1.212,
         # Week 29, July 2026). Hard ceilings on how many times a runaway-prone

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -44,11 +44,13 @@ def test_config_parses_nested_warn_and_hard_stop_thresholds():
                 "exact_failure": 3,
                 "same_tool_failure": 4,
                 "idempotent_no_progress": 5,
+                "repeated_success": 6,
             },
             "hard_stop_after": {
                 "exact_failure": 6,
                 "same_tool_failure": 7,
                 "idempotent_no_progress": 8,
+                "repeated_success": 9,
             },
         }
     )
@@ -58,9 +60,11 @@ def test_config_parses_nested_warn_and_hard_stop_thresholds():
     assert cfg.exact_failure_warn_after == 3
     assert cfg.same_tool_failure_warn_after == 4
     assert cfg.no_progress_warn_after == 5
+    assert cfg.repeated_success_warn_after == 6
     assert cfg.exact_failure_block_after == 6
     assert cfg.same_tool_failure_halt_after == 7
     assert cfg.no_progress_block_after == 8
+    assert cfg.repeated_success_block_after == 9
 
 
 def test_default_repeated_identical_failed_call_warns_without_blocking():
@@ -119,16 +123,69 @@ def test_hard_stop_enabled_blocks_repeated_exact_failure_before_next_execution()
 
 
 
-def test_mutating_or_unknown_tools_are_not_blocked_for_repeated_identical_success_output_by_default():
+def test_mutating_or_unknown_tools_warn_without_blocking_repeated_success_by_default():
     controller = ToolCallGuardrailController(
-        ToolCallGuardrailConfig(no_progress_warn_after=2, no_progress_block_after=2)
+        ToolCallGuardrailConfig(
+            repeated_success_warn_after=2,
+            repeated_success_block_after=2,
+        )
     )
 
-    for _ in range(3):
-        assert controller.before_call("write_file", {"path": "/tmp/x", "content": "x"}).action == "allow"
-        assert controller.after_call("write_file", {"path": "/tmp/x", "content": "x"}, "ok", failed=False).action == "allow"
-        assert controller.before_call("custom_tool", {"x": 1}).action == "allow"
-        assert controller.after_call("custom_tool", {"x": 1}, "ok", failed=False).action == "allow"
+    calls = [
+        ("write_file", {"path": "/tmp/x", "content": "x"}),
+        ("custom_tool", {"x": 1}),
+    ]
+    for tool_name, args in calls:
+        assert controller.before_call(tool_name, args).action == "allow"
+        assert controller.after_call(tool_name, args, "ok", failed=False).action == "allow"
+
+        assert controller.before_call(tool_name, args).action == "allow"
+        warning = controller.after_call(tool_name, args, "ok", failed=False)
+        assert warning.action == "warn"
+        assert warning.code == "repeated_success_warning"
+        assert warning.count == 2
+
+        # Hard stops remain opt-in even after the configured threshold.
+        assert controller.before_call(tool_name, args).action == "allow"
+
+
+def test_hard_stop_blocks_repeated_success_before_next_execution():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            repeated_success_warn_after=2,
+            repeated_success_block_after=2,
+        )
+    )
+    args = {"command": "hermes config get memory.provider"}
+    result = '{"output":"local","exit_code":0,"error":null}'
+
+    assert controller.before_call("terminal", args).action == "allow"
+    assert controller.after_call("terminal", args, result, failed=False).action == "allow"
+    assert controller.before_call("terminal", args).action == "allow"
+    warning = controller.after_call("terminal", args, result, failed=False)
+    assert warning.code == "repeated_success_warning"
+
+    blocked = controller.before_call("terminal", args)
+    assert blocked.action == "block"
+    assert blocked.code == "repeated_success_block"
+    assert blocked.count == 2
+
+
+def test_changed_success_result_resets_repeated_success_count():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(repeated_success_warn_after=2)
+    )
+    args = {"command": "check-state"}
+
+    first = controller.after_call("terminal", args, "pending", failed=False)
+    repeated = controller.after_call("terminal", args, "pending", failed=False)
+    changed = controller.after_call("terminal", args, "ready", failed=False)
+
+    assert first.action == "allow"
+    assert repeated.code == "repeated_success_warning"
+    assert changed.action == "allow"
+    assert changed.count == 1
 
 
 
@@ -167,7 +224,6 @@ def test_web_search_cap_blocks_after_limit_regardless_of_hard_stop():
     assert decision.action == "block"
     assert decision.code == "loop_web_search_cap"
     assert decision.should_halt is True
-
 
 
 

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -70,6 +70,22 @@ def _seed_exact_failures(agent: AIAgent, tool_name: str, args: dict, count: int 
         )
 
 
+def _seed_successes(
+    agent: AIAgent,
+    tool_name: str,
+    args: dict,
+    result: str,
+    count: int = 2,
+) -> None:
+    for _ in range(count):
+        agent._tool_guardrails.after_call(
+            tool_name,
+            args,
+            result,
+            failed=False,
+        )
+
+
 def _hard_stop_config(**overrides) -> dict:
     cfg = {
         "tool_loop_guardrails": {
@@ -79,6 +95,7 @@ def _hard_stop_config(**overrides) -> dict:
                 "exact_failure": 2,
                 "same_tool_failure": 8,
                 "idempotent_no_progress": 5,
+                "repeated_success": 2,
             },
         }
     }
@@ -151,6 +168,43 @@ def test_sequential_after_call_appends_guidance_to_tool_result_without_extra_mes
     assert messages[0]["tool_call_id"] == "c-warn"
     assert "Tool loop warning" in messages[0]["content"]
     assert "repeated_exact_failure_warning" in messages[0]["content"]
+
+
+def test_default_sequential_path_warns_repeated_successful_terminal_call():
+    agent = _make_agent("terminal")
+    args = {"command": "hermes config get memory.provider"}
+    result = json.dumps({"output": "local", "exit_code": 0, "error": None})
+    _seed_successes(agent, "terminal", args, result, count=1)
+    tc = _mock_tool_call("terminal", json.dumps(args), "c-success-warn")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with patch("run_agent.handle_function_call", return_value=result) as dispatch:
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+
+    dispatch.assert_called_once()
+    assert len(messages) == 1
+    assert "repeated_success_warning" in messages[0]["content"]
+    assert "successful result already provided" in messages[0]["content"]
+    assert agent._tool_guardrail_halt_decision is None
+
+
+def test_config_enabled_hard_stop_blocks_repeated_successful_terminal_call():
+    agent = _make_agent("terminal", config=_hard_stop_config())
+    args = {"command": "hermes config get memory.provider"}
+    result = json.dumps({"output": "local", "exit_code": 0, "error": None})
+    _seed_successes(agent, "terminal", args, result)
+    tc = _mock_tool_call("terminal", json.dumps(args), "c-success-block")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with patch("run_agent.handle_function_call", return_value="SHOULD_NOT_RUN") as dispatch:
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+
+    dispatch.assert_not_called()
+    assert len(messages) == 1
+    assert "repeated_success_block" in messages[0]["content"]
+    assert agent._tool_guardrail_halt_decision is not None
 
 
 def test_same_tool_failure_warning_tells_model_to_recover_with_tools():

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1650,7 +1650,7 @@ agent:
 
 ## Tool-Loop Guardrails
 
-Hermes detects when the agent is stuck in an unproductive tool-calling loop — the same tool call failing repeatedly, the same tool failing over and over, or an idempotent call returning the same result with no progress. By default it injects a **warning** into the tool result so the model self-corrects; it does not hard-stop, since a person watching the CLI/TUI can intervene.
+Hermes detects when the agent is stuck in an unproductive tool-calling loop — the same tool call failing repeatedly, the same tool failing over and over, an idempotent call returning the same result with no progress, or any successful call repeating with identical arguments and output. By default it injects a **warning** into the tool result so the model self-corrects; it does not hard-stop, since a person watching the CLI/TUI can intervene.
 
 For unattended gateway / server deployments, enable hard stops so a stuck agent is circuit-broken instead of burning the iteration budget:
 
@@ -1662,10 +1662,12 @@ tool_loop_guardrails:
     exact_failure: 2           # identical failing call repeated N times
     same_tool_failure: 3       # same tool failing N times (different args)
     idempotent_no_progress: 2  # same result, no progress, N times
+    repeated_success: 2        # identical successful call and result N times
   hard_stop_after:
     exact_failure: 5
     same_tool_failure: 8
     idempotent_no_progress: 5
+    repeated_success: 5
   loop_caps:
     max_web_searches: 50       # max web_search calls per turn (0 = unlimited)
     max_subagents: 50          # max subagents spawned per turn (0 = unlimited)

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -79,6 +79,7 @@ tool_loop_guardrails:
   hard_stop_after:
     exact_failure: 5
     idempotent_no_progress: 5
+    repeated_success: 5
 ```
 :::
 


### PR DESCRIPTION
## What does this PR do?

Extends the existing per-turn tool-loop guardrail to detect successful calls that repeat with identical tool names, arguments, and textual results. This closes the blind spot where `terminal` and other non-idempotent tools cleared failure state and then bypassed no-progress tracking entirely.

The implementation deliberately does not cache, replay, or silently skip tool calls because tools such as `terminal`, `write_file`, and gateway delivery tools may have side effects. It preserves the existing warning-first policy: the second identical successful result gets model-facing guidance by default, while `hard_stop_enabled: true` blocks execution after the configurable threshold. A changed result resets the repeat count, so state polling that makes progress is not treated as the same loop.

## Related Issue

Fixes #89069

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Security fix
- [x] Documentation update
- [x] Tests
- [ ] Refactor
- [ ] New skill

## Changes Made

- Extend `ToolCallGuardrailController` success-result tracking beyond idempotent tools.
- Add `repeated_success` warning and hard-stop thresholds with backward-safe defaults.
- Keep structured multimodal results outside the textual guidance path.
- Document the new thresholds in the example config and gateway guidance.
- Add controller and sequential executor regressions using the command from #89069.

## How to Test

1. Run `scripts/run_tests.sh tests/agent/test_tool_guardrails.py tests/run_agent/test_tool_call_guardrail_runtime.py tests/run_agent/test_agent_guardrails.py -q`.
2. Run `scripts/run_tests.sh tests/hermes_cli/test_config.py tests/hermes_cli/test_config_validation.py tests/hermes_cli/test_config_loader_e2e.py -q`.
3. Run `uv run --extra dev ruff check .` and `uv run --extra dev ty check agent/tool_guardrails.py`.

Observed: 138 tests passed across the two isolated runs; ruff, ty, and py_compile passed.

## Checklist

### Code

- [x] I have read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched open PRs and found no existing PR for #89069.
- [x] This PR contains only changes related to this fix.
- [ ] I ran the complete test suite locally. CI will run the full matrix; the affected 138 tests pass locally.
- [x] I added tests for the bug.
- [x] Tested on macOS 26.3.2 with Python 3.11.15.

### Documentation & Housekeeping

- [x] Updated relevant documentation.
- [x] Updated `cli-config.yaml.example` for the new config keys.
- [x] Architecture workflow docs are not affected.
- [x] Considered cross-platform impact; the change is pure controller state and hashing logic.
- [x] Tool schemas are not affected.

## Design Invariants

- State remains per turn and resets through `reset_for_turn()`.
- Raw tool arguments and results are retained only as SHA-256 signatures in guardrail state.
- The first tool call always executes; blocked calls continue through the existing protocol-safe synthetic tool-result path.
- Default interactive behavior warns without halting; unattended deployments can enable deterministic circuit breaking.