### PR TITLE
fix(goals): wait out slow DB bootstrap on the goal write path

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -673,6 +673,17 @@ _DB_BOOTSTRAP_INFLIGHT: Dict[str, threading.Event] = {}
 # degrades, with the loop stalled far under the watchdog's probe window.
 _DB_BOOTSTRAP_LOOP_WAIT_S = 0.25
 
+# How long a *write* caller (save_goal) waits for the inflight bootstrap
+# before degrading to a dropped write. Reads keep the tight loop window —
+# a slow load merely reports "no goal yet" — but a dropped save is silent
+# data loss: /goal already answered "Goal set" from in-memory state while
+# the row never lands (#89175). A cold-disk fresh-DB init (schema + FTS
+# DDL) can take seconds on slow runners, so the write path waits once for
+# durability. Still bounded far below the loop-liveness watchdog (10s
+# probe timeout, 3 strikes) so a wedged init degrades instead of
+# crash-looping the gateway.
+_DB_BOOTSTRAP_WRITE_WAIT_S = 5.0
+
 
 def _bootstrap_session_db(home: str, done: threading.Event) -> None:
     """Construct SessionDB off-loop and populate the cache (worker thread)."""
@@ -690,7 +701,7 @@ def _bootstrap_session_db(home: str, done: threading.Event) -> None:
     done.set()
 
 
-def _get_session_db() -> Optional[Any]:
+def _get_session_db(loop_wait_s: Optional[float] = None) -> Optional[Any]:
     """Return a SessionDB instance for the current HERMES_HOME.
 
     SessionDB has no built-in singleton, but opening a new connection per
@@ -707,6 +718,10 @@ def _get_session_db() -> Optional[Any]:
     loop we kick a one-shot background bootstrap and return None; every
     caller already degrades gracefully on None, and a later call returns the
     cached instance.
+
+    ``loop_wait_s`` overrides the loop-thread grace window for durability
+    callers (save_goal): a dropped write is silent data loss, so it waits
+    the longer one-shot write window instead (#89175).
     """
     try:
         from hermes_constants import get_hermes_home
@@ -750,7 +765,9 @@ def _get_session_db() -> Optional[Any]:
         # loop-thread call instead of silently dropping it. A contended init
         # (the crash-loop scenario) exceeds the window and we degrade to
         # None — a bounded stall far below the watchdog's probe timeout.
-        done.wait(_DB_BOOTSTRAP_LOOP_WAIT_S)
+        done.wait(
+            _DB_BOOTSTRAP_LOOP_WAIT_S if loop_wait_s is None else loop_wait_s
+        )
         return _DB_CACHE.get(home)
 
     try:
@@ -797,13 +814,21 @@ def save_goal(session_id: str, state: GoalState) -> None:
     """Persist a goal to SessionDB. No-op if DB unavailable."""
     if not session_id:
         return
-    db = _get_session_db()
+    db = _get_session_db(loop_wait_s=_DB_BOOTSTRAP_WRITE_WAIT_S)
     if db is None:
+        # A dropped save is silent data loss: /goal already answered
+        # "Goal set" from in-memory state while the row never lands, so
+        # surface the drop instead of swallowing it at DEBUG (#89175).
+        logger.warning(
+            "GoalManager: goal write for %s dropped — session DB still "
+            "unavailable after the bootstrap write wait",
+            session_id,
+        )
         return
     try:
         db.set_meta(_meta_key(session_id), state.to_json())
     except Exception as exc:
-        logger.debug("GoalManager: set_meta failed: %s", exc)
+        logger.warning("GoalManager: set_meta failed: %s", exc)
 
 
 def clear_goal(session_id: str) -> None:

--- a/tests/hermes_cli/test_goals_db_bootstrap_off_loop.py
+++ b/tests/hermes_cli/test_goals_db_bootstrap_off_loop.py
@@ -136,3 +136,99 @@ def test_slow_construction_does_not_block_the_loop(monkeypatch):
     assert elapsed is not None and elapsed < 1.0, (
         f"loop-thread call blocked for {elapsed:.2f}s — watchdog territory"
     )
