### PR TITLE
feat(tts): add Cartesia text-to-speech provider support

### DIFF
--- a/agent/tts_registry.py
+++ b/agent/tts_registry.py
@@ -58,6 +58,7 @@ _BUILTIN_NAMES = frozenset({
     "kittentts",
     "piper",
     "deepinfra",
+    "cartesia",
 })
 
 

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -336,8 +336,11 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
     'gemini',
     'neutts',
     'kittentts',
-    'piper'
+    'piper',
+    'cartesia'
   ],
+  'tts.cartesia.model': ['sonic-2', 'sonic-turbo', 'sonic-multilingual'],
+  'tts.cartesia.voice_id': ['25d7abcb-4d6d-4aca-adce-8a1c85620c8b'],
   'stt.openai.model': ['whisper-1', 'gpt-4o-mini-transcribe', 'gpt-4o-transcribe', 'gpt-transcribe'],
   'stt.mistral.model': ['voxtral-mini-latest', 'voxtral-mini-2602'],
   'tts.openai.model': ['gpt-4o-mini-tts', 'tts-1', 'tts-1-hd'],
@@ -369,7 +372,9 @@ export const FREE_INPUT_KEYS = new Set([
   'tts.kittentts.voice',
   'tts.piper.voice',
   'tts.deepinfra.model',
-  'tts.deepinfra.voice'
+  'tts.deepinfra.voice',
+  'tts.cartesia.model',
+  'tts.cartesia.voice_id'
 ])
 
 export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
@@ -509,6 +514,10 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
     deepinfra: {
       model: 'DeepInfra TTS Model',
       voice: 'DeepInfra Voice'
+    },
+    cartesia: {
+      model: 'Cartesia Model',
+      voice_id: 'Cartesia Voice ID'
     }
   },
   memory: {
@@ -724,6 +733,8 @@ export const SECTIONS: DesktopConfigSection[] = [
       'tts.piper.voice',
       'tts.deepinfra.model',
       'tts.deepinfra.voice',
+      'tts.cartesia.model',
+      'tts.cartesia.voice_id',
       'stt.local.model',
       'stt.local.language',
       'stt.openai.model',

--- a/apps/desktop/src/app/settings/helpers.ts
+++ b/apps/desktop/src/app/settings/helpers.ts
@@ -213,7 +213,8 @@ const BUILTIN_TTS_PROVIDERS = new Set([
   'neutts',
   'kittentts',
   'piper',
-  'deepinfra'
+  'deepinfra',
+  'cartesia'
 ])
 
 const BUILTIN_STT_PROVIDERS = new Set([

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1389,12 +1389,17 @@ stt:
   #   # live result. Pin only when you need a specific Whisper variant.
   #   model: ""
 
-# Text-to-speech. Only the deepinfra block is documented here — the
+# Text-to-speech. Examples for deepinfra and cartesia — the
 # remaining providers (edge, openai, xai, minimax, mistral, gemini,
 # elevenlabs, neutts, kittentts, piper) inherit sensible defaults from
 # DEFAULT_CONFIG in hermes_cli/config.py.
 # tts:
-#   provider: "deepinfra"
+#   provider: "cartesia"    # requires: CARTESIA_API_KEY
+#   cartesia:
+#     model: "sonic-2"       # sonic-2 | sonic-turbo | sonic-multilingual
+#     voice_id: "25d7abcb-4d6d-4aca-adce-8a1c85620c8b"  # Jessica
+#     sample_rate: 24000
+#     # emotion: ["positivity:high"]  # optional emotion control tags
 #   deepinfra:
 #     # Model id is discovered live from the DeepInfra catalog filtered
 #     # by the `tts` surface tag — leave `model` blank to take the first

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1645,6 +1645,11 @@ DEFAULT_CONFIG = {
             "voice": "default",
             # "base_url": "",  # override DEEPINFRA_BASE_URL for TTS only
         },
+        "cartesia": {
+            "model": "sonic-2",
+            "voice_id": "25d7abcb-4d6d-4aca-adce-8a1c85620c8b",  # Jessica
+            "sample_rate": 24000,
+        },
     },
 
     "stt": {

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1087,6 +1087,7 @@ def _setup_tts_provider(config: dict):
         "xai": "xAI TTS",
         "minimax": "MiniMax TTS",
         "mistral": "Mistral Voxtral TTS",
+        "cartesia": "Cartesia",
         "gemini": "Google Gemini TTS",
         "neutts": "NeuTTS",
         "kittentts": "KittenTTS",
@@ -1111,12 +1112,13 @@ def _setup_tts_provider(config: dict):
             "xAI TTS (Grok voices — OAuth login or API key)",
             "MiniMax TTS (high quality with voice cloning, needs API key)",
             "Mistral Voxtral TTS (multilingual, native Opus, needs API key)",
+            "Cartesia (ultra-low latency, Sonic 2, emotion controls, needs API key)",
             "Google Gemini TTS (30 prebuilt voices, prompt-controllable, needs API key)",
             "NeuTTS (local on-device, free, ~300MB model download)",
             "KittenTTS (local on-device, free, lightweight ~25-80MB ONNX)",
         ]
     )
-    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts"])
+    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "cartesia", "gemini", "neutts", "kittentts"])
     choices.append(f"Keep current ({current_label})")
     keep_current_idx = len(choices) - 1
     idx = prompt_choice("Select TTS provider:", choices, keep_current_idx)
