### PR TITLE
fix(telegram): send a browser User-Agent on the send_image download fallback

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8091,11 +8091,15 @@ class TelegramAdapter(BasePlatformAdapter):
                 from gateway.platforms.base import _ssrf_redirect_guard
                 from tools.url_safety import create_ssrf_safe_async_client
 
+                _dl_headers = {
+                    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+                    "Accept": "image/*,*/*;q=0.8",
+                }
                 async with create_ssrf_safe_async_client(
                     timeout=30.0,
                     event_hooks={"response": [_ssrf_redirect_guard]},
                 ) as client:
-                    resp = await client.get(image_url)
+                    resp = await client.get(image_url, headers=_dl_headers)
                     resp.raise_for_status()
                     image_data = resp.content
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8089,10 +8089,16 @@ class TelegramAdapter(BasePlatformAdapter):
             # Fallback: download and upload as file (supports up to 10MB)
             try:
                 from gateway.platforms.base import _ssrf_redirect_guard
-                from tools.url_safety import create_ssrf_safe_async_client
+                from tools.url_safety import (
+                    DEFAULT_USER_AGENT,
+                    create_ssrf_safe_async_client,
+                )
 
+                # Same identifying UA already used for direct downloads in
+                # gateway/platforms/base.py and the teams/feishu adapters —
+                # bare httpx gets 403'd by bot-detecting CDNs (#89260).
                 _dl_headers = {
-                    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+                    "User-Agent": DEFAULT_USER_AGENT,
                     "Accept": "image/*,*/*;q=0.8",
                 }
                 async with create_ssrf_safe_async_client(

--- a/tests/gateway/test_telegram_media_read_timeout.py
+++ b/tests/gateway/test_telegram_media_read_timeout.py
@@ -68,8 +68,12 @@ def adapter():
     return a
 
 
-def _stub_download(monkeypatch, size: int):
-    """Make the fallback's SSRF-safe client return ``size`` bytes."""
+def _stub_download(monkeypatch, size: int, captured_headers: dict | None = None):
+    """Make the fallback's SSRF-safe client return ``size`` bytes.
+
+    ``captured_headers``, when given, is filled in with whatever headers the
+    fallback's ``client.get()`` call sends, so a test can assert on them.
+    """
 
     class _Resp:
         content = b"x" * size
@@ -84,7 +88,9 @@ def _stub_download(monkeypatch, size: int):
         async def __aexit__(self, *exc):
             return False
 
-        async def get(self, url):
+        async def get(self, url, headers=None, **kwargs):
+            if captured_headers is not None:
+                captured_headers.update(headers or {})
             return _Resp()
 
     import tools.url_safety as url_safety
@@ -133,3 +139,39 @@ async def test_send_image_upload_fallback_uses_media_read_timeout(adapter, monke
     upload = calls[1]
     assert isinstance(upload["photo"], (bytes, bytearray))
     assert upload["read_timeout"] == tg._MEDIA_SEND_READ_TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_send_image_upload_fallback_sends_identifying_user_agent(adapter, monkeypatch):
+    """The byte-upload fallback must not download with the bare httpx default
+    UA: bot-detecting CDNs (upload.wikimedia.org confirmed) serve
+    ``python-httpx/x`` a 403 while the same URL works from Telegram's own
+    fetch and from a browser seconds earlier (#89260). The fallback must
+    send the same identifying UA already used for direct downloads
+    elsewhere (``tools.url_safety.DEFAULT_USER_AGENT``), not a browser-spoof
+    string — Wikimedia's UA policy asks clients to identify themselves
+    rather than impersonate a browser.
+    """
+    from tools.url_safety import DEFAULT_USER_AGENT
+
+    headers: dict = {}
+    _stub_download(monkeypatch, 8 * 1024 * 1024, captured_headers=headers)
+    calls = []
+
+    async def _photo(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise RuntimeError("Photo too big for a URL send")
+        msg = MagicMock()
+        msg.message_id = 4
+        return msg
+
+    adapter._bot.send_photo = AsyncMock(side_effect=_photo)
+
+    result = await adapter.send_image(
+        "123", "https://upload.wikimedia.org/wikipedia/commons/x/x.jpg", caption="hi"
+    )
+
+    assert result.success and len(calls) == 2
+    assert headers.get("User-Agent") == DEFAULT_USER_AGENT
+    assert "python-httpx" not in headers.get("User-Agent", "")

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -529,7 +529,10 @@ async def test_send_image_upload_dm_topic_reply_not_found_retry_drops_thread_id(
         async def __aexit__(self, *args):
             return None
 
-        async def get(self, _url):
+        async def get(self, _url, **_kwargs):
+            # The fallback download now sends UA/Accept headers (#89260);
+            # accept any request kwargs so this stub matches the real
+            # httpx.AsyncClient.get() shape.
             return _FakeResponse()
 
     adapter._bot = SimpleNamespace(send_photo=mock_send_photo)

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -822,6 +822,17 @@ def _install_ssrf_guard_on_client(client: Any) -> None:
     )
 
 
+# Identifying UA for Hermes-owned direct downloads (media caches, platform
+# adapter fallbacks). CDNs with basic bot detection — upload.wikimedia.org
+# confirmed in #89260 — 403 the bare httpx default (``python-httpx/x``).
+# Wikimedia's UA policy (meta.wikimedia.org/wiki/User-Agent_policy) asks
+# clients to identify themselves rather than impersonate a browser, so this
+# names the agent instead of spoofing Chrome/Firefox. Already used ad hoc in
+# gateway/platforms/base.py and the teams/feishu adapters; call sites should
+# import this constant rather than re-typing the literal.
+DEFAULT_USER_AGENT = "Mozilla/5.0 (compatible; HermesAgent/1.0)"
+
+
 def create_ssrf_safe_async_client(**kwargs: Any) -> Any:
     """Create an ``httpx.AsyncClient`` with connect-time SSRF validation.
 


### PR DESCRIPTION
## What does this PR do?

`TelegramAdapter.send_image()`'s file-upload fallback (taken when the URL-based `send_photo` fails, e.g. with `webpage_media_empty`) downloads the image itself before re-uploading the bytes. The download goes through the SSRF-safe client but sends no headers, so httpx uses its default `python-httpx/x.x` User-Agent. CDNs with basic bot detection — `upload.wikimedia.org` / `commons.wikimedia.org` confirmed in the issue — 403 that UA while the exact same URL works from Telegram's own fetch and from a browser. The fallback then logs `File upload send_photo also failed: Client error '403 Forbidden'` and the message degrades to a bare text link.

This PR sends `tools.url_safety.DEFAULT_USER_AGENT` — a new shared constant holding `"Mozilla/5.0 (compatible; HermesAgent/1.0)"` — on the fallback's GET, plus an image `Accept` header. That string is deliberately not a browser-spoof literal (e.g. a full Chrome UA): it's the identifying UA already used ad hoc in `gateway/platforms/base.py` and the teams/feishu adapters, and Wikimedia's [User-Agent policy](https://meta.wikimedia.org/wiki/User-Agent_policy) asks clients to identify themselves rather than impersonate a browser. Hoisting it into one constant also means every call site that needs this fix imports the same value instead of re-typing the literal. The SSRF-safe client construction and the redirect guard are untouched; only the per-request headers change.

## Related Issue

Fixes #89260

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `tools/url_safety.py` — new `DEFAULT_USER_AGENT` constant (`"Mozilla/5.0 (compatible; HermesAgent/1.0)"`), documented with the 403 context and why it's an identifying string rather than a browser spoof.
- `plugins/platforms/telegram/adapter.py` — the fallback's `client.get(image_url)` now sends `{"User-Agent": DEFAULT_USER_AGENT, "Accept": "image/*,*/*;q=0.8"}`.
- `tests/gateway/test_telegram_media_read_timeout.py` — new regression `test_send_image_upload_fallback_sends_identifying_user_agent`: drives the real URL-fail → download → upload path against a header-capturing fake client and asserts the outgoing `User-Agent` equals `DEFAULT_USER_AGENT` exactly (not a prefix/substring check).
- `tests/gateway/test_telegram_thread_fallback.py` — the rebind-guard test's fake download client now accepts request kwargs, matching the real `httpx.AsyncClient.get()` shape.

## How to Test

```bash
scripts/run_tests.sh tests/gateway/test_telegram_media_read_timeout.py tests/gateway/test_telegram_thread_fallback.py
# Observed result: 23/23 passed (canonical CI-parity runner: hermetic env, TZ=UTC, per-file isolation)

ruff check tools/url_safety.py plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_media_read_timeout.py tests/gateway/test_telegram_thread_fallback.py
# Observed result: All checks passed!
```

**Fail-on-main check:** with `plugins/platforms/telegram/adapter.py` reverted to its pre-fix state (no headers on the fallback's `client.get()`) and everything else kept, the new regression test fails as expected:
```
AssertionError: assert None == 'Mozilla/5.0 (compatible; HermesAgent/1.0)'
 +  where None = <built-in method get of dict object at ...>('User-Agent')
 +    where <built-in method get of dict object at ...> = {}.get
```
i.e. the fallback captured *no* headers at all pre-fix — confirming the test actually exercises the regression rather than passing trivially.

**Also caught while adding that test:** the pre-existing fake HTTP clients in both test files didn't accept a `headers` kwarg, so `client.get(image_url, headers=_dl_headers)` throws `TypeError: get() got an unexpected keyword argument 'headers'` against the unpatched stubs — confirmed both affected tests failing before this PR's stub update, 23/23 passing after. No CI is currently wired to this fork branch, so this would only have surfaced on a maintainer's local run.

**Manual repro (matches the issue):** send a reply containing a real Wikimedia Commons image URL to a Telegram chat where the URL-based send fails (e.g. large enough to trigger `webpage_media_empty`). On `main`, the fallback dies with `403 Forbidden` and the image degrades to a text link. With this change, the fallback downloads and uploads the photo natively.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) before starting — no duplicate existed when this PR was opened (#89264 followed ~14s later; see Scope below)
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run the affected tests (`scripts/run_tests.sh tests/gateway/test_telegram_media_read_timeout.py tests/gateway/test_telegram_thread_fallback.py`) and they pass — the full 3000+ file suite wasn't run locally, only the files this change can plausibly affect; CI covers the rest
- [x] I've added tests for my changes (1 new regression, 2 stub updates)
- [x] Tested on: macOS 15 (Darwin 25.5.0, arm64)

### Documentation & Housekeeping

- [x] N/A — no README/docs changes needed
- [x] N/A — no config keys added/changed
- [x] N/A — no architecture/workflow change
- [x] Cross-platform: change is a plain `dict` passed as HTTP headers, no OS-specific behavior
- [x] N/A — no tool schemas changed

## Scope

`create_ssrf_safe_async_client()` has 15+ call sites repo-wide; most send no UA at all today and are presumably exposed to the same class of bot-detection 403 reported here for Telegram. Centralizing a default UA in the factory itself would cover all of them in one place, but that's a materially larger, harder-to-review change than this issue asked for. Filed #93242 to track that separately rather than widening this PR's diff, and it's now implemented in #93259 — traced the two call sites that looked like they might need an exception (a presigned-URL PUT, a vendor-CDN GET) and found neither actually does, so that PR applies the default uniformly rather than carving out exceptions.

