### PR TITLE
Persist parent links on dependency-block outcomes

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5879,6 +5879,49 @@ def edit_completed_task_result(
     return True
 
 
+_DEPENDENCY_SIBLING_RE = re.compile(r"\bt_[0-9a-f]{8}\b")
+
+
+def _resolve_dependency_sibling(
+    conn: sqlite3.Connection, task_id: str, reason: Optional[str]
+) -> Optional[str]:
+    """Return the first sibling task id named in ``reason`` that exists and
+    is not ``task_id`` itself, else ``None``.
+
+    Best-effort by design: a reason that names no sibling, or names one
+    that cannot be resolved to a card, yields ``None`` so the block still
+    succeeds — the caller records the unresolved state on the block event
+    for alerting instead of failing the worker exit path.
+    """
+    if not reason:
+        return None
+    for candidate in _DEPENDENCY_SIBLING_RE.findall(reason):
+        if candidate == task_id:
+            continue
+        if get_task(conn, candidate) is not None:
+            return candidate
+    return None
+
+
+def _insert_dependency_link(
+    conn: sqlite3.Connection, parent_id: str, child_id: str
+) -> None:
+    """Persist a ``parent_id -> child_id`` dependency link.
+
+    Runs inside the caller's open transaction (``link_tasks`` opens its
+    own, so it cannot be reused here). Raises ``ValueError`` on a cycle;
+    duplicate links are idempotent via ``INSERT OR IGNORE``.
+    """
+    if _would_cycle(conn, parent_id, child_id):
+        raise ValueError(
+            f"linking {parent_id} -> {child_id} would create a cycle"
+        )
+    conn.execute(
+        "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
+        (parent_id, child_id),
+    )
+
+
 def block_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -5960,6 +6003,22 @@ def block_task(
             )
             if cur.rowcount != 1:
                 return False
+            # Persist a parent link to the sibling named in the reason BEFORE the
+            # block outcome lands, so ``recompute_ready`` sees an unmet parent
+            # instead of a parentless todo card (which it would re-promote on the
+            # next tick — the bug this link exists to prevent). Resolution is
+            # best-effort: a reason that names no resolvable sibling must not
+            # fail the block, so any failure is recorded on the event payload
+            # for alerting instead of raised.
+            sibling_id = _resolve_dependency_sibling(conn, task_id, reason)
+            link_created = False
+            link_error = None
+            if sibling_id is not None:
+                try:
+                    _insert_dependency_link(conn, parent_id=sibling_id, child_id=task_id)
+                    link_created = True
+                except ValueError as exc:
+                    link_error = str(exc)
             run_id = _end_run(
                 conn, task_id,
                 outcome="blocked", status="blocked",
@@ -5975,6 +6034,10 @@ def block_task(
                     "reason": reason,
                     "kind": kind,
                     "source_status": source_status,
+                    "sibling_id": sibling_id,
+                    "sibling_resolved": sibling_id is not None,
+                    "link_created": link_created,
+                    "link_error": link_error,
                 },
                 run_id=run_id,
             )

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -100,6 +100,71 @@ def test_dependency_then_parent_done_promotes(kanban_home: Path) -> None:
         assert kb.get_task(conn, child).status == "ready"
 
 
+def test_dependency_block_names_sibling_creates_parent_link(kanban_home: Path) -> None:
+    """A dependency block naming sibling X links the blocked card to X."""
+    with kb.connect_closing() as conn:
+        sibling = kb.create_task(conn, title="sibling", assignee="worker")
+        child = _running_task(conn, title="child")
+        kb.block_task(
+            conn, child,
+            reason=f"waiting on sibling {sibling}", kind="dependency",
+        )
+        assert kb.get_task(conn, child).status == "todo"
+        link = conn.execute(
+            "SELECT parent_id, child_id FROM task_links "
+            "WHERE parent_id = ? AND child_id = ?",
+            (sibling, child),
+        ).fetchone()
+        assert link is not None, "expected parent link child -> sibling"
+        ev = [e for e in kb.list_events(conn, child)
+              if e.kind == "dependency_wait"][-1]
+        payload = ev.payload or {}
+        assert payload.get("sibling_id") == sibling
+        assert payload.get("sibling_resolved") is True
+        assert payload.get("link_created") is True
+
+
+def test_dependency_block_unknown_sibling_fails_safe(kanban_home: Path) -> None:
+    """An unresolvable sibling id still blocks, with alert metadata recorded."""
+    with kb.connect_closing() as conn:
+        child = _running_task(conn, title="child")
+        kb.block_task(
+            conn, child,
+            reason="waiting on t_ffffffff (missing)", kind="dependency",
+        )
+        assert kb.get_task(conn, child).status == "todo"
+        assert conn.execute(
+            "SELECT 1 FROM task_links WHERE child_id = ?", (child,)
+        ).fetchone() is None
+        ev = [e for e in kb.list_events(conn, child)
+              if e.kind == "dependency_wait"][-1]
+        payload = ev.payload or {}
+        assert payload.get("sibling_resolved") is False
+        assert payload.get("link_created") is False
+
+
+def test_dependency_block_sibling_gates_recompute_ready(kanban_home: Path) -> None:
+    """A dependency-blocked card stays parked until the named sibling completes."""
+    with kb.connect_closing() as conn:
+        sibling = kb.create_task(conn, title="sibling", assignee="worker")
+        child = _running_task(conn, title="child")
+        kb.block_task(
+            conn, child,
+            reason=f"needs {sibling} first", kind="dependency",
+        )
+        assert kb.get_task(conn, child).status == "todo"
+        # Sibling still incomplete: recompute_ready must NOT re-promote.
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, child).status == "todo"
+        # Sibling completes: the card may now promote.
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (sibling,))
+        kb.claim_task(conn, sibling, claimer="worker")
+        kb.complete_task(conn, sibling, result="done")
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, child).status == "ready"
+
+
 # ---------------------------------------------------------------------------
 # Completion resets loop memory
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
TabJoy fleet card t_3136e251: dependency-block outcomes create parent links to sibling cards so recompute_ready does not re-promote blocked cards. 5+56 tests green. Branch commit b215ee0.