### PR TITLE
fix(installer): propagate --hermes-home to launchers and skills sync

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -46,6 +46,11 @@ BOLD='\033[1m'
 REPO_URL_SSH="git@github.com:NousResearch/hermes-agent.git"
 REPO_URL_HTTPS="https://github.com/NousResearch/hermes-agent.git"
 HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+# Export so child processes spawned by the installer (skills_sync.py, the
+# setup wizard's python, ...) resolve the same home instead of silently
+# falling back to the platform default. Launcher templates below also bake
+# the value in for runtime (#89231).
+export HERMES_HOME
 # INSTALL_DIR is resolved AFTER arg parsing and OS detection so we can pick an
 # FHS-style layout for root installs.  Track whether the user gave us an
 # explicit directory — if so we never override it.
@@ -1777,6 +1782,7 @@ setup_path() {
 #!/usr/bin/env bash
 unset PYTHONPATH
 unset PYTHONHOME
+export HERMES_HOME="\${HERMES_HOME:-$HERMES_HOME}"
 exec "$HERMES_BIN" "$HERMES_ENTRYPOINT" "\$@"
 EOF
     else
@@ -1784,6 +1790,7 @@ EOF
 #!/usr/bin/env bash
 unset PYTHONPATH
 unset PYTHONHOME
+export HERMES_HOME="\${HERMES_HOME:-$HERMES_HOME}"
 exec "$HERMES_BIN" "\$@"
 EOF
     fi
@@ -1800,6 +1807,7 @@ EOF
 #!/usr/bin/env bash
 unset PYTHONPATH
 unset PYTHONHOME
+export HERMES_HOME="\${HERMES_HOME:-$HERMES_HOME}"
 exec "$HERMES_BIN" "$INSTALL_DIR/run_agent.py" "\$@"
 EOF
     else
@@ -1807,6 +1815,7 @@ EOF
 #!/usr/bin/env bash
 unset PYTHONPATH
 unset PYTHONHOME
+export HERMES_HOME="\${HERMES_HOME:-$HERMES_HOME}"
 exec "$HERMES_BIN" run_agent.py "\$@"
 EOF
     fi
@@ -1825,6 +1834,7 @@ EOF
 #!/usr/bin/env bash
 unset PYTHONPATH
 unset PYTHONHOME
+export HERMES_HOME="\${HERMES_HOME:-$HERMES_HOME}"
 exec "$HERMES_BIN" "$HERMES_ENTRYPOINT" acp "\$@"
 EOF
     else
@@ -1832,6 +1842,7 @@ EOF
 #!/usr/bin/env bash
 unset PYTHONPATH
 unset PYTHONHOME
+export HERMES_HOME="\${HERMES_HOME:-$HERMES_HOME}"
 exec "$HERMES_BIN" acp "\$@"
 EOF
     fi
@@ -2000,7 +2011,7 @@ SOUL_EOF
 
     log_success "Configuration directory ready: ~/.hermes/"
 
-    # Seed bundled skills into ~/.hermes/skills/ (manifest-based, one-time per skill)
+    # Seed bundled skills into $HERMES_HOME/skills/ (manifest-based, one-time per skill)
     if [ "$NO_SKILLS" = true ]; then
         # Blank-slate install: write the opt-out marker and skip seeding.
         # skills_sync.py and `hermes update` both honor this marker, so the
@@ -2012,14 +2023,14 @@ SOUL_EOF
         log_info "Skipping bundled skills (--no-skills). Wrote $HERMES_HOME/.no-bundled-skills"
         log_info "  Future 'hermes update' runs will not inject bundled skills. Delete the marker to opt back in."
     else
-        log_info "Syncing bundled skills to ~/.hermes/skills/ ..."
+        log_info "Syncing bundled skills to $HERMES_HOME/skills/ ..."
         if "$INSTALL_DIR/venv/bin/python" "$INSTALL_DIR/tools/skills_sync.py" 2>/dev/null; then
-            log_success "Skills synced to ~/.hermes/skills/"
+            log_success "Skills synced to $HERMES_HOME/skills/"
         else
             # Fallback: simple directory copy if Python sync fails
             if [ -d "$INSTALL_DIR/skills" ] && [ ! "$(ls -A "$HERMES_HOME/skills/" 2>/dev/null | grep -v '.bundled_manifest')" ]; then
                 cp -r "$INSTALL_DIR/skills/"* "$HERMES_HOME/skills/" 2>/dev/null || true
-                log_success "Skills copied to ~/.hermes/skills/"
+                log_success "Skills copied to $HERMES_HOME/skills/"
             fi
         fi
     fi

--- a/tests/test_install_sh_hermes_home_export.py
+++ b/tests/test_install_sh_hermes_home_export.py
@@ -1,0 +1,70 @@
+"""Contract test: install.sh propagates --hermes-home end to end (#89231).
+
+``--hermes-home PATH`` used to be visible only to the installer's own
+writes: ``HERMES_HOME`` was assigned but never exported, so the
+``skills_sync.py`` child resolved the platform default, and the generated
+launchers (hermes / hermes-agent / hermes-acp) carried no home at all —
+every runtime invocation silently fell back to ``~/.hermes``. The result
+was a split-brain install: config/.env/profiles under the requested home,
+launcher and bundled skills under the platform default, with success
+messages hardcoding ``~/.hermes`` so the logs looked correct either way.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def test_hermes_home_is_exported_after_assignment() -> None:
+    text = INSTALL_SH.read_text()
+    assign = re.search(r'^HERMES_HOME="\$\{HERMES_HOME:-\$HOME/\.hermes\}"', text, re.M)
+    assert assign, "install.sh must keep the HERMES_HOME default assignment"
+    export = re.search(r"^export HERMES_HOME$", text, re.M)
+    assert export, (
+        "install.sh must export HERMES_HOME so child processes "
+        "(skills_sync.py, setup wizard) resolve the same home (#89231)"
+    )
+    assert export.start() > assign.start(), (
+        "the export must follow the default assignment (--hermes-home "
+        "reassignments later in arg parsing keep the export attribute)"
+    )
+
+
+def test_every_launcher_template_bakes_in_hermes_home() -> None:
+    """All six launcher heredocs (hermes/hermes-agent/hermes-acp, venv and
+    no-venv variants) must export the install-time home as a default that
+    the caller's environment can still override."""
+    text = INSTALL_SH.read_text()
+    templates = re.findall(
+        r'cat > "\$command_link_dir/hermes[^"]*" <<EOF\n(.*?)EOF',
+        text,
+        re.S,
+    )
+    assert len(templates) >= 6, (
+        f"expected >=6 launcher templates, found {len(templates)} — update "
+        "this test alongside any new launcher"
+    )
+    for body in templates:
+        assert 'export HERMES_HOME="\\${HERMES_HOME:-' in body, (
+            "launcher template must bake in the install-time home with "
+            "runtime override: "
+            + body.splitlines()[0]
+        )
+
+
+def test_skills_sync_messages_report_the_real_home() -> None:
+    """The sync success/info lines must print the requested home, not a
+    hardcoded ~/.hermes that looks correct for every install."""
+    text = INSTALL_SH.read_text()
+    for msg in (
+        r'log_info "Syncing bundled skills to \$HERMES_HOME/skills/ \.\.\."',
+        r'log_success "Skills synced to \$HERMES_HOME/skills/"',
+        r'log_success "Skills copied to \$HERMES_HOME/skills/"',
+    ):
+        assert re.search(msg, text), f"missing real-path message: {msg}"
+    assert 'Skills synced to ~/.hermes/skills/' not in text, (
+        "hardcoded ~/.hermes success message masks a split-brain install (#89231)"
+    )


### PR DESCRIPTION
## What does this PR do?

`install.sh --hermes-home PATH` only affected the installer's own writes: `HERMES_HOME` was assigned (and reassigned by the flag) but **never exported**, and the generated launchers baked nothing in. Two consumers silently resolved the platform default instead:

- **Bundled-skills sync** — the child Python process inherited no `HERMES_HOME`, so skills landed in `~/.hermes/skills/` regardless of the requested home, while config/.env/profiles went to the right place.
- **The `hermes` / `hermes-agent` / `hermes-acp` launchers** — no home in the script, so every runtime invocation read and wrote `~/.hermes`: the installed config was never used, with no indication anything was wrong.

The success messages hardcoded `~/.hermes/skills/`, so the log looked correct either way and could not be used to diagnose the split brain.

This PR makes the requested home propagate end to end:

- `export HERMES_HOME` right after the default assignment (bash keeps the export attribute through the `--hermes-home` reassignment in arg parsing), so every installer child process resolves the same home — matching the pattern the file already uses explicitly at the desktop-config call site.
- All six launcher heredocs (three commands × venv/no-venv) now emit `export HERMES_HOME="${HERMES_HOME:-<install-time home>}"`: the requested home is baked in as a default that the caller's environment can still override (e.g. profile switching).
- The skills-sync info/success lines print the real `$HERMES_HOME/skills/` instead of a hardcoded `~/.hermes/skills/`.

## Related Issue

Fixes #89231

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `scripts/install.sh` — `export HERMES_HOME` after the default assignment; `export HERMES_HOME="${HERMES_HOME:-$HERMES_HOME}"` added to all six launcher templates (runtime-overridable baked default); skills-sync log lines report `$HERMES_HOME/skills/`; one comment path updated to match.
- `tests/test_install_sh_hermes_home_export.py` — new contract tests: export present and after the assignment; every launcher template bakes the home in; sync messages report the real path and the hardcoded `~/.hermes` success message is gone.

## How to Test

```bash
bash -n scripts/install.sh
# Observed result: no syntax errors

python -m pytest tests/test_install_sh_hermes_home_export.py -q
# Observed result: 3 passed

python -m pytest tests/test_install_sh_install_method_stamp.py tests/test_install_sh_setup_wizard_tty_probe.py tests/test_install_sh_browser_install.py -q
# Observed result: 17 passed (existing installer contract tests unchanged)
```

Heredoc-expansion check for the launcher line (install-time bake + runtime override):

```bash
HERMES_HOME=/tmp/custom-home bash -c 'cat <<EOF
export HERMES_HOME="\${HERMES_HOME:-$HERMES_HOME}"
EOF'
# emits: export HERMES_HOME="${HERMES_HOME:-/tmp/custom-home}"
# sourcing it without HERMES_HOME in the environment resolves /tmp/custom-home;
# with HERMES_HOME already exported, the environment wins.
```

Fail-on-main check: with the installer change stashed, all three new tests fail on main (no export, no baked launcher line, hardcoded success message).

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments explain intent (why the export sits at the assignment, why the launcher default stays runtime-overridable)
- [x] Corresponding changes documented via comments
- [x] Tests added and passing (3 new; adjacent installer suites green)
- [x] Single root cause, no unrelated changes
