### PR TITLE
fix(sessions): include open sessions in bulk exports

### DIFF
--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -445,7 +445,7 @@ def cmd_sessions(args, sessions_parser=None):
                     return None
                 return [data]
             if filters:
-                candidates = db.list_prune_candidates(**filters)
+                candidates = db.list_prune_candidates(include_open=True, **filters)
                 if args.dry_run:
                     print(
                         f"Would export {len(candidates)} session(s) "
@@ -577,7 +577,7 @@ def cmd_sessions(args, sessions_parser=None):
             def _trace_ids():
                 if session_id:
                     return [db.resolve_session_id(session_id)]
-                candidates = db.list_prune_candidates(**filters)
+                candidates = db.list_prune_candidates(include_open=True, **filters)
                 if args.dry_run:
                     print(
                         f"Would export {len(candidates)} session(s) "
@@ -666,7 +666,7 @@ def cmd_sessions(args, sessions_parser=None):
                     print(f"Exported 1 session to {args.output}")
             else:
                 if filters:
-                    candidates = db.list_prune_candidates(**filters)
+                    candidates = db.list_prune_candidates(include_open=True, **filters)
                     if args.dry_run:
                         print(
                             f"Would export {len(candidates)} session(s) "
@@ -841,7 +841,7 @@ def cmd_sessions(args, sessions_parser=None):
             )
             db.close()
             return
-        candidates = db.list_prune_candidates(**filters)
+        candidates = db.list_prune_candidates(include_open=True, **filters)
         if args.dry_run:
             print(
                 f"Would export {len(candidates)} session(s) "

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -13353,6 +13353,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         self,
         older_than_days: Optional[float] = None,
         source: str = None,
+        *,
+        include_open: bool = False,
         **filters,
     ) -> List[Dict[str, Any]]:
         """Return the sessions a matching :meth:`prune_sessions` /
@@ -13365,9 +13367,29 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         message_count, archived``. ``older_than_days`` is an inactivity
         threshold: it uses the latest message timestamp, falling back to
         ``started_at`` for sessions without messages.
+
+        ``include_open=True`` neutralizes the ``ended_at IS NOT NULL``
+        safety guard for read-only callers (bulk session export): the guard
+        exists so destructive pruning can never touch a live session, but an
+        export that silently skips every open session is the opposite of
+        what "export everything" means — open/live sessions are often the
+        ones a user most wants to back up (#89223). Destructive callers
+        keep the default.
         """
         self._apply_prune_age_filter(older_than_days, filters)
         where, params = self._prune_filter_where(source=source, **filters)
+        if include_open:
+            ended_guard = "s.ended_at IS NOT NULL"
+            if not where.startswith(ended_guard):
+                raise RuntimeError(
+                    "prune filter lost its ended-session safety guard"
+                )
+            # Parenthesized so the remaining AND-chain applies to both
+            # branches: "(ended OR open) AND <filters>".
+            where = (
+                "(s.ended_at IS NOT NULL OR s.ended_at IS NULL)"
+                + where[len(ended_guard):]
+            )
         with self._lock:
             cursor = self._conn.execute(
                 f"""SELECT s.id, s.source, s.title, s.model, s.started_at,

--- a/tests/hermes_cli/test_sessions_delete.py
+++ b/tests/hermes_cli/test_sessions_delete.py
@@ -127,3 +127,58 @@ def test_sessions_prune_surfaces_matching_open_sessions(monkeypatch, capsys):
     assert "prune only deletes ended sessions" in out
     assert "hermes sessions delete <id>" in out
     assert "No sessions match" in out
+
+
+def test_sessions_export_bulk_includes_open_sessions(monkeypatch, capsys):
+    """Bulk ``sessions export`` selects open sessions too (#89223): the
+    ended-session guard is a destructive-prune safety net, not an export
+    filter — "export everything" must not silently drop every live session."""
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    seen = {}
+    rows = [
+        {
+            "id": "20260818_000000_openaaa",
+            "source": "desktop",
+            "title": "live session",
+            "started_at": 1_750_000_000.0,
+            "last_active": 1_750_000_050.0,
+            "ended_at": None,
+            "message_count": 41,
+            "archived": 0,
+        },
+    ]
+
+    class FakeDB:
+        def list_prune_candidates(self, **kwargs):
+            seen.update(kwargs)
+            return rows
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "hermes", "sessions", "export", "--dry-run", "-",
+            "--newer-than", "7d",
+        ],
+    )
+    main_mod.main()
+
+    out = capsys.readouterr().out
+    assert seen.get("include_open") is True, (
+        "bulk export must neutralize the ended-session prune guard"
+    )
+    assert "Would export 1 session(s)" in out
+    assert "20260818_000000_openaaa" in out
+
+
+def test_sessions_prune_dry_run_keeps_ended_guard(monkeypatch, capsys):
+    """The destructive preview keeps the ended-session guard: include_open
+    is an export-only relaxation (#89223)."""
+    filters, _out = _run_prune(monkeypatch, capsys, ["--source", "cron", "--dry-run"])
+    assert "include_open" not in filters

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1154,6 +1154,39 @@ class TestPruneSessions:
             older_than_days=90, source="cron", archived=False
         )} == {"ended"}
 
+    def test_list_prune_candidates_include_open(self, db):
+        """``include_open=True`` is for read-only callers (bulk export):
+        it neutralizes only the ended-session guard while every other
+        filter still applies. The default keeps the destructive-prune
+        semantics untouched (#89223)."""
+        db.create_session(session_id="open-cron", source="cron")
+        db.create_session(session_id="open-cli", source="cli")
+        db.create_session(session_id="ended-cron", source="cron")
+        db.end_session("ended-cron", "completed")
+        old = time.time() - 200 * 86400
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id IN (?, ?, ?)",
+            (old, "open-cron", "open-cli", "ended-cron"),
+        )
+        db._conn.commit()
+
+        # Default: destructive semantics — only ended sessions.
+        assert {row["id"] for row in db.list_prune_candidates(
+            older_than_days=90, source="cron", archived=False
+        )} == {"ended-cron"}
+
+        # include_open: same filters, open sessions now eligible too.
+        assert {row["id"] for row in db.list_prune_candidates(
+            older_than_days=90, source="cron", archived=False,
+            include_open=True,
+        )} == {"open-cron", "ended-cron"}
+
+        # Other filters still apply with include_open (source narrows it).
+        assert {row["id"] for row in db.list_prune_candidates(
+            older_than_days=90, source="cli", archived=False,
+            include_open=True,
+        )} == {"open-cli"}
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Bulk session exports (`hermes sessions export` with filters, the trace export, and the jsonl/markdown bulk paths) reuse the prune-candidate selector, whose WHERE clause opens with the `ended_at IS NOT NULL` safety guard. That guard exists so destructive pruning can never touch a live session — but for export it inverted the meaning of "export everything": any filter silently skipped every open session, so a live desktop/gateway session was unexportable in bulk while `--session-id` export of the very same session worked fine. A dry-run would report "Would export 0 session(s)" and look successful.

`list_prune_candidates` gains an `include_open` keyword that neutralizes only the ended-session guard (parenthesized so the remaining AND-chain applies to both ended and open rows); every other filter still narrows the set exactly as before. All four bulk-export call sites pass it. The prune/archive preview, the delete flows, and `count_open_prune_matches` keep the default and are byte-identical.

Note for reviewers — #85171 (open) gives reversible *archive* its own unended-inclusive selector and states "filtered export remain ended-only". This PR takes the opposite stance for export on purpose: export is a read-only backup operation, and #89223 reports the ended-only behavior as the bug (open/live sessions are the ones a user most wants to back up). If both merge, that one-line description in #85171 needs a small update, but the code paths are disjoint.

## Related Issue

Fixes #89223

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state.py` — `list_prune_candidates(..., include_open: bool = False)`: when True, rewrites the guard prefix to `(s.ended_at IS NOT NULL OR s.ended_at IS NULL)` so the AND-chain of remaining filters applies to both branches; docstring states it is for read-only callers only. Guard-prefix presence is asserted (same RuntimeError as `count_open_prune_matches`).
- `hermes_cli/sessions_cmd.py` — the four bulk-export call sites (`sessions export` main path, trace `_trace_ids`, the jsonl bulk branch, and the filter-required bulk export branch) pass `include_open=True`. The prune/archive preview call site is untouched.
- `tests/test_hermes_state.py` — `test_list_prune_candidates_include_open`: default stays ended-only; `include_open=True` adds open sessions while `source`/age filters still apply.
- `tests/hermes_cli/test_sessions_delete.py` — `test_sessions_export_bulk_includes_open_sessions` (CLI passes `include_open=True` and dry-run lists an open session) and `test_sessions_prune_dry_run_keeps_ended_guard` (destructive preview never receives `include_open`).

## How to Test

```bash
python -m pytest tests/test_hermes_state.py::TestPruneSessions tests/hermes_cli/test_sessions_delete.py tests/hermes_cli/test_session_filters.py tests/hermes_cli/test_sessions_export_md_cli.py tests/hermes_cli/test_session_export.py tests/hermes_cli/test_session_browse.py -q
# Observed result: 50 passed
```

Fail-on-main check: with the two source files stashed, `test_list_prune_candidates_include_open` and `test_sessions_export_bulk_includes_open_sessions` fail on main (unexpected keyword / missing `include_open`); the prune-guard pin passes on both.

Manual repro from the issue: with live sessions present (`ended_at IS NULL`), `hermes sessions export --dry-run - --newer-than 7d` reported "Would export 0 session(s)" on main; with this change the same command lists the open sessions.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments explain intent (why export may drop the guard but prune must not)
- [x] Corresponding changes documented via docstrings
- [x] Tests added and passing (3 new; adjacent suites green)
- [x] Single root cause, no unrelated changes
