### PR TITLE
fix(models): support OpenRouter preset references

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -5331,6 +5331,42 @@ def validate_requested_model(
             "message": "Model names cannot contain spaces.",
         }
 
+    # OpenRouter presets are account-scoped configurations, so direct
+    # ``@preset/<slug>`` references never appear in the public /v1/models
+    # listing. Combined ``<model>@preset/<slug>`` references are also valid;
+    # validate their base model normally and preserve the preset suffix if a
+    # close match is auto-corrected. OpenRouter validates the preset slug when
+    # the inference request is made.
+    preset_suffix = ""
+    if normalized == "openrouter":
+        marker = "@preset/"
+        if marker in requested:
+            if requested.count(marker) != 1:
+                preset_slug = ""
+                preset_base = requested
+            else:
+                preset_base, preset_slug = requested.split(marker, 1)
+            if re.fullmatch(r"[A-Za-z0-9._~-]+", preset_slug) is None:
+                return {
+                    "accepted": False,
+                    "persist": False,
+                    "recognized": False,
+                    "message": (
+                        "OpenRouter preset slugs must be non-empty URL-safe "
+                        "identifiers using only letters, digits, '.', '_', "
+                        "'~', or '-'."
+                    ),
+                }
+            preset_suffix = f"{marker}{preset_slug}"
+            if not preset_base:
+                return {
+                    "accepted": True,
+                    "persist": True,
+                    "recognized": False,
+                    "message": None,
+                }
+            requested_for_lookup = preset_base
+
     if normalized == "lmstudio":
         from hermes_cli.auth import AuthError
         # Use probe_lmstudio_models so we can distinguish None (unreachable
