### PR TITLE
fix(agent): guard callable api_key in resolve_provider_client (#88667)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6653,7 +6653,11 @@ def resolve_provider_client(
         # credential can authenticate against endpoints where no built-in
         # credential is registered for this provider alias.
         if explicit_api_key:
-            api_key = explicit_api_key.strip() or api_key
+            api_key = (
+                explicit_api_key.strip()
+                if isinstance(explicit_api_key, str)
+                else explicit_api_key
+            ) or api_key
         raw_base_url = str(creds.get("base_url", "")).strip().rstrip("/") or pconfig.inference_base_url
         if explicit_base_url:
             raw_base_url = explicit_base_url.strip().rstrip("/")


### PR DESCRIPTION
## Summary

Fixes #88667.

When a custom provider is configured with `key_cmd`, the resolved credential is a `CommandTokenSource` (callable object), not a string. The generic provider fallback path in `resolve_provider_client()` called `.strip()` on it unconditionally, crashing with `AttributeError: 'CommandTokenSource' object has no attribute 'strip'`.

## Changes

- `agent/auxiliary_client.py`: Guard `explicit_api_key.strip()` with `isinstance(explicit_api_key, str)` check. When `explicit_api_key` is callable, preserve it as-is — the OpenAI client accepts callable `api_key` parameters natively.

## Context

The codebase already has this callable guard pattern at multiple sites:
- Line 3413: `api_key.strip() if isinstance(api_key, str) else api_key if callable(api_key) else ""`
- Line 3771: `bool(api_key) if not callable(api_key) else True`
- Line 3920: `if field == "api_key" and callable(value) and not isinstance(value, str)`
- Line 7398: `if field == "api_key" and callable(value)`

This fix applies the same pattern to the one remaining unguarded call site.

## Testing

- Verified syntax with `python3 -m py_compile agent/auxiliary_client.py`
