### PR TITLE
fix(whatsapp): map text, web, and data document extensions to proper MIME types (#89074)

### DIFF
--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -255,6 +255,25 @@ import {
 }
 
 {
+  for (const [ext, expectedMime] of [
+    ['html', 'text/html'],
+    ['htm', 'text/html'],
+    ['txt', 'text/plain'],
+    ['csv', 'text/csv'],
+    ['json', 'application/json'],
+  ]) {
+    const payload = mediaPayloadForFile({
+      buffer: Buffer.from('test content'),
+      filePath: `/tmp/report.${ext}`,
+      caption: `report ${ext}`,
+    });
+    assert.ok(payload.document);
+    assert.equal(payload.mimetype, expectedMime, `expected ${expectedMime} for .${ext}`);
+  }
+  console.log('  ✓ mediaPayloadForFile maps text/web extensions (.html, .txt, .csv, .json) correctly (#89074)');
+}
+
+{
   const payload = buildPollPayload({
     question: 'Proceed?',
     options: ['Approve', 'Deny'],

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -10,7 +10,14 @@ export const MIME_MAP = {
   pdf: 'application/pdf',
   doc: 'application/msword',
   docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  xls: 'application/vnd.ms-excel',
   xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  ppt: 'application/vnd.ms-powerpoint',
+  pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  html: 'text/html', htm: 'text/html',
+  txt: 'text/plain', csv: 'text/csv',
+  json: 'application/json', xml: 'application/xml',
+  md: 'text/markdown', zip: 'application/zip',
 };
 
 export function normalizeWhatsAppId(value) {


### PR DESCRIPTION
## Summary
Fixes #89074.

The WhatsApp Baileys bridge previously lacked entries in `MIME_MAP` for common text, web, and document formats (`.html`, `.htm`, `.txt`, `.csv`, `.json`, `.xml`, `.md`, `.zip`, `.xls`, `.ppt`, `.pptx`). As a result, `mediaPayloadForFile()` fell back to `application/octet-stream`, causing files like HTML summaries or CSV exports to be received as unopenable \"BIN\" objects on phones.

## Changes
- In `scripts/whatsapp-bridge/bridge_helpers.js`: add MIME mappings for `html`, `htm`, `txt`, `csv`, `json`, `xml`, `md`, `zip`, `xls`, `ppt`, `pptx`.
- In `scripts/whatsapp-bridge/bridge.native.test.mjs`: add test assertions verifying that `mediaPayloadForFile()` maps `.html`, `.htm`, `.txt`, `.csv`, and `.json` files to their expected MIME types.

## Verification
- Verified mapping logic and `mediaPayloadForFile()` with Node.js.
- `pytest tests/gateway/test_whatsapp_formatting.py tests/gateway/test_whatsapp_connect.py tests/hermes_cli/test_web_server.py` passed.
- GPG signed on Mac and `git diff --check` clean.