### PR TITLE
feat(doctor): add profile composition diagnostics

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -583,12 +583,22 @@ def _apply_profile_override() -> None:
             break
         if arg == "--args" and _inside_mcp_add_args(i):
             break
+        # `hermes doctor --profile NAME` is a read-only inspection target,
+        # not the global profile override. The doctor subparser owns that
+        # spelling; retain the historical global override everywhere else.
+        doctor_before = "doctor" in argv[:i]
         if arg in {"--profile", "-p"} and i + 1 < len(argv):
+            if doctor_before:
+                i += 2
+                continue
             profile_name = argv[i + 1]
             consume = 2
             profile_index = i
             break
         if arg.startswith("--profile="):
+            if doctor_before:
+                i += 1
+                continue
             profile_name = arg.split("=", 1)[1]
             consume = 1
             profile_index = i
@@ -5841,6 +5851,29 @@ def cmd_hooks(args):
 
 def cmd_doctor(args):
     """Check configuration and dependencies."""
+    if getattr(args, "json", False) and not (
+        getattr(args, "profile", None) is not None
+        or getattr(args, "all_profiles", False)
+    ):
+        raise SystemExit("--json requires --profile NAME or --all-profiles")
+    if (
+        getattr(args, "profile", None) is not None
+        or getattr(args, "all_profiles", False)
+        or getattr(args, "json", False)
+    ):
+        from hermes_cli.profile_doctor import render_profile_doctor_report
+
+        try:
+            output = render_profile_doctor_report(
+                profile=getattr(args, "profile", None),
+                all_profiles=getattr(args, "all_profiles", False),
+                as_json=getattr(args, "json", False),
+            )
+        except ValueError as exc:
+            raise SystemExit(str(exc)) from exc
+        print(output)
+        return
+
     from hermes_cli.doctor import run_doctor
 
     run_doctor(args)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -524,6 +524,7 @@ def _apply_profile_override() -> None:
     profile_name = None
     consume = 0
     profile_index = None
