### PR TITLE
fix(cron): show delivery failures in cron list when last_status is ok

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -115,6 +115,7 @@ def cron_list(show_all: bool = False):
 
     from cron.jobs import effective_job_state
 
+    delivery_warning_count = 0
     for job in jobs:
         job_id = job.get("id", "?")
         name = job.get("name", "(unnamed)")
@@ -179,7 +180,18 @@ def cron_list(show_all: bool = False):
         if last_status:
             last_run = job.get("last_run_at", "?")
             if last_status == "ok":
-                status_display = color("ok", Colors.GREEN)
+                delivery_unconfirmed = (
+                    job.get("delivery_state") == "pending"
+                    and int(job.get("delivery_attempts") or 0) == 0
+                )
+                delivery_warning = (
+                    bool(job.get("last_delivery_error")) or delivery_unconfirmed
+                )
+                if delivery_warning:
+                    delivery_warning_count += 1
+                    status_display = color("ok, delivery failed", Colors.YELLOW)
+                else:
+                    status_display = color("ok", Colors.GREEN)
             else:
                 status_display = color(f"{last_status}: {job.get('last_error', '?')}", Colors.RED)
                 streak = int(job.get("failure_streak") or 0)
@@ -206,6 +218,14 @@ def cron_list(show_all: bool = False):
             )
 
         print()
+
+    if delivery_warning_count:
+        print(
+            color(
+                f"⚠ {delivery_warning_count} job(s) completed but delivery failed or unconfirmed",
+                Colors.YELLOW,
+            )
+        )
 
     _warn_if_gateway_not_running()
 

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from cron.jobs import create_job, get_job, list_jobs
+from cron.jobs import create_job, get_job, list_jobs, mark_job_run, update_job
 from hermes_cli import cron as cron_cli
 from hermes_cli.cron import cron_command
 from hermes_cli.subcommands.cron import build_cron_parser
@@ -144,6 +144,51 @@ class TestGatewayNotRunningWarning:
         cron_command(Namespace(cron_command="list", all=True))
         out = capsys.readouterr().out
         assert "Gateway is not running" in out
+
+
+def test_cron_list_warns_when_ok_run_delivery_failed(
+    tmp_cron_dir, capsys, monkeypatch
+):
+    job = create_job(prompt="Daily report", schedule="every 1h")
+    assert mark_job_run(job["id"], True, None, delivery_error="boom")
+
+    persisted = get_job(job["id"])
+    assert persisted["last_status"] == "ok"
+    assert persisted["last_delivery_error"] == "boom"
+    assert persisted.get("failure_streak", 0) == 0
+
+    monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [])
+    monkeypatch.setattr(cron_cli, "_active_cron_provider_name", lambda: "builtin")
+    cron_cli.cron_list()
+
+    out = capsys.readouterr().out
+    assert "Delivery failed" in out
+    assert "ok, delivery failed" in out
+    assert "Last run:" in out
+
+    assert mark_job_run(job["id"], True, None, delivery_error=None)
+    cron_cli.cron_list()
+    recovered = capsys.readouterr().out
+    assert "Delivery failed" not in recovered
+    assert "ok, delivery failed" not in recovered
+
+
+def test_cron_list_warns_when_delivery_is_pending_without_attempts(
+    tmp_cron_dir, capsys, monkeypatch
+):
+    job = create_job(prompt="Daily report", schedule="every 1h")
+    assert mark_job_run(job["id"], True, None)
+    assert update_job(
+        job["id"], {"delivery_state": "pending", "delivery_attempts": 0}
+    )
+
+    monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [])
+    monkeypatch.setattr(cron_cli, "_active_cron_provider_name", lambda: "builtin")
+    cron_cli.cron_list()
+
+    out = capsys.readouterr().out
+    assert "ok, delivery failed" in out
+    assert "completed but delivery failed or unconfirmed" in out
 
 
 class TestExternalCronProviderStatus:


### PR DESCRIPTION
Addresses #83993

## What

`cron list` renders a bare green `ok` as the primary status when a job's agent run succeeded but delivery failed, making the failure missable on skim. This PR makes delivery failure visible in the CLI listing only.

When `last_status == "ok"`:

- if `last_delivery_error` is set, the primary status renders as yellow `ok, delivery failed` (the existing yellow `Delivery failed: <err>` detail line is kept unchanged);
- if the job completed but `delivery_state` is still `pending` with `delivery_attempts == 0` (the standalone-fallback no-channel case where output is saved to `last_output` but never delivered), it gets the same warning treatment;
- a single list-level warning is printed when any listed job is affected, so a skim cannot read as healthy.

## Non-goals (deliberate)

No new messages, no routing or fallback change, no retry, no hooks, no env vars. `last_status` and `failure_streak` semantics are unchanged: `last_status` remains the agent-success bit, and delivery failures still do not count toward `failure_streak` (the agent did its job).

## Why display-only

The scheduler already persists the failure. `mark_job_run` accepts a `delivery_error` kwarg and both the success and failure completion paths pass it through `mark_kwargs`; the interrupted-by-shutdown path records it via `update_job` (#82232). The no-channel origin skip is intentional (output persisted in `last_output`), which is why the listing reads `delivery_state`/`delivery_attempts` rather than fabricating an error. This PR only makes existing state visible; the write path is untouched.

## Evidence

- The issue's production case: on 2026-08-10 daily/weekly jobs silently failed to deliver over Weixin for 13 hours (ret=-2 misclassified), zero indication, discoverable only by reading job metadata, recovery required a gateway restart.
- The pending/0 drill: a completed `ok` job that never attempted delivery reads as healthy in `cron list` today.
- Our deployment runs ~30 cron jobs and has hit the same green-`ok`-despite-failed-delivery state; `last_delivery_error` was only found by digging into job state.

## Related

- #42371: one-shot retention semantics, separate fix, no overlap.
- #65401: delivery-outcome observer hook, complementary feature request, needs-decision.
- #16645: delivery-only retry from cached output, stalled, complementary not substitute.

## Sweeper note (sweeper:risk-message-delivery)

No delivery path is touched. No message content is mutated, no channel behavior changes, nothing is sent or retried; the change is confined to the `cron list` renderer in `hermes_cli/cron.py`.

## Tests

E2E against the real store with a temp `HERMES_HOME` (real imports, no mocks on the data path): `mark_job_run(ok, delivery_error=...)` persists `last_status: ok` plus the error with `failure_streak` unchanged; the renderer then shows `ok, delivery failed` and the list-level warning; a follow-up successful delivery clears both. The primary assertion (`ok, delivery failed` present) fails on current main and passes with this change. `tests/hermes_cli/test_cron.py`: 16 passed.
