### PR TITLE
fix(gateway): stop lease-wait refreshes flooding non-editing chat adapters

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -874,6 +874,45 @@ async def _send_or_update_status_coro(adapter, chat_id, status_key, content, met
     return await adapter.send(chat_id, content, metadata=metadata)
 
 
+_SESSION_TURN_LEASE_REFRESH_RE = None
+
+
+def _session_turn_lease_refresh_re():
+    """Compile-once matcher for run_agent's periodic lease-wait refresh.
+
+    Derived from the SAME template constant the emit site formats
+    (SESSION_TURN_LEASE_WAIT_REFRESH_STATUS_TEMPLATE, #89166) — never
+    re-inlined wording, same convention as _COMPRESSION_PROGRESS_STATUS_RE
+    (#69550). The import stays lazy because gateway/run.py never imports
+    run_agent at module scope.
+    """
+    global _SESSION_TURN_LEASE_REFRESH_RE
+    if _SESSION_TURN_LEASE_REFRESH_RE is None:
+        from run_agent import SESSION_TURN_LEASE_WAIT_REFRESH_STATUS_TEMPLATE
+
+        _SESSION_TURN_LEASE_REFRESH_RE = re.compile(
+            _status_template_to_regex(SESSION_TURN_LEASE_WAIT_REFRESH_STATUS_TEMPLATE),
+            re.IGNORECASE,
+        )
+    return _SESSION_TURN_LEASE_REFRESH_RE
+
+
+def _should_suppress_lease_wait_refresh(adapter, message: str) -> bool:
+    """True when a periodic turn-lease wait refresh would flood this adapter.
+
+    The periodic refresh exists to update the initial "Another Hermes process
+    is using this session..." notice in place. On adapters without
+    ``send_or_update_status`` (WeCom, Weixin, QQ, Signal, ... — all
+    SUPPORTS_MESSAGE_EDITING = False) ``_send_or_update_status_coro`` falls
+    back to a plain send, so every ~15s refresh lands as another standalone
+    chat message (#89166). Suppress the refresh there; the initial notice and
+    the lease-timeout warning use different wording and are always delivered.
+    """
+    if callable(getattr(adapter, "send_or_update_status", None)):
+        return False
+    return bool(_session_turn_lease_refresh_re().search(str(message or "")))
+
+
 def _resolve_progress_thread_id(
     platform: Any,
     source_thread_id: Any,
@@ -5153,6 +5192,15 @@ class TurnRunner:
                 ctx.source.platform.value if ctx.source.platform else "unknown",
                 event_type,
                 _redact_gateway_user_facing_secrets(str(message or ""))[:160],
+            )
+            return
+        if _should_suppress_lease_wait_refresh(
+            ctx._status_adapter, prepared_message
+        ):
+            logger.debug(
+                "suppressed periodic lease-wait refresh for %s: adapter has "
+                "no in-place status updates",
+                ctx.source.platform.value if ctx.source.platform else "unknown",
             )
             return
         _fut = safe_schedule_threadsafe(

--- a/run_agent.py
+++ b/run_agent.py
@@ -264,6 +264,16 @@ def _is_ephemeral_scaffolding(msg: Any) -> bool:
 
 _MAX_TOOL_WORKERS = 8
 
+# Wording of the periodic refresh emitted while a cross-process session turn
+# lease is held elsewhere (``_on_session_turn_lease_wait``). The refresh only
+# makes sense on surfaces that can update the initial wait notice in place;
+# gateway/run.py derives its no-in-place-update suppression matcher from this
+# constant (#89166) — never re-inline the wording at either site.
+SESSION_TURN_LEASE_WAIT_REFRESH_STATUS_TEMPLATE = (
+    "⏳ Still waiting for the other Hermes process on "
+    "this session ({elapsed_seconds}s)..."
+)
+
 # Intrinsic marker stamped on a message dict once it has been written to the
 # SQLite session store.  Used by ``_flush_messages_to_session_db`` to decide
 # what is already durable.  An object-identity (``id(msg)``) dedup set cannot be
@@ -8484,8 +8494,9 @@ class AIAgent:
                         )
                     else:
                         self._emit_status(
-                            "⏳ Still waiting for the other Hermes process on "
-                            f"this session ({int(elapsed)}s)..."
+                            SESSION_TURN_LEASE_WAIT_REFRESH_STATUS_TEMPLATE.format(
+                                elapsed_seconds=int(elapsed)
+                            )
                         )
 
                 if not _turn_db.acquire_session_turn_lease(

--- a/tests/gateway/test_session_lease_wait_refresh.py
+++ b/tests/gateway/test_session_lease_wait_refresh.py
@@ -1,0 +1,107 @@
+"""Cross-process session lease-wait refresh must not flood chat gateways (#89166).
+
+While a durable session's turn lease is held by another Hermes process,
+``run_agent._on_session_turn_lease_wait`` emits an initial wait notice once
+and then a periodic "Still waiting ... (Ns)" refresh roughly every 15s. The
+refresh only makes sense on surfaces that can update the initial notice in
+place: on adapters without ``send_or_update_status`` (WeCom, Weixin, QQ,
+Signal, ... — all SUPPORTS_MESSAGE_EDITING = False) the status path falls
+back to a plain send, and a two-minute wait produced eight standalone
+chat messages that drowned the eventual delivery.
+
+``_should_suppress_lease_wait_refresh`` gates the refresh by adapter
+capability; the initial notice and the lease-timeout warning use different
+wording and must always be delivered.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from gateway.config import Platform
+from gateway.run import (
+    _prepare_gateway_status_message,
+    _should_suppress_lease_wait_refresh,
+)
+from run_agent import SESSION_TURN_LEASE_WAIT_REFRESH_STATUS_TEMPLATE
+
+INITIAL_WAIT_NOTICE = (
+    "⏳ Another Hermes process is using this session; "
+    "waiting for it to finish before starting your turn..."
+)
+LEASE_TIMEOUT_WARNING = (
+    "⏳ Another Hermes process kept this session busy too "
+    "long. Your message was not processed - wait for the "
+    "other process to finish, then send it again."
+)
+
+
+def _adapter_without_status_update():
+    # Shape of the WeCom/Weixin/QQ/Signal adapters: plain send, no
+    # send_or_update_status, SUPPORTS_MESSAGE_EDITING = False.
+    return SimpleNamespace(send=AsyncMock(), SUPPORTS_MESSAGE_EDITING=False)
+
+
+def _adapter_with_status_update():
+    # Shape of the Telegram/Slack adapters: refreshes edit the same bubble.
+    return SimpleNamespace(
+        send=AsyncMock(),
+        send_or_update_status=AsyncMock(),
+        SUPPORTS_MESSAGE_EDITING=True,
+    )
+
+
+def _prepared_refresh(elapsed_seconds: int) -> str:
+    message = SESSION_TURN_LEASE_WAIT_REFRESH_STATUS_TEMPLATE.format(
+        elapsed_seconds=elapsed_seconds
+    )
+    prepared = _prepare_gateway_status_message(
+        Platform.WECOM, "lifecycle", message
+    )
+    assert prepared is not None, "refresh must survive the noise filter first"
+    return prepared
+
+
+def test_refresh_suppressed_on_adapter_without_in_place_updates():
+    adapter = _adapter_without_status_update()
+    for elapsed in (15, 30, 105, 120):
+        assert (
+            _should_suppress_lease_wait_refresh(
+                adapter, _prepared_refresh(elapsed)
+            )
+            is True
+        )
+
+
+def test_refresh_delivered_when_adapter_updates_in_place():
+    adapter = _adapter_with_status_update()
+    assert (
+        _should_suppress_lease_wait_refresh(adapter, _prepared_refresh(15))
+        is False
+    )
+
+
+def test_initial_wait_notice_never_suppressed():
+    adapter = _adapter_without_status_update()
+    prepared = _prepare_gateway_status_message(
+        Platform.WECOM, "lifecycle", INITIAL_WAIT_NOTICE
+    )
+    assert prepared is not None
+    assert _should_suppress_lease_wait_refresh(adapter, prepared) is False
+
+
+def test_lease_timeout_warning_never_suppressed():
+    adapter = _adapter_without_status_update()
+    prepared = _prepare_gateway_status_message(
+        Platform.WECOM, "lifecycle", LEASE_TIMEOUT_WARNING
+    )
+    assert prepared is not None
+    assert _should_suppress_lease_wait_refresh(adapter, prepared) is False
+
+
+def test_unrelated_lifecycle_status_never_suppressed():
+    adapter = _adapter_without_status_update()
+    prepared = _prepare_gateway_status_message(
+        Platform.WECOM, "lifecycle", "Resumed session after gateway restart"
+    )
+    assert prepared is not None
+    assert _should_suppress_lease_wait_refresh(adapter, prepared) is False


### PR DESCRIPTION
## What does this PR do?

While a durable session's cross-process turn lease is held by another Hermes process, the waiting process emits an initial "Another Hermes process is using this session…" notice once, then a periodic "Still waiting… (Ns)" refresh roughly every 15s. That refresh only makes sense on surfaces that can update the initial notice in place. On adapters without `send_or_update_status` (WeCom, Weixin, QQ, Signal, … — all `SUPPORTS_MESSAGE_EDITING = False`) the status path falls back to a plain `adapter.send`, so every refresh landed as another standalone chat message: a two-minute wait produced eight separate messages that drowned the eventual delivery.

This PR suppresses the periodic refresh when the adapter cannot update the status in place:

- Extracts the refresh wording into a module-level template constant at the emit site.
- Derives a compile-once matcher from that constant (same constants-are-the-wording convention as `_COMPRESSION_PROGRESS_STATUS_RE`, #69550) and gates it on adapter capability in the status callback.
- Adapters that CAN update in place (Telegram, Slack) keep refreshing the existing bubble unchanged.

The initial wait notice and the lease-timeout warning use different wording and are always delivered, on every platform.

## Related Issue

Fixes #89166

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

- `SESSION_TURN_LEASE_WAIT_REFRESH_STATUS_TEMPLATE`: the periodic refresh wording as a format template; the emit site now formats it instead of an inline f-string.
- `_session_turn_lease_refresh_re()`: lazy compile-once regex derived from that template via the existing `_status_template_to_regex` helper (lazy because this module never imports run_agent at module scope).
- `_should_suppress_lease_wait_refresh(adapter, message)`: True only when the adapter has no callable `send_or_update_status` AND the message is the periodic refresh.
- `_status_callback_sync`: early-returns (with a debug log) when that helper says the refresh would flood this adapter.
- New regression test suite covering: refresh suppressed across elapsed values on a no-update adapter, refresh delivered on an update-capable adapter, initial notice / timeout warning / unrelated lifecycle statuses never suppressed, and the refresh surviving the noise filter before the gate runs.

Related but distinct from #12610 (which suppresses ALL lifecycle events on the email platform by platform enum): this change is scoped to the single periodic lease-wait refresh template and keys off adapter capability, so every other lifecycle status keeps flowing to non-editing platforms.

## How to Test

```bash
python -m pytest tests/gateway/test_session_lease_wait_refresh.py -q
# 5 passed

python -m pytest tests/gateway/test_telegram_noise_filter.py tests/gateway/test_compression_progress_notices.py tests/gateway/test_telegram_status_update.py tests/state/test_session_turn_lease.py tests/run_agent/test_cross_process_turn_lease.py -q
# all passed locally
```

Manual repro from the issue: open the same durable session from Desktop and send a DM through a WeCom/Weixin gateway while Desktop holds the turn; previously each 15s tick posted a new chat message, now only the single initial wait notice appears (and the lease-timeout warning if the wait exceeds the budget).

Fail-on-main check: with the source changes stashed, the new suite fails at collection (the gate and template constant do not exist on main).

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments explain intent (why the refresh must be capability-gated)
- [x] Corresponding changes documented via docstrings
- [x] Tests added and passing (5 new; adjacent suites green)
- [x] Single root cause, no unrelated changes
