### PR TITLE
feat(cli): add hermes update --no-restart

### DIFF
--- a/hermes_cli/subcommands/update.py
+++ b/hermes_cli/subcommands/update.py
@@ -73,4 +73,10 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
         default=False,
         help="Windows: mutate the venv even while other processes are running from its interpreter (desktop backend, gateway, terminals). Those processes keep native .pyd files locked, so the dependency sync will likely fail partway and strand the install half-updated. Use only if you know the detected holders are false positives.",
     )
+    update_parser.add_argument(
+        "--no-restart",
+        action="store_true",
+        default=False,
+        help="Skip restarting running gateway profiles after a successful update",
+    )
     update_parser.set_defaults(func=cmd_update)

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -5981,751 +5981,757 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # Auto-restart ALL gateways after update.
         # The code update (git pull) is shared across all profiles, so every
         # running gateway needs restarting to pick up the new code.
-        try:
-            from hermes_cli.gateway import (
-                is_macos,
-                supports_systemd_services,
-                _ensure_user_systemd_env,
-                find_gateway_pids,
-                find_profile_gateway_processes,
-                _prepare_profile_gateway_update_restart,
-                _get_service_pids,
-                _graceful_restart_via_sigusr1,
-                _wait_for_gateway_exit,
-            )
-            import signal as _signal
+        # ``--no-restart`` skips systemd / launchd / manual fleet restart.
+        # Install and post-install hooks still run.
+        if getattr(args, "no_restart", False):
+            print()
+            print("  ℹ Skipped restarting running gateway profiles (--no-restart).")
+        else:
+            try:
+                from hermes_cli.gateway import (
+                    is_macos,
+                    supports_systemd_services,
+                    _ensure_user_systemd_env,
+                    find_gateway_pids,
+                    find_profile_gateway_processes,
+                    _prepare_profile_gateway_update_restart,
+                    _get_service_pids,
+                    _graceful_restart_via_sigusr1,
+                    _wait_for_gateway_exit,
+                )
+                import signal as _signal
 
-            def _wait_for_service_active(
-                scope_cmd_: list,
-                svc_name_: str,
-                timeout: float = 10.0,
-            ) -> bool:
-                """Poll ``systemctl is-active`` until the unit reports active.
+                def _wait_for_service_active(
+                    scope_cmd_: list,
+                    svc_name_: str,
+                    timeout: float = 10.0,
+                ) -> bool:
+                    """Poll ``systemctl is-active`` until the unit reports active.
 
-                systemd's Stopped -> Started transition after a graceful exit
-                (or a hard restart) is not instantaneous; a one-shot check
-                races that window and falsely reports the unit as down.
-                Poll every 0.5s up to ``timeout`` seconds before giving up.
-                """
-                deadline = _time.monotonic() + max(timeout, 0.5)
-                while True:
+                    systemd's Stopped -> Started transition after a graceful exit
+                    (or a hard restart) is not instantaneous; a one-shot check
+                    races that window and falsely reports the unit as down.
+                    Poll every 0.5s up to ``timeout`` seconds before giving up.
+                    """
+                    deadline = _time.monotonic() + max(timeout, 0.5)
+                    while True:
+                        try:
+                            _verify = subprocess.run(
+                                scope_cmd_ + ["is-active", svc_name_],
+                                capture_output=True,
+                                text=True, encoding="utf-8", errors="replace",
+                                timeout=5,
+                            )
+                            if _verify.stdout.strip() == "active":
+                                return True
+                        except (FileNotFoundError, subprocess.TimeoutExpired):
+                            pass
+                        if _time.monotonic() >= deadline:
+                            return False
+                        _time.sleep(0.5)
+
+                def _service_restart_sec(
+                    scope_cmd_: list,
+                    svc_name_: str,
+                    default: float = 0.0,
+                ) -> float:
+                    """Read the unit's ``RestartUSec`` (RestartSec) in seconds.
+
+                    After a graceful exit-75, systemd waits ``RestartSec`` before
+                    respawning the unit.  Callers that poll for ``is-active``
+                    must use a timeout >= ``RestartSec`` + transition slack, or
+                    they'll give up *during* the cooldown window and wrongly
+                    conclude the unit didn't relaunch.
+                    """
                     try:
