### PR TITLE
fix(computer-use): bind typing to captured elements

### DIFF
--- a/contributors/emails/paccloud@gmail.com
+++ b/contributors/emails/paccloud@gmail.com
@@ -1,0 +1,2 @@
+paccloud
+# PR #89152 computer-use element-bound typing

--- a/tests/tools/test_computer_use_cua_0_9.py
+++ b/tests/tools/test_computer_use_cua_0_9.py
@@ -191,13 +191,9 @@ def test_invalid_delivery_mode_is_rejected_before_driver_call():
 
 
 def test_type_text_targets_captured_element_with_snapshot_token():
-    class _TokenSession(_FakeSession):
-        def supports_capability(
-            self, capability: str, tool: Optional[str] = None
-        ) -> bool:
-            return capability == "accessibility.element_tokens" and tool == "type_text"
-
-    session = _TokenSession(input_properties={"type_text": {"element_index"}})
+    session = _FakeSession(
+        input_properties={"type_text": {"element_index", "element_token"}}
+    )
     backend = _make_backend(session)
     backend._snapshot_tokens = {7: "s12345678:7"}
 

--- a/tests/tools/test_computer_use_cua_0_9.py
+++ b/tests/tools/test_computer_use_cua_0_9.py
@@ -190,6 +190,46 @@ def test_invalid_delivery_mode_is_rejected_before_driver_call():
     assert session.calls == []
 
 
+def test_type_text_targets_captured_element_with_snapshot_token():
+    class _TokenSession(_FakeSession):
+        def supports_capability(
+            self, capability: str, tool: Optional[str] = None
+        ) -> bool:
+            return capability == "accessibility.element_tokens" and tool == "type_text"
+
+    session = _TokenSession(input_properties={"type_text": {"element_index"}})
+    backend = _make_backend(session)
+    backend._snapshot_tokens = {7: "s12345678:7"}
+
+    result = backend.type_text("session-bound", element=7)
+
+    assert result.ok is True
+    assert session.calls == [
+        (
+            "type_text",
+            {
+                "pid": 42,
+                "window_id": 7,
+                "text": "session-bound",
+                "element_index": 7,
+                "element_token": "s12345678:7",
+                "session": "hermes-session",
+            },
+        )
+    ]
+
+
+def test_type_text_element_target_fails_closed_on_older_driver_schema():
+    session = _FakeSession()
+    backend = _make_backend(session)
+
+    result = backend.type_text("session-bound", element=7)
+
+    assert result.ok is False
+    assert result.code == "element_type_unsupported"
+    assert session.calls == []
+
+
 # ---------------------------------------------------------------------------
 # Deterministic verdict precedence and backend isolation
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_computer_use_input_target_guard.py
+++ b/tests/tools/test_computer_use_input_target_guard.py
@@ -83,6 +83,27 @@ def test_type_with_matching_app_reaches_backend():
     assert out.get("ok") is True
 
 
+def test_type_forwards_captured_element_to_backend():
+    backend = _backend("kate")
+    calls = {}
+
+    def _type_text(text, **kw):
+        calls["text"] = text
+        calls.update(kw)
+        return _fake_action_result()
+
+    backend.type_text = _type_text
+    out = _dispatch_result(
+        backend,
+        "type",
+        {"text": "session-bound", "element": 7, "app": "kate"},
+    )
+
+    assert calls["text"] == "session-bound"
+    assert calls["element"] == 7
+    assert out.get("ok") is True
+
+
 def test_type_without_app_unchanged():
     """Legacy flows that never pass app= keep working (fail open)."""
     backend = _backend("kcalc")

--- a/tools/computer_use/backend.py
+++ b/tools/computer_use/backend.py
@@ -179,7 +179,8 @@ class ComputerUseBackend(ABC):
 
     # ── Keyboard ────────────────────────────────────────────────────
     @abstractmethod
