### PR TITLE
Kanban delete/archive guards + decompose priority inheritance

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -742,6 +742,17 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         default=None,
         help="Permanently delete already-archived task ids from the board",
     )
+    p_archive.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Archive even when a worker run is still active: the run is "
+            "closed with outcome='reclaimed'. Use only for stuck workers "
+            "that will not respond to a kanban_block; without --force the "
+            "command refuses so a running worker can always finish or "
+            "comment on its own card."
+        ),
+    )
 
     # --- tail ---
     p_tail = sub.add_parser("tail", help="Follow a task's event stream")
@@ -2559,23 +2570,48 @@ def _cmd_archive(args: argparse.Namespace) -> int:
     if not ids and not purge_ids:
         print("at least one task_id is required", file=sys.stderr)
         return 1
+    force = bool(getattr(args, "force", False))
     failed: list[str] = []
+    refused: list[tuple[str, int]] = []
     with kb.connect_closing() as conn:
         if purge_ids:
             for tid in purge_ids:
-                if not kb.delete_archived_task(conn, tid):
-                    failed.append(tid)
-                    print(f"cannot delete {tid} (must already be archived)", file=sys.stderr)
-                else:
-                    print(f"Deleted {tid}")
-            return 0 if not failed else 1
+                try:
+                    if not kb.delete_archived_task(conn, tid):
+                        failed.append(tid)
+                        print(f"cannot delete {tid} (must already be archived)", file=sys.stderr)
+                    else:
+                        print(f"Deleted {tid}")
+                except kb.TaskHasActiveRunError as exc:
+                    refused.append((exc.task_id, exc.run_id))
+                    print(str(exc), file=sys.stderr)
+            if refused:
+                print(
+                    "delete refused: one or more tasks still have a worker "
+                    "run in flight; kanban_block the card first to land "
+                    "the run cleanly before removing the row.",
+                    file=sys.stderr,
+                )
+            return 0 if not failed and not refused else 1
         for tid in ids:
