### PR TITLE
fix(retry): let the Z.AI overload adaptive backoff run before provider fallback

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5220,9 +5220,17 @@ def run_conversation(
                 )
                 if _is_zai_coding_overload:
                     max_retries = max(max_retries, zai_coding_overload_retry_ceiling())
+                # The raised ceiling above is dead code if the fallback gate
+                # below still switches providers at the default transport
+                # threshold — `overloaded` counts as a transport failure, so
+                # Hermes bails to the fallback chain at retry 2 (~seconds)
+                # and the 30/60/90/120s adaptive schedule never runs. Let a
+                # Z.AI coding overload run to its raised ceiling; ordinary
+                # transport failures keep the original threshold of 2.
+                _fallback_threshold = max_retries if _is_zai_coding_overload else 2
                 _should_fallback = (
                     is_rate_limited
-                    or (_is_transport_failure and retry_count >= 2)
+                    or (_is_transport_failure and retry_count >= _fallback_threshold)
                 )
                 if _should_fallback and agent._fallback_index < len(agent._fallback_chain):
                     # Don't eagerly fallback if credential pool rotation may

--- a/tests/run_agent/test_zai_overload_backoff_before_fallback.py
+++ b/tests/run_agent/test_zai_overload_backoff_before_fallback.py
@@ -1,0 +1,199 @@
+"""E2E: the Z.AI Coding overload adaptive backoff must actually run before
+provider fallback fires.
+
+`zai_coding_overload_retry_ceiling()` raises the retry ceiling for the narrow
+Z.AI Coding Plan GLM-5.2 overload 429 shape precisely so the long backoff
+schedule (30/60/90/120s) executes. But `overloaded` also counts as a transport
+failure, and the eager-fallback gate used a hardcoded `retry_count >= 2` for
+ALL transport failures — so Hermes switched to the fallback chain at retry 2
+(a few seconds in) and the raised ceiling + adaptive schedule were dead code.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+_ZAI_BASE = "https://api.z.ai/api/coding/paas/v4"
+
+
+class _ZaiOverloadError(Exception):
+    """The exact shape `is_zai_coding_overload_error` detects: 429 + code 1305."""
+
+    status_code = 429
+
+    def __init__(self):
+        super().__init__(
+            '{"error": {"code": 1305, "message": '
+            '"The service may be temporarily overloaded. Please try again later."}}'
+        )
+
+
+def _make_agent():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url=_ZAI_BASE,
+            model="glm-5.2",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=[{"provider": "openai", "model": "gpt-4o"}],
+        )
+    agent.client = MagicMock()
+    agent.client.base_url = _ZAI_BASE
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent._persist_session = lambda *a, **k: None
+    agent._save_trajectory = lambda *a, **k: None
+    agent._fallback_activated = False
+    return agent
+
+
+class TestZaiOverloadRunsBackoffBeforeFallback:
+    def test_overload_retries_past_threshold_two_before_fallback(self, monkeypatch):
+        """With a fallback chain configured, a Z.AI overload must NOT switch
+        providers at retry 2 — the adaptive long backoff owns those retries.
+        The loop keeps retrying the primary until its raised ceiling
+        (zai_coding_overload_retry_ceiling, 8) is reached; only then may the
+        fallback chain activate. Without the fix the fallback fires at
+        retry_count == 2 and the primary never sees attempt 3+.
+        """
+        from agent import conversation_loop as _conv
+        from agent.retry_utils import zai_coding_overload_retry_ceiling
+
+        agent = _make_agent()
+        ceiling = zai_coding_overload_retry_ceiling()
+        assert ceiling > 2, "precondition: the ZAI ceiling raises the default budget"
+
+        attempts = {"primary": 0, "fallback": 0}
+        overload = _ZaiOverloadError()
+
+        def _create(*args, **kwargs):
+            url = str(agent.base_url)
+            if "api.z.ai/api/coding/paas/v4" in url:
+                attempts["primary"] += 1
+                raise overload
+            attempts["fallback"] += 1
+            return SimpleNamespace(
+                choices=[SimpleNamespace(
+                    message=SimpleNamespace(content="fallback reply", tool_calls=None),
+                    finish_reason="stop",
+                )],
+                usage=None,
+            )
+
+        agent.client.chat.completions.create.side_effect = _create
+
+        def _fake_activate_fallback(reason=None):
+            # Minimal stand-in for the real swap: mark the fallback active
+            # and move the dispatch marker so the next create() succeeds.
+            agent._fallback_index += 1
+            agent._fallback_activated = True
+            agent.base_url = "https://api.openai.com/v1"
+            agent.model = "gpt-4o"
+            return True
+
+        agent._try_activate_fallback = _fake_activate_fallback
+
+        monkeypatch.setattr(_conv, "jittered_backoff", lambda *a, **k: 0.0)
+        monkeypatch.setattr(
+            _conv, "adaptive_rate_limit_backoff",
+            lambda attempt, **k: (0.0, "zai_coding_overload_long"),
+        )
+
+        result = agent.run_conversation("hello")
+
+        # The primary provider was retried to its raised ceiling, not cut off
+        # at the transport threshold of 2.
+        assert attempts["primary"] >= ceiling, (
+            f"primary retried only {attempts['primary']} times — the fallback "
+            "gate cut the adaptive Z.AI backoff schedule short"
+        )
+        assert attempts["fallback"] == 1
+        assert result["completed"] is True
+        assert result["final_response"] == "fallback reply"
+
+    def test_ordinary_transport_failure_still_falls_back_at_two(self, monkeypatch):
+        """The threshold change is scoped to the Z.AI overload shape: a plain
+        timeout/transport failure still switches providers after 2 retries."""
+        from agent import conversation_loop as _conv
+
+        agent = _make_agent()
+        attempts = {"primary": 0, "fallback": 0}
+
+        class _TimeoutError(Exception):
+            pass
+
+        def _create(*args, **kwargs):
+            url = str(agent.base_url)
+            if "api.z.ai" in url:
+                attempts["primary"] += 1
+                raise _TimeoutError("Connection to provider timed out.")
+            attempts["fallback"] += 1
+            return SimpleNamespace(
+                choices=[SimpleNamespace(
+                    message=SimpleNamespace(content="fallback reply", tool_calls=None),
+                    finish_reason="stop",
+                )],
+                usage=None,
+            )
+
+        agent.client.chat.completions.create.side_effect = _create
+
+        def _fake_activate_fallback(reason=None):
+            agent._fallback_index += 1
+            agent._fallback_activated = True
+            agent.base_url = "https://api.openai.com/v1"
+            agent.model = "gpt-4o"
+            return True
+
+        agent._try_activate_fallback = _fake_activate_fallback
+
+        monkeypatch.setattr(_conv, "jittered_backoff", lambda *a, **k: 0.0)
+
+        result = agent.run_conversation("hello")
+
+        # Original behavior preserved: primary sees at most 3 attempts
+        # (initial + 2 retries), then the fallback takes over.
+        assert 1 <= attempts["primary"] <= 3
+        assert attempts["fallback"] == 1
+        assert result["completed"] is True
+
+    def test_no_fallback_configured_overload_exhausts_at_ceiling(self, monkeypatch):
+        """Without a fallback chain the loop must keep retrying to the raised
+        ceiling rather than surfacing an error at the default budget."""
+        from agent import conversation_loop as _conv
+        from agent.retry_utils import zai_coding_overload_retry_ceiling
+
+        agent = _make_agent()
+        agent._fallback_chain = []
+        agent.fallback_model = None
+        ceiling = zai_coding_overload_retry_ceiling()
+
+        attempts = {"n": 0}
+
+        def _create(*args, **kwargs):
+            attempts["n"] += 1
+            raise _ZaiOverloadError()
+
+        agent.client.chat.completions.create.side_effect = _create
+
+        monkeypatch.setattr(_conv, "jittered_backoff", lambda *a, **k: 0.0)
+        monkeypatch.setattr(
+            _conv, "adaptive_rate_limit_backoff",
+            lambda attempt, **k: (0.0, "zai_coding_overload_long"),
+        )
+
+        result = agent.run_conversation("hello")
+
+        assert attempts["n"] >= ceiling
+        assert result["failed"] is True


### PR DESCRIPTION
## Symptom

On the Z.AI Coding Plan, a GLM-5.2 overload 429 (HTTP 429, body code 1305, "The service may be temporarily overloaded") caused Hermes to switch to the fallback provider after ~2 retries — a few seconds — instead of riding out the transient overload on the primary. The carefully built adaptive backoff for exactly this error (short retries, then 30/60/90/120s long waits) never ran, so any short provider blip needlessly abandoned the primary model for the rest of the turn (and, with `fallback_providers`, often the session).

## Root cause

`agent/conversation_loop.py` raises the retry ceiling for this shape (`max_retries = max(max_retries, zai_coding_overload_retry_ceiling())`) precisely so the long-backoff tier is reachable — see the existing tests in `tests/test_retry_utils.py` (`test_zai_overload_ceiling_makes_long_tier_reachable`). But two blocks later, the eager-fallback gate classifies `overloaded` as a transport failure and uses a **hardcoded `retry_count >= 2`** for *all* transport failures. The raised ceiling is dead code: the fallback chain activates at retry 2 regardless.

## Fix

Derive the fallback threshold from the retry budget for the narrow Z.AI coding-overload shape (`_fallback_threshold = max_retries if _is_zai_coding_overload else 2`), so those overloads run to their raised ceiling before fallback is considered. Ordinary transport failures (timeouts, unreachable providers) keep the original threshold of 2 — their behavior is unchanged, and rate-limit/billing 429s still switch immediately as before.

## Validation

- New `tests/run_agent/test_zai_overload_backoff_before_fallback.py` (full `run_conversation` loop with a mocked client): (1) a Z.AI overload with a fallback chain configured retries the primary to the raised ceiling before the fallback fires — fails without this change (fallback at retry 2); (2) a plain timeout still falls back after ≤2 retries (scope guard, passes before and after); (3) with no fallback chain, the overload exhausts at the raised ceiling rather than erroring at the default budget.
- `python -m py_compile agent/conversation_loop.py`; existing retry suites (`tests/test_retry_utils.py`) unaffected.
