### PR TITLE
fix(install): export HERMES_HOME so --hermes-home reaches skills and the launcher

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -210,6 +210,11 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# --hermes-home (and an inherited HERMES_HOME) must reach Python children
+# such as skills_sync.py. A local assignment is invisible to subprocesses
+# (#89231). Export once after parse so every later stage inherits it.
+export HERMES_HOME
+
 # ============================================================================
 # Helper functions
 # ============================================================================
@@ -1768,6 +1773,17 @@ setup_path() {
     # the rm, `cat >` follows the symlink and overwrites the venv pip entry
     # point with this shim — making `exec "$HERMES_BIN"` self-recurse. (#21454)
     rm -f "$command_link_dir/hermes"
+    # User-scoped shims (~/.local/bin) bake a non-default data dir so
+    # `hermes` after --hermes-home uses that path. System FHS shims
+    # (/usr/local/bin/hermes) are world-runnable (#21457) — never bake
+    # into them. Inherited root HERMES_HOME or even an explicit
+    # --hermes-home would otherwise pin every later uid to that directory.
+    # Operators set HERMES_HOME on the unit / login env instead.
+    # printf %q so a quote in the path cannot break the generated script.
+    launcher_hermes_home_line=""
+    if [ "${ROOT_FHS_LAYOUT:-false}" != true ] && [ "$HERMES_HOME" != "$HOME/.hermes" ]; then
+        launcher_hermes_home_line=$(printf ': "${HERMES_HOME:=%q}"\nexport HERMES_HOME' "$HERMES_HOME")
+    fi
     if [ "$USE_VENV" = true ]; then
         # uv-generated console scripts resolve themselves through `realpath`,
         # which stock macOS does not provide. Run the checked-in entrypoint
@@ -1777,6 +1793,7 @@ setup_path() {
 #!/usr/bin/env bash
 unset PYTHONPATH
 unset PYTHONHOME
+$launcher_hermes_home_line
 exec "$HERMES_BIN" "$HERMES_ENTRYPOINT" "\$@"
 EOF
     else
@@ -1784,6 +1801,7 @@ EOF
 #!/usr/bin/env bash
 unset PYTHONPATH
 unset PYTHONHOME
+$launcher_hermes_home_line
 exec "$HERMES_BIN" "\$@"
 EOF
     fi
@@ -1800,6 +1818,7 @@ EOF
 #!/usr/bin/env bash
 unset PYTHONPATH
 unset PYTHONHOME
+$launcher_hermes_home_line
 exec "$HERMES_BIN" "$INSTALL_DIR/run_agent.py" "\$@"
 EOF
     else
@@ -1807,6 +1826,7 @@ EOF
 #!/usr/bin/env bash
 unset PYTHONPATH
 unset PYTHONHOME
+$launcher_hermes_home_line
 exec "$HERMES_BIN" run_agent.py "\$@"
 EOF
     fi
@@ -1825,6 +1845,7 @@ EOF
 #!/usr/bin/env bash
 unset PYTHONPATH
 unset PYTHONHOME
+$launcher_hermes_home_line
 exec "$HERMES_BIN" "$HERMES_ENTRYPOINT" acp "\$@"
 EOF
     else
@@ -1832,6 +1853,7 @@ EOF
 #!/usr/bin/env bash
 unset PYTHONPATH
 unset PYTHONHOME
+$launcher_hermes_home_line
 exec "$HERMES_BIN" acp "\$@"
 EOF
     fi
@@ -1962,13 +1984,13 @@ copy_config_templates() {
     if [ ! -f "$HERMES_HOME/.env" ]; then
         if [ -f "$INSTALL_DIR/.env.example" ]; then
             cp "$INSTALL_DIR/.env.example" "$HERMES_HOME/.env"
-            log_success "Created ~/.hermes/.env from template"
+            log_success "Created $HERMES_HOME/.env from template"
         else
             touch "$HERMES_HOME/.env"
-            log_success "Created ~/.hermes/.env"
+            log_success "Created $HERMES_HOME/.env"
         fi
     else
-        log_info "~/.hermes/.env already exists, keeping it"
+        log_info "$HERMES_HOME/.env already exists, keeping it"
     fi
     # Restrict .env permissions — this file holds API keys and tokens.
     # 0600 ensures only the file owner can read/write, matching standard
@@ -1980,10 +2002,10 @@ copy_config_templates() {
     if [ ! -f "$HERMES_HOME/config.yaml" ]; then
         if [ -f "$INSTALL_DIR/cli-config.yaml.example" ]; then
             cp "$INSTALL_DIR/cli-config.yaml.example" "$HERMES_HOME/config.yaml"
-            log_success "Created ~/.hermes/config.yaml from template"
+            log_success "Created $HERMES_HOME/config.yaml from template"
         fi
     else
-        log_info "~/.hermes/config.yaml already exists, keeping it"
+        log_info "$HERMES_HOME/config.yaml already exists, keeping it"
     fi
 
     # Create SOUL.md if it doesn't exist (global persona file).
@@ -1995,10 +2017,10 @@ copy_config_templates() {
         cat > "$HERMES_HOME/SOUL.md" << 'SOUL_EOF'
 You are Hermes Agent, an intelligent AI assistant created by Nous Research. You are helpful, knowledgeable, and direct. You assist users with a wide range of tasks including answering questions, writing and editing code, analyzing information, creative work, and executing actions via your tools. You communicate clearly, admit uncertainty when appropriate, and prioritize being genuinely useful over being verbose unless otherwise directed below. Be targeted and efficient in your exploration and investigations.
 SOUL_EOF
-        log_success "Created ~/.hermes/SOUL.md (edit to customize personality)"
+        log_success "Created $HERMES_HOME/SOUL.md (edit to customize personality)"
     fi
 
-    log_success "Configuration directory ready: ~/.hermes/"
+    log_success "Configuration directory ready: $HERMES_HOME/"
 
     # Seed bundled skills into ~/.hermes/skills/ (manifest-based, one-time per skill)
     if [ "$NO_SKILLS" = true ]; then
@@ -2012,14 +2034,14 @@ SOUL_EOF
         log_info "Skipping bundled skills (--no-skills). Wrote $HERMES_HOME/.no-bundled-skills"
         log_info "  Future 'hermes update' runs will not inject bundled skills. Delete the marker to opt back in."
     else
-        log_info "Syncing bundled skills to ~/.hermes/skills/ ..."
-        if "$INSTALL_DIR/venv/bin/python" "$INSTALL_DIR/tools/skills_sync.py" 2>/dev/null; then
-            log_success "Skills synced to ~/.hermes/skills/"
+        log_info "Syncing bundled skills to $HERMES_HOME/skills/ ..."
+        if HERMES_HOME="$HERMES_HOME" "$INSTALL_DIR/venv/bin/python" "$INSTALL_DIR/tools/skills_sync.py" 2>/dev/null; then
+            log_success "Skills synced to $HERMES_HOME/skills/"
         else
             # Fallback: simple directory copy if Python sync fails
             if [ -d "$INSTALL_DIR/skills" ] && [ ! "$(ls -A "$HERMES_HOME/skills/" 2>/dev/null | grep -v '.bundled_manifest')" ]; then
                 cp -r "$INSTALL_DIR/skills/"* "$HERMES_HOME/skills/" 2>/dev/null || true
-                log_success "Skills copied to ~/.hermes/skills/"
+                log_success "Skills copied to $HERMES_HOME/skills/"
             fi
         fi
     fi
@@ -2702,7 +2724,7 @@ maybe_start_gateway() {
             fi
             nohup $HERMES_CMD gateway > "$HERMES_HOME/logs/gateway.log" 2>&1 &
             GATEWAY_PID=$!
-            log_success "Gateway started (PID $GATEWAY_PID). Logs: ~/.hermes/logs/gateway.log"
+            log_success "Gateway started (PID $GATEWAY_PID). Logs: $HERMES_HOME/logs/gateway.log"
             log_info "To stop: kill $GATEWAY_PID"
             log_info "To restart later: hermes gateway"
             if [ "$DISTRO" = "termux" ]; then

--- a/tests/test_install_sh_hermes_home.py
+++ b/tests/test_install_sh_hermes_home.py
@@ -1,0 +1,304 @@
+"""--hermes-home must reach skills_sync and the generated launcher (#89231).
+
+The posix installer assigns HERMES_HOME for its own writes but historically
+did not export it. Python children and the public `hermes` shim then silently
+fell back to ~/.hermes. These tests drive the real install.sh helpers in a
+stubbed shell — they do not snapshot script text.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import stat
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _extract_function(source: str, name: str) -> str:
+    """Extract a top-level ``name() { ... }`` body, skipping heredocs.
+
+    A naive ``.*?^}`` cut stops at the first column-0 ``}`` — including one
+    that only exists inside a heredoc. Count braces outside heredocs and
+    ignore ``${...}`` / quoted spans so a later install.sh edit does not
+    silently truncate the helper.
+    """
+    lines = source.splitlines(keepends=True)
+    start = next(
+        (
+            i
+            for i, line in enumerate(lines)
+            if re.match(rf"^{re.escape(name)}\(\) \{{", line)
+        ),
+        None,
+    )
+    assert start is not None, f"could not extract {name}() from install.sh"
+    depth = 0
+    heredoc_end: str | None = None
+    out: list[str] = []
+    for line in lines[start:]:
+        out.append(line)
+        raw = line.rstrip("\n")
+        if heredoc_end is not None:
+            if raw == heredoc_end:
+                heredoc_end = None
+            continue
+        heredoc = re.search(r"<<-?\s*['\"]?(\w+)['\"]?", line)
+        if heredoc and not line.lstrip().startswith("#"):
+            heredoc_end = heredoc.group(1)
+        code = re.sub(r"\$\{[^{}]*\}", "", line)
+        code = re.sub(r"'[^']*'", "", code)
+        code = re.sub(r'"[^"]*"', "", code)
+        depth += code.count("{") - code.count("}")
+        if heredoc_end is None and depth <= 0 and len(out) > 1:
+            break
+    assert "".join(out).rstrip().endswith("}"), f"unbalanced extract of {name}()"
+    return "".join(out)
+
+
+def test_extract_function_skips_braces_inside_heredoc() -> None:
+    """A column-0 `}` in a heredoc must not truncate the extracted function."""
+    src = (
+        "other() {\n"
+        "  true\n"
+        "}\n"
+        "sample() {\n"
+        "  cat <<EOF\n"
+        "}\n"
+        "EOF\n"
+        "  echo done\n"
+        "}\n"
+    )
+    body = _extract_function(src, "sample")
+    assert "echo done" in body
+    assert body.rstrip().endswith("}")
+
+
+def _python_probe_script() -> str:
+    return (
+        "#!/usr/bin/env python3\n"
+        "import os, pathlib, sys\n"
+        "out = os.environ.get('PROBE_OUT')\n"
+        "if out:\n"
+        "    pathlib.Path(out).write_text(os.environ.get('HERMES_HOME', '<unset>'))\n"
+        "    sys.exit(0)\n"
+        "sys.stdout.write(os.environ.get('HERMES_HOME', '<unset>'))\n"
+    )
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
+
+def _run_copy_config_templates(tmp_path: Path) -> dict[str, str]:
+    """Run copy_config_templates the way install.sh does: assign, do not export."""
+    source = INSTALL_SH.read_text()
+    body = _extract_function(source, "copy_config_templates")
+    home = tmp_path / "home"
+    hermes_home = tmp_path / "custom-home"
+    install_dir = tmp_path / "install"
+    probe_out = tmp_path / "child-hermes-home"
+    log_out = tmp_path / "install.log"
+    stub_python = install_dir / "venv" / "bin" / "python"
+    _write_executable(stub_python, _python_probe_script())
+    (install_dir / "tools").mkdir(parents=True)
+    (install_dir / "tools" / "skills_sync.py").write_text("# probe target\n")
+
+    harness = f"""
+set -eu
+HOME={str(home)!r}
+HERMES_HOME={str(hermes_home)!r}
+INSTALL_DIR={str(install_dir)!r}
+NO_SKILLS=false
+PROBE_OUT={str(probe_out)!r}
+export PROBE_OUT
+unset HERMES_HOME
+HERMES_HOME={str(hermes_home)!r}
+
+log_info() {{ echo "INFO: $*" >>{str(log_out)!r}; }}
+log_success() {{ echo "SUCCESS: $*" >>{str(log_out)!r}; }}
+configure_browser_env_from_system_browser() {{ :; }}
+
+{body}
+
+copy_config_templates
+"""
+    env = {k: v for k, v in os.environ.items() if k != "HERMES_HOME"}
+    proc = subprocess.run(
+        ["bash", "-c", harness],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    child = probe_out.read_text() if probe_out.exists() else "<missing>"
+    logs = log_out.read_text() if log_out.exists() else ""
+    return {
+        "child_hermes_home": child,
+        "logs": logs,
+        "hermes_home": str(hermes_home),
+    }
+
+
+def _run_setup_path(
+    tmp_path: Path,
+    *,
+    hermes_home: Path | None = None,
+    use_venv: bool = True,
+    root_fhs: bool = False,
+) -> Path:
+    """Generate public launchers via setup_path; return the command-link dir."""
+    source = INSTALL_SH.read_text()
+    parts = [
+        _extract_function(source, "is_termux"),
+        _extract_function(source, "get_command_link_dir"),
+        _extract_function(source, "get_command_link_display_dir"),
+        _extract_function(source, "setup_path"),
+    ]
+    home = tmp_path / "home"
+    if hermes_home is None:
+        hermes_home = tmp_path / "custom-home"
+    install_dir = tmp_path / "install"
+    stub_python = install_dir / "venv" / "bin" / "python"
+    entry = install_dir / "hermes"
+    _write_executable(stub_python, _python_probe_script())
+    entry.write_text("# entrypoint\n")
+    command_dir = home / ".local" / "bin"
+    command_dir.mkdir(parents=True)
+    extra_bin = install_dir / "bin"
+    extra_bin.mkdir(parents=True)
+    # Non-venv setup_path uses `which hermes`. Keep that binary off the
+    # command-link dir so `rm -f "$command_link_dir/hermes"` cannot replace
+    # HERMES_BIN with the shim (self-exec loop).
+    _write_executable(extra_bin / "hermes", _python_probe_script())
+
+    fhs_override = ""
+    if root_fhs:
+        # Real FHS writes /usr/local/bin; redirect the link dir so the test
+        # never touches the host. The ROOT_FHS_LAYOUT flag still drives bake.
+        fhs_override = f"""
+get_command_link_dir() {{ echo {str(command_dir)!r}; }}
+get_command_link_display_dir() {{ echo '~/.local/bin'; }}
+"""
+
+    harness = f"""
+set -eu
+HOME={str(home)!r}
+export HOME
+HERMES_HOME={str(hermes_home)!r}
+export HERMES_HOME
+INSTALL_DIR={str(install_dir)!r}
+USE_VENV={"true" if use_venv else "false"}
+DISTRO=linux
+ROOT_FHS_LAYOUT={"true" if root_fhs else "false"}
+PATH={str(extra_bin)!r}:{str(command_dir)!r}:"$PATH"
+export PATH
+
+log_info() {{ :; }}
+log_success() {{ :; }}
+log_warn() {{ :; }}
+
+{chr(10).join(parts)}
+{fhs_override}
+
+setup_path
+"""
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    env["HERMES_HOME"] = str(hermes_home)
+    proc = subprocess.run(
+        ["bash", "-c", harness],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    launcher = command_dir / "hermes"
+    assert launcher.is_file(), launcher
+    return command_dir
+
+
+def _probe_launcher(launcher: Path, *, extra_env: dict[str, str] | None = None) -> str:
+    env = {k: v for k, v in os.environ.items() if k != "HERMES_HOME"}
+    if extra_env:
+        env.update(extra_env)
+    proc = subprocess.run(
+        ["bash", str(launcher)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    return proc.stdout
+
+
+def test_copy_config_templates_passes_hermes_home_to_skills_sync(tmp_path: Path) -> None:
+    """skills_sync must see --hermes-home even when the shell did not export it."""
+    result = _run_copy_config_templates(tmp_path)
+    assert result["child_hermes_home"] == result["hermes_home"]
+
+
+def test_copy_config_templates_logs_requested_home(tmp_path: Path) -> None:
+    """Install logs must name the requested home, not a hardcoded ~/.hermes."""
+    result = _run_copy_config_templates(tmp_path)
+    assert f"Skills synced to {result['hermes_home']}/skills/" in result["logs"]
+    assert "Skills synced to ~/.hermes/skills/" not in result["logs"]
+
+
+def test_generated_launcher_defaults_install_hermes_home(tmp_path: Path) -> None:
+    """A login-shell `hermes` with no HERMES_HOME must use the install home."""
+    hermes_home = tmp_path / "custom-home"
+    command_dir = _run_setup_path(tmp_path)
+    assert _probe_launcher(command_dir / "hermes") == str(hermes_home)
+
+
+def test_generated_launcher_preserves_caller_hermes_home(tmp_path: Path) -> None:
+    """A caller-exported HERMES_HOME must win over the baked install default."""
+    command_dir = _run_setup_path(tmp_path)
+    override = tmp_path / "caller-home"
+    assert _probe_launcher(
+        command_dir / "hermes", extra_env={"HERMES_HOME": str(override)}
+    ) == str(override)
+
+
+def test_generated_launcher_does_not_pin_default_per_user_home(tmp_path: Path) -> None:
+    """Default $HOME/.hermes must not be baked into a user-scoped shim."""
+    home = tmp_path / "home"
+    default_home = home / ".hermes"
+    command_dir = _run_setup_path(tmp_path, hermes_home=default_home)
+    assert _probe_launcher(command_dir / "hermes") == "<unset>"
+
+
+def test_fhs_shim_does_not_bake_inherited_root_home(tmp_path: Path) -> None:
+    """A root FHS /usr/local/bin/hermes must not pin inherited HERMES_HOME.
+
+    Root may have HERMES_HOME=/root/experimental in the install environment
+    without passing --hermes-home. Baking that path into the world-runnable
+    shim would send every later uid into root's directory (#21457).
+    """
+    inherited = tmp_path / "root-experimental"
+    command_dir = _run_setup_path(tmp_path, hermes_home=inherited, root_fhs=True)
+    assert _probe_launcher(command_dir / "hermes") == "<unset>"
+    assert _probe_launcher(command_dir / "hermes-agent") == "<unset>"
+    assert _probe_launcher(command_dir / "hermes-acp") == "<unset>"
+
+
+def test_non_venv_and_sibling_shims_bake_custom_home(tmp_path: Path) -> None:
+    """Non-venv hermes plus hermes-agent / hermes-acp share the same bake."""
+    hermes_home = tmp_path / "custom-home"
+    command_dir = _run_setup_path(tmp_path, use_venv=False)
+    for name in ("hermes", "hermes-agent", "hermes-acp"):
+        assert _probe_launcher(command_dir / name) == str(hermes_home), name
+
+
+def test_baked_home_survives_quote_in_path(tmp_path: Path) -> None:
+    """A quote in --hermes-home must not produce a syntactically dead shim."""
+    hermes_home = tmp_path / 'quoted"home'
+    hermes_home.mkdir()
+    command_dir = _run_setup_path(tmp_path, hermes_home=hermes_home)
+    assert _probe_launcher(command_dir / "hermes") == str(hermes_home)


### PR DESCRIPTION
## What does this PR do?

`--hermes-home PATH` was only a shell assignment. Python children (`skills_sync.py`) and the generated `hermes` / `hermes-agent` / `hermes-acp` shims never saw it, so config landed in the requested home while skills and later `hermes` invocations silently used `~/.hermes`. Success logs were hardcoded to `~/.hermes/skills/`, which hid the split.

The installer now exports `HERMES_HOME` after argument parsing, prefixes the skills-sync child with that value, and logs the real path. User-scoped shims (`~/.local/bin`) bake a quote-safe default **only when** the data dir is not `$HOME/.hermes`. Root FHS shims (`/usr/local/bin/hermes`) never bake — an inherited root `HERMES_HOME` must not pin every later uid (#21457). A caller-set `HERMES_HOME` still wins.

## Related Issue

Fixes #89231

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `scripts/install.sh` — `export HERMES_HOME` after parse; prefix on `skills_sync.py`; honest `$HERMES_HOME/...` logs; user-scoped quote-safe bake; **no bake** on FHS `/usr/local/bin`
- `tests/test_install_sh_hermes_home.py` — behavioral tests: child env, logs, bake, caller override, default no-bake, FHS inherited-env, non-venv + sibling shims, quote in path

## How to Test

1. `scripts/run_tests.sh tests/test_install_sh_hermes_home.py tests/test_install_sh_symlink_stomp.py tests/test_install_macos_launcher.py tests/test_install_sh_acp_launcher.py -q --tb=short`
2. Expected: 4 files, 17 tests passed (this change: 9 in `test_install_sh_hermes_home.py`).
3. Optional class check: user-scoped `--hermes-home /tmp/hh` bakes that default; default `$HOME/.hermes` and any root-FHS shim do **not** bake.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Ubuntu), Python 3.12, `scripts/run_tests.sh`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (`install.ps1` already sets User + process `HERMES_HOME`)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
