### PR TITLE
feat(kanban): add generic plugin worker lane protocol

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -73,6 +73,51 @@ def _kanban_dispatch_allowed() -> bool:
     return not check_paused("kanban", logger)
 
 
+def _worker_lane_callbacks(context: str):
+    """Resolve plugin lane callbacks without making plugins a hard dependency."""
+    try:
+        from hermes_cli.plugins import build_worker_lane_dispatch
+
+        return build_worker_lane_dispatch()
+    except Exception:
+        logger.warning(
+            "%s: worker lane discovery failed; using native profiles",
+            context,
+            exc_info=True,
+        )
+        return None, None
+
+
+def _dispatch_kanban_once(kanban_db, conn, **kwargs):
+    """Dispatch one gateway tick with the shared plugin lane resolver."""
+    spawn_fn, is_spawnable = _worker_lane_callbacks("kanban dispatcher")
+    return kanban_db.dispatch_once(
+        conn,
+        spawn_fn=spawn_fn,
+        spawnable_assignee_fn=is_spawnable,
+        **kwargs,
+    )
+
+
+def _has_spawnable_kanban_work(kanban_db, conn, *, review: bool) -> bool:
+    """Probe readiness with the same lane predicate used for dispatch."""
+    _unused_spawn, is_spawnable = _worker_lane_callbacks(
+        "kanban dispatcher health"
+    )
+    if kanban_db.has_spawnable_ready(
+        conn,
+        spawnable_assignee_fn=is_spawnable,
+    ):
+        return True
+    return bool(
+        review
+        and kanban_db.has_spawnable_review(
+            conn,
+            spawnable_assignee_fn=is_spawnable,
+        )
+    )
+
+
 def _acquire_singleton_lock(lock_path) -> "tuple[Optional[object], str]":
     """Take an exclusive, non-blocking advisory lock for the sole dispatcher.
 
@@ -1457,7 +1502,8 @@ class GatewayKanbanWatchersMixin:
                 # re-ran the migration on a second connection, racing
                 # the first. See the matching comment in
                 # `_kanban_notifier_watcher` and issue #21378.
-                return _kb.dispatch_once(
+                return _dispatch_kanban_once(
+                    _kb,
                     conn,
                     board=slug,
                     max_spawn=max_spawn,
@@ -1550,9 +1596,9 @@ class GatewayKanbanWatchersMixin:
                 conn = None
                 try:
                     conn = _kb.connect(board=slug)
-                    if _kb.has_spawnable_ready(conn):
-                        return True
-                    if _review_probe and _kb.has_spawnable_review(conn):
+                    if _has_spawnable_kanban_work(
+                        _kb, conn, review=_review_probe
+                    ):
                         return True
                 except Exception:
                     continue

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import json
+import logging
 import os
 import shlex
 import sys
@@ -26,6 +27,8 @@ from typing import Any, Optional
 
 from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_swarm as ks
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -330,6 +333,11 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_create = sub.add_parser("create", help="Create a new task")
     p_create.add_argument("title", help="Task title")
     p_create.add_argument("--body", default=None, help="Optional opening post")
+    p_create.add_argument(
+        "--metadata",
+        default=None,
+        help="Stable task metadata as a JSON object (for worker integrations)",
+    )
     p_create.add_argument("--assignee", default=None, help="Profile name to assign")
     p_create.add_argument("--parent", action="append", default=[],
                           help="Parent task id (repeatable)")
@@ -1562,6 +1570,16 @@ def _cmd_create(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
+    metadata = None
+    raw_metadata = getattr(args, "metadata", None)
+    if raw_metadata:
+        try:
+            metadata = json.loads(raw_metadata)
+            if not isinstance(metadata, dict):
+                raise ValueError("must decode to a JSON object")
+        except (json.JSONDecodeError, ValueError) as exc:
+            print(f"kanban: --metadata: {exc}", file=sys.stderr)
+            return 2
     with kb.connect_closing() as conn:
         task_id = kb.create_task(
             conn,
@@ -1586,6 +1604,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
             initial_status=getattr(args, "initial_status", "running"),
+            metadata=metadata,
         )
         task = kb.get_task(conn, task_id)
     if getattr(args, "json", False):
@@ -2654,9 +2673,21 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         max_in_progress_per_profile = None
         max_in_progress = None
         max_spawn = getattr(args, "max", None)
+    try:
+        from hermes_cli.plugins import build_worker_lane_dispatch
+
+        worker_lane_spawn, worker_lane_is_spawnable = build_worker_lane_dispatch()
+    except Exception:
+        logger.warning(
+            "kanban dispatch: worker lane discovery failed; using native profiles",
+            exc_info=True,
+        )
+        worker_lane_spawn, worker_lane_is_spawnable = None, None
     with kb.connect_closing() as conn:
         res = kb.dispatch_once(
             conn,
+            spawn_fn=worker_lane_spawn,
+            spawnable_assignee_fn=worker_lane_is_spawnable,
             dry_run=args.dry_run,
             max_spawn=max_spawn,
             max_in_progress=max_in_progress,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1141,6 +1141,10 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # Stable integration context supplied when the card is created. This is
+    # distinct from per-run completion metadata and is available to worker-lane
+    # spawn callbacks after the dispatcher has claimed the task.
+    metadata: Optional[dict] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1154,6 +1158,14 @@ class Task:
                     skills_value = [str(s) for s in parsed if s]
             except Exception:
                 skills_value = None
+        metadata_value: Optional[dict] = None
+        if "metadata" in keys and row["metadata"]:
+            try:
+                parsed_metadata = json.loads(row["metadata"])
+                if isinstance(parsed_metadata, dict):
+                    metadata_value = parsed_metadata
+            except Exception:
+                metadata_value = None
         return cls(
             id=row["id"],
             title=row["title"],
@@ -1235,6 +1247,7 @@ class Task:
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
             ),
+            metadata=metadata_value,
         )
 
 
@@ -1351,6 +1364,8 @@ CREATE TABLE IF NOT EXISTS tasks (
     claim_lock           TEXT,
     claim_expires        INTEGER,
     tenant               TEXT,
+    -- Stable card-level integration context. Distinct from task_runs.metadata.
+    metadata             TEXT,
     result               TEXT,
     idempotency_key      TEXT,
     -- Unified consecutive-failure counter. Incremented on spawn
@@ -2538,6 +2553,8 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         _add_column_if_missing(conn, "tasks", "tenant", "tenant TEXT")
     if "result" not in cols:
         _add_column_if_missing(conn, "tasks", "result", "result TEXT")
+    if "metadata" not in cols:
+        _add_column_if_missing(conn, "tasks", "metadata", "metadata TEXT")
     if "branch_name" not in cols:
         _add_column_if_missing(conn, "tasks", "branch_name", "branch_name TEXT")
     if "project_id" not in cols:
@@ -3183,6 +3200,7 @@ def create_task(
     board: Optional[str] = None,
     project_id: Optional[str] = None,
     project_source_task_id: Optional[str] = None,
+    metadata: Optional[dict] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -3244,6 +3262,20 @@ def create_task(
         branch_name = str(branch_name).strip() or None
     if branch_name and workspace_kind != "worktree":
         raise ValueError("branch_name is only valid for worktree workspaces")
+    if metadata is not None and not isinstance(metadata, dict):
+        raise ValueError("metadata must be an object/dict")
+    try:
+        metadata_json = (
+            json.dumps(metadata, ensure_ascii=False, separators=(",", ":"))
+            if metadata is not None
+            else None
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"metadata must be JSON-serializable: {exc}") from exc
+    if metadata_json and len(metadata_json.encode("utf-8")) > _CTX_MAX_FIELD_BYTES:
+        raise ValueError(
+            f"metadata exceeds {_CTX_MAX_FIELD_BYTES}-byte task context limit"
+        )
 
     # Inherit the board's scoped project when the caller didn't name one, so a
     # project-scoped board anchors every new task to that project's repo
@@ -3494,11 +3526,12 @@ def create_task(
                         id, title, body, assignee, status, priority,
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, project_id, tenant, idempotency_key,
+                        metadata,
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
                         reasoning_effort,
                         goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -3515,6 +3548,7 @@ def create_task(
                         project_id,
                         tenant,
                         idempotency_key,
+                        metadata_json,
                         int(max_runtime_seconds) if max_runtime_seconds is not None else None,
                         json.dumps(skills_list) if skills_list is not None else None,
                         int(max_retries) if max_retries is not None else None,
@@ -9530,7 +9564,28 @@ def check_respawn_guard(
     return None
 
 
-def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
+def _assignee_is_spawnable(assignee: object, spawnable_assignee_fn=None) -> bool:
+    """Return whether an assignee can be launched by a native or plugin lane."""
+    if spawnable_assignee_fn is not None:
+        try:
+            if spawnable_assignee_fn(assignee):
+                return True
+        except Exception:
+            _log.debug(
+                "kanban dispatch: plugin lane predicate failed for %r",
+                assignee,
+                exc_info=True,
+            )
+    try:
+        from hermes_cli.profiles import profile_exists  # local import: avoids cycle
+    except Exception:
+        # Can't introspect profiles in a partial install. Preserve the legacy
+        # fail-open behavior so diagnostics still report queued work.
+        return True
+    return bool(profile_exists(str(assignee or "")))
+
+
+def has_spawnable_ready(conn: sqlite3.Connection, *, spawnable_assignee_fn=None) -> bool:
     """Return True iff there is at least one ready+assigned+unclaimed task
     whose assignee maps to a real Hermes profile.
 
