### PR TITLE
feat(weixin): support multi-account shared sessions

### DIFF
--- a/docs/weixin-shared-dm.md
+++ b/docs/weixin-shared-dm.md
@@ -1,0 +1,47 @@
+# Weixin multi-account shared sessions
+
+Hermes normally keeps Weixin direct-message sessions isolated per sender. Tencent
+iLink commonly exposes one QR-created Bot identity to only one personal WeChat
+account, so sharing one iLink between two people is not a reliable design.
+
+Use two independently QR-paired iLink accounts behind one Hermes gateway:
+
+```yaml
+platforms:
+  weixin:
+    enabled: true
+    extra:
+      accounts:
+        - name: huihui
+          account_id: HUIHUI_ILINK_ACCOUNT_ID
+          shared_dm_session: boge-huihui
+          shared_dm_users:
+            - HUIHUI_WEIXIN_USER_ID
+        - name: boge
+          account_id: BOGE_ILINK_ACCOUNT_ID
+          shared_dm_session: boge-huihui
+          shared_dm_users:
+            - BOGE_WEIXIN_USER_ID
+```
+
+Each account's token is loaded from its QR-login file:
+
+```text
+~/.hermes/weixin/accounts/<account_id>.json
+```
+
+Do not put tokens in `config.yaml`. The two child adapters keep independent
+long-poll connections, credentials, media/context-token stores, and outbound
+transports. Their inbound events use the same `shared_dm_session` value, so the
+Hermes agent sees one conversation while the response is sent through the child
+account that received the triggering message.
+
+Only exact IDs in `shared_dm_users` participate in the shared session. Other
+Weixin users remain isolated or are rejected by the normal DM policy. A shared
+session intentionally exposes both participants' messages to the same model;
+do not add users casually.
+
+The second account is paired without replacing the first one by running the QR
+login helper for the same Hermes home and then adding its returned account ID to
+the `accounts` list. The QR scan creates a second iLink identity; it is not a
+second login to the first identity.

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -167,8 +167,29 @@ class GatewayAuthorizationMixin:
         adapter_ref = getattr(source, "_transport_adapter_ref", None)
         adapter = adapter_ref() if callable(adapter_ref) else None
         platform = getattr(source, "platform", None)
+        if adapter is None and platform == Platform.WEIXIN:
+            account_id = str(getattr(source, "transport_account_id", "") or "")
+            if account_id:
+                for candidate in (getattr(self, "adapters", None) or {}).values():
+                    for child in getattr(candidate, "_children", ()):
+                        if (
+                            getattr(child, "_gateway_transport_child", False)
+                            and getattr(child, "gateway_runner", None) is self
+                            and getattr(child, "_account_id", "") == account_id
+                        ):
+                            return child
         if adapter is None or platform is None:
             return None
+        # A multi-account Weixin adapter keeps child transports outside the
+        # runner's one-adapter-per-platform registry. They are still trusted
+        # only when created by the live runner and explicitly marked by the
+        # multi-account wrapper.
+        if (
+            getattr(adapter, "_gateway_transport_child", False)
+            and getattr(adapter, "gateway_runner", None) is self
+            and getattr(adapter, "platform", None) == platform
+        ):
+            return adapter
         if adapter is (getattr(self, "adapters", None) or {}).get(platform):
             return adapter
         profile_maps = getattr(self, "_profile_adapters", None) or {}

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -880,9 +880,36 @@ def _has_usable_api_server_key(key: object) -> bool:
     return has_usable_secret(key, min_length=16)
 
 
