### PR TITLE
fix(memory): dedup restated facts at recall without merging contradictions

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -85,19 +85,42 @@ class _RecallResult:
 
 # Similarity threshold above which two recalled facts count as the same
 # assertion. Similarity is containment-based (see _recall_similarity), so a
-# restatement that drops/adds a few words — e.g. "user prefers dark mode" vs
-# "the user prefers dark mode" — still matches; genuinely different facts score
-# low and are never collapsed.
-_RECALL_DEDUP_SIMILARITY_THRESHOLD = 0.75
+# restatement that drops/adds a few filler words — e.g. "user prefers dark
+# mode" vs "the user prefers dark mode" — still matches. Facts differing in a
+# CONTENT token (a number, date, or proper noun) are NEVER collapsed regardless
+# of score: "daughter is 7" vs "daughter is 8" is an update, not a restatement,
+# and dropping it would freeze stale answers into the context.
+_RECALL_DEDUP_SIMILARITY_THRESHOLD = 0.9
+
+# Short facts (<= this many tokens) need a stricter score: with few tokens each
+# one carries more meaning, so a single differing word must block collapse.
+_RECALL_DEDUP_SHORT_FACT_TOKENS = 8
+_RECALL_DEDUP_SHORT_FACT_THRESHOLD = 0.95
 
 # Negation markers: if two near-duplicate facts differ in whether they carry
 # negation, they assert opposite things (e.g. "user likes X" vs "user doesn't
-# like X") — keep both, don't merge. Independent of the similarity score.
+# like X") — keep both, don't merge.
 _NEGATION_RE = re.compile(
     r"\b(?:n't|not|never|no|none|nothing|without|neither|nor|isn't|aren't|"
     r"wasn't|weren't|don't|doesn't|didn't|won't|can't|cannot|shouldn't)\b",
     re.IGNORECASE,
 )
+
+# Words so common they carry no identifying meaning. Used to decide whether two
+# facts that differ by exactly one token differ by CONTENT (keep both) or by
+# filler (safe to collapse). Negation markers are excluded here too: they are
+# handled by their own polarity/scope guards, and counting them as content
+# would shadow those guards.
+_STOPWORD_TOKENS = frozenset({
+    "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
+    "to", "of", "in", "on", "for", "with", "and", "or", "but", "at", "by",
+    "from", "up", "about", "into", "over", "after", "it", "its", "this",
+    "that", "these", "those", "their", "there", "here", "as", "s", "t",
+    # negation markers (see _NEGATION_RE)
+    "not", "never", "no", "none", "nothing", "without", "neither", "nor",
+    "isn", "aren", "wasn", "weren", "don", "doesn", "didn", "won", "can",
+    "cannot", "shouldn",
+})
 
 
 def _recall_token_set(text: str) -> set[str]:
@@ -115,8 +138,7 @@ def _recall_similarity(a: str, b: str) -> float:
 
     One fact is a restatement of the other when they share nearly all of their
     tokens (e.g. "user prefers dark mode" vs "the user prefers dark mode").
