### PR TITLE
feat(delegation): add Devin CLI as a first-class delegate backend

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1890,8 +1890,8 @@ DEFAULT_CONFIG = {
         "devin": {
             "enabled": False,            # opt-in gate for the delegate_to_devin tool
             "model": "",                 # optional Devin model short name (opus/swe/codex/...); empty = Devin default
-            "permission_mode": "dangerous",  # auto|accept-edits|smart|dangerous — Devin autonomy for unattended runs
-            "timeout_seconds": 1800,     # per-call wall-clock cap (floor 60)
+            "permission_mode": "accept-edits",  # auto|accept-edits|smart|dangerous — accept-edits is the safe default; dangerous requires explicit opt-in
+            "timeout_seconds": 1800,     # per-call wall-clock cap (floor 60, model override clamped to this)
             "max_result_chars": 20000,   # truncate Devin stdout above this in the returned summary
         },
     },

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1881,6 +1881,19 @@ DEFAULT_CONFIG = {
         # Flip to true only if you trust delegated work to run dangerous cmds
         # without human review (cron pipelines, batch automation, etc.).
         "subagent_auto_approve": False,
+        # Devin CLI delegate backend (tools/devin_delegate.py). Shells out to
+        # the local `devin` binary in non-interactive `-p` mode as a peer to
+        # delegate_task. Opt-in: the delegate_to_devin tool is gated by a
+        # check_fn (enabled + devin on $PATH) and has zero schema footprint
+        # unless turned on here. Devin runs its own full agent loop and
+        # returns a finished answer, so this is for self-contained subtasks.
+        "devin": {
+            "enabled": False,            # opt-in gate for the delegate_to_devin tool
+            "model": "",                 # optional Devin model short name (opus/swe/codex/...); empty = Devin default
+            "permission_mode": "dangerous",  # auto|accept-edits|smart|dangerous — Devin autonomy for unattended runs
+            "timeout_seconds": 1800,     # per-call wall-clock cap (floor 60)
+            "max_result_chars": 20000,   # truncate Devin stdout above this in the returned summary
+        },
     },
 
     # Ephemeral prefill messages file — JSON list of {role, content} dicts

--- a/tests/tools/test_devin_delegate.py
+++ b/tests/tools/test_devin_delegate.py
@@ -228,6 +228,22 @@ class TestDelegateToDevin(unittest.TestCase):
         self.assertEqual(entry["status"], "timeout")
         self.assertEqual(entry["exit_reason"], "timeout")
         self.assertIn("60s", entry["error"])
+        # No model override → hint points to config
+        self.assertIn("timeout_seconds", entry["error"])
+
+    def test_timeout_with_model_override_shows_override_hint(self):
+        """When the model supplied a timeout override, the error hint should
+        mention the override, not just the config knob."""
+        p1, p2, p3 = self._patch_env(cfg={"enabled": True, "timeout_seconds": 1800})
+        proc = _mock_popen()
+        proc.communicate.side_effect = subprocess.TimeoutExpired(cmd=["devin"], timeout=120)
+        with p1, p2, p3, \
+             patch.object(mod.subprocess, "Popen", return_value=proc), \
+             patch.object(mod, "_kill_process_group", lambda p: None):
+            result = json.loads(delegate_to_devin(goal="do thing", timeout=120))
+        entry = result["results"][0]
+        self.assertEqual(entry["status"], "timeout")
+        self.assertIn("override", entry["error"].lower())
 
     def test_truncation_flag_when_stdout_exceeds_limit(self):
         p1, p2, p3 = self._patch_env(cfg={"enabled": True, "max_result_chars": 256})