-                        _verify = subprocess.run(
-                            scope_cmd_ + ["is-active", svc_name_],
+                        _show = subprocess.run(
+                            scope_cmd_
+                            + [
+                                "show",
+                                svc_name_,
+                                "--property=RestartUSec",
+                                "--value",
+                            ],
                             capture_output=True,
                             text=True, encoding="utf-8", errors="replace",
                             timeout=5,
                         )
-                        if _verify.stdout.strip() == "active":
-                            return True
                     except (FileNotFoundError, subprocess.TimeoutExpired):
-                        pass
-                    if _time.monotonic() >= deadline:
-                        return False
-                    _time.sleep(0.5)
+                        return default
+                    raw = (_show.stdout or "").strip()
+                    # systemd emits values like "30s", "100ms", "1min 30s", or
+                    # "infinity".  Parse conservatively; on any miss return default.
+                    if not raw or raw == "infinity":
+                        return default
+                    total = 0.0
+                    matched = False
+                    for part in raw.split():
+                        for _suf, _mult in (
+                            ("ms", 0.001),
+                            ("us", 0.000001),
+                            ("min", 60.0),
+                            ("s", 1.0),
+                        ):
+                            if part.endswith(_suf):
+                                try:
+                                    total += float(part[: -len(_suf)]) * _mult
+                                    matched = True
+                                except ValueError:
+                                    pass
+                                break
+                    return total if matched else default
 
-            def _service_restart_sec(
-                scope_cmd_: list,
-                svc_name_: str,
-                default: float = 0.0,
-            ) -> float:
-                """Read the unit's ``RestartUSec`` (RestartSec) in seconds.
+                _manage_cmd_cache: dict = {}
 
-                After a graceful exit-75, systemd waits ``RestartSec`` before
-                respawning the unit.  Callers that poll for ``is-active``
-                must use a timeout >= ``RestartSec`` + transition slack, or
-                they'll give up *during* the cooldown window and wrongly
-                conclude the unit didn't relaunch.
-                """
-                try:
-                    _show = subprocess.run(
-                        scope_cmd_
-                        + [
-                            "show",
-                            svc_name_,
-                            "--property=RestartUSec",
-                            "--value",
-                        ],
-                        capture_output=True,
-                        text=True, encoding="utf-8", errors="replace",
-                        timeout=5,
-                    )
-                except (FileNotFoundError, subprocess.TimeoutExpired):
-                    return default
-                raw = (_show.stdout or "").strip()
-                # systemd emits values like "30s", "100ms", "1min 30s", or
-                # "infinity".  Parse conservatively; on any miss return default.
-                if not raw or raw == "infinity":
-                    return default
-                total = 0.0
-                matched = False
-                for part in raw.split():
-                    for _suf, _mult in (
-                        ("ms", 0.001),
-                        ("us", 0.000001),
-                        ("min", 60.0),
-                        ("s", 1.0),
+                def _resolve_manage_cmd(scope_: str, scope_cmd_: list, svc_name_: str):
+                    """Resolve the command prefix for manage-units operations.
+
+                    Read-only systemctl calls (``is-active``, ``show``,
+                    ``list-units``) work unprivileged, but manage-units verbs
+                    (``reset-failed``, ``start``, ``restart``) on a *system*
+                    service trigger a polkit ``org.freedesktop.systemd1.manage-units``
+                    authentication prompt when run as a non-root user.  That
+                    interactive prompt runs inside our captured subprocess with a
+                    10-15s timeout — the user sees the prompt flash and "exit
+                    directly" before they can answer, and the resulting
+                    TimeoutExpired used to be swallowed silently.
+
+                    Strategy: if root, plain systemctl.  If not root, try
+                    non-interactive sudo (``sudo -n``) — first a blanket probe,
+                    then a targeted ``systemctl reset-failed`` probe so a
+                    least-privilege sudoers entry scoped to
+                    ``systemctl ... hermes-gateway*`` also qualifies
+                    (``reset-failed`` is an idempotent no-op we run before every
+                    privileged restart anyway).  If neither works, return None —
+                    the caller must SKIP the restart (without draining the
+                    gateway first!) and tell the user how to restart manually.
+                    ``--no-ask-password`` guarantees polkit can never hang a
+                    captured subprocess on this path.
+                    """
+                    if scope_ in _manage_cmd_cache:
+                        return _manage_cmd_cache[scope_]
+                    cmd = scope_cmd_ + ["--no-ask-password"]
+                    if (
+                        scope_ == "system"
+                        and hasattr(os, "geteuid")
+                        and os.geteuid() != 0  # windows-footgun: ok — systemd path, Linux-only
                     ):
-                        if part.endswith(_suf):
-                            try:
-                                total += float(part[: -len(_suf)]) * _mult
-                                matched = True
-                            except ValueError:
-                                pass
-                            break
-                return total if matched else default
-
-            _manage_cmd_cache: dict = {}
-
-            def _resolve_manage_cmd(scope_: str, scope_cmd_: list, svc_name_: str):
-                """Resolve the command prefix for manage-units operations.
-
-                Read-only systemctl calls (``is-active``, ``show``,
-                ``list-units``) work unprivileged, but manage-units verbs
-                (``reset-failed``, ``start``, ``restart``) on a *system*
-                service trigger a polkit ``org.freedesktop.systemd1.manage-units``
-                authentication prompt when run as a non-root user.  That
-                interactive prompt runs inside our captured subprocess with a
-                10-15s timeout — the user sees the prompt flash and "exit
-                directly" before they can answer, and the resulting
-                TimeoutExpired used to be swallowed silently.
-
-                Strategy: if root, plain systemctl.  If not root, try
-                non-interactive sudo (``sudo -n``) — first a blanket probe,
-                then a targeted ``systemctl reset-failed`` probe so a
-                least-privilege sudoers entry scoped to
-                ``systemctl ... hermes-gateway*`` also qualifies
-                (``reset-failed`` is an idempotent no-op we run before every
-                privileged restart anyway).  If neither works, return None —
-                the caller must SKIP the restart (without draining the
-                gateway first!) and tell the user how to restart manually.
-                ``--no-ask-password`` guarantees polkit can never hang a
-                captured subprocess on this path.
-                """
-                if scope_ in _manage_cmd_cache:
-                    return _manage_cmd_cache[scope_]
-                cmd = scope_cmd_ + ["--no-ask-password"]
-                if (
-                    scope_ == "system"
-                    and hasattr(os, "geteuid")
-                    and os.geteuid() != 0  # windows-footgun: ok — systemd path, Linux-only
-                ):
-                    sudo_cmd = ["sudo", "-n"] + scope_cmd_ + ["--no-ask-password"]
-                    sudo_ok = False
-                    try:
-                        _probe = subprocess.run(
-                            ["sudo", "-n", "true"],
-                            capture_output=True,
-                            timeout=5,
-                        )
-                        sudo_ok = _probe.returncode == 0
-                        if not sudo_ok:
-                            # Blanket sudo refused — a targeted sudoers entry
-                            # (NOPASSWD for systemctl ... hermes-gateway*)
-                            # may still allow the exact commands we need.
+                        sudo_cmd = ["sudo", "-n"] + scope_cmd_ + ["--no-ask-password"]
+                        sudo_ok = False
+                        try:
                             _probe = subprocess.run(
-                                sudo_cmd + ["reset-failed", svc_name_],
+                                ["sudo", "-n", "true"],
                                 capture_output=True,
                                 timeout=5,
                             )
                             sudo_ok = _probe.returncode == 0
-                    except (FileNotFoundError, subprocess.TimeoutExpired):
-                        sudo_ok = False
-                    cmd = sudo_cmd if sudo_ok else None
-                _manage_cmd_cache[scope_] = cmd
-                return cmd
-
-            # Wait budget for graceful SIGUSR1 restarts.  In-band restart
-            # may defer stop() until active turns finish
-            # (``restart_after_turn_timeout``, #77184) and then spend up to
-            # ``restart_drain_timeout`` inside stop(). Cover both phases so
-            # we don't fall back to a hard kill while the gateway is still
-            # patiently waiting for the requesting turn. On older systemd
-            # units without SIGUSR1 wiring this wait just times out and we
-            # fall back to ``systemctl restart`` (the old behaviour).
-            try:
-                from hermes_cli.gateway import _get_restart_exit_wait_budget
-
-                _drain_budget = max(float(_get_restart_exit_wait_budget()), 45.0)
-            except Exception:
-                _drain_budget = 45.0
-
-            failed_or_stale_units = []
-            killed_pids = set()
-            relaunched_profiles = []
-            externally_supervised_profiles = []
-
-            # Record which gateways are running before any stop/drain, so a
-            # later failure that leaves the survivor probe empty can still be
-            # recognised as "a running gateway was stopped and did not come
-            # back" rather than "nothing was running" (#78574). Best-effort:
-            # if the probe itself raises, leave the snapshot as-is (the
-            # survivor probe's own None result already fails closed).
-            try:
-                _pre_restart_gateway_pids = list(find_gateway_pids(all_profiles=True))
-            except Exception:
-                _pre_restart_gateway_pids = None
-
-            # --- Systemd services (Linux) ---
-            # Discover all hermes-gateway* units (default + profiles) plus
-            # hermes-serve* units (the Desktop app's backend, #83438).
-            if supports_systemd_services():
-                try:
-                    _ensure_user_systemd_env()
-                except Exception:
-                    pass
-
-                for scope, scope_cmd in [
-                    ("user", ["systemctl", "--user"]),
-                    ("system", ["systemctl"]),
-                ]:
-                    try:
-                        result = subprocess.run(
-                            scope_cmd
-                            + [
-                                "list-units",
-                                "hermes-gateway*",
-                                "hermes-serve*",
-                                "--plain",
-                                "--no-legend",
-                                "--no-pager",
-                            ],
-                            capture_output=True,
-                            text=True, encoding="utf-8", errors="replace",
-                            timeout=10,
-                        )
-                    except FileNotFoundError:
-                        continue
-                    except subprocess.TimeoutExpired as exc:
-                        # Discovery timeout — skip this scope, keep the other.
-                        print(
-                            f"  ⚠ systemctl timed out listing {scope}-scope "
-                            f"gateway units ({exc.cmd if exc.cmd else 'unknown command'}). "
-                            f"Check the gateway with: hermes gateway status"
-                        )
-                        continue
-
-                    def _restart_one_systemd_gateway_unit(svc_name: str) -> None:
-                        # Check if active
-                        check = subprocess.run(
-                            scope_cmd + ["is-active", svc_name],
-                            capture_output=True,
-                            text=True, encoding="utf-8", errors="replace",
-                            timeout=5,
-                        )
-                        if check.stdout.strip() != "active":
-                            return
-
-                        # Resolve how we may run manage-units verbs
-                        # (reset-failed/start/restart) for this scope.
-                        # None ⇒ no non-interactive privilege path; we
-                        # must avoid those verbs entirely or polkit will
-                        # throw an interactive auth prompt inside our
-                        # captured 10-15s subprocess (the user sees it
-                        # flash and "exit directly" — reported June 2026).
-                        _manage_cmd = _resolve_manage_cmd(
-                            scope, scope_cmd, svc_name
-                        )
-
-                        # Prefer a graceful SIGUSR1 restart so in-flight
-                        # agent runs drain instead of being SIGKILLed.
-                        # The gateway's SIGUSR1 handler calls
-                        # request_restart(via_service=True) → drain →
-                        # exit; systemd's Restart=always respawns the unit.
-                        # hermes-serve has no such handler (it isn't
-                        # gateway/run.py), so skip straight to the blunt
-                        # restart below rather than sending it an unhandled
-                        # signal and waiting out the drain budget for
-                        # nothing.
-                        _main_pid = 0
-                        if _service_unit_supports_graceful_sigusr1_restart(svc_name):
-                            try:
-                                _show = subprocess.run(
-                                    scope_cmd
-                                    + [
-                                        "show",
-                                        svc_name,
-                                        "--property=MainPID",
-                                        "--value",
-                                    ],
+                            if not sudo_ok:
+                                # Blanket sudo refused — a targeted sudoers entry
+                                # (NOPASSWD for systemctl ... hermes-gateway*)
+                                # may still allow the exact commands we need.
+                                _probe = subprocess.run(
+                                    sudo_cmd + ["reset-failed", svc_name_],
                                     capture_output=True,
-                                    text=True, encoding="utf-8", errors="replace",
                                     timeout=5,
                                 )
-                                _main_pid = int((_show.stdout or "").strip() or 0)
-                            except (
-                                ValueError,
-                                subprocess.TimeoutExpired,
-                                FileNotFoundError,
-                            ):
-                                _main_pid = 0
+                                sudo_ok = _probe.returncode == 0
+                        except (FileNotFoundError, subprocess.TimeoutExpired):
+                            sudo_ok = False
+                        cmd = sudo_cmd if sudo_ok else None
+                    _manage_cmd_cache[scope_] = cmd
+                    return cmd
 
-                        _graceful_ok = False
-                        if _main_pid > 0:
-                            from hermes_cli.gateway import (
-                                GATEWAY_LOOP_WEDGED,
-                                _escalate_wedged_gateway,
-                                probe_gateway_loop_liveness,
+                # Wait budget for graceful SIGUSR1 restarts.  In-band restart
+                # may defer stop() until active turns finish
+                # (``restart_after_turn_timeout``, #77184) and then spend up to
+                # ``restart_drain_timeout`` inside stop(). Cover both phases so
+                # we don't fall back to a hard kill while the gateway is still
+                # patiently waiting for the requesting turn. On older systemd
+                # units without SIGUSR1 wiring this wait just times out and we
+                # fall back to ``systemctl restart`` (the old behaviour).
+                try:
+                    from hermes_cli.gateway import _get_restart_exit_wait_budget
+
+                    _drain_budget = max(float(_get_restart_exit_wait_budget()), 45.0)
+                except Exception:
+                    _drain_budget = 45.0
+
+                failed_or_stale_units = []
+                killed_pids = set()
+                relaunched_profiles = []
+                externally_supervised_profiles = []
+
+                # Record which gateways are running before any stop/drain, so a
+                # later failure that leaves the survivor probe empty can still be
+                # recognised as "a running gateway was stopped and did not come
+                # back" rather than "nothing was running" (#78574). Best-effort:
+                # if the probe itself raises, leave the snapshot as-is (the
+                # survivor probe's own None result already fails closed).
+                try:
+                    _pre_restart_gateway_pids = list(find_gateway_pids(all_profiles=True))
+                except Exception:
+                    _pre_restart_gateway_pids = None
+
+                # --- Systemd services (Linux) ---
+                # Discover all hermes-gateway* units (default + profiles) plus
+                # hermes-serve* units (the Desktop app's backend, #83438).
+                if supports_systemd_services():
+                    try:
+                        _ensure_user_systemd_env()
+                    except Exception:
+                        pass
+
+                    for scope, scope_cmd in [
+                        ("user", ["systemctl", "--user"]),
+                        ("system", ["systemctl"]),
+                    ]:
+                        try:
+                            result = subprocess.run(
+                                scope_cmd
+                                + [
+                                    "list-units",
+                                    "hermes-gateway*",
+                                    "hermes-serve*",
+                                    "--plain",
+                                    "--no-legend",
+                                    "--no-pager",
+                                ],
+                                capture_output=True,
+                                text=True, encoding="utf-8", errors="replace",
+                                timeout=10,
+                            )
+                        except FileNotFoundError:
+                            continue
+                        except subprocess.TimeoutExpired as exc:
+                            # Discovery timeout — skip this scope, keep the other.
+                            print(
+                                f"  ⚠ systemctl timed out listing {scope}-scope "
+                                f"gateway units ({exc.cmd if exc.cmd else 'unknown command'}). "
+                                f"Check the gateway with: hermes gateway status"
+                            )
+                            continue
+
+                        def _restart_one_systemd_gateway_unit(svc_name: str) -> None:
+                            # Check if active
+                            check = subprocess.run(
+                                scope_cmd + ["is-active", svc_name],
+                                capture_output=True,
+                                text=True, encoding="utf-8", errors="replace",
+                                timeout=5,
+                            )
+                            if check.stdout.strip() != "active":
+                                return
+
+                            # Resolve how we may run manage-units verbs
+                            # (reset-failed/start/restart) for this scope.
+                            # None ⇒ no non-interactive privilege path; we
+                            # must avoid those verbs entirely or polkit will
+                            # throw an interactive auth prompt inside our
+                            # captured 10-15s subprocess (the user sees it
+                            # flash and "exit directly" — reported June 2026).
+                            _manage_cmd = _resolve_manage_cmd(
+                                scope, scope_cmd, svc_name
                             )
 
-                            if (
-                                probe_gateway_loop_liveness(_main_pid)
-                                == GATEWAY_LOOP_WEDGED
-                            ):
-                                # Loop-liveness probe says the gateway's event
-                                # loop is provably dead (#81642): SIGUSR1 can
-                                # never drain it, so waiting the full budget
-                                # (180s default) only wedges the update too.
-                                # Bounded escalation (SIGTERM grace → SIGKILL,
-                                # ~10s) then restart the unit. A busy gateway
-                                # keeps a fresh heartbeat and never takes this
-                                # path — its drain (incl. the #86684 cron
-                                # floor) is untouched.
-                                print(
-                                    f"  ⚠ {svc_name}: gateway event loop is "
-                                    "unresponsive — skipping drain, forcing "
-                                    "a bounded stop..."
-                                )
-                                _escalate_wedged_gateway(_main_pid)
-                                _graceful_ok = True
-                            else:
-                                print(
-                                    f"  → {svc_name}: draining (up to {int(_drain_budget)}s)..."
-                                )
-                                _graceful_ok = _graceful_restart_via_sigusr1(
-                                    _main_pid,
-                                    drain_timeout=_drain_budget,
+                            # Prefer a graceful SIGUSR1 restart so in-flight
+                            # agent runs drain instead of being SIGKILLed.
+                            # The gateway's SIGUSR1 handler calls
+                            # request_restart(via_service=True) → drain →
+                            # exit; systemd's Restart=always respawns the unit.
+                            # hermes-serve has no such handler (it isn't
+                            # gateway/run.py), so skip straight to the blunt
+                            # restart below rather than sending it an unhandled
+                            # signal and waiting out the drain budget for
+                            # nothing.
+                            _main_pid = 0
+                            if _service_unit_supports_graceful_sigusr1_restart(svc_name):
+                                try:
+                                    _show = subprocess.run(
+                                        scope_cmd
+                                        + [
+                                            "show",
+                                            svc_name,
+                                            "--property=MainPID",
+                                            "--value",
+                                        ],
+                                        capture_output=True,
+                                        text=True, encoding="utf-8", errors="replace",
+                                        timeout=5,
+                                    )
+                                    _main_pid = int((_show.stdout or "").strip() or 0)
+                                except (
+                                    ValueError,
+                                    subprocess.TimeoutExpired,
+                                    FileNotFoundError,
+                                ):
+                                    _main_pid = 0
+
+                            _graceful_ok = False
+                            if _main_pid > 0:
+                                from hermes_cli.gateway import (
+                                    GATEWAY_LOOP_WEDGED,
+                                    _escalate_wedged_gateway,
+                                    probe_gateway_loop_liveness,
                                 )
 
-                        if _graceful_ok:
-                            # Gateway exited after a planned restart.
-                            # ``Restart=always`` means systemd WILL respawn
-                            # the unit — but only after
-                            # ``RestartSec`` (default 60s on our unit
-                            # file). That 60s wait is a crash-loop guard,
-                            # and is the right default when the gateway
-                            # dies unexpectedly. For a voluntary restart
-                            # on update, it's dead time the user watches.
-                            #
-                            # Shortcut it: ``reset-failed`` + ``start``
-                            # skips RestartSec entirely (we're manually
-                            # initiating the unit, not waiting for
-                            # systemd's auto-restart logic). Takes about
-                            # as long as the process takes to come up
-                            # (~1-3s on a warm box).
-                            #
-                            # If the unit is already active because
-                            # RestartSec elapsed while we were draining,
-                            # ``start`` is a no-op and we fall through to
-                            # the poll below. Either way we collapse the
-                            # 60s+ delay to a ~5s one.
-                            #
-                            # The shortcut needs manage-units privileges.
-                            # Without them (system service, non-root, no
-                            # passwordless sudo) skip it — systemd's own
-                            # auto-restart still relaunches the unit after
-                            # RestartSec, no privileges required.
-                            if _manage_cmd is not None:
-                                subprocess.run(
-                                    _manage_cmd + ["reset-failed", svc_name],
-                                    capture_output=True,
-                                    text=True, encoding="utf-8", errors="replace",
-                                    timeout=10,
+                                if (
+                                    probe_gateway_loop_liveness(_main_pid)
+                                    == GATEWAY_LOOP_WEDGED
+                                ):
+                                    # Loop-liveness probe says the gateway's event
+                                    # loop is provably dead (#81642): SIGUSR1 can
+                                    # never drain it, so waiting the full budget
+                                    # (180s default) only wedges the update too.
+                                    # Bounded escalation (SIGTERM grace → SIGKILL,
+                                    # ~10s) then restart the unit. A busy gateway
+                                    # keeps a fresh heartbeat and never takes this
+                                    # path — its drain (incl. the #86684 cron
+                                    # floor) is untouched.
+                                    print(
+                                        f"  ⚠ {svc_name}: gateway event loop is "
+                                        "unresponsive — skipping drain, forcing "
+                                        "a bounded stop..."
+                                    )
+                                    _escalate_wedged_gateway(_main_pid)
+                                    _graceful_ok = True
+                                else:
+                                    print(
+                                        f"  → {svc_name}: draining (up to {int(_drain_budget)}s)..."
+                                    )
+                                    _graceful_ok = _graceful_restart_via_sigusr1(
+                                        _main_pid,
+                                        drain_timeout=_drain_budget,
+                                    )
+
+                            if _graceful_ok:
+                                # Gateway exited after a planned restart.
+                                # ``Restart=always`` means systemd WILL respawn
+                                # the unit — but only after
+                                # ``RestartSec`` (default 60s on our unit
+                                # file). That 60s wait is a crash-loop guard,
+                                # and is the right default when the gateway
+                                # dies unexpectedly. For a voluntary restart
+                                # on update, it's dead time the user watches.
+                                #
+                                # Shortcut it: ``reset-failed`` + ``start``
+                                # skips RestartSec entirely (we're manually
+                                # initiating the unit, not waiting for
+                                # systemd's auto-restart logic). Takes about
+                                # as long as the process takes to come up
+                                # (~1-3s on a warm box).
+                                #
+                                # If the unit is already active because
+                                # RestartSec elapsed while we were draining,
+                                # ``start`` is a no-op and we fall through to
+                                # the poll below. Either way we collapse the
+                                # 60s+ delay to a ~5s one.
+                                #
+                                # The shortcut needs manage-units privileges.
+                                # Without them (system service, non-root, no
+                                # passwordless sudo) skip it — systemd's own
+                                # auto-restart still relaunches the unit after
+                                # RestartSec, no privileges required.
+                                if _manage_cmd is not None:
+                                    subprocess.run(
+                                        _manage_cmd + ["reset-failed", svc_name],
+                                        capture_output=True,
+                                        text=True, encoding="utf-8", errors="replace",
+                                        timeout=10,
+                                    )
+                                    subprocess.run(
+                                        _manage_cmd + ["start", svc_name],
+                                        capture_output=True,
+                                        text=True, encoding="utf-8", errors="replace",
+                                        timeout=15,
+                                    )
+                                    # Short poll: the gateway should be up
+                                    # within a few seconds now that we
+                                    # bypassed RestartSec.
+                                    if _wait_for_service_active(
+                                        scope_cmd,
+                                        svc_name,
+                                        timeout=10.0,
+                                    ):
+                                        restarted_services.append(svc_name)
+                                        return
+                                # Passive poll: systemd's auto-restart fires
+                                # after RestartSec regardless of privileges.
+                                # This is the primary path when _manage_cmd is
+                                # None, and the fallback when the explicit
+                                # start didn't take.
+                                _restart_sec = _service_restart_sec(
+                                    scope_cmd,
+                                    svc_name,
+                                    default=0.0,
                                 )
-                                subprocess.run(
-                                    _manage_cmd + ["start", svc_name],
-                                    capture_output=True,
-                                    text=True, encoding="utf-8", errors="replace",
-                                    timeout=15,
+                                _post_drain_timeout = max(
+                                    10.0,
+                                    _restart_sec + 10.0,
                                 )
-                                # Short poll: the gateway should be up
-                                # within a few seconds now that we
-                                # bypassed RestartSec.
+                                if _manage_cmd is None and _restart_sec > 5.0:
+                                    print(
+                                        f"  → {svc_name}: waiting for systemd "
+                                        f"auto-restart (~{int(_restart_sec)}s; "
+                                        "no root for an immediate restart)..."
+                                    )
                                 if _wait_for_service_active(
                                     scope_cmd,
                                     svc_name,
-                                    timeout=10.0,
+                                    timeout=_post_drain_timeout,
                                 ):
                                     restarted_services.append(svc_name)
                                     return
-                            # Passive poll: systemd's auto-restart fires
-                            # after RestartSec regardless of privileges.
-                            # This is the primary path when _manage_cmd is
-                            # None, and the fallback when the explicit
-                            # start didn't take.
-                            _restart_sec = _service_restart_sec(
-                                scope_cmd,
-                                svc_name,
-                                default=0.0,
-                            )
-                            _post_drain_timeout = max(
-                                10.0,
-                                _restart_sec + 10.0,
-                            )
-                            if _manage_cmd is None and _restart_sec > 5.0:
+                                # Process exited but wasn't respawned (older
+                                # unit without Restart=on-failure or
+                                # RestartForceExitStatus=75).  Fall through
+                                # to systemctl start/restart.
                                 print(
-                                    f"  → {svc_name}: waiting for systemd "
-                                    f"auto-restart (~{int(_restart_sec)}s; "
-                                    "no root for an immediate restart)..."
+                                    f"  ⚠ {svc_name} drained but didn't relaunch — forcing restart"
                                 )
-                            if _wait_for_service_active(
-                                scope_cmd,
-                                svc_name,
-                                timeout=_post_drain_timeout,
-                            ):
-                                restarted_services.append(svc_name)
+
+                            # Forcing a restart requires manage-units
+                            # privileges.  Without a non-interactive path,
+                            # running systemctl here would spawn a polkit
+                            # auth prompt inside a captured 10-15s subprocess
+                            # — it flashes and dies before the user can
+                            # answer.  Skip with clear instructions instead.
+                            if _manage_cmd is None:
+                                failed_or_stale_units.append(svc_name)
+                                print(
+                                    f"  ⚠ {svc_name} is a system service and restarting it needs root.\n"
+                                    f"    Restart it manually to load the new version:\n"
+                                    f"      sudo systemctl restart {svc_name}\n"
+                                    f"    To let `hermes update` restart it automatically, allow\n"
+                                    f"    passwordless sudo for systemctl, or run updates with sudo."
+                                )
                                 return
-                            # Process exited but wasn't respawned (older
-                            # unit without Restart=on-failure or
-                            # RestartForceExitStatus=75).  Fall through
-                            # to systemctl start/restart.
-                            print(
-                                f"  ⚠ {svc_name} drained but didn't relaunch — forcing restart"
-                            )
 
-                        # Forcing a restart requires manage-units
-                        # privileges.  Without a non-interactive path,
-                        # running systemctl here would spawn a polkit
-                        # auth prompt inside a captured 10-15s subprocess
-                        # — it flashes and dies before the user can
-                        # answer.  Skip with clear instructions instead.
-                        if _manage_cmd is None:
-                            failed_or_stale_units.append(svc_name)
-                            print(
-                                f"  ⚠ {svc_name} is a system service and restarting it needs root.\n"
-                                f"    Restart it manually to load the new version:\n"
-                                f"      sudo systemctl restart {svc_name}\n"
-                                f"    To let `hermes update` restart it automatically, allow\n"
-                                f"    passwordless sudo for systemctl, or run updates with sudo."
+                            # Fallback: blunt systemctl restart.  This is
+                            # what the old code always did; we get here only
+                            # when the graceful path failed (unit missing
+                            # SIGUSR1 wiring, drain exceeded the budget,
+                            # restart-policy mismatch).
+                            #
+                            # Always `reset-failed` first.  If systemd's own
+                            # auto-restart attempts already parked the unit
+                            # in a failed state (transient CHDIR / OOM /
+                            # filesystem race after our drain + exit-75),
+                            # a plain `systemctl restart` can wedge against
+                            # the RestartSec backoff and leave the unit
+                            # dead.  Clearing the failed state first makes
+                            # the restart idempotent.  Mirrors the recovery
+                            # path in `hermes gateway restart`
+                            # (`systemd_restart()`) as of PR #20949.
+                            subprocess.run(
+                                _manage_cmd + ["reset-failed", svc_name],
+                                capture_output=True,
+                                text=True, encoding="utf-8", errors="replace",
+                                timeout=10,
                             )
-                            return
-
-                        # Fallback: blunt systemctl restart.  This is
-                        # what the old code always did; we get here only
-                        # when the graceful path failed (unit missing
-                        # SIGUSR1 wiring, drain exceeded the budget,
-                        # restart-policy mismatch).
-                        #
-                        # Always `reset-failed` first.  If systemd's own
-                        # auto-restart attempts already parked the unit
-                        # in a failed state (transient CHDIR / OOM /
-                        # filesystem race after our drain + exit-75),
-                        # a plain `systemctl restart` can wedge against
-                        # the RestartSec backoff and leave the unit
-                        # dead.  Clearing the failed state first makes
-                        # the restart idempotent.  Mirrors the recovery
-                        # path in `hermes gateway restart`
-                        # (`systemd_restart()`) as of PR #20949.
-                        subprocess.run(
-                            _manage_cmd + ["reset-failed", svc_name],
-                            capture_output=True,
-                            text=True, encoding="utf-8", errors="replace",
-                            timeout=10,
-                        )
-                        restart = subprocess.run(
-                            _manage_cmd + ["restart", svc_name],
-                            capture_output=True,
-                            text=True, encoding="utf-8", errors="replace",
-                            timeout=15,
-                        )
-                        if restart.returncode == 0:
-                            # Verify the service actually survived the
-                            # restart.  systemctl restart returns 0 even
-                            # if the new process crashes immediately.
-                            if _wait_for_service_active(
-                                scope_cmd,
-                                svc_name,
-                                timeout=10.0,
-                            ):
-                                restarted_services.append(svc_name)
-                            else:
-                                # Retry once — transient startup failures
-                                # (stale module cache, import race) often
-                                # resolve on the second attempt.  Again
-                                # clear any failed state first so the
-                                # retry isn't blocked by the previous
-                                # crash.
-                                print(
-                                    f"  ⚠ {svc_name} died after restart, retrying..."
-                                )
-                                subprocess.run(
-                                    _manage_cmd + ["reset-failed", svc_name],
-                                    capture_output=True,
-                                    text=True, encoding="utf-8", errors="replace",
-                                    timeout=10,
-                                )
-                                subprocess.run(
-                                    _manage_cmd + ["restart", svc_name],
-                                    capture_output=True,
-                                    text=True, encoding="utf-8", errors="replace",
-                                    timeout=15,
-                                )
+                            restart = subprocess.run(
+                                _manage_cmd + ["restart", svc_name],
+                                capture_output=True,
+                                text=True, encoding="utf-8", errors="replace",
+                                timeout=15,
+                            )
+                            if restart.returncode == 0:
+                                # Verify the service actually survived the
+                                # restart.  systemctl restart returns 0 even
+                                # if the new process crashes immediately.
                                 if _wait_for_service_active(
                                     scope_cmd,
                                     svc_name,
                                     timeout=10.0,
                                 ):
                                     restarted_services.append(svc_name)
-                                    print(f"  ✓ {svc_name} recovered on retry")
                                 else:
-                                    failed_or_stale_units.append(svc_name)
-                                    _scope_flag = "--user " if scope == "user" else ""
-                                    _sudo_hint = "sudo " if scope == "system" else ""
+                                    # Retry once — transient startup failures
+                                    # (stale module cache, import race) often
+                                    # resolve on the second attempt.  Again
+                                    # clear any failed state first so the
+                                    # retry isn't blocked by the previous
+                                    # crash.
                                     print(
-                                        f"  ✗ {svc_name} failed to stay running after restart.\n"
-                                        f"    Check logs: {_sudo_hint}journalctl {_scope_flag}-u {svc_name} --since '2 min ago'\n"
-                                        f"    Recover manually:\n"
-                                        f"      {_sudo_hint}systemctl {_scope_flag}reset-failed {svc_name}\n"
-                                        f"      {_sudo_hint}systemctl {_scope_flag}restart {svc_name}"
+                                        f"  ⚠ {svc_name} died after restart, retrying..."
                                     )
-                        else:
+                                    subprocess.run(
+                                        _manage_cmd + ["reset-failed", svc_name],
+                                        capture_output=True,
+                                        text=True, encoding="utf-8", errors="replace",
+                                        timeout=10,
+                                    )
+                                    subprocess.run(
+                                        _manage_cmd + ["restart", svc_name],
+                                        capture_output=True,
+                                        text=True, encoding="utf-8", errors="replace",
+                                        timeout=15,
+                                    )
+                                    if _wait_for_service_active(
+                                        scope_cmd,
+                                        svc_name,
+                                        timeout=10.0,
+                                    ):
+                                        restarted_services.append(svc_name)
+                                        print(f"  ✓ {svc_name} recovered on retry")
+                                    else:
+                                        failed_or_stale_units.append(svc_name)
+                                        _scope_flag = "--user " if scope == "user" else ""
+                                        _sudo_hint = "sudo " if scope == "system" else ""
+                                        print(
+                                            f"  ✗ {svc_name} failed to stay running after restart.\n"
+                                            f"    Check logs: {_sudo_hint}journalctl {_scope_flag}-u {svc_name} --since '2 min ago'\n"
+                                            f"    Recover manually:\n"
+                                            f"      {_sudo_hint}systemctl {_scope_flag}reset-failed {svc_name}\n"
+                                            f"      {_sudo_hint}systemctl {_scope_flag}restart {svc_name}"
+                                        )
+                            else:
+                                failed_or_stale_units.append(svc_name)
+                                print(
+                                    f"  ⚠ Failed to restart {svc_name}: {restart.stderr.strip()}"
+                                )
+
+                        def _on_unit_timeout(svc_name: str, exc: subprocess.TimeoutExpired) -> None:
+                            # Isolate the timeout to this unit and keep going
+                            # (#68523). A scope-wide handler used to abort every
+                            # later gateway and leave the fleet on mixed code.
                             failed_or_stale_units.append(svc_name)
                             print(
-                                f"  ⚠ Failed to restart {svc_name}: {restart.stderr.strip()}"
+                                f"  ⚠ systemctl timed out restarting {svc_name} "
+                                f"({exc.cmd if exc.cmd else 'unknown command'}); "
+                                f"continuing with remaining gateways"
                             )
 
-                    def _on_unit_timeout(svc_name: str, exc: subprocess.TimeoutExpired) -> None:
-                        # Isolate the timeout to this unit and keep going
-                        # (#68523). A scope-wide handler used to abort every
-                        # later gateway and leave the fleet on mixed code.
-                        failed_or_stale_units.append(svc_name)
-                        print(
-                            f"  ⚠ systemctl timed out restarting {svc_name} "
-                            f"({exc.cmd if exc.cmd else 'unknown command'}); "
-                            f"continuing with remaining gateways"
+                        _for_each_systemd_gateway_unit(
+                            result.stdout,
+                            process_unit=_restart_one_systemd_gateway_unit,
+                            on_unit_timeout=_on_unit_timeout,
                         )
 
-                    _for_each_systemd_gateway_unit(
-                        result.stdout,
-                        process_unit=_restart_one_systemd_gateway_unit,
-                        on_unit_timeout=_on_unit_timeout,
-                    )
-
-            # --- Launchd services (macOS) ---
-            if is_macos():
-                try:
-                    from hermes_cli.gateway import (
-                        launchd_restart,
-                        get_launchd_label,
-                        get_launchd_plist_path,
-                    )
-
-                    plist_path = get_launchd_plist_path()
-                    if plist_path.exists():
-                        check = subprocess.run(
-                            ["launchctl", "list", get_launchd_label()],
-                            capture_output=True,
-                            text=True, encoding="utf-8", errors="replace",
-                            timeout=5,
+                # --- Launchd services (macOS) ---
+                if is_macos():
+                    try:
+                        from hermes_cli.gateway import (
+                            launchd_restart,
+                            get_launchd_label,
+                            get_launchd_plist_path,
                         )
-                        if check.returncode == 0:
-                            try:
-                                launchd_restart()
-                                restarted_services.append(get_launchd_label())
-                            except subprocess.CalledProcessError as e:
-                                stderr = (getattr(e, "stderr", "") or "").strip()
-                                print(f"  ⚠ Gateway restart failed: {stderr}")
-                except (FileNotFoundError, subprocess.TimeoutExpired, ImportError):
-                    pass
 
-            # --- Manual (non-service) gateways ---
-            # Kill any remaining gateway processes not managed by a service.
-            # Exclude PIDs that belong to just-restarted services so we don't
-            # immediately kill the process that systemd/launchd just spawned.
-            service_pids = _get_service_pids()
-            manual_pids = find_gateway_pids(
-                exclude_pids=service_pids, all_profiles=True
-            )
-            profile_processes = {
-                proc.pid: proc
-                for proc in find_profile_gateway_processes(exclude_pids=service_pids)
-                if proc.pid in manual_pids
-            }
-            for pid, proc in profile_processes.items():
-                restart_mode = _prepare_profile_gateway_update_restart(
-                    proc.profile, pid
-                )
-                if restart_mode is None:
-                    continue
-                # Prefer a graceful SIGUSR1 drain so in-flight agent runs
-                # finish before the watcher respawns the gateway.  If the
-                # gateway doesn't support SIGUSR1 or doesn't exit within
-                # the drain budget, fall back to SIGTERM — the watcher
-                # still sees the exit and relaunches either way.
-                # Announce the drain first: this wait can hold for the full
-                # budget per gateway with no other output, and on surfaces
-                # that stream update progress (the desktop updater most of
-                # all) the silence reads as a hung update (#44515).
-                print(
-                    f"  → {proc.profile}: draining gateway PID {pid} "
-                    f"(up to {int(_drain_budget)}s)..."
-                )
-                from hermes_cli.gateway import (
-                    GATEWAY_LOOP_WEDGED,
-                    _escalate_wedged_gateway,
-                    probe_gateway_loop_liveness,
-                )
+                        plist_path = get_launchd_plist_path()
+                        if plist_path.exists():
+                            check = subprocess.run(
+                                ["launchctl", "list", get_launchd_label()],
+                                capture_output=True,
+                                text=True, encoding="utf-8", errors="replace",
+                                timeout=5,
+                            )
+                            if check.returncode == 0:
+                                try:
+                                    launchd_restart()
+                                    restarted_services.append(get_launchd_label())
+                                except subprocess.CalledProcessError as e:
+                                    stderr = (getattr(e, "stderr", "") or "").strip()
+                                    print(f"  ⚠ Gateway restart failed: {stderr}")
+                    except (FileNotFoundError, subprocess.TimeoutExpired, ImportError):
+                        pass
 
-                if probe_gateway_loop_liveness(pid) == GATEWAY_LOOP_WEDGED:
-                    # Loop-liveness probe: this gateway's event loop is
-                    # provably dead (#81642) — SIGUSR1/SIGTERM shutdown can
-                    # never run, so the drain wait would burn the full budget
-                    # and stall the update. Bounded stop instead (SIGTERM
-                    # grace → SIGKILL, ~10s). A busy-but-alive gateway keeps
-                    # a fresh heartbeat and never takes this branch, so live
-                    # drains (incl. the #86684 cron floor) are unaffected.
+                # --- Manual (non-service) gateways ---
+                # Kill any remaining gateway processes not managed by a service.
+                # Exclude PIDs that belong to just-restarted services so we don't
+                # immediately kill the process that systemd/launchd just spawned.
+                service_pids = _get_service_pids()
+                manual_pids = find_gateway_pids(
+                    exclude_pids=service_pids, all_profiles=True
+                )
+                profile_processes = {
+                    proc.pid: proc
+                    for proc in find_profile_gateway_processes(exclude_pids=service_pids)
+                    if proc.pid in manual_pids
+                }
+                for pid, proc in profile_processes.items():
+                    restart_mode = _prepare_profile_gateway_update_restart(
+                        proc.profile, pid
+                    )
+                    if restart_mode is None:
+                        continue
+                    # Prefer a graceful SIGUSR1 drain so in-flight agent runs
+                    # finish before the watcher respawns the gateway.  If the
+                    # gateway doesn't support SIGUSR1 or doesn't exit within
+                    # the drain budget, fall back to SIGTERM — the watcher
+                    # still sees the exit and relaunches either way.
+                    # Announce the drain first: this wait can hold for the full
+                    # budget per gateway with no other output, and on surfaces
+                    # that stream update progress (the desktop updater most of
+                    # all) the silence reads as a hung update (#44515).
                     print(
-                        f"  ⚠ {proc.profile}: gateway event loop is "
-                        "unresponsive — skipping drain, forcing a bounded stop..."
+                        f"  → {proc.profile}: draining gateway PID {pid} "
+                        f"(up to {int(_drain_budget)}s)..."
                     )
-                    _escalate_wedged_gateway(pid)
-                    drained = True
-                else:
-                    drained = _graceful_restart_via_sigusr1(
-                        pid,
-                        drain_timeout=_drain_budget,
+                    from hermes_cli.gateway import (
+                        GATEWAY_LOOP_WEDGED,
+                        _escalate_wedged_gateway,
+                        probe_gateway_loop_liveness,
                     )
-                if not drained:
+
+                    if probe_gateway_loop_liveness(pid) == GATEWAY_LOOP_WEDGED:
+                        # Loop-liveness probe: this gateway's event loop is
+                        # provably dead (#81642) — SIGUSR1/SIGTERM shutdown can
+                        # never run, so the drain wait would burn the full budget
+                        # and stall the update. Bounded stop instead (SIGTERM
+                        # grace → SIGKILL, ~10s). A busy-but-alive gateway keeps
+                        # a fresh heartbeat and never takes this branch, so live
+                        # drains (incl. the #86684 cron floor) are unaffected.
+                        print(
+                            f"  ⚠ {proc.profile}: gateway event loop is "
+                            "unresponsive — skipping drain, forcing a bounded stop..."
+                        )
+                        _escalate_wedged_gateway(pid)
+                        drained = True
+                    else:
+                        drained = _graceful_restart_via_sigusr1(
+                            pid,
+                            drain_timeout=_drain_budget,
+                        )
+                    if not drained:
+                        try:
+                            os.kill(pid, _signal.SIGTERM)
+                        except (ProcessLookupError, PermissionError):
+                            pass
+                    # Wait for the old process to fully exit before the watcher
+                    # spawns the new gateway.  Telegram holds the previous
+                    # getUpdates long-poll session open on its servers for up to
+                    # ~30s after the client disconnects.  If the new gateway
+                    # connects before that window expires it receives a 409
+                    # Conflict, which _handle_polling_conflict() recovers from
+                    # via back-off retries — but a brief wait here reduces the
+                    # chance of hitting that path at all, especially on fast
+                    # machines where the watcher loop restarts in < 1s.
+                    # We wait up to 5s for the process to exit (the OS-level
+                    # close, not the Telegram server-side expiry), then let the
+                    # watcher take over.  The Telegram adapter's retry logic
+                    # handles any remaining 409s if the server session is still
+                    # live when the new gateway polls.
+                    _wait_for_gateway_exit(timeout=5.0, force_after=None)
+                    killed_pids.add(pid)
+                    if restart_mode == "external-supervisor":
+                        externally_supervised_profiles.append(proc.profile)
+                    else:
+                        relaunched_profiles.append(proc.profile)
+
+                for pid in manual_pids:
+                    if pid in profile_processes:
+                        continue
                     try:
                         os.kill(pid, _signal.SIGTERM)
+                        killed_pids.add(pid)
                     except (ProcessLookupError, PermissionError):
                         pass
-                # Wait for the old process to fully exit before the watcher
-                # spawns the new gateway.  Telegram holds the previous
-                # getUpdates long-poll session open on its servers for up to
-                # ~30s after the client disconnects.  If the new gateway
-                # connects before that window expires it receives a 409
-                # Conflict, which _handle_polling_conflict() recovers from
-                # via back-off retries — but a brief wait here reduces the
-                # chance of hitting that path at all, especially on fast
-                # machines where the watcher loop restarts in < 1s.
-                # We wait up to 5s for the process to exit (the OS-level
-                # close, not the Telegram server-side expiry), then let the
-                # watcher take over.  The Telegram adapter's retry logic
-                # handles any remaining 409s if the server session is still
-                # live when the new gateway polls.
-                _wait_for_gateway_exit(timeout=5.0, force_after=None)
-                killed_pids.add(pid)
-                if restart_mode == "external-supervisor":
-                    externally_supervised_profiles.append(proc.profile)
-                else:
-                    relaunched_profiles.append(proc.profile)
 
-            for pid in manual_pids:
-                if pid in profile_processes:
-                    continue
-                try:
-                    os.kill(pid, _signal.SIGTERM)
-                    killed_pids.add(pid)
-                except (ProcessLookupError, PermissionError):
+                if restarted_services or killed_pids:
+                    print()
+                    for svc in restarted_services:
+                        print(f"  ✓ Restarted {svc}")
+                    if relaunched_profiles:
+                        names = ", ".join(relaunched_profiles)
+                        print(f"  ✓ Restarting manual gateway profile(s): {names}")
+                    if externally_supervised_profiles:
+                        names = ", ".join(externally_supervised_profiles)
+                        print(
+                            "  ✓ Handed gateway profile(s) back to their external "
+                            f"supervisor: {names}"
+                        )
+                    unmapped_count = (
+                        len(killed_pids)
+                        - len(relaunched_profiles)
+                        - len(externally_supervised_profiles)
+                    )
+                    if unmapped_count:
+                        print(f"  → Stopped {unmapped_count} manual gateway process(es)")
+                        print("    Restart manually: hermes gateway run")
+                        if unmapped_count > 1:
+                            print(
+                                "    (or: hermes -p <profile> gateway run  for each profile)"
+                            )
+
+                if failed_or_stale_units:
+                    gateway_fleet_restart_incomplete = True
+                    if gateway_mode:
+                        _exit_code_path = get_hermes_home() / ".update_exit_code"
+                        try:
+                            _exit_code_path.write_text("1", encoding="utf-8")
+                        except OSError:
+                            pass
+                _warn_incomplete_gateway_fleet_restart(failed_or_stale_units)
+
+                if not restarted_services and not killed_pids:
+                    # No gateways were running — nothing to do
                     pass
 
-            if restarted_services or killed_pids:
-                print()
-                for svc in restarted_services:
-                    print(f"  ✓ Restarted {svc}")
-                if relaunched_profiles:
-                    names = ", ".join(relaunched_profiles)
-                    print(f"  ✓ Restarting manual gateway profile(s): {names}")
-                if externally_supervised_profiles:
-                    names = ", ".join(externally_supervised_profiles)
-                    print(
-                        "  ✓ Handed gateway profile(s) back to their external "
-                        f"supervisor: {names}"
+                # --- Post-restart survivor sweep -----------------------------
+                # Issue #17648: some gateways ignore SIGTERM (stuck drain,
+                # blocked I/O, PID dead but zombie).  The detached profile
+                # watchers wait 120s for the old PID to exit — if it never
+                # does, no respawn happens and the user keeps hitting
+                # ImportError against a stale sys.modules.  Give the
+                # graceful paths a brief window to complete, then SIGKILL
+                # any remaining pre-update PIDs so the watcher / service
+                # manager can relaunch with fresh code.
+                try:
+                    _time.sleep(3.0)
+                    _service_pids_after = _get_service_pids()
+                    _surviving = find_gateway_pids(
+                        exclude_pids=_service_pids_after,
+                        all_profiles=True,
                     )
-                unmapped_count = (
-                    len(killed_pids)
-                    - len(relaunched_profiles)
-                    - len(externally_supervised_profiles)
-                )
-                if unmapped_count:
-                    print(f"  → Stopped {unmapped_count} manual gateway process(es)")
-                    print("    Restart manually: hermes gateway run")
-                    if unmapped_count > 1:
+                    # Scope to PIDs we already tried to kill during this
+                    # update (killed_pids).  Anything new is a gateway that
+                    # started AFTER our restart attempt — respecting user
+                    # intent, we don't kill those.
+                    _stuck = [pid for pid in _surviving if pid in killed_pids]
+                    if _stuck:
+                        print()
                         print(
-                            "    (or: hermes -p <profile> gateway run  for each profile)"
+                            f"  ⚠ {len(_stuck)} gateway process(es) ignored SIGTERM — force-killing"
                         )
+                        from gateway.status import terminate_pid as _terminate_pid
+                        for pid in _stuck:
+                            try:
+                                # Routes through taskkill /T /F on Windows,
+                                # SIGKILL on POSIX — _signal.SIGKILL doesn't
+                                # exist on Windows so the old raw os.kill call
+                                # used to crash the entire update path.
+                                _terminate_pid(pid, force=True)
+                            except (ProcessLookupError, PermissionError, OSError):
+                                pass
+                        # Give the OS a beat to reap the processes so the
+                        # watchers see them exit and respawn.
+                        _time.sleep(1.5)
+                except Exception as _sweep_exc:
+                    logger.debug("Post-restart survivor sweep failed: %s", _sweep_exc)
 
-            if failed_or_stale_units:
-                gateway_fleet_restart_incomplete = True
-                if gateway_mode:
-                    _exit_code_path = get_hermes_home() / ".update_exit_code"
-                    try:
-                        _exit_code_path.write_text("1", encoding="utf-8")
-                    except OSError:
-                        pass
-            _warn_incomplete_gateway_fleet_restart(failed_or_stale_units)
-
-            if not restarted_services and not killed_pids:
-                # No gateways were running — nothing to do
-                pass
-
-            # --- Post-restart survivor sweep -----------------------------
-            # Issue #17648: some gateways ignore SIGTERM (stuck drain,
-            # blocked I/O, PID dead but zombie).  The detached profile
-            # watchers wait 120s for the old PID to exit — if it never
-            # does, no respawn happens and the user keeps hitting
-            # ImportError against a stale sys.modules.  Give the
-            # graceful paths a brief window to complete, then SIGKILL
-            # any remaining pre-update PIDs so the watcher / service
-            # manager can relaunch with fresh code.
-            try:
-                _time.sleep(3.0)
-                _service_pids_after = _get_service_pids()
-                _surviving = find_gateway_pids(
-                    exclude_pids=_service_pids_after,
-                    all_profiles=True,
-                )
-                # Scope to PIDs we already tried to kill during this
-                # update (killed_pids).  Anything new is a gateway that
-                # started AFTER our restart attempt — respecting user
-                # intent, we don't kill those.
-                _stuck = [pid for pid in _surviving if pid in killed_pids]
-                if _stuck:
-                    print()
-                    print(
-                        f"  ⚠ {len(_stuck)} gateway process(es) ignored SIGTERM — force-killing"
-                    )
-                    from gateway.status import terminate_pid as _terminate_pid
-                    for pid in _stuck:
+            except Exception as e:
+                logger.debug("Gateway restart during update failed: %s", e)
+                # An exception escaping the whole phase means the drain/restart
+                # output the user relies on never printed. Don't let that pass for
+                # a clean update: surface it and treat the fleet as stale unless we
+                # can positively prove no gateway is running (#78574).
+                #
+                # A positive-empty ``_surviving`` is only proof-of-safety when
+                # nothing was running before we touched anything. If a gateway was
+                # discovered pre-restart and none survive now, it was stopped and
+                # its replacement was never verified — the same fail-open contract
+                # this fix closes — so we must still fail closed on ``[]``.
+                _surviving = _surviving_gateway_pids_after_failed_restart()
+                if _restart_phase_failure_is_incomplete(
+                    _surviving, _pre_restart_gateway_pids
+                ):
+                    gateway_fleet_restart_incomplete = True
+                    _warn_gateway_restart_phase_aborted(e, _surviving)
+                    if gateway_mode:
+                        _exit_code_path = get_hermes_home() / ".update_exit_code"
                         try:
-                            # Routes through taskkill /T /F on Windows,
-                            # SIGKILL on POSIX — _signal.SIGKILL doesn't
-                            # exist on Windows so the old raw os.kill call
-                            # used to crash the entire update path.
-                            _terminate_pid(pid, force=True)
-                        except (ProcessLookupError, PermissionError, OSError):
+                            _exit_code_path.write_text("1", encoding="utf-8")
+                        except OSError:
                             pass
-                    # Give the OS a beat to reap the processes so the
-                    # watchers see them exit and respawn.
-                    _time.sleep(1.5)
-            except Exception as _sweep_exc:
-                logger.debug("Post-restart survivor sweep failed: %s", _sweep_exc)
-
-        except Exception as e:
-            logger.debug("Gateway restart during update failed: %s", e)
-            # An exception escaping the whole phase means the drain/restart
-            # output the user relies on never printed. Don't let that pass for
-            # a clean update: surface it and treat the fleet as stale unless we
-            # can positively prove no gateway is running (#78574).
-            #
-            # A positive-empty ``_surviving`` is only proof-of-safety when
-            # nothing was running before we touched anything. If a gateway was
-            # discovered pre-restart and none survive now, it was stopped and
-            # its replacement was never verified — the same fail-open contract
-            # this fix closes — so we must still fail closed on ``[]``.
-            _surviving = _surviving_gateway_pids_after_failed_restart()
-            if _restart_phase_failure_is_incomplete(
-                _surviving, _pre_restart_gateway_pids
-            ):
-                gateway_fleet_restart_incomplete = True
-                _warn_gateway_restart_phase_aborted(e, _surviving)
-                if gateway_mode:
-                    _exit_code_path = get_hermes_home() / ".update_exit_code"
-                    try:
-                        _exit_code_path.write_text("1", encoding="utf-8")
-                    except OSError:
-                        pass
 
         _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
 

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1,5 +1,6 @@
 """Tests for cmd_update — branch fallback when remote branch doesn't exist."""
 
+import argparse
 import hashlib
 import subprocess
 from types import SimpleNamespace
@@ -8,6 +9,7 @@ from unittest.mock import ANY, patch
 import pytest
 
 from hermes_cli.main import cmd_update, PROJECT_ROOT
+from hermes_cli.subcommands.update import build_update_parser
 
 
 def _make_run_side_effect(branch="main", verify_ok=True, commit_count="0"):
@@ -1236,3 +1238,96 @@ class TestUpdateNodeDependencies:
         assert cwd_calls, "expected at least one npm call"
         for cwd in cwd_calls:
             assert cwd == tmp_path, f"npm must run from PROJECT_ROOT; got cwd={cwd}"
+
+
+def _systemctl_restart_units(mock_run):
+    """Return unit names passed to ``systemctl ... restart <unit>``."""
+    units = []
+    for call in mock_run.call_args_list:
+        if not call.args:
+            continue
+        cmd = [str(part) for part in call.args[0]]
+        if "systemctl" not in cmd or "restart" not in cmd:
+            continue
+        # ``systemctl [--user] [--no-ask-password] restart <unit>``
+        restart_at = cmd.index("restart")
+        if restart_at + 1 < len(cmd):
+            units.append(cmd[restart_at + 1])
+    return units
+
+
+def _make_update_run_side_effect(commit_count="1", systemd_units=None):
+    """Git mocks from ``_make_run_side_effect`` plus systemd fleet-restart replies."""
+    git_side_effect = _make_run_side_effect(branch="main", verify_ok=True, commit_count=commit_count)
+    units = list(systemd_units or [])
+
+    def side_effect(cmd, **kwargs):
+        joined = " ".join(str(c) for c in cmd)
+        if "list-units" in joined:
+            stdout = "".join(f"{name}.service loaded active running\n" for name in units)
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+        if "is-active" in joined:
+            return subprocess.CompletedProcess(cmd, 0, stdout="active\n", stderr="")
+        if "systemctl" in joined and "show" in joined:
+            if "MainPID" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="0\n", stderr="")
+            return subprocess.CompletedProcess(cmd, 0, stdout="100ms\n", stderr="")
+        return git_side_effect(cmd, **kwargs)
+
+    return side_effect
+
+
+class TestCmdUpdateNoRestart:
+    """``hermes update --no-restart`` skips fleet restart after a successful update."""
+
+    def _run_successful_update(self, *, no_restart):
+        args = SimpleNamespace(no_restart=no_restart)
+        with patch("shutil.which", return_value=None), patch(
+            "subprocess.run"
+        ) as mock_run, patch(
+            "hermes_cli.gateway.supports_systemd_services", return_value=True
+        ), patch(
+            "hermes_cli.gateway.is_macos", return_value=False
+        ), patch(
+            "hermes_cli.gateway.find_gateway_pids", return_value=[]
+        ), patch(
+            "hermes_cli.gateway.find_profile_gateway_processes", return_value=[]
+        ), patch(
+            "hermes_cli.gateway._ensure_user_systemd_env"
+        ), patch(
+            "hermes_cli.gateway._get_service_pids", return_value=[]
+        ), patch(
+            "hermes_cli.update_cmd._service_unit_supports_graceful_sigusr1_restart",
+            return_value=False,
+        ), patch(
+            "hermes_cli.update_cmd._time.sleep"
+        ), patch(
+            "hermes_cli.update_cmd._finish_dashboard_update_cleanup"
+        ):
+            mock_run.side_effect = _make_update_run_side_effect(
+                commit_count="1", systemd_units=["hermes-gateway"]
+            )
+            cmd_update(args)
+        return mock_run
+
+    def test_parser_defaults_restart_and_accepts_flag(self):
+        parser = argparse.ArgumentParser()
+        build_update_parser(parser.add_subparsers(), cmd_update=lambda _args: None)
+        assert parser.parse_args(["update"]).no_restart is False
+        assert parser.parse_args(["update", "--no-restart"]).no_restart is True
+
+    def test_skips_fleet_restart_when_flag_set(self, capsys):
+        mock_run = self._run_successful_update(no_restart=True)
+        out = capsys.readouterr().out
+
+        assert "Updating Python dependencies" in out
+        assert "Skipped restarting running gateway profiles" in out
+        assert _systemctl_restart_units(mock_run) == []
+
+    def test_restarts_fleet_when_flag_unset(self, capsys):
+        mock_run = self._run_successful_update(no_restart=False)
+        out = capsys.readouterr().out
+
+        assert "Updating Python dependencies" in out
+        assert "Skipped restarting running gateway profiles" not in out
+        assert "hermes-gateway" in _systemctl_restart_units(mock_run)

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -29,7 +29,15 @@ When you run `hermes update`, the following steps occur:
 3. **Post-pull syntax validation + auto-rollback** — after the pull, Hermes compiles the nine critical files every `hermes` invocation imports at startup. If any fails to parse (e.g. an orphan merge-conflict marker, an accidentally truncated file), Hermes runs `git reset --hard <pre-pull-sha>` to roll the install back so your shell stays bootable. Re-run `hermes update` once the upstream fix lands.
 4. **Dependency install** — runs `uv pip install -e ".[all]"` to pick up new or changed dependencies
 5. **Config migration** — detects new config options added since your version and prompts you to set them
-6. **Gateway auto-restart** — running gateways are refreshed after the update completes so the new code takes effect immediately. Service-managed gateways (systemd on Linux, launchd on macOS) are restarted through the service manager. Manual gateways are relaunched automatically when Hermes can map the running PID back to a profile.
+6. **Gateway auto-restart**: running gateways are refreshed after the update completes so the new code takes effect immediately. Service-managed gateways (systemd on Linux, launchd on macOS) are restarted through the service manager. Manual gateways are relaunched automatically when Hermes can map the running PID back to a profile. Pass `--no-restart` to skip restarting running gateway profiles after update.
+
+### Skip gateway restart: `--no-restart`
+
+```bash
+hermes update --no-restart
+```
+
+Dependency install and post-install hooks still run. Restart later with `hermes gateway restart` when you want running profiles to load the new code.
 
 ### Updating against a non-default branch: `--branch`
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1729,7 +1729,7 @@ hermes completion fish > ~/.config/fish/completions/hermes.fish
 ## `hermes update`
 
 ```bash
-hermes update [--gateway] [--check] [--no-backup] [--backup] [--yes]
+hermes update [--gateway] [--check] [--no-backup] [--backup] [--yes] [--no-restart]
 ```
 
 Pulls the latest `hermes-agent` code and reinstalls dependencies in the managed venv, then re-runs the post-install hooks (MCP servers, skills sync, completion install). Safe to run on a live install. Use `--check` to see whether your checkout is behind `origin/main` without installing.
@@ -1743,10 +1743,11 @@ Pulls the latest `hermes-agent` code and reinstalls dependencies in the managed 
 | `--no-backup` | Skip all pre-update backups for this run (both the quick state snapshot and the full zip), regardless of `updates.pre_update_backup`. |
 | `--backup` | Force a **full** pre-update backup for this run: the quick state snapshot plus a complete zip of `HERMES_HOME` (config, auth, sessions, skills, pairing data). The default mode is `quick` — a lightweight state snapshot only. Set the permanent mode via `updates.pre_update_backup: quick | full | off` in `config.yaml`. |
 | `--yes`, `-y` | Assume yes for interactive prompts such as config migration and stash restore. API-key entry is skipped; run `hermes config migrate` separately for those. |
+| `--no-restart` | Skip restarting running gateway profiles after a successful update. Dependency install and post-install hooks still run. |
 
 Additional behavior:
 
-- **Gateway restart.** After a successful update, Hermes attempts to restart all running gateway profiles automatically so they pick up the new code. Use `hermes gateway restart` when you want to restart a gateway without applying an update.
+- **Gateway restart.** After a successful update, Hermes attempts to restart all running gateway profiles automatically so they pick up the new code. Pass `--no-restart` to skip that step. Use `hermes gateway restart` when you want to restart a gateway without applying an update.
 - **Local source changes.** For git installs, dirty tracked files and untracked files are auto-stashed before branch checkout or pull (`git stash push --include-untracked`). Interactive terminal updates ask before restoring the stash. Non-interactive updates restore it by default; set `updates.non_interactive_local_changes: discard` only on managed installs where local source edits should be thrown away after a successful pull. If stash restore conflicts or the pull fails, the stash is left in place for manual recovery.
 - **npm lockfile churn.** Before stashing or switching branches, Hermes makes a best-effort cleanup of tracked `package-lock.json` diffs produced by npm install/build steps. Commit or manually stash intentional lockfile edits before running `hermes update`.
 - **Pairing data snapshot.** Even when `--backup` is off, `hermes update` takes a lightweight snapshot of `~/.hermes/pairing/` and the Feishu comment rules before `git pull`. You can roll it back with `hermes backup restore --state pre-update` if a pull rewrites a file you were editing.


### PR DESCRIPTION
## What does this PR do?

`hermes update` always restarts running gateway profiles after a successful update (and after already-up-to-date / already-at-pin paths that still refresh the fleet). That is the right default, but there is no way to refresh the checkout without bouncing those processes.

This adds `--no-restart` so an update can skip systemd, launchd, and manual fleet restart. Dependency install and post-install hooks still run. Restart later with `hermes gateway restart` when you want running profiles to load the new code.

Default `hermes update` is unchanged.

Related: #30824 added a similar flag against an older `hermes update` layout and was closed without merge.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/subcommands/update.py`: add `--no-restart`
- `hermes_cli/update_cmd.py`: skip systemd / launchd / manual fleet restart when the flag is set
- `tests/hermes_cli/test_cmd_update.py`: parser default, skip-on-flag, and default-restart coverage
- `website/docs/getting-started/updating.md` and `website/docs/reference/cli-commands.md`: document `--no-restart`

## How to Test

```bash
scripts/run_tests.sh tests/hermes_cli/test_cmd_update.py \
  tests/hermes_cli/test_update_gateway_restart_aborted.py \
  tests/hermes_cli/test_update_fleet_restart_timeout.py \
  tests/hermes_cli/test_subcommands_batch.py
```

Manual (git install):

1. `hermes update --help` lists `--no-restart`
2. `hermes update --no-restart --yes` prints the skip notice and does not restart running gateway profiles
3. `hermes update --yes` without the flag still restarts running gateway profiles
4. Install and post-install hooks still run when `--no-restart` is set

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6 (darwin 24.6.0). Targeted suite above: 59 passed.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

`--no-restart` covers systemd, launchd, and manual fleet restart. Unit tests cover the systemd path. Live Linux/Windows fleet restart was not run. Windows pause/resume of other `hermes.exe` processes during update is unchanged.

## Screenshots / Logs

N/A
