### PR TITLE
fix(doctor): show install command for not-installed optional packages (#89121)

### DIFF
--- a/hermes_cli/doctor_platform.py
+++ b/hermes_cli/doctor_platform.py
@@ -406,25 +406,32 @@ def _check_certificates(should_fix: bool, f: Finding) -> None:
     check_certificates(should_fix=should_fix, issues=f.manual_issues)
 
 
-# (import name, display name, optional)
+# (import name, display name, pip install spec, optional). The pip spec is
+# spelled out because the install name diverges from the import name for several
+# packages (dotenv -> python-dotenv, yaml -> pyyaml, telegram ->
+# python-telegram-bot, discord -> discord.py), so a naive `pip install <module>`
+# would grab the wrong package or nothing useful (#89121).
 _PACKAGES = (
-    ("openai", "OpenAI SDK", False), ("rich", "Rich (terminal UI)", False), ("dotenv", "python-dotenv", False),
-    ("yaml", "PyYAML", False), ("httpx", "HTTPX", False),
-    ("croniter", "Croniter (cron expressions)", True), ("telegram", "python-telegram-bot", True), ("discord", "discord.py", True),
+    ("openai", "OpenAI SDK", "openai", False), ("rich", "Rich (terminal UI)", "rich", False),
+    ("dotenv", "python-dotenv", "python-dotenv", False),
+    ("yaml", "PyYAML", "pyyaml", False), ("httpx", "HTTPX", "httpx", False),
+    ("croniter", "Croniter (cron expressions)", "croniter", True),
+    ("telegram", "python-telegram-bot", "python-telegram-bot", True), ("discord", "discord.py", "discord.py", True),
 )
 
 
 @doctor_check()
 def _check_required_packages(should_fix: bool, f: Finding) -> None:
-    for module, name, optional in _PACKAGES:
+    install_cmd = _python_install_cmd()
+    for module, name, pip_spec, optional in _PACKAGES:
         try:
             __import__(module)
             check_ok(name, "(optional)" if optional else "")
         except ImportError:
             if optional:
-                check_warn(name, "(optional, not installed)")
+                check_warn(name, f"(optional, not installed) — install with: {install_cmd} {pip_spec}")
             else:
-                _fail_and_issue(name, "(missing)", f"Install {name}: {_python_install_cmd()} {module}", f.issues)
+                _fail_and_issue(name, "(missing)", f"Install {name}: {install_cmd} {pip_spec}", f.issues)
 
 
 @doctor_check()

--- a/tests/hermes_cli/test_doctor_required_packages_install_hint.py
+++ b/tests/hermes_cli/test_doctor_required_packages_install_hint.py
@@ -1,0 +1,55 @@
+"""Regression tests for the Required Packages check in ``hermes doctor``.
+
+Covers #89121: a missing package's install hint must spell out the *pip
+distribution* name, not the import name, for packages whose install name diverges
+(``dotenv`` -> ``python-dotenv``, ``yaml`` -> ``pyyaml``, ``telegram`` ->
+``python-telegram-bot``, ``discord`` -> ``discord.py``); and an optional package
+that is not installed must still surface an install command, not just a bare
+"(optional, not installed)" note.
+"""
+
+import hermes_cli.doctor_platform as dp
+
+
+def test_packages_table_uses_diverging_pip_specs():
+    """Every import name whose pip distribution differs is mapped explicitly."""
+    specs = {module: pip_spec for module, _name, pip_spec, _optional in dp._PACKAGES}
+    assert specs["dotenv"] == "python-dotenv"
+    assert specs["yaml"] == "pyyaml"
+    assert specs["telegram"] == "python-telegram-bot"
+    assert specs["discord"] == "discord.py"
+
+
+def test_missing_required_package_hint_uses_pip_spec(monkeypatch):
+    """A missing required dep is reported with ``<install cmd> <pip_spec>``."""
+    monkeypatch.setattr(dp, "_python_install_cmd", lambda: "uv pip install")
+    monkeypatch.setattr(
+        dp, "_PACKAGES",
+        (("hermes_missing_required_xyz", "Fake Required", "fake-required-dist", False),),
+    )
+
+    finding = dp._check_required_packages(False)
+
+    assert finding.issues, "a missing required package should record an issue"
+    fix = finding.issues[0]
+    assert "uv pip install fake-required-dist" in fix
+    assert "fake-required-dist" in fix
+    # The import name must not leak into the hint.
+    assert "hermes_missing_required_xyz" not in fix
+
+
+def test_missing_optional_package_hint_uses_pip_spec(monkeypatch, capsys):
+    """A missing optional dep still shows an install command with the pip spec."""
+    monkeypatch.setattr(dp, "_python_install_cmd", lambda: "uv pip install")
+    monkeypatch.setattr(
+        dp, "_PACKAGES",
+        (("hermes_missing_optional_xyz", "Fake Optional", "fake-optional-dist", True),),
+    )
+
+    finding = dp._check_required_packages(False)
+
+    # Optional deps are warnings, not blocking issues.
+    assert not finding.issues
+    out = capsys.readouterr().out
+    assert "install with: uv pip install fake-optional-dist" in out
+    assert "hermes_missing_optional_xyz" not in out


### PR DESCRIPTION
## What

`hermes doctor` printed an actionable install command for **missing required** packages, but **not-installed optional** packages only warned with a dead-end message:

```
⚠ discord.py (optional, not installed)
```

This adds an explicit pip install spec per optional package and surfaces it in the warning:

```
⚠ discord.py (optional, not installed) — install with: uv pip install discord.py
```

(The command respects the environment: `python -m pip install` on Termux, `uv pip install` otherwise — same `_python_install_cmd()` the required section already uses.)

## Why the pip spec is spelled out explicitly

The install name diverges from the import name for two of the three optional packages, so a naive `pip install <module>` would grab the wrong package:

| import module | pip package |
|---|---|
| `discord` | `discord.py` |
| `telegram` | `python-telegram-bot` |
| `croniter` | `croniter` |

So the optional list now carries `(module, display_name, pip_spec)` and the warning uses `pip_spec`.

## Test

Added `test_missing_optional_package_shows_install_command` — forces `discord` unimportable via `sys.modules` (env-independent) and asserts the warning carries `install with: … discord.py`. Also added `encoding="utf-8"` to two pre-existing bare `write_text` calls in the same test file to satisfy the windows-footgun gate. Preflight (footguns, ruff, affected tests incl. `test_doctor.py`) all green.

Fixes #89121