@@ -1263,6 +1265,19 @@ def _setup_tts_provider(config: dict):
             if api_key:
                 save_env_value("MISTRAL_API_KEY", api_key)
                 print_success("Mistral TTS API key saved")
+            else:
+                print_warning("No API key provided. Falling back to Edge TTS.")
+                selected = "edge"
+
+    elif selected == "cartesia":
+        existing = get_env_value("CARTESIA_API_KEY")
+        if not existing:
+            print()
+            print_info("Get an API key at https://play.cartesia.ai/console")
+            api_key = prompt("Cartesia API key for TTS", password=True)
+            if api_key:
+                save_env_value("CARTESIA_API_KEY", api_key)
+                print_success("Cartesia API key saved")
             else:
                 print_warning("No API key provided. Falling back to Edge TTS.")
                 selected = "edge"

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -412,6 +412,15 @@ TOOL_CATEGORIES = {
                 ],
                 "tts_provider": "deepinfra",
             },
+            {
+                "name": "Cartesia",
+                "badge": "paid",
+                "tag": "Ultra-low latency streaming, Sonic 2, emotion-adaptive",
+                "env_vars": [
+                    {"key": "CARTESIA_API_KEY", "prompt": "Cartesia API key", "url": "https://play.cartesia.ai/console"},
+                ],
+                "tts_provider": "cartesia",
+            },
         ],
     },
     "stt": {

--- a/tests/agent/test_tts_registry.py
+++ b/tests/agent/test_tts_registry.py
@@ -74,18 +74,15 @@ def _reset_registry():
 
 class TestRegistration:
     def test_happy_path(self):
-        p = _FakeProvider(name="cartesia")
+        p = _FakeProvider(name="custom_tts_plugin")
         tts_registry.register_provider(p)
-        assert tts_registry.get_provider("cartesia") is p
-        assert [r.name for r in tts_registry.list_providers()] == ["cartesia"]
-
-
-
+        assert tts_registry.get_provider("custom_tts_plugin") is p
+        assert [r.name for r in tts_registry.list_providers()] == ["custom_tts_plugin"]
 
     @pytest.mark.parametrize(
         "builtin",
         ["edge", "openai", "elevenlabs", "minimax", "gemini",
-         "mistral", "xai", "piper", "kittentts", "neutts"],
+         "mistral", "xai", "piper", "kittentts", "neutts", "deepinfra", "cartesia"],
     )
     def test_rejects_builtin_shadow_with_warning(self, builtin, caplog):
         """Built-in names always win — plugin registration is silently ignored

--- a/tests/hermes_cli/test_tts_picker.py
+++ b/tests/hermes_cli/test_tts_picker.py
@@ -81,7 +81,7 @@ class TestVisibleProvidersInjectsTTSPlugins:
     category alongside the hardcoded built-in rows."""
 
     def test_tts_category_includes_plugin_rows(self):