--- a/tests/tools/test_devin_delegate.py
+++ b/tests/tools/test_devin_delegate.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Tests for the Devin CLI delegate backend (tools/devin_delegate.py).
+
+Covers the check_fn gate, config resolution, prompt building, and the
+subprocess handler's success/error/timeout paths — all with the `devin`
+binary and its auth probe mocked so no real Devin invocation happens.
+
+Run with:  python -m pytest tests/tools/test_devin_delegate.py -v
+   or:     python tests/tools/test_devin_delegate.py
+"""
+
+import json
+import subprocess
+import unittest
+from unittest.mock import patch
+
+import tools.devin_delegate as mod
+from tools.devin_delegate import (
+    DELEGATE_TO_DEVIN_SCHEMA,
+    _build_prompt,
+    _resolve_max_result_chars,
+    _resolve_permission_mode,
+    _resolve_timeout,
+    check_devin_requirements,
+    delegate_to_devin,
+)
+
+
+def _ok_proc(stdout="", stderr="", returncode=0):
+    """A CompletedProcess-like object for mocked subprocess.run."""
+    return subprocess.CompletedProcess(
+        args=["devin"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+class TestCheckRequirements(unittest.TestCase):
+    """check_devin_requirements is the schema gate — must be cheap and exact."""
+
+    def test_disabled_when_not_enabled(self):
+        with patch.object(mod, "_devin_config", lambda: {}), \
+             patch.object(mod, "_devin_binary", lambda: "/usr/bin/devin"):
+            self.assertFalse(check_devin_requirements())
+
+    def test_disabled_when_enabled_but_no_binary(self):
+        with patch.object(mod, "_devin_config", lambda: {"enabled": True}), \
+             patch.object(mod, "_devin_binary", lambda: None):
+            self.assertFalse(check_devin_requirements())
+
+    def test_enabled_when_enabled_and_binary_present(self):
+        with patch.object(mod, "_devin_config", lambda: {"enabled": "true"}), \
+             patch.object(mod, "_devin_binary", lambda: "/usr/bin/devin"):
+            self.assertTrue(check_devin_requirements())
+
+    def test_falsy_enabled_value_rejected(self):
+        with patch.object(mod, "_devin_config", lambda: {"enabled": "false"}), \
+             patch.object(mod, "_devin_binary", lambda: "/usr/bin/devin"):
+            self.assertFalse(check_devin_requirements())
+
+
+class TestConfigResolution(unittest.TestCase):
+    def test_permission_mode_default(self):
+        self.assertEqual(_resolve_permission_mode({}), "dangerous")
+
+    def test_permission_mode_override(self):
+        self.assertEqual(_resolve_permission_mode({"permission_mode": "auto"}), "auto")
+
+    def test_permission_mode_invalid_falls_back(self):
+        self.assertEqual(_resolve_permission_mode({"permission_mode": "yolo"}), "dangerous")
+
+    def test_timeout_default(self):
+        self.assertEqual(_resolve_timeout({}, None), 1800.0)
+
+    def test_timeout_floored_at_60(self):
+        self.assertEqual(_resolve_timeout({}, 5), 60.0)
+
+    def test_timeout_override(self):
+        self.assertEqual(_resolve_timeout({}, 120), 120.0)
+
+    def test_timeout_config_used_when_no_override(self):
+        self.assertEqual(_resolve_timeout({"timeout_seconds": 300}, None), 300.0)
+
+    def test_timeout_invalid_falls_back(self):
+        self.assertEqual(_resolve_timeout({"timeout_seconds": "abc"}, None), 1800.0)
+
+    def test_max_result_chars_default(self):
+        self.assertEqual(_resolve_max_result_chars({}), 20000)
+
+    def test_max_result_chars_floor(self):
+        self.assertEqual(_resolve_max_result_chars({"max_result_chars": 10}), 20000)
+
+
+class TestBuildPrompt(unittest.TestCase):
+    def test_goal_only(self):
+        self.assertEqual(_build_prompt("fix the bug", None), "fix the bug")
+        self.assertEqual(_build_prompt("fix the bug", ""), "fix the bug")
+
+    def test_goal_with_context(self):
+        out = _build_prompt("fix the bug", "see src/foo.py line 42")
+        self.assertIn("fix the bug", out)
+        self.assertIn("--- Context ---", out)
+        self.assertIn("see src/foo.py line 42", out)
+
+
+class TestDelegateToDevin(unittest.TestCase):
+    """Handler paths with subprocess + auth fully mocked."""
+
+    def _patch_env(self, cfg=None, binary="/usr/bin/devin", logged_in=True,
+                   auth_detail=""):
+        cfg = cfg if cfg is not None else {"enabled": True}
+        return (
+            patch.object(mod, "_devin_config", lambda: cfg),
+            patch.object(mod, "_devin_binary", lambda: binary),
+            patch.object(mod, "_is_logged_in", lambda: (logged_in, auth_detail)),
+        )
+
+    def test_missing_goal_returns_error(self):
+        with patch.object(mod, "_devin_config", lambda: {"enabled": True}):
+            result = json.loads(delegate_to_devin(goal="   "))
+        self.assertIn("error", result)
+        self.assertIn("goal", result["error"])
+
+    def test_no_binary_returns_error(self):
+        with patch.object(mod, "_devin_config", lambda: {"enabled": True}), \
+             patch.object(mod, "_devin_binary", lambda: None):
+            result = json.loads(delegate_to_devin(goal="do thing"))
+        self.assertIn("error", result)
+        self.assertIn("not on $PATH", result["error"])
+
+    def test_not_logged_in_returns_error(self):
+        p1, p2, p3 = self._patch_env(logged_in=False,
+                                     auth_detail="Devin is not authenticated (logged out).")
+        with p1, p2, p3:
+            result = json.loads(delegate_to_devin(goal="do thing"))
+        self.assertIn("error", result)
+        self.assertIn("not authenticated", result["error"])
+
+    def test_success_returns_completed_result(self):
+        p1, p2, p3 = self._patch_env()
+        with p1, p2, p3, \
+             patch.object(mod.subprocess, "run",
+                          return_value=_ok_proc(stdout="All done. Fixed the bug.")):
+            result = json.loads(delegate_to_devin(goal="fix the bug", context="see foo.py"))
+        self.assertEqual(result["results"][0]["status"], "completed")
+        self.assertEqual(result["results"][0]["summary"], "All done. Fixed the bug.")
+        self.assertEqual(result["results"][0]["exit_reason"], "completed")
+        self.assertEqual(result["results"][0]["backend"], "devin")
+        self.assertFalse(result["results"][0]["truncated"])
+        self.assertIn("duration_seconds", result["results"][0])
+
+    def test_nonzero_exit_returns_error_result(self):
+        p1, p2, p3 = self._patch_env()
+        with p1, p2, p3, \
+             patch.object(mod.subprocess, "run",
+                          return_value=_ok_proc(stdout="", stderr="boom",
+                                                returncode=2)):
+            result = json.loads(delegate_to_devin(goal="do thing"))
+        entry = result["results"][0]
+        self.assertEqual(entry["status"], "error")
+        self.assertEqual(entry["exit_reason"], "error")
+        self.assertIn("code 2", entry["error"])
+        self.assertIn("boom", entry["error"])
+
+    def test_timeout_returns_timeout_result(self):
+        p1, p2, p3 = self._patch_env(cfg={"enabled": True, "timeout_seconds": 60})
+        with p1, p2, p3, \
+             patch.object(mod.subprocess, "run",
+                          side_effect=subprocess.TimeoutExpired(cmd=["devin"], timeout=60)):
+            result = json.loads(delegate_to_devin(goal="do thing"))
+        entry = result["results"][0]
+        self.assertEqual(entry["status"], "timeout")
+        self.assertEqual(entry["exit_reason"], "timeout")
+        self.assertIn("60s", entry["error"])
+
+    def test_truncation_flag_when_stdout_exceeds_limit(self):
+        p1, p2, p3 = self._patch_env(cfg={"enabled": True, "max_result_chars": 256})
+        long_out = "x" * 1000
+        with p1, p2, p3, \
+             patch.object(mod.subprocess, "run",
+                          return_value=_ok_proc(stdout=long_out)):
+            result = json.loads(delegate_to_devin(goal="do thing"))
+        entry = result["results"][0]
+        self.assertEqual(entry["status"], "completed")
+        self.assertTrue(entry["truncated"])
+        self.assertEqual(len(entry["summary"]), 256)
+
+    def test_model_override_passed_to_argv(self):
+        p1, p2, p3 = self._patch_env()
+        captured = {}
+
+        def fake_run(argv, **kw):
+            captured["argv"] = argv
+            return _ok_proc(stdout="ok")
+
+        with p1, p2, p3, patch.object(mod.subprocess, "run", side_effect=fake_run):
+            delegate_to_devin(goal="do thing", model="opus")
+        argv = captured["argv"]
+        self.assertIn("--model", argv)
+        self.assertIn("opus", argv)
+        # Print mode + unattended defaults always present.
+        self.assertIn("-p", argv)
+        self.assertIn("--permission-mode", argv)
+        self.assertIn("dangerous", argv)
+        self.assertIn("--respect-workspace-trust", argv)
+        self.assertIn("false", argv)
+        # Prompt after the -- separator.
+        self.assertEqual(argv[argv.index("--") + 1:], ["do thing"])
+
+    def test_permission_mode_from_config_not_model_controllable(self):
+        p1, p2, p3 = self._patch_env(cfg={"enabled": True, "permission_mode": "accept-edits"})
+        captured = {}
+
+        def fake_run(argv, **kw):
+            captured["argv"] = argv
+            return _ok_proc(stdout="ok")
+
+        with p1, p2, p3, patch.object(mod.subprocess, "run", side_effect=fake_run):
+            delegate_to_devin(goal="do thing")
+        argv = captured["argv"]
+        idx = argv.index("--permission-mode")
+        self.assertEqual(argv[idx + 1], "accept-edits")
+
+
+class TestSchema(unittest.TestCase):
+    def test_name_and_required(self):
+        self.assertEqual(DELEGATE_TO_DEVIN_SCHEMA["name"], "delegate_to_devin")
+        self.assertEqual(DELEGATE_TO_DEVIN_SCHEMA["parameters"]["required"], ["goal"])
+
+    def test_has_goal_context_model_timeout(self):
+        props = DELEGATE_TO_DEVIN_SCHEMA["parameters"]["properties"]
+        for key in ("goal", "context", "model", "timeout"):
+            self.assertIn(key, props)
+
+    def test_permission_mode_not_model_controllable(self):
+        """permission_mode is a security-sensitive knob — config-only, never
+        in the model-facing schema (a prompt-injected model must not be able
+        to escalate Devin's autonomy)."""
+        props = DELEGATE_TO_DEVIN_SCHEMA["parameters"]["properties"]
+        self.assertNotIn("permission_mode", props)
+
+
+class TestRegistryWiring(unittest.TestCase):
+    """The tool self-registers and is gated by check_fn in the registry."""
+
+    def test_registered_in_delegation_toolset(self):
+        from tools.registry import registry
+        entry = registry.get_entry("delegate_to_devin")
+        self.assertIsNotNone(entry, "delegate_to_devin not registered")
+        self.assertEqual(entry.toolset, "delegation")
+        self.assertEqual(entry.check_fn, check_devin_requirements)
+
+    def test_listed_in_core_tools_and_delegation_toolset(self):
+        import toolsets
+        self.assertIn("delegate_to_devin", toolsets._HERMES_CORE_TOOLS)
+        self.assertIn("delegate_to_devin", toolsets.TOOLSETS["delegation"]["tools"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_devin_delegate.py
+++ b/tests/tools/test_devin_delegate.py
@@ -10,9 +10,10 @@ Run with:  python -m pytest tests/tools/test_devin_delegate.py -v
 """
 
 import json
+import os
 import subprocess
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import tools.devin_delegate as mod
 from tools.devin_delegate import (
@@ -26,11 +27,15 @@ from tools.devin_delegate import (
 )
 
 
-def _ok_proc(stdout="", stderr="", returncode=0):
-    """A CompletedProcess-like object for mocked subprocess.run."""
-    return subprocess.CompletedProcess(
-        args=["devin"], returncode=returncode, stdout=stdout, stderr=stderr
-    )
+def _mock_popen(stdout="", stderr="", returncode=0):
+    """A mock Popen for the handler's Popen+communicate pattern."""
+    proc = MagicMock()
+    proc.stdout = stdout
+    proc.stderr = stderr
+    proc.returncode = returncode
+    proc.pid = 12345
+    proc.communicate = MagicMock(return_value=(stdout, stderr))
+    return proc
 
 
 class TestCheckRequirements(unittest.TestCase):
@@ -59,13 +64,16 @@ class TestCheckRequirements(unittest.TestCase):
 
 class TestConfigResolution(unittest.TestCase):
     def test_permission_mode_default(self):
-        self.assertEqual(_resolve_permission_mode({}), "dangerous")
+        self.assertEqual(_resolve_permission_mode({}), "accept-edits")
 
     def test_permission_mode_override(self):
         self.assertEqual(_resolve_permission_mode({"permission_mode": "auto"}), "auto")
 
     def test_permission_mode_invalid_falls_back(self):
-        self.assertEqual(_resolve_permission_mode({"permission_mode": "yolo"}), "dangerous")
+        self.assertEqual(_resolve_permission_mode({"permission_mode": "yolo"}), "accept-edits")
+
+    def test_permission_mode_dangerous_requires_explicit_config(self):
+        self.assertEqual(_resolve_permission_mode({"permission_mode": "dangerous"}), "dangerous")
 
     def test_timeout_default(self):
         self.assertEqual(_resolve_timeout({}, None), 1800.0)
@@ -81,6 +89,23 @@ class TestConfigResolution(unittest.TestCase):
 
     def test_timeout_invalid_falls_back(self):
         self.assertEqual(_resolve_timeout({"timeout_seconds": "abc"}, None), 1800.0)
+
+    def test_timeout_model_override_clamped_to_config(self):
+        """Model override cannot exceed config timeout (prompt-injection guard)."""
+        self.assertEqual(_resolve_timeout({"timeout_seconds": 300}, 99999), 300.0)
+
+    def test_timeout_model_override_clamped_to_hard_cap(self):
+        """With a high config timeout, model override is still capped at
+        _MAX_MODEL_TIMEOUT_SECONDS (the hard safety ceiling)."""
+        from tools.devin_delegate import _MAX_MODEL_TIMEOUT_SECONDS
+        self.assertEqual(
+            _resolve_timeout({"timeout_seconds": 999999}, 999999),
+            _MAX_MODEL_TIMEOUT_SECONDS,
+        )
+
+    def test_timeout_model_override_can_shorten(self):
+        """Model can shorten the timeout for a quick task."""
+        self.assertEqual(_resolve_timeout({"timeout_seconds": 1800}, 120), 120.0)
 
     def test_max_result_chars_default(self):
         self.assertEqual(_resolve_max_result_chars({}), 20000)
@@ -137,8 +162,8 @@ class TestDelegateToDevin(unittest.TestCase):
     def test_success_returns_completed_result(self):
         p1, p2, p3 = self._patch_env()
         with p1, p2, p3, \
-             patch.object(mod.subprocess, "run",
-                          return_value=_ok_proc(stdout="All done. Fixed the bug.")):
+             patch.object(mod.subprocess, "Popen",
+                          return_value=_mock_popen(stdout="All done. Fixed the bug.")):
             result = json.loads(delegate_to_devin(goal="fix the bug", context="see foo.py"))
         self.assertEqual(result["results"][0]["status"], "completed")
         self.assertEqual(result["results"][0]["summary"], "All done. Fixed the bug.")
@@ -150,9 +175,9 @@ class TestDelegateToDevin(unittest.TestCase):
     def test_nonzero_exit_returns_error_result(self):
         p1, p2, p3 = self._patch_env()
         with p1, p2, p3, \
-             patch.object(mod.subprocess, "run",
-                          return_value=_ok_proc(stdout="", stderr="boom",
-                                                returncode=2)):
+             patch.object(mod.subprocess, "Popen",
+                          return_value=_mock_popen(stdout="", stderr="boom",
+                                                   returncode=2)):
             result = json.loads(delegate_to_devin(goal="do thing"))
         entry = result["results"][0]
         self.assertEqual(entry["status"], "error")
@@ -160,11 +185,26 @@ class TestDelegateToDevin(unittest.TestCase):
         self.assertIn("code 2", entry["error"])
         self.assertIn("boom", entry["error"])
 
+    def test_error_truncation_flag_when_stderr_exceeds_limit(self):
+        """Error path must report truncated=True when error text is clipped."""
+        p1, p2, p3 = self._patch_env(cfg={"enabled": True, "max_result_chars": 256})
+        long_err = "e" * 1000
+        with p1, p2, p3, \
+             patch.object(mod.subprocess, "Popen",
+                          return_value=_mock_popen(stdout="", stderr=long_err,
+                                                   returncode=1)):
+            result = json.loads(delegate_to_devin(goal="do thing"))
+        entry = result["results"][0]
+        self.assertEqual(entry["status"], "error")
+        self.assertTrue(entry["truncated"])
+
     def test_timeout_returns_timeout_result(self):
         p1, p2, p3 = self._patch_env(cfg={"enabled": True, "timeout_seconds": 60})
+        proc = _mock_popen()
+        proc.communicate.side_effect = subprocess.TimeoutExpired(cmd=["devin"], timeout=60)
         with p1, p2, p3, \
-             patch.object(mod.subprocess, "run",
-                          side_effect=subprocess.TimeoutExpired(cmd=["devin"], timeout=60)):
+             patch.object(mod.subprocess, "Popen", return_value=proc), \
+             patch.object(mod, "_kill_process_group", lambda p: None):
             result = json.loads(delegate_to_devin(goal="do thing"))
         entry = result["results"][0]
         self.assertEqual(entry["status"], "timeout")
@@ -175,8 +215,8 @@ class TestDelegateToDevin(unittest.TestCase):
         p1, p2, p3 = self._patch_env(cfg={"enabled": True, "max_result_chars": 256})
         long_out = "x" * 1000
         with p1, p2, p3, \
-             patch.object(mod.subprocess, "run",
-                          return_value=_ok_proc(stdout=long_out)):
+             patch.object(mod.subprocess, "Popen",
+                          return_value=_mock_popen(stdout=long_out)):
             result = json.loads(delegate_to_devin(goal="do thing"))
         entry = result["results"][0]
         self.assertEqual(entry["status"], "completed")
@@ -187,11 +227,11 @@ class TestDelegateToDevin(unittest.TestCase):
         p1, p2, p3 = self._patch_env()
         captured = {}
 
-        def fake_run(argv, **kw):
+        def fake_popen(argv, **kw):
             captured["argv"] = argv
-            return _ok_proc(stdout="ok")
+            return _mock_popen(stdout="ok")
 
-        with p1, p2, p3, patch.object(mod.subprocess, "run", side_effect=fake_run):
+        with p1, p2, p3, patch.object(mod.subprocess, "Popen", side_effect=fake_popen):
             delegate_to_devin(goal="do thing", model="opus")
         argv = captured["argv"]
         self.assertIn("--model", argv)
@@ -199,25 +239,40 @@ class TestDelegateToDevin(unittest.TestCase):
         # Print mode + unattended defaults always present.
         self.assertIn("-p", argv)
         self.assertIn("--permission-mode", argv)
-        self.assertIn("dangerous", argv)
+        self.assertIn("accept-edits", argv)  # new safe default
         self.assertIn("--respect-workspace-trust", argv)
         self.assertIn("false", argv)
         # Prompt after the -- separator.
         self.assertEqual(argv[argv.index("--") + 1:], ["do thing"])
 
     def test_permission_mode_from_config_not_model_controllable(self):
-        p1, p2, p3 = self._patch_env(cfg={"enabled": True, "permission_mode": "accept-edits"})
+        p1, p2, p3 = self._patch_env(cfg={"enabled": True, "permission_mode": "dangerous"})
         captured = {}
 
-        def fake_run(argv, **kw):
+        def fake_popen(argv, **kw):
             captured["argv"] = argv
-            return _ok_proc(stdout="ok")
+            return _mock_popen(stdout="ok")
 
-        with p1, p2, p3, patch.object(mod.subprocess, "run", side_effect=fake_run):
+        with p1, p2, p3, patch.object(mod.subprocess, "Popen", side_effect=fake_popen):
             delegate_to_devin(goal="do thing")
         argv = captured["argv"]
         idx = argv.index("--permission-mode")
-        self.assertEqual(argv[idx + 1], "accept-edits")
+        self.assertEqual(argv[idx + 1], "dangerous")
+
+    def test_uses_terminal_cwd_when_set(self):
+        """Devin should launch in TERMINAL_CWD, not os.getcwd()."""
+        p1, p2, p3 = self._patch_env()
+        captured = {}
+
+        def fake_popen(argv, **kw):
+            captured["cwd"] = kw.get("cwd")
+            return _mock_popen(stdout="ok")
+
+        with p1, p2, p3, \
+             patch.dict(os.environ, {"TERMINAL_CWD": "/tmp/test-workspace"}), \
+             patch.object(mod.subprocess, "Popen", side_effect=fake_popen):
+            delegate_to_devin(goal="do thing")
+        self.assertEqual(captured["cwd"], "/tmp/test-workspace")
 
 
 class TestSchema(unittest.TestCase):
@@ -248,9 +303,12 @@ class TestRegistryWiring(unittest.TestCase):
         self.assertEqual(entry.toolset, "delegation")
         self.assertEqual(entry.check_fn, check_devin_requirements)
 
-    def test_listed_in_core_tools_and_delegation_toolset(self):
+    def test_listed_in_delegation_toolset_not_core(self):
+        """delegate_to_devin is in the delegation toolset but NOT in
+        _HERMES_CORE_TOOLS — it's a third-party opt-in backend, not a
+        core tool that ships on every API call."""
         import toolsets
-        self.assertIn("delegate_to_devin", toolsets._HERMES_CORE_TOOLS)
+        self.assertNotIn("delegate_to_devin", toolsets._HERMES_CORE_TOOLS)
         self.assertIn("delegate_to_devin", toolsets.TOOLSETS["delegation"]["tools"])
 
 

--- a/tests/tools/test_devin_delegate.py
+++ b/tests/tools/test_devin_delegate.py
@@ -107,6 +107,16 @@ class TestConfigResolution(unittest.TestCase):
         """Model can shorten the timeout for a quick task."""
         self.assertEqual(_resolve_timeout({"timeout_seconds": 1800}, 120), 120.0)
 
+    def test_timeout_rejects_nan(self):
+        """NaN must fall back to default, not bypass the floor check."""
+        self.assertEqual(_resolve_timeout({}, float("nan")), 1800.0)
+        self.assertEqual(_resolve_timeout({"timeout_seconds": float("nan")}, None), 1800.0)
+
+    def test_timeout_rejects_infinity(self):
+        """Infinity must fall back to default, not remove the timeout cap."""
+        self.assertEqual(_resolve_timeout({}, float("inf")), 1800.0)
+        self.assertEqual(_resolve_timeout({"timeout_seconds": float("inf")}, None), 1800.0)
+
     def test_max_result_chars_default(self):
         self.assertEqual(_resolve_max_result_chars({}), 20000)
 
@@ -150,6 +160,14 @@ class TestDelegateToDevin(unittest.TestCase):
             result = json.loads(delegate_to_devin(goal="do thing"))
         self.assertIn("error", result)
         self.assertIn("not on $PATH", result["error"])
+
+    def test_handler_rejects_when_disabled_at_runtime(self):
+        """Handler must re-check enabled gate — registry caches check_fn,
+        so a runtime config change could leave the tool callable."""
+        with patch.object(mod, "_devin_config", lambda: {"enabled": False}):
+            result = json.loads(delegate_to_devin(goal="do thing"))
+        self.assertIn("error", result)
+        self.assertIn("disabled", result["error"])
 
     def test_not_logged_in_returns_error(self):
         p1, p2, p3 = self._patch_env(logged_in=False,

--- a/tests/tools/test_devin_delegate.py
+++ b/tests/tools/test_devin_delegate.py
@@ -232,8 +232,8 @@ class TestDelegateToDevin(unittest.TestCase):
         self.assertIn("timeout_seconds", entry["error"])
 
     def test_timeout_with_model_override_shows_override_hint(self):
-        """When the model supplied a timeout override, the error hint should
-        mention the override, not just the config knob."""
+        """When the model supplied a timeout override that actually shortens
+        the effective timeout, the error hint should mention the override."""
         p1, p2, p3 = self._patch_env(cfg={"enabled": True, "timeout_seconds": 1800})
         proc = _mock_popen()
         proc.communicate.side_effect = subprocess.TimeoutExpired(cmd=["devin"], timeout=120)
@@ -244,6 +244,24 @@ class TestDelegateToDevin(unittest.TestCase):
         entry = result["results"][0]
         self.assertEqual(entry["status"], "timeout")
         self.assertIn("override", entry["error"].lower())
+
+    def test_timeout_with_override_at_ceiling_shows_config_hint(self):
+        """When the model override is at/above the config ceiling, the resolved
+        timeout equals the config default — the hint should point to config,
+        not mention the override."""
+        p1, p2, p3 = self._patch_env(cfg={"enabled": True, "timeout_seconds": 300})
+        proc = _mock_popen()
+        proc.communicate.side_effect = subprocess.TimeoutExpired(cmd=["devin"], timeout=300)
+        with p1, p2, p3, \
+             patch.object(mod.subprocess, "Popen", return_value=proc), \
+             patch.object(mod, "_kill_process_group", lambda p: None):
+            # Override at ceiling → resolved = 300 = config default
+            result = json.loads(delegate_to_devin(goal="do thing", timeout=99999))
+        entry = result["results"][0]
+        self.assertEqual(entry["status"], "timeout")
+        # Should show config hint, not override hint
+        self.assertIn("timeout_seconds", entry["error"])
+        self.assertNotIn("override", entry["error"].lower())
 
     def test_truncation_flag_when_stdout_exceeds_limit(self):
         p1, p2, p3 = self._patch_env(cfg={"enabled": True, "max_result_chars": 256})

--- a/tests/tools/test_devin_delegate.py
+++ b/tests/tools/test_devin_delegate.py
@@ -284,13 +284,31 @@ class TestDelegateToDevin(unittest.TestCase):
 
         def fake_popen(argv, **kw):
             captured["cwd"] = kw.get("cwd")
+            captured["stdin"] = kw.get("stdin")
             return _mock_popen(stdout="ok")
 
         with p1, p2, p3, \
-             patch.dict(os.environ, {"TERMINAL_CWD": "/tmp/test-workspace"}), \
+             patch.dict(os.environ, {"TERMINAL_CWD": "/tmp"}), \
              patch.object(mod.subprocess, "Popen", side_effect=fake_popen):
             delegate_to_devin(goal="do thing")
-        self.assertEqual(captured["cwd"], "/tmp/test-workspace")
+        self.assertTrue(captured["cwd"].endswith("/tmp") or captured["cwd"] == "/tmp")
+        # stdin must be DEVNULL to prevent interactive prompts from blocking
+        self.assertEqual(captured["stdin"], subprocess.DEVNULL)
+
+    def test_falls_back_to_cwd_when_terminal_cwd_invalid(self):
+        """If TERMINAL_CWD points to a non-existent dir, fall back to os.getcwd()."""
+        p1, p2, p3 = self._patch_env()
+        captured = {}
+
+        def fake_popen(argv, **kw):
+            captured["cwd"] = kw.get("cwd")
+            return _mock_popen(stdout="ok")
+
+        with p1, p2, p3, \
+             patch.dict(os.environ, {"TERMINAL_CWD": "/nonexistent/path/xyz"}), \
+             patch.object(mod.subprocess, "Popen", side_effect=fake_popen):
+            delegate_to_devin(goal="do thing")
+        self.assertEqual(captured["cwd"], os.getcwd())
 
 
 class TestSchema(unittest.TestCase):

--- a/tools/devin_delegate.py
+++ b/tools/devin_delegate.py
@@ -388,9 +388,13 @@ def delegate_to_devin(
             except Exception:
                 stdout, stderr = "", ""
             duration = time.monotonic() - start
-            # Tailor the error hint: if the model supplied a timeout override,
-            # raising the config default won't help — the model chose this cap.
-            if timeout is not None:
+            # Tailor the error hint: only show the "override" message when the
+            # model's timeout actually shortened the effective timeout (i.e.,
+            # the resolved timeout is less than the config default). If the
+            # override was invalid or at/above the ceiling, _resolve_timeout
+            # returns the config default and the "override" hint is misleading.
+            config_default = _resolve_timeout(cfg, None)
+            if timeout is not None and timeout_seconds < config_default:
                 timeout_hint = (
                     "The model supplied a shorter timeout override; ask it to "
                     "retry without the timeout parameter or raise "

--- a/tools/devin_delegate.py
+++ b/tools/devin_delegate.py
@@ -87,8 +87,13 @@ def _kill_process_group(proc: subprocess.Popen) -> None:
     """
     killpg = getattr(os, "killpg", None)
     if killpg is not None:
+        # start_new_session=True makes the child the process-group leader,
+        # so its pgid is reliably proc.pid. Using proc.pid directly (instead
+        # of os.getpgid(proc.pid)) avoids a ProcessLookupError if the direct
+        # child has already exited while descendants still hold the pipe open
+        # — which is exactly the case when communicate(timeout=...) timed out.
         try:
-            os.killpg(os.getpgid(proc.pid), 9)  # SIGKILL
+            os.killpg(proc.pid, 9)  # SIGKILL
         except (ProcessLookupError, PermissionError, OSError):
             try:
                 proc.kill()
@@ -353,7 +358,7 @@ def delegate_to_devin(
         workdir = str(Path(workdir).resolve())
         if not Path(workdir).is_dir():
             workdir = os.getcwd()
-    except (OSError, ValueError):
+    except (OSError, ValueError, RuntimeError):
         workdir = os.getcwd()
 
     start = time.monotonic()
@@ -383,6 +388,19 @@ def delegate_to_devin(
             except Exception:
                 stdout, stderr = "", ""
             duration = time.monotonic() - start
+            # Tailor the error hint: if the model supplied a timeout override,
+            # raising the config default won't help — the model chose this cap.
+            if timeout is not None:
+                timeout_hint = (
+                    "The model supplied a shorter timeout override; ask it to "
+                    "retry without the timeout parameter or raise "
+                    "delegation.devin.timeout_seconds in config.yaml."
+                )
+            else:
+                timeout_hint = (
+                    "Raise delegation.devin.timeout_seconds if the task needs "
+                    "more time."
+                )
             return json.dumps(
                 {"results": [{
                     "task_index": 0,
@@ -390,8 +408,7 @@ def delegate_to_devin(
                     "summary": "",
                     "error": (
                         f"Devin did not finish within {timeout_seconds:.0f}s. "
-                        "Raise delegation.devin.timeout_seconds if the task needs "
-                        "more time."
+                        f"{timeout_hint}"
                     ),
                     "duration_seconds": round(duration, 3),
                     "model": resolved_model,

--- a/tools/devin_delegate.py
+++ b/tools/devin_delegate.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import shutil
 import subprocess
@@ -222,6 +223,8 @@ def _resolve_timeout(cfg: Dict[str, Any], override: Any) -> float:
             config_timeout = float(config_timeout)
         except (TypeError, ValueError):
             config_timeout = _DEFAULT_TIMEOUT_SECONDS
+        if not math.isfinite(config_timeout):
+            config_timeout = _DEFAULT_TIMEOUT_SECONDS
     else:
         config_timeout = _DEFAULT_TIMEOUT_SECONDS
     config_timeout = max(_MIN_TIMEOUT_SECONDS, config_timeout)
@@ -234,6 +237,13 @@ def _resolve_timeout(cfg: Dict[str, Any], override: Any) -> float:
     except (TypeError, ValueError):
         logger.warning(
             "delegate_to_devin timeout=%r is not a valid number; "
+            "using config default %.0f",
+            override, config_timeout,
+        )
+        return config_timeout
+    if not math.isfinite(parsed):
+        logger.warning(
+            "delegate_to_devin timeout=%r is not finite; "
             "using config default %.0f",
             override, config_timeout,
         )
@@ -292,6 +302,17 @@ def delegate_to_devin(
         return tool_error("delegate_to_devin requires a non-empty 'goal'.")
 
     cfg = _devin_config()
+
+    # Re-check the enabled gate at handler time. The registry TTL-caches
+    # check_fn results, so if an operator disables delegation.devin.enabled
+    # while a cached schema still exposes the tool, the handler must still
+    # refuse the call rather than launching Devin with no authorization.
+    if not _truthy(cfg.get("enabled"), default=False):
+        return tool_error(
+            "Devin delegation is disabled. Enable delegation.devin.enabled "
+            "in config.yaml to use this tool."
+        )
+
     binary = _devin_binary()
     if binary is None:
         return tool_error(

--- a/tools/devin_delegate.py
+++ b/tools/devin_delegate.py
@@ -1,0 +1,396 @@
+"""Devin CLI delegate backend.
+
+Exposes the local ``devin`` CLI binary as a first-class delegation backend,
+peer to ``delegate_task``. Unlike ``delegate_task`` (which spawns an in-process
+``AIAgent`` child against a chat-completions inference endpoint), this tool
+shells out to the external Devin CLI in non-interactive ``-p`` (print) mode
+and returns the finished response. Devin runs its *own* internal agent loop
+and hands back a completed answer — there is no chat-completions token stream
+for Hermes's conversation loop to consume, so it cannot be a ``ProviderProfile``.
+
+This is the CLI-delegate shape the user asked for: Hermes keeps its own
+agent loop; Devin handles a delegated, self-contained subtask end-to-end.
+
+Gating (Footprint Ladder rung 3 — service-gated tool):
+  ``check_devin_requirements()`` returns True only when
+  ``delegation.devin.enabled`` is truthy in config.yaml AND the ``devin``
+  binary is on ``$PATH``. The registry TTL-caches ``check_fn`` results, so
+  the tool has ZERO schema footprint for users who have not opted in — it
+  never appears in the tool list sent to the model on every API call unless
+  Devin is actually configured. Authentication is verified at handler time
+  (not in ``check_fn``) so a stale Devin login produces a clear, actionable
+  error instead of the tool silently disappearing from the schema.
+
+Config (``delegation.devin.*`` in config.yaml — behavioral settings live in
+config, not env vars, per the AGENTS.md ``.env``-is-for-secrets-only rule)::
+
+    delegation:
+      devin:
+        enabled: true                  # opt-in; default false
+        model: swe                      # optional Devin model short name
+        permission_mode: dangerous      # auto|accept-edits|smart|dangerous
+        timeout_seconds: 1800           # per-call wall-clock cap (>= 60)
+        max_result_chars: 20000         # truncate Devin stdout above this
+
+The handler is synchronous (blocking) by design for v1: the model receives
+Devin's full result within the same turn. The async re-entry machinery that
+``delegate_task`` uses (background subagents whose results re-enter the
+conversation as new messages) is a deliberate follow-up, not in scope here —
+it would touch the core agent loop (run_agent.py), which the narrow-waist
+rule keeps off-limits unless the capability is fundamental.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import time
+from typing import Any, Dict, Optional
+
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+# ── Defaults ────────────────────────────────────────────────────────────────
+# Floor 60s so a typo can't make Devin unrunnable; ceiling is the user's call.
+_DEFAULT_TIMEOUT_SECONDS = 1800.0
+_MIN_TIMEOUT_SECONDS = 60.0
+# Match delegate_task's sane upper bound for a returned summary so a verbose
+# Devin run can't blow out the conversation context.
+_DEFAULT_MAX_RESULT_CHARS = 20000
+# permission_mode sent to Devin for unattended delegation. "dangerous" is the
+# explicit opt-in for non-interactive runs — the whole tool is already gated
+# behind delegation.devin.enabled, so the user has acknowledged Devin will act
+# autonomously on the delegated subtask.
+_DEFAULT_PERMISSION_MODE = "dangerous"
+_VALID_PERMISSION_MODES = ("auto", "accept-edits", "smart", "dangerous")
+
+
+def _devin_config() -> Dict[str, Any]:
+    """Return the ``delegation.devin`` config block (a dict, possibly empty).
+
+    Reuses ``delegate_tool._load_config()`` so the same config priority
+    (config.yaml via ``load_config_readonly()`` → legacy ``cli.CLI_CONFIG``)
+    and the same ``HERMES_IGNORE_USER_CONFIG`` semantics apply. Never raises.
+    """
+    try:
+        from tools.delegate_tool import _load_config
+
+        delegation = _load_config() or {}
+        devin = delegation.get("devin") or {}
+        return devin if isinstance(devin, dict) else {}
+    except Exception:
+        return {}
+
+
+def _devin_binary() -> Optional[str]:
+    """Return the path to the ``devin`` executable on ``$PATH``, or None."""
+    return shutil.which("devin")
+
+
+# Local truthy set — mirrors utils.TRUTHY_STRINGS so ``check_fn`` doesn't have
+# to import ``utils`` (which pulls a top-level ``import yaml``) on every schema
+# rebuild. ``check_fn`` must stay cheap and dependency-light; the handler path
+# still uses the full ``_load_config`` machinery for config priority.
+_TRUTHY_STRINGS = frozenset({"1", "true", "yes", "on"})
+
+
+def _truthy(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in _TRUTHY_STRINGS
+    return bool(value)
+
+
+def check_devin_requirements() -> bool:
+    """``check_fn`` gate for the ``delegate_to_devin`` tool.
+
+    True only when the user has opted in via ``delegation.devin.enabled`` AND
+    the ``devin`` binary is reachable on ``$PATH``. Kept deliberately cheap
+    (no subprocess, no heavy imports) because the registry calls ``check_fn``
+    on every ``get_definitions()`` rebuild; authentication is verified at
+    handler time so a missing login yields a clear error rather than the tool
+    vanishing.
+    """
+    try:
+        cfg = _devin_config()
+        if not _truthy(cfg.get("enabled"), default=False):
+            return False
+        return _devin_binary() is not None
+    except Exception:
+        return False
+
+
+def _is_logged_in() -> tuple[bool, str]:
+    """Probe ``devin auth status``. Returns (logged_in, detail).
+
+    Best-effort: any failure to run/parse is treated as "not logged in" with
+    a detail string suitable for the tool error. Never raises.
+    """
+    binary = _devin_binary()
+    if binary is None:
+        return False, "the `devin` binary is not on $PATH"
+    try:
+        proc = subprocess.run(
+            [binary, "auth", "status"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except subprocess.TimeoutExpired:
+        return False, "`devin auth status` timed out"
+    except Exception as exc:  # pragma: no cover — environment-dependent
+        return False, f"`devin auth status` failed to run: {exc}"
+    out = (proc.stdout or "") + "\n" + (proc.stderr or "")
+    # `devin auth status` prints "Logged in ..." when authenticated; a non-zero
+    # exit or a "not logged in"/"logged out" line means no credentials.
+    lowered = out.lower()
+    if proc.returncode == 0 and "logged in" in lowered and "not logged in" not in lowered:
+        return True, ""
+    snippet = (proc.stdout or proc.stderr or "").strip().splitlines()
+    detail = snippet[0] if snippet else "not logged in"
+    return False, f"Devin is not authenticated ({detail}). Run `devin auth login`."
+
+
+def _resolve_permission_mode(cfg: Dict[str, Any]) -> str:
+    mode = str(cfg.get("permission_mode") or _DEFAULT_PERMISSION_MODE).strip().lower()
+    return mode if mode in _VALID_PERMISSION_MODES else _DEFAULT_PERMISSION_MODE
+
+
+def _resolve_timeout(cfg: Dict[str, Any], override: Any) -> float:
+    raw = override if override is not None else cfg.get("timeout_seconds")
+    if raw is None:
+        return _DEFAULT_TIMEOUT_SECONDS
+    try:
+        parsed = float(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "delegation.devin.timeout_seconds=%r is not a valid number; "
+            "using default %.0f",
+            raw, _DEFAULT_TIMEOUT_SECONDS,
+        )
+        return _DEFAULT_TIMEOUT_SECONDS
+    return _MIN_TIMEOUT_SECONDS if parsed < _MIN_TIMEOUT_SECONDS else parsed
+
+
+def _resolve_max_result_chars(cfg: Dict[str, Any]) -> int:
+    raw = cfg.get("max_result_chars", _DEFAULT_MAX_RESULT_CHARS)
+    try:
+        val = int(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_MAX_RESULT_CHARS
+    return val if val >= 256 else _DEFAULT_MAX_RESULT_CHARS
+
+
+def _build_prompt(goal: str, context: Optional[str]) -> str:
+    goal = goal.strip()
+    context = (context or "").strip()
+    if not context:
+        return goal
+    return f"{goal}\n\n--- Context ---\n{context}"
+
+
+def _truncate(text: str, limit: int) -> tuple[str, bool]:
+    if len(text) <= limit:
+        return text, False
+    return text[:limit], True
+
+
+def delegate_to_devin(
+    goal: Optional[str] = None,
+    context: Optional[str] = None,
+    model: Optional[str] = None,
+    timeout: Any = None,
+    **_kw: Any,
+) -> str:
+    """Delegate a self-contained subtask to the local Devin CLI.
+
+    Spawns ``devin -p --permission-mode <mode> --respect-workspace-trust false
+    [--model <m>] -- <prompt>`` in the current working directory, waits for it
+    to finish, and returns a JSON result shaped like ``delegate_task``'s
+    (``{"results": [entry]}``) so the model can consume either backend
+    uniformly.
+
+    Synchronous: blocks the caller's turn until Devin returns. A
+    ``timeout_seconds`` cap (default 1800, floor 60) kills the run and reports
+    ``status="timeout"``.
+    """
+    goal = (goal or "").strip()
+    if not goal:
+        return tool_error("delegate_to_devin requires a non-empty 'goal'.")
+
+    cfg = _devin_config()
+    binary = _devin_binary()
+    if binary is None:
+        return tool_error(
+            "The `devin` CLI is not on $PATH. Install Devin for Terminal and "
+            "retry, or disable delegation.devin in config.yaml."
+        )
+
+    # Verify auth at handler time so a stale login is a clear, actionable
+    # error rather than the tool silently absent from the schema.
+    logged_in, auth_detail = _is_logged_in()
+    if not logged_in:
+        return tool_error(auth_detail)
+
+    permission_mode = _resolve_permission_mode(cfg)
+    timeout_seconds = _resolve_timeout(cfg, timeout)
+    max_chars = _resolve_max_result_chars(cfg)
+
+    # Model: per-call override beats config. Devin accepts short names
+    # (opus, swe, codex, ...) or full model ids.
+    resolved_model = (model or cfg.get("model") or "").strip() or None
+
+    prompt = _build_prompt(goal, context)
+
+    argv = [binary, "-p", "--permission-mode", permission_mode,
+            "--respect-workspace-trust", "false"]
+    if resolved_model:
+        argv += ["--model", resolved_model]
+    argv += ["--", prompt]
+
+    start = time.monotonic()
+    try:
+        proc = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            cwd=os.getcwd(),
+        )
+    except subprocess.TimeoutExpired:
+        duration = time.monotonic() - start
+        return json.dumps(
+            {"results": [{
+                "task_index": 0,
+                "status": "timeout",
+                "summary": "",
+                "error": (
+                    f"Devin did not finish within {timeout_seconds:.0f}s. "
+                    "Raise delegation.devin.timeout_seconds if the task needs "
+                    "more time."
+                ),
+                "duration_seconds": round(duration, 3),
+                "model": resolved_model,
+                "exit_reason": "timeout",
+                "truncated": False,
+                "backend": "devin",
+            }]},
+            ensure_ascii=False,
+        )
+    except Exception as exc:  # pragma: no cover — environment-dependent
+        return tool_error(f"Failed to spawn Devin: {exc}")
+
+    duration = time.monotonic() - start
+    stdout = proc.stdout or ""
+    stderr = proc.stderr or ""
+
+    if proc.returncode != 0:
+        err, _ = _truncate(stderr.strip() or stdout.strip(), max_chars)
+        return json.dumps(
+            {"results": [{
+                "task_index": 0,
+                "status": "error",
+                "summary": "",
+                "error": f"Devin exited with code {proc.returncode}: {err}",
+                "duration_seconds": round(duration, 3),
+                "model": resolved_model,
+                "exit_reason": "error",
+                "truncated": False,
+                "backend": "devin",
+            }]},
+            ensure_ascii=False,
+        )
+
+    summary, truncated = _truncate(stdout.strip(), max_chars)
+    return json.dumps(
+        {"results": [{
+            "task_index": 0,
+            "status": "completed",
+            "summary": summary,
+            "duration_seconds": round(duration, 3),
+            "model": resolved_model,
+            "exit_reason": "completed",
+            "truncated": truncated,
+            "backend": "devin",
+        }]},
+        ensure_ascii=False,
+    )
+
+
+DELEGATE_TO_DEVIN_SCHEMA = {
+    "name": "delegate_to_devin",
+    "description": (
+        "Delegate a self-contained subtask to the local Devin CLI (an external "
+        "agent) and return its finished response. Devin runs its own complete "
+        "agent loop — terminal, file edits, browser — and hands back a done "
+        "answer, so use this for well-scoped, end-to-end subtasks you do not "
+        "need to observe step-by-step. Unlike `delegate_task` (which spawns a "
+        "Hermes subagent you can steer and stream), this is a single blocking "
+        "call: you receive Devin's full result in this turn. Only available "
+        "when `delegation.devin.enabled` is set in config.yaml and the Devin "
+        "CLI is installed and authenticated. Provide a fully self-contained "
+        "goal — Devin knows nothing about your current conversation."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "goal": {
+                "type": "string",
+                "description": (
+                    "What Devin should accomplish. Be specific and "
+                    "self-contained — Devin has none of your conversation "
+                    "context. Include file paths, constraints, and the "
+                    "definition of done."
+                ),
+            },
+            "context": {
+                "type": "string",
+                "description": (
+                    "Optional background: project structure, error messages, "
+                    "relevant code snippets. Appended to the goal under a "
+                    "Context header."
+                ),
+            },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Optional Devin model short name or id (e.g. 'opus', "
+                    "'swe', 'codex'). Overrides delegation.devin.model in "
+                    "config.yaml for this call."
+                ),
+            },
+            "timeout": {
+                "type": "integer",
+                "description": (
+                    "Optional wall-clock cap in seconds (min 60, default "
+                    "1800). If Devin does not finish in time it is killed and "
+                    "a timeout result is returned."
+                ),
+            },
+        },
+        "required": ["goal"],
+    },
+}
+
+
+registry.register(
+    name="delegate_to_devin",
+    toolset="delegation",
+    schema=DELEGATE_TO_DEVIN_SCHEMA,
+    handler=lambda args, **kw: delegate_to_devin(
+        goal=args.get("goal"),
+        context=args.get("context"),
+        model=args.get("model"),
+        timeout=args.get("timeout"),
+        **kw,
+    ),
+    check_fn=check_devin_requirements,
+    emoji="🤖",
+)

--- a/tools/devin_delegate.py
+++ b/tools/devin_delegate.py
@@ -61,12 +61,56 @@ _MIN_TIMEOUT_SECONDS = 60.0
 # Match delegate_task's sane upper bound for a returned summary so a verbose
 # Devin run can't blow out the conversation context.
 _DEFAULT_MAX_RESULT_CHARS = 20000
-# permission_mode sent to Devin for unattended delegation. "dangerous" is the
-# explicit opt-in for non-interactive runs — the whole tool is already gated
-# behind delegation.devin.enabled, so the user has acknowledged Devin will act
-# autonomously on the delegated subtask.
-_DEFAULT_PERMISSION_MODE = "dangerous"
+# permission_mode sent to Devin for unattended delegation. "accept-edits" is
+# the safe default — Devin can modify files but still prompts for dangerous
+# operations (shell commands, etc.). Users who want fully autonomous Devin
+# must explicitly set permission_mode: dangerous in config.yaml.
+_DEFAULT_PERMISSION_MODE = "accept-edits"
 _VALID_PERMISSION_MODES = ("auto", "accept-edits", "smart", "dangerous")
+# Ceiling for model-controllable timeout override. The model can request a
+# timeout up to this value, but not beyond — prevents a prompt-injected model
+# from stalling the turn with an arbitrarily long subprocess.run. The config
+# value (timeout_seconds) is the real ceiling for unattended runs; this only
+# caps the model-facing override.
+_MAX_MODEL_TIMEOUT_SECONDS = 7200.0  # 2 hours
+
+
+def _kill_process_group(proc: subprocess.Popen) -> None:
+    """Kill the child and its entire process tree.
+
+    On POSIX, ``start_new_session=True`` puts the child in a new process
+    group, so ``killpg`` reaches all descendants (Devin spawns shell,
+    browser, etc.). On Windows, fall back to psutil-based tree kill
+    (mirrors ``tools/code_execution_tool.py:_kill_process_group``).
+    """
+    killpg = getattr(os, "killpg", None)
+    if killpg is not None:
+        try:
+            os.killpg(os.getpgid(proc.pid), 9)  # SIGKILL
+        except (ProcessLookupError, PermissionError, OSError):
+            try:
+                proc.kill()
+            except Exception:
+                pass
+    else:
+        # Windows: no killpg, use psutil to kill the tree
+        try:
+            import psutil
+            parent = psutil.Process(proc.pid)
+            for child in parent.children(recursive=True):
+                try:
+                    child.kill()
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    pass
+            try:
+                parent.kill()
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                pass
+        except ImportError:
+            try:
+                proc.kill()
+            except Exception:
+                pass
 
 
 def _devin_config() -> Dict[str, Any]:
@@ -164,19 +208,41 @@ def _resolve_permission_mode(cfg: Dict[str, Any]) -> str:
 
 
 def _resolve_timeout(cfg: Dict[str, Any], override: Any) -> float:
-    raw = override if override is not None else cfg.get("timeout_seconds")
-    if raw is None:
-        return _DEFAULT_TIMEOUT_SECONDS
+    """Resolve the effective timeout, clamping the model override.
+
+    Config ``timeout_seconds`` is the real ceiling (user-set, not model-
+    controllable). When the model passes a ``timeout`` override, it is
+    clamped to ``[60, min(config_timeout, _MAX_MODEL_TIMEOUT_SECONDS)]``
+    so a prompt-injected model cannot stall the turn with an arbitrarily
+    long subprocess, but can still shorten the cap for a quick task.
+    """
+    config_timeout = cfg.get("timeout_seconds")
+    if config_timeout is not None:
+        try:
+            config_timeout = float(config_timeout)
+        except (TypeError, ValueError):
+            config_timeout = _DEFAULT_TIMEOUT_SECONDS
+    else:
+        config_timeout = _DEFAULT_TIMEOUT_SECONDS
+    config_timeout = max(_MIN_TIMEOUT_SECONDS, config_timeout)
+
+    if override is None:
+        return config_timeout
+
     try:
-        parsed = float(raw)
+        parsed = float(override)
     except (TypeError, ValueError):
         logger.warning(
-            "delegation.devin.timeout_seconds=%r is not a valid number; "
-            "using default %.0f",
-            raw, _DEFAULT_TIMEOUT_SECONDS,
+            "delegate_to_devin timeout=%r is not a valid number; "
+            "using config default %.0f",
+            override, config_timeout,
         )
-        return _DEFAULT_TIMEOUT_SECONDS
-    return _MIN_TIMEOUT_SECONDS if parsed < _MIN_TIMEOUT_SECONDS else parsed
+        return config_timeout
+    # Clamp model override: floor 60s, ceiling = min(config, hard cap).
+    # The model can shorten the timeout but cannot extend it beyond what
+    # the user configured (or the hard safety cap).
+    ceiling = min(config_timeout, _MAX_MODEL_TIMEOUT_SECONDS)
+    return max(_MIN_TIMEOUT_SECONDS, min(parsed, ceiling))
 
 
 def _resolve_max_result_chars(cfg: Dict[str, Any]) -> int:
@@ -255,44 +321,63 @@ def delegate_to_devin(
         argv += ["--model", resolved_model]
     argv += ["--", prompt]
 
+    # Resolve cwd the same way the terminal tool does — TERMINAL_CWD is
+    # force-exported from config.yaml's terminal.cwd by cli.py, so messaging
+    # gateway sessions delegate to the user's configured workspace, not the
+    # gateway launch directory.
+    workdir = os.environ.get("TERMINAL_CWD") or os.getcwd()
+
     start = time.monotonic()
     try:
-        proc = subprocess.run(
+        # Use Popen with start_new_session so we can kill the entire process
+        # group on timeout — Devin spawns child processes (shell, browser,
+        # etc.) and subprocess.run only kills the direct child, leaving
+        # descendants running. Mirrors tools/code_execution_tool.py's pattern.
+        proc = subprocess.Popen(
             argv,
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             text=True,
-            timeout=timeout_seconds,
-            cwd=os.getcwd(),
+            cwd=workdir,
+            start_new_session=True,  # creates a new process group (POSIX)
         )
-    except subprocess.TimeoutExpired:
-        duration = time.monotonic() - start
-        return json.dumps(
-            {"results": [{
-                "task_index": 0,
-                "status": "timeout",
-                "summary": "",
-                "error": (
-                    f"Devin did not finish within {timeout_seconds:.0f}s. "
-                    "Raise delegation.devin.timeout_seconds if the task needs "
-                    "more time."
-                ),
-                "duration_seconds": round(duration, 3),
-                "model": resolved_model,
-                "exit_reason": "timeout",
-                "truncated": False,
-                "backend": "devin",
-            }]},
-            ensure_ascii=False,
-        )
+        try:
+            stdout, stderr = proc.communicate(timeout=timeout_seconds)
+        except subprocess.TimeoutExpired:
+            # Kill the entire process group so Devin's children don't outlive it.
+            _kill_process_group(proc)
+            try:
+                stdout, stderr = proc.communicate(timeout=10)
+            except Exception:
+                stdout, stderr = "", ""
+            duration = time.monotonic() - start
+            return json.dumps(
+                {"results": [{
+                    "task_index": 0,
+                    "status": "timeout",
+                    "summary": "",
+                    "error": (
+                        f"Devin did not finish within {timeout_seconds:.0f}s. "
+                        "Raise delegation.devin.timeout_seconds if the task needs "
+                        "more time."
+                    ),
+                    "duration_seconds": round(duration, 3),
+                    "model": resolved_model,
+                    "exit_reason": "timeout",
+                    "truncated": False,
+                    "backend": "devin",
+                }]},
+                ensure_ascii=False,
+            )
     except Exception as exc:  # pragma: no cover — environment-dependent
         return tool_error(f"Failed to spawn Devin: {exc}")
 
     duration = time.monotonic() - start
-    stdout = proc.stdout or ""
-    stderr = proc.stderr or ""
+    stdout = stdout or ""
+    stderr = stderr or ""
 
     if proc.returncode != 0:
-        err, _ = _truncate(stderr.strip() or stdout.strip(), max_chars)
+        err, err_truncated = _truncate(stderr.strip() or stdout.strip(), max_chars)
         return json.dumps(
             {"results": [{
                 "task_index": 0,
@@ -302,7 +387,7 @@ def delegate_to_devin(
                 "duration_seconds": round(duration, 3),
                 "model": resolved_model,
                 "exit_reason": "error",
-                "truncated": False,
+                "truncated": err_truncated,
                 "backend": "devin",
             }]},
             ensure_ascii=False,

--- a/tools/devin_delegate.py
+++ b/tools/devin_delegate.py
@@ -367,7 +367,7 @@ DELEGATE_TO_DEVIN_SCHEMA = {
                 ),
             },
             "timeout": {
-                "type": "integer",
+                "type": "number",
                 "description": (
                     "Optional wall-clock cap in seconds (min 60, default "
                     "1800). If Devin does not finish in time it is killed and "

--- a/tools/devin_delegate.py
+++ b/tools/devin_delegate.py
@@ -49,6 +49,7 @@ import os
 import shutil
 import subprocess
 import time
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 from tools.registry import registry, tool_error
@@ -345,8 +346,15 @@ def delegate_to_devin(
     # Resolve cwd the same way the terminal tool does — TERMINAL_CWD is
     # force-exported from config.yaml's terminal.cwd by cli.py, so messaging
     # gateway sessions delegate to the user's configured workspace, not the
-    # gateway launch directory.
+    # gateway launch directory. Validate and fall back to os.getcwd() if the
+    # configured directory is relative, deleted, or inaccessible.
     workdir = os.environ.get("TERMINAL_CWD") or os.getcwd()
+    try:
+        workdir = str(Path(workdir).resolve())
+        if not Path(workdir).is_dir():
+            workdir = os.getcwd()
+    except (OSError, ValueError):
+        workdir = os.getcwd()
 
     start = time.monotonic()
     try:
@@ -354,8 +362,11 @@ def delegate_to_devin(
         # group on timeout — Devin spawns child processes (shell, browser,
         # etc.) and subprocess.run only kills the direct child, leaving
         # descendants running. Mirrors tools/code_execution_tool.py's pattern.
+        # stdin=DEVNULL prevents interactive prompts from blocking the
+        # synchronous tool call until timeout expires.
         proc = subprocess.Popen(
             argv,
+            stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,

--- a/toolsets.py
+++ b/toolsets.py
@@ -420,7 +420,7 @@ TOOLSETS = {
             "browser_exec",
             "todo", "memory",
             "session_search", "clarify",
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "delegate_to_devin",
         ],
         "includes": [],
         # Posture toolset: selected per-session by agent/coding_context.py,
@@ -453,7 +453,7 @@ TOOLSETS = {
             "browser_exec",
             "todo", "memory",
             "session_search",
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "delegate_to_devin",
         ],
         "includes": []
     },
@@ -486,7 +486,7 @@ TOOLSETS = {
             # Session history search
             "session_search",
             # Code execution + delegation
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "delegate_to_devin",
             # Cronjob management
             "cronjob",
             # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)

--- a/toolsets.py
+++ b/toolsets.py
@@ -72,11 +72,6 @@ _HERMES_CORE_TOOLS = [
     "clarify",
     # Code execution + delegation
     "execute_code", "delegate_task",
-    # Devin CLI delegate backend — peer to delegate_task, but shells out to the
-    # local `devin` binary instead of spawning an in-process AIAgent. Opt-in:
-    # gated by check_fn (delegation.devin.enabled + devin on $PATH), so it has
-    # zero schema footprint unless Devin is configured.
-    "delegate_to_devin",
     # Cronjob management
     "cronjob",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)

--- a/toolsets.py
+++ b/toolsets.py
@@ -72,6 +72,11 @@ _HERMES_CORE_TOOLS = [
     "clarify",
     # Code execution + delegation
     "execute_code", "delegate_task",
+    # Devin CLI delegate backend — peer to delegate_task, but shells out to the
+    # local `devin` binary instead of spawning an in-process AIAgent. Opt-in:
+    # gated by check_fn (delegation.devin.enabled + devin on $PATH), so it has
+    # zero schema footprint unless Devin is configured.
+    "delegate_to_devin",
     # Cronjob management
     "cronjob",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
@@ -298,7 +303,7 @@ TOOLSETS = {
     
     "delegation": {
         "description": "Spawn subagents with isolated context for complex subtasks",
-        "tools": ["delegate_task"],
+        "tools": ["delegate_task", "delegate_to_devin"],
         "includes": []
     },
 


### PR DESCRIPTION
## Summary

Resolves #89279

- Adds `delegate_to_devin` — a first-class peer to `delegate_task` that shells out to the local `devin` CLI binary in non-interactive `-p` (print) mode and returns the finished response
- Devin has no chat-completions inference endpoint (only a sessions API at `api.devin.ai/v3`), so it cannot be a `ProviderProfile` — this is the CLI-delegate shape instead
- Gated by `check_fn` (`delegation.devin.enabled` + `devin` on `$PATH`) — zero schema footprint unless configured
- `permission_mode` is config-only, never model-controllable (security: a prompt-injected model cannot escalate Devin's autonomy)
- Synchronous v1 — no changes to `run_agent.py` or the async re-entry machinery
- 30 tests covering check_fn gating, config resolution, prompt building, subprocess success/error/timeout paths, truncation, and registry wiring

### Files
- `tools/devin_delegate.py` — new self-contained module
- `toolsets.py` — added to `_HERMES_CORE_TOOLS` + `delegation` toolset
- `hermes_cli/config_defaults.py` — documented `delegation.devin.*` defaults
- `tests/tools/test_devin_delegate.py` — 30 tests

### Config
```yaml
delegation:
  devin:
    enabled: true
    model: ""              # optional Devin model short name
    permission_mode: dangerous
    timeout_seconds: 1800
    max_result_chars: 20000
```

### Design decisions (per AGENTS.md)
- **Footprint Ladder rung 3** (service-gated tool) — not a new core tool, not a ProviderProfile
- **Narrow waist preserved** — no changes to `run_agent.py` or async re-entry machinery
- **No new `HERMES_*` env vars** — all behavioral settings in `config.yaml`
- **Extend, don't duplicate** — reuses `delegate_tool._load_config()` for config priority; mirrors `delegate_task`'s result shape

#### Test plan
- [x] 30/30 unit tests pass (`python -m unittest tests.tools.test_devin_delegate`)
- [x] Tool absent from schema when not configured (zero footprint verified)
- [x] Tool present in schema when `delegation.devin.enabled=true` + `devin` on PATH
- [x] `permission_mode` not in model-facing schema
- [ ] E2E: live `devin -p` invocation with real auth (requires Devin CLI installed + authenticated)

**Shadow review (fork):** https://github.com/ThePlenkov/hermes-agent/pull/1
**Upstream issue:** #89279

Generated with [Devin](https://devin.ai)