### PR TITLE
fix(vision): treat a model without image support as an answer, not a crash

### DIFF
--- a/tests/tools/test_vision_capability_error_surface.py
+++ b/tests/tools/test_vision_capability_error_surface.py
@@ -1,0 +1,328 @@
+"""A model without vision is an ANSWER, not a crash (#89114).
+
+#89114 was filed as "Vision tool crashes with BadRequestError when model lacks
+image support", with an ``openai.BadRequestError`` traceback pasted in.  The
+traceback is real but it is not a crash: it is ``vision_analyze_tool``'s own
+``logger.error(..., exc_info=True)`` line, emitted from inside the handler that
+had *already* classified the failure and was about to return
+``success: false`` with a readable sentence.  Logging a handled, classified,
+user-actionable outcome at ERROR with a full stack made it indistinguishable
+from an unhandled exception — to the reporter, and to anyone reading logs.
+
+Three properties are pinned here:
+
+1. ``vision_analyze_tool`` does not raise on the reporter's exact provider
+   message, and logs it at WARNING without a traceback.  An *unclassified*
+   failure still gets ERROR + ``exc_info`` — that is the case where a stack
+   actually earns its place.
+2. ``browser_vision`` reaches the same auxiliary vision model by the same
+   route, so the same rejection must produce the same kind of answer.  Before
+   this change it alone handed the agent a raw ``Error code: 400 - {...}``
+   blob while ``vision_analyze`` produced a sentence.
+3. ``computer_use`` -- the tool the issue names -- stops presenting a failed
+   analysis as ``vision_analysis``, and takes the graceful-degradation path
+   it already had instead.
+"""
+
+import json
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tools.vision_tools import is_vision_capability_error, vision_analyze_tool
+
+
+# The exact string the provider returned in #89114 (mimo-v2.5 via an
+# OpenCode-compatible Go provider).  Everything below keys off it.
+REPORTED_ERROR = (
+    "Error code: 400 - {'error': {'message': 'This model does not support "
+    "image inputs', 'type': 'invalid_request_error', 'param': 'messages', "
+    "'code': 'invalid_request_error'}}"
+)
+
+
+class _BadRequestError(Exception):
+    """Stand-in for ``openai.BadRequestError`` — the tests only use its text."""
+
+
+class TestCapabilityClassification:
+    """``is_vision_capability_error`` — the shared predicate."""
+
+    @pytest.mark.parametrize("message", [
+        REPORTED_ERROR,
+        "This model does not support image inputs",
+        "model is not multimodal",
+        "unrecognized request argument supplied: image_url",
+        "image input is not supported for this model",
+        "does not support vision",
+    ])
+    def test_capability_rejections_are_recognised(self, message):
+        assert is_vision_capability_error(_BadRequestError(message)) is True
+
+    @pytest.mark.parametrize("message", [
+        # A size rejection is a different remedy (resize and retry), and
+        # _is_image_size_error already owns it.
+        "image is too large: maximum payload size is 20 MB",
+        # Billing is a different remedy again (top up the account).
+        "Error code: 402 - insufficient credits",
+        # An outage says nothing about the model's capabilities; calling it a
+        # capability error would tell the user to change their config for a
+        # problem that fixes itself.
+        "Error code: 500 - internal server error",
+        "Connection timed out",
+    ])
+    def test_unrelated_failures_are_not_capability_errors(self, message):
+        assert is_vision_capability_error(_BadRequestError(message)) is False
+
+
+class TestVisionAnalyzeDoesNotCrash:
+    """The report itself: ``vision_analyze`` on a text-only model."""
+
+    @staticmethod
+    async def _run_with_error(error, image_path):
+        with (
+            patch(
+                "tools.vision_tools._image_to_base64_data_url",
+                return_value="data:image/png;base64,abc",
+            ),
+            patch(
+                "tools.vision_tools.async_call_llm",
+                new_callable=AsyncMock,
+                side_effect=error,
+            ),
+        ):
+            return json.loads(
+                await vision_analyze_tool(str(image_path), "describe this", "mimo-v2.5")
+            )
+
+    @pytest.fixture
+    def image(self, tmp_path):
+        img = tmp_path / "screenshot.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 32)
+        return img
+
+    @pytest.mark.asyncio
+    async def test_reported_error_returns_an_answer_instead_of_raising(self, image):
+        """The `needs-repro` question: it does not propagate, it answers."""
+        result = await self._run_with_error(_BadRequestError(REPORTED_ERROR), image)
+
+        assert result["success"] is False
+        # The analysis must name the cause in words the agent can relay.
+        assert "does not support vision" in result["analysis"]
+        assert "mimo-v2.5" in result["analysis"]
+
+    @pytest.mark.asyncio
+    async def test_classified_failure_logs_warning_without_a_traceback(
+        self, image, caplog
+    ):
+        """The actual defect: a handled outcome logged like an unhandled crash."""
+        with caplog.at_level(logging.WARNING, logger="tools.vision_tools"):
+            await self._run_with_error(_BadRequestError(REPORTED_ERROR), image)
+
+        records = [
+            r for r in caplog.records
+            if "Error analyzing image" in r.getMessage()
+        ]
+        assert len(records) == 1
+        assert records[0].levelno == logging.WARNING
+        assert records[0].exc_info is None, (
+            "a classified, answered failure must not print a stack trace — "
+            "the traceback in #89114 is this very log line"
+        )
+
+    @pytest.mark.asyncio
+    async def test_unclassified_failure_keeps_error_and_traceback(
+        self, image, caplog
+    ):
+        """The negative half: surprises still get the loudest treatment."""
+        with caplog.at_level(logging.WARNING, logger="tools.vision_tools"):
+            await self._run_with_error(
+                _BadRequestError("kernel panic in the tensor mines"), image
+            )
+
+        records = [
+            r for r in caplog.records
+            if "Error analyzing image" in r.getMessage()
+        ]
+        assert len(records) == 1
+        assert records[0].levelno == logging.ERROR
+        assert records[0].exc_info is not None
+
+    @pytest.mark.asyncio
+    async def test_content_policy_still_routes_to_the_capability_message(self, image):
+        """Behaviour preservation across the helper extraction.
+
+        ``content_policy`` was one arm of the inline hint tuple this change
+        replaced with ``is_vision_capability_error``.  It is *not* a capability
+        problem, so it stays out of the shared predicate — but the branch must
+        still fire for it, or the refactor silently changed the truth table.
+        """
+        assert is_vision_capability_error(
+            _BadRequestError("content_policy violation")
+        ) is False
+
+        result = await self._run_with_error(
+            _BadRequestError("content_policy violation"), image
+        )
+        assert "does not support vision" in result["analysis"]
+
+    @pytest.mark.asyncio
+    async def test_credit_errors_keep_their_own_remedy(self, image):
+        """Ordering guard: billing is checked before capability."""
+        result = await self._run_with_error(
+            _BadRequestError("Error code: 402 - insufficient credits"), image
+        )
+        assert "top up" in result["analysis"].lower()
+
+
+class TestBrowserVisionSurfacesTheSameAnswer:
+    """``browser_vision`` takes the same route to the same aux model."""
+
+    @staticmethod
+    def _invoke(error, screenshot):
+        import tools.browser_tool as bt
+
+        def fake_run(task_id, command, args=None, **kwargs):
+            return {"success": True, "data": {"path": str(screenshot)}}
+
+        with (
+            patch.object(bt, "_is_camofox_mode", lambda: False),
+            patch.object(bt, "_is_local_backend", lambda: True),
+            patch.object(bt, "_get_browser_engine", lambda: "chrome"),
+            patch.object(bt, "_cleanup_old_screenshots", lambda *a, **k: None),
+            patch.object(bt, "_run_browser_command", fake_run),
+            patch.object(bt, "_get_vision_model", lambda: "mimo-v2.5"),
+            patch("tools.vision_tools._should_use_native_vision_fast_path",
+                  lambda: False),
+            patch.object(bt, "_lazy_call_llm", side_effect=error),
+        ):
+            return json.loads(bt.browser_vision("what is on screen?"))
+
+    @pytest.fixture
+    def screenshot(self, tmp_path):
+        shot = tmp_path / "browser_screenshot.png"
+        shot.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 32)
+        return shot
+
+    def test_capability_rejection_becomes_a_sentence_not_a_400_blob(
+        self, screenshot
+    ):
+        result = self._invoke(_BadRequestError(REPORTED_ERROR), screenshot)
+
+        assert result["success"] is False
+        assert "does not support image inputs" in result["error"]
+        assert "auxiliary.vision" in result["error"], (
+            "the message must name the config key that fixes it — otherwise "
+            "the agent can relay the failure but not the remedy"
+        )
+
+    def test_unclassified_failure_keeps_the_raw_error(self, screenshot):
+        """No over-reach: an unrecognised failure is reported verbatim."""
+        result = self._invoke(_BadRequestError("socket hang up"), screenshot)
+
+        assert result["success"] is False
+        assert "socket hang up" in result["error"]
+        assert "auxiliary.vision" not in result["error"]
+
+    def test_screenshot_is_preserved_on_a_classified_failure(self, screenshot):
+        """The pre-existing contract still holds through the new branch."""
+        result = self._invoke(_BadRequestError(REPORTED_ERROR), screenshot)
+
+        assert result.get("screenshot_path") == str(screenshot)
+
+
+class TestComputerUseDegradesInsteadOfNarratingTheFailure:
+    """``computer_use`` is the tool #89114 was actually filed against.
+
+    ``_route_capture_through_aux_vision`` read ``analysis`` out of
+    ``vision_analyze_tool``'s envelope without checking ``success``.  Because
+    that field is populated on the failure path too, a capability rejection
+    was merged into the response as ``vision_analysis`` — the main model was
+    handed a 400 blob under a key that promises a description of the screen.
+
+    The caller already had the graceful degradation the reporter asks for
+    (screenshot omitted, ``vision_unavailable``, element index still
+    drivable); it simply never fired, because the helper never reported
+    failure.
+    """
+
+    # 8x8 transparent PNG — same bytes the existing routing tests use.
+    _PNG_B64 = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAADUlEQVR4nG"
+        "NgGAUgAAABCAABgukLHQAAAABJRU5ErkJggg=="
+    )
+
+    @pytest.fixture
+    def cache_dir(self, tmp_path):
+        cache = tmp_path / "cache_vision"
+        cache.mkdir()
+        with patch("hermes_constants.get_hermes_dir", lambda *a, **k: cache):
+            yield cache
+
+    def _capture(self):
+        import base64
+
+        from tools.computer_use.backend import CaptureResult, UIElement
+
+        return CaptureResult(
+            mode="som",
+            width=1280,
+            height=800,
+            png_b64=self._PNG_B64,
+            elements=[
+                UIElement(index=0, role="AXButton", label="Sign in",
+                          bounds=(10, 20, 80, 30)),
+            ],
+            app="Safari",
+            window_title="Hermes",
+            png_bytes_len=len(base64.b64decode(self._PNG_B64, validate=False)),
+        )
+
+    def _route(self, envelope, cache_dir):
+        from tools.computer_use import tool as cu_tool
+
+        with (
+            patch.object(cu_tool, "_should_route_through_aux_vision",
+                         return_value=True),
+            patch("model_tools._run_async", side_effect=lambda _c: envelope),
+            patch("tools.vision_tools.vision_analyze_tool",
+                  new_callable=lambda: MagicMock(return_value="<coro>")),
+        ):
+            return json.loads(cu_tool._capture_response(self._capture()))
+
+    def test_capability_failure_degrades_to_the_ax_payload(self, cache_dir):
+        envelope = json.dumps({
+            "success": False,
+            "error": f"Error analyzing image: {REPORTED_ERROR}",
+            "analysis": (
+                "mimo-v2.5 does not support vision or our request was not "
+                f"accepted by the server. Error: {REPORTED_ERROR}"
+            ),
+        })
+
+        body = self._route(envelope, cache_dir)
+
+        assert body.get("vision_unavailable") is True
+        assert "vision_analysis" not in body, (
+            "a failed analysis must not be presented as a description of the "
+            "screen — the main model cannot tell the difference"
+        )
+        assert "Error code: 400" not in json.dumps(body)
+        # The degradation is useful, not just safe: the element index the
+        # agent drives with survives.
+        assert len(body["elements"]) == 1
+        assert body["elements"][0]["label"] == "Sign in"
+
+    def test_successful_analysis_is_still_routed_through(self, cache_dir):
+        """The guard is narrow: a real description reaches the model intact."""
+        envelope = json.dumps({
+            "success": True,
+            "analysis": "A Safari window showing a 'Sign in' button.",
+        })
+
+        body = self._route(envelope, cache_dir)
+
+        assert body["vision_analysis_routed_via"] == "auxiliary.vision"
+        assert "Sign in" in body["vision_analysis"]
+        assert "vision_unavailable" not in body

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -4824,8 +4824,41 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
         # in the LLM vision analysis, not the capture.  Deleting a valid
         # screenshot loses evidence the user might need.  The 24-hour cleanup
         # in _cleanup_old_screenshots prevents unbounded disk growth.
