### PR TITLE
feat: add confidence memory provider

### DIFF
--- a/agent/write_guard.py
+++ b/agent/write_guard.py
@@ -1,0 +1,124 @@
+"""Scope-aware write guard utilities.
+
+This is a deterministic preflight helper for any future write surface that needs
+to compare source content scope against target audience scope.  It deliberately
+keeps a tiny API so individual tools can adopt it incrementally.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Literal
+
+
+class Bucket(str, Enum):
+    RESTRICTED = "restricted"
+    PRIVATE = "private"
+    SHARED_LIMITED = "shared_limited"
+    TEAMSPACE = "teamspace"
+    WORKSPACE = "workspace"
+    PUBLIC = "public"
+    EXTERNAL = "external"
+
+
+class Confidence(str, Enum):
+    CONFIRMED = "confirmed"
+    INFERRED = "inferred"
+    TENTATIVE = "tentative"
+
+
+RANK = {
+    Bucket.RESTRICTED: 0,
+    Bucket.PRIVATE: 1,
+    Bucket.SHARED_LIMITED: 2,
+    Bucket.TEAMSPACE: 3,
+    Bucket.WORKSPACE: 4,
+    Bucket.PUBLIC: 5,
+    Bucket.EXTERNAL: 6,
+}
+
+
+@dataclass(frozen=True)
+class ScopedContent:
+    content_ref: str
+    bucket: Bucket
+    bucket_confidence: Literal["metadata", "inferred", "unknown"] = "metadata"
+    labels: tuple[str, ...] = ()
+
+    @property
+    def effective_bucket(self) -> Bucket:
+        if self.bucket_confidence == "unknown":
+            return Bucket.RESTRICTED
+        if any(label in {"credentials", "hr", "legal"} for label in self.labels):
+            return Bucket.RESTRICTED
+        return self.bucket
+
+
+@dataclass(frozen=True)
+class Target:
+    content_ref: str
+    bucket: Bucket
+    audience_description: str = ""
+
+
+@dataclass(frozen=True)
+class WriteRequest:
+    sources: list[ScopedContent]
+    target: Target
+    operation: str = "write"
+    injection_signals: list[str] = field(default_factory=list)
+    memory_confidences: list[Confidence] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class WriteGuardDecision:
+    verdict: Literal["allow", "confirm", "block"]
+    source_min_bucket: Bucket
+    target_bucket: Bucket
+    triggered_rules: list[str]
+    evaluated_at: str
+
+
+def _narrowest_source_bucket(sources: list[ScopedContent]) -> Bucket:
+    if not sources:
+        return Bucket.RESTRICTED
+    return min((source.effective_bucket for source in sources), key=lambda bucket: RANK[bucket])
+
+
+def evaluate_write_guard(request: WriteRequest) -> WriteGuardDecision:
+    """Return allow/confirm/block for a proposed write.
+
+    Retrieved content is monotonic: it can only make the decision stricter
+    through injection_signals; it can never loosen a scope broadening rule.
+    """
+    source_min = _narrowest_source_bucket(request.sources)
+    target = request.target.bucket
+    rules: list[str] = []
+
+    def decision(verdict: Literal["allow", "confirm", "block"], rules_: list[str]) -> WriteGuardDecision:
+        return WriteGuardDecision(
+            verdict=verdict,
+            source_min_bucket=source_min,
+            target_bucket=target,
+            triggered_rules=rules_,
+            evaluated_at=datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        )
+
+    if source_min == Bucket.RESTRICTED and target in {Bucket.PUBLIC, Bucket.EXTERNAL}:
+        return decision("block", [f"restricted->{target.value}"])
+
+    if (
+        RANK[target] >= RANK[Bucket.TEAMSPACE]
+        and Confidence.TENTATIVE in request.memory_confidences
+    ):
+        return decision("block", ["tentative_memory_to_shared"])
+
+    if RANK[source_min] < RANK[target]:
+        rules.append(f"broadening:{source_min.value}->{target.value}")
+
+    rules.extend(f"injection_signal:{signal}" for signal in request.injection_signals)
+
+    if rules:
+        return decision("confirm", rules)
+    return decision("allow", [])

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -472,6 +472,81 @@ def _write_env_vars(env_path: Path, env_writes: dict) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Provider action helpers
+# ---------------------------------------------------------------------------
+
+def _load_active_provider_for_command():
+    """Load and initialize the active external memory provider for CLI actions."""
+    from hermes_cli.config import load_config
+    from plugins.memory import load_memory_provider
+
+    config = load_config()
+    mem_config = config.get("memory", {}) if isinstance(config.get("memory"), dict) else {}
+    provider_name = mem_config.get("provider", "")
+    if not provider_name:
+        print("\n  No external memory provider is active. Run 'hermes memory setup confidence'.\n")
+        return None
+    provider = load_memory_provider(provider_name)
+    if not provider:
+        print(f"\n  Memory provider '{provider_name}' is not installed.\n")
+        return None
+    provider.initialize("cli-memory-command", hermes_home=str(get_hermes_home()), platform="cli")
+    return provider
+
+
+def _print_provider_json_result(result: str) -> None:
+    try:
+        import json
+        data = json.loads(result)
+        print(json.dumps(data, ensure_ascii=False, indent=2))
+    except Exception:
+        print(result)
+
+
+def cmd_provider_action(args) -> None:
+    provider = _load_active_provider_for_command()
+    if not provider:
+        return
+    try:
+        sub = getattr(args, "memory_command", "")
+        if sub == "review":
+            payload = {
+                "action": "list",
+                "include_inactive": bool(getattr(args, "include_inactive", False)),
+                "limit": int(getattr(args, "limit", 50)),
+            }
+        elif sub == "search":
+            payload = {
+                "action": "search",
+                "query": getattr(args, "query", ""),
+                "include_inactive": bool(getattr(args, "include_inactive", False)),
+                "limit": int(getattr(args, "limit", 10)),
+            }
+        elif sub == "confirm":
+            payload = {
+                "action": "confirm",
+                "id": getattr(args, "id", ""),
+                "source_kind": "user_confirmed",
+                "source_excerpt": getattr(args, "source_excerpt", "user confirmed via CLI"),
+            }
+        elif sub == "delete":
+            payload = {"action": "delete", "id": getattr(args, "id", "")}
+        else:
+            print(f"\n  Unsupported memory provider action: {sub}\n")
+            return
+        if not hasattr(provider, "handle_tool_call"):
+            print(f"\n  Active provider '{provider.name}' does not support CLI memory actions.\n")
+            return
+        result = provider.handle_tool_call("confidence_memory", payload)
+        _print_provider_json_result(result)
+    finally:
+        try:
+            provider.shutdown()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
 # Status
 # ---------------------------------------------------------------------------
 
@@ -580,5 +655,7 @@ def memory_command(args) -> None:
             cmd_setup(args)
     elif sub == "status":
         cmd_status(args)
+    elif sub in {"review", "search", "confirm", "delete"}:
+        cmd_provider_action(args)
     else:
         cmd_status(args)

--- a/hermes_cli/subcommands/memory.py
+++ b/hermes_cli/subcommands/memory.py
@@ -33,6 +33,30 @@ def build_memory_parser(subparsers, *, cmd_memory: Callable) -> None:
         help="Provider to configure directly (e.g. honcho), skipping the picker",
     )
     memory_sub.add_parser("status", help="Show current memory provider config")
+    _review_parser = memory_sub.add_parser(
+        "review",
+        help="List confidence-memory items for review when the active provider supports it",
+    )
+    _review_parser.add_argument("--include-inactive", action="store_true")
+    _review_parser.add_argument("--limit", type=int, default=50)
+    _search_parser = memory_sub.add_parser(
+        "search",
+        help="Search confidence-memory items when the active provider supports it",
+    )
+    _search_parser.add_argument("query")
+    _search_parser.add_argument("--include-inactive", action="store_true")
+    _search_parser.add_argument("--limit", type=int, default=10)
+    _confirm_parser = memory_sub.add_parser(
+        "confirm",
+        help="Confirm a confidence-memory item by id",
+    )
+    _confirm_parser.add_argument("id")
+    _confirm_parser.add_argument("--source-excerpt", default="user confirmed via CLI")
+    _delete_parser = memory_sub.add_parser(
+        "delete",
+        help="Delete a confidence-memory item by id",
+    )
+    _delete_parser.add_argument("id")
     memory_sub.add_parser("off", help="Disable external provider (built-in only)")
     _reset_parser = memory_sub.add_parser(
         "reset",

--- a/plugins/memory/confidence/__init__.py
+++ b/plugins/memory/confidence/__init__.py
@@ -105,7 +105,7 @@ class ConfidenceMemoryProvider(MemoryProvider):
             logger.debug("Failed to save confidence memory config", exc_info=True)
 
     def initialize(self, session_id: str, **kwargs) -> None:
-        hermes_home = str(get_hermes_home())
+        hermes_home = str(kwargs.get("hermes_home") or get_hermes_home())
         db_path = self._config.get("db_path") or "$HERMES_HOME/confidence_memory.db"
         if isinstance(db_path, str):
             db_path = db_path.replace("$HERMES_HOME", hermes_home).replace("${HERMES_HOME}", hermes_home)

--- a/plugins/memory/confidence/__init__.py
+++ b/plugins/memory/confidence/__init__.py
@@ -1,0 +1,240 @@
+"""Confidence memory provider.
+
+A local, profile-scoped provider that stores durable memory as atomic statements
+with layer/confidence/source/TTL metadata.  It complements the built-in
+MEMORY.md/USER.md stores instead of replacing them.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List
+
+from agent.memory_provider import MemoryProvider
+from hermes_constants import get_hermes_home
+from tools.registry import tool_error
+
+from .schemas import Confidence, Layer, MemorySource, Scope, SourceKind, now_utc
+from .store import ConfidenceMemoryStore
+
+logger = logging.getLogger(__name__)
+
+CONFIDENCE_MEMORY_SCHEMA = {
+    "name": "confidence_memory",
+    "description": (
+        "Layered long-term memory with confidence, source excerpts, TTL, and injection policy. "
+        "Use for reviewing, adding, confirming, searching, and deleting confidence-scored memories. "
+        "Tentative memories are internal hints only and are never injected into shared-destination output."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["add", "list", "search", "confirm", "delete", "refresh"],
+            },
+            "id": {"type": "string", "description": "Memory id for confirm/delete."},
+            "statement": {"type": "string", "description": "Atomic memory statement for add."},
+            "layer": {
+                "type": "string",
+                "enum": ["profile", "ongoing_theme", "unresolved_question"],
+            },
+            "confidence": {
+                "type": "string",
+                "enum": ["confirmed", "inferred", "tentative"],
+            },
+            "source_kind": {
+                "type": "string",
+                "enum": ["user_stated", "user_confirmed", "document", "activity_pattern", "inference"],
+            },
+            "source_ref": {"type": "string"},
+            "source_excerpt": {"type": "string"},
+            "ttl": {"type": "string", "description": "Optional TTL like 14d, 60d, 180d."},
+            "query": {"type": "string", "description": "Search query."},
+            "include_inactive": {"type": "boolean"},
+            "limit": {"type": "integer"},
+        },
+        "required": ["action"],
+    },
+}
+
+
+class ConfidenceMemoryProvider(MemoryProvider):
+    """Local SQLite provider for confidence-scored durable memory."""
+
+    def __init__(self, config: dict | None = None):
+        self._config = config or self._load_config()
+        self._store: ConfidenceMemoryStore | None = None
+        self._session_id = ""
+        self._profile_limit = int(self._config.get("profile_limit", 15))
+
+    @property
+    def name(self) -> str:
+        return "confidence"
+
+    def is_available(self) -> bool:
+        return True
+
+    def _load_config(self) -> dict:
+        try:
+            from hermes_cli.config import cfg_get, load_config_readonly
+            config = load_config_readonly()
+            return cfg_get(config, "memory", "confidence", default={}) or {}
+        except Exception:
+            return {}
+
+    def get_config_schema(self):
+        return [
+            {"key": "db_path", "description": "SQLite DB path", "default": "$HERMES_HOME/confidence_memory.db"},
+            {"key": "profile_limit", "description": "Max profile memories injected", "default": "15"},
+        ]
+
+    def save_config(self, values, hermes_home):
+        config_path = Path(hermes_home) / "config.yaml"
+        try:
+            import yaml
+            from hermes_cli.config import read_user_config_raw
+            existing = read_user_config_raw(config_path)
+            existing.setdefault("memory", {})
+            existing["memory"].setdefault("confidence", {})
+            existing["memory"]["confidence"].update(values)
+            with open(config_path, "w", encoding="utf-8") as handle:
+                yaml.dump(existing, handle, default_flow_style=False, allow_unicode=True)
+        except Exception:
+            logger.debug("Failed to save confidence memory config", exc_info=True)
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        hermes_home = str(get_hermes_home())
+        db_path = self._config.get("db_path") or "$HERMES_HOME/confidence_memory.db"
+        if isinstance(db_path, str):
+            db_path = db_path.replace("$HERMES_HOME", hermes_home).replace("${HERMES_HOME}", hermes_home)
+        self._store = ConfidenceMemoryStore(db_path)
+        self._session_id = session_id
+        self._profile_limit = int(self._config.get("profile_limit", 15))
+
+    def system_prompt_block(self) -> str:
+        return (
+            "# Confidence Memory\n"
+            "Active. Memories have confidence labels: [confirmed] facts, [inferred] soft guidance, "
+            "and [tentative] internal hints only. Tentative memories must never be stated as fact, "
+            "cited as a reason, or written to shared destinations. If current user input conflicts "
+            "with memory, the current user input wins."
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if not self._store:
+            return ""
+        try:
+            items = self._store.select_for_injection(query=query or "", profile_limit=self._profile_limit)
+            if not items:
+                return ""
+            formatted = self._store.format_for_prompt(items)
+            if not formatted:
+                return ""
+            return "## Confidence Memory Context\n" + formatted
+        except Exception:
+            logger.debug("confidence memory prefetch failed", exc_info=True)
+            return ""
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [CONFIDENCE_MEMORY_SCHEMA]
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        if tool_name != "confidence_memory":
+            return tool_error(f"Unknown tool: {tool_name}")
+        if not self._store:
+            return tool_error("confidence memory provider is not initialized")
+        action = args.get("action")
+        try:
+            if action == "add":
+                return self._handle_add(args)
+            if action == "list":
+                return self._handle_list(args)
+            if action == "search":
+                return self._handle_search(args)
+            if action == "confirm":
+                return self._handle_confirm(args)
+            if action == "delete":
+                return self._handle_delete(args)
+            if action == "refresh":
+                self._store.refresh_statuses()
+                return json.dumps({"success": True})
+            return tool_error(f"Unknown action: {action}")
+        except Exception as exc:
+            return tool_error(str(exc))
+
+    def _source_from_args(self, args: Dict[str, Any], *, default_kind: SourceKind = SourceKind.INFERENCE) -> MemorySource:
+        return MemorySource(
+            kind=SourceKind(args.get("source_kind") or default_kind.value),
+            observed_at=now_utc(),
+            ref=args.get("source_ref") or self._session_id,
+            excerpt=args.get("source_excerpt") or "",
+        )
+
+    def _handle_add(self, args: Dict[str, Any]) -> str:
+        statement = (args.get("statement") or "").strip()
+        if not statement:
+            return tool_error("statement is required for add")
+        item_id = self._store.add(
+            statement=statement,
+            layer=Layer(args.get("layer") or Layer.ONGOING_THEME.value),
+            confidence=Confidence(args.get("confidence") or Confidence.TENTATIVE.value),
+            sources=[self._source_from_args(args)],
+            ttl=args.get("ttl") or "",
+            scope=Scope.INJECTION,
+        )
+        item = self._store.get(item_id)
+        return json.dumps({"success": True, "id": item_id, "scope": item.scope, "confidence": item.confidence})
+
+    def _serialize_item(self, item) -> dict:
+        return {
+            "id": item.id,
+            "layer": item.layer,
+            "statement": item.statement,
+            "confidence": item.confidence,
+            "status": item.status,
+            "scope": item.scope,
+            "ttl": item.ttl,
+            "sources": [source.to_json() for source in item.sources],
+            "supersededBy": item.superseded_by,
+        }
+
+    def _handle_list(self, args: Dict[str, Any]) -> str:
+        include = bool(args.get("include_inactive", False))
+        limit = int(args.get("limit") or 50)
+        items = self._store.list_items(include_inactive=include)[:limit]
+        return json.dumps({"success": True, "items": [self._serialize_item(item) for item in items]}, ensure_ascii=False)
+
+    def _handle_search(self, args: Dict[str, Any]) -> str:
+        query = args.get("query") or ""
+        limit = int(args.get("limit") or 10)
+        items = self._store.search(query, include_inactive=bool(args.get("include_inactive", False)), limit=limit)
+        return json.dumps({"success": True, "items": [self._serialize_item(item) for item in items]}, ensure_ascii=False)
+
+    def _handle_confirm(self, args: Dict[str, Any]) -> str:
+        item_id = args.get("id") or ""
+        if not item_id:
+            return tool_error("id is required for confirm")
+        self._store.confirm(item_id, self._source_from_args(args, default_kind=SourceKind.USER_CONFIRMED))
+        return json.dumps({"success": True, "id": item_id})
+
+    def _handle_delete(self, args: Dict[str, Any]) -> str:
+        item_id = args.get("id") or ""
+        if not item_id:
+            return tool_error("id is required for delete")
+        self._store.delete(item_id)
+        return json.dumps({"success": True, "id": item_id})
+
+    def shutdown(self) -> None:
+        if self._store:
+            try:
+                self._store.close()
+            finally:
+                self._store = None
+
+
+# Plugin discovery finds MemoryProvider subclasses automatically, but keeping
+# this explicit function makes the directory easy for humans to inspect.
+def register_memory_provider() -> ConfidenceMemoryProvider:
+    return ConfidenceMemoryProvider()

--- a/plugins/memory/confidence/plugin.yaml
+++ b/plugins/memory/confidence/plugin.yaml
@@ -1,0 +1,6 @@
+name: confidence
+version: 0.1.0
+description: "Confidence memory — local SQLite memory with layer/confidence/source/TTL metadata and safe injection policy."
+hooks:
+  - prefetch
+  - on_session_end

--- a/plugins/memory/confidence/schemas.py
+++ b/plugins/memory/confidence/schemas.py
@@ -1,0 +1,123 @@
+"""Schemas for the confidence memory provider.
+
+The provider keeps durable memory candidates as atomic statements with a
+layer, confidence level, source evidence, TTL, and injection policy.  The
+shape mirrors the Notion-Harness-inspired design while remaining local and
+profile-scoped.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import Optional
+from uuid import uuid4
+
+
+class Layer(str, Enum):
+    PROFILE = "profile"
+    ONGOING_THEME = "ongoing_theme"
+    UNRESOLVED_QUESTION = "unresolved_question"
+
+
+class Confidence(str, Enum):
+    CONFIRMED = "confirmed"
+    INFERRED = "inferred"
+    TENTATIVE = "tentative"
+
+
+class Status(str, Enum):
+    ACTIVE = "active"
+    STALE = "stale"
+    EXPIRED = "expired"
+    SUPERSEDED = "superseded"
+    REJECTED = "rejected"
+
+
+class Scope(str, Enum):
+    INJECTION = "injection"
+    RETRIEVAL_ONLY = "retrieval_only"
+
+
+class SourceKind(str, Enum):
+    USER_STATED = "user_stated"
+    USER_CONFIRMED = "user_confirmed"
+    DOCUMENT = "document"
+    ACTIVITY_PATTERN = "activity_pattern"
+    INFERENCE = "inference"
+
+
+DEFAULT_TTLS = {
+    Layer.PROFILE: "180d",
+    Layer.ONGOING_THEME: "60d",
+    Layer.UNRESOLVED_QUESTION: "14d",
+}
+
+
+def now_utc() -> datetime:
+    return datetime.now(timezone.utc).replace(microsecond=0)
+
+
+def parse_ttl(ttl: str) -> timedelta:
+    if not ttl or len(ttl) < 2:
+        raise ValueError("ttl must look like '14d', '60d', or '180d'")
+    unit = ttl[-1]
+    value = int(ttl[:-1])
+    if unit == "d":
+        return timedelta(days=value)
+    if unit == "h":
+        return timedelta(hours=value)
+    raise ValueError("only h/d TTL units are supported")
+
+
+@dataclass
+class MemorySource:
+    kind: SourceKind
+    observed_at: datetime
+    ref: str = ""
+    excerpt: str = ""
+
+    def to_json(self) -> dict:
+        return {
+            "kind": self.kind.value,
+            "observedAt": self.observed_at.isoformat(),
+            "ref": self.ref,
+            "excerpt": self.excerpt,
+        }
+
+    @staticmethod
+    def from_json(data: dict) -> "MemorySource":
+        return MemorySource(
+            kind=SourceKind(data["kind"]),
+            observed_at=datetime.fromisoformat(data["observedAt"]),
+            ref=data.get("ref", ""),
+            excerpt=data.get("excerpt", ""),
+        )
+
+
+@dataclass
+class MemoryItem:
+    statement: str
+    layer: Layer
+    confidence: Confidence
+    sources: list[MemorySource]
+    id: str = field(default_factory=lambda: f"m_{uuid4().hex[:12]}")
+    created_at: datetime = field(default_factory=now_utc)
+    last_reinforced_at: Optional[datetime] = None
+    reinforcement_count: int = 0
+    ttl: str = ""
+    status: Status = Status.ACTIVE
+    superseded_by: Optional[str] = None
+    scope: Scope = Scope.INJECTION
+
+    def __post_init__(self) -> None:
+        if not self.statement.strip():
+            raise ValueError("statement is required")
+        if not self.sources:
+            raise ValueError("at least one source is required")
+        if not self.ttl:
+            self.ttl = DEFAULT_TTLS[self.layer]
+        if self.confidence == Confidence.TENTATIVE:
+            # Tentative memories are internal hints only. They must not enter
+            # system prompt injection or shared-destination content.
+            self.scope = Scope.RETRIEVAL_ONLY

--- a/plugins/memory/confidence/store.py
+++ b/plugins/memory/confidence/store.py
@@ -1,0 +1,260 @@
+"""SQLite store for confidence memory items."""
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Optional
+
+from .schemas import (
+    Confidence,
+    Layer,
+    MemoryItem,
+    MemorySource,
+    Scope,
+    SourceKind,
+    Status,
+    now_utc,
+    parse_ttl,
+)
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS memory_items (
+    id TEXT PRIMARY KEY,
+    layer TEXT NOT NULL,
+    statement TEXT NOT NULL,
+    confidence TEXT NOT NULL,
+    sources_json TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    last_reinforced_at TEXT,
+    reinforcement_count INTEGER NOT NULL DEFAULT 0,
+    ttl TEXT NOT NULL,
+    status TEXT NOT NULL,
+    superseded_by TEXT,
+    scope TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_confmem_active ON memory_items(status, scope, confidence);
+CREATE INDEX IF NOT EXISTS idx_confmem_layer ON memory_items(layer);
+"""
+
+
+class ConfidenceMemoryStore:
+    """Local SQLite store for layered, confidence-scored memory."""
+
+    def __init__(self, db_path: str | Path):
+        self.db_path = Path(db_path).expanduser()
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
+        self.conn.row_factory = sqlite3.Row
+        try:
+            from hermes_state import apply_wal_with_fallback
+            apply_wal_with_fallback(self.conn, db_label="confidence_memory.db")
+        except Exception:
+            pass
+        self.conn.executescript(SCHEMA)
+
+    def close(self) -> None:
+        self.conn.close()
+
+    def __enter__(self) -> "ConfidenceMemoryStore":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def _to_row(self, item: MemoryItem) -> tuple:
+        return (
+            item.id,
+            item.layer.value,
+            item.statement,
+            item.confidence.value,
+            json.dumps([s.to_json() for s in item.sources], ensure_ascii=False),
+            item.created_at.isoformat(),
+            item.last_reinforced_at.isoformat() if item.last_reinforced_at else None,
+            item.reinforcement_count,
+            item.ttl,
+            item.status.value,
+            item.superseded_by,
+            item.scope.value,
+        )
+
+    def _from_row(self, row: sqlite3.Row) -> MemoryItem:
+        return MemoryItem(
+            id=row["id"],
+            layer=Layer(row["layer"]),
+            statement=row["statement"],
+            confidence=Confidence(row["confidence"]),
+            sources=[MemorySource.from_json(x) for x in json.loads(row["sources_json"])],
+            created_at=datetime.fromisoformat(row["created_at"]),
+            last_reinforced_at=(
+                datetime.fromisoformat(row["last_reinforced_at"])
+                if row["last_reinforced_at"]
+                else None
+            ),
+            reinforcement_count=int(row["reinforcement_count"]),
+            ttl=row["ttl"],
+            status=Status(row["status"]),
+            superseded_by=row["superseded_by"],
+            scope=Scope(row["scope"]),
+        )
+
+    def add_item(self, item: MemoryItem) -> str:
+        self.conn.execute(
+            """
+            INSERT INTO memory_items
+              (id, layer, statement, confidence, sources_json, created_at,
+               last_reinforced_at, reinforcement_count, ttl, status,
+               superseded_by, scope)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            self._to_row(item),
+        )
+        self.conn.commit()
+        return item.id
+
+    def add(
+        self,
+        *,
+        statement: str,
+        layer: Layer | str,
+        confidence: Confidence | str,
+        sources: list[MemorySource],
+        created_at: Optional[datetime] = None,
+        ttl: str = "",
+        scope: Scope | str = Scope.INJECTION,
+    ) -> str:
+        item = MemoryItem(
+            statement=statement,
+            layer=Layer(layer),
+            confidence=Confidence(confidence),
+            sources=sources,
+            created_at=created_at or now_utc(),
+            ttl=ttl,
+            scope=Scope(scope),
+        )
+        return self.add_item(item)
+
+    def get(self, item_id: str) -> MemoryItem:
+        row = self.conn.execute("SELECT * FROM memory_items WHERE id = ?", (item_id,)).fetchone()
+        if not row:
+            raise KeyError(item_id)
+        return self._from_row(row)
+
+    def list_items(self, include_inactive: bool = False) -> list[MemoryItem]:
+        sql = "SELECT * FROM memory_items"
+        if not include_inactive:
+            sql += " WHERE status IN ('active','stale')"
+        sql += " ORDER BY created_at ASC"
+        return [self._from_row(row) for row in self.conn.execute(sql)]
+
+    def search(self, query: str, *, include_inactive: bool = False, limit: int = 10) -> list[MemoryItem]:
+        query = (query or "").strip().lower()
+        if not query:
+            return self.list_items(include_inactive=include_inactive)[:limit]
+        candidates = self.list_items(include_inactive=include_inactive)
+        terms = [t for t in query.split() if t]
+        scored: list[tuple[int, MemoryItem]] = []
+        for item in candidates:
+            haystack = item.statement.lower()
+            score = sum(1 for term in terms if term in haystack)
+            if score:
+                scored.append((score, item))
+        scored.sort(key=lambda pair: (-pair[0], pair[1].created_at))
+        return [item for _, item in scored[:limit]]
+
+    def confirm(self, item_id: str, source: MemorySource) -> None:
+        item = self.get(item_id)
+        sources = item.sources + [source]
+        self.conn.execute(
+            """
+            UPDATE memory_items
+            SET confidence = 'confirmed', status = 'active', scope = 'injection',
+                sources_json = ?, last_reinforced_at = ?, reinforcement_count = reinforcement_count + 1
+            WHERE id = ?
+            """,
+            (
+                json.dumps([s.to_json() for s in sources], ensure_ascii=False),
+                source.observed_at.isoformat(),
+                item_id,
+            ),
+        )
+        self.conn.commit()
+
+    def delete(self, item_id: str) -> None:
+        self.conn.execute("DELETE FROM memory_items WHERE id = ?", (item_id,))
+        self.conn.commit()
+
+    def refresh_statuses(self, as_of: Optional[datetime] = None) -> None:
+        as_of = as_of or now_utc()
+        for item in self.list_items(include_inactive=True):
+            if item.status not in {Status.ACTIVE, Status.STALE}:
+                continue
+            age_anchor = item.last_reinforced_at or item.created_at
+            ttl = parse_ttl(item.ttl)
+            age = as_of - age_anchor
+            new_status = item.status
+            if age >= ttl:
+                new_status = Status.EXPIRED
+            elif age >= ttl / 2:
+                new_status = Status.STALE
+            if new_status != item.status:
+                self.conn.execute(
+                    "UPDATE memory_items SET status = ? WHERE id = ?",
+                    (new_status.value, item.id),
+                )
+        self.conn.commit()
+
+    def resolve_user_stated_conflict(
+        self,
+        old_item_id: str,
+        new_statement: str,
+        source: MemorySource,
+        *,
+        layer: Optional[Layer] = None,
+    ) -> str:
+        old = self.get(old_item_id)
+        if source.kind not in {SourceKind.USER_STATED, SourceKind.USER_CONFIRMED}:
+            raise ValueError("only user-stated/user-confirmed observations can auto-supersede")
+        new_id = self.add(
+            statement=new_statement,
+            layer=layer or old.layer,
+            confidence=Confidence.CONFIRMED,
+            sources=[source],
+            scope=Scope.INJECTION,
+        )
+        self.conn.execute(
+            "UPDATE memory_items SET status = 'superseded', superseded_by = ? WHERE id = ?",
+            (new_id, old_item_id),
+        )
+        self.conn.commit()
+        return new_id
+
+    def select_for_injection(self, query: str = "", *, profile_limit: int = 15) -> list[MemoryItem]:
+        self.refresh_statuses()
+        selected: list[MemoryItem] = []
+        profile_count = 0
+        for item in self.list_items(include_inactive=False):
+            if item.status != Status.ACTIVE:
+                continue
+            if item.scope != Scope.INJECTION:
+                continue
+            if item.confidence == Confidence.TENTATIVE:
+                continue
+            if item.layer == Layer.PROFILE:
+                if profile_count >= profile_limit:
+                    continue
+                profile_count += 1
+                selected.append(item)
+            elif item.layer == Layer.ONGOING_THEME and query:
+                selected.append(item)
+            elif item.layer == Layer.UNRESOLVED_QUESTION:
+                selected.append(item)
+        return selected
+
+    @staticmethod
+    def format_for_prompt(items: Iterable[MemoryItem]) -> str:
+        return "\n".join(
+            f"- [{item.confidence.value}] ({item.layer.value}) {item.statement}"
+            for item in items
+        )

--- a/plugins/memory/confidence/store.py
+++ b/plugins/memory/confidence/store.py
@@ -53,6 +53,17 @@ class ConfidenceMemoryStore:
         except Exception:
             pass
         self.conn.executescript(SCHEMA)
+        self._secure_database_files()
+
+    def _secure_database_files(self) -> None:
+        """Keep memory data and SQLite sidecars readable only by the owner."""
+        for path in (
+            self.db_path,
+            Path(f"{self.db_path}-wal"),
+            Path(f"{self.db_path}-shm"),
+        ):
+            if path.exists():
+                path.chmod(0o600)
 
     def close(self) -> None:
         self.conn.close()

--- a/tests/agent/test_write_guard.py
+++ b/tests/agent/test_write_guard.py
@@ -1,0 +1,83 @@
+from agent.write_guard import (
+    Bucket,
+    Confidence,
+    ScopedContent,
+    Target,
+    WriteRequest,
+    evaluate_write_guard,
+)
+
+
+def decision_for(source_bucket, target_bucket, **kwargs):
+    return evaluate_write_guard(
+        WriteRequest(
+            sources=[ScopedContent(content_ref="src", bucket=source_bucket)],
+            target=Target(content_ref="dst", bucket=target_bucket),
+            **kwargs,
+        )
+    )
+
+
+def test_same_bucket_allows_without_over_confirmation():
+    decision = decision_for(Bucket.TEAMSPACE, Bucket.TEAMSPACE)
+    assert decision.verdict == "allow"
+    assert decision.triggered_rules == []
+
+
+def test_private_to_workspace_requires_confirmation():
+    decision = decision_for(Bucket.PRIVATE, Bucket.WORKSPACE)
+    assert decision.verdict == "confirm"
+    assert "broadening:private->workspace" in decision.triggered_rules
+
+
+def test_restricted_to_public_blocks():
+    decision = decision_for(Bucket.RESTRICTED, Bucket.PUBLIC)
+    assert decision.verdict == "block"
+    assert "restricted->public" in decision.triggered_rules
+
+
+def test_injection_signal_escalates_allow_to_confirm():
+    decision = decision_for(
+        Bucket.TEAMSPACE,
+        Bucket.TEAMSPACE,
+        injection_signals=["skip_confirmation_directive"],
+    )
+    assert decision.verdict == "confirm"
+    assert "injection_signal:skip_confirmation_directive" in decision.triggered_rules
+
+
+def test_tentative_memory_to_shared_destination_blocks():
+    decision = decision_for(
+        Bucket.PRIVATE,
+        Bucket.TEAMSPACE,
+        memory_confidences=[Confidence.TENTATIVE],
+    )
+    assert decision.verdict == "block"
+    assert "tentative_memory_to_shared" in decision.triggered_rules
+
+
+def test_unknown_bucket_confidence_fails_closed_as_restricted():
+    decision = evaluate_write_guard(
+        WriteRequest(
+            sources=[ScopedContent(content_ref="src", bucket=Bucket.WORKSPACE, bucket_confidence="unknown")],
+            target=Target(content_ref="dst", bucket=Bucket.WORKSPACE),
+        )
+    )
+    assert decision.source_min_bucket == Bucket.RESTRICTED
+    assert decision.verdict == "confirm"
+    assert "broadening:restricted->workspace" in decision.triggered_rules
+
+
+def test_multiple_sources_use_narrowest_source():
+    decision = evaluate_write_guard(
+        WriteRequest(
+            sources=[
+                ScopedContent(content_ref="a", bucket=Bucket.WORKSPACE),
+                ScopedContent(content_ref="b", bucket=Bucket.PRIVATE),
+            ],
+            target=Target(content_ref="dst", bucket=Bucket.TEAMSPACE),
+        )
+    )
+    assert decision.source_min_bucket == Bucket.PRIVATE
+    assert decision.verdict == "confirm"
+    assert "broadening:private->teamspace" in decision.triggered_rules

--- a/tests/hermes_cli/test_memory_confidence_commands.py
+++ b/tests/hermes_cli/test_memory_confidence_commands.py
@@ -1,0 +1,61 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from hermes_cli import memory_setup
+
+
+class FakeConfidenceProvider:
+    name = "confidence"
+
+    def __init__(self):
+        self.initialized = False
+        self.calls = []
+
+    def is_available(self):
+        return True
+
+    def initialize(self, session_id, **kwargs):
+        self.initialized = True
+
+    def handle_tool_call(self, tool_name, args):
+        self.calls.append((tool_name, args))
+        return '{"success": true, "items": [{"id": "m1", "statement": "remembered"}]}'
+
+    def shutdown(self):
+        pass
+
+
+def _run(command, **kwargs):
+    provider = FakeConfidenceProvider()
+    args = SimpleNamespace(memory_command=command, **kwargs)
+    with patch("hermes_cli.config.load_config", return_value={"memory": {"provider": "confidence"}}), \
+         patch("plugins.memory.load_memory_provider", return_value=provider):
+        memory_setup.memory_command(args)
+    return provider
+
+
+def test_memory_review_routes_to_active_provider(capsys):
+    provider = _run("review", include_inactive=False, limit=50)
+
+    assert provider.initialized
+    assert provider.calls == [("confidence_memory", {"action": "list", "include_inactive": False, "limit": 50})]
+    assert "remembered" in capsys.readouterr().out
+
+
+def test_memory_confirm_routes_to_active_provider(capsys):
+    provider = _run("confirm", id="m1", source_excerpt="user confirmed")
+
+    assert provider.calls == [("confidence_memory", {
+        "action": "confirm",
+        "id": "m1",
+        "source_kind": "user_confirmed",
+        "source_excerpt": "user confirmed",
+    })]
+    assert "success" in capsys.readouterr().out
+
+
+def test_memory_delete_routes_to_active_provider(capsys):
+    provider = _run("delete", id="m1")
+
+    assert provider.calls == [("confidence_memory", {"action": "delete", "id": "m1"})]
+    assert "success" in capsys.readouterr().out

--- a/tests/plugins/memory/test_confidence_memory_provider.py
+++ b/tests/plugins/memory/test_confidence_memory_provider.py
@@ -1,0 +1,118 @@
+from datetime import timedelta
+
+from plugins.memory import load_memory_provider
+from plugins.memory.confidence import ConfidenceMemoryProvider
+from plugins.memory.confidence.schemas import Confidence, Layer, MemorySource, SourceKind, Status, now_utc
+from plugins.memory.confidence.store import ConfidenceMemoryStore
+
+
+def source(kind=SourceKind.USER_STATED, excerpt="user said it"):
+    return MemorySource(kind=kind, observed_at=now_utc(), excerpt=excerpt)
+
+
+def test_provider_is_discoverable():
+    provider = load_memory_provider("confidence")
+    assert isinstance(provider, ConfidenceMemoryProvider)
+    assert provider.is_available()
+
+
+def test_store_confirmed_profile_injection_and_tentative_exclusion(tmp_path):
+    store = ConfidenceMemoryStore(tmp_path / "confidence.db")
+    confirmed = store.add(
+        statement="User prefers concise executive summaries.",
+        layer=Layer.PROFILE,
+        confidence=Confidence.CONFIRMED,
+        sources=[source()],
+    )
+    tentative = store.add(
+        statement="User may prepare weekly materials on Monday mornings.",
+        layer=Layer.PROFILE,
+        confidence=Confidence.TENTATIVE,
+        sources=[source(SourceKind.ACTIVITY_PATTERN, "single observation")],
+        scope="injection",
+    )
+
+    assert store.get(tentative).scope == "retrieval_only"
+    selected = store.select_for_injection(query="")
+    assert [item.id for item in selected] == [confirmed]
+
+
+def test_store_ttl_stale_expired_and_user_statement_supersedes(tmp_path):
+    store = ConfidenceMemoryStore(tmp_path / "confidence.db")
+    created = now_utc() - timedelta(days=8)
+    old = store.add(
+        statement="User prefers long-form reports.",
+        layer=Layer.PROFILE,
+        confidence=Confidence.INFERRED,
+        sources=[source(SourceKind.ACTIVITY_PATTERN, "three prior approvals")],
+        created_at=created,
+        ttl="14d",
+    )
+
+    store.refresh_statuses(as_of=created + timedelta(days=8))
+    assert store.get(old).status == Status.STALE.value
+
+    new = store.resolve_user_stated_conflict(
+        old,
+        "User prefers short executive summaries.",
+        source(SourceKind.USER_STATED, "短くして"),
+    )
+
+    assert store.get(old).status == Status.SUPERSEDED.value
+    assert store.get(old).superseded_by == new
+    assert store.get(new).confidence == Confidence.CONFIRMED.value
+
+
+def test_provider_tool_add_list_confirm_delete(tmp_path):
+    provider = ConfidenceMemoryProvider(config={"db_path": str(tmp_path / "confidence.db")})
+    provider.initialize("session-1")
+
+    add_result = provider.handle_tool_call("confidence_memory", {
+        "action": "add",
+        "statement": "User likes verified citations.",
+        "layer": "profile",
+        "confidence": "tentative",
+        "source_excerpt": "single observation",
+        "source_kind": "activity_pattern",
+    })
+    assert '"success": true' in add_result
+    item_id = provider._store.list_items(include_inactive=True)[0].id
+    assert provider._store.get(item_id).scope == "retrieval_only"
+
+    provider.handle_tool_call("confidence_memory", {
+        "action": "confirm",
+        "id": item_id,
+        "source_excerpt": "user confirmed",
+    })
+    assert provider._store.get(item_id).confidence == "confirmed"
+    assert provider._store.get(item_id).scope == "injection"
+
+    listed = provider.handle_tool_call("confidence_memory", {"action": "list"})
+    assert "User likes verified citations" in listed
+
+    provider.handle_tool_call("confidence_memory", {"action": "delete", "id": item_id})
+    assert provider._store.list_items(include_inactive=True) == []
+    provider.shutdown()
+
+
+def test_provider_prefetch_formats_confirmed_and_inferred_but_not_tentative(tmp_path):
+    provider = ConfidenceMemoryProvider(config={"db_path": str(tmp_path / "confidence.db")})
+    provider.initialize("session-1")
+    provider._store.add(
+        statement="Confirmed profile fact.",
+        layer=Layer.PROFILE,
+        confidence=Confidence.CONFIRMED,
+        sources=[source()],
+    )
+    provider._store.add(
+        statement="Tentative profile hint.",
+        layer=Layer.PROFILE,
+        confidence=Confidence.TENTATIVE,
+        sources=[source(SourceKind.ACTIVITY_PATTERN)],
+    )
+
+    context = provider.prefetch("anything")
+    assert "[confirmed]" in context
+    assert "Confirmed profile fact" in context
+    assert "Tentative profile hint" not in context
+    provider.shutdown()

--- a/tests/plugins/memory/test_confidence_memory_provider.py
+++ b/tests/plugins/memory/test_confidence_memory_provider.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+import stat
 
 from plugins.memory import load_memory_provider
 from plugins.memory.confidence import ConfidenceMemoryProvider
@@ -14,6 +15,27 @@ def test_provider_is_discoverable():
     provider = load_memory_provider("confidence")
     assert isinstance(provider, ConfidenceMemoryProvider)
     assert provider.is_available()
+
+
+def test_provider_default_db_uses_injected_profile_home(tmp_path):
+    profile_home = tmp_path / "profiles" / "work"
+    provider = ConfidenceMemoryProvider(config={})
+
+    provider.initialize("session-1", hermes_home=str(profile_home))
+
+    assert provider._store is not None
+    assert provider._store.db_path == profile_home / "confidence_memory.db"
+    assert provider._store.db_path.exists()
+    provider.shutdown()
+
+
+def test_store_database_is_owner_only(tmp_path):
+    db_path = tmp_path / "confidence.db"
+
+    store = ConfidenceMemoryStore(db_path)
+
+    assert stat.S_IMODE(db_path.stat().st_mode) == 0o600
+    store.close()
 
 
 def test_store_confirmed_profile_injection_and_tentative_exclusion(tmp_path):


### PR DESCRIPTION
## Summary

- Adds a local `confidence` memory provider with layer/confidence/source/TTL metadata.
- Adds `confidence_memory` provider tool actions: add, list, search, confirm, delete, refresh.
- Adds CLI helpers: `hermes memory review`, `search`, `confirm`, and `delete` for providers that expose confidence memory actions.
- Adds a scope-aware write guard utility for future write preflight integration.

## Related

- Related: #625 — Feature: Structured Temporal Memory with Confidence-Gated Facts. This PR implements the core of that request: layered memory (profile / ongoing_theme / unresolved_question), confidence labels (confirmed / inferred / tentative), source provenance, TTL lifecycle, and a shared-destination injection policy where `tentative` items never leak into shared output.

## Test Plan

- `venv/bin/python -m pytest tests/plugins/memory/test_confidence_memory_provider.py tests/agent/test_write_guard.py tests/hermes_cli/test_memory_confidence_commands.py tests/hermes_cli/test_memory_status.py tests/agent/test_memory_provider.py -q -o 'addopts='`
  - Result: `83 passed in 1.32s`
- Static diff scan: no hardcoded secret assignments, unsafe exec/eval, fake `[System: ...]` directives, or dangerous git operations.

## Notes

This replaces #89228 with a clean, single-purpose PR. The prior branch had unrelated local provider/fallback/Anthropic changes mixed in; those were intentionally removed from this PR.
