### PR TITLE
fix(tools): check read_only_hint in snake_case for MCP trust gate (#88858)

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4337,9 +4337,11 @@ def _annotation_read_only_hint(mcp_tool: Any) -> bool:
     if annotations is None:
         return False
     if isinstance(annotations, dict):
-        hint = annotations.get("readOnlyHint")
+        hint = annotations.get("readOnlyHint") or annotations.get("read_only_hint")
     else:
-        hint = getattr(annotations, "readOnlyHint", None)
+        hint = getattr(annotations, "readOnlyHint", None) or getattr(
+            annotations, "read_only_hint", None
+        )
     return hint is True
 
 


### PR DESCRIPTION
## Summary

Fixes #88858.

The MCP Python SDK materializes tool annotations in **snake_case** (`read_only_hint`) while the trust gate in `_annotation_read_only_hint()` only checked **camelCase** (`readOnlyHint`). This caused every tool to be classified as write-capable regardless of server annotations, making `trust: untrusted` MCP servers unusable in practice — every read-only tool required approval.

## Changes

- `tools/mcp_tool.py`: Updated `_annotation_read_only_hint()` to check both camelCase (`readOnlyHint`) and snake_case (`read_only_hint`) variants in both the dict and attribute-access branches.

## Root Cause

The MCP Python SDK v1.x uses `@dataclass` annotations that expose fields in snake_case:
- `annotations.read_only_hint` (SDK attribute access)
- `{"read_only_hint": true}` (JSON schema)

The existing code only checked:
- `annotations.get("readOnlyHint")` (dict branch)
- `getattr(annotations, "readOnlyHint", None)` (attribute branch)

## Testing

- Verified syntax with `python3 -m py_compile tools/mcp_tool.py`
- The fix is backward-compatible: camelCase is checked first (for direct JSON/dict annotations), then snake_case as fallback (for SDK objects)