-        logger.warning("browser_vision failed: %s", e, exc_info=True)
-        error_info = {"success": False, "error": f"Error during vision analysis: {str(e)}"}
+        # Classify the failure the way vision_analyze_tool does.  Without this
+        # a model that simply has no vision hands the agent a raw
+        # ``Error code: 400 - {...}`` blob it cannot act on, while the very
+        # same rejection through ``vision_analyze`` produces a sentence
+        # (#89114).  Same auxiliary model, same route, same rejection -- the
+        # answer should not depend on which tool asked.
+        from tools.vision_tools import is_vision_capability_error
+
+        _err_str = str(e).lower()
+        if any(hint in _err_str for hint in (
+            "402", "insufficient", "payment required", "credits", "billing",
+        )):
+            reason = (
+                "Insufficient credits or payment required for the vision "
+                f"model. Top up your API provider account and try again. Error: {e}"
+            )
+        elif is_vision_capability_error(e):
+            reason = (
+                "The configured vision model does not support image inputs, so "
+                "the screenshot could not be analyzed. Point auxiliary.vision "
+                "in config.yaml at a multimodal model. "
+                f"Error: {e}"
+            )
+        else:
+            reason = None
+
+        # Same rule as vision_analyze_tool: a traceback for the surprises only.
+        if reason is None:
+            logger.warning("browser_vision failed: %s", e, exc_info=True)
+        else:
+            logger.warning("browser_vision failed: %s", e)
+        error_info = {
+            "success": False,
+            "error": reason or f"Error during vision analysis: {str(e)}",
+        }
         if screenshot_path.exists():
             error_info["screenshot_path"] = str(screenshot_path)
             error_info["note"] = "Screenshot was captured but vision analysis failed. You can still share it via MEDIA:<path>."

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -1458,7 +1458,8 @@ def _route_capture_through_aux_vision(
 
     Returns:
       A JSON-encoded text response on success.
-      ``None`` on failure (caller falls back to the multimodal envelope).
+      ``None`` on failure -- including a ``success: false`` result from
+      ``vision_analyze_tool`` -- so the caller degrades to its AX/SOM payload.
     """
     if not cap.png_b64:
         return None
@@ -1530,6 +1531,23 @@ def _route_capture_through_aux_vision(
         try:
             parsed = json.loads(result_json)
             if isinstance(parsed, dict):
+                # ``vision_analyze_tool`` fills ``analysis`` on failure too --
+                # with an explanation of why it could not look, not a
+                # description of what it saw.  Reading it without checking
+                # ``success`` merges that explanation into ``vision_analysis``,
+                # so the main model is told the screenshot "shows"
+                # ``mimo-v2.5 does not support vision ... Error code: 400``
+                # (#89114).  A failed analysis is not an analysis: return None
+                # and let the caller take the degradation path it already has,
+                # which omits the screenshot, flags ``vision_unavailable`` and
+                # keeps the element index drivable.
+                if parsed.get("success") is False:
+                    logger.warning(
+                        "computer_use: auxiliary.vision could not analyse the "
+                        "capture (%s); degrading to the AX/SOM payload",
+                        str(parsed.get("analysis") or "").strip() or "no detail",
+                    )
+                    return None
                 analysis_text = str(parsed.get("analysis") or "").strip()
         except (TypeError, json.JSONDecodeError):
             analysis_text = result_json.strip()

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -660,6 +660,27 @@ def _is_image_size_error(error: Exception) -> bool:
     ))
 
 
+def is_vision_capability_error(error: Exception) -> bool:
+    """True when a provider rejected the request because the model has no vision.
+
+    Providers word this differently -- "This model does not support image
+    inputs" (#89114), "multimodal", "unrecognized request argument:
+    image_url" -- but they all mean the same thing: the request was well
+    formed and the *model* cannot answer it.  That is an answer, not a
+    fault, and callers use it to say so instead of handing the agent a raw
+    ``Error code: 400 - {...}`` blob.
+
+    Public (no leading underscore) because ``tools.browser_tool`` imports it:
+    ``browser_vision`` reaches the same auxiliary vision model by the same
+    route, so it has to recognise the same rejection.
+    """
+    err_str = str(error).lower()
+    return any(hint in err_str for hint in (
+        "does not support", "not support image",
+        "multimodal", "unrecognized request argument", "image input",
+    ))
+
+
 def _image_exceeds_dimension(image_path: Path, max_dimension: int) -> bool:
     """True if the image's longest side exceeds ``max_dimension`` px.
 
@@ -1563,11 +1584,11 @@ async def vision_analyze_tool(
         
     except Exception as e:
         error_msg = f"Error analyzing image: {str(e)}"
-        logger.error("%s", error_msg, exc_info=True)
         
         # Detect vision capability errors — give the model a clear message
         # so it can inform the user instead of a cryptic API error.
         err_str = str(e).lower()
+        classified = True
         if any(hint in err_str for hint in (
             "402", "insufficient", "payment required", "credits", "billing",
         )):
@@ -1575,11 +1596,7 @@ async def vision_analyze_tool(
                 "Insufficient credits or payment required. Please top up your "
                 f"API provider account and try again. Error: {e}"
             )
-        elif any(hint in err_str for hint in (
-            "does not support", "not support image",
-            "content_policy", "multimodal",
-            "unrecognized request argument", "image input",
-        )):
+        elif is_vision_capability_error(e) or "content_policy" in err_str:
             analysis = (
                 f"{model} does not support vision or our request was not "
                 f"accepted by the server. Error: {e}"
@@ -1596,6 +1613,21 @@ async def vision_analyze_tool(
                 "There was a problem with the request and the image could not "
                 f"be analyzed. Error: {e}"
             )
+            classified = False
+
+        # A classified failure is an ANSWER, not a crash: the branches
+        # above already turned it into something the model can act on, and
+        # this function returns ``success: false`` rather than propagating.
+        # Logging it at ERROR with a full traceback made that
+        # indistinguishable from an unhandled exception -- #89114 was filed
+        # as "crashes with unhandled openai.BadRequestError", and the
+        # traceback quoted in it is this very log line.  Keep ERROR plus a
+        # traceback for the unclassified case, the one where a traceback
+        # earns its place.
+        if classified:
+            logger.warning("%s", error_msg)
+        else:
+            logger.error("%s", error_msg, exc_info=True)
         
         # Prepare error response
         result = {


### PR DESCRIPTION
## What does this PR do?

A provider rejecting a request because the model has no vision is a **well-formed request the model cannot answer**. Three call sites reach the same auxiliary vision model by the same route, and each mishandled that rejection differently. This makes all three treat it as an answer.

**The reported traceback is not an unhandled exception.** `vision_analyze_tool` already caught, classified and answered this; it just logged the caught exception at `ERROR` with `exc_info=True` first. The stack quoted in #89114 as an "unhandled `openai.BadRequestError`" *is that log line*. A handled, classified, user-actionable outcome printed exactly like a crash cost the reporter a triage cycle, and would cost the next person one.

**The defect they actually felt is in `computer_use`.** `_route_capture_through_aux_vision` reads `analysis` out of `vision_analyze_tool`'s envelope without checking `success`. That field is populated on the failure path too — with an explanation of why it could not look, not a description of what it saw — so the rejection was merged into the response as `vision_analysis`. The main model was told the screenshot *shows* `Error code: 400 - {...}`.

The fix is small because **the graceful degradation the issue asks for already exists in the caller and simply never fired.** `_capture_response` omits the screenshot, flags `vision_unavailable: true`, and tells the model "element-index actions still work — drive via the element list above." It is guarded on `_route_capture_through_aux_vision` returning `None`, which its own docstring says it does "on failure". It never reported this failure. Now it does — items 2 and 3 of the issue's Expected Behavior, using machinery already in the tree.

**Why not item 1 (pre-flight capability detection).** Deliberately not implemented. There is no reliable capability signal for an arbitrary OpenAI-compatible endpoint — `/models` does not carry modality for most providers, and the reporter's is a Go proxy in front of another vendor, so a local capability table would be wrong for exactly the setups that hit this. A static allowlist would also fail closed on new multimodal models. The provider's 400 *is* the capability check; it only has to be read as an answer. That costs one wasted call the first time, which is the better trade than silently refusing a model that would have worked. A per-model+provider negative cache is a reasonable separable follow-up and shouldn't gate this.

## Related Issue

Fixes #89114

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**`tools/vision_tools.py`**

- New public `is_vision_capability_error(error)` — the shared predicate. Public (no leading underscore) because `tools/browser_tool.py` imports it; the two tools reach the same aux model by the same route and must recognise the same rejection.
- `vision_analyze_tool`'s handler sets `classified` across the existing if/elif chain and logs **after** it: `WARNING` without a stack for a classified failure, `ERROR` + `exc_info=True` kept for the unclassified branch, where a traceback earns its place.
- The inline capability-hint tuple is replaced by `is_vision_capability_error(e) or "content_policy" in err_str`. `content_policy` is deliberately **excluded** from the shared predicate — it is not a capability problem, and `browser_vision` should not tell a user to change `auxiliary.vision` because of it — but it still routes to the same branch here, so the truth table is unchanged. There is a test pinning exactly that.

**`tools/browser_tool.py`**

- `browser_vision`'s handler classifies before responding. Capability rejections become a sentence that names the config key that fixes it (`auxiliary.vision`); billing rejections get their own remedy; anything unrecognised keeps the raw error text **and** the traceback. Previously it classified nothing, so the same rejection that produced a sentence through `vision_analyze` handed the agent a raw `Error code: 400 - {...}` blob.

**`tools/computer_use/tool.py`**

- `_route_capture_through_aux_vision` returns `None` when the envelope reports `success: false`, logging what the aux model said. This routes the failure into the caller's existing `vision_unavailable` degradation instead of presenting a failed analysis as `vision_analysis`.
- Docstring corrected: the caller degrades to its AX/SOM payload, not to the multimodal envelope (that changed in the `vision_unavailable` work and the docstring did not follow).

**`tests/tools/test_vision_capability_error_surface.py`** — new, 20 tests.

## How to Test

**Reproduce the reported setup** — point `auxiliary.vision` at any text-only model and analyse a PNG:

```bash
hermes --toolsets vision -q "Use vision_analyze on ./shot.png and describe it"
```

Before: an `ERROR` line with a full `openai.BadRequestError` stack (the traceback in the issue). After: a `WARNING` with the same message, no stack, and the same `success: false` JSON the tool has always returned.

**The `computer_use` half** — the one that changes behaviour rather than logging:

```bash
hermes --toolsets computer_use -q "Capture the screen and tell me what app is in front"
```

Before: the model receives `"vision_analysis": "<model> does not support vision ... Error code: 400 - {...}"` under a key promising a description of the screen. After: `"vision_unavailable": true`, the screenshot omitted, and the AX/SOM element index intact so index-driven actions still work.

**Automated:**

```bash
pytest tests/tools/test_vision_capability_error_surface.py -q      # 20 passed
```

**Mutation proof** — each production change is independently load-bearing. Reverting one fails only its own test(s):

| Reverted | Tests that fail |
|---|---|
| `is_vision_capability_error` → `return False` | 8 (6 predicate cases + `vision_analyze` message + `browser_vision` message) |
| `browser_vision`'s classification block | 1 — `test_capability_rejection_becomes_a_sentence_not_a_400_blob` |
| the `classified` log split → unconditional `logger.error(..., exc_info=True)` | 1 — `test_classified_failure_logs_warning_without_a_traceback` |
| `computer_use`'s `success is False` guard | 1 — `test_capability_failure_degrades_to_the_ax_payload` |

**Baseline over the affected slice** (`tests/tools/test_vision_*.py`, `test_browser_content_none_guard.py`, `test_computer_use*.py`, `tests/agent/test_vision_routing_31179.py`, `tests/gateway/test_vision_preprocess.py`), run serially with and without the change: **6 failures both ways, the same 6** — all pre-existing and unrelated to this diff. 200 → 220 passed, the delta being exactly the new file.

For the record, since I had to characterise them: two of the six (`TestBrowserSourceLinesAreGuarded` in `test_browser_content_none_guard.py`) are a genuine Windows-only test bug — `open(path)` with no `encoding=` decodes `tools/browser_tool.py` as cp1252 and dies on the emoji in the tool registration. Three are Linux/env-specific `test_computer_use.py` cases, and one is `test_vision_routing_31179.py::test_vision_capable_main_used` failing to resolve a client in this environment. I left all six alone rather than widen this PR; happy to send the one-line `encoding="utf-8"` fix separately if that is wanted.

## Overlap with open PRs

Searched before building. Five open PRs touch `tools/vision_tools.py` + `tools/browser_tool.py` together, and none of them touches the `except` handlers this PR changes:

| PR | What it is | Overlap |
|---|---|---|
| #63850 | cap `browser_vision` native embeds | embed sizing on the success path |
| #62820 | pre-flight shrink oversized images | resize before the first call |
| #65390 | split per-tool vision/video gates | which tools advertise which modality |
| #24875 | respect auxiliary vision routing | routing decision |
| #83865 | session-scoped media provenance | provenance, different files |
| #83150 | describe images via aux vision on text-only failover | conversation-loop failover; touches `vision_tools.py` but not its handler |
| #72516 | fall back to `image_url` when a provider rejects `video_url` | a *retry* on rejection, in the video path |

None classifies a provider rejection in a handler, and none touches `tools/computer_use/tool.py`. #72516 is the closest in spirit — it also reacts to a provider rejection — but it retries a different request shape rather than deciding how to report an unrecoverable one, and it is video-only.

**Worth a maintainer's attention: #51551** (`route opencode-go / opencode-zen captures to native fast path`) is adjacent and this PR makes it safer rather than conflicting with it. #51551 marks the reporter's transport (`opencode-go`) `supports_vision=True` so captures take the native path. That is right for the vision-capable models behind that proxy and wrong for `mimo-v2.5`, which is the one in this issue — per-model overrides still apply, but a user who has not set one would move the same 400 from the aux call onto the main-model turn. With this PR, whichever path is taken, a capability rejection degrades instead of narrating itself. No file conflict: #51551 edits `tests/tools/test_computer_use_capture_routing.py`, which this PR does not touch.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — see the Overlap table above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits) — one commit
- [x] I've run the affected slice serially with and without the change (see How to Test). I did **not** run `pytest tests/ -q` wholesale: on Windows `tests/hermes_cli/` cannot be collected (`test_doctor_journal_modes.py` calls `os.geteuid`), so the full-suite result would be meaningless from here. CI runs it.
- [x] I've added tests for my changes — 20, with the mutation proof above
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings only; `_route_capture_through_aux_vision`'s return contract was stale and is corrected
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact — no platform-specific code; the change is pure control flow and string classification, and the tests use `tmp_path` with no shell-outs or path assumptions
- [x] N/A — no tool description or schema change. `computer_use`'s response shape on this path was already documented by the existing `vision_unavailable` branch; this PR only makes that branch reachable.

## Screenshots / Logs

Before (`computer_use` on a text-only model — what the main model was handed):

```json
{
  "mode": "som",
  "vision_analysis": "mimo-v2.5 does not support vision or our request was not accepted by the server. Error: Error code: 400 - {'error': {'message': 'This model does not support image inputs', ...}}",
  "vision_analysis_routed_via": "auxiliary.vision"
}
```

After:

```json
{
  "mode": "som",
  "elements": [{"index": 0, "role": "AXButton", "label": "Sign in", ...}],
  "summary": "... (vision unavailable: the auxiliary vision model could not be reached; screenshot omitted. Element-index actions still work — drive via the element list above.)",
  "vision_unavailable": true
}
```

And the log line the issue was filed on, `vision_analyze` with the reporter's provider string:

```
before:  ERROR   tools.vision_tools: Error analyzing image: Error code: 400 - {...}
         Traceback (most recent call last): ...   <- read as a crash
after:   WARNING tools.vision_tools: Error analyzing image: Error code: 400 - {...}
```