-    def type_text(self, text: str, *, delivery_mode: Optional[str] = None,
+    def type_text(self, text: str, *, element: Optional[int] = None,
+                  delivery_mode: Optional[str] = None,
                   bring_to_front: bool = False) -> ActionResult: ...
 
     @abstractmethod

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -3911,9 +3911,11 @@ class CuaDriverBackend(ComputerUseBackend):
            supplied. Returns an explicit 'stale' error if the snapshot
            has been superseded."
 
-        Gated on the per-tool capability claim so we don't send the
-        field to drivers that predate the surface (which would reject
-        the schema with `additionalProperties: false`).
+        Gated on either the per-tool capability claim or the live action schema's
+        `element_token` property. cua-driver 0.20 exposes the schema property
+        without the legacy capability token; older drivers may advertise only
+        the capability. Requiring both would send a bare index to current
+        drivers, which correctly fail closed once snapshots are mandatory.
         """
         idx = args.get("element_index")
         if not isinstance(idx, int):
@@ -3921,9 +3923,10 @@ class CuaDriverBackend(ComputerUseBackend):
         token = self._snapshot_tokens.get(idx)
         if not token:
             return
-        if not self._session.supports_capability(
+        supports_token = self._session.supports_capability(
             "accessibility.element_tokens", tool=tool
-        ):
+        ) or self._session.supports_input_property(tool, "element_token")
+        if not supports_token:
             return
         args["element_token"] = token
 

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -3427,7 +3427,8 @@ class CuaDriverBackend(ComputerUseBackend):
         return self._run_input_action("scroll", args, delivery_mode, bring_to_front)
 
     # ── Keyboard ───────────────────────────────────────────────────
-    def type_text(self, text: str, *, delivery_mode: Optional[str] = None,
+    def type_text(self, text: str, *, element: Optional[int] = None,
+                  delivery_mode: Optional[str] = None,
                   bring_to_front: bool = False) -> ActionResult:
         pid = self._active_pid
         window_id = self._active_window_id
@@ -3435,6 +3436,19 @@ class CuaDriverBackend(ComputerUseBackend):
             return ActionResult(ok=False, action="type_text",
                                 message="No active window — call capture() first.")
         args: Dict[str, Any] = {"pid": pid, "window_id": window_id, "text": text}
+        if element is not None:
+            if not self._session.supports_input_property("type_text", "element_index"):
+                return ActionResult(
+                    ok=False,
+                    action="type_text",
+                    code="element_type_unsupported",
+                    message=(
+                        "The connected cua-driver does not support element-bound typing. "
+                        "Update cua-driver or use a separately verified input route; "
+                        "Hermes will not silently redirect text to the focused control."
+                    ),
+                )
+            args["element_index"] = element
         return self._run_input_action("type_text", args, delivery_mode, bring_to_front)
 
     def key(self, keys: str, *, delivery_mode: Optional[str] = None,

--- a/tools/computer_use/schema.py
+++ b/tools/computer_use/schema.py
@@ -134,7 +134,9 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
                 "description": (
                     "The 1-based SOM index returned by the last "
                     "`capture(mode='som')` call. Strongly preferred over "
-                    "raw coordinates."
+                    "raw coordinates. For action='type', binds the text "
+                    "insertion to that captured field so a focus change cannot "
+                    "silently redirect typing to another control."
                 ),
             },
             "coordinate": {

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -902,7 +902,7 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
         return _maybe_follow_capture(backend, res, capture_after)
 
     if action == "type":
-        res = backend.type_text(args.get("text", ""),
+        res = backend.type_text(args.get("text", ""), element=args.get("element"),
                                 delivery_mode=delivery_mode, bring_to_front=bring_to_front)
         return _maybe_follow_capture(backend, res, capture_after)
 


### PR DESCRIPTION
## What does this PR do?

`computer_use(action="type", element=N, ...)` accepted a captured SOM element but silently dropped it before calling cua-driver. Typing therefore targeted the process/window's currently focused control rather than the field the agent selected.

For long synthesized input in an Electron app, a focus/session switch could redirect the remaining characters into a newly focused composer. This was reproduced while creating a compact Hermes Desktop handoff: switching fresh chats during a long type action left partial/garbled handoff text in other session composers.

This PR binds typing to the captured element identity:

- threads `element` through the public dispatch and backend interface;
- sends `element_index` to cua-driver;
- reuses the existing `_action()` token attachment so the last capture's opaque `element_token` accompanies the call and stale targets fail closed;
- discovers token support from either the legacy capability claim or the live `element_token` input property used by cua-driver 0.20;
- refuses element-bound typing on older driver schemas instead of silently downgrading to focus-based typing;
- documents the `type` element contract in the public tool schema.

## Related issue

Closes #89151

Related symptom family, distinct root cause: #85691, #66662, #66661, #74133, #46194.

## Root cause

The public tool schema exposed `element`, but the `type` branch in `tools/computer_use/tool.py` called:

```python
backend.type_text(text, delivery_mode=..., bring_to_front=...)
```

`CuaDriverBackend.type_text()` then sent only:

```python
{"pid": pid, "window_id": window_id, "text": text}
```

cua-driver 0.20.0 already supports `type_text.element_index`, `element_token`, and stale snapshot rejection. Hermes simply never forwarded the target.

## Test-driven verification

The two new regression tests failed before the production change:

- public dispatch did not pass `element` to `backend.type_text()`;
- `CuaDriverBackend.type_text()` rejected the wished-for `element` parameter.

A third RED/GREEN test verifies compatibility behavior: an element target on an older driver schema must fail closed with `element_type_unsupported` and make no driver call.

Commands run from the isolated worktree:

```text
.venv/bin/pytest \
  tests/tools/test_computer_use_input_target_guard.py \
  tests/tools/test_computer_use_cua_0_9.py -q
# 56 passed

.venv/bin/pytest tests/tools/test_computer_use*.py -q \
  -k 'not test_linux_default_capture_skips_gnome_shell_helper'
# 290 passed, 2 skipped, 1 deselected

.venv/bin/ruff check \
  tools/computer_use/backend.py \
  tools/computer_use/cua_backend.py \
  tools/computer_use/tool.py \
  tools/computer_use/schema.py \
  tests/tools/test_computer_use_input_target_guard.py \
  tests/tools/test_computer_use_cua_0_9.py
# All checks passed

python3 -m compileall -q tools/computer_use \
  tests/tools/test_computer_use_input_target_guard.py \
  tests/tools/test_computer_use_cua_0_9.py

git diff --check
```

The deselected test is an unrelated existing Linux-default-capture assertion that fails on macOS because it expects Linux-only shell-window filtering without platform-gating. It also fails alone on untouched `origin/main`; no production or test file in this PR touches that path.

### Manual integration test

Using the patched worktree backend with the installed cua-driver 0.20.0, I opened a disposable TextEdit document, captured its native `AXTextArea`, and invoked `type_text(..., element=<captured index>)`. The live result was:

```json
{
  "capture_app": "TextEdit",
  "field_role": "AXTextArea",
  "element_token_present": true,
  "type_ok": true,
  "type_effect": "confirmed"
}
```

The first manual attempt exposed the schema-discovery compatibility gap: current cua-driver advertises `element_token` in the live action schema without the legacy capability claim. A RED/GREEN regression and the schema-property fallback were added before the successful run above.

Additional contributor-guide checks:

```text
scripts/run_tests.sh <two targeted files> -q
# 56 passed through the hermetic per-file runner

python scripts/check-windows-footguns.py --diff origin/main
# No Windows footguns found

python scripts/audit_pr_attribution.py
# All contributor emails mapped
```

## Environment

- macOS 26.5.2 arm64
- Hermes main `e02d1e41fc`
- Hermes Desktop v0.20.4
- cua-driver 0.20.0
- Python 3.11 contributor venv

## Type of change

- [x] Bug fix
- [x] Regression tests
- [x] Cross-version compatibility guard

## Checklist

- [x] Isolated branch/worktree from current `origin/main`
- [x] No unrelated local changes included
- [x] Conventional commit message
- [x] Tests written and observed failing before implementation
- [x] Targeted and broad computer-use suites run
- [x] Blocking ruff checks pass
- [x] No config, secrets, generated media, or user data included
