### PR TITLE
fix(desktop): keep Bot Mode routines docked

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/dock-enforce.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/dock-enforce.test.ts
@@ -44,8 +44,8 @@ describe('enforced dock (stacked Bots pane → sessions-zone tab, every boot)', 
     vi.resetModules()
   })
 
-  async function setup() {
-    window.localStorage.setItem(TREE_KEY, JSON.stringify(stackedTree))
+  async function setupTree(initialTree: object, options: { routines?: boolean } = {}) {
+    window.localStorage.setItem(TREE_KEY, JSON.stringify(initialTree))
 
     const tree = await import('@/components/pane-shell/tree/store')
     const model = await import('@/components/pane-shell/tree/model')
@@ -76,7 +76,21 @@ describe('enforced dock (stacked Bots pane → sessions-zone tab, every boot)', 
       render: () => null
     })
 
+    if (options.routines) {
+      registry.register({
+        id: 'hermes-bots:routines',
+        area: 'panes',
+        title: 'Cronjobs',
+        data: { placement: 'main', dock: { pane: 'workspace', pos: 'right', enforce: true } },
+        render: () => null
+      })
+    }
+
     return { model, registry, tree }
+  }
+
+  async function setup() {
+    return setupTree(stackedTree)
   }
 
   it('re-homes a stacked bots pane into the sessions tab strip, keeping sessions active', async () => {
@@ -188,33 +202,7 @@ describe('enforced dock (stacked Bots pane → sessions-zone tab, every boot)', 
       ]
     }
 
-    window.localStorage.setItem(TREE_KEY, JSON.stringify(hiddenStackedTree))
-
-    const tree = await import('@/components/pane-shell/tree/store')
-    const model = await import('@/components/pane-shell/tree/model')
-    const { registry } = await import('@/contrib/registry')
-
-    registry.register({
-      id: 'workspace',
-      area: 'panes',
-      title: 'chat',
-      data: { placement: 'main' },
-      render: () => null
-    })
-    registry.register({
-      id: 'sessions',
-      area: 'panes',
-      title: 'sessions',
-      data: { placement: 'left' },
-      render: () => null
-    })
-    registry.register({
-      id: 'hermes-bots:pane',
-      area: 'panes',
-      title: 'Bots',
-      data: { placement: 'left', dock: { pane: 'sessions', pos: 'center', enforce: true } },
-      render: () => null
-    })
+    const { model, tree } = await setupTree(hiddenStackedTree)
 
     tree.watchContributedPanes()
 
@@ -224,5 +212,65 @@ describe('enforced dock (stacked Bots pane → sessions-zone tab, every boot)', 
     // reachable again. The active tab is NOT stolen mid-boot.
     expect(group.panes).toEqual(['sessions', 'hermes-bots:pane'])
     expect(group.headerHidden).not.toBe(true)
+  })
+
+  it('re-homes an edge-enforced pane stranded in the sessions tab strip', async () => {
+    const staleRoutinesTree = {
+      type: 'split',
+      id: 'root',
+      orientation: 'row',
+      weights: [1, 3],
+      children: [
+        {
+          type: 'group',
+          id: 'g-sessions',
+          panes: ['sessions', 'hermes-bots:pane', 'hermes-bots:routines'],
+          active: 'hermes-bots:pane'
+        },
+        { type: 'group', id: 'g-main', panes: ['workspace'], active: 'workspace' }
+      ]
+    }
+
+    const { model, tree } = await setupTree(staleRoutinesTree, { routines: true })
+
+    tree.watchContributedPanes()
+
+    const botsGroup = model.findGroupOfPane(tree.$layoutTree.get()!, 'hermes-bots:pane')!
+    const routinesGroup = model.findGroupOfPane(tree.$layoutTree.get()!, 'hermes-bots:routines')!
+
+    expect(botsGroup.panes).toEqual(['sessions', 'hermes-bots:pane'])
+    expect(botsGroup.active).toBe('hermes-bots:pane')
+    expect(routinesGroup.panes).toEqual(['hermes-bots:routines'])
+    expect(routinesGroup.id).not.toBe(botsGroup.id)
+  })
+
+  it('leaves an edge-enforced pane alone when it already occupies the declared split', async () => {
+    const dockedRoutinesTree = {
+      type: 'split',
+      id: 'root',
+      orientation: 'row',
+      weights: [1, 3, 1],
+      children: [
+        {
+          type: 'group',
+          id: 'g-sessions',
+          panes: ['sessions', 'hermes-bots:pane'],
+          active: 'hermes-bots:pane'
+        },
+        { type: 'group', id: 'g-main', panes: ['workspace'], active: 'workspace' },
+        {
+          type: 'group',
+          id: 'g-routines',
+          panes: ['hermes-bots:routines'],
+          active: 'hermes-bots:routines'
+        }
+      ]
+    }
+
+    const { tree } = await setupTree(dockedRoutinesTree, { routines: true })
+
+    tree.watchContributedPanes()
+
+    expect(tree.$layoutTree.get()).toEqual(dockedRoutinesTree)
   })
 })

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -1095,8 +1095,8 @@ interface PaneDockHint {
   pos: DropPosition
   /** Center docks: stack BEFORE this pane id (the strip divider's slot). */
   before?: null | string
-  /** Enforced dock invariant: the pane is re-homed onto this hint's center
-   *  anchor on EVERY boot when it isn't already stacked with the anchor —
+  /** Enforced dock invariant: the pane is re-homed onto this hint's anchor
+   *  on EVERY boot when it isn't already in the declared relationship —
    *  no one-time token, and user placement does not exempt it. Once per
    *  adoption lifetime (per boot), so an intra-session drag sticks until the
    *  next boot. See `enforceDockedPanes`. */
@@ -1116,13 +1116,13 @@ const enforcedDocksThisBoot = new Set<string>()
 
 /**
  * A `panes` contribution whose dock hint carries `enforce: true` is re-homed
- * onto the hint's center anchor at every boot's first adoption pass when it
- * isn't already stacked there. Unlike the retired one-time heal, nothing
+ * onto the hint's anchor at every boot's first adoption pass when it isn't
+ * already docked there. Unlike the retired one-time heal, nothing
  * exempts the pane — not a burned token, not $userPlacedPanes — because the
  * hint is the owner's standing invariant about where the pane lives
  * (Bot Mode's Bots pane IS the SESSIONS | BOTS tab strip), not a one-shot
- * migration. Center re-homes only: the invariant consolidates the pane into
- * its anchor's tab strip, it never re-runs arbitrary splits.
+ * migration. Center hints consolidate panes into their anchor's tab strip;
+ * edge hints restore the declared split beside their anchor.
  *
  * Silent like adoption — the anchor zone keeps its active tab. The center
  * insert pins the zone's header shown, which is the point: the strip is how
@@ -1137,7 +1137,7 @@ function enforceDockedPanes(
   for (const pane of registry.getArea('panes')) {
     const dock = dataOf(pane.id)?.dock
 
-    if (!dock?.enforce || dock.pos !== 'center' || !allPaneIds(next).includes(pane.id)) {
+    if (!dock?.enforce || !allPaneIds(next).includes(pane.id)) {
       continue
     }
 
@@ -1154,7 +1154,7 @@ function enforceDockedPanes(
       continue
     }
 
-    if (from.id === anchor.id) {
+    if (dock.pos === 'center' && from.id === anchor.id) {
       // Already stacked with its anchor — but an enforced tab must be
       // REACHABLE, not just co-located. Community regression (Aug 2026):
       // persisted trees where the enforced pane was center-stacked with the
@@ -1163,6 +1163,20 @@ function enforceDockedPanes(
       // sessions"). An enforced zone always shows its strip.
       if (anchor.headerHidden === true) {
         next = setGroupHeaderHiddenOp(next, anchor.id, false) ?? next
+      }
+
+      continue
+    }
+
+    if (dock.pos !== 'center') {
+      const moved = movePaneOp(next, pane.id, {
+        groupId: anchor.id,
+        pos: dock.pos,
+        before: dock.before
+      })
+
+      if (moved !== next) {
+        next = moved
       }
 
       continue

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -9373,7 +9373,8 @@ export default {
         title: 'Cronjobs',
         data: {
           placement: 'main',
-          dock: { pane: 'workspace', pos: 'right' },
+          // Repair persisted layouts that stranded Cronjobs in the Bots tab strip.
+          dock: { pane: 'workspace', pos: 'right', enforce: true },
           width: '250px'
         },
         render: () => jsx(RoutinesPane, {})

--- a/apps/desktop/src/plugins/hermes-bots/tests/pane-dock-layout.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/pane-dock-layout.test.mjs
@@ -25,6 +25,7 @@ test('the Bots pane center-docks into the sessions zone as an enforced invariant
 
 test('routines registration is a reusable disposer-returning function', () => {
   assert.match(source, /const registerRoutinesPane = \(\) =>\s*\n\s*ctx\.register\(\{\s*\n\s*id: 'routines'/)
+  assert.match(source, /dock: \{ pane: 'workspace', pos: 'right', enforce: true \}/)
 })
 
 test('routines pane rides Bots visibility via feature-detected host.paneVisibility', () => {


### PR DESCRIPTION
## What does this PR do?

Fixes a persisted-layout regression where Bot Mode's Cronjobs pane can be restored inside the `SESSIONS | BOTS` tab strip. In that state, opening Bot Mode briefly exposes a `Cronjobs` tab in the left pane; selecting it can then make the tab disappear while leaving the user in Bot Mode.

The pane registry already declares Cronjobs as a right-side dock beside the workspace, but the boot-time `enforce` path only honored center docks. This change makes enforced dock hints honor edge positions as well, then opts the Cronjobs pane into that invariant.

The repair runs once per pane adoption lifetime on each launch. An intentional drag still sticks for the current session, while the declared plugin layout is restored on the next launch. Layouts that are already correct are left unchanged.

## Related Issue

No linked issue. The regression was reproduced from a persisted Desktop pane tree. I also searched the open PR and issue queues for an existing Cronjobs docking fix and found no duplicate.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/components/pane-shell/tree/store.ts`
  - generalize enforced pane docking from center-only placement to declared center or edge placement
  - preserve the existing once-per-launch behavior so live user rearrangement is not fought during the session
- `apps/desktop/src/components/pane-shell/tree/dock-enforce.test.ts`
  - reproduce and repair a Cronjobs pane stranded in the Sessions/Bots tab strip
  - prove an already-correct right-side split is a no-op
- `apps/desktop/src/plugins/hermes-bots/plugin.js`
  - declare the Cronjobs right-side dock as enforced
- `apps/desktop/src/plugins/hermes-bots/tests/pane-dock-layout.test.mjs`
  - cover the plugin registration contract

## How to Test

1. Restore a persisted pane tree with `hermes-bots:routines` stacked beside `sessions` and `hermes-bots:pane`.
2. Register the Bot Mode pane contributions and run the adoption pass.
3. Confirm Sessions and Bots stay in their left tab strip, while Cronjobs is restored to a right-side split beside the workspace without changing the active Bots tab.
4. Repeat with Cronjobs already in the declared right-side split and confirm the tree is unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit message follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs and issues to make sure this isn't a duplicate
- [x] This PR contains only changes related to this fix
- [x] Frontend test scope completed; no Python source changed, so the local Python suite was not rerun
- [x] Tests cover both the stale-layout repair and the already-correct no-op case
- [x] Tested on macOS 26; the pane-tree behavior is platform-independent

### Documentation & Housekeeping

- [x] Documentation update: N/A — no user-facing API or configuration changed
- [x] `cli-config.yaml.example`: N/A — no configuration keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A — no contributor workflow changed
- [x] Cross-platform impact considered — the change is renderer-only and uses the shared pane-tree model
- [x] Tool descriptions/schemas: N/A — no tool behavior changed

## Validation

- `git diff --check origin/main...HEAD`
- `node --check apps/desktop/src/plugins/hermes-bots/plugin.js`
- `npm --prefix apps/desktop run test:ui -- src/components/pane-shell/tree/dock-enforce.test.ts` — **8 passed**
- `node --test apps/desktop/src/plugins/hermes-bots/tests/pane-dock-layout.test.mjs` — **4 passed**
- `npm --prefix apps/desktop run check:test:plugins` — **268 passed**
- `tsc -p apps/desktop --noEmit`
- zero-warning ESLint on the changed TypeScript files

The branch was rebased and retested after the latest Bot Mode cold-open hydration fixes landed on `main`.

## Screenshots / Logs

N/A — this restores the existing declared pane placement and adds no new UI.