+    subcommand = None
 
     def _inside_mcp_add_args(index: int) -> bool:
         """True once argv reaches `hermes mcp add ... --args <command argv>`.
@@ -583,10 +584,12 @@ def _apply_profile_override() -> None:
             break
         if arg == "--args" and _inside_mcp_add_args(i):
             break
+        if subcommand is None and not arg.startswith("-"):
+            subcommand = arg
         # `hermes doctor --profile NAME` is a read-only inspection target,
         # not the global profile override. The doctor subparser owns that
         # spelling; retain the historical global override everywhere else.
-        doctor_before = "doctor" in argv[:i]
+        doctor_before = subcommand == "doctor"
         if arg in {"--profile", "-p"} and i + 1 < len(argv):
             if doctor_before:
                 i += 2

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -577,6 +577,35 @@ def _apply_profile_override() -> None:
     from hermes_cli._parser import top_level_value_flag_sets
 
     value_flags, optional_value_flags = top_level_value_flag_sets()
+
+    def _find_subcommand() -> tuple[str | None, int | None]:
+        """Find the first positional command, skipping option values.
+
+        Looking for the literal ``doctor`` in the preceding tokens is not
+        sufficient: ``--model doctor chat`` contains the word without
+        selecting the doctor command.
+        """
+        i = 0
+        while i < len(argv):
+            arg = argv[i]
+            if arg == "--" or (arg == "--args" and _inside_mcp_add_args(i)):
+                return None, None
+            if arg in {"--profile", "-p"} or arg in value_flags:
+                i += 2 if i + 1 < len(argv) else 1
+            elif arg in optional_value_flags:
+                if i + 1 < len(argv) and not argv[i + 1].startswith("-"):
+                    i += 2
+                else:
+                    i += 1
+            elif arg.startswith("--profile=") or "=" in arg:
+                i += 1
+            elif arg.startswith("-"):
+                i += 1
+            else:
+                return arg, i
+        return None, None
+
+    subcommand, subcommand_index = _find_subcommand()
     i = 0
     while i < len(argv):
         arg = argv[i]
@@ -589,7 +618,11 @@ def _apply_profile_override() -> None:
         # `hermes doctor --profile NAME` is a read-only inspection target,
         # not the global profile override. The doctor subparser owns that
         # spelling; retain the historical global override everywhere else.
-        doctor_before = subcommand == "doctor"
+        doctor_before = (
+            subcommand == "doctor"
+            and subcommand_index is not None
+            and i > subcommand_index
+        )
         if arg in {"--profile", "-p"} and i + 1 < len(argv):
             if doctor_before:
                 i += 2

--- a/hermes_cli/profile_doctor.py
+++ b/hermes_cli/profile_doctor.py
@@ -1,0 +1,94 @@
+"""Read-only profile composition diagnostics for ``hermes doctor``.
+
+This module intentionally reports only presence and non-secret configuration
+metadata. It does not load dotenv files, inspect sessions, or mutate state.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _profile_record(info: Any) -> dict[str, Any]:
+    path = Path(info.path)
+    config_path = path / "config.yaml"
+    memory_dir = path / "memories"
+    plugin_dir = path / "plugins"
+    gateway_artifacts = (
+        path / "gateway.pid",
+        path / "gateway_state.json",
+    )
+    config: dict[str, Any] = {}
+    if config_path.is_file():
+        try:
+            from hermes_cli.config import read_user_config_raw
+
+            raw = read_user_config_raw(config_path)
+            if isinstance(raw, dict):
+                config = raw
+        except Exception:
+            pass
+    memory_configured = isinstance(config.get("memory"), dict) and bool(
+        config.get("memory")
+    )
+    plugins_configured = bool(config.get("plugins"))
+    gateway_configured = bool(config.get("gateway"))
+    return {
+        "name": str(info.name),
+        "status": "configured" if config_path.is_file() else "missing-config",
+        "config_present": config_path.is_file(),
+        "model": info.model,
+        "provider": info.provider,
+        "memory_present": memory_dir.exists() or memory_configured,
+        "plugins_present": plugin_dir.exists() or plugins_configured,
+        "gateway_present": any(item.exists() for item in gateway_artifacts)
+        or gateway_configured,
+        "gateway_running": bool(info.gateway_running),
+    }
+
+
+def build_profile_doctor_report(
+    *, profile: str | None = None, all_profiles: bool = False
+) -> dict[str, Any]:
+    """Build a deterministic, JSON-serializable profile composition report."""
+    from hermes_cli.profiles import list_profiles
+
+    if profile is not None and all_profiles:
+        raise ValueError("--profile and --all-profiles cannot be used together")
+
+    profiles = sorted(
+        list_profiles(), key=lambda item: (not item.is_default, item.name)
+    )
+    if profile is not None:
+        selected = [item for item in profiles if item.name == profile]
+        if not selected:
+            raise ValueError(f"Profile '{profile}' does not exist")
+    elif all_profiles:
+        selected = profiles
+    else:
+        selected = [item for item in profiles if item.is_default][:1]
+        if not selected and profiles:
+            selected = profiles[:1]
+
+    return {"profiles": [_profile_record(item) for item in selected]}
+
+
+def render_profile_doctor_report(
+    *, profile: str | None = None, all_profiles: bool = False, as_json: bool = False
+) -> str:
+    """Render the report for CLI output."""
+    report = build_profile_doctor_report(profile=profile, all_profiles=all_profiles)
+    if as_json:
+        return json.dumps(report, sort_keys=True, separators=(",", ":"))
+    lines = ["Profile composition:"]
+    for item in report["profiles"]:
+        lines.append(
+            f"- {item['name']}: {item['status']} "
+            f"(model={'present' if item['model'] else 'missing'}, "
+            f"memory={'present' if item['memory_present'] else 'missing'}, "
+            f"plugins={'present' if item['plugins_present'] else 'missing'}, "
+            f"gateway={'running' if item['gateway_running'] else 'stopped'})"
+        )
+    return "\n".join(lines)

--- a/hermes_cli/subcommands/doctor.py
+++ b/hermes_cli/subcommands/doctor.py
@@ -41,4 +41,17 @@ def build_doctor_parser(subparsers, *, cmd_doctor: Callable) -> None:
             "doctor` first to see active advisories and their IDs."
         ),
     )
