### PR TITLE
fix(kanban): run the stop-nudge guard on truncation early-exits so workers still reach a terminal board call

### DIFF
--- a/agent/turn_iteration_prep.py
+++ b/agent/turn_iteration_prep.py
@@ -436,6 +436,14 @@ def apply_retry_restarts(
         _retry.restart_with_redirected_messages = False
         return _verdict("continue")
 
+    if _retry.restart_with_kanban_stop_nudge:
+        # A truncation early-exit took the kanban stop nudge: the synthetic user
+        # nudge is already appended to ``messages``; re-enter the turn loop for a
+        # fresh API call against the nudged history (no budget refund — the
+        # truncated attempt itself is kept as history).
+        _retry.restart_with_kanban_stop_nudge = False
+        return _verdict("continue")
+
     if interrupted:
         _turn_exit_reason = "interrupted_during_api_call"
         return _verdict("break")

--- a/agent/turn_retry_state.py
+++ b/agent/turn_retry_state.py
@@ -50,6 +50,10 @@ class TurnRetryState:
     # A user correction cancelled the in-flight request: append a role-safe checkpoint +
     # user message, rebuild the payload, and retry the same logical iteration.
     restart_with_redirected_messages: bool = False
+    # A truncation early-exit took the kanban stop nudge (worker ended a partial
+    # turn without kanban_complete/kanban_block); re-enter the turn loop for a
+    # fresh API call against the nudged history.
+    restart_with_kanban_stop_nudge: bool = False
 
 
 # ---- BEGIN PLUGIN-COMPAT (revert-scheduled; see COMPAT_MANIFEST.md) ----

--- a/agent/turn_truncation.py
+++ b/agent/turn_truncation.py
@@ -10,6 +10,7 @@ the final roll-back. Nothing here imports ``agent.conversation_loop`` at module 
 from __future__ import annotations
 
 import logging
+import os
 import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
@@ -145,6 +146,7 @@ class _Trunc(TruncationVerdict):
     api_call_count: int
     effective_task_id: Any
     current_turn_user_idx: Any
+    _retry: Any = None
     action: str = "fallthrough"
     result: Optional[Dict[str, Any]] = None
     window_filled: Optional[tuple[int, int]] = None  # (prompt_tokens, context_length)
@@ -171,6 +173,60 @@ class _Trunc(TruncationVerdict):
             self.messages if result_messages is None else result_messages, self.api_call_count,
             final_response, error, failed=failed, compression_exhausted=compression_exhausted,
         ))
+
+    def end_turn_with_kanban_nudge(
+        self, final_response: str, error: Optional[str] = None, *,
+        result_messages: Optional[List[Dict[str, Any]]] = None, cleanup: bool = True,
+        failed: bool = False,
+    ) -> TruncationVerdict:
+        """``end_turn`` with the kanban worker stop-nudge check first.
+
+        Truncation early-exits (output-length ceiling, truncated tool-call refusal,
+        roll-back, first-response failure) previously returned before the
+        finish_reason=stop stop-gates ran, so a kanban worker session could end
+        rc=0 with no ``kanban_complete`` / ``kanban_block`` and the dispatcher
+        records ``protocol_violation``. Before ending the turn, give the worker
+        the same bounded nudges the text-stop path gets (``build_kanban_stop_nudge``);
+        when a nudge fires, arm ``restart_with_kanban_stop_nudge`` so the loop
+        re-enters with a fresh API call against the nudged history instead of
+        returning a partial result."""
+        from agent.kanban_stop import build_kanban_stop_nudge
+
+        nudge = None
+        try:
+            nudge = build_kanban_stop_nudge(
+                messages=self.messages, attempts=getattr(self.agent, "_kanban_stop_nudges", 0)
+            )
+        except Exception:
+            logger.debug("kanban truncation stop-nudge check failed", exc_info=True)
+        if nudge is None:
+            return self.end_turn(
+                final_response, error, result_messages=result_messages,
+                cleanup=cleanup, failed=failed,
+            )
+        agent = self.agent
+        agent._kanban_stop_nudges = getattr(agent, "_kanban_stop_nudges", 0) + 1
+        # A trailing tool result must not be followed by a bare user turn on
+        # strict-alternation providers (#48879 class) — close it first.
+        close_interrupted_tool_sequence(self.messages, final_response)
+        append_message(self.messages, {
+            "role": "user", "content": nudge, "_kanban_stop_synthetic": True,
+        })
+        agent._session_messages = self.messages
+        logger.info(
+            "kanban truncation stop-loop nudge issued (attempt %d) task=%s",
+            agent._kanban_stop_nudges,
+            os.environ.get("HERMES_KANBAN_TASK", ""),
+        )
+        try:
+            agent._emit_status(
+                "⚠️  Truncation exit on a kanban worker without "
+                "kanban_complete/kanban_block — nudging to finish"
+            )
+        except Exception:
+            pass
+        self._retry.restart_with_kanban_stop_nudge = True
+        return self.done("break")
 
     @property
     def is_stub(self) -> bool:
