### PR TITLE
test(conftest): widen audio-playback guard to tools.voice_mode's real sink

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1062,10 +1062,19 @@ def _wal_is_usable() -> bool:
 #    gateway call sites late-import, so patching the module attribute catches
 #    them wherever they import it from.
 #  • ``hermes_cli.voice.play_audio_file`` — the module-level binding
-#    ``speak_text`` actually plays through. Patching the binding inside
-#    ``hermes_cli.voice`` (not ``tools.voice_mode``) keeps the real function
-#    available to the tests that legitimately exercise it with a mocked
-#    audio backend (``tests/tools/test_voice_mode.py``).
+#    ``speak_text`` actually plays through.
+#
+# #88898 found a second, independent leak through the same class of bug:
+# ``tools.tts_tool``'s synthesis pipeline and ``cli.py``'s
+# ``_voice_speak_response`` late-import ``tools.voice_mode.play_audio_file``
+# directly — they never touch ``hermes_cli.voice``, so the guard above never
+# saw them, and a bare ``pytest tests/gateway`` run spoke real TTS output out
+# loud. ``tools.voice_mode.play_audio_file`` (and the ``_play_int16_via_tempfile``
+# tone/beep path that also calls it) is the true choke point every player
+# — ``afplay``/``ffplay``/``aplay``/``sounddevice`` — funnels through, so we
+# patch it there too. Tests that legitimately exercise the real function with
+# a mocked audio backend (``tests/tools/test_voice_mode.py`` and friends) opt
+# out with ``@pytest.mark.real_audio_playback``.
 #
 # Config cannot re-open this hole: the ``tts:`` section of ``config.yaml``
 # only selects *which* provider speaks, never *whether* to speak — that gate
@@ -1681,6 +1690,17 @@ def _audio_playback_guard(request, monkeypatch):
         monkeypatch.setattr(_voice, "speak_text", _blocked_speak_text)
     if hasattr(_voice, "play_audio_file"):
         monkeypatch.setattr(_voice, "play_audio_file", _blocked_play_audio_file)
+
+    # ``hermes_cli.voice`` imports ``tools.voice_mode`` at module load, so a
+    # successful import above guarantees this one succeeds too (#88898).
+    import tools.voice_mode as _vm
+
+    if hasattr(_vm, "play_audio_file"):
+        monkeypatch.setattr(_vm, "play_audio_file", _blocked_play_audio_file)
+    if hasattr(_vm, "_play_int16_via_tempfile"):
+        monkeypatch.setattr(
+            _vm, "_play_int16_via_tempfile", lambda audio, sample_rate: None
+        )
 
     yield
 

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -564,6 +564,7 @@ class TestWhisperHallucinationFilter:
 
 class TestPlayAudioFile:
     @pytest.mark.linux_only
+    @pytest.mark.real_audio_playback
     def test_play_wav_via_sounddevice(self, monkeypatch, sample_wav):
         np = pytest.importorskip("numpy")
         # Linux-gated rather than faking a non-macOS platform: on macOS WAV
@@ -600,6 +601,7 @@ class TestMacOSAudioOutputPolicy:
     and `afplay` only resolves on a real macOS host."""
 
     @pytest.mark.macos_only
+    @pytest.mark.real_audio_playback
     def test_play_audio_file_skips_sounddevice_on_macos(self, monkeypatch, sample_wav):
         """On macOS, WAV playback must not import sounddevice; it routes to afplay."""
 
@@ -695,7 +697,13 @@ class TestCleanupTempRecordings:
 # ============================================================================
 
 class TestPlayBeep:
+    @pytest.mark.linux_only
     def test_beep_calls_sounddevice_play(self, mock_sd):
+        """sounddevice is only the beep path off Darwin — see
+        _sounddevice_output_allowed(). On macOS play_beep routes through
+        _play_int16_via_tempfile -> play_audio_file -> afplay before mock_sd
+        is ever consulted (#88898); that arm is covered separately by
+        test_play_beep_routes_through_afplay_on_macos."""
         np = pytest.importorskip("numpy")
 
         from tools.voice_mode import play_beep
@@ -1391,6 +1399,7 @@ class TestWSL2PowerShellFallback:
             return next(it)
         return _side_effect
 
+    @pytest.mark.real_audio_playback
     def test_powershell_pipeline_preserves_real_exit_status(self, sample_wav):
         """Regression (review of #63768): the shell pipeline must preserve
         the (ffmpeg && powershell) exit status past the unconditional
@@ -1440,6 +1449,7 @@ class TestWSL2PowerShellFallback:
             "Shell pipeline must preserve the real exit status past cleanup: " + sh_script
         )
 
+    @pytest.mark.real_audio_playback
     def test_wsl2_unique_temp_filename(self, monkeypatch, tmp_path, sample_wav):
         """Two concurrent calls must use different temp WAV filenames."""
         from unittest.mock import patch, MagicMock
@@ -1485,6 +1495,7 @@ class TestWSL2PowerShellFallback:
             "Concurrent TTS calls must use unique temp WAV filenames"
         )
 
+    @pytest.mark.real_audio_playback
     def test_non_wsl_skips_powershell_fallback(self, monkeypatch, sample_wav):
         """On non-WSL Linux, the PowerShell player must not be inserted."""
         from unittest.mock import patch, MagicMock

