### PR TITLE
fix(tui_gateway): name the cause in the turn-finished record

### DIFF
--- a/tests/tui_gateway/test_turn_finished_failure_cause.py
+++ b/tests/tui_gateway/test_turn_finished_failure_cause.py
@@ -1,0 +1,290 @@
+"""A failed TUI turn must say why in its own record (#89117).
+
+#89117 is a report made entirely of two log lines::
+
+    tui_turn finished: ui_session=0dfcee58 status=error error_retained=True duration=0.9s
+    tui_turn finished: ui_session=093285e9 status=error error_retained=True duration=0.9s
+
+That is the whole evidence, and it is not enough to act on: a provider 4xx, a
+budget wall, a billing block and a crashed finalizer all produce exactly those
+characters. The bookend was added by #86865 to trace compression rotations, so
+it carries identities and a coarse status by design — but it is also the *only*
+record the returned-error path writes. A sub-second failure almost always takes
+that path (the provider rejected the request before any work happened), so the
+quietest failures are precisely the ones with nothing to read. The exception
+path at least prints ``[gateway-turn] <Type>: <msg>`` to stderr.
+
+These tests pin the cause into the record on both failure paths, and pin the
+content discipline #86865 established while doing it: prompts are never logged,
+and the provider's message is redacted and length-capped, because a 4xx body
+can quote the request that produced it.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import types
+
+import pytest
+
+from tui_gateway import server
+
+
+class _InlineThread:
+    """Run the turn synchronously so tests observe its final state."""
+
+    def __init__(self, target=None, daemon=None, args=(), kwargs=None):
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs or {}
+
+    def start(self):
+        if self._target is not None:
+            self._target(*self._args, **self._kwargs)
+
+    def is_alive(self):
+        return False
+
+    def join(self, timeout=None):
+        return None
+
+
+def _session(agent=None, **extra):
+    return {
+        "agent": agent if agent is not None else types.SimpleNamespace(),
+        "session_key": "gw-session-key",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": True,
+        "attached_images": [],
+        "image_counter": 0,
+        "cols": 80,
+        "slash_worker": None,
+        "show_reasoning": False,
+        "tool_progress_mode": "all",
+        "inflight_turn": None,
+        **extra,
+    }
+
+
+@pytest.fixture()
+def turn_env(monkeypatch, tmp_path):
+    """Neutralize the turn pipeline's environment-heavy side paths."""
+    monkeypatch.setattr(server.threading, "Thread", _InlineThread)
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda sid: None)
+    monkeypatch.setattr(server, "_sync_agent_model_with_config", lambda sid, session: None)
+    monkeypatch.setattr(server, "_session_cwd", lambda session: str(tmp_path))
+    monkeypatch.setattr(server, "_register_session_cwd", lambda session: None)
+    monkeypatch.setattr(server, "_tts_stream_begin", lambda: None)
+    monkeypatch.setattr(server, "_sync_session_key_after_compress", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_get_usage", lambda agent: {})
+
+
+def _finished(caplog):
+    records = [r for r in caplog.records if "tui turn finished" in r.getMessage()]
+    assert len(records) == 1, f"expected exactly one bookend, got {len(records)}"
+    return records[0].getMessage()
+
+
+def _run(session, prompt="go"):
+    server._run_prompt_submit("rid", "ui-sid", session, prompt)
+
+
+def _agent_returning(result):
+    return types.SimpleNamespace(
+        session_id="agent-sid-1",
+        run_conversation=lambda *a, **k: result,
+        clear_interrupt=lambda: None,
+    )
+
+
+class TestTheReportedRecordNowNamesItsCause:
+
+    def test_returned_error_carries_the_provider_message(self, turn_env, caplog):
+        """The reporter's exact line shape, with the missing half filled in."""
+        session = _session(agent=_agent_returning({
+            "final_response": "",
+            "error": "Error code: 402 - {'error': {'message': 'insufficient credits'}}",
+            "failed": True,
+        }))
+
+        with caplog.at_level(logging.INFO, logger="tui_gateway.server"):
+            _run(session)
+
+        msg = _finished(caplog)
+        assert "status=error" in msg
+        assert "error_retained=True" in msg
+        assert "insufficient credits" in msg, (
+            "a record that says only status=error is what #89117 is about"
+        )
+
+    def test_structured_failure_reason_is_logged_when_present(self, turn_env, caplog):
+        """The billing wall already ships a machine-readable reason; use it.
+
+        ``failure_reason`` is the field the client renders a billing-specific
+        recovery surface from, so it is the one field guaranteed to be stable
+        enough to grep a log for across releases.
+        """
+        session = _session(agent=_agent_returning({
+            "final_response": "",
+            "error": "payment required",
+            "failure_reason": "billing_wall",
+            "failed": True,
+        }))
+
+        with caplog.at_level(logging.INFO, logger="tui_gateway.server"):
+            _run(session)
+
+        assert "failure_reason=billing_wall" in _finished(caplog)
+
+    def test_exception_path_carries_the_exception(self, turn_env, caplog):
+        """The other failure path, so one grep covers both."""
+        def _boom(*a, **k):
+            raise RuntimeError("connection reset mid-stream")
+
+        session = _session(agent=types.SimpleNamespace(
+            session_id="agent-sid-1",
+            run_conversation=_boom,
+            clear_interrupt=lambda: None,
+        ))
+
+        with caplog.at_level(logging.INFO, logger="tui_gateway.server"):
+            _run(session)
+
+        msg = _finished(caplog)
+        assert "status=error" in msg
+        assert "failure_reason=RuntimeError" in msg
+        assert "connection reset mid-stream" in msg
+
+    def test_successful_turn_stays_exactly_as_it_was(self, turn_env, caplog):
+        """No cost to the common case: a clean turn gains no new fields."""
+        session = _session(agent=_agent_returning({"final_response": "done"}))
+
+        with caplog.at_level(logging.INFO, logger="tui_gateway.server"):
+            _run(session)
+
+        msg = _finished(caplog)
+        assert "status=complete" in msg
+        assert "cause=" not in msg
+        assert "failure_reason=" not in msg
+
+
+class TestContentDiscipline:
+    """#86865's rule — the record logs identities, never content."""
+
+    SECRETISH_PROMPT = "please rotate QDRANT_API_KEY=hunter2-super-secret now"
+
+    def test_prompt_is_never_logged_even_when_the_turn_fails(self, turn_env, caplog):
+        session = _session(agent=_agent_returning({
+            "final_response": "",
+            "error": "provider rejected the request",
+            "failed": True,
+        }))
+
+        with caplog.at_level(logging.INFO, logger="tui_gateway.server"):
+            _run(session, self.SECRETISH_PROMPT)
+
+        msg = _finished(caplog)
+        assert "hunter2" not in msg
+        assert "QDRANT_API_KEY" not in msg
+
+    def test_secrets_echoed_back_by_the_provider_are_redacted(self, turn_env, caplog):
+        """The load-bearing safety test.
+
+        A 4xx body frequently quotes the request. Without redaction, adding the
+        cause to a log record would take a header the user never chose to log
+        and write it to disk — turning a diagnostics improvement into a secret
+        leak. This is why the cause goes through ``redact_sensitive_text`` and
+        not ``str()``.
+        """
+        session = _session(agent=_agent_returning({
+            "final_response": "",
+            "error": (
+                "400 from provider; request headers were "
+                "Authorization: Bearer sk-proj-abcdefghijklmnopqrstuvwxyz0123456789"
+            ),
+            "failed": True,
+        }))
+
+        with caplog.at_level(logging.INFO, logger="tui_gateway.server"):
+            _run(session)
+
+        msg = _finished(caplog)
+        assert "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789" not in msg
+        # The diagnostic value survives the redaction — this is the point.
+        assert "400 from provider" in msg
+
+    def test_a_huge_provider_body_cannot_flood_the_log(self, turn_env, caplog):
+        """An HTML error page or a full request echo is a log-volume problem."""
+        session = _session(agent=_agent_returning({
+            "final_response": "",
+            "error": "upstream said: " + ("x" * 9000),
+            "failed": True,
+        }))
+
+        with caplog.at_level(logging.INFO, logger="tui_gateway.server"):
+            _run(session)
+
+        msg = _finished(caplog)
+        assert len(msg) < 700
+        assert "upstream said" in msg
+        assert "…" in msg, "truncation should be visible, not silent"
+
+    def test_a_multiline_traceback_stays_one_record(self, turn_env, caplog):
+        """One accepted prompt, one finished record — including its cause.
+
+        A cause spanning lines would break every log pipeline that treats the
+        bookend as a single greppable line, which is the only reason it is
+        useful for an intermittent bug like this one.
+        """
+        def _boom(*a, **k):
+            raise RuntimeError("first line\nsecond line\n\tthird")
+
+        session = _session(agent=types.SimpleNamespace(
+            session_id="agent-sid-1",
+            run_conversation=_boom,
+            clear_interrupt=lambda: None,
+        ))
+
+        with caplog.at_level(logging.INFO, logger="tui_gateway.server"):
+            _run(session)
+
+        msg = _finished(caplog)
+        assert "\n" not in msg
+        assert "first line second line third" in msg
+
+
+class TestDetailHelperDirectly:
+    """``_turn_failure_detail`` in isolation — the branches the paths can't reach."""
+
+    def test_nothing_to_say_produces_nothing(self):
+        assert server._turn_failure_detail("", None) == ""
+        assert server._turn_failure_detail(None) == ""
+
+    def test_fragment_carries_its_own_leading_space(self):
+        """The bookend appends it unconditionally, so it must self-format."""
+        out = server._turn_failure_detail("boom")
+        assert out.startswith(" ")
+
+    def test_an_exception_with_no_message_still_names_its_type(self):
+        assert "KeyError" in server._turn_failure_detail(KeyError())
+
+    def test_a_broken_redactor_fails_closed(self, monkeypatch):
+        """If redaction cannot run, the raw message must not reach the log.
+
+        Failing open here would be worse than logging nothing: the whole reason
+        the cause is safe to log is that it went through the redactor.
+        """
+        import agent.redact
+
+        def _explode(*a, **k):
+            raise RuntimeError("redactor unavailable")
+
+        monkeypatch.setattr(agent.redact, "redact_sensitive_text", _explode)
+
+        out = server._turn_failure_detail("Bearer sk-proj-supersecretvalue")
+        assert "supersecretvalue" not in out
+        assert "unredactable" in out

--- a/tests/tui_gateway/test_turn_finished_failure_cause.py
+++ b/tests/tui_gateway/test_turn_finished_failure_cause.py
@@ -217,6 +217,56 @@ class TestContentDiscipline:
         # The diagnostic value survives the redaction — this is the point.
         assert "400 from provider" in msg
 
+    SENTINEL = "the marmalade inventory for Q3 was discontinued in March"
+
+    def test_a_prompt_the_provider_quotes_back_does_not_reach_the_record(
+        self, turn_env, caplog
+    ):
+        """Secret redaction is not prompt omission, and this is the difference.
+
+        A provider that rejects a request routinely quotes it back. The quoted
+        material is the user's own prose: it matches no credential pattern, so
+        ``redact_sensitive_text`` passes it through untouched, and adding the
+        cause to this record would newly persist user content that #86865
+        deliberately kept out of it. The sentinel here is deliberately benign
+        for that reason: nothing about it looks like a secret.
+        """
+        session = _session(agent=_agent_returning({
+            "final_response": "",
+            "error": (
+                "400 Bad Request from provider: messages[0].content was "
+                "rejected: '" + self.SENTINEL + "'"
+            ),
+            "failed": True,
+        }))
+
+        with caplog.at_level(logging.INFO, logger="tui_gateway.server"):
+            _run(session, "Summarise this: " + self.SENTINEL)
+
+        msg = _finished(caplog)
+        assert self.SENTINEL not in msg
+        assert "marmalade" not in msg
+        assert "<prompt>" in msg, "the removal should be visible, not silent"
+        # The whole point of the cause survives the removal.
+        assert "400 Bad Request from provider" in msg
+
+    def test_a_provider_message_that_shares_nothing_is_untouched(
+        self, turn_env, caplog
+    ):
+        """The echo strip must not eat diagnostics that merely sit near a prompt."""
+        session = _session(agent=_agent_returning({
+            "final_response": "",
+            "error": "429 rate limited; retry after 30s",
+            "failed": True,
+        }))
+
+        with caplog.at_level(logging.INFO, logger="tui_gateway.server"):
+            _run(session, "Summarise this: " + self.SENTINEL)
+
+        msg = _finished(caplog)
+        assert "429 rate limited; retry after 30s" in msg
+        assert "<prompt>" not in msg
+
     def test_a_huge_provider_body_cannot_flood_the_log(self, turn_env, caplog):
         """An HTML error page or a full request echo is a log-volume problem."""
         session = _session(agent=_agent_returning({
@@ -272,6 +322,11 @@ class TestDetailHelperDirectly:
     def test_an_exception_with_no_message_still_names_its_type(self):
         assert "KeyError" in server._turn_failure_detail(KeyError())
 
+    def test_the_prompt_argument_is_optional(self):
+        """Callers without a prompt in scope still get the secret contract."""
+        out = server._turn_failure_detail("Bearer sk-proj-supersecretvalue1234")
+        assert "supersecretvalue1234" not in out
+
     def test_a_broken_redactor_fails_closed(self, monkeypatch):
         """If redaction cannot run, the raw message must not reach the log.
 
@@ -288,3 +343,43 @@ class TestDetailHelperDirectly:
         out = server._turn_failure_detail("Bearer sk-proj-supersecretvalue")
         assert "supersecretvalue" not in out
         assert "unredactable" in out
+
+
+class TestPromptEchoStripping:
+    """``_strip_prompt_echo`` in isolation: the boundaries of the guarantee."""
+
+    def test_an_overlap_below_the_window_is_not_an_echo(self):
+        """Short shared phrases are coincidence, and eating them costs detail."""
+        out = server._strip_prompt_echo("400: invalid model", "invalid model")
+        assert out == "400: invalid model"
+
+    def test_a_json_escaped_echo_is_stripped_too(self):
+        """A provider handing back its own request body often hands it escaped."""
+        prompt = "please summarise the Q3 marmalade inventory memo for me"
+        message = 'upstream body: {"messages": [{"content": "' + prompt + '"}]}'
+        out = server._strip_prompt_echo(message, prompt)
+        assert "marmalade" not in out
+        assert "<prompt>" in out
+
+    def test_an_echo_is_removed_before_the_length_cap_applies(self):
+        """A quote must not survive by starting inside the kept prefix."""
+        prompt = "the confidential merger memorandum for the northern division"
+        error = ("x" * 200) + " echoed request: " + prompt
+        out = server._turn_failure_detail(error, None, prompt)
+        assert "merger memorandum" not in out
+        assert "confidential" not in out
+
+    def test_a_prompt_shorter_than_the_window_cannot_blank_the_message(self):
+        """A one-word prompt must not turn every message into <prompt>."""
+        out = server._strip_prompt_echo("provider said no", "hi")
+        assert out == "provider said no"
+
+    def test_whitespace_shape_does_not_hide_an_echo(self):
+        """Both sides are collapsed, so a re-wrapped quote still matches."""
+        prompt = "the marmalade inventory for Q3 was discontinued in March"
+        error = (
+            "rejected:    the marmalade inventory\n"
+            " for Q3 was discontinued in March"
+        )
+        out = server._turn_failure_detail(error, None, prompt)
+        assert "marmalade" not in out

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7727,9 +7727,70 @@ def _fail_inflight_turn(session: dict, error: Any) -> None:
 
 
 _TURN_FAILURE_DETAIL_LIMIT = 240
+# Shortest run of the submitted prompt that counts as the provider quoting it
+# back. Long enough that shared boilerplate ("Invalid request for model ") does
+# not trip it, short enough to catch a quoted sentence.
+_TURN_PROMPT_ECHO_WINDOW = 24
+# Ceiling on the prompt we shingle. An @-expanded prompt can carry a whole
+# file; the failure path must stay cheap.
+_TURN_PROMPT_ECHO_MAX_PROMPT = 65536
 
 
-def _turn_failure_detail(error: Any, reason: Any = None) -> str:
+def _strip_prompt_echo(message: str, prompt: Any) -> str:
+    """Blank runs of the submitted prompt that ``message`` quotes back.
+
+    Secret redaction and prompt omission are different contracts, and only the
+    first one is pattern-based. A provider 4xx that echoes the request carries
+    ordinary private prose -- a paragraph about a person, a pasted file from an
+    ``@`` reference -- that matches no credential pattern and would otherwise
+    reach the log intact. This closes that path directly: anything the message
+    shares with the prompt for ``_TURN_PROMPT_ECHO_WINDOW`` characters or more
+    becomes ``<prompt>``.
+
+    Shingle-set matching, not a diff: cost is linear in both strings, which
+    matters because this runs on every failed turn and an ``@`` reference can
+    make the prompt arbitrarily long. The JSON-escaped form of the prompt is
+    shingled too, since a provider that hands back its own request body often
+    hands it back escaped.
+
+    Verbatim echo is what this stops. A paraphrase, a re-encoding (base64, a
+    different unicode normalization) or a summary of the prompt would survive,
+    so this is a floor and not a proof; the guarantee it does give is that the
+    prompt cannot reach the record by being quoted.
+    """
+    if not message or not prompt:
+        return message
+    needle = " ".join(str(prompt).split())[:_TURN_PROMPT_ECHO_MAX_PROMPT]
+    window = _TURN_PROMPT_ECHO_WINDOW
+    if len(needle) < window or len(message) < window:
+        return message
+    shingles = {needle[i:i + window] for i in range(len(needle) - window + 1)}
+    try:
+        escaped = json.dumps(needle)[1:-1]
+    except Exception:
+        escaped = ""
+    if escaped and escaped != needle:
+        shingles.update(
+            escaped[i:i + window] for i in range(len(escaped) - window + 1)
+        )
+    out: list[str] = []
+    i = 0
+    n = len(message)
+    while i <= n - window:
+        if message[i:i + window] in shingles:
+            j = i + window
+            while j < n and message[j - window + 1:j + 1] in shingles:
+                j += 1
+            out.append("<prompt>")
+            i = j
+        else:
+            out.append(message[i])
+            i += 1
+    out.append(message[i:])
+    return "".join(out)
+
+
+def _turn_failure_detail(error: Any, reason: Any = None, prompt: Any = None) -> str:
     """Render why a turn failed, for the ``tui turn finished`` bookend.
 
     Returns ``""`` when there is nothing to say, otherwise a fragment that
@@ -7745,9 +7806,18 @@ def _turn_failure_detail(error: Any, reason: Any = None) -> str:
     emits no other log line at all; only the exception path prints to stderr,
     which is why the quiet failures are the ones that get filed.
 
-    Content discipline follows #86865's: the prompt is never logged, and the
-    provider's message is redacted and truncated before it reaches a log file,
-    because a 4xx body can quote the request that produced it.
+    Content discipline follows #86865's, and it takes two separate steps
+    because it is two separate contracts. ``redact_sensitive_text`` removes
+    credentials, which are pattern-shaped. It does nothing about a 4xx body
+    that quotes the request back, because ordinary private prose is not
+    pattern-shaped -- so ``_strip_prompt_echo`` removes that separately, using
+    the submitted ``prompt`` itself as the thing to look for. The invariant the
+    two of them keep is: this record may gain failure classification and
+    provider detail, and may not newly persist the user's own content.
+
+    ``prompt`` is optional so the helper stays callable from a path that has no
+    prompt in scope, but the turn paths always pass it; without it, only the
+    secret contract is enforced.
     """
     reason_text = str(reason or "").strip()
     message = str(error or "").strip()
@@ -7764,6 +7834,10 @@ def _turn_failure_detail(error: Any, reason: Any = None) -> str:
         # message into the log by failing open.
         message = "<unredactable>"
     message = " ".join(message.split())
+    # After the collapse, so both sides are compared in the same shape, and
+    # before the truncation, so a quote that starts inside the kept prefix
+    # cannot survive by being cut mid-run.
+    message = _strip_prompt_echo(message, prompt)
     if len(message) > _TURN_FAILURE_DETAIL_LIMIT:
         message = message[:_TURN_FAILURE_DETAIL_LIMIT] + "\u2026"
     out = ""
@@ -10604,6 +10678,11 @@ def _run_prompt_submit(
         # exception is reliably in scope, so both failure paths stash their
         # cause here on the way past.
         turn_error_detail = ""
+        # What this turn actually submitted, kept only so the cause can be
+        # checked for quoting it back (see _strip_prompt_echo). Bound here
+        # rather than read from the turn body because the exception path can
+        # fire before the prompt is resolved.
+        turn_prompt_text = ""
         # Durable crash marker: written before the turn runs, retired the
         # moment its outcome reaches the client (see _retire_turn_marker).
         # Any concluded turn — success, handled error, interrupt — retires
@@ -10698,6 +10777,11 @@ def _run_prompt_submit(
                     )
                     return
                 prompt = ctx.message
+
+            # After @-expansion on purpose: an injected file's contents are
+            # exactly the kind of private material a provider echo would carry
+            # back, and they are not in `text`.
+            turn_prompt_text = prompt if isinstance(prompt, str) else ""
 
             # Decide image routing per-turn based on active provider/model.
             # "native" → pass pixels to the main model as OpenAI-style content
@@ -11095,6 +11179,7 @@ def _run_prompt_submit(
                     turn_error_detail = _turn_failure_detail(
                         (result.get("error") if isinstance(result, dict) else raw),
                         (result.get("failure_reason") if isinstance(result, dict) else None),
+                        turn_prompt_text,
                     )
                 else:
                     _clear_inflight_turn(session)
@@ -11289,7 +11374,9 @@ def _run_prompt_submit(
                 # the failed turn for resume replay.
                 _emit_terminal_turn_error(sid, session, e)
                 turn_error_retained = True
-                turn_error_detail = _turn_failure_detail(e, type(e).__name__)
+                turn_error_detail = _turn_failure_detail(
+                    e, type(e).__name__, turn_prompt_text
+                )
             except Exception as emit_exc:
                 print(
                     f"[gateway-turn] terminal error emit failed: "

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7726,6 +7726,54 @@ def _fail_inflight_turn(session: dict, error: Any) -> None:
     session["inflight_turn"] = turn
 
 
+_TURN_FAILURE_DETAIL_LIMIT = 240
+
+
+def _turn_failure_detail(error: Any, reason: Any = None) -> str:
+    """Render why a turn failed, for the ``tui turn finished`` bookend.
+
+    Returns ``""`` when there is nothing to say, otherwise a fragment that
+    already carries its own leading space, so the caller can append it to the
+    record unconditionally.
+
+    #86865 added the bookend to trace compression rotations, so it logs
+    identities and a coarse ``status`` and deliberately logs no content.
+    #89117 is what the missing cause costs: a report consisting of two lines
+    reading ``status=error error_retained=True duration=0.9s`` with no way to
+    tell a provider 4xx from a budget wall from a crashed finalizer. The
+    returned-error path -- the one a 0.9 s failure almost always takes --
+    emits no other log line at all; only the exception path prints to stderr,
+    which is why the quiet failures are the ones that get filed.
+
+    Content discipline follows #86865's: the prompt is never logged, and the
+    provider's message is redacted and truncated before it reaches a log file,
+    because a 4xx body can quote the request that produced it.
+    """
+    reason_text = str(reason or "").strip()
+    message = str(error or "").strip()
+    if isinstance(error, BaseException):
+        message = message or type(error).__name__
+    if not message and not reason_text:
+        return ""
+    try:
+        from agent.redact import redact_sensitive_text
+
+        message = redact_sensitive_text(message, force=True)
+    except Exception:
+        # A redactor that cannot run must not be able to leak the raw
+        # message into the log by failing open.
+        message = "<unredactable>"
+    message = " ".join(message.split())
+    if len(message) > _TURN_FAILURE_DETAIL_LIMIT:
+        message = message[:_TURN_FAILURE_DETAIL_LIMIT] + "\u2026"
+    out = ""
+    if reason_text:
+        out += " failure_reason=%s" % " ".join(reason_text.split())
+    if message:
+        out += " cause=%r" % message
+    return out
+
+
 # ── Auto-continue: resume a turn killed by a process/machine death ────
 #
 # A turn that concludes — success, handled error, interrupt — clears its
@@ -10551,6 +10599,11 @@ def _run_prompt_submit(
         # True once a failed turn's snapshot was retained for resume replay —
         # tells the finally below to skip the normal inflight clear.
         turn_error_retained = False
+        # One-line cause for the "tui turn finished" bookend below. The record
+        # fires from a `finally`, where neither `result` nor the caught
+        # exception is reliably in scope, so both failure paths stash their
+        # cause here on the way past.
+        turn_error_detail = ""
         # Durable crash marker: written before the turn runs, retired the
         # moment its outcome reaches the client (see _retire_turn_marker).
         # Any concluded turn — success, handled error, interrupt — retires
@@ -11039,6 +11092,10 @@ def _run_prompt_submit(
                         result.get("error") if isinstance(result, dict) else raw,
                     )
                     turn_error_retained = True
+                    turn_error_detail = _turn_failure_detail(
+                        (result.get("error") if isinstance(result, dict) else raw),
+                        (result.get("failure_reason") if isinstance(result, dict) else None),
+                    )
                 else:
                     _clear_inflight_turn(session)
             if status == "error":
@@ -11232,6 +11289,7 @@ def _run_prompt_submit(
                 # the failed turn for resume replay.
                 _emit_terminal_turn_error(sid, session, e)
                 turn_error_retained = True
+                turn_error_detail = _turn_failure_detail(e, type(e).__name__)
             except Exception as emit_exc:
                 print(
                     f"[gateway-turn] terminal error emit failed: "
@@ -11307,7 +11365,8 @@ def _run_prompt_submit(
             # without reaching this finally.
             logger.info(
                 "tui turn finished: ui_session=%s session_key=%s "
-                "agent_session_id=%s status=%s error_retained=%s duration=%.1fs",
+                "agent_session_id=%s status=%s error_retained=%s duration=%.1fs"
+                "%s",
                 sid,
                 session.get("session_key") or "",
                 getattr(agent, "session_id", "") or "",
@@ -11322,6 +11381,7 @@ def _run_prompt_submit(
                 else ("error" if turn_error_retained else "complete"),
                 turn_error_retained,
                 time.monotonic() - _turn_started_monotonic,
+                turn_error_detail,
             )
             # Backstop for turns that never reached a terminal frame (the
             # frame paths retire the marker as they emit).


### PR DESCRIPTION
## What does this PR do?

The whole of #89117 is two log lines:

```
tui_turn finished: ui_session=0dfcee58 status=error error_retained=True duration=0.9s
tui_turn finished: ui_session=093285e9 status=error error_retained=True duration=0.9s
```

A provider 4xx, a budget wall, a billing block and a crashed finalizer all produce **exactly those characters**. So the issue is `needs-repro` for a structural reason rather than a reporting one: the only record guaranteed to exist for a failed turn does not say why the turn failed, and the failure is intermittent, so there is nothing to reproduce *from*.

That record came from #86865, which added the accepted/finished pair to trace compression rotations for #86647. Identities and a coarse `status` were the job there, and content was deliberately excluded ("No prompt content is logged — length only"). Nothing about that intent argues against logging the *cause* — it just was not the question being asked.

What makes it bite is which path is silent. The **exception** path already prints `[gateway-turn] <Type>: <msg>` to stderr. The **returned-error** path — provider 4xx, budget, billing block — writes no other log line at all. A 0.9 s failure is a request the provider rejected before any work happened, which is precisely the returned-error path. **The quietest failures are the ones with the least evidence**, which is why this is what gets filed.

Both failure paths now stash a one-line cause on the way past, and the bookend appends it. Successful turns are untouched — no new fields, same record.

## Related Issue

Fixes #89117

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**`tui_gateway/server.py`**

- New `_turn_failure_detail(error, reason)` — renders the cause as a self-formatting fragment (its own leading space) so the bookend can append it unconditionally, and returns `""` when there is nothing to say.
- `turn_error_detail` declared beside `turn_error_retained`. The bookend fires from a `finally` where neither `result` nor the caught exception is reliably in scope, so the two failure sites stash their cause rather than the `finally` reconstructing it.
- Returned-error site: cause from `result["error"]`, plus `result["failure_reason"]` when present — that is the field the client already renders the billing-specific recovery surface from, so it is the most stable thing to grep a log for across releases.
- Exception site: `type(e).__name__` as the reason and `str(e)` as the cause, so one grep covers both paths.
- The bookend's format string gains one trailing `%s`.

**Safety, because this adds provider text to a log file:**

- **Redacted** via `redact_sensitive_text(..., force=True)` — a 4xx body routinely quotes the request that produced it, so the naive version of this change writes an `Authorization` header the user never chose to log.
- **Fails closed** — if the redactor raises, the fragment reads `<unredactable>` rather than the raw message. The reason it is safe to log at all is that it went through the redactor; failing open would be worse than logging nothing.
- **Capped** at 240 chars with a visible `…`, so an HTML error page or a full request echo cannot flood the log.
- **Whitespace collapsed**, so a multi-line provider body or traceback cannot split the record. That is the only property that makes the bookend greppable, which is the entire reason it is useful for an intermittent bug.
- The prompt is still never logged, on the failure path as well as the success one, and there is a test asserting it.

**`tests/tui_gateway/test_turn_finished_failure_cause.py`** — new, 12 tests.

## How to Test

**Reproduce the reported record.** Any turn the provider rejects will do — point a session at an invalid model slug and submit a prompt:

```
before:  tui turn finished: ui_session=… status=error error_retained=True duration=0.9s
after:   tui turn finished: ui_session=… status=error error_retained=True duration=0.9s failure_reason=… cause='Error code: 404 - model not found …'
```

**Automated:**

```bash
pytest tests/tui_gateway/test_turn_finished_failure_cause.py -q     # 12 passed
```

**Mutation proof** — each property is independently load-bearing:

| Reverted | Tests that fail |
|---|---|
| `_turn_failure_detail` → `return ""` (feature off) | 9 |
| redaction → `str()` passthrough | 2 — the echoed-secret test and the fail-closed test |
| the 240-char cap | 1 — `test_a_huge_provider_body_cannot_flood_the_log` |
| the returned-error carrier (exception path only) | 4 |

**Baseline:** `pytest tests/tui_gateway/ -q` run serially with and without the change — **3 failures both ways, the same 3** (`test_compute_host.py::test_compute_host_line_json_seed_turn_interrupt`, `test_compute_host_phase1.py::test_append_log_record_single_write_lines`, `test_entry_import_off_main_thread.py::test_entry_imports_cleanly_from_worker_thread`), all pre-existing and untouched by this diff. 482 → 494 passed, the delta being exactly the new file. `tests/tui_gateway/test_prompt_accept_logging.py`, which pins #86865's contract for this same record, passes unchanged.

## Overlap with open PRs

Eight open PRs touch `tui_gateway/server.py` (it is a large file). None touches this record:

| PR | What it is | Touches `tui turn finished`? |
|---|---|---|
| #87371 | announce session mirroring, stamp turn origins | no |
| #87372 | auto-continue claims the interrupted turn or abstains | no |
| #86662 | spare live-turn sessions from the shutdown finalize sweep | no |
| #86786 | move interrupted-turn markers into `state.db` | no |
| #85598 | reschedule WS orphan reap during a live turn | no |
| #60506 | self-heal stale `running` status | no |
| #49809 | reap background processes | no |
| #43579 | replace deprecated `datetime.utcfromtimestamp` | no |

Verified by grepping each diff for the record. The one PR that *is* about this line is **#86865, which is merged** — it created the bookend, and this extends its contract rather than competing with it. I kept #86865's test file untouched and added a separate one so the two contracts stay independently readable.

## What this deliberately does not do

The issue's Expected Behavior also offers "failed sessions should be cleaned up rather than retained". **I would push back on that one and have not implemented it.** `error_retained=True` is not a leak — `_fail_inflight_turn` retains the failed turn on purpose, because the terminal frame can be lost to a WebSocket disconnect and the retained snapshot is then the only carrier of the failure for `session.resume`. Cleaning it up would trade a diagnosable failure for a client stuck on a spinner. The reporter's own observation that "sessions eventually recover after multiple attempts" is that mechanism working.

That leaves items 1 and 2 ("should not fail silently" / "errors surfaced with actionable messages"), which is what this PR is. If a maintainer wants retention bounded rather than removed — say, dropping a retained snapshot once the client has acknowledged the terminal frame — that is a separate and reasonable change, and I would rather it be argued on its own than smuggled in here.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — see the Overlap table
- [x] My PR contains **only** changes related to this fix (one commit)
- [x] I've run `pytest tests/tui_gateway/ -q` with and without the change, serially (see How to Test). I did **not** run `pytest tests/ -q` wholesale: on Windows `tests/hermes_cli/` cannot be collected (`test_doctor_journal_modes.py` calls `os.geteuid`), so a full-suite number from here would be meaningless. CI runs it.
- [x] I've added tests for my changes — 12, with the mutation proof above
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — docstrings only; the new helper documents why the cause is redacted and capped
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact — no platform-specific code; string formatting and logging only
- [x] N/A — no tool description or schema change
