### PR TITLE
fix(gateway): allow persisted DM /resume across a flipped user_id namespace (#89123)

### DIFF
--- a/gateway/slash_commands_session.py
+++ b/gateway/slash_commands_session.py
@@ -330,6 +330,18 @@ class GatewaySessionCommandsMixin:
             # A no-chat_id DM is keyed PURELY on the participant (alt-keyed caller fails closed).
             if caller_keys_on_alt and not (row_chat and caller_chat):
                 return False
+            # A DM WITH a chat_id is keyed purely on chat_id (build_session_key appends chat_id, never
+            # the participant, for DMs that carry one) and thread equality is proven by origin above.
+            # A p2p DM is 1:1, so an equal non-blank chat_id proves the same owner even when the
+            # persisted user_id is a stale snapshot from a DIFFERENT id namespace — Feishu flips
+            # source.user_id from the app-scoped open_id to the tenant-scoped user_id once the contacts
+            # scope is granted, and reset_session persists the pre-grant open_id, so row_uid never
+            # equals the runtime caller_uid (#89123). This mirrors the live-origin _same_origin_chat
+            # branch, which already treats an equal non-empty DM chat_id as sufficient.
+            if row_chat and caller_chat and row_chat == caller_chat:
+                return True
+            # No chat_id on one/both sides: keyed on the participant; require the same owner AND the
+            # same (possibly-blank) chat_id, exactly as before.
             return bool(row_uid) and row_uid == caller_uid and row_chat == caller_chat
         # Non-DM: both sides must carry chat_id and match (legacy NULL-chat rows fail closed).
         if not (row_chat and caller_chat and row_chat == caller_chat):

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -846,6 +846,43 @@ class TestHandleSessionsCommand:
         tg_db.close()
 
     @pytest.mark.asyncio
+    async def test_resume_persisted_dm_allows_same_chat_across_user_id_namespace(
+        self, tmp_path
+    ):
+        """#89123: Feishu flips ``source.user_id`` from the app-scoped open_id to
+        the tenant-scoped user_id once the contacts scope is granted, and
+        ``reset_session`` persists the pre-grant open_id into the new row. The
+        persisted DM row therefore stores a stale user_id that never equals the
+        runtime caller's — but a DM WITH a chat_id is keyed purely on chat_id
+        (``build_session_key`` appends chat_id, never the participant, for DMs
+        that carry one), and a p2p DM is 1:1, so an equal non-blank chat_id
+        proves the same owner. The persisted fallback must allow it (mirroring
+        the live-origin ``_same_origin_chat`` branch), while a DIFFERENT DM chat
+        stays blocked."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        # Row created via reset_session inherits the stale pre-grant open_id.
+        db.create_session("feishu_dm", "feishu", user_id="ou_stale_openid",
+                          chat_id="oc_dm_chat", chat_type="dm")
+        runner = _make_runner(session_db=db)
+        runner._gateway_session_origin_for_id = lambda sid: None  # persisted-only
+
+        # Runtime caller in the SAME DM chat but with the post-grant tenant
+        # user_id (different id namespace from the persisted open_id).
+        caller = SessionSource(platform=Platform.FEISHU, chat_id="oc_dm_chat",
+                               chat_type="dm", user_id="b86c5474")
+        assert await runner._resume_target_allowed(
+            caller, "feishu_dm", allow_override=False) is True
+
+        # A DIFFERENT DM chat stays blocked even with the same runtime user_id —
+        # equal chat_id is required, so this is not an ownership widening.
+        other = SessionSource(platform=Platform.FEISHU, chat_id="oc_other_chat",
+                              chat_type="dm", user_id="b86c5474")
+        assert await runner._resume_target_allowed(
+            other, "feishu_dm", allow_override=False) is False
+        db.close()
+
+    @pytest.mark.asyncio
     async def test_gateway_dispatches_sessions_command(self, tmp_path):
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")


### PR DESCRIPTION
## Summary

Fixes #89123. On Feishu (Lark) DMs, `/resume <title>` is deterministically blocked with:

```
⚠️ /resume blocked: '…' belongs to a different user or chat. You can only resume sessions from this chat.
```

even for the session's own owner in the same DM. `/resume` works on Telegram and elsewhere.

## Root cause

The persisted DB-branch of `_resume_target_allowed` (`gateway/slash_commands.py`) required `row_uid == caller_uid` for DM sessions, but Feishu changes `SessionSource.user_id` for the *same human* over time:

- Before the operator grants the bot the contacts/directory scope, message events carry only the app-scoped `open_id` (`ou_…`).
- After the grant, events carry the tenant-scoped `user_id` (a short hash).

`reset_session` copies the old entry's origin into every `/new` row, so the persisted `user_id` is the stale pre-grant `open_id` while the runtime caller now presents the tenant `user_id` — the two never compare equal, and resume fails closed.

This is comparing **two different id namespaces** as one key, not an ownership violation. A DM **with** a `chat_id` is keyed purely on `chat_id` — `build_session_key` appends `chat_id` (never the participant) for DMs that carry one — and a p2p DM is 1:1, so an equal non-blank `chat_id` already proves the same owner. The **live-origin** guard `_same_origin_chat` already reflects this (returns `True` for an equal non-empty DM `chat_id`); the **persisted** fallback was simply out of lock-step with it.

## Fix

In the persisted DM tail, short-circuit to allowed when both sides carry an equal non-blank `chat_id` (thread equality is already proven by `origin_ok` just above), mirroring `_same_origin_chat`. Everything else is unchanged: a different or missing `chat_id` still falls through to the existing `row_uid == caller_uid` owner check, so no-`chat_id` DMs, `user_id_alt`-keyed callers, and cross-chat resumes all stay fail-closed.

The change is a pure additive branch — no existing pass/fail path is altered except the equal-non-blank-`chat_id` DM case that was previously (wrongly) gated on a stale `user_id`.

## Test

`tests/gateway/test_resume_command.py::TestResumeAuthorizationPersistedFallback::test_resume_persisted_dm_allows_same_chat_across_user_id_namespace`:

- persisted DM row stores a stale `open_id`; runtime caller in the **same** DM chat with the post-grant tenant `user_id` → resume **allowed**;
- a **different** DM chat with the same runtime `user_id` → still **blocked** (equal `chat_id` is required — not an ownership widening).

Fails without the fix (`ou_stale_openid != b86c5474`), passes with it. Full `test_resume_command.py` (28 tests) green; preflight gates pass.

## Relation to other PRs

Distinct from #67945 / #68024, which relax **thread_id** comparison for DM sessions — a different root cause the issue explicitly separates. This PR touches only the **user_id-namespace** comparison in the persisted DM tail and is complementary to that work.

Credit to the issue author for the precise root-cause analysis and the minimal-fix direction.