@@ -300,11 +356,11 @@ def _continue_text(st: _Trunc, _retry: TurnRetryState, assistant_message: Any) -
     agent._session_messages = messages
     if filled is not None:
         notice = _WINDOW_FILLED.format(prompt=filled[0], ctx=filled[1])
-        return st.end_turn(
+        return st.end_turn_with_kanban_nudge(
             f"{partial_response}\n\n{notice}" if partial_response else notice,
             f"Prompt used {filled[0]} of {filled[1]} context tokens; no room to answer",
         )
-    return st.end_turn(
+    return st.end_turn_with_kanban_nudge(
         partial_response or _CEILING_NO_TEXT,
         "Response remained truncated after 4 continuation attempts",
     )
@@ -344,7 +400,7 @@ def _retry_truncated_tool_call(st: _Trunc, api_kwargs: Any) -> TruncationVerdict
     agent._cleanup_task_resources(st.effective_task_id)
     # Prior tool batches can leave a tool-result tail; this path never reaches finalize_turn.
     close_interrupted_tool_sequence(st.messages, _final_response)
-    return st.end_turn(_final_response, cleanup=False)
+    return st.end_turn_with_kanban_nudge(_final_response, cleanup=False)
 
 
 def recover_from_truncation(
@@ -365,7 +421,7 @@ def recover_from_truncation(
         messages=messages, length_continue_retries=length_continue_retries,
         truncated_response_parts=truncated_response_parts,
         truncated_tool_call_retries=truncated_tool_call_retries, retry_count=retry_count,
-        compression_attempts=compression_attempts,
+        compression_attempts=compression_attempts, _retry=_retry,
     )
     st.window_filled = _prompt_filled_window(agent, response)
     agent._vprint(
@@ -413,7 +469,7 @@ def recover_from_truncation(
     if abort is not None:
         line, user_response, error = abort
         agent._vprint(f"{agent.log_prefix}{line}", force=True)
-        return st.end_turn(user_response, error)
+        return st.end_turn_with_kanban_nudge(user_response, error)
 
     if agent.api_mode in _CONTINUABLE_MODES:
         cf = _content_filter_fallback(st, _retry)
@@ -426,13 +482,13 @@ def recover_from_truncation(
 
     if len(messages) > 1:
         agent._vprint(f"{agent.log_prefix}   ⏪ Rolling back to last complete assistant turn")
-        return st.end_turn(
+        return st.end_turn_with_kanban_nudge(
             _TRUNCATED_FINAL, result_messages=agent._get_messages_up_to_last_assistant(messages)
         )
     # First message was truncated - mark as failed
     agent._flush_status_buffer()
     agent._vprint(f"{agent.log_prefix}❌ First response truncated - cannot recover", force=True)
-    return st.end_turn(_FIRST_TRUNCATED_FINAL, cleanup=False, failed=True)
+    return st.end_turn_with_kanban_nudge(_FIRST_TRUNCATED_FINAL, cleanup=False, failed=True)
 
 
 _CODEX_REPLAY_KEYS = (

--- a/tests/agent/test_kanban_stop_truncation_exits.py
+++ b/tests/agent/test_kanban_stop_truncation_exits.py
@@ -1,0 +1,244 @@
+"""Kanban stop-nudge on truncation early-exits (``agent/turn_truncation.py``).
+
+The truncation early-exits (output-length ceiling, truncated tool-call refusal,
+thinking/repetition abort, roll-back, first-response failure) end the turn with a
+partial result BEFORE the finish_reason=stop stop-gates run, so a kanban worker
+session could end rc=0 without ``kanban_complete`` / ``kanban_block`` and the
+dispatcher records ``protocol_violation``. ``_Trunc.end_turn_with_kanban_nudge``
+routes those exits through the same bounded nudge policy the text-stop path uses,
+arming ``TurnRetryState.restart_with_kanban_stop_nudge`` so the loop re-enters with
+a fresh API call against the nudged history.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent.kanban_stop import (
+    build_kanban_stop_nudge,
+    kanban_stop_nudge_enabled,
+)
+from agent.turn_retry_state import TurnRetryState
+from agent.turn_truncation import _Trunc, recover_from_truncation
+
+
+@pytest.fixture
+def clear_kanban_env(monkeypatch):
+    for var in ("HERMES_KANBAN_TASK", "HERMES_KANBAN_STOP_NUDGE"):
+        monkeypatch.delenv(var, raising=False)
+    return monkeypatch
+
+
+def _trunc_state(agent, messages, _retry=None):
+    """A minimal ``_Trunc`` with only the fields the nudge path touches."""
+    return _Trunc(
+        agent=agent, response=None, finish_reason="length",
+        conversation_history=None, api_call_count=1,
+        effective_task_id=None, current_turn_user_idx=0,
+        messages=messages, length_continue_retries=4,
+        truncated_response_parts=[], truncated_tool_call_retries=4,
+        retry_count=0, compression_attempts=0, _retry=_retry or TurnRetryState(),
+    )
+
+
+def _agent(persisted):
+    return SimpleNamespace(
+        _kanban_stop_nudges=0,
+        _session_messages=None,
+        _emit_status=lambda *_a, **_k: None,
+        _cleanup_task_resources=lambda *_a, **_k: None,
+        _persist_session=lambda *a, **k: persisted.append(a),
+        # Minimal stand-ins for the conversation-loop helpers _continue_text touches.
+        _build_assistant_message=lambda am, fr: {
+            "role": "assistant", "content": getattr(am, "content", None), "finish_reason": fr,
+        },
+        _strip_think_blocks=lambda text: text or "",
+        _vprint=lambda *_a, **_k: None,
+        log_prefix="",
+    )
+
+
+def _worker_messages():
+    return [
+        {"role": "user", "content": "work the task"},
+        {
+            "role": "assistant",
+            "content": "I will now write the report.",
+            "tool_calls": [
+                {
+                    "id": "1",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "name": "terminal", "tool_call_id": "1", "content": "ok"},
+    ]
+
+
+class TestEndTurnWithKanbanNudge:
+    def test_appends_nudge_and_arms_restart(self, clear_kanban_env):
+        clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_nudge1")
+        assert kanban_stop_nudge_enabled() is True
+
+        persisted = []
+        agent = _agent(persisted)
+        messages = _worker_messages()
+        retry = TurnRetryState()
+        st = _trunc_state(agent, messages, retry)
+
+        verdict = st.end_turn_with_kanban_nudge(
+            "Response truncated due to output length limit"
+        )
+
+        # Nudge fired: loop must re-enter, not return a partial result.
+        assert verdict.action == "break"
+        assert retry.restart_with_kanban_stop_nudge is True
+        assert agent._kanban_stop_nudges == 1
+        # The synthetic user nudge is appended in place...
+        assert messages[-1]["role"] == "user"
+        assert "kanban_complete" in messages[-1]["content"]
+        assert messages[-1].get("_kanban_stop_synthetic") is True
+        # ...and the trailing tool result was closed first (strict role
+        # alternation: no bare user turn directly after a tool result).
+        assert messages[-2]["role"] != "tool"
+        assert agent._session_messages is messages
+        # The turn did NOT end: no partial-result persistence on this path.
+        assert persisted == []
+
+    def test_bounded_at_max_attempts_falls_through_to_end_turn(self, clear_kanban_env):
+        clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_nudge2")
+        persisted = []
+        agent = _agent(persisted)
+        agent._kanban_stop_nudges = 2  # build_kanban_stop_nudge default ceiling
+        messages = [{"role": "user", "content": "work the task"}]
+        retry = TurnRetryState()
+        st = _trunc_state(agent, messages, retry)
+
+        verdict = st.end_turn_with_kanban_nudge("truncated again")
+
+        # No nudge left: normal partial-result end (persisted, turn over).
+        assert verdict.action == "return"
+        assert verdict.result is not None and verdict.result["partial"] is True
+        assert retry.restart_with_kanban_stop_nudge is False
+        assert agent._kanban_stop_nudges == 2  # unchanged
+        assert len(persisted) == 1
+
+    def test_inert_outside_kanban_workers(self, clear_kanban_env):
+        persisted = []
+        agent = _agent(persisted)
+        messages = [{"role": "user", "content": "normal chat"}]
+        st = _trunc_state(agent, messages)
+
+        verdict = st.end_turn_with_kanban_nudge("truncated")
+
+        assert verdict.action == "return"
+        assert len(messages) == 1  # nothing appended
+        assert len(persisted) == 1
+
+    def test_no_nudge_when_already_completed(self, clear_kanban_env):
+        clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_nudge3")
+        persisted = []
+        agent = _agent(persisted)
+        messages = [
+            {"role": "user", "content": "work the task"},
+            {
+                "role": "assistant",
+                "content": "done",
+                "tool_calls": [
+                    {
+                        "id": "1",
+                        "type": "function",
+                        "function": {"name": "kanban_complete", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "name": "kanban_complete", "tool_call_id": "1", "content": "ok"},
+        ]
+        st = _trunc_state(agent, messages)
+
+        verdict = st.end_turn_with_kanban_nudge("truncated")
+
+        assert verdict.action == "return"
+        assert agent._kanban_stop_nudges == 0
+
+    def test_restart_flag_consumed_by_apply_retry_restarts(self, clear_kanban_env):
+        from agent.turn_iteration_prep import apply_retry_restarts
+
+        agent = SimpleNamespace(iteration_budget=SimpleNamespace(refund=lambda: None))
+        retry = TurnRetryState()
+        retry.restart_with_kanban_stop_nudge = True
+
+        verdict = apply_retry_restarts(
+            agent, _retry=retry, response=None, interrupted=False,
+            messages=[], conversation_history=None, user_message=None,
+            api_kwargs=None, current_turn_user_idx=0, final_response=None,
+            retry_count=0, max_retries=3, api_call_count=1, restart_count=0,
+            length_continue_retries=0,
+            _preflight_compression_blocked=False, _turn_exit_reason=None,
+        )
+
+        assert verdict.action == "continue"
+        assert retry.restart_with_kanban_stop_nudge is False  # consumed, no loop
+
+    def test_first_response_failure_also_nudged(self, clear_kanban_env):
+        """The first-message-truncated failure exit takes the same nudge path."""
+        clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_nudge4")
+        persisted = []
+        agent = _agent(persisted)
+        messages = [{"role": "user", "content": "work the task"}]
+        retry = TurnRetryState()
+
+        st = _trunc_state(agent, messages, retry)
+        # Simulate the recover_from_truncation tail: single-message history.
+        verdict = st.end_turn_with_kanban_nudge(
+            "First response truncated due to output length limit", failed=True
+        )
+
+        assert verdict.action == "break"
+        assert retry.restart_with_kanban_stop_nudge is True
+
+    def test_window_filled_ceiling_exit_also_nudged(self, clear_kanban_env):
+        """The prompt-filled-the-window ceiling exit (main's newer truncation dead-end)
+        takes the same nudge path: it, too, ends the turn before the stop-gates run."""
+        import agent.turn_truncation as tt
+
+        clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_nudge5")
+        persisted = []
+        agent = _agent(persisted)
+        messages = _worker_messages()
+        retry = TurnRetryState()
+        st = _trunc_state(agent, messages, retry)
+        st.length_continue_retries = 4  # ceiling reached → no continuation attempt
+        st.window_filled = (9000, 8192)  # prompt left no continuation headroom
+
+        verdict = tt._continue_text(st, retry, SimpleNamespace(content="partial"))
+
+        assert verdict.action == "break"
+        assert retry.restart_with_kanban_stop_nudge is True
+        assert agent._kanban_stop_nudges == 1
+        assert persisted == []  # turn did not end with a partial result
+        assert messages[-1]["role"] == "user"
+        assert messages[-1].get("_kanban_stop_synthetic") is True
+
+    def test_window_filled_ceiling_exit_plain_outside_kanban_workers(
+        self, clear_kanban_env
+    ):
+        import agent.turn_truncation as tt
+
+        persisted = []
+        agent = _agent(persisted)
+        messages = [{"role": "user", "content": "normal chat"}]
+        retry = TurnRetryState()
+        st = _trunc_state(agent, messages, retry)
+        st.length_continue_retries = 4
+        st.window_filled = (9000, 8192)
+
+        verdict = tt._continue_text(st, retry, SimpleNamespace(content="partial"))
+
+        assert verdict.action == "return"
+        assert retry.restart_with_kanban_stop_nudge is False
+        assert len(persisted) == 1  # normal partial-result end
+        assert verdict.result is not None and verdict.result["partial"] is True

--- a/tests/agent/test_turn_retry_state.py
+++ b/tests/agent/test_turn_retry_state.py
@@ -36,6 +36,7 @@ EXPECTED_FIELDS = {
     "restart_with_length_continuation",
     "restart_with_rebuilt_messages",
     "restart_with_redirected_messages",
+    "restart_with_kanban_stop_nudge",
 }
 
 


### PR DESCRIPTION
## Symptom

A Kanban worker session whose model output gets truncated (provider output-length cap, or a stream that drops mid-tool-call) exits the conversation loop through one of the truncation early-returns — **before** the `finish_reason=stop` kanban guard at the end of the loop ever fires. The worker process then ends `rc=0` without calling `kanban_complete` / `kanban_block`, and the dispatcher records a `protocol_violation` for a task that was mid-flight. On truncation-prone providers this kills a meaningful fraction of dispatched tasks.

## Root cause

The stop-nudge guard (`agent/kanban_stop.py`, wired at the finish_reason=stop path) only sees clean stops. The five truncation-shaped early returns in `agent/conversation_loop.py` (repeated truncation after continuation attempts, truncated-tool-call refusal, rollback-on-length, first-response truncation, post-loop invalid-args truncation) each `return` directly and never consult it.

## Fix

- New module-level helper `_maybe_nudge_kanban_stop()` in `conversation_loop.py`: reuses `build_kanban_stop_nudge` (same policy module, same bounded 2-attempt counter `agent._kanban_stop_nudges`, inert outside kanban workers / when already completed), closes a trailing tool result via the existing `close_interrupted_tool_sequence` (strict role alternation), and appends the synthetic user nudge in place.
- All five truncation early-return sites call it before returning. Sites inside the API retry loop set a new `TurnRetryState.restart_with_kanban_stop_nudge` flag and `break`; a new post-loop handler (after the `restart_with_length_continuation` handler) resets the flag and `continue`s the outer loop so the model gets a fresh API call against the nudged history. The first-response-truncation site only nudges on chat-completions-style modes (consecutive user turns are rejected by strict-alternation providers).

## Validation

- New `TestMaybeNudgeKanbanStop` unit tests: nudge appended + tool tail closed + continue signaled on a truncation exit; bounded at 2 attempts; inert outside kanban workers and after `kanban_complete`; `TurnRetryState` field contract extended (`test_field_set_matches_contract` updated accordingly). All new tests fail without the change.
- `tests/agent/test_turn_retry_state.py`, `tests/agent/test_kanban_stop.py`, `tests/run_agent/test_continuation_ceiling_wedge.py` — 21/21 pass; `py_compile` clean on both touched files.
