### PR TITLE
Make a remote gateway's localhost URLs actually load in the browser pane

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -241,6 +241,7 @@ import { selectPoolEvictions } from './pool-eviction'
 import { createPoolStopper } from './pool-stop'
 import { poolTouchKeys } from './pool-touch-scope'
 import { createKeepAwake } from './power-save'
+import { PreviewReachRegistry } from './preview-reach'
 import {
   createPrimaryRemoteConnection,
   FirstRunSetupResetError,
@@ -8968,6 +8969,61 @@ function activeSshTerminalTarget() {
   return null
 }
 
+// Loopback reach for the browser pane. Scoped to the SSH connection that
+// authorized it: a different host (or none) must never inherit live forwards
+// into somebody else's machine.
+const previewReach = new PreviewReachRegistry()
+let previewReachScope: null | string = null
+
+async function resetPreviewReach() {
+  previewReachScope = null
+  await previewReach.closeAll()
+}
+
+/**
+ * Rewrite a gateway-loopback URL into one this machine can actually load.
+ *
+ * Returns the URL unchanged when no rewrite is needed or possible — a local
+ * backend (the address is already true), a non-loopback host, or a url/cloud
+ * remote with no tunnel to borrow. Callers must not treat an unchanged URL as
+ * failure; the pane explains an unreachable one on its own.
+ */
+async function reachablePreviewUrl(rawUrl: string): Promise<string> {
+  const target = activeSshTerminalTarget()
+
+  if (!target || target === 'pending') {
+    // No SSH transport behind this gateway; nothing to forward through.
+    await resetPreviewReach()
+
+    return rawUrl
+  }
+
+  const { scope, ssh } = target as { scope: string; ssh: any }
+
+  if (previewReachScope !== scope) {
+    await resetPreviewReach()
+    previewReachScope = scope
+  }
+
+  try {
+    const rewritten = await previewReach.resolve(rawUrl, {
+      cancel: (localPort, remotePort) => ssh.cancelForward(localPort, remotePort),
+      forward: (localPort, remotePort, remoteHost) => ssh.forward(localPort, remotePort, remoteHost),
+      isCurrent: () => sshConnections.get(scope)?.ssh === ssh,
+      // pickLocalPort predates the typed surface here and infers `unknown`.
+      pickLocalPort: () => pickLocalPort() as Promise<number>
+    })
+
+    return rewritten || rawUrl
+  } catch (error: any) {
+    // A failed forward is a preview problem, not a session problem: log it and
+    // let the original URL through so the pane shows its own explanation.
+    sshRememberLog(`preview reach failed for ${rawUrl}: ${error?.message || error}`)
+
+    return rawUrl
+  }
+}
+
 function effectiveSshConfigFingerprint(sshConfig) {
   const ssh =
     process.platform === 'win32'
@@ -14124,6 +14180,10 @@ ipcMain.handle('hermes:stop-find-in-page', event => {
 
   stopFind(win.webContents)
 })
+
+// The renderer can't know whether a loopback URL is reachable — only main
+// knows which transport backs this gateway. Ask before loading one.
+ipcMain.handle('hermes:preview:reach', async (_event, url) => reachablePreviewUrl(String(url || '')))
 
 ipcMain.handle('hermes:openPreviewInBrowser', async (_event, url) => {
   if (!(await openPreviewInBrowser(url))) {

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -207,6 +207,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   setPreviewShortcutActive: active => ipcRenderer.send('hermes:previewShortcutActive', Boolean(active)),
   openExternal: url => ipcRenderer.invoke('hermes:openExternal', url),
   openPreviewInBrowser: url => ipcRenderer.invoke('hermes:openPreviewInBrowser', url),
+  reachPreviewUrl: url => ipcRenderer.invoke('hermes:preview:reach', url),
   fetchLinkTitle: url => ipcRenderer.invoke('hermes:fetchLinkTitle', url),
   sanitizeWorkspaceCwd: cwd => ipcRenderer.invoke('hermes:workspace:sanitize', cwd),
   settings: {

--- a/apps/desktop/electron/preview-reach.e2e.mts
+++ b/apps/desktop/electron/preview-reach.e2e.mts
@@ -1,0 +1,135 @@
+// E2E: the real preview-reach module against a real remote host.
+//
+// Not a unit test — this spawns actual `ssh -N -L` tunnels to a live box and
+// fetches a dev server that is bound to THAT machine's loopback and is
+// provably unreachable from here. Run manually:
+//   node --experimental-strip-types electron/preview-reach.e2e.mts <user@host>
+import http from 'node:http'
+import { spawn } from 'node:child_process'
+import net from 'node:net'
+
+import { loopbackTarget, PreviewReachRegistry, rewriteToLocalPort } from './preview-reach.ts'
+
+const HOST = process.argv[2] || 'root@5.161.224.47'
+const REMOTE_PORT = 5173
+
+function pickLocalPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer()
+    server.unref()
+    server.on('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as net.AddressInfo
+      server.close(() => resolve(port))
+    })
+  })
+}
+
+const tunnels = new Map<string, ReturnType<typeof spawn>>()
+
+async function forward(localPort: number, remotePort: number, remoteHost = '127.0.0.1') {
+  const spec = `127.0.0.1:${localPort}:${remoteHost}:${remotePort}`
+  const child = spawn(
+    'ssh',
+    ['-o', 'BatchMode=yes', '-o', 'ExitOnForwardFailure=yes', '-v', '-N', '-L', spec, '--', HOST],
+    { stdio: ['ignore', 'ignore', 'pipe'] }
+  )
+
+  tunnels.set(spec, child)
+
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('forward timed out')), 15_000)
+    child.stderr?.on('data', d => {
+      if (new RegExp(`Local forwarding listening on .* port ${localPort}\\b`).test(String(d))) {
+        clearTimeout(timer)
+        resolve()
+      }
+    })
+    child.on('exit', code => {
+      clearTimeout(timer)
+      reject(new Error(`ssh exited ${code}`))
+    })
+  })
+}
+
+async function cancel(localPort: number, remotePort: number) {
+  const spec = `127.0.0.1:${localPort}:127.0.0.1:${remotePort}`
+  tunnels.get(spec)?.kill()
+  tunnels.delete(spec)
+}
+
+function get(url: string, timeoutMs = 6000): Promise<{ body: string; status: number }> {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, res => {
+      let body = ''
+      res.on('data', c => (body += c))
+      res.on('end', () => resolve({ body, status: res.statusCode || 0 }))
+    })
+    req.setTimeout(timeoutMs, () => req.destroy(new Error('timeout')))
+    req.on('error', reject)
+  })
+}
+
+const results: string[] = []
+const check = (name: string, ok: boolean, detail = '') => {
+  results.push(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`)
+}
+
+const registry = new PreviewReachRegistry()
+const deps = { cancel, forward, isCurrent: () => true, pickLocalPort }
+const REMOTE_URL = `http://localhost:${REMOTE_PORT}/`
+
+try {
+  // 0. The bug itself: the agent's URL must be dead on this machine.
+  let unreachable = false
+  try {
+    await get(REMOTE_URL, 4000)
+  } catch {
+    unreachable = true
+  }
+  check('agent URL is unreachable locally (the bug)', unreachable)
+
+  // 1. Reach it.
+  const reached = await registry.resolve(REMOTE_URL, deps)
+  check('resolve() returns a rewritten URL', Boolean(reached) && reached !== REMOTE_URL, String(reached))
+
+  const page = await get(reached!)
+  check('rewritten URL serves the REMOTE page', page.status === 200 && page.body.includes('REMOTE box'), `status=${page.status}`)
+
+  // 2. Same remote port reuses one tunnel; the path must survive the rewrite.
+  const second = await registry.resolve(`http://localhost:${REMOTE_PORT}/index.html?q=1#frag`, deps)
+  check('same port reuses one lease', registry.size === 1, `size=${registry.size}`)
+  check('path/query/hash preserved', second!.endsWith('/index.html?q=1#frag'), String(second))
+
+  const deep = await get(second!.split('#')[0])
+  check('deep URL still serves the remote page', deep.status === 200 && deep.body.includes('REMOTE box'))
+
+  // 3. Non-loopback is left alone — no tunnel to a public host.
+  const external = await registry.resolve('https://example.com/x', deps)
+  check('non-loopback returns null', external === null, String(external))
+
+  // 4. Teardown actually closes the socket.
+  const port = Number(new URL(reached!).port)
+  await registry.closeAll()
+  await new Promise(r => setTimeout(r, 500))
+  let closed = false
+  try {
+    await get(`http://127.0.0.1:${port}/`, 2500)
+  } catch {
+    closed = true
+  }
+  check('closeAll() tears the forward down', closed && registry.size === 0)
+
+  // 5. Pure helpers agree with the live behavior.
+  check('loopbackTarget parses ipv6 loopback', loopbackTarget('http://[::1]:5173/')?.port === 5173)
+  check('loopbackTarget rejects public host', loopbackTarget('http://example.com:5173/') === null)
+  check('rewriteToLocalPort forces http', rewriteToLocalPort('https://localhost:5173/a', 42).startsWith('http://127.0.0.1:42/a'))
+} finally {
+  for (const child of tunnels.values()) {
+    child.kill()
+  }
+}
+
+console.log(results.join('\n'))
+console.log(results.some(r => r.startsWith('FAIL')) ? '\nE2E FAILED' : '\nE2E PASSED')
+process.exit(results.some(r => r.startsWith('FAIL')) ? 1 : 0)

--- a/apps/desktop/electron/preview-reach.test.ts
+++ b/apps/desktop/electron/preview-reach.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  loopbackTarget,
+  openPreviewReach,
+  PREVIEW_REACH_LEASE_MS,
+  PreviewReachRegistry,
+  rewriteToLocalPort
+} from './preview-reach'
+
+function deps(overrides: Partial<Parameters<typeof openPreviewReach>[1]> = {}) {
+  return {
+    cancel: vi.fn(async () => {}),
+    forward: vi.fn(async () => {}),
+    isCurrent: () => true,
+    pickLocalPort: vi.fn(async () => 45_173),
+    ...overrides
+  }
+}
+
+describe('loopbackTarget', () => {
+  it.each([
+    ['http://localhost:5173/', 5173],
+    ['http://127.0.0.1:3000/app', 3000],
+    ['http://0.0.0.0:8080', 8080],
+    ['http://[::1]:4321/x', 4321]
+  ])('recognizes %s', (url, port) => {
+    expect(loopbackTarget(url)?.port).toBe(port)
+  })
+
+  // An allowlist of "known" dev ports just means the next framework's default
+  // silently fails; the transport is the security boundary, not the port.
+  it('accepts any port, not a curated list', () => {
+    expect(loopbackTarget('http://localhost:61234/')?.port).toBe(61_234)
+  })
+
+  it('defaults the port by scheme', () => {
+    expect(loopbackTarget('http://localhost/')?.port).toBe(80)
+    expect(loopbackTarget('https://localhost/')?.port).toBe(443)
+  })
+
+  it.each([
+    ['a public host', 'https://example.com/x'],
+    ['a lookalike subdomain', 'http://localhost.evil.com/'],
+    ['a non-web scheme', 'file:///etc/passwd'],
+    ['junk', 'not a url']
+  ])('rejects %s', (_name, url) => {
+    expect(loopbackTarget(url)).toBeNull()
+  })
+})
+
+describe('rewriteToLocalPort', () => {
+  it('keeps path, query and hash — they are what make the URL useful', () => {
+    expect(rewriteToLocalPort('http://localhost:5173/a/b?q=1#f', 42)).toBe('http://127.0.0.1:42/a/b?q=1#f')
+  })
+
+  // The forward carries plain TCP to a dev server that is almost never
+  // TLS-terminated; keeping https would fail the handshake.
+  it('forces http', () => {
+    expect(rewriteToLocalPort('https://localhost:5173/', 42)).toBe('http://127.0.0.1:42/')
+  })
+})
+
+describe('openPreviewReach', () => {
+  it('forwards the remote port and returns the local URL', async () => {
+    const d = deps()
+    const lease = await openPreviewReach('http://localhost:5173/app', d)
+
+    expect(d.forward).toHaveBeenCalledWith(45_173, 5173, '127.0.0.1')
+    expect(lease?.url).toBe('http://127.0.0.1:45173/app')
+    expect(lease?.expiresAt).toBeGreaterThan(Date.now())
+    expect(lease?.expiresAt).toBeLessThanOrEqual(Date.now() + PREVIEW_REACH_LEASE_MS)
+  })
+
+  it('ignores a non-loopback URL without opening anything', async () => {
+    const d = deps()
+
+    expect(await openPreviewReach('https://example.com/', d)).toBeNull()
+    expect(d.forward).not.toHaveBeenCalled()
+  })
+
+  // The connection can die between picking a port and using it; forwarding
+  // then would tunnel into whatever host replaced it.
+  it('bails when the authorizing connection went away mid-open', async () => {
+    const d = deps({ isCurrent: () => false })
+
+    expect(await openPreviewReach('http://localhost:5173/', d)).toBeNull()
+    expect(d.forward).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a failed forward instead of pretending it worked', async () => {
+    const d = deps({
+      forward: vi.fn(async () => {
+        throw new Error('ssh exited 255')
+      })
+    })
+
+    await expect(openPreviewReach('http://localhost:5173/', d)).rejects.toThrow('ssh exited 255')
+  })
+
+  it('cancels exactly once however many times close is called', async () => {
+    const d = deps()
+    const lease = await openPreviewReach('http://localhost:5173/', d)
+
+    await lease!.close()
+    await lease!.close()
+
+    expect(d.cancel).toHaveBeenCalledExactlyOnceWith(45_173, 5173)
+  })
+
+  it('closes itself when the lease expires', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const d = deps()
+
+      await openPreviewReach('http://localhost:5173/', d)
+      expect(d.cancel).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(PREVIEW_REACH_LEASE_MS + 1)
+      expect(d.cancel).toHaveBeenCalledWith(45_173, 5173)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('PreviewReachRegistry', () => {
+  // Navigating a dev server is the same tunnel; a lease per page would leak a
+  // socket per click.
+  it('reuses one lease per remote port across pages', async () => {
+    const registry = new PreviewReachRegistry()
+    const d = deps()
+
+    const first = await registry.resolve('http://localhost:5173/', d)
+    const second = await registry.resolve('http://localhost:5173/about?x=1', d)
+
+    expect(d.forward).toHaveBeenCalledOnce()
+    expect(registry.size).toBe(1)
+    expect(first).toBe('http://127.0.0.1:45173/')
+    expect(second).toBe('http://127.0.0.1:45173/about?x=1')
+  })
+
+  it('opens a separate lease per distinct remote port', async () => {
+    const registry = new PreviewReachRegistry()
+    let next = 46_000
+    const d = deps({ pickLocalPort: vi.fn(async () => (next += 1)) })
+
+    await registry.resolve('http://localhost:5173/', d)
+    await registry.resolve('http://localhost:3000/', d)
+
+    expect(registry.size).toBe(2)
+    expect(d.forward).toHaveBeenCalledTimes(2)
+  })
+
+  it('replaces an expired lease rather than serving a dead port', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const registry = new PreviewReachRegistry()
+      let next = 47_000
+      const d = deps({ pickLocalPort: vi.fn(async () => (next += 1)) })
+
+      const first = await registry.resolve('http://localhost:5173/', d)
+
+      await vi.advanceTimersByTimeAsync(PREVIEW_REACH_LEASE_MS + 1)
+
+      const second = await registry.resolve('http://localhost:5173/', d)
+
+      expect(second).not.toBe(first)
+      expect(d.forward).toHaveBeenCalledTimes(2)
+      expect(registry.size).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('closeAll tears down every forward — the connection changed hosts', async () => {
+    const registry = new PreviewReachRegistry()
+    let next = 48_000
+    const d = deps({ pickLocalPort: vi.fn(async () => (next += 1)) })
+
+    await registry.resolve('http://localhost:5173/', d)
+    await registry.resolve('http://localhost:3000/', d)
+    await registry.closeAll()
+
+    expect(d.cancel).toHaveBeenCalledTimes(2)
+    expect(registry.size).toBe(0)
+  })
+
+  it('leaves a non-loopback URL alone', async () => {
+    const registry = new PreviewReachRegistry()
+    const d = deps()
+
+    expect(await registry.resolve('https://example.com/', d)).toBeNull()
+    expect(registry.size).toBe(0)
+  })
+})

--- a/apps/desktop/electron/preview-reach.ts
+++ b/apps/desktop/electron/preview-reach.ts
@@ -1,0 +1,210 @@
+/**
+ * Loopback reach for the in-app browser against a REMOTE gateway.
+ *
+ * The `<webview>` renders on the user's machine. The agent runs on the gateway
+ * host. So when the agent says "your dev server is at http://localhost:5173",
+ * that address is true *there* and meaningless *here* — locally it is usually
+ * nothing at all, and occasionally somebody else's service on the same port.
+ *
+ * The fix is to make the address true here too: open a local→remote forward
+ * over the transport we are ALREADY authenticated on, and hand the renderer a
+ * `127.0.0.1:<localPort>` URL that lands on the gateway's port. No new
+ * credentials, no new listening surface beyond one loopback-bound port.
+ *
+ * Only SSH-backed remotes can do this today: a `url`/`cloud` gateway is an HTTP
+ * endpoint with no tunnel to borrow, so there is nothing to forward through.
+ * Those callers get `null` and the pane keeps explaining the mismatch instead
+ * of failing silently — see `isRemoteLoopbackUrl` in preview-pane.tsx.
+ *
+ * The lease/capability shape here is adapted from tuancookiez-hub's #87243,
+ * which solved the same problem for Windows SSH previews.
+ */
+
+/** Hosts that mean "the machine this resolved on" — the whole problem class. */
+const LOOPBACK_HOSTS = new Set(['0.0.0.0', '127.0.0.1', '::1', 'localhost'])
+
+/** A forward is a live socket to someone else's machine; it should not outlive
+ *  the user's attention on it. Refreshed on every reuse. */
+export const PREVIEW_REACH_LEASE_MS = 15 * 60 * 1000
+
+export interface PreviewReachDeps {
+  /** Tear the forward down. */
+  cancel: (localPort: number, remotePort: number) => Promise<void>
+  /** Open it. Mirrors `SshConnection.forward`. */
+  forward: (localPort: number, remotePort: number, remoteHost?: string) => Promise<void>
+  /** False once the connection that authorized this lease is gone. */
+  isCurrent: () => boolean
+  /** Kernel-assigned free loopback port. */
+  pickLocalPort: () => Promise<number>
+}
+
+export interface PreviewReachLease {
+  close: () => Promise<void>
+  expiresAt: number
+  localPort: number
+  remoteHost: string
+  remotePort: number
+  /** The address to hand the renderer. */
+  url: string
+}
+
+interface ParsedLoopback {
+  host: string
+  port: number
+}
+
+/**
+ * The loopback target inside `rawUrl`, or null when the URL isn't one.
+ *
+ * Deliberately permissive about the port: a dev server is whatever the
+ * framework picked (5173, 3000, 8080, 4321, …), and an allowlist just means
+ * the next framework's default silently fails. The security boundary is the
+ * transport — we can only ever reach a host we are already authenticated to —
+ * not a guess about which ports are wholesome.
+ */
+export function loopbackTarget(rawUrl: string): null | ParsedLoopback {
+  let parsed: URL
+
+  try {
+    parsed = new URL(rawUrl)
+  } catch {
+    return null
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return null
+  }
+
+  const host = parsed.hostname.replace(/^\[|\]$/g, '').toLowerCase()
+
+  if (!LOOPBACK_HOSTS.has(host)) {
+    return null
+  }
+
+  const port = Number(parsed.port || (parsed.protocol === 'https:' ? 443 : 80))
+
+  return Number.isInteger(port) && port > 0 && port < 65_536 ? { host, port } : null
+}
+
+/** Swap the authority for the local end of a forward, preserving everything
+ *  else. Path, query, and hash are what make the URL useful. */
+export function rewriteToLocalPort(rawUrl: string, localPort: number): string {
+  const parsed = new URL(rawUrl)
+
+  parsed.hostname = '127.0.0.1'
+  parsed.port = String(localPort)
+  // The forward carries plain TCP to a dev server that is almost never
+  // TLS-terminated; https would fail the handshake against it.
+  parsed.protocol = 'http:'
+
+  return parsed.toString()
+}
+
+/**
+ * Open a forward for `rawUrl`, or null when it isn't a loopback address.
+ *
+ * Failure to forward is thrown, not swallowed: the caller decides whether a
+ * dead tunnel is worth surfacing, and a silent null here would be
+ * indistinguishable from "this URL was fine all along".
+ */
+export async function openPreviewReach(rawUrl: string, deps: PreviewReachDeps): Promise<null | PreviewReachLease> {
+  const target = loopbackTarget(rawUrl)
+
+  if (!target) {
+    return null
+  }
+
+  const localPort = await deps.pickLocalPort()
+
+  // The connection can die between picking a port and using it.
+  if (!deps.isCurrent()) {
+    return null
+  }
+
+  await deps.forward(localPort, target.port, '127.0.0.1')
+
+  let closed = false
+  let timer: null | ReturnType<typeof setTimeout> = null
+
+  const close = async () => {
+    if (closed) {
+      return
+    }
+
+    closed = true
+
+    if (timer) {
+      clearTimeout(timer)
+      timer = null
+    }
+
+    await deps.cancel(localPort, target.port)
+  }
+
+  timer = setTimeout(() => void close(), PREVIEW_REACH_LEASE_MS)
+  // A pending lease timer must never hold the app open at quit. Node's timer
+  // has unref; the DOM lib's number type (what tsc picks here) does not.
+  ;(timer as unknown as { unref?: () => void }).unref?.()
+
+  return {
+    close,
+    expiresAt: Date.now() + PREVIEW_REACH_LEASE_MS,
+    localPort,
+    remoteHost: target.host,
+    remotePort: target.port,
+    url: rewriteToLocalPort(rawUrl, localPort)
+  }
+}
+
+/**
+ * Forwards currently open, keyed by the remote port they reach.
+ *
+ * One lease per remote port, not per URL: navigating around a dev server
+ * (`/`, `/about`, `?q=1`) is the same tunnel, and minting a fresh one per page
+ * would leak a socket per click.
+ */
+export class PreviewReachRegistry {
+  private leases = new Map<number, PreviewReachLease>()
+
+  /** Reuse a live lease for this port, else open one. */
+  async resolve(rawUrl: string, deps: PreviewReachDeps): Promise<null | string> {
+    const target = loopbackTarget(rawUrl)
+
+    if (!target) {
+      return null
+    }
+
+    const existing = this.leases.get(target.port)
+
+    if (existing && existing.expiresAt > Date.now()) {
+      return rewriteToLocalPort(rawUrl, existing.localPort)
+    }
+
+    if (existing) {
+      await existing.close().catch(() => {})
+      this.leases.delete(target.port)
+    }
+
+    const lease = await openPreviewReach(rawUrl, deps)
+
+    if (!lease) {
+      return null
+    }
+
+    this.leases.set(target.port, lease)
+
+    return lease.url
+  }
+
+  /** Drop every forward — the authorizing connection changed or went away. */
+  async closeAll(): Promise<void> {
+    const open = [...this.leases.values()]
+
+    this.leases.clear()
+    await Promise.allSettled(open.map(lease => lease.close()))
+  }
+
+  get size(): number {
+    return this.leases.size
+  }
+}

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
@@ -185,7 +185,9 @@ describe('PreviewPane console state', () => {
     fireEvent.keyDown(address, { key: 'Enter' })
 
     // loadURL, not a `src` swap — re-entering the current address must reload.
-    expect(loadURL).toHaveBeenCalledWith('http://localhost:4000/app')
+    // Awaited: navigation first asks main whether the address needs a loopback
+    // forward, so the load lands a microtask later.
+    await waitFor(() => expect(loadURL).toHaveBeenCalledWith('http://localhost:4000/app'))
     expect(webview.getAttribute('src')).toBe('http://localhost:5174')
   })
 

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -9,6 +9,7 @@ import { isDesktopFsRemoteMode } from '@/lib/desktop-fs'
 import { guardGuestPointers } from '@/lib/guest-pointer-guard'
 import { openPreviewTargetInBrowser, remoteHtmlPreviewDocument } from '@/lib/local-preview'
 import { isRemoteGateway } from '@/lib/media'
+import { reachablePreviewUrl } from '@/lib/preview-reach'
 import { rafCoalesce } from '@/lib/raf-coalesce'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
@@ -350,17 +351,25 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
   const navigateTo = useCallback(
     (url: string) => {
       setLoadError(null)
-      // loadURL, not a `src` swap: `src` only reloads when the value CHANGES, so
-      // re-entering the address you're already on would do nothing. A rejected
-      // load is a real navigation failure the user has to see — `did-fail-load`
-      // doesn't fire for every rejection (a bad scheme rejects outright).
-      void Promise.resolve(webviewRef.current?.loadURL?.(url)).catch((error: unknown) => {
-        setLoadError({
-          description: error instanceof Error ? error.message : copy.unreachableDescription,
-          url
+      // Typed addresses get the same loopback reach as agent-opened ones — on a
+      // remote gateway `localhost:5173` is usually the dev server the user is
+      // there to look at, not something on their own laptop.
+      void reachablePreviewUrl(url)
+        .then(reached =>
+          // loadURL, not a `src` swap: `src` only reloads when the value CHANGES,
+          // so re-entering the address you're already on would do nothing. A
+          // rejected load is a real navigation failure the user has to see —
+          // `did-fail-load` doesn't fire for every rejection (a bad scheme
+          // rejects outright).
+          webviewRef.current?.loadURL?.(reached)
+        )
+        .catch((error: unknown) => {
+          setLoadError({
+            description: error instanceof Error ? error.message : copy.unreachableDescription,
+            url
+          })
+          setLoading(false)
         })
-        setLoading(false)
-      })
     },
     [copy.unreachableDescription]
   )

--- a/apps/desktop/src/app/session/hooks/use-preview-routing.ts
+++ b/apps/desktop/src/app/session/hooks/use-preview-routing.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 
 import { gatewayEventCompletedFileDiff } from '@/lib/gateway-events'
 import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
+import { reachablePreviewUrl } from '@/lib/preview-reach'
 import {
   $previewTabs,
   beginPreviewServerRestart,
@@ -81,12 +82,22 @@ export function usePreviewRouting({ baseHandleGatewayEvent, currentCwd, requestG
           $sessionTiles.get().some(tile => tile.runtimeId === sid)
 
         if (target && (!event.session_id || onScreen(event.session_id))) {
-          void normalizeOrLocalPreviewTarget(target, $currentCwd.get() || currentCwd || undefined).then(resolved => {
-            if (resolved) {
+          void normalizeOrLocalPreviewTarget(target, $currentCwd.get() || currentCwd || undefined).then(
+            async resolved => {
+              if (!resolved) {
+                return
+              }
+
               const trimmedLabel = typeof label === 'string' ? label.trim() : ''
-              openPreview(trimmedLabel ? { ...resolved, label: trimmedLabel } : resolved, 'tool-result')
+              // The agent's loopback is the GATEWAY's loopback. Give the pane a
+              // URL this machine can load, keeping the original as the label so
+              // the user still sees the address the agent named.
+              const url = resolved.kind === 'url' ? await reachablePreviewUrl(resolved.url) : resolved.url
+              const reached = url === resolved.url ? resolved : { ...resolved, label: resolved.label || target, url }
+
+              openPreview(trimmedLabel ? { ...reached, label: trimmedLabel } : reached, 'tool-result')
             }
-          })
+          )
         }
 
         return

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -350,6 +350,7 @@ declare global {
         start: (options?: { cols?: number; cwd?: string; rows?: number }) => Promise<HermesTerminalSession>
         write: (id: string, data: string) => Promise<boolean>
       }
+      reachPreviewUrl?: (url: string) => Promise<string>
       onClosePreviewRequested?: (callback: () => void) => () => void
       onPreviewNav?: (callback: (command: 'back' | 'forward' | 'reload') => void) => () => void
       onOpenFolderRequested?: (callback: () => void) => () => void

--- a/apps/desktop/src/lib/preview-reach.test.ts
+++ b/apps/desktop/src/lib/preview-reach.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { $connection } from '@/store/session'
+
+import { reachablePreviewUrl } from './preview-reach'
+
+const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
+
+function installBridge(reachPreviewUrl?: unknown) {
+  desktopWindow.hermesDesktop = { reachPreviewUrl } as unknown as Window['hermesDesktop']
+}
+
+afterEach(() => {
+  $connection.set(null)
+  delete desktopWindow.hermesDesktop
+})
+
+describe('reachablePreviewUrl', () => {
+  // On a local backend the agent's localhost IS this machine's localhost —
+  // rewriting would break a URL that already works.
+  it('leaves a local gateway alone without touching the bridge', async () => {
+    const bridge = vi.fn()
+
+    $connection.set({ mode: 'local' } as never)
+    installBridge(bridge)
+
+    expect(await reachablePreviewUrl('http://localhost:5173/')).toBe('http://localhost:5173/')
+    expect(bridge).not.toHaveBeenCalled()
+  })
+
+  it('asks main to resolve the URL on a remote gateway', async () => {
+    const bridge = vi.fn(async () => 'http://127.0.0.1:45173/')
+
+    $connection.set({ mode: 'remote' } as never)
+    installBridge(bridge)
+
+    expect(await reachablePreviewUrl('http://localhost:5173/')).toBe('http://127.0.0.1:45173/')
+    expect(bridge).toHaveBeenCalledWith('http://localhost:5173/')
+  })
+
+  // A url/cloud remote has no tunnel to borrow, so main hands the URL back
+  // unchanged; the pane's own error explains it from there.
+  it('passes the original through when main cannot reach it', async () => {
+    $connection.set({ mode: 'remote' } as never)
+    installBridge(vi.fn(async (url: string) => url))
+
+    expect(await reachablePreviewUrl('http://localhost:5173/')).toBe('http://localhost:5173/')
+  })
+
+  it('falls back to the original when the bridge throws', async () => {
+    $connection.set({ mode: 'remote' } as never)
+    installBridge(
+      vi.fn(async () => {
+        throw new Error('no handler')
+      })
+    )
+
+    expect(await reachablePreviewUrl('http://localhost:5173/')).toBe('http://localhost:5173/')
+  })
+
+  // An older Electron main predates the handler entirely.
+  it('survives a bridge with no reach method', async () => {
+    $connection.set({ mode: 'remote' } as never)
+    installBridge(undefined)
+
+    expect(await reachablePreviewUrl('http://localhost:5173/')).toBe('http://localhost:5173/')
+  })
+
+  it('ignores an empty url', async () => {
+    $connection.set({ mode: 'remote' } as never)
+    const bridge = vi.fn()
+
+    installBridge(bridge)
+
+    expect(await reachablePreviewUrl('')).toBe('')
+    expect(bridge).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/lib/preview-reach.ts
+++ b/apps/desktop/src/lib/preview-reach.ts
@@ -1,0 +1,26 @@
+import { isRemoteGateway } from '@/lib/media'
+
+/**
+ * Make a URL loadable from THIS machine before the pane tries it.
+ *
+ * Against a remote gateway the agent's `localhost:5173` names the gateway's
+ * loopback, not ours. Main owns the answer — it knows whether an SSH transport
+ * is behind this connection and can open a forward through it — so the
+ * renderer asks rather than guessing.
+ *
+ * Always resolves to a usable URL. A local gateway, a non-loopback host, a
+ * remote with no tunnel to borrow, or a failed forward all return the original,
+ * and the pane's own load error explains an address it still can't reach.
+ */
+export async function reachablePreviewUrl(url: string): Promise<string> {
+  if (!url || !isRemoteGateway()) {
+    return url
+  }
+
+  try {
+    return (await window.hermesDesktop?.reachPreviewUrl?.(url)) || url
+  } catch {
+    // An older Electron main has no such handler; the URL is no worse for it.
+    return url
+  }
+}

--- a/apps/desktop/tsconfig.electron.json
+++ b/apps/desktop/tsconfig.electron.json
@@ -17,5 +17,5 @@
     "outDir": "build/electron-types"
   },
   "include": ["electron", "../shared/src/translucency.ts"],
-  "exclude": ["src"]
+  "exclude": ["src", "electron/**/*.e2e.mts"]
 }


### PR DESCRIPTION
## Summary

A remote gateway's `localhost` is not your `localhost`. The `<webview>` renders on your machine, the agent runs on the gateway host, so when the agent reports a dev server at `http://localhost:5173` the pane resolves that here — where the port is usually nothing, or occasionally an unrelated service of your own. #89174 explained the mismatch. This fixes it.

When the gateway is SSH-backed, the browser pane now opens a local→remote forward over the transport it is **already authenticated on** and loads the page through it. No new credentials, no new listening surface beyond one loopback-bound port, and the address the agent named is still what you see.

Both entry points route through it — a URL the agent opens, and one you type into the address bar.

**A `url`/`cloud` gateway has no tunnel to borrow**, so those return the URL unchanged and the pane keeps explaining the mismatch (#89174) rather than failing silently. Fixing those needs a gateway-side proxy endpoint; that is a separate, larger change with its own security review, and I did not want to smuggle it in here.

### Design notes

- **One lease per remote port**, reused across pages and expired after 15 minutes. A lease per URL would leak a socket per click.
- **No port allowlist.** #87243 restricted forwards to `[3000, 8765]`, which silently fails for Vite's 5173 and every other framework default. The security boundary is the transport — we can only reach a host we already hold an authenticated connection to — not a guess about which ports are wholesome.
- **Forwards are scoped to the authorizing connection** and dropped whenever it changes, so a new host never inherits a tunnel into the old one.
- **Every failure path returns the original URL.** A dead forward is a preview problem, not a session problem.

Supersedes the tunneling half of #87243, whose lease/capability shape this adapts (`Co-authored-by: tuancookiez-hub`). That PR remains the reference for the Windows-specific reporting it also carries.

## Test plan

- [x] **E2E against a real remote host** (Hetzner box, not localhost-pretending-to-be-remote): a dev server bound to the remote's `127.0.0.1:5173`, provably unreachable from this machine, loads through the forward. Harness committed as `electron/preview-reach.e2e.mts`; run `node --experimental-strip-types electron/preview-reach.e2e.mts <user@host>`.
  - bug reproduces (agent URL dead locally) → rewritten URL serves the remote page (200) → path/query/hash preserved → one lease reused per port → `closeAll()` tears the socket down
- [x] `vitest run` — 6197 passing (620 files), 29 new
- [x] Mutation-verified 6 ways: tunneling any host, ignoring a stale connection, never reusing a lease, serving expired leases, dropping the path on rewrite, double-cancel — all caught
- [x] `tsc` clean on both projects; `eslint` 0 errors
- [ ] Manual: connect Desktop to an SSH gateway, ask the agent to open a dev server, confirm it renders
