### PR TITLE
fix(config): prevent false-positive deprecated cwd warning for bridged local cwd (#89016)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2193,8 +2193,9 @@ def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> Non
     These env vars are deprecated — the canonical setting is terminal.cwd
     in config.yaml.  Prints a migration hint to stderr.
     """
-    messaging_cwd = os.environ.get("MESSAGING_CWD")
-    terminal_cwd_env = os.environ.get("TERMINAL_CWD")
+    env_file = load_env()
+    messaging_cwd = env_file.get("MESSAGING_CWD") or os.environ.get("MESSAGING_CWD")
+    terminal_cwd_env = env_file.get("TERMINAL_CWD") or os.environ.get("TERMINAL_CWD")
 
     if config is None:
         try:
@@ -2204,8 +2205,15 @@ def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> Non
 
     terminal_cfg = config.get("terminal", {})
     config_cwd = terminal_cfg.get("cwd", ".") if isinstance(terminal_cfg, dict) else "."
-    # Only warn if config.yaml doesn't have an explicit path
-    config_has_explicit_cwd = config_cwd not in {".", "auto", "cwd", ""}
+    # If TERMINAL_CWD is not defined in .env and matches the local process working directory,
+    # it was bridged by CLI/TUI startup for the local backend (terminal.cwd = .) — do not warn (#89016).
+    terminal_in_dot_env = "TERMINAL_CWD" in env_file
+    is_bridged_local_cwd = (
+        not terminal_in_dot_env
+        and terminal_cwd_env == os.getcwd()
+        and (config_cwd in {".", "auto", "cwd", ""} or (isinstance(terminal_cfg, dict) and "cwd" in terminal_cfg))
+    )
+    config_has_explicit_cwd = config_cwd not in {".", "auto", "cwd", ""} or is_bridged_local_cwd
 
     lines: list[str] = []
     if messaging_cwd:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2193,7 +2193,10 @@ def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> Non
     These env vars are deprecated — the canonical setting is terminal.cwd
     in config.yaml.  Prints a migration hint to stderr.
     """
-    env_file = load_env()
+    try:
+        env_file = load_env()
+    except Exception:
+        env_file = {}
     messaging_cwd = env_file.get("MESSAGING_CWD") or os.environ.get("MESSAGING_CWD")
     terminal_cwd_env = env_file.get("TERMINAL_CWD") or os.environ.get("TERMINAL_CWD")
 

--- a/tests/hermes_cli/test_deprecated_cwd_warning.py
+++ b/tests/hermes_cli/test_deprecated_cwd_warning.py
@@ -27,3 +27,32 @@ class TestDeprecatedCwdWarning:
         captured = capsys.readouterr()
         assert "MESSAGING_CWD" in captured.err
         assert "TERMINAL_CWD" in captured.err
+
+    def test_local_backend_dot_cwd_does_not_warn_when_bridged(self, monkeypatch, capsys):
+        """When terminal.cwd is '.' and TERMINAL_CWD is bridged from os.getcwd()
+        (and not in .env), no false-positive warning is emitted (#89016)."""
+        import os
+        from hermes_cli import config as config_mod
+
+        monkeypatch.delenv("MESSAGING_CWD", raising=False)
+        monkeypatch.setenv("TERMINAL_CWD", os.getcwd())
+        monkeypatch.setattr(config_mod, "load_env", lambda: {})
+
+        config_mod.warn_deprecated_cwd_env_vars(config={"terminal": {"cwd": "."}})
+        captured = capsys.readouterr()
+        assert "TERMINAL_CWD" not in captured.err
+        assert captured.err == ""
+
+    def test_dot_env_terminal_cwd_warns(self, monkeypatch, capsys):
+        """When TERMINAL_CWD is actually in .env, warning is emitted."""
+        import os
+        from hermes_cli import config as config_mod
+
+        monkeypatch.delenv("MESSAGING_CWD", raising=False)
+        monkeypatch.setenv("TERMINAL_CWD", os.getcwd())
+        monkeypatch.setattr(config_mod, "load_env", lambda: {"TERMINAL_CWD": os.getcwd()})
+
+        config_mod.warn_deprecated_cwd_env_vars(config={"terminal": {"cwd": "."}})
+        captured = capsys.readouterr()
+        assert "TERMINAL_CWD" in captured.err
+        assert "deprecated" in captured.err.lower()


### PR DESCRIPTION
## Summary
Fixes #89016.

When `terminal.cwd` is set to `.` (the default/documented follow-the-launch-dir setting for the local backend), the CLI bridge exports `os.environ['TERMINAL_CWD'] = os.getcwd()`. `warn_deprecated_cwd_env_vars()` was checking only the presence of `TERMINAL_CWD` in the process environment and whether `terminal.cwd` was an explicit non-placeholder path, leading to a misleading 'Deprecated .env settings detected' warning on every startup even when `.env` contained no such key.

## Changes
- In `hermes_cli/config.py` (`warn_deprecated_cwd_env_vars`):
  - Read from `load_env()` to check if `TERMINAL_CWD` is truly present in `.env`.
  - Skip the deprecation warning when `TERMINAL_CWD` was bridged by the local backend and is not present in `.env`.
- In `tests/hermes_cli/test_deprecated_cwd_warning.py`:
  - Added test `test_local_backend_dot_cwd_does_not_warn_when_bridged`.
  - Added test `test_dot_env_terminal_cwd_warns`.

## Verification
- `pytest tests/hermes_cli/test_deprecated_cwd_warning.py tests/hermes_cli/test_config.py tests/hermes_cli/test_web_server.py` passed (83/83 passed).
- GPG signed on Mac and `git diff --check` clean.