### PR TITLE
fix(minimax): auto-remap stale /v1 base_url, warn user to re-run setup (#84838)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -928,6 +928,56 @@ def managed_scope_check() -> None:
         check_info(f"managed dir set via HERMES_MANAGED_DIR={managed_dir}")
 
 
+def check_stale_minimax_base_urls() -> list[str]:
+    """Detect auth.json credential_pool entries still on the catalog /v1 surface.
+
+    When MiniMax / MiniMax-CN credential_pool entries carry a ``/v1`` URL,
+    runtime routes the request to the OpenAI-style surface while MiniMax's
+    transport is ``anthropic_messages`` — every auxiliary call (title
+    generation, compression, vision, ...) 404s with ``HTTP 404: 404 page
+    not found`` (#84838). The runtime silently remaps these to ``/anthropic``
+    for the current process, but the on-disk config still 404s the next
+    time ``auth.json`` is read fresh, so a doctor warning is needed to push
+    the user toward running ``hermes model`` again.
+
+    Returns remediation instructions to feed into the doctor summary list.
+    """
+    instructions: list[str] = []
+    try:
+        from hermes_cli.runtime_provider import _STALE_MINIMAX_V1_TO_ANTHROPIC
+    except Exception:  # noqa: BLE001 — diagnostics must never crash
+        return instructions
+
+    pool: dict = {}
+    try:
+        from hermes_cli.auth import read_credential_pool
+        pool = read_credential_pool() or {}
+    except Exception:
+        return instructions
+
+    for provider_id in ("minimax", "minimax-cn"):
+        entries = pool.get(provider_id)
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            base_url = (entry.get("base_url") or "").strip().rstrip("/")
+            correct = _STALE_MINIMAX_V1_TO_ANTHROPIC.get(base_url)
+            if not correct:
+                continue
+            label = entry.get("label") or provider_id
+            check_warn(
+                f"{label} base_url uses deprecated /v1 surface ({base_url})",
+                f"(runtime auto-remaps to {correct}; persist by re-running `hermes model` — #84838)",
+            )
+            instructions.append(
+                f"Re-run `hermes model` for `{provider_id}` to persist "
+                f"the correct /anthropic base_url and silence this warning."
+            )
+    return instructions
+
+
 def run_doctor(args):
     """Run diagnostic checks."""
     should_fix = getattr(args, 'fix', False)
@@ -1649,6 +1699,12 @@ def run_doctor(args):
                 check_info(xai_oauth_status["error"])
     except Exception:
         pass
+
+    _section("Provider base_url health")
+    try:
+        manual_issues.extend(check_stale_minimax_base_urls())
+    except Exception as e:
+        check_warn(f"Provider base_url check failed: {e}")
 
     _section("Directory Structure")
     hermes_home = HERMES_HOME

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -2832,6 +2832,20 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
         if chosen_base and chosen_base != effective_base and base_url_env:
             save_env_value(base_url_env, chosen_base)
         effective_base = chosen_base
+    elif provider_id in {"minimax", "minimax-cn"}:
+        # MiniMax uses the AnthropicMessages protocol under /anthropic. The
+        # registry default in PROVIDER_REGISTRY is already /anthropic; the
+        # OpenAI-style /v1 surface 404s for MiniMax (#84838). Don't prompt —
+        # earlier flows let users type /v1 and silently broke auxiliary
+        # tasks (title generation, compression, vision). If no env var is
+        # already set, persist the canonical URL so future reads don't
+        # have to consult the registry.
+        if effective_base and base_url_env and not get_env_value(base_url_env):
+            save_env_value(base_url_env, effective_base)
+        print(
+            f"  Base URL: {effective_base} "
+            f"(AnthropicMessages — fixed for MiniMax; see #84838)"
+        )
     else:
         try:
             override = input(f"Base URL [{effective_base}]: ").strip()

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -119,6 +119,7 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
     ),
     "minimax": HermesOverlay(
         transport="anthropic_messages",
+        base_url_override="https://api.minimax.io/anthropic",
         base_url_env_var="MINIMAX_BASE_URL",
     ),
     "minimax-oauth": HermesOverlay(
@@ -128,6 +129,7 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
     ),
     "minimax-cn": HermesOverlay(
         transport="anthropic_messages",
+        base_url_override="https://api.minimaxi.com/anthropic",
         base_url_env_var="MINIMAX_CN_BASE_URL",
     ),
     "deepseek": HermesOverlay(

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -257,7 +257,49 @@ def _host_derived_api_key(base_url: str) -> str:
     if sanitized in ("OPENAI", "OPENROUTER", "OLLAMA"):
         return ""
     env_name = f"{sanitized}_API_KEY"
-    return (_getenv(env_name, "") or "").strip()
+    return (_getenv(env_name, "").strip() or "").strip()
+
+
+_STALE_MINIMAX_V1_TO_ANTHROPIC = {
+    "https://api.minimax.io/v1": "https://api.minimax.io/anthropic",
+    "https://api.minimaxi.com/v1": "https://api.minimaxi.com/anthropic",
+}
+
+# Module-level one-shot gate: every Hermes process emits at most one
+# "your auth.json still has a stale /v1 URL for MiniMax" warning. Auxiliary
+# tasks (title generation, compression, vision, ...) all flow through the
+# same remap, so without this gate we'd spam once per call.
+_minimax_v1_remap_warned: bool = False
+
+
+def _minimax_anthropic_url_for_stale_v1(base_url: str) -> str:
+    """Return the Anthropic twin of a persisted MiniMax /v1 catalog default."""
+    return _STALE_MINIMAX_V1_TO_ANTHROPIC.get((base_url or "").strip().rstrip("/"), "")
+
+
+def _maybe_warn_stale_minimax_v1(provider: str, original_url: str) -> str:
+    """One-shot warning for stale MiniMax /v1 base_url. Returns the remapped URL.
+
+    Triggered when ``provider`` is MiniMax/MiniMax-CN and ``original_url`` is
+    one of the catalog-era /v1 URLs that 404 against the AnthropicMessages
+    surface. Emits a single ``logger.warning`` per process; subsequent calls
+    are silent. Re-running ``hermes model`` persists the correct /anthropic
+    URL so the warning stops firing on future runs.
+    """
+    global _minimax_v1_remap_warned
+    remapped = _minimax_anthropic_url_for_stale_v1(original_url)
+    if provider not in {"minimax", "minimax-cn"} or not remapped:
+        return remapped
+    if not _minimax_v1_remap_warned:
+        _minimax_v1_remap_warned = True
+        logger.warning(
+            "⚠ %s 配置的是旧版 OpenAI 风格 base_url (%s)；"
+            "本次运行已自动切换到 %s 以恢复功能。"
+            "建议运行 `hermes model` 重新走一遍配置流程，"
+            "写入正确的持久化配置（参考 #84838）。",
+            provider, original_url, remapped,
+        )
+    return remapped
 
 
 def _anthropic_base_url_override_ok(base_url: str) -> bool:
@@ -565,6 +607,10 @@ def _resolve_runtime_from_pool_entry(
         if configured_provider == provider and pool_url_is_default:
             cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
             if cfg_base_url:
+                if provider in {"minimax", "minimax-cn"}:
+                    cfg_base_url = _maybe_warn_stale_minimax_v1(
+                        provider, cfg_base_url
+                    ) or cfg_base_url
                 base_url = cfg_base_url
         configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
         if provider in {"opencode-zen", "opencode-go"}:
@@ -2285,6 +2331,14 @@ def resolve_runtime_provider(
         cfg_base_url = ""
         if cfg_provider == provider:
             cfg_base_url = (model_cfg.get("base_url") or "").strip().rstrip("/")
+        # hermes setup / models.dev persist the OpenAI-style /v1 default.
+        # MiniMax's transport is anthropic_messages, so that path 404s
+        # (#84838). Remap only the known stale catalog URLs; a user-set
+        # China or custom host is left alone.
+        if provider in {"minimax", "minimax-cn"}:
+            cfg_base_url = _maybe_warn_stale_minimax_v1(
+                provider, cfg_base_url
+            ) or cfg_base_url
         base_url = cfg_base_url or creds.get("base_url", "").rstrip("/")
         if provider == "actual":
             base_url = normalize_actual_base_url(base_url)


### PR DESCRIPTION
## Root cause (precise)

The Anthropic SDK calls `POST <base_url>/v1/messages`. MiniMax's AnthropicMessages endpoint only exists at `<base>/v1/messages` — i.e. the SDK's appended `/v1/messages` must land under MiniMax's `/anthropic` prefix, not at the host root. So:

| `base_url` (configured) | Final URL the SDK calls | Status |
|---|---|---|
| `https://api.minimaxi.com/anthropic` | `…/anthropic/v1/messages` | **200** ✓ |
| `https://api.minimaxi.com/v1` | `…/v1/messages` | **404** ✗ |

The bug: `auth.json` carried `https://api.minimaxi.com/v1` (the `models.dev` / catalog default), so every auxiliary call (title generation, compression, vision, session_search, ...) landed at `/v1/messages` — which MiniMax doesn't expose — and returned `HTTP 404: 404 page not found` on every user turn. The main agent path happened to take a different code branch and worked.

Verified directly against MiniMax CN with the real `MiniMax-M3` model + the user's API key:

```
https://api.minimaxi.com/v1/messages                     HTTP 404  (AnthropicMessages)
https://api.minimaxi.com/anthropic/messages              HTTP 404
https://api.minimaxi.com/messages                        HTTP 404
https://api.minimaxi.com/v1/chat/completions             HTTP 200  (OpenAI wire)
https://api.minimaxi.com/anthropic/v1/messages           HTTP 200  ← SDK path
```

Note: this is *not* "MiniMax doesn't support OpenAI format" — it's that **the Anthropic SDK's URL composition (`<base>/v1/messages`) requires `base_url` to end with `/anthropic`** for MiniMax, not `/v1`.

## Fix

Four coordinated changes — runtime auto-remap, setup-flow guard, doctor check, registry overlays:

1. **`hermes_cli/providers.py`** — add `base_url_override` to the MiniMax / MiniMax-CN overlays so the registry's `inference_base_url` and the runtime overlay agree on `https://api.minimax{i,i}.com/anthropic`.

2. **`hermes_cli/runtime_provider.py`** — detect the two known stale `/v1` URLs (`api.minimaxi.com/v1` and `api.minimax.io/v1`) and remap them to their `/anthropic` twins at runtime. Emit a one-shot `logger.warning` per process so the user notices their on-disk config is wrong and is told to run `hermes model` to persist the correction. Module-level `_minimax_v1_remap_warned` flag prevents per-call log spam (auxiliary tasks all flow through the same remap).

3. **`hermes_cli/model_setup_flows.py`** — for `minimax` / `minimax-cn`, skip the `Base URL [...]` input prompt and print the registry default instead. Earlier flows let users type `/v1` and silently broke auxiliary tasks; the registry default is already the correct `/anthropic` URL. If no env var is set, persist the canonical URL so future reads don't have to consult the registry.

4. **`hermes_cli/doctor.py`** — add `check_stale_minimax_base_urls()` which scans `auth.json` for entries still pointing at the deprecated `/v1` surface and feeds remediation instructions into the doctor summary, so users running `hermes doctor` get the same "re-run `hermes model`" nudge.

Together: the runtime auto-remap keeps existing users working immediately, the warning + doctor check surface the stale config, and the setup flow prevents new users from typing `/v1` in the first place.

## Files

- `hermes_cli/providers.py` (+2)
- `hermes_cli/runtime_provider.py` (+55/-1)
- `hermes_cli/model_setup_flows.py` (+14)
- `hermes_cli/doctor.py` (+56)

## Verification

```bash
# Verify the precise endpoint behavior
$ for path in /v1/messages /anthropic/messages /messages /anthropic/v1/messages; do
    curl -X POST https://api.minimaxi.com$path \
      -H "Authorization: Bearer $MINIMAX_CN_API_KEY" \
      -H "anthropic-version: 2023-06-01" \
      -d '{"model":"MiniMax-M3","max_tokens":10,"messages":[{"role":"user","content":"hi"}]}'
  done
# Only /anthropic/v1/messages returns 200 (the SDK path)
```

Manual end-to-end with `auth.json` deliberately seeded with `/v1`:
- `Auxiliary title generation failed: HTTP 404` should disappear
- One `⚠ minimax-cn 配置的是旧版 OpenAI 风格 base_url (...)` warning per process
- `hermes doctor` should report the stale entry until `hermes model` re-runs

## Related

- #84838 — bug report
- #16254, #83642 — adjacent upstream fixes for `/anthropic` suffix handling