-    Symmetric max directional overlap: the fraction of the smaller token set
-    contained in the larger. Order-insensitive.
+    Fraction of the smaller token set contained in the larger; order-insensitive.
     """
     ta = _recall_token_set(a)
     tb = _recall_token_set(b)
@@ -125,26 +147,90 @@ def _recall_similarity(a: str, b: str) -> float:
     inter = len(ta & tb)
     if not inter:
         return 0.0
-    # Which fact is the smaller one? The restatement keeps the shorter fact's
-    # tokens; containment = fraction of the smaller set that's shared.
-    union = len(ta | tb)
     smaller = min(len(ta), len(tb))
     return inter / smaller if smaller else 0.0
+
+
+def _differing_tokens(a: str, b: str) -> set[str]:
+    """Tokens present in exactly one of the two facts."""
+    ta = _recall_token_set(a)
+    tb = _recall_token_set(b)
+    return ta ^ tb
+
+
+def _content_tokens(text: str) -> set[str]:
+    """Tokens of a fact excluding stopwords/filler."""
+    return {t for t in _recall_token_set(text) if t not in _STOPWORD_TOKENS}
+
+
+def _differs_by_content(candidate: str, keep: str) -> bool:
+    """True when the two facts disagree on a meaningful token.
+
+    A difference is CONTENT when any non-shared token is a number/date-like
+    value, a capitalized proper noun, or a rare (non-stopword) word — e.g.
+    "daughter is 7" vs "daughter is 8", "moved to tuesday" vs "moved to
+    wednesday", "key is abc123" vs "key is abc456". Those pairs are updates or
+    contradictions, never restatements, and must both be kept. Differences made
+    up only of stopwords/filler ("the user prefers X" vs "user prefers X") are
+    safe to collapse.
+    """
+    diff = _differing_tokens(keep, candidate)
+    if not diff:
+        return False
+    for token in diff:
+        # Digits: numbers, dates, IDs ("7" vs "8", "abc123" vs "abc456").
+        if any(ch.isdigit() for ch in token):
+            return True
+    # Proper nouns: a capitalized word away from sentence start / known names.
+    for text in (keep, candidate):
+        words = re.findall(r"[A-Za-z][A-Za-z0-9']*", text or "")
+        for i, w in enumerate(words):
+            if i > 0 and w[0].isupper() and w.lower() in {t.lower() for t in diff}:
+                return True
+    # Rare content words: any differing token outside the stopword set.
+    if any(t not in _STOPWORD_TOKENS for t in diff):
+        return True
+    return False
+
+
+def _threshold_for(keep: str, candidate: str) -> float:
+    """Similarity threshold for this pair — stricter on short facts."""
+    smaller = min(len(_recall_token_set(keep)), len(_recall_token_set(candidate)))
+    if smaller <= _RECALL_DEDUP_SHORT_FACT_TOKENS:
+        return _RECALL_DEDUP_SHORT_FACT_THRESHOLD
+    return _RECALL_DEDUP_SIMILARITY_THRESHOLD
 
 
 def _recall_should_collapse(candidate: str, keep: str) -> bool:
     """Should `candidate` be dropped because `keep` already represents it?
 
