### PR TITLE
feat(desktop): more expressive Bot Mode faces (moods, gaze drift, per-bot blink timing)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -1131,42 +1131,218 @@ function ringToPath(pts) {
   return d + 'Z'
 }
 
-/** Grok-style pose. thinking/working lean and sway. idle is a small sine. */
-function facePose(mood, t) {
-  if (mood === 'work') {
-    return {
-      turn: -11 + Math.sin(t * 0.48) * 8,
-      tilt: Math.sin(t * 0.42) * 8 + Math.sin(t * 1.1) * 1.6,
-      roll: Math.sin(t * 0.75) * 4.2,
-      gazeX: Math.sin(t * 0.55) * 3.6,
-      gazeY: -1.6 + Math.sin(t * 0.38) * 2,
-      blink: t % 1.45 > 1.26,
-      d0: 0.2 + 0.8 * Math.max(0, Math.sin(t * 2.6)),
-      d1: 0.2 + 0.8 * Math.max(0, Math.sin(t * 2.6 - 0.7)),
-      d2: 0.2 + 0.8 * Math.max(0, Math.sin(t * 2.6 - 1.4))
-    }
-  }
+/** Moods a face can hold. Anything else paints as idle. */
+const FACE_MOODS = ['idle', 'work', 'happy', 'sad', 'sleepy', 'shy', 'surprised', 'sick']
 
-  return {
+/** Per-face time offset so a roster of faces doesn't blink and glance in
+ *  lockstep. Seeded from the bot name, so a bot keeps its own rhythm. */
+function facePhase(name) {
+  return sigilRng(String(name || 'agent'))() * 20
+}
+
+/** Deterministic 0..1 noise for an integer slot, so blink and glance
+ *  schedules are irregular but replayable (pure function of time). */
+function slotNoise(n, salt = 0) {
+  let h = Math.imul((n | 0) ^ 0x9e3779b9, 0x85ebca6b) ^ Math.imul(salt + 1, 0xc2b2ae35)
+  h = Math.imul(h ^ (h >>> 15), 0x27d4eb2d)
+  h ^= h >>> 13
+  return (h >>> 0) / 4294967296
+}
+
+/**
+ * Blink as a vertical squash, 0 (open) .. 1 (shut). Each `period`-second slot
+ * holds one blink at a random offset, sometimes a quick double, and the
+ * squash follows a sine so the lid closes and opens instead of cutting.
+ */
+function blinkSquash(t, period = 3.4, dur = 0.16) {
+  const slot = Math.floor(t / period)
+  const local = t - slot * period
+  const at = slotNoise(slot) * (period - dur * 2.6)
+  const shut = u => (u >= 0 && u < 1 ? Math.sin(u * Math.PI) : 0)
+  let s = shut((local - at) / dur)
+  if (slotNoise(slot, 7) < 0.18) {
+    s = Math.max(s, shut((local - at - dur * 1.7) / dur))
+  }
+  return s
+}
+
+/** Slow wandering gaze with a saccade every few seconds: the "someone is home"
+ *  signal. Returns [x, y] in pupil-offset units. */
+function idleGaze(t) {
+  const driftX = Math.sin(t * 0.31) * 0.6 + Math.sin(t * 0.77 + 1.3) * 0.35
+  const driftY = Math.sin(t * 0.23 + 0.6) * 0.3
+  // Every ~6s (jittered) look somewhere for a beat, then come back.
+  const period = 6.1
+  const slot = Math.floor(t / period)
+  const local = t - slot * period
+  const at = 1 + slotNoise(slot, 3) * 3
+  const hold = 0.9 + slotNoise(slot, 4) * 0.8
+  const u = (local - at) / hold
+  const env = u >= 0 && u < 1 ? Math.sin(u * Math.PI) ** 0.6 : 0
+  const dirX = (slotNoise(slot, 5) - 0.5) * 5.2
+  const dirY = (slotNoise(slot, 6) - 0.5) * 1.6
+  return [driftX + env * dirX, driftY + env * dirY]
+}
+
+/**
+ * Pose for a mood at time t. Head channels (turn/tilt/roll) drive the body
+ * projection and slide the eyes across it, the rest drive the eyes:
+ *   gazeX/gazeY  pupil offset            sx/sy   pupil scale (squint, wide)
+ *   cant         pupil rotation, mirrored L/R (+ inner corners up = pleading,
+ *                - inner corners down = focused / cross)
+ *   lid          0..1 upper-lid coverage (sleepy, drowsy, unwell)
+ *   cheek        0..1 lower-lid rise: leaves an upward crescent (happy squint)
+ *   blink        0..1 vertical squash     bob     body y bounce
+ *   d0..d2       thinking dots (work only)
+ * Every channel is numeric so paintMathFace can ease between moods instead
+ * of snapping.
+ */
+function facePose(mood, t) {
+  const [gx, gy] = idleGaze(t)
+  const base = {
     turn: Math.sin(t * 0.5) * 1.5,
     tilt: Math.sin(t * 0.27),
     roll: Math.sin(t * 0.85) * 1.2,
-    gazeX: 0,
-    gazeY: 0,
-    blink: t % 3.2 > 3.02,
+    gazeX: gx,
+    gazeY: gy,
+    sx: 1,
+    sy: 1,
+    cant: 0,
+    lid: 0,
+    cheek: 0,
+    bob: 0,
+    blink: blinkSquash(t),
     d0: 0,
     d1: 0,
     d2: 0
   }
+
+  switch (mood) {
+    case 'work':
+      return {
+        ...base,
+        turn: -11 + Math.sin(t * 0.48) * 8,
+        tilt: Math.sin(t * 0.42) * 8 + Math.sin(t * 1.1) * 1.6,
+        roll: Math.sin(t * 0.75) * 4.2,
+        gazeX: Math.sin(t * 0.55) * 3.6,
+        gazeY: -1.6 + Math.sin(t * 0.38) * 2,
+        sy: 1.13,
+        cant: -5,
+        blink: blinkSquash(t, 1.6, 0.13),
+        d0: 0.2 + 0.8 * Math.max(0, Math.sin(t * 2.6)),
+        d1: 0.2 + 0.8 * Math.max(0, Math.sin(t * 2.6 - 0.7)),
+        d2: 0.2 + 0.8 * Math.max(0, Math.sin(t * 2.6 - 1.4))
+      }
+    case 'happy':
+      // Squinted-up eyes and a light bounce: something arrived for you.
+      return {
+        ...base,
+        roll: Math.sin(t * 2.1) * 3,
+        gazeX: gx * 0.4,
+        gazeY: -0.5,
+        sx: 1.15,
+        sy: 1.05,
+        cheek: 0.62,
+        bob: -Math.abs(Math.sin(t * 2.2)) * 0.9,
+        blink: 0
+      }
+    case 'sad':
+      return {
+        ...base,
+        roll: 4 + Math.sin(t * 0.6) * 0.8,
+        gazeX: gx * 0.5,
+        gazeY: 1.3,
+        sy: 0.85,
+        cant: 14,
+        lid: 0.22,
+        blink: blinkSquash(t, 4.4, 0.24)
+      }
+    case 'sleepy':
+      return {
+        ...base,
+        turn: Math.sin(t * 0.3) * 2,
+        roll: Math.sin(t * 0.6) * 2.5,
+        gazeX: gx * 0.3,
+        gazeY: 0.6,
+        sx: 1.05,
+        lid: 0.48 + Math.sin(t * 0.9) * 0.06,
+        bob: Math.sin(t * 0.9) * 0.4,
+        blink: blinkSquash(t, 5.2, 0.55)
+      }
+    case 'shy':
+      // Looks away and down, eyes a touch smaller.
+      return {
+        ...base,
+        turn: -20,
+        roll: -5,
+        gazeX: -2.6 + gx * 0.3,
+        gazeY: 1.4,
+        sx: 0.85,
+        sy: 0.85,
+        blink: blinkSquash(t, 2.6, 0.16)
+      }
+    case 'surprised':
+      return {
+        ...base,
+        turn: 0,
+        roll: 0,
+        gazeX: 0,
+        gazeY: -0.6,
+        sx: 1.28,
+        sy: 1.38,
+        bob: -0.6,
+        blink: blinkSquash(t, 5.5, 0.12)
+      }
+    case 'sick':
+      // Woozy: slow sway, heavy lids, pleading cant.
+      return {
+        ...base,
+        turn: Math.sin(t * 1.7) * 5,
+        tilt: Math.sin(t * 0.7) * 3,
+        roll: Math.sin(t * 0.9) * 3.5,
+        gazeX: Math.sin(t * 1.3) * 0.8,
+        gazeY: 1,
+        sx: 0.9,
+        sy: 0.8,
+        cant: 8,
+        lid: 0.4,
+        blink: blinkSquash(t, 3.8, 0.3)
+      }
+    default:
+      return base
+  }
+}
+
+const EASED_CHANNELS = ['gazeX', 'gazeY', 'sx', 'sy', 'cant', 'lid', 'cheek', 'bob']
+// blink is deliberately not eased: it is already a sine and should stay crisp.
+const facePoseMemo = typeof WeakMap === 'function' ? new WeakMap() : null
+
+/** Ease the eye channels toward the target so a mood switch morphs instead of
+ *  snapping. Head channels stay live (they are already sines). ~300ms at 15fps. */
+function easeFacePose(svg, target) {
+  if (!facePoseMemo) {
+    return target
+  }
+  const prev = facePoseMemo.get(svg)
+  if (!prev) {
+    facePoseMemo.set(svg, { ...target })
+    return target
+  }
+  const next = { ...target }
+  for (const k of EASED_CHANNELS) {
+    next[k] = prev[k] + (target[k] - prev[k]) * 0.28
+  }
+  facePoseMemo.set(svg, next)
+  return next
 }
 
 function paintMathFace(svg, t) {
-  const mood = svg.getAttribute('data-hb-mood') || 'idle'
+  const moodAttr = svg.getAttribute('data-hb-mood') || 'idle'
+  const mood = FACE_MOODS.includes(moodAttr) ? moodAttr : 'idle'
   const shape = svg.getAttribute('data-hb-shape') || 'circle'
-  const pose = facePose(mood, t)
+  const phase = Number(svg.getAttribute('data-hb-phase')) || 0
+  const pose = easeFacePose(svg, facePose(mood, t + phase))
   const body = svg.querySelector('[data-hb-body]')
-  const open = svg.querySelector('[data-hb-open]')
-  const shut = svg.querySelector('[data-hb-shut]')
   const el = svg.querySelector('[data-hb-el]')
   const er = svg.querySelector('[data-hb-er]')
   const dots = svg.querySelectorAll('[data-hb-dot]')
@@ -1180,43 +1356,106 @@ function paintMathFace(svg, t) {
     }
   }
 
+  // The eyes sit on the head, not on the screen: a turn slides the pair
+  // sideways and narrows the eye on the far side, which is what reads as
+  // volume at 34px. The cloud keeps its eyes still (its body is a fixed path).
+  const turnRad = shape === 'cloud' ? 0 : (pose.turn * Math.PI) / 180
+  const slide = Math.sin(turnRad) * 4.2
+  const spread = 4.6 * (0.72 + 0.28 * Math.cos(turnRad))
   const eyeY = (shape === 'cloud' ? 22 : 17.2) + pose.gazeY
-  const eyeL = 15.4 + pose.gazeX
-  const eyeR = 24.6 + pose.gazeX
+  const eyeL = 20 - spread + slide + pose.gazeX
+  const eyeR = 20 + spread + slide + pose.gazeX
+  // Blink is a vertical squash of the pupil down to a sliver, then back.
+  const blinkScale = 1 - 0.92 * pose.blink
+  const rxL = 2.2 * pose.sx * (1 + 0.28 * Math.sin(turnRad))
+  const rxR = 2.2 * pose.sx * (1 - 0.28 * Math.sin(turnRad))
+  const ry = 2.3 * pose.sy
+  const ryDrawn = ry * blinkScale
+  const cant = pose.cant.toFixed(2)
 
   if (el) {
-    el.setAttribute('cx', eyeL)
-    el.setAttribute('cy', eyeY)
+    el.setAttribute('cx', eyeL.toFixed(2))
+    el.setAttribute('cy', eyeY.toFixed(2))
+    el.setAttribute('rx', rxL.toFixed(2))
+    el.setAttribute('ry', ryDrawn.toFixed(2))
+    el.setAttribute('transform', `rotate(${cant} ${eyeL.toFixed(2)} ${eyeY.toFixed(2)})`)
   }
 
   if (er) {
-    er.setAttribute('cx', eyeR)
-    er.setAttribute('cy', eyeY)
+    er.setAttribute('cx', eyeR.toFixed(2))
+    er.setAttribute('cy', eyeY.toFixed(2))
+    er.setAttribute('rx', rxR.toFixed(2))
+    er.setAttribute('ry', ryDrawn.toFixed(2))
+    er.setAttribute('transform', `rotate(${-cant} ${eyeR.toFixed(2)} ${eyeY.toFixed(2)})`)
   }
 
   // Catchlights ride the pupils (upper-left offset) — without this they
   // stay at the circle-face position and drift outside e.g. the cloud's
-  // lower-set eyes.
+  // lower-set eyes. They fade as the eye squints, blinks or the lid drops so
+  // a happy squint doesn't keep a full sparkle floating above the slit.
   const hl = svg.querySelector('[data-hb-hl-l]')
   const hr = svg.querySelector('[data-hb-hl-r]')
+  const hlOpacity =
+    Math.max(0, Math.min(1, (pose.sy * blinkScale - 0.45) * 2.2)) * (1 - pose.lid) * (1 - pose.cheek * 0.5)
 
   if (hl) {
-    hl.setAttribute('cx', eyeL - 0.6)
-    hl.setAttribute('cy', eyeY - 0.7)
+    hl.setAttribute('cx', (eyeL - 0.6).toFixed(2))
+    hl.setAttribute('cy', (eyeY - 0.7 * pose.sy * blinkScale).toFixed(2))
+    hl.setAttribute('opacity', hlOpacity.toFixed(2))
   }
 
   if (hr) {
-    hr.setAttribute('cx', eyeR - 0.6)
-    hr.setAttribute('cy', eyeY - 0.7)
+    hr.setAttribute('cx', (eyeR - 0.6).toFixed(2))
+    hr.setAttribute('cy', (eyeY - 0.7 * pose.sy * blinkScale).toFixed(2))
+    hr.setAttribute('opacity', hlOpacity.toFixed(2))
   }
 
-  if (open) {
-    open.setAttribute('opacity', pose.blink ? '0' : '1')
+  // Upper lids: body-colored, pupil-sized ellipses that slide down over the
+  // pupils. Kept pupil-sized and hidden at lid 0 so they never leak past a
+  // tight body outline (the cloud hugs its eyes closely).
+  const lidL = svg.querySelector('[data-hb-lid-l]')
+  const lidR = svg.querySelector('[data-hb-lid-r]')
+  const lidCy = (eyeY - 2 * ry - 0.4 + pose.lid * (2 * ry + 0.8)).toFixed(2)
+  const lidRy = (ry + 0.4).toFixed(2)
+  const lidOpacity = pose.lid > 0.04 ? '1' : '0'
+
+  if (lidL) {
+    lidL.setAttribute('cx', eyeL.toFixed(2))
+    lidL.setAttribute('cy', lidCy)
+    lidL.setAttribute('rx', (rxL + 0.8).toFixed(2))
+    lidL.setAttribute('ry', lidRy)
+    lidL.setAttribute('opacity', lidOpacity)
   }
 
-  if (shut) {
-    shut.setAttribute('d', `M${eyeL - 2.6} ${eyeY} L${eyeL + 2.6} ${eyeY} M${eyeR - 2.6} ${eyeY} L${eyeR + 2.6} ${eyeY}`)
-    shut.setAttribute('opacity', pose.blink ? '1' : '0')
+  if (lidR) {
+    lidR.setAttribute('cx', eyeR.toFixed(2))
+    lidR.setAttribute('cy', lidCy)
+    lidR.setAttribute('rx', (rxR + 0.8).toFixed(2))
+    lidR.setAttribute('ry', lidRy)
+    lidR.setAttribute('opacity', lidOpacity)
+  }
+
+  // Lower lids ("cheeks"): same trick from below. A raised cheek leaves the
+  // top of the pupil as an upward crescent, which is the happy squint.
+  const cheekL = svg.querySelector('[data-hb-cheek-l]')
+  const cheekR = svg.querySelector('[data-hb-cheek-r]')
+  const cheekCy = (eyeY + 2 * ry + 0.4 - pose.cheek * (2 * ry + 0.8)).toFixed(2)
+  const cheekOpacity = pose.cheek > 0.04 ? '1' : '0'
+
+  if (cheekL) {
+    cheekL.setAttribute('cx', eyeL.toFixed(2))
+    cheekL.setAttribute('cy', cheekCy)
+    cheekL.setAttribute('rx', (rxL + 0.8).toFixed(2))
+    cheekL.setAttribute('ry', lidRy)
+    cheekL.setAttribute('opacity', cheekOpacity)
+  }
+
+  if (cheekR) {
+    cheekR.setAttribute('cx', eyeR.toFixed(2))
+    cheekR.setAttribute('cy', cheekCy)
+    cheekR.setAttribute('rx', (rxR + 0.8).toFixed(2))
+    cheekR.setAttribute('ry', lidRy)
+    cheekR.setAttribute('opacity', cheekOpacity)
   }
 
   dots.forEach((dot, i) => {
@@ -1224,7 +1463,7 @@ function paintMathFace(svg, t) {
     dot.setAttribute('opacity', String(o))
   })
 
-  svg.style.transform = `rotate(${pose.tilt}deg)`
+  svg.style.transform = `translateY(${pose.bob.toFixed(2)}px) rotate(${pose.tilt}deg)`
   svg.style.transformOrigin = '50% 70%'
 }
 
@@ -1460,7 +1699,8 @@ function BotFace({ shape, color, image, size = 36, name = 'agent', mood = 'idle'
     })
   }
 
-  const working = mood === 'work'
+  const faceMood = FACE_MOODS.includes(mood) ? mood : 'idle'
+  const working = faceMood === 'work'
   const eyeFill = isDarkColor(color) ? 'rgba(232,220,195,0.95)' : 'rgba(0,0,0,0.85)'
   // Catchlight contrast follows the pupil, not the body: dark pupils get the
   // white sparkle, light (cream) pupils on dark bodies get a dark one — a
@@ -1468,17 +1708,19 @@ function BotFace({ shape, color, image, size = 36, name = 'agent', mood = 'idle'
   // maroon/ink/oxblood avatars.
   const hlFill = isDarkColor(color) ? 'rgba(0,0,0,0.6)' : 'rgba(255,255,255,0.85)'
   const ring = sampleFaceRing(shape)
-  const rest = facePose(working ? 'work' : 'idle', 0)
+  const rest = facePose(faceMood, 0)
   // Shape-aware initial eye line — the cloud body sits lower, so its eyes
   // (and their catchlights) start at the cloud position instead of jumping
   // there on the first clock paint.
   const eyeY0 = shape === 'cloud' ? 22 : 17.2
+  const ry0 = 2.3 * rest.sy
 
   return jsxs('svg', {
     'data-bot-face': name,
     'data-hb-math': '1',
-    'data-hb-mood': working ? 'work' : 'idle',
+    'data-hb-mood': faceMood,
     'data-hb-shape': shape || 'circle',
+    'data-hb-phase': facePhase(name).toFixed(2),
     viewBox: '0 0 40 44',
     width: size,
     height: size,
@@ -1493,22 +1735,20 @@ function BotFace({ shape, color, image, size = 36, name = 'agent', mood = 'idle'
         fill: color
       }),
       jsxs('g', {
-        'data-hb-open': '1',
+        'data-hb-eyes': '1',
         children: [
-          jsx('ellipse', { 'data-hb-el': '1', cx: 15.4, cy: eyeY0, rx: 2.2, ry: working ? 2.6 : 2.3, fill: eyeFill }),
-          jsx('ellipse', { 'data-hb-er': '1', cx: 24.6, cy: eyeY0, rx: 2.2, ry: working ? 2.6 : 2.3, fill: eyeFill }),
+          jsx('ellipse', { 'data-hb-el': '1', cx: 15.4, cy: eyeY0, rx: 2.2 * rest.sx, ry: ry0, fill: eyeFill }),
+          jsx('ellipse', { 'data-hb-er': '1', cx: 24.6, cy: eyeY0, rx: 2.2 * rest.sx, ry: ry0, fill: eyeFill }),
           jsx('circle', { 'data-hb-hl-l': '1', cx: 14.8, cy: eyeY0 - 0.7, r: 0.65, fill: hlFill }),
-          jsx('circle', { 'data-hb-hl-r': '1', cx: 24, cy: eyeY0 - 0.7, r: 0.65, fill: hlFill })
+          jsx('circle', { 'data-hb-hl-r': '1', cx: 24, cy: eyeY0 - 0.7, r: 0.65, fill: hlFill }),
+          // Upper lids: body-colored, parked above the eye until a mood
+          // lowers them (sleepy / sad / sick). Blink is a squash of the
+          // pupils themselves, so there is no separate shut-eye line.
+          jsx('ellipse', { 'data-hb-lid-l': '1', cx: 15.4, cy: eyeY0 - 2 * ry0 - 0.4, rx: 3, ry: ry0 + 0.4, fill: color, opacity: 0 }),
+          jsx('ellipse', { 'data-hb-lid-r': '1', cx: 24.6, cy: eyeY0 - 2 * ry0 - 0.4, rx: 3, ry: ry0 + 0.4, fill: color, opacity: 0 }),
+          jsx('ellipse', { 'data-hb-cheek-l': '1', cx: 15.4, cy: eyeY0 + 2 * ry0 + 0.4, rx: 3, ry: ry0 + 0.4, fill: color, opacity: 0 }),
+          jsx('ellipse', { 'data-hb-cheek-r': '1', cx: 24.6, cy: eyeY0 + 2 * ry0 + 0.4, rx: 3, ry: ry0 + 0.4, fill: color, opacity: 0 })
         ]
-      }),
-      jsx('path', {
-        'data-hb-shut': '1',
-        d: `M12.8 ${eyeY0} L18 ${eyeY0} M22 ${eyeY0} L27.2 ${eyeY0}`,
-        stroke: eyeFill,
-        strokeWidth: 2,
-        strokeLinecap: 'round',
-        fill: 'none',
-        opacity: 0
       }),
       working
         ? jsxs('g', {
@@ -4211,15 +4451,32 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
   // Keep user photos/pets. Drop the 160px SVG backfill so the math face can move.
   const photo = Boolean(image && !isBackfilledFacePng(image))
   const gatewayState = useValue(host.state.gateway)
+  // Turn-busy for the focused chat. `host.state.gateway` is the SOCKET state
+  // ('idle' | 'connecting' | 'open' | 'closed' | 'error') and is never 'busy'.
+  const turnBusy = useValue(host.state.busy)
   const activeNow = Boolean(last?.last_active && Date.now() / 1000 - last.last_active < ACTIVE_WINDOW_S)
-  // Work pose only when this bot is actually doing something: the active
-  // profile while the gateway is busy, or a bot that wrote within the
-  // liveness window. Not every bot whenever the gateway is busy.
-  const botMood = (isActive && gatewayState === 'busy') || activeNow ? 'work' : 'idle'
   // Subscribe on every render. A source switch turns the same keyed row from
   // thin to rich; conditionally calling useValue here breaks React hook order.
   const unreadByName = useValue($botUnread)
   const unread = !bot.remoteSource && Boolean(unreadByName[bot.name])
+  // Work pose only when this bot is actually doing something: the active
+  // profile mid-turn, or a bot that wrote within the liveness window. Not
+  // every bot whenever the gateway is busy. Beyond that the face reads the
+  // room: local gateway down -> sick, connecting -> sleepy, a message waiting
+  // -> happy, hidden -> shy, otherwise idle.
+  const localSocket = !bot.remoteSource
+  const botMood =
+    localSocket && (gatewayState === 'error' || gatewayState === 'closed')
+      ? 'sick'
+      : localSocket && gatewayState === 'connecting'
+        ? 'sleepy'
+        : (isActive && turnBusy) || activeNow
+          ? 'work'
+          : unread
+            ? 'happy'
+            : meta?.hidden
+              ? 'shy'
+              : 'idle'
   // WHO sent the last message (bot-to-bot DM vs human) — the full stored
   // history lives in the Sessions workspace (context menu), not inline.
   // Preview identity must match click identity (#88200): when the backend

--- a/apps/desktop/src/plugins/hermes-bots/tests/face-pose.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/face-pose.test.mjs
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+// The pose engine is a set of pure functions between the ring samplers and
+// the easing memo. Slice them out (plus the string PRNG they seed from) so
+// they run in a bare vm without the ES-module surface.
+function slice(startMarker, endMarker) {
+  const start = pluginSource.indexOf(startMarker)
+  const end = pluginSource.indexOf(endMarker, start)
+  assert.ok(start > 0 && end > start, `${startMarker} present in plugin.js`)
+  return pluginSource.slice(start, end)
+}
+
+const source = [
+  slice('function sigilRng(text)', '\n/**\n * Angular hermetic sigil'),
+  slice('/** Moods a face can hold.', 'const EASED_CHANNELS')
+].join('\n')
+
+const context = {}
+vm.runInNewContext(
+  `${source}\nglobalThis.FACE_MOODS = FACE_MOODS; globalThis.facePose = facePose; ` +
+    'globalThis.facePhase = facePhase; globalThis.blinkSquash = blinkSquash; globalThis.idleGaze = idleGaze',
+  context
+)
+
+const CHANNELS = ['turn', 'tilt', 'roll', 'gazeX', 'gazeY', 'sx', 'sy', 'cant', 'lid', 'cheek', 'bob', 'blink', 'd0', 'd1', 'd2']
+
+test('facePose: every mood returns every channel as a finite number', () => {
+  for (const mood of context.FACE_MOODS) {
+    for (const t of [0, 0.5, 3.7, 12.25, 61]) {
+      const pose = context.facePose(mood, t)
+      for (const key of CHANNELS) {
+        assert.equal(typeof pose[key], 'number', `${mood}.${key} at t=${t} is a number`)
+        assert.ok(Number.isFinite(pose[key]), `${mood}.${key} at t=${t} is finite`)
+      }
+      assert.ok(pose.blink >= 0 && pose.blink <= 1, `${mood}.blink in [0,1]`)
+      assert.ok(pose.lid >= 0 && pose.lid <= 1, `${mood}.lid in [0,1]`)
+      assert.ok(pose.cheek >= 0 && pose.cheek <= 1, `${mood}.cheek in [0,1]`)
+    }
+  }
+})
+
+test('facePose: a pure function of time (replayable, no hidden state)', () => {
+  for (const mood of context.FACE_MOODS) {
+    const a = context.facePose(mood, 8.4)
+    context.facePose(mood, 100)
+    const b = context.facePose(mood, 8.4)
+    assert.deepEqual(a, b, `${mood} replays identically`)
+  }
+})
+
+test('facePose: unknown moods fall back to the idle pose', () => {
+  assert.deepEqual(context.facePose('nonsense', 2.2), context.facePose('idle', 2.2))
+})
+
+test('facePose: moods read the way the roster expects', () => {
+  const at = mood => context.facePose(mood, 1)
+  // Happy is an upward crescent (cheek up), not a squint from above.
+  assert.ok(at('happy').cheek > 0.4)
+  assert.equal(at('happy').lid, 0)
+  // Sleepy and sick drop the upper lid; idle and work keep it up.
+  assert.ok(at('sleepy').lid > 0.3)
+  assert.ok(at('sick').lid > 0.3)
+  assert.equal(at('idle').lid, 0)
+  assert.equal(at('work').lid, 0)
+  // Sad cants the pupils inner-corner-up, work inner-corner-down.
+  assert.ok(at('sad').cant > 0)
+  assert.ok(at('work').cant < 0)
+  // Shy looks away, surprised opens wide.
+  assert.ok(at('shy').gazeX < -1.5)
+  assert.ok(at('surprised').sy > 1.2 && at('surprised').sx > 1.2)
+  // Only work lights the thinking dots.
+  assert.ok(at('work').d0 + at('work').d1 + at('work').d2 > 0)
+  assert.equal(at('idle').d0 + at('idle').d1 + at('idle').d2, 0)
+})
+
+test('blinkSquash: blinks happen, are brief, and are irregular between slots', () => {
+  const period = 3.4
+  let closedFrames = 0
+  let total = 0
+  const blinkStarts = []
+  let wasOpen = true
+
+  for (let t = 0; t < period * 12; t += 1 / 60) {
+    const s = context.blinkSquash(t, period, 0.16)
+    total += 1
+    if (s > 0.5) closedFrames += 1
+    if (s > 0 && wasOpen) blinkStarts.push(t % period)
+    wasOpen = s === 0
+  }
+
+  // Shut less than a tenth of the time, but not never.
+  assert.ok(closedFrames > 0 && closedFrames / total < 0.1, `shut fraction ${closedFrames / total}`)
+  // Offsets inside the slot vary (not a fixed metronome).
+  const distinct = new Set(blinkStarts.map(x => x.toFixed(1)))
+  assert.ok(distinct.size >= 4, `distinct blink offsets: ${[...distinct].join(', ')}`)
+})
+
+test('idleGaze: bounded wander with occasional glances', () => {
+  let maxX = 0
+  for (let t = 0; t < 60; t += 0.05) {
+    const [x, y] = context.idleGaze(t)
+    assert.ok(Math.abs(x) < 4 && Math.abs(y) < 2, `gaze stays inside the eye area at t=${t}`)
+    maxX = Math.max(maxX, Math.abs(x))
+  }
+  assert.ok(maxX > 1.5, 'at least one glance aside within a minute')
+})
+
+test('facePhase: bots get their own rhythm, stable per name', () => {
+  assert.equal(context.facePhase('research'), context.facePhase('research'))
+  assert.notEqual(context.facePhase('research'), context.facePhase('ops'))
+  assert.ok(context.facePhase('') >= 0)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
@@ -64,7 +64,7 @@ function renderBotRow(input = 'alpha') {
     useEffect: () => undefined,
     useState: initial => [typeof initial === 'function' ? initial() : initial, () => undefined],
     host: {
-      state: { gateway: atom('open'), profile: atom('default') },
+      state: { busy: atom(false), gateway: atom('open'), profile: atom('default') },
       ensureAgent: async (connectionId, profile) => {
         ensured.push([connectionId, profile])
         liveConnectionId = connectionId
@@ -189,7 +189,7 @@ test('behavior: remote default does not open this-device chat when the source di
     useEffect: () => undefined,
     useState: initial => [typeof initial === 'function' ? initial() : initial, () => undefined],
     host: {
-      state: { gateway: atom('open'), profile: atom('default') },
+      state: { busy: atom(false), gateway: atom('open'), profile: atom('default') },
       ensureAgent: async (connectionId, profile) => ensured.push([connectionId, profile]),
       activeConnectionId: () => 'local',
       warmAgent: () => undefined,

--- a/website/docs/user-guide/bot-mode.md
+++ b/website/docs/user-guide/bot-mode.md
@@ -60,7 +60,7 @@ Remote-creation notes:
 
 Every Bot gets a face:
 
-- **Geometric faces** — 7 shapes × 10 colors, with blinking eyes that scan while the Bot works.
+- **Geometric faces** — 7 shapes × 10 colors, with eyes that blink, look around, and change with the Bot's state: a message you have not read makes it happy, a working Bot turns and thinks, a hidden Bot looks shy, and a Bot whose gateway is down looks unwell.
 - **An uploaded image** — any picture you like.
 - **An AI-generated portrait** — when an image backend is configured, generated in place (this rides the standard `image.generate` RPC and works over both local and remote gateways).
 - **A pixel pet** — a companion from the [petdex gallery](./features/pets.md) that bounces beside the avatar while the Bot is busy. Run `hermes pets` in a terminal to explore the gallery.


### PR DESCRIPTION
## What does this PR do?

Bot Mode faces in the Desktop app could only be idle or working, and they all blinked at the same time. This PR keeps the same face, shapes and colors, and makes it feel more alive:

- Eight moods instead of two: idle, work, happy, sad, sleepy, shy, surprised, sick.
- The Bots pane picks the mood from what is going on: a message you have not read makes the bot happy, a closed or errored local gateway makes it look sick, a connecting gateway makes it sleepy, a hidden bot looks shy, and an active turn or recent activity is still the working pose.
- Each bot gets its own timing offset from its name, so a roster of faces no longer blinks in step.
- Idle bots slowly drift their gaze and glance to the side every few seconds.
- The blink is now a smooth squash of the eye on a slightly random schedule, with an occasional double blink, instead of swapping to a flat line every 3.2 seconds.
- When the head turns (working pose), the eyes slide with it and the far eye gets narrower, so it reads as a real turn.
- Mood changes ease in over about 300 ms instead of snapping.

It also fixes a small bug: the row used `gatewayState === 'busy'` to decide the working pose, but that atom is the socket state and is never `'busy'`. It now reads `host.state.busy`.

Why this approach: the existing face already has an animation clock, and users have picked shapes and colors for their bots. Extending it keeps every existing avatar the same and adds no dependency.

## Related Issue

Fixes #89099

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.js`
  - New pose engine: `FACE_MOODS`, `facePhase`, `slotNoise`, `blinkSquash`, `idleGaze`, and a rewritten `facePose` that returns numeric channels for every mood (gaze, eye scale, eye cant, upper lid, lower lid, bounce, blink, thinking dots).
  - `easeFacePose` eases the eye channels between moods.
  - `paintMathFace` now places the eyes on the turning head, draws blink as a squash, and drives the new lid and cheek nodes. The old shut-eye line is gone.
  - `BotFace` passes the mood through, adds `data-hb-phase`, and adds body colored lid and cheek ellipses (hidden until a mood uses them).
  - `BotRow` maps roster state to a mood and reads `host.state.busy` for the turn signal.
- `apps/desktop/src/plugins/hermes-bots/tests/face-pose.test.mjs` (new): checks that every mood returns every channel, that the pose is a pure function of time, that moods read the way the roster expects, that blinks are brief and not on a metronome, and that gaze stays inside the eye area.
- `apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs`: the mocked `host.state` gains `busy`.
- `website/docs/user-guide/bot-mode.md`: Avatars section describes the new behavior.

## How to Test

1. `cd apps/desktop && npm run dev`, then open the BOTS tab in the sidebar.
2. Watch a few idle bots for half a minute. They should blink at different times, and each should glance aside now and then.
3. Send a message to a bot from another bot or another client so it has an unread message. Its face should switch to the happy `^ ^` look and gently bounce.
4. Hide a bot (right click, Hide, then click the eye icon to show hidden bots). Its face should look away and down.
5. Stop the gateway. Local bots should look sick. While it reconnects they should look sleepy.
6. Start a chat with the active bot. While it is answering, the face should turn and show the thinking dots, and the eyes should slide with the turn.
7. Run `node --test src/plugins/hermes-bots/tests/*.test.mjs` from `apps/desktop`. All 265 tests pass (7 of them new).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (Python side is untouched; ran the desktop plugin tests, `tsc`, and `vite build` instead)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<img width="784" height="460" alt="demo" src="https://github.com/user-attachments/assets/60075751-c341-45fd-bf1c-d7fbeb264b97" />

