### PR TITLE
Cmd/Ctrl+C with typed input no longer interrupts a streaming turn

### DIFF
--- a/ui-tui/src/__tests__/useInputHandlers.test.ts
+++ b/ui-tui/src/__tests__/useInputHandlers.test.ts
@@ -5,6 +5,7 @@ import {
   applyVoiceRecordResponse,
   dismissSensitivePrompt,
   handleIdleHotkeyExit,
+  resolveCtrlCComposerAction,
   shouldAllowIdleHotkeyExit,
   shouldFallThroughForScroll
 } from '../app/useInputHandlers.js'
@@ -56,6 +57,28 @@ describe('shouldAllowIdleHotkeyExit', () => {
 
   it('disables idle exit hotkeys in dashboard chat', () => {
     expect(shouldAllowIdleHotkeyExit(true)).toBe(false)
+  })
+})
+
+describe('resolveCtrlCComposerAction — draft wins over interrupt', () => {
+  it('clears a non-empty composer even while the agent is streaming', () => {
+    expect(resolveCtrlCComposerAction({ busy: true, hasDraft: true, hasSession: true })).toBe('clear')
+  })
+
+  it('interrupts a running turn when the composer is empty', () => {
+    expect(resolveCtrlCComposerAction({ busy: true, hasDraft: false, hasSession: true })).toBe('interrupt')
+  })
+
+  it('clears an idle composer instead of exiting', () => {
+    expect(resolveCtrlCComposerAction({ busy: false, hasDraft: true, hasSession: true })).toBe('clear')
+  })
+
+  it('exits when idle with an empty composer', () => {
+    expect(resolveCtrlCComposerAction({ busy: false, hasDraft: false, hasSession: true })).toBe('exit')
+  })
+
+  it('does not interrupt a busy session that has no sid yet', () => {
+    expect(resolveCtrlCComposerAction({ busy: true, hasDraft: false, hasSession: false })).toBe('exit')
   })
 })
 

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -62,6 +62,29 @@ export function handleIdleHotkeyExit(
   return actions.die()
 }
 
+export type CtrlCComposerAction = 'clear' | 'interrupt' | 'exit'
+
+/**
+ * Ctrl+C (and terminals that rewrite Cmd+C to it) is clear / interrupt / exit
+ * in that order. A non-empty composer always wins — mid-stream, the chord
+ * used to interrupt the turn even when the user was trying to dump a draft.
+ */
+export function resolveCtrlCComposerAction(opts: {
+  busy: boolean
+  hasDraft: boolean
+  hasSession: boolean
+}): CtrlCComposerAction {
+  if (opts.hasDraft) {
+    return 'clear'
+  }
+
+  if (opts.busy && opts.hasSession) {
+    return 'interrupt'
+  }
+
+  return 'exit'
+}
+
 /**
  * Approval / clarify / confirm overlays mount their own `useInput` handlers
  * for the in-prompt keys (arrows, numbers, Enter, sometimes Esc).  The global
@@ -334,10 +357,9 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
   }
 
   // Double-Esc discards the draft, matching Claude Code / Gemini CLI. It
-  // sits above the isBlocked early-return on purpose: Ctrl+C interrupts a
-  // running turn rather than clearing, so while the agent streams there is
-  // otherwise no way to throw away a half-typed prompt. The draft is pushed
-  // to history first so Up recalls it.
+  // sits above the isBlocked early-return so a prompt overlay cannot swallow
+  // it. Ctrl+C now clears a non-empty composer even mid-stream; Esc Esc is
+  // still the dedicated discard (pushes the draft to history so Up recalls it).
   const lastEscRef = useRef(0)
 
   useInput((ch, key) => {
@@ -610,17 +632,23 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
     }
 
     if (key.ctrl && ch.toLowerCase() === 'c') {
-      if (live.busy && live.sid) {
+      const ctrlC = resolveCtrlCComposerAction({
+        busy: live.busy,
+        hasDraft: Boolean(cState.input || cState.inputBuf.length),
+        hasSession: Boolean(live.sid)
+      })
+
+      if (ctrlC === 'clear') {
+        return cActions.clearIn()
+      }
+
+      if (ctrlC === 'interrupt' && live.sid) {
         return turnController.interruptTurn({
           appendMessage: actions.appendMessage,
           gw: gateway.gw,
           sid: live.sid,
           sys: actions.sys
         })
-      }
-
-      if (cState.input || cState.inputBuf.length) {
-        return cActions.clearIn()
       }
 
       return handleIdleHotkeyExit(actions, DASHBOARD_TUI_MODE, () => {

--- a/ui-tui/src/content/hotkeys.ts
+++ b/ui-tui/src/content/hotkeys.ts
@@ -6,14 +6,14 @@ const paste = isMac ? 'Cmd' : 'Alt'
 const copyHotkeys: [string, string][] = isMac
   ? [
       ['Cmd+C', 'copy selection'],
-      ['Ctrl+C', 'interrupt / clear draft / exit']
+      ['Ctrl+C', 'clear draft / interrupt / exit']
     ]
   : isRemoteShell()
     ? [
         ['Cmd+C', 'copy selection when forwarded by the terminal'],
-        ['Ctrl+C', 'copy selection / interrupt / clear draft / exit']
+        ['Ctrl+C', 'copy selection / clear draft / interrupt / exit']
       ]
-    : [['Ctrl+C', 'copy selection / interrupt / clear draft / exit']]
+    : [['Ctrl+C', 'copy selection / clear draft / interrupt / exit']]
 
 export const HOTKEYS: [string, string][] = [
   ...copyHotkeys,


### PR DESCRIPTION
## Summary

In the TUI, Cmd+C / Ctrl+C while a turn is streaming used to interrupt the agent even if the composer had text. That's the chord people use to dump a half-typed prompt, so mid-stream it felt like the input-clear shortcut had been stolen.

A non-empty composer now clears first. Interrupt only fires when the input is already empty. Idle empty still exits.

## How to Verify

1. Start a turn in `hermes --tui` so the agent is streaming.
2. Type something into the composer.
3. Press Cmd+C (or Ctrl+C). The draft should clear; the turn should keep running.
4. Press it again on the empty composer. The turn should interrupt.

## Test Plan

- [x] Added `resolveCtrlCComposerAction` cases: draft+busy → clear, empty+busy → interrupt, idle draft → clear, idle empty → exit
- [ ] Existing TUI tests still pass
- [ ] Manual: mid-stream typed Cmd+C clears, second press interrupts

## Risk Assessment

Low — TUI key routing only. Empty-composer interrupt and idle-exit are unchanged. Overlay Ctrl+C (approval / sudo / pager) is a separate earlier branch.