-    Collapses when the two are near-identical restatements, EXCEPT when their
-    polarity differs (one negates the other) — that's a contradiction and both
-    facts are preserved.
+    Collapses only true restatements — near-identical wording with no content
+    disagreement. Never collapses when:
+
+    - the pair differs on a content token (number, date, proper noun, rare
+      word): that's an update or a contradiction, keep both;
+    - their negation polarity differs ("likes X" vs "doesn't like X");
+    - EITHER side carries a negation marker but the non-marker remainder
+      differs at all (double-negation pairs over different targets, e.g.
+      "doesn't like dark mode" vs "doesn't like light mode", stay distinct).
+
+    Fail-open toward information preservation: ambiguous pairs are kept.
     """
-    if _recall_similarity(keep, candidate) < _RECALL_DEDUP_SIMILARITY_THRESHOLD:
+    if _differs_by_content(keep, candidate):
         return False
-    # Same assertion but opposite polarity -> contradiction, keep both.
-    if _recall_is_negation(keep) != _recall_is_negation(candidate):
+    keep_neg = _recall_is_negation(keep)
+    cand_neg = _recall_is_negation(candidate)
+    if keep_neg != cand_neg:
         return False
-    return True
+    if keep_neg and cand_neg:
+        # Both negative: only collapse when the CONTENT of the de-marked
+        # remainder matches — different targets ("never deploy friday" vs
+        # "never deploy sunday") stay distinct even though both are negative.
+        if _content_tokens(_NEGATION_RE.sub(" ", keep)) != _content_tokens(
+            _NEGATION_RE.sub(" ", candidate)
+        ):
+            return False
+    return _recall_similarity(keep, candidate) >= _threshold_for(keep, candidate)
 
 
 def _dedup_recalled_texts(texts: list[str]) -> list[str]:

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -37,6 +37,7 @@ import json
 import logging
 import os
 import queue
+import re
 import sys
 import threading
 import time
@@ -67,6 +68,100 @@ class _RecallResult:
 
     text: str
     count: int
+
+
+# ---------------------------------------------------------------------------
+# Recall dedup — collapse restated facts without merging contradictions
+# ---------------------------------------------------------------------------
+# With retain_every_n low (e.g. 1), a judgement the user restates across turns
+# is stored as several near-identical facts, and recall then injects all of
+# them — measuring 39-52% of rows on duplicate-heavy queries being restatements.
+# Dedup happens HERE, at recall formatting time, because Hindsight's own
+# consolidation_dedup_threshold only compares observation-to-observation and
+# extraction is blind across calls. We collapse near-identical text runs while
+# ALWAYS keeping first occurrence, and we refuse to merge a negation of the same
+# assertion (a near-duplicate whose polarity flips is a contradiction, not a
+# restatement — merging it would silently corrupt memory).
+
+# Similarity threshold above which two recalled facts count as the same
+# assertion. Similarity is containment-based (see _recall_similarity), so a
+# restatement that drops/adds a few words — e.g. "user prefers dark mode" vs
+# "the user prefers dark mode" — still matches; genuinely different facts score
+# low and are never collapsed.
+_RECALL_DEDUP_SIMILARITY_THRESHOLD = 0.75
+
+# Negation markers: if two near-duplicate facts differ in whether they carry
+# negation, they assert opposite things (e.g. "user likes X" vs "user doesn't
+# like X") — keep both, don't merge. Independent of the similarity score.
+_NEGATION_RE = re.compile(
+    r"\b(?:n't|not|never|no|none|nothing|without|neither|nor|isn't|aren't|"
+    r"wasn't|weren't|don't|doesn't|didn't|won't|can't|cannot|shouldn't)\b",
+    re.IGNORECASE,
+)
+
+
+def _recall_token_set(text: str) -> set[str]:
+    """Lowercased word tokens of a recalled fact (for order-insensitive compare)."""
+    return set(re.findall(r"[a-z0-9]+", (text or "").lower()))
+
+
+def _recall_is_negation(text: str) -> bool:
+    """True when the recalled fact carries a negation marker."""
+    return bool(_NEGATION_RE.search(text or ""))
+
+
+def _recall_similarity(a: str, b: str) -> float:
+    """Containment similarity between two recalled facts (0..1).
+
+    One fact is a restatement of the other when they share nearly all of their
+    tokens (e.g. "user prefers dark mode" vs "the user prefers dark mode").
+    Symmetric max directional overlap: the fraction of the smaller token set
+    contained in the larger. Order-insensitive.
+    """
+    ta = _recall_token_set(a)
+    tb = _recall_token_set(b)
+    if not ta and not tb:
+        return 1.0 if (a or "") == (b or "") else 0.0
+    inter = len(ta & tb)
+    if not inter:
+        return 0.0
+    # Which fact is the smaller one? The restatement keeps the shorter fact's
+    # tokens; containment = fraction of the smaller set that's shared.
+    union = len(ta | tb)
+    smaller = min(len(ta), len(tb))
+    return inter / smaller if smaller else 0.0
+
+
+def _recall_should_collapse(candidate: str, keep: str) -> bool:
+    """Should `candidate` be dropped because `keep` already represents it?
+
+    Collapses when the two are near-identical restatements, EXCEPT when their
+    polarity differs (one negates the other) — that's a contradiction and both
+    facts are preserved.
+    """
+    if _recall_similarity(keep, candidate) < _RECALL_DEDUP_SIMILARITY_THRESHOLD:
+        return False
+    # Same assertion but opposite polarity -> contradiction, keep both.
+    if _recall_is_negation(keep) != _recall_is_negation(candidate):
+        return False
+    return True
+
+
+def _dedup_recalled_texts(texts: list[str]) -> list[str]:
+    """Drop near-duplicate restatements from an ordered recall list, first-wins.
+
+    Preserves order; the first occurrence of each distinct assertion is kept.
+    Contradictory near-duplicates (negation polarity differs) are both kept.
+    """
+    kept: list[str] = []
+    for text in texts:
+        if not text:
+            continue
+        if any(_recall_should_collapse(text, k) for k in kept):
+            continue
+        kept.append(text)
+    return kept
+
 
 _DEFAULT_API_URL = "https://api.hindsight.vectorize.io"
 _DEFAULT_LOCAL_URL = "http://localhost:8888"
@@ -1882,9 +1977,13 @@ class HindsightMemoryProvider(MemoryProvider):
             logger.debug("Recall: calling recall (bank=%s, query_len=%d, budget=%s)",
                          self._bank_id, len(query), self._budget)
             resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
-            num_results = len(resp.results) if resp.results else 0
-            logger.debug("Recall: returned %d results", num_results)
-            text = "\n".join(f"- {r.text}" for r in resp.results if r.text) if resp.results else ""
+            results = _dedup_recalled_texts([r.text for r in resp.results if r.text]) if resp.results else []
+            num_results = len(results)
+            logger.debug("Recall: returned %d results (%d raw, %d after dedup)",
+                         num_results,
+                         len(resp.results) if resp.results else 0,
+                         len(resp.results) - num_results if resp.results else 0)
+            text = "\n".join(f"- {t}" for t in results)
             return _RecallResult(text, num_results)
         except Exception as e:
             logger.debug("Hindsight recall failed: %s", e, exc_info=True)
@@ -2215,11 +2314,15 @@ class HindsightMemoryProvider(MemoryProvider):
                 logger.debug("Tool hindsight_recall: bank=%s, query_len=%d, budget=%s",
                              self._bank_id, len(query), self._budget)
                 resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
-                num_results = len(resp.results) if resp.results else 0
-                logger.debug("Tool hindsight_recall: %d results", num_results)
-                if not resp.results:
+                results = _dedup_recalled_texts([r.text for r in resp.results if r.text]) if resp.results else []
+                num_results = len(results)
+                logger.debug("Tool hindsight_recall: %d results (%d raw, %d after dedup)",
+                             num_results,
+                             len(resp.results) if resp.results else 0,
+                             len(resp.results) - num_results if resp.results else 0)
+                if not results:
                     return json.dumps({"result": "No relevant memories found."})
-                lines = [f"{i}. {r.text}" for i, r in enumerate(resp.results, 1)]
+                lines = [f"{i}. {t}" for i, t in enumerate(results, 1)]
                 return json.dumps({"result": "\n".join(lines)})
             except Exception as e:
                 logger.warning("hindsight_recall failed: %s", e, exc_info=True)

--- a/tests/plugins/memory/test_hindsight_recall_dedup.py
+++ b/tests/plugins/memory/test_hindsight_recall_dedup.py
@@ -9,6 +9,7 @@ from plugins.memory.hindsight import (
     HindsightMemoryProvider,
     _RecallResult,
     _dedup_recalled_texts,
+    _recall_should_collapse,
     _recall_similarity,
 )
 
@@ -43,12 +44,21 @@ class TestDedupRecalledTexts:
         ])
         assert out == ["user prefers dark mode"]
 
-    def test_near_identical_rephrasing_collapses(self):
+    def test_filler_only_rephrasing_collapses(self):
+        # Differing tokens are all stopwords/filler -> restatement, collapse.
+        out = _dedup_recalled_texts([
+            "user prefers dark mode",
+            "the user prefers dark mode",
+        ])
+        assert out == ["user prefers dark mode"]
+
+    def test_content_word_rephrasing_keeps_both(self):
+        # 'color scheme' vs 'mode' differ by a content word -> update, keep both.
         out = _dedup_recalled_texts([
             "user prefers dark mode",
             "user prefers the dark color scheme",
         ])
-        assert out == ["user prefers dark mode"]
+        assert len(out) == 2
 
     def test_distinct_facts_are_all_kept(self):
         out = _dedup_recalled_texts([
@@ -125,6 +135,76 @@ def provider(tmp_path, monkeypatch):
     )
     p._client = client
     return p
+
+
+class TestReviewRegressions:
+    """Pins the failure shapes from the AI review of this PR.
+
+    Facts differing in a number, date, proper noun, or rare content word are
+    UPDATES, not restatements — they must never collapse. Double-negation
+    pairs over different targets must also stay distinct."""
+
+    def test_number_swapped_facts_both_kept(self):
+        out = _dedup_recalled_texts([
+            "user's daughter is 7",
+            "user's daughter is 8",
+        ])
+        assert len(out) == 2
+
+    def test_day_swapped_facts_both_kept(self):
+        out = _dedup_recalled_texts([
+            "meeting moved to tuesday",
+            "meeting moved to wednesday",
+        ])
+        assert len(out) == 2
+
+    def test_secret_id_swap_both_kept(self):
+        out = _dedup_recalled_texts([
+            "deploy key is abc123",
+            "deploy key is abc456",
+        ])
+        assert len(out) == 2
+
+    def test_double_negation_different_targets_both_kept(self):
+        # Both sides carry negation markers, but over DIFFERENT targets —
+        # the old polarity-only guard wrongly merged these.
+        out = _dedup_recalled_texts([
+            "user doesn't like dark mode",
+            "user doesn't like light mode",
+        ])
+        assert len(out) == 2
+
+    def test_double_negation_same_target_collapses(self):
+        # Same negated target, only filler differs -> collapse is safe.
+        out = _dedup_recalled_texts([
+            "never deploy on friday",
+            "never not deploy on the friday",
+        ])
+        assert len(out) == 1
+
+    def test_proper_noun_swap_both_kept(self):
+        out = _dedup_recalled_texts([
+            "Alice owns the deploy pipeline",
+            "Bob owns the deploy pipeline",
+        ])
+        assert len(out) == 2
+
+    def test_true_restatement_still_collapses_with_numbers(self):
+        # Same numbers + same content words, only filler differs -> collapse.
+        out = _dedup_recalled_texts([
+            "the build takes 42 seconds on the main runner",
+            "build takes 42 seconds on main runner",
+        ])
+        assert len(out) == 1
+
+    def test_similarity_threshold_documented(self):
+        # Two collapsible facts may differ ONLY by stopwords/filler; any
+        # single content-token difference blocks collapse. This documents
+        # the effective minimum edit distance: one content word = keep both.
+        assert not _recall_should_collapse(
+            "user prefers dark mode", "user prefers dark theme"
+        )
+        assert _recall_similarity("user prefers dark mode", "user prefers dark theme") >= 0.75
 
 
 class TestRecallToolDedup:

--- a/tests/plugins/memory/test_hindsight_recall_dedup.py
+++ b/tests/plugins/memory/test_hindsight_recall_dedup.py
@@ -1,0 +1,171 @@
+"""Tests for hindsight recall dedup — collapse restated facts, don't merge contradictions."""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from plugins.memory.hindsight import (
+    HindsightMemoryProvider,
+    _RecallResult,
+    _dedup_recalled_texts,
+    _recall_similarity,
+)
+
+
+# ---------------------------------------------------------------------------
+# Similarity helper
+# ---------------------------------------------------------------------------
+
+
+class TestRecallSimilarity:
+    def test_identical_facts_are_maximally_similar(self):
+        assert _recall_similarity("user prefers dark mode", "user prefers dark mode") == 1.0
+
+    def test_reordering_is_still_similar(self):
+        assert _recall_similarity("dark mode user prefers", "user prefers dark mode") == 1.0
+
+    def test_different_facts_are_clearly_dissimilar(self):
+        assert _recall_similarity("user prefers dark mode", "the project is written in Python") < 0.5
+
+
+# ---------------------------------------------------------------------------
+# Pure dedup helper
+# ---------------------------------------------------------------------------
+
+
+class TestDedupRecalledTexts:
+    def test_exact_restatements_collapse_to_first(self):
+        out = _dedup_recalled_texts([
+            "user prefers dark mode",
+            "user prefers dark mode",
+            "user prefers dark mode",
+        ])
+        assert out == ["user prefers dark mode"]
+
+    def test_near_identical_rephrasing_collapses(self):
+        out = _dedup_recalled_texts([
+            "user prefers dark mode",
+            "user prefers the dark color scheme",
+        ])
+        assert out == ["user prefers dark mode"]
+
+    def test_distinct_facts_are_all_kept(self):
+        out = _dedup_recalled_texts([
+            "user prefers dark mode",
+            "the project uses a SQLite database",
+            "team meets on wednesdays",
+        ])
+        assert len(out) == 3
+
+    def test_contradictory_near_duplicates_are_both_kept(self):
+        # Near-identical but opposite polarity — a contradiction, not a restatement.
+        out = _dedup_recalled_texts([
+            "user prefers dark mode",
+            "user does not prefer dark mode",
+        ])
+        assert len(out) == 2
+
+    def test_negation_spelling_variants_do_not_merge(self):
+        out = _dedup_recalled_texts([
+            "user likes dark mode",
+            "user doesn't like dark mode",
+        ])
+        assert len(out) == 2
+
+    def test_order_is_preserved_first_wins(self):
+        out = _dedup_recalled_texts([
+            "first fact about cats",
+            "second fact about dogs",
+            "first fact about cats",  # duplicate of first, later — dropped
+        ])
+        assert out == ["first fact about cats", "second fact about dogs"]
+
+
+# ---------------------------------------------------------------------------
+# Integration: dedup runs on both recall paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def provider(tmp_path, monkeypatch):
+    from pathlib import Path
+
+    config = {
+        "mode": "cloud",
+        "apiKey": "test-key",
+        "api_url": "http://localhost:9999",
+        "bank_id": "test-bank",
+        "budget": "mid",
+        "memory_mode": "hybrid",
+    }
+    config_path = tmp_path / "hindsight" / "config.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps(config))
+
+    monkeypatch.setattr(
+        "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+    )
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "user-home"))
+
+    p = HindsightMemoryProvider()
+    p.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
+
+    from unittest.mock import AsyncMock
+
+    client = SimpleNamespace()
+    client.arecall = AsyncMock(
+        return_value=SimpleNamespace(
+            results=[
+                SimpleNamespace(text="user prefers dark mode"),
+                SimpleNamespace(text="user prefers dark mode"),
+                SimpleNamespace(text="user prefers dark mode"),
+            ]
+        )
+    )
+    p._client = client
+    return p
+
+
+class TestRecallToolDedup:
+    def test_recall_tool_dedupes_restated_facts(self, provider):
+        result = json.loads(provider.handle_tool_call("hindsight_recall", {"query": "dark"}))
+        assert result["result"] == "1. user prefers dark mode"
+        assert result["result"].count("dark mode") == 1
+
+
+class TestRecallAutoInjectionDedup:
+    def test_auto_injection_dedupes_and_collapses_other_facts(self, provider):
+        # Rework the mock to return two distinct + one duplicate.
+        from unittest.mock import AsyncMock
+
+        provider._client.arecall = AsyncMock(
+            return_value=SimpleNamespace(
+                results=[
+                    SimpleNamespace(text="fact alpha"),
+                    SimpleNamespace(text="fact alpha"),
+                    SimpleNamespace(text="fact beta"),
+                ]
+            )
+        )
+        res = provider._do_recall("alpha")
+        assert isinstance(res, _RecallResult)
+        assert res.count == 2  # fact alpha collapsed to 1, fact beta kept
+        assert res.text.count("fact alpha") == 1
+        assert res.text.count("fact beta") == 1
+
+    def test_auto_injection_keeps_contradictions(self, provider):
+        from unittest.mock import AsyncMock
+
+        provider._client.arecall = AsyncMock(
+            return_value=SimpleNamespace(
+                results=[
+                    SimpleNamespace(text="user prefers dark mode"),
+                    SimpleNamespace(text="user does not prefer dark mode"),
+                ]
+            )
+        )
+        res = provider._do_recall("dark")
+        assert res.count == 2  # contradiction preserved — no merge
+        assert "does not prefer" in res.text
+        assert "prefers dark" in res.text


