### PR TITLE
feat(cli): show reasoning effort level in TUI status bar

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6103,6 +6103,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         snapshot = {
             "model_name": model_name,
             "model_short": model_short,
+            "reasoning_effort": self._status_bar_reasoning_label(),
             "duration": format_duration_compact(elapsed_seconds),
             "session_title": self._get_status_bar_session_title(),
             "prompt_elapsed": self._format_prompt_elapsed(
@@ -6268,6 +6269,22 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._status_bar_title_cache = title
         self._status_bar_title_checked_at = now
         return title
+
+    def _status_bar_reasoning_label(self) -> str:
+        """Return a short reasoning-effort label for the status bar.
+
+        Shows the current thinking level (e.g. 'high', 'medium') when
+        reasoning is enabled, or '⊘ off' when explicitly disabled.
+        Returns empty string when no reasoning config is set (defaults
+        to provider behaviour).
+        """
+        cfg = getattr(self, "reasoning_config", None)
+        if cfg is None:
+            return ""
+        if not cfg.get("enabled", True):
+            return "⊘ off"
+        effort = str(cfg.get("effort", "")).strip().lower()
+        return effort if effort else ""
 
     @staticmethod
     def _status_bar_display_width(text: str) -> int:
@@ -6860,8 +6877,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
             yolo_active = self._is_session_yolo_active()
             goal_segment = self._status_bar_goal_segment(snapshot)
+            reasoning_label = snapshot.get("reasoning_effort") or ""
+            model_display = f"⚕ {snapshot['model_short']}"
+            if reasoning_label:
+                model_display += f" · {reasoning_label}"
             if width < 52:
-                text = f"{battery_prefix}⚕ {snapshot['model_short']} · {duration_label}"
+                text = f"{battery_prefix}{model_display} · {duration_label}"
                 if goal_segment:
                     text += f" · {goal_segment}"
                 if focus_label:
@@ -6870,7 +6891,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     text += " · ⚠ YOLO"
                 return self._right_align_status_title(text, session_title, width)
             if width < 76:
-                parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                parts = [model_display, percent_label]
                 if battery_label:
                     parts.insert(0, battery_label)
                 compressions = snapshot.get("compressions", 0)
@@ -6902,7 +6923,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 context_label = "ctx --"
 
             compressions = snapshot.get("compressions", 0)
-            parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            parts = [model_display, context_label, percent_label]
             if battery_label:
                 parts.insert(0, battery_label)
             if compressions:
@@ -6953,12 +6974,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             session_title = snapshot.get("session_title") or ""
 
             if width < 52:
+                reasoning_label = snapshot.get("reasoning_effort") or ""
                 frags = [
                     ("class:status-bar", " ⚕ "),
                     ("class:status-bar-strong", snapshot["model_short"]),
+                ]
+                if reasoning_label:
+                    frags.append(("class:status-bar-dim", " · "))
+                    frags.append(("class:status-bar-dim", reasoning_label))
+                frags.extend([
                     ("class:status-bar-dim", " · "),
                     ("class:status-bar-dim", duration_label),
-                ]
+                ])
                 if goal_segment:
                     frags.append(("class:status-bar-dim", " · "))
                     frags.append(("class:status-bar-strong", goal_segment))
@@ -6977,12 +7004,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     bg_count = snapshot.get("active_background_tasks", 0)
                     bg_proc_count = snapshot.get("active_background_processes", 0)
                     bg_subagent_count = snapshot.get("active_background_subagents", 0)
+                    reasoning_label = snapshot.get("reasoning_effort") or ""
                     frags = [
                         ("class:status-bar", " ⚕ "),
                         ("class:status-bar-strong", snapshot["model_short"]),
+                    ]
+                    if reasoning_label:
+                        frags.append(("class:status-bar-dim", " · "))
+                        frags.append(("class:status-bar-dim", reasoning_label))
+                    frags.extend([
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
-                    ]
+                    ])
                     if compressions:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))
@@ -7022,16 +7055,22 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     bg_count = snapshot.get("active_background_tasks", 0)
                     bg_proc_count = snapshot.get("active_background_processes", 0)
                     bg_subagent_count = snapshot.get("active_background_subagents", 0)
+                    reasoning_label = snapshot.get("reasoning_effort") or ""
                     frags = [
                         ("class:status-bar", " ⚕ "),
                         ("class:status-bar-strong", snapshot["model_short"]),
+                    ]
+                    if reasoning_label:
+                        frags.append(("class:status-bar-dim", " · "))
+                        frags.append(("class:status-bar-dim", reasoning_label))
+                    frags.extend([
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", context_label),
                         ("class:status-bar-dim", " │ "),
                         (bar_style, self._build_context_bar(percent)),
                         ("class:status-bar-dim", " "),
                         (bar_style, percent_label),
-                    ]
+                    ])
                     if compressions:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -368,5 +368,80 @@ class TestIdleSinceLastTurn:
         cli_obj._prompt_duration = 5.0
         snapshot = cli_obj._get_status_bar_snapshot()
         assert snapshot["idle_since"].startswith("✓ ")