--- a/tests/tools/test_voice_mode_playback_env_scrub.py
+++ b/tests/tools/test_voice_mode_playback_env_scrub.py
@@ -1,8 +1,10 @@
 """Voice-mode system playback must scrub credential env (sibling of #70342)."""
 
+import pytest
 from unittest.mock import MagicMock, patch
 
 
+@pytest.mark.real_audio_playback
 def test_play_audio_file_scrubbed_env(tmp_path, monkeypatch):
     audio = tmp_path / "t.mp3"
     audio.write_bytes(b"ID3fake")

--- a/tests/tools/test_voice_thinking_sound.py
+++ b/tests/tools/test_voice_thinking_sound.py
@@ -123,9 +123,13 @@ class TestAudioOutputRefcount:
         vm.mark_audio_output_active(False)
         assert vm.is_audio_output_active() is False
 
+    @pytest.mark.real_audio_playback
     def test_play_audio_file_brackets_refcount(self, tmp_path):
         """play_audio_file flags real speaker output for its whole duration,
-        so the thinking loop knows audio is flowing."""
+        so the thinking loop knows audio is flowing. _play_audio_file_impl is
+        mocked, so this never touches real hardware; the marker only bypasses
+        the autouse guard's whole-function stub, which would otherwise
+        shadow the real play_audio_file wrapper this test targets (#88898)."""
         _reset()
         seen = []
 

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1633,6 +1633,11 @@ def play_audio_file(file_path: str) -> bool:
     Returns:
         ``True`` if playback succeeded, ``False`` otherwise.
     """
+    # Process-wide kill switch (#88898): headless/agent/CI contexts can set
+    # this once instead of relying on every entry point being mocked.
+    if os.environ.get("HERMES_TTS_NO_PLAYBACK", "").strip() == "1":
+        return False
+
     # Ref-count real speaker output for the whole call so the thinking-sound
     # loop (and any other ambient cue) knows audio is flowing right now.
     mark_audio_output_active(True)


### PR DESCRIPTION
## What does this PR do?

`_audio_playback_guard` (autouse, `tests/conftest.py`) only patches `hermes_cli.voice.speak_text` / `hermes_cli.voice.play_audio_file`. `tools.tts_tool`'s synthesis pipeline (`_SyncSentencePipeline._drain`, `_play_via_tempfile`) and `cli.py`'s `_voice_speak_response` all late-import `tools.voice_mode.play_audio_file` directly — they never touch `hermes_cli.voice`, so the guard never sees them and a stray unmocked test can still reach real `afplay`/`ffplay`/`aplay`. This is the gap #66788's guard left open.

## Related Issue

Part of #88898. That issue has three findings; #88948 (open) already fixes the first (the test that leaks TTS synthesis + playback). This PR fixes the other two — the guard gap and the `play_beep` test — and does not touch the file #88948 is already changing, to avoid stepping on it.

## Changes Made

- `tests/conftest.py`: widen `_audio_playback_guard` to also patch `tools.voice_mode.play_audio_file` and `_play_int16_via_tempfile` — the real choke point every player funnels through. Tests that legitimately exercise the real function with a mocked backend now opt out with the existing `@pytest.mark.real_audio_playback` marker (6 tests across `tests/tools/test_voice_mode.py`, `tests/tools/test_voice_mode_playback_env_scrub.py`, and `tests/tools/test_voice_thinking_sound.py` — each already mocks `subprocess.Popen`/`sounddevice`/`_play_audio_file_impl` itself at its own boundary, so none of them touch real hardware).
- `tools/voice_mode.py`: honor `HERMES_TTS_NO_PLAYBACK=1` inside `play_audio_file` itself, so headless/agent/CI contexts can kill host playback process-wide regardless of which entry point is used.
- `tests/tools/test_voice_mode.py`: mark `TestPlayBeep::test_beep_calls_sounddevice_play` `linux_only`. On macOS, `play_beep` checks `_sounddevice_output_allowed()` before `_import_audio`, so it routes through `_play_int16_via_tempfile -> play_audio_file -> afplay` and never reaches the `mock_sd` fixture — the test both spawns real `afplay` and fails its own assertion on Darwin. Its sibling `test_play_beep_routes_through_afplay_on_macos` already covers the Darwin arm correctly.

## How to Test

```
pytest tests/tools/test_voice_mode.py tests/tools/test_voice_mode_playback_env_scrub.py \
       tests/tools/test_voice_thinking_sound.py tests/tools/test_tts_streaming.py \
       tests/tools/test_voice_cli_integration.py tests/hermes_cli/test_voice_wrapper.py \
       tests/gateway/test_voice_command.py -q
```

All pass except 4 pre-existing failures unrelated to this change (`TestPulseSocketReachable` — `AF_UNIX path too long` on macOS's deep tmp paths, and `TestWSL2PowerShellFallback` — Darwin-vs-Linux dispatch that only exercises correctly on a Linux host); confirmed identical on `main` via `git stash` before making any change.

## Type of Change

- [x] Tests (adding or improving test coverage)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've tested on my platform: macOS (Darwin), Python 3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)