### PR TITLE
fix(config): resolve ${env:VAR} refs from ~/.hermes/.env

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2606,7 +2606,8 @@ def _env_expand_match(m: re.Match) -> str:
     * ``${env:VAR}`` — Cursor-style SecretRef, same resolution after the
       ``env:`` prefix is stripped.  Before this, the prefixed form worked in
       MCP config but stayed a literal string in config.yaml — a confusing
-      half-support.
+      half-support.  Process environment values take precedence, with a
+      direct ``~/.hermes/.env`` lookup as the startup-order fallback.
 
     Other SecretRef sources (``file:``, ``bitwarden:``, ``vault:``, ...)
     are NOT resolved here — external secret backends inject their values
@@ -2621,6 +2622,8 @@ def _env_expand_match(m: re.Match) -> str:
         if not name:
             return raw
         val = os.environ.get(name)
+        if val is None:
+            val = load_env().get(name)
         if val is not None:
             return val
         logger.warning(
@@ -2661,8 +2664,9 @@ def _expand_env_vars(obj):
     values.
 
     Only string values are processed; dict keys, numbers, booleans, and
-    None are left untouched.  Unresolved references (variable not in
-    ``os.environ``) are kept verbatim so callers can detect them.
+    None are left untouched.  Unresolved references (variable not available
+    from ``os.environ`` or ``~/.hermes/.env``) are kept verbatim so callers
+    can detect them.
     """
     if isinstance(obj, str):
         return re.sub(r"\${([^}]+)}", _env_expand_match, obj)

--- a/tests/hermes_cli/test_config_env_expansion.py
+++ b/tests/hermes_cli/test_config_env_expansion.py
@@ -1,5 +1,7 @@
 """Tests for ${ENV_VAR} substitution in config.yaml values."""
 
+import logging
+
 import pytest
 from hermes_cli.config import _expand_env_vars, load_config
 
@@ -48,6 +50,41 @@ class TestLoadConfigExpansion:
         assert config["platforms"]["telegram"]["token"] == "1234567:ABC-token"
         assert config["plain"] == "no-substitution"
 
+
+    def test_load_config_resolves_env_ref_from_dotenv_without_warning(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            "mcp_servers:\n"
+            "  bring:\n"
+            "    env:\n"
+            "      BRING_EMAIL: ${env:BRING_EMAIL}\n",
+            encoding="utf-8",
+        )
+        (tmp_path / ".env").write_text(
+            "BRING_EMAIL=user@example.com\n", encoding="utf-8"
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("BRING_EMAIL", raising=False)
+        # Patch the imported function's own globals. Other tests may reload
+        # hermes_cli.config, so string-target monkeypatches can hit a
+        # different module object than this collection-time import.
+        monkeypatch.setitem(
+            load_config.__globals__, "get_config_path", lambda: config_file
+        )
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.config"):
+            config = load_config()
+
+        assert config["mcp_servers"]["bring"]["env"]["BRING_EMAIL"] == (
+            "user@example.com"
+        )
+        assert not any(
+            "BRING_EMAIL is not set" in record.getMessage()
+            for record in caplog.records
+        )
 
 class TestLoadConfigCacheEnvStaleness:
     """The load_config() cache must not pin expansions made against a stale


### PR DESCRIPTION
## Summary

Resolve `${env:VAR}` references from the user's `~/.hermes/.env` during early config loading, so standalone `hermes config` commands do not report variables as missing when they are present in the dotenv file.

## Root cause

`hermes_cli/config.py::_env_expand_match` only checked `os.environ`. The standalone CLI can call `load_config()` before `load_hermes_dotenv()` populates that mapping, so valid dotenv-backed references triggered a warning and remained literal during the first expansion pass.

## Fix

Keep the existing process-environment lookup as the precedence path and fall back to the existing memoized `load_env()` parser when the process variable is absent. The existing warning remains for references missing from both sources.

## Testing

- `HERMES_PYTHON=/tmp/hermes-89199-venv/bin/python scripts/run_tests.sh tests/hermes_cli/test_config_env_expansion.py tests/hermes_cli/test_config_env_ref_parity.py tests/hermes_cli/test_config_env_refs.py tests/hermes_cli/test_env_load_cache.py tests/hermes_cli/test_env_loader.py tests/hermes_cli/test_config_loader_e2e.py -q` — 42 passed
- `/tmp/hermes-89199-venv/bin/python -m ruff check hermes_cli/config.py tests/hermes_cli/test_config_env_expansion.py` — passed
- `/tmp/hermes-89199-venv/bin/python -m compileall -q hermes_cli/config.py tests/hermes_cli/test_config_env_expansion.py` — passed
- Manual `hermes config get mcp_servers.bring.env --json` reproduction with a temporary `HERMES_HOME/.env` — resolved value printed with no stderr warning

## Issue

Fixes #89199