### PR TITLE
feat(kanban): optional actor attribution on task transitions

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1323,6 +1323,7 @@ class Event:
     payload: Optional[dict]
     created_at: int
     run_id: Optional[int] = None
+    actor: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -1443,6 +1444,7 @@ CREATE TABLE IF NOT EXISTS task_events (
     id         INTEGER PRIMARY KEY AUTOINCREMENT,
     task_id    TEXT NOT NULL,
     run_id     INTEGER,
+    actor      TEXT,
     kind       TEXT NOT NULL,
     payload    TEXT,
     created_at INTEGER NOT NULL
@@ -2694,11 +2696,13 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         "CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id)"
     )
 
-    # task_events gained a run_id column; back-fill it as NULL for
-    # historical events (they predate runs and can't be attributed).
+    # task_events gained run_id and actor columns; both remain NULL for
+    # historical events because their attempt and initiator are unknown.
     ev_cols = {row["name"] for row in conn.execute("PRAGMA table_info(task_events)")}
     if "run_id" not in ev_cols:
         _add_column_if_missing(conn, "task_events", "run_id", "run_id INTEGER")
+    if "actor" not in ev_cols:
+        _add_column_if_missing(conn, "task_events", "actor", "actor TEXT")
 
     # Same ordering rule as the additive ``tasks`` indexes above: create the
     # index after the additive column migration so legacy ``task_events``
