### PR TITLE
fix(nix): gate Linux-only dev tools on Darwin

### DIFF
--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -3,7 +3,7 @@
 # Checks are Linux-only: the full Python venv (via uv2nix) includes
 # transitive deps like onnxruntime that lack compatible wheels on
 # aarch64-darwin. The package and devShell still work on macOS.
-{ inputs, ... }: {
+{ inputs, config, ... }: {
   perSystem = { pkgs, lib, self', ... }:
     let
       hermes-agent = self'.packages.default;
@@ -132,20 +132,28 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
         # errors (e.g. sphinx dropping python311) without needing a darwin builder.
         # Evaluation is pure and instant; it doesn't build anything.
         cross-eval = let
-          targetSystems = builtins.filter
-            (s: inputs.self.packages ? ${s})
-            [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
-          tryEvalPkg = sys:
-            let pkg = inputs.self.packages.${sys}.default;
-            in builtins.tryEval (builtins.seq pkg.drvPath true);
-          results = map (sys: { inherit sys; result = tryEvalPkg sys; }) targetSystems;
+          targetSystems = config.systems;
+          tryEvalSystem = sys:
+            let
+              hasPackage = (inputs.self.packages or {}) ? ${sys}.default;
+              hasDevShell = (inputs.self.devShells or {}) ? ${sys}.default;
+            in
+            if !(hasPackage && hasDevShell) then
+              { success = false; value = false; }
+            else
+              let
+                pkg = inputs.self.packages.${sys}.default;
+                devShell = inputs.self.devShells.${sys}.default;
+              in
+              builtins.tryEval (builtins.deepSeq [ pkg.drvPath devShell.drvPath ] true);
+          results = map (sys: { inherit sys; result = tryEvalSystem sys; }) targetSystems;
           failures = builtins.filter (r: !r.result.success) results;
           failMsg = lib.concatMapStringsSep "\n" (r: "  - ${r.sys}") failures;
         in pkgs.runCommand "hermes-cross-eval" { } (
           if failures != [] then
-            throw "Package fails to evaluate on:\n${failMsg}"
+            throw "Package or devShell fails to evaluate on:\n${failMsg}"
           else ''
-            echo "PASS: package evaluates on all ${toString (builtins.length targetSystems)} platforms"
+            echo "PASS: package and devShell evaluate on all ${toString (builtins.length targetSystems)} platforms"
             mkdir -p $out
             echo "ok" > $out/result
           ''
@@ -645,6 +653,31 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
               ''
           );
       } // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+        # Preserve the Linux-only development and visual-capture tools while
+        # keeping them out of Darwin devShell evaluation.
+        linux-devshell-tools =
+          let
+            expectedTools = {
+              sandbox = self'.packages.sandbox;
+              cage = pkgs.cage;
+              libglvnd = lib.getDev pkgs.libglvnd;
+              ghostty = pkgs.ghostty;
+              grim = pkgs.grim;
+            };
+            inputPaths = map (input: input.outPath) self'.devShells.default.nativeBuildInputs;
+            missingTools = lib.filterAttrs (_: tool: !(builtins.elem tool.outPath inputPaths)) expectedTools;
+          in
+          pkgs.runCommand "hermes-linux-devshell-tools" { } (
+            if missingTools != { } then
+              throw "Linux devShell is missing required tools: ${lib.concatStringsSep ", " (lib.attrNames missingTools)}"
+            else
+              ''
+                echo "PASS: Linux devShell preserves its platform-specific tools"
+                mkdir -p $out
+                echo "ok" > $out/result
+              ''
+          );
+
         # ── The NixOS module ─────────────────────────────────────────────
         # This check runs on Linux only. The evaluation of a NixOS module
         # needs a Linux hostPlatform.

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -8,7 +8,12 @@
 { ... }:
 {
   perSystem =
-    { pkgs, self', ... }:
+    {
+      pkgs,
+      lib,
+      self',
+      ...
+    }:
     let
       packages = builtins.attrValues self'.packages;
       hermesNpmLib = self'.packages.default.passthru.hermesNpmLib;
@@ -19,6 +24,28 @@
       );
 
       hermesAgentDevShellHook = self'.packages.default.passthru.devShellHook;
+
+      # The development sandbox and visual-capture stack depend on Linux
+      # namespaces and Wayland. Define the list inside the condition so Darwin
+      # evaluation never needs to resolve Linux-only package attributes.
+      linuxDevTools =
+        if pkgs.stdenv.isLinux then
+          with pkgs; [
+            self'.packages.sandbox
+            # Headless Wayland compositor for E2E tests (test:e2e:visual).
+            # cage renders a single client with no window management, so
+            # the Electron window opens at a fixed size without tiling.
+            cage
+            # libglvnd provides libEGL.so.1 that cage needs on NixOS.
+            libglvnd
+            # Graphical terminal + Wayland screenshot client for CLI/TUI UI
+            # evidence. `cage -- ghostty ...` keeps captures off the user's
+            # live compositor; grim runs inside that isolated client session.
+            ghostty
+            grim
+          ]
+        else
+          [];
     in
     {
       devShells.default = pkgs.mkShell {
@@ -27,20 +54,9 @@
             mkdir -p $out/bin
             install -Dm755 ${../hermes} $out/bin/hermes
           '')
-          self'.packages.sandbox
           uv
-          # Headless Wayland compositor for E2E tests (test:e2e:visual).
-          # cage renders a single client with no window management, so
-          # the Electron window opens at a fixed size without tiling.
-          # libglvnd provides libEGL.so.1 that cage needs on NixOS.
-          cage
-          libglvnd
-          # Graphical terminal + Wayland screenshot client for CLI/TUI UI
-          # evidence. `cage -- ghostty ...` keeps captures off the user's
-          # live compositor; grim runs inside that isolated client session.
-          ghostty
-          grim
         ]
+        ++ linuxDevTools
         ++ self'.packages.default.passthru.devDeps;
         shellHook = ''
           ${hermesAgentDevShellHook}
@@ -57,7 +73,7 @@
           export VIRTUAL_ENV="$(dirname "$(dirname "$(readlink -f "$(command -v python)")")")"
 
           echo "Hermes Agent dev shell in $HERMES_PYTHON_SRC_ROOT"
-          echo "Ready. Run 'hermes' or 'sandbox hermes' to start."
+          echo "Ready. Run 'hermes'${lib.optionalString pkgs.stdenv.isLinux " or 'sandbox hermes'"} to start."
         '';
       };
     };

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -54,8 +54,6 @@
           }).node-gyp;
         default = full;
 
