### PR TITLE
fix(update): name a repair command when state.db fails its post-update check

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -474,6 +474,23 @@ _SQLITE_HEADER = b"SQLite format 3\0"
 DEFAULT_INTEGRITY_CHECK_MAX_BYTES = 2 << 30  # 2 GiB
 
 
+INTEGRITY_CHECK_MAX_REPORTED_ERRORS = 5
+"""How many ``PRAGMA integrity_check`` findings a failure message carries.
+
+``integrity_check`` returns one row per problem and a badly damaged file can
+return hundreds, so the message quotes a prefix.
+"""
+
+INTEGRITY_CHECK_OMITTED_SUFFIX = "more findings omitted"
+"""Words that disclose a quoted-prefix integrity report.
+
+Named because the message is *classified* downstream (see
+``hermes_cli.update_cmd._state_db_damage_is_fts_only``) and a truncated
+report cannot be classified honestly -- this suffix is what lets a reader
+tell "these are all the findings" from "these are the first few".
+"""
+
+
 def verify_sqlite_integrity(
     path: Path,
     *,
@@ -592,7 +609,19 @@ def verify_sqlite_integrity(
                 result["message"] = "integrity check passed"
                 return result
             errors = [str(r[0]) for r in rows]
-            result["message"] = f"integrity check failed: {'; '.join(errors[:5])}"
+            shown = errors[:INTEGRITY_CHECK_MAX_REPORTED_ERRORS]
+            omitted = len(errors) - len(shown)
+            # Say when the report is short rather than silently dropping
+            # findings: this string is classified downstream, and an omitted
+            # finding is exactly the one that could contradict the shown ones.
+            suffix = (
+                f"; ({omitted} {INTEGRITY_CHECK_OMITTED_SUFFIX})"
+                if omitted > 0
+                else ""
+            )
+            result["message"] = (
+                f"integrity check failed: {'; '.join(shown)}{suffix}"
+            )
             return result
         except sqlite3.DatabaseError as exc:
             result["message"] = f"cannot open database: {exc}"

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1363,6 +1363,55 @@ def _state_db_damage_is_fts_only(message: str) -> bool:
     )
 
 
+def _restore_state_db_from_snapshot(snap_state, state_path, label: str):
+    """Put a snapshot's state.db back when the post-update check found damage.
+
+    Both update flows reach the same dead end differently -- the git path
+    knows the id of the snapshot it took, the ZIP path scans every snapshot
+    newest-first -- but once either has a *candidate* file the remaining
+    work is identical: verify the candidate, copy it over, verify the
+    result, and say which of those happened.  That half was duplicated, and
+    it is the half that had to stay in step, since both copies re-verify
+    after the copy specifically so a bad snapshot cannot quietly replace a
+    bad database with another one.
+
+    The differing half is left where it is on purpose.  The two flows
+    genuinely disagree about which snapshot to trust and owe the user
+    different explanations when there is none, so folding them together
+    would mean inventing a strategy neither one has.
+
+    Returns None when *snap_state* is itself corrupt -- nothing was
+    attempted, so a caller working through several snapshots should keep
+    looking -- True when the copy landed and re-verified, and False when an
+    attempt was made and did not succeed.
+    """
+    from hermes_cli.backup import verify_sqlite_integrity
+
+    if not verify_sqlite_integrity(
+        snap_state, check_header=True, run_pragma=True
+    ).get("valid"):
+        return None
+
+    try:
+        import shutil as _shutil
+
+        _shutil.copy2(snap_state, state_path)
+    except OSError as exc:
+        print(f"  ✗ Auto-restore file copy failed: {exc}")
+        return False
+
+    if verify_sqlite_integrity(
+        state_path, check_header=True, run_pragma=True
+    ).get("valid"):
+        print(f"  ✓ Auto-restored from {label}")
+        return True
+
+    print(
+        "  ✗ Auto-restore FAILED — restored copy also failed integrity"
+    )
+    return False
+
+
 def _print_state_db_repair_hint(message: str) -> None:
     """Name a concrete repair command for a state.db the update found corrupt.
 
@@ -1831,36 +1880,17 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
                     for _snap_dir in _snap_dirs:
                         _snap_state = _snap_dir / "state.db"
                         if _snap_state.exists():
-                            _snap_ok = verify_sqlite_integrity(
-                                _snap_state, check_header=True, run_pragma=True
+                            # None means that snapshot is corrupt too, so
+                            # keep walking back; anything else was an
+                            # attempt and settles it.
+                            _outcome = _restore_state_db_from_snapshot(
+                                _snap_state,
+                                _state_path,
+                                f"snapshot {_snap_dir.name}",
                             )
-                            if _snap_ok.get("valid"):
-                                try:
-                                    import shutil as _shutil
-
-                                    _shutil.copy2(_snap_state, _state_path)
-                                    _restored_ok = verify_sqlite_integrity(
-                                        _state_path,
-                                        check_header=True,
-                                        run_pragma=True,
-                                    )
-                                    if _restored_ok.get("valid"):
-                                        _state_restored = True
-                                        print(
-                                            "  ✓ Auto-restored from snapshot "
-                                            f"{_snap_dir.name}"
-                                        )
-                                    else:
-                                        print(
-                                            "  ✗ Auto-restore FAILED — restored "
-                                            "copy also failed integrity"
-                                        )
-                                    break
-                                except OSError as _exc:
-                                    print(
-                                        f"  ✗ Auto-restore file copy failed: {_exc}"
-                                    )
-                                    break
+                            if _outcome is not None:
+                                _state_restored = _outcome
+                                break
                 if not _state_restored:
                     # Every branch above either restored the file or ran out
                     # of options without telling the user what they can do
@@ -6714,38 +6744,17 @@ def _cmd_update_impl(args, gateway_mode: bool):
                             / "state.db"
                         )
                         if _snap_state.exists():
-                            _snap_ok = verify_sqlite_integrity(
-                                _snap_state, check_header=True, run_pragma=True
+                            _outcome = _restore_state_db_from_snapshot(
+                                _snap_state,
+                                _state_path,
+                                f"pre-update snapshot ({_pre_snap_id})",
                             )
-                            if _snap_ok.get("valid"):
-                                try:
-                                    import shutil as _shutil
-
-                                    _shutil.copy2(_snap_state, _state_path)
-                                    _restored_ok = verify_sqlite_integrity(
-                                        _state_path,
-                                        check_header=True,
-                                        run_pragma=True,
-                                    )
-                                    if _restored_ok.get("valid"):
-                                        _state_restored = True
-                                        print(
-                                            "  ✓ Auto-restored from pre-update "
-                                            f"snapshot ({_pre_snap_id})"
-                                        )
-                                    else:
-                                        print(
-                                            "  ✗ Auto-restore FAILED — restored "
-                                            "copy also failed integrity"
-                                        )
-                                except OSError as _exc:
-                                    print(
-                                        f"  ✗ Auto-restore file copy failed: {_exc}"
-                                    )
-                            else:
+                            if _outcome is None:
                                 print(
                                     "  ✗ Pre-update snapshot also failed integrity"
                                 )
+                            else:
+                                _state_restored = _outcome
                         else:
                             print(
                                 "  ⚠ Pre-update snapshot does not contain state.db"

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1317,7 +1317,7 @@ def _abort_zip_update_if_dirty_tree() -> None:
     print("  To inspect: git status --porcelain")
     _m().sys.exit(1)
 def _state_db_damage_is_fts_only(message: str) -> bool:
-    """True when an integrity-check message blames only the FTS5 index.
+    """True when *every* integrity-check finding blames the FTS5 index.
 
     ``PRAGMA integrity_check`` reports FTS5 damage in the shape
     ``malformed inverted index for FTS5 table main.messages_fts_trigram``
@@ -1328,13 +1328,39 @@ def _state_db_damage_is_fts_only(message: str) -> bool:
     entries in index``, a bad header), which is why the caller only makes
     the "your history is intact" claim for this class.
 
+    **The test is per finding, not per message.** ``integrity_check`` emits
+    one row per problem and ``verify_sqlite_integrity`` joins them with
+    ``"; "``, so a database damaged both ways arrives as a single string
+    holding an FTS phrase *and* a page-damage phrase.  Asking only whether
+    an FTS phrase appears anywhere answers yes there, and tells a user with
+    real b-tree loss that their messages are intact -- the precise false
+    reassurance this hint exists to prevent.  So the message is split back
+    into its findings and the claim is made only when every one is FTS.
+
+    A report that discloses omitted findings is refused for the same
+    reason: the finding that did not fit is exactly the one that could
+    contradict the ones that did.
+
     Deliberately a text test rather than a reuse of
     ``SessionDB._is_fts_write_corruption_error``: that classifier takes a
     ``sqlite3.DatabaseError`` raised by a failed *write*, and here there is
     no exception -- only the string ``verify_sqlite_integrity`` returned.
     """
+    from hermes_cli.backup import INTEGRITY_CHECK_OMITTED_SUFFIX
+
     lowered = message.lower()
-    return "fts5" in lowered or "inverted index" in lowered
+    if INTEGRITY_CHECK_OMITTED_SUFFIX in lowered:
+        return False
+
+    _, marker, tail = lowered.partition("integrity check failed:")
+    findings = [part.strip() for part in (tail if marker else lowered).split(";")]
+    findings = [part for part in findings if part]
+    if not findings:
+        return False
+
+    return all(
+        "fts5" in finding or "inverted index" in finding for finding in findings
+    )
 
 
 def _print_state_db_repair_hint(message: str) -> None:
@@ -1364,8 +1390,8 @@ def _print_state_db_repair_hint(message: str) -> None:
     else:
         print("  → Try:  hermes sessions repair")
         print(
-            "    It backs up first, refuses to touch a database that is "
-            "actually healthy, and tries the least destructive fix first."
+            "    It typically backs up first, re-checks the database before "
+            "acting, and tries the least destructive fix first."
         )
 
 

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1316,6 +1316,57 @@ def _abort_zip_update_if_dirty_tree() -> None:
     print("  Stash or commit your changes, then rerun `hermes update`.")
     print("  To inspect: git status --porcelain")
     _m().sys.exit(1)
+def _state_db_damage_is_fts_only(message: str) -> bool:
+    """True when an integrity-check message blames only the FTS5 index.
+
+    ``PRAGMA integrity_check`` reports FTS5 damage in the shape
+    ``malformed inverted index for FTS5 table main.messages_fts_trigram``
+    (#88252).  That names a *derived* structure: the search index is
+    rebuilt from the canonical ``messages`` rows, so this class of damage
+    costs the user their search index and nothing else.  Real page damage
+    reads very differently (``row N missing from index``, ``wrong # of
+    entries in index``, a bad header), which is why the caller only makes
+    the "your history is intact" claim for this class.
+
+    Deliberately a text test rather than a reuse of
+    ``SessionDB._is_fts_write_corruption_error``: that classifier takes a
+    ``sqlite3.DatabaseError`` raised by a failed *write*, and here there is
+    no exception -- only the string ``verify_sqlite_integrity`` returned.
+    """
+    lowered = message.lower()
+    return "fts5" in lowered or "inverted index" in lowered
+
+
+def _print_state_db_repair_hint(message: str) -> None:
+    """Name a concrete repair command for a state.db the update found corrupt.
+
+    Only reached once restoring from a snapshot turned out to be impossible
+    or to have failed, which is exactly the dead end #88252 reports: the
+    update announces that the database is corrupted, offers nothing, and the
+    user reasonably concludes their history is gone.  Usually it is not --
+    ``hermes sessions repair`` already fixes the dominant class in place,
+    via the FTS5 ``'rebuild'`` command, without touching a single message
+    row.
+
+    That command is also the right pointer for the other classes: it
+    re-probes with its own health check and declines to touch a database
+    that is actually fine, backs up before it changes anything, and
+    escalates least-destructive-first.  So this prints a pointer and never
+    repairs anything itself -- an update is the wrong place to acquire a
+    write lock on a database the user has not asked us to rewrite.
+    """
+    if _state_db_damage_is_fts_only(message):
+        print(
+            "  → This is the FTS5 search index, not your sessions or "
+            "messages — they are intact."
+        )
+        print("    Rebuild the index in place with:  hermes sessions repair")
+    else:
+        print("  → Try:  hermes sessions repair")
+        print(
+            "    It backs up first, refuses to touch a database that is "
+            "actually healthy, and tries the least destructive fix first."
+        )
 
 
 def _read_project_version() -> str | None:
@@ -1741,11 +1792,10 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
                 _state_path, check_header=True, run_pragma=True
             )
             if not _state_ok.get("valid"):
