### PR TITLE
fix(config): preserve max_output_tokens during custom provider normalization (#88997)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1372,6 +1372,8 @@ def _normalize_custom_provider_entry(
         "apiKeyEnv": "key_env",  # alias — OpenClaw-compatible + docs variant
         "defaultModel": "default_model",
         "contextLength": "context_length",
+        "maxOutputTokens": "max_output_tokens",
+        "maxTokens": "max_tokens",
         "rateLimitDelay": "rate_limit_delay",
     }
     # api_key_env is a documented snake_case alias for key_env (see
@@ -1389,7 +1391,7 @@ def _normalize_custom_provider_entry(
         "key_cmd",
         "api_mode", "transport", "model", "default_model", "models",
         "models_discovered",
-        "context_length", "rate_limit_delay",
+        "context_length", "max_output_tokens", "max_tokens", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body", "extra_headers",
         "ssl_ca_cert", "ssl_verify",
@@ -1525,6 +1527,12 @@ def _normalize_custom_provider_entry(
     if isinstance(context_length, int) and context_length > 0:
         normalized["context_length"] = context_length
 
+    max_output_tokens = entry.get("max_output_tokens")
+    if max_output_tokens is None:
+        max_output_tokens = entry.get("max_tokens")
+    if isinstance(max_output_tokens, int) and max_output_tokens > 0:
+        normalized["max_output_tokens"] = max_output_tokens
+
     rate_limit_delay = entry.get("rate_limit_delay")
     if isinstance(rate_limit_delay, (int, float)) and rate_limit_delay >= 0:
         normalized["rate_limit_delay"] = rate_limit_delay
@@ -1579,6 +1587,7 @@ def _custom_provider_entry_to_provider_config(
         "models",
         "models_discovered",
         "context_length",
+        "max_output_tokens",
         "rate_limit_delay",
         "discover_models",
         "extra_body",
@@ -2019,8 +2028,8 @@ _KNOWN_ROOT_KEYS = frozenset(DEFAULT_CONFIG.keys()) | _EXTRA_KNOWN_ROOT_KEYS
 # Valid fields inside a custom_providers list entry
 _VALID_CUSTOM_PROVIDER_FIELDS = {
     "name", "base_url", "api_key", "api_mode", "model", "models",
-    "context_length", "rate_limit_delay", "extra_body",
-    "ssl_ca_cert", "ssl_verify",
+    "context_length", "max_output_tokens", "max_tokens", "rate_limit_delay",
+    "extra_body", "ssl_ca_cert", "ssl_verify",
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
     # — include it here so the set accurately describes the supported schema.
     "key_env",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1345,6 +1345,19 @@ def _canonical_api_mode(api_mode: str) -> str:
     return _API_MODE_ALIASES.get(cleaned.lower(), cleaned)
 
 
+def _positive_int(value) -> Optional[int]:
+    """A strictly-positive integer, or None.
+
+    ``bool`` is a subclass of ``int``, so a plain ``isinstance(v, int)``
+    accepts a YAML ``true`` and silently persists it as ``1`` — a token
+    ceiling of one, from what reads like a feature flag typo. Rejecting
+    bools here keeps that out of every numeric provider field at once.
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value if value > 0 else None
+
+
 def _normalize_custom_provider_entry(
     entry: Any,
     *,
@@ -1523,18 +1536,23 @@ def _normalize_custom_provider_entry(
     if models_discovered:
         normalized["models_discovered"] = True
 
-    context_length = entry.get("context_length")
-    if isinstance(context_length, int) and context_length > 0:
+    context_length = _positive_int(entry.get("context_length"))
+    if context_length is not None:
         normalized["context_length"] = context_length
 
     max_output_tokens = entry.get("max_output_tokens")
     if max_output_tokens is None:
         max_output_tokens = entry.get("max_tokens")
-    if isinstance(max_output_tokens, int) and max_output_tokens > 0:
+    max_output_tokens = _positive_int(max_output_tokens)
+    if max_output_tokens is not None:
         normalized["max_output_tokens"] = max_output_tokens
 
     rate_limit_delay = entry.get("rate_limit_delay")
-    if isinstance(rate_limit_delay, (int, float)) and rate_limit_delay >= 0:
+    if (
+        isinstance(rate_limit_delay, (int, float))
+        and not isinstance(rate_limit_delay, bool)
+        and rate_limit_delay >= 0
+    ):
         normalized["rate_limit_delay"] = rate_limit_delay
 
     discover_models = entry.get("discover_models")

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -67,4 +67,40 @@ class TestNormalizeCustomProviderEntry:
         assert result is not None
         assert result["base_url"] == "${PROVIDER_A_BASE_URL}"
 
+    def test_max_output_tokens_preserved_without_warning(self, caplog):
+        """max_output_tokens and max_tokens alias must be preserved in normalized
+        entry without triggering unknown key warning (#88997)."""
+        entry = {
+            "name": "ollama-local",
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "ollama",
+            "model": "gpt-oss:20b-64k",
+            "max_output_tokens": 8192,
+        }
+        with caplog.at_level(logging.WARNING):
+            result = _normalize_custom_provider_entry(entry, provider_key="ollama-local")
+        assert result is not None
+        assert result["max_output_tokens"] == 8192
+        assert not [r for r in caplog.records if "unknown config keys" in r.message.lower()]
 
+    def test_max_tokens_alias_and_camelcase_preserved(self, caplog):
+        """max_tokens and camelCase maxOutputTokens/maxTokens are preserved."""
+        entry1 = {
+            "name": "vllm-local",
+            "base_url": "http://localhost:8000/v1",
+            "api_key": "vllm",
+            "max_tokens": 4096,
+        }
+        result1 = _normalize_custom_provider_entry(entry1, provider_key="vllm-local")
+        assert result1 is not None
+        assert result1["max_output_tokens"] == 4096
+
+        entry2 = {
+            "name": "lmstudio-local",
+            "base_url": "http://localhost:1234/v1",
+            "api_key": "lmstudio",
+            "maxOutputTokens": 2048,
+        }
+        result2 = _normalize_custom_provider_entry(entry2, provider_key="lmstudio-local")
+        assert result2 is not None
+        assert result2["max_output_tokens"] == 2048

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -67,6 +67,28 @@ class TestNormalizeCustomProviderEntry:
         assert result is not None
         assert result["base_url"] == "${PROVIDER_A_BASE_URL}"
 
+    @pytest.mark.parametrize("field", ["max_output_tokens", "context_length", "rate_limit_delay"])
+    def test_a_yaml_true_is_not_taken_as_a_number(self, field):
+        """bool is an int subclass, so ``field: true`` used to persist as 1.
+
+        A token ceiling of 1 from what reads like a feature-flag typo is
+        worse than the field being absent — the provider answers with one
+        token and nothing explains why.
+        """
+        entry = {"name": "local", "base_url": "http://x/v1", field: True}
+        result = _normalize_custom_provider_entry(entry, provider_key="local")
+        assert field not in result, (
+            f"{field}: true was accepted as a number ({result.get(field)!r})"
+        )
+
+    @pytest.mark.parametrize(
+        "field,good",
+        [("max_output_tokens", 8192), ("context_length", 32000), ("rate_limit_delay", 0.5)],
+    )
+    def test_real_numbers_still_pass(self, field, good):
+        entry = {"name": "local", "base_url": "http://x/v1", field: good}
+        assert _normalize_custom_provider_entry(entry, provider_key="local")[field] == good
+
     def test_max_output_tokens_preserved_without_warning(self, caplog):
         """max_output_tokens and max_tokens alias must be preserved in normalized
         entry without triggering unknown key warning (#88997)."""

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1677,3 +1677,39 @@ def test_resolve_runtime_provider_opencode_free_missing_env_still_resolves(monke
     assert resolved["provider"] == "opencode-free"
     assert resolved["api_key"] == "opencode-zen-free-keyless"
     assert resolved["base_url"] == "https://opencode.ai/zen/v1"
+
+
+def test_custom_provider_resolves_max_output_tokens(monkeypatch):
+    """Custom provider entry with max_output_tokens propagates to resolved runtime dict (#88997)."""
+    custom_entry = {
+        "name": "ollama-local",
+        "base_url": "http://localhost:11434/v1",
+        "api_key": "ollama",
+        "model": "gpt-oss:20b",
+        "max_output_tokens": 8192,
+    }
+    monkeypatch.setattr(rp, "get_compatible_custom_providers", lambda *a, **k: [custom_entry])
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "custom")
+
+    resolved = rp.resolve_runtime_provider(requested="ollama-local")
+    assert resolved is not None
+    assert resolved.get("max_output_tokens") == 8192
+
+
+def test_custom_provider_resolves_max_tokens_alias(monkeypatch):
+    """Custom provider entry with max_tokens alias propagates to max_output_tokens (#88997)."""
+    custom_entry = {
+        "name": "vllm-local",
+        "base_url": "http://localhost:8000/v1",
+        "api_key": "vllm",
+        "model": "qwen",
+        "max_tokens": 4096,
+    }
+    from hermes_cli.config import _normalize_custom_provider_entry
+    normalized = _normalize_custom_provider_entry(custom_entry)
+    monkeypatch.setattr(rp, "get_compatible_custom_providers", lambda *a, **k: [normalized])
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "custom")
+
+    resolved = rp.resolve_runtime_provider(requested="vllm-local")
+    assert resolved is not None
+    assert resolved.get("max_output_tokens") == 4096


### PR DESCRIPTION
## Summary
Fixes #88997.

`custom_providers[].max_output_tokens` and its `max_tokens` alias were stripped by `_normalize_custom_provider_entry` and logged as unknown configuration keys. As a result, per-provider token budgets could not reach runtime provider resolution or subagent delegation credentials.

## Changes
- In `hermes_cli/config.py`:
  - Add `max_output_tokens` and `max_tokens` to `_KNOWN_KEYS`, `_CAMEL_ALIASES` (`maxOutputTokens`, `maxTokens`), and `_VALID_CUSTOM_PROVIDER_FIELDS`.
  - Preserve `max_output_tokens` in `_normalize_custom_provider_entry` and `_custom_provider_entry_to_provider_config`.
- In `tests/hermes_cli/test_provider_config_validation.py`: add tests for `max_output_tokens`, `max_tokens`, and camelCase alias normalization without warnings.
- In `tests/hermes_cli/test_runtime_provider_resolution.py`: add tests for resolving `max_output_tokens` from custom providers.

## Verification
- `pytest tests/hermes_cli/test_provider_config_validation.py tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_config.py tests/hermes_cli/test_web_server.py` passed (147/147 tests).
- GPG signed on Mac and `git diff --check` clean.