### PR TITLE
fix(dashboard): coalesce repeat gateway restarts for a short window

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4381,6 +4381,30 @@ _ACTION_PROCS: Dict[str, subprocess.Popen] = {}
 _ACTION_COMMANDS: Dict[str, Tuple[str, ...]] = {}
 _ACTION_IDS: Dict[str, str] = {}
 
+# A finished ``gateway-restart`` child does not mean the gateway is back: the
+# child exits as soon as it has handed the restart to the supervisor (or to the
+# running gateway), while the gateway itself is still stopping and coming up.
+# The in-flight reuse in :func:`_spawn_gateway_restart` therefore stops
+# coalescing exactly when repeat requests do the most damage, so a stale cached
+# frontend that re-fires its restart every few seconds gets a brand new restart
+# every time (#89034: 77 restarts, 17 of them inside one minute, killing the
+# gateway often enough mid-FTS5-write to corrupt state.db).  Suppress repeats
+# for a short window after the last spawn as well.
+#
+# MAINTAINER DECISION: a fixed window, not "until the gateway reports healthy".
+# Health-gating is what #89034 asks for, but it cannot be made to fail safe
+# here — a gateway that never comes back would leave the restart action
+# permanently inert, which is a worse failure than the flood it prevents.  A
+# fixed window always releases.  10s is above the ~3.5s spacing of the reported
+# storm and below the time an operator waits before deliberately retrying.
+GATEWAY_RESTART_COOLDOWN_SECONDS = 10.0
+
+# ``(monotonic spawn time, Popen, command)`` for the last gateway restart this
+# process started.  Deliberately NOT read out of ``_ACTION_PROCS``: entries
+# there are reaped once the child exits, and a guard that disappears when the
+# child exits is the bug this exists to fix.
+_LAST_GATEWAY_RESTART: Optional[Tuple[float, subprocess.Popen, Tuple[str, ...]]] = None
+
 # ``name`` → completed synthetic action result for actions the server handled
 # without spawning a subprocess (for example, unsupported Docker updates).
 _ACTION_RESULTS: Dict[str, Dict[str, Any]] = {}