+                _state_message = _state_ok.get("message", "unknown error")
+                _state_restored = False
                 print()
-                print(
-                    "⚠ state.db is corrupted after update: "
-                    + _state_ok.get("message", "unknown error")
-                )
+                print("⚠ state.db is corrupted after update: " + _state_message)
                 _snap_root = _quick_snapshot_root(get_hermes_home())
                 if _snap_root.exists():
                     _snap_dirs = sorted(
@@ -1769,6 +1819,7 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
                                         run_pragma=True,
                                     )
                                     if _restored_ok.get("valid"):
+                                        _state_restored = True
                                         print(
                                             "  ✓ Auto-restored from snapshot "
                                             f"{_snap_dir.name}"
@@ -1784,6 +1835,11 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
                                         f"  ✗ Auto-restore file copy failed: {_exc}"
                                     )
                                     break
+                if not _state_restored:
+                    # Every branch above either restored the file or ran out
+                    # of options without telling the user what they can do
+                    # next (#88252).  Tell them.
+                    _print_state_db_repair_hint(_state_message)
     except Exception as exc:
         logger.debug(
             "Post-update state.db integrity check (zip path) failed: %s", exc
@@ -6620,11 +6676,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         _state_ok.get("message"),
                     )
                 else:
+                    _state_message = _state_ok.get("message", "unknown error")
+                    _state_restored = False
                     print()
