### PR TITLE
fix(tests): tui gateway server timing waits no longer flake on loaded CI runners

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3304,7 +3304,7 @@ def test_session_resume_deferred_history_acknowledges_and_reuses(monkeypatch):
         def get_resume_conversations(self, target):
             history_calls.append(("resume", target))
             history_started.set()
-            assert release_history.wait(timeout=2.0)
+            assert release_history.wait(timeout=5.0)
             return [loaded], [ancestor, loaded]
 
         def get_ancestor_display_prefix(self, target):
@@ -3340,7 +3340,7 @@ def test_session_resume_deferred_history_acknowledges_and_reuses(monkeypatch):
         assert first["result"]["hydrating"] is True
         assert first["result"]["messages"] == []
         assert first["result"]["message_count"] == 1200
-        assert history_started.wait(timeout=1.0)
+        assert history_started.wait(timeout=5.0)
 
         second = server._methods["session.resume"](
             "r2",
@@ -3352,8 +3352,8 @@ def test_session_resume_deferred_history_acknowledges_and_reuses(monkeypatch):
 
         release_history.set()
         sid = first["result"]["session_id"]
-        assert server._sessions[sid]["resume_history_ready"].wait(timeout=1.0)
-        assert build_started.wait(timeout=1.0)
+        assert server._sessions[sid]["resume_history_ready"].wait(timeout=5.0)
+        assert build_started.wait(timeout=5.0)
         assert history_calls == [
             ("resume", "large-session"),
             ("prefix", "large-session"),
@@ -3421,7 +3421,7 @@ def test_session_resume_deferred_history_failure_can_retry(monkeypatch):
             {"session_id": "retry-session", "defer_history": True},
         )
         first_sid = first["result"]["session_id"]
-        assert first_released.wait(timeout=1.0)
+        assert first_released.wait(timeout=5.0)
         assert first_sid not in server._sessions
 
         second = server._methods["session.resume"](
@@ -3430,8 +3430,8 @@ def test_session_resume_deferred_history_failure_can_retry(monkeypatch):
         )
         second_sid = second["result"]["session_id"]
         assert second_sid != first_sid
-        assert server._sessions[second_sid]["resume_history_ready"].wait(timeout=1.0)
-        assert build_started.wait(timeout=1.0)
+        assert server._sessions[second_sid]["resume_history_ready"].wait(timeout=5.0)
+        assert build_started.wait(timeout=5.0)
     finally:
         for sid, session in list(server._sessions.items()):
             if session.get("session_key") == "retry-session":
@@ -3458,7 +3458,7 @@ def test_session_resume_deferred_history_close_cancels_build(monkeypatch):
 
         def get_resume_conversations(self, _target):
             history_started.set()
-            assert release_history.wait(timeout=2.0)
+            assert release_history.wait(timeout=5.0)
             loaded = [{"role": "user", "content": "late"}]
             return loaded, loaded
 
@@ -3482,7 +3482,7 @@ def test_session_resume_deferred_history_close_cancels_build(monkeypatch):
         )
         sid = response["result"]["session_id"]
         session = server._sessions[sid]
-        assert history_started.wait(timeout=1.0)
+        assert history_started.wait(timeout=5.0)
 
         assert server._close_session_by_id(sid, end_reason="tui_close") is True
         assert session["resume_history_ready"].is_set()
@@ -4420,7 +4420,7 @@ def test_session_close_releases_resume_lock_before_slow_teardown(monkeypatch):
     def _slow_teardown(_session, *, end_reason="tui_close"):
         assert end_reason == "tui_close"
         teardown_started.set()
-        assert release_teardown.wait(timeout=2.0)
+        assert release_teardown.wait(timeout=5.0)
 
     monkeypatch.setattr(server, "_teardown_session", _slow_teardown)
     server._sessions["slow-close"] = _session()
@@ -4440,9 +4440,9 @@ def test_session_close_releases_resume_lock_before_slow_teardown(monkeypatch):
     thread.start()
     acquired = False
     try:
-        assert teardown_started.wait(timeout=1.0)
+        assert teardown_started.wait(timeout=5.0)
         assert "slow-close" not in server._sessions
-        acquired = server._session_resume_lock.acquire(timeout=0.2)
+        acquired = server._session_resume_lock.acquire(timeout=2.0)
         assert acquired, "slow teardown kept the global resume lock held"
     finally:
         if acquired:
@@ -4464,7 +4464,7 @@ def test_session_close_settles_active_turn_before_teardown(monkeypatch):
 
     def _turn():
         turn_started.set()
-        assert release_turn.wait(timeout=2.0)
+        assert release_turn.wait(timeout=5.0)
 
     def _teardown(_session, *, end_reason="tui_close"):
         if end_reason == "tui_close":