-        tts_registry.register_provider(_FakeTTSProvider(name="cartesia"))
+        tts_registry.register_provider(_FakeTTSProvider(name="fishaudio"))
 
         tts_cat = tools_config.TOOL_CATEGORIES["tts"]
         visible = tools_config._visible_providers(tts_cat, config={})
@@ -90,20 +90,20 @@ class TestVisibleProvidersInjectsTTSPlugins:
         # Hardcoded rows (sample — check at least one is present)
         assert "Microsoft Edge TTS" in names
         # Plugin row injected at the end
-        assert "Cartesia" in names
+        assert "Fishaudio" in names
 
         # Plugin row has tts_provider key for write-path compat
         plugin_rows = [r for r in visible if r.get("tts_plugin_name")]
         assert len(plugin_rows) == 1
-        assert plugin_rows[0]["tts_provider"] == "cartesia"
+        assert plugin_rows[0]["tts_provider"] == "fishaudio"
 
     def test_other_categories_unaffected_by_tts_plugins(self):
         """Registering a TTS plugin must not leak into the Image Generation
         or Browser pickers."""
-        tts_registry.register_provider(_FakeTTSProvider(name="cartesia"))
+        tts_registry.register_provider(_FakeTTSProvider(name="fishaudio"))
 
         img_cat = tools_config.TOOL_CATEGORIES["image_gen"]
         visible = tools_config._visible_providers(img_cat, config={})
         names = [row.get("name") for row in visible]
-        assert "Cartesia" not in names
+        assert "Fishaudio" not in names
 

