### PR TITLE
fix reasoning-only output exhaustion detection

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3536,6 +3536,10 @@ def run_conversation(
 
                     _trunc_content = getattr(_trunc_msg, "content", None) if _trunc_msg else None
                     _trunc_has_tool_calls = bool(getattr(_trunc_msg, "tool_calls", None)) if _trunc_msg else False
+                    _trunc_reasoning = (
+                        getattr(_trunc_msg, "reasoning_content", None)
+                        or getattr(_trunc_msg, "reasoning", None)
+                    ) if _trunc_msg else None
 
                     # ── Detect thinking-budget exhaustion ──────────────
                     # When the model spends ALL output tokens on reasoning
@@ -3556,13 +3560,20 @@ def run_conversation(
                             re.IGNORECASE,
                         )
                     )
-                    _thinking_exhausted = (
-                        not _trunc_has_tool_calls
-                        and _has_think_tags
+                    _inline_thinking_exhausted = (
+                        _has_think_tags
                         and (
                             (_trunc_content is not None and not agent._has_content_after_think_block(_trunc_content))
                             or _trunc_content is None
                         )
+                    )
+                    _structured_thinking_exhausted = (
+                        bool(_trunc_reasoning)
+                        and not str(_trunc_content or "").strip()
+                    )
+                    _thinking_exhausted = (
+                        not _trunc_has_tool_calls
+                        and (_inline_thinking_exhausted or _structured_thinking_exhausted)
                     )
 
                     if _thinking_exhausted:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4104,6 +4104,31 @@ class TestRunConversation:
         assert "/thinkon" in result["final_response"]
 
 
+    def test_length_structured_reasoning_exhausted_skips_continuation(self, agent):
+        """Separate reasoning_content with no visible text must skip retries."""
+        self._setup_agent(agent)
+        resp = _mock_response(
+            content="",
+            reasoning_content="internal reasoning returned out of band",
+            finish_reason="length",
+        )
+        agent.client.chat.completions.create.return_value = resp
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is False
+        assert result["api_calls"] == 1
+        assert "reasoning" in result["error"].lower()
+        assert "output tokens" in result["error"].lower()
+        assert result["final_response"] is not None
+        assert "Thinking Budget Exhausted" in result["final_response"]
+        assert "/thinkon" in result["final_response"]
+
     def test_length_with_tool_calls_returns_partial_without_executing_tools(self, agent):
         self._setup_agent(agent)
         bad_tc = _mock_tool_call(


### PR DESCRIPTION
## Summary

- detect output-budget exhaustion when reasoning arrives through structured reasoning_content or reasoning fields
- stop after the first length-limited reasoning-only response instead of issuing three deterministic continuation retries
- preserve normal continuation when visible content or tool calls are present

## Root cause

The existing guard only recognized inline think tags. OpenAI-compatible reasoning models can return the same reasoning out of band, leaving visible content empty. That shape bypassed the guard and exhausted all four continuation attempts.

## Validation

- ruff check passed for the changed files
- targeted exhaustion tests: 2 passed on current upstream main
- continuation-focused regression suite: 21 passed on the originating checkout

The production trace used to diagnose this contained private user content and is intentionally not attached.