@@ -9551,18 +9606,13 @@ def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
     ).fetchall()
     if not rows:
         return False
-    try:
-        from hermes_cli.profiles import profile_exists  # local import: avoids cycle
-    except Exception:
-        # Can't introspect — assume spawnable, preserve legacy behavior.
-        return True
     for row in rows:
-        if profile_exists(row["assignee"]):
+        if _assignee_is_spawnable(row["assignee"], spawnable_assignee_fn):
             return True
     return False
 
 
-def has_spawnable_review(conn: sqlite3.Connection) -> bool:
+def has_spawnable_review(conn: sqlite3.Connection, *, spawnable_assignee_fn=None) -> bool:
     """Return True iff there is at least one review+assigned+unclaimed task
     whose assignee maps to a real Hermes profile.
 
@@ -9577,12 +9627,8 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
     ).fetchall()
     if not rows:
         return False
-    try:
-        from hermes_cli.profiles import profile_exists  # local import: avoids cycle
-    except Exception:
-        return True
     for row in rows:
-        if profile_exists(row["assignee"]):
+        if _assignee_is_spawnable(row["assignee"], spawnable_assignee_fn):
             return True
     return False
 
@@ -9607,6 +9653,7 @@ def dispatch_once(
     conn: sqlite3.Connection,
     *,
     spawn_fn=None,
+    spawnable_assignee_fn=None,
     ttl_seconds: Optional[int] = None,
     dry_run: bool = False,
     max_spawn: Optional[int] = None,
@@ -9642,6 +9689,7 @@ def dispatch_once(
         result = _dispatch_once_locked(
             conn,
             spawn_fn=spawn_fn,
+            spawnable_assignee_fn=spawnable_assignee_fn,
             ttl_seconds=ttl_seconds,
             dry_run=dry_run,
             max_spawn=max_spawn,
@@ -9662,6 +9710,7 @@ def dispatch_once(
             result = _dispatch_once_locked(
                 conn,
                 spawn_fn=spawn_fn,
+                spawnable_assignee_fn=spawnable_assignee_fn,
                 ttl_seconds=ttl_seconds,
                 dry_run=dry_run,
                 max_spawn=max_spawn,
@@ -9689,6 +9738,7 @@ def _dispatch_once_locked(
     conn: sqlite3.Connection,
     *,
     spawn_fn=None,
+    spawnable_assignee_fn=None,
     ttl_seconds: Optional[int] = None,
     dry_run: bool = False,
     max_spawn: Optional[int] = None,
@@ -9813,20 +9863,14 @@ def _dispatch_once_locked(
             _per_profile_running[prow["assignee"]] = int(prow["n"])
     # Normalize default_assignee once: empty/whitespace string → None so the
     # rest of the loop can use ``if default_assignee:`` as a single check.
-    # We also resolve profile_exists once here for the same reason.
+    # Resolve both native profiles and plugin lanes through the same predicate
+    # used by the dispatch loops and health telemetry.
     _default_assignee = (default_assignee or "").strip() or None
     _default_assignee_resolved = False
     if _default_assignee:
-        try:
-            from hermes_cli.profiles import profile_exists as _pe
-            _default_assignee_resolved = bool(_pe(_default_assignee))
-        except Exception:
-            # Profiles module not importable (test stubs, exotic envs).
-            # Trust the operator's config and try the assignment; the
-            # downstream profile_exists check on the assigned row will
-            # bucket it as nonspawnable if the profile genuinely isn't
-            # there, with the existing diagnostic.
-            _default_assignee_resolved = True
+        _default_assignee_resolved = _assignee_is_spawnable(
+            _default_assignee, spawnable_assignee_fn
+        )
     for row in ready_rows:
         if max_spawn is not None and running_count + spawned >= max_spawn:
             break
@@ -9884,11 +9928,7 @@ def _dispatch_once_locked(
         # subprocess would crash on startup, get reaped as a zombie,
         # the task would loop back to ``ready`` on next tick, and we'd
         # burn CPU forever (#kanban-dispatcher-crash-loop 2026-05-05).
-        try:
-            from hermes_cli.profiles import profile_exists  # local import: avoids cycle
-        except Exception:
-            profile_exists = None  # type: ignore[assignment]
-        if profile_exists is not None and not profile_exists(row_assignee):
+        if not _assignee_is_spawnable(row_assignee, spawnable_assignee_fn):
             # Bucket separately from skipped_unassigned: the operator
             # cannot fix this by assigning a profile (the assignee IS the
             # intended owner — a terminal lane). Health telemetry uses
@@ -10038,11 +10078,7 @@ def _dispatch_once_locked(
         if not row["assignee"]:
             result.skipped_unassigned.append(row["id"])
             continue
-        try:
-            from hermes_cli.profiles import profile_exists
-        except Exception:
-            profile_exists = None  # type: ignore[assignment]
-        if profile_exists is not None and not profile_exists(row["assignee"]):
+        if not _assignee_is_spawnable(row["assignee"], spawnable_assignee_fn):
             result.skipped_nonspawnable.append(row["id"])
             continue
         if _per_profile_cap is not None:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import fnmatch
 import hashlib
 import importlib.metadata
 import importlib.util
@@ -1200,6 +1201,20 @@ class PluginRegistration:
                 self._on_dispose(self)
 
 
+@dataclass(frozen=True)
+class WorkerLaneRegistration:
+    """One plugin-owned Kanban worker lane.
+
+    ``match`` is an exact assignee name or a shell-style glob.  The host owns
+    task claiming and lifecycle state; the plugin callback owns only process
+    creation for a matching task.
+    """
+
+    match: str
+    spawn_fn: Callable
+    plugin: str
+
+
 # ---------------------------------------------------------------------------
 # PluginContext  – handed to each plugin's ``register()`` function
 # ---------------------------------------------------------------------------
@@ -2164,6 +2179,48 @@ class PluginContext:
             ),
         )
         logger.debug("Plugin %s registered command: /%s", self.manifest.name, clean)
+        return handle
+
+    # -- kanban worker lane registration ------------------------------------
+
+    def register_worker_lane(
+        self,
+        *,
+        match: str,
+        spawn_fn: Callable,
+    ) -> PluginRegistration:
+        """Register a plugin-owned Kanban worker lane.
+
+        ``match`` is an exact assignee name or shell-style glob such as
+        ``agentplane-*``. Matching tasks remain fully owned by the Hermes
+        dispatcher (claim, run, retry, timeout, and completion state); only
+        process creation is delegated to ``spawn_fn(task, workspace, board=...)``.
+        """
+        pattern = str(match or "").strip()
+        if not pattern:
+            raise ValueError(
+                f"Plugin '{self.manifest.name}' worker lane match cannot be empty"
+            )
+        if not callable(spawn_fn):
+            raise ValueError(
+                f"Plugin '{self.manifest.name}' worker lane {pattern!r} "
+                "requires a callable spawn_fn"
+            )
+        owner_id = self.manifest.key or self.manifest.name
+        lane = WorkerLaneRegistration(
+            match=pattern,
+            spawn_fn=spawn_fn,
+            plugin=owner_id,
+        )
+        self._manager._worker_lanes.append(lane)
+        handle = self._track(
+            "worker_lane",
+            pattern,
+            lambda: self._manager._remove_identity(
+                self._manager._worker_lanes, lane
+            ),
+        )
+        logger.debug("Plugin %s registered worker lane: %s", owner_id, pattern)
         return handle
 
     # -- tool dispatch -------------------------------------------------------
@@ -3403,6 +3460,7 @@ class PluginManager:
         self._cli_commands: Dict[str, dict] = {}
         self._context_engine = None  # Set by a plugin via register_context_engine()
         self._plugin_commands: Dict[str, dict] = {}  # Slash commands registered by plugins
+        self._worker_lanes: List[WorkerLaneRegistration] = []
         self._system_prompt_sections: Dict[str, PluginSystemPromptSection] = {}
         self._discovered: bool = False
         self._cli_ref = None  # Set by CLI after plugin discovery
@@ -3719,6 +3777,7 @@ class PluginManager:
             self._plugin_platform_names.clear()
             self._cli_commands.clear()
             self._plugin_commands.clear()
+            self._worker_lanes.clear()
             self._plugin_skills.clear()
             self._portable_mcp_servers.clear()
             self._aux_tasks.clear()
@@ -6498,6 +6557,56 @@ def get_plugin_auxiliary_tasks() -> List[Dict[str, Any]]:
     """
     manager = _ensure_plugins_discovered()
     return [manager._aux_tasks[k] for k in sorted(manager._aux_tasks)]
