### PR TITLE
fix(compaction): let the legacy summarizer read pre-prune tool bodies

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3829,12 +3829,24 @@ class ContextCompressor(ContextEngine):
     # carries the full rationale) so subclasses/tests can override per-class.
     _SUMMARY_INPUT_MAX_CHARS = _SUMMARY_INPUT_MAX_CHARS
 
-    def _serialize_for_summary(self, turns: List[Dict[str, Any]]) -> str:
+    def _serialize_for_summary(
+        self,
+        turns: List[Dict[str, Any]],
+        pristine: "dict[str, str] | None" = None,
+    ) -> str:
         """Serialize conversation turns into labeled text for the summarizer.
 
         Includes tool call arguments and result content (up to
         ``_CONTENT_MAX`` chars per message) so the summarizer can preserve
         specific details like file paths, commands, and outputs.
+
+        ``pristine`` is the pre-Phase-1 snapshot of tool bodies keyed by
+        ``tool_call_id``. Phase-1 pruning runs before summarization and may
+        already have demoted a tool result to a one-line stub; reading the
+        snapshot instead lets the summary carry the content forward rather
+        than recording only that a tool ran. Per-message truncation to
+        ``_CONTENT_MAX`` still applies, so a restored body cannot crowd the
+        prompt.
 
         All content is redacted before serialization to prevent secrets
         (API keys, tokens, passwords) from leaking into the summary that
@@ -3864,6 +3876,15 @@ class ContextCompressor(ContextEngine):
                     elif isinstance(part, str):
                         text_parts.append(part)
                 content = "\n".join(text_parts)
+            # Phase-1 pruning may already have demoted this tool result to a
+            # one-line stub; summarize from the pristine snapshot instead so
+            # the summary carries the content forward, not just the receipt.
+            # Restoration happens before redaction so a recovered body is
+            # scrubbed on exactly the same path as a live one.
+            if pristine and role == "tool":
+                original = pristine.get(str(msg.get("tool_call_id") or ""))
+                if original and len(original) > len(content or ""):
+                    content = original
             content = _redact_compaction_text(content or "")
             content = _MEDIA_DIRECTIVE_RE.sub("[media attachment]", content)
             # Strip inline reasoning blocks (<think>, <reasoning>, etc.) from
@@ -4185,7 +4206,7 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         main summary.
         """
         text = _serialize_turns_for_digest(
-            turns, getattr(self, "_lean_pristine_tools", None),
+            turns, getattr(self, "_pristine_tools", None),
         )
         if not text:
             return ""
@@ -4363,7 +4384,9 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             self._previous_summary = _redact_compaction_text(self._previous_summary)
 
         summary_budget = self._compute_summary_budget(turns_to_summarize)
-        content_to_summarize = self._serialize_for_summary(turns_to_summarize)
+        content_to_summarize = self._serialize_for_summary(
+            turns_to_summarize, getattr(self, "_pristine_tools", None),
+        )
         # P2 ghost-skill defense (#32106): [SKILL_PRUNED: ...] markers entering
         # the summarizer are prompt INPUT only — LLMs routinely paraphrase them
         # into vague prose ("some skills were loaded"), which erases the reload
@@ -6973,18 +6996,20 @@ This compaction should PRIORITISE preserving all information related to the focu
 
         display_tokens = current_tokens if current_tokens else self.last_prompt_tokens or estimate_messages_tokens_rough(messages)
 
