### PR TITLE
fix(desktop): let users remove a pasted composer image

### DIFF
--- a/apps/desktop/electron/image-context-menu.test.ts
+++ b/apps/desktop/electron/image-context-menu.test.ts
@@ -2,14 +2,20 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { imageContextMenuItems } from './image-context-menu'
+import {
+  clickComposerAttachmentRemoveScript,
+  composerAttachmentIdAtPointScript,
+  imageContextMenuItems,
+  resolveComposerAttachmentRemove
+} from './image-context-menu'
 
-function createActions() {
+function createActions(extra = {}) {
   const calls = {
     copyImageAt: [],
     openImage: [],
     copyImageAddress: [],
-    saveImage: []
+    saveImage: [],
+    removeAttachment: 0
   }
 
   return {
@@ -18,9 +24,14 @@ function createActions() {
       copyImageAt: (x, y) => calls.copyImageAt.push([x, y]),
       openImage: url => calls.openImage.push(url),
       copyImageAddress: url => calls.copyImageAddress.push(url),
-      saveImage: url => calls.saveImage.push(url)
+      saveImage: url => calls.saveImage.push(url),
+      ...extra
     }
   }
+}
+
+function menuLabels(items) {
+  return items.map(item => (item.type === 'separator' ? '---' : item.label))
 }
 
 test('keeps Copy Image available when Chromium omits a large image srcURL', () => {
@@ -31,10 +42,7 @@ test('keeps Copy Image available when Chromium omits a large image srcURL', () =
     actions
   )
 
-  assert.deepEqual(
-    items.map(item => item.label),
-    ['Copy Image']
-  )
+  assert.deepEqual(menuLabels(items), ['Copy Image'])
 
   items[0].click()
   assert.deepEqual(calls.copyImageAt, [[100, 120]])
@@ -46,10 +54,7 @@ test('keeps URL-dependent image actions when srcURL is available', () => {
 
   const items = imageContextMenuItems({ mediaType: 'image', hasImageContents: true, srcURL: url, x: 5, y: 8 }, actions)
 
-  assert.deepEqual(
-    items.map(item => item.label),
-    ['Open Image', 'Copy Image', 'Copy Image Address', 'Save Image As...']
-  )
+  assert.deepEqual(menuLabels(items), ['Open Image', 'Copy Image', 'Copy Image Address', 'Save Image As...'])
 
   items[0].click()
   items[1].click()
@@ -62,8 +67,32 @@ test('keeps URL-dependent image actions when srcURL is available', () => {
   assert.deepEqual(calls.saveImage, [url])
 })
 
+test('puts Remove Attachment first when the image is a composer chip', () => {
+  const { actions, calls } = createActions({
+    removeAttachment: () => {
+      calls.removeAttachment += 1
+    }
+  })
+  const url = 'https://example.com/image.png'
+
+  const items = imageContextMenuItems({ mediaType: 'image', hasImageContents: true, srcURL: url, x: 5, y: 8 }, actions)
+
+  assert.deepEqual(menuLabels(items), [
+    'Remove Attachment',
+    '---',
+    'Open Image',
+    'Copy Image',
+    'Copy Image Address',
+    'Save Image As...'
+  ])
+
+  items[0].click()
+  assert.equal(calls.removeAttachment, 1)
+  assert.deepEqual(calls.openImage, [])
+})
+
 test('does not add image actions for a non-image target', () => {
-  const { actions } = createActions()
+  const { actions } = createActions({ removeAttachment: () => undefined })
 
   assert.deepEqual(
     imageContextMenuItems({ mediaType: 'none', hasImageContents: false, srcURL: '', x: 0, y: 0 }, actions),
@@ -77,5 +106,60 @@ test('does not offer Copy Image when the target has no decoded image contents', 
   assert.deepEqual(
     imageContextMenuItems({ mediaType: 'image', hasImageContents: false, srcURL: '', x: 0, y: 0 }, actions),
     []
+  )
+})
+
+test('composerAttachmentIdAtPointScript reads the chip under the cursor', () => {
+  assert.match(composerAttachmentIdAtPointScript(12, 34), /elementFromPoint\(12, 34\)/)
+  assert.equal(composerAttachmentIdAtPointScript(Number.NaN, 0), 'null')
+})
+
+test('clickComposerAttachmentRemoveScript targets the chip remove control', () => {
+  const script = clickComposerAttachmentRemoveScript('image:shot.png')
+
+  assert.match(script, /document\.querySelector/)
+  assert.match(script, /composer-attachment-remove/)
+  assert.match(script, /image:shot\.png/)
+})
+
+test('resolveComposerAttachmentRemove clicks the matching chip remove control', async () => {
+  const scripts = []
+  const webContents = {
+    executeJavaScript: async script => {
+      scripts.push(script)
+
+      if (script.includes('elementFromPoint')) {
+        return 'image:shot.png'
+      }
+
+      return undefined
+    }
+  }
+
+  const remove = await resolveComposerAttachmentRemove(webContents, { mediaType: 'image', x: 10, y: 20 }, () => false)
+
+  assert.equal(typeof remove, 'function')
+  remove()
+  assert.equal(scripts.length, 2)
+  assert.match(scripts[1], /composer-attachment-remove/)
+  assert.match(scripts[1], /image:shot\.png/)
+})
+
+test('resolveComposerAttachmentRemove ignores transcript images and destroyed windows', async () => {
+  const webContents = {
+    executeJavaScript: async () => null
+  }
+
+  assert.equal(
+    await resolveComposerAttachmentRemove(webContents, { mediaType: 'image', x: 1, y: 1 }, () => false),
+    undefined
+  )
+  assert.equal(
+    await resolveComposerAttachmentRemove(webContents, { mediaType: 'image', x: 1, y: 1 }, () => true),
+    undefined
+  )
+  assert.equal(
+    await resolveComposerAttachmentRemove(webContents, { mediaType: 'none', x: 1, y: 1 }, () => false),
+    undefined
   )
 })

--- a/apps/desktop/electron/image-context-menu.ts
+++ b/apps/desktop/electron/image-context-menu.ts
@@ -6,8 +6,17 @@ export function imageContextMenuItems(params, actions) {
   const items = []
   const srcURL = params.srcURL || ''
 
-  if (srcURL) {
+  if (actions.removeAttachment) {
     items.push({
+      label: 'Remove Attachment',
+      click: actions.removeAttachment
+    })
+  }
+
+  const mediaItems = []
+
+  if (srcURL) {
+    mediaItems.push({
       label: 'Open Image',
       click: () => {
         if (!srcURL.startsWith('data:')) {
@@ -18,13 +27,13 @@ export function imageContextMenuItems(params, actions) {
     })
   }
 
-  items.push({
+  mediaItems.push({
     label: 'Copy Image',
     click: () => actions.copyImageAt(params.x, params.y)
   })
 
   if (srcURL) {
-    items.push(
+    mediaItems.push(
       {
         label: 'Copy Image Address',
         click: () => actions.copyImageAddress(srcURL)
@@ -36,5 +45,57 @@ export function imageContextMenuItems(params, actions) {
     )
   }
 
+  if (items.length && mediaItems.length) {
+    items.push({ type: 'separator' })
+  }
+
+  items.push(...mediaItems)
+
   return items
+}
+
+export function composerAttachmentIdAtPointScript(x, y) {
+  const left = Number(x)
+  const top = Number(y)
+
+  if (!Number.isFinite(left) || !Number.isFinite(top)) {
+    return 'null'
+  }
+
+  return `(() => {
+    const el = document.elementFromPoint(${left}, ${top})
+    return el?.closest('[data-composer-attachment-id]')?.getAttribute('data-composer-attachment-id') || null
+  })()`
+}
+
+export function clickComposerAttachmentRemoveScript(id) {
+  const selector = `[data-composer-attachment-id=${JSON.stringify(id)}] [data-slot="composer-attachment-remove"]`
+
+  return `document.querySelector(${JSON.stringify(selector)})?.click()`
+}
+
+export async function resolveComposerAttachmentRemove(webContents, params, isDestroyed = () => false) {
+  if (params.mediaType !== 'image' || isDestroyed()) {
+    return undefined
+  }
+
+  let attachmentId
+
+  try {
+    attachmentId = await webContents.executeJavaScript(composerAttachmentIdAtPointScript(params.x, params.y))
+  } catch {
+    return undefined
+  }
+
+  if (!attachmentId || typeof attachmentId !== 'string') {
+    return undefined
+  }
+
+  return () => {
+    if (isDestroyed()) {
+      return
+    }
+
+    void webContents.executeJavaScript(clickComposerAttachmentRemoveScript(attachmentId)).catch(() => undefined)
+  }
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -205,7 +205,7 @@ import { cursorPointInWindow } from './hud-cursor'
 import { snapHudBounds } from './hud-snap'
 import { createHudSnapShortcut } from './hud-snap-shortcut'
 import { buildHudWindowUrl } from './hud-url'
-import { imageContextMenuItems } from './image-context-menu'
+import { imageContextMenuItems, resolveComposerAttachmentRemove } from './image-context-menu'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
 import { ensureMainWindow } from './main-window-lifecycle'
 import { createMediaProtocolHandler, MEDIA_PROTOCOL } from './media-protocol'
@@ -6395,91 +6395,105 @@ function installZoomShortcuts(window) {
 
 function installContextMenu(window) {
   window.webContents.on('context-menu', (_event, params) => {
-    const template = []
-    const hasSelection = Boolean(params.selectionText?.trim())
-    const hasLink = Boolean(params.linkURL)
-    const isEditable = Boolean(params.isEditable)
+    void popupWindowContextMenu(window, params)
+  })
+}
+
+async function popupWindowContextMenu(window, params) {
+  if (!window || window.isDestroyed()) {
+    return
+  }
+
+  const template = []
+  const hasSelection = Boolean(params.selectionText?.trim())
+  const hasLink = Boolean(params.linkURL)
+  const isEditable = Boolean(params.isEditable)
+  const removeAttachment = await resolveComposerAttachmentRemove(window.webContents, params, () => window.isDestroyed())
+
+  if (window.isDestroyed()) {
+    return
+  }
+
+  template.push(
+    ...imageContextMenuItems(params, {
+      copyImageAt: (x, y) => window.webContents.copyImageAt(x, y),
+      openImage: openExternalUrl,
+      copyImageAddress: url => clipboard.writeText(url),
+      removeAttachment,
+      saveImage: url => {
+        void saveImageFromUrl(url).catch(error => rememberLog(`Save image failed: ${error.message}`))
+      }
+    })
+  )
+
+  if (hasLink) {
+    if (template.length) {
+      template.push({ type: 'separator' })
+    }
 
     template.push(
-      ...imageContextMenuItems(params, {
-        copyImageAt: (x, y) => window.webContents.copyImageAt(x, y),
-        openImage: openExternalUrl,
-        copyImageAddress: url => clipboard.writeText(url),
-        saveImage: url => {
-          void saveImageFromUrl(url).catch(error => rememberLog(`Save image failed: ${error.message}`))
-        }
-      })
+      {
+        label: 'Open Link',
+        click: () => openExternalUrl(params.linkURL)
+      },
+      {
+        label: 'Copy Link',
+        click: () => clipboard.writeText(params.linkURL)
+      }
     )
+  }
 
-    if (hasLink) {
-      if (template.length) {
-        template.push({ type: 'separator' })
-      }
+  // Spell-check suggestions for the misspelled word under the caret.
+  // Chromium surfaces them on `params.dictionarySuggestions`; we offer the
+  // top 5 plus a "Add to dictionary" affordance.
+  const suggestions = Array.isArray(params.dictionarySuggestions) ? params.dictionarySuggestions : []
 
-      template.push(
-        {
-          label: 'Open Link',
-          click: () => openExternalUrl(params.linkURL)
-        },
-        {
-          label: 'Copy Link',
-          click: () => clipboard.writeText(params.linkURL)
-        }
-      )
+  if (isEditable && params.misspelledWord && suggestions.length > 0) {
+    if (template.length) {
+      template.push({ type: 'separator' })
     }
 
-    // Spell-check suggestions for the misspelled word under the caret.
-    // Chromium surfaces them on `params.dictionarySuggestions`; we offer the
-    // top 5 plus a "Add to dictionary" affordance.
-    const suggestions = Array.isArray(params.dictionarySuggestions) ? params.dictionarySuggestions : []
-
-    if (isEditable && params.misspelledWord && suggestions.length > 0) {
-      if (template.length) {
-        template.push({ type: 'separator' })
-      }
-
-      for (const suggestion of suggestions.slice(0, 5)) {
-        template.push({
-          label: suggestion,
-          click: () => window.webContents.replaceMisspelling(suggestion)
-        })
-      }
-
-      template.push({ type: 'separator' })
+    for (const suggestion of suggestions.slice(0, 5)) {
       template.push({
-        label: 'Add to dictionary',
-        click: () => window.webContents.session.addWordToSpellCheckerDictionary(params.misspelledWord)
+        label: suggestion,
+        click: () => window.webContents.replaceMisspelling(suggestion)
       })
     }
 
-    if (hasSelection || isEditable) {
-      if (template.length) {
-        template.push({ type: 'separator' })
-      }
+    template.push({ type: 'separator' })
+    template.push({
+      label: 'Add to dictionary',
+      click: () => window.webContents.session.addWordToSpellCheckerDictionary(params.misspelledWord)
+    })
+  }
 
-      if (isEditable) {
-        template.push(
-          { role: 'cut', enabled: params.editFlags.canCut },
-          { role: 'copy', enabled: params.editFlags.canCopy },
-          { role: 'paste', enabled: params.editFlags.canPaste },
-          { type: 'separator' },
-          { role: 'selectAll', enabled: params.editFlags.canSelectAll }
-        )
-      } else {
-        template.push({ role: 'copy', enabled: params.editFlags.canCopy })
-      }
+  if (hasSelection || isEditable) {
+    if (template.length) {
+      template.push({ type: 'separator' })
     }
 
-    // Bare right-click on non-editable, non-selected, non-media content (a pane
-    // body, the sidebar, chrome): the renderer's own context menus own those
-    // surfaces, and anywhere without one shows nothing — not a lone, useless
-    // "Select All" from the native fallback.
-    if (!template.length) {
-      return
+    if (isEditable) {
+      template.push(
+        { role: 'cut', enabled: params.editFlags.canCut },
+        { role: 'copy', enabled: params.editFlags.canCopy },
+        { role: 'paste', enabled: params.editFlags.canPaste },
+        { type: 'separator' },
+        { role: 'selectAll', enabled: params.editFlags.canSelectAll }
+      )
+    } else {
+      template.push({ role: 'copy', enabled: params.editFlags.canCopy })
     }
+  }
 
-    Menu.buildFromTemplate(template).popup({ window })
-  })
+  // Bare right-click on non-editable, non-selected, non-media content (a pane
+  // body, the sidebar, chrome): the renderer's own context menus own those
+  // surfaces, and anywhere without one shows nothing — not a lone, useless
+  // "Select All" from the native fallback.
+  if (!template.length) {
+    return
+  }
+
+  Menu.buildFromTemplate(template).popup({ window })
 }
 
 // Microphone and camera capture. The voice composer drives mic access and

--- a/apps/desktop/src/app/chat/composer/attachments.test.tsx
+++ b/apps/desktop/src/app/chat/composer/attachments.test.tsx
@@ -41,6 +41,28 @@ describe('AttachmentList', () => {
     expect(screen.getByText('img.png')).toBeDefined()
   })
 
+  it('exposes a visible remove control that drops the attachment', async () => {
+    const onRemove = vi.fn()
+    const image: ComposerAttachment = {
+      id: 'image:shot.png',
+      kind: 'image',
+      label: 'shot.png',
+      thumbnailUrl: THUMBNAIL_URL
+    }
+
+    const { container } = await renderWithI18n(<AttachmentList attachments={[image]} onRemove={onRemove} />)
+    const chip = container.querySelector('[data-composer-attachment-id="image:shot.png"]')
+    const remove = screen.getByRole('button', { name: 'Remove shot.png' })
+
+    expect(chip).not.toBeNull()
+    expect(remove.getAttribute('data-slot')).toBe('composer-attachment-remove')
+    expect(remove.className.includes('opacity-0')).toBe(false)
+
+    fireEvent.click(remove)
+    expect(onRemove).toHaveBeenCalledOnce()
+    expect(onRemove).toHaveBeenCalledWith('image:shot.png')
+  })
+
   it('renders empty list without error', async () => {
     const { container } = await renderWithI18n(<AttachmentList attachments={[]} />)
 

--- a/apps/desktop/src/app/chat/composer/attachments.tsx
+++ b/apps/desktop/src/app/chat/composer/attachments.tsx
@@ -149,7 +149,7 @@ function AttachmentPill({ attachment, onRemove }: { attachment: ComposerAttachme
   return (
     <>
       <Tip label={attachment.path || attachment.detail || attachment.label}>
-        <div className="group/attachment relative min-w-0 shrink-0">
+        <div className="relative min-w-0 shrink-0" data-composer-attachment-id={attachment.id}>
           <button
             aria-busy={isUploading || undefined}
             aria-label={canPreview ? c.previewLabel(attachment.label) : attachment.label}
@@ -204,7 +204,8 @@ function AttachmentPill({ attachment, onRemove }: { attachment: ComposerAttachme
           {onRemove && (
             <button
               aria-label={c.removeAttachment(attachment.label)}
-              className="absolute -right-1 -top-1 grid size-3.5 place-items-center rounded-full border border-border/70 bg-background text-muted-foreground opacity-0 shadow-xs transition hover:bg-accent hover:text-foreground group-hover/attachment:opacity-100 focus-visible:opacity-100"
+              className="absolute -right-1 -top-1 z-10 grid size-4 place-items-center rounded-full border border-border/70 bg-background text-muted-foreground shadow-xs transition hover:bg-accent hover:text-foreground"
+              data-slot="composer-attachment-remove"
               onClick={() => onRemove(attachment.id)}
               type="button"
             >


### PR DESCRIPTION
## Summary
- Composer image chips now keep a visible remove control instead of a hover-only X.
- Right-clicking a pasted thumbnail adds **Remove Attachment** to the native image menu. Transcript images are unchanged.

## Test plan
- [ ] Paste an image into the Desktop composer (`Ctrl+V` / `Cmd+V`)
- [ ] Click the X on the chip — the attachment disappears and nothing is sent
- [ ] Paste again, right-click the thumbnail — the menu includes **Remove Attachment**
- [ ] Right-click an image already in the transcript — no Remove Attachment item
- [ ] From `apps/desktop`: `npx vitest run --config vitest.config.ts src/app/chat/composer/attachments.test.tsx electron/image-context-menu.test.ts`