@@ -2854,7 +2858,7 @@ _REBUILD_SPECS = {
     "task_events": (
         "CREATE TABLE task_events ("
         " id INTEGER PRIMARY KEY AUTOINCREMENT,"
-        " task_id TEXT NOT NULL, run_id INTEGER, kind TEXT NOT NULL,"
+        " task_id TEXT NOT NULL, run_id INTEGER, actor TEXT, kind TEXT NOT NULL,"
         " payload TEXT, created_at INTEGER NOT NULL)",
         (
             "CREATE INDEX idx_events_task ON task_events(task_id, created_at)",
@@ -3162,6 +3166,7 @@ def create_task(
     body: Optional[str] = None,
     assignee: Optional[str] = None,
     created_by: Optional[str] = None,
+    actor: Optional[str] = None,
     workspace_kind: str = "scratch",
     workspace_path: Optional[str] = None,
     branch_name: Optional[str] = None,
@@ -3553,6 +3558,7 @@ def create_task(
                         "model_override": model_override,
                         "provider_override": provider_override,
                     },
+                    actor=actor,
                 )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
             return task_id
@@ -3699,7 +3705,13 @@ def list_tasks(
     return [Task.from_row(r) for r in rows]
 
 
-def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) -> bool:
+def assign_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    profile: Optional[str],
+    *,
+    actor: Optional[str] = None,
+) -> bool:
     """Assign or reassign a task.  Returns True on success.
 
     Refuses to reassign a task that's currently running (claim_lock set).
@@ -3728,7 +3740,9 @@ def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) 
             )
         else:
             conn.execute("UPDATE tasks SET assignee = ? WHERE id = ?", (profile, task_id))
-        _append_event(conn, task_id, "assigned", {"assignee": profile})
+        _append_event(
+            conn, task_id, "assigned", {"assignee": profile}, actor=actor
+        )
     # Task-mutation observer (RFC #58548), fired AFTER the assignment txn
     # has committed so subscribers always observe durable board state.
     notify_task_updated(conn, task_id, ("assignee",))
@@ -3740,6 +3754,8 @@ def set_model_override(
     task_id: str,
     model: Optional[str],
     provider: Optional[str] = None,
+    *,
+    actor: Optional[str] = None,
 ) -> bool:
     """Set (or clear) the per-task model/provider override.
 
@@ -3776,6 +3792,7 @@ def set_model_override(
         _append_event(
             conn, task_id, "model_override_set",
             {"model": model, "provider": provider},
+            actor=actor,
         )
     # Task-mutation observer (RFC #58548), fired AFTER the txn commits.
     notify_task_updated(conn, task_id, ("model_override", "provider_override"))
@@ -3786,6 +3803,8 @@ def set_reasoning_effort(
     conn: sqlite3.Connection,
     task_id: str,
     effort: Optional[str],
+    *,
+    actor: Optional[str] = None,
 ) -> bool:
     """Set (or clear) the per-task reasoning effort.
 
@@ -3815,7 +3834,11 @@ def set_reasoning_effort(
             (effort, task_id),
         )
         _append_event(
-            conn, task_id, "reasoning_effort_set", {"reasoning_effort": effort}
+            conn,
+            task_id,
+            "reasoning_effort_set",
+            {"reasoning_effort": effort},
+            actor=actor,
         )
     # Task-mutation observer (RFC #58548), fired AFTER the txn commits.
     notify_task_updated(conn, task_id, ("reasoning_effort",))
@@ -3826,7 +3849,13 @@ def set_reasoning_effort(
 # Links
 # ---------------------------------------------------------------------------
 
-def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
+def link_tasks(
+    conn: sqlite3.Connection,
+    parent_id: str,
+    child_id: str,
+    *,
+    actor: Optional[str] = None,
+) -> None:
     if parent_id == child_id:
         raise ValueError("a task cannot depend on itself")
     with write_txn(conn):
@@ -3853,6 +3882,7 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
         _append_event(
             conn, child_id, "linked",
             {"parent": parent_id, "child": child_id},
+            actor=actor,
         )
         _inherit_notify_subs(conn, child_id, (parent_id,))
 
@@ -3880,7 +3910,13 @@ def _would_cycle(conn: sqlite3.Connection, parent_id: str, child_id: str) -> boo
     return False
 
 
-def unlink_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> bool:
+def unlink_tasks(
+    conn: sqlite3.Connection,
+    parent_id: str,
+    child_id: str,
+    *,
+    actor: Optional[str] = None,
+) -> bool:
     with write_txn(conn):
         cur = conn.execute(
             "DELETE FROM task_links WHERE parent_id = ? AND child_id = ?",
@@ -3890,6 +3926,7 @@ def unlink_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> boo
             _append_event(
                 conn, child_id, "unlinked",
                 {"parent": parent_id, "child": child_id},
+                actor=actor,
             )
         removed = cur.rowcount > 0
     if removed:
@@ -3980,7 +4017,12 @@ def parent_results(conn: sqlite3.Connection, task_id: str) -> list[tuple[str, Op
 # ---------------------------------------------------------------------------
 
 def add_comment(
-    conn: sqlite3.Connection, task_id: str, author: str, body: str
+    conn: sqlite3.Connection,
+    task_id: str,
+    author: str,
+    body: str,
+    *,
+    actor: Optional[str] = None,
 ) -> int:
     if not body or not body.strip():
         raise ValueError("comment body is required")
@@ -3999,7 +4041,13 @@ def add_comment(
             "VALUES (?, ?, ?, ?)",
             (task_id, author.strip(), body.strip(), now),
         )
-        _append_event(conn, task_id, "commented", {"author": author, "len": len(body)})
+        _append_event(
+            conn,
+            task_id,
+            "commented",
+            {"author": author, "len": len(body)},
+            actor=actor,
+        )
         return int(cur.lastrowid or 0)
 
 
@@ -4292,6 +4340,7 @@ def list_events(conn: sqlite3.Connection, task_id: str) -> list[Event]:
                 payload=payload,
                 created_at=r["created_at"],
                 run_id=(int(r["run_id"]) if "run_id" in r.keys() and r["run_id"] is not None else None),
+                actor=(r["actor"] if "actor" in r.keys() else None),
             )
         )
     return out
@@ -4304,20 +4353,23 @@ def _append_event(
     payload: Optional[dict] = None,
     *,
     run_id: Optional[int] = None,
+    actor: Optional[str] = None,
 ) -> None:
     """Record an event row.  Called from within an already-open txn.
 
     ``run_id`` is optional: pass the current run id so UIs can group
-    events by attempt. For events that aren't scoped to a single run
-    (task created/edited/archived, dependency promotion) leave it None
-    and the row carries NULL.
+    events by attempt. ``actor`` is also optional caller-supplied attribution
+    for the mutation initiator. Omitted values remain SQL NULL so legacy
+    callers retain their existing behavior.
     """
     now = int(time.time())
     pl = json.dumps(payload, ensure_ascii=False) if payload else None
+    actor = (actor or "").strip() or None
     conn.execute(
-        "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
-        "VALUES (?, ?, ?, ?, ?)",
-        (task_id, run_id, kind, pl, now),
+        "INSERT INTO task_events "
+        "(task_id, run_id, actor, kind, payload, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (task_id, run_id, actor, kind, pl, now),
     )
 
 
@@ -5117,6 +5169,7 @@ def reclaim_task(
     *,
     reason: Optional[str] = None,
     signal_fn=None,
+    actor: Optional[str] = None,
 ) -> bool:
     """Operator-driven reclaim: release the claim and restore its source phase.
 
@@ -5173,6 +5226,7 @@ def reclaim_task(
             conn, task_id, "reclaimed",
             payload,
             run_id=run_id,
+            actor=actor,
         )
     # Operator intervention — they've looked at the task, so the
     # consecutive-failures counter is now stale. Give the next retry
@@ -5189,6 +5243,7 @@ def reassign_task(
     *,
     reclaim_first: bool = False,
     reason: Optional[str] = None,
+    actor: Optional[str] = None,
 ) -> bool:
     """Reassign a task, optionally reclaiming a stuck running worker first.
 
@@ -5203,10 +5258,12 @@ def reassign_task(
     """
     if reclaim_first:
         # Safe to call even if nothing to reclaim.
-        reclaim_task(conn, task_id, reason=reason or "reassign")
+        reclaim_task(
+            conn, task_id, reason=reason or "reassign", actor=actor
+        )
     # assign_task handles its own txn + the still-running guard.
     try:
-        return assign_task(conn, task_id, profile)
+        return assign_task(conn, task_id, profile, actor=actor)
     except RuntimeError:
         # Task is still running and reclaim_first was False; caller
         # needs to decide whether to retry with reclaim.
@@ -5359,6 +5416,7 @@ def complete_task(
     created_cards: Optional[Iterable[str]] = None,
     expected_run_id: Optional[int] = None,
     fire_lifecycle_hook: bool = True,
+    actor: Optional[str] = None,
 ) -> bool:
     """Transition ``running|ready|blocked|review -> done`` and record ``result``.
 
@@ -5420,6 +5478,7 @@ def complete_task(
                             else None
                         ),
                     },
+                    actor=actor,
                 )
             raise HallucinatedCardsError(phantom_cards, task_id)
     else:
@@ -5548,6 +5607,7 @@ def complete_task(
             conn, task_id, "completed",
             completed_payload,
             run_id=run_id,
+            actor=actor,
         )
     # Prose-scan the summary + result for t_<hex> references that do
     # not resolve. Advisory — does not block the completion. Runs in
@@ -5569,6 +5629,7 @@ def complete_task(
                         "source": "completion_summary",
                     },
                     run_id=run_id,
+                    actor=actor,
                 )
     # Successful completion — wipe the consecutive-failures counter.
     # Failure history stays on the event log for audit; the counter
@@ -6250,6 +6311,7 @@ def block_task(
     reason: Optional[str] = None,
     kind: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    actor: Optional[str] = None,
 ) -> bool:
     """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
 
@@ -6341,6 +6403,7 @@ def block_task(
                     "source_status": source_status,
                 },
                 run_id=run_id,
+                actor=actor,
             )
             _blocked_task = get_task(conn, task_id)
             _fire_kanban_lifecycle_hook(
@@ -6401,6 +6464,7 @@ def block_task(
                     "source_status": source_status,
                 },
                 run_id=run_id,
+                actor=actor,
             )
         else:
             if expected_run_id is None:
@@ -6458,6 +6522,7 @@ def block_task(
                     "source_status": source_status,
                 },
                 run_id=run_id,
+                actor=actor,
             )
         _blocked_task = get_task(conn, task_id)
     _fire_kanban_lifecycle_hook(
@@ -6497,6 +6562,7 @@ def request_review(
     expected_run_id: Optional[int] = None,
     force: bool = False,
     with_reason: bool = False,
+    actor: Optional[str] = None,
 ):
     """Transition implementation work into the first-class review phase.
 
@@ -6645,6 +6711,7 @@ def request_review(
                 "reviewer": reviewer,
             },
             run_id=run_id,
+            actor=actor,
         )
     return _ret(True)
 
@@ -6655,6 +6722,7 @@ def request_changes(
     *,
     reason: str,
     expected_run_id: Optional[int] = None,
+    actor: Optional[str] = None,
 ) -> tuple[bool, Optional[str]]:
     """Finish an active review run and route the task back for rework.
 
@@ -6764,6 +6832,7 @@ def request_changes(
                 "status": new_status,
             },
             run_id=run_id,
+            actor=actor,
         )
     return True, implementer
 
@@ -6833,6 +6902,7 @@ def promote_task(
             task_id,
             "promoted_manual",
             {"actor": actor, "reason": reason, "forced": force},
+            actor=actor,
         )
 
     return True, None
@@ -6887,7 +6957,12 @@ def _landing_status_after_parents(conn: sqlite3.Connection, task_id: str) -> str
     return "todo" if undone_parents else "ready"
 
 
-def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
+def unblock_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    actor: Optional[str] = None,
+) -> bool:
     """Transition ``blocked``/``scheduled`` to its safe resumable phase.
 
     Defensively closes any stale ``current_run_id`` pointer before flipping
@@ -6944,11 +7019,17 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
                 if new_status != "ready" or resume_status != "ready"
                 else None
             ),
+            actor=actor,
         )
         return True
 
 
-def reopen_review_task(conn: sqlite3.Connection, task_id: str) -> bool:
+def reopen_review_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    actor: Optional[str] = None,
+) -> bool:
     """Transition ``review`` -> ready (or todo) so the implementer re-runs.
 
     The "changes requested" counterpart of :func:`request_review`: sends the
@@ -7012,6 +7093,7 @@ def reopen_review_task(conn: sqlite3.Connection, task_id: str) -> bool:
             task_id,
             "review_reopened",
             payload if payload != {"status": "ready"} else None,
+            actor=actor,
         )
         return True
 
