### PR TITLE
feat(desktop): add visible close button to pane tabs

### DIFF
--- a/apps/desktop/src/components/ui/pane-tab.test.tsx
+++ b/apps/desktop/src/components/ui/pane-tab.test.tsx
@@ -102,7 +102,28 @@ describe('PaneTab hover close button', () => {
       </PaneTab>
     )
 
-    expect(screen.getByRole('button', { name: 'Close tab' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Close' })).toBeTruthy()
+  })
+
+  it('reveals the close button for keyboard focus as well as pointer hover', () => {
+    const onClose = vi.fn()
+    render(
+      <PaneTab onClose={onClose}>
+        <PaneTabLabel>tab</PaneTabLabel>
+      </PaneTab>
+    )
+
+    expect(screen.getByRole('button', { name: 'Close' }).className).toContain('focus-visible:opacity-100')
+  })
+
+  it('retains the dirty marker on a closeable tab', () => {
+    const { container } = render(
+      <PaneTab dirty onClose={vi.fn()}>
+        <PaneTabLabel>tab</PaneTabLabel>
+      </PaneTab>
+    )
+
+    expect(container.querySelector('[data-pane-tab-dirty]')).not.toBeNull()
   })
 
   it('clicking the close button calls onClose and stops propagation', () => {
@@ -114,12 +135,42 @@ describe('PaneTab hover close button', () => {
       </PaneTab>
     )
 
-    const closeBtn = screen.getByRole('button', { name: 'Close tab' })
+    const closeBtn = screen.getByRole('button', { name: 'Close' })
     fireEvent.pointerDown(closeBtn)
     fireEvent.click(closeBtn)
     expect(onClose).toHaveBeenCalledTimes(1)
     // The tab's own pointerdown handler must NOT fire — the X is a leaf action.
     expect(onTabPointerDown).not.toHaveBeenCalled()
+  })
+
+  it('keeps the established meta-click close gesture over the close button', () => {
+    const onClose = vi.fn()
+    render(
+      <PaneTab onClose={onClose}>
+        <PaneTabLabel>tab</PaneTabLabel>
+      </PaneTab>
+    )
+
+    const closeBtn = screen.getByRole('button', { name: 'Close' })
+    fireEvent.pointerDown(closeBtn, { button: 0, metaKey: true })
+    fireEvent.click(closeBtn, { button: 0, metaKey: true })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('is focusable and closes from a keyboard-style activation click', () => {
+    const onClose = vi.fn()
+    render(
+      <PaneTab onClose={onClose}>
+        <PaneTabLabel>tab</PaneTabLabel>
+      </PaneTab>
+    )
+
+    const closeBtn = screen.getByRole('button', { name: 'Close' })
+    closeBtn.focus()
+    expect(closeBtn.ownerDocument.activeElement).toBe(closeBtn)
+
+    fireEvent.click(closeBtn, { detail: 0 })
+    expect(onClose).toHaveBeenCalledTimes(1)
   })
 
   it('does not render a close button on vertical tabs', () => {
@@ -130,7 +181,7 @@ describe('PaneTab hover close button', () => {
       </PaneTab>
     )
 
-    expect(screen.queryByRole('button', { name: 'Close tab' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Close' })).toBeNull()
   })
 
   it('does not render a close button without onClose', () => {
@@ -140,6 +191,6 @@ describe('PaneTab hover close button', () => {
       </PaneTab>
     )
 
-    expect(screen.queryByRole('button', { name: 'Close tab' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Close' })).toBeNull()
   })
 })

--- a/apps/desktop/src/components/ui/pane-tab.test.tsx
+++ b/apps/desktop/src/components/ui/pane-tab.test.tsx
@@ -92,3 +92,54 @@ describe('PaneTab close gestures', () => {
     expect(onPointerDown).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('PaneTab hover close button', () => {
+  it('renders a close button when onClose is set on a horizontal tab', () => {
+    const onClose = vi.fn()
+    render(
+      <PaneTab onClose={onClose}>
+        <PaneTabLabel>tab</PaneTabLabel>
+      </PaneTab>
+    )
+
+    expect(screen.getByRole('button', { name: 'Close tab' })).toBeTruthy()
+  })
+
+  it('clicking the close button calls onClose and stops propagation', () => {
+    const onClose = vi.fn()
+    const onTabPointerDown = vi.fn()
+    render(
+      <PaneTab onClose={onClose} onPointerDown={onTabPointerDown}>
+        <PaneTabLabel>tab</PaneTabLabel>
+      </PaneTab>
+    )
+
+    const closeBtn = screen.getByRole('button', { name: 'Close tab' })
+    fireEvent.pointerDown(closeBtn)
+    fireEvent.click(closeBtn)
+    expect(onClose).toHaveBeenCalledTimes(1)
+    // The tab's own pointerdown handler must NOT fire — the X is a leaf action.
+    expect(onTabPointerDown).not.toHaveBeenCalled()
+  })
+
+  it('does not render a close button on vertical tabs', () => {
+    const onClose = vi.fn()
+    render(
+      <PaneTab onClose={onClose} vertical>
+        <PaneTabLabel>tab</PaneTabLabel>
+      </PaneTab>
+    )
+
+    expect(screen.queryByRole('button', { name: 'Close tab' })).toBeNull()
+  })
+
+  it('does not render a close button without onClose', () => {
+    render(
+      <PaneTab>
+        <PaneTabLabel>tab</PaneTabLabel>
+      </PaneTab>
+    )
+
+    expect(screen.queryByRole('button', { name: 'Close tab' })).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/ui/pane-tab.tsx
+++ b/apps/desktop/src/components/ui/pane-tab.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 
 import { type MenuKit, renderActionItem } from '@/components/ui/actions-menu'
 import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
 import { Tip } from '@/components/ui/tooltip'
 import { translateNow } from '@/i18n'
 import { isMetaClose, middleClickHandlers } from '@/lib/middle-click'
@@ -44,8 +45,8 @@ const TAB_SELECTED =
 interface PaneTabProps extends React.ComponentProps<'div'> {
   active?: boolean
   dirty?: boolean
-  /** Close gesture, no hover X (too easy to hit on small tabs): middle-click,
-   *  or ⌘-click as the trackpad-friendly Mac equivalent. */
+  /** Close gesture: hover X on horizontal tabs, plus middle-click and ⌘-click
+   *  (the trackpad-friendly Mac equivalent). */
   onClose?: () => void
   /** Part of a multi-tab selection (⌥/Ctrl-click, Shift-click) — an accent
    *  wash marks every tab that a drag would carry, Chrome-style. */
@@ -140,7 +141,35 @@ export const PaneTab = React.forwardRef<HTMLDivElement, PaneTabProps>(function P
       {...props}
     >
       {children}
-      {dirty && (
+      {onClose && !vertical && (
+        <button
+          aria-label="Close tab"
+          className={cn(
+            'grid size-4 shrink-0 place-items-center self-center rounded-sm text-(--ui-text-tertiary) transition-opacity',
+            // Always reserve the slot; visible on hover. The dirty dot
+            // (below) yields to the X on hover so the two never overlap.
+            // Opacity transitions keep the layout stable (no width shift
+            // when the X appears).
+            'mr-1.5 opacity-0 group-hover/tab:opacity-100',
+            'hover:bg-(--ui-control-hover-background) hover:text-foreground'
+          )}
+          onClick={event => {
+            event.preventDefault()
+            event.stopPropagation()
+            onClose()
+          }}
+          onPointerDown={event => {
+            // Claim the press so the tab's drag/activate pointerdown handler
+            // can't fire — the X is a leaf action, never a drag start.
+            event.preventDefault()
+            event.stopPropagation()
+          }}
+          type="button"
+        >
+          <Codicon name="close" size="0.625rem" />
+        </button>
+      )}
+      {dirty && !(onClose && !vertical) && (
         <span
           aria-hidden
           className={cn(

--- a/apps/desktop/src/components/ui/pane-tab.tsx
+++ b/apps/desktop/src/components/ui/pane-tab.tsx
@@ -42,6 +42,12 @@ const TAB_IDLE =
 const TAB_SELECTED =
   '[background-image:linear-gradient(color-mix(in_srgb,var(--ui-accent)_14%,transparent),color-mix(in_srgb,var(--ui-accent)_14%,transparent))] text-foreground'
 
+function targetsPaneTabClose(target: EventTarget | null): boolean {
+  const element = target as Element | null
+
+  return typeof element?.closest === 'function' && Boolean(element.closest('[data-pane-tab-close]'))
+}
+
 interface PaneTabProps extends React.ComponentProps<'div'> {
   active?: boolean
   dirty?: boolean
@@ -84,6 +90,7 @@ export const PaneTab = React.forwardRef<HTMLDivElement, PaneTabProps>(function P
 ) {
   // Vertical rails only. Horizontal tabs draw no bottom border — the strip owns
   // that rule, and a per-tab border stacked a second translucent line over it.
+  const closeLabel = translateNow('common.close')
   const edge = vertical ? (side === 'right' ? 'border-l' : 'border-r') : undefined
   const middle = middleClickHandlers(onClose)
 
@@ -106,7 +113,7 @@ export const PaneTab = React.forwardRef<HTMLDivElement, PaneTabProps>(function P
         // Sites whose tab activates on the label's own onClick (the preview
         // rail) fire it AFTER our pointerdown close — swallow that stray click
         // in the capture phase so it can't re-select the just-closed tab.
-        if (onClose && isMetaClose(event)) {
+        if (onClose && isMetaClose(event) && !targetsPaneTabClose(event.target)) {
           event.preventDefault()
           event.stopPropagation()
         }
@@ -142,32 +149,44 @@ export const PaneTab = React.forwardRef<HTMLDivElement, PaneTabProps>(function P
     >
       {children}
       {onClose && !vertical && (
-        <button
-          aria-label="Close tab"
-          className={cn(
-            'grid size-4 shrink-0 place-items-center self-center rounded-sm text-(--ui-text-tertiary) transition-opacity',
-            // Always reserve the slot; visible on hover. The dirty dot
-            // (below) yields to the X on hover so the two never overlap.
-            // Opacity transitions keep the layout stable (no width shift
-            // when the X appears).
-            'mr-1.5 opacity-0 group-hover/tab:opacity-100',
-            'hover:bg-(--ui-control-hover-background) hover:text-foreground'
+        <span className="relative mr-1.5 grid size-4 shrink-0 place-items-center self-center">
+          {dirty && (
+            <span
+              aria-hidden
+              className="pointer-events-none absolute inset-0 grid place-items-center transition-opacity group-hover/tab:opacity-0 group-focus-within/tab:opacity-0"
+              data-pane-tab-dirty
+            >
+              <span className="size-2 rounded-full bg-amber-500 shadow-[0_0_0_2px_var(--tab-bg),0_1px_2px_rgba(0,0,0,0.45)] dark:bg-amber-400" />
+            </span>
           )}
-          onClick={event => {
-            event.preventDefault()
-            event.stopPropagation()
-            onClose()
-          }}
-          onPointerDown={event => {
-            // Claim the press so the tab's drag/activate pointerdown handler
-            // can't fire — the X is a leaf action, never a drag start.
-            event.preventDefault()
-            event.stopPropagation()
-          }}
-          type="button"
-        >
-          <Codicon name="close" size="0.625rem" />
-        </button>
+          <button
+            aria-label={closeLabel}
+            className={cn(
+              'absolute inset-0 grid place-items-center rounded-sm text-(--ui-text-tertiary) opacity-0 transition-opacity outline-none',
+              // The slot stays reserved so hover/focus never shifts the tab.
+              // Keyboard focus must reveal the action too: global app styles
+              // suppress native outlines, so carry the shared focus ring here.
+              'group-hover/tab:opacity-100 group-focus-within/tab:opacity-100 focus-visible:opacity-100',
+              'hover:bg-(--ui-control-hover-background) hover:text-foreground focus-visible:ring-[0.1875rem] focus-visible:ring-ring/50'
+            )}
+            data-pane-tab-close
+            onClick={event => {
+              event.preventDefault()
+              event.stopPropagation()
+              onClose()
+            }}
+            onPointerDown={event => {
+              // Claim the press so the tab's drag/activate pointerdown handler
+              // can't fire — the X is a leaf action, never a drag start.
+              event.preventDefault()
+              event.stopPropagation()
+            }}
+            title={closeLabel}
+            type="button"
+          >
+            <Codicon name="close" size="0.625rem" />
+          </button>
+        </span>
       )}
       {dirty && !(onClose && !vertical) && (
         <span
@@ -176,6 +195,7 @@ export const PaneTab = React.forwardRef<HTMLDivElement, PaneTabProps>(function P
             'pointer-events-none absolute grid size-4 place-items-center',
             vertical ? 'bottom-1.5 left-1/2 -translate-x-1/2' : 'right-1.5 top-1/2 -translate-y-1/2'
           )}
+          data-pane-tab-dirty
         >
           <span className="size-2 rounded-full bg-amber-500 shadow-[0_0_0_2px_var(--tab-bg),0_1px_2px_rgba(0,0,0,0.45)] dark:bg-amber-400" />
         </span>


### PR DESCRIPTION
## Summary

Add a conventional hover/focus **×** to closeable horizontal pane tabs, including file, artifact, and Browser previews.

Today these tabs can be closed through a context menu, middle-click, ⌘-click, or the focused-zone shortcut, but none of those paths is visible in the UI. In a preview such as an artifact source view, the visible toolbar only exposes actions like Copy and Download, so users reasonably conclude that the pane cannot be closed.

## Implementation

- Reserve a fixed-size close slot so revealing the × never changes tab width.
- Reveal the close button on pointer hover **and** keyboard focus.
- Give the button the app's focus-visible ring because global styles suppress native outlines.
- Stop ordinary pointer/click propagation so closing cannot also activate or drag the tab.
- Preserve the established ⌘-click close gesture even when the pointer is directly over the new close button.
- Keep the existing middle-click and ⌘-click gestures on the rest of the tab.
- Preserve the dirty marker in the reserved slot; it yields visually to the × on hover/focus instead of disappearing permanently.
- Use the existing localized `common.close` label for the accessible name and tooltip.
- Keep vertical collapsed rails unchanged, where an inline × does not fit their writing mode.

## Prior work / duplicate handling

This deliberately preserves Austin Pickett's original commit and authorship from #69392 by cherry-picking it rather than reimplementing the feature. That PR is currently unmergeable against `main` (`mergeable_state: dirty`) and has `maintainer_can_modify: false`, so it cannot be refreshed upstream. The follow-up commit resolves the outstanding keyboard-focus review note, preserves the dirty indicator, and includes the post-submission independent-review fix for meta-clicks over the new button.

This is complementary to #80958 / #86191, which address a separate persisted-hidden-header trap. This PR supplies the missing visible close affordance whenever the pane tab strip is present.

Supersedes #69392 while retaining its author credit.

## Verification

- `npx vitest run --project ui src/components/ui/pane-tab.test.tsx` — **14 passed**
- `npm run test:ui` — **513 files / 4,779 tests passed**
- `npm run check:lint` — **passed** (typecheck clean; 0 lint errors, existing warnings only)
- `npx prettier --check src/components/ui/pane-tab.tsx src/components/ui/pane-tab.test.tsx` — **passed**
- `git diff origin/main...HEAD --check` — **passed**

### Regression-test sabotage

With the new tests retained and `PaneTab` temporarily restored to `origin/main`, the focused test fails in four relevant cases: no accessible close button, no focus-visible close path, no retained dirty marker, and no clickable close action. Restoring the implementation returns the original suite to passing. A separate reviewer-discovered meta-click regression test failed against the first submitted revision (`0` closes) and passes after the event-routing fix (`1` close).
