### PR TITLE
fix(gateway): make loop-liveness watchdog tolerant of transient reconnect stalls

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -983,7 +983,23 @@ class GatewayConfig:
     # missed probes it dumps all-thread stacks and hard-exits with the
     # service-restart code so the supervisor can revive the process. On by
     # default; set gateway.loop_watchdog: false in config.yaml to disable.
+    #
+    # Tuning knobs (all seconds unless noted) make the watchdog tolerate
+    # *transient, self-recovering* event-loop stalls — e.g. Telegram/Discord
+    # reconnect doing synchronous socket I/O during a network blip — so a
+    # short block does not force exit code 75 and trigger a restart churn
+    # that stalls cron dispatch (recurring fleet incidents on 2026-08-17,
+    # kanban t_0f76430f/t_70483f23). A genuine wedge (event loop frozen for
+    # the full tolerance window) still escalates to a supervised restart.
     loop_watchdog: bool = True
+    # Seconds the watchdog waits between liveness probes.
+    loop_watchdog_probe_interval_s: float = 30.0
+    # Seconds a single probe may go unprocessed before it counts as a miss.
+    loop_watchdog_probe_timeout_s: float = 10.0
+    # Consecutive missed probes allowed before the watchdog hard-exits.
+    # Default raised from 3 to 8: a transient reconnect stall (~60-120s) is
+    # tolerated while a genuine multi-minute wedge still escalates.
+    loop_watchdog_max_strikes: int = 8
 
     # Unauthorized DM policy
     unauthorized_dm_behavior: str = "pair"  # "pair" or "ignore"
@@ -1124,6 +1140,9 @@ class GatewayConfig:
             "multiplex_profile_allowlist": self.multiplex_profile_allowlist,
             "systemd_watchdog_seconds": self.systemd_watchdog_seconds,
             "loop_watchdog": self.loop_watchdog,
+            "loop_watchdog_probe_interval_s": self.loop_watchdog_probe_interval_s,
+            "loop_watchdog_probe_timeout_s": self.loop_watchdog_probe_timeout_s,
+            "loop_watchdog_max_strikes": self.loop_watchdog_max_strikes,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
             "session_store_max_age_days": self.session_store_max_age_days,
@@ -1207,6 +1226,30 @@ class GatewayConfig:
         else:
             loop_watchdog_raw = nested_gateway.get("loop_watchdog")
         loop_watchdog = _coerce_bool(loop_watchdog_raw, True)
+        loop_watchdog_probe_interval_s = _coerce_float(
+            data.get("loop_watchdog_probe_interval_s")
+            if "loop_watchdog_probe_interval_s" in data
+            else nested_gateway.get("loop_watchdog_probe_interval_s"),
+            30.0,
+        )
+        loop_watchdog_probe_timeout_s = _coerce_float(
+            data.get("loop_watchdog_probe_timeout_s")
+            if "loop_watchdog_probe_timeout_s" in data
+            else nested_gateway.get("loop_watchdog_probe_timeout_s"),
+            10.0,
+        )
+        loop_watchdog_max_strikes = _coerce_int(
+            data.get("loop_watchdog_max_strikes")
+            if "loop_watchdog_max_strikes" in data
+            else nested_gateway.get("loop_watchdog_max_strikes"),
+            8,
+        )
+        if loop_watchdog_probe_interval_s < 1.0:
+            loop_watchdog_probe_interval_s = 30.0
+        if loop_watchdog_probe_timeout_s < 1.0:
+            loop_watchdog_probe_timeout_s = 10.0
+        if loop_watchdog_max_strikes < 1:
+            loop_watchdog_max_strikes = 8
         if multiplex_profiles is None and isinstance(nested_gateway, dict):
             # Also honor gateway.multiplex_profiles written by
             # ``hermes config set gateway.multiplex_profiles true``.