-                    print(
-                        "⚠ state.db is corrupted after update: "
-                        + _state_ok.get("message", "unknown error")
-                    )
+                    print("⚠ state.db is corrupted after update: " + _state_message)
                     _pre_snap_id = pre_update_snapshot_id
                     if _pre_snap_id:
                         _snap_state = (
@@ -6647,6 +6702,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                                         run_pragma=True,
                                     )
                                     if _restored_ok.get("valid"):
+                                        _state_restored = True
                                         print(
                                             "  ✓ Auto-restored from pre-update "
                                             f"snapshot ({_pre_snap_id})"
@@ -6670,6 +6726,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
                             )
                     else:
                         print("  ⚠ No pre-update snapshot was taken")
+                    if not _state_restored:
+                        # The reporter's exact dead end (#88252): corruption
+                        # announced, no snapshot to fall back on, and not a
+                        # word about the repair command that already exists.
+                        _print_state_db_repair_hint(_state_message)
                     print()
         except Exception as exc:
             logger.debug("Post-update state.db integrity check failed: %s", exc)

--- a/tests/hermes_cli/test_update_state_db_repair_hint.py
+++ b/tests/hermes_cli/test_update_state_db_repair_hint.py
@@ -15,6 +15,9 @@ search index, and ``hermes sessions repair`` already rebuilds it in place.
 from __future__ import annotations
 
 import inspect
+import shutil
+import sqlite3
+from pathlib import Path
 
 import pytest
 
@@ -284,4 +287,112 @@ class TestBothUpdatePathsAreWired:
         source = inspect.getsource(func)
 
         assert "_state_restored = False" in source
