### PR TITLE
fix(moa): stop coercing absent or null max_tokens to 4096

### DIFF
--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -303,7 +303,9 @@ def _default_preset() -> dict[str, Any]:
         "aggregator_temperature": None,
         "reference_timeout": DEFAULT_MOA_REFERENCE_TIMEOUT,
         "degraded_reference_policy": "loud",
-        "max_tokens": 4096,
+        # None means no preset-level output cap.  The acting aggregator is
+        # intentionally uncapped; reference output uses reference_max_tokens.
+        "max_tokens": None,
         "reference_max_tokens": None,
         "fanout": "user_turn",
         "enabled": True,
@@ -333,6 +335,7 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
 
     aggregator = _clean_slot(raw.get("aggregator")) or deepcopy(DEFAULT_MOA_AGGREGATOR)
 
+    raw_mt = raw.get("max_tokens")
     return {
         "enabled": _coerce_bool(raw.get("enabled"), True),
         "reference_models": refs,
@@ -343,7 +346,10 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
         "degraded_reference_policy": _coerce_degraded_reference_policy(
             raw.get("degraded_reference_policy")
         ),
-        "max_tokens": _coerce_int(raw.get("max_tokens"), 4096),
+        # Preserve an explicit null (and the absent value) as uncapped.  This
+        # field is retained for API compatibility; the runtime's actual
+        # reference cap is reference_max_tokens.
+        "max_tokens": None if raw_mt is None else _coerce_int(raw_mt, 4096),
         # Optional cap on how much each reference ADVISOR may generate per turn.
         # None (default) = uncapped: advisors write full-length advice, matching
         # prior behavior so existing presets are unchanged. Set a value (e.g.

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -5,6 +5,7 @@ from hermes_cli.moa_config import (
     DEFAULT_MOA_AGGREGATOR,
     DEFAULT_MOA_PRESET_NAME,
     DEFAULT_MOA_REFERENCE_MODELS,
+    _default_preset,
     build_moa_turn_prompt,
     decode_moa_turn,
     exact_moa_preset_name,
@@ -46,6 +47,41 @@ def test_normalize_moa_config_uses_default_named_preset():
     assert list(cfg["presets"]) == [DEFAULT_MOA_PRESET_NAME]
     assert cfg["reference_models"] == _enabled_refs(DEFAULT_MOA_REFERENCE_MODELS)
     assert cfg["aggregator"] == DEFAULT_MOA_AGGREGATOR
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, None),
+        (8192, 8192),
+        ("abc", 4096),
+        ("", 4096),
+        (0, 0),
+    ],
+)
+def test_moa_preset_max_tokens_normalization(value, expected):
+    cfg = normalize_moa_config({"max_tokens": value})
+
+    assert cfg["presets"][DEFAULT_MOA_PRESET_NAME]["max_tokens"] == expected
+
+
+def test_moa_preset_max_tokens_absent_defaults_to_none():
+    assert normalize_moa_config({})["max_tokens"] is None
+    assert _default_preset()["max_tokens"] is None
+
+
+def test_moa_preset_max_tokens_resolve_and_flatten_preserve_none():
+    cfg = normalize_moa_config(
+        {
+            "default_preset": "uncapped",
+            "presets": {"uncapped": {"max_tokens": None}},
+        }
+    )
+
+    assert resolve_moa_preset(cfg, "uncapped")["max_tokens"] is None
+    assert cfg["max_tokens"] is None
+    assert cfg["max_tokens"] != 4096
+
 
 
 
@@ -175,9 +211,6 @@ def test_validate_moa_payload_agrees_with_clean_slot():
 
 
 # --- privacy_filter normalization ---
-
-
-
 
 
 

--- a/website/docs/user-guide/features/mixture-of-agents.md
+++ b/website/docs/user-guide/features/mixture-of-agents.md
@@ -90,7 +90,7 @@ moa:
       # the same behavior as a single-model Hermes agent.
       # reference_temperature: 0.6
       # aggregator_temperature: 0.4
-      max_tokens: 4096
+      max_tokens: null       # uncapped; reference_max_tokens controls advisors
       enabled: true
 ```
 


### PR DESCRIPTION
# PR A body — Fixes #89227 (MoA max_tokens)

## Summary

Fixes #89227

`hermes_cli/moa_config.py` manufactures a hardcoded `4096` for `max_tokens` in two places: the default preset and `_normalize_preset`'s coercion for absent or explicitly-`null` values. The runtime (`agent/moa_loop.py`) deliberately stopped capping synthesis at 4096 (None is passed through and the model's real maximum is used); this config-layer cap silently truncates long aggregator syntheses whenever the key is omitted or set to `null`, contradicting the runtime's documented intent.

## Behavior change

- Omitted `max_tokens` or explicit `max_tokens: null`: no longer coerced to 4096; the runtime uses the model's real maximum (matching `reference_max_tokens` semantics).
- Explicit integer values (e.g. `max_tokens: 4096`) are unchanged and still take effect.
- Malformed non-null values (`"abc"`, `""`) still fall back to 4096 rather than being silently converted to uncapped.

To restore the old cap, set `max_tokens: 4096` explicitly.

## Notes

- This is distinct from #60388 (different MoA surface).
- `reference_models[].max_tokens` already uses `_coerce_int_or_none` (None = uncapped); this change makes the preset-level field consistent.
- Display/JSON surface: the flattened view passes the normalized value through unchanged, but the desktop/API contract in `hermes_cli/web_models.py` still declares `max_tokens: int = 4096`. Desktop callers round-tripping the GET payload can therefore still see 4096. This PR leaves that contract unchanged; it needs a follow-up update to `Optional[int]`.

No em-dashes in this body.
