### PR TITLE
fix(desktop): keep the session tab strip visible

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -73,6 +73,7 @@ import { type DoubleTapContext, startPaneDrag } from './drag-session'
 import { forceLoneHeaderForPanes } from './lone-header'
 import { useActiveTabVisible } from './tab-strip-scroll'
 import { paneChrome } from './track-model'
+import { resolveZoneHeaderHidden, sessionStripAllowsHide } from './zone-header'
 
 /** Right-click zone menu: the tab verbs (close this / others / to the right /
  *  all) plus the strip's own chrome toggles. Same items and icons as a session
@@ -83,6 +84,7 @@ function ZoneMenu({
   children,
   closable,
   minimizable = true,
+  canHideHeader = true,
   headerHidden,
   minimized,
   nodeId,
@@ -95,6 +97,8 @@ function ZoneMenu({
   /** False for the zone hosting the uncloseable workspace — collapsing the
    *  MAIN pane strands the app behind a strip. */
   minimizable?: boolean
+  /** False for the chat session switcher — hiding that strip is a dead end. */
+  canHideHeader?: boolean
   headerHidden?: boolean
   minimized?: boolean
   nodeId: string
@@ -129,12 +133,13 @@ function ZoneMenu({
           onCloseOthers: () => closeOtherTreeTabs(targetId),
           onCloseToRight: () => closeTreeTabsToRight(targetId)
         })}