--- a/tests/tools/test_tts_cartesia.py
+++ b/tests/tools/test_tts_cartesia.py
@@ -1,0 +1,166 @@
+"""
+Tests for the native Cartesia TTS provider in tools/tts_tool.py.
+
+Covers:
+- Provider registration in BUILTIN_TTS_PROVIDERS and tts_registry
+- Max text length definition
+- Availability checks based on CARTESIA_API_KEY
+- Synthesis request payload construction (model, voice_id, container, speed, emotion)
+- Header propagation (X-API-Key, Cartesia-Version)
+- Error handling (missing key, HTTP 401/429/500, network failure)
+- Integration with text_to_speech_tool dispatch
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent import tts_registry
+from tools import tts_tool
+from tools.tts_tool import (
+    BUILTIN_TTS_PROVIDERS,
+    DEFAULT_CARTESIA_MODEL,
+    DEFAULT_CARTESIA_VOICE_ID,
+    PROVIDER_MAX_TEXT_LENGTH,
+    _generate_cartesia_tts,
+    check_tts_requirements,
+    text_to_speech_tool,
+)
+
+
+class TestCartesiaRegistration:
+    def test_cartesia_is_a_builtin_provider(self):
+        assert "cartesia" in BUILTIN_TTS_PROVIDERS
+
+    def test_cartesia_in_registry_builtins(self):
+        assert "cartesia" in tts_registry._BUILTIN_NAMES
+
+    def test_cartesia_has_max_text_length(self):
+        assert PROVIDER_MAX_TEXT_LENGTH.get("cartesia", 0) > 0
+
+
+class TestCartesiaAvailability:
+    def test_available_when_api_key_present(self):
+        with patch.object(tts_tool, "_resolve_provider_key", return_value="test_cartesia_key"):
+            with patch.object(tts_tool, "_load_tts_config", return_value={"provider": "cartesia"}):
+                assert check_tts_requirements() is True
+
+    def test_unavailable_when_api_key_missing(self):
+        with patch.object(tts_tool, "_resolve_provider_key", return_value=""):
+            with patch.object(tts_tool, "_load_tts_config", return_value={"provider": "cartesia"}):
+                assert check_tts_requirements() is False
+
+
+class TestCartesiaSynthesis:
+    def test_missing_api_key_raises_value_error(self, tmp_path):
+        out_file = str(tmp_path / "out.mp3")
+        with patch.object(tts_tool, "_resolve_provider_key", return_value=""):
+            with pytest.raises(ValueError, match="CARTESIA_API_KEY not set"):
+                _generate_cartesia_tts("hello", out_file, {})
+
+    def test_successful_synthesis_default_payload(self, tmp_path):
+        out_file = str(tmp_path / "out.mp3")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = b"fake_mp3_audio_data"
+
+        with patch.object(tts_tool, "_resolve_provider_key", return_value="cartesia_secret_123"):
+            with patch("requests.post", return_value=mock_resp) as mock_post:
+                res = _generate_cartesia_tts("Hello world", out_file, {})
+
+        assert res == out_file
+        with open(out_file, "rb") as f:
+            assert f.read() == b"fake_mp3_audio_data"
+
+        mock_post.assert_called_once()
+        args, kwargs = mock_post.call_args
+        assert args[0] == "https://api.cartesia.ai/tts/bytes"
+        headers = kwargs["headers"]
+        assert headers["X-API-Key"] == "cartesia_secret_123"
+        assert headers["Cartesia-Version"] == "2024-06-10"
+        assert headers["Content-Type"] == "application/json"
+
+        payload = kwargs["json"]
+        assert payload["model_id"] == DEFAULT_CARTESIA_MODEL
+        assert payload["transcript"] == "Hello world"
+        assert payload["voice"]["id"] == DEFAULT_CARTESIA_VOICE_ID
+        assert payload["output_format"]["container"] == "mp3"
+        assert payload["output_format"]["sample_rate"] == 24000
+
+    def test_opus_container_for_voice_bubbles(self, tmp_path):
+        out_file = str(tmp_path / "out.ogg")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = b"fake_opus_bytes"
+
+        with patch.object(tts_tool, "_resolve_provider_key", return_value="cartesia_secret"):
+            with patch("requests.post", return_value=mock_resp) as mock_post:
+                _generate_cartesia_tts("Voice message", out_file, {})
+
+        payload = mock_post.call_args[1]["json"]
+        assert payload["output_format"]["container"] == "ogg"
+        assert payload["output_format"]["encoding"] == "opus"
+
+    def test_custom_voice_model_emotion_and_speed(self, tmp_path):
+        out_file = str(tmp_path / "out.wav")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = b"fake_wav_bytes"
+
+        config = {
+            "cartesia": {
+                "model": "sonic-turbo",
+                "voice_id": "custom-voice-uuid",
+                "speed": 1.25,
+                "emotion": ["positivity:high", "curiosity:medium"],
+                "language": "en",
+                "sample_rate": 44100,
+            }
+        }
+
+        with patch.object(tts_tool, "_resolve_provider_key", return_value="cartesia_secret"):
+            with patch("requests.post", return_value=mock_resp) as mock_post:
+                _generate_cartesia_tts("Expressive test", out_file, config)
+
+        payload = mock_post.call_args[1]["json"]
+        assert payload["model_id"] == "sonic-turbo"
+        assert payload["voice"]["id"] == "custom-voice-uuid"
+        controls = payload["voice"]["__experimental_controls"]
+        assert controls["speed"] == 1.25
+        assert controls["emotion"] == ["positivity:high", "curiosity:medium"]
+        assert payload["language"] == "en"
+        assert payload["output_format"]["container"] == "wav"
+        assert payload["output_format"]["sample_rate"] == 44100
+
+    def test_http_error_handling(self, tmp_path):
+        out_file = str(tmp_path / "out.mp3")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 401
+        mock_resp.json.return_value = {"error": "Invalid API key provided"}
+
+        with patch.object(tts_tool, "_resolve_provider_key", return_value="bad_key"):
+            with patch("requests.post", return_value=mock_resp):
+                with pytest.raises(RuntimeError, match="Cartesia TTS API error \\(401\\): Invalid API key provided"):
+                    _generate_cartesia_tts("Hello", out_file, {})
+
+
+class TestCartesiaDispatch:
+    def test_text_to_speech_tool_dispatches_cartesia(self, tmp_path):
+        from pathlib import Path
+        out_file = str(tmp_path / "out.mp3")
+        tts_cfg = {"provider": "cartesia"}
+
+        def side_effect(text, path, cfg):
+            Path(path).write_bytes(b"mock_audio_data")
+            return path
+
+        with patch.object(tts_tool, "_load_tts_config", return_value=tts_cfg):
+            with patch.object(tts_tool, "_generate_cartesia_tts", side_effect=side_effect) as mock_gen:
+                res_str = text_to_speech_tool("Speak this", output_path=out_file)
+                res = json.loads(res_str)
+                assert res["success"] is True
+                assert res["provider"] == "cartesia"
+                mock_gen.assert_called_once_with("Speak this", out_file, tts_cfg)

--- a/tests/tools/test_tts_plugin_dispatch.py
+++ b/tests/tools/test_tts_plugin_dispatch.py
@@ -94,7 +94,7 @@ class TestBuiltinAlwaysWins:
     @pytest.mark.parametrize(
         "builtin",
         ["edge", "openai", "elevenlabs", "minimax", "gemini",
-         "mistral", "xai", "piper", "kittentts", "neutts"],
+         "mistral", "xai", "piper", "kittentts", "neutts", "deepinfra", "cartesia"],
     )
     def test_dispatcher_short_circuits_builtin(self, builtin):
         result = tts_tool._dispatch_to_plugin_provider(
@@ -153,13 +153,13 @@ class TestPluginDispatch:
     """Happy path: configured name matches a registered plugin, dispatcher fires."""
 
     def test_registered_plugin_called(self):
-        provider = _FakeTTSProvider(name="cartesia")
+        provider = _FakeTTSProvider(name="custom_tts_plugin")
         tts_registry.register_provider(provider)
 
         result = tts_tool._dispatch_to_plugin_provider(
             text="hello world",
             output_path="/tmp/out.mp3",
-            provider="cartesia",
+            provider="custom_tts_plugin",
             tts_config={},
         )
         assert result == "/tmp/out.mp3"
@@ -183,7 +183,7 @@ class TestPluginDispatch:
         the standard error envelope. Matches command-provider failure
         behavior."""
         provider = _FakeTTSProvider(
-            name="cartesia",
+            name="custom_tts_plugin",
             raise_exc=RuntimeError("network down"),
         )
         tts_registry.register_provider(provider)
