### PR TITLE
fix(api_server): hide [System: ...] scaffolding rows from session messages

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7868,11 +7868,26 @@ def run_conversation(
                     final_response = _join_truncated_parts([*truncated_response_parts, final_response])
                     truncated_response_parts = []
                     length_continue_retries = 0
-                    # The continuation recovered, so the fragments stay in the transcript.
-                    for _frag in messages:
-                        if isinstance(_frag, dict):
-                            _frag.pop("_length_continuation_fragment", None)
-                            _frag.pop("_length_continuation_nudge", None)
+                    # The continuation recovered and the content is already
+                    # folded into final_response via truncated_response_parts.
+                    # Strip the trailing scaffolding pair (interim assistant
+                    # fragment + [System: ...] continuation nudge) so the
+                    # transcript doesn't carry an assistant->assistant
+                    # adjacency that models treat as a real user turn on the
+                    # next query.  Only strip the trailing-most pair;
+                    # multiple previous recovery rounds are each cleaned up
+                    # as the success path reaches this point.
+                    if (
+                        len(messages) >= 2
+                        and isinstance(messages[-1], dict)
+                        and isinstance(messages[-2], dict)
+                        and messages[-1].get("role") == "user"
+                        and isinstance(messages[-1].get("content"), str)
+                        and messages[-1]["content"].lstrip().startswith("[System:")
+                        and messages[-2].get("role") == "assistant"
+                    ):
+                        messages.pop()
+                        messages.pop()
                 
                 final_response = agent._strip_think_blocks(final_response).strip()
                 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -215,6 +215,49 @@ def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
         return default
 
 
+def _message_text_for_display(content: Any) -> str:
+    """Coerce a message ``content`` (str / list / dict) into plain text.
+
+    Mirrors ``tui_gateway.server._coerce_message_text``: provider-side content
+    may be a plain string, a list of multimodal parts, or a structured dict.
+    List/dict shapes are flattened so display projections (like
+    ``_is_display_hidden_marker``) can sniff the text reliably without
+    crashing on non-string content.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "\n".join(
+            _message_text_for_display(part.get("text") if isinstance(part, dict) else part)
+            for part in content
+        )
+    if isinstance(content, dict):
+        text = content.get("text")
+        if isinstance(text, str):
+            return text
+        image = content.get("image_url")
+        if isinstance(image, dict):
+            return str(image.get("url") or "")
+        if isinstance(image, str):
+            return image
+        return ""
+    return str(content)
+
+
+def _is_display_hidden_marker(role: Any, text: str) -> bool:
+    """Return True when a persisted row is model-facing scaffolding, not a user turn.
+
+    Mirrors ``tui_gateway.server._is_display_hidden_marker``: gateway
+    bookkeeping notices (model-switch, personality, continuation nudges) are
+    persisted as ``role=user`` ``[System: …]`` rows so strict providers accept
+    them mid-history.  They are runtime metadata, not user turns, and must not
+    render as a user bubble in any client transcript (desktop, TUI, CLI, web).
+    """
+    return role == "user" and text.lstrip().startswith("[System:")
+
+
 _TRUE_REQUEST_BOOL_STRINGS = frozenset({"1", "true", "yes", "on"})
 _FALSE_REQUEST_BOOL_STRINGS = frozenset({"0", "false", "no", "off"})
 
@@ -3662,15 +3705,32 @@ class APIServerAdapter(BasePlatformAdapter):
             offset=offset,
             latest=latest_page,
         )
+        # Display projection: model-facing scaffolding rows (continuation
+        # nudges, model-switch/personality notices, compaction checkpoints)
+        # are persisted as role=user "[System: …]" rows (or carry an explicit
+        # display_kind="hidden") so strict providers accept them mid-history.
+        # They are runtime metadata, not user turns — never render them as
+        # user bubbles. Mirrors tui_gateway.server._history_to_messages.
+        visible = []
+        for m in messages:
+            if not isinstance(m, dict):
+                continue
+            if m.get("display_kind") == "hidden":
+                continue
+            if _is_display_hidden_marker(
+                m.get("role"), _message_text_for_display(m.get("content"))
+            ):
+                continue
+            visible.append(m)
         return web.json_response({
             "object": "list",
             "session_id": resolved_id,
-            "data": [self._message_response(m) for m in messages],
+            "data": [self._message_response(m) for m in visible],
             "pagination": {
                 "limit": limit,
                 "offset": offset,
                 "order": order or ("latest" if default_page else "oldest"),
-                "returned": len(messages),
+                "returned": len(visible),
             },
         })
 

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -117,6 +117,58 @@ async def test_session_messages_default_to_latest_bounded_page(adapter, session_
 
 
 @pytest.mark.asyncio
+async def test_session_messages_hide_display_scaffolding(adapter, session_db):
+    """[System: ...] continuation nudges / display_kind=hidden rows never render."""
+    session_id = session_db.create_session("hidden-scaffolding", "api_server")
+    session_db.replace_messages(
+        session_id,
+        [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+            {
+                "role": "user",
+                "content": (
+                    "[System: Your previous response was truncated by the output "
+                    "length limit. Continue exactly where you left off. Do not "
+                    "restart or repeat prior text. Finish the answer directly.]"
+                ),
+            },
+            {"role": "assistant", "content": "the rest of the answer"},
+            {
+                "role": "user",
+                "content": "[System: The previous response was cut off by a network error mid-stream.]",
+            },
+            {"role": "assistant", "content": "more"},
+            {"role": "user", "content": "next question"},
+            {"role": "user", "content": "hidden row", "display_kind": "hidden"},
+            {"role": "assistant", "content": "final"},
+        ],
+    )
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.get(f"/api/sessions/{session_id}/messages")
+        assert resp.status == 200
+        payload = await resp.json()
+
+    rendered = [m["content"] for m in payload["data"]]
+    assert rendered == [
+        "hello",
+        "hi",
+        "the rest of the answer",
+        "more",
+        "next question",
+        "final",
+    ]
+    # No user bubble may ever carry a [System: ...] scaffolding marker.
+    assert not any(
+        m["role"] == "user" and str(m.get("content", "")).lstrip().startswith("[System:")
+        for m in payload["data"]
+    )
+    assert "hidden row" not in rendered
+
+
+@pytest.mark.asyncio
 async def test_run_agent_binds_api_session_context_for_tool_env(adapter, monkeypatch):
     """API-server request sessions should reach tools and terminal subprocess env."""
     monkeypatch.setenv("HERMES_SESSION_ID", "stale-session")


### PR DESCRIPTION
## Problem

When the model's output is truncated (output-length limit, network stall, mid-tool timeout), the recovery loop appends an **interim assistant fragment** + a `[System: ...]` **continuation nudge** (`role=user`) to `messages` to drive the retry. On the recovered path, these scaffolding rows **stayed in the transcript** — the flag-strip loop (`_length_continuation_fragment`/`_nudge`) only removed metadata tags, not the actual messages.

The result: on the next user turn, the model sees an assistant→assistant adjacency (the interim fragment is a partial answer, and the `[System: ...]` row is a user message), which it treats as a real user turn — producing a phantom response bubble that the user must dismiss with "go".

## Fix

Strip the trailing scaffolding **pair** (interim assistant + `[System: ...]` user nudge) from `messages` after the continuation succeeds, before appending `final_msg`. The text is already folded into `final_response` via `truncated_response_parts`, so removing the raw scaffolding rows is safe and fixes the transcript.

Only the trailing-most pair is stripped — multiple previous recovery rounds (rare) are each cleaned up as the success path reaches this point.

Also removes the old `_length_continuation_fragment`/`_nudge` flag-strip loop (which left the actual messages in place and was the root cause of the stale transcript).

## Display-layer guard (api_server.py)

Even with the persist-layer fix, a crash/interrupt mid-persist can leave a `[System: ...]` row in the transcript. The api_server session-messages endpoint now filters `role=user` rows starting with `[System:` (plus `display_kind=hidden`), mirroring `tui_gateway.server._is_display_hidden_marker` — a defense-in-depth display filter.

## Tests

`tests/gateway/test_session_api.py::test_session_messages_hide_display_scaffolding` — seeds a session with continuation nudges + a `display_kind=hidden` row and asserts they never appear in the response.

```
21 passed
```