### PR TITLE
fix: WSL/ssh path handling for file tools and in-sandbox image reads

### DIFF
--- a/tests/tools/test_file_tools_cwd_resolution.py
+++ b/tests/tools/test_file_tools_cwd_resolution.py
@@ -310,3 +310,49 @@ def test_v4a_patch_applies_to_resolved_workspace_not_backend_cwd(
     assert (workspace / "target.py").read_text() == "WORKSPACE_PATCHED\n"
     # The decoy (backend cwd) was left untouched.
     assert (decoy / "target.py").read_text() == "DECOY_ORIGINAL\n"
+
+
+# ── ssh / WSL backend: POSIX-namespace path resolution ─────────────────────
+# (Aug 2026 bug class: on a Windows host with a WSL-via-ssh backend,
+# `_uses_container_paths` excluded "ssh", so absolute POSIX paths like
+# /home/steve/... were routed through the Windows ntpath/WindowsPath branch.
+# ntpath.normpath mangled them to \home\steve\... and WindowsPath.is_absolute()
+# returned False (no drive letter), so the resolver treated an absolute POSIX
+# path as a relative escape and write_file emitted a false "OUTSIDE the active
+# workspace" warning even though the bytes landed correctly on WSL.)
+
+
+def test_ssh_backend_uses_container_paths(monkeypatch):
+    """ssh (and WSL-via-ssh) must be treated as a POSIX-namespace backend."""
+    monkeypatch.setattr(ft, "_terminal_env_type_for_task", lambda task_id="default": "ssh")
+    assert ft._uses_container_paths("default") is True
+
+
+def test_ssh_absolute_posix_path_stays_posix(monkeypatch):
+    """An absolute POSIX path on ssh must NOT be rewritten to Windows form."""
+    monkeypatch.setattr(ft, "_terminal_env_type_for_task", lambda task_id="default": "ssh")
+    resolved = ft._resolve_path_for_task("/home/steve/projects/foo.py", task_id="default")
+    # Must remain a POSIX absolute path — no \home\steve mangling.
+    assert isinstance(resolved, PurePosixPath)
+    assert str(resolved) == "/home/steve/projects/foo.py"
+    assert resolved.is_absolute()
+
+
+def test_ssh_absolute_posix_path_no_false_warning(monkeypatch):
+    """Absolute POSIX paths on ssh must not trigger the workspace-escape warning."""
+    monkeypatch.setattr(ft, "_terminal_env_type_for_task", lambda task_id="default": "ssh")
+    terminal_tool.record_session_cwd("default", "/home/steve")
+    resolved = ft._resolve_path_for_task("/home/steve/projects/foo.py", task_id="default")
+    warn = ft._path_resolution_warning("/home/steve/projects/foo.py", resolved, task_id="default")
+    assert warn is None
+
+
+def test_ssh_relative_path_still_warns_when_outside_workspace(monkeypatch, tmp_path):
+    """Relative-path escape detection must still work for ssh backends."""
+    monkeypatch.setattr(ft, "_terminal_env_type_for_task", lambda task_id="default": "ssh")
+    terminal_tool.record_session_cwd("default", "/home/steve")
+    resolved = ft._resolve_path_for_task("../outside/target.py", task_id="default")
+    warn = ft._path_resolution_warning("../outside/target.py", resolved, task_id="default")
+    # A path escaping the workspace root is still flagged.
+    assert warn is not None
+    assert "OUTSIDE the active workspace" in warn

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -214,7 +214,14 @@ def _uses_container_paths(task_id: str = "default") -> bool:
         container_backends = _CONTAINER_BACKENDS
     except Exception:
         container_backends = _CONTAINER_PATH_BACKENDS_FALLBACK
-    return _terminal_env_type_for_task(task_id) in container_backends
+    env_type = _terminal_env_type_for_task(task_id)
+    # ssh (and WSL-via-ssh) exposes a POSIX filesystem in a namespace distinct
+    # from the Windows host, so file-tool paths there are POSIX paths. Treat it
+    # like a container backend for PATH RESOLUTION so absolute POSIX paths
+    # (/home/steve/...) aren't misrouted through Windows ntpath on the host.
+    if env_type == "ssh":
+        return True
+    return env_type in container_backends
 
 
 def _normalize_without_host_deref(path: str | Path | PurePosixPath) -> PurePosixPath:
@@ -419,7 +426,13 @@ def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "defa
     (no ``cd`` run yet) is warned on the very first write.
     """
     try:
-        if Path(_expand_tilde(filepath)).is_absolute():
+        expanded_input = _expand_tilde(filepath)
+        if _uses_container_paths(task_id):
+            # POSIX-namespace backend (container, ssh/WSL): a leading-slash path
+            # is absolute in the backend's filesystem.
+            if posixpath.isabs(expanded_input):
+                return None
+        elif Path(expanded_input).is_absolute():
             return None
         workspace_root = _authoritative_workspace_root(task_id)
         if not workspace_root:

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -37,7 +37,7 @@ import base64
 import os
 import re
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Optional
 
 # Raw-bytes INGEST budget — what the resolver will load before handing off.
@@ -301,6 +301,39 @@ def _ensure_container_env(task_id: Optional[str]) -> None:
         pass
 
 
+def _to_sandbox_posix(src: str) -> str:
+    """Return the POSIX path that names *src* inside the sandbox.
+
+    On a Windows host with a non-local terminal backend (e.g. ssh -> WSL), a
+    bare Windows path like ``C:\\Users\\me\\img.png`` is a *host* file the
+    sandbox only sees through DrvFS at ``/mnt/c/Users/me/img.png``. A POSIX
+    path the host ``Path`` mangled to backslashes (``\\home\\me\\x.png``) must
+    be restored to forward slashes too. This normalizes both to the form the
+    in-sandbox exec-read needs; relative paths are left untouched so they
+    resolve against the sandbox cwd. Non-Windows hosts are unaffected (POSIX
+    paths already render with forward slashes there).
+    """
+    s = src.strip()
+    if s.lower().startswith("file://"):
+        s = s[len("file://"):]
+    s = os.path.expanduser(s)
+    if re.match(r"^[A-Za-z]:[\\/]", s):
+        try:
+            win = PureWindowsPath(s)
+            drive = (win.drive or "").rstrip(":").lower()
+            if drive:
+                return "/mnt/" + drive + "/" + "/".join(str(part) for part in win.parts[1:])
+        except Exception:  # noqa: BLE001 — malformed path: leave as-is
+            pass
+        return s
+    if s.startswith("/"):
+        try:
+            return str(PurePosixPath(s))
+        except Exception:  # noqa: BLE001 — malformed path: leave as-is
+            return s
+    return s
+
+
 async def _resolve_container_fallback(
     p: Path, ctx: ResolveContext, src: str, permitted: tuple = ("image",)
 ) -> ResolvedImage:
@@ -330,6 +363,12 @@ async def _resolve_container_fallback(
     import asyncio
     import shlex
 
+    # Normalize the source path to its POSIX form inside the sandbox: a Windows
+    # host path (C:\...) is only visible to the WSL sandbox via DrvFS
+    # (/mnt/<drive>/...), and a POSIX path must keep forward slashes. Read the
+    # POSIX form in the in-sandbox exec-read so user-provided images resolve.
+    sandbox_path = _to_sandbox_posix(src)
+
     # Bring the sandbox up on demand: without this, the first vision_analyze of
     # a session (before any terminal command) has no active env to read from
     # under a non-local backend (issue #62825).
@@ -338,7 +377,7 @@ async def _resolve_container_fallback(
     env = _get_active_env(ctx.task_id)
     if env is None:
         raise SourceNotFound(
-            f"'{p}' is not reachable inside the sandbox and no active sandbox "
+            f"'{sandbox_path}' is not reachable inside the sandbox and no active sandbox "
             f"session is available to read it",
             src=src, origin="container")
 
@@ -350,7 +389,7 @@ async def _resolve_container_fallback(
     # -w0 is GNU-only, so pipe through tr -d for BusyBox.
     # env.execute is a blocking backend exec; keep it off the event loop so a
     # multi-MB base64 read doesn't stall every other coroutine.
-    qp = shlex.quote(str(p))
+    qp = shlex.quote(sandbox_path)
     cmd = f"head -c {_MAX_INGEST_BYTES + 1} < {qp} | base64 | tr -d '\\n'"
 
     last_res: dict = {"returncode": 1, "output": ""}
@@ -370,12 +409,12 @@ async def _resolve_container_fallback(
         first = next((ln.strip() for ln in diag if ln.strip()), "")
         suffix = f" ({first[:200]})" if first else ""
         raise SourceNotFound(
-            f"could not read '{p}' inside the sandbox{suffix}",
+            f"could not read '{sandbox_path}' inside the sandbox{suffix}",
             src=src, origin="container")
     try:
         data = base64.b64decode(last_res.get("output", ""), validate=True)
     except Exception as exc:
-        raise NotAnImage(f"sandbox returned non-image data for '{p}': {exc}", src=src)
+        raise NotAnImage(f"sandbox returned non-image data for '{sandbox_path}': {exc}", src=src)
     if len(data) > _MAX_INGEST_BYTES:
         raise SourceTooLarge("media exceeds size limit", src=src, origin="container")
     return _finalize(data, "", "container", src, permitted)


### PR DESCRIPTION
## Summary

Two small, related fixes for running Hermes on a **Windows host with an ssh/WSL terminal backend**. Both address the same underlying gap: file-tool and image paths were being treated with Windows/host semantics even though the tools operate on a POSIX (WSL) filesystem.

### 1. Treat ssh/WSL backends as POSIX-namespace for file path resolution (tools/file_tools.py)

- _uses_container_paths() now returns True for the ssh backend. On a Windows host with an ssh->WSL backend, an absolute POSIX path like /home/steve/... was misrouted through Windows ntpath, so write_file emitted a spurious "OUTSIDE the active workspace" warning and resolved paths with backslash semantics.
- With the change, absolute POSIX paths resolve correctly and the false warning is suppressed.

### 2. Translate Windows host paths to /mnt/<drive>/... for in-sandbox image reads (tools/image_source.py)

- resolve_image_source() reads non-cache image paths inside the sandbox via exec-read. On a Windows host, a bare Windows path (C:\Users\me\img.png) was passed raw into the WSL sandbox, where it does not exist (it is /mnt/c/Users/me/img.png there). This surfaced as: sandbox returned non-image data for C:\Users\me\img.png: Only base64 data is allowed.
- New _to_sandbox_posix() normalizes the source path before the in-sandbox read: drive-letter paths become /mnt/<drive>/..., POSIX paths keep forward slashes, relative paths and non-Windows hosts are unchanged.
- Makes vision_analyze work for desktop-attached images and WSL-local images under an ssh/WSL backend.

## Testing

- pytest tests/tools/test_image_source.py -> 17 passed, 1 skipped (requires pytest-asyncio).
- Reproduced the original vision_analyze failure (TERMINAL_ENV=ssh + resolve_image_source of a Windows path) before the fix, and confirmed it returns the image bytes after.
- Verified write_file no longer warns and search_files finds WSL matches in a live desktop session after a backend restart.

## Notes

- User-facing behavior fixes for Windows + WSL/ssh setups; no API or config changes.