@@ -7021,6 +7103,7 @@ def invalidate_descendants_for_parent_reopen(
     task_id: str,
     *,
     author: str,
+    actor: Optional[str] = None,
 ) -> dict[str, Any]:
     """Retract every dispatchable/completed descendant of a reopened ancestor.
 
@@ -7137,6 +7220,7 @@ def invalidate_descendants_for_parent_reopen(
                     "resume_status": resume_status,
                 },
                 run_id=run_id,
+                actor=actor,
             )
             # Legacy 'status' event kept so existing live-feed consumers
             # still see the move without learning the new event kind.
@@ -7152,6 +7236,7 @@ def invalidate_descendants_for_parent_reopen(
                     "resume_status": resume_status,
                 },
                 run_id=run_id,
+                actor=actor,
             )
             # Inline comment insert (not add_comment: no txn-opening helper
             # calls inside a txn per file convention).
@@ -7510,7 +7595,12 @@ def decompose_triage_task(
     return child_ids
 
 
-def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
+def archive_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    actor: Optional[str] = None,
+) -> bool:
     with write_txn(conn):
         cur = conn.execute(
             "UPDATE tasks SET status = 'archived', "
@@ -7528,7 +7618,9 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
             outcome="reclaimed", status="reclaimed",
             summary="task archived with run still active",
         )
-        _append_event(conn, task_id, "archived", None, run_id=run_id)
+        _append_event(
+            conn, task_id, "archived", None, run_id=run_id, actor=actor
+        )
     # ``archived`` parents no longer block children, same as ``done``.
     # Promote newly-unblocked dependents immediately instead of waiting
     # for a later dispatcher tick.
@@ -7918,6 +8010,7 @@ def schedule_task(
     *,
     reason: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    actor: Optional[str] = None,
 ) -> bool:
     """Park a task in ``scheduled`` so it is waiting on time, not human input.
 
@@ -7953,7 +8046,14 @@ def schedule_task(
                 outcome="scheduled",
                 summary=reason,
             )
-        _append_event(conn, task_id, "scheduled", {"reason": reason}, run_id=run_id)
+        _append_event(
+            conn,
+            task_id,
+            "scheduled",
+            {"reason": reason},
+            run_id=run_id,
+            actor=actor,
+        )
         return True
 
 
@@ -8375,6 +8475,7 @@ def heartbeat_worker(
     *,
     note: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    actor: Optional[str] = None,
 ) -> bool:
     """Record a ``heartbeat`` event + touch ``last_heartbeat_at``.
 
@@ -8416,6 +8517,7 @@ def heartbeat_worker(
             conn, task_id, "heartbeat",
             {"note": note} if note else None,
             run_id=run_id,
+            actor=actor,
         )
     return True
 
@@ -11758,6 +11860,7 @@ def unseen_events_for_sub(
             id=r["id"], task_id=r["task_id"], kind=r["kind"],
             payload=payload, created_at=r["created_at"],
             run_id=(int(r["run_id"]) if "run_id" in r.keys() and r["run_id"] is not None else None),
+            actor=(r["actor"] if "actor" in r.keys() else None),
         ))
         max_id = max(max_id, int(r["id"]))
     return max_id, out

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -86,6 +86,14 @@
     return body || raw;
   }
 
+  // Attribute task mutations at the UI call site so generic REST callers
+  // that omit actor retain the API's nullable, backward-compatible default.
+  function dashboardMutationBody(body) {
+    return JSON.stringify(Object.assign({}, body || {}, {
+      actor: "human:dashboard",
+    }));
+  }
+
   // Board column display order; any backend status not listed here renders after these.
   const COLUMN_ORDER = ["triage", "todo", "ready", "running", "blocked", "review", "done"];
   // English fallback dictionaries — used when the i18n catalog is missing
@@ -848,7 +856,7 @@
         SDK.fetchJSON(withBoard(`${API}/tasks/bulk`, board), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(Object.assign({ ids: ids }, finalPatch)),
+          body: dashboardMutationBody(Object.assign({ ids: ids }, finalPatch)),
         }).then(function (res) {
           const failed = (res.results || []).filter(function (r) { return !r.ok; });
           if (failed.length > 0) {
@@ -887,7 +895,7 @@
       SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(taskId)}`, board), {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(finalPatch),
+        body: dashboardMutationBody(finalPatch),
       }).catch(function (err) {
         setError(tx(t, "moveFailed", "Move failed: ") + parseApiErrorMessage(err));
         loadBoard();
@@ -984,7 +992,7 @@
       return SDK.fetchJSON(withBoard(`${API}/tasks`, board), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
+        body: dashboardMutationBody(body),
       }).then(function (res) {
         // Surface dispatcher-presence warnings (e.g. "no gateway is
         // running") via the existing error banner channel. Not fatal —
@@ -1100,7 +1108,7 @@
         SDK.fetchJSON(withBoard(`${API}/tasks/bulk`, board), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(body),
+          body: dashboardMutationBody(body),
         })
           .then(function (res) {
             const failed = (res.results || []).filter(function (r) { return !r.ok; });
@@ -1583,7 +1591,7 @@
         SDK.fetchJSON(url, {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ status: "ready" }),
+          body: dashboardMutationBody({ status: "ready" }),
         }).then(function () {
           setMsg({ ok: true, text: tx(t, "unblockedMessage",
             "Unblocked {id}. Task is ready for the next tick.", { id: task.id }) });
@@ -1599,7 +1607,7 @@
         SDK.fetchJSON(url, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ reason: `recovery action for ${diag.kind}` }),
+          body: dashboardMutationBody({ reason: `recovery action for ${diag.kind}` }),
         }).then(function () {
           setMsg({ ok: true, text: tx(t, "reclaimedMessage",
             "Reclaimed {id}. Task is back to ready.", { id: task.id }) });
@@ -1624,7 +1632,7 @@
         SDK.fetchJSON(url, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(body),
+          body: dashboardMutationBody(body),
         }).then(function () {
           setMsg({
             ok: true,
@@ -3447,7 +3455,7 @@
       SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}/comments`, boardSlug), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ body }),
+        body: dashboardMutationBody({ body }),
       }).then(function () {
         setNewComment("");
         load();
@@ -3539,7 +3547,7 @@
         return SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}`, boardSlug), {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(finalPatch),
+          body: dashboardMutationBody(finalPatch),
         }).then(function () { load(); props.onRefresh(); })
           .catch(function (e) { setPatchErr(parseApiErrorMessage(e)); });
       }
@@ -3610,12 +3618,16 @@
       return SDK.fetchJSON(withBoard(`${API}/links`, boardSlug), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ parent_id: parentId, child_id: props.taskId }),
+        body: dashboardMutationBody({ parent_id: parentId, child_id: props.taskId }),
       }).then(function () { load(); props.onRefresh(); })
         .catch(function (e) { setErr(String(e.message || e)); });
     };
     const removeLink = function (parentId) {
-      const qs = new URLSearchParams({ parent_id: parentId, child_id: props.taskId });
+      const qs = new URLSearchParams({
+        parent_id: parentId,
+        child_id: props.taskId,
+        actor: "human:dashboard",
+      });
       return SDK.fetchJSON(withBoard(`${API}/links?${qs}`, boardSlug), { method: "DELETE" })
         .then(function () { load(); props.onRefresh(); })
         .catch(function (e) { setErr(String(e.message || e)); });
@@ -3624,12 +3636,16 @@
       return SDK.fetchJSON(withBoard(`${API}/links`, boardSlug), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ parent_id: props.taskId, child_id: childId }),
+        body: dashboardMutationBody({ parent_id: props.taskId, child_id: childId }),
       }).then(function () { load(); props.onRefresh(); })
         .catch(function (e) { setErr(String(e.message || e)); });
     };
     const removeChild = function (childId) {
-      const qs = new URLSearchParams({ parent_id: props.taskId, child_id: childId });
+      const qs = new URLSearchParams({
+        parent_id: props.taskId,
+        child_id: childId,
+        actor: "human:dashboard",
+      });
       return SDK.fetchJSON(withBoard(`${API}/links?${qs}`, boardSlug), { method: "DELETE" })
         .then(function () { load(); props.onRefresh(); })
         .catch(function (e) { setErr(String(e.message || e)); });

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -184,6 +184,7 @@ def _event_dict(event: kanban_db.Event) -> dict[str, Any]:
         "payload": event.payload,
         "created_at": event.created_at,
         "run_id": event.run_id,
+        "actor": event.actor,
     }
 
 
@@ -597,6 +598,7 @@ def get_task(
 
 class CreateTaskBody(BaseModel):
     title: str
+    actor: Optional[str] = None
     body: Optional[str] = None
     assignee: Optional[str] = None
     tenant: Optional[str] = None
@@ -647,6 +649,7 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             reasoning_effort=payload.reasoning_effort,
             project_id=payload.project_id,
             board=board,
+            actor=payload.actor,
         )
         task = kanban_db.get_task(conn, task_id)
         body: dict[str, Any] = {"task": _task_dict(task) if task else None}
@@ -826,6 +829,7 @@ def remove_attachment(attachment_id: int, board: Optional[str] = Query(None)):
 # ---------------------------------------------------------------------------
 
 class UpdateTaskBody(BaseModel):
+    actor: Optional[str] = None
     status: Optional[str] = None
     assignee: Optional[str] = None
     priority: Optional[int] = None
@@ -853,7 +857,13 @@ class UpdateTaskBody(BaseModel):
     clear_reasoning_effort: bool = False
 
 
-def _reopen_if_review(conn, task_id: str, current) -> Optional[bool]:
+def _reopen_if_review(
+    conn,
+    task_id: str,
+    current,
+    *,
+    actor: Optional[str] = None,
+) -> Optional[bool]:
     """Route a task leaving the ``review`` lane through ``reopen_review_task``
     (proper transition: stale-run recovery, parent re-gate, ``review_reopened``
     event) instead of a raw status write. Returns the transition result, or
