### PR TITLE
feat(resume): add resume.restore_model config option to prefer config default on resume (#89084)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8592,9 +8592,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         kept so the session still opens (the first turn surfaces the auth
         error instead of the resume dying).
 
-        Skips when the session has no model recorded or when the CLI was
-        launched with an explicit ``-m`` override (user intent wins).
+        Skips when ``resume.restore_model`` is disabled in config.yaml, when the
+        session has no model recorded, or when the CLI was launched with an
+        explicit ``-m`` override (user intent wins).
         """
+        resume_cfg = CLI_CONFIG.get("resume", {})
+        if isinstance(resume_cfg, dict):
+            if not resume_cfg.get("restore_model", True):
+                return
+        elif resume_cfg is False:
+            return
+
         stored_model = (session_meta or {}).get("model")
         if not stored_model:
             return

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -42,6 +42,13 @@ DEFAULT_CONFIG = {
         # behavior everywhere.
         "terminal_continue": True,
     },
+    "resume": {
+        # When true (default), resuming a session (--resume, -c, /resume)
+        # restores the model that was active in that session unless an
+        # explicit --model flag was passed on the CLI. When false, resume
+        # leaves the current config.yaml default model active.
+        "restore_model": True,
+    },
     "agent": {
         "max_turns": 500,
         # Inactivity timeout for gateway agent execution (seconds).

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1180,6 +1180,10 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "type": "boolean",
         "description": "Run the local browser in headed mode (visible window). Also keeps the window open between turns; idle sessions are still reaped after browser.inactivity_timeout.",
     },
+    "resume.restore_model": {
+        "type": "boolean",
+        "description": "Restore the session-stored model on resume (--resume, -c, /resume) rather than falling back to the current config default model.",
+    },
 }
 
 # Categories with fewer fields get merged into "general" to avoid tab sprawl.
@@ -1231,6 +1235,9 @@ _CATEGORY_MERGE: Dict[str, str] = {
     # `session.terminal_continue` is the only schema-surfaced session field —
     # fold it into general rather than spawning a one-field orphan category.
     "session": "general",
+    # `resume.restore_model` (#89084) is the only schema-surfaced resume
+    # field — fold it into general rather than spawning a one-field orphan category.
+    "resume": "general",
 }
 
 # Display order for tabs — unlisted categories sort alphabetically after these.

--- a/tests/cli/test_resume_model_restore.py
+++ b/tests/cli/test_resume_model_restore.py
@@ -109,6 +109,30 @@ def test_restore_session_model_enabled_by_config_restores_model(monkeypatch):
     assert stub.model == "session-stored-model"
 
 
+@pytest.mark.parametrize(
+    "resume_cfg,expected",
+    [
+        ({"restore_model": False}, "config-default-model"),  # documented opt-out
+        ({"restore_model": True}, "session-stored-model"),   # documented opt-in
+        ({}, "session-stored-model"),                        # section present, key absent
+        (False, "config-default-model"),                     # bare `resume: false`
+        (True, "session-stored-model"),                      # bare `resume: true`
+        (None, "session-stored-model"),                      # bare `resume:` -> default
+    ],
+)
+def test_restore_session_model_config_shapes(monkeypatch, resume_cfg, expected):
+    """Pin every shape a user can write, including the scalar shorthands.
+
+    The scalar branch (`resume: false`) and the null case are easy to
+    "simplify" away, and only the dict shapes were covered — losing either
+    would silently change what a bare key does.
+    """
+    stub = _make_stub(model="config-default-model")
+    monkeypatch.setitem(cli_mod.CLI_CONFIG, "resume", resume_cfg)
+    stub._restore_session_model(_row(model="session-stored-model"))
+    assert stub.model == expected
+
+
 def test_restore_session_model_matching_state_is_silent_noop():
     notes = []
     stub = _make_stub(model="glm-4.7", provider="custom:feather",

--- a/tests/cli/test_resume_model_restore.py
+++ b/tests/cli/test_resume_model_restore.py
@@ -95,6 +95,20 @@ def test_restore_session_model_no_stored_model_is_noop():
     assert stub.model == "ambient-model"
 
 
+def test_restore_session_model_disabled_by_config_preserves_ambient_model(monkeypatch):
+    stub = _make_stub(model="config-default-model")
+    monkeypatch.setitem(cli_mod.CLI_CONFIG, "resume", {"restore_model": False})
+    stub._restore_session_model(_row(model="session-stored-model"))
+    assert stub.model == "config-default-model"
+
+
+def test_restore_session_model_enabled_by_config_restores_model(monkeypatch):
+    stub = _make_stub(model="config-default-model")
+    monkeypatch.setitem(cli_mod.CLI_CONFIG, "resume", {"restore_model": True})
+    stub._restore_session_model(_row(model="session-stored-model"))
+    assert stub.model == "session-stored-model"
+
+
 def test_restore_session_model_matching_state_is_silent_noop():
     notes = []
     stub = _make_stub(model="glm-4.7", provider="custom:feather",


### PR DESCRIPTION
## Summary
Fixes #89084.

Adds a configuration option `resume.restore_model` (boolean, default: `true` for backward compatibility) to allow users to control whether resuming a session (`--resume`, `-c`, or `/resume`) restores the model that was active in that session or falls back to the current `config.yaml` default model.

## Changes
- In `hermes_cli/config_defaults.py`: add `"resume": {"restore_model": True}` to `DEFAULT_CONFIG`.
- In `cli.py` (`_restore_session_model`): check `resume.restore_model` in `CLI_CONFIG` before restoring session model.
- In `tests/cli/test_resume_model_restore.py`: add test cases verifying:
  - `resume.restore_model: false` keeps the configured ambient default model.
  - `resume.restore_model: true` restores the stored session model.
  - An explicit CLI flag `-m`/`--model` continues to take precedence over both.

## Verification
- `pytest tests/cli/test_resume_model_restore.py tests/cli/test_cli_resume_command.py tests/hermes_cli/test_config.py` passed (112/112 tests).
- GPG signed and `git diff --check` clean.