### PR TITLE
docs: surface Bot Mode in docs landing paths

### DIFF
--- a/website/docs/getting-started/learning-path.md
+++ b/website/docs/getting-started/learning-path.md
@@ -80,6 +80,16 @@ Schedule recurring tasks, run batch jobs, or chain agent actions together.
 Cron jobs let Hermes Agent run tasks on a schedule — daily summaries, periodic checks, automated reports — without you being present.
 :::
 
+### "I want a team of specialist Bots"
+
+Create named Bots with their own model, memory, skills, routines, and chats, then bring them together in group chats or through `@mentions`.
+
+1. [Desktop](/user-guide/desktop)
+2. [Profiles](/user-guide/profiles)
+3. [Bot Mode](/user-guide/bot-mode)
+4. [Cron Scheduling](/user-guide/features/cron)
+5. [Multi-connection Desktop](/user-guide/multi-connection-desktop)
+
 ### "I want to build custom tools/skills"
 
 Extend Hermes Agent with your own tools and reusable skill packages.
@@ -132,6 +142,7 @@ Not sure what's available? Here's a quick directory of major features:
 | **Tools** | Built-in tools the agent can call (file I/O, search, shell, etc.) | [Tools](/user-guide/features/tools) |
 | **Skills** | Installable plugin packages that add new capabilities | [Skills](/user-guide/features/skills) |
 | **Memory** | Persistent memory across sessions | [Memory](/user-guide/features/memory) |
+| **Bot Mode** | Named specialist Bots with persistent chats, routines, group chats, and `@mentions` | [Bot Mode](/user-guide/bot-mode) |
 | **Context Files** | Feed files and directories into conversations | [Context Files](/user-guide/features/context-files) |
 | **MCP** | Connect to external tool servers via Model Context Protocol | [MCP](/user-guide/features/mcp) |
 | **Cron** | Schedule recurring agent tasks | [Cron](/user-guide/features/cron) |

--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -35,6 +35,18 @@ The self-improving AI agent built by [Nous Research](https://nousresearch.com). 
   >
     Get Started →
   </Link>
+  <Link
+    to="/user-guide/bot-mode"
+    style={{
+      display: "inline-block",
+      padding: "0.6rem 1.2rem",
+      border: "1px solid rgba(255,215,0,0.2)",
+      borderRadius: "8px",
+      textDecoration: "none",
+    }}
+  >
+    Explore Bot Mode
+  </Link>
   <a
     href="https://hermes-agent.nousresearch.com/"
     style={{
@@ -104,6 +116,7 @@ It's not a coding copilot tethered to an IDE or a chatbot wrapper around a singl
 | 🗺️ **[Learning Path](/getting-started/learning-path)**                  | Find the right docs for your experience level                         |
 | ⚙️ **[Configuration](/user-guide/configuration)**                       | Config file, providers, models, and options                           |
 | 💬 **[Messaging Gateway](/user-guide/messaging)**                       | Set up Telegram, Discord, Slack, WhatsApp, Teams, or more             |
+| 🤖 **[Bot Mode](/user-guide/bot-mode)**                                | Named Bots with their own model, memory, skills, routines, and chats  |
 | 🔧 **[Tools & Toolsets](/user-guide/features/tools)**                   | 60+ built-in tools and how to configure them                          |
 | 🧠 **[Memory System](/user-guide/features/memory)**                     | Persistent memory that grows across sessions                          |
 | 📚 **[Skills System](/user-guide/features/skills)**                     | Procedural memory the agent creates and reuses                        |
@@ -125,6 +138,7 @@ It's not a coding copilot tethered to an IDE or a chatbot wrapper around a singl
 - **Lives where you do** — CLI, Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Mattermost, Email, SMS, DingTalk, Feishu, WeCom, Weixin, QQ Bot, Yuanbao, BlueBubbles, Home Assistant, Microsoft Teams, Google Chat, and more — 20+ platforms from one gateway
 - **Built by model trainers** — Created by [Nous Research](https://nousresearch.com), the lab behind Hermes, Nomos, and Psyche. Works with [Nous Portal](https://portal.nousresearch.com), [OpenRouter](https://openrouter.ai), OpenAI, or any endpoint
 - **Scheduled automations** — Built-in cron with delivery to any platform
+- **[Bot Mode](/user-guide/bot-mode)** — Build a durable team of specialist Bots that work together in group chats and through `@mentions`
 - **Delegates & parallelizes** — Spawn isolated subagents for parallel workstreams. Programmatic Tool Calling via `execute_code` collapses multi-step pipelines into single inference calls
 - **Open standard skills** — Compatible with [agentskills.io](https://agentskills.io). Skills are portable, shareable, and community-contributed via the Skills Hub
 - **Full web control** — Search, extract, browse, vision, image generation, TTS — one subscription via [Nous Portal](/integrations/nous-portal) bundles all of them


### PR DESCRIPTION
## Summary

- add a top-level Bot Mode CTA to the documentation home page
- add Bot Mode to Quick Links and Key Features
- add a specialist-Bot use case and feature-table entry to the Learning Path

## Why

Bot Mode ships built into Hermes Desktop and already has a detailed guide, but users cannot discover it from the documentation landing page or Learning Path.

Related root-homepage request: https://github.com/NousResearch/hermes-agent/issues/89251.

## Validation

- `npx --yes npm@11.17.0 ci --prefer-offline --no-audit --fund=false` ✅
- `npx --yes npm@11.17.0 run build:fast` ✅
- generated HTML assertions for the CTA, Bot Mode target page, and all 5 Learning Path routes ✅
- local production server returned HTTP 200 for `/docs/` and `/docs/user-guide/bot-mode` ✅
- 390 px and desktop screenshots reviewed; no clipping or horizontal overflow from the new content ✅
- `git diff --check` ✅

## Independent review

- read-only quality challenge: PASS, 9.5/10
- objective product defects: none
- exact product corrections requested: none
- reviewed process risk (accidental `.helix` staging) was mitigated by explicit 2-file staging and cached-diff readback

## Existing upstream tool failures

These reproduce from the current lockfile/config and are outside this 2-file documentation patch:

- `npm run typecheck` stops with `TS5101` because TypeScript 6.0.3 rejects the inherited Docusaurus `baseUrl` without `ignoreDeprecations`
- `npm run lint:diagrams` cannot start because the `ascii-guard` command is not declared in the website dependencies and is unavailable from npm
- the English Docusaurus build reports existing broken-link warnings for `/docs/llms.txt` and `/docs/llms-full.txt`, then completes successfully

## Scope

Only these product files change:

- `website/docs/index.mdx`
- `website/docs/getting-started/learning-path.md`