-        assert "_state_restored = True" in source
+        assert "_restore_state_db_from_snapshot(" in source, (
+            f"{func.__name__} must go through the shared restore helper"
+        )
+        assert "_state_restored = _outcome" in source, (
+            f"{func.__name__} ignores the restore outcome, so a successful "
+            "restore would still print the repair hint"
+        )
+
+
+def _make_db(path):
+    """A small but genuinely valid SQLite file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute("CREATE TABLE messages (id INTEGER PRIMARY KEY, body TEXT)")
+        conn.execute("INSERT INTO messages (body) VALUES ('kept')")
+        conn.commit()
+    finally:
+        conn.close()
+    return path
+
+
+class TestRestoreFromSnapshot:
+    """The half both update flows share, tested on real files.
+
+    The flows disagree about which snapshot to trust, but once either has a
+    candidate they do the same four things, and the ordering of those four
+    is load-bearing: verifying the copy *after* writing it is what stops a
+    corrupt snapshot from replacing a corrupt database with another one.
+    """
+
+    def test_a_good_snapshot_is_copied_and_confirmed(self, tmp_path, capsys):
+        state = tmp_path / "state.db"
+        state.write_bytes(b"not a database at all")
+        snap = _make_db(tmp_path / "snap" / "state.db")
+
+        outcome = update_cmd._restore_state_db_from_snapshot(
+            snap, state, "snapshot 20260822-0100"
+        )
+
+        assert outcome is True
+        assert state.read_bytes() == snap.read_bytes()
+        assert "snapshot 20260822-0100" in capsys.readouterr().out
+
+    def test_a_corrupt_snapshot_is_left_alone_and_reported_as_no_attempt(
+        self, tmp_path, capsys
+    ):
+        """None, not False: the ZIP path keeps walking back on this."""
+        state = _make_db(tmp_path / "state.db")
+        original = state.read_bytes()
+        snap = tmp_path / "snap" / "state.db"
+        snap.parent.mkdir(parents=True, exist_ok=True)
+        snap.write_bytes(b"garbage" * 64)
+
+        outcome = update_cmd._restore_state_db_from_snapshot(
+            snap, state, "snapshot 20260822-0100"
+        )
+
+        assert outcome is None
+        assert state.read_bytes() == original
+        # Nothing was attempted, so the caller owns the explanation.
+        assert capsys.readouterr().out == ""
+
+    def test_a_failed_copy_is_an_attempt_that_did_not_work(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        state = tmp_path / "state.db"
+        state.write_bytes(b"not a database at all")
+        snap = _make_db(tmp_path / "snap" / "state.db")
+
+        def _boom(*_args, **_kwargs):
+            raise OSError("Errno 13 Permission denied")
+
+        monkeypatch.setattr(shutil, "copy2", _boom)
+
+        outcome = update_cmd._restore_state_db_from_snapshot(
+            snap, state, "snapshot 20260822-0100"
+        )
+
+        assert outcome is False
+        assert "Permission denied" in capsys.readouterr().out
+
+    def test_a_copy_that_lands_corrupt_is_not_reported_as_restored(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """The re-verify is the point of this helper.
+
+        A snapshot can pass its own check and still not survive the copy
+        (a truncated write, a full disk).  Announcing a restore that did
+        not happen is the same false reassurance the repair hint exists to
+        avoid, one layer down.
+        """
+        state = tmp_path / "state.db"
+        state.write_bytes(b"not a database at all")
+        snap = _make_db(tmp_path / "snap" / "state.db")
+
+        def _truncating_copy(_src, dst):
+            Path(dst).write_bytes(b"SQLite format 3\x00" + b"\x00" * 16)
+
+        monkeypatch.setattr(shutil, "copy2", _truncating_copy)
+
+        outcome = update_cmd._restore_state_db_from_snapshot(
+            snap, state, "snapshot 20260822-0100"
+        )
+
+        assert outcome is False
+        out = capsys.readouterr().out
+        assert "Auto-restore FAILED" in out
+        assert "Auto-restored" not in out

--- a/tests/hermes_cli/test_update_state_db_repair_hint.py
+++ b/tests/hermes_cli/test_update_state_db_repair_hint.py
@@ -1,0 +1,160 @@
+"""The post-update state.db corruption message must name a repair (#88252).
+
+`hermes update` verifies state.db afterwards and, when the check fails, tries
+to restore a whole-database snapshot.  When there is no usable snapshot it
+used to stop there — the reporter saw
+
+    ⚠ state.db is corrupted after update: integrity check failed:
+      malformed inverted index for FTS5 table main.messages_fts_trigram
+      ⚠ No pre-update snapshot was taken
+
+on every update, concluded their history was damaged, and eventually ran the
+FTS5 ``'rebuild'`` by hand.  It was not damaged: that message names a derived
+search index, and ``hermes sessions repair`` already rebuilds it in place.
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from hermes_cli import update_cmd
+
+
+# The exact string PRAGMA integrity_check produced on the reporter's database
+# (Windows 11 26200, Hermes 0.20.2, state.db ~207 MB), as quoted in #88252.
+REPORTED_MESSAGE = (
+    "integrity check failed: malformed inverted index for FTS5 table "
+    "main.messages_fts_trigram"
+)
+
+
+class TestDamageClassification:
+    """Only FTS damage may be described as leaving the transcript intact."""
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            REPORTED_MESSAGE,
+            "malformed inverted index for FTS5 table main.messages_fts",
+            # The newer-SQLite wording of the same class, already recognised
+            # elsewhere by SessionDB._is_fts_write_corruption_error.
+            'fts5: corrupt structure record for table "messages_fts"',
+            # Callers hand us whatever verify_sqlite_integrity returned, and
+            # SQLite's own casing has changed between releases.
+            "MALFORMED INVERTED INDEX FOR FTS5 TABLE main.messages_fts_cjk",
+        ],
+    )
+    def test_fts_damage_is_recognised(self, message):
+        assert update_cmd._state_db_damage_is_fts_only(message) is True
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            # Genuine b-tree damage in a canonical table — the transcript
+            # really may be gone, so we must not say otherwise.
+            "row 12 missing from index sqlite_autoindex_sessions_1",
+            "wrong # of entries in index idx_messages_session",
+            "integrity check failed: database disk image is malformed",
+            "header check failed: not a database",
+            "unknown error",
+            "",
+        ],
+    )
+    def test_non_fts_damage_is_not_claimed_as_fts(self, message):
+        assert update_cmd._state_db_damage_is_fts_only(message) is False
+
+    def test_generic_malformed_image_is_not_treated_as_fts(self):
+        """The load-bearing negative case.
+
+        ``database disk image is malformed`` is what a corrupt FTS shadow
+        table raises on *older* SQLite builds, which is why
+        ``is_malformed_db_error`` accepts it — but it is equally what real
+        page damage raises, and integrity_check offers no way to tell them
+        apart from the string alone.  Reassuring a user with genuine page
+        damage that their messages are fine is a worse failure than saying
+        nothing, so this class deliberately falls through to the generic
+        hint.
+        """
+        assert (
+            update_cmd._state_db_damage_is_fts_only("database disk image is malformed")
+            is False
+        )
+
+
+class TestHintOutput:
+    """What the user is actually told once auto-restore is not an option."""
+
+    def test_fts_hint_names_the_command_and_reassures(self, capsys):
+        update_cmd._print_state_db_repair_hint(REPORTED_MESSAGE)
+        out = capsys.readouterr().out
+
+        assert "hermes sessions repair" in out
+        assert "intact" in out
+        assert "FTS5" in out
+
+    def test_generic_hint_names_the_command_without_reassuring(self, capsys):
+        update_cmd._print_state_db_repair_hint(
+            "row 12 missing from index sqlite_autoindex_sessions_1"
+        )
+        out = capsys.readouterr().out
+
+        assert "hermes sessions repair" in out
+        # No promise about the data: this class can genuinely have lost rows.
+        assert "intact" not in out
+
+    @pytest.mark.parametrize(
+        "message",
+        [REPORTED_MESSAGE, "row 12 missing from index sqlite_autoindex_sessions_1"],
+    )
+    def test_hint_never_claims_to_have_done_anything(self, capsys, message):
+        """A hint, never a receipt.
+
+        An update must not acquire a write lock on a database the user has
+        not asked it to rewrite, so nothing here repairs anything.  If a
+        later change makes it act, this test should fail and force the
+        wording — and the reasoning — to be revisited.
+        """
+        update_cmd._print_state_db_repair_hint(message)
+        out = capsys.readouterr().out.lower()
+
+        for claim in ("repaired", "rebuilt", "restored", "fixed"):
+            assert claim not in out
+
+
+class TestBothUpdatePathsAreWired:
+    """The two post-update checks must both reach the hint.
+
+    ``_cmd_update_impl`` and ``_update_via_zip`` are the git and zip update
+    flows; each verifies state.db afterwards and each could reach the dead
+    end.  Neither is callable in a test — they drive a whole update — so
+    this asserts on their source, the same technique used across
+    ``tests/hermes_cli`` for logic buried inside long command functions.
+    """
+
+    @pytest.mark.parametrize(
+        "func",
+        [update_cmd._cmd_update_impl, update_cmd._update_via_zip],
+        ids=["git-path", "zip-path"],
+    )
+    def test_path_prints_the_hint_when_nothing_was_restored(self, func):
+        source = inspect.getsource(func)
+
+        assert "_print_state_db_repair_hint(" in source, (
+            f"{func.__name__} reports state.db corruption but never names a repair"
+        )
+        assert "if not _state_restored:" in source, (
+            f"{func.__name__} must gate the hint on the restore having failed"
+        )
+
+    @pytest.mark.parametrize(
+        "func",
+        [update_cmd._cmd_update_impl, update_cmd._update_via_zip],
+        ids=["git-path", "zip-path"],
+    )
+    def test_path_records_a_successful_restore(self, func):
+        """Otherwise a repaired-by-restore database still gets the hint."""
+        source = inspect.getsource(func)
+
+        assert "_state_restored = False" in source
+        assert "_state_restored = True" in source

