### PR TITLE
fix(google-chat): stop format_message leaking GC1 placeholders

### DIFF
--- a/plugins/platforms/google_chat/cards.py
+++ b/plugins/platforms/google_chat/cards.py
@@ -40,7 +40,7 @@ def format_message(content: str) -> str:
     placeholders: Dict[str, str] = {}
 
     def _ph(value: str) -> str:
-        key = f"\x00GC{len(placeholders)}\x00"
+        key = f"@@HERMES_GC_PH_{len(placeholders)}@@"
         placeholders[key] = value
         return key
 
@@ -58,7 +58,11 @@ def format_message(content: str) -> str:
     text = _INVISIBLE_RE.sub("", text)
     # Collapse double spaces left over from stripped chars.
     text = re.sub(r"  +", " ", text)
-    for key, value in placeholders.items():
+    # Restore outer placeholders first so nested keys inside values
+    # (bold/link/header wrapping code) still expand. NUL-wrapped GC{n}
+    # tokens leaked as "GC1" in Chat when restore order was wrong or
+    # when the API stripped NULs.
+    for key, value in reversed(list(placeholders.items())):
         text = text.replace(key, value)
     return text
 

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -1510,6 +1510,21 @@ class TestFormatMessage:
         assert out == "*Heading*\nbody with # mid-line hash"
 
 
+    def test_nested_backticks_inside_bold_restore(self):
+        """Bold wrapping inline code must not leak GC{n} placeholders."""
+        out = GoogleChatAdapter.format_message("as **`octocat`** (using GH_TOKEN)")
+        assert "GC" not in out
+        assert "HERMES_GC_PH" not in out
+        assert "`octocat`" in out
+
+    def test_inline_code_survives_nul_strip_placeholder(self):
+        out = GoogleChatAdapter.format_message(
+            "Yes, I am authenticated with GitHub via the gh CLI as `user` (using GH_TOKEN)."
+        )
+        assert out == (
+            "Yes, I am authenticated with GitHub via the gh CLI as `user` (using GH_TOKEN)."
+        )
+
     def test_strips_zwj_and_variation_selector(self):
         """ZWJ (U+200D) + Variation Selector 16 (U+FE0F) get stripped.
 


### PR DESCRIPTION
## What does this PR do?

Google Chat `format_message()` parks fenced/inline code, headers, bold, and links behind placeholders, then restores them after markdown conversion. Stock placeholders were NUL-wrapped `\x00GC{n}\x00`, restored in insertion order.

Two failures showed up as random `GC1` / `GC4` in outbound Chat text instead of the real word (often a backticked token):

1. Nested markdown (`**`code`**`, links or headers wrapping code) puts an inner placeholder inside an outer placeholder's value. A forward restore expands the inner key first; the outer value then re-inserts `\x00GC0\x00` after that key was already consumed.
2. Google Chat / JSON drops NUL, so an unrestored key renders as `GC1`.

This switches to opaque `@@HERMES_GC_PH_{n}@@` tokens and restores outer placeholders first so nested regions still expand.

## Related Issue

No existing issue found (searched open/closed PRs and issues for `format_message` / `GC1` on Google Chat).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/google_chat/adapter.py` — `format_message()` placeholder key and reverse-order restore
- `tests/gateway/test_google_chat.py` — nested backticks-in-bold and inline-code restore cases

## How to Test

1. `uv run --extra dev pytest tests/gateway/test_google_chat.py::TestFormatMessage -q`
2. Send a Google Chat reply that wraps inline code in bold, e.g. `**`octocat`**`, and confirm the username/token appears instead of `GC1`.
3. Send a reply with a single backticked token in prose and confirm it is unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Fedora Linux (`tests/gateway/test_google_chat.py::TestFormatMessage` only; full `scripts/run_tests.sh` not run)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (string substitution only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — unit coverage for the leak; live Chat repro was `GC1` replacing a backticked GitHub login in a gateway reply.