### PR TITLE
fix(hindsight): propagate bank mission config to the server; add opt-in sync_turn content filter

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -861,7 +861,11 @@ class HindsightMemoryProvider(MemoryProvider):
         # Bank
         self._bank_mission = ""
         self._bank_retain_mission: str | None = None
+        self._bank_observations_mission: str | None = None
         self._bank_id_template = ""
+        # Optional content-quality gate for sync_turn (off by default: every
+        # turn keeps being retained unless the user opts in).
+        self._sync_turn_filter = False
 
     @property
     def name(self) -> str:
@@ -1180,9 +1184,11 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "bank_id_template", "description": "Optional template to derive bank_id dynamically. Placeholders: {profile}, {workspace}, {platform}, {user}, {session}. Example: hermes-{profile}", "default": ""},
             {"key": "bank_mission", "description": "Mission/purpose description for the memory bank"},
             {"key": "bank_retain_mission", "description": "Custom extraction prompt for memory retention"},
+            {"key": "bank_observations_mission", "description": "Custom mission for observation consolidation"},
             {"key": "recall_budget", "description": "Recall thoroughness", "default": "mid", "choices": ["low", "mid", "high"]},
             {"key": "memory_mode", "description": "Memory integration mode", "default": "hybrid", "choices": ["hybrid", "context", "tools"]},
             {"key": "recall_prefetch_method", "description": "Auto-recall method", "default": "recall", "choices": ["recall", "reflect"]},
+            {"key": "sync_turn_filter", "description": "Skip retaining ephemeral/operational turns (short acknowledgments, status updates, tool-output-only turns)", "default": False},
             {"key": "retain_tags", "description": "Default tags applied to retained memories (comma-separated)", "default": ""},
             {"key": "observation_scopes", "description": "How observations are scoped during consolidation: 'combined' (default — one pass over all tags), 'per_tag' (one isolated observation per tag), 'all_combinations' (every tag subset — expensive), or a JSON list of tag-lists for explicit custom scopes. Empty uses Hindsight's 'combined' default.", "default": ""},
             {"key": "retain_source", "description": "Metadata source value attached to retained memories (identifies the client that stored them)", "default": _DEFAULT_RETAIN_SOURCE},
@@ -1670,6 +1676,8 @@ class HindsightMemoryProvider(MemoryProvider):
         # Bank options
         self._bank_mission = self._config.get("bank_mission", "")
         self._bank_retain_mission = self._config.get("bank_retain_mission") or None
+        self._bank_observations_mission = self._config.get("bank_observations_mission") or None
+        self._sync_turn_filter = bool(self._config.get("sync_turn_filter", False))
 
         # Tags
         self._retain_tags = _normalize_retain_tags(
@@ -1746,6 +1754,27 @@ class HindsightMemoryProvider(MemoryProvider):
                      self._auto_retain, self._auto_recall, self._retain_every_n_turns,
                      self._retain_async, self._retain_context, self._recall_max_tokens, self._recall_max_input_chars,
                      self._tags, self._recall_tags)
+
+        # Ensure bank-level mission/extraction config is applied to the server.
+        # The _bank_mission/_bank_retain_mission fields were read from config
+        # but never propagated to the Hindsight API (dead-config bug). This
+        # call pushes them on every initialize so the server uses them during
+        # fact extraction and observation synthesis.
+        if self._bank_retain_mission or self._bank_mission or self._bank_observations_mission:
+            try:
+                client = self._get_client()
+                updates = {}
+                if self._bank_retain_mission:
+                    updates["retain_mission"] = self._bank_retain_mission
+                if self._bank_mission:
+                    updates["reflect_mission"] = self._bank_mission
+                if self._bank_observations_mission:
+                    updates["observations_mission"] = self._bank_observations_mission
+                if updates:
+                    client.update_bank_config(self._bank_id, **updates)
+                    logger.info("Applied bank config from config.json: %s", list(updates.keys()))
+            except Exception as e:
+                logger.warning("Failed to apply bank config from config.json: %s", e)
 
         # For local mode, start the embedded daemon in the background so it
         # doesn't block the chat. Redirect stdout/stderr to a log file to
