### PR TITLE
fix(fallback): route kimi-coding /coding fallback onto Anthropic Messages wire

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2620,6 +2620,18 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 # the same way determine_api_mode() and _detect_api_mode_for_url()
                 # do on the primary path. (#32243, #49247)
                 fb_api_mode = "anthropic_messages"
+            elif (
+                base_url_hostname(fb_base_url) == "api.kimi.com"
+                and "/coding" in fb_base_url.rstrip("/").lower()
+            ):
+                # Kimi Code's /coding endpoint only speaks the Anthropic
+                # Messages protocol — POST /coding/chat/completions returns
+                # HTTP 404 ("resource_not_found_error"). The primary path
+                # already maps this host via _detect_api_mode_for_url() in
+                # hermes_cli/runtime_provider.py; mirror it here so a
+                # kimi-coding entry in fallback_providers doesn't 404 on every
+                # call while the same provider works fine as a primary.
+                fb_api_mode = "anthropic_messages"
             elif _fb_is_azure:
                 # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT
                 # support the Responses API. Stay on chat_completions.


### PR DESCRIPTION
## Problem

A `kimi-coding` entry in `fallback_providers` 404s on every call when the fallback activates, while the exact same provider/model works fine as a **primary**.

The fallback activation path in `try_activate_fallback()` re-computes `fb_api_mode` with an inline elif chain that does not know `api.kimi.com/coding`, so it stays on the `chat_completions` default → `POST /coding/chat/completions` → HTTP 404 (`resource_not_found_error`). Observed live: 8/8 retries failing on two separate nights (2026-08-13 05:07, 2026-08-15 01:17) on a cron deployment. The primary path is unaffected because `hermes_cli/runtime_provider.py::_detect_api_mode_for_url()` already maps that host to `anthropic_messages`.

## Fix

Mirror the `api.kimi.com` + `/coding` mapping in the fallback api_mode chain (same pattern as the existing `api.anthropic.com` branch, and only inside the `not fb_api_mode_explicit` guard, so an explicitly pinned `api_mode` is still respected).

## Verification

Against the live endpoint with the same key and model `k3-256k`:
- `POST /coding/chat/completions` → **404**
- `POST /coding/v1/messages` → **200**

After the patch, the kimi-coding fallback activates and serves requests (running patched in production since 2026-08-15, multiple successful failovers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSeuahWtkVPxLsArMTkoXE