### PR TITLE
fix(desktop): force-redial half-open gateways after wake

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -23,6 +23,7 @@ import { useGatewayBoot } from './use-gateway-boot'
 
 type Listener = (ev: unknown) => void
 let connectionApplied: null | (() => void) = null
+let powerResume: null | (() => void) = null
 
 // Minimal WebSocket stand-in implementing only what json-rpc-gateway.connect()
 // touches: readyState, add/removeEventListener('open'|'error'|'close'), close().
@@ -122,7 +123,13 @@ function fakeDesktop() {
         connectionApplied = null
       }
     }),
-    onPowerResume: vi.fn(() => () => undefined),
+    onPowerResume: vi.fn(callback => {
+      powerResume = callback
+
+      return () => {
+        powerResume = null
+      }
+    }),
     revalidateConnection: vi.fn(async () => ({ ok: true, rebuilt: false })),
     onWindowStateChanged: vi.fn(() => () => undefined),
     touchBackend: vi.fn(async () => undefined),
@@ -168,6 +175,7 @@ beforeEach(() => {
   FakeWebSocket.mode = 'open'
   FakeWebSocket.instances = []
   connectionApplied = null
+  powerResume = null
   ;(globalThis as { WebSocket: unknown }).WebSocket = FakeWebSocket
   ;(window as { hermesDesktop?: unknown }).hermesDesktop = fakeDesktop()
   $gatewayState.set('idle')
@@ -419,6 +427,32 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     const lastCall = desktop.getConnection.mock.calls.at(-1) ?? []
     expect(lastCall.length === 0 || lastCall[0] == null || lastCall[0] === '').toBe(true)
     expect(desktop.getGatewayWsUrl).toHaveBeenCalledTimes(2)
+    expect(FakeWebSocket.instances).toHaveLength(2)
+    expect($gatewayState.get()).toBe('open')
+  })
+
+  it('power resume force-redials a half-open primary socket that still reports OPEN', async () => {
+    const desktop = fakeDesktop()
+
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+
+    const staleSocket = FakeWebSocket.instances[0]
+
+    expect(staleSocket.readyState).toBe(FakeWebSocket.OPEN)
+    expect($gatewayState.get()).toBe('open')
+    expect(powerResume).not.toBeNull()
+
+    // macOS can discard the TCP connection during sleep without updating the
+    // renderer WebSocket object. Leave readyState OPEN and emit only resume.
+    act(() => powerResume?.())
+    await flushAsync()
+    await flushAsync()
+
+    expect(staleSocket.readyState).toBe(FakeWebSocket.CLOSED)
+    expect(desktop.revalidateConnection).toHaveBeenCalledOnce()
     expect(FakeWebSocket.instances).toHaveLength(2)
     expect($gatewayState.get()).toBe('open')
   })

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -299,7 +299,7 @@ export function useGatewayBoot({
       }, delay)
     }
 
