### PR TITLE
fix(cron): deliver via live native adapter when the profile has no platforms block

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2672,18 +2672,21 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             pconfig = config.platforms.get(platform)
             runtime_adapter = None
 
-        if transport is not None and transport.is_relay:
-            # A relay transport carries the RELAY adapter's config, and
-            # resolve_delivery_transport already applied relay's enablement
-            # rule (config block absent OR enabled). The logical platform is
-            # deliberately NOT natively enabled in a relay-fronted deployment
-            # (its credential lives in the connector), so the native
-            # configured/enabled gate below must not apply — it used to
-            # reject exactly the targets the relay was resolved to serve.
-            if pconfig is None:
-                from gateway.config import PlatformConfig
-                pconfig = PlatformConfig(enabled=True)
-        elif not pconfig or not pconfig.enabled:
+        if transport is not None and pconfig is None:
+            # A resolved LIVE transport with no config block means "live
+            # adapter, no per-profile platforms: section", not "disabled".
+            # Relay transports land here in relay-fronted deployments (the
+            # logical platform's credential lives in the connector, and
+            # resolve_delivery_transport already applied the relay's
+            # enablement rule). Native plugin platforms land here under
+            # multiplex (HERMES_HOME remapped to profiles/<slug>/) when the
+            # profile config carries no platforms block — the live adapter's
+            # presence is itself the enablement signal; rejecting it made
+            # every deliver=origin job to a native platform silently fail
+            # (#89302). An explicit enabled=False block still rejects below.
+            from gateway.config import PlatformConfig
+            pconfig = PlatformConfig(enabled=True)
+        if not pconfig or not pconfig.enabled:
             msg = f"platform '{platform_name}' not configured/enabled"
             logger.warning("Job '%s': %s", job["id"], msg)
             delivery_errors.append(msg)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -432,6 +432,90 @@ class TestDeliverResultWrapping:
         standalone_send.assert_not_awaited()
 
 
+    def test_live_native_adapter_with_no_config_block_is_enabled(self):
+        """A live native adapter with no per-profile platforms block delivers.
+
+        Under multiplex, HERMES_HOME is remapped to profiles/<slug>/ and the
+        profile config often has no platforms section while the gateway passes
+        the live native adapter. resolve_delivery_transport already treats a
+        missing config block as enabled; the configured/enabled gate in
+        _deliver_result used to reject it anyway, silently failing every
+        deliver=origin job to a native platform (#89302)."""
+        from concurrent.futures import Future
+
+        from gateway.config import GatewayConfig, Platform
+
+        native = MagicMock()
+        native.send = AsyncMock(return_value=MagicMock(success=True, message_id="m1"))
+
+        config = GatewayConfig(platforms={})  # no platforms block at all
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        def fake_run_coro(coro, _loop):
+            import asyncio as _asyncio
+
+            future = Future()
+            try:
+                future.set_result(_asyncio.run(coro))
+            except BaseException as exc:  # noqa: BLE001
+                future.set_exception(exc)
+            return future
+
+        job = {
+            "id": "native-cron",
+            "deliver": "telegram",
+            "origin": {"platform": "telegram", "chat_id": "42"},
+        }
+
+        with (
+            patch("gateway.config.load_gateway_config", return_value=config),
+            patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}),
+            patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro),
+        ):
+            result = _deliver_result(
+                job,
+                "native delivery",
+                adapters={Platform.TELEGRAM: native},
+                loop=loop,
+            )
+
+        assert result is None, f"delivery rejected: {result}"
+        native.send.assert_awaited_once()
+
+    def test_explicitly_disabled_native_config_still_rejects(self):
+        """An explicit enabled=False block must keep rejecting delivery — the
+        no-config synthesis only covers the config-absent shape."""
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+        native = MagicMock()
+        native.send = AsyncMock(return_value=MagicMock(success=True))
+
+        config = GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=False)}
+        )
+        job = {
+            "id": "disabled-cron",
+            "deliver": "telegram",
+            "origin": {"platform": "telegram", "chat_id": "42"},
+        }
+
+        with (
+            patch("gateway.config.load_gateway_config", return_value=config),
+            patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}),
+        ):
+            result = _deliver_result(
+                job,
+                "should not deliver",
+                adapters={Platform.TELEGRAM: native},
+                loop=None,
+            )
+
+        assert result is not None
+        assert "not configured/enabled" in result
+        native.send.assert_not_awaited()
+
+
     def test_live_adapter_sends_media_as_attachments(self, tmp_path, monkeypatch):
         """When a live adapter is available, MEDIA files should be sent as native
         platform attachments (e.g., Discord voice, Telegram audio) rather than


### PR DESCRIPTION
## What does this PR do?

The configured/enabled gate in the cron delivery path only exempted config-less transports when `transport.is_relay`. A native plugin platform under multiplex hits the same shape from the other direction:

- the gateway passes the **live native adapter** for the platform,
- the profile `config.yaml` (HERMES_HOME remapped to `profiles/<slug>/`) has no `platforms:` section, so `resolve_delivery_transport` returns the transport with `config is None` — the delivery layer already treats a missing config block as enabled for a live adapter,
- but `_deliver_result` then hit `not pconfig` and rejected the target with `platform '<name>' not configured/enabled`.

Result: every `deliver=origin` job to a native plugin platform under multiplex silently failed — `last_status=ok`, `last_delivery_error=platform '...' not configured/enabled`, destination chat got nothing.

This PR synthesizes `PlatformConfig(enabled=True)` for **any** resolved live transport whose config is `None` (the relay case keeps its existing behavior, just under the unified condition — `resolve_delivery_transport` already applied the relay enablement rule, and a relay transport's config is the relay's own, so nothing changes for relay-fronted deployments). An explicit `enabled=False` config block still rejects delivery: the synthesis covers only the config-absent shape, mirroring the delivery layer's own native rule ("a concrete native adapter always wins… never let an explicitly disabled native adapter shadow an enabled Relay").

## Related Issue

Fixes #89302

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/scheduler.py` — the `is_relay`-gated config synthesis in `_deliver_result` becomes `transport is not None and pconfig is None` (relay semantics unchanged; native config-less transports now enabled), with a comment explaining the multiplex shape and the still-rejecting explicit-disable path.
- `tests/cron/test_scheduler.py` — `test_live_native_adapter_with_no_config_block_is_enabled`: live Telegram adapter + `GatewayConfig(platforms={})` + `deliver=origin` must deliver via the adapter (fails on main with "not configured/enabled"); `test_explicitly_disabled_native_config_still_rejects`: an explicit `enabled=False` block still rejects (pins the boundary the synthesis must not cross).

## How to Test

```bash
python -m pytest tests/cron/test_scheduler.py -q -k "native or relay"
# Observed result: 4 passed

python -m pytest tests/cron/test_scheduler.py tests/cron/test_cron_relay_delivery_guards.py tests/cron/test_cleanup_timeout.py -q
# Observed result: 109 passed
```

Fail-on-main check: with the scheduler change stashed, `test_live_native_adapter_with_no_config_block_is_enabled` fails on main (delivery rejected); the explicit-disable pin passes on both.

Manual repro from the issue: multiplex cron tick with a profile that has no `platforms:` block and a live native adapter for the origin platform — on main the job records `last_delivery_error=platform '...' not configured/enabled`; with this change the turn result is delivered through the live adapter.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments explain intent (why config-absent means enabled for a live transport, and what still rejects)
- [x] Corresponding changes documented via comments
- [x] Tests added and passing (2 new; relay-guard suites unchanged and green)
- [x] Single root cause, no unrelated changes