@@ -2048,6 +2077,30 @@ class HindsightMemoryProvider(MemoryProvider):
             kwargs["observation_scopes"] = self._observation_scopes
         return kwargs
 
+    def _is_retainable_turn(self, user_content: str, assistant_content: str) -> bool:
+        """Content quality gate: return False for ephemeral/operational turns.
+
+        Filters out short acknowledgments, status updates, and tool-output-only
+        turns that should not be retained in durable memory.
+        """
+        combined = (user_content or "") + (assistant_content or "")
+        # Skip very short exchanges (< 50 chars combined)
+        if len(combined.strip()) < 50:
+            return False
+        # Skip turns where the assistant response is just a short acknowledgment
+        ack_patterns = (
+            "done.", "ok.", "understood.", "will do.", "got it.",
+            "noted.", "sure.", "yes.", "no.", "(empty)",
+            "dispatched to", "it's running",
+        )
+        ac_lower = (assistant_content or "").strip().lower()
+        if len(ac_lower) < 100 and any(ac_lower.startswith(p) for p in ack_patterns):
+            return False
+        # Skip pure tool-output turns (assistant content is mostly JSON/code)
+        if assistant_content and assistant_content.strip().startswith(("{\"output\":", "{\"status\":")):
+            return False
+        return True
+
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
         """Enqueue a retain for the current turn. Non-blocking.
 
@@ -2061,6 +2114,13 @@ class HindsightMemoryProvider(MemoryProvider):
             return
         if self._shutting_down.is_set():
             logger.debug("sync_turn: skipped (shutting down)")
+            return
+
+        # Content quality gate — skip ephemeral/operational turns when the
+        # user opted in (sync_turn_filter). Default off: retention behavior
+        # is unchanged for existing setups.
+        if self._sync_turn_filter and not self._is_retainable_turn(user_content, assistant_content):
+            logger.debug("sync_turn: skipped (content quality gate)")
             return
 
         if session_id:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1561,3 +1561,107 @@ class TestClientAutoUpgradeRoutesThroughLazyDeps:
         assert len(calls) == 1  # attempted exactly once, init still completed
         assert any("runtime installs are disabled" in r.getMessage()
                    for r in caplog.records)
+
+
+class TestBankConfigPropagation:
+    """bank_mission / bank_retain_mission / bank_observations_mission were
+    read from config but never pushed to the Hindsight server — dead config.
+    initialize() must forward all three via update_bank_config()."""
+
+    def _init_with_missions(self, tmp_path, monkeypatch, **overrides):
+        config = {
+            "mode": "cloud",
+            "apiKey": "test-key",
+            "api_url": "http://localhost:9999",
+            "bank_id": "test-bank",
+            "budget": "mid",
+            "memory_mode": "hybrid",
+        }
+        config.update(overrides)
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
+
+        captured = {}
+
+        class _Client:
+            def update_bank_config(self, bank_id, **updates):
+                captured["bank_id"] = bank_id
+                captured["updates"] = updates
+
+        _client = _Client()
+
+        def _fake_get_client(self):
+            return _client
+
+        monkeypatch.setattr(
+            HindsightMemoryProvider, "_get_client", _fake_get_client
+        )
+        p = HindsightMemoryProvider()
+        p.initialize(session_id="s", hermes_home=str(tmp_path), platform="cli")
+        return p, captured
+
+    def test_missions_are_pushed_to_the_server(self, tmp_path, monkeypatch):
+        p, captured = self._init_with_missions(
+            tmp_path, monkeypatch,
+            bank_mission="reflect framing",
+            bank_retain_mission="retain framing",
+            bank_observations_mission="observation framing",
+        )
+        assert captured["bank_id"] == "test-bank"
+        assert captured["updates"] == {
+            "reflect_mission": "reflect framing",
+            "retain_mission": "retain framing",
+            "observations_mission": "observation framing",
+        }
+
+    def test_no_missions_means_no_server_write(self, tmp_path, monkeypatch):
+        p, captured = self._init_with_missions(tmp_path, monkeypatch)
+        assert captured == {}
+
+    def test_partial_missions_forward_only_what_is_set(self, tmp_path, monkeypatch):
+        p, captured = self._init_with_missions(
+            tmp_path, monkeypatch, bank_retain_mission="retain only"
+        )
+        assert captured["updates"] == {"retain_mission": "retain only"}
+
+
+class TestSyncTurnContentFilter:
+    """Opt-in sync_turn_filter skips ephemeral/operational turns."""
+
+    def test_filter_off_by_default_retains_short_turns(self, provider_with_config):
+        p = provider_with_config(retain_async=False)
+        p.sync_turn("hello", "hi there")
+        p._retain_queue.join()
+        p._client.aretain_batch.assert_called_once()
+
+    def test_filter_on_skips_acknowledgment_turns(self, provider_with_config):
+        p = provider_with_config(retain_async=False, sync_turn_filter=True)
+        p.sync_turn(
+            "please run the deployment",
+            "Done. The deployment task was dispatched to the worker queue.",
+        )
+        p._retain_queue.join()
+        p._client.aretain_batch.assert_not_called()
+
+    def test_filter_on_retains_substantive_turns(self, provider_with_config):
+        p = provider_with_config(retain_async=False, sync_turn_filter=True)
+        p.sync_turn(
+            "what did we decide about the database migration?",
+            "We decided to postpone the migration until the replication "
+            "lag issue is fixed; the plan is documented in runbook 7.",
+        )
+        p._retain_queue.join()
+        p._client.aretain_batch.assert_called_once()
+
+    def test_filter_on_skips_tool_output_only_turns(self, provider_with_config):
+        p = provider_with_config(retain_async=False, sync_turn_filter=True)
+        p.sync_turn(
+            "what is the status of the backup job?",
+            '{"status": "ok", "output": "backup completed at 03:00"}',
+        )
+        p._retain_queue.join()
+        p._client.aretain_batch.assert_not_called()


### PR DESCRIPTION
## Symptom

Setting `bank_mission`, `bank_retain_mission`, or `bank_observations_mission` in the Hindsight provider config had no effect: the values are read into provider attributes during `initialize()` but never sent anywhere, so the server kept its default extraction / reflection / observation-consolidation framing. Silent dead config — the setup wizard even lists the first two keys.

Additionally, on chatty setups (agents, gateway workers) every turn is retained, including "ok." / "done." acknowledgments and raw tool-output replies, so the memory bank accumulates operational noise the user then pays to store, consolidate, and recall past.

## Root cause

1. `_bank_mission` / `_bank_retain_mission` (and the newer `bank_observations_mission` key, which had no attribute at all) stop at the provider: nothing calls the client's `update_bank_config()`, whose whole purpose is to push these per-bank missions to the server.
2. `sync_turn()` unconditionally enqueues every turn; there is no shape check for ephemeral content.

## Fix

- During `initialize()`, after config load, push whichever of the three missions are set via `client.update_bank_config(bank_id, reflect_mission=..., retain_mission=..., observations_mission=...)`. Fail-soft: a push failure logs a warning and initialization continues (bank config can also be managed server-side; a reachable-later server shouldn't break provider startup). `bank_observations_mission` is now declared in `get_config_schema()` alongside its siblings.
- New `sync_turn_filter` config key (default `False` — retention behavior unchanged for existing setups). When enabled, `_is_retainable_turn()` skips turns that are <50 chars combined, start with a short acknowledgment, or are tool-output-shaped JSON blobs.

## Validation

- New `TestBankConfigPropagation` (all three missions pushed, partial sets forwarded as-is, no missions ⇒ no server write) and `TestSyncTurnContentFilter` (default retains short turns; filter on skips acknowledgment and tool-output turns, retains substantive ones). The four directional tests fail on the previous code and pass with the fix.
- Full `tests/plugins/memory/test_hindsight_provider.py` — 84/84 pass; hindsight config-schema/template/health/root-guard suites — 26/26 pass; `py_compile` clean.