+    doctor_parser.add_argument(
+        "--profile", metavar="NAME", help="Report composition for one profile"
+    )
+    doctor_parser.add_argument(
+        "--all-profiles",
+        action="store_true",
+        help="Report composition for the default and every named profile",
+    )
+    doctor_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the profile composition report as deterministic JSON",
+    )
     doctor_parser.set_defaults(func=cmd_doctor)

--- a/tests/hermes_cli/test_apply_profile_override.py
+++ b/tests/hermes_cli/test_apply_profile_override.py
@@ -16,6 +16,8 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 
 def _run_apply_profile_override(
     tmp_path, monkeypatch, *, hermes_home: str | None, active_profile: str | None,
@@ -109,6 +111,72 @@ class TestApplyProfileOverrideHermesHomeGuard:
 
         assert os.environ.get("HERMES_HOME") == str(profile_dir)
         assert sys.argv == ["hermes", "gateway", "install", "--system"]
+
+    def test_doctor_value_before_real_subcommand_does_not_hide_global_profile(
+        self, tmp_path, monkeypatch
+    ):
+        """A value such as ``--model doctor`` is not the doctor command."""
+        hermes_root = tmp_path / ".hermes"
+        (hermes_root / "profiles" / "coder").mkdir(parents=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(
+            sys, "argv", ["hermes", "--model", "doctor", "chat", "--profile", "coder"]
+        )
+
+        from hermes_cli.main import _apply_profile_override
+        _apply_profile_override()
+
+        assert os.environ.get("HERMES_HOME") == str(hermes_root / "profiles" / "coder")
+        assert sys.argv == ["hermes", "--model", "doctor", "chat"]
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["hermes", "doctor", "--profile", "coder"],
+            ["hermes", "--profile", "base", "doctor", "--profile", "coder"],
+            ["hermes", "--profile=base", "doctor", "--profile", "coder"],
+        ],
+    )
+    def test_supported_doctor_profile_layouts_preserve_scope(
+        self, tmp_path, monkeypatch, argv
+    ):
+        """Doctor's target profile is distinct from the global profile flag."""
+        hermes_root = tmp_path / ".hermes"
+        (hermes_root / "profiles" / "base").mkdir(parents=True)
+        (hermes_root / "profiles" / "coder").mkdir(parents=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(sys, "argv", argv)
+
+        from hermes_cli.main import _apply_profile_override
+        _apply_profile_override()
+
+        has_global_base = "base" in argv or "--profile=base" in argv
+        expected = hermes_root / "profiles" / "base" if has_global_base else None
+        assert os.environ.get("HERMES_HOME") == (str(expected) if expected else None)
+        if expected:
+            assert sys.argv == ["hermes", "doctor", "--profile", "coder"]
+        else:
+            assert sys.argv == argv
+
+    def test_mcp_args_profile_belongs_to_child_command(self, tmp_path, monkeypatch):
+        """A ``--profile`` after MCP ``--args`` is not Hermes' profile flag."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        argv = [
+            "hermes", "mcp", "add", "server", "--args", "docker",
+            "run", "--profile", "child",
+        ]
+        monkeypatch.setattr(sys, "argv", argv)
+
+        from hermes_cli.main import _apply_profile_override
+        _apply_profile_override()
+
+        assert os.environ.get("HERMES_HOME") is None
+        assert sys.argv == argv
 
 
 

--- a/tests/hermes_cli/test_profile_doctor.py
+++ b/tests/hermes_cli/test_profile_doctor.py
@@ -1,0 +1,73 @@
+"""Focused tests for the read-only profile composition doctor report."""
+
+import json
+from argparse import ArgumentParser
+
+import pytest
+
+from hermes_cli.subcommands.doctor import build_doctor_parser
+
+
+def _parser():
+    parser = ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    build_doctor_parser(subparsers, cmd_doctor=lambda args: args)
+    return parser
+
+
+def test_doctor_parser_accepts_profile_report_flags():
+    args = _parser().parse_args(
+        ["doctor", "--profile", "coder", "--json"]
+    )
+    assert args.profile == "coder"
+    assert args.all_profiles is False
+    assert args.json is True
+
+
+def test_profile_report_is_json_safe_deterministic_and_redacted(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    (home / "profiles" / "coder" / "memories").mkdir(parents=True)
+    (home / "profiles" / "coder" / "plugins").mkdir()
+    (home / "config.yaml").write_text("model:\n  default: root-model\n")
+    (home / "profiles" / "coder" / "config.yaml").write_text(
+        "model:\n  default: coder-model\n  provider: local\n"
+    )
+    (home / "profiles" / "coder" / ".env").write_text(
+        "OPENAI_API_KEY=super-secret\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    from hermes_cli.profile_doctor import build_profile_doctor_report
+
+    report = build_profile_doctor_report(all_profiles=True)
+    encoded = json.dumps(report, sort_keys=True)
+    assert json.loads(encoded) == report
+    assert [item["name"] for item in report["profiles"]] == ["default", "coder"]
+    coder = report["profiles"][1]
+    assert coder["config_present"] is True
+    assert coder["model"] == "coder-model"
+    assert coder["memory_present"] is True
+    assert coder["plugins_present"] is True
+    assert coder["gateway_present"] is False
+    assert "super-secret" not in encoded
+    assert ".env" not in encoded
+
+
+def test_profile_report_selects_named_profile_and_rejects_unknown(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    (home / "profiles" / "coder").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    from hermes_cli.profile_doctor import build_profile_doctor_report
+
+    report = build_profile_doctor_report(profile="coder")
+    assert [item["name"] for item in report["profiles"]] == ["coder"]
+    with pytest.raises(ValueError, match="does not exist"):
+        build_profile_doctor_report(profile="missing")
+
+
+def test_profile_report_rejects_ambiguous_scope():
+    from hermes_cli.profile_doctor import build_profile_doctor_report
+
+    with pytest.raises(ValueError, match="cannot be used together"):
+        build_profile_doctor_report(profile="coder", all_profiles=True)

--- a/website/docs/developer-guide/bot-mode-routing-diagnostics.md
+++ b/website/docs/developer-guide/bot-mode-routing-diagnostics.md
@@ -1,0 +1,72 @@
+# Bot Mode and Group/User Routing Diagnostics (PR2 design spec)
+
+> **Status:** design-only follow-up to the profile composition doctor. This
+> document defines a future diagnostic surface; PR1 does not implement it.
+
+## Problem
+
+Bot Mode can multiplex several profiles across group and direct-user
+conversations. When a message is routed to an unexpected profile, operators
+need an explainable, read-only diagnostic that distinguishes configuration,
+identity, and runtime routing decisions without exposing conversation content.
+
+## Proposed interface
+
+Extend `hermes doctor` in a future PR with an explicitly opt-in routing mode,
+for example:
+
+```text
+hermes doctor --routing --profile NAME [--group GROUP_ID] [--user USER_ID]
+hermes doctor --routing --all-profiles --json
+```
+
+The exact flag names remain subject to CLI review. The report should include,
+for each evaluated profile:
+
+- whether Bot Mode/group/user routing is enabled;
+- configured platform and gateway presence (not credentials);
+- normalized, redacted route-match dimensions (platform, group/user scope,
+  allow/deny outcome, precedence class);
+- selected profile and a bounded reason code (for example
+  `explicit-profile`, `group-rule`, `user-rule`, `default-fallback`, or
+  `no-match`);
+- configuration errors and actionable remediation hints;
+- an evaluation timestamp only when requested by a human-readable mode (JSON
+  should otherwise be deterministic).
+
+The implementation must use the same profile/config discovery APIs as PR1,
+avoid changing active-profile state, and never start a gateway or send a
+platform request. IDs should be hashed or partially redacted unless the
+operator explicitly supplies a safe local diagnostic mode.
+
+## Non-goals
+
+- No changes to Bot Mode routing semantics, precedence, or authorization.
+- No automatic repair, profile mutation, gateway restart, or message delivery.
+- No transcript, message body, attachment, contact name, token, API key,
+  cookie, OAuth credential, or raw `.env` content in output.
+- No live network probes or platform API calls.
+- No speculative routing plugin hooks or new user-facing environment variables.
+- No replacement of the existing full `hermes doctor` checks.
+- No snapshot tests tied to the number or order of platforms; behavior tests
+  should assert routing invariants and redaction.
+
+## Acceptance criteria
+
+1. Existing `hermes doctor` with no new routing flags is byte-for-byte behavior
+   compatible, including read-only semantics.
+2. Routing diagnostics run against a temporary `HERMES_HOME` in tests using
+   real imports and representative group/user configuration.
+3. Given the same filesystem/config inputs, JSON output is deterministic,
+   JSON-serializable, and stably ordered.
+4. Tests prove that secrets and message content cannot appear in either text
+   or JSON output, including values in malformed or unexpected config fields.
+5. Tests cover explicit profile selection, group match, user match,
+   precedence conflicts, default fallback, no-match, missing profile, and
+   malformed routing configuration.
+6. The command performs no writes and does not acquire gateway/network
+   side-effects; this is verified with filesystem and network guards.
+7. CLI reference documentation defines examples, redaction guarantees, and
+   the distinction between static routing diagnostics and live gateway logs.
+8. A reviewer can implement the feature without changing PR1's profile
+   composition report contract.

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -814,11 +814,26 @@ Subscriptions persist to `~/.hermes/webhook_subscriptions.json` and are hot-relo
 
 ```bash
 hermes doctor [--fix]
+hermes doctor --profile NAME [--json]
+hermes doctor --all-profiles [--json]
 ```
+
+The default invocation remains the full configuration and dependency
+diagnostics. The profile-report modes are read-only and only expose composition
+metadata (never dotenv values, secrets, or message/session content). The
+`--json` option is valid with `--profile` or `--all-profiles`; it does not
+change the output format of the existing full doctor.
+
+The global `--profile NAME` form before the command continues to select the
+runtime profile for existing commands. The `hermes doctor --profile NAME` form
+is a non-mutating inspection of a named profile.
 
 | Option | Description |
 |--------|-------------|
 | `--fix` | Attempt automatic repairs where possible. |
+| `--profile NAME` | Report one named profile's composition. |
+| `--all-profiles` | Report the default profile and all discovered named profiles. |
+| `--json` | Emit deterministic, machine-readable JSON for the profile report. |
 
 ## `hermes dump`
 


### PR DESCRIPTION
## Summary

- add read-only profile composition diagnostics to `hermes doctor`
- support a named profile, all profiles, and deterministic JSON output
- preserve the existing global `--profile` runtime selector and default doctor behavior
- add a design-only follow-up specification for Bot Mode/group/user routing diagnostics

## User-visible commands

```bash
hermes doctor --profile NAME
hermes doctor --all-profiles
hermes doctor --all-profiles --json
```

The report exposes only non-secret composition metadata: config presence, model/provider, memory/plugin/gateway presence, and gateway running state. It never reads dotenv values, sessions, transcripts, or message content.

`hermes doctor --profile NAME` is an inspection target. The existing global `hermes --profile NAME ...` form remains the runtime profile selector for existing commands.

## Design boundaries

- report mode is read-only and does not start gateways, call providers, or mutate profiles;
- profile discovery reuses Hermes' existing profile APIs;
- JSON is stable and machine-readable for support, CI, and profile tooling;
- the Bot Mode/group/user routing work is documented but intentionally not implemented in this PR.

## Test plan

- [x] focused profile doctor tests (4 passed)
- [x] existing doctor tests excluding the pre-existing Vercel environment diagnostic failure (53 passed, 1 deselected)
- [x] real CLI smoke test with temporary `HERMES_HOME`
- [x] secret redaction smoke check
- [x] Ruff checks on changed Python files
- [x] Python compilation
- [x] `git diff --check`

The full existing `tests/hermes_cli/test_doctor.py` run still has the unrelated environment-sensitive failure in `test_doctor_reports_vercel_backend_diagnostics`; the changed default doctor path is not entered when no new flags are supplied, and `hermes_cli/doctor.py` is unchanged.

## Follow-up

`website/docs/developer-guide/bot-mode-routing-diagnostics.md` contains the scoped PR2 design, non-goals, privacy requirements, and acceptance criteria. It does not change Bot Mode routing semantics.
