### PR TITLE
fix(gateway): isolate multiplex profile personalities

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5216,6 +5216,7 @@ class TurnRunner:
             ctx.source.chat_id or "",
             thread_id=getattr(ctx.source, "thread_id", None),
             parent_id=getattr(ctx.source, "parent_chat_id", None),
+            profile_name=getattr(ctx.source, "profile", None),
         )
         if cfg_channel_prompt:
             combined_ephemeral = (combined_ephemeral + "\n\n" + cfg_channel_prompt).strip()
@@ -6669,6 +6670,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Both are injected at API-call time only and never persisted.
         self._prefill_messages = self._load_prefill_messages()
         self._ephemeral_system_prompt = self._load_ephemeral_system_prompt()
+        # Secondary multiplex profiles resolve their own personality/system
+        # prompt during startup. The process-level value above belongs only
+        # to the default profile.
+        self._ephemeral_system_prompts_by_profile: Dict[str, str] = {}
         self._reasoning_config = self._load_reasoning_config()
         self._service_tier = self._load_service_tier()
         self._show_reasoning = self._load_show_reasoning()
@@ -9155,6 +9160,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         *,
         thread_id: Optional[str] = None,
         parent_id: Optional[str] = None,
+        profile_name: Optional[str] = None,
     ) -> str:
         """Ephemeral system prompt for this channel/thread.
 
@@ -9174,6 +9180,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             if override and override.system_prompt:
                 return (override.system_prompt or "").strip()
+        if profile_name and getattr(
+            getattr(self, "config", None), "multiplex_profiles", False
+        ):
+            profile_prompts = getattr(
+                self, "_ephemeral_system_prompts_by_profile", None
+            )
+            if isinstance(profile_prompts, dict):
+                # An explicitly routed profile must never inherit another
+                # profile's prompt when its startup snapshot is unavailable.
+                return profile_prompts.get(profile_name, "")
         return getattr(self, "_ephemeral_system_prompt", None) or ""
 
     @staticmethod
@@ -9416,6 +9432,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         text_modes = self.__dict__.setdefault("_busy_text_modes_by_profile", {})
         input_modes[profile_name] = input_mode
         text_modes[profile_name] = text_mode
+
+    def _snapshot_profile_ephemeral_system_prompt(
+        self, profile_name: str, config: dict
+    ) -> None:
+        """Cache one secondary profile's personality/system-prompt overlay."""
+        from hermes_cli.config import resolve_ephemeral_system_prompt_from_config
+
+        prompts = self.__dict__.setdefault(
+            "_ephemeral_system_prompts_by_profile", {}
+        )
+        prompts[profile_name] = resolve_ephemeral_system_prompt_from_config(config)
 
     def _busy_profile_name_for_source(self, source: SessionSource) -> Optional[str]:
         """Return the routed profile whose busy policy applies, if any."""
@@ -14915,6 +14942,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return 0
 
         active = get_active_profile_name() or "default"
+        profile_prompts = self.__dict__.setdefault(
+            "_ephemeral_system_prompts_by_profile", {}
+        )
+        profile_prompts[active] = getattr(self, "_ephemeral_system_prompt", "")
         connected = 0
         # Resource claim -> profile that owns it. Credential claims prevent two
         # profiles polling the same account; listener claims prevent sidecars
@@ -14999,6 +15030,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             profile_cfg = load_gateway_config()
             violation = _own_policy_open_startup_violation(profile_cfg)
         self._snapshot_profile_busy_modes(profile_name, profile_runtime_cfg)
