### PR TITLE
feat(desktop): show model and token usage in Bots roster rows

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -4234,6 +4234,10 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
       ? (previewSession?.preview || '').replace(A2A_PREFIX_RE, '').trim() || '…'
       : previewSession?.preview || bot.description || 'No conversations yet — say hi'
   )
+  const usageModel = previewSession?.model
+  const usageTokens =
+    (Number(previewSession?.input_tokens) || 0) + (Number(previewSession?.output_tokens) || 0)
+  const usageTokenLabel = formatBotTokenCount(usageTokens)
 
   const warm = () => {
     // Multi-source row: pre-dial the agent's OWN source (feature-detected).
@@ -4380,6 +4384,19 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
                     title: 'Active in the last 90s'
                   })
                 : null,
+              usageModel
+                ? jsx('span', {
+                    className: 'max-w-[9rem] truncate text-[0.6875rem] text-(--ui-text-quaternary)',
+                    title: usageModel,
+                    children: usageModel
+                  })
+                : null,
+              usageTokenLabel
+                ? jsx('span', {
+                    className: 'shrink-0 text-[0.6875rem] text-(--ui-text-quaternary)',
+                    children: usageTokenLabel
+                  })
+                : null,
               last
                 ? jsx('span', {
                     className: 'shrink-0 text-[0.6875rem] text-(--ui-text-quaternary)',
@@ -4503,6 +4520,37 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
       })
     ]
   })
+}
+
+function formatBotTokenCount(value) {
+  const count = Number(value)
+
+  if (!Number.isFinite(count) || count <= 0) {
+    return ''
+  }
+
+  if (count < 1000) {
+    const rounded = Math.round(count)
+    return rounded >= 1000 ? '1.0k tokens' : `${rounded} tokens`
+  }
+
+  const units = ['', 'k', 'M', 'B']
+  let scaled = count
+  let unitIndex = 0
+
+  while (scaled >= 1000 && unitIndex < units.length - 1) {
+    scaled /= 1000
+    unitIndex += 1
+  }
+
+  const precision = scaled < 10 ? 1 : 0
+  const rounded = Number(scaled.toFixed(precision))
+
+  if (rounded >= 1000 && unitIndex < units.length - 1) {
+    return `${(rounded / 1000).toFixed(1)}${units[unitIndex + 1]} tokens`
+  }
+
+  return `${scaled.toFixed(precision)}${units[unitIndex]} tokens`
 }
 
 // ── model picker (provider/model dropdowns via model.options) ───────────────

--- a/apps/desktop/src/plugins/hermes-bots/tests/roster-preview.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/roster-preview.test.mjs
@@ -26,7 +26,7 @@ function runtime() {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__previewKind = previewKind;\nglobalThis.__generatedSessionTitle = generatedSessionTitle;\nglobalThis.__isGenericTitle = isGenericTitle;'
+      '\nglobalThis.__previewKind = previewKind;\nglobalThis.__generatedSessionTitle = generatedSessionTitle;\nglobalThis.__isGenericTitle = isGenericTitle;\nglobalThis.__formatBotTokenCount = formatBotTokenCount;'
     )
   vm.runInNewContext(code, context)
   return context
@@ -87,7 +87,17 @@ test('generatedSessionTitle: caps the generated label length', () => {
   assert.ok(out.length <= 34, `expected <= 34 chars, got ${out.length}: ${out}`)
 })
 