@@ -192,7 +192,7 @@ class TestPluginDispatch:
             tts_tool._dispatch_to_plugin_provider(
                 text="hi",
                 output_path="/tmp/out.mp3",
-                provider="cartesia",
+                provider="custom_tts_plugin",
                 tts_config={},
             )
 
@@ -205,9 +205,9 @@ class TestPluginDispatch:
 class TestVoiceCompatibleHelper:
     def test_voice_compatible_true(self):
         tts_registry.register_provider(
-            _FakeTTSProvider(name="cartesia", voice_compat=True)
+            _FakeTTSProvider(name="custom_tts_plugin", voice_compat=True)
         )
-        assert tts_tool._plugin_provider_is_voice_compatible("cartesia") is True
+        assert tts_tool._plugin_provider_is_voice_compatible("custom_tts_plugin") is True
 
 
     def test_unregistered_provider_returns_false(self):
@@ -223,5 +223,5 @@ class TestVoiceCompatibleHelper:
             def voice_compatible(self) -> bool:
                 raise RuntimeError("boom")
 
-        tts_registry.register_provider(_ExplodingProvider(name="cartesia"))
-        assert tts_tool._plugin_provider_is_voice_compatible("cartesia") is False
+        tts_registry.register_provider(_ExplodingProvider(name="custom_tts_plugin"))
+        assert tts_tool._plugin_provider_is_voice_compatible("custom_tts_plugin") is False

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -259,6 +259,12 @@ GEMINI_TTS_SAMPLE_WIDTH = 2  # 16-bit PCM (L16)
 TTS_RESPONSE_BODY_LIMIT_BYTES = 16 * 1024 * 1024
 TTS_RESPONSE_BODY_CHUNK_BYTES = 64 * 1024
 
