### PR TITLE
feat(cli): set one provider/model for all auxiliary tasks

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4077,6 +4077,41 @@ def _format_aux_current(task_cfg: dict) -> str:
     return provider
 
 
+def _format_aux_all_current(cfg: dict) -> str:
+    """Summarize routing across ALL aux tasks (incl. delegation) for the menu.
+
+    Returns a single shared value when every slot resolves identically
+    (all "auto", or all the same provider·model), otherwise "mixed".
+    """
+    aux = cfg.get("auxiliary", {}) if isinstance(cfg.get("auxiliary"), dict) else {}
+    seen: set[tuple[str, str, str]] = set()
+    for task, _name, _desc in _all_aux_tasks():
+        entry = aux.get(task, {}) if isinstance(aux.get(task), dict) else {}
+        base_url = str(entry.get("base_url") or "").strip()
+        provider = str(entry.get("provider") or "auto").strip() or "auto"
+        model = str(entry.get("model") or "").strip()
+        seen.add((base_url, provider, model))
+    dele = _delegation_cfg_as_task(cfg)
+    seen.add(
+        (
+            str(dele.get("base_url") or "").strip(),
+            str(dele.get("provider") or "auto").strip() or "auto",
+            str(dele.get("model") or "").strip(),
+        )
+    )
+    if len(seen) <= 1:
+        base_url, provider, model = next(iter(seen))
+        if base_url:
+            short = base_url.replace("https://", "").replace("http://", "").rstrip("/")
+            return f"custom ({short})" + (f" · {model}" if model else "")
+        if provider == "auto":
+            return "auto" + (f" · {model}" if model else "")
+        if model:
+            return f"{provider} · {model}"
+        return provider
+    return "mixed (configured per task)"
+
+
 def _delegation_cfg_as_task(cfg: dict) -> dict:
     """Project the top-level ``delegation`` section into aux-task shape.
 
@@ -4199,6 +4234,42 @@ def _reset_aux_to_auto() -> int:
     return count
 
 
+def _apply_aux_choice_to_all(
+    provider: str,
+    model: str = "",
+    base_url: str = "",
+    api_key: str = "",
+) -> int:
+    """Apply one provider/model to every aux task, including delegation.
+
+    One-shot apply: writes the choice into each ``auxiliary.<task>`` slot and
+    the top-level ``delegation`` section. Each task goes through
+    ``_save_aux_choice`` so the delegation special-case (``auto`` stored as an
+    empty provider) and per-task preservation of timeouts/extra_body are
+    handled identically to the single-task flow. Returns the number of tasks
+    written.
+    """
+    count = 0
+    for task, _name, _desc in _all_aux_tasks():
+        _save_aux_choice(
+            task,
+            provider=provider,
+            model=model,
+            base_url=base_url,
+            api_key=api_key,
+        )
+        count += 1
+    _save_aux_choice(
+        _DELEGATION_TASK_KEY,
+        provider=provider,
+        model=model,
+        base_url=base_url,
+        api_key=api_key,
+    )
+    count += 1
+    return count
+
+
 def _aux_config_menu() -> None:
     """Top-level auxiliary-model picker — choose a task to configure.
 
@@ -4241,6 +4312,7 @@ def _aux_config_menu() -> None:
                 f"{name.ljust(name_col)}{('(' + desc + ')').ljust(desc_col)}{current}"
             )
             entries.append((task_key, label))
+        entries.append(("__set_all__", "Set one provider/model for all auxiliary tasks..."))
         entries.append(("__reset__", "Reset all to auto"))
         entries.append(("__back__", "Back"))
 
@@ -4253,6 +4325,9 @@ def _aux_config_menu() -> None:
         key = entries[idx][0]
         if key == "__back__":
             return
+        if key == "__set_all__":
+            _aux_select_apply_all()
+            continue
         if key == "__reset__":
             n = _reset_aux_to_auto()
             if n:
@@ -4263,6 +4338,141 @@ def _aux_config_menu() -> None:
             continue
         # Otherwise configure the specific task
         _aux_select_for_task(key)
