### PR TITLE
fix(secrets): force colorless bws JSON output

### DIFF
--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -674,7 +674,7 @@ def _summarize_bws_stderr(raw: str) -> str:
 def _run_bws_list(
     bws: Path, access_token: str, project_id: str, server_url: str = ""
 ) -> Tuple[Dict[str, str], List[str]]:
-    cmd = [str(bws), "secret", "list", project_id, "--output", "json"]
+    cmd = [str(bws), "secret", "list", project_id, "--output", "json", "--color", "no"]
     # bws child intentionally receives the access token.  Under a profile-local
     # fetch it must not inherit sibling credentials from process-global env.
     source_env = get_source_environment()
@@ -685,8 +685,15 @@ def _run_bws_list(
     else:
         env = dict(source_env)
     env["BWS_ACCESS_TOKEN"] = access_token
-    # Make sure we're not echoing telemetry / colour codes into json.
-    env.setdefault("NO_COLOR", "1")
+    # Make sure we're not echoing telemetry / colour codes into the json stream.
+    # bws 2.0.0 lets FORCE_COLOR / CLICOLOR_FORCE override NO_COLOR and ANSI-colorizes
+    # even `--output json`; the first byte then becomes ESC (0x1b) and json.loads breaks
+    # at char 0.  `--color no` on the command line is the deterministic fix; forcing
+    # NO_COLOR and stripping the colour-forcing vars a parent (e.g. an agent/CI harness
+    # that exports FORCE_COLOR=3) may hold is defence in depth.
+    env["NO_COLOR"] = "1"
+    for _colour_var in ("FORCE_COLOR", "CLICOLOR_FORCE", "CLICOLOR"):
+        env.pop(_colour_var, None)
     # Region / self-hosted support.  bws defaults to https://vault.bitwarden.com
     # (US Cloud); EU Cloud users need https://vault.bitwarden.eu, and
     # self-hosted users need their own URL.  When unset, fall back to whatever

--- a/tests/test_bitwarden_secrets.py
+++ b/tests/test_bitwarden_secrets.py
@@ -210,6 +210,53 @@ def test_fetch_server_url_sets_env(monkeypatch, tmp_path):
     assert captured_env.get("BWS_SERVER_URL") == "https://vault.bitwarden.eu"
 
 
+def test_bws_json_disables_forced_color(monkeypatch, tmp_path):
+    """Inherited color-forcing vars must not corrupt ``--output json``."""
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("")
+    source_env = {
+        "PATH": "/usr/bin",
+        "FORCE_COLOR": "3",
+        "CLICOLOR_FORCE": "1",
+        "CLICOLOR": "1",
+        "NO_COLOR": "0",
+    }
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs["env"]
+        return mock.Mock(
+            returncode=0,
+            stdout=_fake_bws_payload([{"key": "SAFE_KEY", "value": "value"}]),
+            stderr="",
+        )
+
+    monkeypatch.setattr(bw, "get_source_environment", lambda: source_env)
+    monkeypatch.setattr(bw.subprocess, "run", fake_run)
+
+    secrets, warnings = bw._run_bws_list(fake_binary, "0.test", "project-id")
+
+    assert captured["cmd"] == [
+        str(fake_binary),
+        "secret",
+        "list",
+        "project-id",
+        "--output",
+        "json",
+        "--color",
+        "no",
+    ]
+    assert captured["env"]["BWS_ACCESS_TOKEN"] == "0.test"
+    assert captured["env"]["NO_COLOR"] == "1"
+    assert "FORCE_COLOR" not in captured["env"]
+    assert "CLICOLOR_FORCE" not in captured["env"]
+    assert "CLICOLOR" not in captured["env"]
+    assert source_env["FORCE_COLOR"] == "3"
+    assert secrets == {"SAFE_KEY": "value"}
+    assert warnings == []
+
+
 
 
 


### PR DESCRIPTION
## Summary

- force the Bitwarden Secrets Manager CLI to disable color when requesting JSON
- strip parent color-forcing variables from the copied child environment
- preserve parent environment immutability
- add a regression test covering `FORCE_COLOR`, `CLICOLOR_FORCE`, and `CLICOLOR`

## Root cause

With bws 2.0.0, parent color-forcing variables can override `NO_COLOR` and prefix JSON output with ANSI bytes. `json.loads` then fails at character 0 during Hermes startup.

## Validation

- 75 focused Bitwarden/env-loader/registry/remediation tests passed on the review branch
- independent security and logic review passed
- verified against bws 2.0.0 argument parsing

No secret values or credentials are included in the changes or tests.

## Rebase verification — 2026-08-19

Rebased onto current upstream `5dd15872a687` (head `a44c0b1e509e`). The fix is still absent from main. Fresh isolated verification: `tests/test_bitwarden_secrets.py` **19/19 passed** via `uv` with no project dependency change; diff check clean.

This account has `READ` permission on NousResearch/hermes-agent, so the remaining gate is maintainer review/merge, not an author-side conflict.
