### PR TITLE
fix(telegram): send a browser-like User-Agent on the image-upload fallback

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8095,7 +8095,19 @@ class TelegramAdapter(BasePlatformAdapter):
                     timeout=30.0,
                     event_hooks={"response": [_ssrf_redirect_guard]},
                 ) as client:
-                    resp = await client.get(image_url)
+                    # The bare httpx default UA ("python-httpx/x") is served
+                    # 403 by CDNs with basic bot detection (e.g.
+                    # upload.wikimedia.org). Match the UA the shared media
+                    # fetcher in gateway/platforms/base.py already sends so
+                    # the fallback can download what send-by-URL could not
+                    # (#89260).
+                    resp = await client.get(
+                        image_url,
+                        headers={
+                            "User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)",
+                            "Accept": "image/*,*/*;q=0.8",
+                        },
+                    )
                     resp.raise_for_status()
                     image_data = resp.content
 

--- a/tests/gateway/test_telegram_media_read_timeout.py
+++ b/tests/gateway/test_telegram_media_read_timeout.py
@@ -84,7 +84,7 @@ def _stub_download(monkeypatch, size: int):
         async def __aexit__(self, *exc):
             return False
 
-        async def get(self, url):
+        async def get(self, url, **kwargs):
             return _Resp()
 
     import tools.url_safety as url_safety
@@ -133,3 +133,62 @@ async def test_send_image_upload_fallback_uses_media_read_timeout(adapter, monke
     upload = calls[1]
     assert isinstance(upload["photo"], (bytes, bytearray))
     assert upload["read_timeout"] == tg._MEDIA_SEND_READ_TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_send_image_upload_fallback_sends_browser_like_user_agent(
+    adapter, monkeypatch
+):
+    """The byte-upload fallback must not download with the bare httpx default
+    UA: CDNs with basic bot detection (e.g. upload.wikimedia.org) serve the
+    "python-httpx/x" UA a 403 while the URL worked from Telegram only
+    seconds before, so the image silently degraded to a text link (#89260).
+    The fallback must send the same UA the shared media fetcher in
+    gateway/platforms/base.py sends."""
+    seen = {}
+
+    class _Resp:
+        content = b"x" * 512
+
+        def raise_for_status(self):
+            return None
+
+    class _Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def get(self, url, headers=None, **kwargs):
+            seen["url"] = url
+            seen["headers"] = headers or {}
+            return _Resp()
+
+    import tools.url_safety as url_safety
+
+    monkeypatch.setattr(
+        url_safety, "create_ssrf_safe_async_client", lambda **kw: _Client()
+    )
+    calls = []
+
+    async def _photo(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise RuntimeError("webpage_media_empty: URL send refused")
+        msg = MagicMock()
+        msg.message_id = 3
+        return msg
+
+    adapter._bot.send_photo = AsyncMock(side_effect=_photo)
+
+    result = await adapter.send_image(
+        "123", "https://upload.wikimedia.org/wikipedia/commons/x/x.jpg", caption="c"
+    )
+
+    assert result.success and len(calls) == 2
+    ua = seen["headers"].get("User-Agent", "")
+    assert ua.startswith("Mozilla/5.0"), (
+        f"fallback downloaded with a bot-detected User-Agent: {ua!r}"
+    )
+    assert "python-httpx" not in ua

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -529,7 +529,9 @@ async def test_send_image_upload_dm_topic_reply_not_found_retry_drops_thread_id(
         async def __aexit__(self, *args):
             return None
 
-        async def get(self, _url):
+        async def get(self, _url, **_kwargs):
+            # The fallback download sends UA headers now (#89260); accept
+            # any request kwargs so this stub tracks the real client shape.
             return _FakeResponse()
 
     adapter._bot = SimpleNamespace(send_photo=mock_send_photo)


### PR DESCRIPTION
## What does this PR do?

`TelegramAdapter.send_image()`'s byte-upload fallback (taken when the URL-based `send_photo` fails, e.g. with `webpage_media_empty`) downloads the image itself before re-uploading the bytes. On current `main` that download goes through the SSRF-safe client but sends **no User-Agent**, so httpx uses its default `python-httpx/x`. CDNs with basic bot detection — `upload.wikimedia.org` / `commons.wikimedia.org` confirmed in the issue — serve that UA a hard `403 Forbidden` while the exact same URL works moments later from Telegram's own fetch and from a browser. The fallback then logs "File upload send_photo also failed: Client error '403 Forbidden'" and the message degrades to a bare text link.

This PR sends the same browser-like UA the shared media fetcher in `gateway/platforms/base.py` already uses on its downloads — `Mozilla/5.0 (compatible; HermesAgent/1.0)` plus an image `Accept` — on the fallback's GET. The SSRF-safe client construction and the redirect guard are untouched; only the per-request headers change.

## Related Issue

Fixes #89260

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/telegram/adapter.py` — the fallback's `client.get(image_url)` now passes `headers={"User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)", "Accept": "image/*,*/*;q=0.8"}` (verbatim match with the shared fetcher in `gateway/platforms/base.py`), with a comment naming the 403 class of CDNs.
- `tests/gateway/test_telegram_media_read_timeout.py` — new regression `test_send_image_upload_fallback_sends_browser_like_user_agent`: drives the real URL-fail → download → upload path against a capturing fake client and asserts the UA starts with `Mozilla/5.0` and is not `python-httpx`; the file's `_stub_download` fake now accepts request kwargs (the real client shape).
- `tests/gateway/test_telegram_thread_fallback.py` — the rebind-guard test's fake download client accepts request kwargs the same way; its assertions are unchanged.

## How to Test

```bash
python -m pytest tests/gateway/test_telegram_media_read_timeout.py -q
# Observed result: 3 passed

python -m pytest tests/gateway/test_telegram_status_update.py tests/gateway/test_telegram_thread_fallback.py -q
# Observed result: 24 passed, 1 environment-noise failure
# (test_send_image_upload_fallback_blocks_connect_time_rebind attempts a
#  127.0.0.1:7890 proxy connect on this dev machine regardless of this
#  branch — it fails identically with the source change stashed, i.e. it
#  is local-proxy pollution, not a regression; CI has no such proxy)
```

Fail-on-main check: with the adapter change stashed, the new UA regression fails on main (empty headers captured).

Manual repro from the issue: send a reply containing a real Wikimedia Commons image URL to a Telegram chat; on main the URL send fails with `webpage_media_empty` and the fallback dies with `403 Forbidden`; with this change the fallback downloads and uploads the photo.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments explain intent (why the UA must be browser-like and where the value comes from)
- [x] Corresponding changes documented via comments
- [x] Tests added and passing (1 new regression; stubs updated to the real client shape)
- [x] Single root cause, no unrelated changes
