### PR TITLE
fix(doctor): keep keyless OAuth checks read-only

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2852,6 +2852,54 @@ def resolve_qwen_runtime_credentials(
     }
 
 
+def get_qwen_auth_status_local() -> Dict[str, Any]:
+    """Return Qwen OAuth status without refreshing or writing credentials.
+
+    `hermes doctor` is a read-only diagnostic command, so it needs a structural
+    snapshot of the Qwen CLI token file rather than the runtime credential
+    resolver, which may refresh expired tokens via HTTP POST and rewrite the
+    token file.
+    """
+    auth_path = _qwen_cli_auth_path()
+    try:
+        tokens = _read_qwen_cli_tokens()
+        access_token = str(tokens.get("access_token", "") or "").strip()
+        if not access_token:
+            raise AuthError(
+                "Qwen OAuth access token missing. Re-run 'qwen auth qwen-oauth'.",
+                provider="qwen-oauth",
+                code="qwen_access_token_missing",
+            )
+        expires_at_ms = tokens.get("expiry_date")
+        if _qwen_access_token_is_expiring(expires_at_ms, skew_seconds=0):
+            return {
+                "logged_in": False,
+                "auth_file": str(auth_path),
+                "source": "qwen-cli",
+                "expires_at_ms": expires_at_ms,
+                "error": "Qwen OAuth access token is expired. Run `hermes auth status qwen-oauth` or `qwen auth qwen-oauth` to refresh.",
+            }
+        return {
+            "logged_in": True,
+            "auth_file": str(auth_path),
+            "source": "qwen-cli",
+            "expires_at_ms": expires_at_ms,
+        }
+    except AuthError as exc:
+        return {
+            "logged_in": False,
+            "auth_file": str(auth_path),
+            "error": str(exc),
+            "code": exc.code,
+        }
+    except Exception as exc:
+        return {
+            "logged_in": False,
+            "auth_file": str(auth_path),
+            "error": str(exc),
+        }
+
+
 def get_qwen_auth_status() -> Dict[str, Any]:
     auth_path = _qwen_cli_auth_path()
     try:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -312,6 +312,44 @@ def _apply_doctor_tool_availability_overrides(available: list[str], unavailable:
     return updated_available, updated_unavailable
 
 
+def _safe_oauth_status_logged_in(status_fn) -> bool:
+    """Best-effort OAuth status check for read-only doctor probes."""
+    try:
+        return bool((status_fn() or {}).get("logged_in"))
+    except Exception:
+        return False
+
+
+def _oauth_auth_configured_for_doctor() -> bool:
+    """Return True when any supported OAuth provider has a local login.
+
+    This must stay side-effect-free: doctor is a read-only diagnostic command.
+    In particular, use the refresh-free Nous local snapshot and the refresh-free
+    Qwen local token-file snapshot instead of runtime credential resolvers.
+    """
+    try:
+        from hermes_cli.auth import (
+            get_codex_auth_status,
+            get_minimax_oauth_auth_status,
+            get_nous_auth_status_local,
+            get_qwen_auth_status_local,
+            get_xai_oauth_auth_status,
+        )
+    except Exception:
+        return False
+
+    return any(
+        _safe_oauth_status_logged_in(status)
+        for status in (
+            get_nous_auth_status_local,
+            get_codex_auth_status,
+            get_minimax_oauth_auth_status,
+            get_xai_oauth_auth_status,
+            get_qwen_auth_status_local,
+        )
+    )
+
+
 def _has_healthy_oauth_fallback_for_apikey_provider(provider_label: str) -> bool:
     """Return True when a direct API-key probe failure is non-blocking.
 
@@ -324,13 +362,13 @@ def _has_healthy_oauth_fallback_for_apikey_provider(provider_label: str) -> bool
     if normalized == "minimax":
         try:
             from hermes_cli.auth import get_minimax_oauth_auth_status
-            return bool((get_minimax_oauth_auth_status() or {}).get("logged_in"))
+            return _safe_oauth_status_logged_in(get_minimax_oauth_auth_status)
         except Exception:
             return False
     if normalized == "xai":
         try:
             from hermes_cli.auth import get_xai_oauth_auth_status
-            return bool((get_xai_oauth_auth_status() or {}).get("logged_in"))
+            return _safe_oauth_status_logged_in(get_xai_oauth_auth_status)
         except Exception:
             return False
     return False
@@ -1151,6 +1189,8 @@ def run_doctor(args):
             content = env_path.read_text(encoding="latin-1")
         if _has_provider_env_config(content):
             check_ok("API key or custom endpoint configured")
+        elif _oauth_auth_configured_for_doctor():
+            check_ok("API key or OAuth auth configured")
         else:
             check_warn(f"No API key found in {_DHH}/.env")
             issues.append("Run 'hermes setup' to configure API keys")
@@ -1598,6 +1638,7 @@ def run_doctor(args):
         from hermes_cli.auth import (
             get_nous_auth_status_local,
             get_codex_auth_status,
+            get_qwen_auth_status_local,
             get_minimax_oauth_auth_status,
         )
 
@@ -1626,6 +1667,14 @@ def run_doctor(args):
                     "(optional — only required to import tokens "
                     "from an existing Codex CLI login)"
                 )
+
+        qwen_status = get_qwen_auth_status_local()
+        if qwen_status.get("logged_in"):
+            check_ok("Qwen OAuth", "(logged in)")
+        else:
+            check_warn("Qwen OAuth", "(not logged in)")
+            if qwen_status.get("error"):
+                check_info(qwen_status["error"])
 
         minimax_status = get_minimax_oauth_auth_status()
         if minimax_status.get("logged_in"):

--- a/tests/hermes_cli/test_auth_qwen_provider.py
+++ b/tests/hermes_cli/test_auth_qwen_provider.py
@@ -24,6 +24,7 @@ from hermes_cli.auth import (
     _refresh_qwen_cli_tokens,
     resolve_qwen_runtime_credentials,
     get_qwen_auth_status,
+    get_qwen_auth_status_local,
 )
 
 
@@ -150,6 +151,31 @@ def test_get_qwen_auth_status_logged_in(qwen_env):
     assert status["logged_in"] is True
     assert status["api_key"] == "status-at"
 
+
+
+def test_get_qwen_auth_status_local_does_not_refresh_expired_token(qwen_env):
+    expired_ms = int((time.time() - 3600) * 1000)
+    tokens = _make_qwen_tokens(access_token="old-at", expiry_date=expired_ms)
+    _write_qwen_creds(qwen_env, tokens)
+
+    with patch("hermes_cli.auth._refresh_qwen_cli_tokens") as mock_refresh:
+        status = get_qwen_auth_status_local()
+
+    mock_refresh.assert_not_called()
+    assert status["logged_in"] is False
+    assert "expired" in status["error"]
+
+
+def test_get_qwen_auth_status_local_reports_fresh_token(qwen_env):
+    expires_ms = int((time.time() + 3600) * 1000)
+    tokens = _make_qwen_tokens(access_token="local-at", expiry_date=expires_ms)
+    _write_qwen_creds(qwen_env, tokens)
+
+    status = get_qwen_auth_status_local()
+
+    assert status["logged_in"] is True
+    assert status["source"] == "qwen-cli"
+    assert status["expires_at_ms"] == expires_ms
 
 def test_get_qwen_auth_status_refreshes_expired_token(qwen_env):
     expired_ms = int((time.time() - 3600) * 1000)

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1189,6 +1189,7 @@ class TestDoctorXaiOAuthStatus:
         monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {"logged_in": False})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {"logged_in": False})
         monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(_auth_mod, "get_qwen_auth_status_local", lambda: {"logged_in": False})
         monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", xai_auth_fn)
 
         buf = io.StringIO()
@@ -1231,6 +1232,7 @@ class TestDoctorXaiOAuthStatus:
         monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {"logged_in": True})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {"logged_in": False})
         monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(_auth_mod, "get_qwen_auth_status_local", lambda: {"logged_in": False})
         monkeypatch.delattr(_auth_mod, "get_xai_oauth_auth_status", raising=False)
 
         buf = io.StringIO()
@@ -1248,6 +1250,105 @@ class TestDoctorXaiOAuthStatus:
         out = self._run(monkeypatch, tmp_path, xai_auth_fn=_raise)
         assert "Auth Providers" in out
 
+
+
+def test_run_doctor_accepts_keyless_oauth_without_runtime_nous_refresh(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / ".env").write_text("# keyless OAuth setup\n", encoding="utf-8")
+    (home / "config.yaml").write_text("model:\n  provider: nous\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for key in (
+        "OPENROUTER_API_KEY",
+        "NOUS_API_KEY",
+        "OPENAI_API_KEY",
+        "MINIMAX_API_KEY",
+        "XAI_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    from hermes_cli import auth as _auth_mod
+
+    def forbidden_runtime_nous_status():
+        raise AssertionError("doctor must use the local Nous snapshot, not the runtime resolver")
+
+    monkeypatch.setattr(_auth_mod, "get_nous_auth_status", forbidden_runtime_nous_status)
+    monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {"logged_in": True})
+    monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {"logged_in": False})
+    monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {"logged_in": False})
+    monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {"logged_in": False})
+    monkeypatch.setattr(_auth_mod, "get_qwen_auth_status_local", lambda: {"logged_in": False})
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert "API key or OAuth auth configured" in out
+    assert "No API key found" not in out
+    assert "Run 'hermes setup' to configure API keys" not in out
+
+
+def test_run_doctor_accepts_qwen_only_oauth_keyless_env(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / ".env").write_text("# keyless Qwen OAuth setup\n", encoding="utf-8")
+    (home / "config.yaml").write_text("model:\n  provider: qwen-oauth\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for key in (
+        "OPENROUTER_API_KEY",
+        "NOUS_API_KEY",
+        "OPENAI_API_KEY",
+        "MINIMAX_API_KEY",
+        "XAI_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    from hermes_cli import auth as _auth_mod
+
+    monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {"logged_in": False})
+    monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {"logged_in": False})
+    monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {"logged_in": False})
+    monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {"logged_in": False})
+    monkeypatch.setattr(_auth_mod, "get_qwen_auth_status_local", lambda: {"logged_in": True})
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert "API key or OAuth auth configured" in out
+    assert "Qwen OAuth" in out
+    assert "No API key found" not in out
+    assert "Run 'hermes setup' to configure API keys" not in out
 
 # ---------------------------------------------------------------------------
 # ◆ Auth Providers — codex CLI import hint placement (issue #27975)
@@ -1284,6 +1385,7 @@ class TestDoctorCodexCliHintPlacement:
         monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {"logged_in": False})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {"logged_in": codex_logged_in})
         monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(_auth_mod, "get_qwen_auth_status_local", lambda: {"logged_in": False})
         monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {"logged_in": False})
 
         real_which = doctor_mod.shutil.which


### PR DESCRIPTION
## Summary

Reworks the useful part of #68785 onto current `origin/main` as a small code-only doctor/auth change.

This keeps the stale `package-lock.json` and `ui-tui/package.json` churn out of scope while preserving the review-requested behavior:

- keyless `.env` can pass doctor when a supported OAuth provider has a healthy local login;
- doctor uses side-effect-free/local OAuth status checks for the keyless probe;
- adds a refresh-free Qwen OAuth local status snapshot for doctor;
- includes regression coverage for keyless OAuth and Qwen local status behavior.

## Why this replaces #68785

The original PR is still useful, but its GitHub patch includes stale package hunks that do not apply cleanly to current `origin/main`:

- `package-lock.json`
- `ui-tui/package.json`

The code-only salvage applies cleanly and keeps the diff focused on doctor/auth behavior.

## Testing

- `python -m py_compile hermes_cli/auth.py hermes_cli/doctor.py tests/hermes_cli/test_doctor.py tests/hermes_cli/test_auth_qwen_provider.py`
- `python -m pytest tests/hermes_cli/test_doctor.py tests/hermes_cli/test_auth_qwen_provider.py -q -o 'addopts='` → 64 passed, 1 warning