-        inherit sandbox;
-
         inherit minimal;
 
         # Ships discord.py + python-telegram-bot + slack-sdk so a plain
@@ -70,6 +68,9 @@
         desktop = full.hermesDesktop;
 
         update-npm-lockfile = full.hermesNpmLib.updateNpmLockfile;
+      }
+      // lib.optionalAttrs pkgs.stdenv.isLinux {
+        inherit sandbox;
       };
     };
 }


### PR DESCRIPTION
## Summary

- expose the development sandbox only on Linux
- omit the sandbox and Wayland visual-capture stack from Darwin dev shells
- cross-evaluate dev shells alongside packages to catch platform regressions

## Problem

`devShells.aarch64-darwin.default` currently pulls in `sandbox`, whose runtime closure reaches Linux-only `bubblewrap`. `cage`, `ghostty`, and `grim` are also Linux-only in nixpkgs, so gating only the first failing dependency would leave the dev shell broken.

The failure reproduces on the current `origin/main` revision while evaluating the Darwin dev shell:

```text
Refusing to evaluate package 'bubblewrap-0.11.2'
hostPlatform.system = "aarch64-darwin"
```

The existing cross-evaluation check only forces package derivations, so it misses this dev-shell-only failure on Linux CI.

## Validation

- `nix-instantiate --parse` passes for all three changed Nix files
- `nix eval .#devShells.aarch64-darwin.default.drvPath` succeeds
- `packages.aarch64-darwin` no longer exposes `sandbox`
- `packages.x86_64-linux` still exposes `sandbox`
- the Linux dev shell still includes `sandbox`, `cage`, `libglvnd`, `ghostty`, and `grim`
- `nix eval .#checks.x86_64-linux.cross-eval.drvPath` succeeds

A full `nix flake check` was not run because it triggers the complete build suite; this bug and its regression check operate at evaluation time.
