### PR TITLE
fix(logging): rate-limit Slack reconnect traceback spam

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -35,9 +35,10 @@ import os
 import queue
 import sys
 import threading
+import time
 from logging.handlers import QueueHandler, QueueListener
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Callable, Optional, Sequence
 
 # On Windows, stdlib ``RotatingFileHandler`` calls ``os.rename()`` in
 # ``doRollover()`` and fails with ``PermissionError [WinError 32]`` whenever
@@ -231,6 +232,88 @@ class _ComponentFilter(logging.Filter):
         return record.name.startswith(self._prefixes)
 
 
+class _SlackReconnectSpamFilter(logging.Filter):
+    """Rate-limit identical Slack Socket Mode reconnect tracebacks.
+
+    Slack Bolt logs every failed reconnect attempt with ``exc_info``.  During
+    an extended outage that can produce hundreds of thousands of identical
+    tracebacks on stderr.  Preserve the first failure, suppress duplicates for
+    a short window, then report how many retries were omitted on the next
+    emitted copy.
+    """
+
+    _MESSAGE_PREFIX = "Failed to connect (error: "
+    _MESSAGE_SUFFIX = "); Retrying..."
+
+    def __init__(
+        self,
+        window_seconds: float = 60.0,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        super().__init__()
+        self._window_seconds = window_seconds
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._state: dict[tuple[str, str], tuple[float, int]] = {}
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage()
+        if not (
+            message.startswith(self._MESSAGE_PREFIX)
+            and message.endswith(self._MESSAGE_SUFFIX)
+        ):
+            return True
+
+        key = (record.name, message)
+        now = self._clock()
+        with self._lock:
+            previous = self._state.get(key)
+            if previous is None:
+                self._state[key] = (now, 0)
+                return True
+
+            last_emitted, suppressed = previous
+            if now - last_emitted < self._window_seconds:
+                self._state[key] = (last_emitted, suppressed + 1)
+                return False
+
+            self._state[key] = (now, 0)
+
+        if suppressed:
+            record.msg = (
+                f"{message} [+{suppressed} identical reconnect retries suppressed]"
+            )
+            record.args = ()
+        return True
+
+
+_SLACK_BOLT_LOGGERS = ("slack_bolt.AsyncApp", "slack_bolt.App")
+_SLACK_FILTER_MARKER = "_hermes_slack_reconnect_spam_filter"
+
+
+def _install_slack_reconnect_spam_filter() -> None:
+    """Install one shared reconnect filter on Slack Bolt's app loggers."""
+    existing = next(
+        (
+            log_filter
+            for logger_name in _SLACK_BOLT_LOGGERS
+            for log_filter in logging.getLogger(logger_name).filters
+            if getattr(log_filter, _SLACK_FILTER_MARKER, False)
+        ),
+        None,
+    )
+    spam_filter = existing or _SlackReconnectSpamFilter()
+    setattr(spam_filter, _SLACK_FILTER_MARKER, True)
+
+    for logger_name in _SLACK_BOLT_LOGGERS:
+        logger = logging.getLogger(logger_name)
+        if not any(
+            getattr(log_filter, _SLACK_FILTER_MARKER, False)
+            for log_filter in logger.filters
+        ):
+            logger.addFilter(spam_filter)
+
+
 # Logger name prefixes that belong to each component.
 # Used by _ComponentFilter and exposed for ``hermes logs --component``.
 COMPONENT_PREFIXES = {
@@ -316,6 +399,11 @@ def setup_logging(
     from agent.redact import RedactingFormatter
 
     root = logging.getLogger()
+
+    # Filter at the Slack logger rather than on Hermes' file handlers so the
+    # same retry storm is also suppressed on stderr (which launchd captures in
+    # gateway.error.log).
+    _install_slack_reconnect_spam_filter()
 
     # --- agent.log (INFO+) — the main activity log -------------------------
     _add_rotating_handler(

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -31,6 +31,11 @@ def _reset_logging_state():
     assertions are stable regardless of test ordering.
     """
     hermes_logging._logging_initialized = False
+    for logger_name in hermes_logging._SLACK_BOLT_LOGGERS:
+        logger = logging.getLogger(logger_name)
+        for log_filter in list(logger.filters):
+            if getattr(log_filter, hermes_logging._SLACK_FILTER_MARKER, False):
+                logger.removeFilter(log_filter)
     # File handlers now live behind the async QueueListener, not on the root
     # logger; tear down any leaked from other xdist tests in this worker.
     hermes_logging._reset_queued_handlers()
@@ -51,6 +56,11 @@ def _reset_logging_state():
             h.close()
     root.setLevel(prev_root_level)
     hermes_logging._logging_initialized = False
+    for logger_name in hermes_logging._SLACK_BOLT_LOGGERS:
+        logger = logging.getLogger(logger_name)
+        for log_filter in list(logger.filters):
+            if getattr(log_filter, hermes_logging._SLACK_FILTER_MARKER, False):
+                logger.removeFilter(log_filter)
     hermes_logging.clear_session_context()
 
 
@@ -97,6 +107,95 @@ class TestSetupLogging:
             and "agent.log" in getattr(h, "baseFilename", "")
         ]
         assert len(agent_handlers) == 1
+
+    def test_installs_one_shared_slack_reconnect_filter(self, hermes_home):
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+
+        installed = []
+        for logger_name in hermes_logging._SLACK_BOLT_LOGGERS:
+            filters = [
+                log_filter
+                for log_filter in logging.getLogger(logger_name).filters
+                if getattr(
+                    log_filter, hermes_logging._SLACK_FILTER_MARKER, False
+                )
+            ]
+            assert len(filters) == 1
+            installed.extend(filters)
+
+        assert installed[0] is installed[1]
+
+
+class TestSlackReconnectSpamFilter:
+    """Slack reconnect storms retain signal without flooding stderr."""
+
+    @staticmethod
+    def _record(message, *, name="slack_bolt.AsyncApp"):
+        return logging.LogRecord(
+            name=name,
+            level=logging.ERROR,
+            pathname=__file__,
+            lineno=1,
+            msg=message,
+            args=(),
+            exc_info=None,
+        )
+
+    def test_suppresses_duplicates_and_reports_count_after_window(self):
+        now = [100.0]
+        spam_filter = hermes_logging._SlackReconnectSpamFilter(
+            window_seconds=60.0,
+            clock=lambda: now[0],
+        )
+        message = "Failed to connect (error: Session is closed); Retrying..."
+
+        assert spam_filter.filter(self._record(message))
+        for _ in range(25):
+            assert not spam_filter.filter(self._record(message))
+
+        now[0] += 60.0
+        summary = self._record(message)
+        assert spam_filter.filter(summary)
+        assert summary.getMessage() == (
+            f"{message} [+25 identical reconnect retries suppressed]"
+        )
+
+    def test_does_not_suppress_unrelated_slack_errors(self):
+        spam_filter = hermes_logging._SlackReconnectSpamFilter(clock=lambda: 0.0)
+        message = "Slack API request failed"
+
+        assert spam_filter.filter(self._record(message))
+        assert spam_filter.filter(self._record(message))
+
+    def test_tracks_distinct_reconnect_errors_independently(self):
+        spam_filter = hermes_logging._SlackReconnectSpamFilter(clock=lambda: 0.0)
+        closed = "Failed to connect (error: Session is closed); Retrying..."
+        timeout = "Failed to connect (error: Timeout); Retrying..."
+
+        assert spam_filter.filter(self._record(closed))
+        assert spam_filter.filter(self._record(timeout))
+        assert not spam_filter.filter(self._record(closed))
+        assert not spam_filter.filter(self._record(timeout))
+
+    def test_filter_is_thread_safe(self):
+        spam_filter = hermes_logging._SlackReconnectSpamFilter(clock=lambda: 0.0)
+        message = "Failed to connect (error: Session is closed); Retrying..."
+        barrier = threading.Barrier(20)
+        results = []
+
+        def emit_once():
+            barrier.wait()
+            results.append(spam_filter.filter(self._record(message)))
+
+        threads = [threading.Thread(target=emit_once) for _ in range(20)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert results.count(True) == 1
+        assert results.count(False) == 19
 
 
 
@@ -676,5 +775,4 @@ class TestAsyncQueueLogging:
             "agent.log" in getattr(h, "baseFilename", "")
             for h in hermes_logging.rotating_file_handlers()
         )
-
 


### PR DESCRIPTION
Addresses the reconnect-spam half of #88895.

Slack Bolt currently writes a full traceback for every Socket Mode reconnect attempt. During an extended outage, those identical records can grow launchd's unbounded `gateway.error.log` by hundreds of megabytes.

Install one idempotent filter on the sync and async Slack Bolt app loggers. The first copy is preserved, identical retries are suppressed for 60 seconds, and the next emitted copy reports the suppressed count. Distinct reconnect errors and unrelated Slack logs remain untouched.

Regression coverage:
- duplicate suppression and count reporting after the window
- independent tracking for distinct reconnect errors
- unrelated-log pass-through
- thread safety and idempotent installation

Validation:
`uv run pytest tests/test_hermes_logging.py -q`
`uv run ruff check hermes_logging.py tests/test_hermes_logging.py`
`git diff --check`

Result: 32 passed, 2 skipped; lint and diff checks clean.