### PR TITLE
treat non-deliverable cron origins as local

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2155,6 +2155,14 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
 
     if deliver_value == "origin":
         if origin:
+            origin_platform = str(origin["platform"]).lower()
+            if not _is_known_delivery_platform(origin_platform):
+                logger.info(
+                    "Job %s: origin platform %r has no cron delivery "
+                    "transport — treating output as local",
+                    job.get("name", job.get("id", "?")), origin_platform,
+                )
+                return None
             return {
                 "platform": origin["platform"],
                 "chat_id": str(origin["chat_id"]),

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2081,6 +2081,28 @@ class TestDeliverOriginUnresolvableIsLocal:
         assert self._deliver(job, monkeypatch) is None
 
 
+class TestDeliverWebUIOriginIsLocal:
+    """WebUI is an origin surface, not a gateway delivery transport."""
+
+    def test_webui_origin_has_no_delivery_target(self):
+        from cron.scheduler import _resolve_delivery_targets
+
+        job = {
+            "id": "webui-job",
+            "deliver": "origin",
+            "origin": {"platform": "webui", "chat_id": "session-123"},
+        }
+        assert _resolve_delivery_targets(job) == []
+
+    def test_webui_origin_delivery_succeeds_locally(self):
+        job = {
+            "id": "webui-job",
+            "deliver": "origin",
+            "origin": {"platform": "webui", "chat_id": "session-123"},
+        }
+        assert _deliver_result(job, "Saved cron output") is None
+
+
 class TestSendMediaTimeoutCancelsFuture:
     """Same orphan-coroutine guarantee for _send_media_via_adapter's
     future.result(timeout=30) call. If this times out mid-batch, the

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -387,8 +387,9 @@ def _local_delivery_notice(job: Dict[str, Any], user_deliver: Optional[str]) -> 
     return (
         "This is a local-only cron job: its output is saved (view it with "
         "cronjob(action='list')) but will NOT be delivered back into this "
-        "session — CLI/TUI sessions have no live-delivery channel. To be "
-        "notified when it runs, recreate or update the job with deliver set to "
+        "session because its origin has no live cron-delivery channel "
+        "(for example, CLI, TUI, or WebUI). To be notified when it runs, "
+        "recreate or update the job with deliver set to "
         "a gateway-connected platform, e.g. deliver='telegram' or deliver='all'."
     )
 


### PR DESCRIPTION
## Summary

- treat origin delivery as local when the captured origin is not a registered cron delivery platform
- prevent WebUI-created jobs from finishing successfully and then reporting unknown platform webui
- broaden the creation notice to cover WebUI as well as CLI and TUI origins

## Root cause

WebUI is a valid session origin but not a gateway delivery transport. The origin resolver converted it into a concrete target without validating deliverability, so failure occurred only after the scheduled work had completed.

## Validation

- ruff check passed for the changed files
- current-upstream targeted tests: 3 passed
- full scheduler and cronjob tool files: 164 passed on the originating checkout
