### PR TITLE
fix: distinguish failed tool call argument repair

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4318,9 +4318,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         # returns "{}" for unrepairable args, which is far
                         # better than a crashed session.
                         repaired = _repair_tool_call_arguments(arguments, tool_name)
-                        if repaired != "{}":
+                        if repaired.ok:
                             # Successfully repaired — use the fixed args
-                            arguments = repaired
+                            if repaired.arguments == "{}" and arguments.strip() != "{}":
+                                has_truncated_tool_args = True
+                            arguments = repaired.arguments
                         else:
                             # Unrepairable — flag for truncation handling
                             has_truncated_tool_args = True

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -48,6 +48,7 @@ from agent.turn_context import (
 from agent.turn_retry_state import TurnRetryState
 from agent.runtime_cwd import resolve_agent_cwd
 from agent.message_sanitization import (
+    TOOL_CALL_ARGUMENTS_ERROR,
     close_interrupted_tool_sequence,
     _repair_tool_call_arguments,
     _sanitize_messages_non_ascii,
@@ -1264,12 +1265,13 @@ def _canonicalize_api_tool_calls(api_messages) -> None:
                     # stream that died mid ``write_file`` lost the file
                     # content it had already streamed, with only a WARNING
                     # to show for it (#80498).
+                    repaired = _repair_tool_call_arguments(
+                        tc["function"]["arguments"],
+                        tc["function"].get("name", "?"),
+                    )
                     tc = {**tc, "function": {
                         **tc["function"],
-                        "arguments": _repair_tool_call_arguments(
-                            tc["function"]["arguments"],
-                            tc["function"].get("name", "?"),
-                        ),
+                        "arguments": repaired.arguments,
                     }}
             new_tcs.append(tc)
         am["tool_calls"] = new_tcs
@@ -6978,12 +6980,7 @@ def run_conversation(
                         invalid_names = {name for name, _ in invalid_json_args}
                         for tc in assistant_message.tool_calls:
                             if tc.function.name in invalid_names:
-                                err = next(e for n, e in invalid_json_args if n == tc.function.name)
-                                tool_result = (
-                                    f"Error: Invalid JSON arguments. {err}. "
-                                    f"For tools with no required parameters, use an empty object: {{}}. "
-                                    f"Please retry with valid JSON."
-                                )
+                                tool_result = TOOL_CALL_ARGUMENTS_ERROR
                             else:
                                 tool_result = "Skipped: other tool call in this response had invalid JSON."
                             append_message(messages, {

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -18,7 +18,7 @@ import hashlib
 import json
 import logging
 import re
-from typing import Any
+from typing import Any, NamedTuple
 
 logger = logging.getLogger(__name__)
 
@@ -191,33 +191,51 @@ def _escape_invalid_chars_in_json_strings(raw: str) -> str:
 # the log.
 _FULL_ARGS_LOG_BOUND = 100_000
 
+TOOL_CALL_ARGUMENTS_ERROR = (
+    "Tool call arguments could not be parsed. The streamed arguments were "
+    "truncated or malformed and the tool was not executed. Retry with "
+    "complete, valid JSON arguments; if the payload is large, split it "
+    "across several smaller tool calls."
+)
 
-def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
+
+class RepairedArguments(NamedTuple):
+    arguments: str
+    ok: bool
+
+
+def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> RepairedArguments:
     """Attempt to repair malformed tool_call argument JSON.
 
     Models like GLM-5.1 via Ollama can produce truncated JSON, trailing
     commas, Python ``None``, etc.  The API proxy rejects these with HTTP 400
     "invalid tool call arguments".  This function applies common repairs;
     if all fail it returns ``"{}"`` so the request succeeds (better than
-    crashing the session).  All repairs are logged at WARNING level.
+    crashing the session). The ``ok`` flag distinguishes that fallback from
+    a legitimate empty-argument call.
     """
     raw_stripped = raw_args.strip() if isinstance(raw_args, str) else ""
 
     # Fast-path: empty / whitespace-only -> empty object
     if not raw_stripped:
         logger.warning("Sanitized empty tool_call arguments for %s", tool_name)
-        return "{}"
+        return RepairedArguments("{}", True)
 
     # Python-literal None -> normalise to {}
     if raw_stripped == "None":
         logger.warning("Sanitized Python-None tool_call arguments for %s", tool_name)
-        return "{}"
+        return RepairedArguments("{}", True)
 
     # Repair pass 0: llama.cpp backends sometimes emit literal control
     # characters (tabs, newlines) inside JSON string values. json.loads
     # with strict=False accepts these and lets us re-serialise the
     # result into wire-valid JSON without any string surgery. This is
     # the most common local-model repair case (#12068).
+    try:
+        json.loads(raw_stripped)
+        return RepairedArguments(raw_stripped, True)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        pass
     try:
         parsed = json.loads(raw_stripped, strict=False)
         reserialised = json.dumps(parsed, separators=(",", ":"))
@@ -226,7 +244,7 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
                 "Repaired unescaped control chars in tool_call arguments for %s",
                 tool_name,
             )
-        return reserialised
+        return RepairedArguments(reserialised, True)
     except (json.JSONDecodeError, TypeError, ValueError):
         pass
 
@@ -260,7 +278,7 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
             "Repaired malformed tool_call arguments for %s: %s → %s",
             tool_name, raw_stripped[:80], fixed[:80],
         )
-        return fixed
+        return RepairedArguments(fixed, True)
     except json.JSONDecodeError:
         pass
 
@@ -275,7 +293,7 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
                 "Repaired control-char-laced tool_call arguments for %s: %s → %s",
                 tool_name, raw_stripped[:80], escaped[:80],
             )
-            return escaped
+            return RepairedArguments(escaped, True)
     except (json.JSONDecodeError, TypeError, ValueError):
         pass
 
@@ -286,11 +304,11 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     # contain real user content (#80498: a truncated write_file call's
     # streamed file content).
     logger.warning(
-        "Unrepairable tool_call arguments for %s — "
+        "Unrepairable tool_call arguments for %s - "
         "replaced with empty object (was: %s)",
         tool_name, raw_stripped[:_FULL_ARGS_LOG_BOUND],
     )
-    return "{}"
+    return RepairedArguments("{}", False)
 
 
 def close_interrupted_tool_sequence(messages: list, final_response: Any = None) -> bool:
@@ -478,6 +496,8 @@ def _sanitize_structure_non_ascii(payload: Any) -> bool:
 
 
 __all__ = [
+    "RepairedArguments",
+    "TOOL_CALL_ARGUMENTS_ERROR",
     "_SURROGATE_RE",
     "close_interrupted_tool_sequence",
     "_sanitize_surrogates",

--- a/run_agent.py
+++ b/run_agent.py
@@ -180,6 +180,8 @@ from agent.message_sanitization import (  # noqa: F401
     _sanitize_messages_surrogates,
     _escape_invalid_chars_in_json_strings,
     _repair_tool_call_arguments,
+    RepairedArguments,
+    TOOL_CALL_ARGUMENTS_ERROR,
     _strip_non_ascii,
     _sanitize_messages_non_ascii,
     _sanitize_tools_non_ascii,

--- a/tests/agent/test_canon_args_memo_parity.py
+++ b/tests/agent/test_canon_args_memo_parity.py
@@ -113,7 +113,7 @@ def canonicalize_pass_OLD(api_messages):
                     tc["function"]["arguments"] = _repair_tool_call_arguments(
                         tc["function"]["arguments"],
                         tc["function"].get("name", "?"),
-                    )
+                    ).arguments
             new_tcs.append(tc)
         am["tool_calls"] = new_tcs
 

--- a/tests/agent/test_send_path_history_isolation.py
+++ b/tests/agent/test_send_path_history_isolation.py
@@ -21,6 +21,7 @@ here loudly).
 
 import copy
 import json
+import logging
 
 import agent.conversation_loop as cl
 from agent.message_sanitization import (
@@ -87,6 +88,41 @@ def _run_full_pipeline(api_messages):
 
 
 class TestSendPathNeverMutatesHistory:
+    def test_failed_repair_is_healed_once_in_send_copy(self, caplog):
+        messages = [{
+            "role": "assistant",
+            "tool_calls": [{
+                "id": "c1",
+                "type": "function",
+                "function": {"name": "write_file", "arguments": TRUNCATED_ARGS},
+            }],
+        }]
+        api_messages = _api_copy(messages)
+        with caplog.at_level(logging.WARNING, logger="agent.message_sanitization"):
+            cl._canonicalize_api_tool_calls(api_messages)
+            first_warnings = [r for r in caplog.records if "Unrepairable" in r.message]
+            cl._canonicalize_api_tool_calls(api_messages)
+            second_warnings = [r for r in caplog.records if "Unrepairable" in r.message]
+
+        assert api_messages[0]["tool_calls"][0]["function"]["arguments"] == "{}"
+        assert len(first_warnings) == 1
+        assert len(second_warnings) == 1
+
+    def test_valid_arguments_remain_structurally_equal_after_repair(self):
+        messages = [{
+            "role": "assistant",
+            "tool_calls": [{
+                "id": "c1",
+                "type": "function",
+                "function": {"name": "read_file", "arguments": VALID_ARGS},
+            }],
+        }]
+        api_messages = _api_copy(messages)
+        cl._canonicalize_api_tool_calls(api_messages)
+        assert json.loads(
+            api_messages[0]["tool_calls"][0]["function"]["arguments"]
+        ) == json.loads(VALID_ARGS)
+
     def test_full_pipeline_leaves_history_byte_identical(self):
         history = _adversarial_history()
         before = copy.deepcopy(history)

--- a/tests/run_agent/test_repair_tool_call_arguments.py
+++ b/tests/run_agent/test_repair_tool_call_arguments.py
@@ -1,7 +1,11 @@
 """Tests for _repair_tool_call_arguments — malformed JSON repair pipeline."""
 
 import json
+import logging
 
+import pytest
+
+from agent.message_sanitization import RepairedArguments
 from run_agent import _repair_tool_call_arguments
 
 
@@ -11,7 +15,13 @@ class TestRepairToolCallArguments:
     # -- Stage 1: empty / whitespace-only --
 
     def test_empty_string_returns_empty_object(self):
-        assert _repair_tool_call_arguments("", "t") == "{}"
+        assert _repair_tool_call_arguments("", "t") == RepairedArguments("{}", True)
+
+    @pytest.mark.parametrize("raw", ["", "  \n\t", "{}"])
+    def test_empty_arguments_are_successful(self, raw):
+        result = _repair_tool_call_arguments(raw, "t")
+        assert result.arguments == "{}"
+        assert result.ok is True
 
 
 
@@ -24,8 +34,14 @@ class TestRepairToolCallArguments:
 
     def test_trailing_comma_in_array(self):
         result = _repair_tool_call_arguments('{"a": [1, 2,]}', "t")
-        parsed = json.loads(result)
+        assert result.ok is True
+        parsed = json.loads(result.arguments)
         assert parsed == {"a": [1, 2]}
+
+    def test_valid_arguments_are_byte_identical(self):
+        raw = '{"query":"café","n":1}'
+        result = _repair_tool_call_arguments(raw, "t")
+        assert result == RepairedArguments(raw, True)
 
 
     # -- Stage 4: unclosed brackets --
@@ -39,9 +55,15 @@ class TestRepairToolCallArguments:
     # -- Stage 6: last resort --
 
 
-    def test_unrepairable_partial_returns_empty_object(self):
+    def test_unrepairable_partial_returns_empty_object_and_warns(self, caplog):
         # Truncated in the middle of a string key — bracket closing won't help
-        assert _repair_tool_call_arguments('{"truncated": "val', "t") == "{}"
+        raw = '{"truncated": "val'
+        with caplog.at_level(logging.WARNING, logger="agent.message_sanitization"):
+            result = _repair_tool_call_arguments(raw, "t")
+        assert result == RepairedArguments("{}", False)
+        warnings = [record for record in caplog.records if "Unrepairable" in record.message]
+        assert len(warnings) == 1
+        assert raw in warnings[0].message
 
     # -- Valid JSON passthrough (this path is via except, but still works) --
 
@@ -59,5 +81,3 @@ class TestRepairToolCallArguments:
 
 
     # -- Stage 4: control-char escape fallback --
-
-

--- a/tests/run_agent/test_streaming_tool_call_repair.py
+++ b/tests/run_agent/test_streaming_tool_call_repair.py
@@ -31,7 +31,7 @@ class TestStreamingAssemblyRepair:
         """Model stops mid-JSON, common with output length limits."""
         raw = '{"command": "ls -la", "timeout": 30'
         result = _repair_tool_call_arguments(raw, "terminal")
-        parsed = json.loads(result)
+        parsed = json.loads(result.arguments)
         assert parsed["command"] == "ls -la"
         assert parsed["timeout"] == 30
 
@@ -47,7 +47,7 @@ class TestStreamingAssemblyRepair:
     # -- Empty arguments (some models emit empty string) --
 
     def test_empty_string(self):
-        assert _repair_tool_call_arguments("", "test") == "{}"
+        assert _repair_tool_call_arguments("", "test").arguments == "{}"
 
 
     # -- Already-valid JSON passes through unchanged --
@@ -57,5 +57,4 @@ class TestStreamingAssemblyRepair:
 
 
     # -- Real-world GLM-5.1 truncation pattern --
-
 


### PR DESCRIPTION
## Summary

Fixes #89207

When a streamed `tool_call` carries truncated or malformed `arguments`, `_repair_tool_call_arguments` runs four repair passes and, on failure, returns `"{}"`. Callers had no way to distinguish "repair failed" from "the model legitimately called with no arguments", which caused two failure modes:

1. **Legit empty calls treated as truncation.** An empty arguments string repairs to `"{}"`, which the streaming path compared against `"{}"` and flagged as truncation (`has_truncated_tool_args = True`), sending the turn into the output-length handling and, after retries, killing the session with "Response truncated due to output length limit" for a call that never needed arguments.
2. **Silent no-op on the send path.** The canonicalize pass could only record `"{}"` in the send-path message copy, so an unrepairable call looked like a successful no-argument call in the transcript, and the poisoned turn was re-healed on every subsequent request (39+ healings observed in one session).

This PR makes repair failure explicit:

- `_repair_tool_call_arguments` now returns a `RepairedArguments` named tuple: `arguments` is always wire-safe JSON text (still `"{}"` on failure) and `ok` is `False` only when the raw input was non-empty and all repair passes failed.
- The streaming path branches on `ok` instead of string comparison, so genuinely empty calls (valid no-argument invocations) are no longer misrouted to the truncation/length handler, while repair failures still flag `has_truncated_tool_args` and take the existing honest path (refuse to execute, partial-stream stub or length handling with retries).
- The send-path canonicalizer keeps the wire-safe `"{}"` (copy-on-write; stored history is untouched) and the bounded WARNING log remains the sole surviving copy of the original truncated bytes (the #80498 contract is preserved).
- The invalid-JSON recovery tool result is now a single shared constant (`TOOL_CALL_ARGUMENTS_ERROR`) so the message stays consistent across call sites.

Behavior change to note: empty-argument tool calls no longer trip the truncation handler; unrepairable truncated calls keep the existing refusal-and-retry behavior instead of silently executing with no arguments.

Streaming-timeout capping and large-payload spill are deliberately out of scope (client-side capping recreates truncation); follow-up in #89245.
