### PR TITLE
fix(cli): accept singular `hermes plugin` alias

### DIFF
--- a/hermes_cli/subcommands/plugins.py
+++ b/hermes_cli/subcommands/plugins.py
@@ -13,6 +13,7 @@ def build_plugins_parser(subparsers, *, cmd_plugins: Callable) -> None:
     """Attach the ``plugins`` subcommand to ``subparsers``."""
     plugins_parser = subparsers.add_parser(
         "plugins",
+        aliases=["plugin"],
         help="Manage and validate plugins",
         description=(
             "Install, update, remove, list, or validate native Hermes plugins "

--- a/tests/hermes_cli/test_plugins_parser_builder.py
+++ b/tests/hermes_cli/test_plugins_parser_builder.py
@@ -1,0 +1,30 @@
+"""Unit tests for the ``hermes plugins`` parser builder."""
+
+from __future__ import annotations
+
+import argparse
+
+from hermes_cli.subcommands.plugins import build_plugins_parser
+
+
+def _sentinel_handler(args):  # pragma: no cover - only identity is asserted
+    return "plugins-handler"
+
+
+def _build():
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    build_plugins_parser(subparsers, cmd_plugins=_sentinel_handler)
+    return parser
+
+
+def test_plugin_singular_alias_dispatches_to_plugins_handler():
+    parser = _build()
+
+    plural = parser.parse_args(["plugins", "list"])
+    singular = parser.parse_args(["plugin", "list"])
+
+    assert plural.plugins_action == "list"
+    assert singular.plugins_action == "list"
+    assert plural.func is _sentinel_handler
+    assert singular.func is _sentinel_handler


### PR DESCRIPTION
## What does this PR do?

Adds `plugin` as an argparse alias for the existing top-level `plugins` command, so both `hermes plugin …` and `hermes plugins …` dispatch through the same parser and handler.

Fixes #89120.

## Type of Change

- [x] 🐛 Bug fix (non-breaking)
- [x] ✅ Tests

## Changes Made

- add `aliases=["plugin"]` to the existing `plugins` top-level parser
- add focused parser regression coverage proving `plugin list` and `plugins list` resolve the same action and handler

## Validation

The change is limited to argparse wiring plus a parser-level regression test. No runtime plugin behavior or configuration changes are involved.

## Checklist

- [x] Read the contributing guide
- [x] Searched open issues and PRs for duplicates
- [x] Minimal scoped change
- [x] Added regression coverage
- [x] Conventional commit messages
