### PR TITLE
fix(session_search): forward the profile parameter through both inline dispatch paths

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3160,6 +3160,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                     detail=next_args.get("detail", "adaptive"),
                     db=session_db,
                     current_session_id=agent.session_id,
+                    profile=next_args.get("profile"),
                 ),
                 next_args,
             )

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -2060,6 +2060,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     detail=next_args.get("detail", "adaptive"),
                     db=session_db,
                     current_session_id=agent.session_id,
+                    profile=next_args.get("profile"),
                 )
             function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_agent_tool_execution_middleware(
                 agent,

--- a/tests/agent/test_session_search_profile_forwarding.py
+++ b/tests/agent/test_session_search_profile_forwarding.py
@@ -1,0 +1,114 @@
+"""Regression tests: the session_search `profile` parameter must survive the
+inline dispatch paths.
+
+`session_search(profile="X")` is the documented way to read another profile's
+session DB (resolving an ``@session:<profile>/<id>`` link). The tool schema
+accepts the parameter and ``session_search()`` implements it, but the inline
+agent-level dispatch sites in ``agent/agent_runtime_helpers.py`` (concurrent
+path) and ``agent/tool_executor.py`` (sequential path) rebuilt the kwargs by
+hand and silently dropped ``profile`` — a cross-profile query then ran against
+the caller's own DB and returned confidently wrong results.
+"""
+
+import inspect
+from unittest.mock import MagicMock
+
+from agent import agent_runtime_helpers, tool_executor
+
+
+class _FakeSessionDB:
+    """Stand-in for the recall SessionDB; the dispatch only passes it through."""
+
+    closed = 0
+
+    def close(self):
+        self.closed += 1
+
+
+def _make_agent():
+    return MagicMock(
+        session_id="session-dispatch",
+        _get_session_db_for_recall=lambda: _FakeSessionDB(),
+    )
+
+
+def _capture_session_search(monkeypatch):
+    captured = {}
+
+    def _fake_session_search(**kwargs):
+        captured.update(kwargs)
+        return '{"results": []}'
+
+    monkeypatch.setattr(
+        "tools.session_search_tool.session_search", _fake_session_search
+    )
+    return captured
+
+
+_ARGS = {
+    "query": "deploy notes",
+    "session_id": "sess-other-profile",
+    "profile": "work",
+}
+
+
+class TestInvokeToolForwardsProfile:
+    def test_concurrent_dispatch_forwards_profile(self, monkeypatch):
+        captured = _capture_session_search(monkeypatch)
+        agent = _make_agent()
+
+        agent_runtime_helpers.invoke_tool(
+            agent,
+            "session_search",
+            dict(_ARGS),
+            effective_task_id="",
+            # Skip both middleware layers: this test exercises the plain
+            # dispatch table, not the middleware pipeline.
+            skip_tool_request_middleware=True,
+            skip_tool_execution_middleware=True,
+        )
+
+        assert captured.get("profile") == "work", (
+            "invoke_tool dropped the profile parameter — the cross-profile "
+            "query ran against the caller's own session DB"
+        )
+        assert captured.get("session_id") == "sess-other-profile"
+
+    def test_profile_absent_passes_none(self, monkeypatch):
+        captured = _capture_session_search(monkeypatch)
+        agent = _make_agent()
+
+        agent_runtime_helpers.invoke_tool(
+            agent,
+            "session_search",
+            {"query": "anything"},
+            effective_task_id="",
+            skip_tool_request_middleware=True,
+            skip_tool_execution_middleware=True,
+        )
+
+        # No profile given: session_search() keeps its default behavior
+        # (the caller's own DB).
+        assert "profile" in captured
+        assert captured["profile"] is None
+
+
+class TestSequentialDispatchForwardsProfile:
+    def test_sequential_dispatch_calls_session_search_with_profile(self, monkeypatch):
+        """The sequential tool executor's session_search branch forwards profile.
+
+        That branch lives inside a closure rebuilt per tool-call inside
+        ``execute_tool_calls_sequential``; the cheapest reliable probe is the
+        source contract: the hand-built kwargs must include ``profile=``.
+        A behavioral test would need a full assistant-message + agent-loop
+        scaffold disproportionate to a one-kwarg forwarding fix.
+        """
+
+        source = inspect.getsource(tool_executor.execute_tool_calls_sequential)
+        start = source.index('elif function_name == "session_search":')
+        end = source.index("elif", start + 10)
+        branch = source[start:end]
+        assert 'profile=next_args.get("profile")' in branch, (
+            "the sequential session_search dispatch must forward the profile "
+            "parameter alongside the other hand-listed kwargs"
+        )


### PR DESCRIPTION
## Symptom

`session_search(profile="work")` — the documented way to read another profile's sessions, e.g. resolving an `@session:<profile>/<id>` link the user dropped into chat — silently returned results from the **caller's own** profile database. No error, just confidently wrong output.

## Root cause

The tool schema accepts `profile` and `tools/session_search_tool.py::session_search()` fully implements it (it resolves the target profile's `state.db` read-only). But the two inline agent-level dispatch sites that hand-rebuild the kwargs — `agent/agent_runtime_helpers.py::invoke_tool` (concurrent path) and `agent/tool_executor.py::execute_tool_calls_sequential` (sequential path) — list every other parameter explicitly and simply never forward `profile`, so it falls back to its default (the caller's DB).

## Fix

One line per dispatch site: add `profile=next_args.get("profile"),` to the hand-built kwargs, matching the existing style of the surrounding parameters.

## Validation

- New `tests/agent/test_session_search_profile_forwarding.py`: a behavioral test drives the real `invoke_tool` with a stubbed `session_search` and asserts `profile` arrives (and is `None` when absent); a source-contract test pins the sequential branch's kwarg list (that branch lives inside a per-call closure — a behavioral test would need a full agent-loop scaffold disproportionate to a one-kwarg fix). All 3 tests fail without the patch and pass with it.
- `tests/tools/test_session_search.py` + `tests/agent/test_tool_executor_checkpoint_paths.py` — 54/54 pass.