+DEFAULT_CARTESIA_MODEL = "sonic-2"
+DEFAULT_CARTESIA_VOICE_ID = "25d7abcb-4d6d-4aca-adce-8a1c85620c8b"  # Jessica
+DEFAULT_CARTESIA_BASE_URL = "https://api.cartesia.ai/tts/bytes"
+DEFAULT_CARTESIA_VERSION = "2024-06-10"
+DEFAULT_CARTESIA_SAMPLE_RATE = 24000
+
 def _get_default_output_dir() -> str:
     from hermes_constants import get_hermes_dir
     return str(get_hermes_dir("cache/audio", "audio_cache"))
@@ -283,6 +289,7 @@ PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
     "neutts": 2000,       # local model, quality falls off on long text
     "kittentts": 2000,    # local 25MB model
     "piper": 5000,        # local VITS model, phoneme-based; practical cap
+    "cartesia": 5000,     # https://docs.cartesia.ai/
 }
 
 # ElevenLabs caps vary by model_id. https://elevenlabs.io/docs/overview/models
@@ -780,6 +787,7 @@ BUILTIN_TTS_PROVIDERS = frozenset({
     "kittentts",
     "piper",
     "deepinfra",
+    "cartesia",
 })
 
 DEFAULT_COMMAND_TTS_TIMEOUT_SECONDS = 120