-// ── render smoke: BotRow must paint the new row furniture without throwing ──
+test('formatBotTokenCount: keeps compact labels readable across unit boundaries', () => {
+  const format = runtime().__formatBotTokenCount
+
+  assert.equal(format(999), '999 tokens')
+  assert.equal(format(999_500), '1.0M tokens')
+  assert.equal(format(1_000_000), '1.0M tokens')
+  assert.equal(format(1_500_000_000), '1.5B tokens')
+  assert.equal(format(0), '')
+})
+
+// ── render: BotRow must paint the new row furniture without throwing ──
 
 function renderRuntime() {
   const atom = value => ({ get: () => value, set: () => undefined })
@@ -155,6 +165,9 @@ const DM_BOT = {
   last_session: {
     id: 's1',
     title: 'Bot Chat',
+    model: 'anthropic/claude-sonnet-4',
+    input_tokens: 1200,
+    output_tokens: 345,
     preview: 'Message from 🤖 manager (@manager): Learn-share: skill installed in your profile',
     last_active: Math.floor(Date.now() / 1000) - 5
   }
@@ -166,6 +179,8 @@ test('render: BotRow shows the sender badge and stripped DM preview', () => {
   const text = textOf(tree)
   assert.match(text, /@manager/)
   assert.match(text, /Learn-share/)
+  assert.match(text, /anthropic\/claude-sonnet-4/)
+  assert.match(text, /1.5k tokens/)
   assert.doesNotMatch(text, /Message from/)
 })
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -9004,7 +9004,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 for key in (
                     "id", "ended_at", "end_reason", "message_count",
                     "tool_call_count", "title", "last_active", "preview",
-                    "model", "system_prompt", "cwd", "git_branch", "git_repo_root",
+                    "model", "input_tokens", "output_tokens", "system_prompt", "cwd",
+                    "git_branch", "git_repo_root",
                 ):
                     if key in tip_row:
                         merged[key] = tip_row[key]

--- a/tests/tui_gateway/test_profiles_list_preferred_session.py
+++ b/tests/tui_gateway/test_profiles_list_preferred_session.py
@@ -47,12 +47,16 @@ def _db(profile_dir):
 
 
 def _add_session(db, sid, *, source="cli", title="", ts, text, hidden=False,
-                 parent=None, end_reason=None):
+                 parent=None, end_reason=None, model=None, input_tokens=0,
+                 output_tokens=0):
     """Create one session with a single user message at an exact timestamp."""
     db.create_session(sid, source, parent_session_id=parent)
     db.append_message(sid, "user", text, timestamp=ts)
     with db._lock:
-        db._conn.execute("UPDATE sessions SET title = ? WHERE id = ?", (title, sid))
+        db._conn.execute(
+            "UPDATE sessions SET title = ?, model = ?, input_tokens = ?, output_tokens = ? WHERE id = ?",
+            (title, model, input_tokens, output_tokens, sid),
+        )
         if end_reason:
             # Mark ended AFTER appending: the DB (correctly) refuses writes
             # to a compression-closed session.
@@ -94,6 +98,28 @@ def test_preferred_session_summarizes_pin_not_latest(home):
     assert "pinned chat content" in pref["preview"]
     # last_session keeps its own contract: the most recently active session.
     assert row["last_session"]["id"] == "other1"
+
+
+def test_session_summaries_include_model_and_token_counts(home):
+    db = _db(home)
+    _add_session(
+        db,
+        "usage1",
+        title="Bot Chat",
+        ts=1000,
+        text="usage content",
+        model="anthropic/claude-sonnet-4",
+        input_tokens=1200,
+        output_tokens=345,
+    )
+    db.close()
+
+    row = _row(_profiles({"preferred_session_ids": {"default": "usage1"}}), "default")
+
+    for summary in (row["last_session"], row["preferred_session"]):
+        assert summary["model"] == "anthropic/claude-sonnet-4"
+        assert summary["input_tokens"] == 1200
+        assert summary["output_tokens"] == 345
 
 
 def test_preferred_session_resolves_hidden_pin(home):
@@ -162,6 +188,40 @@ def test_preferred_session_resolves_compression_tip(home):
 # ---------------------------------------------------------------------------
 # Contract guards
 # ---------------------------------------------------------------------------
+
+
+def test_last_session_projection_keeps_compression_tip_usage(home):
+    db = _db(home)
+    _add_session(
+        db,
+        "root-usage",
+        title="Bot Chat",
+        ts=1000,
+        text="pre-compression content",
+        end_reason="compression",
+        model="old-model",
+        input_tokens=100,
+        output_tokens=20,
+    )
+    _add_session(
+        db,
+        "tip-usage",
+        title="Bot Chat (continued)",
+        ts=3000,
+        text="post-compression content",
+        parent="root-usage",
+        model="new-model",
+        input_tokens=1200,
+        output_tokens=345,
+    )
+    db.close()
+
+    last = _row(_profiles({}), "default")["last_session"]
+
+    assert last["id"] == "tip-usage"
+    assert last["model"] == "new-model"
+    assert last["input_tokens"] == 1200
+    assert last["output_tokens"] == 345
 
 
 def test_no_param_omits_preferred_key(home):

--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -111,6 +111,9 @@ def _(rid, params: dict) -> dict:
                     "resolved_id": tip,
                     "title": tip_row.get("title") or "",
                     "preview": preview,
+                    "model": tip_row.get("model") or row.get("model") or "",
+                    "input_tokens": tip_row.get("input_tokens") or row.get("input_tokens") or 0,
+                    "output_tokens": tip_row.get("output_tokens") or row.get("output_tokens") or 0,
                     "started_at": tip_row.get("started_at") or row.get("started_at") or 0,
                     "last_active": (
                         tip_row.get("last_activity_at")
@@ -156,6 +159,9 @@ def _(rid, params: dict) -> dict:
                         "id": s["id"],
                         "title": s.get("title") or "",
                         "preview": s.get("preview") or "",
+                        "model": s.get("model") or "",
+                        "input_tokens": s.get("input_tokens") or 0,
+                        "output_tokens": s.get("output_tokens") or 0,
                         "started_at": s.get("started_at") or 0,
                         "last_active": s.get("last_active") or s.get("started_at") or 0,
                         "message_count": s.get("message_count") or 0,


### PR DESCRIPTION
## Summary

Adds **model name** and **compact total token usage** (input + output) next to the existing chat preview and timestamp in each Hermes Desktop Bots pane row.

This surfaces per-agent usage information at a glance, making it easier to understand which model served a conversation and how much it cost — without opening the session.

### Backend (`tui_gateway/methods_profiles.py`)
- `profiles.list` now returns `model`, `input_tokens`, and `output_tokens` in both `last_session` and `preferred_session` summaries.
- Fields are best-effort: older gateways that don't store these columns produce empty/zero values and the UI simply omits them.

### State (`hermes_state.py`)
- Compression-tip projection now preserves `input_tokens` and `output_tokens` alongside `model`, so compressed conversations show the live session's usage, not the pre-compression root's.

### UI (`apps/desktop/src/plugins/hermes-bots/plugin.js`)
- `BotRow` renders the model name (truncated, with full model as tooltip) and a compact token count (e.g. `1.5k tokens`, `3.2M tokens`).
- Model is sourced from the **session being previewed** (the pinned canonical chat or the most recent session), not the profile's configured default — so after a `/model` switch the row reflects reality.
- `formatBotTokenCount` handles unit boundaries correctly (e.g. `999.5k → 1.0M`).

### Tests
- **Backend**: `test_session_summaries_include_model_and_token_counts` verifies both `last_session` and `preferred_session` carry the fields. `test_last_session_projection_keeps_compression_tip_usage` verifies compression-tip projection preserves usage.
- **UI**: `formatBotTokenCount: keeps compact labels readable across unit boundaries` covers formatter edge cases. The BotRow render assertion confirms model and token labels appear.

### Verification
- `node --test apps/desktop/src/plugins/hermes-bots/tests/*.mjs` → **262 passed**
- `.venv/bin/python -m pytest -q tests/tui_gateway/test_profiles_list_preferred_session.py` → **10 passed**
- `node --check plugin.js`, `py_compile`, `git diff --check` → all pass

## Test Plan
- [x] Bots plugin test suite passes (262 tests)
- [x] Backend profiles.list contract tests pass (10 tests)
- [x] JavaScript and Python syntax checks pass