@@ -1269,6 +1312,9 @@ class GatewayConfig:
             multiplex_profile_allowlist=multiplex_profile_allowlist,
             systemd_watchdog_seconds=systemd_watchdog_seconds,
             loop_watchdog=loop_watchdog,
+            loop_watchdog_probe_interval_s=loop_watchdog_probe_interval_s,
+            loop_watchdog_probe_timeout_s=loop_watchdog_probe_timeout_s,
+            loop_watchdog_max_strikes=loop_watchdog_max_strikes,
             max_concurrent_sessions=max_concurrent_sessions,
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12075,7 +12075,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         watchdog = getattr(self, "_loop_liveness_watchdog", None)
         if watchdog is None or not watchdog.is_alive():
             try:
-                self._loop_liveness_watchdog = start_loop_liveness_watchdog(loop)
+                interval = 30.0
+                timeout = 10.0
+                strikes = 8
+                if config is not None:
+                    interval = getattr(
+                        config, "loop_watchdog_probe_interval_s", 30.0
+                    ) or 30.0
+                    timeout = getattr(
+                        config, "loop_watchdog_probe_timeout_s", 10.0
+                    ) or 10.0
+                    strikes = getattr(
+                        config, "loop_watchdog_max_strikes", 8
+                    ) or 8
+                self._loop_liveness_watchdog = start_loop_liveness_watchdog(
+                    loop,
+                    probe_interval=float(interval),
+                    probe_timeout=float(timeout),
+                    max_strikes=int(strikes),
+                )
             except Exception:
                 logger.debug("Failed to start gateway loop liveness watchdog", exc_info=True)
 

--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -48,7 +48,12 @@ DEFAULT_HEARTBEAT_INTERVAL_S = 30.0
 DEFAULT_LOOP_FLOOR_TIMER_INTERVAL_S = 5.0
 DEFAULT_LOOP_WATCHDOG_INTERVAL_S = 30.0
 DEFAULT_LOOP_WATCHDOG_TIMEOUT_S = 10.0
-DEFAULT_LOOP_WATCHDOG_MAX_STRIKES = 3
+# Raised from 3 to 8 (kanban t_70483f23): tolerate transient, self-recovering
+# event-loop stalls during Telegram/Discord reconnect (sync socket I/O on a
+# network blip) so a short block does not force exit code 75. A genuine
+# multi-minute wedge still escalates. Tuned via gateway.loop_watchdog_* in
+# config.yaml when the default is too loose or too tight for a deployment.
+DEFAULT_LOOP_WATCHDOG_MAX_STRIKES = 8
 _HEARTBEAT_RELATIVE = ("state", "gateway.heartbeat")
 _WATCHDOG_DUMP_RELATIVE = ("logs", "gateway-shutdown-watchdog.log")
 

--- a/tests/gateway/test_loop_liveness_watchdog.py
+++ b/tests/gateway/test_loop_liveness_watchdog.py
@@ -166,12 +166,67 @@ def test_gateway_config_loop_watchdog_round_trip():
     assert config.to_dict()["loop_watchdog"] is False
 
 