-        # Lean mode: snapshot pristine tool contents BEFORE Phase-1 pruning so
-        # the chunk digests summarize what actually happened, not the pruned
-        # stubs (#compaction-v2). Bounded per entry to keep memory sane.
-        if getattr(self, "tail_mode", "legacy") == "lean":
-            self._lean_pristine_tools = {
-                str(m.get("tool_call_id") or ""): (m.get("content") or "")[:80_000]
-                for m in messages
-                if m.get("role") == "tool" and isinstance(m.get("content"), str)
-                and len(m.get("content") or "") > 400
-            }
-        else:
-            self._lean_pristine_tools = {}
+        # Snapshot pristine tool contents BEFORE Phase-1 pruning so the
+        # summarizer sees what actually happened, not the pruned stubs
+        # (#compaction-v2). Bounded per entry to keep memory sane.
+        #
+        # This began as a lean-mode-only snapshot feeding the chunk digests,
+        # but the same ordering hurts legacy mode: Phase 1 stubs the very
+        # tool results ``_generate_summary`` is about to read, so the LLM pass
+        # could only ever record *that* a tool ran. Both modes read it now.
+        self._pristine_tools = {
+            str(m.get("tool_call_id") or ""): (m.get("content") or "")[:80_000]
+            for m in messages
+            if m.get("role") == "tool" and isinstance(m.get("content"), str)
+            and len(m.get("content") or "") > 400
+        }
 
         # Phase 1: Prune old tool results (cheap, no LLM call)
         messages, pruned_count = self._prune_old_tool_results(

--- a/tests/agent/test_compaction_summarizer_sees_pruned_bodies.py
+++ b/tests/agent/test_compaction_summarizer_sees_pruned_bodies.py
@@ -1,0 +1,145 @@
+"""The summarizer must see tool-result bodies Phase 1 stubbed out.
+
+Phase 1 of ``compress()`` replaces bulky tool results with 1-line metadata
+stubs, and the messages it stubs are the same ones the LLM pass is about to
+summarize. Lean mode already reads around this via the pre-prune
+``_pristine_tools`` snapshot; legacy mode did not, so ``_serialize_for_summary``
+saw ``[read_file] read tasks.md from line 1 (12,362 chars)`` and could record
+that a file was read but never what was in it.
+
+Observed downstream: an agent whose file reads were stubbed mid-turn reported
+"every read_file returns stubs, I cannot verify anything" and refused to answer.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from agent.context_compressor import ContextCompressor
+
+
+def _make_compressor(tail_mode="legacy"):
+    compressor = ContextCompressor.__new__(ContextCompressor)
+    compressor.quiet_mode = True
+    compressor.tail_mode = tail_mode
+    return compressor
+
+
+def _make_summarizing_compressor():
+    """A compressor with just enough state to run ``_generate_summary``."""
+    compressor = _make_compressor()
+    compressor.protect_first_n = 2
+    compressor.protect_last_n = 5
+    compressor.tail_token_budget = 20000
+    compressor.context_length = 200000
+    compressor.threshold_percent = 0.80
+    compressor.threshold_tokens = 160000
+    compressor.summary_target_ratio = 0.20
+    compressor.max_summary_tokens = 10000
+    compressor.compression_count = 0
+    compressor.last_prompt_tokens = 0
+    compressor._previous_summary = None
+    compressor._ineffective_compression_count = 0
+    compressor._verify_compaction_cleared_threshold = False
+    compressor._summary_failure_cooldown_until = 0.0
+    compressor.summary_model = None
+    compressor.model = "test-model"
+    compressor.provider = "test"
+    compressor.base_url = "http://localhost"
+    compressor.api_key = "test-key"
+    compressor.api_mode = "chat_completions"
+    return compressor
+
+
+def _tool_msg(call_id: str, content: str) -> dict:
+    return {"role": "tool", "tool_call_id": call_id, "content": content}
+
+
+def test_serializer_prefers_the_pristine_body_over_a_stub():
+    compressor = _make_compressor()
+    body = "TASK BACKLOG\n" + ("georgian documents register line\n" * 50)
+    stub = "[read_file] read tasks.md from line 1 (1,700 chars)"
+    turns = [
+        {"role": "user", "content": "what is on my plate?"},
+        _tool_msg("call-1", stub),
+    ]
+
+    text = compressor._serialize_for_summary(turns, {"call-1": body})
+
+    assert "georgian documents register line" in text
+    assert stub not in text
+
+
+def test_summary_prompt_carries_the_body_in_legacy_mode():
+    """The end-to-end pin: what the LLM pass actually receives.
+
+    Before this fix the legacy summarizer prompt contained the stub only, so
+    the summary could say a file was read and never what it said.
+    """
+    compressor = _make_summarizing_compressor()
+    compressor._pristine_tools = {
+        "call-1": "TASK BACKLOG\n" + ("georgian documents register line\n" * 50),
+    }
+    turns = [
+        {"role": "user", "content": "what is on my plate?"},
+        _tool_msg("call-1", "[read_file] read tasks.md from line 1 (1,700 chars)"),
+    ]
+
+    captured = {}
+
+    def mock_call_llm(**kwargs):
+        captured["messages"] = kwargs["messages"]
+        resp = MagicMock()
+        resp.choices = [MagicMock()]
+        resp.choices[0].message.content = "## Goal\nReview the backlog."
+        return resp
+
+    with patch("agent.context_compressor.call_llm", mock_call_llm):
+        assert compressor._generate_summary(turns) is not None
+
+    prompt = "\n".join(m["content"] for m in captured["messages"])
+    assert "georgian documents register line" in prompt
+
+
+def test_serializer_without_a_snapshot_is_unchanged():
+    """Every existing caller passes no snapshot and must keep old behaviour."""
+    compressor = _make_compressor()
+    turns = [_tool_msg("call-1", "[read_file] read tasks.md from line 1")]
+
+    assert compressor._serialize_for_summary(turns) == (
+        compressor._serialize_for_summary(turns, None)
+    )
+    assert "[read_file] read tasks.md" in compressor._serialize_for_summary(turns)
+
+
+def test_snapshot_never_shortens_a_live_tool_result():
+    """A result Phase 1 left alone must not be replaced by a stale snapshot."""
+    compressor = _make_compressor()
+    live = "full live output\n" + ("still here\n" * 50)
+    turns = [_tool_msg("call-1", live)]
+
+    text = compressor._serialize_for_summary(turns, {"call-1": "shorter old body"})
+
+    assert "still here" in text
+    assert "shorter old body" not in text
+
+
+def test_restored_body_is_redacted_like_a_live_one():
+    """Restoration happens before redaction, so secrets cannot ride it in."""
+    compressor = _make_compressor()
+    body = "here is the key sk-ant-api03-DEADBEEFDEADBEEFDEADBEEFDEADBEEF\n" * 5
+    turns = [_tool_msg("call-1", "[terminal] ran `cat .env` -> exit 0")]
+
+    text = compressor._serialize_for_summary(turns, {"call-1": body})
+
+    assert "DEADBEEFDEADBEEFDEADBEEFDEADBEEF" not in text
+
+
+def test_restored_body_is_truncated_per_message():
+    """A recovered body cannot crowd the prompt: _CONTENT_MAX still applies."""
+    compressor = _make_compressor()
+    body = "x" * (ContextCompressor._CONTENT_MAX * 4)
+    turns = [_tool_msg("call-1", "[read_file] read big.txt from line 1")]
+
+    text = compressor._serialize_for_summary(turns, {"call-1": body})
+
+    assert "[truncated]" in text
+    assert len(text) < ContextCompressor._CONTENT_MAX * 2


### PR DESCRIPTION
## What does this PR do?

`compress()` runs its cheap Phase-1 tool-result prune **before** the LLM summary
pass, and the messages Phase 1 stubs are the same ones the summarizer is about
to read. So `_serialize_for_summary` sees

```
[read_file] read tasks.md from line 1 (12,362 chars)
```

and the summary can faithfully record *that* a file was read but never *what
was in it*. The one mechanism able to carry content across a compaction is
handed a transcript with the content already removed.

**Lean mode already solves this.** `compress()` snapshots pristine tool bodies
before Phase 1 into `_lean_pristine_tools`, and `_serialize_turns_for_digest`
reads that snapshot so the chunk digests "see what actually happened, not the
stub" (#compaction-v2). Legacy mode has the identical ordering problem and no
such read.

This PR extends the existing mechanism instead of adding a second one:

- the snapshot is taken in both modes (renamed `_lean_pristine_tools` →
  `_pristine_tools`, since it is no longer lean-only — it is a private
  attribute with three references in one file);
- `_serialize_for_summary` gains the same optional `pristine` parameter
  `_serialize_turns_for_digest` already has, with the same
  "only if the snapshot is longer" guard;
- `_generate_summary` passes the snapshot through.

No new state, no new lifecycle, no change to Phase 1's boundary math or output.
The transcript keeps its stubs, so every token Phase 1 reclaimed stays
reclaimed — only the summarizer's *view* is restored.

**Deliberately out of scope:** `_serialize_one_exchange` (the micro-summarizer)
also delegates to `_serialize_for_summary`, and I left it passing no snapshot.
It runs post-turn on an already-compacted transcript and outside `compress()`,
so the snapshot there would be stale by construction and would work against the
shrink it exists to perform. Happy to revisit in a follow-up if you'd rather it
be consistent.

### Why this cannot inflate the summary prompt

Restoration happens inside the existing serializer, upstream of both existing
bounds: `_CONTENT_MAX` (6,000 chars) still truncates each message body, and
`_bound_summary_input` (160,000 chars) still bounds the serialized whole. A
recovered body is therefore capped exactly like a live one and cannot crowd out
the rest of the window. Both are pinned by tests below.

Restoration also happens *before* `_redact_compaction_text`, so a recovered
body is scrubbed for secrets on precisely the same path as a live one — also
pinned by a test.

### Why it bites small-context models hardest

With a 65,536-token window the incompressible floor is already ~21K tokens
(tool schemas plus system prompt). The protected tail is
`threshold_tokens * summary_target_ratio` = 40000 × 0.20 = **8,000 tokens**, so
a turn that reads a handful of source files exceeds the tail immediately and its
evidence is stubbed *while the agent is still working with it*. The agent then
re-reads what it lost, which regrows the turn, which triggers the next
compression pass, which stubs the re-read copy.

## Related Issue

No existing issue covers this. Searched open and closed issues and PRs before
filing; the nearest neighbours are different defects, not duplicates: #80449,
#88778, #79540, #75449, #4379.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/context_compressor.py`
  - `compress()`: the pre-Phase-1 pristine snapshot is no longer gated on
    `tail_mode == "lean"`; `_lean_pristine_tools` → `_pristine_tools`. It is
    still rebuilt on every `compress()` call and still bounded to 80,000 chars
    per entry for tool results over 400 chars, so memory behaviour is unchanged
    in kind.
  - `_serialize_for_summary(turns, pristine=None)`: new optional parameter;
    for `role == "tool"` rows it prefers the snapshot body when that body is
    longer than the (possibly stubbed) current content. Default `None` keeps
    every existing caller behaviourally identical.
  - `_generate_summary`: passes `self._pristine_tools` into the serializer.
  - `_build_chunk_digests`: follows the rename.
- `tests/agent/test_compaction_summarizer_sees_pruned_bodies.py` — new, 6 tests.

## How to Test

1. `pytest tests/agent/test_compaction_summarizer_sees_pruned_bodies.py -q`
   → 6 passed.
2. Negative control — revert only `agent/context_compressor.py` and rerun
   `test_summary_prompt_carries_the_body_in_legacy_mode`, which asserts on the
   prompt the summarizer actually receives. It fails with
   `AssertionError: assert 'georgian documents register line' in 'You are a
   summarization agent...'` — the body is genuinely absent before the fix, so
   the test pins behaviour rather than restating the new signature.
3. Regression sweep: `pytest tests/agent/ -q` (377 files) on this branch and on
   a clean `main` worktree, compared failure-for-failure — see below.

The six tests cover: the stub→body swap; the summarizer prompt end-to-end in
legacy mode; no-snapshot callers unchanged; a stale snapshot never *shortening*
a live result; redaction of a restored body; and per-message truncation of a
restored body.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (one commit, two files)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu, Python 3.13
- [ ] I've run `pytest tests/ -q` and all tests pass — see the note below

**On the full-suite box:** I ran `pytest tests/agent/ -q` (the package this
change touches) on this branch **and** on an unmodified `main` worktree and
compared results; see "Screenshots / Logs". I did not run the whole `tests/`
tree to completion — it is ~3,090 test files and the run was competing for CPU
with a live deployment on the same host. Rather than tick a box I cannot
evidence, I am stating the scope I actually verified. Happy to run more if CI
does not cover it.

### Documentation & Housekeeping

- [x] Docstrings on the touched methods explain the ordering hazard — no
      README/`docs/` change needed
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] Cross-platform: pure-Python dict/str handling, no platform surface
- [x] N/A — no tool descriptions or schemas changed

## Screenshots / Logs

Field evidence from a live deployment (65,536-token local model, legacy tail
mode, one agent turn per scheduled execution). The agent's own reasoning,
recorded verbatim in its session store while its file reads were being stubbed
underneath it:

> The tool results keep coming back as stubs — it seems the environment is
> returning only metadata and not showing the actual content. […] every
> `read_file` returns `[read_file] read <path> from line 1 (N chars)`

It then declined to answer at all rather than assert something it could not
ground. Measured on the same deployment while `compression.max_attempts` was
briefly raised 3 → 10 (since reverted), which adds prune passes:

| | before | after |
|---|---|---|
| tool results per turn | 44–73 | 214–352 |
| share of them stubbed | 14–38% | 50–63% |

Raising the round budget accelerates the re-read loop rather than relieving it,
because each extra round is another prune pass over content the summarizer never
got to read.
