### PR TITLE
fix(whatsapp): preserve MIME types for text documents

### DIFF
--- a/scripts/whatsapp-bridge/bridge.mime.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.mime.test.mjs
@@ -1,0 +1,24 @@
+import { strict as assert } from 'node:assert';
+
+import { mediaPayloadForFile } from './bridge_helpers.js';
+
+const cases = [
+  ['report.html', 'text/html'],
+  ['report.htm', 'text/html'],
+  ['notes.txt', 'text/plain'],
+  ['data.csv', 'text/csv'],
+];
+
+for (const [fileName, expectedMime] of cases) {
+  const payload = mediaPayloadForFile({
+    buffer: Buffer.from('test'),
+    filePath: `/tmp/${fileName}`,
+    mediaType: 'document',
+  });
+
+  assert.ok(payload.document);
+  assert.equal(payload.fileName, fileName);
+  assert.equal(payload.mimetype, expectedMime);
+}
+
+console.log('  ✓ text/web documents keep a WhatsApp-openable MIME type');

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -11,6 +11,8 @@ export const MIME_MAP = {
   doc: 'application/msword',
   docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
   xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  html: 'text/html', htm: 'text/html',
+  txt: 'text/plain', csv: 'text/csv',
 };
 
 export function normalizeWhatsAppId(value) {


### PR DESCRIPTION
## What does this PR do?

Fixes WhatsApp document payloads for `.html`, `.htm`, `.txt`, and `.csv` files. These extensions were missing from `MIME_MAP`, so `mediaPayloadForFile()` fell back to `application/octet-stream`; WhatsApp then displayed the files as generic BIN documents and could fail to open them.

## Related Issue

Fixes #89074

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding regression coverage)

## Changes Made

- `scripts/whatsapp-bridge/bridge_helpers.js`
  - map `.html` / `.htm` to `text/html`
  - map `.txt` to `text/plain`
  - map `.csv` to `text/csv`
- `scripts/whatsapp-bridge/bridge.mime.test.mjs`
  - add focused regression coverage for all four extensions through `mediaPayloadForFile()`

## How to Test

Run the WhatsApp bridge Node tests:

```bash
node --test scripts/whatsapp-bridge/*.test.mjs
```

The new regression asserts that each affected document keeps its filename and receives the expected WhatsApp-openable MIME type instead of `application/octet-stream`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing issues and PRs for duplicates
- [x] My PR contains only changes related to this bug
- [x] I've added regression coverage for the change
- [ ] Full test suite run locally — not available in this connector-only environment; CI is expected to validate the focused Node test

### Documentation & Housekeeping

- [x] Documentation update: N/A — no user-facing configuration changes
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact considered — MIME mapping is platform-independent
- [x] Tool descriptions/schemas: N/A