@@ -5664,15 +5700,18 @@ def validate_requested_model(
             # Auto-correct if the top match is very similar (e.g. typo)
             auto = get_close_matches(requested_for_lookup, api_models, n=1, cutoff=0.9)
             if auto:
+                corrected = f"{auto[0]}{preset_suffix}"
                 return {
                     "accepted": True,
                     "persist": True,
                     "recognized": True,
-                    "corrected_model": auto[0],
-                    "message": f"Auto-corrected `{requested}` → `{auto[0]}`",
+                    "corrected_model": corrected,
+                    "message": f"Auto-corrected `{requested}` → `{corrected}`",
                 }
 
-            suggestions = get_close_matches(requested, api_models, n=3, cutoff=0.5)
+            suggestions = get_close_matches(
+                requested_for_lookup, api_models, n=3, cutoff=0.5
+            )
             suggestion_text = ""
             if suggestions:
                 suggestion_text = "\n  Similar models: " + ", ".join(f"`{s}`" for s in suggestions)
@@ -5785,12 +5824,15 @@ def validate_requested_model(
         )
         if auto:
             corrected = catalog_lower[auto[0]]
+            corrected_with_suffix = f"{corrected}{preset_suffix}"
             return {
                 "accepted": True,
                 "persist": True,
                 "recognized": True,
-                "corrected_model": corrected,
-                "message": f"Auto-corrected `{requested}` → `{corrected}`",
+                "corrected_model": corrected_with_suffix,
+                "message": (
+                    f"Auto-corrected `{requested}` → `{corrected_with_suffix}`"
+                ),
             }
         suggestions = get_close_matches(
             requested_for_lookup.lower(), catalog_lower_list, n=3, cutoff=0.5

--- a/tests/hermes_cli/test_openrouter_preset_validation.py
+++ b/tests/hermes_cli/test_openrouter_preset_validation.py
@@ -1,0 +1,245 @@
+"""Regression coverage for OpenRouter preset references (issue #31739)."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.models import validate_requested_model
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    ["@preset/email-copywriter", "@preset/Foo_bar.~9"],
+)
+def test_direct_openrouter_preset_reference_skips_model_listing(model_name):
+    """An account-scoped direct preset has no public model row to probe."""
+    with patch(
+        "hermes_cli.models.fetch_api_models",
+        side_effect=AssertionError("direct preset references must not probe /models"),
+    ):
+        result = validate_requested_model(
+            model_name,
+            "openrouter",
+            api_key="key",
+            base_url="https://openrouter.ai/api/v1",
+        )
+
+    assert result == {
+        "accepted": True,
+        "persist": True,
+        "recognized": False,
+        "message": None,
+    }
+
+
+def test_combined_openrouter_preset_reference_validates_base_model():
+    """Combined references validate the base model, not the preset-decorated ID."""
+    with patch(
+        "hermes_cli.models.fetch_api_models",
+        return_value=["openai/gpt-5.4"],
+    ) as mock_fetch:
+        result = validate_requested_model(
+            "openai/gpt-5.4@preset/email-copywriter",
+            "openrouter",
+            api_key="key",
+            base_url="https://openrouter.ai/api/v1",
+        )
+
+    mock_fetch.assert_called_once_with("key", "https://openrouter.ai/api/v1")
+    assert result == {
+        "accepted": True,
+        "persist": True,
+        "recognized": True,
+        "message": None,
+    }
+
+
+def test_combined_openrouter_preset_reference_rejects_unknown_base_model():
+    with patch("hermes_cli.models.fetch_api_models", return_value=["openai/gpt-5.4"]):
+        result = validate_requested_model(
+            "openai/gpt-5.4-preview@preset/email-copywriter",
+            "openrouter",
+            api_key="key",
+            base_url="https://openrouter.ai/api/v1",
+        )
+
+    assert result["accepted"] is False
+    assert result["persist"] is False
+    assert result["recognized"] is False
+    assert "Similar models" in result["message"]
+    assert "openai/gpt-5.4" in result["message"]
+
+
+def test_combined_openrouter_preset_reference_preserves_suffix_on_autocorrect():
+    with patch("hermes_cli.models.fetch_api_models", return_value=["openai/gpt-5.4"]):
+        result = validate_requested_model(
+            "openai/gpt-5.44@preset/email-copywriter",
+            "openrouter",
+            api_key="key",
+            base_url="https://openrouter.ai/api/v1",
+        )
+
+    corrected = "openai/gpt-5.4@preset/email-copywriter"
+    assert result["accepted"] is True
+    assert result["corrected_model"] == corrected
+    assert corrected in result["message"]
+
+
+def test_combined_preset_preserves_suffix_on_catalog_autocorrect():
+    with (
+        patch("hermes_cli.models.fetch_api_models", return_value=None),
+        patch(
+            "hermes_cli.models.provider_model_ids",
+            return_value=["openai/gpt-5.4"],
+        ),
+    ):
+        result = validate_requested_model(
+            "openai/gpt-5.44@preset/email-copywriter",
+            "openrouter",
+            api_key="key",
+            base_url="https://openrouter.ai/api/v1",
+        )
+
+    corrected = "openai/gpt-5.4@preset/email-copywriter"
+    assert result["accepted"] is True
+    assert result["corrected_model"] == corrected
+    assert corrected in result["message"]
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "@preset/",
+        "openai/gpt-5.4@preset/",
+        "@preset/foo/bar",
+        "@preset/foo?bar",
+        "@preset/☃",
+        "@preset/foo@preset/bar",
+        "openai/gpt-5.4@preset/foo/bar",
+    ],
+)
+def test_openrouter_preset_reference_requires_a_url_safe_slug(model_name):
+    """Malformed preset references must fail before model-list probing."""
+    with patch(
+        "hermes_cli.models.fetch_api_models",
+        side_effect=AssertionError("malformed presets must not probe /models"),
+    ):
+        result = validate_requested_model(
+            model_name,
+            "openrouter",
+            api_key="key",
+            base_url="https://openrouter.ai/api/v1",
+        )
+
+    assert result["accepted"] is False
+    assert result["persist"] is False
+    assert result["recognized"] is False
+    assert "URL-safe" in result["message"]
+
+
+def test_preset_reference_does_not_bypass_other_provider_validation():
+    with patch("hermes_cli.models.fetch_api_models", return_value=["gpt-5.4"]):
+        result = validate_requested_model(
+            "@preset/email-copywriter",
+            "openai",
+            api_key="key",
+            base_url="https://api.openai.com/v1",
+        )
+
+    assert result["accepted"] is False
+    assert result["persist"] is False
+
+
+def test_preset_reference_does_not_bypass_custom_endpoint_validation():
+    probe = {
+        "models": ["local-model"],
+        "probed_url": "https://proxy.example/v1/models",
+        "resolved_base_url": "https://proxy.example/v1",
+        "suggested_base_url": None,
+        "used_fallback": False,
+    }
+    with patch("hermes_cli.models.probe_api_models", return_value=probe) as mock_probe:
+        result = validate_requested_model(
+            "@preset/email-copywriter",
+            "openrouter",
+            api_key="key",
+            base_url="https://proxy.example/v1",
+        )
+
+    mock_probe.assert_called_once()
+    assert result["accepted"] is True
+    assert result["recognized"] is False
+    assert "custom endpoint's model listing" in result["message"]
+
+
+def test_configured_alias_switches_preset_through_real_resolution_chain(tmp_path):
+    """Exercise config loading, alias resolution, runtime resolution, and validation."""
+    (tmp_path / "config.yaml").write_text(
+        """
+model:
+  default: openai/gpt-5.4
+  provider: openrouter
+  base_url: https://openrouter.ai/api/v1
+model_aliases:
+  email-copywriter:
+    model: '@preset/email-copywriter'
+    provider: openrouter
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    script = r"""
+import json
+import hermes_cli.model_switch as model_switch
+import hermes_cli.models as models
+
+
+def fail_model_probe(*args, **kwargs):
+    raise AssertionError("preset references must not probe /models")
+
+
+models.fetch_api_models = fail_model_probe
+model_switch.get_model_capabilities = lambda *args, **kwargs: None
+model_switch.get_model_info = lambda *args, **kwargs: None
+result = model_switch.switch_model(
+    "email-copywriter",
+    current_provider="openrouter",
+    current_model="openai/gpt-5.4",
+    current_base_url="https://openrouter.ai/api/v1",
+    current_api_key="key",
+)
+print(json.dumps(vars(result)))
+"""
+    env = {
+        "HOME": str(tmp_path),
+        "HERMES_HOME": str(tmp_path),
+        "LANG": "C.UTF-8",
+        "OPENROUTER_API_KEY": "key",
+        "PATH": os.environ.get("PATH", ""),
+        "PYTHONIOENCODING": "utf-8",
+    }
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, (
+        f"subprocess failed with exit {completed.returncode}\n"
+        f"stdout:\n{completed.stdout}\n"
+        f"stderr:\n{completed.stderr}"
+    )
+    result = json.loads(completed.stdout.splitlines()[-1])
+
+    assert result["success"] is True
+    assert result["new_model"] == "@preset/email-copywriter"
+    assert result["target_provider"] == "openrouter"
+    assert result["resolved_via_alias"] == "email-copywriter"
+    assert result["warning_message"] == ""


### PR DESCRIPTION
## What does this PR do?

Allows native OpenRouter model switches to use account-scoped preset references without being rejected by `/v1/models` validation.

OpenRouter documents two model-field forms:

- `@preset/<slug>` — accepted without probing because account presets never appear in the public model list
- `<model>@preset/<slug>` — validates the base model normally, while preserving the preset suffix through auto-correction

Malformed/non-URL-safe preset slugs are rejected before probing; other providers and custom endpoints keep their existing validation behavior.

## Related Issue

Addresses the OpenRouter preset-validation portion of #31739. This does **not** close that broader issue, which also requests unrelated provider/config work.

Related but not duplicate: #42184 suppresses warnings for declared models on custom providers with `discover_models: false`; this PR fixes native OpenRouter preset references in `validate_requested_model`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/models.py`: validate preset slugs as RFC-style URL-safe identifiers; recognize direct OpenRouter presets before live model-list probing; validate combined references by their base model; preserve preset suffixes when correcting model IDs.
- `tests/hermes_cli/test_openrouter_preset_validation.py`: cover valid/invalid slug syntax, direct and combined references, provider isolation, custom endpoints, online/offline auto-correction, and a real config → alias → runtime-provider → `switch_model` path using temporary `HERMES_HOME`.

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_openrouter_preset_validation.py -q -o 'addopts='`.
2. Run `python -m pytest tests/hermes_cli/test_openrouter_preset_validation.py tests/hermes_cli/test_model_validation.py tests/hermes_cli/test_models.py -q -o 'addopts='`.
3. Confirm an alias resolving to `@preset/<slug>` switches successfully with an empty warning message.

## Verification

- Regression sabotage: the new suite fails when the production change is temporarily removed, then passes after restoration.
- Targeted model suites: **75 passed**.
- `git diff --check`: passed.
- Python compilation: passed.
- Added-line security scan: no secret, shell-injection, eval/exec, pickle, or SQL-format findings.
- `uvx ruff check` on changed files: passed.
- Canonical `scripts/run_tests.sh`: stopped at 26.4% after 690 unrelated async-test failures because the installed test environment lacks the async pytest plugin. A clean detached `origin/main` worktree reproduced the shown context-reference failure identically (2 failed, 11 passed, `PytestUnknownMarkWarning: Unknown pytest.mark.asyncio`). The all-tests checkbox remains unchecked.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux 24.04, Python 3.12

### Documentation & Housekeeping

- [x] Relevant documentation update — N/A (behavior follows existing OpenRouter API docs; no config or user-facing command changes)
- [x] `cli-config.yaml.example` update — N/A (no config keys changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A (no architecture/workflow change)
- [x] Cross-platform impact considered — pure provider-string validation with platform-independent tests
- [x] Tool descriptions/schemas update — N/A (no tool schema changed)

## Note on authorship

The diagnosis, patch, and tests were prepared with AI assistance. The submitter reviewed the work and takes responsibility for the change.

**AI assistance.** The model used was `gpt-5.6-sol` via the `openai-codex` provider in Hermes Agent. The agent reconstructed the original reproduction, reviewed current upstream code and issue/PR state, drafted the patch and regression tests, and ran the verification listed above.

**Manual reproduction.** The installed Hermes checkout rejected a valid account preset after a successful live OpenRouter model-list probe because presets are not model-list entries. The regression suite reproduces that branch deterministically; the sabotage run confirms the tests fail against the pre-fix implementation.

**Test coverage.** The PR includes unit coverage plus a fresh subprocess that loads the alias from temporary `HERMES_HOME`, resolves native OpenRouter runtime credentials, and executes the real `switch_model` path. Only outbound model-metadata calls are stubbed. A live inference call was not run because it would use a private account preset and incur provider usage; project CI remains the clean-environment authority.

**Risk and scope.** Low. The exception is gated to the native `openrouter` provider and an RFC-style URL-safe `@preset/` slug. Combined references still validate the base model; malformed markers, custom endpoints, and other providers retain existing behavior. Reviewers should pay particular attention to preserving the preset suffix in both live-list and static-catalog auto-correction branches.
