### PR TITLE
fix(desktop): keep read_preview on the visible preview tab

### DIFF
--- a/apps/desktop/src/app/chat/preview-tile.tsx
+++ b/apps/desktop/src/app/chat/preview-tile.tsx
@@ -12,8 +12,14 @@
 
 import { useStore } from '@nanostores/react'
 
-import { findGroup } from '@/components/pane-shell/tree/model'
-import { $activeTreeGroup, $layoutTree, revealTreePane, treePanesWithPrefix } from '@/components/pane-shell/tree/store'
+import { findGroup, findGroupOfPane } from '@/components/pane-shell/tree/model'
+import {
+  $activeTreeGroup,
+  $layoutTree,
+  noteActiveTreeGroup,
+  revealTreePane,
+  treePanesWithPrefix
+} from '@/components/pane-shell/tree/store'
 import { type MenuKit, renderActionItem } from '@/components/ui/actions-menu'
 import { FileTypeIcon } from '@/components/ui/file-type-icon'
 import { ToolIcon } from '@/components/ui/tool-icon'
@@ -206,11 +212,25 @@ export function watchPreviewTiles(): void {
   // un-minimize, un-hide, activate in its zone. Both stores, because re-opening
   // the already-active tab changes only `$previewTabs` (fresh tab object), while
   // switching tabs changes only the active id.
+  //
+  // Also mark that zone as the interacted tree group. Without this, a split
+  // layout leaves `$activeTreeGroup` on a sibling file preview; `follow` then
+  // runs on the layout commit from reveal and clobbers `$rightRailActiveTabId`
+  // back to the file while Browser still shows the URL (read_preview desync).
   const reveal = () => {
     const tabId = $rightRailActiveTabId.get()
 
-    if (tabId && targetFor(tabId)) {
-      revealTreePane(`${PREVIEW_TILE_PREFIX}:${tabId}`)
+    if (!tabId || !targetFor(tabId)) {
+      return
+    }
+
+    const paneId = `${PREVIEW_TILE_PREFIX}:${tabId}`
+    revealTreePane(paneId)
+
+    const tree = $layoutTree.get()
+    const group = tree ? findGroupOfPane(tree, paneId) : null
+    if (group) {
+      noteActiveTreeGroup(group.id)
     }
   }
 

--- a/apps/desktop/src/app/chat/right-rail/preview-reader.test.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-reader.test.ts
@@ -1,9 +1,16 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
+import { findGroup, findGroupOfPane } from '@/components/pane-shell/tree/model'
+import * as tree from '@/components/pane-shell/tree/store'
 import { $rightRailActiveTabId, selectRightRailTab } from '@/store/layout'
-import { closeRightRail, openPreview, type PreviewTarget } from '@/store/preview'
+import { $previewTabs, closeRightRail, openPreview, type PreviewTarget } from '@/store/preview'
 
-import { PREVIEW_READ_MAX_CHARS, readActivePreview, registerPreviewPageReader } from './preview-reader'
+import {
+  PREVIEW_READ_MAX_CHARS,
+  readActivePreview,
+  registerPreviewPageReader,
+  resolveActivePreviewTab
+} from './preview-reader'
 
 function urlTarget(url: string): PreviewTarget {
   return { kind: 'url', label: 'Browser', source: url, url }
@@ -13,9 +20,19 @@ function fileTarget(path: string): PreviewTarget {
   return { kind: 'file', label: path, path, previewKind: 'text', source: path, url: `file://${path}` }
 }
 
+/** Browser tab id minted by openPreview (url:browser-<uuid>), not a fixed singleton. */
+function activeTabId(): string {
+  const id = $rightRailActiveTabId.get()
+  if (!id) {
+    throw new Error('expected an active right-rail tab')
+  }
+
+  return id
+}
+
 describe('readActivePreview (read_preview tool)', () => {
-  // All URL targets share the singleton Browser tab id, so a reader registered
-  // in one test would answer the next — unregister whatever a test installed.
+  // URL targets share a Browser vessel when one is already active, so a reader
+  // registered in one test would answer the next — unregister whatever a test installed.
   let cleanups: Array<() => void> = []
 
   const register = (tabId: string, reader: Parameters<typeof registerPreviewPageReader>[1]) => {
@@ -34,6 +51,10 @@ describe('readActivePreview (read_preview tool)', () => {
     cleanups = []
     closeRightRail()
     window.localStorage.clear()
+    tree.noteActiveTreeGroup(null)
+    tree.noteHoveredTreeGroup(null)
+    // declareDefaultTree only fully replaces when no current tree exists.
+    tree.$layoutTree.set(null)
   })
 
   it('answers null when nothing is open, so the tool reports it cleanly', async () => {
@@ -42,13 +63,15 @@ describe('readActivePreview (read_preview tool)', () => {
 
   it('serializes the Browser tab through its registered page reader', async () => {
     openPreview(urlTarget('https://news.ycombinator.com'), 'tool-result')
-    register($rightRailActiveTabId.get()!, async () => ({
+    const browserId = activeTabId()
+    register(browserId, async () => ({
       text: 'Top stories…',
       title: 'Hacker News',
       url: 'https://news.ycombinator.com/news'
     }))
 
     expect(await readActivePreview()).toMatchObject({
+      active_tab_id: browserId,
       kind: 'url',
       text: 'Top stories…',
       title: 'Hacker News',
@@ -60,7 +83,7 @@ describe('readActivePreview (read_preview tool)', () => {
 
   it('windows long pages with start/count and reports the full length', async () => {
     openPreview(urlTarget('https://example.com'), 'tool-result')
-    register($rightRailActiveTabId.get()!, async () => ({
+    register(activeTabId(), async () => ({
       text: 'abcdefghij',
       title: 't',
       url: ''
@@ -76,7 +99,7 @@ describe('readActivePreview (read_preview tool)', () => {
 
   it('caps a single read at PREVIEW_READ_MAX_CHARS even when asked for more', async () => {
     openPreview(urlTarget('https://example.com'), 'tool-result')
-    register($rightRailActiveTabId.get()!, async () => ({
+    register(activeTabId(), async () => ({
       text: 'x'.repeat(PREVIEW_READ_MAX_CHARS + 5000),
       title: 't',
       url: ''
@@ -119,7 +142,7 @@ describe('readActivePreview (read_preview tool)', () => {
 
   it('falls back to the identity answer when the reader throws (webview booting)', async () => {
     openPreview(urlTarget('https://example.com'), 'tool-result')
-    register($rightRailActiveTabId.get()!, async () => {
+    register(activeTabId(), async () => {
       throw new Error('webview gone')
     })
 
@@ -128,7 +151,7 @@ describe('readActivePreview (read_preview tool)', () => {
 
   it('unregister is idempotent and scoped to the same reader', async () => {
     openPreview(urlTarget('https://example.com'), 'tool-result')
-    const tabId = $rightRailActiveTabId.get()!
+    const tabId = activeTabId()
     const first = register(tabId, async () => ({ text: 'first', title: '', url: '' }))
 
     register(tabId, async () => ({ text: 'second', title: '', url: '' }))
@@ -136,5 +159,149 @@ describe('readActivePreview (read_preview tool)', () => {
     first()
 
     expect(await readActivePreview()).toMatchObject({ text: 'second' })
+  })
+
+  it('includes tabs[] metadata when more than one preview is open', async () => {
+    openPreview(fileTarget('/work/project-network.html'), 'tool-result')
+    const fileId = activeTabId()
+    openPreview(urlTarget('https://example.com/tickets'), 'tool-result')
+    const browserId = activeTabId()
+
+    const result = await readActivePreview()
+    expect(result).toMatchObject({
+      active_tab_id: browserId,
+      kind: 'url',
+      url: 'https://example.com/tickets'
+    })
+    expect(result?.tabs?.map(t => t.id).sort()).toEqual([fileId, browserId].sort())
+    expect(result?.note).toMatch(/Multiple preview tabs/i)
+  })
+
+  it('honors the hovered preview zone over a stale global file selection', async () => {
+    const model = await import('@/components/pane-shell/tree/model')
+
+    openPreview(fileTarget('/work/a.md'), 'file-browser')
+    const fileId = activeTabId()
+    openPreview(urlTarget('https://example.com'), 'tool-result')
+    const browserId = activeTabId()
+    // Stale global active (pre-fix clobber) while Browser remains open.
+    selectRightRailTab(fileId)
+
+    tree.declareDefaultTree(
+      model.split('row', [
+        model.group([`preview-tile:${browserId}`], {
+          active: `preview-tile:${browserId}`,
+          id: 'grp-browser'
+        }),
+        model.group([`preview-tile:${fileId}`], { active: `preview-tile:${fileId}`, id: 'grp-file' })
+      ])
+    )
+
+    tree.noteHoveredTreeGroup('grp-browser')
+    expect(resolveActivePreviewTab()?.id).toBe(browserId)
+    expect(await readActivePreview()).toMatchObject({ active_tab_id: browserId, kind: 'url' })
+  })
+
+  it('honors the focused preview zone over a stale global file selection', async () => {
+    const model = await import('@/components/pane-shell/tree/model')
+
+    openPreview(fileTarget('/work/a.md'), 'file-browser')
+    const fileId = activeTabId()
+    openPreview(urlTarget('https://example.com'), 'tool-result')
+    const browserId = activeTabId()
+    selectRightRailTab(fileId)
+
+    tree.declareDefaultTree(
+      model.split('row', [
+        model.group([`preview-tile:${browserId}`], {
+          active: `preview-tile:${browserId}`,
+          id: 'grp-browser'
+        }),
+        model.group([`preview-tile:${fileId}`], { active: `preview-tile:${fileId}`, id: 'grp-file' })
+      ])
+    )
+
+    tree.noteActiveTreeGroup('grp-browser')
+    expect(resolveActivePreviewTab()?.id).toBe(browserId)
+  })
+
+  it('falls back to the last open Browser when global active is a missing id', async () => {
+    openPreview(urlTarget('https://example.com'), 'tool-result')
+    const browserId = activeTabId()
+    // Simulate a stale global pointer (old singleton id, closed tab, etc.).
+    selectRightRailTab('url:browser' as typeof browserId)
+
+    expect($previewTabs.get().some(t => t.id === browserId)).toBe(true)
+    expect(resolveActivePreviewTab()?.id).toBe(browserId)
+  })
+})
+
+describe('openPreview reveal retargets activeTreeGroup (split-zone clobber)', () => {
+  beforeEach(() => {
+    closeRightRail()
+    window.localStorage.clear()
+    tree.noteActiveTreeGroup(null)
+    tree.noteHoveredTreeGroup(null)
+    tree.$layoutTree.set(null)
+  })
+
+  it('notes the Browser zone on reveal so follow cannot snap global active back to a file sibling', async () => {
+    const model = await import('@/components/pane-shell/tree/model')
+
+    openPreview(fileTarget('/work/project-network.html'), 'tool-result')
+    const fileId = activeTabId()
+
+    // Pre-create the Browser vessel so the split layout can name its pane before open.
+    openPreview(urlTarget('about:blank'), 'manual')
+    const browserId = activeTabId()
+    const browserPane = `preview-tile:${browserId}`
+    const filePane = `preview-tile:${fileId}`
+
+    // File zone is what the user last touched; Browser will re-front in a sibling zone.
+    tree.declareDefaultTree(
+      model.split('row', [
+        model.group([browserPane], { active: browserPane, id: 'grp-browser' }),
+        model.group([filePane], { active: filePane, id: 'grp-file' })
+      ])
+    )
+    tree.noteActiveTreeGroup('grp-file')
+    selectRightRailTab(fileId)
+
+    // Mirror watchPreviewTiles reveal (noteActiveTreeGroup after revealTreePane).
+    const reveal = (tabId: string) => {
+      const paneId = `preview-tile:${tabId}`
+      tree.revealTreePane(paneId)
+      const t = tree.$layoutTree.get()
+      const group = t ? findGroupOfPane(t, paneId) : null
+      if (group) {
+        tree.noteActiveTreeGroup(group.id)
+      }
+    }
+
+    openPreview(urlTarget('https://example.com/tickets'), 'tool-result')
+    expect($rightRailActiveTabId.get()).toBe(browserId)
+    reveal(browserId)
+
+    // follow from layout would previously use stale grp-file and clobber Browser.
+    const follow = () => {
+      const t = tree.$layoutTree.get()
+      const groupId = tree.$activeTreeGroup.get()
+      const active = groupId && t ? findGroup(t, groupId)?.active : undefined
+      if (!active?.startsWith('preview-tile:')) return
+      const tabId = active.slice('preview-tile:'.length)
+      if ($rightRailActiveTabId.get() !== tabId) {
+        selectRightRailTab(tabId as typeof fileId)
+      }
+    }
+
+    follow()
+
+    expect(tree.$activeTreeGroup.get()).toBe('grp-browser')
+    expect($rightRailActiveTabId.get()).toBe(browserId)
+    expect(await readActivePreview()).toMatchObject({
+      active_tab_id: browserId,
+      kind: 'url',
+      url: 'https://example.com/tickets'
+    })
   })
 })

--- a/apps/desktop/src/app/chat/right-rail/preview-reader.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-reader.ts
@@ -5,15 +5,18 @@
  *
  * A URL/HTML preview renders in a sandboxed <webview> owned by PreviewPane;
  * that pane registers a PAGE READER here (url + title + rendered text), keyed
- * by tab id. `readActivePreview` resolves the ACTIVE tab from the store and
- * owns the windowing: a registered reader answers with the live page's text;
- * a tab with no reader (a file peek, an artifact) still answers with its
- * identity and a note pointing the agent at the tool that reads that content
- * directly (read_file / the conversation's artifact).
+ * by tab id. `readActivePreview` resolves the tab the user is looking at (or
+ * the one tools just opened) and owns the windowing: a registered reader
+ * answers with the live page's text; a tab with no reader (a file peek, an
+ * artifact) still answers with its identity and a note pointing the agent at
+ * the tool that reads that content directly (read_file / the conversation's
+ * artifact).
  */
 
-import { $rightRailActiveTabId } from '@/store/layout'
-import { $previewTabs } from '@/store/preview'
+import { findGroup } from '@/components/pane-shell/tree/model'
+import { $activeTreeGroup, $hoveredTreeGroup, $layoutTree } from '@/components/pane-shell/tree/store'
+import { $rightRailActiveTabId, type RightRailTabId } from '@/store/layout'
+import { $previewTabs, type PreviewTab } from '@/store/preview'
 
 import { nudgeOverlay } from './preview-nudge'
 
@@ -24,12 +27,23 @@ export interface PreviewReadOptions {
   start?: number
 }
 
+export interface PreviewReadTabSummary {
+  id: string
+  kind: string
+  label: string
+  url: string
+}
+
 export interface PreviewReadResult {
+  /** Tab id that was read (`file:…` / `url:browser-…` / `artifact:…`). */
+  active_tab_id: string
   end: number
   kind: string
   note?: string
   path?: string
   start: number
+  /** Open preview tabs at read time — multi-tab layouts used to desync eyes vs tool. */
+  tabs: PreviewReadTabSummary[]
   text: string
   title: string
   total_chars: number
@@ -48,6 +62,9 @@ type PageReader = () => Promise<PreviewPage>
 /** Default + hard cap on one read — a page's innerText can be megabytes, and
  *  this crosses the gateway into model context. Page with start/count. */
 export const PREVIEW_READ_MAX_CHARS = 24_000
+
+/** Must match `PREVIEW_TILE_PREFIX` in preview-tile.tsx (pane id = prefix:tabId). */
+const PREVIEW_TILE_PREFIX = 'preview-tile'
 
 const readers = new Map<string, PageReader>()
 
@@ -75,21 +92,121 @@ function windowText(
   return { ...base, end: to, start: from, text: text.slice(from, to), total_chars: total }
 }
 
+function tabSummary(tab: PreviewTab): PreviewReadTabSummary {
+  return {
+    id: tab.id,
+    kind: tab.target.kind,
+    label: tab.target.label,
+    url: tab.target.url
+  }
+}
+
+function tabIdFromPreviewPane(paneId: string | undefined): null | RightRailTabId {
+  if (!paneId?.startsWith(`${PREVIEW_TILE_PREFIX}:`)) {
+    return null
+  }
+
+  return paneId.slice(PREVIEW_TILE_PREFIX.length + 1) as RightRailTabId
+}
+
+/** Active preview-tile tab id in a layout group, if that tab is still open. */
+function openTabInGroup(groupId: null | string, tabs: PreviewTab[]): null | PreviewTab {
+  const tree = $layoutTree.get()
+  if (!tree || !groupId) {
+    return null
+  }
+
+  const tabId = tabIdFromPreviewPane(findGroup(tree, groupId)?.active)
+  if (!tabId) {
+    return null
+  }
+
+  return tabs.find(tab => tab.id === tabId) ?? null
+}
+
+/**
+ * Resolve which preview tab `read_preview` should serialize.
+ *
+ * Ladder (mirrors keyboard tab-verb eligibility: hover → focus → store):
+ * 1. Hovered zone's active preview tile, if still open
+ * 2. Focused (`$activeTreeGroup`) zone's active preview tile, if still open
+ * 3. `$rightRailActiveTabId` when it still names an open tab
+ * 4. Most recent open Browser tab (`url:browser-*`) — agent-opened pages
+ * 5. First open tab
+ *
+ * Split layouts used to leave global `$rightRailActiveTabId` on a file tab while
+ * Browser stayed visible in another zone; steps 1–2 and 4 close that gap.
+ *
+ * Browser tab ids are minted (`url:browser-<uuid>`), not a fixed singleton, so
+ * step 4 picks the last open URL vessel rather than a hard-coded id.
+ */
+export function resolveActivePreviewTab(tabs: PreviewTab[] = $previewTabs.get()): null | PreviewTab {
+  if (tabs.length === 0) {
+    return null
+  }
+
+  const byId = (id: null | string | undefined) => (id ? (tabs.find(tab => tab.id === id) ?? null) : null)
+  const lastBrowser = () => {
+    for (let i = tabs.length - 1; i >= 0; i--) {
+      if (tabs[i]?.target.kind === 'url') {
+        return tabs[i] ?? null
+      }
+    }
+
+    return null
+  }
+
+  return (
+    openTabInGroup($hoveredTreeGroup.get(), tabs) ??
+    openTabInGroup($activeTreeGroup.get(), tabs) ??
+    byId($rightRailActiveTabId.get()) ??
+    lastBrowser() ??
+    tabs[0] ??
+    null
+  )
+}
+
+function identityNote(kind: PreviewTab['target']['kind'], multiTab: boolean): string {
+  const base =
+    kind === 'file'
+      ? 'File preview — read the file itself with read_file.'
+      : kind === 'artifact'
+        ? 'Generated artifact — its content is in the conversation that produced it.'
+        : 'The page has not finished loading — retry in a moment.'
+
+  if (!multiTab) {
+    return base
+  }
+
+  return `${base} Multiple preview tabs are open; this read used the focused/hovered preview (see tabs).`
+}
+
 /** Read the ACTIVE preview tab. Null only when no tab is open at all. */
-export async function readActivePreview(opts: PreviewReadOptions = {}): Promise<PreviewReadResult | null> {
+export async function readActivePreview(opts: PreviewReadOptions = {}): Promise<null | PreviewReadResult> {
   const tabs = $previewTabs.get()
-  const tab = tabs.find(t => t.id === $rightRailActiveTabId.get()) ?? tabs[0]
+  const tab = resolveActivePreviewTab(tabs)
 
   if (!tab) {
     return null
   }
 
+  const summaries = tabs.map(tabSummary)
+  const multiTab = tabs.length > 1
   const { target } = tab
   const reader = readers.get(tab.id)
+  const meta = {
+    active_tab_id: tab.id,
+    kind: target.kind,
+    path: target.path,
+    tabs: summaries
+  }
 
   if (reader) {
     try {
       const page = await reader()
+      const multiNote = multiTab
+        ? 'Multiple preview tabs are open; this read used the focused/hovered preview (see tabs).'
+        : undefined
 
       // Say it on the page. Reading is by far the cheapest thing the agent
       // does — a few hundredths of a second against a model round trip either
@@ -99,7 +216,12 @@ export async function readActivePreview(opts: PreviewReadOptions = {}): Promise<
       nudgeOverlay('read')
 
       return windowText(
-        { kind: target.kind, path: target.path, title: page.title || target.label, url: page.url || target.url },
+        {
+          ...meta,
+          note: multiNote,
+          title: page.title || target.label,
+          url: page.url || target.url
+        },
         page.text,
         opts
       )
@@ -114,14 +236,8 @@ export async function readActivePreview(opts: PreviewReadOptions = {}): Promise<
   // screen and which of its own tools reads the content directly.
   return windowText(
     {
-      kind: target.kind,
-      note:
-        target.kind === 'file'
-          ? 'File preview — read the file itself with read_file.'
-          : target.kind === 'artifact'
-            ? 'Generated artifact — its content is in the conversation that produced it.'
-            : 'The page has not finished loading — retry in a moment.',
-      path: target.path,
+      ...meta,
+      note: identityNote(target.kind, multiTab),
       title: target.label,
       url: target.url
     },


### PR DESCRIPTION
## Summary

Fixes #89272.

When Browser and a file preview were both open (especially split into two zones), `read_preview` could serialize the **file** tab while the user was looking at the **Browser** URL the agent had just opened. Root cause: dual “active” state — per-zone `group.active` vs global `$rightRailActiveTabId` — plus `follow()` re-applying a stale `$activeTreeGroup` after `openPreview` revealed Browser.

### Changes

1. **`readActivePreview` resolution ladder** (`preview-reader.ts`): hover zone → focused zone → `$rightRailActiveTabId` → singleton `url:browser` → first tab. Returns `active_tab_id` + `tabs[]` and a multi-tab note so the agent can see ambiguity.
2. **`watchPreviewTiles` reveal** (`preview-tile.tsx`): after `revealTreePane`, `noteActiveTreeGroup` on the opened pane’s zone so a subsequent `follow` cannot snap global active back to a sibling file zone.
3. **Tests**: multi-tab metadata, hover/focus override of stale global active, reveal retarget regression. Sabotage-checked (pre-fix resolver fails the hover test).

### Non-goals (follow-ups)

- `open_preview` fire-and-forget ack / normalize failure as error (P1 on the issue)
- Optional `tab:` tool argument

## Test plan

- [x] `cd apps/desktop && npx vitest run src/app/chat/right-rail/preview-reader.test.ts` (13 passed)
- [x] Sabotage: old `tabs.find(rightRail) ?? tabs[0]` fails “honors the hovered preview zone…”
- [ ] CI desktop/ui checks on this PR
- [ ] Manual (optional): open local HTML preview + `open_preview` a URL without clicking Browser → `read_preview` returns the URL

## Risk

Low–medium, Desktop-only. Touches preview selection/read path used by agent tools. No protocol/API break beyond additive JSON fields on `read_preview` (`active_tab_id`, `tabs`).