-            if not kb.archive_task(conn, tid):
-                failed.append(tid)
-                print(f"cannot archive {tid}", file=sys.stderr)
-            else:
-                print(f"Archived {tid}")
-    return 0 if not failed else 1
+            try:
+                if not kb.archive_task(conn, tid, force=force):
+                    failed.append(tid)
+                    print(f"cannot archive {tid}", file=sys.stderr)
+                else:
+                    print(f"Archived {tid}")
+            except kb.TaskHasActiveRunError as exc:
+                refused.append((exc.task_id, exc.run_id))
+                print(str(exc), file=sys.stderr)
+        if refused and not force:
+            print(
+                "archive refused: one or more tasks still have a worker "
+                "run in flight. Re-run with --force to reclaim the run "
+                "and archive anyway, or kanban_block the card so the "
+                "worker can land its own result first.",
+                file=sys.stderr,
+            )
+    return 0 if not failed and not refused else 1
 
 
 def _cmd_tail(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7231,9 +7231,14 @@ def archive_task(
 def delete_archived_task(conn: sqlite3.Connection, task_id: str) -> bool:
     """Permanently remove an already-archived task and its related rows.
 
-    Safety guard: only archived tasks can be deleted. Active / blocked / done
-    tasks must be explicitly archived first so accidental data loss requires a
-    second deliberate action.
+    Safety guards:
+      1. Only archived tasks can be deleted. Active / blocked / done
+         tasks must be explicitly archived first so accidental data loss
+         requires a second deliberate action.
+      2. Refuses with :class:`TaskHasActiveRunError` if a worker run is
+         still in flight. Same stranded-worker guard as :func:`delete_task`
+         — cleanup flows (``archive --rm``, post-verification purge) must
+         SKIP such cards and retry later, never delete mid-run.
     """
     with write_txn(conn):
         row = conn.execute(
@@ -7242,6 +7247,9 @@ def delete_archived_task(conn: sqlite3.Connection, task_id: str) -> bool:
         ).fetchone()
         if not row or row["status"] != "archived":
             return False
+        active_run = _has_active_run(conn, task_id)
+        if active_run is not None:
+            raise TaskHasActiveRunError(task_id, active_run)
         conn.execute(
             "DELETE FROM task_links WHERE parent_id = ? OR child_id = ?",
             (task_id, task_id),

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5066,6 +5066,43 @@ class ArtifactPreservationError(RuntimeError):
     """Raised when a declared scratch deliverable cannot be preserved."""
 
 
+class TaskHasActiveRunError(RuntimeError):
+    """Raised when delete/archive is attempted while a worker run is still active.
+
+    Carries ``task_id`` and ``run_id`` so callers can surface the live run
+    identifier and an actionable next step (complete/block the run first, or
+    pass ``force=True`` to archive and reclaim the run). Workers always need a
+    way to complete or comment on their own card; deleting or archiving the
+    card mid-run orphans the worker session.
+    """
+
+    def __init__(self, task_id: str, run_id: int):
+        self.task_id = task_id
+        self.run_id = run_id
+        super().__init__(
+            f"task {task_id} has an active worker run (id={run_id}); "
+            f"complete or block the run first "
+            f"(or pass force=True to archive and reclaim the run)"
+        )
+
+
+def _has_active_run(conn: sqlite3.Connection, task_id: str) -> Optional[int]:
+    """Return the active run id for ``task_id`` or ``None``.
+
+    "Active" = ``task_runs.status='running'`` AND ``ended_at IS NULL``. This
+    matches what the dispatcher treats as in-flight; stale claim rows whose
+    ``ended_at`` is set are excluded so the refusal does not fire on
+    long-completed work.
+    """
+    row = conn.execute(
+        "SELECT id FROM task_runs "
+        "WHERE task_id = ? AND status = 'running' AND ended_at IS NULL "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    return int(row["id"]) if row else None
+
+
 def complete_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -7146,7 +7183,20 @@ def decompose_triage_task(
     return child_ids
 
 
-def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
+def archive_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    force: bool = False,
+) -> bool:
+    """Archive a task.
+
+    Refuses with :class:`TaskHasActiveRunError` when a worker run is still
+    in flight, unless ``force=True``. Force reclaims the active run (closes
+    it with ``outcome='reclaimed'``) so cleanup can still race past a stuck
+    worker; without ``force`` we want a worker to always finish or block
+    on its own card before the card is removed.
+    """
     with write_txn(conn):
         cur = conn.execute(
             "UPDATE tasks SET status = 'archived', "
@@ -7156,13 +7206,19 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
         )
         if cur.rowcount != 1:
             return False
-        # If archive happened while a run was still in flight (e.g. user
-        # archived a running task from the dashboard), close that run with
-        # outcome='reclaimed' so attempt history isn't orphaned.
+        active_run = _has_active_run(conn, task_id)
+        if active_run is not None and not force:
+            # Roll back the archive we just did — refuse, don't silently
+            # orphan a worker. Force-mode keeps the archive and reclaims
+            # the run below.
+            raise TaskHasActiveRunError(task_id, active_run)
+        # If archive happened while a run was still in flight (force path,
+        # or the user archived a long-running task from the dashboard), close
+        # that run with outcome='reclaimed' so attempt history isn't orphaned.
         run_id = _end_run(
             conn, task_id,
             outcome="reclaimed", status="reclaimed",
-            summary="task archived with run still active",
+            summary="task archived with run still active" if force else None,
         )
         _append_event(conn, task_id, "archived", None, run_id=run_id)
     # ``archived`` parents no longer block children, same as ``done``.
@@ -7205,10 +7261,18 @@ def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
     we explicitly delete from child tables first, then the task row.
     This keeps the operation atomic (single ``write_txn``).
 
+    Refuses with :class:`TaskHasActiveRunError` if a worker run is still
+    in flight. Delete has no force-mode escape hatch — there is no
+    graceful close path; the operator must ``kanban_block`` (kind=capability)
+    the card first so the run lands cleanly before the row goes away.
+
     Returns ``True`` if the task existed and was deleted, ``False``
     if the task was not found.
     """
     with write_txn(conn):
+        active_run = _has_active_run(conn, task_id)
+        if active_run is not None:
+            raise TaskHasActiveRunError(task_id, active_run)
         cur = conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
         if cur.rowcount != 1:
             return False

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -56,7 +56,7 @@ into a small graph of concrete child tasks and route each one to the best-
 matching profile from the available roster.
 
 You will be given:
-  - The original task title and body
+  - The original task title, body, and priority (with its band label)
   - The list of available profiles (each with name + description)
   - The fallback "default_assignee" used when no profile fits
 
@@ -70,7 +70,9 @@ Output a single JSON object with this exact shape:
         "title": "<concrete task title, imperative voice, <= 80 chars>",
         "body":  "<detailed spec for the worker on this child task>",
         "assignee": "<profile name from the roster, or null for default>",
-        "parents": [<int>, ...]
+        "parents": [<int>, ...],
+        "priority": <int>,
+        "priority_reason": "<string>"
       },
       ...
     ]
@@ -89,6 +91,17 @@ Rules:
     and the system will route to the default_assignee.
   - Each child task body is what a fresh worker will read with no other
     context — be specific about goal, approach, and acceptance criteria.
+  - PRIORITY is an integer on the same scale as the parent's priority
+    (higher = more urgent, 0 = lowest). Rules:
+      * Omit "priority" (or set null) to inherit the parent's priority.
+        This is the default — do NOT invent a lower number.
+      * Set a HIGHER priority than the parent only when a child genuinely
+        needs to run ahead of the parent's band (e.g. an urgent blocker).
+      * Set a LOWER priority than the parent ONLY when you also give a
+        concrete "priority_reason" (one sentence). A lower priority with
+        no reason is rejected and clamped back up to the parent's.
+      * Never emit priority 0 for a child of a higher-priority parent —
+        that silently buries work the parent was triaged for.
 
 When the task is genuinely a single unit of work (no useful decomposition),
 return:
@@ -111,6 +124,7 @@ No preamble, no closing remarks, no code fences. Output only the JSON object.
 
 _USER_TEMPLATE = """Task id: {task_id}
 Title: {title}
+Priority: {priority} ({priority_band})
 Body:
 {body}
 
@@ -140,6 +154,40 @@ def _truncate(text: str, limit: int) -> str:
     if len(text) <= limit:
         return text
     return text[: limit - 1] + "…"
+
+
+def _priority_band(priority: int) -> str:
+    """Human label for a board priority (higher = more urgent)."""
+    if priority >= 10:
+        return "critical"
+    if priority >= 7:
+        return "high"
+    if priority >= 4:
+        return "normal"
+    if priority >= 1:
+        return "low"
+    return "lowest"
+
+
+def _resolve_child_priority(parent_priority: int, entry: dict) -> int:
+    """Resolve a child's priority from the decomposer spec.
+
+    Rules (deterministic — never model judgment):
+      * No "priority" key or a non-integer value -> inherit the parent's.
+      * Explicit int higher than the parent -> override wins (run ahead).
+      * Explicit int lower than the parent -> allowed ONLY when the spec
+        also gives a non-empty "priority_reason"; otherwise clamped back
+        to the parent's priority so work never silently buries itself.
+    """
+    raw = entry.get("priority")
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        return parent_priority
+    if raw >= parent_priority:
+        return raw
+    reason = entry.get("priority_reason")
+    if isinstance(reason, str) and reason.strip():
+        return raw
+    return parent_priority
 
 
 def _extract_json_blob(raw: str) -> Optional[dict]:
@@ -273,6 +321,7 @@ def decompose_task(
     *,
     author: Optional[str] = None,
     timeout: Optional[int] = None,
+    child_priority: Optional[int] = None,
 ) -> DecomposeOutcome:
     """Decompose a triage task into a graph of child tasks.
 
@@ -280,6 +329,11 @@ def decompose_task(
     expected failure modes (task not in triage, no aux client
     configured, API error, malformed response, decomposer returned
     fanout=true with empty task list) — those surface via ``ok=False``.
+
+    ``child_priority`` is the value stored on every created child when no
+    per-child ``priority`` override is supplied. Pass ``None`` (the
+    default) and children inherit the root task's stored priority so
+    a p10 parent fans out into p10 children rather than dropping to 0.
     """
     with kb.connect_closing() as conn:
         task = kb.get_task(conn, task_id)
@@ -303,9 +357,13 @@ def decompose_task(
         logger.debug("decompose: auxiliary client import failed: %s", exc)
         return DecomposeOutcome(task_id, False, "auxiliary client unavailable")
 
+    parent_priority = task.priority if isinstance(task.priority, int) else 0
+
     user_msg = _USER_TEMPLATE.format(
         task_id=task.id,
         title=_truncate(task.title or "", 400),
+        priority=parent_priority,
+        priority_band=_priority_band(parent_priority),
         body=_truncate(task.body or "(no body)", 4000),
         roster=_format_roster(roster),
         default_assignee=default_assignee,
@@ -427,6 +485,7 @@ def decompose_task(
             "body": body.strip(),
             "assignee": chosen,
             "parents": clean_parents,
+            "priority": _resolve_child_priority(parent_priority, entry),
         })
 
     try:
@@ -438,6 +497,7 @@ def decompose_task(
                 children=children,
                 author=audit_author,
                 auto_promote=auto_promote,
+                child_priority=child_priority,
             )
     except ValueError as exc:
         return DecomposeOutcome(task_id, False, f"DB rejected graph: {exc}")

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -851,6 +851,10 @@ class UpdateTaskBody(BaseModel):
     # override doesn't silently reset the depth the operator chose.
     reasoning_effort: Optional[str] = None
     clear_reasoning_effort: bool = False
+    # Forwarded to archive_task(force=...). Only consulted when
+    # status='archived'. Lets the dashboard surface an "archive anyway"
+    # affordance when the refusal fires on a stuck worker.
+    force: bool = False
 
 
 def _reopen_if_review(conn, task_id: str, current) -> Optional[bool]:
@@ -934,7 +938,28 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     # Direct status write for drag-drop (todo -> ready etc).
                     ok = reopened if reopened is not None else _set_status_direct(conn, task_id, "ready")
             elif s == "archived":
-                ok = kanban_db.archive_task(conn, task_id)
+                # PATCH path: honor UpdateTaskBody.force so the dashboard
+                # "force archive" button can reclaim a stuck worker; without
+                # force we surface the active-run refusal to the caller.
+                try:
+                    ok = kanban_db.archive_task(
+                        conn, task_id, force=bool(payload.force),
+                    )
+                except kanban_db.TaskHasActiveRunError as exc:
+                    raise HTTPException(
+                        status_code=409,
+                        detail={
+                            "error": "task_has_active_run",
+                            "task_id": exc.task_id,
+                            "run_id": exc.run_id,
+                            "message": (
+                                f"task {exc.task_id} has an active worker "
+                                f"run (id={exc.run_id}); retry with "
+                                f"force=true to reclaim the run and "
+                                f"archive anyway."
+                            ),
+                        },
+                    )
             elif s == "running":
                 raise HTTPException(
                     status_code=400,
@@ -1051,7 +1076,23 @@ def delete_task(task_id: str, board: Optional[str] = Query(None)):
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
-        ok = kanban_db.delete_task(conn, task_id)
+        try:
+            ok = kanban_db.delete_task(conn, task_id)
+        except kanban_db.TaskHasActiveRunError as exc:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error": "task_has_active_run",
+                    "task_id": exc.task_id,
+                    "run_id": exc.run_id,
+                    "message": (
+                        f"task {exc.task_id} has an active worker run "
+                        f"(id={exc.run_id}); block the card first so the "
+                        f"worker can land its own result, then retry the "
+                        f"delete."
+                    ),
+                },
+            )
         if not ok:
             raise HTTPException(status_code=404, detail=f"task {task_id} not found")
         return {"deleted": True, "task_id": task_id}
@@ -1298,6 +1339,8 @@ class BulkTaskBody(BaseModel):
     # Bulk thinking-depth override — same semantics as UpdateTaskBody.
     reasoning_effort: Optional[str] = None
     clear_reasoning_effort: bool = False
+    # Forwarded to archive_task(force=...). Only used when archive=True.
+    force: bool = False
 
 
 @router.post("/tasks/bulk")
@@ -1323,8 +1366,18 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                     results.append(entry)
                     continue
                 if payload.archive:
-                    if not kanban_db.archive_task(conn, tid):
-                        entry.update(ok=False, error="archive refused")
+                    try:
+                        if not kanban_db.archive_task(
+                            conn, tid, force=bool(payload.force),
+                        ):
+                            entry.update(ok=False, error="archive refused")
+                    except kanban_db.TaskHasActiveRunError as exc:
+                        entry.update(
+                            ok=False,
+                            error="task_has_active_run",
+                            run_id=exc.run_id,
+                            message=str(exc),
+                        )
                 if payload.status is not None and not payload.archive:
                     s = payload.status
                     if s == "done":

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -179,3 +179,54 @@ def test_run_slash_reclaim_running_task(kanban_home):
 # ---------------------------------------------------------------------------
 
 
+
+
+# ---------------------------------------------------------------------------
+# archive / --rm CLI active-run refusal
+# ---------------------------------------------------------------------------
+
+
+def test_kanban_cli_archive_refuses_while_run_active(kanban_home, capsys):
+    """`hermes kanban archive` exits non-zero and prints the run id when
+    a worker run is still active. Regression for RV2 cleanup deleting
+    running cards mid-run."""
+    parser = kc.build_parser(_top_subparsers())
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="running", assignee="worker")
+        kb.claim_task(conn, tid, claimer="test:worker")
+        run_id = kb.get_task(conn, tid).current_run_id
+
+        args = parser.parse_args(["archive", tid])
+        rc = kc._cmd_archive(args)
+        captured = capsys.readouterr()
+        assert rc == 1, "archive must exit non-zero when refusing"
+        assert f"run (id={run_id})" in captured.err
+        assert "complete or block" in captured.err
+        # Card untouched.
+        assert kb.get_task(conn, tid).status == "running"
+
+
+def test_kanban_cli_archive_force_reclaims_run(kanban_home, capsys):
+    """`hermes kanban archive --force` reclaims the run and archives anyway."""
+    parser = kc.build_parser(_top_subparsers())
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="stuck", assignee="worker")
+        kb.claim_task(conn, tid, claimer="test:stuck")
+        run_id = kb.get_task(conn, tid).current_run_id
+
+        args = parser.parse_args(["archive", tid, "--force"])
+        rc = kc._cmd_archive(args)
+        capsys.readouterr()
+        assert rc == 0
+        assert kb.get_task(conn, tid).status == "archived"
+        run = conn.execute(
+            "SELECT status, outcome FROM task_runs WHERE id = ?", (run_id,),
+        ).fetchone()
+        assert run["status"] == "reclaimed"
+
+
+def _top_subparsers():
+    """Return a parent subparsers action for ``build_parser``."""
+    top = argparse.ArgumentParser()
+    sub = top.add_subparsers()
+    return sub

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1591,3 +1591,81 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# Active-run guard on archive / delete
+# ---------------------------------------------------------------------------
+
+
+def test_archive_task_refuses_while_run_active(kanban_home):
+    """archive_task must refuse when a worker run is still in flight, and
+    the error must name the run id so the caller knows what to land first.
+    Regression for RV2 cleanup that archived running cards mid-run.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="running", assignee="worker")
+        claimed = kb.claim_task(conn, tid, claimer="test:worker")
+        assert claimed is not None
+        assert kb.get_task(conn, tid).status == "running"
+        run_id = kb.get_task(conn, tid).current_run_id
+        assert run_id, "claim_task must record a current run"
+
+        with pytest.raises(kb.TaskHasActiveRunError) as ei:
+            kb.archive_task(conn, tid)
+        assert ei.value.task_id == tid
+        assert ei.value.run_id == run_id
+        # The card is untouched — still running, not archived.
+        assert kb.get_task(conn, tid).status == "running"
+
+
+def test_archive_task_force_reclaims_active_run(kanban_home):
+    """force=True keeps the archive path live and reclaims the active run
+    so cleanup can still race past a stuck worker."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="stuck", assignee="worker")
+        kb.claim_task(conn, tid, claimer="test:stuck")
+        run_id = kb.get_task(conn, tid).current_run_id
+
+        assert kb.archive_task(conn, tid, force=True) is True
+        task = kb.get_task(conn, tid)
+        assert task.status == "archived"
+        # Run row closed with outcome='reclaimed' so attempt history isn't orphaned.
+        run = conn.execute(
+            "SELECT status, outcome FROM task_runs WHERE id = ?", (run_id,),
+        ).fetchone()
+        assert run["status"] == "reclaimed"
+        assert run["outcome"] == "reclaimed"
+
+
+def test_delete_task_refuses_while_run_active(kanban_home):
+    """delete_task must refuse when a worker run is still in flight. No
+    force escape hatch — delete the row only when no worker can still
+    reference it."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="running", assignee="worker")
+        kb.claim_task(conn, tid, claimer="test:worker")
+        run_id = kb.get_task(conn, tid).current_run_id
+
+        with pytest.raises(kb.TaskHasActiveRunError) as ei:
+            kb.delete_task(conn, tid)
+        assert ei.value.task_id == tid
+        assert ei.value.run_id == run_id
+        # Row still present.
+        assert kb.get_task(conn, tid) is not None
+
+
+def test_archive_and_delete_proceed_after_run_ends(kanban_home):
+    """Once the active run is closed, archive/delete must succeed again.
+    Guards against an over-broad check that would lock the card forever."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="will-finish", assignee="worker")
+        kb.claim_task(conn, tid, claimer="test:w")
+        # Simulate the worker landing its result.
+        assert kb.complete_task(conn, tid, result="ok")
+        assert kb.get_task(conn, tid).status == "done"
+
+        assert kb.archive_task(conn, tid) is True
+        assert kb.get_task(conn, tid).status == "archived"
+        assert kb.delete_archived_task(conn, tid) is True
+        assert kb.get_task(conn, tid) is None

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -161,3 +161,79 @@ def test_decompose_returns_false_when_task_not_triage(kanban_home):
     assert "not in triage" in outcome.reason
 
 
+def test_decompose_child_priority_inherit_and_override(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="p10 triage", triage=True, priority=10)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "priority test",
+        "tasks": [
+            # No priority key -> inherit p10.
+            {"title": "inherit me", "body": "b", "assignee": "engineer", "parents": []},
+            # Explicit higher priority -> override wins.
+            {"title": "run ahead", "body": "b", "assignee": "engineer", "parents": [],
+             "priority": 12},
+            # Lower priority WITHOUT a reason -> clamped back to p10.
+            {"title": "sneaky low", "body": "b", "assignee": "engineer", "parents": [],
+             "priority": 0},
+            # Lower priority WITH a reason -> honored.
+            {"title": "justified low", "body": "b", "assignee": "engineer", "parents": [],
+             "priority": 3, "priority_reason": "background cleanup, non-urgent"},
+        ],
+    })
+
+    patches = _patch_list_profiles(["orchestrator", "engineer"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body():
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason
+    assert outcome.child_ids and len(outcome.child_ids) == 4
+    with kb.connect() as conn:
+        c0 = kb.get_task(conn, outcome.child_ids[0])
+        c1 = kb.get_task(conn, outcome.child_ids[1])
+        c2 = kb.get_task(conn, outcome.child_ids[2])
+        c3 = kb.get_task(conn, outcome.child_ids[3])
+    assert c0.priority == 10      # inherited
+    assert c1.priority == 12      # higher override
+    assert c2.priority == 10      # silent downgrade clamped
+    assert c3.priority == 3       # justified downgrade honored
+
+
+def test_decompose_child_priority_non_int_and_bool_inherit(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="junk priority", triage=True, priority=7)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "junk priority",
+        "tasks": [
+            {"title": "str priority", "body": "b", "assignee": "engineer", "parents": [],
+             "priority": "10"},
+            {"title": "bool priority", "body": "b", "assignee": "engineer", "parents": [],
+             "priority": True},
+        ],
+    })
+
+    patches = _patch_list_profiles(["orchestrator", "engineer"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body():
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason
+    with kb.connect() as conn:
+        c0 = kb.get_task(conn, outcome.child_ids[0])
+        c1 = kb.get_task(conn, outcome.child_ids[1])
+    assert c0.priority == 7   # non-int strings ignored -> inherit
+    assert c1.priority == 7   # bool rejected -> inherit

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -88,5 +88,30 @@ def test_decompose_records_audit_comment_and_event(kanban_home):
     assert any(ev.kind == "decomposed" for ev in events)
 
 
+def test_decompose_child_priority_inherits_root_and_honors_override(kanban_home):
+    with kb.connect() as conn:
+        tid = _create_triage(conn, title="p10 triage")
+        conn.execute("UPDATE tasks SET priority = 10 WHERE id = ?", (tid,))
 
+    children = [
+        {"title": "inherit", "assignee": "researcher", "parents": []},
+        {"title": "override", "assignee": "researcher", "parents": [], "priority": 15},
+        {"title": "garbage", "assignee": "researcher", "parents": [], "priority": "10"},
+    ]
+    with kb.connect() as conn:
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orchestrator",
+            children=children,
+            author="decomposer",
+        )
+    assert child_ids is not None and len(child_ids) == 3
 
+    with kb.connect() as conn:
+        c0 = kb.get_task(conn, child_ids[0])
+        c1 = kb.get_task(conn, child_ids[1])
+        c2 = kb.get_task(conn, child_ids[2])
+    assert c0.priority == 10   # absent -> root priority
+    assert c1.priority == 15   # explicit int stored
+    assert c2.priority == 10   # non-int -> root priority

--- a/tests/hermes_cli/test_kanban_decompose_priority.py
+++ b/tests/hermes_cli/test_kanban_decompose_priority.py
@@ -1,0 +1,184 @@
+"""Acceptance tests for parent-priority inheritance and the ``--priority``
+flag on ``kanban decompose``. Drives the DB layer directly so the test
+is hermetic — no LLM, no watcher tick, no dashboard.
+
+Acceptance contract (from the task body):
+
+  - Parent priority p10, no ``--priority`` flag         -> every child priority p10
+  - Parent priority p10, ``--priority p20`` flag        -> every child priority p20
+  - Parent priority 0                                   -> children priority 0
+  - Per-child override from the decomposer model       -> wins over both
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Force a fresh kanban DB per test so each run is hermetic.
+_TMPDIR = tempfile.mkdtemp(prefix="kanban-priority-")
+os.environ["HERMES_KANBAN_DB"] = os.path.join(_TMPDIR, "kanban.db")
+os.environ["HERMES_KANBAN_BOARD"] = "default-test-board"
+
+# Repo root on path so `hermes_cli` resolves cleanly under `python -m pytest`.
+_REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(_REPO))
+
+from hermes_cli import kanban_db as kb  # noqa: E402
+
+
+def _seed_triage(conn, *, priority: int) -> str:
+    """Create one triage task owned by a throwaway board anchor.
+
+    The dispatcher doesn't run in these tests, so we just INSERT a row
+    in ``tasks`` with the minimum shape ``decompose_triage_task``
+    expects (status='triage', a tenant). Auto-id allocation via
+    ``_new_task_id`` is public through ``kb.create_task`` but that one
+    forces status='todo'; we want triage, so write the row directly.
+    """
+    new_id = kb._new_task_id()  # type: ignore[attr-defined]
+    import time
+    now = int(time.time())
+    conn.execute(
+        "INSERT INTO tasks "
+        "(id, title, body, assignee, status, workspace_kind, "
+        " workspace_path, tenant, priority, created_at, created_by) "
+        "VALUES (?, ?, ?, ?, 'triage', 'scratch', NULL, ?, ?, ?, 'test')",
+        (new_id, "Parent", "body", None, "default-test-board", priority, now),
+    )
+    return new_id
+
+
+def _seed_board(conn, slug: str) -> None:
+    """Ensure the board row exists (the DB init does this lazily on
+    connect, but our connect path may not run before the test reads
+    tasks; a direct INSERT is enough)."""
+    try:
+        conn.execute(
+            "INSERT OR IGNORE INTO kanban_boards (slug, name, tenant) "
+            "VALUES (?, ?, NULL)",
+            (slug, slug),
+        )
+    except Exception:
+        # Table doesn't exist yet; let kb.init_db() create it later.
+        pass
+
+
+class PriorityInheritanceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        kb.init_db(Path(_TMPDIR) / "kanban.db")
+        # ``init_db`` is idempotent; reopen a fresh connection that
+        # reads/writes the seeded board.
+        with kb.connect_closing() as conn:
+            _seed_board(conn, "default-test-board")
+
+    def _children(self, parent_id: str) -> dict[str, int]:
+        """Return {child_id: priority} for every direct child of parent_id.
+
+        ``decompose_triage_task`` links the root as a *child* of every
+        leaf child (root waits for the whole graph), so direct children
+        of the root are rows in ``task_links`` where ``child_id`` is
+        the root id.
+        """
+        with kb.connect_closing() as conn:
+            rows = conn.execute(
+                "SELECT c.id, c.priority "
+                "FROM tasks c "
+                "JOIN task_links t ON t.parent_id = c.id "
+                "WHERE t.child_id = ?",
+                (parent_id,),
+            ).fetchall()
+        return {r["id"]: r["priority"] for r in rows}
+
+    def test_inherits_parent_priority_when_flag_omitted(self) -> None:
+        with kb.connect_closing() as conn:
+            parent = _seed_triage(conn, priority=10)
+            child_ids = kb.decompose_triage_task(
+                conn, parent,
+                root_assignee=None,
+                children=[
+                    {"title": "A"},
+                    {"title": "B"},
+                    {"title": "C"},
+                ],
+            )
+        self.assertIsNotNone(child_ids)
+        priorities = self._children(parent)
+        self.assertEqual(set(priorities), set(child_ids))
+        self.assertTrue(
+            all(p == 10 for p in priorities.values()),
+            f"expected all children priority=10, got {priorities}",
+        )
+
+    def test_flag_override_applies_to_every_child(self) -> None:
+        with kb.connect_closing() as conn:
+            parent = _seed_triage(conn, priority=10)
+            child_ids = kb.decompose_triage_task(
+                conn, parent,
+                root_assignee=None,
+                children=[
+                    {"title": "A"},
+                    {"title": "B"},
+                ],
+                child_priority=20,
+            )
+        self.assertIsNotNone(child_ids)
+        priorities = self._children(parent)
+        self.assertTrue(
+            all(p == 20 for p in priorities.values()),
+            f"expected all children priority=20, got {priorities}",
+        )
+
+    def test_parent_priority_zero_propagates_zero(self) -> None:
+        """A parent at the schema default 0 must produce children at 0
+        — no spurious re-defaulting."""
+        with kb.connect_closing() as conn:
+            parent = _seed_triage(conn, priority=0)
+            child_ids = kb.decompose_triage_task(
+                conn, parent,
+                root_assignee=None,
+                children=[{"title": "Only"}],
+            )
+        self.assertIsNotNone(child_ids)
+        priorities = self._children(parent)
+        self.assertTrue(
+            all(p == 0 for p in priorities.values()),
+            f"expected all children priority=0, got {priorities}",
+        )
+
+    def test_per_child_priority_override_wins(self) -> None:
+        """Per-child ``priority`` from the decomposer beats the
+        effective-child-priority default (root or flag)."""
+        with kb.connect_closing() as conn:
+            parent = _seed_triage(conn, priority=10)
+            child_ids = kb.decompose_triage_task(
+                conn, parent,
+                root_assignee=None,
+                children=[
+                    {"title": "A"},                     # inherits -> 10
+                    {"title": "B", "priority": 99},     # explicit
+                    {"title": "C"},                     # inherits -> 10
+                ],
+                child_priority=20,
+            )
+        self.assertIsNotNone(child_ids)
+        # Direct INSERT-by-title lookup so we can assert per-child IDs
+        # without coupling to insertion order.
+        with kb.connect_closing() as conn:
+            rows = conn.execute(
+                "SELECT title, priority FROM tasks WHERE id IN ("
+                + ",".join("?" * len(child_ids))
+                + ") ORDER BY title",
+                list(child_ids),
+            ).fetchall()
+        by_title = {r["title"]: r["priority"] for r in rows}
+        self.assertEqual(by_title["A"], 20)
+        self.assertEqual(by_title["B"], 99)
+        self.assertEqual(by_title["C"], 20)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/hermes_cli/test_kanban_delete_active_run.py
+++ b/tests/hermes_cli/test_kanban_delete_active_run.py
@@ -1,0 +1,142 @@
+"""Stranded-worker guard on the ARCHIVED-task purge path.
+
+Sibling commit fa3efdcc7 guarded ``archive_task`` / ``delete_task`` (and the
+``--rm`` CLI loop's try/except around ``delete_archived_task``), but
+``delete_archived_task`` itself never raised the refusal — the ``--rm`` purge
+path (the exact RV2 post-verification cleanup that deleted running children
+mid-run) was unguarded. These tests close that gap:
+
+* ``delete_archived_task`` refuses while a run is active,
+* stale terminal-status runs never block a delete,
+* the CLI ``archive --rm`` loop skips the in-flight card and keeps going.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _seed_archived_with_active_run(kanban_home):
+    """Create + claim a card, then force it to archived while its run is
+    still active — the RV2 incident shape (post-verification cleanup trying
+    to purge children whose worker runs are still in flight)."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="archived but running", assignee="worker")
+        kb.claim_task(conn, tid)
+        run_id = int(
+            conn.execute(
+                "SELECT current_run_id FROM tasks WHERE id = ?", (tid,)
+            ).fetchone()["current_run_id"]
+        )
+        conn.execute(
+            "UPDATE tasks SET status = 'archived' WHERE id = ?", (tid,)
+        )
+        conn.commit()
+    return tid, run_id
+
+
+def test_delete_archived_task_refused_while_run_active(kanban_home):
+    tid, run_id = _seed_archived_with_active_run(kanban_home)
+
+    with kb.connect() as conn:
+        with pytest.raises(kb.TaskHasActiveRunError) as ei:
+            kb.delete_archived_task(conn, tid)
+        assert ei.value.task_id == tid
+        assert ei.value.run_id == run_id
+        # Card + run untouched.
+        assert kb.get_task(conn, tid) is not None
+        assert (
+            conn.execute(
+                "SELECT status FROM task_runs WHERE id = ?", (run_id,)
+            ).fetchone()["status"]
+            == "running"
+        )
+
+
+def test_delete_archived_task_succeeds_after_run_ends(kanban_home):
+    tid, run_id = _seed_archived_with_active_run(kanban_home)
+    with kb.connect() as conn:
+        kb._end_run(conn, tid, outcome="completed", status="done")
+    with kb.connect() as conn:
+        assert kb.delete_archived_task(conn, tid) is True
+        assert kb.get_task(conn, tid) is None
+
+
+def test_delete_archived_task_clears_task_links(kanban_home):
+    """Deleting an archived card with no active run still cleans links."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent], assignee="worker")
+        kb.complete_task(conn, child, result="ok")
+        assert kb.archive_task(conn, child)
+        assert kb.delete_archived_task(conn, child) is True
+        leftover = conn.execute(
+            "SELECT COUNT(*) FROM task_links "
+            "WHERE parent_id = ? OR child_id = ?",
+            (child, child),
+        ).fetchone()[0]
+        assert leftover == 0
+
+
+def test_terminal_run_statuses_do_not_block_delete(kanban_home):
+    """Stale runs in ANY terminal status must not block a delete — only
+    'running' counts as active. Guards against an over-broad check."""
+    for terminal in ("done", "blocked", "crashed", "timed_out", "failed", "released"):
+        with kb.connect() as conn:
+            tid = kb.create_task(conn, title=f"stale {terminal}", assignee="worker")
+            cur = conn.execute(
+                "INSERT INTO task_runs (task_id, status, started_at, ended_at) "
+                "VALUES (?, ?, ?, ?)",
+                (tid, terminal, int(time.time()), int(time.time())),
+            )
+            run_id = int(cur.lastrowid)
+            conn.execute(
+                "UPDATE tasks SET current_run_id = ? WHERE id = ?",
+                (run_id, tid),
+            )
+            conn.commit()
+
+        with kb.connect() as conn:
+            assert kb.delete_task(conn, tid) is True, f"terminal={terminal}"
+            assert kb.get_task(conn, tid) is None
+
+
+def test_cli_archive_purge_loop_skips_active_run(capsys, monkeypatch, kanban_home):
+    """The CLI ``hermes kanban archive --rm <ids>`` loop must skip a card
+    whose run is still active and continue the batch — not abort."""
+    from hermes_cli.kanban import _cmd_archive
+
+    active_tid, _ = _seed_archived_with_active_run(kanban_home)
+    with kb.connect() as conn:
+        clean_tid = kb.create_task(conn, title="clean", assignee="worker")
+        kb.complete_task(conn, clean_tid, result="ok")
+        assert kb.archive_task(conn, clean_tid)
+
+    args = argparse.Namespace(task_ids=[], purge_ids=[active_tid, clean_tid])
+    rc = _cmd_archive(args)
+
+    captured = capsys.readouterr()
+    # Refusal is tracked (exit 1 signals retry needed) but the batch
+    # continues: the clean card still got deleted.
+    assert rc == 1
+    assert active_tid in captured.err
+    assert "active worker run" in captured.err or "active run" in captured.err
+    assert f"Deleted {clean_tid}" in captured.out
+    with kb.connect() as conn:
+        assert kb.get_task(conn, clean_tid) is None
+        assert kb.get_task(conn, active_tid) is not None

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -416,6 +416,27 @@ def test_create_happy_path(worker_env):
         conn.close()
 
 
+def test_create_happy_path_persists_priority(worker_env):
+    """kanban_create must store the caller's priority verbatim (the
+    decomposer's per-child inheritance relies on create honoring it)."""
+    from tools import kanban_tools as kt
+    out = kt._handle_create({
+        "title": "priority child",
+        "assignee": "peer",
+        "parents": [worker_env],
+        "priority": 7,
+    })
+    d = json.loads(out)
+    assert d["ok"] is True
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        child = kb.get_task(conn, d["task_id"])
+        assert child.priority == 7
+    finally:
+        conn.close()
+
+
 def test_link_happy_path(worker_env):
     from hermes_cli import kanban_db as kb
     conn = kb.connect()


### PR DESCRIPTION
Stranded commits from TabJoy fleet (devbxylw): \n- fa3efdcc7 Refuse kanban delete/archive while a worker run is still active\n- 136e5b026 Guard delete_archived_task (archive --rm purge) against active worker runs\n- f9b9d0387 Decomposer priority: parent context in prompt, per-child spec overrides\n- 9c0033dcf Regression tests for decompose priority inherit/override/create\n\n44 kanban tests green locally. Repo ACL denied direct push (read-only), so land via PR.