### PR TITLE
fix(time): organize import blocks into stdlib and first-party groups in hermes_time.py

### DIFF
--- a/hermes_time.py
+++ b/hermes_time.py
@@ -16,8 +16,9 @@ crashes due to a bad timezone string.
 import logging
 import os
 from datetime import datetime
-from hermes_constants import get_config_path
 from typing import Optional
+
+from hermes_constants import get_config_path
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
### Summary
- In `hermes_time.py`, cleanly separate stdlib imports from first-party imports (`from hermes_constants import get_config_path`) according to PEP 8 and isort formatting rules.
- Verified with `ruff check hermes_time.py` and `pytest tests/test_timezone.py`.