### PR TITLE
feat(cli): add 'list' and 'status' aliases for config, mcp, and memory subcommands (#89115)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5589,7 +5589,7 @@ def config_command(args):
     """Handle config subcommands."""
     subcmd = getattr(args, 'config_command', None)
     
-    if subcmd is None or subcmd == "show":
+    if subcmd is None or subcmd in {"show", "list", "ls"}:
         show_config()
     
     elif subcmd == "edit":

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -1126,6 +1126,7 @@ def mcp_command(args):
         "rm": cmd_mcp_remove,
         "list": cmd_mcp_list,
         "ls": cmd_mcp_list,
+        "status": cmd_mcp_list,
         "test": cmd_mcp_test,
         "configure": cmd_mcp_configure,
         "config": cmd_mcp_configure,

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -578,7 +578,7 @@ def memory_command(args) -> None:
             cmd_setup_provider(provider)
         else:
             cmd_setup(args)
-    elif sub == "status":
+    elif sub in {"status", "list", "ls", "show"}:
         cmd_status(args)
     else:
         cmd_status(args)

--- a/hermes_cli/subcommands/config.py
+++ b/hermes_cli/subcommands/config.py
@@ -22,7 +22,9 @@ def build_config_parser(subparsers, *, cmd_config: Callable) -> None:
     config_subparsers = config_parser.add_subparsers(dest="config_command")
 
     # config show (default)
-    config_subparsers.add_parser("show", help="Show current configuration")
+    config_subparsers.add_parser(
+        "show", aliases=["list", "ls"], help="Show current configuration"
+    )
 
     # config edit
     config_subparsers.add_parser("edit", help="Open config file in editor")

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -75,7 +75,7 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
     mcp_rm_p = mcp_sub.add_parser("remove", aliases=["rm"], help="Remove an MCP server")
     mcp_rm_p.add_argument("name", help="Server name to remove")
 
-    mcp_sub.add_parser("list", aliases=["ls"], help="List configured MCP servers")
+    mcp_sub.add_parser("list", aliases=["ls", "status"], help="List configured MCP servers")
 
     mcp_test_p = mcp_sub.add_parser("test", help="Test MCP server connection")
     mcp_test_p.add_argument("name", help="Server name to test")

--- a/hermes_cli/subcommands/memory.py
+++ b/hermes_cli/subcommands/memory.py
@@ -32,7 +32,11 @@ def build_memory_parser(subparsers, *, cmd_memory: Callable) -> None:
         default=None,
         help="Provider to configure directly (e.g. honcho), skipping the picker",
     )
-    memory_sub.add_parser("status", help="Show current memory provider config")
+    memory_sub.add_parser(
+        "status",
+        aliases=["list", "ls", "show"],
+        help="Show current memory provider config",
+    )
     memory_sub.add_parser("off", help="Disable external provider (built-in only)")
     _reset_parser = memory_sub.add_parser(
         "reset",

--- a/tests/cron/test_parallel_pool.py
+++ b/tests/cron/test_parallel_pool.py
@@ -302,18 +302,22 @@ class TestSequentialPool:
             "workdir": str(tmp_path),  # makes it sequential
         }
 
+        done_event = threading.Event()
         barrier = threading.Barrier(2, timeout=5)
 
         def slow_run(j, *, defer_agent_teardown=None, **_kw):
             barrier.wait()
             return True, "out", "resp", None
 
+        def deliver_done(*_a, **_kw):
+            done_event.set()
+
         monkeypatch.setattr(sched, "get_due_jobs", lambda: [job])
         monkeypatch.setattr(sched, "claim_job_for_fire", lambda *_a, **_kw: True)
         monkeypatch.setattr(sched, "run_job", slow_run)
         monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: "/tmp/out")
         monkeypatch.setattr(sched, "mark_job_run", lambda *_a, **_kw: None)
-        monkeypatch.setattr(sched, "_deliver_result", lambda *_a, **_kw: None)
+        monkeypatch.setattr(sched, "_deliver_result", deliver_done)
 
         start = time.monotonic()
         n = sched.tick(verbose=False, sync=False)
@@ -323,7 +327,7 @@ class TestSequentialPool:
         assert elapsed < 1.0  # did NOT block on the slow workdir job
 
         barrier.wait()
