### PR TITLE
fix(dashboard-auth): auto-select OAuth provider for native login with multiple providers

### DIFF
--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -318,11 +318,21 @@ async def auth_native_authorize(
     # Resolve the provider. With exactly one session provider registered
     # (the common hosted case) an empty ``provider`` selects it, mirroring
     # the auto-SSO convenience so the desktop needn't hardcode the name.
+    # When several providers are registered, auto-select among the
+    # brokerable (non-password) ones only: native PKCE brokering is
+    # meaningless for a password provider (rejected below), so a password
+    # provider registered alongside the OAuth provider must not defeat
+    # the desktop's provider-less native login.
     p = get_provider(provider) if provider else None
     if p is None and not provider:
-        sess_providers = list_session_providers()
-        if len(sess_providers) == 1:
-            p = sess_providers[0]
+        brokerable = [
+            sp
+            for sp in list_session_providers()
+            if getattr(sp, "supports_session", True)
+            and not getattr(sp, "supports_password", False)
+        ]
+        if len(brokerable) == 1:
+            p = brokerable[0]
     if p is None:
         raise HTTPException(
             status_code=404, detail=f"Unknown provider: {provider!r}"

--- a/tests/hermes_cli/test_dashboard_auth_native_flow.py
+++ b/tests/hermes_cli/test_dashboard_auth_native_flow.py
@@ -181,6 +181,56 @@ def test_native_authorize_rejects_non_loopback_redirect(gated_client):
     assert "loopback" in r.json()["detail"].lower()
 
 
+def test_native_authorize_auto_selects_oauth_provider_with_password_provider_present():
+    """Provider-less native login must work when a password provider is
+    registered alongside the OAuth provider.
+
+    The desktop's native PKCE flow never sends ``provider``; the gateway
+    auto-selects it. With several session providers registered, only the
+    brokerable (non-password) ones are candidates — a password provider
+    has no IDP round trip to broker and must not defeat the auto-select
+    (regression: multi-provider gateways 404'd with "Unknown provider: ''").
+    """
+    from tests.hermes_cli.test_dashboard_auth_password_login import (
+        PasswordProvider,
+    )
+
+    clear_providers()
+    register_provider(PasswordProvider())
+    register_provider(StubAuthProvider())
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.bound_host = "fly-app.fly.dev"
+    web_server.app.state.bound_port = 443
+    web_server.app.state.auth_required = True
+    client = TestClient(
+        web_server.app, base_url="https://fly-app.fly.dev",
+        follow_redirects=False,
+    )
+    try:
+        _verifier, challenge = _make_pkce()
+        # No ``provider`` param — exactly what the desktop sends.
+        r = client.get(
+            "/auth/native/authorize",
+            params={
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+                "redirect_uri": "http://127.0.0.1:54321/callback",
+                "state": "s",
+            },
+        )
+        assert r.status_code == 302, r.text
+        # The redirect must be the OAuth provider's IDP round trip, not the
+        # password provider (which has no start_login).
+        assert "stub_code" in r.headers["location"]
+    finally:
+        clear_providers()
+        web_server.app.state.bound_host = prev_host
+        web_server.app.state.bound_port = prev_port
+        web_server.app.state.auth_required = prev_required
+
+
 # ---------------------------------------------------------------------------
 # Cookieless bearer auth of a gated route — the core deliverable
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The desktop app's native PKCE login flow (`/auth/native/authorize`) never sends a `provider` name — the gateway auto-selects it. The auto-select only fired when **exactly one** session provider was registered. On a gateway with a password provider registered alongside the OIDC provider (e.g. `dashboard.basic_auth` + self-hosted OIDC), the provider-less native login 404'd with `Unknown provider: ''` and the desktop fell back to the embedded login window.

Native PKCE brokering is only meaningful for OAuth providers — a password provider is rejected right after with "does not support native OAuth login" — so the auto-select now considers only **brokerable** (non-password) session providers. A password provider no longer defeats the desktop's provider-less native login.

## Changes

- `hermes_cli/dashboard_auth/routes.py`: auto-select among brokerable (non-password) session providers when `provider` is omitted
- `tests/hermes_cli/test_dashboard_auth_native_flow.py`: regression test — provider-less native authorize with a password provider + OAuth provider registered must 302 to the OAuth provider's IDP round trip

## Test Plan

- New test fails on unpatched code with the exact production error (`Unknown provider: ''` → 404) and passes with the fix
- Full native-flow + password-login suites: 18 passed