+
+
+def _aux_select_apply_all() -> None:
+    """Pick ONE provider+model and apply it to every auxiliary task.
+
+    One-shot apply: the choice is written into each ``auxiliary.<task>`` slot
+    (and the top-level ``delegation`` section) now. Slots stay independently
+    tweakable afterwards via the per-task flow.
+    """
+    from hermes_cli.config import load_config
+    from hermes_cli.inventory import build_aux_picker_rows, format_aux_picker_entries
+
+    cfg = load_config()
+
+    print()
+    print(f"  Configure ALL auxiliary tasks — current: {_format_aux_all_current(cfg)}")
+    print()
+
+    # Gather authenticated providers (has credentials + curated model list)
+    try:
+        providers = build_aux_picker_rows(
+            current_provider="",
+            current_model="",
+            current_base_url="",
+        )
+    except Exception as exc:
+        print(f"Could not detect authenticated providers: {exc}")
+        providers = []
+
+    entries: list[tuple[str, str, list[str]]] = [
+        ("__auto__", "auto (recommended)", []),
+    ]
+    entries.extend(format_aux_picker_entries(providers))
+    entries.append(("__custom__", "Custom endpoint (direct URL)", []))
+    entries.append(("__back__", "Back", []))
+
+    idx = _prompt_provider_choice([label for _, label, _ in entries], default=0)
+    if idx is None:
+        return
+    slug, _label, models = entries[idx]
+
+    if slug == "__back__":
+        return
+
+    if slug == "__auto__":
+        n = _reset_aux_to_auto()
+        if n:
+            print(f"Reset {n} auxiliary task(s) to auto.")
+        else:
+            print("All auxiliary tasks were already set to auto.")
+        return
+
+    if slug == "__custom__":
+        _aux_apply_all_custom()
+        return
+
+    _aux_apply_all_provider_model(slug, models)
+
+
+def _aux_apply_all_provider_model(provider_slug: str, curated_models: list) -> None:
+    """Pick a model under an already-authenticated provider, apply it to all aux tasks."""
+    from hermes_cli.auth import _prompt_model_selection
+    from hermes_cli.models import get_pricing_for_provider
+
+    # Fetch live pricing for this provider (non-blocking)
+    pricing: dict = {}
+    try:
+        pricing = get_pricing_for_provider(provider_slug) or {}
+    except Exception:
+        pricing = {}
+
+    model_list = list(curated_models)
+
+    if not model_list:
+        print(f"No curated model list for {provider_slug}.")
+        print("Enter a model slug manually (blank = use provider default):")
+        try:
+            val = input("Model: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            return
+        selected = val or ""
+    else:
+        selected = _prompt_model_selection(
+            model_list,
+            current_model="",
+            pricing=pricing,
+            confirm_provider=provider_slug,
+        )
+        if selected is None:
+            print("No change.")
+            return
+
+    n = _apply_aux_choice_to_all(provider=provider_slug, model=selected or "")
+    if selected:
+        print(f"Applied {provider_slug} · {selected} to {n} auxiliary task(s).")
+    else:
+        print(f"Applied {provider_slug} (provider default model) to {n} auxiliary task(s).")
+
+
+def _aux_apply_all_custom() -> None:
+    """Prompt for a direct OpenAI-compatible endpoint, apply it to all aux tasks."""
+    from hermes_cli.secret_prompt import masked_secret_prompt
+
+    print()
+    print("  Custom endpoint for ALL auxiliary tasks")
+    print("  Provide an OpenAI-compatible base URL (e.g. http://localhost:11434/v1)")
+    print()
+    try:
+        url = input("Base URL: ").strip()
+    except (KeyboardInterrupt, EOFError):
+        print()
+        return
+    if not url:
+        print("No URL provided. No change.")
+        return
+    try:
+        model = input("Model slug (optional): ").strip()
+    except (KeyboardInterrupt, EOFError):
+        print()
+        return
+    try:
+        api_key = masked_secret_prompt(
+            "API key (optional, blank = use OPENAI_API_KEY): "
+        ).strip()
+    except (KeyboardInterrupt, EOFError):
+        print()
+        return
+
+    n = _apply_aux_choice_to_all(
+        provider="custom", model=model, base_url=url, api_key=api_key
+    )
+    short_url = url.replace("https://", "").replace("http://", "").rstrip("/")
+    suffix = f" · {model}" if model else ""
+    print(f"Applied custom ({short_url}){suffix} to {n} auxiliary task(s).")
 
 
 def _aux_select_for_task(task: str) -> None:

--- a/tests/hermes_cli/test_aux_config.py
+++ b/tests/hermes_cli/test_aux_config.py
@@ -18,7 +18,10 @@ from hermes_cli.config import DEFAULT_CONFIG, load_config
 from hermes_cli.main import (
     _AUX_TASKS,
     _DELEGATION_TASK_KEY,
+    _all_aux_tasks,
+    _apply_aux_choice_to_all,
     _delegation_cfg_as_task,
+    _format_aux_all_current,
     _format_aux_current,
     _reset_aux_to_auto,
     _save_aux_choice,
@@ -199,3 +202,121 @@ def test_leave_unchanged_replaces_cancel_label(tmp_path, monkeypatch):
     assert "Leave unchanged" in labels
     assert "Cancel" not in labels, "Cancel label should be replaced"
     assert any("Configure auxiliary models" in label for label in labels)
+
+
+# ── Set one provider/model for ALL auxiliary tasks ──────────────────────────
+
+
+def test_apply_aux_choice_to_all_writes_every_task(tmp_path, monkeypatch):
+    """Apply-all writes provider/model to every aux task AND the delegation section."""
+    _isolate_home(tmp_path, monkeypatch)
+
+    n = _apply_aux_choice_to_all(provider="openrouter", model="google/gemini-3-flash")
+    assert n == len(_all_aux_tasks()) + 1  # built-ins + delegation
+
+    cfg = load_config()
+    aux = cfg["auxiliary"]
+    for task, _name, _desc in _all_aux_tasks():
+        entry = aux.get(task, {})
+        assert entry.get("provider") == "openrouter", task
+        assert entry.get("model") == "google/gemini-3-flash", task
+    d = cfg["delegation"]
+    assert d["provider"] == "openrouter"
+    assert d["model"] == "google/gemini-3-flash"
+
+
+def test_apply_aux_choice_to_all_preserves_timeouts(tmp_path, monkeypatch):
+    """Apply-all overwrites only routing fields; per-task timeouts survive."""
+    from hermes_cli.config import load_config as _lc, save_config
+
+    _isolate_home(tmp_path, monkeypatch)
+    cfg = _lc()
+    cfg.setdefault("auxiliary", {}).setdefault("compression", {})["timeout"] = 999
+    cfg["auxiliary"]["compression"]["extra_body"] = {"plugins": [{"id": "x"}]}
+    save_config(cfg)
+
+    _apply_aux_choice_to_all(provider="openrouter", model="m")
+
+    cfg = _lc()
+    comp = cfg["auxiliary"]["compression"]
+    assert comp["provider"] == "openrouter"
+    assert comp["model"] == "m"
+    assert comp["timeout"] == 999
+    assert comp["extra_body"] == {"plugins": [{"id": "x"}]}
+
+
+def test_apply_aux_choice_to_all_auto_resets(tmp_path, monkeypatch):
+    """provider='auto' resets every aux task to auto and delegation to empty."""
+    _isolate_home(tmp_path, monkeypatch)
+
+    _apply_aux_choice_to_all(provider="openrouter", model="m")
+    _apply_aux_choice_to_all(provider="auto", model="", base_url="", api_key="")
+
+    cfg = load_config()
+    aux = cfg["auxiliary"]
+    for task, _name, _desc in _all_aux_tasks():
+        entry = aux.get(task, {})
+        assert entry.get("provider") in {None, "", "auto"}, task
+        assert not entry.get("model"), task
+    d = cfg["delegation"]
+    assert d["provider"] == ""
+    assert d["model"] == ""
+
+
+def test_apply_aux_choice_to_all_custom_endpoint(tmp_path, monkeypatch):
+    """Apply-all custom endpoint writes base_url/api_key into every slot."""
+    _isolate_home(tmp_path, monkeypatch)
+
+    n = _apply_aux_choice_to_all(
+        provider="custom",
+        model="qwen2.5-coder",
+        base_url="http://localhost:11434/v1",
+        api_key="",
+    )
+    assert n == len(_all_aux_tasks()) + 1
+
+    cfg = load_config()
+    vision = cfg["auxiliary"]["vision"]
+    assert vision["provider"] == "custom"
+    assert vision["model"] == "qwen2.5-coder"
+    assert vision["base_url"] == "http://localhost:11434/v1"
+    assert cfg["delegation"]["base_url"] == "http://localhost:11434/v1"
+
+
+def test_format_aux_all_current():
+    """Summary shows 'auto', a shared value, or 'mixed' across all tasks."""
+    assert _format_aux_all_current({}) == "auto"
+
+    cfg: dict = {"auxiliary": {}}
+    for task, _name, _desc in _all_aux_tasks():
+        cfg["auxiliary"][task] = {"provider": "nous", "model": "Hermes-4.5"}
+    cfg["delegation"] = {"provider": "nous", "model": "Hermes-4.5"}
+    assert _format_aux_all_current(cfg) == "nous · Hermes-4.5"
+
+    cfg["auxiliary"]["vision"]["provider"] = "openrouter"
+    assert _format_aux_all_current(cfg) == "mixed (configured per task)"
+
+
+def test_aux_config_menu_shows_set_all_entry(tmp_path, monkeypatch):
+    """The aux menu surfaces 'Set one provider/model for all auxiliary tasks...'."""
+    _isolate_home(tmp_path, monkeypatch)
+
+    from hermes_cli import main as main_mod
+
+    captured: list[list[str]] = []
+
+    def fake_prompt(choices, *, default=0, title="Select provider:"):
+        captured.append(list(choices))
+        for i, label in enumerate(choices):
+            if label == "Back":
+                return i
+        raise AssertionError("Back not in aux menu")
+
+    monkeypatch.setattr(main_mod, "_prompt_provider_choice", fake_prompt)
+    main_mod._aux_config_menu()
+
+    assert captured, "aux menu never rendered"
+    labels = captured[0]
+    assert any(
+        "Set one provider/model for all auxiliary tasks" in label for label in labels
+    )

--- a/tests/hermes_cli/test_plugin_auxiliary_tasks.py
+++ b/tests/hermes_cli/test_plugin_auxiliary_tasks.py
@@ -157,6 +157,34 @@ def test_reset_aux_to_auto_resets_plugin_tasks(tmp_path, monkeypatch, patched_ma
     assert cfg["auxiliary"]["my_aux"]["model"] == ""
 
 
+# ── _apply_aux_choice_to_all includes plugin tasks ───────────────────────────
+
+
+def test_apply_aux_choice_to_all_includes_plugin_tasks(tmp_path, monkeypatch, patched_manager):
+    """Apply-all writes the shared choice to plugin-registered aux tasks too."""
+    from pathlib import Path
+    from hermes_cli.config import load_config
+    from hermes_cli.main import _apply_aux_choice_to_all
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    (tmp_path / ".hermes").mkdir(exist_ok=True)
+
+    manifest = PluginManifest(name="plug")
+    ctx = PluginContext(manifest, patched_manager)
+    ctx.register_auxiliary_task(
+        key="my_aux",
+        display_name="My Aux",
+        description="d",
+    )
+
+    _apply_aux_choice_to_all(provider="openrouter", model="gpt-4o")
+
+    cfg = load_config()
+    assert cfg["auxiliary"]["my_aux"]["provider"] == "openrouter"
+    assert cfg["auxiliary"]["my_aux"]["model"] == "gpt-4o"
+
+
 # ── auxiliary_client._get_auxiliary_task_config defaults layering ────────────
 
 


### PR DESCRIPTION
## What does this PR do?

Adds a **"Set one provider/model for all auxiliary tasks..."** entry to the
auxiliary-model menu in `hermes model` ("Configure auxiliary models..."), so a
user can route every side task (vision, compression, web extract, approval,
MCP, title generation, skills hub, kanban, curator, delegation, ...) to a
single provider+model in one shot instead of configuring each task
individually.

This mirrors the web dashboard's existing `scope="auxiliary", task=""`
apply-all behavior (`POST /api/model/set`). The choice is a one-shot apply —
each slot stays independently tweakable afterwards.

Implementation notes:
- Reuses the existing single-task picker substrate (`build_aux_picker_rows` /
  `format_aux_picker_entries` / `_prompt_model_selection`) so the new surface
  shows the same authenticated providers and curated model lists.
- Persists through the existing `_save_aux_choice()`, so per-task
  `timeout`/`extra_body` are preserved and the special **Delegation** task
  (top-level `delegation.*`, `auto` stored as empty provider) is handled
  identically to the single-task flow.
- A `_format_aux_all_current()` summary shows whether all tasks are `auto`,
  a shared `provider · model`, or `mixed` before applying.

## Related Issue

N/A — no existing issue. The web dashboard already has apply-all; the CLI
menu did not.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`
  - `_aux_config_menu()`: new "Set one provider/model for all auxiliary tasks..." row + dispatch
  - `_aux_select_apply_all()`: apply-all picker (auto / authenticated providers / custom endpoint)
  - `_aux_apply_all_provider_model()`: model selection under a provider, then apply to all
  - `_aux_apply_all_custom()`: custom OpenAI-compatible endpoint flow, then apply to all
  - `_apply_aux_choice_to_all()`: writes the choice into every aux task incl. delegation via `_save_aux_choice`
  - `_format_aux_all_current()`: all-task routing summary for the menu header
- `tests/hermes_cli/test_aux_config.py`: apply-all writes every task + delegation, preserves timeouts/`extra_body`, auto-reset, custom endpoint, summary rendering, menu label
- `tests/hermes_cli/test_plugin_auxiliary_tasks.py`: apply-all includes plugin-registered tasks

## How to Test

1. `hermes model` → arrow to the bottom → **"Configure auxiliary models..."**
2. Select **"Set one provider/model for all auxiliary tasks..."**
3. Pick a provider → model (or `Custom endpoint (direct URL)`, or `auto (recommended)`)
4. Reopen the menu — all task rows and the `current:` header reflect the applied value
5. Optionally check `hermes config get auxiliary` — every slot plus `delegation` is updated

Automated: `scripts/run_tests.sh tests/hermes_cli/test_aux_config.py tests/hermes_cli/test_plugin_auxiliary_tasks.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (menu/UI code only; `scripts/check-windows-footguns.py` passes)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