+
+
+def _resolve_worker_lane(
+    manager: PluginManager,
+    assignee: object,
+) -> Optional[WorkerLaneRegistration]:
+    name = str(assignee or "").strip()
+    if not name:
+        return None
+    for lane in manager._worker_lanes:
+        if fnmatch.fnmatchcase(name, lane.match):
+            return lane
+    return None
+
+
+def resolve_worker_lane(assignee: object) -> Optional[WorkerLaneRegistration]:
+    """Resolve a plugin worker lane for an assignee, if one is registered.
+
+    Registrations are checked in discovery order.  This is the single lane
+    predicate used by dispatch, dry-run, and readiness telemetry so those
+    surfaces cannot disagree about whether a non-profile assignee is runnable.
+    """
+    return _resolve_worker_lane(_ensure_plugins_discovered(), assignee)
+
+
+def build_worker_lane_dispatch(
+) -> tuple[Optional[Callable], Optional[Callable[[object], bool]]]:
+    """Build the composite dispatcher callbacks for registered worker lanes.
+
+    The spawn callback delegates matching assignees to their plugin and falls
+    back to Hermes' native profile spawner.  The predicate is passed to both
+    dispatch and readiness probes.  ``(None, None)`` preserves the built-in
+    path when no plugin lanes exist.
+    """
+    manager = _ensure_plugins_discovered()
+    if not manager._worker_lanes:
+        return None, None
+
+    def is_spawnable(assignee: object) -> bool:
+        return _resolve_worker_lane(manager, assignee) is not None
+
+    def spawn(task: Any, workspace: str, *, board: Optional[str] = None) -> Any:
+        lane = _resolve_worker_lane(manager, getattr(task, "assignee", None))
+        if lane is not None:
+            return lane.spawn_fn(task, workspace, board=board)
+        from hermes_cli import kanban_db
+
+        return kanban_db._default_spawn(task, workspace, board=board)
+
+    return spawn, is_spawnable
 
 
 def get_plugin_subscriptions() -> Dict[str, List[Callable]]:

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -598,6 +598,7 @@ def get_task(
 class CreateTaskBody(BaseModel):
     title: str
     body: Optional[str] = None
+    metadata: Optional[dict[str, Any]] = None
     assignee: Optional[str] = None
     tenant: Optional[str] = None
     priority: int = 0
@@ -629,6 +630,7 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             conn,
             title=payload.title,
             body=payload.body,
+            metadata=payload.metadata,
             assignee=payload.assignee,
             created_by="dashboard",
             workspace_kind=payload.workspace_kind,
@@ -2287,8 +2289,26 @@ def dispatch(
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
+        try:
+            from hermes_cli.plugins import build_worker_lane_dispatch
+
+            worker_lane_spawn, worker_lane_is_spawnable = (
+                build_worker_lane_dispatch()
+            )
+        except Exception:
+            log.warning(
+                "kanban dashboard dispatch: worker lane discovery failed; "
+                "using native profiles",
+                exc_info=True,
+            )
+            worker_lane_spawn, worker_lane_is_spawnable = None, None
         result = kanban_db.dispatch_once(
-            conn, dry_run=dry_run, max_spawn=max_n, board=board,
+            conn,
+            spawn_fn=worker_lane_spawn,
+            spawnable_assignee_fn=worker_lane_is_spawnable,
+            dry_run=dry_run,
+            max_spawn=max_n,
+            board=board,
         )
         # DispatchResult is a dataclass.
         try:

--- a/tests/gateway/test_kanban_watchers_mixin.py
+++ b/tests/gateway/test_kanban_watchers_mixin.py
@@ -8,7 +8,9 @@ that GatewayRunner picks them up via the MRO (behavior-neutral relocation).
 from __future__ import annotations
 
 import inspect
+from types import SimpleNamespace
 
+from gateway import kanban_watchers
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
 
 KANBAN_METHODS = [
@@ -25,4 +27,55 @@ def test_mixin_defines_kanban_methods():
     for m in KANBAN_METHODS:
         assert hasattr(GatewayKanbanWatchersMixin, m), f"mixin missing {m}"
 
+
+def test_gateway_dispatch_threads_worker_lane_callbacks(monkeypatch):
+    lane_spawn = lambda *_args, **_kwargs: None
+    lane_predicate = lambda _assignee: True
+    monkeypatch.setattr(
+        kanban_watchers,
+        "_worker_lane_callbacks",
+        lambda _context: (lane_spawn, lane_predicate),
+    )
+    captured = {}
+    fake_db = SimpleNamespace(
+        dispatch_once=lambda conn, **kwargs: captured.update(kwargs) or "result"
+    )
+
+    result = kanban_watchers._dispatch_kanban_once(
+        fake_db, object(), board="main", max_spawn=2
+    )
+
+    assert result == "result"
+    assert captured["spawn_fn"] is lane_spawn
+    assert captured["spawnable_assignee_fn"] is lane_predicate
+    assert captured["board"] == "main"
+
+
+def test_gateway_readiness_uses_worker_lane_predicate(monkeypatch):
+    lane_predicate = lambda assignee: assignee == "agentplane-executor"
+    monkeypatch.setattr(
+        kanban_watchers,
+        "_worker_lane_callbacks",
+        lambda _context: (None, lane_predicate),
+    )
+    captured = {}
+
+    def ready(_conn, **kwargs):
+        captured["ready"] = kwargs
+        return False
+
+    def review(_conn, **kwargs):
+        captured["review"] = kwargs
+        return True
+
+    fake_db = SimpleNamespace(
+        has_spawnable_ready=ready,
+        has_spawnable_review=review,
+    )
+
+    assert kanban_watchers._has_spawnable_kanban_work(
+        fake_db, object(), review=True
+    ) is True
+    assert captured["ready"]["spawnable_assignee_fn"] is lane_predicate
+    assert captured["review"]["spawnable_assignee_fn"] is lane_predicate
 

--- a/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
+++ b/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
@@ -56,6 +56,12 @@ def test_cli_dispatch_passes_max_in_progress_from_config(isolated_kanban_home, m
         return kanban_db.DispatchResult()
 
     monkeypatch.setattr(kanban_db, "dispatch_once", fake_dispatch_once)
+    lane_spawn = lambda *_args, **_kwargs: None
+    lane_predicate = lambda _assignee: True
+    monkeypatch.setattr(
+        "hermes_cli.plugins.build_worker_lane_dispatch",
+        lambda: (lane_spawn, lane_predicate),
+    )
 
     args = argparse.Namespace(dry_run=True, max=None, failure_limit=2, json=False)
     kb_cli._cmd_dispatch(args)
@@ -69,6 +75,8 @@ def test_cli_dispatch_passes_max_in_progress_from_config(isolated_kanban_home, m
     )
     assert captured.get("default_assignee") == "default"
     assert captured.get("max_in_progress_per_profile") == 2
+    assert captured.get("spawn_fn") is lane_spawn
+    assert captured.get("spawnable_assignee_fn") is lane_predicate
 
 
 def test_cli_max_flag_overrides_config_max_spawn(isolated_kanban_home, monkeypatch):
@@ -92,5 +100,4 @@ def test_cli_max_flag_overrides_config_max_spawn(isolated_kanban_home, monkeypat
     assert captured.get("max_spawn") == 2, (
         f"CLI --max=2 must override config kanban.max_spawn=10; got {captured.get('max_spawn')!r}"
     )
-
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -158,6 +158,7 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
     assert "session_id" in task_columns
     assert "tenant" in task_columns
     assert "idempotency_key" in task_columns
+    assert "metadata" in task_columns
     assert "run_id" in event_columns
     # And their indexes — the regression scope of this test:
     assert "idx_tasks_session_id" in indexes

--- a/tests/hermes_cli/test_kanban_worker_lanes.py
+++ b/tests/hermes_cli/test_kanban_worker_lanes.py
@@ -1,0 +1,109 @@
+"""Native dispatcher coverage for plugin-registered worker lanes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import profiles
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def test_plugin_lane_is_spawnable_in_ready_and_review(kanban_home, monkeypatch):
+    monkeypatch.setattr(profiles, "profile_exists", lambda _name: False)
+    lane = lambda assignee: str(assignee).startswith("agentplane-")
+
+    with kb.connect_closing() as conn:
+        ready_id = kb.create_task(
+            conn,
+            title="ready external work",
+            assignee="agentplane-executor",
+        )
+        review_id = kb.create_task(
+            conn,
+            title="review external work",
+            assignee="agentplane-reviewer",
+        )
+        conn.execute(
+            "UPDATE tasks SET status = 'review' WHERE id = ?",
+            (review_id,),
+        )
+        conn.commit()
+
+        assert kb.has_spawnable_ready(
+            conn, spawnable_assignee_fn=lane
+        ) is True
+        assert kb.has_spawnable_review(
+            conn, spawnable_assignee_fn=lane
+        ) is True
+
+        result = kb.dispatch_once(
+            conn,
+            spawnable_assignee_fn=lane,
+            dry_run=True,
+            max_spawn=2,
+        )
+
+    assert {item[0] for item in result.spawned} == {ready_id, review_id}
+    assert result.skipped_nonspawnable == []
+
+
+def test_plugin_lane_spawn_receives_claimed_task_context(kanban_home, monkeypatch):
+    monkeypatch.setattr(profiles, "profile_exists", lambda _name: False)
+    captured = {}
+
+    def spawn(task, workspace, *, board=None):
+        captured.update(task=task, workspace=workspace, board=board)
+        return None
+
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="external semantic episode",
+            assignee="agentplane-executor",
+            metadata={"agentplane": {"task_id": "20260817-ABC"}},
+        )
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=spawn,
+            spawnable_assignee_fn=lambda assignee: assignee == "agentplane-executor",
+        )
+
+    task = captured["task"]
+    assert result.spawned[0][0] == task_id
+    assert task.id == task_id
+    assert task.assignee == "agentplane-executor"
+    assert task.current_run_id is not None
+    assert task.claim_lock
+    assert task.metadata == {"agentplane": {"task_id": "20260817-ABC"}}
+    assert captured["workspace"]
+
+
+def test_unknown_non_profile_lane_remains_nonspawnable(kanban_home, monkeypatch):
+    monkeypatch.setattr(profiles, "profile_exists", lambda _name: False)
+
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="unknown lane",
+            assignee="unregistered-runner",
+        )
+        result = kb.dispatch_once(
+            conn,
+            spawnable_assignee_fn=lambda _assignee: False,
+            dry_run=True,
+        )
+
+    assert result.spawned == []
+    assert result.skipped_nonspawnable == [task_id]

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -2066,3 +2066,79 @@ class TestDispatchToolWithoutCliRef:
             assert calls[0][1].get("parent_agent") is None
         finally:
             registry.deregister("_test_dispatch_probe")
+
+
+class TestWorkerLaneRegistration:
+    """Plugin lanes share one resolver across dispatch and readiness."""
+
+    def test_registration_resolves_and_disposes(self, monkeypatch):
+        from hermes_cli import plugins as plugins_mod
+
+        manager = PluginManager()
+        manager._discovered = True
+        ctx = PluginContext(
+            PluginManifest(name="lane-plugin", key="lane-plugin", source="user"),
+            manager,
+        )
+        spawn = MagicMock(return_value=4321)
+        handle = ctx.register_worker_lane(match="agentplane-*", spawn_fn=spawn)
+        monkeypatch.setattr(plugins_mod, "get_plugin_manager", lambda: manager)
+
+        lane = plugins_mod.resolve_worker_lane("agentplane-executor")
+        assert lane is not None
+        assert lane.plugin == "lane-plugin"
+        assert plugins_mod.resolve_worker_lane("default") is None
+
+        composite_spawn, is_spawnable = plugins_mod.build_worker_lane_dispatch()
+        task = types.SimpleNamespace(assignee="agentplane-executor")
+        assert is_spawnable is not None and is_spawnable(task.assignee)
+        assert composite_spawn is not None
+        assert composite_spawn(task, "/workspace", board="main") == 4321
+        spawn.assert_called_once_with(task, "/workspace", board="main")
+
+        handle.dispose()
+        assert plugins_mod.resolve_worker_lane("agentplane-executor") is None
+
+    def test_registration_has_no_profile_exists_override(self):
+        manager = PluginManager()
+        ctx = PluginContext(PluginManifest(name="lane-plugin"), manager)
+
+        with pytest.raises(TypeError):
+            ctx.register_worker_lane(
+                match="external-*",
+                spawn_fn=lambda *_args, **_kwargs: None,
+                profile_exists=True,
+            )
+
+    def test_enabled_plugin_lane_is_discovered(self, tmp_path, monkeypatch):
+        from hermes_cli import plugins as plugins_mod
+
+        home = tmp_path / "home"
+        plugin = home / "plugins" / "lane-plugin"
+        plugin.mkdir(parents=True)
+        (plugin / "plugin.yaml").write_text(
+            yaml.safe_dump({"name": "lane-plugin", "version": "1.0.0"})
+        )
+        (plugin / "__init__.py").write_text(
+            "def _spawn(task, workspace, *, board=None):\n"
+            "    return 9876\n\n"
+            "def register(ctx):\n"
+            "    ctx.register_worker_lane(match='agentplane-*', spawn_fn=_spawn)\n"
+        )
+        home.mkdir(exist_ok=True)
+        (home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["lane-plugin"]}})
+        )
+        bundled = tmp_path / "bundled"
+        bundled.mkdir()
+        monkeypatch.setenv("HOME", str(tmp_path / "os-home"))
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr(plugins_mod, "get_bundled_plugins_dir", lambda: bundled)
+
+        manager = PluginManager()
+        manager.discover_and_load()
+        monkeypatch.setattr(plugins_mod, "get_plugin_manager", lambda: manager)
+
+        lane = plugins_mod.resolve_worker_lane("agentplane-planner")
+        assert lane is not None
+        assert lane.spawn_fn(types.SimpleNamespace(), "/workspace", board="main") == 9876

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -40,6 +40,7 @@ def _load_plugin_router():
     mod = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = mod
     spec.loader.exec_module(mod)
+    mod.router._test_plugin_module = mod
     return mod.router
 
 
@@ -57,7 +58,9 @@ def kanban_home(tmp_path, monkeypatch):
 @pytest.fixture
 def client(kanban_home):
     app = FastAPI()
-    app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")
+    router = _load_plugin_router()
+    app.include_router(router, prefix="/api/plugins/kanban")
+    app.state.kanban_plugin_module = router._test_plugin_module
     return TestClient(app)
 
 
@@ -519,14 +522,15 @@ def test_dispatch_dry_run(client, monkeypatch):
         "build_worker_lane_dispatch",
         lambda: (lane_spawn, lane_predicate),
     )
-    original_dispatch = kb.dispatch_once
+    endpoint_kb = client.app.state.kanban_plugin_module.kanban_db
+    original_dispatch = endpoint_kb.dispatch_once
     captured = {}
 
     def capture_dispatch(conn, **kwargs):
         captured.update(kwargs)
         return original_dispatch(conn, **kwargs)
 
-    monkeypatch.setattr(kb, "dispatch_once", capture_dispatch)
+    monkeypatch.setattr(endpoint_kb, "dispatch_once", capture_dispatch)
     r = client.post("/api/plugins/kanban/dispatch?dry_run=true&max=4")
     assert r.status_code == 200
     body = r.json()

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -94,6 +94,7 @@ def test_create_task_appears_on_board(client):
             "assignee": "researcher",
             "priority": 3,
             "tenant": "acme",
+            "metadata": {"agentplane": {"task_id": "20260817-ABC"}},
         },
     )
     assert r.status_code == 200, r.text
@@ -103,6 +104,7 @@ def test_create_task_appears_on_board(client):
     assert task["status"] == "ready"  # no parents -> immediately ready
     assert task["priority"] == 3
     assert task["tenant"] == "acme"
+    assert task["metadata"] == {"agentplane": {"task_id": "20260817-ABC"}}
     task_id = task["id"]
 
     # Board now lists it under 'ready'.
@@ -503,16 +505,35 @@ def test_add_comment(client):
 # ---------------------------------------------------------------------------
 
 
-def test_dispatch_dry_run(client):
+def test_dispatch_dry_run(client, monkeypatch):
+    from hermes_cli import plugins as plugins_mod
+
     client.post(
         "/api/plugins/kanban/tasks",
         json={"title": "work", "assignee": "researcher"},
     )
+    lane_spawn = lambda *_args, **_kwargs: None
+    lane_predicate = lambda _assignee: True
+    monkeypatch.setattr(
+        plugins_mod,
+        "build_worker_lane_dispatch",
+        lambda: (lane_spawn, lane_predicate),
+    )
+    original_dispatch = kb.dispatch_once
+    captured = {}
+
+    def capture_dispatch(conn, **kwargs):
+        captured.update(kwargs)
+        return original_dispatch(conn, **kwargs)
+
+    monkeypatch.setattr(kb, "dispatch_once", capture_dispatch)
     r = client.post("/api/plugins/kanban/dispatch?dry_run=true&max=4")
     assert r.status_code == 200
     body = r.json()
     # DispatchResult is serialized as a dataclass dict.
     assert isinstance(body, dict)
+    assert captured["spawn_fn"] is lane_spawn
+    assert captured["spawnable_assignee_fn"] is lane_predicate
 
 
 # ---------------------------------------------------------------------------
@@ -1228,5 +1249,3 @@ def test_specify_happy_path(client, monkeypatch):
 # ---------------------------------------------------------------------------
 # Final result visibility for Done cards
 # ---------------------------------------------------------------------------
-
-

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -401,6 +401,7 @@ def test_create_happy_path(worker_env):
         "title": "child task",
         "assignee": "peer",
         "parents": [worker_env],
+        "metadata": {"agentplane": {"task_id": "20260817-ABC"}},
     })
     d = json.loads(out)
     assert d["ok"] is True
@@ -412,6 +413,7 @@ def test_create_happy_path(worker_env):
         child = kb.get_task(conn, d["task_id"])
         assert child.title == "child task"
         assert child.assignee == "peer"
+        assert child.metadata == {"agentplane": {"task_id": "20260817-ABC"}}
     finally:
         conn.close()
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1359,6 +1359,11 @@ def _handle_create(args: dict, **kw) -> str:
             "task (the dispatcher will only spawn tasks with an assignee)"
         )
     body = args.get("body")
+    metadata = args.get("metadata")
+    if metadata is not None and not isinstance(metadata, dict):
+        return tool_error(
+            f"metadata must be an object/dict, got {type(metadata).__name__}"
+        )
     parents = args.get("parents") or []
     tenant = args.get("tenant") or os.environ.get("HERMES_TENANT")
     # Stamp the originating session id when the agent loop runs under
@@ -1461,6 +1466,7 @@ def _handle_create(args: dict, **kw) -> str:
                 initial_status=str(initial_status),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
                 session_id=session_id,
+                metadata=metadata,
             )
             new_task = kb.get_task(conn, new_tid)
             subscribed = _maybe_auto_subscribe(conn, new_tid)
@@ -2162,6 +2168,15 @@ KANBAN_CREATE_SCHEMA = {
                     "links. The assigned worker reads this as part of "
                     "its context."
                 ),
+            },
+            "metadata": {
+                "type": "object",
+                "description": (
+                    "Stable machine-readable task context for worker integrations. "
+                    "Do not include secrets. Example: "
+                    "{'agentplane': {'task_id': '20260817-ABC'}}."
+                ),
+                "additionalProperties": True,
             },
             "parents": {
                 "type": "array",

--- a/website/docs/user-guide/features/kanban-worker-lanes.md
+++ b/website/docs/user-guide/features/kanban-worker-lanes.md
@@ -26,7 +26,7 @@ To be a kanban worker lane, an integration must provide three things:
 
 ### 1. An assignee string
 
-The dispatcher matches `task.assignee` against either a Hermes profile name (the default lane shape) or a registered non-spawnable identifier (the plugin lane shape — see [Adding an external CLI worker lane](#adding-an-external-cli-worker-lane) below). Tasks whose assignee doesn't resolve are left on `ready` with a `skipped_nonspawnable` event so a board operator can fix them; they are not silently dropped or executed by an arbitrary fallback.
+The dispatcher matches `task.assignee` against either a Hermes profile name (the default lane shape) or a plugin-registered worker lane (see [Adding an external CLI worker lane](#adding-an-external-cli-worker-lane) below). Tasks whose assignee doesn't resolve are left on `ready` with a `skipped_nonspawnable` event so a board operator can fix them; they are not silently dropped or executed by an arbitrary fallback.
 
 ### 2. A spawn mechanism
 
@@ -44,7 +44,7 @@ For Hermes profile lanes, the dispatcher's `_default_spawn` runs `hermes -p <ass
 | `HERMES_PROFILE` | the worker's own profile name (for `kanban_comment` author attribution) |
 | `HERMES_TENANT` | tenant namespace, if the task has one |
 
-For non-Hermes lanes (registered via a plugin), the plugin supplies its own `spawn_fn` callable that gets `task`, `workspace`, and `board` and returns an optional pid for crash detection.
+For non-Hermes lanes, a plugin registers an assignee pattern and supplies its own `spawn_fn`. The callback receives the claimed `task` object, resolved `workspace`, and `board`, and returns an optional pid for crash detection. The task object includes the canonical task id plus the current run and claim context; the plugin does not query or mutate the Kanban database directly.
 
 ### 3. A lifecycle terminator
 
@@ -93,9 +93,31 @@ A specialisation of the profile lane: an orchestrator is a Hermes profile whose 
 
 ## Adding an external CLI worker lane
 
-Wiring a non-Hermes CLI tool (Codex CLI, Claude Code CLI, OpenCode CLI, a local coding-model runner, etc.) as a kanban worker lane is *not yet a paved path*. The dispatcher's spawn function is pluggable (`spawn_fn` is a parameter on `dispatch_once`), and a plugin could register its own `spawn_fn` for a non-Hermes assignee, but the surrounding integration work — wrapping the CLI's exit code into `kanban_complete` / `kanban_block` calls, mapping the CLI's workspace/sandbox conventions onto the dispatcher's `HERMES_KANBAN_WORKSPACE` env, handling auth and per-CLI policy — is still per-integration design work.
+Plugins can add a non-Hermes lane without patching the dispatcher:
 
-If you're considering adding a CLI lane, open an issue describing the specific CLI and the workflow you're trying to enable. The contract above is the constraints any such lane must satisfy; the implementation shape (one plugin per CLI vs a generic CLI-runner plugin parameterised by config) is open.
+```python
+def register(ctx):
+    ctx.register_worker_lane(
+        match="my-runner-*",
+        spawn_fn=spawn_my_runner,
+    )
+```
+
+`match` accepts an exact assignee or a shell-style glob. The same resolver is used by CLI dispatch, dashboard dispatch, the gateway dispatcher, dry-run, and readiness telemetry. Hermes still owns the claim, run record, retry policy, concurrency caps, crash detection, timeout, and final Kanban state. The plugin owns only process creation for matching tasks and must return a pid when crash detection should track the child.
+
+Integration identifiers belong in stable task metadata, not in prose or an overloaded Hermes card id:
+
+```bash
+hermes kanban create "Execute AgentPlane task" \
+  --assignee agentplane-executor \
+  --metadata '{"agentplane":{"task_id":"20260817-ABC"}}'
+```
+
+The same `metadata` object is accepted by `kanban_create` and the dashboard task API and is exposed on the claimed `Task` passed to `spawn_fn`.
+
+The external worker must eventually terminate the current run through the public Kanban lifecycle API. Integrations may wrap Codex CLI, Claude Code CLI, OpenCode CLI, a local model runner, or a control-plane supervisor, but they must map their result into `kanban_complete`, `kanban_request_review`, or `kanban_block` and preserve the supplied task/run/claim identity. Authentication, sandbox policy, and environment forwarding remain integration-specific.
+
+Lane registration deliberately has no `profile_exists` option. A plugin lane is spawnable because its registered pattern resolves; Hermes profile existence remains an internal native-lane concern.
 
 The historical issue for this is [#19931](https://github.com/NousResearch/hermes-agent/issues/19931) and the closed-not-merged Codex-specific PR [#19924](https://github.com/NousResearch/hermes-agent/pull/19924) — those describe the original architecture proposal but didn't land a runner.
 


### PR DESCRIPTION
## Summary

- add a generic `register_worker_lane(match, spawn_fn)` plugin extension point
- route CLI, gateway, dashboard, readiness, and dry-run dispatch through one worker-lane resolver
- persist stable task metadata so external task IDs survive create, claim, run, and workspace flows
- preserve the native profile lane and keep AgentPlane-specific behavior outside Hermes core
- isolate the dashboard dispatch regression test from module reload order

Hermes still performs every LLM semantic episode. External controllers such as AgentPlane own only formal lifecycle, authority, evidence, and state transitions through the standalone plugin.

This supersedes #37659 with a narrower generic interface and a protocol-v2 bridge. It also replaces #88346 solely to move the head branch to the `basilisk-labs` organization fork; the code head remains commit `fd3b69bc51c2c8e65d1e2f42b45ade884bf4709f`.

Companion changes:
- AgentPlane: https://github.com/basilisk-labs/agentplane/pull/4837
- Signed approval-receipt authority: https://github.com/basilisk-labs/agentplane/pull/4840
- Standalone plugin v0.2.2: https://github.com/basilisk-labs/agentplane-hermes-plugin/releases/tag/v0.2.2
- Design discussion: #36079

## Verification

- original focused suite: 197 passed, one Windows-only test skipped on macOS
- combined reload-order regression suite: 145 passed
- Ruff and compile checks pass
- cross-repository worker-lane contract passes
- real AgentPlane 0.7.6 signed plan-receipt E2E reaches an approved plan with audited actor `USER:denis@hermes-dialog`
- the approval signing key is kept out of Hermes worker and LLM subprocesses
- installed plugin v0.2.2 passes runtime discovery, manifest parsing, import, and registration
- fully configured host doctors report `ok=true`, protocol `agentplane.hermes.plugin.v2`, native worker lane registered, and approval receipt bridge ready
