### PR TITLE
fix(gateway): keep the audio path when a voice message transcribes successfully

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24393,7 +24393,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # what they said: ...") read as a meta-instruction and made
                     # the LLM volunteer commentary about voice mode rather than
                     # reply to the content.
-                    enriched_parts.append(f'"{transcript}"')
+                    #
+                    # The PATH is appended after it, because `content` is the
+                    # only record of where the audio lives — the messages table
+                    # has no media column, and consumers recover attachments by
+                    # parsing these markers back out of the text. Dropping it
+                    # here made a SUCCESSFUL transcription the one outcome that
+                    # loses the recording: every failure branch below keeps the
+                    # path, so the better STT got, the more audio became
+                    # unreachable.
+                    #
+                    # The wording is `_build_media_placeholder`'s existing
+                    # audio grammar, NOT the "[The user sent a voice message:
+                    # ...]" prose the stt-disabled branch emits. Consumers
+                    # already parse the former; a consumer matching on media
+                    # markers does not match the prose, so reusing it would
+                    # keep the path visible to the model while leaving the
+                    # attachment just as unrecoverable.
+                    from tools.credential_files import to_agent_visible_cache_path
+
+                    agent_path = to_agent_visible_cache_path(os.path.abspath(path))
+                    enriched_parts.append(
+                        f'"{transcript}"\n'
+                        f"[User sent audio: {agent_path}]"
+                    )
                 else:
                     error = result.get("error", "unknown error")
                     # All failure branches: a single, minimal, neutral marker.

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -95,3 +95,158 @@ async def test_enrich_message_with_transcription_guards_empty_transcript():
     assert transcripts == []
 
 
