### PR TITLE
fix(secrets): defer unknown source warning during early bootstrap (#89078)

### DIFF
--- a/agent/secret_sources/registry.py
+++ b/agent/secret_sources/registry.py
@@ -163,6 +163,11 @@ def register_source(
         target[name] = source
         if scope is None:
             _SOURCE_ORIGINS[name] = "builtin" if builtin else "plugin"
+    # A name parked as "unknown" during bootstrap is resolved the moment its
+    # plugin registers — the #89078 case. Drop it so the post-discovery
+    # report only names sources that never arrived.
+    with _pending_unknown_lock:
+        _pending_unknown_sources.discard(name)
     return True
 
 
@@ -280,7 +285,10 @@ def _reset_registry_for_tests() -> None:
         _SOURCE_ORIGINS.clear()
         _SCOPED_SOURCES.clear()
         _BUILTINS_LOADED = False
-
+    # Parked unknown-source names are process-global; leaving them behind
+    # leaks one test's misconfiguration into the next one's report.
+    with _pending_unknown_lock:
+        _pending_unknown_sources.clear()
 
 # ---------------------------------------------------------------------------
 # Orchestrated apply
@@ -340,6 +348,40 @@ def _fetch_with_timeout(
         res.error_kind = ErrorKind.INTERNAL
         return res
     return result
+
+
+# Names from ``secrets.sources`` that were unknown during early bootstrap.
+# Not yet a diagnosis: a plugin-provided source registers later in the same
+# process. Discharged by register_source(), reported by
+# warn_unresolved_source_names() once plugin discovery has run.
+_pending_unknown_sources: set = set()
+_pending_unknown_lock = threading.Lock()
+
+
+def warn_unresolved_source_names(*, scope: Optional[str] = None) -> List[str]:
+    """Warn about ``secrets.sources`` names still unknown after discovery.
+
+    The bootstrap pass parks unknown names instead of warning, because
+    plugins have not registered yet at that point (#89078). Call this once
+    plugin discovery is complete: anything still missing from ``_SOURCES``
+    is a real misconfiguration — a typo, or a plugin that is disabled or
+    failed to load — which is exactly the case #89078 asked to keep warning
+    about. Returns the names reported, and clears the pending set so a
+    second call is silent.
+    """
+    with _pending_unknown_lock:
+        pending = sorted(_pending_unknown_sources)
+        _pending_unknown_sources.clear()
+    # Same effective set the resolver uses, so a scope-registered plugin
+    # source is not reported as missing just because it is not global.
+    known = {source.name for source in list_sources(scope=scope)}
+    still_unknown = [n for n in pending if n not in known]
+    if still_unknown:
+        logger.warning(
+            "secrets.sources names unknown source(s): %s (known: %s)",
+            ", ".join(still_unknown), ", ".join(sorted(known)) or "none",
+        )
+    return still_unknown
 
 
 def _ordered_enabled_sources(

--- a/agent/secret_sources/registry.py
+++ b/agent/secret_sources/registry.py
@@ -343,7 +343,10 @@ def _fetch_with_timeout(
 
 
 def _ordered_enabled_sources(
-    secrets_cfg: dict, *, scope: Optional[str] = None
+    secrets_cfg: dict,
+    *,
+    scope: Optional[str] = None,
+    warn_unknown: bool = True,
 ) -> List[SecretSource]:
     """Resolve which sources run, in which order.
 
@@ -363,10 +366,19 @@ def _ordered_enabled_sources(
         unknown = [e for e in explicit
                    if isinstance(e, str) and e not in sources]
         if unknown:
-            logger.warning(
-                "secrets.sources names unknown source(s): %s (known: %s)",
-                ", ".join(unknown), ", ".join(sources) or "none",
-            )
+            if warn_unknown:
+                logger.warning(
+                    "secrets.sources names unknown source(s): %s (known: %s)",
+                    ", ".join(unknown), ", ".join(sources) or "none",
+                )
+            else:
+                # Bootstrap runs before plugins register their sources
+                # (#89078), so "unknown" here is not yet a verdict. Park the
+                # names; register_source() discharges the ones a plugin
+                # supplies, and warn_unresolved_source_names() reports
+                # whatever is still unknown once discovery is done.
+                with _pending_unknown_lock:
+                    _pending_unknown_sources.update(unknown)
     for name in sources:
         if name not in order:
             order.append(name)
@@ -423,7 +435,8 @@ def _profile_alias_target(var: str, profile: str) -> Optional[str]:
 
 
 def apply_all(secrets_cfg: dict, home_path: Path,
-              environ: Optional[MutableMapping[str, str]] = None) -> ApplyReport:
+              environ: Optional[MutableMapping[str, str]] = None,
+              *, warn_unknown: bool = True) -> ApplyReport:
     """Fetch from every enabled source and apply the merged result to env.
 
     ``environ`` defaults to ``os.environ``; injectable for tests.
@@ -456,7 +469,7 @@ def apply_all(secrets_cfg: dict, home_path: Path,
 
     secrets_cfg = secrets_cfg if isinstance(secrets_cfg, dict) else {}
     enabled = _ordered_enabled_sources(
-        secrets_cfg, scope=hermes_home_key(home_path)
+        secrets_cfg, scope=hermes_home_key(home_path), warn_unknown=warn_unknown
     )
     if not enabled:
         return report

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -218,7 +218,7 @@ def _hydrate_profile_secret_sources(home: Path) -> dict[str, str]:
             for _name, _value in load_env_file(op_env).items():
                 local_env.setdefault(_name, _value)
         local_env["HERMES_HOME"] = str(home)
-        report = apply_all(cfg, home, environ=local_env)
+        report = apply_all(cfg, home, environ=local_env, warn_unknown=False)
     except Exception:  # noqa: BLE001 — preserve fail-open startup behavior
         return {}
 
@@ -678,7 +678,7 @@ def _apply_external_secret_sources(home_path: Path) -> None:
         return
 
     try:
-        report = apply_all(cfg, home_path)
+        report = apply_all(cfg, home_path, warn_unknown=False)
     except Exception:  # noqa: BLE001 — belt-and-braces; apply_all shouldn't raise
         return
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -5708,6 +5708,15 @@ def discover_plugins(force: bool = False) -> None:
     """
     _join_background_discovery()
     get_plugin_manager().discover_and_load(force=force)
+    # Plugin secret sources are registered by now, so a ``secrets.sources``
+    # name still missing from the registry is genuinely unknown rather than
+    # merely early (#89078). Never let reporting break discovery.
+    try:
+        from agent.secret_sources.registry import warn_unresolved_source_names
+
+        warn_unresolved_source_names()
+    except Exception:  # noqa: BLE001
+        logger.debug("Deferred secret-source warning failed", exc_info=True)
 
 
 _background_discovery_thread: Optional[threading.Thread] = None

--- a/tests/gateway/test_multiplex_credential_isolation.py
+++ b/tests/gateway/test_multiplex_credential_isolation.py
@@ -122,10 +122,15 @@ def test_cold_profile_hydrates_external_source_without_global_env(
 
     calls = {"count": 0}
 
-    def _fake_apply_all(_cfg, _home, *, environ=None):
+    def _fake_apply_all(_cfg, _home, *, environ=None, warn_unknown=True):
         calls["count"] += 1
         assert environ is not os.environ
         assert environ is not None
+        # Bootstrap defers the unknown-source diagnosis until plugins have
+        # registered (#89078). Mirrored here because env_loader swallows a
+        # TypeError from this fake as a fail-open empty result, so a
+        # signature drift would look like "no secrets" rather than an error.
+        assert warn_unknown is False
         assert environ["EXPLICIT_API_KEY"] == "dotenv-wins"
         environ["TEST_PROVIDER_API_KEY"] = "profile-only"
         return ApplyReport(

--- a/tests/secret_sources/test_secret_source_registry.py
+++ b/tests/secret_sources/test_secret_source_registry.py
@@ -213,6 +213,59 @@ class TestApplyAll:
         assert sources[0].name == "dummy"
         assert not any("secrets.sources names unknown source(s)" in r.message for r in caplog.records)
 
+    def test_suppressed_warning_is_parked_not_dropped(self, caplog):
+        """warn_unknown=False defers the diagnosis; it must not delete it."""
+        import logging
+        reg.register_source(_make_source(name="dummy"))
+        cfg = {"sources": ["passward", "dummy"], "dummy": {"enabled": True}}
+
+        reg._ordered_enabled_sources(cfg, warn_unknown=False)
+
+        with caplog.at_level(logging.WARNING, logger="agent.secret_sources.registry"):
+            reported = reg.warn_unresolved_source_names()
+
+        assert reported == ["passward"], (
+            "a misspelled secrets.sources entry produced no diagnostic at any "
+            "point — the user's source silently does nothing"
+        )
+        assert any(
+            "unknown source(s): passward" in r.message for r in caplog.records
+        )
+
+    def test_a_late_registering_plugin_source_is_never_warned_about(self, caplog):
+        """#89078 itself: the name is unknown at bootstrap, known by discovery."""
+        import logging
+        cfg = {"sources": ["passbolt"], "passbolt": {"enabled": True}}
+        reg._ordered_enabled_sources(cfg, warn_unknown=False)
+
+        # ...the plugin loads and registers its source.
+        reg.register_source(_make_source(name="passbolt"))
+
+        with caplog.at_level(logging.WARNING, logger="agent.secret_sources.registry"):
+            reported = reg.warn_unresolved_source_names()
+
+        assert reported == []
+        assert not any(
+            "unknown source(s)" in r.message for r in caplog.records
+        ), "warned about a source the plugin did register"
+
+    def test_the_deferred_report_fires_once(self, caplog):
+        import logging
+        reg._ordered_enabled_sources({"sources": ["nope"]}, warn_unknown=False)
+        assert reg.warn_unresolved_source_names() == ["nope"]
+
+        caplog.clear()  # the first report is expected; only the second matters
+        with caplog.at_level(logging.WARNING, logger="agent.secret_sources.registry"):
+            assert reg.warn_unresolved_source_names() == []
+        assert not any("unknown source(s)" in r.message for r in caplog.records)
+
+    def test_repeated_bootstrap_passes_collapse_to_one_report(self):
+        """Both apply_all call sites run early; the user sees one line."""
+        cfg = {"sources": ["nope", "alsonope"]}
+        for _ in range(3):
+            reg._ordered_enabled_sources(cfg, warn_unknown=False)
+        assert reg.warn_unresolved_source_names() == ["alsonope", "nope"]
+
     def test_apply_all_forwards_warn_unknown_flag(self, tmp_path, caplog):
         import logging
         reg.register_source(_make_source(name="dummy", secrets={"K": "v"}))

--- a/tests/secret_sources/test_secret_source_registry.py
+++ b/tests/secret_sources/test_secret_source_registry.py
@@ -193,6 +193,35 @@ class TestApplyAll:
             report = reg.apply_all(cfg, tmp_path, environ={})
             assert isinstance(report, reg.ApplyReport)
 
+    def test_ordered_enabled_sources_warns_on_unknown_by_default(self, caplog):
+        import logging
+        reg.register_source(_make_source(name="dummy"))
+        cfg = {"sources": ["passbolt", "dummy"], "dummy": {"enabled": True}}
+        with caplog.at_level(logging.WARNING, logger="agent.secret_sources.registry"):
+            sources = reg._ordered_enabled_sources(cfg)
+        assert len(sources) == 1
+        assert sources[0].name == "dummy"
+        assert any("secrets.sources names unknown source(s): passbolt" in r.message for r in caplog.records)
+
+    def test_ordered_enabled_sources_suppresses_warning_when_warn_unknown_false(self, caplog):
+        import logging
+        reg.register_source(_make_source(name="dummy"))
+        cfg = {"sources": ["passbolt", "dummy"], "dummy": {"enabled": True}}
+        with caplog.at_level(logging.WARNING, logger="agent.secret_sources.registry"):
+            sources = reg._ordered_enabled_sources(cfg, warn_unknown=False)
+        assert len(sources) == 1
+        assert sources[0].name == "dummy"
+        assert not any("secrets.sources names unknown source(s)" in r.message for r in caplog.records)
+
+    def test_apply_all_forwards_warn_unknown_flag(self, tmp_path, caplog):
+        import logging
+        reg.register_source(_make_source(name="dummy", secrets={"K": "v"}))
+        cfg = {"sources": ["passbolt", "dummy"], "dummy": {"enabled": True}}
+        with caplog.at_level(logging.WARNING, logger="agent.secret_sources.registry"):
+            report = reg.apply_all(cfg, tmp_path, environ={}, warn_unknown=False)
+        assert report.applied_any
+        assert not any("secrets.sources names unknown source(s)" in r.message for r in caplog.records)
+
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -198,7 +198,7 @@ def test_cold_profile_hydration_seeds_op_env_bootstrap(tmp_path, monkeypatch):
 
     seen_env = {}
 
-    def _capture_apply_all(_cfg, home_path, environ=None):
+    def _capture_apply_all(_cfg, home_path, environ=None, *args, **kwargs):
         from agent.secret_sources.registry import ApplyReport
         seen_env.update(environ or {})
         return ApplyReport(sources=[], provenance={})
@@ -233,7 +233,7 @@ def test_cold_profile_hydration_dotenv_wins_over_op_env(tmp_path, monkeypatch):
 
     seen_env = {}
 
-    def _capture_apply_all(_cfg, home_path, environ=None):
+    def _capture_apply_all(_cfg, home_path, environ=None, *args, **kwargs):
         from agent.secret_sources.registry import ApplyReport
         seen_env.update(environ or {})
         return ApplyReport(sources=[], provenance={})
@@ -386,7 +386,7 @@ def test_external_secret_values_are_isolated_between_homes(tmp_path, monkeypatch
         str(home_b.resolve()): "value-b",
     }
 
-    def _fake_apply_all(_cfg, home_path):
+    def _fake_apply_all(_cfg, home_path, *args, **kwargs):
         value = values[str(Path(home_path).resolve())]
         monkeypatch.setenv("SHARED_API_KEY", value)
         return ApplyReport(


### PR DESCRIPTION
## Summary
Fixes #89078.

When a third-party plugin provides a custom secret source (e.g. `passbolt`) and the user lists it in `secrets.sources`, Hermes emitted a premature `secrets.sources names unknown source(s): passbolt` warning during early `load_hermes_dotenv()` bootstrap before plugins had discovered and registered their secret sources.

## Changes
- Add `warn_unknown: bool = True` parameter to `_ordered_enabled_sources()` and `apply_all()` in `agent/secret_sources/registry.py`.
- Pass `warn_unknown=False` during early `_apply_external_secret_sources()` bootstrap and `_hydrate_profile_secret_sources()` in `hermes_cli/env_loader.py`.
- Add unit tests in `tests/secret_sources/test_secret_source_registry.py` verifying that:
  - Unknown sources warn by default (`warn_unknown=True`).
  - Warnings are suppressed when `warn_unknown=False`.
  - `apply_all` forwards the `warn_unknown` flag.

## Verification
- `pytest tests/secret_sources/ tests/test_env_loader_secret_sources.py` passed (52/52 tests).
- `git diff --check` passed cleanly.
- Python compilation verified without issues.