### PR TITLE
fix(tui): serialize config timestamps

### DIFF
--- a/tests/tui_gateway/test_config_rpc.py
+++ b/tests/tui_gateway/test_config_rpc.py
@@ -1,0 +1,30 @@
+"""Tests for JSON-safe TUI config RPC responses."""
+
+from __future__ import annotations
+
+import json
+
+import tui_gateway.server as server
+
+
+def test_full_config_serializes_yaml_timestamp(monkeypatch, tmp_path):
+    (tmp_path / "config.yaml").write_text(
+        """\
+plugins:
+  entries:
+    delegation-guard:
+      capabilities_consent:
+        granted_at: 2026-08-17 14:50:10+00:00
+"""
+    )
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    monkeypatch.setattr(server, "_cfg_cache", None)
+    monkeypatch.setattr(server, "_cfg_mtime", None)
+    monkeypatch.setattr(server, "_cfg_path", None)
+
+    response = server._methods["config.get"](1, {"key": "full"})
+
+    assert response["result"]["config"]["plugins"]["entries"]["delegation-guard"][
+        "capabilities_consent"
+    ]["granted_at"] == "2026-08-17T14:50:10+00:00"
+    json.dumps(response)

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -189,7 +189,18 @@ def _(rid, params: dict) -> dict:
         cwd = _completion_cwd({"cwd": raw} if raw else {})
         return _ok(rid, {"cwd": cwd, "branch": _git_branch_for_cwd(cwd)})
     if key == "full":
-        return _ok(rid, {"config": _load_cfg()})
+        from datetime import date, time
+
+        def json_safe(value):
+            if isinstance(value, (date, time)):
+                return value.isoformat()
+            if isinstance(value, dict):
+                return {item_key: json_safe(item) for item_key, item in value.items()}
+            if isinstance(value, (list, tuple)):
+                return [json_safe(item) for item in value]
+            return value
+
+        return _ok(rid, {"config": json_safe(_load_cfg())})
     if key == "prompt":
         return _ok(rid, {"prompt": _load_cfg().get("custom_prompt", "")})
     if key == "skin":


### PR DESCRIPTION
## Summary
- Normalize YAML date and time values returned by the full TUI config RPC.
- Add a real temporary-HERMES_HOME regression test for unquoted YAML timestamps.

## Test plan
- /home/hermes/.hermes/hermes-agent/venv/bin/python -m pytest tests/tui_gateway/test_config_rpc.py tests/tui_gateway/test_reasoning_config_per_model.py

Fixes #89203