### PR TITLE
fix(desktop): raise the manual /compress RPC budget from 120s to 600s

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -650,7 +650,7 @@ describe('usePromptActions /compress', () => {
     expect(requestGateway).toHaveBeenCalledWith(
       'session.compress',
       expect.objectContaining({ session_id: RUNTIME_SESSION_ID }),
-      120_000
+      600_000
     )
     expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
     expect(requestGateway).not.toHaveBeenCalledWith('command.dispatch', expect.anything())
@@ -784,7 +784,7 @@ describe('usePromptActions /compress', () => {
     expect(requestGateway).toHaveBeenCalledWith(
       'session.compress',
       expect.objectContaining({ focus_topic: 'the auth refactor' }),
-      120_000
+      600_000
     )
   })
 
@@ -891,7 +891,7 @@ describe('usePromptActions /compress', () => {
     act(() => {
       submitted = handle!.submitTextRaw('/compress')
     })
-    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('session.compress', expect.anything(), 120_000))
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('session.compress', expect.anything(), 600_000))
 
     // Switch to session B before compression resolves.
     activeSessionIdRef.current = RUNTIME_SESSION_B
@@ -950,7 +950,7 @@ describe('usePromptActions /compress', () => {
     act(() => {
       submitted = handle!.submitTextRaw('/compress')
     })
-    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('session.compress', expect.anything(), 120_000))
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('session.compress', expect.anything(), 600_000))
     activeSessionIdRef.current = RUNTIME_SESSION_B
     storedSessionIdRef.current = 'stored-b'
     rejectCompress(new Error('compression failed'))

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -68,9 +68,14 @@ import {
 } from './utils'
 
 // Manual compression is LLM-bound and routinely outlives the desktop's 30s
-// default WS request timeout on large sessions — give it the TUI client's
-// 120s RPC budget (HERMES_TUI_RPC_TIMEOUT_MS default) instead.
-const SESSION_COMPRESS_TIMEOUT_MS = 120_000
+// default WS request timeout on large sessions. It is ONE summarisation call
+// over the whole session and exceeds 2 minutes on large histories or slow
+// providers; the server-side auxiliary compression timeout is floored at 300s
+// (_COMPRESSION_TIMEOUT_FLOOR_SECONDS), so a 120s client budget abandoned the
+// RPC while the server kept working (#83087 / #88988). Give it 600s — the
+// budget the issue prescribes — so the client waits out the server instead
+// of racing it.
+const SESSION_COMPRESS_TIMEOUT_MS = 600_000
 const WAKE_START_TIMEOUT_MS = 180_000
 
 const wakeDeviceLabel = (device?: WakeInputDeviceStatus): string => {


### PR DESCRIPTION
## Summary

Closes #83087 and completes the #88988 class: the `/compress` path had a fixed 120s budget on BOTH ends of the RPC.

- Server side (already fixed in #89024): the compute-host wait now scales with the compression budget.
- **Client side (this PR)**: `SESSION_COMPRESS_TIMEOUT_MS` was 120s while the server-side auxiliary compression timeout is floored at **300s** — the desktop abandoned the RPC while the server kept working. Raised to **600s**, the budget #83087 prescribes.

## Validation

- Test expectations updated to the 600s budget (both the plain and focus-topic compress call paths).
- Atomic commits: fix → tests.

## Related

- #89024 (server-side wait) — same class, other end of the RPC.
- #88988 (desktop /compress "timed out after 120s" while compression succeeded) — the symptom this class produced.
