### PR TITLE
feat(desktop): expose provider-neutral voice lifecycle to plugins

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 
+import { setUserSpeaking } from '@/store/voice-lifecycle'
+
 type BrowserAudioContext = typeof AudioContext
 
 export interface MicRecorderOptions {
@@ -79,6 +81,8 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
   const stopResolverRef = useRef<((recording: MicRecording | null) => void) | null>(null)
 
   const cleanup = () => {
+    setUserSpeaking(false, 'voice-capture')
+
     if (animationRef.current) {
       window.cancelAnimationFrame(animationRef.current)
       animationRef.current = null
@@ -138,6 +142,10 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
 
         if (speechThreshold > 0 && options.onSilence && !silenceTriggeredRef.current) {
           if (normalized >= speechThreshold) {
+            if (!heardSpeechRef.current) {
+              setUserSpeaking(true, 'voice-capture')
+            }
+
             heardSpeechRef.current = true
             silenceStartedAtRef.current = null
           } else if (heardSpeechRef.current && silenceMs > 0) {
@@ -145,6 +153,7 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
 
             if (now - silenceStartedAtRef.current >= silenceMs) {
               silenceTriggeredRef.current = true
+              setUserSpeaking(false, 'voice-capture')
               options.onSilence()
 
               return

--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
@@ -79,9 +79,10 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
   const silenceTriggeredRef = useRef(false)
   const silenceStartedAtRef = useRef<number | null>(null)
   const stopResolverRef = useRef<((recording: MicRecording | null) => void) | null>(null)
+  const speechSourceRef = useRef<symbol>(Symbol('voice-capture'))
 
   const cleanup = () => {
-    setUserSpeaking(false, 'voice-capture')
+    setUserSpeaking(false, speechSourceRef.current)
 
     if (animationRef.current) {
       window.cancelAnimationFrame(animationRef.current)
@@ -143,7 +144,7 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
         if (speechThreshold > 0 && options.onSilence && !silenceTriggeredRef.current) {
           if (normalized >= speechThreshold) {
             if (!heardSpeechRef.current) {
-              setUserSpeaking(true, 'voice-capture')
+              setUserSpeaking(true, speechSourceRef.current)
             }
 
             heardSpeechRef.current = true
@@ -153,7 +154,7 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
 
             if (now - silenceStartedAtRef.current >= silenceMs) {
               silenceTriggeredRef.current = true
-              setUserSpeaking(false, 'voice-capture')
+              setUserSpeaking(false, speechSourceRef.current)
               options.onSilence()
 
               return

--- a/apps/desktop/src/lib/voice-barge-in.ts
+++ b/apps/desktop/src/lib/voice-barge-in.ts
@@ -55,6 +55,7 @@ export interface BargeMonitorCallbacks {
 }
 
 export function monitorSpeechDuringPlayback(callbacks: BargeMonitorCallbacks): () => void {
+  const speechSource = Symbol('barge-in')
   let disposed = false
   let stream: MediaStream | null = null
   let context: AudioContext | null = null
@@ -65,7 +66,7 @@ export function monitorSpeechDuringPlayback(callbacks: BargeMonitorCallbacks): (
 
   const cleanup = () => {
     disposed = true
-    setUserSpeaking(false, 'barge-in')
+    setUserSpeaking(false, speechSource)
 
     if (frame !== null) {
       window.cancelAnimationFrame(frame)
@@ -283,7 +284,7 @@ export function monitorSpeechDuringPlayback(callbacks: BargeMonitorCallbacks): (
             tripped = true
             trippedAt = now
             quietSince = null
-            setUserSpeaking(true, 'barge-in')
+            setUserSpeaking(true, speechSource)
             callbacks.onSpeech()
 
             if (!callbacks.onUtterance || !recorder) {

--- a/apps/desktop/src/lib/voice-barge-in.ts
+++ b/apps/desktop/src/lib/voice-barge-in.ts
@@ -19,6 +19,8 @@
 // - Detection is a windowed majority (>=80% of the last SUSTAINED_MS above
 //   trigger) so intra-word energy dips don't reset progress.
 
+import { setUserSpeaking } from '@/store/voice-lifecycle'
+
 const CALIBRATION_MS = 400
 const SUSTAINED_MS = 300
 const SUSTAINED_MAJORITY = 0.8
@@ -63,6 +65,7 @@ export function monitorSpeechDuringPlayback(callbacks: BargeMonitorCallbacks): (
 
   const cleanup = () => {
     disposed = true
+    setUserSpeaking(false, 'barge-in')
 
     if (frame !== null) {
       window.cancelAnimationFrame(frame)
@@ -280,6 +283,7 @@ export function monitorSpeechDuringPlayback(callbacks: BargeMonitorCallbacks): (
             tripped = true
             trippedAt = now
             quietSince = null
+            setUserSpeaking(true, 'barge-in')
             callbacks.onSpeech()
 
             if (!callbacks.onUtterance || !recorder) {

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -71,6 +71,7 @@ import {
   $sessionStates
 } from '@/store/session-states'
 import { runGatewayRestart } from '@/store/system-actions'
+import { $voiceLifecycle, onVoiceLifecycleEvent, type VoiceLifecycleState } from '@/store/voice-lifecycle'
 import type { UsageStats } from '@/types/hermes'
 
 // -- state: readonly views over the app's live atoms -------------------------
@@ -233,7 +234,10 @@ export const host = {
     /** Profile the live gateway is routed to. */
     profile: readonlyAtom<string>($activeGatewayProfile),
     /** Window geometry ({ width, height, narrow }). */
-    viewport: readonlyAtom<ViewportRect>($viewport)
+    viewport: readonlyAtom<ViewportRect>($viewport),
+    /** Provider-neutral voice activity from the authoritative VAD/TTS seams.
+     *  No audio, transcript, prompt, or tool payload is exposed. */
+    voiceLifecycle: readonlyAtom<VoiceLifecycleState>($voiceLifecycle)
   },
 
   /** Toast into the app's notification stack. */
@@ -475,6 +479,12 @@ export const host = {
    *  activity, …) by event type — `'*'` for everything. Returns a disposer.
    *  Listeners are isolated; a throw can't affect app dispatch. */
   onEvent: onGatewayEvent,
+
+  /** Subscribe to provider-neutral local voice transitions. Event types are
+   *  `user_speech_started`, `user_speech_ended`, `tts_started`, and
+   *  `tts_ended`; `'*'` subscribes to all four. Events intentionally carry no
+   *  audio, transcript, prompt, or tool payload. */
+  onVoiceEvent: onVoiceLifecycleEvent,
 
   /** Restart the backend gateway (progress surfaces in the core statusbar). */
   restartGateway: async () => runGatewayRestart(),
@@ -728,6 +738,7 @@ export {
   type TranscriptDirectiveProps
 } from '@/lib/transcript-directives'
 export { cn } from '@/lib/utils'
+export type { VoiceLifecycleEvent, VoiceLifecycleEventType, VoiceLifecycleState } from '@/store/voice-lifecycle'
 export { THEMES_AREA } from '@/themes/user-themes'
 export type { RpcEvent, StatusResponse } from '@/types/hermes'
 /** Subscribe a component to a `host.state` atom. */

--- a/apps/desktop/src/sdk/voice-lifecycle.test.ts
+++ b/apps/desktop/src/sdk/voice-lifecycle.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { host } from '@/sdk/index'
+import { setTtsSpeaking, setUserSpeaking } from '@/store/voice-lifecycle'
+import { setVoicePlaybackState } from '@/store/voice-playback'
+
+describe('host voice lifecycle', () => {
+  afterEach(() => {
+    setUserSpeaking(false)
+    setTtsSpeaking(false)
+  })
+
+  it('exposes the current snapshot and provider-neutral transition events', () => {
+    const events: string[] = []
+    const off = host.onVoiceEvent('*', event => events.push(event.type))
+
+    setUserSpeaking(true)
+    setTtsSpeaking(true)
+
+    expect(host.state.voiceLifecycle.get()).toEqual({ ttsSpeaking: true, userSpeaking: true })
+    expect(events).toEqual(['user_speech_started', 'tts_started'])
+
+    off()
+  })
+
+  it('follows authoritative playback state transitions', () => {
+    const events: string[] = []
+    const off = host.onVoiceEvent('*', event => events.push(event.type))
+
+    setVoicePlaybackState({ audioElement: null, messageId: null, sequence: 1, source: 'read-aloud', status: 'speaking' })
+    setVoicePlaybackState({ audioElement: null, messageId: null, sequence: 1, source: null, status: 'idle' })
+
+    expect(events).toEqual(['tts_started', 'tts_ended'])
+
+    off()
+  })
+})

--- a/apps/desktop/src/sdk/voice-lifecycle.test.ts
+++ b/apps/desktop/src/sdk/voice-lifecycle.test.ts
@@ -27,7 +27,13 @@ describe('host voice lifecycle', () => {
     const events: string[] = []
     const off = host.onVoiceEvent('*', event => events.push(event.type))
 
-    setVoicePlaybackState({ audioElement: null, messageId: null, sequence: 1, source: 'read-aloud', status: 'speaking' })
+    setVoicePlaybackState({
+      audioElement: null,
+      messageId: null,
+      sequence: 1,
+      source: 'read-aloud',
+      status: 'speaking'
+    })
     setVoicePlaybackState({ audioElement: null, messageId: null, sequence: 1, source: null, status: 'idle' })
 
     expect(events).toEqual(['tts_started', 'tts_ended'])

--- a/apps/desktop/src/store/voice-lifecycle.test.ts
+++ b/apps/desktop/src/store/voice-lifecycle.test.ts
@@ -56,15 +56,17 @@ describe('voice lifecycle', () => {
   it('keeps speech active while another VAD source still owns it', () => {
     const events: VoiceLifecycleEventType[] = []
     const off = onVoiceLifecycleEvent('*', event => events.push(event.type))
+    const firstCapture = Symbol('voice-capture')
+    const secondCapture = Symbol('voice-capture')
 
-    setUserSpeaking(true, 'voice-capture')
-    setUserSpeaking(true, 'barge-in')
-    setUserSpeaking(false, 'voice-capture')
+    setUserSpeaking(true, firstCapture)
+    setUserSpeaking(true, secondCapture)
+    setUserSpeaking(false, firstCapture)
 
     expect($voiceLifecycle.get().userSpeaking).toBe(true)
     expect(events).toEqual(['user_speech_started'])
 
-    setUserSpeaking(false, 'barge-in')
+    setUserSpeaking(false, secondCapture)
     expect(events).toEqual(['user_speech_started', 'user_speech_ended'])
 
     off()

--- a/apps/desktop/src/store/voice-lifecycle.test.ts
+++ b/apps/desktop/src/store/voice-lifecycle.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  $voiceLifecycle,
+  onVoiceLifecycleEvent,
+  setTtsSpeaking,
+  setUserSpeaking,
+  type VoiceLifecycleEventType
+} from './voice-lifecycle'
+
+describe('voice lifecycle', () => {
+  afterEach(() => {
+    setUserSpeaking(false)
+    setTtsSpeaking(false)
+  })
+
+  it('emits each transition once and keeps a current snapshot', () => {
+    const events: VoiceLifecycleEventType[] = []
+    const off = onVoiceLifecycleEvent('*', event => events.push(event.type))
+
+    setUserSpeaking(true)
+    setUserSpeaking(true)
+    setTtsSpeaking(true)
+    setUserSpeaking(false)
+    setTtsSpeaking(false)
+
+    expect(events).toEqual(['user_speech_started', 'tts_started', 'user_speech_ended', 'tts_ended'])
+    expect($voiceLifecycle.get()).toEqual({ ttsSpeaking: false, userSpeaking: false })
+
+    off()
+  })
+
+  it('isolates listener failures and disposes subscriptions', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const listener = vi.fn()
+
+    const offFailing = onVoiceLifecycleEvent('tts_started', () => {
+      throw new Error('plugin failure')
+    })
+
+    const offListener = onVoiceLifecycleEvent('tts_started', listener)
+
+    setTtsSpeaking(true)
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(error).toHaveBeenCalledTimes(1)
+
+    offFailing()
+    offListener()
+    setTtsSpeaking(false)
+    setTtsSpeaking(true)
+    expect(listener).toHaveBeenCalledTimes(1)
+
+    error.mockRestore()
+  })
+
+  it('keeps speech active while another VAD source still owns it', () => {
+    const events: VoiceLifecycleEventType[] = []
+    const off = onVoiceLifecycleEvent('*', event => events.push(event.type))
+
+    setUserSpeaking(true, 'voice-capture')
+    setUserSpeaking(true, 'barge-in')
+    setUserSpeaking(false, 'voice-capture')
+
+    expect($voiceLifecycle.get().userSpeaking).toBe(true)
+    expect(events).toEqual(['user_speech_started'])
+
+    setUserSpeaking(false, 'barge-in')
+    expect(events).toEqual(['user_speech_started', 'user_speech_ended'])
+
+    off()
+  })
+})

--- a/apps/desktop/src/store/voice-lifecycle.ts
+++ b/apps/desktop/src/store/voice-lifecycle.ts
@@ -12,6 +12,7 @@ export interface VoiceLifecycleState {
 }
 
 export type VoiceLifecycleListener = (event: VoiceLifecycleEvent) => void
+export type VoiceSpeechSource = string | symbol
 
 export const $voiceLifecycle = atom<VoiceLifecycleState>({
   ttsSpeaking: false,
@@ -19,7 +20,7 @@ export const $voiceLifecycle = atom<VoiceLifecycleState>({
 })
 
 const listeners = new Map<VoiceLifecycleEventType | '*', Set<VoiceLifecycleListener>>()
-const userSpeechSources = new Set<string>()
+const userSpeechSources = new Set<VoiceSpeechSource>()
 
 export function onVoiceLifecycleEvent(
   type: VoiceLifecycleEventType | '*',
@@ -72,7 +73,7 @@ export function setTtsSpeaking(active: boolean): void {
   setLifecycleFlag('ttsSpeaking', active)
 }
 
-export function setUserSpeaking(active: boolean, source = 'default'): void {
+export function setUserSpeaking(active: boolean, source: VoiceSpeechSource = 'default'): void {
   if (active) {
     userSpeechSources.add(source)
   } else {

--- a/apps/desktop/src/store/voice-lifecycle.ts
+++ b/apps/desktop/src/store/voice-lifecycle.ts
@@ -1,0 +1,83 @@
+import { atom } from 'nanostores'
+
+export type VoiceLifecycleEventType = 'tts_ended' | 'tts_started' | 'user_speech_ended' | 'user_speech_started'
+
+export interface VoiceLifecycleEvent {
+  type: VoiceLifecycleEventType
+}
+
+export interface VoiceLifecycleState {
+  ttsSpeaking: boolean
+  userSpeaking: boolean
+}
+
+export type VoiceLifecycleListener = (event: VoiceLifecycleEvent) => void
+
+export const $voiceLifecycle = atom<VoiceLifecycleState>({
+  ttsSpeaking: false,
+  userSpeaking: false
+})
+
+const listeners = new Map<VoiceLifecycleEventType | '*', Set<VoiceLifecycleListener>>()
+const userSpeechSources = new Set<string>()
+
+export function onVoiceLifecycleEvent(
+  type: VoiceLifecycleEventType | '*',
+  listener: VoiceLifecycleListener
+): () => void {
+  const set = listeners.get(type) ?? new Set<VoiceLifecycleListener>()
+  set.add(listener)
+  listeners.set(type, set)
+
+  return () => {
+    set.delete(listener)
+
+    if (set.size === 0) {
+      listeners.delete(type)
+    }
+  }
+}
+
+function emitVoiceLifecycleEvent(type: VoiceLifecycleEventType): void {
+  const event = { type }
+
+  for (const key of [type, '*'] as const) {
+    for (const listener of listeners.get(key) ?? []) {
+      try {
+        listener(event)
+      } catch (error) {
+        console.error('[plugins] voice lifecycle listener failed', error)
+      }
+    }
+  }
+}
+
+function setLifecycleFlag(flag: keyof VoiceLifecycleState, active: boolean): void {
+  const current = $voiceLifecycle.get()
+
+  if (current[flag] === active) {
+    return
+  }
+
+  $voiceLifecycle.set({ ...current, [flag]: active })
+
+  if (flag === 'userSpeaking') {
+    emitVoiceLifecycleEvent(active ? 'user_speech_started' : 'user_speech_ended')
+  } else {
+    emitVoiceLifecycleEvent(active ? 'tts_started' : 'tts_ended')
+  }
+}
+
+export function setTtsSpeaking(active: boolean): void {
+  setLifecycleFlag('ttsSpeaking', active)
+}
+
+export function setUserSpeaking(active: boolean, source = 'default'): void {
+  if (active) {
+    userSpeechSources.add(source)
+  } else {
+    userSpeechSources.delete(source)
+  }
+
+  setLifecycleFlag('userSpeaking', userSpeechSources.size > 0)
+}

--- a/apps/desktop/src/store/voice-playback.ts
+++ b/apps/desktop/src/store/voice-playback.ts
@@ -1,5 +1,7 @@
 import { atom } from 'nanostores'
 
+import { setTtsSpeaking } from './voice-lifecycle'
+
 export type VoicePlaybackSource = 'read-aloud' | 'voice-conversation'
 export type VoicePlaybackStatus = 'idle' | 'preparing' | 'speaking'
 
@@ -20,5 +22,6 @@ export const $voicePlayback = atom<VoicePlaybackState>({
 })
 
 export function setVoicePlaybackState(next: VoicePlaybackState) {
+  setTtsSpeaking(next.status === 'speaking')
   $voicePlayback.set(next)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1834,6 +1834,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1850,6 +1851,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1866,6 +1868,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1882,6 +1885,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1898,6 +1902,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1914,6 +1919,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1930,6 +1936,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1946,6 +1953,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1962,6 +1970,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1978,6 +1987,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1994,6 +2004,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2010,6 +2021,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2026,6 +2038,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2042,6 +2055,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2058,6 +2072,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2074,6 +2089,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2090,6 +2106,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2106,6 +2123,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2122,6 +2140,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2138,6 +2157,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2154,6 +2174,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2170,6 +2191,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2186,6 +2208,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2202,6 +2225,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2218,6 +2242,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2234,6 +2259,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17633,6 +17659,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -544,6 +544,39 @@ const busy = useValue(host.state.busy)
 For token-level detail, listen with `host.onEvent` (`message.start`,
 `message.delta`, `message.complete`).
 
+### Voice lifecycle
+
+Reactive plugins can subscribe to provider-neutral voice transitions without
+reading audio, transcripts, DOM labels, or Desktop internals:
+
+```javascript
+const off = host.onVoiceEvent('*', ({ type }) => {
+  if (type === 'user_speech_started') showListening()
+  if (type === 'user_speech_ended') stopListening()
+  if (type === 'tts_started') animateSpeaking()
+  if (type === 'tts_ended') stopSpeaking()
+})
+```
+
+The four stable event types are `user_speech_started`, `user_speech_ended`,
+`tts_started`, and `tts_ended`. Events intentionally carry no audio,
+transcript, prompt, or tool payload. The user-speech pair comes from the same
+VAD threshold and silence boundary used by Desktop voice capture. The TTS pair
+comes from actual playback: `tts_started` fires on the first playable PCM chunk
+(or when fallback audio starts), and `tts_ended` fires after drain, stop, or
+failure cleanup.
+
+Read `host.state.voiceLifecycle` for the current snapshot. This avoids missing
+an earlier start event when a plugin mounts during active speech:
+
+```javascript
+const voice = useValue(host.state.voiceLifecycle)
+// { userSpeaking: boolean, ttsSpeaking: boolean }
+```
+
+Feature-detect `host.onVoiceEvent` and `host.state.voiceLifecycle` when keeping
+compatibility with Desktop versions that predate this additive SDK surface.
+
 `host.onEvent` streams live gateway events (message deltas,
 session lifecycle, tool activity). Listeners are isolated — a throw in your
 listener can't affect app dispatch. Every `host` door is async-safe: a sync throw


### PR DESCRIPTION
## Summary

- add a provider-neutral Desktop voice lifecycle contract with `user_speech_started`, `user_speech_ended`, `tts_started`, and `tts_ended`
- expose both `host.onVoiceEvent(...)` and the current `host.state.voiceLifecycle` snapshot so late-mounted plugins cannot miss an active state
- wire user speech to the existing VAD boundaries (normal capture and full-duplex barge-in) and TTS to authoritative playback transitions
- expose no audio, transcript, prompt, or tool payload
- document the additive Desktop Plugin SDK surface

This addresses the voice-lifecycle portion of #87574 and the independent JARVIS HUD use case reported there. It intentionally keeps the first phase renderer-local; a future Dashboard transport can forward the same semantic event names without changing plugin behavior.

## Verification

- `npm run test:ui -- src/store/voice-lifecycle.test.ts src/sdk/voice-lifecycle.test.ts src/app/chat/composer/hooks/use-voice-conversation.test.tsx src/app/chat/composer/hooks/use-voice-conversation-rearm.test.tsx` — 16 passed
- `npm run typecheck` — passed
- ESLint on all changed TypeScript files — passed
- `npm run build` — passed (`assert-dist-built` confirmed renderer assets)
- independent pre-commit review — PASS, no blocking security or logic issues

## Compatibility

This is additive. Plugins can feature-detect `host.onVoiceEvent` / `host.state.voiceLifecycle` when supporting older Desktop builds.