### PR TITLE
fix(gateway): do not consume delivery attempts for async completions unroutable in this process

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24674,6 +24674,39 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception as exc:
                 logger.error("Watch notification injection error: %s", exc)
 
+    def _resolve_watch_route(self, evt: dict):
+        """Resolve a concrete route available to this gateway process.
+
+        This is the single dry-run resolver used by both classification and
+        injection.  An unroutable process must not claim durable work, since
+        another gateway may own the adapter that can deliver it.
+        """
+        source = self._build_process_event_source(evt)
+        if source:
+            platform_name = (
+                source.platform.value
+                if hasattr(source.platform, "value")
+                else str(source.platform)
+            )
+            for platform, adapter in self.adapters.items():
+                if platform.value == platform_name and adapter:
+                    return source
+            return None
+
+        # Raw API sessions have no structured source.  They are concrete only
+        # when this process has the non-push api_server adapter to self-post.
+        raw_sid = str(evt.get("origin_session_id") or "").strip()
+        if not raw_sid:
+            session_key = str(evt.get("session_key") or "").strip()
+            if session_key and _parse_session_key(session_key) is None:
+                raw_sid = session_key
+        if raw_sid:
+            adapter = self.adapters.get(Platform.API_SERVER)
+            from gateway.wake import adapter_supports_push
+            if adapter and not adapter_supports_push(adapter):
+                return ("raw_api_server", raw_sid)
+        return None
+
     async def _inject_watch_notification(
         self, synth_text: str, evt: dict,
     ) -> Optional[bool]:
@@ -24686,7 +24719,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         is not a transactional boundary: a process crash after adapter
         acceptance can still cause durable at-least-once replay.
         """
-        source = await asyncio.to_thread(self._build_process_event_source, evt)
+        route = await asyncio.to_thread(self._resolve_watch_route, evt)
+        source = route if not isinstance(route, tuple) else None
         if not source:
             # API-server-originated sessions bind a RAW session key (the
             # X-Hermes-Session-Id value — see _bind_api_server_session), not a
@@ -24695,11 +24729,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Recover the raw session id and wake the real session via the API
             # server's own /v1/chat/completions entry point instead of
             # dropping the event.
-            raw_sid = str(evt.get("origin_session_id") or "").strip()
-            if not raw_sid:
-                _sk = str(evt.get("session_key") or "").strip()
-                if _sk and _parse_session_key(_sk) is None:
-                    raw_sid = _sk
+            raw_sid = route[1] if isinstance(route, tuple) else ""
             if raw_sid:
                 adapter = self.adapters.get(Platform.API_SERVER)
                 from gateway.wake import adapter_supports_push, deliver_wake
@@ -24719,11 +24749,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             raw_sid, e,
                         )
                         return False
-                logger.warning(
-                    "Dropping watch notification for raw session %s: no "
-                    "api_server adapter to self-post through",
-                    raw_sid,
-                )
+                logger.warning("Dropping watch notification for raw session %s", raw_sid)
                 return None
             logger.warning(
                 "Dropping watch notification with no routing metadata for process %s",
@@ -24841,7 +24867,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return (evt_type, producer_id, started_at)
         return None
 
-    async def _classify_completion_target(self, parent_session_id: str) -> str:
+    async def _classify_async_completion(self, evt: dict) -> str:
         """Classify an async-completion delivery target before adapter acceptance.
 
         Returns one of:
