### PR TITLE
fix(matrix): restore nested mention placeholders

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -4881,8 +4881,13 @@ class MatrixAdapter(BasePlatformAdapter):
             protected,
         )
 
-        for idx, original in enumerate(placeholders):
-            linked = linked.replace(f"\x00MENTION_PROTECTED{idx}\x00", original)
+        # Markdown regions can nest after protection (for example, inline code
+        # inside a link label). Restore the outer/latest placeholders first so
+        # inner placeholders are present when their turn is reached.
+        for idx in reversed(range(len(placeholders))):
+            linked = linked.replace(
+                f"\x00MENTION_PROTECTED{idx}\x00", placeholders[idx]
+            )
 
         return linked
 

--- a/tests/gateway/test_matrix_mention.py
+++ b/tests/gateway/test_matrix_mention.py
@@ -156,6 +156,24 @@ class TestOutboundMentions:
             "@alice:example.org</a>, please check this."
         )
 
+    @pytest.mark.asyncio
+    async def test_send_preserves_inline_code_inside_markdown_link(self):
+        text = (
+            "Branch: "
+            "[`feat/clear-path-landing-refresh`]"
+            "(https://github.com/example/repo/tree/feat/clear-path-landing-refresh)"
+        )
+
+        result = await self.adapter.send("!room1:example.org", text)
+
+        assert result.success is True
+        content = self._sent_content(self.mock_client)
+        assert content["body"] == text
+        assert "MENTION_PROTECTED" not in content["formatted_body"]
+        assert "<code>feat/clear-path-landing-refresh</code>" in content[
+            "formatted_body"
+        ]
+
 
 # ---------------------------------------------------------------------------
 # Require-mention gating in _on_room_message


### PR DESCRIPTION
## Summary

- restore protected outbound Matrix Markdown regions in reverse order
- preserve nested regions such as inline-code branch names inside Markdown links
- add an end-to-end outbound send regression test

## Root cause

Outbound mention detection temporarily replaces fenced code, inline code, and links with placeholders. Because inline code is protected before links, a link label such as ``[`feat/name`](https://example.test/feat/name)`` creates an outer link placeholder containing an earlier inline-code placeholder.

The restore loop ran in ascending order. It attempted to restore the inner placeholder before the outer link had been restored, then restored the outer placeholder containing the now-unvisited inner token. Matrix clients therefore received literal `MENTION_PROTECTED0` text instead of the branch name.

Restoring latest/outer placeholders first makes the earlier/inner placeholders available when their turn is reached.

## Verification

- Regression test observed failing on current upstream `main` with literal `MENTION_PROTECTED0` in `formatted_body`
- `tests/gateway/test_matrix_mention.py`: 18 passed
- Broader Matrix adapter suite: 184 passed, 1 skipped with one environment-sensitive baseline test deselected; the deselected test fails identically on untouched upstream `main` in an E2EE-capable environment
- Ruff lint: passed for both changed files
- Exact branch-link reproduction returns unchanged with no placeholder text
