### PR TITLE
fix(agent): qualify unverified "tests passed" claims when verify_on_stop is on

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7952,13 +7952,24 @@ def run_conversation(
                 try:
                     from agent.verification_stop import (
                         build_verify_on_stop_nudge,
+                        qualify_unverified_claim,
                         verify_on_stop_enabled,
                     )
 
                     if verify_on_stop_enabled():
+                        _changed_paths = getattr(agent, "_turn_file_mutation_paths", set())
+                        _qualified = qualify_unverified_claim(
+                            final_response or "",
+                            session_id=getattr(agent, "session_id", None),
+                            changed_paths=_changed_paths,
+                        )
+                        if _qualified != (final_response or "") and isinstance(final_response, str):
+                            final_response = _qualified
+                            if isinstance(final_msg.get("content"), str):
+                                final_msg["content"] = _qualified
                         _verify_nudge = build_verify_on_stop_nudge(
                             session_id=getattr(agent, "session_id", None),
-                            changed_paths=getattr(agent, "_turn_file_mutation_paths", set()),
+                            changed_paths=_changed_paths,
                             attempts=getattr(agent, "_verification_stop_nudges", 0),
                         )
                     else:

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -528,6 +528,25 @@ def finalize_turn(
         except Exception as _ver_err:
             logger.debug("file-mutation verifier footer failed: %s", _ver_err)
 
+        # Verification-claim gate (P0 of the verify_on_stop extension):
+        # if the model claims tests/checks passed after editing code and
+        # the ledger is not passed, append a footer. Idempotent with the
+        # same helper used on the interim candidate in conversation_loop.
+        try:
+            from agent.verification_stop import (
+                qualify_unverified_claim,
+                verify_on_stop_enabled,
+            )
+
+            if verify_on_stop_enabled():
+                final_response = qualify_unverified_claim(
+                    final_response,
+                    session_id=getattr(agent, "session_id", None),
+                    changed_paths=getattr(agent, "_turn_file_mutation_paths", set()),
+                )
+        except Exception as _claim_err:
+            logger.debug("verification claim footer failed: %s", _claim_err)
+
     # Turn-completion explainer.
     # When a turn ends abnormally after substantive work — empty content
     # after retries, a partial/truncated stream, a still-pending tool

--- a/agent/verification_stop.py
+++ b/agent/verification_stop.py
@@ -3,11 +3,17 @@
 This module is intentionally policy-only. It never runs checks itself; it turns
 the passive verification ledger into a bounded follow-up when the model tries to
 finish immediately after editing code without fresh evidence.
+
+When the model still claims tests/checks passed after that budget is exhausted
+(or on the interim candidate), ``qualify_unverified_claim`` appends a footer so
+the over-claim cannot stand as the delivered answer. Default remains off
+(``verify_on_stop``).
 """
 
 from __future__ import annotations
 
 import os
+import re
 import tempfile
 from pathlib import Path
 from typing import Any, Iterable
@@ -313,4 +319,108 @@ def build_verify_on_stop_nudge(
     )
 
 
-__all__ = ["build_verify_on_stop_nudge", "verify_on_stop_enabled"]
+# ---------------------------------------------------------------------------
+# Claim gate: do not let "tests passed" stand without ledger evidence.
+# ---------------------------------------------------------------------------
+
+UNVERIFIED_CLAIM_FOOTER_MARK = "⚠️ Verification status:"
+
+_SUCCESS_CLAIM_RE = re.compile(
+    r"(?is)(?:"
+    r"\btests?\s+passed\b"
+    r"|\ball\s+tests\s+pass(?:ed)?\b"
+    r"|\b(?:test\s+)?suite\s+(?:is\s+)?green\b"
+    r"|\bchecks?\s+passed\b"
+    r"|\bci\s+(?:is\s+)?green\b"
+    r"|\bverification\s+passed\b"
+    r"|\bfully\s+verified\b"
+    r"|\bverified\s+in\s+(?:prod|production)\b"
+    r"|\bstatus\s*:\s*done\b"
+    r"|\bimplemented\s+and\s+verified\b"
+    r"|\bi(?:'ve| have)?\s+verified\b"
+    r"|\bwork\s+is\s+(?:fully\s+)?verified\b"
+    r")"
+)
+
+_ALREADY_LABELED_RE = re.compile(
+    r"(?is)(?:"
+    r"\bnot\s+verified\b"
+    r"|\bunverified\b"
+    r"|\bcould\s+not\s+verify\b"
+    r"|\bcannot\s+verify\b"
+    r"|\bcan'?t\s+verify\b"
+    r"|\bverification\s+is\s+not\s+possible\b"
+    r"|\bno\s+(?:fresh\s+)?passing\s+verification\b"
+    r"|\bdid\s+not\s+(?:run|execute)\s+(?:the\s+)?tests\b"
+    r"|\btests?\s+(?:were\s+)?not\s+run\b"
+    r"|\bconcrete\s+blocker\b"
+    r"|"
+    + re.escape(UNVERIFIED_CLAIM_FOOTER_MARK)
+    + r")"
+)
+
+
+def claims_verification_success(text: str | None) -> bool:
+    """True when the assistant text asserts tests/checks/verification passed."""
+    if not text:
+        return False
+    return bool(_SUCCESS_CLAIM_RE.search(text))
+
+
+def already_labels_unverified(text: str | None) -> bool:
+    """True when the text already admits the work is unverified or blocked."""
+    if not text:
+        return False
+    return bool(_ALREADY_LABELED_RE.search(text))
+
+
+def qualify_unverified_claim(
+    text: str,
+    *,
+    session_id: str | None,
+    changed_paths: Iterable[str],
+) -> str:
+    """Append a footer when a success-claim is not backed by the ledger.
+
+    No-ops when there is no claim, the agent already labeled a blocker, there
+    are no verifiable code edits, the ledger is ``passed``, or the footer is
+    already present. Never invents a workspace or upgrades a targeted check
+    into ``repo green``.
+    """
+    if not isinstance(text, str) or not text.strip():
+        return text
+    if UNVERIFIED_CLAIM_FOOTER_MARK in text:
+        return text
+    if not claims_verification_success(text):
+        return text
+    if already_labels_unverified(text):
+        return text
+
+    paths = sorted({str(p) for p in _filter_verifiable_paths(changed_paths)})
+    if not paths:
+        return text
+
+    snapshot = _verification_snapshot(session_id=session_id, changed_paths=paths)
+    if snapshot is None:
+        return text
+    status, _facts = snapshot
+    if str(status.get("status") or "unverified") == "passed":
+        return text
+
+    state = str(status.get("status") or "unverified")
+    footer = (
+        f"{UNVERIFIED_CLAIM_FOOTER_MARK} {state}. "
+        "This turn edited code without fresh passing verification evidence. "
+        "Wording above that says tests or checks passed is not backed by the ledger."
+    )
+    return text.rstrip() + "\n\n" + footer
+
+
+__all__ = [
+    "UNVERIFIED_CLAIM_FOOTER_MARK",
+    "already_labels_unverified",
+    "build_verify_on_stop_nudge",
+    "claims_verification_success",
+    "qualify_unverified_claim",
+    "verify_on_stop_enabled",
+]

--- a/tests/agent/test_verification_stop.py
+++ b/tests/agent/test_verification_stop.py
@@ -248,3 +248,121 @@ def test_is_non_code_path_classification():
     assert _is_non_code_path("src/app.ts") is False
     assert _is_non_code_path("config.yaml") is False
     assert _is_non_code_path("run_agent.py") is False
+
+
+# ---------------------------------------------------------------------------
+# P0 claim gate: success wording without ledger evidence cannot stand.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("All tests passed.", True),
+        ("STATUS: DONE — checks passed.", True),
+        ("I've verified the fix in production.", True),
+        ("The suite is green.", True),
+        ("Patched the helper and left a note.", False),
+        ("I have not verified this.", False),
+        ("", False),
+    ],
+)
+def test_claims_verification_success(text, expected):
+    from agent.verification_stop import claims_verification_success
+
+    assert claims_verification_success(text) is expected
+
+
+def test_qualify_appends_footer_when_claim_lacks_ledger(tmp_path, monkeypatch):
+    from agent.verification_stop import (
+        UNVERIFIED_CLAIM_FOOTER_MARK,
+        qualify_unverified_claim,
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    changed = str(tmp_path / "src" / "app.ts")
+    mark_workspace_edited(session_id="s1", cwd=tmp_path, paths=[changed])
+
+    out = qualify_unverified_claim(
+        "All tests passed.",
+        session_id="s1",
+        changed_paths=[changed],
+    )
+    assert UNVERIFIED_CLAIM_FOOTER_MARK in out
+    assert "All tests passed." in out
+    assert "not backed by the ledger" in out
+
+
+def test_qualify_skips_when_ledger_passed(tmp_path, monkeypatch):
+    from agent.verification_stop import (
+        UNVERIFIED_CLAIM_FOOTER_MARK,
+        qualify_unverified_claim,
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    changed = str(tmp_path / "src" / "app.ts")
+    record_terminal_result(
+        command="pnpm test",
+        cwd=tmp_path,
+        session_id="s1",
+        exit_code=0,
+        output="green",
+    )
+
+    text = "All tests passed."
+    assert qualify_unverified_claim(
+        text, session_id="s1", changed_paths=[changed]
+    ) == text
+    assert UNVERIFIED_CLAIM_FOOTER_MARK not in text
+
+
+def test_qualify_skips_labeled_blocker(tmp_path, monkeypatch):
+    from agent.verification_stop import qualify_unverified_claim
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    changed = str(tmp_path / "src" / "app.ts")
+    mark_workspace_edited(session_id="s1", cwd=tmp_path, paths=[changed])
+
+    text = "I could not verify this. Concrete blocker: no test runner."
+    assert qualify_unverified_claim(
+        text, session_id="s1", changed_paths=[changed]
+    ) == text
+
+
+def test_qualify_skips_doc_only_edits(tmp_path, monkeypatch):
+    from agent.verification_stop import (
+        UNVERIFIED_CLAIM_FOOTER_MARK,
+        qualify_unverified_claim,
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    doc = str(tmp_path / "README.md")
+    text = "All tests passed."
+    out = qualify_unverified_claim(text, session_id="s1", changed_paths=[doc])
+    assert out == text
+    assert UNVERIFIED_CLAIM_FOOTER_MARK not in out
+
+
+def test_qualify_is_idempotent(tmp_path, monkeypatch):
+    from agent.verification_stop import qualify_unverified_claim
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    changed = str(tmp_path / "src" / "app.ts")
+    mark_workspace_edited(session_id="s1", cwd=tmp_path, paths=[changed])
+
+    once = qualify_unverified_claim(
+        "All tests passed.",
+        session_id="s1",
+        changed_paths=[changed],
+    )
+    twice = qualify_unverified_claim(
+        once, session_id="s1", changed_paths=[changed]
+    )
+    assert once == twice
+    assert once.count("⚠️ Verification status:") == 1
+


### PR DESCRIPTION
## What does this PR do?

P0 of #89182: when `verify_on_stop` is on and the model finishes a coding turn claiming tests/checks passed **without fresh ledger evidence**, append a footer so the over-claim cannot stand.

This is the same pattern as the file-mutation verifier footer. It does **not** add a model tool, does **not** change the default (`verify_on_stop` stays off), and does **not** vendor a judge.

## Related Issue

- Closes nothing yet (P0 only).
- Implements P0 of #89182
- Overlaps #45577 (unsupported "verified / tests passed" summaries) for the coding-edit path

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `agent/verification_stop.py` — `claims_verification_success` + `qualify_unverified_claim`
- `agent/conversation_loop.py` — qualify the interim candidate before the existing nudge
- `agent/turn_finalizer.py` — qualify the delivered final response (idempotent)
- `tests/agent/test_verification_stop.py` — claim detect, ledger pass skip, labeled blocker skip, doc-only skip, idempotent footer

## How to Test

```bash
python -m pytest tests/agent/test_verification_stop.py -o 'addopts=' -q
```

With `agent.verify_on_stop: true`, edit a source file, claim "all tests passed" without running them, and confirm the response gets `⚠️ Verification status: unverified`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs / issues (#89182, #45577)
- [x] My PR contains only changes related to this fix
- [x] Targeted tests pass (`tests/agent/test_verification_stop.py` — 26 passed)
- [x] I've added tests for my changes

### Documentation & Housekeeping

- [x] Documentation N/A (opt-in existing flag)
- [x] No new `HERMES_*` env
- [x] No new model tool schema