@@ -862,7 +872,7 @@ def _reopen_if_review(conn, task_id: str, current) -> Optional[bool]:
     the review-reopen routing can't drift between them.
     """
     if current is not None and getattr(current, "status", None) == "review":
-        return kanban_db.reopen_review_task(conn, task_id)
+        return kanban_db.reopen_review_task(conn, task_id, actor=actor)
     return None
 
 
@@ -885,7 +895,10 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
         if payload.assignee is not None and not review_assignee_deferred:
             try:
                 ok = kanban_db.assign_task(
-                    conn, task_id, payload.assignee or None,
+                    conn,
+                    task_id,
+                    payload.assignee or None,
+                    actor=payload.actor,
                 )
             except RuntimeError as e:
                 raise HTTPException(status_code=409, detail=str(e))
@@ -902,11 +915,22 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     result=payload.result,
                     summary=payload.summary,
                     metadata=payload.metadata,
+                    actor=payload.actor,
                 )
             elif s == "blocked":
-                ok = kanban_db.block_task(conn, task_id, reason=payload.block_reason)
+                ok = kanban_db.block_task(
+                    conn,
+                    task_id,
+                    reason=payload.block_reason,
+                    actor=payload.actor,
+                )
             elif s == "scheduled":
-                ok = kanban_db.schedule_task(conn, task_id, reason=payload.block_reason)
+                ok = kanban_db.schedule_task(
+                    conn,
+                    task_id,
+                    reason=payload.block_reason,
+                    actor=payload.actor,
+                )
             elif s == "review":
                 # Manual "request review" from the board. Routes through
                 # request_review so it is NOT a
@@ -919,22 +943,46 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     # Dashboard PATCH is an explicit human action — allowed
                     # to override a live worker claim (M1 guard).
                     force=True,
+                    actor=payload.actor,
                 )
                 if ok and review_assignee_deferred and not payload.assignee:
-                    ok = kanban_db.assign_task(conn, task_id, None)
+                    ok = kanban_db.assign_task(
+                        conn,
+                        task_id,
+                        None,
+                        actor=payload.actor,
+                    )
             elif s == "ready":
                 # Re-open a blocked/scheduled/review task, or just an explicit
                 # status set. "Changes requested" (review -> ready) goes through
                 # reopen_review_task via _reopen_if_review.
                 current = kanban_db.get_task(conn, task_id)
                 if current and current.status in ("blocked", "scheduled"):
-                    ok = kanban_db.unblock_task(conn, task_id)
+                    ok = kanban_db.unblock_task(
+                        conn,
+                        task_id,
+                        actor=payload.actor,
+                    )
                 else:
-                    reopened = _reopen_if_review(conn, task_id, current)
+                    reopened = _reopen_if_review(
+                        conn,
+                        task_id,
+                        current,
+                        actor=payload.actor,
+                    )
                     # Direct status write for drag-drop (todo -> ready etc).
-                    ok = reopened if reopened is not None else _set_status_direct(conn, task_id, "ready")
+                    ok = (
+                        reopened
+                        if reopened is not None
+                        else _set_status_direct(
+                            conn,
+                            task_id,
+                            "ready",
+                            actor=payload.actor,
+                        )
+                    )
             elif s == "archived":
-                ok = kanban_db.archive_task(conn, task_id)
+                ok = kanban_db.archive_task(conn, task_id, actor=payload.actor)
             elif s == "running":
                 raise HTTPException(
                     status_code=400,
@@ -944,8 +992,22 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                 # Only a review task moving to 'todo' needs the reopen
                 # transition; fetch lazily so triage/scheduled skip the query.
                 current = kanban_db.get_task(conn, task_id) if s == "todo" else None
-                reopened = _reopen_if_review(conn, task_id, current)
-                ok = reopened if reopened is not None else _set_status_direct(conn, task_id, s)
+                reopened = _reopen_if_review(
+                    conn,
+                    task_id,
+                    current,
+                    actor=payload.actor,
+                )
+                ok = (
+                    reopened
+                    if reopened is not None
+                    else _set_status_direct(
+                        conn,
+                        task_id,
+                        s,
+                        actor=payload.actor,
+                    )
+                )
             else:
                 raise HTTPException(status_code=400, detail=f"unknown status: {s}")
             if not ok:
@@ -981,6 +1043,7 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                 ok = kanban_db.set_model_override(
                     conn, task_id, new_model,
                     provider=payload.provider_override,
+                    actor=payload.actor,
                 )
             except (ValueError, RuntimeError) as e:
                 raise HTTPException(status_code=400, detail=str(e))
@@ -994,7 +1057,12 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                 else payload.reasoning_effort
             )
             try:
-                ok = kanban_db.set_reasoning_effort(conn, task_id, new_effort)
+                ok = kanban_db.set_reasoning_effort(
+                    conn,
+                    task_id,
+                    new_effort,
+                    actor=payload.actor,
+                )
             except (ValueError, RuntimeError) as e:
                 raise HTTPException(status_code=400, detail=str(e))
             if not ok:
@@ -1007,11 +1075,12 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     "UPDATE tasks SET priority = ? WHERE id = ?",
                     (int(payload.priority), task_id),
                 )
-                conn.execute(
-                    "INSERT INTO task_events (task_id, kind, payload, created_at) "
-                    "VALUES (?, 'reprioritized', ?, ?)",
-                    (task_id, json.dumps({"priority": int(payload.priority)}),
-                     int(time.time())),
+                kanban_db._append_event(
+                    conn,
+                    task_id,
+                    "reprioritized",
+                    {"priority": int(payload.priority)},
+                    actor=payload.actor,
                 )
             # Mutation-boundary observer (RFC #58548): this direct-SQL write
             # bypasses every kanban_db mutator, so report it here — after
@@ -1036,10 +1105,11 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                 conn.execute(
                     f"UPDATE tasks SET {', '.join(sets)} WHERE id = ?", vals,
                 )
-                conn.execute(
-                    "INSERT INTO task_events (task_id, kind, payload, created_at) "
-                    "VALUES (?, 'edited', NULL, ?)",
-                    (task_id, int(time.time())),
+                kanban_db._append_event(
+                    conn,
+                    task_id,
+                    "edited",
+                    actor=payload.actor,
                 )
             # Mutation-boundary observer (RFC #58548), post-commit. Field
             # names only — values never leave the DB via this payload.
@@ -1099,6 +1169,8 @@ def _invalidate_descendants_for_parent_reopen(
     conn: sqlite3.Connection,
     parent_id: str,
     terminations: list[tuple[Optional[int], Optional[str]]],
+    *,
+    actor: Optional[str] = None,
 ) -> None:
     """Delegate to the domain-layer implementation in :mod:`kanban_db`.
 
