### PR TITLE
fix(cli): accept singular 'plugin' as an alias for the plugins command (#89120)

### DIFF
--- a/hermes_cli/subcommands/plugins.py
+++ b/hermes_cli/subcommands/plugins.py
@@ -13,6 +13,11 @@ def build_plugins_parser(subparsers, *, cmd_plugins: Callable) -> None:
     """Attach the ``plugins`` subcommand to ``subparsers``."""
     plugins_parser = subparsers.add_parser(
         "plugins",
+        # Accept the singular `plugin` too: users reach for it out of muscle
+        # memory and argparse would otherwise reject it as an invalid choice
+        # with no hint. The alias shares this parser, so `hermes plugin ...`
+        # dispatches through the same handler as `hermes plugins ...`.
+        aliases=["plugin"],
         help="Manage and validate plugins",
         description=(
             "Install, update, remove, list, or validate native Hermes plugins "

--- a/tests/hermes_cli/test_subcommands_followup.py
+++ b/tests/hermes_cli/test_subcommands_followup.py
@@ -55,6 +55,23 @@ def test_followup_builders_dispatch(name, builder, kw, argv):
     assert ns.func is handler
 
 
+def test_plugins_singular_alias_dispatches():
+    # `hermes plugin` (singular) is a muscle-memory alias for `plugins`; it must
+    # reach the same handler and still parse the nested action, rather than
+    # failing as an invalid choice.
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    handler = _h("plugins")
+    build_plugins_parser(sub, cmd_plugins=handler)
+
+    ns = parser.parse_args(["plugin"])
+    assert ns.func is handler
+
+    ns = parser.parse_args(["plugin", "list"])
+    assert ns.func is handler
+    assert ns.plugins_action == "list"
+
+
 def test_mcp_and_acp_accept_hooks_flag():
     # mcp/acp parser blocks use the shared add_accept_hooks_flag helper.
     parser = argparse.ArgumentParser(prog="hermes")


### PR DESCRIPTION
## What

`hermes plugin` (singular) was rejected by argparse as an invalid choice with no hint — only the plural `hermes plugins` was accepted:

```
hermes: error: argument command: invalid choice: 'plugin' (choose from 'chat', 'model', … 'plugins', …)
```

This registers `plugin` as an argparse alias of the existing `plugins` subparser (`aliases=["plugin"]`). Because the alias shares the same parser object and its `set_defaults(func=cmd_plugins)`, the singular form dispatches through the exact same handler and nested actions — no dispatch changes needed. `hermes plugin list`, `hermes plugin install …`, etc. all work identically to the plural form.

This matches the `list`/`ls`, `remove`/`rm` alias pattern already used across the CLI (`hermes_cli/subcommands/mcp.py`, `projects_cmd.py`, `kanban.py`, MoA).

## Why

Confusing for users who reach for the singular out of muscle memory from other CLI tools, with no "did you mean" hint offered. One-line, behavior-preserving addition.

## Test

Added `test_plugins_singular_alias_dispatches` in `tests/hermes_cli/test_subcommands_followup.py`: asserts `hermes plugin` and `hermes plugin list` reach `cmd_plugins` and parse the nested `plugins_action`. Full file passes (11 tests). Preflight gates (windows-footguns, ruff, affected tests) all green.

Fixes #89120