-        time.sleep(0.1)
+        assert done_event.wait(timeout=5)
         sched._shutdown_parallel_pool()
 
     def test_sequential_running_guard_prevents_double_dispatch(self, tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_subcommand_aliases.py
+++ b/tests/hermes_cli/test_subcommand_aliases.py
@@ -1,0 +1,75 @@
+"""Tests for CLI subcommand aliases (config list, mcp status, memory list/show)."""
+
+import argparse
+from unittest.mock import patch
+
+from hermes_cli.subcommands.config import build_config_parser
+from hermes_cli.subcommands.mcp import build_mcp_parser
+from hermes_cli.subcommands.memory import build_memory_parser
+
+
+def test_config_show_aliases():
+    """Verify that hermes config list and hermes config ls parse to the show action."""
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    build_config_parser(subparsers, cmd_config=lambda args: None)
+
+    for alias in ["show", "list", "ls"]:
+        args = parser.parse_args(["config", alias])
+        assert args.command == "config"
+        assert args.config_command == alias
+
+
+def test_mcp_list_aliases():
+    """Verify that hermes mcp status and hermes mcp ls parse to mcp list actions."""
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    build_mcp_parser(subparsers, cmd_mcp=lambda args: None)
+
+    for alias in ["list", "ls", "status"]:
+        args = parser.parse_args(["mcp", alias])
+        assert args.command == "mcp"
+        assert args.mcp_action == alias
+
+
+def test_memory_status_aliases():
+    """Verify that hermes memory list, ls, and show parse to memory status actions."""
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    build_memory_parser(subparsers, cmd_memory=lambda args: None)
+
+    for alias in ["status", "list", "ls", "show"]:
+        args = parser.parse_args(["memory", alias])
+        assert args.command == "memory"
+        assert args.memory_command == alias
+
+
+def test_config_command_dispatcher_with_list_alias():
+    """Verify that config_command dispatches list to show_config."""
+    from hermes_cli import config as config_mod
+
+    with patch.object(config_mod, "show_config") as mock_show:
+        config_mod.config_command(argparse.Namespace(config_command="list"))
+        mock_show.assert_called_once()
+
+    with patch.object(config_mod, "show_config") as mock_show:
+        config_mod.config_command(argparse.Namespace(config_command="ls"))
+        mock_show.assert_called_once()
+
+
+def test_mcp_command_dispatcher_with_status_alias():
+    """Verify that mcp_command dispatches status to cmd_mcp_list."""
+    from hermes_cli import mcp_config
+
+    with patch.object(mcp_config, "cmd_mcp_list") as mock_list:
+        mcp_config.mcp_command(argparse.Namespace(mcp_action="status"))
+        mock_list.assert_called_once()
+
+
+def test_memory_command_dispatcher_with_list_alias():
+    """Verify that memory_command dispatches list to cmd_status."""
+    from hermes_cli import memory_setup
+
+    with patch.object(memory_setup, "cmd_status") as mock_status:
+        memory_setup.memory_command(argparse.Namespace(memory_command="list"))
+        mock_status.assert_called_once()


### PR DESCRIPTION
## Summary
Fixes #89115.

CLI subcommands had inconsistent naming conventions: some subcommands accepted `list` (e.g., `hermes sessions list`, `hermes plugins list`, `hermes skills list`, `hermes mcp list`) while others threw invalid choice errors when users tried common synonyms (`hermes config list`, `hermes mcp status`, `hermes memory list`).

## The resulting alias matrix

Deliberately asymmetric — each command keeps its existing canonical verb and only gains the synonyms a user would plausibly reach for. It is **not** "every command gets every spelling":

| command | canonical | added aliases |
|---|---|---|
| `hermes config` | `show` | `list`, `ls` |
| `hermes mcp` | `list` | `ls`, `status` |
| `hermes memory` | `status` | `list`, `ls`, `show` |

`config` gains no `status` (there is no config health to report) and `mcp` gains no `show` (it lists servers, it does not render one).

## Changes
- **`hermes config`**: add `list` and `ls` aliases to `hermes config show` parser in `hermes_cli/subcommands/config.py` and handle them in `hermes_cli/config.py:config_command`.
- **`hermes mcp`**: add `status` alias to `hermes mcp list` parser in `hermes_cli/subcommands/mcp.py` and dispatch it in `hermes_cli/mcp_config.py:mcp_command`.
- **`hermes memory`**: add `list`, `ls`, `show` aliases to `hermes memory status` parser in `hermes_cli/subcommands/memory.py` and route them in `hermes_cli/memory_setup.py:memory_command`.
- **Tests**: add `tests/hermes_cli/test_subcommand_aliases.py` covering argparse parsing and dispatcher delegation for all added aliases.
- **Unrelated, carried here:** `tests/cron/test_parallel_pool.py` swaps a `sleep` for `done_event.wait`, making that barrier test deterministic instead of timing-dependent. It is not alias work — it was in the way of a clean local run and is trivially separable if you would rather it landed on its own.

## Verification
- `pytest tests/hermes_cli/test_subcommand_aliases.py tests/hermes_cli/test_mcp_config.py tests/hermes_cli/test_config.py` passed (100%).
- GPG signed on Mac and `git diff --check` clean.