+@pytest.mark.asyncio
+async def test_successful_transcription_keeps_the_audio_path():
+    """A SUCCESSFUL transcription must still record where the audio is.
+
+    ``content`` is the only record of an attachment's path — the messages table
+    has no media column, and consumers recover attachments by parsing these
+    markers back out of the text. Every failure branch keeps the path; success
+    used to drop it, so the better STT got, the more recordings became
+    unreachable even though the bytes were still in the cache.
+    """
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner._has_setup_skill = lambda: False
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={
+            "success": True,
+            "transcript": "two cartons please",
+            "provider": "local",
+        },
+    ):
+        result, transcripts = await runner._enrich_message_with_transcription(
+            "",
+            ["/tmp/cache/audio/aud_abc123.ogg"],
+        )
+
+    # The transcript is still the message the model reads.
+    assert '"two cartons please"' in result
+    assert transcripts == ["two cartons please"]
+    # ...and the recording is still locatable.
+    assert "aud_abc123.ogg" in result
+
+
+@pytest.mark.asyncio
+async def test_successful_transcription_uses_the_media_placeholder_grammar():
+    """The marker must be the one media consumers actually parse.
+
+    ``_build_media_placeholder`` emits ``[User sent audio: <path>]`` and
+    downstream consumers match on that. The stt-disabled branch emits prose
+    ("[The user sent a voice message: ...]") which no media parser matches — so
+    emitting the prose form here would put the path in front of the model while
+    leaving the attachment unrecoverable, a fix that looks right in the diff and
+    changes nothing for the consumer. This pins the grammar, not just the path.
+    """
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner._has_setup_skill = lambda: False
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": True, "transcript": "hello", "provider": "local"},
+    ):
+        result, _ = await runner._enrich_message_with_transcription(
+            "",
+            ["/tmp/cache/audio/aud_abc123.ogg"],
+        )
+
+    assert "[User sent audio: /tmp/cache/audio/aud_abc123.ogg]" in result
+    assert "The user sent a voice message" not in result
+
+
+@pytest.mark.asyncio
+async def test_transcript_precedes_the_media_marker():
+    """Order matters: the transcript is the message, the marker is metadata.
+
+    #41603 moved to a bare quoted transcript so the model replies to the words
+    instead of narrating that a voice message arrived. Putting the marker first
+    would reintroduce exactly that — the model leads with the attachment rather
+    than the content — so the transcript stays on the first line.
+    """
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner._has_setup_skill = lambda: False
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": True, "transcript": "send fifty", "provider": "local"},
+    ):
+        result, _ = await runner._enrich_message_with_transcription(
+            "",
+            ["/tmp/cache/audio/aud_abc123.ogg"],
+        )
+
+    assert result.index('"send fifty"') < result.index("[User sent audio:")
+
+
+@pytest.mark.asyncio
+async def test_empty_transcript_still_emits_no_media_marker():
+    """The empty/inaudible sentinel (#41603) is unchanged by this fix.
+
+    That branch deliberately does NOT surface a transcript, and it `continue`s
+    before the append — so it must not start emitting a media marker either, or
+    a silent clip would look to a consumer like a normal voice note.
+    """
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner._has_setup_skill = lambda: False
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": True, "transcript": "   ", "provider": "local"},
+    ):
+        result, transcripts = await runner._enrich_message_with_transcription(
+            "caption",
+            ["/tmp/cache/audio/aud_abc123.ogg"],
+        )
+
+    assert "empty or inaudible" in result
+    assert "[User sent audio:" not in result
+    assert transcripts == []
+
+
+@pytest.mark.asyncio
+async def test_each_clip_in_a_batch_keeps_its_own_path():
+    """Several voice notes in one turn must each stay individually locatable.
+
+    A shared or last-wins marker would silently collapse a multi-clip turn to
+    one recoverable attachment, which is the same data loss one layer in.
+    """
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner._has_setup_skill = lambda: False
+
+    transcripts_by_path = {
+        "/tmp/cache/audio/aud_one.ogg": "first clip",
+        "/tmp/cache/audio/aud_two.ogg": "second clip",
+    }
+
+    def fake_transcribe(path, *args, **kwargs):
+        return {
+            "success": True,
+            "transcript": transcripts_by_path[path],
+            "provider": "local",
+        }
+
+    with patch("tools.transcription_tools.transcribe_audio", side_effect=fake_transcribe):
+        result, transcripts = await runner._enrich_message_with_transcription(
+            "",
+            list(transcripts_by_path),
+        )
+
+    assert "[User sent audio: /tmp/cache/audio/aud_one.ogg]" in result
+    assert "[User sent audio: /tmp/cache/audio/aud_two.ogg]" in result
+    assert transcripts == ["first clip", "second clip"]

--- a/tests/gateway/test_telegram_voice_v0_regressions.py
+++ b/tests/gateway/test_telegram_voice_v0_regressions.py
@@ -160,7 +160,12 @@ async def test_pending_voice_interrupt_reuses_transcript_and_echo():
             drain_transcripts,
         )
 
-    assert interrupt_text == '"hello once"'
+    # The enriched text now carries the `[User sent audio: <path>]` marker on
+    # its own line after the quoted transcript, so assert on the transcript
+    # prefix rather than exact equality. What this test pins is that the
+    # transcript is reused rather than re-transcribed, and
+    # mock_transcribe.assert_called_once_with below still checks that exactly.
+    assert interrupt_text.startswith('"hello once"')
     assert drain_text == interrupt_text
     assert drain_transcripts == interrupt_transcripts == ["hello once"]
     mock_transcribe.assert_called_once_with("/tmp/telegram-voice.ogg", None, "gateway")
@@ -215,7 +220,12 @@ async def test_monitor_to_drain_transcribes_and_echoes_pending_voice_once(
         )
 
     assert result["final_response"] == "follow-up complete"
-    assert _PendingVoiceAgent.messages == ["initial turn", '"hello once"']
+    # Same reason as above: tolerate the appended `[User sent audio: <path>]`
+    # line while still pinning that exactly two messages reached the agent, in
+    # order, the second being the voice transcript.
+    assert len(_PendingVoiceAgent.messages) == 2
+    assert _PendingVoiceAgent.messages[0] == "initial turn"
+    assert _PendingVoiceAgent.messages[1].startswith('"hello once"')
     mock_transcribe.assert_called_once_with("/tmp/telegram-pending-voice.ogg", None, "gateway")
     assert adapter.sent == [("12345", '🎙️ "hello once"', None)]
 