@@ -1112,13 +1184,20 @@ def _invalidate_descendants_for_parent_reopen(
     must be durable BEFORE the kill).
     """
     result = kanban_db.invalidate_descendants_for_parent_reopen(
-        conn, parent_id, author="dashboard",
+        conn,
+        parent_id,
+        author="dashboard",
+        actor=actor,
     )
     terminations.extend(result["terminations"])
 
 
 def _set_status_direct(
-    conn: sqlite3.Connection, task_id: str, new_status: str,
+    conn: sqlite3.Connection,
+    task_id: str,
+    new_status: str,
+    *,
+    actor: Optional[str] = None,
 ) -> bool:
     """Direct status write for drag-drop moves that aren't covered by the
     structured complete/block/unblock/archive verbs (e.g. todo<->ready,
@@ -1198,26 +1277,23 @@ def _set_status_direct(
                 summary=f"status changed to {effective_status} (dashboard/direct)",
             )
             terminations.append((prev["worker_pid"], prev["claim_lock"]))
-        conn.execute(
-            "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
-            "VALUES (?, ?, 'status', ?, ?)",
-            (
-                task_id,
-                run_id,
-                json.dumps(
-                    {
-                        "status": effective_status,
-                        "requested_status": new_status,
-                    }
-                ),
-                int(time.time()),
-            ),
+        kanban_db._append_event(
+            conn,
+            task_id,
+            "status",
+            {
+                "status": effective_status,
+                "requested_status": new_status,
+            },
+            run_id=run_id,
+            actor=actor,
         )
         if reopening_satisfied_parent:
             _invalidate_descendants_for_parent_reopen(
                 conn,
                 task_id,
                 terminations,
+                actor=actor,
             )
     for pid, claim_lock in terminations:
         kanban_db._terminate_reclaimed_worker(pid, claim_lock)
@@ -1234,6 +1310,7 @@ def _set_status_direct(
 class CommentBody(BaseModel):
     body: str
     author: Optional[str] = "dashboard"
+    actor: Optional[str] = None
 
 
 @router.post("/tasks/{task_id}/comments")
@@ -1247,6 +1324,7 @@ def add_comment(task_id: str, payload: CommentBody, board: Optional[str] = Query
             raise HTTPException(status_code=404, detail=f"task {task_id} not found")
         kanban_db.add_comment(
             conn, task_id, author=payload.author or "dashboard", body=payload.body,
+            actor=payload.actor,
         )
         return {"ok": True}
     finally:
@@ -1260,6 +1338,7 @@ def add_comment(task_id: str, payload: CommentBody, board: Optional[str] = Query
 class LinkBody(BaseModel):
     parent_id: str
     child_id: str
+    actor: Optional[str] = None
 
 
 @router.post("/links")
@@ -1267,7 +1346,12 @@ def add_link(payload: LinkBody, board: Optional[str] = Query(None)):
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
-        kanban_db.link_tasks(conn, payload.parent_id, payload.child_id)
+        kanban_db.link_tasks(
+            conn,
+            payload.parent_id,
+            payload.child_id,
+            actor=payload.actor,
+        )
         return {"ok": True}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
@@ -1279,12 +1363,18 @@ def add_link(payload: LinkBody, board: Optional[str] = Query(None)):
 def delete_link(
     parent_id: str = Query(...),
     child_id: str = Query(...),
+    actor: Optional[str] = Query(None),
     board: Optional[str] = Query(None),
 ):
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
-        ok = kanban_db.unlink_tasks(conn, parent_id, child_id)
+        ok = kanban_db.unlink_tasks(
+            conn,
+            parent_id,
+            child_id,
+            actor=actor,
+        )
         return {"ok": bool(ok)}
     finally:
         conn.close()
@@ -1296,6 +1386,7 @@ def delete_link(
 
 class BulkTaskBody(BaseModel):
     ids: list[str]
+    actor: Optional[str] = None
     status: Optional[str] = None
     assignee: Optional[str] = None  # "" or None = unassign
     priority: Optional[int] = None
@@ -1336,7 +1427,11 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                     results.append(entry)
                     continue
                 if payload.archive:
-                    if not kanban_db.archive_task(conn, tid):
+                    if not kanban_db.archive_task(
+                        conn,
+                        tid,
+                        actor=payload.actor,
+                    ):
                         entry.update(ok=False, error="archive refused")
                 if payload.status is not None and not payload.archive:
                     s = payload.status
@@ -1346,9 +1441,14 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                             result=payload.result,
                             summary=payload.summary,
                             metadata=payload.metadata,
+                            actor=payload.actor,
                         )
                     elif s == "blocked":
-                        ok = kanban_db.block_task(conn, tid)
+                        ok = kanban_db.block_task(
+                            conn,
+                            tid,
+                            actor=payload.actor,
+                        )
                     elif s == "review":
                         # Non-block review handoff (mirror of PATCH /tasks/{id}).
                         ok = kanban_db.request_review(
@@ -1357,14 +1457,33 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                             reviewer=(payload.assignee or None),
                             # Bulk dashboard action: explicit human override.
                             force=True,
+                            actor=payload.actor,
                         )
                     elif s == "ready":
                         cur = kanban_db.get_task(conn, tid)
                         if cur and cur.status in ("blocked", "scheduled"):
-                            ok = kanban_db.unblock_task(conn, tid)
+                            ok = kanban_db.unblock_task(
+                                conn,
+                                tid,
+                                actor=payload.actor,
+                            )
                         else:
-                            reopened = _reopen_if_review(conn, tid, cur)
-                            ok = reopened if reopened is not None else _set_status_direct(conn, tid, "ready")
+                            reopened = _reopen_if_review(
+                                conn,
+                                tid,
+                                cur,
+                                actor=payload.actor,
+                            )
+                            ok = (
+                                reopened
+                                if reopened is not None
+                                else _set_status_direct(
+                                    conn,
+                                    tid,
+                                    "ready",
+                                    actor=payload.actor,
+                                )
+                            )
                     elif s == "running":
                         entry.update(
                             ok=False,
@@ -1376,12 +1495,30 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                         results.append(entry)
                         continue
                     elif s == "scheduled":
-                        ok = kanban_db.schedule_task(conn, tid)
+                        ok = kanban_db.schedule_task(
+                            conn,
+                            tid,
+                            actor=payload.actor,
+                        )
                     elif s in {"todo", "triage"}:
                         # Fetch lazily: only review->todo needs reopen.
                         cur = kanban_db.get_task(conn, tid) if s == "todo" else None
-                        reopened = _reopen_if_review(conn, tid, cur)
-                        ok = reopened if reopened is not None else _set_status_direct(conn, tid, s)
+                        reopened = _reopen_if_review(
+                            conn,
+                            tid,
+                            cur,
+                            actor=payload.actor,
+                        )
+                        ok = (
+                            reopened
+                            if reopened is not None
+                            else _set_status_direct(
+                                conn,
+                                tid,
+                                s,
+                                actor=payload.actor,
+                            )
+                        )
                     else:
                         entry.update(ok=False, error=f"unknown status {s!r}")
                         results.append(entry)
@@ -1394,10 +1531,14 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                             ok = kanban_db.reassign_task(
                                 conn, tid, payload.assignee or None,
                                 reclaim_first=True,
+                                actor=payload.actor,
                             )
                         else:
                             ok = kanban_db.assign_task(
-                                conn, tid, payload.assignee or None,
+                                conn,
+                                tid,
+                                payload.assignee or None,
+                                actor=payload.actor,
                             )
                         if not ok:
                             entry.update(ok=False, error="assign refused")
@@ -1409,11 +1550,12 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                             "UPDATE tasks SET priority = ? WHERE id = ?",
                             (int(payload.priority), tid),
                         )
-                        conn.execute(
-                            "INSERT INTO task_events (task_id, kind, payload, created_at) "
-                            "VALUES (?, 'reprioritized', ?, ?)",
-                            (tid, json.dumps({"priority": int(payload.priority)}),
-                             int(time.time())),
+                        kanban_db._append_event(
+                            conn,
+                            tid,
+                            "reprioritized",
+                            {"priority": int(payload.priority)},
+                            actor=payload.actor,
                         )
                     # Mutation-boundary observer (RFC #58548): the bulk
                     # editor writes with direct SQL too — report each task's
@@ -1430,6 +1572,7 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                         ok = kanban_db.set_model_override(
                             conn, tid, new_model,
                             provider=payload.provider_override,
+                            actor=payload.actor,
                         )
                         if not ok:
                             entry.update(ok=False, error="model override refused")
@@ -1441,7 +1584,12 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                         else payload.reasoning_effort
                     )
                     try:
-                        ok = kanban_db.set_reasoning_effort(conn, tid, new_effort)
+                        ok = kanban_db.set_reasoning_effort(
+                            conn,
+                            tid,
+                            new_effort,
+                            actor=payload.actor,
+                        )
                         if not ok:
                             entry.update(ok=False, error="reasoning override refused")
                     except (ValueError, RuntimeError) as e:
@@ -1701,6 +1849,7 @@ def inspect_run_endpoint(
 
 class TerminateRunBody(BaseModel):
     reason: Optional[str] = None
+    actor: Optional[str] = None
 
 
 @router.post("/runs/{run_id}/terminate")
@@ -1737,7 +1886,12 @@ def terminate_run_endpoint(
                 status_code=409,
                 detail=f"run {run_id} already ended",
             )
-        ok = kanban_db.reclaim_task(conn, r.task_id, reason=payload.reason)
+        ok = kanban_db.reclaim_task(
+            conn,
+            r.task_id,
+            reason=payload.reason,
+            actor=payload.actor,
+        )
         if not ok:
             raise HTTPException(
                 status_code=409,
@@ -1757,6 +1911,7 @@ def terminate_run_endpoint(
 
 class ReclaimBody(BaseModel):
     reason: Optional[str] = None
+    actor: Optional[str] = None
 
 
 @router.post("/tasks/{task_id}/reclaim")
@@ -1775,7 +1930,12 @@ def reclaim_task_endpoint(
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
-        ok = kanban_db.reclaim_task(conn, task_id, reason=payload.reason)
+        ok = kanban_db.reclaim_task(
+            conn,
+            task_id,
+            reason=payload.reason,
+            actor=payload.actor,
+        )
         if not ok:
             raise HTTPException(
                 status_code=409,
@@ -1845,6 +2005,7 @@ class ReassignBody(BaseModel):
     profile: Optional[str] = None  # "" or None = unassign
     reclaim_first: bool = False
     reason: Optional[str] = None
+    actor: Optional[str] = None
 
 
 @router.post("/tasks/{task_id}/reassign")
@@ -1868,6 +2029,7 @@ def reassign_task_endpoint(
             payload.profile or None,
             reclaim_first=bool(payload.reclaim_first),
             reason=payload.reason,
+            actor=payload.actor,
         )
         if not ok:
             raise HTTPException(
@@ -2921,7 +3083,7 @@ async def stream_events(ws: WebSocket):
             conn = kanban_db.connect(board=ws_board)
             try:
                 rows = conn.execute(
-                    "SELECT id, task_id, run_id, kind, payload, created_at "
+                    "SELECT id, task_id, run_id, kind, payload, created_at, actor "
                     "FROM task_events WHERE id > ? ORDER BY id ASC LIMIT 200",
                     (cursor_val,),
                 ).fetchall()
@@ -2939,6 +3101,7 @@ async def stream_events(ws: WebSocket):
                         "kind": r["kind"],
                         "payload": payload,
                         "created_at": r["created_at"],
+                        "actor": r["actor"],
                     })
                     new_cursor = r["id"]
                 return new_cursor, out

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -120,9 +120,9 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
             claim_expires INTEGER
         )
     """)
-    # Pre-#17805 ``task_events`` shape: missing run_id. Required because
+    # Pre-#17805 ``task_events`` shape: missing run_id and actor. Required because
     # ``_migrate_add_optional_columns`` unconditionally runs PRAGMA on
-    # ``task_events`` for run_id back-fill.
+    # ``task_events`` for additive-column back-fill.
     conn.execute("""
         CREATE TABLE task_events (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -136,6 +136,10 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
         "INSERT INTO tasks (id, title, status, created_at) "
         "VALUES ('legacy', 'old board task', 'ready', 1)"
     )
+    conn.execute(
+        "INSERT INTO task_events (task_id, kind, payload, created_at) "
+        "VALUES ('legacy', 'created', NULL, 1)"
+    )
     conn.commit()
     conn.close()
 
@@ -147,6 +151,9 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
             row["name"]
             for row in migrated.execute("PRAGMA table_info(task_events)")
         }
+        historical_actor = migrated.execute(
+            "SELECT actor FROM task_events WHERE task_id = 'legacy'"
+        ).fetchone()["actor"]
         indexes = {
             row["name"]
             for row in migrated.execute(
@@ -159,11 +166,58 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
     assert "tenant" in task_columns
     assert "idempotency_key" in task_columns
     assert "run_id" in event_columns
+    assert "actor" in event_columns
+    assert historical_actor is None
     # And their indexes — the regression scope of this test:
     assert "idx_tasks_session_id" in indexes
     assert "idx_tasks_tenant" in indexes
     assert "idx_tasks_idempotency" in indexes
     assert "idx_events_run" in indexes
+
+
+def test_append_event_persists_actor_and_reads_it_back(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="Attributed transition")
+        kb._append_event(
+            conn,
+            task_id,
+            "status_changed",
+            {"status": "done"},
+            actor="human:alice",
+        )
+
+    with kb.connect() as conn:
+        event = next(
+            event
+            for event in kb.list_events(conn, task_id)
+            if event.kind == "status_changed"
+        )
+        persisted_actor = conn.execute(
+            "SELECT actor FROM task_events WHERE id = ?", (event.id,)
+        ).fetchone()["actor"]
+
+    assert event.actor == "human:alice"
+    assert persisted_actor == "human:alice"
+
+
+def test_append_event_without_actor_reads_back_none(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="Unattributed transition")
+        kb._append_event(
+            conn,
+            task_id,
+            "status_changed",
+            {"status": "done"},
+        )
+
+    with kb.connect() as conn:
+        event = next(
+            event
+            for event in kb.list_events(conn, task_id)
+            if event.kind == "status_changed"
+        )
+
+    assert event.actor is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_db_init.py
+++ b/tests/hermes_cli/test_kanban_db_init.py
@@ -88,8 +88,17 @@ def test_legacy_text_pk_tables_rebuilt_to_integer_autoincrement(tmp_path, monkey
         assert lei["last_event_id"]["type"].upper() == "INTEGER"
         assert "delivery_metadata" in lei
 
+        event_columns = {
+            row["name"] for row in conn.execute("PRAGMA table_info(task_events)")
+        }
+        assert "actor" in event_columns
+
         # Data preserved across the rebuild.
-        assert len(conn.execute("SELECT * FROM task_events").fetchall()) == 2
+        event_rows = conn.execute(
+            "SELECT actor FROM task_events ORDER BY id"
+        ).fetchall()
+        assert len(event_rows) == 2
+        assert [row["actor"] for row in event_rows] == [None, None]
         assert conn.execute("SELECT body FROM task_comments").fetchone()["body"] == "hi"
         assert len(conn.execute("SELECT * FROM task_runs").fetchall()) == 1
         # Non-numeric legacy cursor ("e-1") casts to 0.

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -225,6 +225,91 @@ def test_task_detail_includes_links_and_events(client):
 # ---------------------------------------------------------------------------
 
 
+def test_patch_task_actor_persists_and_is_returned_in_events(client):
+    task = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "attributed transition"},
+    ).json()["task"]
+    actor = "human:dashboard-session-42"
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{task['id']}",
+        json={
+            "status": "blocked",
+            "block_reason": "waiting for approval",
+            "actor": actor,
+        },
+    )
+    assert response.status_code == 200, response.text
+
+    with kb.connect() as conn:
+        blocked_event = [
+            event
+            for event in kb.list_events(conn, task["id"])
+            if event.kind == "blocked"
+        ][-1]
+        assert blocked_event.actor == actor
+
+    detail = client.get(f"/api/plugins/kanban/tasks/{task['id']}")
+    assert detail.status_code == 200, detail.text
+    blocked_event_json = [
+        event
+        for event in detail.json()["events"]
+        if event["kind"] == "blocked"
+    ][-1]
+    assert blocked_event_json["actor"] == actor
+
+
+def test_patch_task_without_actor_returns_null_event_actor(client):
+    task = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "backward-compatible transition"},
+    ).json()["task"]
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{task['id']}",
+        json={"status": "blocked", "block_reason": "waiting"},
+    )
+    assert response.status_code == 200, response.text
+
+    detail = client.get(f"/api/plugins/kanban/tasks/{task['id']}")
+    assert detail.status_code == 200, detail.text
+    blocked_event = [
+        event
+        for event in detail.json()["events"]
+        if event["kind"] == "blocked"
+    ][-1]
+    assert "actor" in blocked_event
+    assert blocked_event["actor"] is None
+
+
+def test_create_and_comment_actors_are_returned_in_events(client):
+    create_actor = "human:dashboard-creator"
+    response = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "attributed task", "actor": create_actor},
+    )
+    assert response.status_code == 200, response.text
+    task = response.json()["task"]
+
+    comment_actor = "human:dashboard-commenter"
+    response = client.post(
+        f"/api/plugins/kanban/tasks/{task['id']}/comments",
+        json={"body": "Approved to proceed", "actor": comment_actor},
+    )
+    assert response.status_code == 200, response.text
+
+    detail = client.get(f"/api/plugins/kanban/tasks/{task['id']}")
+    assert detail.status_code == 200, detail.text
+    events = detail.json()["events"]
+    created_event = [event for event in events if event["kind"] == "created"][-1]
+    commented_event = [
+        event for event in events if event["kind"] == "commented"
+    ][-1]
+    assert created_event["actor"] == create_actor
+    assert commented_event["actor"] == comment_actor
+
+
 def test_patch_review_lifecycle_preserves_handoff_and_reopens(client):
     secret = "ghp_" + "D" * 40
     task = client.post(
@@ -1228,5 +1313,4 @@ def test_specify_happy_path(client, monkeypatch):
 # ---------------------------------------------------------------------------
 # Final result visibility for Done cards
 # ---------------------------------------------------------------------------
-
 

--- a/tests/plugins/test_kanban_ws_idle_disconnect.py
+++ b/tests/plugins/test_kanban_ws_idle_disconnect.py
@@ -15,6 +15,8 @@ from pathlib import Path
 
 import pytest
 
+from hermes_cli import kanban_db as kb
+
 
 def _load_plugin_module():
     repo_root = Path(__file__).resolve().parents[2]
@@ -53,6 +55,29 @@ class _IdleDisconnectingWebSocket:
         pass
 
 
+class _PollingWebSocket:
+    """Waits for one event batch, then reports a client disconnect."""
+
+    def __init__(self):
+        self.accepted = False
+        self.sent: list[dict] = []
+        self.query_params = {"since": "0"}
+
+    async def accept(self):
+        self.accepted = True
+
+    async def receive(self):
+        if self.sent:
+            return {"type": "websocket.disconnect"}
+        await asyncio.Event().wait()
+
+    async def send_json(self, payload):
+        self.sent.append(payload)
+
+    async def close(self, code=None):
+        pass
+
+
 @pytest.mark.asyncio
 async def test_stream_events_exits_on_idle_disconnect(monkeypatch, tmp_path):
     mod = _load_plugin_module()
@@ -68,3 +93,36 @@ async def test_stream_events_exits_on_idle_disconnect(monkeypatch, tmp_path):
     assert ws.accepted
     assert ws.receive_calls == 1
     assert ws.sent == []  # returned before any poll, no zombie loop
+
+
+@pytest.mark.asyncio
+async def test_stream_events_includes_actor(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+
+    actor = "agent:researcher"
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="stream attributed event",
+            actor=actor,
+        )
+
+    mod = _load_plugin_module()
+    monkeypatch.setattr(mod, "_ws_upgrade_authorized", lambda ws: True)
+    monkeypatch.setattr(mod, "_EVENT_POLL_SECONDS", 0.01)
+    ws = _PollingWebSocket()
+
+    await asyncio.wait_for(mod.stream_events(ws), timeout=5)
+
+    assert ws.accepted
+    assert len(ws.sent) == 1
+    event = next(
+        event
+        for event in ws.sent[0]["events"]
+        if event["task_id"] == task_id and event["kind"] == "created"
+    )
+    assert event["actor"] == actor

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -132,6 +132,25 @@ def test_complete_happy_path(worker_env):
         conn.close()
 
 
+def test_complete_attributes_event_to_worker_profile(worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    out = kt._handle_complete({"summary": "attributed completion"})
+    assert json.loads(out)["ok"] is True
+
+    conn = kb.connect()
+    try:
+        completed = [
+            event
+            for event in kb.list_events(conn, worker_env)
+            if event.kind == "completed"
+        ]
+        assert completed[-1].actor == "agent:test-worker"
+    finally:
+        conn.close()
+
+
 def test_complete_retry_with_empty_created_cards_succeeds(worker_env):
     """After a phantom rejection, retrying kanban_complete with
     created_cards=[] (the documented escape hatch) must complete the

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -139,6 +139,11 @@ def _check_kanban_orchestrator_mode() -> bool:
 # Shared helpers
 # ---------------------------------------------------------------------------
 
+def _agent_actor() -> str:
+    """Return the trusted task-event actor for this agent process."""
+    return f"agent:{os.environ.get('HERMES_PROFILE') or 'worker'}"
+
+
 def _default_task_id(arg: Optional[str]) -> Optional[str]:
     """Resolve ``task_id`` arg or fall back to the env var the dispatcher set."""
     if arg:
@@ -343,7 +348,13 @@ def heartbeat_current_worker_from_env() -> bool:
             except (TypeError, ValueError):
                 run_id = None
             try:
-                kb.heartbeat_worker(conn, tid, note=None, expected_run_id=run_id)
+                kb.heartbeat_worker(
+                    conn,
+                    tid,
+                    note=None,
+                    expected_run_id=run_id,
+                    actor=_agent_actor(),
+                )
             except Exception:
                 logger.debug("auto-heartbeat: heartbeat_worker failed", exc_info=True)
         finally:
@@ -771,6 +782,7 @@ def _handle_complete(args: dict, **kw) -> str:
                     result=result, summary=summary, metadata=metadata,
                     created_cards=created_cards,
                     expected_run_id=_worker_run_id(tid),
+                    actor=_agent_actor(),
                 )
             except kb.ArtifactPreservationError as artifact_err:
                 return tool_error(
@@ -870,6 +882,7 @@ def _handle_block(args: dict, **kw) -> str:
                 reason=reason,
                 kind=kind,
                 expected_run_id=_worker_run_id(tid),
+                actor=_agent_actor(),
             )
             if not ok:
                 return tool_error(
@@ -951,6 +964,7 @@ def _handle_request_review(args: dict, **kw) -> str:
                 reviewer=reviewer,
                 expected_run_id=_worker_run_id(tid),
                 with_reason=True,
+                actor=_agent_actor(),
             )
             if not ok:
                 detail = fail_reason or "unknown id or not in running/ready"
@@ -999,6 +1013,7 @@ def _handle_request_changes(args: dict, **kw) -> str:
                 tid,
                 reason=reason,
                 expected_run_id=_worker_run_id(tid),
+                actor=_agent_actor(),
             )
             if not ok:
                 return tool_error(
@@ -1060,6 +1075,7 @@ def _handle_heartbeat(args: dict, **kw) -> str:
                 tid,
                 note=note,
                 expected_run_id=_worker_run_id(tid),
+                actor=_agent_actor(),
             )
             if not ok:
                 return tool_error(
@@ -1104,7 +1120,13 @@ def _handle_comment(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
-            cid = kb.add_comment(conn, tid, author=author, body=str(body))
+            cid = kb.add_comment(
+                conn,
+                tid,
+                author=author,
+                body=str(body),
+                actor=_agent_actor(),
+            )
             return _ok(task_id=tid, comment_id=cid)
         finally:
             conn.close()
@@ -1461,6 +1483,7 @@ def _handle_create(args: dict, **kw) -> str:
                 initial_status=str(initial_status),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
                 session_id=session_id,
+                actor=_agent_actor(),
             )
             new_task = kb.get_task(conn, new_tid)
             subscribed = _maybe_auto_subscribe(conn, new_tid)
@@ -1627,7 +1650,7 @@ def _handle_unblock(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
-            ok = kb.unblock_task(conn, str(tid))
+            ok = kb.unblock_task(conn, str(tid), actor=_agent_actor())
             if not ok:
                 return tool_error(f"could not unblock {tid} (not blocked or unknown)")
             task = kb.get_task(conn, str(tid))
@@ -1654,7 +1677,12 @@ def _handle_link(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
-            kb.link_tasks(conn, parent_id=parent_id, child_id=child_id)
+            kb.link_tasks(
+                conn,
+                parent_id=parent_id,
+                child_id=child_id,
+                actor=_agent_actor(),
+            )
             return _ok(parent_id=parent_id, child_id=child_id)
         finally:
             conn.close()

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -674,6 +674,10 @@ All routes are mounted under `/api/plugins/kanban/` and protected by the dashboa
 | `GET` | `/config` | Read `dashboard.kanban` preferences from `config.yaml` — `default_tenant`, `lane_by_profile`, `include_archived_by_default`, `render_markdown` |
 | `WS` | `/events?since=<event_id>` | Live stream of `task_events` rows |
 
+Task mutation request bodies accept an optional, nullable `actor` string. This includes task creation, task PATCHes (status transitions and edits), bulk mutations, and comments. When present, the value is persisted on the event row directly emitted for that mutation and is returned in both the `events` array from `GET /tasks/:id` and the `/events` WebSocket stream. Existing callers can omit it; their events store `actor` as `NULL` and otherwise behave exactly as before. Automatic dispatcher and maintenance events that do not supply attribution also remain `NULL`. Namespaced values such as `human:<id>`, `agent:<id>`, and `system:<source>` are recommended so consumers can distinguish actor classes without a second field. The built-in dashboard uses `human:dashboard`.
+
+`actor` is caller-supplied attribution metadata, not authentication or authorization. Do not treat it as cryptographic proof that the named principal initiated the mutation.
+
 Every handler is a thin wrapper — the plugin is ~700 lines of Python (router + WebSocket tail + bulk batcher + config reader) and adds no new business logic. A tiny `_conn()` helper auto-initializes `kanban.db` on every read and write, so a fresh install works whether the user opened the dashboard first, hit the REST API directly, or ran `hermes kanban init`.
 
 ### Dashboard config
@@ -1117,7 +1121,7 @@ Two nullable columns on `tasks` are reserved for v2 workflow routing: `workflow_
 
 ## Event reference
 
-Every transition appends a row to `task_events`. Each row carries an optional `run_id` so UIs can group events by attempt. Kinds group into three clusters so filtering is easy (`hermes kanban watch --kinds completed,gave_up,timed_out`):
+Every transition appends a row to `task_events`. Each row carries an optional `run_id` so UIs can group events by attempt and an optional `actor` string for caller-supplied attribution. Both fields are exposed by task-detail responses and the live WebSocket stream. Kinds group into three clusters so filtering is easy (`hermes kanban watch --kinds completed,gave_up,timed_out`):
 
 **Lifecycle** (what changed about the task as a logical unit):
 


### PR DESCRIPTION
## Problem

Kanban task transitions record no actor. `PATCH /tasks/:id` and the `task_events` stream both capture *what* changed but not *who* changed it, so a card moving to `done` can't be distinguished as human-moved vs agent-moved.

That blocks a useful pattern in multi-agent setups: using board state as a human-approval audit trail. If an agent can move its own card to `done` and the record looks identical to a human doing it, the board can't serve as evidence that a person reviewed anything.

## Solution

An **optional** `actor` field on task mutations, persisted on the event row and echoed back on reads and the events stream.

- Nullable `TEXT` column, matching the existing string-identity convention used by `created_by` and comment authors.
- Recommended value shapes: `human:<id>`, `agent:<id>`, `system:<source>`.
- Wired through the dashboard route (the human path — the one that makes board-as-approval-record possible) and the tool/dispatcher call sites.
- Omitted or blank stays `NULL`.

This is attribution only — it deliberately does **not** add authentication to the plugin API, which is a separate concern and a bigger design conversation.

## Backward compatibility

Fully optional. Existing callers that omit `actor` store `NULL` and behave exactly as before; readers that ignore the field are unaffected. Migration follows the existing kanban_db schema-versioning pattern.

## Tests & docs

Coverage for: transition with actor persists and reads back, transition without actor stores NULL, and the events stream surfacing actor when present. Kanban feature docs updated to describe the field.

Glad to adjust the value shape or the wired call sites if you'd prefer different conventions.