### PR TITLE
fix(moa): stop coercing preset max_tokens to a 4096 cap

### DIFF
--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -303,7 +303,10 @@ def _default_preset() -> dict[str, Any]:
         "aggregator_temperature": None,
         "reference_timeout": DEFAULT_MOA_REFERENCE_TIMEOUT,
         "degraded_reference_policy": "loud",
-        "max_tokens": 4096,
+        # None = uncapped: parameter omitted → the model's real maximum,
+        # matching the runtime loop's documented contract (a hardcoded 4096
+        # truncated long syntheses and was deliberately removed there).
+        "max_tokens": None,
         "reference_max_tokens": None,
         "fanout": "user_turn",
         "enabled": True,
@@ -343,7 +346,10 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
         "degraded_reference_policy": _coerce_degraded_reference_policy(
             raw.get("degraded_reference_policy")
         ),
-        "max_tokens": _coerce_int(raw.get("max_tokens"), 4096),
+        # Missing/null = uncapped, exactly like the runtime contract: the
+        # old 4096 coercion silently reintroduced a cap the loop had
+        # deliberately removed (#89227). Explicit values pass through.
+        "max_tokens": _coerce_int_or_none(raw.get("max_tokens")),
         # Optional cap on how much each reference ADVISOR may generate per turn.
         # None (default) = uncapped: advisors write full-length advice, matching
         # prior behavior so existing presets are unchanged. Set a value (e.g.

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -189,7 +189,10 @@ class MoaPresetPayload(_MoaReferenceControls):
     # single-model agent behavior.
     reference_temperature: Optional[float] = None
     aggregator_temperature: Optional[float] = None
-    max_tokens: int = 4096
+    # None = uncapped (parameter omitted → the model's real maximum), same
+    # contract as moa_config._normalize_preset; a 4096 default here would
+    # re-inject the removed cap on every dashboard save (#89227).
+    max_tokens: Optional[int] = None
     # Newer per-preset knobs (see moa_config._normalize_preset). Optional so
     # older clients that never send them keep working; declared so clients
     # that round-trip the GET payload don't silently erase hand-set values.
@@ -208,7 +211,10 @@ class MoaConfigPayload(_MoaReferenceControls):
     aggregator: MoaModelSlot = MoaModelSlot()
     reference_temperature: Optional[float] = None
     aggregator_temperature: Optional[float] = None
-    max_tokens: int = 4096
+    # None = uncapped (parameter omitted → the model's real maximum), same
+    # contract as moa_config._normalize_preset; a 4096 default here would
+    # re-inject the removed cap on every dashboard save (#89227).
+    max_tokens: Optional[int] = None
     reference_max_tokens: Optional[int] = None
     fanout: Optional[str] = None
     enabled: bool = True

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -48,6 +48,34 @@ def test_normalize_moa_config_uses_default_named_preset():
     assert cfg["aggregator"] == DEFAULT_MOA_AGGREGATOR
 
 
+def test_preset_max_tokens_missing_or_null_means_uncapped():
+    """A preset's max_tokens must be able to express "no cap" (#89227).
+
+    The runtime loop treats None as omitted → the model's real maximum
+    (the old hardcoded 4096 aggregator cap was deliberately removed there),
+    so normalization coercing missing/null to 4096 silently reintroduced
+    the truncation for every normalized/flattened consumer."""
+    cfg = normalize_moa_config({
+        "presets": {
+            "missing": {},
+            "nulled": {"max_tokens": None},
+            "capped": {"max_tokens": 6000},
+        }
+    })
+    presets = cfg["presets"]
+    assert presets["missing"]["max_tokens"] is None
+    assert presets["nulled"]["max_tokens"] is None
+    assert presets["capped"]["max_tokens"] == 6000
+
+
+def test_default_preset_max_tokens_is_uncapped():
+    """A bare config's default preset is uncapped too: the flattened view
+    feeds dashboards, and 4096 there misreported what the loop sends."""
+    cfg = normalize_moa_config({})
+    assert cfg["presets"][DEFAULT_MOA_PRESET_NAME]["max_tokens"] is None
+    assert cfg["max_tokens"] is None
+
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

A MoA preset's `max_tokens` could not express "no cap": omitting the key or setting `max_tokens: null` was coerced to a hard 4096 by `_normalize_preset`, and the built-in default preset hardcoded 4096 as well. The runtime loop's contract is the opposite — `max_tokens: None` means the parameter is omitted so the model uses its real maximum, and the loop's own old 4096 aggregator default was deliberately removed because it truncated long syntheses. Normalization quietly reintroduced that cap for every normalized/flattened consumer, and the value shown by `hermes moa list` / the dashboard did not match what the interactive loop actually sends.

Additionally, the dashboard save path (`MoaPresetPayload` / `MoaConfigPayload`) defaulted `max_tokens` to `4096` with a non-optional `int` type — so even after fixing normalization, a dashboard save of an uncapped preset would re-inject the cap on write.

This PR aligns all config-side surfaces with the runtime contract:

- Preset normalization keeps `None` for missing/null (`_coerce_int_or_none`, the same helper `reference_max_tokens` already uses); explicit values pass through unchanged.
- The built-in default preset is uncapped (`None`).
- Both dashboard payload fields become `Optional[int] = None`, so an unset cap round-trips as unset. Explicit values (including 4096) still validate exactly as before.

## Related Issue

Fixes #89227

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/moa_config.py` — `_normalize_preset` uses `_coerce_int_or_none(raw.get("max_tokens"))` instead of `_coerce_int(..., 4096)`; `_default_preset` returns `"max_tokens": None`. Comments state the None = uncapped contract.
- `hermes_cli/web_models.py` — `MoaPresetPayload.max_tokens` and the flat `MoaConfigPayload.max_tokens` become `Optional[int] = None` with a comment explaining why a 4096 default would re-inject the removed cap.
- `tests/hermes_cli/test_moa_config.py` — `test_preset_max_tokens_missing_or_null_means_uncapped` (missing → None, null → None, explicit 6000 → 6000) and `test_default_preset_max_tokens_is_uncapped` (bare config's default preset and flattened view both None).

## How to Test

```bash
python -m pytest tests/hermes_cli/test_moa_config.py tests/hermes_cli/test_moa_set_models_preserves_extra_keys.py -q
# Observed result: 9 passed

python -m pytest tests/agent/test_moa*.py -q
# Observed result: 54 passed
```

Fail-on-main check: with the two source files stashed, both new tests fail on main (normalization returns 4096 for missing/null).

Manual repro from the issue: a preset without `max_tokens` now reports `None` through the normalized/flattened config (`hermes moa list`) and the runtime omits the parameter, matching single-model agent behavior.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments explain intent (None = uncapped contract, and why payloads must not default)
- [x] Corresponding changes documented via comments
- [x] Tests added and passing (2 new; MoA suites green: 63 total)
- [x] Single root cause, no unrelated changes