@@ -4493,7 +4493,7 @@ def test_session_close_settles_active_turn_before_teardown(monkeypatch):
     run_thread.start()
     close_thread.start()
     try:
-        assert turn_started.wait(timeout=1.0)
+        assert turn_started.wait(timeout=5.0)
         assert not teardown_started.wait(timeout=0.1)
         release_turn.set()
         close_thread.join(timeout=2.0)
@@ -4554,7 +4554,7 @@ def test_ws_orphan_reap_releases_resume_lock_before_slow_teardown(monkeypatch):
     def _slow_teardown(_session, *, end_reason="tui_close"):
         assert end_reason == "ws_orphan_reap"
         teardown_started.set()
-        assert release_teardown.wait(timeout=2.0)
+        assert release_teardown.wait(timeout=5.0)
 
     monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0.01)
     monkeypatch.setattr(server.threading, "Timer", _Timer)
@@ -4569,9 +4569,9 @@ def test_ws_orphan_reap_releases_resume_lock_before_slow_teardown(monkeypatch):
     thread.start()
     acquired = False
     try:
-        assert teardown_started.wait(timeout=1.0)
+        assert teardown_started.wait(timeout=5.0)
         assert "slow-orphan" not in server._sessions
-        acquired = server._session_resume_lock.acquire(timeout=0.2)
+        acquired = server._session_resume_lock.acquire(timeout=2.0)
         assert acquired, "orphan teardown kept the global resume lock held"
     finally:
         if acquired:
@@ -6261,7 +6261,7 @@ def test_run_prompt_submit_rejects_worker_when_close_wins_publication(
     def _blocking_emit(event, *_args, **_kwargs):
         if event == "message.start":
             emit_entered.set()
-            assert release_emit.wait(timeout=2.0)
+            assert release_emit.wait(timeout=5.0)
 
     monkeypatch.setattr(server, "_emit", _blocking_emit)
     server._sessions[sid] = session
@@ -6273,7 +6273,7 @@ def test_run_prompt_submit_rejects_worker_when_close_wins_publication(
 
     try:
         dispatch_thread.start()
-        assert emit_entered.wait(timeout=1.0)
+        assert emit_entered.wait(timeout=5.0)
         popped.append(server._pop_session_by_id(sid))
         assert popped == [session]
         release_emit.set()
@@ -12777,7 +12777,7 @@ def test_session_create_close_race_does_not_orphan_worker(monkeypatch):
     assert resp.get("result"), f"got error: {resp.get('error')}"
     sid = resp["result"]["session_id"]
     own_key = resp["result"]["stored_session_id"]
-    assert build_entered.wait(timeout=1.0), "deferred build did not start"
+    assert build_entered.wait(timeout=5.0), "deferred build did not start"
 
     # Wait until the (deferred) build thread has actually entered
     # _make_agent — otherwise session.close pops _sessions[sid] before


### PR DESCRIPTION
## Summary

`tests/test_tui_gateway_server.py` no longer manufactures FLAKY retry-passes on loaded CI runners: every positive-path thread-timing wait now has ≥ 2s headroom per the AGENTS.md flake policy.

Root cause: the file raced spawned threads against `Event.wait(timeout=1.0)` and `Lock.acquire(timeout=0.2)` bounds. Under CI load (subprocess-per-test isolation at 8× parallelism) thread scheduling can exceed 1s, so a healthy test failed attempt 1 and passed on retry — seen 2026-08-18 in [PR run 32153457192](https://github.com/NousResearch/hermes-agent/actions/runs/32153457192) (`test_ws_orphan_reap_releases_resume_lock_before_slow_teardown`, `teardown_started.wait(timeout=1.0)` → `assert False`, retry green).

## Changes

- `tests/test_tui_gateway_server.py`: positive-path `wait(timeout=1.0)` → `5.0` (12 sites), helper-thread release `wait(timeout=2.0)` → `5.0` (6 sites), `acquire(timeout=0.2)` → `2.0` (2 sites). Whole class fixed, not just the site that flaked.
- Negative-timing asserts (`assert not ...wait(timeout=0.1)`) untouched — loosening those would change what they test.

No production code changes; only test scheduling headroom.

## Validation

| | Result |
|---|---|
| Full file (`585 tests`) | 585 passed in 19.2s |
| Flaked subset, 5 consecutive runs | 12 passed × 5 |
| Stress: 30 consecutive runs of the two orphan-reap tests | 30 × green |

## Infographic

![CI flake fix: test timing headroom](https://v3b.fal.media/files/b/0aa6da74/3fIDJbwakTfATrDSzeyrs_yPTXAf3R.png)
