### PR TITLE
fix(install): export HERMES_HOME so child tools honor --hermes-home

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -45,7 +45,7 @@ BOLD='\033[1m'
 # Configuration
 REPO_URL_SSH="git@github.com:NousResearch/hermes-agent.git"
 REPO_URL_HTTPS="https://github.com/NousResearch/hermes-agent.git"
-HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+export HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
 # INSTALL_DIR is resolved AFTER arg parsing and OS detection so we can pick an
 # FHS-style layout for root installs.  Track whether the user gave us an
 # explicit directory — if so we never override it.
@@ -2012,9 +2012,9 @@ SOUL_EOF
         log_info "Skipping bundled skills (--no-skills). Wrote $HERMES_HOME/.no-bundled-skills"
         log_info "  Future 'hermes update' runs will not inject bundled skills. Delete the marker to opt back in."
     else
-        log_info "Syncing bundled skills to ~/.hermes/skills/ ..."
+        log_info "Syncing bundled skills to $HERMES_HOME/skills/ ..."
         if "$INSTALL_DIR/venv/bin/python" "$INSTALL_DIR/tools/skills_sync.py" 2>/dev/null; then
-            log_success "Skills synced to ~/.hermes/skills/"
+            log_success "Skills synced to $HERMES_HOME/skills/"
         else
             # Fallback: simple directory copy if Python sync fails
             if [ -d "$INSTALL_DIR/skills" ] && [ ! "$(ls -A "$HERMES_HOME/skills/" 2>/dev/null | grep -v '.bundled_manifest')" ]; then


### PR DESCRIPTION
## Summary

Fixes #89231

`scripts/install.sh` resolves `--hermes-home` (and the `HERMES_HOME` env default) into a shell variable but never exports it. Child processes spawned during install (e.g. `skills_sync.py`) therefore resolve the home independently from `$HOME/.hermes`, ignoring the flag, causing a silent split-brain: the flag path is populated and used by the installer, while child tools read and write a different directory. Line 3273 already proves the intended design (children must see the resolved home).

## Change

- Export `HERMES_HOME` once, immediately after its resolution (bash's export attribute is sticky across later plain reassignment, so the later `--hermes-home` assignment at the arg-parse site propagates too).
- Hardcoded log strings at ~:2015/:2017 use `"$HERMES_HOME/skills/"` instead of the literal `~/.hermes` path so logs reflect the custom location.

## Compatibility

- Unset flag/env: behavior identical to before (default `$HOME/.hermes`, now merely inherited by children instead of silently re-derived).
- Set `--hermes-home`: children now honor it.

## Known scope

- Launcher baking is deferred: the installer-process export only fixes children spawned during install. Whether generated launchers resolve `HERMES_HOME` at invocation time needs a separate follow-up (quoting a path containing spaces in a baked launcher is the open hazard). macOS branches untested here (CI is Linux).