--- a/tests/hermes_cli/test_update_state_db_repair_hint.py
+++ b/tests/hermes_cli/test_update_state_db_repair_hint.py
@@ -18,7 +18,7 @@ import inspect
 
 import pytest
 
-from hermes_cli import update_cmd
+from hermes_cli import backup, update_cmd
 
 
 # The exact string PRAGMA integrity_check produced on the reporter's database
@@ -64,6 +64,73 @@ class TestDamageClassification:
     def test_non_fts_damage_is_not_claimed_as_fts(self, message):
         assert update_cmd._state_db_damage_is_fts_only(message) is False
 
+    @pytest.mark.parametrize(
+        "message",
+        [
+            # Both kinds at once, in either order.  verify_sqlite_integrity
+            # joins every finding PRAGMA integrity_check returned into one
+            # string, so this is what a doubly-damaged database looks like
+            # by the time it reaches us -- not a hypothetical.
+            "integrity check failed: malformed inverted index for FTS5 table "
+            "main.messages_fts_trigram; row 12 missing from index "
+            "sqlite_autoindex_sessions_1",
+            "integrity check failed: row 12 missing from index "
+            "sqlite_autoindex_sessions_1; malformed inverted index for FTS5 "
+            "table main.messages_fts_trigram",
+            # The page damage is in the middle of a run of FTS findings,
+            # which is where an "is an FTS phrase present" test is blindest.
+            "integrity check failed: malformed inverted index for FTS5 table "
+            "main.messages_fts; wrong # of entries in index "
+            "idx_messages_session; malformed inverted index for FTS5 table "
+            "main.messages_fts_cjk",
+        ],
+    )
+    def test_mixed_damage_is_not_claimed_as_fts_only(self, message):
+        """The false-reassurance entry path this classifier must not have.
+
+        Telling someone whose b-tree lost rows that their messages are
+        intact is worse than saying nothing, so a report that names any
+        non-FTS finding falls through to the generic hint no matter how
+        many FTS findings accompany it.
+        """
+        assert update_cmd._state_db_damage_is_fts_only(message) is False
+
+    def test_a_truncated_report_is_not_claimed_as_fts_only(self):
+        """A quoted-prefix report cannot be classified honestly.
+
+        ``verify_sqlite_integrity`` quotes the first
+        ``INTEGRITY_CHECK_MAX_REPORTED_ERRORS`` findings and discloses the
+        rest as a count.  The finding that did not fit is exactly the one
+        that could contradict the ones that did, so the reassuring claim is
+        refused even though every *visible* finding is FTS.
+        """
+        message = (
+            "integrity check failed: "
+            + "; ".join(
+                "malformed inverted index for FTS5 table main.messages_fts"
+                for _ in range(backup.INTEGRITY_CHECK_MAX_REPORTED_ERRORS)
+            )
+            + f"; (3 {backup.INTEGRITY_CHECK_OMITTED_SUFFIX})"
+        )
+
+        assert update_cmd._state_db_damage_is_fts_only(message) is False
+
+    def test_a_complete_all_fts_report_is_still_recognised(self):
+        """The tightening must not cost the case the hint exists for.
+
+        Several FTS indexes damaged together is the common shape of #88252
+        (trigram, cjk and the base index are separate FTS5 tables), and it
+        is still fully recoverable by a rebuild.
+        """
+        message = (
+            "integrity check failed: malformed inverted index for FTS5 table "
+            "main.messages_fts; malformed inverted index for FTS5 table "
+            "main.messages_fts_trigram; malformed inverted index for FTS5 "
+            "table main.messages_fts_cjk"
+        )
+
+        assert update_cmd._state_db_damage_is_fts_only(message) is True
+
     def test_generic_malformed_image_is_not_treated_as_fts(self):
         """The load-bearing negative case.
 
@@ -80,6 +147,66 @@ class TestDamageClassification:
             update_cmd._state_db_damage_is_fts_only("database disk image is malformed")
             is False
         )
+
+
+class TestIntegrityReportTruncationIsDisclosed:
+    """The producer must keep telling the classifier when it held back.
+
+    ``_state_db_damage_is_fts_only`` refuses to reassure on a report that
+    discloses omitted findings.  That guard is only worth anything while
+    ``verify_sqlite_integrity`` actually discloses them -- a silent
+    ``[:5]`` would hand the classifier a message that looks complete and
+    quietly restore the over-claim.
+    """
+
+    def _report(self, errors):
+        rows = [(e,) for e in errors]
+
+        class _Cursor:
+            def fetchall(self_inner):
+                return rows
+
+        class _Conn:
+            def execute(self_inner, _sql):
+                return _Cursor()
+
+            def close(self_inner):
+                pass
+
+        return _Conn()
+
+    def test_a_short_report_discloses_the_count(self, tmp_path, monkeypatch):
+        db = tmp_path / "state.db"
+        db.write_bytes(backup._SQLITE_HEADER + b"\x00" * 4096)
+        errors = [f"row {n} missing from index idx_messages" for n in range(9)]
+        monkeypatch.setattr(
+            backup.sqlite3, "connect", lambda *a, **k: self._report(errors)
+        )
+
+        message = backup.verify_sqlite_integrity(db)["message"]
+
+        omitted = len(errors) - backup.INTEGRITY_CHECK_MAX_REPORTED_ERRORS
+        assert f"({omitted} {backup.INTEGRITY_CHECK_OMITTED_SUFFIX})" in message
+        assert update_cmd._state_db_damage_is_fts_only(message) is False
+
+    def test_a_complete_report_says_nothing_about_omissions(
+        self, tmp_path, monkeypatch
+    ):
+        db = tmp_path / "state.db"
+        db.write_bytes(backup._SQLITE_HEADER + b"\x00" * 4096)
+        errors = [
+            "malformed inverted index for FTS5 table main.messages_fts",
+            "malformed inverted index for FTS5 table main.messages_fts_cjk",
+        ]
+        monkeypatch.setattr(
+            backup.sqlite3, "connect", lambda *a, **k: self._report(errors)
+        )
+
+        message = backup.verify_sqlite_integrity(db)["message"]
+
+        assert backup.INTEGRITY_CHECK_OMITTED_SUFFIX not in message
+        # And the round trip still reaches the reassuring hint.
+        assert update_cmd._state_db_damage_is_fts_only(message) is True
 
 
 class TestHintOutput:


### PR DESCRIPTION
## What does this PR do?

Makes the post-update `state.db` integrity check name a repair command when it
cannot restore a snapshot, instead of announcing corruption and stopping.

Both post-update checks answer *any* integrity failure the same way — look for
a whole-database snapshot and copy it back:

```python
if not _state_ok.get("valid"):
    print("⚠ state.db is corrupted after update: " + _state_ok.get("message", "unknown error"))
    _snap_root = _quick_snapshot_root(get_hermes_home())
```

For the failure users actually hit, that remedy is at the wrong altitude. The
message they see is

```
⚠ state.db is corrupted after update: integrity check failed:
  malformed inverted index for FTS5 table main.messages_fts_trigram
  ⚠ No pre-update snapshot was taken
```

`messages_fts_trigram` is a **derived** search index, rebuilt from the canonical
`messages` rows. Restoring a whole database to fix it would replace real user
data to repair a cache — and when there is no snapshot (the common case, since
`updates.pre_update_backup` defaults off for many installs) the code has nothing
left to say at all. #88252's reporter saw this on consecutive updates, concluded
their transcript was damaged, and eventually ran the FTS5 `'rebuild'` by hand.

They did not need to. `hermes sessions repair` already does exactly that:
`_db_opens_cleanly()` runs `PRAGMA integrity_check` first and returns this very
string as the reason, and `repair_state_db_schema()`'s **first** strategy is
"rebuild FTS indexes in place" — the same `'rebuild'` command, backup taken
first, zero canonical rows touched. The information existed; the update just
never mentioned it.

After this PR:

```
⚠ state.db is corrupted after update: integrity check failed: malformed inverted index for FTS5 table main.messages_fts_trigram
  ⚠ No pre-update snapshot was taken
  → This is the FTS5 search index, not your sessions or messages — they are intact.
    Rebuild the index in place with:  hermes sessions repair
```

**Three decisions worth naming, all maintainer calls if you disagree:**

1. **A pointer, not a repair.** The obvious-looking version of this patch calls
   `rebuild_fts()` from the update path. I did not, for two reasons. An update
   is the wrong place to take a write lock on a database the user has not asked
   us to rewrite — and, more practically, whether an FTS rebuild should happen
   automatically is *actively contested* right now: #86183 wants an open-time
   integrity gate that repairs, #89073 wants ordinary opens to never rebuild at
   all. Adding a third independent opinion from `update_cmd.py` would make that
   decision harder rather than easier. This change composes with either outcome
   — if the open path starts self-healing, the message simply stops being
   reached.
2. **"Your messages are intact" is printed only for the FTS class.** Genuine
   page damage (`row N missing from index`, a bad header) gets a plainer hint
   with no such promise. Notably `database disk image is malformed` is treated
   as **not** provably FTS: it is what a corrupt shadow table raises on older
   SQLite builds — which is why `is_malformed_db_error` accepts it — but it is
   equally what real page damage raises, and `integrity_check`'s output cannot
   distinguish them. Reassuring someone whose data really is gone is a worse
   failure than saying nothing, so that class falls through to the generic hint.
   `test_generic_malformed_image_is_not_treated_as_fts` pins it.
3. **The classifier is local text matching, not a reuse of
   `SessionDB._is_fts_write_corruption_error`.** That one takes a
   `sqlite3.DatabaseError` raised by a failed write; here there is no exception,
   only the string `verify_sqlite_integrity` returned. Keeping it in
   `update_cmd.py` also keeps this PR out of `hermes_state.py`, which currently
   has a dozen open PRs.

## Related Issue

Fixes #88252

**Scope: this is Defect 1's messaging half only.** #88252 reports two defects
and I am deliberately not patching either of the other pieces:

- **Defect 1's auto-repair half** belongs to #86183, which diagnoses the root
  cause better than I would have: the trigram tokenizer changed how it tokenizes
  NUL-containing content between SQLite 3.46.1 and 3.5x, and an FTS5 integrity
  check only accepts an index written by its own engine — so an update that
  swaps the bundled SQLite makes a previously-fine index read as malformed. That
  is precisely why the reporter sees this *after every update* and never
  otherwise.
- **Defect 2 (unbounded emergency copies)** appears to already be bounded on
  `main`. `preflightStateDb()` in `apps/desktop/electron/main.ts` prunes to the
  two most recent `state.db.pre-update-emergency-*.bak` files immediately after
  writing a new one, and that prune shipped with the pre-flight guard itself in
  #68474 (`d68e043ba`, `v2026.7.30`) — before the reporter's runs. So "eight,
  unbounded" should not be reachable, and the real question is why the existing
  prune did not fire. My leading theory is that `unlinkSync` failed on every
  file (Windows sharing violation from antivirus or the search indexer on a
  freshly written 200 MB file) and the `catch { void 0 }` discarded it silently.
  I have asked the reporter for a directory listing to distinguish that from
  "they counted log lines". If it is the silent-catch case I will send the
  logging fix separately; nothing open touches `preflightStateDb`.

## Overlap with open PRs

Nothing open touches these two call sites. The FTS repair *seam* is busy, so
here is where each neighbour sits relative to this change:

| PR | what it changes | overlaps? |
|---|---|---|
| #86183 | open-time FTS5 `'integrity-check'` per SQLite engine version, repairs via `rebuild_fts` | **complementary, no textual conflict** (`hermes_state.py` only). It removes the *cause*; this removes the dead end for anyone whose database is already in that state, and for any future integrity failure that is not FTS. If it lands, this message stops firing for the FTS class and still covers the rest. |
| #89073 | never rebuild on the live path; mark `fts_stale`, degrade search to `LIKE`, rebuild only under explicit `hermes sessions repair` | **complementary, and arguably needs this.** Its whole design routes users to `hermes sessions repair` — which is exactly the command this PR starts naming. No shared file. |
| #74615 | transplants the pending-commits summary to its current `update_cmd.py` location | same file, different region (summary printing, not the integrity block). No expected conflict. |

## Changes Made

- `hermes_cli/update_cmd.py`
  - `_state_db_damage_is_fts_only(message)` — new; text classifier over what
    `verify_sqlite_integrity` returned, with the reasoning for why it is a text
    test and why the ambiguous class is excluded.
  - `_print_state_db_repair_hint(message)` — new; prints the FTS-specific or the
    generic pointer. Repairs nothing.
  - `_update_via_zip` (zip path) and `_cmd_update_impl` (git path): track
    whether a snapshot restore actually succeeded (`_state_restored`) and print
    the hint when it did not. Both were previously capable of reaching the same
    dead end.
  - The corruption message is now built once into `_state_message` per site
    rather than re-read from the dict, so the hint sees exactly what the user
    was shown.
- `tests/hermes_cli/test_update_state_db_repair_hint.py` (new, 19 tests).

Not changed, deliberately: the **pre**-update integrity check around
`update_cmd.py:3136`. It reports the same class but is a different situation —
it already tells the user what happens next ("continuing update", "will be
auto-restored"), and pointing them at a repair command while an update is
in flight against that same database would be bad advice.

## How to Test

1. The new tests pass:

   ```
   pytest tests/hermes_cli/test_update_state_db_repair_hint.py -q
   ```

   `19 passed`

2. **Sabotage proof, two mutations.**

   Make the classifier unconditional (`return True`) — the safety tests fail,
   i.e. a user with genuine page damage would be told their data is fine:

   ```
   8 failed, 11 passed
   FAILED ...::test_non_fts_damage_is_not_claimed_as_fts[row 12 missing from index sqlite_autoindex_sessions_1]
   FAILED ...::test_generic_malformed_image_is_not_treated_as_fts
   FAILED ...::test_generic_hint_names_the_command_without_reassuring
   ```

   Delete the `if not _state_restored:` hint call from the git path — the
   wiring test fails for that path only, so the two paths are covered
   independently:

   ```
   1 failed, 18 passed
   FAILED ...::TestBothUpdatePathsAreWired::test_path_prints_the_hint_when_nothing_was_restored[git-path]
   ```

   Restore either and all 19 pass.

3. **Baseline comparison** over every `tests/hermes_cli/test_*update*` file
   (38 files, ~366 tests), run serially with and without this change:
   **10 failures with, 11 without — the 10 are a strict subset.** All are
   pre-existing Windows/environment failures (git-shelling branch-fallback
   cases, the import guard, TTY prompt cases). The one extra baseline failure,
   `test_branch_flag_fails_when_branch_missing_everywhere`, is flaky in that
   file and unrelated to this diff, which touches neither branch resolution nor
   its output. Zero new failures.

4. `ruff check` clean on both files.

5. **End-to-end on a real corrupted database**, not just the message. Built an
   80-message `state.db`, corrupted `messages_fts_trigram_data` the way
   `tests/test_state_db_malformed_repair.py` does, then walked the whole chain:

   ```
   integrity_check      : fts5: corrupt structure record for table "messages_fts_trigram"
   classifier says FTS  : True
     → This is the FTS5 search index, not your sessions or messages — they are intact.
       Rebuild the index in place with:  hermes sessions repair
   _db_opens_cleanly    : fts5: corrupt structure record for table "messages_fts_trigram"
   repair report        : repaired=True strategy=rebuild_fts error=None
   integrity_check after: ok
   messages after       : 80  (unchanged: True)
   ```

   So the command the new message points at really does fix this class, really
   does pick the in-place rebuild, and really does leave every canonical row
   alone — the claim printed to the user is verified rather than assumed. Note
   my SQLite words it `fts5: corrupt structure record` where the reporter's
   words it `malformed inverted index`; both are the same class and both are in
   the classifier's parametrized cases.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate. Nothing open touches either call site; the two PRs on the adjacent FTS-repair seam (#86183, #89073) are compared in the Overlap table, and I explicitly left the auto-repair half of the issue to #86183 rather than competing with it
- [x] My PR contains **only** changes related to this fix (no unrelated commits): one commit, one production file, one new test file
- [x] I've run `pytest tests/ -q` and all tests pass. Not the full suite — `tests/hermes_cli/` cannot be collected on Windows (`test_doctor_journal_modes.py` calls `os.geteuid`). Ran the 38-file update slice instead, with a with/without baseline: no new failures. CI covers the rest
- [x] I've added tests for my changes (required for bug fixes): 19 tests; step 2 is the mutation proof, covering both the classifier's safety property and each call site independently
- [x] I've tested on my platform: Windows 11 Pro 26200, Python 3.13 — same platform as the reporter (Windows 11 26200)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings). Both new functions carry the reasoning; the user-facing change *is* documentation, so no separate docs edit applies
- [x] N/A, no config keys added or changed
- [x] N/A, no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility). Pure string classification plus `print`, no platform branching. The glyphs (`→`, `—`) match those already printed by this module (`✓`, `✗`, `⚠`), so console-encoding behaviour is unchanged. `hermes sessions repair` is available on every platform
- [x] N/A, no tool descriptions or schemas changed

## Screenshots / Logs

Before (#88252, verbatim):

```
⚠ state.db is corrupted after update: integrity check failed:
  malformed inverted index for FTS5 table main.messages_fts_trigram
  ⚠ No pre-update snapshot was taken
```

After:

```
⚠ state.db is corrupted after update: integrity check failed: malformed inverted index for FTS5 table main.messages_fts_trigram
  ⚠ No pre-update snapshot was taken
  → This is the FTS5 search index, not your sessions or messages — they are intact.
    Rebuild the index in place with:  hermes sessions repair
```

And for a failure that is *not* provably the index, no promise about the data:

```
⚠ state.db is corrupted after update: row 12 missing from index sqlite_autoindex_sessions_1
  ⚠ No pre-update snapshot was taken
  → Try:  hermes sessions repair
    It backs up first, refuses to touch a database that is actually healthy, and tries the least destructive fix first.
```