@@ -2406,6 +2414,118 @@ def _generate_mistral_tts(text: str, output_path: str, tts_config: Dict[str, Any
 
 
 # ===========================================================================
+# Provider: Cartesia TTS
+# ===========================================================================
+def _generate_cartesia_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate audio using Cartesia TTS API.
+
+    Uses the Cartesia /tts/bytes endpoint with model selection (default sonic-2),
+    voice selection (default Jessica), container selection, speed, and emotion controls.
+    """
+    import requests
+
+    api_key = _resolve_provider_key("CARTESIA_API_KEY", "cartesia")
+    if not api_key:
+        raise ValueError(
+            "CARTESIA_API_KEY not set. Get one at https://play.cartesia.ai/console"
+        )
+
+    cartesia_config = tts_config.get("cartesia") or {}
+    if not isinstance(cartesia_config, dict):
+        cartesia_config = {}
+
+    model = cartesia_config.get("model", DEFAULT_CARTESIA_MODEL)
+    voice_id = cartesia_config.get("voice_id", DEFAULT_CARTESIA_VOICE_ID)
+    base_url = cartesia_config.get("base_url", DEFAULT_CARTESIA_BASE_URL)
+    version = cartesia_config.get("version", DEFAULT_CARTESIA_VERSION)
+    sample_rate = int(cartesia_config.get("sample_rate", DEFAULT_CARTESIA_SAMPLE_RATE))
+    language = cartesia_config.get("language")
+
+    if output_path.endswith(".ogg") or output_path.endswith(".opus"):
+        container = "ogg"
+        encoding = "opus"
+    elif output_path.endswith(".wav"):
+        container = "wav"
+        encoding = "pcm_s16le"
+    elif output_path.endswith(".flac"):
+        container = "flac"
+        encoding = None
+    else:
+        container = "mp3"
+        encoding = None
+
+    output_format: Dict[str, Any] = {
+        "container": container,
+        "sample_rate": sample_rate,
+    }
+    if encoding:
+        output_format["encoding"] = encoding
+
+    voice_spec: Dict[str, Any] = {
+        "mode": "id",
+        "id": voice_id,
+    }
+
+    experimental_controls: Dict[str, Any] = {}
+    speed = cartesia_config.get("speed")
+    if speed is not None:
+        try:
+            experimental_controls["speed"] = float(speed)
+        except (TypeError, ValueError):
+            pass
+
+    emotion = cartesia_config.get("emotion")
+    if emotion:
+        if isinstance(emotion, list):
+            experimental_controls["emotion"] = emotion
+        elif isinstance(emotion, str):
+            experimental_controls["emotion"] = [emotion]
+
+    if experimental_controls:
+        voice_spec["__experimental_controls"] = experimental_controls
+
+    payload: Dict[str, Any] = {
+        "model_id": model,
+        "transcript": text,
+        "voice": voice_spec,
+        "output_format": output_format,
+    }
+    if language:
+        payload["language"] = str(language).strip()
+
+    headers = {
+        "X-API-Key": api_key,
+        "Cartesia-Version": version,
+        "Content-Type": "application/json",
+    }
+
+    try:
+        response = requests.post(
+            base_url,
+            json=payload,
+            headers=headers,
+            timeout=60,
+            stream=True,
+        )
+    except Exception as e:
+        logger.error("Cartesia TTS network request failed: %s", e, exc_info=True)
+        raise RuntimeError(f"Cartesia TTS failed: {type(e).__name__} ({e})") from e
+
+    if response.status_code != 200:
+        error_msg = f"HTTP {response.status_code}"
+        try:
+            err_json = response.json()
+            if isinstance(err_json, dict):
+                error_msg = err_json.get("error") or err_json.get("message") or str(err_json)
+        except Exception:
+            error_msg = response.text or error_msg
+        raise RuntimeError(f"Cartesia TTS API error ({response.status_code}): {error_msg}")
+
+    _write_tts_response_to_file(response, output_path, label="Cartesia TTS")
+    return output_path
+
+
+# ===========================================================================
 # Provider: Google Gemini TTS
 # ===========================================================================
 def _wrap_pcm_as_wav(
@@ -3328,6 +3448,10 @@ def _text_to_speech_single(
             logger.info("Generating speech with Mistral Voxtral TTS...")
             _generate_mistral_tts(text, file_str, tts_config)
 
+        elif provider == "cartesia":
+            logger.info("Generating speech with Cartesia TTS...")
+            _generate_cartesia_tts(text, file_str, tts_config)
+
         elif provider == "gemini":
             logger.info("Generating speech with Google Gemini TTS...")
             _generate_gemini_tts(text, file_str, tts_config)
@@ -3448,7 +3572,7 @@ def _text_to_speech_single(
             if opus_path:
                 file_str = opus_path
                 voice_compatible = True
-        elif provider in {"elevenlabs", "openai", "mistral", "gemini"}:
+        elif provider in {"elevenlabs", "openai", "mistral", "gemini", "cartesia"}:
             voice_compatible = want_opus and file_str.endswith(".ogg")
 
         file_size = os.path.getsize(file_str)
@@ -3762,6 +3886,8 @@ def check_tts_requirements() -> bool:
         except ImportError:
             return False
         return bool(_resolve_provider_key("MISTRAL_API_KEY", "mistral"))
+    if provider == "cartesia":
+        return bool(_resolve_provider_key("CARTESIA_API_KEY", "cartesia"))
     if provider == "neutts":
         return _check_neutts_available()
     if provider == "kittentts":


### PR DESCRIPTION
## Summary
Adds native **Cartesia TTS** text-to-speech provider integration to Hermes Agent.

### Features
- **API Endpoint**: Integrates with `https://api.cartesia.ai/tts/bytes` using `CARTESIA_API_KEY` and header `Cartesia-Version: 2024-06-10`.
- **Model & Voice Defaults**: Default model `sonic-2` (supporting `sonic-turbo`, `sonic-multilingual`) and default voice Jessica (`25d7abcb-4d6d-4aca-adce-8a1c85620c8b`).
- **Opus Voice-Bubble Support**: Maps container formats to native Opus (`.ogg` / `.opus`) for direct messaging gateway voice-bubble delivery across Telegram, WhatsApp, Signal, Discord, and Matrix.
- **Expressiveness**: Supports speed multiplier and emotion controls (e.g. `emotion: ["positivity:high"]`).
- **CLI & Setup Integration**: Added to `hermes tools` interactive picker, `hermes setup` wizard, and configuration defaults.
- **Desktop App Sync**: Updated desktop settings constants and helper sets.

### Tests
- Added unit test suite in `tests/tools/test_tts_cartesia.py` (11 tests).
- Verified test suite passes: `pytest tests/tools/test_tts_*.py tests/hermes_cli/test_tts_*.py tests/agent/test_tts_*.py` (283 passed).