+        self._snapshot_profile_ephemeral_system_prompt(
+            profile_name, profile_runtime_cfg
+        )
         if violation:
             raise MultiplexConfigError(
                 f"Profile '{profile_name}' enables {violation}. "

--- a/tests/gateway/test_channel_overrides.py
+++ b/tests/gateway/test_channel_overrides.py
@@ -105,6 +105,83 @@ class TestGetSystemPromptForChannel:
         prompt = runner._get_system_prompt_for_channel(Platform.DISCORD, "chan_1")
         assert prompt == "You are a coding assistant."
 
+    def test_uses_secondary_profile_personality(self):
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._ephemeral_system_prompt = "Default personality"
+        runner._ephemeral_system_prompts_by_profile = {}
+        runner._snapshot_profile_ephemeral_system_prompt(
+            "reviewer",
+            {
+                "display": {"personality": "reviewer"},
+                "agent": {
+                    "personalities": {"reviewer": "Secondary personality"}
+                },
+            },
+        )
+
+        prompt = runner._get_system_prompt_for_channel(
+            Platform.DISCORD,
+            "chan_1",
+            profile_name="reviewer",
+        )
+
+        assert prompt == "Secondary personality"
+
+    def test_empty_secondary_prompt_does_not_leak_default_profile_prompt(self):
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._ephemeral_system_prompt = "Default personality"
+        runner._ephemeral_system_prompts_by_profile = {"reviewer": ""}
+
+        prompt = runner._get_system_prompt_for_channel(
+            Platform.DISCORD,
+            "chan_1",
+            profile_name="reviewer",
+        )
+
+        assert prompt == ""
+
+    def test_missing_profile_snapshot_fails_closed(self):
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._ephemeral_system_prompt = "Default personality"
+        runner._ephemeral_system_prompts_by_profile = {}
+
+        prompt = runner._get_system_prompt_for_channel(
+            Platform.DISCORD,
+            "chan_1",
+            profile_name="reviewer",
+        )
+
+        assert prompt == ""
+
+    def test_channel_override_wins_for_secondary_profile(self):
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            multiplex_profiles=True,
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "chan_1": ChannelOverride(system_prompt="Channel prompt"),
+                    },
+                ),
+            },
+        )
+        runner._ephemeral_system_prompt = "Default personality"
+        runner._ephemeral_system_prompts_by_profile = {
+            "reviewer": "Secondary personality"
+        }
+
+        prompt = runner._get_system_prompt_for_channel(
+            Platform.DISCORD,
+            "chan_1",
+            profile_name="reviewer",
+        )
+
+        assert prompt == "Channel prompt"
+
 
 class TestResolveSessionAgentRuntimePriority:
     """Model/runtime priority: session /model → channel_overrides → global."""
@@ -152,5 +229,3 @@ class TestResolveSessionAgentRuntimePriority:
             )
         assert model == "channel/model"
         assert runtime["provider"] == "openrouter"
-
-


### PR DESCRIPTION
Fixes #89161.

The multiplexed gateway resolves the ephemeral personality/system prompt once at process startup, so every routed turn falls back to the default profile's cached value. Secondary profiles therefore lose their own `display.personality` and `agent.personalities` configuration.

Resolve and snapshot each secondary profile's prompt inside that profile's existing runtime scope, then select it from the routed `source.profile` when building the turn prompt. Default-profile behavior and channel-override precedence remain unchanged; a missing secondary snapshot fails closed instead of leaking the default profile prompt.

Regression coverage:
- named personality resolution for a secondary profile
- empty and missing secondary prompts do not inherit the default prompt
- channel overrides retain precedence
- adjacent adapter-registry, pairing-store, lifecycle, busy-mode, and profile-authorization behavior

Validation:
`uv run pytest tests/gateway/test_multiplex_pairing_stores.py tests/gateway/test_multiplex_adapter_registry.py tests/gateway/test_channel_overrides.py tests/gateway/test_multiplex_busy_input_mode.py tests/gateway/test_multiplex_lifecycle.py tests/gateway/test_multiplex_profile_authz.py -q`
`uv run ruff check gateway/run.py tests/gateway/test_channel_overrides.py`
`git diff --check origin/main...HEAD`

Result: 59 passed; lint and diff checks clean.