### PR TITLE
fix(agent): add message-eligibility check to should_compress_info (#88778)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3203,7 +3203,7 @@ class ContextCompressor(ContextEngine):
         projected_real = self.last_real_prompt_tokens + growth
         return projected_real < self.threshold_tokens
 
-    def should_compress(self, prompt_tokens: int = None) -> bool:
+    def should_compress(self, prompt_tokens: int = None, n_messages: int = None) -> bool:
         """Check if context exceeds the compression threshold.
 
         Returns ``True`` when compression should run now. For the caller-facing
@@ -3215,11 +3215,11 @@ class ContextCompressor(ContextEngine):
         each saved less than 10%, skip compression to avoid infinite loops
         where each pass removes only 1-2 messages.
         """
-        decision, _reason = self.should_compress_info(prompt_tokens)
+        decision, _reason = self.should_compress_info(prompt_tokens, n_messages=n_messages)
         return decision
 
     def should_compress_info(
-        self, prompt_tokens: int = None
+        self, prompt_tokens: int = None, n_messages: int = None
     ) -> "tuple[bool, str | None]":
         """Check if context exceeds the compression threshold.
 
@@ -3243,10 +3243,24 @@ class ContextCompressor(ContextEngine):
         Includes anti-thrashing protection: if the last two compressions
         each saved less than 10%, skip compression to avoid infinite loops
         where each pass removes only 1-2 messages.
+
+        Includes message-eligibility check (#88778): when the caller provides
+        ``n_messages`` and every message falls inside the protected head/tail
+        window, there is structurally nothing to compress.  Returning
+        ``False`` early avoids a guaranteed no-op LLM summarization pass.
         """
         tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
         if tokens < self.threshold_tokens:
             return False, None
+        # Message-eligibility guard (#88778): when the caller supplies the
+        # message count, check whether there are enough messages outside the
+        # protected head/tail window to make compression worthwhile.  Uses a
+        # conservative head-size estimate (system prompt + protect_first_n)
+        # so the check works without access to the full messages list.
+        if n_messages is not None:
+            head_estimate = 1 + self.protect_first_n
+            if n_messages <= self.protect_last_n + head_estimate + 1:
+                return False, None
         if self._automatic_compression_blocked():
             return False, self._compression_block_reason() or "blocked"
         return True, None

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2528,7 +2528,7 @@ def run_conversation(
             and not _preflight_compression_blocked
             and not _defer_preflight(request_pressure_tokens)
             and not _compression_cooldown
-            and _compressor.should_compress(request_pressure_tokens)
+            and _compressor.should_compress(request_pressure_tokens, n_messages=len(messages))
         ):
             if _moa_prepared_request is not None:
                 pending_moa_prepared_request = _moa_prepared_request


### PR DESCRIPTION
## Summary

Fixes #88778.

`should_compress_info()` only compared `prompt_tokens` against `threshold_tokens`, without checking whether enough unprotected messages exist to make compression worthwhile. On sessions with few messages where every turn falls inside the protected head/tail window, compression fired anyway, wasting an API round-trip for a guaranteed no-op LLM summarization pass.

This is the same pattern as `prune_tool_results_only()` at line 3737 which correctly bails out: `if len(messages) <= self.protect_last_n + self._protect_head_size(messages) + 1`.

## Changes

- `agent/context_compressor.py`:
  - Added optional `n_messages` parameter to `should_compress_info()` and `should_compress()`
  - When `n_messages` is provided, checks `n_messages <= protect_last_n + head_estimate + 1` (conservative head-size estimate of `1 + protect_first_n`) and returns `(False, None)` early when all messages are in the protected window
- `agent/conversation_loop.py`:
  - Updated the pre-API call site to pass `len(messages)` to `should_compress()`

## Testing

- Verified syntax with `python3 -m py_compile` for both files
- The fix is backward-compatible: `n_messages` defaults to `None`, so all existing callers that don't pass it get the old behavior