@@ -24860,6 +24886,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
           continuation exists). The claim should be released so a later
           consumer can retry; the attempt cap bounds the churn.
         """
+        parent_session_id = str(evt.get("parent_session_id") or "").strip()
+        if not parent_session_id:
+            # The watcher waits for adapters to finish connecting before this
+            # classification runs.  If no concrete route is visible, leave
+            # the row pending for the gateway process that owns the target.
+            return "deliver" if self._resolve_watch_route(evt) is not None else "unroutable"
+
         session_db = getattr(self, "_session_db", None)
         if session_db is None:
             return "retry"
@@ -24924,6 +24957,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         durable_delegation_id = ""
         if evt.get("type") == "async_delegation":
             durable_delegation_id = str(evt.get("delegation_id") or "")
+            verdict = await self._classify_async_completion(evt)
+            if verdict == "unroutable":
+                logger.debug(
+                    "Async completion %s is unroutable in this gateway process; "
+                    "leaving its durable delivery row pending",
+                    durable_delegation_id or "<legacy>",
+                )
+                return None
             if durable_delegation_id:
                 try:
                     from tools.async_delegation import claim_completion_delivery
@@ -24947,7 +24988,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # would falsely acknowledge the durable row as delivered.
                 # Verify the target here, before acceptance, and give drops an
                 # honest durable disposition.
-                verdict = await self._classify_completion_target(parent_session_id)
                 if verdict == "terminal":
                     logger.warning(
                         "Async delegation %s targets permanently-gone session %s; "

--- a/tests/gateway/test_async_unroutable_attempts.py
+++ b/tests/gateway/test_async_unroutable_attempts.py
@@ -1,0 +1,196 @@
+"""Durable async completion routing must precede delivery claiming."""
+
+from collections import OrderedDict
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+
+
+@pytest.fixture
+def durable_event(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "unroute-test",
+        "session_key": "raw-cli-session",
+        "status": "completed",
+        "summary": "done",
+        "dispatched_at": 1.0,
+        "completed_at": 2.0,
+    }
+    from tools import async_delegation
+
+    async_delegation._persist_dispatch({
+        "delegation_id": event["delegation_id"],
+        "session_key": event["session_key"],
+        "origin_ui_session_id": "",
+        "parent_session_id": event.get("parent_session_id"),
+        "dispatched_at": event["dispatched_at"],
+    })
+    async_delegation._persist_completion(event, event)
+    return event
+
+
+def _row():
+    from tools import async_delegation
+
+    with async_delegation._connect() as conn:
+        return conn.execute(
+            "SELECT delivery_state, delivery_attempts, delivery_claim "
+            "FROM async_delegations WHERE delegation_id=?",
+            ("unroute-test",),
+        ).fetchone()
+
+
+def _runner(adapters):
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = adapters
+    runner.session_store = SimpleNamespace(_ensure_loaded=lambda: None, _entries={})
+    runner._session_source_cache = {}
+    runner._completion_delivery_lock = __import__("threading").Lock()
+    runner._completion_deliveries_inflight = set()
+    runner._completion_deliveries_delivered = OrderedDict()
+    runner._completion_delivery_retention = 2048
+    return runner
+
+
+def _api_adapter():
+    return SimpleNamespace(
+        supports_async_delivery=False,
+        handle_message=AsyncMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_unroutable_raw_completion_does_not_claim(durable_event, monkeypatch):
+    from tools import async_delegation
+
+    def claim_should_not_run(*_args):
+        raise AssertionError("unroutable completion was claimed")
+
+    monkeypatch.setattr(async_delegation, "claim_completion_delivery", claim_should_not_run)
+    runner = _runner({Platform.TELEGRAM: SimpleNamespace(handle_message=AsyncMock())})
+
+    result = await runner._deliver_completion_notification("done", durable_event)
+
+    assert result is None
+    assert _row() == ("pending", 0, None)
+
+
+@pytest.mark.asyncio
+async def test_raw_completion_delivers_with_api_server(durable_event, monkeypatch):
+    from gateway import wake
+
+    posts = []
+    async def fake_deliver_wake(adapter, *, text, session_id):
+        posts.append(session_id)
+
+    monkeypatch.setattr(wake, "deliver_wake", fake_deliver_wake)
+    api = _api_adapter()
+    runner = _runner({Platform.API_SERVER: api})
+
+    assert await runner._deliver_completion_notification("done", durable_event)
+    assert posts == ["raw-cli-session"]
+    assert _row()[0:2] == ("delivered", 1)
+
+
+@pytest.mark.asyncio
+async def test_structured_parent_completion_still_acks(durable_event):
+    from tools import async_delegation
+
+    durable_event.update({
+        "delegation_id": "telegram-test",
+        "session_key": "agent:main:telegram:dm:123",
+        "platform": "telegram",
+        "chat_type": "dm",
+        "chat_id": "123",
+        "parent_session_id": "live-parent",
+    })
+    async_delegation._persist_dispatch({
+        "delegation_id": "telegram-test", "session_key": durable_event["session_key"],
+        "origin_ui_session_id": "", "parent_session_id": "live-parent", "dispatched_at": 1.0,
+    })
+    async_delegation._persist_completion(durable_event, durable_event)
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner({Platform.TELEGRAM: adapter})
+    runner._session_db = SimpleNamespace(
+        get_session=AsyncMock(return_value={"ended_at": None}),
+    )
+
+    assert await runner._deliver_completion_notification("done", durable_event)
+    assert adapter.handle_message.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_adapter_exception_releases_claim(durable_event):
+    from tools import async_delegation
+
+    durable_event.update({
+        "delegation_id": "exception-test", "session_key": "agent:main:telegram:dm:123",
+        "platform": "telegram", "chat_type": "dm", "chat_id": "123",
+    })
+    async_delegation._persist_dispatch({
+        "delegation_id": "exception-test", "session_key": durable_event["session_key"],
+        "origin_ui_session_id": "", "parent_session_id": None, "dispatched_at": 1.0,
+    })
+    async_delegation._persist_completion(durable_event, durable_event)
+    adapter = SimpleNamespace(handle_message=AsyncMock(side_effect=RuntimeError("temporary")))
+    runner = _runner({Platform.TELEGRAM: adapter})
+
+    assert await runner._deliver_completion_notification("done", durable_event) is False
+    with async_delegation._connect() as conn:
+        row = conn.execute(
+            "SELECT delivery_state, delivery_attempts, delivery_claim FROM async_delegations "
+            "WHERE delegation_id='exception-test'"
+        ).fetchone()
+    assert row == ("pending", 1, None)
+
+
+@pytest.mark.asyncio
+async def test_terminal_parent_is_claimed_and_dropped(durable_event):
+    from tools import async_delegation
+
+    durable_event.update({
+        "delegation_id": "terminal-test", "session_key": "agent:main:telegram:dm:123",
+        "platform": "telegram", "chat_type": "dm", "chat_id": "123",
+        "parent_session_id": "gone-parent",
+    })
+    async_delegation._persist_dispatch({
+        "delegation_id": "terminal-test", "session_key": durable_event["session_key"],
+        "origin_ui_session_id": "", "parent_session_id": "gone-parent", "dispatched_at": 1.0,
+    })
+    async_delegation._persist_completion(durable_event, durable_event)
+    runner = _runner({Platform.TELEGRAM: SimpleNamespace(handle_message=AsyncMock())})
+    runner._session_db = SimpleNamespace(get_session=AsyncMock(return_value=None))
+
+    assert await runner._deliver_completion_notification("done", durable_event) is None
+    with async_delegation._connect() as conn:
+        row = conn.execute(
+            "SELECT delivery_state, delivery_attempts FROM async_delegations "
+            "WHERE delegation_id='terminal-test'"
+        ).fetchone()
+    assert row == ("dropped", 1)
+
+
+@pytest.mark.asyncio
+async def test_ownership_handoff_leaves_row_for_api_server(durable_event, monkeypatch):
+    from gateway import wake
+
+    posts = []
+    async def fake_deliver_wake(adapter, *, text, session_id):
+        posts.append(session_id)
+
+    monkeypatch.setattr(wake, "deliver_wake", fake_deliver_wake)
+    telegram = _runner({Platform.TELEGRAM: SimpleNamespace(handle_message=AsyncMock())})
+    assert await telegram._deliver_completion_notification("done", durable_event) is None
+    assert _row() == ("pending", 0, None)
+
+    api = _runner({Platform.API_SERVER: _api_adapter()})
+    assert await api._deliver_completion_notification("done", durable_event)
+    assert posts == ["raw-cli-session"]
+    assert _row()[0] == "delivered"


### PR DESCRIPTION
## Summary

Fixes #82703

A gateway restart restores every durable `async_delegation` row with `delivery_state='pending'`, and the watcher processes each one. For completions belonging to raw CLI sessions (opaque session id, no adapter route), each restart:

1. Claims the durable row (`delivery_attempts + 1` happens inside the claim UPDATE).
2. Cannot resolve a platform/chat route from the opaque CLI session id.
3. With no `api_server` adapter registered, injection returns `None`.
4. The event is dropped from the in-memory queue (only `False` is requeued).
5. The durable claim is released back to `pending`, but the attempt stays consumed.

After `_MAX_DELIVERY_ATTEMPTS` the row converges to terminal `dropped`, even though this gateway was never a valid owner. Symptom logs: "Synthetic event source unresolvable: platform='' chat_type='' chat_id=''" and "Dropping watch notification for raw session <opaque>: no api_server adapter to self-post through".

## Root cause

Attempts are consumed at claim time, before route resolvability is known. The claim precedes any classification, and the pre-flight target classification (#65838-class) only runs when `parent_session_id` is present. Raw-session events skip it entirely.

## Fix

Reorder so routability is decided before the claim, through the existing #65838 seam (no second classifier):

- **IP-3: `_resolve_watch_route(evt)`** — one pure resolver extracted from `_inject_watch_notification`. Returns the concrete route this process can deliver to, or `None`. No I/O, no send.
- **IP-2: `_classify_async_completion(evt)`** — the existing `_classify_completion_target` generalized to take the event: `parent_session_id` present keeps the #65838 logic verbatim; absent falls back to the resolver dry run.
- **IP-1: classify before claim** — `unroutable` verdict returns `None` without entering `claim_completion_delivery`. The durable row stays `pending` with zero attempts, available to any consumer that can prove ownership (the api_server self-post path, per the issue's request).

Everything past resolution keeps today's semantics exactly: claim, then `terminal` -> drop, `retry`/adapter exception -> release + `False`, success -> ack.

## Evidence

- Primary regression: raw-CLI pending row (attempts 0, no `parent_session_id`) against a Telegram-only gateway stays `pending` with `delivery_attempts == 0` and `delivery_claim IS NULL`; return value is `None`; the event leaves the in-memory queue; a spy proves `claim_completion_delivery` is never entered.
- Sabotage run on unpatched `47363a9`: the same test FAILS (claim spy fires, attempts consumed), and the ownership-handoff control fails (`1 != 0`). Patched tree: all tests pass.
- Controls: raw session + api_server adapter delivers and acks (attempts 1, `delivered`); structured Telegram claim + ack unchanged; adapter exception -> claim, release, `False`, row still `pending`; terminal verdict -> claim + drop; ownership handoff (Telegram-only skips, api_server then delivers).

## Test plan

`pytest tests/gateway/test_async_unroutable_attempts.py -q` (6 passed). Focused gateway regressions 25 passed. Broader suite 4,993 passed, 29 skipped, 1 xfailed, 7 unrelated environment/dependency failures.

## Non-goals

- Structured Telegram delivery behavior (unchanged)
- Retry/backoff redesign (#16645)
- `_MAX_DELIVERY_ATTEMPTS` semantics (unchanged)
- Watchdog work
- No schema change, no new `delivery_state`, no env vars, no config surface
- No persisted `unroutable` disposition: process-local routability is inherently per-process, and persisting it would destroy the cross-restart ownership handoff the issue explicitly asks for