-        <kit.Separator />
-        {renderActionItem(kit, {
-          icon: headerHidden ? 'eye' : 'eye-closed',
-          label: headerHidden ? t.zones.showHeader : t.zones.hideHeader,
-          onSelect: () => setTreeGroupHeaderHidden(nodeId, !headerHidden)
-        })}
+        {(canHideHeader || minimizable) && <kit.Separator />}
+        {canHideHeader &&
+          renderActionItem(kit, {
+            icon: headerHidden ? 'eye' : 'eye-closed',
+            label: headerHidden ? t.zones.showHeader : t.zones.hideHeader,
+            onSelect: () => setTreeGroupHeaderHidden(nodeId, !headerHidden)
+          })}
         {minimizable &&
           renderActionItem(kit, {
             // Same action-direction contract as the strip button below: the
@@ -237,16 +242,25 @@ export function TreeGroup({
   //    tile in its own zone is unclosable (the "3rd tile has no tab" trap);
   //  - a TOOL PANEL (terminal/logs — a collapse pane) dragged out of the main
   //    stack, else it's a dead zone with no tab to grab or ✕ to close.
-  // The uncloseable workspace and side chrome (sessions/files) keep the clean
-  // no-tab default. Double-click toggles it either way; a minimized group
-  // always shows its header (it IS the header).
+  //  - the SESSION SWITCHER (workspace + session tiles): hiding that strip
+  //    is how the header "just disappears" after a click, restart, or update.
+  // The uncloseable workspace used to keep the clean no-tab default; that
+  // made the only session-switcher vanish on a lone main tab. Double-click
+  // still toggles hide on tool/side zones; a minimized group always shows
+  // its header (it IS the header).
   // Session-tile ids force the header even before chrome registers — cycling
   // onto a freshly-split tile used to land headerless ("name card missing").
   const forceLoneHeader = forceLoneHeaderForPanes(shown, id => paneChrome(paneFor(id)), isCollapsePane)
+  const canHideHeader = sessionStripAllowsHide(shown)
 
   // A full-page view (headerVeto) suppresses the strip while it's the active
   // pane — a page is not a tab-able surface; the bar returns with the chat.
-  const headerHidden = paneChrome(active).headerVeto || (node.headerHidden ?? (shown.length <= 1 && !forceLoneHeader))
+  const headerHidden = resolveZoneHeaderHidden({
+    forceLoneHeader,
+    headerVeto: Boolean(paneChrome(active).headerVeto),
+    persistedHidden: node.headerHidden,
+    shown
+  })
 
   // A group collapses ALONG its parent split's axis. In a row that means the
   // WIDTH collapses — a full-width horizontal header would strand a tall
@@ -271,6 +285,10 @@ export function TreeGroup({
   const hideHeaderDoubleTap: DoubleTapContext = {
     key: `hide-header-${node.id}`,
     onDoubleTap: () => {
+      if (!canHideHeader) {
+        return
+      }
+
       setTreeGroupMinimized(node.id, false)
       setTreeGroupHeaderHidden(node.id, true)
     }
@@ -316,6 +334,7 @@ export function TreeGroup({
 
   // Same menu on the header strip and the edit veil — one prop bag.
   const zoneMenu = {
+    canHideHeader,
     closable,
     headerHidden,
     minimizable,
@@ -326,9 +345,8 @@ export function TreeGroup({
 
   // NO body double-click toggle: virtualized content (the thread) recreates
   // its nodes between clicks, so the gesture was hopelessly unreliable. The
-  // bar's lifecycle is explicit instead — gaining a tab sticky-shows it
-  // (insertAtGroup pins headerHidden false), the main tab's context menu
-  // hides it, and full-page views veto it via paneChrome.headerVeto.
+  // session switcher stays visible; tool/side zones can still hide via their
+  // own strip. Full-page views veto the bar via paneChrome.headerVeto.
 
   return (
     <div

--- a/apps/desktop/src/components/pane-shell/tree/renderer/zone-header.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/zone-header.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveZoneHeaderHidden, sessionStripAllowsHide } from './zone-header'
+
+describe('resolveZoneHeaderHidden', () => {
+  it('keeps the session switcher visible for a lone workspace', () => {
+    expect(
+      resolveZoneHeaderHidden({
+        forceLoneHeader: false,
+        headerVeto: false,
+        shown: ['workspace']
+      })
+    ).toBe(false)
+  })
+
+  it('ignores persisted headerHidden on a session-strip zone', () => {
+    expect(
+      resolveZoneHeaderHidden({
+        forceLoneHeader: false,
+        headerVeto: false,
+        persistedHidden: true,
+        shown: ['workspace', 'session-tile:abc']
+      })
+    ).toBe(false)
+  })
+
+  it('still stands down for a full-page view', () => {
+    expect(
+      resolveZoneHeaderHidden({
+        forceLoneHeader: false,
+        headerVeto: true,
+        shown: ['workspace']
+      })
+    ).toBe(true)
+  })
+
+  it('still auto-hides a lone uncloseable side-chrome pane', () => {
+    expect(
+      resolveZoneHeaderHidden({
+        forceLoneHeader: false,
+        headerVeto: false,
+        shown: ['files']
+      })
+    ).toBe(true)
+  })
+
+  it('still honors an explicit hide on a tool zone', () => {
+    expect(
+      resolveZoneHeaderHidden({
+        forceLoneHeader: true,
+        headerVeto: false,
+        persistedHidden: true,
+        shown: ['terminal']
+      })
+    ).toBe(true)
+  })
+})
+
+describe('sessionStripAllowsHide', () => {
+  it('refuses hide when the zone hosts the chat switcher', () => {
+    expect(sessionStripAllowsHide(['workspace'])).toBe(false)
+    expect(sessionStripAllowsHide(['session-tile:abc'])).toBe(false)
+    expect(sessionStripAllowsHide(['terminal'])).toBe(true)
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/renderer/zone-header.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/zone-header.ts
@@ -1,0 +1,38 @@
+/**
+ * When a zone's tab strip is hidden.
+ *
+ * Default: a single pane isn't a "tab", so the header auto-hides; a stack
+ * shows its chips. Closeable tiles and collapse tool panels force a lone
+ * header so they stay closable.
+ *
+ * Session-strip zones (the workspace + session tiles) are the chat switcher.
+ * Auto-hiding them on a lone workspace — or honoring a persisted
+ * `headerHidden` from a double-tap / crash-stale layout — is how the bar
+ * vanishes across restarts and client updates. Those zones keep the strip
+ * unless a full-page view vetoes it.
+ */
+
+export function isSessionStripPaneId(paneId: string): boolean {
+  return paneId === 'workspace' || paneId.startsWith('session-tile:')
+}
+
+export function sessionStripAllowsHide(shown: readonly string[]): boolean {
+  return !shown.some(isSessionStripPaneId)
+}
+
+export function resolveZoneHeaderHidden(input: {
+  forceLoneHeader: boolean
+  headerVeto: boolean
+  persistedHidden?: boolean
+  shown: readonly string[]
+}): boolean {
+  if (input.headerVeto) {
+    return true
+  }
+
+  if (!sessionStripAllowsHide(input.shown)) {
+    return false
+  }
+
+  return input.persistedHidden ?? (input.shown.length <= 1 && !input.forceLoneHeader)
+}


### PR DESCRIPTION
## Bug Description

The top session tab bar — the only header for switching open chats — disappears and stays gone.

Two current-`main` paths produce that:

1. A lone workspace tab is treated as “not a tab”, so the strip auto-hides (`shown.length <= 1 && !forceLoneHeader`). After a restart, client swap, or when session tiles fail to persist, the user is left on exactly that lone workspace — and the switcher is gone.
2. A double-tap / “Hide header” writes `headerHidden: true` onto the zone. The only “Show header” control lives on the strip that just vanished.

Reported live after a client update; same class as #88534.

Fixes #89350. Related: #88534.

## Root Cause

`TreeGroup` resolved visibility as:

```ts
headerVeto || (node.headerHidden ?? (shown.length <= 1 && !forceLoneHeader))
```

`forceLoneHeader` is **false** for the uncloseable workspace. So the default desktop layout — one main chat, no extra tiles — never shows the switcher. Persisted `headerHidden` then locks that dead end across restarts.

## Fix

Session-strip zones (`workspace` + `session-tile:*`) keep their header unless a full-page view vetoes it.

- Ignore auto-hide and persisted `headerHidden` for those zones.
- Drop “Hide header” from their zone menu.
- No-op the double-tap hide gesture there.

Tool / side zones are unchanged: they can still auto-hide a lone pane and honor an explicit hide.

This is stronger than #79520 (force-show on reveal/adopt, but still allows hide) and complementary to #86278 / #84458 / #81638 (recovery after hide). Those stay useful for preview/tool zones.

Does **not** restore wiped `sessionTiles` rows. If tiles were dropped from storage, this PR still shows the workspace tab + `+`. Recovering lost tiles is a separate persistence bug.

## How to Verify

1. Open Desktop on a fresh / single-session workspace. The top tab strip stays (current session + `+`).
2. Double-click the session tab / strip background. The strip stays.
3. Right-click the strip. There is no “Hide header”.
4. Open a Settings/page view. The strip still stands down (`headerVeto`).
5. Hide a terminal / preview zone header. That still works.

## Test Plan

- [x] Added `zone-header.test.ts`: lone workspace stays visible; persisted hide ignored; page veto still hides; files/terminal hide policy unchanged
- [x] Sabotage: removing the session-strip short-circuit fails the two new stay-visible tests; restore passes
- [x] Existing `lone-header.test.ts` + `tree-group.test.tsx` still pass (11 tests)

## Risk Assessment

Low — renderer-only policy for chat zones. Tool-panel hide/minimize and page `headerVeto` are preserved. No persistence schema change.
