### PR TITLE
feat(sessions): inspect delegated task progress

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13044,6 +13044,20 @@ def main():
         "(matched by path substring or basename).",
     )
 
+    sessions_inspect = sessions_subparsers.add_parser(
+        "inspect",
+        help="Show a session's current activity and task-plan progress",
+    )
+    sessions_inspect.add_argument(
+        "session_id",
+        help="Session ID or unique ID prefix",
+    )
+    sessions_inspect.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the activity and task plan as JSON",
+    )
+
     def _add_session_filter_args(p, default_older_help):
         p.add_argument(
             "--older-than",

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -142,13 +142,14 @@ def _session_inspection(db, session_id):
     resolved = db.resolve_session_id(session_id)
     if not resolved:
         return None
-    exported = db.export_session(resolved)
+    exported = db.export_session_lineage(resolved)
     if not exported:
         return None
-    activity = db.get_session_activity(resolved) or {}
+    current_id = exported.get("id") or resolved
+    activity = db.get_session_activity(current_id) or {}
     return {
         "session": {
-            "id": resolved,
+            "id": current_id,
             "title": exported.get("title"),
             "source": exported.get("source"),
             "state": "active" if exported.get("ended_at") is None else "ended",

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -19,6 +19,7 @@ one-way (main.py imports this module; the reverse happens only lazily at call
 time — no import cycle).
 """
 
+import json
 import os
 import sys
 from pathlib import Path
@@ -59,6 +60,153 @@ def _confirm_prompt(prompt: str) -> bool:
 #: generous: the rows are worthless but harmless, and a young never-active row
 #: may simply be a chat that nobody has replied to yet.
 _NEVER_ACTIVE_DEFAULT_DAYS = 30.0
+
+
+def _decode_tool_calls(value):
+    """Return persisted tool calls as a list, tolerating JSON storage."""
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except (TypeError, ValueError):
+            return []
+    return value if isinstance(value, list) else []
+
+
+def _is_paired_todo_result(messages, tool_index):
+    """Whether a tool row belongs to the nearest assistant's todo call."""
+    tool_call_id = messages[tool_index].get("tool_call_id")
+    if not tool_call_id:
+        return False
+    for prior in reversed(messages[:tool_index]):
+        role = prior.get("role")
+        if role == "assistant":
+            for call in _decode_tool_calls(prior.get("tool_calls")):
+                if not isinstance(call, dict) or call.get("id") != tool_call_id:
+                    continue
+                function = call.get("function")
+                return isinstance(function, dict) and function.get("name") == "todo"
+            return False
+        if role in {"user", "system"}:
+            return False
+    return False
+
+
+def _latest_todo_plan(messages):
+    """Project the latest canonical todo result into inspect-friendly state."""
+    from tools.todo_tool import MAX_TODO_RESULT_CHARS, TodoStore
+
+    for index in range(len(messages) - 1, -1, -1):
+        message = messages[index]
+        if message.get("role") != "tool" or not _is_paired_todo_result(messages, index):
+            continue
+        content = message.get("content")
+        if not isinstance(content, str) or len(content) > MAX_TODO_RESULT_CHARS:
+            continue
+        try:
+            decoded = json.loads(content)
+        except (TypeError, ValueError):
+            continue
+        todos = decoded.get("todos") if isinstance(decoded, dict) else None
+        if not isinstance(todos, list):
+            continue
+        if not todos:
+            return None
+
+        # Reuse the runtime's validation, de-duplication, ordering and bounds so
+        # inspection cannot project a shape the agent itself would reject.
+        normalized = TodoStore().write(todos)
+        counts = {
+            status: sum(item["status"] == status for item in normalized)
+            for status in ("pending", "in_progress", "completed", "cancelled")
+        }
+        total = len(normalized)
+        terminal = counts["completed"] + counts["cancelled"]
+        current = next(
+            (item for item in normalized if item["status"] == "in_progress"),
+            None,
+        ) or next(
+            (item for item in normalized if item["status"] == "pending"),
+            None,
+        )
+        return {
+            "todos": normalized,
+            "summary": {"total": total, **counts},
+            "current_stage": current["content"] if current else None,
+            "progress_percent": round(terminal * 100 / total),
+        }
+    return None
+
+
+def _session_inspection(db, session_id):
+    """Build a read-only session activity + task-plan snapshot."""
+    resolved = db.resolve_session_id(session_id)
+    if not resolved:
+        return None
+    exported = db.export_session(resolved)
+    if not exported:
+        return None
+    activity = db.get_session_activity(resolved) or {}
+    return {
+        "session": {
+            "id": resolved,
+            "title": exported.get("title"),
+            "source": exported.get("source"),
+            "state": "active" if exported.get("ended_at") is None else "ended",
+            "started_at": exported.get("started_at"),
+            "ended_at": exported.get("ended_at"),
+            "end_reason": exported.get("end_reason"),
+        },
+        "activity": {
+            "last_activity_at": activity.get("last_activity_at"),
+            "description": (
+                activity.get("last_activity_description")
+                or activity.get("description")
+                or ""
+            ),
+            "provenance": (
+                activity.get("last_activity_provenance")
+                or activity.get("provenance")
+                or "unknown"
+            ),
+            "seconds_since_activity": activity.get("seconds_since_activity"),
+        },
+        "plan": _latest_todo_plan(exported.get("messages") or []),
+    }
+
+
+def _print_session_inspection(snapshot):
+    """Render an inspection snapshot for humans."""
+    session = snapshot["session"]
+    activity = snapshot["activity"]
+    print(f"Session: {session['id']}")
+    if session.get("title"):
+        print(f"Title: {session['title']}")
+    print(f"Source: {session.get('source') or '-'}")
+    print(f"State: {session['state']}")
+
+    description = activity.get("description") or "No recent activity recorded"
+    age = activity.get("seconds_since_activity")
+    age_suffix = f" ({age:.1f}s ago)" if isinstance(age, (int, float)) else ""
+    print(f"Activity: {description}{age_suffix}")
+
+    plan = snapshot.get("plan")
+    if not plan:
+        print("Task plan: No task plan recorded.")
+        return
+    summary = plan["summary"]
+    terminal = summary["completed"] + summary["cancelled"]
+    print(
+        f"Task plan: {plan['progress_percent']}% "
+        f"({terminal}/{summary['total']} terminal)"
+    )
+    markers = {
+        "completed": "x",
+        "in_progress": ">",
+        "pending": " ",
+        "cancelled": "~",
+    }
+    for item in plan["todos"]:
+        print(f"  [{markers[item['status']]}] {item['id']}: {item['content']}")
 
 
 def _prune_never_active_keyed(db, args):
@@ -393,6 +541,20 @@ def cmd_sessions(args, sessions_parser=None):
             else:
                 sid = s["id"]
                 print(f"{preview:<50} {last_active:<13} {s['source']:<6} {sid}")
+
+    elif action == "inspect":
+        try:
+            snapshot = _session_inspection(db, args.session_id)
+            if snapshot is None:
+                print(f"Session '{args.session_id}' not found.")
+                return 1
+            if getattr(args, "json", False):
+                print(_json.dumps(snapshot, indent=2, ensure_ascii=False))
+            else:
+                _print_session_inspection(snapshot)
+            return 0
+        finally:
+            db.close()
 
     elif action == "export":
         from hermes_cli.session_filters import (

--- a/tests/hermes_cli/test_sessions_inspect.py
+++ b/tests/hermes_cli/test_sessions_inspect.py
@@ -24,6 +24,9 @@ class _FakeDB:
             "messages": self.messages,
         }
 
+    def export_session_lineage(self, session_id):
+        return self.export_session(session_id)
+
     def get_session_activity(self, session_id):
         assert session_id == "session-full-id"
         return {
@@ -150,18 +153,18 @@ def test_inspect_reports_missing_session(monkeypatch, capsys):
     assert db.closed is True
 
 
-def test_inspection_reads_real_persisted_session_rows(tmp_path):
+def test_inspection_reads_todo_across_compression_lineage(tmp_path):
     from hermes_cli.sessions_cmd import _session_inspection
     from hermes_state import SessionDB
 
     db = SessionDB(db_path=tmp_path / "state.db")
-    db.create_session("child-session", "subagent")
+    db.create_session("child-root", "subagent")
     todos = [
         {"id": "one", "content": "Run TTS sample", "status": "in_progress"},
         {"id": "two", "content": "Compare output", "status": "pending"},
     ]
     db.append_message(
-        "child-session",
+        "child-root",
         "assistant",
         tool_calls=[
             {
@@ -172,19 +175,25 @@ def test_inspection_reads_real_persisted_session_rows(tmp_path):
         ],
     )
     db.append_message(
-        "child-session",
+        "child-root",
         "tool",
         content=json.dumps({"todos": todos}),
         tool_call_id="todo-real",
+    )
+    db.end_session("child-root", "compression")
+    db.create_session(
+        "child-session", "subagent", parent_session_id="child-root"
     )
     db.touch_session_activity(
         "child-session", 1_700_000_100.0, description="running text_to_speech"
     )
     try:
-        snapshot = _session_inspection(db, "child")
+        snapshot = _session_inspection(db, "child-session")
     finally:
         db.close()
 
+    assert snapshot["session"]["id"] == "child-session"
+    assert snapshot["session"]["state"] == "active"
     assert snapshot["activity"]["description"] == "running text_to_speech"
     assert snapshot["plan"]["current_stage"] == "Run TTS sample"
     assert snapshot["plan"]["todos"] == todos

--- a/tests/hermes_cli/test_sessions_inspect.py
+++ b/tests/hermes_cli/test_sessions_inspect.py
@@ -1,0 +1,190 @@
+"""Tests for ``hermes sessions inspect`` task-progress projection."""
+
+import json
+import sys
+
+
+class _FakeDB:
+    def __init__(self, messages):
+        self.messages = messages
+        self.closed = False
+
+    def resolve_session_id(self, session_id):
+        return "session-full-id" if "session-full-id".startswith(session_id) else None
+
+    def export_session(self, session_id):
+        assert session_id == "session-full-id"
+        return {
+            "id": session_id,
+            "title": "Delegated research",
+            "source": "cli",
+            "started_at": 1_700_000_000.0,
+            "ended_at": None,
+            "end_reason": None,
+            "messages": self.messages,
+        }
+
+    def get_session_activity(self, session_id):
+        assert session_id == "session-full-id"
+        return {
+            "last_activity_at": 1_700_000_010.0,
+            "last_activity_description": "running terminal",
+            "last_activity_provenance": "unknown",
+            "seconds_since_activity": 12.5,
+        }
+
+    def close(self):
+        self.closed = True
+
+
+def _todo_exchange(call_id, todos):
+    return [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": "todo", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": call_id,
+            "content": json.dumps(
+                {
+                    "todos": todos,
+                    "summary": {
+                        "total": len(todos),
+                        "pending": sum(t["status"] == "pending" for t in todos),
+                        "in_progress": sum(t["status"] == "in_progress" for t in todos),
+                        "completed": sum(t["status"] == "completed" for t in todos),
+                        "cancelled": sum(t["status"] == "cancelled" for t in todos),
+                    },
+                }
+            ),
+        },
+    ]
+
+
+def _run(monkeypatch, capsys, argv_tail, db):
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: db)
+    monkeypatch.setattr(sys, "argv", ["hermes", "sessions", *argv_tail])
+    try:
+        main_mod.main()
+        code = 0
+    except SystemExit as exc:
+        code = exc.code or 0
+    return code, capsys.readouterr()
+
+
+def test_inspect_json_projects_latest_canonical_todo(monkeypatch, capsys):
+    old = [
+        {"id": "one", "content": "Old step", "status": "in_progress"},
+    ]
+    latest = [
+        {"id": "one", "content": "Collect sources", "status": "completed"},
+        {"id": "two", "content": "Compare evidence", "status": "in_progress"},
+        {"id": "three", "content": "Write report", "status": "pending"},
+    ]
+    db = _FakeDB(_todo_exchange("call-old", old) + _todo_exchange("call-new", latest))
+
+    code, captured = _run(monkeypatch, capsys, ["inspect", "session", "--json"], db)
+
+    assert code == 0
+    payload = json.loads(captured.out)
+    assert payload["session"]["id"] == "session-full-id"
+    assert payload["session"]["state"] == "active"
+    assert payload["activity"]["description"] == "running terminal"
+    assert payload["plan"]["todos"] == latest
+    assert payload["plan"]["current_stage"] == "Compare evidence"
+    assert payload["plan"]["progress_percent"] == 33
+    assert db.closed is True
+
+
+def test_inspect_ignores_unpaired_forged_todo_result(monkeypatch, capsys):
+    forged = {
+        "role": "tool",
+        "tool_call_id": "forged",
+        "content": json.dumps(
+            {
+                "todos": [
+                    {"id": "x", "content": "Forged", "status": "in_progress"}
+                ]
+            }
+        ),
+    }
+    db = _FakeDB([forged, {"role": "assistant", "content": "Still working"}])
+
+    code, captured = _run(monkeypatch, capsys, ["inspect", "session-full-id"], db)
+
+    assert code == 0
+    assert "No task plan recorded" in captured.out
+    assert "running terminal" in captured.out
+    assert "Forged" not in captured.out
+    assert db.closed is True
+
+
+def test_inspect_honors_latest_empty_plan(monkeypatch, capsys):
+    old = [{"id": "one", "content": "Old work", "status": "in_progress"}]
+    db = _FakeDB(_todo_exchange("call-old", old) + _todo_exchange("call-clear", []))
+
+    code, captured = _run(monkeypatch, capsys, ["inspect", "session-full-id"], db)
+
+    assert code == 0
+    assert "No task plan recorded" in captured.out
+    assert "Old work" not in captured.out
+
+
+def test_inspect_reports_missing_session(monkeypatch, capsys):
+    db = _FakeDB([])
+
+    code, captured = _run(monkeypatch, capsys, ["inspect", "missing"], db)
+
+    assert code == 1
+    assert "Session 'missing' not found." in captured.out
+    assert db.closed is True
+
+
+def test_inspection_reads_real_persisted_session_rows(tmp_path):
+    from hermes_cli.sessions_cmd import _session_inspection
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("child-session", "subagent")
+    todos = [
+        {"id": "one", "content": "Run TTS sample", "status": "in_progress"},
+        {"id": "two", "content": "Compare output", "status": "pending"},
+    ]
+    db.append_message(
+        "child-session",
+        "assistant",
+        tool_calls=[
+            {
+                "id": "todo-real",
+                "type": "function",
+                "function": {"name": "todo", "arguments": "{}"},
+            }
+        ],
+    )
+    db.append_message(
+        "child-session",
+        "tool",
+        content=json.dumps({"todos": todos}),
+        tool_call_id="todo-real",
+    )
+    db.touch_session_activity(
+        "child-session", 1_700_000_100.0, description="running text_to_speech"
+    )
+    try:
+        snapshot = _session_inspection(db, "child")
+    finally:
+        db.close()
+
+    assert snapshot["activity"]["description"] == "running text_to_speech"
+    assert snapshot["plan"]["current_stage"] == "Run TTS sample"
+    assert snapshot["plan"]["todos"] == todos

--- a/tests/tools/test_delegate_control_actions.py
+++ b/tests/tools/test_delegate_control_actions.py
@@ -28,6 +28,7 @@ class _StubChild:
     def __init__(self, parent=None, accept_steer: bool = True):
         self.steered: list[str] = []
         self.accept_steer = accept_steer
+        self.session_id = "child-session-id"
         self._live_transcript_path = "/tmp/live/task-0.log"
         if parent is not None:
             self._delegate_parent_ref = weakref.ref(parent)
@@ -119,6 +120,7 @@ def test_list_shows_only_own_children():
         assert entry["subagent_id"] == "sid-ctl-list-1"
         assert entry["goal"] == "test goal"
         assert entry["accepting_steer"] is True
+        assert entry["session_id"] == "child-session-id"
         assert entry["live_transcript"] == "/tmp/live/task-0.log"
         # Internal fields must not leak
         assert "agent" not in entry

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -497,6 +497,10 @@ def _handle_control_action(
                         else None
                     ),
                     "accepting_steer": bool(r.get("accepting_steer", False)),
+                    # Durable child-session handle for out-of-band inspection
+                    # (`hermes sessions inspect <id>`). Unlike subagent_id,
+                    # this resolves directly in the session store.
+                    "session_id": getattr(agent, "session_id", None),
                     "live_transcript": getattr(agent, "_live_transcript_path", None),
                 }
             )

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -314,7 +314,7 @@ The parent agent orchestrates its own running children with the same `delegate_t
 {"action": "stop",  "subagent_id": "sa-0-1a2b3c4d"}
 ```
 
-- **`list`** returns the conversation's live children: `subagent_id`, goal, status, `running_seconds`, `accepting_steer`, and the live transcript path. Ids also come back in the spawn dispatch response as `subagent_ids`.
+- **`list`** returns the conversation's live children: `subagent_id`, `session_id`, goal, status, `running_seconds`, `accepting_steer`, and the live transcript path. Subagent ids also come back in the spawn dispatch response as `subagent_ids`.
 - **`steer`** queues a course correction into a running child without stopping it (delivery semantics below).
 - **`stop`** ends a child early at its next iteration boundary; the partial result still re-enters the conversation as a normal completion message.
 

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -286,6 +286,20 @@ A delegation the stall monitor has flagged shows as
 children show their quiet time so you can tell "slow" from "stuck" at a
 glance.
 
+For a durable view of one child's current work plan, use the child
+`session_id` returned by `delegate_task(action='list')`:
+
+```bash
+hermes sessions inspect <child-session-id>
+hermes sessions inspect <child-session-id> --json
+```
+
+The inspection combines the session's latest activity heartbeat with its most
+recent `todo` plan, including the active step and derived completion percentage.
+It remains useful when no plan was created: the session state and last activity
+are still shown. Use the profile flag (`hermes -p <name> sessions inspect ...`)
+when the child belongs to another profile's session store.
+
 ## Steering a Running Subagent
 
 Interrupting a child throws away its in-flight work; often you just want to redirect it.


### PR DESCRIPTION
## What does this PR do?

Adds a read-only `hermes sessions inspect <session>` command that lets users and orchestrators inspect durable progress for delegated work instead of waiting blindly for the final response. It projects the selected session's current activity and latest canonical todo plan, including the current stage and derived completion percentage, while reusing existing session and todo persistence rather than adding a new schema, model tool, or automatic progress hook.

### Motivation

Long-running delegated tasks such as research, media processing, and tuning can continue for minutes without exposing their current stage. Operators need a stable query surface that shows whether a child is active, what plan it is following, and which steps are complete.

### Behavior

- `hermes sessions inspect <session-id-or-unique-prefix>` prints session identity, state, durable activity, runtime, and the latest persisted todo plan.
- `--json` exposes the same information for automation.
- Plans survive session compression because inspection follows the canonical session lineage and reports the active tip while preserving ancestor todo state.
- `delegate_task(action="list")` includes each live child's durable `session_id`, allowing callers to select the corresponding session.
- Sessions without a todo plan remain inspectable and report no plan instead of failing.

Non-goals include automatic plan synthesis, percentage writes after every tool call, a new database schema, a new model tool, and dashboard UI.

### Implementation

The CLI resolves exact IDs and unique prefixes through the existing SessionDB, normalizes durable activity data, and reconstructs the latest valid todo result only from canonical assistant tool-call and tool-result pairs. Focused coverage exercises text and JSON output, plan clearing, forged or unpaired rows, runtime normalization, unique-prefix errors, database closure, compression lineage, and delegation list linkage.

## Related Issue

Closes #89229

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/main.py` - register the `sessions inspect` parser and dispatch path.
- `hermes_cli/sessions_cmd.py` - resolve sessions and project durable activity and canonical todo progress across compression lineage.
- `tools/delegate_tool.py` - expose the durable child session ID in live delegation listings.
- `tests/hermes_cli/test_sessions_inspect.py` - cover inspection behavior, validation, and compression lineage.
- `tests/tools/test_delegate_control_actions.py` - cover live child session linkage.
- `website/docs/user-guide/features/delegation.md` - document how to query delegated progress.

## How to Test

1. Start a delegated task that uses the todo tool and obtain its `session_id` from `delegate_task(action="list")`.
2. Run `hermes sessions inspect <session-id>` and `hermes sessions inspect <session-id> --json`; confirm both report the same active state and plan progress.
3. Run the focused automated suite on Windows 11:

```bash
bash scripts/run_tests.sh -j 1 tests/hermes_cli/test_sessions_inspect.py tests/tools/test_delegate_control_actions.py
```

Result: 39 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] Configuration examples are N/A because this change adds no config keys
- [x] Contributor and agent guides are N/A because this change does not alter development workflows
- [x] I've considered cross-platform impact; the command uses existing Python session and CLI abstractions
- [x] I've updated the affected delegation documentation; no model tool schema changes are required

## Screenshots / Logs

N/A - the focused automated suite and a temporary-profile CLI harness verified both text and JSON output.