+
+
+class _SlowThenReadyDB:
+    """Stands in for a cold-disk SessionDB: init (schema + FTS DDL) is slow
+    but healthy — finishes well past the 0.25s read window, well inside the
+    write window. Records set_meta writes."""
+
+    writes: dict = {}
+
+    def __init__(self):
+        time.sleep(0.6)
+
+    def get_meta(self, key):
+        return self.writes.get(key)
+
+    def set_meta(self, key, value):
+        self.writes[key] = value
+
+
+def test_save_goal_waits_out_slow_bootstrap(monkeypatch):
+    """A slow-but-healthy cold init must not drop the first /goal write
+    (#89175): save_goal waits the one-shot write window for durability, so
+    the row lands even when init exceeds the read grace window."""
+    import hermes_state
+
+    _SlowThenReadyDB.writes = {}
+    monkeypatch.setattr(hermes_state, "SessionDB", _SlowThenReadyDB)
+    persisted = []
+
+    async def main():
+        state = goals.GoalState(goal="ship it", max_turns=7)
+        goals.save_goal("sess-89175", state)
+
+    asyncio.run(main())
+    db = next(iter(goals._DB_CACHE.values()), None)
+    assert db is not None, "background bootstrap never populated the cache"
+    persisted = db.writes.get("goal:sess-89175")
+    assert persisted, (
+        "first /goal write was dropped: bootstrap exceeded the wait window"
+    )
+    assert '"ship it"' in persisted
+
+
+def test_load_goal_keeps_tight_loop_window(monkeypatch):
+    """Reads keep the 0.25s grace window: a slow init degrades load_goal to
+    None quickly instead of stalling the loop thread (#89175)."""
+    import hermes_state
+
+    _SlowThenReadyDB.writes = {}
+    monkeypatch.setattr(hermes_state, "SessionDB", _SlowThenReadyDB)
+    elapsed = None
+    result = "UNSET"
+
+    async def main():
+        nonlocal elapsed, result
+        t0 = time.monotonic()
+        result = goals.load_goal("sess-89175")
+        elapsed = time.monotonic() - t0
+
+    asyncio.run(main())
+    assert result is None, "slow init must not fabricate a goal for reads"
+    assert elapsed is not None and elapsed < 0.5, (
+        f"read path blocked for {elapsed:.2f}s — reads must keep the tight window"
+    )
+
+
+def test_save_goal_drop_warns_after_write_wait(monkeypatch, caplog):
+    """When even the write window expires (wedged init), the dropped write
+    is surfaced at WARNING instead of vanishing below DEBUG (#89175)."""
+    import hermes_state
+
+    class _NeverReadyDB:
+        def __init__(self):
+            time.sleep(30.0)  # wedged far past any wait
+
+        def get_meta(self, key):
+            return None
+
+    monkeypatch.setattr(hermes_state, "SessionDB", _NeverReadyDB)
+    monkeypatch.setattr(goals, "_DB_BOOTSTRAP_WRITE_WAIT_S", 0.15)
+    wrote = []
+
+    async def main():
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.goals"):
+            state = goals.GoalState(goal="later", max_turns=3)
+            t0 = time.monotonic()
+            goals.save_goal("sess-wedged", state)
+            wrote.append(time.monotonic() - t0)
+
+    asyncio.run(main())
+    assert wrote and wrote[0] < 1.0, "write wait must stay bounded"
+    assert any(
+        "dropped" in rec.message for rec in caplog.records
+    ), "dropped goal write must log at WARNING"


### PR DESCRIPTION
## What does this PR do?

Since c9dbdbcea, `_get_session_db()` on an event-loop thread never constructs `SessionDB` inline: it kicks a background bootstrap thread and waits a fixed 0.25s grace window. On a slow/cold runner a fresh-DB init (schema init + FTS DDL) takes longer than the window, so every goals persistence call on the first turn degrades to `None` — `save_goal` is fail-open by design, so the write is **silently dropped** while `/goal` still answers "⊙ Goal set…" from in-memory state. Beyond the two CI flakes quoted in the issue, this is a production data-loss shape after a gateway start on a slow disk.

This PR takes the issue's first suggested direction — writes wait for the inflight bootstrap to *finish* rather than the fixed grace window:

- `save_goal` now passes a dedicated one-shot write window (`_DB_BOOTSTRAP_WRITE_WAIT_S = 5.0`) to `_get_session_db(loop_wait_s=...)`. 5s covers slow-but-healthy cold inits while staying far below the loop-liveness watchdog (10s probe timeout, 3 strikes), so a wedged init still degrades instead of crash-looping the gateway.
- A write that still cannot land after the write window now logs at WARNING (with the session id) instead of vanishing below DEBUG, and a `set_meta` failure is escalated from DEBUG to WARNING too — both are silent data loss otherwise.
- Reads (`load_goal`) keep the tight 0.25s window unchanged: a slow load merely reports "no goal yet" and must not stall the loop thread. The non-loop-thread path (inline construction) is untouched.

## Related Issue

Fixes #89175

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

- `hermes_cli/goals.py`
  - Added `_DB_BOOTSTRAP_WRITE_WAIT_S = 5.0` with a comment explaining the read/write window split and the watchdog budget.
  - `_get_session_db(loop_wait_s=None)`: optional per-call override of the loop-thread grace window; default behavior byte-identical for every existing caller (heartbeat reuses this helper unchanged).
  - `save_goal`: waits the write window; on a dropped write logs `WARNING` naming the session; `set_meta` failure escalated to WARNING.
- `tests/hermes_cli/test_goals_db_bootstrap_off_loop.py`
  - `test_save_goal_waits_out_slow_bootstrap`: 0.6s cold init (> 0.25s, < 5s) — the first `/goal` write must land (fails on main: the write is dropped).
  - `test_load_goal_keeps_tight_loop_window`: same slow init — `load_goal` still returns None quickly (< 0.5s), pinning the read window.
  - `test_save_goal_drop_warns_after_write_wait`: wedged init (write window monkeypatched to 0.15s) — the drop is bounded and surfaces at WARNING (fails on main: silent return).

## How to Test

```bash
python -m pytest tests/hermes_cli/test_goals_db_bootstrap_off_loop.py -q
# Observed result: 7 passed

python -m pytest tests/hermes_cli/test_goals.py tests/hermes_cli/test_goal_gates.py tests/hermes_cli/test_kanban_goal_mode.py tests/hermes_cli/test_heartbeat.py tests/gateway/test_goal_max_turns_config.py tests/gateway/test_goal_continuation_drain.py -q
# Observed result: 94 passed
```

Fail-on-main check: with the source change stashed, `test_save_goal_waits_out_slow_bootstrap` and `test_save_goal_drop_warns_after_write_wait` fail on main; the read-window pin passes on both.

Deterministic repro from the issue (delaying `_bootstrap_session_db` by 5s, then `/goal` on the loop thread): with this PR the write waits and lands; on main `GoalManager(sid).state` is `None` while the response claims success.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments explain intent (why writes wait, why reads must not)
- [x] Corresponding changes documented via docstrings/constants
- [x] Tests added and passing (3 new; adjacent suites green)
- [x] Single root cause, no unrelated changes