+def test_gateway_config_loop_watchdog_tuning_round_trip():
+    """Watchdog tolerance knobs parse, serialize, and clamp malformed values."""
+    from gateway.config import GatewayConfig
+
+    # Defaults
+    default = GatewayConfig.from_dict({})
+    assert default.loop_watchdog is True
+    assert default.loop_watchdog_probe_interval_s == 30.0
+    assert default.loop_watchdog_probe_timeout_s == 10.0
+    assert default.loop_watchdog_max_strikes == 8
+
+    # Explicit values round-trip
+    cfg = GatewayConfig.from_dict(
+        {
+            "loop_watchdog_probe_interval_s": 45,
+            "loop_watchdog_probe_timeout_s": 15,
+            "loop_watchdog_max_strikes": 12,
+        }
+    )
+    assert cfg.loop_watchdog_probe_interval_s == 45.0
+    assert cfg.loop_watchdog_probe_timeout_s == 15.0
+    assert cfg.loop_watchdog_max_strikes == 12
+    d = cfg.to_dict()
+    assert d["loop_watchdog_probe_interval_s"] == 45.0
+    assert d["loop_watchdog_probe_timeout_s"] == 15.0
+    assert d["loop_watchdog_max_strikes"] == 12
+
+    # Nested gateway.* form honored
+    nested = GatewayConfig.from_dict(
+        {
+            "gateway": {
+                "loop_watchdog_probe_interval_s": 60,
+                "loop_watchdog_probe_timeout_s": 20,
+                "loop_watchdog_max_strikes": 20,
+            }
+        }
+    )
+    assert nested.loop_watchdog_probe_interval_s == 60.0
+    assert nested.loop_watchdog_probe_timeout_s == 20.0
+    assert nested.loop_watchdog_max_strikes == 20
+
+    # Malformed / degenerate values fall back to safe defaults
+    clamped = GatewayConfig.from_dict(
+        {
+            "loop_watchdog_probe_interval_s": 0,
+            "loop_watchdog_probe_timeout_s": -5,
+            "loop_watchdog_max_strikes": 0,
+        }
+    )
+    assert clamped.loop_watchdog_probe_interval_s == 30.0
+    assert clamped.loop_watchdog_probe_timeout_s == 10.0
+    assert clamped.loop_watchdog_max_strikes == 8
+
+
 def test_gateway_runner_liveness_guards_start_and_stop():
     from gateway.run import GatewayRunner
 
     runner = object.__new__(GatewayRunner)
     runner._loop_floor_timer_handle = None
     runner._loop_liveness_watchdog = None
+    runner.config = None
     loop = MagicMock(spec=asyncio.AbstractEventLoop)
     floor_timer = MagicMock()
     watchdog = MagicMock()
@@ -188,7 +243,12 @@ def test_gateway_runner_liveness_guards_start_and_stop():
         runner._start_loop_liveness_guards(loop)
 
     arm_floor.assert_called_once_with(loop)
-    start_watchdog.assert_called_once_with(loop)
+    start_watchdog.assert_called_once_with(
+        loop,
+        probe_interval=30.0,
+        probe_timeout=10.0,
+        max_strikes=8,
+    )
     assert runner._loop_floor_timer_handle is floor_timer
     assert runner._loop_liveness_watchdog is watchdog
 


### PR DESCRIPTION
## Problem
Recurring structural root cause behind 4 fleet cron-liveness breaches (kanban t_0f76430f, t_74818fb6, t_bcb3889a, t_13b2a948): the gateway event loop blocks on synchronous Telegram-polling network calls during a Telegram/Discord reconnect on a network blip. `gateway.shutdown_watchdog`'s loop-liveness watchdog hard-exited with code 75 after 3 consecutive missed probes (~90-120s of loop block), killing the gateway mid-recovery and stalling ALL cron dispatch ~21h.

## Fix
The reconnect stalls are transient and self-recovering (the loop returns within 60-90s). The smallest safe structural fix:
- Raise default `max_strikes` 3 → 8 in `gateway/shutdown_watchdog.py` so a transient reconnect stall is tolerated while a genuine multi-minute wedge still escalates.
- Expose the three tolerance knobs in config.yaml (`gateway.loop_watchdog_probe_interval_s`, `_probe_timeout_s`, `_max_strikes`) and wire them through `GatewayRunner._start_loop_liveness_guards` → `start_loop_liveness_watchdog`.

Does not rewrite the already-hardened adapter async paths.

## Verification
- 75 unit tests pass (test_loop_liveness_watchdog, test_config, test_config_cwd_bridge, test_runtime_config_env_expansion).
- Isolated real-loop canary (real asyncio loop blocked in sync `time.sleep`): OLD default kills on transient stall (exit 75), NEW default tolerates it AND still escalates a genuine wedge.

Refs: kanban t_70483f23