### PR TITLE
feat(desktop): opt-in settings for pinned display in inbox style and project lanes

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -43,6 +43,8 @@ import {
   $sidebarGrouping,
   $sidebarMessagingOpenIds,
   $sidebarOrdering,
+  $sidebarPinnedCardRows,
+  $sidebarPinnedInProjects,
   $sidebarPinsOpen,
   $sidebarPrDataWanted,
   $sidebarPrFilter,
@@ -364,6 +366,8 @@ export function ChatSidebar({
   const filtersActive = useStore($sidebarFiltersActive)
   const showArchived = useStore($sidebarShowArchived)
   const cardRows = useStore($sidebarCardRows)
+  const pinnedCardRows = useStore($sidebarPinnedCardRows)
+  const pinnedInProjects = useStore($sidebarPinnedInProjects)
   const archivedSessions = useStore($archivedSessions)
   const dotStates = useStore($sessionDotStateById)
   // The active sort key as an id order. The flat list applies it within its
@@ -611,8 +615,12 @@ export function ChatSidebar({
   // anything the active filters exclude, so filtering works the same whether
   // you're looking at the flat list or the lanes.
   const isHiddenFromProjects = useCallback(
-    (session: SessionInfo) => isPinnedSession(session) || (filtersNarrow && !sessionMatchesFilters(session)),
-    [isPinnedSession, filtersNarrow, sessionMatchesFilters]
+    (session: SessionInfo) =>
+      // Pinned chats normally live in the Pinned section and nowhere else.
+      // The opt-in "show pinned in projects" setting keeps them in their
+      // project/worktree lanes too — without it, a pin is still exclusive.
+      (isPinnedSession(session) && !pinnedInProjects) || (filtersNarrow && !sessionMatchesFilters(session)),
+    [isPinnedSession, pinnedInProjects, filtersNarrow, sessionMatchesFilters]
   )
 
   // Full-text search across *all* sessions (not just the loaded page) so 699
@@ -1631,6 +1639,10 @@ export function ChatSidebar({
             {!trimmedQuery && (
               <SidebarSessionsSection
                 activeSessionId={activeSidebarSessionId}
+                // Pinned rows stay compact unless the opt-in "Pinned in Inbox
+                // style" setting is on — then they render the same three-line
+                // cards as the flat recents list.
+                card={pinnedCardRows}
                 contentClassName="flex flex-col gap-px rounded-lg pb-2 pt-1"
                 dndSensors={dndSensors}
                 emptyState={<SidebarPinnedEmptyState />}

--- a/apps/desktop/src/app/settings/sessions-settings-pinned-display.test.tsx
+++ b/apps/desktop/src/app/settings/sessions-settings-pinned-display.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  $sidebarPinnedCardRows,
+  $sidebarPinnedInProjects,
+  setSidebarPinnedCardRows,
+  setSidebarPinnedInProjects
+} from '@/store/layout'
+
+import { PinnedDisplaySettings } from './sessions-settings'
+
+beforeEach(() => {
+  setSidebarPinnedCardRows(false)
+  setSidebarPinnedInProjects(false)
+})
+
+afterEach(cleanup)
+
+describe('PinnedDisplaySettings', () => {
+  it('renders both opt-in toggles off by default', () => {
+    render(<PinnedDisplaySettings />)
+
+    expect(screen.getByRole('switch', { name: 'Display pinned threads in Inbox style' })).toBeTruthy()
+    expect(screen.getByRole('switch', { name: 'Show pinned threads in their project / worktree' })).toBeTruthy()
+    expect($sidebarPinnedCardRows.get()).toBe(false)
+    expect($sidebarPinnedInProjects.get()).toBe(false)
+  })
+
+  it('Inbox style toggle flips the pinned card-rows atom', () => {
+    render(<PinnedDisplaySettings />)
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Display pinned threads in Inbox style' }))
+    expect($sidebarPinnedCardRows.get()).toBe(true)
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Display pinned threads in Inbox style' }))
+    expect($sidebarPinnedCardRows.get()).toBe(false)
+  })
+
+  it('project / worktree toggle flips the pinned-in-projects atom', () => {
+    render(<PinnedDisplaySettings />)
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Show pinned threads in their project / worktree' }))
+    expect($sidebarPinnedInProjects.get()).toBe(true)
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Show pinned threads in their project / worktree' }))
+    expect($sidebarPinnedInProjects.get()).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/settings/sessions-settings.tsx
+++ b/apps/desktop/src/app/settings/sessions-settings.tsx
@@ -1,3 +1,4 @@
+import { useStore } from '@nanostores/react'
 import { useCallback, useEffect, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
@@ -14,8 +15,14 @@ import { useI18n } from '@/i18n'
 import { sessionTitle } from '@/lib/chat-runtime'
 import { pathLeaf } from '@/lib/display-path'
 import { triggerHaptic } from '@/lib/haptics'
-import { Archive, ArchiveOff, FolderOpen, Loader2, Trash2 } from '@/lib/icons'
+import { Archive, ArchiveOff, FolderOpen, Loader2, Pin, Trash2 } from '@/lib/icons'
 import { confirm } from '@/store/confirm'
+import {
+  $sidebarPinnedCardRows,
+  $sidebarPinnedInProjects,
+  setSidebarPinnedCardRows,
+  setSidebarPinnedInProjects
+} from '@/store/layout'
 import { notify, notifyError } from '@/store/notifications'
 import { untombstoneSessions } from '@/store/projects'
 import { applyConfiguredDefaultProjectDir, ensureDefaultWorkspaceCwd, setSessions } from '@/store/session'
@@ -121,6 +128,8 @@ export function SessionsSettings() {
 
       <AutoArchiveSetting />
 
+      <PinnedDisplaySettings />
+
       <SectionHeading
         icon={Archive}
         meta={sessions.length ? String(sessions.length) : undefined}
@@ -178,6 +187,33 @@ export function SessionsSettings() {
         </div>
       )}
     </SettingsContent>
+  )
+}
+
+// Pinned-thread display preferences. Both are opt-in overrides of the default
+// "pinned rows stay compact and live only in the Pinned section" behavior.
+export function PinnedDisplaySettings() {
+  const { t } = useI18n()
+  const s = t.settings.sessions
+  const pinnedCardRows = useStore($sidebarPinnedCardRows)
+  const pinnedInProjects = useStore($sidebarPinnedInProjects)
+
+  return (
+    <div className="mb-6">
+      <SectionHeading icon={Pin} title={s.pinnedDisplayTitle} />
+      <ToggleRow
+        checked={pinnedCardRows}
+        description={s.pinnedCardRowsDesc}
+        label={s.pinnedCardRowsTitle}
+        onChange={setSidebarPinnedCardRows}
+      />
+      <ToggleRow
+        checked={pinnedInProjects}
+        description={s.pinnedInProjectsDesc}
+        label={s.pinnedInProjectsTitle}
+        onChange={setSidebarPinnedInProjects}
+      />
+    </div>
   )
 }
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1171,7 +1171,13 @@ export const en: Translations = {
       unarchiveFailed: 'Unarchive failed',
       deleteFailed: 'Delete failed',
       updateDirFailed: 'Could not update default directory',
-      clearDirFailed: 'Could not clear default directory'
+      clearDirFailed: 'Could not clear default directory',
+      pinnedDisplayTitle: 'Pinned threads',
+      pinnedCardRowsTitle: 'Display pinned threads in Inbox style',
+      pinnedCardRowsDesc: 'Render pinned threads as three-line inbox cards instead of compact rows.',
+      pinnedInProjectsTitle: 'Show pinned threads in their project / worktree',
+      pinnedInProjectsDesc:
+        'Also show pinned threads inside the project or worktree they belong to, in addition to the Pinned section.'
     },
     toolsets: {
       loadingConfig: 'Loading configuration',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1016,6 +1016,11 @@ export interface Translations {
       deleteFailed: string
       updateDirFailed: string
       clearDirFailed: string
+      pinnedDisplayTitle: string
+      pinnedCardRowsTitle: string
+      pinnedCardRowsDesc: string
+      pinnedInProjectsTitle: string
+      pinnedInProjectsDesc: string
     }
     toolsets: {
       loadingConfig: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1361,7 +1361,12 @@ export const zh: Translations = {
       unarchiveFailed: '取消归档失败',
       deleteFailed: '删除失败',
       updateDirFailed: '无法更新默认目录',
-      clearDirFailed: '无法清除默认目录'
+      clearDirFailed: '无法清除默认目录',
+      pinnedDisplayTitle: '置顶会话',
+      pinnedCardRowsTitle: '以收件箱样式显示置顶会话',
+      pinnedCardRowsDesc: '将置顶会话渲染为三行收件箱卡片，而不是紧凑的单行。',
+      pinnedInProjectsTitle: '在项目 / 工作树中显示置顶会话',
+      pinnedInProjectsDesc: '除“置顶”区域外，也在其所属的项目或工作树中显示置顶会话。'
     },
     toolsets: {
       loadingConfig: '正在加载配置',

--- a/apps/desktop/src/store/layout-pinned-display.test.ts
+++ b/apps/desktop/src/store/layout-pinned-display.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  $sidebarPinnedCardRows,
+  $sidebarPinnedInProjects,
+  setSidebarPinnedCardRows,
+  setSidebarPinnedInProjects
+} from '@/store/layout'
+
+// The two pinned-display preferences default to the deliberate behavior:
+// pinned rows stay compact (not inbox cards) and a pinned chat lives in the
+// Pinned section only (not duplicated into project/worktree lanes). Each
+// setting is an opt-in override, persisted per the storage keys below.
+const CARD_ROWS_KEY = 'hermes.desktop.sidebarPinnedCardRows'
+const IN_PROJECTS_KEY = 'hermes.desktop.sidebarPinnedInProjects'
+
+beforeEach(() => {
+  window.localStorage.removeItem(CARD_ROWS_KEY)
+  window.localStorage.removeItem(IN_PROJECTS_KEY)
+  setSidebarPinnedCardRows(false)
+  setSidebarPinnedInProjects(false)
+})
+
+describe('pinned display atoms', () => {
+  it('default to off (preserve compact one-line Pinned rows)', () => {
+    expect($sidebarPinnedCardRows.get()).toBe(false)
+    expect($sidebarPinnedInProjects.get()).toBe(false)
+  })
+
+  it('setSidebarPinnedCardRows flips the atom and persists it', () => {
+    setSidebarPinnedCardRows(true)
+    expect($sidebarPinnedCardRows.get()).toBe(true)
+    expect(window.localStorage.getItem(CARD_ROWS_KEY)).toBe('true')
+
+    setSidebarPinnedCardRows(false)
+    expect($sidebarPinnedCardRows.get()).toBe(false)
+    expect(window.localStorage.getItem(CARD_ROWS_KEY)).toBe('false')
+  })
+
+  it('setSidebarPinnedInProjects flips the atom and persists it', () => {
+    setSidebarPinnedInProjects(true)
+    expect($sidebarPinnedInProjects.get()).toBe(true)
+    expect(window.localStorage.getItem(IN_PROJECTS_KEY)).toBe('true')
+
+    setSidebarPinnedInProjects(false)
+    expect($sidebarPinnedInProjects.get()).toBe(false)
+    expect(window.localStorage.getItem(IN_PROJECTS_KEY)).toBe('false')
+  })
+})

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -40,6 +40,8 @@ const SIDEBAR_ALL_PROFILES_AGENTS_GROUPED_STORAGE_KEY = 'hermes.desktop.sidebarA
 const SIDEBAR_SORT_KEY_STORAGE_KEY = 'hermes.desktop.sidebarSortKey'
 const SIDEBAR_ROW_META_STORAGE_KEY = 'hermes.desktop.sidebarRowMeta'
 const SIDEBAR_CARD_ROWS_STORAGE_KEY = 'hermes.desktop.sidebarCardRows'
+const SIDEBAR_PINNED_CARD_ROWS_STORAGE_KEY = 'hermes.desktop.sidebarPinnedCardRows'
+const SIDEBAR_PINNED_IN_PROJECTS_STORAGE_KEY = 'hermes.desktop.sidebarPinnedInProjects'
 const SIDEBAR_STATUS_FILTER_STORAGE_KEY = 'hermes.desktop.sidebarStatusFilter'
 const SIDEBAR_SHOW_ARCHIVED_STORAGE_KEY = 'hermes.desktop.sidebarShowArchived'
 const SIDEBAR_PROJECT_FILTER_STORAGE_KEY = 'hermes.desktop.sidebarProjectFilter'
@@ -319,6 +321,26 @@ export const $sidebarCardRows = persistentAtom(SIDEBAR_CARD_ROWS_STORAGE_KEY, fa
 
 export function setSidebarCardRows(on: boolean) {
   $sidebarCardRows.set(on)
+}
+
+/** Opt-in companion to $sidebarCardRows: render the Pinned section's rows as
+ *  the same three-line inbox cards, even though dense pinned rows normally
+ *  stay one-line. Off by default — preserves the deliberate compact Pinned
+ *  section; a user who wants Pinned to look like the inbox turns it on. */
+export const $sidebarPinnedCardRows = persistentAtom(SIDEBAR_PINNED_CARD_ROWS_STORAGE_KEY, false, Codecs.bool)
+
+export function setSidebarPinnedCardRows(on: boolean) {
+  $sidebarPinnedCardRows.set(on)
+}
+
+/** Opt-in override of the "a pinned chat belongs to the Pinned section and
+ *  nowhere else" rule: when on, pinned sessions ALSO stay visible in their
+ *  project/worktree lanes instead of being filtered out of them. The Pinned
+ *  section keeps rendering them either way. Off by default. */
+export const $sidebarPinnedInProjects = persistentAtom(SIDEBAR_PINNED_IN_PROJECTS_STORAGE_KEY, false, Codecs.bool)
+
+export function setSidebarPinnedInProjects(on: boolean) {
+  $sidebarPinnedInProjects.set(on)
 }
 
 /** Order-insensitive: the menu appends in click order, so ['tokens','updated']


### PR DESCRIPTION
## Summary

Adds two **Settings → Sessions** toggles that opt into showing pinned threads the way the flat list does, while preserving the deliberate compact, Pinned-section-only defaults:

1. **Display pinned threads in Inbox style** — renders the Pinned section's rows as the same three-line inbox cards used by the flat recents list (`card-rows` / "Inbox style"), instead of the compact one-line rows pinned currently keeps by design.
2. **Show pinned threads in their project / worktree** — stops filtering pinned chats out of project/worktree lanes, so a pinned chat appears in **both** the Pinned section and the lane it belongs to.

Both default **off**, so existing behavior is unchanged until a user opts in.

## Motivation (UI/QoL)

- The sidebar's "Inbox style" (card-rows) is a render variant the flat recents list opts into; dense tree surfaces (pinned, projects, messaging) intentionally keep the one-line row. Users who want pinned to look like the inbox currently have no way to get that.
- Pinned chats are deliberately exclusive ("a pinned session belongs to the Pinned section and nowhere else", `index.tsx`), so once pinned, a thread disappears from the project/worktree lanes it came from. This opt-in restores the duplicate view for people who want pins to remain findable in-context.

## Changes

- `apps/desktop/src/store/layout.ts` — two new persisted atoms (`hermes.desktop.sidebarPinnedCardRows`, `hermes.desktop.sidebarPinnedInProjects`) + setters, following the existing `persistentAtom` pattern.
- `apps/desktop/src/app/chat/sidebar/index.tsx` — Pinned section passes `card={pinnedCardRows}`; `isHiddenFromProjects` now skips the pin exclusion when the "show pinned in projects" setting is on.
- `apps/desktop/src/app/settings/sessions-settings.tsx` — new `PinnedDisplaySettings` section with both `ToggleRow`s.
- `apps/desktop/src/i18n/{en,zh,types}.ts` — copy + strict `Translations` type keys.
- Tests: `store/layout-pinned-display.test.ts` (atom defaults/persistence), `app/settings/sessions-settings-pinned-display.test.tsx` (toggle rendering + atom wiring).

## Validation

- `npx vitest run --project ui src/app/chat/sidebar/ src/store/layout-pinned-display.test.ts src/app/settings/sessions-settings-pinned-display.test.tsx src/store/gateway-switch.test.ts` — 177 passed.
- `npx tsc -p . --noEmit` — clean.
- `npx eslint` on all changed files — clean.

## Notes

- Flat recents and messaging sections still filter pins out (unchanged); this PR only affects the Pinned section rendering and project/worktree lanes, per the requested scope.