### PR TITLE
fix(tls): select certifi before macOS clients

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1831,60 +1831,7 @@ def _collect_history_media_paths(agent_history: List[Dict[str, Any]]) -> set:
                         break
     return paths
 
-# ---------------------------------------------------------------------------
-# SSL certificate auto-detection for NixOS and other non-standard systems.
-# Must run BEFORE any HTTP library (discord, aiohttp, etc.) is imported.
-# ---------------------------------------------------------------------------
-def _ensure_ssl_certs() -> None:
-    """Set SSL_CERT_FILE if the system doesn't expose CA certs to Python.
-
-    Windows startup paths (Desktop, Scheduled Tasks, installer children) can
-    occasionally inherit a stale SSL_CERT_FILE. Returning just because the
-    variable is present makes every later httpx/OpenAI client construction fail
-    with FileNotFoundError from ssl.load_verify_locations(). Treat a missing
-    path as unset and fall back to certifi instead.
-    """
-    configured_cert = os.environ.get("SSL_CERT_FILE")
-    if configured_cert:
-        if os.path.exists(configured_cert):
-            return  # user already configured it to a real file
-        logging.getLogger(__name__).warning(
-            "Ignoring stale SSL_CERT_FILE=%r because the path does not exist",
-            configured_cert,
-        )
-        os.environ.pop("SSL_CERT_FILE", None)
-
-    import ssl
-
-    # 1. Python's compiled-in defaults
-    paths = ssl.get_default_verify_paths()
-    for candidate in (paths.cafile, paths.openssl_cafile):
-        if candidate and os.path.exists(candidate):
-            os.environ["SSL_CERT_FILE"] = candidate
-            return
-
-    # 2. certifi (ships its own Mozilla bundle)
-    try:
-        import certifi
-        os.environ["SSL_CERT_FILE"] = certifi.where()
-        return
-    except ImportError:
-        pass
-
-    # 3. Common distro / macOS locations
-    for candidate in (
-        "/etc/ssl/certs/ca-certificates.crt",               # Debian/Ubuntu/Gentoo
-        "/etc/pki/tls/certs/ca-bundle.crt",                 # RHEL/CentOS 7
-        "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", # RHEL/CentOS 8+
-        "/etc/ssl/ca-bundle.pem",                            # SUSE/OpenSUSE
-        "/etc/ssl/cert.pem",                                 # Alpine / macOS
-        "/etc/pki/tls/cert.pem",                             # Fedora
-        "/usr/local/etc/openssl@1.1/cert.pem",               # macOS Homebrew Intel
-        "/opt/homebrew/etc/openssl@1.1/cert.pem",            # macOS Homebrew ARM
-    ):
-        if os.path.exists(candidate):
-            os.environ["SSL_CERT_FILE"] = candidate
-            return
+from hermes_cli.ssl_certs import ensure_ssl_certs as _ensure_ssl_certs
 
 def _home_target_env_var(platform_name: str) -> str:
     """Return the configured home-target env var for a platform.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -708,6 +708,10 @@ load_hermes_dotenv(
     load_external_secrets=sys.argv[1:2] != ["update"],
 )
 
+from hermes_cli.ssl_certs import ensure_ssl_certs as _ensure_ssl_certs
+
+_ensure_ssl_certs()
+
 # Bridge security.redact_secrets from config.yaml → HERMES_REDACT_SECRETS env
 # var BEFORE hermes_logging imports agent.redact (which snapshots the flag at
 # module-import time). Without this, config.yaml's toggle is ignored because

--- a/hermes_cli/ssl_certs.py
+++ b/hermes_cli/ssl_certs.py
@@ -1,0 +1,65 @@
+"""Process-wide CA bundle selection for Hermes entry points."""
+
+from __future__ import annotations
+
+import logging
+import os
+import ssl
+import sys
+
+logger = logging.getLogger(__name__)
+
+
+def _certifi_bundle() -> str | None:
+    try:
+        import certifi
+    except ImportError:
+        return None
+
+    bundle = certifi.where()
+    return bundle if os.path.exists(bundle) else None
+
+
+def ensure_ssl_certs() -> None:
+    """Set ``SSL_CERT_FILE`` when Hermes must choose the process default."""
+    configured_cert = os.environ.get("SSL_CERT_FILE")
+    if configured_cert:
+        if os.path.exists(configured_cert):
+            return
+        logger.warning(
+            "Ignoring stale SSL_CERT_FILE=%r because the path does not exist",
+            configured_cert,
+        )
+        os.environ.pop("SSL_CERT_FILE", None)
+
+    certifi_bundle = _certifi_bundle()
+    if sys.platform == "darwin" and certifi_bundle:
+        os.environ["SSL_CERT_FILE"] = certifi_bundle
+        return
+
+    paths = ssl.get_default_verify_paths()
+    for candidate in (paths.cafile, paths.openssl_cafile):
+        if candidate and os.path.exists(candidate):
+            os.environ["SSL_CERT_FILE"] = candidate
+            return
+
+    if certifi_bundle:
+        os.environ["SSL_CERT_FILE"] = certifi_bundle
+        return
+
+    for candidate in (
+        "/etc/ssl/certs/ca-certificates.crt",
+        "/etc/pki/tls/certs/ca-bundle.crt",
+        "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
+        "/etc/ssl/ca-bundle.pem",
+        "/etc/ssl/cert.pem",
+        "/etc/pki/tls/cert.pem",
+        "/usr/local/etc/openssl@1.1/cert.pem",
+        "/opt/homebrew/etc/openssl@1.1/cert.pem",
+    ):
+        if os.path.exists(candidate):
+            os.environ["SSL_CERT_FILE"] = candidate
+            return
+
+
+__all__ = ["ensure_ssl_certs"]

--- a/tests/gateway/test_ssl_cert_detection.py
+++ b/tests/gateway/test_ssl_cert_detection.py
@@ -1,15 +1,17 @@
 """Regression tests for gateway SSL certificate environment repair."""
 
+import os
+import ssl
+import sys
 from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli.ssl_certs import ensure_ssl_certs
 
 
 def test_ensure_ssl_certs_ignores_stale_ssl_cert_file(monkeypatch, tmp_path):
     """A missing SSL_CERT_FILE should be treated as unset, not trusted."""
-    import ssl
-    import sys
-
-    from gateway.run import _ensure_ssl_certs
-
     cert_file = tmp_path / "cacert.pem"
     cert_file.write_text("dummy cert bundle", encoding="utf-8")
     stale_file = tmp_path / "missing.pem"
@@ -26,9 +28,44 @@ def test_ensure_ssl_certs_ignores_stale_ssl_cert_file(monkeypatch, tmp_path):
         SimpleNamespace(where=lambda: str(cert_file)),
     )
 
-    _ensure_ssl_certs()
+    ensure_ssl_certs()
 
     assert stale_file.exists() is False
-    assert __import__("os").environ["SSL_CERT_FILE"] == str(cert_file)
+    assert os.environ["SSL_CERT_FILE"] == str(cert_file)
 
 
+def test_ensure_ssl_certs_preserves_configured_bundle(monkeypatch, tmp_path):
+    configured_bundle = tmp_path / "corporate-ca.pem"
+    configured_bundle.write_text("configured bundle", encoding="utf-8")
+    monkeypatch.setenv("SSL_CERT_FILE", str(configured_bundle))
+
+    ensure_ssl_certs()
+
+    assert os.environ["SSL_CERT_FILE"] == str(configured_bundle)
+
+
+@pytest.mark.macos_only
+def test_ensure_ssl_certs_prefers_certifi_to_compiled_macos_bundle(
+    monkeypatch,
+    tmp_path,
+):
+    import certifi
+
+    system_bundle = tmp_path / "system-cert.pem"
+    system_bundle.write_text("incomplete system bundle", encoding="utf-8")
+    certifi_bundle = tmp_path / "certifi.pem"
+    certifi_bundle.write_text("certifi bundle", encoding="utf-8")
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    monkeypatch.setattr(
+        ssl,
+        "get_default_verify_paths",
+        lambda: SimpleNamespace(
+            cafile=str(system_bundle),
+            openssl_cafile=str(system_bundle),
+        ),
+    )
+    monkeypatch.setattr(certifi, "where", lambda: str(certifi_bundle))
+
+    ensure_ssl_certs()
+
+    assert os.environ["SSL_CERT_FILE"] == str(certifi_bundle)

--- a/tests/hermes_cli/test_ssl_cert_startup.py
+++ b/tests/hermes_cli/test_ssl_cert_startup.py
@@ -1,0 +1,65 @@
+"""Behavior coverage for CLI certificate initialization order."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.macos_only
+def test_cli_startup_selects_certifi_before_https_context(tmp_path):
+    env = os.environ.copy()
+    for name in (
+        "HERMES_CA_BUNDLE",
+        "SSL_CERT_FILE",
+        "REQUESTS_CA_BUNDLE",
+        "CURL_CA_BUNDLE",
+    ):
+        env.pop(name, None)
+    env["HOME"] = str(tmp_path)
+    env["HERMES_HOME"] = str(tmp_path / ".hermes")
+
+    code = """
+import hashlib
+import http.client
+import os
+from pathlib import Path
+import urllib.request
+
+import certifi
+import hermes_cli.main
+
+selected = Path(os.environ["SSL_CERT_FILE"]).resolve()
+expected_path = Path(certifi.where()).resolve()
+assert selected == expected_path
+
+handler = next(
+    item
+    for item in urllib.request.build_opener().handlers
+    if type(item) is urllib.request.HTTPSHandler
+)
+context = handler._context
+if context is None:
+    context = http.client.HTTPSConnection("example.invalid")._context
+
+expected_context = __import__("ssl").create_default_context(cafile=str(expected_path))
+fingerprints = lambda value: {
+    hashlib.sha256(cert).digest() for cert in value.get_ca_certs(binary_form=True)
+}
+assert fingerprints(context) == fingerprints(expected_context)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

- Select Hermes's pinned certifi CA bundle as the process default on macOS before Desktop or CLI networking clients are created.
- Preserve valid operator-provided `SSL_CERT_FILE` values and the existing non-macOS certificate search order.
- Centralize the existing gateway bootstrap in one lightweight helper and cover real startup behavior on Python 3.11 and 3.13.

## Motivation

Hermes Desktop could return no Actual models and fail Responses calls because startup selected Python's compiled `/private/etc/ssl/cert.pem` before certifi on macOS. That bundle could not validate the Actual relay certificate.

Setting `SSL_CERT_FILE` to the installed certifi path in `.env` proves the root cause, but that workaround embeds a username, install location, virtual-environment layout, and Python version. Hermes should select its installed bundle itself.

## Links

- Linear: [E-998](https://linear.app/actualcomputer/issue/E-998/hermes-desktop-shows-no-models-for-actual-provider-urllib-catalog)
- Related fix: #86492
- Prior implementation: #83554
- Downstream consumer: [actual-computer/actual-computer-monorepo#3283](https://github.com/actual-computer/actual-computer-monorepo/pull/3283)

## Approach

1. Move the existing process-level certificate bootstrap from `gateway.run` into `hermes_cli.ssl_certs` so CLI and gateway entry points share one policy.
2. Keep an existing valid `SSL_CERT_FILE` authoritative and continue repairing stale paths.
3. On macOS only, prefer certifi before Python's compiled OpenSSL cafile; keep the established order everywhere else.
4. Run the helper immediately after profile dotenv loading in the CLI, before Desktop clients construct urllib or httpx/OpenAI TLS contexts.
5. Exercise a real macOS CLI import in a subprocess and compare the resulting HTTPS context's CA fingerprints with certifi. The same behavior test passes under Python 3.11 and Python 3.13 without faking `sys.platform` or mutating private opener state.

Local verification passed 24 focused regression tests on Python 3.11 and the four changed certificate tests on Python 3.13. A live Actual smoke test selected certifi, discovered 27 models through urllib, and completed a Responses request through OpenAI/httpx with `TLS_OK`.

## Reviewer Focus

- Confirm the process default is selected after dotenv but before network clients are created.
- Confirm a valid operator-supplied `SSL_CERT_FILE` remains authoritative.
- Confirm non-macOS certificate selection is behavior-preserving.
- Confirm the startup test would fail if Python 3.13 eagerly captured the wrong CA context.

## Failure Modes

- If certifi is unavailable or its bundle is missing, macOS falls through to the existing compiled and common-path discovery behavior without disabling TLS verification.
- A stale `SSL_CERT_FILE` is logged, removed, and replaced through normal discovery.
- A valid explicit `SSL_CERT_FILE`, including a corporate CA bundle, is left unchanged.
- Platforms without certifi retain their previous system-bundle fallback behavior.

## Breaking Changes

None.

## Post-Merge Behavior

Merging triggers upstream CI and normal release processing only; it does not deploy Actual infrastructure. Source installs and the next Hermes release containing the merge automatically use certifi as the macOS process default. Downstream immutable pins, including Actual PR #3283, must be updated separately after this PR merges.

## Diagrams

```mermaid
flowchart LR
    D[Hermes Desktop or CLI] --> E[Load profile dotenv]
    E --> S[Select process CA]
    S -->|valid SSL_CERT_FILE| C[Operator CA]
    S -->|macOS default| B[Installed certifi bundle]
    C --> U[urllib and httpx/OpenAI clients]
    B --> U
    U --> A[Actual models and Responses endpoints]
```