-    const reconnectNow = async () => {
+    const reconnectNow = async ({ forceOpenSocket = false }: { forceOpenSocket?: boolean } = {}) => {
       if (cancelled || !bootCompleted || $gatewaySwitching.get()) {
         return
       }
@@ -308,7 +308,17 @@ export function useGatewayBoot({
       reconnectAttempt = 0
       reconnectFailingSince = null
       escalated = false
-      reconnectSecondaryGateways()
+      reconnectSecondaryGateways({ forceOpenSockets: forceOpenSocket })
+
+      // Browser WebSocket state can remain OPEN after sleep even though the OS
+      // discarded the underlying TCP connection. Strong recovery signals must
+      // retire that half-open socket before the normal reconnect path can run.
+      if (forceOpenSocket && gatewayOpen()) {
+        gateway.close()
+        // close() publishes `closed`, which schedules the regular backoff.
+        // This path reconnects immediately, so remove that redundant timer.
+        clearReconnectTimer()
+      }
 
       if (!gatewayOpen()) {
         await attemptReconnect()
@@ -545,9 +555,10 @@ export function useGatewayBoot({
 
     // Wake signals: power resume (macOS/Windows), network coming back, and the
     // window regaining focus/visibility. Each nudges an immediate reconnect.
-    const offPowerResume = desktop.onPowerResume?.(() => void reconnectNow())
+    const forceReconnectNow = () => reconnectNow({ forceOpenSocket: true })
+    const offPowerResume = desktop.onPowerResume?.(() => void forceReconnectNow())
     const offConnectionApplied = desktop.onConnectionApplied?.(() => void softSwitch())
-    const offGatewayReconnect = registerGatewayReconnect(reconnectNow)
+    const offGatewayReconnect = registerGatewayReconnect(forceReconnectNow)
 
     // Registry lifecycle: a removed connection's secondaries must close NOW
     // (remote/cloud have no local process whose death would drop the socket —
@@ -561,7 +572,7 @@ export function useGatewayBoot({
       disposeSecondariesForConnection(payload.connectionId, { redial: payload.reason === 'updated' })
     })
 
-    const onOnline = () => void reconnectNow()
+    const onOnline = () => void forceReconnectNow()
 
     const onVisible = () => {
       if (document.visibilityState === 'visible') {

--- a/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
+++ b/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
@@ -218,6 +218,29 @@ describe('retireLocalProfileGateways', () => {
   })
 })
 
+describe('reconnectSecondaryGateways', () => {
+  it('force-redials an open secondary whose transport may be half-open after wake', async () => {
+    const getConnectionFor = vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) =>
+      descriptorFor(connectionId, profile)
+    )
+
+    installDesktop({ getConnectionFor })
+
+    await ensureGatewayForAgent('homelab', 'default')
+    expect(gatewayMocks.connect).toHaveBeenCalledTimes(1)
+    expect(gatewayMocks.instances[0].connectionState).toBe('open')
+
+    reconnectSecondaryGateways({ forceOpenSockets: true })
+
+    await vi.waitFor(() => {
+      expect(gatewayMocks.connect).toHaveBeenCalledTimes(2)
+    })
+    expect(gatewayMocks.instances[0].close).toHaveBeenCalledOnce()
+    expect(getConnectionFor).toHaveBeenCalledTimes(2)
+    expect(gatewayMocks.instances[0].connectionState).toBe('open')
+  })
+})
+
 describe('reconnect fail-stop on a removed connection', () => {
   it('evicts the entry instead of retrying when the registry no longer knows the id', async () => {
     const getConnectionFor = vi

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -836,11 +836,20 @@ export async function ensureActiveGatewayOpen(): Promise<HermesGateway | null> {
 // activation before reporting the gateway as unavailable.
 const ACTIVE_GATEWAY_OPEN_WAIT_MS = 8_000
 
-// Wake signal (sleep/network/visibility): nudge every live secondary back open.
-export function reconnectSecondaryGateways(): void {
+// Recovery signal: nudge every live secondary back open. Power-resume/network
+// signals can force sockets that still report open to retire before redialing.
+export function reconnectSecondaryGateways({ forceOpenSockets = false }: { forceOpenSockets?: boolean } = {}): void {
   for (const entry of g.secondaries.values()) {
-    if (!entry.wantOpen || isOpen(entry.gateway)) {
+    if (!entry.wantOpen) {
       continue
+    }
+
+    if (isOpen(entry.gateway)) {
+      if (!forceOpenSockets) {
+        continue
+      }
+
+      entry.gateway.close()
     }
 
     entry.reconnectAttempt = 0


### PR DESCRIPTION
## What does this PR do?

Hermes Desktop already listens for power-resume, browser-online, and manual reconnect signals, but reconnectNow() skips all work while gateway.connectionState is open. macOS can leave that state stale after sleep even when the underlying TCP connection is gone, so prompts are sent into a half-open socket and the window never recovers.

Treat strong recovery signals as transport invalidation:

- power resume, network online, and the manual Reconnect command close an apparently-open primary socket before running the existing reconnect path
- the same forced sweep applies to retained secondary gateways
- ordinary visibilitychange remains non-forcing, so switching windows does not tear down a healthy connection
- reconnect still flows through the existing backend revalidation, WebSocket URL re-minting, state refresh, and retry/backoff logic

This stays at the Desktop orchestration boundary. Browser WebSocket does not expose native ping frames and the gateway has no JSON-RPC ping contract, so adding a timer here would require a new protocol surface for a case where the OS/browser already provides explicit recovery signals.

This is complementary to #90012: that PR adds capability-gated heartbeat detection when paired with #89958, while this PR keeps power-resume, browser-online, and manual recovery working against older backends that advertise no heartbeat capability.

## Related Issue

Fixes #89083

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Update apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts so strong recovery signals can retire an open primary socket and immediately redial it.
- Extend reconnectSecondaryGateways() with an opt-in forced mode for half-open retained secondaries.
- Add primary and secondary regressions that leave the socket state open, emit only the recovery action, and verify close plus re-dial.

## How to Test

1. Open Hermes Desktop on macOS and verify chat works.
2. Sleep and wake the Mac, then send from the same window.
3. Confirm the existing socket is replaced and chat reconnects without reload.
4. Run:
   npm run --prefix apps/desktop test:ui
   npm run --prefix apps/desktop typecheck
   npm run --prefix apps/desktop lint
   npx prettier --check on the four changed TypeScript files.

Local results after rebasing onto current main: 539 UI test files / 5,035 tests passed; typecheck passed; ESLint passed with zero errors; formatting passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run pytest tests/ -q (N/A: Desktop TypeScript-only change)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.3.2, Node 22.22.2

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing configuration or command changes
- [x] cli-config.yaml.example: N/A; no config keys changed
- [x] CONTRIBUTING.md / AGENTS.md: N/A; no contributor workflow changed
- [x] Cross-platform impact considered: power resume is Electron-provided on macOS/Windows; browser online is platform-neutral
- [x] Tool descriptions/schemas: N/A; no tool behavior changed

## Screenshots / Logs

No visual UI change. The regression tests exercise the stale-open transport state directly.