### PR DESCRIPTION
## What

Recall injects the same fact restated N times. With a low `retain_every_n` (e.g. 1), a judgement a user restates across turns gets stored as several near-identical `world` facts, and recall then injects **all** of them. Measured on production Hindsight banks, duplicate-heavy queries lose **39–52%** of recalled rows to restatements, while diverse queries barely move — exactly the shape you want from a dedup pass.

Implements #88471.

## Why

Beyond token cost, high repetition actively degrades the channel: the reporter's agent nearly ignored a correct injected fact because it had just argued the opposite, and published a conclusion built on a memory it had reason to distrust. The noise trains the agent not to trust recalled memory.

The two existing dedup layers can't fix this:
- extraction dedupes *within* one call and is blind *across* calls
- Hindsight's own `consolidation_dedup_threshold` compares observation-to-observation only — raw identical facts are never merged

## Approach

Dedup at **recall-formatting time**, in both recall paths:

1. `_do_recall()` — the auto-recall/prefetch injection path
2. the `hindsight_recall` tool branch

A new module-level helper set collapses near-identical restatements:

- **`_recall_similarity(a, b)`** — containment-based similarity (max directional overlap of token sets): order-insensitive, so a reordered / lightly-rephrased restatement matches (e.g. `"user prefers dark mode"` vs `"the user prefers dark mode"`).
- **`_dedup_recalled_texts(texts)`** — first-wins, order-preserving: each fact is kept unless a previously-kept fact already represents it.
- **Negation guard** — if two near-duplicates carry *opposite* negation polarity (e.g. `"user likes dark mode"` vs `"user doesn't like dark mode"`), they assert opposite things: **both are kept** — a contradiction is never merged into a single corrupted fact.

The recalled count (`_RecallResult.count` / the tool's result) now reflects the deduplicated set, so the deterministic recall indicator stays accurate.

## Tests

`tests/plugins/memory/test_hindsight_recall_dedup.py` — 12 tests:
- similarity helper: identical = 1.0, reordering still 1.0, distinct facts far apart
- dedup helper: exact restatements collapse to first; near-identical rephrasing collapses; distinct facts all kept; order preserved (first-wins); **contradictions and negation-variant pairs are both kept**
- integration on both paths: `hindsight_recall` tool dedupes; `_do_recall` auto-injection dedupes and collapses duplicates while keeping distinct facts; contradictions preserved inject-time

Verified: `uv run --extra dev python -m pytest tests/plugins/memory/test_hindsight_recall_dedup.py` → **12 passed**. Existing hindsight suite: 91 pass, 6 fail — but those 6 fail identically on clean `main` (they need the `hindsight_client_api` lazy dep, absent in this env) and are unrelated to this change (verified by stashing). `ruff check` clean on both files.

## Risk

Low. Display/context-only: dedup happens at recall formatting, never mutates stored memory. First-wins preserves order, and the negation guard prevents the one dangerous case (merging a contradiction).