### PR DESCRIPTION
Related #78207 #78196 #41603 #65745

## What changed and why

`_enrich_message_with_transcription` records where the audio file is on every outcome **except the one that works**:

| outcome | marker written |
|---|---|
| STT disabled | `[The user sent a voice message: <path>]` |
| transcription failed | `[... the audio is available at: <path>]` |
| exception raised | same as failure |
| **transcription succeeded** | `"<transcript>"` — **path discarded** |

So the better STT gets, the less often the path survives. A box whose STT is broken keeps every audio pointer; a box whose STT works keeps none.

That matters because the message `content` is the **only** record of the path — the `messages` table has no media column, so consumers recover attachments by parsing these markers back out of the text. Once the marker is gone the recording is unreachable even though the bytes are still sitting in the cache directory: nothing else ever wrote the filename down.

Downstream this surfaces as an operator reviewing a conversation, seeing a transcript, and having no way to replay it — precisely when replay matters most: verifying a quantity, a delivery address, or a tone the transcript flattened. On code-switched speech (in our case Malay/Cantonese/Mandarin/English inside one sentence) the transcript is a lossy artefact and the recording is the source of truth.

The fix appends `[User sent audio: <path>]` on its own line after the transcript.

## Three deliberate properties

**The grammar is `_build_media_placeholder`'s existing audio marker** (`gateway/run.py:2997`), *not* the stt-disabled branch's prose. A media consumer matching on placeholders does not match prose, so emitting `[The user sent a voice message: …]` here would put the path in front of the model while leaving the attachment just as unrecoverable — a change that looks correct in the diff and fixes nothing on screen. I found this by running a real consumer's matcher against both forms rather than by reading the code, and `test_successful_transcription_uses_the_media_placeholder_grammar` pins it so a future reword can't silently undo the fix.

**The transcript stays first and verbatim**, preserving #41603's property that the model replies to the words rather than narrating that a voice message arrived. `test_transcript_precedes_the_media_marker` pins the ordering.

**`to_agent_visible_cache_path` is applied** for the same reason the failure branches apply it — under a Docker terminal backend the agent sees the cache at a different mount point, and handing it an unopenable host path would be worse than handing it nothing. Outside Docker the helper returns its input unchanged.

## How to test

```bash
python -m pytest tests/gateway/test_stt_config.py \
  tests/gateway/test_media_extraction.py \
  tests/gateway/test_telegram_audio_vs_voice.py \
  tests/gateway/test_history_media_current_turn.py \
  tests/gateway/test_weixin.py \
  tests/gateway/test_busy_session_ack.py \
  tests/gateway/test_7100_transient_failure_transcript.py \
  -q --no-header -p no:cacheprovider
```

Expected: all pass (67 here on Python 3.13 — 9 in `test_stt_config.py`, plus 58 across the adjacent media/STT/transcription suites).

**Verified as genuine regression tests.** With the one-line fix reverted, 4 of the 5 new tests fail:

```
FAILED test_successful_transcription_keeps_the_audio_path
FAILED test_successful_transcription_uses_the_media_placeholder_grammar
FAILED test_transcript_precedes_the_media_marker
FAILED test_each_clip_in_a_batch_keeps_its_own_path
4 failed, 5 passed
```

The fifth (`test_empty_transcript_still_emits_no_media_marker`) passes either way **by design** — it guards #41603's empty/inaudible sentinel, which this change must not alter, so it would be wrong for it to flip.

## Relationship to existing work

This sits in the Vox Lockin campaign (#78207), lane 07 (`gateway voice media delivery`). It is **distinct from #78196**, which preserves the audio marker only when transcription *stalls past its deadline* — the success path is untouched there. I did not find an open issue or PR covering the successful-transcription case; happy to file one to reference if the campaign prefers `Fixes #<issue>` linkage.