@@ -4607,6 +4631,13 @@ def _spawn_gateway_restart(profile: Optional[str] = None) -> Tuple[subprocess.Po
     concurrent ``hermes gateway restart`` children race each other on the
     manual kill-and-start path, so reuse the live one instead.
 
+    Reusing only the *live* child is not enough. The child exits as soon as
+    the restart has been handed off, long before the gateway is back, so a
+    frontend re-firing every few seconds cleared that guard every time and
+    kept restarting a gateway that was still coming up (#89034). Requests
+    within ``GATEWAY_RESTART_COOLDOWN_SECONDS`` of the last spawn for the
+    same profile are coalesced onto that spawn as well.
+
     Before spawning, sweep for orphaned gateway processes whose parent has
     exited (e.g. desktop-app restarts leaving a reparented gateway child
     under launchd/PPID=1).  Without this the orphan keeps its platform
@@ -4622,6 +4653,8 @@ def _spawn_gateway_restart(profile: Optional[str] = None) -> Tuple[subprocess.Po
     except Exception:
         pass  # best-effort — don't block the restart on a reap failure
 
+    global _LAST_GATEWAY_RESTART
+
     subcommand = _gateway_subcommand(profile, "restart")
     existing = _ACTION_PROCS.get("gateway-restart")
     if existing is not None and existing.poll() is None:
@@ -4629,7 +4662,24 @@ def _spawn_gateway_restart(profile: Optional[str] = None) -> Tuple[subprocess.Po
         if existing_command is None or existing_command == tuple(subcommand):
             return existing, True
         raise RuntimeError("gateway restart already in progress for another profile")
-    return _spawn_hermes_action(subcommand, "gateway-restart"), False
+
+    recent = _LAST_GATEWAY_RESTART
+    if recent is not None:
+        spawned_at, recent_proc, recent_command = recent
+        age = time.monotonic() - spawned_at if recent_command == tuple(subcommand) else None
+        if age is not None and age < GATEWAY_RESTART_COOLDOWN_SECONDS:
+            _log.info(
+                "Coalescing gateway restart: one was started %.1fs ago "
+                "(pid %s) and the gateway may still be coming back; not "
+                "spawning another (#89034).",
+                age,
+                getattr(recent_proc, "pid", "?"),
+            )
+            return recent_proc, True
+
+    proc = _spawn_hermes_action(subcommand, "gateway-restart")
+    _LAST_GATEWAY_RESTART = (time.monotonic(), proc, tuple(subcommand))
+    return proc, False
 
 
 def _restart_gateway_after_webhook_enable(profile: Optional[str] = None) -> dict[str, Any]:

--- a/tests/hermes_cli/test_spawn_gateway_restart_cooldown.py
+++ b/tests/hermes_cli/test_spawn_gateway_restart_cooldown.py
@@ -1,0 +1,228 @@
+"""Tests for the _spawn_gateway_restart repeat-request cooldown (#89034).
+
+A finished ``gateway-restart`` child does not mean the gateway is back, so the
+pre-existing "reuse the in-flight child" guard stops coalescing exactly when
+repeat requests are most harmful.  A stale cached dashboard frontend re-firing
+its restart every few seconds therefore produced a fresh restart every time
+(the reporter measured 77, 17 of them inside one minute), killing the gateway
+often enough mid-FTS5-write to corrupt ``state.db``.
+"""
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reset_restart_cooldown():
+    """Keep the module-level cooldown state out of neighbouring tests."""
+    import hermes_cli.web_server as web_server
+
+    web_server._LAST_GATEWAY_RESTART = None
+    yield
+    web_server._LAST_GATEWAY_RESTART = None
+
+
+def _exited_proc(pid: int = 4242) -> MagicMock:
+    """A Popen handle for a child that has already finished."""
+    proc = MagicMock(spec=subprocess.Popen)
+    proc.poll.return_value = 0
+    proc.pid = pid
+    return proc
+
+
+class TestRepeatRestartWithinCooldown:
+    """Repeats within the window ride the previous spawn."""
+
+    @patch(
+        "hermes_cli.web_server._gateway_subcommand",
+        return_value=["gateway", "restart"],
+    )
+    @patch("hermes_cli.web_server._spawn_hermes_action")
+    @patch("hermes_cli.web_server._ACTION_PROCS", {})
+    def test_second_request_after_the_child_exits_is_coalesced(
+        self, mock_spawn, mock_subcmd
+    ):
+        """The exact #89034 shape: child gone, gateway still coming up."""
+        from hermes_cli.web_server import _spawn_gateway_restart
+
+        proc = _exited_proc()
+        mock_spawn.return_value = proc
+
+        with patch("hermes_cli.gateway._reap_unsupervised_gateway_orphans"), patch(
+            "hermes_cli.web_server.time.monotonic", side_effect=[100.0, 103.5]
+        ):
+            first, first_reused = _spawn_gateway_restart()
+            second, second_reused = _spawn_gateway_restart()
+
+        assert mock_spawn.call_count == 1, (
+            "a repeat request 3.5s later must not start a second restart"
+        )
+        assert first is proc and first_reused is False
+        assert second is proc and second_reused is True
+
+    @patch(
+        "hermes_cli.web_server._gateway_subcommand",
+        return_value=["gateway", "restart"],
+    )
+    @patch("hermes_cli.web_server._spawn_hermes_action")
+    @patch("hermes_cli.web_server._ACTION_PROCS", {})
+    def test_a_storm_of_requests_produces_exactly_one_restart(
+        self, mock_spawn, mock_subcmd
+    ):
+        """17 requests inside one minute, the reported burst rate."""
+        from hermes_cli.web_server import _spawn_gateway_restart
+
+        mock_spawn.return_value = _exited_proc()
+        # One read to stamp the spawn, then one per coalesced repeat.  The
+        # window is anchored to the SPAWN, not to the previous request:
+        # anchoring it to the previous request would let a 3.5s-spaced storm
+        # walk the deadline forward forever and never restart at all.
+        clock = [100.0, 103.5, 107.0]
+
+        with patch("hermes_cli.gateway._reap_unsupervised_gateway_orphans"), patch(
+            "hermes_cli.web_server.time.monotonic", side_effect=clock
+        ):
+            _spawn_gateway_restart()
+            _spawn_gateway_restart()
+            _spawn_gateway_restart()
+
+        assert mock_spawn.call_count == 1
+
+    @patch(
+        "hermes_cli.web_server._gateway_subcommand",
+        return_value=["gateway", "restart"],
+    )
+    @patch("hermes_cli.web_server._spawn_hermes_action")
+    @patch("hermes_cli.web_server._ACTION_PROCS", {})
+    def test_cooldown_survives_the_action_table_being_cleared(
+        self, mock_spawn, mock_subcmd
+    ):
+        """The guard must not live in ``_ACTION_PROCS``.
+
+        Completed action children get reaped out of that table, and a guard
+        that disappears when the child is reaped is the bug this fixes.
+        """
+        import hermes_cli.web_server as web_server
+        from hermes_cli.web_server import _spawn_gateway_restart
+
+        mock_spawn.return_value = _exited_proc()
+
+        with patch("hermes_cli.gateway._reap_unsupervised_gateway_orphans"), patch(
+            "hermes_cli.web_server.time.monotonic", side_effect=[100.0, 102.0]
+        ):
+            _spawn_gateway_restart()
+            web_server._ACTION_PROCS.clear()
+            web_server._ACTION_COMMANDS.clear()
+            _, reused = _spawn_gateway_restart()
+
+        assert mock_spawn.call_count == 1
+        assert reused is True
+
+
+class TestCooldownReleases:
+    """The window always expires; it never wedges the restart action."""
+
+    @patch(
+        "hermes_cli.web_server._gateway_subcommand",
+        return_value=["gateway", "restart"],
+    )
+    @patch("hermes_cli.web_server._spawn_hermes_action")
+    @patch("hermes_cli.web_server._ACTION_PROCS", {})
+    def test_request_after_the_window_starts_a_real_restart(
+        self, mock_spawn, mock_subcmd
+    ):
+        from hermes_cli.web_server import _spawn_gateway_restart
+
+        mock_spawn.side_effect = [_exited_proc(1), _exited_proc(2)]
+
+        with patch("hermes_cli.gateway._reap_unsupervised_gateway_orphans"), patch(
+            "hermes_cli.web_server.time.monotonic",
+            side_effect=[100.0, 111.0, 111.0],
+        ):
+            _spawn_gateway_restart()
+            second, reused = _spawn_gateway_restart()
+
+        assert mock_spawn.call_count == 2
+        assert reused is False
+        assert second.pid == 2
+
+    @patch("hermes_cli.web_server._spawn_hermes_action")
+    @patch("hermes_cli.web_server._ACTION_PROCS", {})
+    def test_a_different_profile_is_never_coalesced(self, mock_spawn):
+        """Two profiles are two services; one's restart is not the other's."""
+        from hermes_cli.web_server import _spawn_gateway_restart
+
+        mock_spawn.side_effect = [_exited_proc(1), _exited_proc(2)]
+
+        with patch("hermes_cli.gateway._reap_unsupervised_gateway_orphans"), patch(
+            "hermes_cli.web_server.time.monotonic",
+            side_effect=[100.0, 101.0],
+        ), patch(
+            "hermes_cli.web_server._gateway_subcommand",
+            side_effect=[["gateway", "restart"], ["-p", "coder", "gateway", "restart"]],
+        ):
+            _spawn_gateway_restart()
+            second, reused = _spawn_gateway_restart(profile="coder")
+
+        assert mock_spawn.call_count == 2
+        assert reused is False
+        assert second.pid == 2
+
+
+class TestExistingBehaviourIsPreserved:
+    """Regression guards on the pre-existing in-flight reuse."""
+
+    @patch(
+        "hermes_cli.web_server._gateway_subcommand",
+        return_value=["gateway", "restart"],
+    )
+    @patch("hermes_cli.web_server._spawn_hermes_action")
+    def test_live_child_is_still_reused_without_consulting_the_clock(
+        self, mock_spawn, mock_subcmd
+    ):
+        from hermes_cli.web_server import _spawn_gateway_restart
+
+        live = MagicMock(spec=subprocess.Popen)
+        live.poll.return_value = None
+        live.pid = 7
+
+        with patch(
+            "hermes_cli.web_server._ACTION_PROCS", {"gateway-restart": live}
+        ), patch(
+            "hermes_cli.web_server._ACTION_COMMANDS",
+            {"gateway-restart": ("gateway", "restart")},
+        ), patch(
+            "hermes_cli.gateway._reap_unsupervised_gateway_orphans"
+        ):
+            proc, reused = _spawn_gateway_restart()
+
+        assert proc is live
+        assert reused is True
+        mock_spawn.assert_not_called()
+
+    @patch(
+        "hermes_cli.web_server._gateway_subcommand",
+        return_value=["gateway", "restart"],
+    )
+    @patch("hermes_cli.web_server._spawn_hermes_action")
+    def test_live_child_for_another_profile_still_raises(self, mock_spawn, mock_subcmd):
+        from hermes_cli.web_server import _spawn_gateway_restart
+
+        live = MagicMock(spec=subprocess.Popen)
+        live.poll.return_value = None
+
+        with patch(
+            "hermes_cli.web_server._ACTION_PROCS", {"gateway-restart": live}
+        ), patch(
+            "hermes_cli.web_server._ACTION_COMMANDS",
+            {"gateway-restart": ("-p", "coder", "gateway", "restart")},
+        ), patch(
+            "hermes_cli.gateway._reap_unsupervised_gateway_orphans"
+        ):
+            with pytest.raises(RuntimeError, match="another profile"):
+                _spawn_gateway_restart()
+
+        mock_spawn.assert_not_called()

--- a/tests/hermes_cli/test_spawn_gateway_restart_reap.py
+++ b/tests/hermes_cli/test_spawn_gateway_restart_reap.py
@@ -7,6 +7,21 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def reset_restart_cooldown():
+    """Clear the #89034 repeat-restart cooldown between cases.
+
+    ``_spawn_gateway_restart`` now coalesces a second restart request that
+    arrives within ``GATEWAY_RESTART_COOLDOWN_SECONDS`` of the last spawn, so
+    without this the first case's spawn suppresses the second case's.
+    """
+    import hermes_cli.web_server as web_server
+
+    web_server._LAST_GATEWAY_RESTART = None
+    yield
+    web_server._LAST_GATEWAY_RESTART = None
+
+
 class TestSpawnGatewayRestartReapsOrphans:
     """_spawn_gateway_restart must reap orphaned gateways before spawning."""
 


### PR DESCRIPTION
## What does this PR do?

Stops the dashboard from starting a fresh gateway restart every time a stale
frontend asks for one, which is the flood at the top of #89034's causal chain.

`_spawn_gateway_restart` already refuses to start a second restart while the
first `hermes gateway restart` child is alive — that is what makes a
double-clicked button safe. The guard evaporates exactly when it matters most.
The child exits as soon as it has handed the restart off (to the supervisor, or
to the running gateway), which is **long before the gateway is back**, so:

```python
existing = _ACTION_PROCS.get("gateway-restart")
if existing is not None and existing.poll() is None:   # False the moment the child exits
    ...
return _spawn_hermes_action(subcommand, "gateway-restart"), False
```

a cached frontend re-firing every few seconds clears `poll() is None` on every
attempt and gets a brand new restart each time. The function's own docstring
already names that frontend as a known caller ("a stale cached frontend firing
its own restart after the server already auto-restarted post-onboarding") — it
just guards the wrong half of the problem.

The reporter measured the consequence on an s6-supervised container: **77**
`gateway-restart started` entries, 17 of them inside one minute. Each one
SIGHUPs a gateway that is still coming up, and enough of those landed
mid-FTS5-write to corrupt `state.db` — `database disk image is malformed` 203x
in `agent.log`, auto-repair failed, operator recreated the file by hand.

This PR coalesces same-profile requests that arrive within
`GATEWAY_RESTART_COOLDOWN_SECONDS` of the last spawn onto that spawn, and logs
each one. A storm becomes one restart plus a run of coalesce lines that say so.

**Two design decisions worth naming, both maintainer calls if you disagree:**

1. **A fixed window, not "until the gateway reports healthy."** #89034's
   Expected section asks for the health-gated version, and it is the more
   precise rule. I did not implement it because it cannot be made to fail safe
   here: a gateway that never comes back would leave the restart action
   permanently inert, and "the restart button no longer works" is a worse
   failure than the flood it prevents. A fixed window always releases. 10s is
   above the ~3.5s spacing of the reported storm and below what an operator
   waits before deliberately retrying.
2. **The cooldown state lives outside `_ACTION_PROCS`.** Completed action
   children are reaped out of that table, and a guard that disappears when the
   child exits is precisely the bug being fixed. There is a regression test for
   this, and it matters for #89060 specifically (see Overlap below).

## Related Issue

Fixes #89034

**Scope: this fixes Defect 1 only.** #89034 reports two compounding defects and
I am deliberately not touching the second one. Defect 2 is the s6 `finish`
script having no death-cap, generated by
`hermes_cli.service_manager.S6ServiceManager._render_finish_script`. I looked at
it and did not write it, for a reason I would rather state than bury: the
suggested cap makes s6 stop supervising after N unclean exits in a window, so a
container that legitimately crash-loops for a transient reason (bad token,
unreachable provider) would stay **permanently down** instead of recovering when
the cause clears. That is a real product tradeoff on a shipped image and it
belongs to a maintainer, not to me. It is also worth noting that s6-supervise
already floors respawns at roughly one per second, so Defect 2 alone does not
produce the observed 3.5s-spaced storm — Defect 1 does. Fixing this half
removes the driver; the death-cap would be a second layer of protection under
it.

## Overlap with open PRs

Three open PRs touch this area. I read all three; none of them rate-limits
restart requests, and I have tried to leave room for each.

| PR | what it changes | overlaps? |
|---|---|---|
| #66595 | `_spawn_gateway_restart` delegates to launchd/systemd/s6 when supervised, instead of spawning a child | **same function, textual conflict likely.** Orthogonal in behaviour: it changes *how* a restart is performed, not *how often*. In #89034's s6 container it would delegate to s6 — still 77 times. If it lands first I will rebase this on top; the guard is a few lines at the top of the function and does not care which path performs the restart. |
| #75845 | `POST /api/system/restart-hermes` sends SIGUSR1 instead of spawning | different endpoint; `/api/gateway/restart` (the one the reported storm used) is unchanged by it |
| #89060 | background reaper so exited action children leave `_ACTION_PROCS` without a status poll | **composes deliberately.** Their reaper removes exited entries from that table. If this cooldown had been implemented by reading `_ACTION_PROCS` — the obvious way — their PR would silently re-open this exact hole. `test_cooldown_survives_the_action_table_being_cleared` pins that. We do both edit `tests/hermes_cli/test_spawn_gateway_restart_reap.py`, so expect a small conflict there. |

## Changes Made

- `hermes_cli/web_server.py`
  - new module constants `GATEWAY_RESTART_COOLDOWN_SECONDS` (10.0) and
    `_LAST_GATEWAY_RESTART`, with the reasoning for both, next to
    `_ACTION_PROCS`.
  - `_spawn_gateway_restart`: after the existing in-flight reuse, coalesce a
    same-profile request made within the window onto the last spawn, log it at
    INFO, and record `(monotonic, proc, command)` on every real spawn. A
    different profile is never coalesced — two profiles are two services.
  - docstring extended to say why in-flight reuse alone was not enough.
- `tests/hermes_cli/test_spawn_gateway_restart_cooldown.py` (new, 7 tests).
- `tests/hermes_cli/test_spawn_gateway_restart_reap.py`: added an autouse
  fixture clearing the new module state. Required — without it the first case's
  spawn suppresses the second case's, and that file fails. It is a fixture
  rather than a per-test decorator so it collides as little as possible with
  #89060.

## How to Test

1. The new tests pass:

   ```
   pytest tests/hermes_cli/test_spawn_gateway_restart_cooldown.py -q
   ```

   `7 passed`

2. **Sabotage proof.** Delete the `recent = _LAST_GATEWAY_RESTART` block from
   `_spawn_gateway_restart` and re-run — the three regression tests fail with
   the storm itself, while the four guardrail tests keep passing (so they are
   not just asserting the fix back to itself):

   ```
   E  AssertionError: a repeat request 3.5s later must not start a second restart
   E  assert 2 == 1
   E  assert 3 == 1     <- test_a_storm_of_requests_produces_exactly_one_restart
   E  assert 2 == 1     <- test_cooldown_survives_the_action_table_being_cleared
   3 failed, 4 passed
   ```

   Restore the block and all 7 pass. The `3 == 1` is the reported behaviour in
   miniature: three requests, three restarts.

3. Neighbouring suites, unchanged:

   ```
   pytest tests/hermes_cli/test_web_server.py \
          tests/hermes_cli/test_spawn_gateway_restart_reap.py \
          tests/hermes_cli/test_spawn_gateway_restart_cooldown.py -q
   ```

   `170 passed, 4 skipped`

4. **Baseline comparison** over every test file in the repo that mentions
   `web_server` (85 files, ~1060 tests), run serially with and without this
   change: **31 failures both times, identical sets** (pre-existing
   Windows/environment failures — `os.geteuid`, resource limits, a
   non-Windows-only platform test). Zero new failures, zero fixed by accident.

5. `ruff check` clean on all three files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate. Nothing open rate-limits gateway restart requests; the three PRs that touch this seam are compared in the Overlap table above, with the conflict risk for each stated
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits): one commit, one production file, two test files
- [x] I've run `pytest tests/ -q` and all tests pass. Not the full suite — `tests/hermes_cli/` cannot be collected on Windows (`test_doctor_journal_modes.py` calls `os.geteuid`). Ran the 85-file `web_server` slice instead, with a with/without baseline: identical failure sets, zero new failures. CI covers the rest
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features): 7 tests, 3 of which fail without the fix — step 2 is the mutation proof
- [x] I've tested on my platform: Windows 11 Pro 26200, Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings). `_spawn_gateway_restart`'s docstring now explains why in-flight reuse alone was insufficient; no user-facing docs affected
- [x] N/A, no config keys added or changed. The window is a module constant rather than a config key on purpose — see the note below
- [x] N/A, no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility). The change is a monotonic-clock comparison with no platform-specific behaviour; it sits above the `sys.platform` branching in `_spawn_hermes_action` and applies equally to launchd, systemd, s6 and unsupervised hosts
- [x] N/A, no tool descriptions or schemas changed

On the constant vs. a config key: I kept it a module constant to stay minimal.
If you would rather it be tunable, `agent.gateway_restart_cooldown` alongside
`restart_drain_timeout` is the obvious home and I am happy to add it — say the
word. I specifically did **not** reuse `restart_drain_timeout` even though it
looked like the principled choice, because it defaults to `0`, which would make
the guard a no-op for everyone who has not configured it.

## Screenshots / Logs

What the storm looks like after the change — one restart, and the suppressed
repeats say so instead of vanishing:

```
=== gateway-restart started 2026-08-18 09:14:02 ===
INFO hermes_cli.web_server: Coalescing gateway restart: one was started 3.5s ago (pid 41822) and the gateway may still be coming back; not spawning another (#89034).
INFO hermes_cli.web_server: Coalescing gateway restart: one was started 7.0s ago (pid 41822) and the gateway may still be coming back; not spawning another (#89034).
```

From #89034, what it looked like before (excerpt):

```
gateway-restart started            77
database disk image is malformed   203x (agent.log), 442x (errors.log)
gateway.previous_unclean_exit      14x
```