+class TestStatusBarReasoningLabel:
+    """Reasoning-effort indicator (thinking level) in the status bar."""
+
+    def test_label_none_config(self):
+        """reasoning_config unset → empty string."""
+        cli_obj = _make_cli()
+        assert cli_obj._status_bar_reasoning_label() == ""
+
+    def test_label_disabled(self):
+        """reasoning disabled → '⊘ off'."""
+        cli_obj = _make_cli()
+        cli_obj.reasoning_config = {"enabled": False}
+        assert cli_obj._status_bar_reasoning_label() == "⊘ off"
+
+    def test_label_enabled_with_effort(self):
+        """reasoning enabled with effort → effort string."""
+        cli_obj = _make_cli()
+        cli_obj.reasoning_config = {"enabled": True, "effort": "high"}
+        assert cli_obj._status_bar_reasoning_label() == "high"
+
+    def test_label_enabled_no_effort_key(self):
+        """reasoning enabled but no effort key → empty string."""
+        cli_obj = _make_cli()
+        cli_obj.reasoning_config = {"enabled": True}
+        assert cli_obj._status_bar_reasoning_label() == ""
+
+    def test_label_empty_effort(self):
+        """reasoning enabled with blank effort → empty string."""
+        cli_obj = _make_cli()
+        cli_obj.reasoning_config = {"enabled": True, "effort": "  "}
+        assert cli_obj._status_bar_reasoning_label() == ""
+
+    def test_label_uppercase_normalized(self):
+        """uppercase effort is lowercased for display."""
+        cli_obj = _make_cli()
+        cli_obj.reasoning_config = {"enabled": True, "effort": "HIGH"}
+        assert cli_obj._status_bar_reasoning_label() == "high"
+
+    def test_label_shown_in_text_output(self):
+        """reasoning label appears in _build_status_bar_text()."""
+        cli_obj = _make_cli()
+        cli_obj.reasoning_config = {"enabled": True, "effort": "high"}
+        text = cli_obj._build_status_bar_text(width=80)
+        assert "high" in text
+        assert "⚕" in text
+
+    def test_label_shown_in_snapshot(self):
+        """reasoning label is present in snapshot dict."""
+        cli_obj = _make_cli()
+        cli_obj.reasoning_config = {"enabled": True, "effort": "medium"}
+        snapshot = cli_obj._get_status_bar_snapshot()
+        assert snapshot["reasoning_effort"] == "medium"
+
+    def test_width_no_overflow_narrow(self):
+        """narrow terminal with reasoning label doesn't overflow."""
+        cli_obj = _make_cli()
+        cli_obj.reasoning_config = {"enabled": True, "effort": "xhigh"}
+        text = cli_obj._build_status_bar_text(width=40)
+        assert cli_obj._status_bar_display_width(text) <= 40
+
+    def test_width_no_overflow_wide(self):
+        """wide terminal with reasoning label doesn't overflow."""
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.reasoning_config = {"enabled": True, "effort": "high"}
+        text = cli_obj._build_status_bar_text(width=120)
+        assert "high" in text
+        assert cli_obj._status_bar_display_width(text) <= 120
 
 


### PR DESCRIPTION
## Summary

Add the current thinking/reasoning effort level next to the model name in the CLI/TUI status bar.

**Before:** 
**After:** 

## What changed

- **New method** `_status_bar_reasoning_label()` — reads `self.reasoning_config` and returns the effort level string (e.g. `high`, `medium`), `⊘ off` when disabled, or empty when unset
- **Snapshot** — `_get_status_bar_snapshot()` now includes `reasoning_effort`
- **Both rendering paths updated:**
  - `_build_status_bar_text()` (plain-text fallback)
  - `_get_status_bar_fragments()` (actual prompt_toolkit TUI rendering)
- **Defensive lowercase** on effort display
- **10 new tests** covering all edge cases and width overflow

## Behavior

| Config state | Status bar shows |
|---|---|
| `reasoning_effort` unset (default) | Nothing extra (backward-compatible) |
| `reasoning_effort: high` | `⚕ model · high` |
| `reasoning_effort: false` | `⚕ model · ⊘ off` |

## Tests

All 37 tests pass (27 original + 10 new).

## Audit

Code reviewed by an independent audit subagent. All findings addressed:
- Blocker: reasoning label added to fragments path (not just text path)
- Major: 10 tests added for coverage
- Minor: defensive lowercase added