+def _weixin_accounts_configured(config: PlatformConfig) -> bool:
+    """Return True when every configured iLink account has saved credentials."""
+    accounts = (config.extra or {}).get("accounts")
+    if not isinstance(accounts, list) or not accounts:
+        return False
+    account_dir = get_hermes_home() / "weixin" / "accounts"
+    seen_ids: set[str] = set()
+    for account in accounts:
+        if not isinstance(account, dict):
+            return False
+        account_id = str(account.get("account_id") or "").strip()
+        if not account_id or Path(account_id).name != account_id or account_id in seen_ids:
+            return False
+        seen_ids.add(account_id)
+        if account.get("token") or (account.get("extra") or {}).get("token"):
+            continue
+        saved = account_dir / f"{account_id}.json"
+        try:
+            payload = json.loads(saved.read_text(encoding="utf-8"))
+        except (OSError, ValueError, TypeError):
+            return False
+        if not isinstance(payload, dict) or not str(payload.get("token") or "").strip():
+            return False
+    return True
+
+
 _PLATFORM_CONNECTED_CHECKERS: dict[Platform, Callable[[PlatformConfig], bool]] = {
-    Platform.WEIXIN: lambda cfg: bool(
-        cfg.extra.get("account_id") and (cfg.token or cfg.extra.get("token"))
+    Platform.WEIXIN: lambda cfg: (
+        bool(cfg.extra.get("account_id") and (cfg.token or cfg.extra.get("token")))
+        or _weixin_accounts_configured(cfg)
     ),
     Platform.WHATSAPP_CLOUD: lambda cfg: bool(
         cfg.extra.get("phone_number_id") and cfg.extra.get("access_token")
@@ -1034,8 +1061,8 @@ class GatewayConfig:
         # the generic token branch doesn't let it through without account_id).
         if platform == Platform.WEIXIN:
             return bool(
-                config.extra.get("account_id")
-                and (config.token or config.extra.get("token"))
+                (config.extra.get("account_id") and (config.token or config.extra.get("token")))
+                or _weixin_accounts_configured(config)
             )
 
         # Generic token/api_key auth covers Telegram, Discord, Slack, etc.

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1193,9 +1193,23 @@ class WeixinAdapter(BasePlatformAdapter):
         self._poll_task: Optional[asyncio.Task] = None
         self._dedup = MessageDeduplicator(ttl_seconds=MESSAGE_DEDUP_TTL_SECONDS)
 
-        self._account_id = str(extra.get("account_id") or _wx_secret("WEIXIN_ACCOUNT_ID", "")).strip()
-        self._token = str(config.token or extra.get("token") or _wx_secret("WEIXIN_TOKEN", "")).strip()
-        self._base_url = str(extra.get("base_url") or _wx_secret("WEIXIN_BASE_URL", ILINK_BASE_URL)).strip().rstrip("/")
+        self._account_id = str(
+            extra.get("account_id")
+            or ("" if extra.get("_disable_env_credentials") else _wx_secret("WEIXIN_ACCOUNT_ID", ""))
+        ).strip()
+        self._shared_dm_session = str(extra.get("shared_dm_session") or "").strip()
+        self._shared_dm_users = set(self._coerce_list(extra.get("shared_dm_users")))
+        self._shared_dm_sender_name = str(extra.get("shared_dm_sender_name") or "").strip()
+        self._token = str(
+            config.token
+            or extra.get("token")
+            or ("" if extra.get("_disable_env_credentials") else _wx_secret("WEIXIN_TOKEN", ""))
+        ).strip()
+        self._base_url = str(
+            extra.get("base_url")
+            or ("" if extra.get("_disable_env_credentials") else _wx_secret("WEIXIN_BASE_URL", ILINK_BASE_URL))
+            or ILINK_BASE_URL
+        ).strip().rstrip("/")
         self._cdn_base_url = str(
             extra.get("cdn_base_url") or _wx_secret("WEIXIN_CDN_BASE_URL", WEIXIN_CDN_BASE_URL)
         ).strip().rstrip("/")
@@ -1294,6 +1308,17 @@ class WeixinAdapter(BasePlatformAdapter):
         if isinstance(value, (list, tuple, set)):
             return [str(item).strip() for item in value if str(item).strip()]
         return [str(value).strip()] if str(value).strip() else []
+
+    def _shared_session_id_for_sender(self, sender_id: str) -> Optional[str]:
+        """Return the configured shared DM identity for an authorized sender."""
+        if self._shared_dm_session and sender_id in self._shared_dm_users:
+            return self._shared_dm_session
+        return None
+
+    def _display_name_for_sender(self, sender_id: str) -> str:
+        if self._shared_session_id_for_sender(sender_id) and self._shared_dm_sender_name:
+            return self._shared_dm_sender_name
+        return sender_id
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         if not check_weixin_requirements():
@@ -1518,8 +1543,14 @@ class WeixinAdapter(BasePlatformAdapter):
             chat_id=effective_chat_id,
             chat_type=chat_type,
             user_id=sender_id,
-            user_name=sender_id,
+            user_name=self._display_name_for_sender(sender_id),
         )
+        source.shared_session_id = (
+            self._shared_session_id_for_sender(sender_id)
+            if chat_type == "dm"
+            else None
+        )
+        source.transport_account_id = self._account_id
         event = MessageEvent(
             text=text,
             message_type=_message_type_from_media(media_types, text),
@@ -2348,6 +2379,196 @@ class WeixinAdapter(BasePlatformAdapter):
         return _wrap_copy_friendly_lines_for_weixin(_normalize_markdown_blocks(content))
 
 
+
+
+class WeixinMultiAccountAdapter(BasePlatformAdapter):
+    """Run multiple independent iLink accounts behind one Hermes session store.
+
+    Each child owns its own token, long-poll loop, context-token cache, and
+    outbound transport. The gateway sees one Weixin platform adapter, while
+    the child's transport reference keeps replies on the account that received
+    the message.
+    """
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform.WEIXIN)
+        raw_accounts = (config.extra or {}).get("accounts") or []
+        if not isinstance(raw_accounts, list) or not raw_accounts:
+            raise ValueError("Weixin multi-account configuration requires a non-empty accounts list")
+        account_ids = [
+            str((account or {}).get("account_id") or "").strip()
+            for account in raw_accounts
+            if isinstance(account, dict)
+        ]
+        if len(account_ids) != len(set(account_ids)):
+            raise ValueError("Weixin multi-account configuration contains duplicate account_id values")
+        self._children: List[WeixinAdapter] = [
+            WeixinAdapter(self._child_config(config, account))
+            for account in raw_accounts
+            if isinstance(account, dict)
+        ]
+        if not self._children:
+            raise ValueError("Weixin multi-account configuration contains no valid account entries")
+        self._share_runtime_state()
+
+    @staticmethod
+    def _child_config(parent: PlatformConfig, account: Dict[str, Any]) -> PlatformConfig:
+        parent_extra = dict(parent.extra or {})
+        parent_extra.pop("accounts", None)
+        for key in ("account_id", "token", "base_url", "cdn_base_url"):
+            parent_extra.pop(key, None)
+        child_extra = dict(parent_extra)
+        nested_extra = account.get("extra")
+        if isinstance(nested_extra, dict):
+            child_extra.update(nested_extra)
+        for key in (
+            "account_id",
+            "token",
+            "base_url",
+            "cdn_base_url",
+            "dm_policy",
+            "group_policy",
+            "allow_from",
+            "group_allow_from",
+            "shared_dm_session",
+            "shared_dm_users",
+            "shared_dm_sender_name",
+        ):
+            if key in account:
+                child_extra[key] = account[key]
+        token = account.get("token") or child_extra.get("token")
+        account_id = str(child_extra.get("account_id") or "").strip()
+        if not account_id:
+            raise ValueError("Each Weixin account entry requires account_id")
+        if Path(account_id).name != account_id:
+            raise ValueError("Weixin account_id must be a single filename-safe identifier")
+        child_extra["_disable_env_credentials"] = True
+        if not token and account_id:
+            saved = load_weixin_account(str(get_hermes_home()), account_id) or {}
+            token = saved.get("token")
+            if not child_extra.get("base_url") and saved.get("base_url"):
+                child_extra["base_url"] = saved["base_url"]
+        return PlatformConfig(
+            enabled=True,
+            token=str(token) if token else None,
+            reply_to_mode=parent.reply_to_mode,
+            gateway_restart_notification=parent.gateway_restart_notification,
+            typing_indicator=parent.typing_indicator,
+            typing_status_text=parent.typing_status_text,
+            extra=child_extra,
+        )
+
+    @property
+    def name(self) -> str:
+        return f"Weixin ({len(self._children)} accounts)"
+
+    def _share_runtime_state(self) -> None:
+        for child in self._children:
+            child._active_sessions = self._active_sessions
+            child._pending_messages = self._pending_messages
+            child._session_tasks = self._session_tasks
+
+    def _propagate(self, method: str, *args: Any) -> None:
+        for child in self._children:
+            getattr(child, method)(*args)
+
+    def set_message_handler(self, handler: Any) -> None:
+        super().set_message_handler(handler)
+        self._propagate("set_message_handler", handler)
+
+    def set_fatal_error_handler(self, handler: Any) -> None:
+        super().set_fatal_error_handler(handler)
+        self._propagate("set_fatal_error_handler", handler)
+
+    def set_session_store(self, session_store: Any) -> None:
+        super().set_session_store(session_store)
+        self._propagate("set_session_store", session_store)
+
+    def set_busy_session_handler(self, handler: Any) -> None:
+        super().set_busy_session_handler(handler)
+        self._propagate("set_busy_session_handler", handler)
+
+    def set_reaction_handler(self, handler: Any) -> None:
+        super().set_reaction_handler(handler)
+        self._propagate("set_reaction_handler", handler)
+
+    def set_topic_recovery_fn(self, fn: Any) -> None:
+        super().set_topic_recovery_fn(fn)
+        self._propagate("set_topic_recovery_fn", fn)
+
+    def set_authorization_check(self, callback: Any) -> None:
+        super().set_authorization_check(callback)
+        self._propagate("set_authorization_check", callback)
+
+    def set_platform_event_handler(self, handler: Any) -> None:
+        super().set_platform_event_handler(handler)
+        self._propagate("set_platform_event_handler", handler)
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        runner = getattr(self, "gateway_runner", None)
+        for child in self._children:
+            child.gateway_runner = runner
+            child._gateway_transport_child = True
+            child._busy_text_mode = self._busy_text_mode
+        results = await asyncio.gather(
+            *(child.connect(is_reconnect=is_reconnect) for child in self._children),
+            return_exceptions=True,
+        )
+        failures = [result for result in results if isinstance(result, Exception)]
+        for failure in failures:
+            logger.error("[%s] child account failed to connect: %s", self.name, failure)
+        self._running = all(result is True for result in results)
+        if not self._running:
+            await self.disconnect()
+        return self._running
+
+    async def cancel_background_tasks(self) -> None:
+        await super().cancel_background_tasks()
+        await asyncio.gather(
+            *(child.cancel_background_tasks() for child in self._children),
+            return_exceptions=True,
+        )
+
+    async def disconnect(self) -> None:
+        await asyncio.gather(
+            *(child.disconnect() for child in self._children),
+            return_exceptions=True,
+        )
+        self._running = False
+
+    def _child_for_metadata(self, metadata: Optional[Dict[str, Any]]) -> Optional[WeixinAdapter]:
+        account_id = str((metadata or {}).get("weixin_account_id") or "").strip()
+        if not account_id:
+            return None
+        return next(
+            (child for child in self._children if child._account_id == account_id),
+            None,
+        )
+
+    async def send(self, chat_id: str, content: str, reply_to: Optional[str] = None,
+                   metadata: Optional[Dict[str, Any]] = None) -> SendResult:
+        child = self._child_for_metadata(metadata)
+        if child is None:
+            return SendResult(
+                success=False,
+                error="Weixin multi-account send requires transport account provenance",
+            )
+        return await child.send(chat_id, content, reply_to, metadata)
+
+    async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+        child = self._child_for_metadata(metadata)
+        if child is not None:
+            await child.send_typing(chat_id, metadata)
+
+    async def stop_typing(self, chat_id: str) -> None:
+        # Typing calls from inbound processing run on the child adapter. The
+        # wrapper cannot safely guess an account when no source is available.
+        return None
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        raise RuntimeError("Weixin multi-account get_chat_info requires an account selector")
+
+
 async def send_weixin_direct(
     *,
     extra: Dict[str, Any],
@@ -2361,6 +2582,13 @@ async def send_weixin_direct(
 
     This bypasses the long-poll adapter lifecycle and uses the raw API directly.
     """
+    if isinstance(extra.get("accounts"), list) and extra.get("accounts"):
+        return {
+            "error": (
+                "Weixin has multiple iLink accounts configured; direct sends require "
+                "an inbound account context and are not supported without an account selector."
+            )
+        }
     account_id = str(extra.get("account_id") or _wx_secret("WEIXIN_ACCOUNT_ID", "")).strip()
     base_url = str(extra.get("base_url") or _wx_secret("WEIXIN_BASE_URL", ILINK_BASE_URL)).strip().rstrip("/")
     cdn_base_url = str(extra.get("cdn_base_url") or _wx_secret("WEIXIN_CDN_BASE_URL", WEIXIN_CDN_BASE_URL)).strip().rstrip("/")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15395,11 +15395,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return SignalAdapter(config)
 
         elif platform == Platform.WEIXIN:
-            from gateway.platforms.weixin import WeixinAdapter, check_weixin_requirements
+            from gateway.platforms.weixin import (
+                WeixinAdapter,
+                WeixinMultiAccountAdapter,
+                check_weixin_requirements,
+            )
             if not check_weixin_requirements():
                 logger.warning("Weixin: aiohttp/cryptography not installed")
                 return None
-            return WeixinAdapter(config)
+            if isinstance(config.extra.get("accounts"), list) and config.extra.get("accounts"):
+                adapter = WeixinMultiAccountAdapter(config)
+            else:
+                adapter = WeixinAdapter(config)
+            adapter.gateway_runner = self
+            return adapter
 
         elif platform == Platform.API_SERVER:
             from gateway.platforms.api_server import APIServerAdapter, check_api_server_requirements

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -182,6 +182,13 @@ class SessionSource:
     # None => the gateway's active/default profile. Drives both session-key
     # namespacing and the per-turn config/credential scope.
     profile: Optional[str] = None
+    # Configured multi-user session identity. This is intentionally separate
+    # from ``chat_id``: DMs still route replies to the actual sender while
+    # selected users share one conversation context.
+    shared_session_id: Optional[str] = None
+    # Stable transport account used to route deferred/recovered replies after
+    # the in-process adapter weak reference is gone.
+    transport_account_id: Optional[str] = None
     # Transport-local fail-closed signal for an explicit profile route whose
     # target is not served. Excluded from repr/equality and wire serialization.
     profile_route_rejected: bool = field(default=False, repr=False, compare=False)
@@ -279,6 +286,10 @@ class SessionSource:
             d["message_id"] = self.message_id
         if self.profile:
             d["profile"] = self.profile
+        if self.shared_session_id:
+            d["shared_session_id"] = self.shared_session_id
+        if self.transport_account_id:
+            d["transport_account_id"] = self.transport_account_id
         if self.auto_thread_created:
             d["auto_thread_created"] = True
         if self.auto_thread_initial_name:
@@ -306,6 +317,8 @@ class SessionSource:
             parent_chat_id=data.get("parent_chat_id"),
             message_id=data.get("message_id"),
             profile=data.get("profile"),
+            shared_session_id=data.get("shared_session_id"),
+            transport_account_id=data.get("transport_account_id"),
             auto_thread_created=bool(data.get("auto_thread_created", False)),
             auto_thread_initial_name=data.get("auto_thread_initial_name"),
             prospective_thread_id=data.get("prospective_thread_id"),
@@ -1060,6 +1073,12 @@ def is_shared_multi_user_session(
       - Non-thread group/channel sessions are shared unless
         ``group_sessions_per_user`` is True (default: True = isolated).
     """
+    if (
+        getattr(source, "shared_session_id", None)
+        and source.platform == Platform.WEIXIN
+        and source.chat_type == "dm"
+    ):
+        return True
     if source.chat_type == "dm":
         return False
     if source.thread_id:
@@ -1127,6 +1146,15 @@ def build_session_key(
     """
     ns = _session_key_namespace(profile)
     platform = source.platform.value
+    if (
+        getattr(source, "shared_session_id", None)
+        and source.platform == Platform.WEIXIN
+        and source.chat_type == "dm"
+    ):
+        return ":".join(
+            str(part)
+            for part in (ns, platform, "dm", "shared", source.shared_session_id)
+        )
     slack_scope_id = (
         str(source.scope_id)
         if source.platform == Platform.SLACK and source.scope_id

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1017,6 +1017,16 @@ class GatewaySlashCommandsMixin:
             return False
         if origin.platform != current.platform:
             return False
+        if (
+            current.platform == Platform.WEIXIN
+            and origin.platform == Platform.WEIXIN
+            and current.chat_type == "dm"
+            and origin.chat_type == "dm"
+            and current.shared_session_id
+            and origin.shared_session_id
+            and current.shared_session_id == origin.shared_session_id
+        ):
+            return True
         if origin.chat_id != current.chat_id:
             return False
         # thread_id is part of the session key for every chat type when present

--- a/tests/gateway/test_weixin_shared_dm.py
+++ b/tests/gateway/test_weixin_shared_dm.py
@@ -1,0 +1,135 @@
+"""Shared Weixin DM session behavior."""
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.weixin import WeixinAdapter, WeixinMultiAccountAdapter
+from gateway.session import (
+    SessionSource,
+    build_session_key,
+    is_shared_multi_user_session,
+)
+
+
+def _weixin_dm(user_id: str, *, shared_session_id: str | None = None) -> SessionSource:
+    return SessionSource(
+        platform=Platform.WEIXIN,
+        chat_id=user_id,
+        chat_type="dm",
+        user_id=user_id,
+        user_name=user_id,
+        shared_session_id=shared_session_id,
+    )
+
+
+def test_configured_shared_weixin_dms_use_one_session_key():
+    boge = _weixin_dm("boge", shared_session_id="boge-huihui")
+    huihui = _weixin_dm("huihui", shared_session_id="boge-huihui")
+
+    assert build_session_key(boge) == build_session_key(huihui)
+    assert build_session_key(boge) == "agent:main:weixin:dm:shared:boge-huihui"
+    assert is_shared_multi_user_session(boge)
+
+
+def test_unconfigured_weixin_dm_remains_isolated():
+    boge = _weixin_dm("boge")
+    huihui = _weixin_dm("huihui")
+
+    assert build_session_key(boge) != build_session_key(huihui)
+    assert not is_shared_multi_user_session(boge)
+
+
+def test_non_weixin_shared_marker_is_ignored():
+    telegram = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="telegram-user",
+        chat_type="dm",
+        user_id="telegram-user",
+        shared_session_id="boge-huihui",
+    )
+
+    assert not is_shared_multi_user_session(telegram)
+    assert build_session_key(telegram) == "agent:main:telegram:dm:telegram-user"
+
+
+def test_shared_session_identity_round_trips_through_source_dict():
+    source = _weixin_dm("boge", shared_session_id="boge-huihui")
+    source.transport_account_id = "boge@im.bot"
+
+    restored = SessionSource.from_dict(source.to_dict())
+
+    assert restored.shared_session_id == "boge-huihui"
+    assert restored.transport_account_id == "boge@im.bot"
+    assert build_session_key(restored) == build_session_key(source)
+
+
+def test_weixin_adapter_only_marks_configured_users_for_sharing():
+    adapter = WeixinAdapter(
+        PlatformConfig(
+            extra={
+                "account_id": "bot@im.bot",
+                "shared_dm_session": "boge-huihui",
+                "shared_dm_users": ["boge", "huihui"],
+                "shared_dm_sender_name": "大哥",
+            }
+        )
+    )
+
+    assert adapter._shared_session_id_for_sender("boge") == "boge-huihui"
+    assert adapter._shared_session_id_for_sender("huihui") == "boge-huihui"
+    assert adapter._shared_session_id_for_sender("stranger") is None
+    assert adapter._display_name_for_sender("boge") == "大哥"
+    assert adapter._display_name_for_sender("stranger") == "stranger"
+
+
+def test_multi_account_adapter_builds_isolated_ilink_children():
+    adapter = WeixinMultiAccountAdapter(
+        PlatformConfig(
+            extra={
+                "accounts": [
+                    {
+                        "name": "boge",
+                        "account_id": "boge@im.bot",
+                        "token": "token-boge",
+                        "shared_dm_session": "boge-huihui",
+                        "shared_dm_users": ["boge-user"],
+                    },
+                    {
+                        "name": "huihui",
+                        "account_id": "huihui@im.bot",
+                        "token": "token-huihui",
+                        "shared_dm_session": "boge-huihui",
+                        "shared_dm_users": ["huihui-user"],
+                    },
+                ]
+            }
+        )
+    )
+
+    assert [child._account_id for child in adapter._children] == [
+        "boge@im.bot",
+        "huihui@im.bot",
+    ]
+    assert adapter._children[0]._token == "token-boge"
+    assert adapter._children[1]._token == "token-huihui"
+    assert adapter._children[0]._shared_session_id_for_sender("boge-user") == "boge-huihui"
+    assert adapter._children[1]._shared_session_id_for_sender("huihui-user") == "boge-huihui"
+
+
+def test_gateway_recognizes_saved_multi_account_weixin_config():
+    config = GatewayConfig.from_dict(
+        {
+            "platforms": {
+                "weixin": {
+                    "enabled": True,
+                    "extra": {
+                        "accounts": [
+                            {"account_id": "a@im.bot", "token": "token-a"},
+                            {"account_id": "b@im.bot", "token": "token-b"},
+                        ]
+                    },
+                }
+            }
+        }
+    )
+
+    platform_config = config.platforms[Platform.WEIXIN]
+    assert config._is_platform_connected(Platform.WEIXIN, platform_config)


### PR DESCRIPTION
## Summary

This PR adds multi-account Weixin/iLink support for shared direct-message sessions.

- Run multiple independent iLink accounts behind one Hermes Weixin adapter.
- Keep each account's token, long-poll connection, context-token store, and outbound transport isolated.
- Route selected Weixin DMs from different iLink accounts into one shared Hermes session.
- Preserve transport account identity for correct reply routing, including persisted session origins.
- Add per-account allowlists and configurable sender labels such as `[大哥]` and `[惠惠]`.
- Reject ambiguous multi-account direct sends instead of silently choosing the wrong account.
- Add documentation and regression tests.

## Validation

- `python -m compileall` on changed Python modules
- `pytest tests/gateway/test_weixin_shared_dm.py tests/gateway/test_multiplex_phase0.py tests/run_agent/test_session_source.py -q`
- Result: 22 passed
- Full `tests/gateway` run: 5793 passed, 17 pre-existing/environment-dependent failures unrelated to this change

## Configuration shape

```yaml
platforms:
  weixin:
    extra:
      accounts:
        - account_id: first@im.bot
          shared_dm_session: shared-room
          shared_dm_users: [first-user@im.wechat]
          shared_dm_sender_name: First User
        - account_id: second@im.bot
          shared_dm_session: shared-room
          shared_dm_users: [second-user@im.wechat]
          shared_dm_sender_name: Second User
```

Account tokens remain in `~/.hermes/weixin/accounts/<account_id>.json` and are not placed in config.yaml.
