### PR TITLE
fix(compaction): re-arm the preflight gate when the request outgrows its verdict

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -41,6 +41,7 @@ from agent.error_classifier import FailoverReason, classify_api_error
 from agent.message_metadata import append_message
 from agent.turn_context import (
     _compression_warrants_another_preflight_pass,
+    _preflight_block_outlived_its_request,
     build_turn_context,
     compose_user_api_content,
     reanchor_current_turn_user_idx,
@@ -1861,6 +1862,7 @@ def run_conversation(
     max_compression_attempts = getattr(agent, "max_compression_attempts", 3)
     _last_preflight_pressure: Optional[int] = None
     _preflight_compression_blocked = _ctx.preflight_compression_blocked
+    _preflight_blocked_at_tokens = _ctx.preflight_blocked_at_tokens
     _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
     # Last composed answer intentionally held back by a verification gate. If
     # that continuation consumes the remaining budget, this is the best
@@ -2495,6 +2497,20 @@ def run_conversation(
         # system text.
         _previous_preflight_pressure = _last_preflight_pressure
         _last_preflight_pressure = None
+        if _preflight_compression_blocked and _preflight_block_outlived_its_request(
+            _preflight_blocked_at_tokens, request_pressure_tokens
+        ):
+            # The verdict was about a smaller request. Everything appended
+            # since was never offered to the compressor, so re-arm the gate
+            # rather than ride the window edge until the provider complains.
+            logger.info(
+                "Pre-API compression re-armed: request grew ~%s -> ~%s "
+                "request tokens since the insufficient-progress verdict",
+                f"{_preflight_blocked_at_tokens:,}",
+                f"{request_pressure_tokens:,}",
+            )
+            _preflight_compression_blocked = False
+            _preflight_blocked_at_tokens = 0
         if (
             _previous_preflight_pressure is not None
             and request_pressure_tokens >= _preflight_threshold
@@ -2509,6 +2525,7 @@ def run_conversation(
             # request truly does not fit, its error handler may still compact
             # with that stronger signal.
             _preflight_compression_blocked = True
+            _preflight_blocked_at_tokens = request_pressure_tokens
             logger.warning(
                 "Pre-API compression made insufficient progress: ~%s -> "
                 "~%s request tokens; skipping additional preflight passes",
@@ -4024,6 +4041,7 @@ def run_conversation(
                         # later pressure spike would grow unchecked until the
                         # provider's overflow handler fired.
                         _preflight_compression_blocked = False
+                        _preflight_blocked_at_tokens = 0
                         _last_preflight_pressure = None
 
                     # Stash this response's canonical usage so the post-turn
@@ -6479,6 +6497,7 @@ def run_conversation(
             # call (#84733). Hoisted here (the single consumer) so every
             # activation site — including ones added later — gets it.
             _preflight_compression_blocked = False
+            _preflight_blocked_at_tokens = 0
             continue
 
         if _retry.restart_with_length_continuation:

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -337,6 +337,25 @@ def _compression_warrants_another_preflight_pass(
     )
 
 
+def _preflight_block_outlived_its_request(
+    blocked_at_tokens: int, current_tokens: int
+) -> bool:
+    """Whether an "insufficient progress" verdict still describes this request.
+
+    The verdict above is a statement about one request shape: compacting *that*
+    transcript did not pay for itself. A turn keeps appending tool results
+    afterwards, and once the request has grown materially past the size that
+    produced the verdict it is a different transcript — one with new bulk that
+    was never offered to the compressor. Left armed, the block keeps the
+    pre-API gate dark for the rest of the turn while the request runs at the
+    window edge, where providers clip and models start returning empty turns.
+
+    Growth is judged with the same 5% materiality margin the shrink test uses,
+    so the gate re-arms on exactly the scale of change it took to keep it open.
+    """
+    return blocked_at_tokens > 0 and current_tokens > blocked_at_tokens * 1.05
+
+
 def _should_run_preflight_estimate(
     messages: List[Dict[str, Any]],
     protect_first_n: int,
@@ -426,6 +445,9 @@ class TurnContext:
     ext_prefetch_cache: str = ""
     # Turn-start preflight already proved an immediate retry ineffective.
     preflight_compression_blocked: bool = False
+    # Request size that verdict was made about, so the loop can tell when the
+    # transcript has grown into a different one and the block should lift.
+    preflight_blocked_at_tokens: int = 0
 
 
 def build_turn_context(
@@ -855,6 +877,7 @@ def build_turn_context(
     # issue #27405 (a few very large messages slipping past the count gate).
     _preflight_compressed = False
     _preflight_compression_blocked = False
+    _preflight_blocked_at_tokens = 0
     agent._turn_received_provider_response = False
     agent._turn_preflight_display_snapshot = None
     if agent.compression_enabled and _should_run_preflight_estimate(
@@ -1036,6 +1059,7 @@ def build_turn_context(
                     _orig_len, len(messages), _orig_tokens, _preflight_tokens
                 ):
                     _preflight_compression_blocked = True
+                    _preflight_blocked_at_tokens = _preflight_tokens
                     break  # Cannot compress further: neither rows nor tokens moved
                 conversation_history = conversation_history_after_compression(
                     agent, messages, conversation_history
@@ -1053,6 +1077,7 @@ def build_turn_context(
                     _compressor.threshold_tokens,
                 ):
                     _preflight_compression_blocked = True
+                    _preflight_blocked_at_tokens = _preflight_tokens
                     logger.warning(
                         "Preflight compression made insufficient progress: "
                         "~%s -> ~%s request tokens; skipping additional passes",
@@ -1405,4 +1430,5 @@ def build_turn_context(
         plugin_user_context=plugin_user_context,
         ext_prefetch_cache=ext_prefetch_cache,
         preflight_compression_blocked=_preflight_compression_blocked,
+        preflight_blocked_at_tokens=_preflight_blocked_at_tokens,
     )

--- a/tests/agent/test_preflight_block_rearms_on_growth.py
+++ b/tests/agent/test_preflight_block_rearms_on_growth.py
@@ -1,0 +1,114 @@
+"""An "insufficient progress" verdict must not outlive the request it judged.
+
+Pre-API preflight sets ``_preflight_compression_blocked`` when a compaction
+pass fails to shrink the request enough to be worth repeating. That verdict is
+a statement about one transcript. The turn keeps appending tool results after
+it, and the flag stayed armed for the rest of the turn, so the new bulk was
+never offered to the compressor.
+
+Observed live on a 65,536-token window: a pass at ~40,297 tokens came back at
+~41,063 (the summary cost more than the tool results it replaced), the gate
+went dark, and the following calls ran at 43,309 -> 53,549 -> 60,126 -> 62,239
+tokens with no further attempt, past the point where the model began returning
+empty turns.
+"""
+
+from __future__ import annotations
+
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.turn_context import (
+    _compression_warrants_another_preflight_pass,
+    _preflight_block_outlived_its_request,
+)
+from tests.agent.test_turn_context import _FakeAgent, _build
+
+
+@pytest.fixture(autouse=True)
+def _stub_runtime_main():
+    with patch("agent.auxiliary_client.set_runtime_main", lambda *a, **k: None):
+        yield
+
+
+def test_growth_past_the_materiality_margin_lifts_the_block():
+    # The live incident: blocked at ~41,063, request later reached ~62,239.
+    assert _preflight_block_outlived_its_request(41_063, 62_239)
+
+
+def test_noise_sized_growth_keeps_the_block():
+    """A few hundred tokens is not a different transcript."""
+    assert not _preflight_block_outlived_its_request(41_063, 41_500)
+
+
+def test_shrinking_request_keeps_the_block():
+    assert not _preflight_block_outlived_its_request(41_063, 38_000)
+
+
+def test_unknown_block_pressure_never_lifts_on_its_own():
+    """0 means "armed by a path that did not record a size" — stay conservative."""
+    assert not _preflight_block_outlived_its_request(0, 62_239)
+
+
+def test_margin_matches_the_shrink_test_that_arms_the_block():
+    """Re-arm on exactly the scale of change it took to keep the gate open.
+
+    ``_compression_warrants_another_preflight_pass`` treats a 5% reduction as
+    the smallest move worth another pass; growth uses the same 5%, so the two
+    halves of the decision cannot drift apart.
+    """
+    threshold = 40_000
+    base = 50_000
+    just_under = int(base * 1.05)
+    just_over = just_under + 1
+
+    assert not _preflight_block_outlived_its_request(base, just_under)
+    assert _preflight_block_outlived_its_request(base, just_over)
+
+    # Mirror image: a 5% shrink is likewise the boundary for continuing.
+    assert not _compression_warrants_another_preflight_pass(
+        base, int(base * 0.95), threshold,
+    )
+    assert _compression_warrants_another_preflight_pass(
+        base, int(base * 0.95) - 1, threshold,
+    )
+
+
+def _pressured_compressor():
+    """Over-threshold compressor stub that opens the preflight threshold path."""
+    return types.SimpleNamespace(
+        protect_first_n=0,
+        protect_last_n=0,
+        threshold_tokens=1,
+        context_length=100_000,
+        last_prompt_tokens=0,
+        should_compress=lambda _tokens=None: True,
+        should_compress_info=lambda _tokens=None: (True, None),
+        should_defer_preflight_to_real_usage=lambda _t: False,
+        get_active_compression_failure_cooldown=lambda: None,
+    )
+
+
+def test_arming_the_block_records_the_request_it_judged():
+    """Without the recorded size the loop has nothing to compare growth against.
+
+    A no-op compaction arms the blocker; the context must carry the request
+    size that verdict was about, or the re-arm check can never fire.
+    """
+    agent = _FakeAgent()
+    agent.compression_enabled = True
+    agent.context_compressor = _pressured_compressor()
+    agent._emit_status = MagicMock()
+    agent._compress_context = lambda messages, _system_message, **_kw: (
+        messages, "SYSTEM",
+    )
+
+    ctx = _build(agent, conversation_history=[
+        {"role": "user", "content": "old"},
+        {"role": "assistant", "content": "older"},
+    ])
+
+    assert ctx.preflight_compression_blocked is True
+    assert ctx.preflight_blocked_at_tokens > 0


### PR DESCRIPTION
## What does this PR do?

The pre-API preflight arms `_preflight_compression_blocked` when a compaction
pass fails to shrink the request enough to be worth repeating:

```
Pre-API compression made insufficient progress: ~40,297 -> ~41,063 request
tokens; skipping additional preflight passes
```

That verdict is a statement about **one request shape** — compacting *that*
transcript did not pay for itself. But the flag then stays armed for the rest
of the turn, while the turn keeps appending tool results that were never
offered to the compressor. In the run above the following calls went

| API call | request tokens |
|---|---|
| #6 (verdict) | 41,063 |
| #7 | 43,309 |
| #8 | 53,549 |
| #9 | 60,126 |
| #10 | 62,239 |

against a 65,536-token window, with no further compaction attempt. Four
`Pre-call sanitizer: healed N empty non-final message(s)` warnings fire across
that stretch — the model returning empty turns as it runs out of room. The
agent noticed from the inside and misdiagnosed itself: *"It keeps getting
interrupted. The problem is probably that I'm outputting content that triggers
truncation."*

Note the pass did not merely fail to shrink — it **grew** the request by 766
tokens, because on a short transcript the generated summary costs more than the
tool results it replaces. So the give-up is right; only its lifetime is wrong.

**The fix:** remember the request size the verdict was made about, and lift the
block once the request has grown materially past it. Growth is judged with the
same 5% materiality margin `_compression_warrants_another_preflight_pass`
already uses to judge shrink, so the two halves of the decision cannot drift
apart.

This is the same reasoning the codebase already applies after a
provider-confirmed recovery, where the comment reads:

> Left armed, `_preflight_compression_blocked` keeps the pre-API gate dark for
> the rest of the turn even though the attempt budget was just rearmed, so a
> later pressure spike would grow unchecked until the provider's overflow
> handler fired.

That hazard is real without a provider error too: a silent-clipping backend
(the ollama `/v1` endpoint, for one) never raises the overflow error that would
have cleared the block, so nothing ever re-arms the gate.

### Why this cannot thrash

Each re-arm costs 5% more growth than the last, and the gate it re-opens is
still behind `compression_attempts < max_compression_attempts` — the hard
per-turn backstop (default 3) shared with the overflow error handlers. So the
number of compactions a turn can run is unchanged; lifting the block only
decides *which* moments are eligible to spend that budget, and the budget now
gets spent where the transcript is largest instead of being stranded by the
first unproductive pass.

## Changes Made

- `agent/turn_context.py`
  - new `_preflight_block_outlived_its_request(blocked_at_tokens, current_tokens)`
    — sibling to the existing shrink predicate, same 5% margin, and it returns
    False for an unknown (`0`) block size so a path that did not record one
    stays conservative.
  - `TurnContext.preflight_blocked_at_tokens` carries the size the turn-prologue
    verdict was made about; both prologue arming sites record it.
- `agent/conversation_loop.py`
  - tracks that size, records it when the pre-API gate arms the block, clears it
    wherever the block is already cleared, and lifts the block (with an `info`
    log naming both sizes) once the predicate says the request has outgrown the
    verdict.

## How to Test

1. `pytest tests/agent/test_preflight_block_rearms_on_growth.py -q` → 6 passed.
2. The tests pin the live numbers (blocked at 41,063, lifted at 62,239), the
   noise case (41,500 keeps the block), a shrinking request, the unknown-size
   case, and the boundary symmetry with the shrink predicate. One test drives
   `build_turn_context` to prove the prologue actually records the size rather
   than leaving the re-arm check permanently unarmed.
3. Regression across the whole compaction/preflight/turn-context surface — every
   test file in `tests/agent/` and `tests/run_agent/` matching
   `preflight|compress|compact|turn_context|conversation_loop|context_engine|turn_retry`,
   78 files: **703 passed, 0 failed** (85s).

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu, Python 3.13
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran the full
      compaction/preflight/turn-context surface (78 files, 703 passed, 0
      failed) rather than the whole ~3,090-file tree, which was competing for
      CPU with a live deployment on the same host. Stating the scope I actually
      verified rather than ticking a box I cannot evidence.

### Documentation & Housekeeping

- [x] Docstrings on the new predicate carry the rationale — no `docs/` change
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] Cross-platform: integer comparison only
- [x] N/A — no tool descriptions or schemas changed
