### PR TITLE
feat(honcho): add provenance and observable direct delivery

### DIFF
--- a/plugins/memory/honcho/README.md
+++ b/plugins/memory/honcho/README.md
@@ -217,6 +217,12 @@ Pick **[e]** at the prompt to set the three keys directly instead of going throu
 | `writeFrequency` | string/int | `"async"` | `"async"` (background), `"turn"` (sync per turn), `"session"` (batch on end), or integer N (every N turns) |
 | `saveMessages` | bool | `true` | Persist messages to Honcho API. When `false`, all automatic writes are skipped — raw turns (`sync_turn`), conclusion mirroring (`on_memory_write`), and session-end/shutdown flushes — while read and tools paths stay fully functional. |
 
+Message writes use the Honcho SDK's bounded transport retries. If those retries
+are exhausted, Hermes remains available, records a content-free delivery
+failure, and keeps the messages unsynchronized so a later flush in the same
+process can retry them. Restart-safe durable replay is not provided; the Hermes
+session transcript remains the source of truth.
+
 ### Session Resolution
 
 | Key | Type | Default | Description |

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -512,6 +512,8 @@ class HonchoMemoryProvider(MemoryProvider):
             context_tokens=cfg.context_tokens,
             runtime_user_peer_name=kwargs.get("user_id") or None,
             runtime_user_peer_name_alt=kwargs.get("user_id_alt") or None,
+            provenance_context=kwargs,
+            source_session_id=session_id,
         )
 
         self._session_key = self._resolve_session_key(cfg, session_id, **kwargs)
@@ -1444,11 +1446,31 @@ class HonchoMemoryProvider(MemoryProvider):
             try:
                 session = self._manager.get_or_create(self._session_key)
                 if clean_user_content:
-                    for chunk in self._chunk_message(clean_user_content, msg_limit):
-                        session.add_message("user", chunk)
+                    chunks = self._chunk_message(clean_user_content, msg_limit)
+                    source_record_id = self._manager.new_source_record_id()
+                    for index, chunk in enumerate(chunks):
+                        self._manager.add_source_message(
+                            session,
+                            "user",
+                            chunk,
+                            source_record_id=source_record_id,
+                            source_session_id=session_id or None,
+                            chunk_index=index,
+                            chunk_count=len(chunks),
+                        )
                 if clean_assistant_content:
-                    for chunk in self._chunk_message(clean_assistant_content, msg_limit):
-                        session.add_message("assistant", chunk)
+                    chunks = self._chunk_message(clean_assistant_content, msg_limit)
+                    source_record_id = self._manager.new_source_record_id()
+                    for index, chunk in enumerate(chunks):
+                        self._manager.add_source_message(
+                            session,
+                            "assistant",
+                            chunk,
+                            source_record_id=source_record_id,
+                            source_session_id=session_id or None,
+                            chunk_index=index,
+                            chunk_count=len(chunks),
+                        )
                 # Route through save() so writeFrequency is honored —
                 # _flush_session() directly bypassed "session"/N batching
                 # and flushed every turn regardless of config.

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -25,6 +25,7 @@ from typing import Any, Callable, Dict, List, Optional
 from agent.memory_manager import sanitize_context
 from agent.memory_provider import TRIVIAL_PROMPT_RE, MemoryProvider, is_trivial_prompt
 from plugins.memory.honcho.client import spawn_context_thread
+from plugins.memory.honcho.session import classify_delivery_error
 from tools.registry import tool_error
 
 logger = logging.getLogger(__name__)
@@ -1475,8 +1476,13 @@ class HonchoMemoryProvider(MemoryProvider):
                 # _flush_session() directly bypassed "session"/N batching
                 # and flushed every turn regardless of config.
                 self._manager.save(session)
-            except Exception as e:
-                logger.debug("Honcho sync_turn failed: %s", e)
+            except Exception as exc:
+                category, status = classify_delivery_error(exc)
+                logger.debug(
+                    "Honcho sync_turn failed category=%s status=%s",
+                    category,
+                    status if status is not None else "none",
+                )
 
         if self._sync_thread and self._sync_thread.is_alive():
             self._sync_thread.join(timeout=5.0)
@@ -1536,8 +1542,13 @@ class HonchoMemoryProvider(MemoryProvider):
             self._sync_thread.join(timeout=10.0)
         try:
             self._manager.flush_all()
-        except Exception as e:
-            logger.debug("Honcho session-end flush failed: %s", e)
+        except Exception as exc:
+            category, status = classify_delivery_error(exc)
+            logger.debug(
+                "Honcho session-end flush failed category=%s status=%s",
+                category,
+                status if status is not None else "none",
+            )
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         """Return tool schemas, respecting recall_mode.

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -211,6 +211,14 @@ def _parse_string_map(host_obj: dict, root_obj: dict, key: str) -> dict[str, str
     return result
 
 
+def _parse_json_object(host_obj: dict, root_obj: dict, key: str) -> dict[str, Any]:
+    """Parse a JSON object with host-level whole-object override."""
+    source: Any = host_obj[key] if key in host_obj else root_obj.get(key)
+    if not isinstance(source, dict):
+        return {}
+    return {str(item_key): item_value for item_key, item_value in source.items()}
+
+
 def _parse_optional_string(
     host_obj: dict, root_obj: dict, key: str, default: str = ""
 ) -> str:
@@ -405,6 +413,9 @@ class HonchoClientConfig:
     user_peer_aliases: dict[str, str] = field(default_factory=dict)
     # Optional prefix for unknown gateway runtime user IDs, e.g. "telegram_".
     runtime_peer_prefix: str = ""
+    # Static/default provider-native message metadata. Runtime provenance
+    # fields are added by HonchoSessionManager and always win on conflicts.
+    message_metadata: dict[str, Any] = field(default_factory=dict)
     # Toggles
     enabled: bool = False
     save_messages: bool = True
@@ -700,6 +711,7 @@ class HonchoClientConfig:
                 raw,
                 "runtimePeerPrefix",
             ),
+            message_metadata=_parse_json_object(host_block, raw, "messageMetadata"),
             enabled=enabled,
             save_messages=save_messages,
             write_frequency=write_frequency,

--- a/plugins/memory/honcho/config_schema.py
+++ b/plugins/memory/honcho/config_schema.py
@@ -195,6 +195,17 @@ CONFIG_SCHEMA = ProviderConfigSchema(
             placeholder="async | turn | session | N",
             group="Message writing",
         ),
+        ProviderField(
+            key="messageMetadata",
+            label="Message metadata defaults",
+            kind=KIND_JSON,
+            description=(
+                "Static provider-native metadata defaults for every saved message. "
+                "Runtime identity, session, timestamp, and event fields always override conflicts."
+            ),
+            placeholder='{"schema": "example.provenance/v1", "authority": "user", "extensions": {}}',
+            group="Message writing",
+        ),
         # — Dialectic —
         ProviderField(
             key="dialecticReasoningLevel",

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -12,6 +12,7 @@ import threading
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, TYPE_CHECKING
 
@@ -27,6 +28,79 @@ logger = logging.getLogger(__name__)
 _ASYNC_SHUTDOWN = object()
 _PEER_ID_HASH_LEN = 8
 _PEER_ID_HASH_ESCALATION_LENGTHS = (_PEER_ID_HASH_LEN, 12, 16, 24, 32, 64)
+
+
+class DeliveryState(str, Enum):
+    """Terminal state of one direct Honcho delivery boundary call."""
+
+    NOOP = "noop"
+    DELIVERED = "delivered"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class DeliveryOutcome:
+    """Content-free result of a bounded, immediate Honcho delivery attempt."""
+
+    state: DeliveryState
+    attempted_count: int = 0
+    delivered_count: int = 0
+    pending_count: int = 0
+    error_category: str | None = None
+    http_status: int | None = None
+
+    @classmethod
+    def aggregate(cls, outcomes: list[DeliveryOutcome]) -> DeliveryOutcome:
+        """Combine boundary results without losing any terminal failure."""
+        if not outcomes:
+            return cls(state=DeliveryState.NOOP)
+        failures = [
+            outcome for outcome in outcomes if outcome.state is DeliveryState.FAILED
+        ]
+        state = (
+            DeliveryState.FAILED
+            if failures
+            else DeliveryState.DELIVERED
+            if any(outcome.state is DeliveryState.DELIVERED for outcome in outcomes)
+            else DeliveryState.NOOP
+        )
+        latest_failure = failures[-1] if failures else None
+        return cls(
+            state=state,
+            attempted_count=sum(outcome.attempted_count for outcome in outcomes),
+            delivered_count=sum(outcome.delivered_count for outcome in outcomes),
+            pending_count=sum(outcome.pending_count for outcome in outcomes),
+            error_category=latest_failure.error_category if latest_failure else None,
+            http_status=latest_failure.http_status if latest_failure else None,
+        )
+
+
+def classify_delivery_error(exc: BaseException) -> tuple[str, int | None]:
+    """Classify a delivery error without retaining or rendering its text."""
+    raw_status = getattr(exc, "status_code", None)
+    if raw_status is None:
+        raw_status = getattr(exc, "status", None)
+    status = (
+        raw_status
+        if isinstance(raw_status, int) and not isinstance(raw_status, bool)
+        else None
+    )
+    if status is not None and not 100 <= status <= 599:
+        status = None
+    if _is_auth_error(exc):
+        return "authentication", status
+    code = getattr(exc, "code", None)
+    if code == "timeout":
+        return "timeout", status
+    if code == "connection_error":
+        return "connection", status
+    if isinstance(exc, TimeoutError):
+        return "timeout", status
+    if isinstance(exc, ConnectionError):
+        return "connection", status
+    if status is not None:
+        return "http_error", status
+    return "sdk_error", None
 
 
 def _utc_now() -> datetime:
@@ -274,6 +348,7 @@ class HonchoSessionManager:
         self._message_metadata = copy.deepcopy(configured_metadata) if isinstance(configured_metadata, dict) else {}
         self._cache: dict[str, HonchoSession] = {}
         self._cache_lock = threading.RLock()
+        self._delivery_lock = threading.RLock()
         self._peers_cache: dict[str, Any] = {}
         self._sessions_cache: dict[str, Any] = {}
         # Bumped (under _cache_lock) whenever _force_reauth rebuilds the client.
@@ -289,6 +364,7 @@ class HonchoSessionManager:
         write_frequency = (config.write_frequency if config else "async")
         self._write_frequency = write_frequency
         self._turn_counter: int = 0
+        self._last_delivery_outcome = DeliveryOutcome(state=DeliveryState.NOOP)
 
         # Prefetch cache: session_key → last context result (consumed once per turn).
         # Dialectic results are cached on the plugin side (HonchoMemoryProvider
@@ -330,6 +406,15 @@ class HonchoSessionManager:
         self._async_thread_lock = threading.Lock()
         if write_frequency == "async":
             self._async_queue = queue.Queue()
+
+    @property
+    def last_delivery_outcome(self) -> DeliveryOutcome:
+        """Latest content-free direct delivery result, including async failures."""
+        return self._last_delivery_outcome
+
+    def _retain_delivery_outcome(self, outcome: DeliveryOutcome) -> DeliveryOutcome:
+        self._last_delivery_outcome = outcome
+        return outcome
 
     @staticmethod
     def new_source_record_id() -> str:
@@ -455,8 +540,7 @@ class HonchoSessionManager:
         if self._auth_failure is None:
             logger.error(
                 "Honcho authentication failed and token refresh did not recover; "
-                "memory sync and recall are paused until the user re-authenticates: %s",
-                detail,
+                "memory sync and recall are paused until the user re-authenticates"
             )
         self._auth_failure = detail
 
@@ -531,7 +615,7 @@ class HonchoSessionManager:
                     self._sessions_cache.clear()
             return True
         except Exception:
-            logger.warning("Honcho post-401 token refresh failed", exc_info=True)
+            logger.warning("Honcho post-401 token refresh failed")
             return False
 
     def _authed_call(self, op_name: str, operation: Callable[[], Any]) -> Any:
@@ -553,7 +637,8 @@ class HonchoSessionManager:
                 raise
             logger.warning(
                 "Honcho %s hit an auth error; forcing token refresh and "
-                "retrying once: %s", op_name, _redact_tokens(str(e)),
+                "retrying once",
+                op_name,
             )
             if not self._force_reauth():
                 self._record_auth_failure(e)
@@ -888,14 +973,23 @@ class HonchoSessionManager:
             self._cache[key] = session
         return session
 
-    def _flush_session(self, session: HonchoSession) -> bool:
-        """Internal: write unsynced messages to Honcho synchronously."""
+    def _flush_session(self, session: HonchoSession) -> DeliveryOutcome:
+        """The single structured boundary for direct Honcho message delivery."""
+        with self._delivery_lock:
+            return self._flush_session_locked(session)
+
+    def _flush_session_locked(self, session: HonchoSession) -> DeliveryOutcome:
+        """Deliver one session while holding the manager-wide delivery lock."""
         if not session.messages:
-            return True
+            return self._retain_delivery_outcome(
+                DeliveryOutcome(state=DeliveryState.NOOP)
+            )
 
         new_messages = [m for m in session.messages if not m.get("_synced")]
         if not new_messages:
-            return True
+            return self._retain_delivery_outcome(
+                DeliveryOutcome(state=DeliveryState.NOOP)
+            )
 
         # Backward-compatible guard for callers that populated the local cache
         # directly. Assign once before the first attempt so retries keep IDs.
@@ -939,17 +1033,46 @@ class HonchoSessionManager:
             synced = self._authed_call("message sync", _sync_messages)
             for msg in new_messages:
                 msg["_synced"] = True
-            logger.debug("Synced %d messages to Honcho for %s", synced, session.key)
+            pending = sum(
+                1 for message in session.messages if not message.get("_synced")
+            )
+            logger.debug("Honcho direct delivery succeeded count=%d", synced)
             with self._cache_lock:
                 self._cache[session.key] = session
-            return True
-        except Exception as e:
+            return self._retain_delivery_outcome(
+                DeliveryOutcome(
+                    state=DeliveryState.DELIVERED,
+                    attempted_count=len(new_messages),
+                    delivered_count=synced,
+                    pending_count=pending,
+                )
+            )
+        except Exception as exc:
             for msg in new_messages:
                 msg["_synced"] = False
-            logger.error("Failed to sync messages to Honcho: %s", e)
+            pending = sum(
+                1 for message in session.messages if not message.get("_synced")
+            )
+            category, status = classify_delivery_error(exc)
+            logger.error(
+                "Honcho direct delivery terminal failure category=%s status=%s attempted=%d pending=%d",
+                category,
+                status if status is not None else "none",
+                len(new_messages),
+                pending,
+            )
             with self._cache_lock:
                 self._cache[session.key] = session
-            return False
+            return self._retain_delivery_outcome(
+                DeliveryOutcome(
+                    state=DeliveryState.FAILED,
+                    attempted_count=len(new_messages),
+                    delivered_count=0,
+                    pending_count=pending,
+                    error_category=category,
+                    http_status=status,
+                )
+            )
 
     def _async_writer_loop(self) -> None:
         """Background daemon thread: drains the async write queue."""
@@ -959,38 +1082,43 @@ class HonchoSessionManager:
                 if item is _ASYNC_SHUTDOWN:
                     break
 
-                first_error: Exception | None = None
                 try:
-                    success = self._flush_session(item)
-                except Exception as e:
-                    success = False
-                    first_error = e
-
-                if success:
-                    continue
-
-                if first_error is not None:
-                    logger.warning("Honcho async write failed, retrying once: %s", first_error)
-                else:
-                    logger.warning("Honcho async write failed, retrying once")
-
-                import time as _time
-                _time.sleep(2)
-
-                try:
-                    retry_success = self._flush_session(item)
-                except Exception as e2:
-                    logger.error("Honcho async write retry failed, dropping batch: %s", e2)
-                    continue
-
-                if not retry_success:
-                    logger.error("Honcho async write retry failed, dropping batch")
+                    outcome = self._retain_delivery_outcome(self._flush_session(item))
+                except Exception as exc:
+                    category, status = classify_delivery_error(exc)
+                    pending = sum(
+                        1 for message in item.messages if not message.get("_synced")
+                    )
+                    outcome = self._retain_delivery_outcome(
+                        DeliveryOutcome(
+                            state=DeliveryState.FAILED,
+                            attempted_count=pending,
+                            delivered_count=0,
+                            pending_count=pending,
+                            error_category=category,
+                            http_status=status,
+                        )
+                    )
+                if outcome.state is DeliveryState.FAILED:
+                    logger.error(
+                        "Honcho async direct delivery terminal failure category=%s status=%s "
+                        "attempted=%d pending=%d; messages remain retryable",
+                        outcome.error_category,
+                        outcome.http_status if outcome.http_status is not None else "none",
+                        outcome.attempted_count,
+                        outcome.pending_count,
+                    )
             except queue.Empty:
                 continue
-            except Exception as e:
-                logger.error("Honcho async writer error: %s", e)
+            except Exception as exc:
+                category, status = classify_delivery_error(exc)
+                logger.error(
+                    "Honcho async writer error category=%s status=%s",
+                    category,
+                    status if status is not None else "none",
+                )
 
-    def save(self, session: HonchoSession) -> None:
+    def save(self, session: HonchoSession) -> DeliveryOutcome | None:
         """Save messages to Honcho, respecting write_frequency.
 
         write_frequency modes:
@@ -1007,15 +1135,16 @@ class HonchoSessionManager:
                 self._ensure_async_writer()
                 self._async_queue.put(session)
         elif wf == "turn":
-            self._flush_session(session)
+            return self._flush_session(session)
         elif wf == "session":
             # Accumulate; caller must call flush_all() at session end
             pass
         elif isinstance(wf, int) and wf > 0:
             if self._turn_counter % wf == 0:
-                self._flush_session(session)
+                return self._flush_session(session)
+        return None
 
-    def flush_all(self) -> None:
+    def flush_all(self) -> DeliveryOutcome:
         """Flush all pending unsynced messages for all cached sessions.
 
         Called at session end for "session" write_frequency, or to force
@@ -1023,21 +1152,49 @@ class HonchoSessionManager:
         """
         with self._cache_lock:
             sessions = list(self._cache.values())
-        for session in sessions:
-            try:
-                self._flush_session(session)
-            except Exception as e:
-                logger.error("Honcho flush_all error for %s: %s", session.key, e)
 
-        # Drain async queue synchronously if it exists
+        # Drain queued references before delivery, then de-duplicate sessions.
         if self._async_queue is not None:
             while not self._async_queue.empty():
                 try:
                     item = self._async_queue.get_nowait()
                     if item is not _ASYNC_SHUTDOWN:
-                        self._flush_session(item)
+                        sessions.append(item)
                 except queue.Empty:
                     break
+
+        outcomes = []
+        seen: set[int] = set()
+        for session in sessions:
+            if id(session) in seen:
+                continue
+            seen.add(id(session))
+            try:
+                outcomes.append(self._flush_session(session))
+            except Exception as exc:
+                category, status = classify_delivery_error(exc)
+                pending = sum(
+                    1 for message in session.messages if not message.get("_synced")
+                )
+                outcomes.append(
+                    self._retain_delivery_outcome(
+                        DeliveryOutcome(
+                            state=DeliveryState.FAILED,
+                            attempted_count=pending,
+                            delivered_count=0,
+                            pending_count=pending,
+                            error_category=category,
+                            http_status=status,
+                        )
+                    )
+                )
+                logger.error(
+                    "Honcho flush_all terminal failure category=%s status=%s pending=%d",
+                    category,
+                    status if status is not None else "none",
+                    pending,
+                )
+        return self._retain_delivery_outcome(DeliveryOutcome.aggregate(outcomes))
 
     def _ensure_async_writer(self) -> None:
         """Start the async writer on first enqueue (idempotent, thread-safe)."""

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import hashlib
+import copy
 import queue
 import re
 import logging
+import platform as _platform
 import threading
+import uuid
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, TYPE_CHECKING
 
@@ -24,6 +27,120 @@ logger = logging.getLogger(__name__)
 _ASYNC_SHUTDOWN = object()
 _PEER_ID_HASH_LEN = 8
 _PEER_ID_HASH_ESCALATION_LENGTHS = (_PEER_ID_HASH_LEN, 12, 16, 24, 32, 64)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _rfc3339(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _resolve_machine_identity(context: dict[str, Any]) -> str:
+    """Resolve a portable machine identity without confusing workspace with host."""
+    for key in ("machine_id", "runtime_machine_id"):
+        value = context.get(key)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    try:
+        value = _platform.node().strip()
+    except Exception:
+        value = ""
+    return value or "unknown-machine"
+
+
+_SECRET_SHAPED_RE = re.compile(
+    r"(?i)(?:-----BEGIN [A-Z ]*PRIVATE KEY-----|\beyJ[A-Za-z0-9_-]{10,}\.|"
+    r"\b(?:api[_-]?key|token|password|secret)\s*[:=]|\b(?:sk-|ghp_|github_pat_)[A-Za-z0-9_-]{12,})"
+)
+_SAFE_CREDENTIAL_REFERENCE_SUFFIXES = (
+    "_path",
+    "_ref",
+    "_reference",
+    "_name",
+    "_id",
+    "_status",
+    "_count",
+    "_policy",
+    "_enabled",
+)
+
+
+def _normalize_metadata_key(key: str) -> str:
+    """Normalize snake/kebab/camel/Pascal/acronym keys for sensitivity checks."""
+    value = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", key)
+    value = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", value)
+    return re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
+
+
+def _is_sensitive_metadata_key(key: str) -> bool:
+    normalized = _normalize_metadata_key(key)
+    if normalized.endswith(_SAFE_CREDENTIAL_REFERENCE_SUFFIXES):
+        return False
+    parts = normalized.split("_")
+    compact = "".join(parts)
+    if any(part in {"password", "passwd", "secret", "token", "authorization"} for part in parts):
+        return True
+    if any(
+        marker in compact
+        for marker in (
+            "apikey",
+            "privatekey",
+            "clientsecret",
+            "accesstoken",
+            "refreshtoken",
+            "authtoken",
+            "password",
+            "authorization",
+        )
+    ):
+        return True
+    return any(
+        parts[index : index + 2] in (["api", "key"], ["private", "key"])
+        for index in range(max(0, len(parts) - 1))
+    )
+
+
+def _redact_metadata_value(value: Any) -> Any:
+    """Force-redact every string in metadata, failing closed on suspicious data."""
+    if isinstance(value, dict):
+        result: dict[str, Any] = {}
+        for key, item in value.items():
+            raw_key = str(key)
+            safe_key = str(_redact_metadata_value(raw_key))
+            result[safe_key] = (
+                "«redacted-metadata»"
+                if _is_sensitive_metadata_key(raw_key)
+                else _redact_metadata_value(item)
+            )
+        return result
+    if isinstance(value, list):
+        return [_redact_metadata_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [_redact_metadata_value(item) for item in value]
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if not isinstance(value, str):
+        # Config-file values are JSON-native, but hand-constructed configs and
+        # runtime extensions can supply arbitrary objects. Do not let their
+        # repr leak local paths, credentials, or fail SDK serialization.
+        return "«redacted-metadata»"
+    try:
+        from agent.redact import redact_sensitive_text
+
+        redacted = redact_sensitive_text(
+            value,
+            force=True,
+            redact_url_credentials=True,
+        )
+    except Exception:
+        return "«redacted-metadata»"
+    if redacted == value and _SECRET_SHAPED_RE.search(value):
+        return "«redacted-metadata»"
+    return redacted
 
 
 class HonchoAuthError(RuntimeError):
@@ -85,20 +202,22 @@ class HonchoSession:
     assistant_peer_id: str  # Honcho peer ID for the assistant
     honcho_session_id: str  # Honcho session ID
     messages: list[dict[str, Any]] = field(default_factory=list)
-    created_at: datetime = field(default_factory=datetime.now)
-    updated_at: datetime = field(default_factory=datetime.now)
+    created_at: datetime = field(default_factory=_utc_now)
+    updated_at: datetime = field(default_factory=_utc_now)
     metadata: dict[str, Any] = field(default_factory=dict)
 
     def add_message(self, role: str, content: str, **kwargs: Any) -> None:
         """Add a message to the local cache."""
+        created_at = kwargs.pop("created_at", None) or _utc_now()
         msg = {
             "role": role,
             "content": content,
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": _rfc3339(created_at),
+            "created_at": created_at,
             **kwargs,
         }
         self.messages.append(msg)
-        self.updated_at = datetime.now()
+        self.updated_at = _utc_now()
 
     def get_history(self, max_messages: int = 50) -> list[dict[str, Any]]:
         """Get message history for LLM context."""
@@ -112,7 +231,7 @@ class HonchoSession:
     def clear(self) -> None:
         """Clear all messages in the session."""
         self.messages = []
-        self.updated_at = datetime.now()
+        self.updated_at = _utc_now()
 
 
 class HonchoSessionManager:
@@ -130,6 +249,8 @@ class HonchoSessionManager:
         config: Any | None = None,
         runtime_user_peer_name: str | None = None,
         runtime_user_peer_name_alt: str | None = None,
+        provenance_context: dict[str, Any] | None = None,
+        source_session_id: str | None = None,
     ):
         """
         Initialize the session manager.
@@ -147,6 +268,10 @@ class HonchoSessionManager:
         self._config = config
         self._runtime_user_peer_name = runtime_user_peer_name
         self._runtime_user_peer_name_alt = runtime_user_peer_name_alt
+        self._provenance_context = dict(provenance_context or {})
+        self._source_session_id = str(source_session_id or "").strip()
+        configured_metadata = getattr(config, "message_metadata", {}) if config else {}
+        self._message_metadata = copy.deepcopy(configured_metadata) if isinstance(configured_metadata, dict) else {}
         self._cache: dict[str, HonchoSession] = {}
         self._cache_lock = threading.RLock()
         self._peers_cache: dict[str, Any] = {}
@@ -205,6 +330,110 @@ class HonchoSessionManager:
         self._async_thread_lock = threading.Lock()
         if write_frequency == "async":
             self._async_queue = queue.Queue()
+
+    @staticmethod
+    def new_source_record_id() -> str:
+        """Return a stable identity shared by all chunks of one role-side turn."""
+        return str(uuid.uuid4())
+
+    def _build_message_metadata(
+        self,
+        session: HonchoSession,
+        role: str,
+        *,
+        created_at: datetime,
+        source_record_id: str,
+        source_session_id: str | None,
+        chunk_index: int,
+        chunk_count: int,
+    ) -> dict[str, Any]:
+        context = self._provenance_context
+        extensions = copy.deepcopy(self._message_metadata.get("extensions", {}))
+        if not isinstance(extensions, dict):
+            extensions = {}
+        static_hermes = extensions.get("hermes")
+        hermes_extension = dict(static_hermes) if isinstance(static_hermes, dict) else {}
+        hermes_extension.update({
+            "platform": str(context.get("platform") or "cli"),
+            "agent_context": str(context.get("agent_context") or "primary"),
+            "agent_identity": str(context.get("agent_identity") or "default"),
+            "agent_workspace": str(context.get("agent_workspace") or "hermes"),
+            "user_id": context.get("user_id"),
+            "user_id_alt": context.get("user_id_alt"),
+            "user_name": context.get("user_name"),
+            "chat_id": context.get("chat_id"),
+            "chat_name": context.get("chat_name"),
+            "chat_type": context.get("chat_type"),
+            "thread_id": context.get("thread_id"),
+            "gateway_session_key": context.get("gateway_session_key"),
+            "session_title": context.get("session_title"),
+            "honcho_session_id": session.honcho_session_id,
+            "chunk_index": chunk_index,
+            "chunk_count": chunk_count,
+        })
+        extensions["hermes"] = hermes_extension
+
+        profile = str(context.get("agent_identity") or "default")
+        agent_context = str(context.get("agent_context") or "primary")
+        metadata = copy.deepcopy(self._message_metadata)
+        metadata.update({
+            "schema": metadata.get("schema") or "hermes.provenance/v1",
+            "event_id": str(uuid.uuid4()),
+            "record_kind": "source_event",
+            "source_kind": "user_statement" if role == "user" else "assistant_statement",
+            "human_peer": session.user_peer_id,
+            "ai_peer": session.assistant_peer_id,
+            "interface": str(context.get("platform") or "cli"),
+            "machine": _resolve_machine_identity(context),
+            "runtime": f"hermes:{profile}:{agent_context}",
+            "session_id": str(source_session_id or self._source_session_id or session.key),
+            "channel_id": context.get("chat_id"),
+            "source_record_id": source_record_id,
+            "observed_at": _rfc3339(created_at),
+            "effective_at": metadata.get("effective_at"),
+            # Authority is an identity-bearing runtime field, not a static
+            # default: a shared metadata template must never attribute an
+            # assistant statement to the human (or vice versa).
+            "authority": session.user_peer_id if role == "user" else session.assistant_peer_id,
+            "evidence_refs": metadata.get("evidence_refs") if isinstance(metadata.get("evidence_refs"), list) else [],
+            "confidence": metadata.get("confidence"),
+            "verification_state": metadata.get("verification_state") or "unverified",
+            "review_state": metadata.get("review_state") or "captured",
+            "sensitivity": metadata.get("sensitivity") or "private",
+            "retention_class": metadata.get("retention_class") or "semantic",
+            "derived_from": metadata.get("derived_from") if isinstance(metadata.get("derived_from"), list) else [],
+            "supersedes": metadata.get("supersedes") if isinstance(metadata.get("supersedes"), list) else [],
+            "superseded_by": metadata.get("superseded_by") if isinstance(metadata.get("superseded_by"), list) else [],
+            "deletion_request_id": metadata.get("deletion_request_id"),
+            "deleted_at": metadata.get("deleted_at"),
+            "target_artifacts": metadata.get("target_artifacts") if isinstance(metadata.get("target_artifacts"), list) else [],
+            "extensions": extensions,
+        })
+        return _redact_metadata_value(metadata)
+
+    def add_source_message(
+        self,
+        session: HonchoSession,
+        role: str,
+        content: str,
+        *,
+        source_record_id: str | None = None,
+        source_session_id: str | None = None,
+        chunk_index: int = 0,
+        chunk_count: int = 1,
+    ) -> None:
+        """Capture one source-message chunk with stable idempotency metadata."""
+        created_at = _utc_now()
+        metadata = self._build_message_metadata(
+            session,
+            role,
+            created_at=created_at,
+            source_record_id=source_record_id or self.new_source_record_id(),
+            source_session_id=source_session_id,
+            chunk_index=chunk_index,
+            chunk_count=chunk_count,
+        )
+        session.add_message(role, content, metadata=metadata, created_at=created_at)
 
     @property
     def honcho(self) -> Honcho:
@@ -641,6 +870,8 @@ class HonchoSessionManager:
                 "role": role,
                 "content": msg.content,
                 "timestamp": msg.created_at.isoformat() if msg.created_at else "",
+                "created_at": msg.created_at,
+                "metadata": copy.deepcopy(getattr(msg, "metadata", None) or {}),
                 "_synced": True,
             })
 
@@ -666,6 +897,24 @@ class HonchoSessionManager:
         if not new_messages:
             return True
 
+        # Backward-compatible guard for callers that populated the local cache
+        # directly. Assign once before the first attempt so retries keep IDs.
+        for message in new_messages:
+            if not isinstance(message.get("metadata"), dict) or not message["metadata"].get("event_id"):
+                created_at = message.get("created_at")
+                if not isinstance(created_at, datetime):
+                    created_at = _utc_now()
+                    message["created_at"] = created_at
+                message["metadata"] = self._build_message_metadata(
+                    session,
+                    message["role"],
+                    created_at=created_at,
+                    source_record_id=self.new_source_record_id(),
+                    source_session_id=None,
+                    chunk_index=0,
+                    chunk_count=1,
+                )
+
         # Resolved inside the operation so a retry after a client rebuild gets fresh objects.
         def _sync_messages() -> int:
             user_peer = self._get_or_create_peer(session.user_peer_id)
@@ -676,7 +925,11 @@ class HonchoSessionManager:
                     session.honcho_session_id, user_peer, assistant_peer
                 )
             honcho_messages = [
-                (user_peer if m["role"] == "user" else assistant_peer).message(m["content"])
+                (user_peer if m["role"] == "user" else assistant_peer).message(
+                    m["content"],
+                    metadata=_redact_metadata_value(m.get("metadata") or {}),
+                    created_at=m.get("created_at"),
+                )
                 for m in new_messages
             ]
             honcho_session.add_messages(honcho_messages)

--- a/tests/honcho_plugin/test_async_memory.py
+++ b/tests/honcho_plugin/test_async_memory.py
@@ -18,6 +18,8 @@ import pytest
 
 from plugins.memory.honcho.client import HonchoClientConfig
 from plugins.memory.honcho.session import (
+    DeliveryOutcome,
+    DeliveryState,
     HonchoSession,
     HonchoSessionManager,
 )
@@ -303,7 +305,11 @@ class TestAsyncWriterThread:
         def capture(session):
             flushed.append(session)
             flushed_event.set()
-            return True
+            return DeliveryOutcome(
+                state=DeliveryState.DELIVERED,
+                attempted_count=1,
+                delivered_count=1,
+            )
 
         mgr._flush_session = capture
         mgr._async_queue.put(sess)
@@ -335,7 +341,14 @@ class TestAsyncWriterThread:
             mgr._cache[sess.key] = sess
 
         flushed = []
-        mgr._flush_session = lambda session: flushed.append(session) or True
+        mgr._flush_session = lambda session: (
+            flushed.append(session)
+            or DeliveryOutcome(
+                state=DeliveryState.DELIVERED,
+                attempted_count=1,
+                delivered_count=1,
+            )
+        )
 
         thread = mgr._async_thread
         mgr.stop_async_writer()
@@ -350,84 +363,98 @@ class TestAsyncWriterThread:
 
 
 # ---------------------------------------------------------------------------
-# async retry on failure
+# async direct delivery failure
 # ---------------------------------------------------------------------------
 
-class TestAsyncWriterRetry:
-    def test_retries_once_on_failure(self, make_manager):
+class TestAsyncWriterFailure:
+    def test_boundary_exception_is_not_retried(self, make_manager):
         mgr = make_manager(write_frequency="async")
         mgr._ensure_async_writer()
         sess = _make_session()
         sess.add_message("user", "msg")
 
         call_count = [0]
-        retry_done = threading.Event()
+        attempt_done = threading.Event()
 
-        def flaky_flush(session):
+        def failing_flush(session):
             call_count[0] += 1
-            if call_count[0] == 1:
-                raise ConnectionError("network blip")
-            retry_done.set()
-            return True
+            attempt_done.set()
+            raise ConnectionError("network blip")
 
-        mgr._flush_session = flaky_flush
+        mgr._flush_session = failing_flush
+        mgr._async_queue.put(sess)
+        assert attempt_done.wait(timeout=10), "async writer never attempted delivery"
 
-        with patch("time.sleep"):  # skip the 2s sleep in retry
-            mgr._async_queue.put(sess)
-            assert retry_done.wait(timeout=10), "async writer never retried"
+        mgr.stop_async_writer()
+        assert call_count[0] == 1
+        assert mgr.last_delivery_outcome.state is DeliveryState.FAILED
 
-        mgr.shutdown()
-        assert call_count[0] == 2
-
-    def test_drops_after_two_failures(self, make_manager):
+    def test_terminal_failure_is_retained_without_claiming_drop(self, make_manager, caplog):
         mgr = make_manager(write_frequency="async")
         mgr._ensure_async_writer()
         sess = _make_session()
         sess.add_message("user", "msg")
 
         call_count = [0]
-        retry_done = threading.Event()
+        attempt_done = threading.Event()
 
         def always_fail(session):
             call_count[0] += 1
-            if call_count[0] >= 2:
-                retry_done.set()
-            raise RuntimeError("always broken")
+            attempt_done.set()
+            return DeliveryOutcome(
+                state=DeliveryState.FAILED,
+                attempted_count=1,
+                pending_count=1,
+                error_category="sdk_error",
+            )
 
         mgr._flush_session = always_fail
 
-        with patch("time.sleep"):
+        with caplog.at_level("ERROR", logger="plugins.memory.honcho.session"):
             mgr._async_queue.put(sess)
-            assert retry_done.wait(timeout=10), "async writer never retried"
+            assert attempt_done.wait(timeout=10), "async writer never attempted delivery"
 
-        mgr.shutdown()
-        # Should have tried exactly twice (initial + one retry) and not crashed
-        assert call_count[0] == 2
+        mgr.stop_async_writer()
+        assert call_count[0] == 1
+        assert mgr.last_delivery_outcome.state is DeliveryState.FAILED
+        assert "dropping" not in caplog.text.lower()
         assert not mgr._async_thread.is_alive()
 
-    def test_retries_when_flush_reports_failure(self, make_manager):
+    def test_later_flush_all_retries_unsynced_records(self, make_manager):
         mgr = make_manager(write_frequency="async")
         mgr._ensure_async_writer()
         sess = _make_session()
         sess.add_message("user", "msg")
 
         call_count = [0]
-        retry_done = threading.Event()
+        first_done = threading.Event()
 
         def fail_then_succeed(session):
             call_count[0] += 1
-            if call_count[0] >= 2:
-                retry_done.set()
-            return call_count[0] > 1
+            if call_count[0] == 1:
+                first_done.set()
+                return DeliveryOutcome(
+                    state=DeliveryState.FAILED,
+                    attempted_count=1,
+                    pending_count=1,
+                    error_category="connection",
+                )
+            return DeliveryOutcome(
+                state=DeliveryState.DELIVERED,
+                attempted_count=1,
+                delivered_count=1,
+            )
 
         mgr._flush_session = fail_then_succeed
+        mgr._cache[sess.key] = sess
+        mgr._async_queue.put(sess)
+        assert first_done.wait(timeout=10), "async writer never attempted delivery"
+        result = mgr.flush_all()
 
-        with patch("time.sleep"):
-            mgr._async_queue.put(sess)
-            assert retry_done.wait(timeout=10), "async writer never retried"
-
-        mgr.shutdown()
         assert call_count[0] == 2
+        assert result.state is DeliveryState.DELIVERED
+        mgr._cache.clear()
+        mgr.stop_async_writer()
 
 
 def _prime_migration_session(mgr, key, honcho_session_id, ai_peer_id="custom-ai"):

--- a/tests/honcho_plugin/test_auth_recovery.py
+++ b/tests/honcho_plugin/test_auth_recovery.py
@@ -388,7 +388,7 @@ def _make_sync_manager(flaky_session, *, reauth_ok=True):
     cfg = HonchoClientConfig(host="hermes", api_key="hch-at-x", enabled=True)
     mgr = HonchoSessionManager(config=cfg)
     peer = MagicMock()
-    peer.message.side_effect = lambda content: content
+    peer.message.side_effect = lambda content, **kwargs: content
     mgr._get_or_create_peer = lambda peer_id: peer
     mgr._sessions_cache["s"] = flaky_session
     mgr._force_reauth = lambda: reauth_ok
@@ -745,12 +745,12 @@ class TestClientRebuildRetry:
         stale_session = MagicMock()
         stale_session.add_messages.side_effect = Exception("Invalid or expired access token")
         stale_peer = MagicMock()
-        stale_peer.message.side_effect = lambda content: content
+        stale_peer.message.side_effect = lambda content, **kwargs: content
 
         fresh_session = MagicMock()
         fresh_session.context.return_value = SimpleNamespace(summary=None, messages=[])
         fresh_peer = MagicMock()
-        fresh_peer.message.side_effect = lambda content: content
+        fresh_peer.message.side_effect = lambda content, **kwargs: content
         fresh_client = MagicMock()
         fresh_client.session.return_value = fresh_session
         fresh_client.peer.return_value = fresh_peer

--- a/tests/honcho_plugin/test_auth_recovery.py
+++ b/tests/honcho_plugin/test_auth_recovery.py
@@ -15,6 +15,7 @@ from plugins.memory.honcho import HonchoMemoryProvider
 from plugins.memory.honcho import oauth
 from plugins.memory.honcho.client import HonchoClientConfig
 from plugins.memory.honcho.session import (
+    DeliveryState,
     HonchoAuthError,
     HonchoSession,
     HonchoSessionManager,
@@ -404,14 +405,14 @@ class TestSyncAuthRetry:
     def test_401_forces_refresh_and_retries_once(self):
         flaky = _FlakyHonchoSession(failures=1)
         mgr, session = _make_sync_manager(flaky)
-        assert mgr._flush_session(session) is True
+        assert mgr._flush_session(session).state is DeliveryState.DELIVERED
         assert flaky.calls == 2
         assert all(m["_synced"] for m in session.messages)
 
     def test_persistent_401_fails_and_records_auth_failure(self):
         flaky = _FlakyHonchoSession(failures=99)
         mgr, session = _make_sync_manager(flaky)
-        assert mgr._flush_session(session) is False
+        assert mgr._flush_session(session).state is DeliveryState.FAILED
         assert flaky.calls == 2  # exactly one retry, no loop
         assert not any(m.get("_synced") for m in session.messages)
         assert mgr._auth_failure is not None
@@ -419,18 +420,18 @@ class TestSyncAuthRetry:
     def test_failed_reauth_fails_without_retry(self):
         flaky = _FlakyHonchoSession(failures=99)
         mgr, session = _make_sync_manager(flaky, reauth_ok=False)
-        assert mgr._flush_session(session) is False
+        assert mgr._flush_session(session).state is DeliveryState.FAILED
         assert flaky.calls == 1
         assert mgr._auth_failure is not None
 
     def test_later_success_recovers_and_clears_auth_state(self):
         flaky = _FlakyHonchoSession(failures=2)
         mgr, session = _make_sync_manager(flaky, reauth_ok=False)
-        assert mgr._flush_session(session) is False
+        assert mgr._flush_session(session).state is DeliveryState.FAILED
         assert mgr._auth_failure is not None
 
         mgr._force_reauth = lambda: True
-        assert mgr._flush_session(session) is True
+        assert mgr._flush_session(session).state is DeliveryState.DELIVERED
         assert all(m["_synced"] for m in session.messages)
         assert mgr._auth_failure is None
 
@@ -493,7 +494,7 @@ class TestDeadGrantSkipsCalls:
         _kill_grant(tmp_path, monkeypatch)
         flaky = _FlakyHonchoSession(failures=0)
         mgr, session = _make_sync_manager(flaky)
-        assert mgr._flush_session(session) is False
+        assert mgr._flush_session(session).state is DeliveryState.FAILED
         assert flaky.calls == 0
         assert mgr._auth_failure is not None
 
@@ -501,11 +502,11 @@ class TestDeadGrantSkipsCalls:
         path = _kill_grant(tmp_path, monkeypatch)
         flaky = _FlakyHonchoSession(failures=0)
         mgr, session = _make_sync_manager(flaky)
-        assert mgr._flush_session(session) is False
+        assert mgr._flush_session(session).state is DeliveryState.FAILED
         assert flaky.calls == 0
 
         _relogin(path)
-        assert mgr._flush_session(session) is True
+        assert mgr._flush_session(session).state is DeliveryState.DELIVERED
         assert flaky.calls == 1
         assert all(m["_synced"] for m in session.messages)
         assert mgr._auth_failure is None
@@ -767,7 +768,7 @@ class TestClientRebuildRetry:
         session.add_message("user", "hello")
         session.add_message("assistant", "hi")
 
-        assert mgr._flush_session(session) is True
+        assert mgr._flush_session(session).state is DeliveryState.DELIVERED
         # The stale pre-rebuild session must not be retried.
         assert stale_session.add_messages.call_count == 1
         assert fresh_session.add_messages.call_count == 1

--- a/tests/honcho_plugin/test_direct_delivery.py
+++ b/tests/honcho_plugin/test_direct_delivery.py
@@ -1,0 +1,331 @@
+"""Behavioral contract for reliable direct Honcho delivery (BC-62A)."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from plugins.memory.honcho import HonchoMemoryProvider
+from plugins.memory.honcho.client import HonchoClientConfig
+from plugins.memory.honcho.session import (
+    DeliveryOutcome,
+    DeliveryState,
+    HonchoSession,
+    HonchoSessionManager,
+    _ASYNC_SHUTDOWN,
+    classify_delivery_error,
+)
+
+
+def _manager(write_frequency="turn") -> HonchoSessionManager:
+    return HonchoSessionManager(
+        honcho=MagicMock(),
+        config=HonchoClientConfig(
+            api_key="test-key",
+            enabled=True,
+            write_frequency=write_frequency,
+        ),
+    )
+
+
+def _session() -> HonchoSession:
+    return HonchoSession(
+        key="cli:test",
+        user_peer_id="human",
+        assistant_peer_id="hermes",
+        honcho_session_id="cli-test",
+    )
+
+
+def _provider_with_manager() -> tuple[HonchoMemoryProvider, MagicMock]:
+    provider = HonchoMemoryProvider()
+    provider._config = HonchoClientConfig(save_messages=True)
+    manager = MagicMock()
+    provider._manager = manager
+    provider._session_key = "cli:test"
+    provider._session_initialized = True
+    return provider, manager
+
+
+def _wire_delivery(mgr, session, side_effect):
+    created = []
+    user_peer = MagicMock()
+    assistant_peer = MagicMock()
+
+    def make(content, *, metadata, created_at):
+        message = SimpleNamespace(
+            content=content, metadata=metadata, created_at=created_at
+        )
+        created.append(message)
+        return message
+
+    user_peer.message.side_effect = make
+    assistant_peer.message.side_effect = make
+    mgr._get_or_create_peer = MagicMock(
+        side_effect=lambda peer_id: (
+            user_peer if peer_id == session.user_peer_id else assistant_peer
+        )
+    )
+    sdk_session = MagicMock()
+    sdk_session.add_messages.side_effect = side_effect
+    mgr._sessions_cache[session.honcho_session_id] = sdk_session
+    return created, sdk_session
+
+
+def test_terminal_failure_returns_safe_outcome_and_preserves_unsynced(caplog):
+    secret_content = "password=message-secret"
+    secret_error = "token=error-secret https://user:pass@example.invalid/private"
+    mgr = _manager()
+    session = _session()
+    mgr.add_source_message(session, "user", secret_content)
+    _wire_delivery(mgr, session, RuntimeError(secret_error))
+
+    with caplog.at_level(logging.ERROR, logger="plugins.memory.honcho.session"):
+        outcome = mgr._flush_session(session)
+
+    assert outcome == DeliveryOutcome(
+        state=DeliveryState.FAILED,
+        attempted_count=1,
+        delivered_count=0,
+        pending_count=1,
+        error_category="sdk_error",
+        http_status=None,
+    )
+    assert outcome is mgr.last_delivery_outcome
+    assert session.messages[0]["_synced"] is False
+    log_text = caplog.text
+    assert secret_content not in log_text
+    assert secret_error not in log_text
+    assert "example.invalid" not in log_text
+    assert "terminal failure" in log_text
+
+
+def test_later_in_process_flush_retries_same_provenance_and_delivers():
+    mgr = _manager()
+    session = _session()
+    mgr.add_source_message(session, "user", "retry me")
+    created, sdk_session = _wire_delivery(
+        mgr,
+        session,
+        [ConnectionError("first attempt failed"), None],
+    )
+
+    failed = mgr._flush_session(session)
+    delivered = mgr.flush_all()
+
+    assert failed.state is DeliveryState.FAILED
+    assert delivered.state is DeliveryState.DELIVERED
+    assert delivered.delivered_count == 1
+    assert session.messages[0]["_synced"] is True
+    assert sdk_session.add_messages.call_count == 2
+    assert created[0].metadata == created[1].metadata
+    assert created[0].created_at == created[1].created_at
+
+
+def test_already_synced_is_structured_noop():
+    mgr = _manager()
+    session = _session()
+    session.add_message("user", "already there", _synced=True)
+
+    outcome = mgr._flush_session(session)
+
+    assert outcome.state is DeliveryState.NOOP
+    assert outcome.attempted_count == 0
+    assert outcome.delivered_count == 0
+    assert outcome.pending_count == 0
+
+
+def test_concurrent_flushes_send_one_sdk_batch():
+    mgr = _manager()
+    session = _session()
+    mgr.add_source_message(session, "user", "send once")
+    entered = threading.Event()
+    release = threading.Event()
+
+    def blocking_delivery(_messages):
+        entered.set()
+        assert release.wait(timeout=5)
+
+    _, sdk_session = _wire_delivery(mgr, session, blocking_delivery)
+    outcomes = []
+    first = threading.Thread(
+        target=lambda: outcomes.append(mgr._flush_session(session))
+    )
+    second = threading.Thread(
+        target=lambda: outcomes.append(mgr._flush_session(session))
+    )
+
+    first.start()
+    assert entered.wait(timeout=5)
+    second.start()
+    release.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert sdk_session.add_messages.call_count == 1
+    assert {outcome.state for outcome in outcomes} == {
+        DeliveryState.DELIVERED,
+        DeliveryState.NOOP,
+    }
+
+
+def test_message_appended_during_flush_remains_pending_for_next_flush():
+    mgr = _manager()
+    session = _session()
+    mgr.add_source_message(session, "user", "first")
+    entered = threading.Event()
+    release = threading.Event()
+
+    def blocking_delivery(_messages):
+        entered.set()
+        assert release.wait(timeout=5)
+
+    call_count = 0
+
+    def delivery(messages):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            blocking_delivery(messages)
+
+    _, sdk_session = _wire_delivery(mgr, session, delivery)
+    first_outcome = []
+    worker = threading.Thread(
+        target=lambda: first_outcome.append(mgr._flush_session(session))
+    )
+    worker.start()
+    assert entered.wait(timeout=5)
+    mgr.add_source_message(session, "assistant", "appended")
+    release.set()
+    worker.join(timeout=5)
+
+    assert not worker.is_alive()
+    assert first_outcome[0].state is DeliveryState.DELIVERED
+    assert first_outcome[0].pending_count == 1
+    assert [message.get("_synced", False) for message in session.messages] == [
+        True,
+        False,
+    ]
+    second_outcome = mgr._flush_session(session)
+    assert second_outcome.state is DeliveryState.DELIVERED
+    assert sdk_session.add_messages.call_count == 2
+
+
+def test_empty_flush_all_returns_fresh_noop():
+    mgr = _manager()
+    mgr._retain_delivery_outcome(
+        DeliveryOutcome(
+            state=DeliveryState.DELIVERED,
+            attempted_count=1,
+            delivered_count=1,
+        )
+    )
+
+    outcome = mgr.flush_all()
+
+    assert outcome == DeliveryOutcome(state=DeliveryState.NOOP)
+    assert outcome is mgr.last_delivery_outcome
+
+
+def test_real_honcho_transport_errors_are_classified():
+    exceptions = pytest.importorskip("honcho.http.exceptions")
+
+    assert classify_delivery_error(exceptions.TimeoutError()) == ("timeout", None)
+    assert classify_delivery_error(exceptions.ConnectionError()) == (
+        "connection",
+        None,
+    )
+
+
+def test_async_writer_calls_boundary_once_and_retains_retryable_failure(caplog):
+    mgr = _manager(write_frequency="async")
+    session = _session()
+    session.add_message("user", "password=do-not-log")
+    failed = DeliveryOutcome(
+        state=DeliveryState.FAILED,
+        attempted_count=1,
+        delivered_count=0,
+        pending_count=1,
+        error_category="connection",
+    )
+    mgr._flush_session = MagicMock(return_value=failed)
+    mgr._async_queue.put(session)
+    mgr._async_queue.put(_ASYNC_SHUTDOWN)
+
+    with caplog.at_level(logging.ERROR, logger="plugins.memory.honcho.session"):
+        mgr._async_writer_loop()
+
+    mgr._flush_session.assert_called_once_with(session)
+    assert mgr.last_delivery_outcome == failed
+    assert session.messages[0].get("_synced") is not True
+    assert "password=do-not-log" not in caplog.text
+    assert "dropping" not in caplog.text.lower()
+
+
+@pytest.mark.parametrize("path", ["sync_turn", "session_end"])
+def test_provider_delivery_exception_logs_are_content_free(path, caplog):
+    secret_error = (
+        "Authorization: Bearer secret-token "
+        "https://user:password@example.invalid/private"
+    )
+    provider, manager = _provider_with_manager()
+
+    with caplog.at_level(logging.DEBUG, logger="plugins.memory.honcho"):
+        if path == "sync_turn":
+            manager.get_or_create.return_value = _session()
+            manager.save.side_effect = RuntimeError(secret_error)
+            provider.sync_turn("safe user", "safe assistant")
+            assert provider._sync_thread is not None
+            provider._sync_thread.join(timeout=5)
+        else:
+            manager.flush_all.side_effect = RuntimeError(secret_error)
+            provider.on_session_end([])
+
+    assert secret_error not in caplog.text
+    assert "Authorization" not in caplog.text
+    assert "example.invalid" not in caplog.text
+    assert "user:password" not in caplog.text
+    assert "category=sdk_error status=none" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("frequency", "action"),
+    [
+        ("turn", "save"),
+        (2, "save-twice"),
+        ("session", "flush-all"),
+        ("async", "writer"),
+    ],
+)
+def test_every_write_frequency_converges_through_one_boundary(frequency, action):
+    mgr = _manager(write_frequency=frequency)
+    session = _session()
+    session.add_message("user", "hello")
+    mgr._cache[session.key] = session
+    delivered = DeliveryOutcome(
+        state=DeliveryState.DELIVERED,
+        attempted_count=1,
+        delivered_count=1,
+        pending_count=0,
+    )
+
+    with patch.object(mgr, "_flush_session", return_value=delivered) as boundary:
+        if action == "save":
+            assert mgr.save(session) == delivered
+        elif action == "save-twice":
+            assert mgr.save(session) is None
+            assert mgr.save(session) == delivered
+        elif action == "flush-all":
+            assert mgr.save(session) is None
+            assert mgr.flush_all() == delivered
+        else:
+            mgr._async_queue.put(session)
+            mgr._async_queue.put(_ASYNC_SHUTDOWN)
+            mgr._async_writer_loop()
+        boundary.assert_called_once_with(session)

--- a/tests/honcho_plugin/test_pin_peer_name.py
+++ b/tests/honcho_plugin/test_pin_peer_name.py
@@ -16,6 +16,7 @@ chosen ``user_peer_id`` can be asserted without touching the network.
 
 import hashlib
 import json
+import os
 from unittest.mock import MagicMock
 
 
@@ -524,7 +525,12 @@ class TestPinTransition:
         cfg_path.write_text(json.dumps({"apiKey": "k", "peerName": "Igor", "pinPeerName": True}))
         sig_pinned = GatewayRunner._extract_cache_busting_config({"memory": {"provider": "honcho"}})
 
+        previous_mtime = cfg_path.stat().st_mtime_ns
         cfg_path.write_text(json.dumps({"apiKey": "k", "peerName": "Igor", "pinPeerName": False}))
+        # The expanded focused suite can rewrite this tiny file within one
+        # filesystem timestamp tick. Force a distinct signature so this
+        # existing cache-busting contract remains deterministic.
+        os.utime(cfg_path, ns=(previous_mtime + 1, previous_mtime + 1))
         sig_unpinned = GatewayRunner._extract_cache_busting_config({"memory": {"provider": "honcho"}})
 
         assert sig_pinned["honcho.pin_peer_name"] != sig_unpinned["honcho.pin_peer_name"]

--- a/tests/honcho_plugin/test_provenance.py
+++ b/tests/honcho_plugin/test_provenance.py
@@ -1,0 +1,397 @@
+"""Behavioral contract for first-class Honcho message provenance (BC-61)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from plugins.memory.honcho import HonchoMemoryProvider
+from plugins.memory.honcho.client import HonchoClientConfig
+from plugins.memory.honcho.session import HonchoSession, HonchoSessionManager
+
+
+AGADOR_DEFAULTS = {
+    "schema": "agador.provenance/v1",
+    "authority": "user",
+    "evidence_refs": [],
+    "effective_at": None,
+    "confidence": None,
+    "verification_state": "unverified",
+    "review_state": "captured",
+    "sensitivity": "private",
+    "retention_class": "semantic",
+    "derived_from": [],
+    "supersedes": [],
+    "superseded_by": [],
+    "deletion_request_id": None,
+    "deleted_at": None,
+    "target_artifacts": [],
+    "extensions": {"agador": {"policy": "synthetic"}},
+}
+
+INIT_CONTEXT = {
+    "hermes_home": "/profiles/work",
+    "platform": "telegram",
+    "agent_context": "primary",
+    "agent_identity": "work",
+    "agent_workspace": "hermes",
+    "user_id": "platform-user",
+    "user_id_alt": "stable-user",
+    "user_name": "Synthetic User",
+    "chat_id": "chat-42",
+    "chat_name": "Synthetic Room",
+    "chat_type": "group",
+    "thread_id": "thread-9",
+    "gateway_session_key": "agent:work:telegram:group:chat-42:thread-9",
+    "session_title": "Synthetic provenance",
+}
+
+
+@pytest.fixture(autouse=True)
+def _stable_machine_identity(monkeypatch):
+    monkeypatch.setattr(
+        "plugins.memory.honcho.session._resolve_machine_identity",
+        lambda _context: "runtime-node-7",
+    )
+
+
+def _manager(*, static=None, **context):
+    cfg = HonchoClientConfig(
+        ai_peer="hermes-coding",
+        peer_name="stable-human",
+        message_metadata=static if static is not None else AGADOR_DEFAULTS,
+        write_frequency="turn",
+    )
+    return HonchoSessionManager(
+        honcho=MagicMock(),
+        config=cfg,
+        runtime_user_peer_name="stable-human",
+        provenance_context={**INIT_CONTEXT, **context},
+        source_session_id="source-session-123",
+    )
+
+
+def _cached_session():
+    return HonchoSession(
+        key="resolved-session",
+        user_peer_id="stable-human",
+        assistant_peer_id="hermes-coding",
+        honcho_session_id="resolved-session",
+    )
+
+
+def _wire_flush(mgr, session, *, fail_first=False):
+    user_peer = MagicMock()
+    assistant_peer = MagicMock()
+    created = []
+
+    def make(role):
+        def factory(content, *, metadata, created_at):
+            msg = SimpleNamespace(content=content, metadata=metadata, created_at=created_at, role=role)
+            created.append(msg)
+            return msg
+        return factory
+
+    user_peer.message.side_effect = make("user")
+    assistant_peer.message.side_effect = make("assistant")
+    mgr._get_or_create_peer = MagicMock(side_effect=lambda peer: user_peer if peer == "stable-human" else assistant_peer)
+    sdk_session = MagicMock()
+    if fail_first:
+        sdk_session.add_messages.side_effect = [RuntimeError("synthetic outage"), None]
+    mgr._sessions_cache[session.honcho_session_id] = sdk_session
+    return created, sdk_session
+
+
+def test_exact_normative_metadata_and_sdk_created_at_for_both_roles():
+    mgr = _manager()
+    session = _cached_session()
+    mgr.add_source_message(session, "user", "hello")
+    mgr.add_source_message(session, "assistant", "hi")
+    created, sdk_session = _wire_flush(mgr, session)
+
+    assert mgr._flush_session(session) is True
+    assert len(created) == 2
+    user, assistant = created
+    for item in created:
+        md = item.metadata
+        assert md["schema"] == "agador.provenance/v1"
+        assert md["record_kind"] == "source_event"
+        assert md["human_peer"] == "stable-human"
+        assert md["ai_peer"] == "hermes-coding"
+        assert md["interface"] == "telegram"
+        assert md["machine"] == "runtime-node-7"
+        assert md["runtime"] == "hermes:work:primary"
+        assert md["session_id"] == "source-session-123"
+        assert md["channel_id"] == "chat-42"
+        assert md["source_record_id"]
+        assert md["observed_at"].endswith("Z")
+        assert md["confidence"] is None
+        assert md["review_state"] == "captured"
+        assert md["retention_class"] == "semantic"
+        assert md["deletion_request_id"] is None
+        assert md["extensions"]["agador"] == {"policy": "synthetic"}
+        assert md["extensions"]["hermes"]["thread_id"] == "thread-9"
+        assert md["extensions"]["hermes"]["agent_workspace"] == "hermes"
+        assert "hermes_home" not in md["extensions"]["hermes"]
+        assert md["extensions"]["hermes"]["chat_type"] == "group"
+        assert md["extensions"]["hermes"]["gateway_session_key"] == INIT_CONTEXT["gateway_session_key"]
+        assert item.created_at == datetime.fromisoformat(md["observed_at"].replace("Z", "+00:00"))
+        assert item.created_at.tzinfo == timezone.utc
+    assert user.metadata["source_kind"] == "user_statement"
+    assert assistant.metadata["source_kind"] == "assistant_statement"
+    assert user.metadata["authority"] == "stable-human"
+    assert assistant.metadata["authority"] == "hermes-coding"
+    assert user.metadata["event_id"] != assistant.metadata["event_id"]
+    sdk_session.add_messages.assert_called_once()
+
+
+def test_failed_flush_retry_preserves_event_ids_metadata_and_created_at():
+    mgr = _manager()
+    session = _cached_session()
+    mgr.add_source_message(session, "user", "retry me")
+    created, _ = _wire_flush(mgr, session, fail_first=True)
+
+    assert mgr._flush_session(session) is False
+    assert mgr._flush_session(session) is True
+    assert len(created) == 2
+    assert created[0].metadata == created[1].metadata
+    assert created[0].created_at == created[1].created_at
+
+
+def test_chunked_role_side_has_one_source_record_and_unique_stable_events():
+    mgr = _manager()
+    session = _cached_session()
+    source_record_id = mgr.new_source_record_id()
+    mgr.add_source_message(session, "user", "part 1", source_record_id=source_record_id, chunk_index=0, chunk_count=2)
+    mgr.add_source_message(session, "user", "part 2", source_record_id=source_record_id, chunk_index=1, chunk_count=2)
+
+    first, second = (m["metadata"] for m in session.messages)
+    assert first["source_record_id"] == second["source_record_id"] == source_record_id
+    assert first["event_id"] != second["event_id"]
+    assert [first["extensions"]["hermes"]["chunk_index"], second["extensions"]["hermes"]["chunk_index"]] == [0, 1]
+    assert first["extensions"]["hermes"]["chunk_count"] == second["extensions"]["hermes"]["chunk_count"] == 2
+
+
+def test_static_defaults_merge_but_dynamic_fields_are_protected():
+    static = {
+        **AGADOR_DEFAULTS,
+        "event_id": "attacker-event",
+        "record_kind": "promoted_artifact",
+        "source_kind": "imported_record",
+        "interface": "discord",
+        "machine": "wrong-machine",
+        "runtime": "wrong-runtime",
+        "session_id": "wrong-session",
+        "channel_id": "wrong-channel",
+        "source_record_id": "wrong-record",
+        "observed_at": "2000-01-01T00:00:00Z",
+        "human_peer": "wrong-human",
+        "ai_peer": "wrong-ai",
+        "extensions": {"custom": {"kept": True}, "hermes": {"thread_id": "wrong-thread", "extra": "kept"}},
+    }
+    mgr = _manager(static=static)
+    session = _cached_session()
+    mgr.add_source_message(session, "assistant", "safe")
+    md = session.messages[0]["metadata"]
+
+    assert md["event_id"] != "attacker-event"
+    assert md["record_kind"] == "source_event"
+    assert md["source_kind"] == "assistant_statement"
+    assert (md["interface"], md["machine"], md["runtime"], md["session_id"]) == (
+        "telegram", "runtime-node-7", "hermes:work:primary", "source-session-123"
+    )
+    assert (md["human_peer"], md["ai_peer"]) == ("stable-human", "hermes-coding")
+    assert md["channel_id"] == "chat-42"
+    assert md["source_record_id"] != "wrong-record"
+    assert md["observed_at"] != "2000-01-01T00:00:00Z"
+    assert md["extensions"]["custom"] == {"kept": True}
+    assert md["extensions"]["hermes"]["extra"] == "kept"
+    assert md["extensions"]["hermes"]["thread_id"] == "thread-9"
+
+
+def test_default_config_emits_coherent_provider_neutral_envelope():
+    mgr = _manager(static={})
+    session = _cached_session()
+    mgr.add_source_message(session, "user", "default metadata")
+
+    md = session.messages[0]["metadata"]
+    assert md["schema"] == "hermes.provenance/v1"
+    assert md["record_kind"] == "source_event"
+    assert md["source_kind"] == "user_statement"
+    assert md["authority"] == "stable-human"
+    assert md["verification_state"] == "unverified"
+    assert md["review_state"] == "captured"
+    assert md["sensitivity"] == "private"
+    assert md["retention_class"] == "semantic"
+    assert md["derived_from"] == []
+    assert md["extensions"]["hermes"]["chunk_count"] == 1
+
+
+@pytest.mark.parametrize("strategy", ["per-session", "per-directory", "per-repo", "global"])
+def test_original_source_session_is_preserved_for_every_session_strategy(strategy):
+    cfg = HonchoClientConfig(session_strategy=strategy, message_metadata=AGADOR_DEFAULTS)
+    provider = HonchoMemoryProvider()
+    provider._config = cfg
+    provider._session_key = f"resolved-{strategy}"
+    manager = _manager()
+    manager._write_frequency = "session"
+    manager._cache[provider._session_key] = _cached_session()
+    provider._manager = manager
+    provider._cron_skipped = False
+    provider._session_initialized = True
+    provider.sync_turn("user", "assistant", session_id="source-session-123")
+    provider._sync_thread.join(timeout=1)
+
+    session = manager._cache.get(provider._session_key)
+    # Avoid remote setup in this behavioral test: if not cached, the implementation
+    # has not yet provided a testable local path and the assertion is intentionally red.
+    assert session is not None
+    assert {m["metadata"]["session_id"] for m in session.messages} == {"source-session-123"}
+
+
+def test_current_sync_session_overrides_initialized_source_session_after_switch():
+    provider = HonchoMemoryProvider()
+    provider._config = HonchoClientConfig(message_metadata=AGADOR_DEFAULTS)
+    provider._session_key = "resolved-session"
+    manager = _manager()
+    manager._write_frequency = "session"
+    manager._cache[provider._session_key] = _cached_session()
+    provider._manager = manager
+    provider._cron_skipped = False
+    provider._session_initialized = True
+
+    provider.sync_turn("after switch", "current response", session_id="source-session-B")
+    assert provider._sync_thread is not None
+    provider._sync_thread.join(timeout=1)
+
+    assert {
+        message["metadata"]["session_id"]
+        for message in manager._cache[provider._session_key].messages
+    } == {"source-session-B"}
+
+
+def test_runtime_aliases_preserve_one_human_peer_across_interfaces():
+    cfg = HonchoClientConfig(
+        ai_peer="hermes-coding",
+        peer_name="stable-human",
+        user_peer_aliases={
+            "telegram-42": "stable-human",
+            "discord-99": "stable-human",
+        },
+        message_metadata=AGADOR_DEFAULTS,
+        write_frequency="session",
+    )
+    peers = []
+    for interface, runtime_id in (("telegram", "telegram-42"), ("discord", "discord-99")):
+        manager = HonchoSessionManager(
+            honcho=MagicMock(),
+            config=cfg,
+            runtime_user_peer_name=runtime_id,
+            provenance_context={**INIT_CONTEXT, "platform": interface},
+            source_session_id=f"{interface}-session",
+        )
+        manager._get_or_create_peer = MagicMock(return_value=MagicMock())
+        manager._get_or_create_honcho_session = MagicMock(return_value=(MagicMock(), []))
+        session = manager.get_or_create(f"{interface}:chat")
+        manager.add_source_message(session, "user", "same human")
+        peers.append(session.messages[0]["metadata"]["human_peer"])
+
+    assert peers == ["stable-human", "stable-human"]
+
+
+def test_metadata_secrets_are_force_redacted_before_sdk_boundary(monkeypatch):
+    secret = "sk-" + "proj-" + ("abc123XYZ" * 5)
+    secret_key = "ghp_" + ("9Az" * 16)
+    static = {
+        **AGADOR_DEFAULTS,
+        "authority": f"api_key={secret}",
+        "extensions": {"custom": {"token": secret, secret_key: "key-carried-secret"}},
+    }
+    mgr = _manager(static=static, chat_name=f"token={secret}")
+    session = _cached_session()
+    mgr.add_source_message(session, "user", "conversation content is not changed")
+    created, _ = _wire_flush(mgr, session)
+
+    assert mgr._flush_session(session) is True
+    serialized = repr(created[0].metadata)
+    assert secret not in serialized
+    assert secret_key not in serialized
+    assert "key-carried-secret" in serialized
+    assert "redacted" in serialized
+    assert created[0].content == "conversation content is not changed"
+
+
+@pytest.mark.parametrize(
+    ("metadata", "plain_secret"),
+    [
+        ({"password": "hunter2"}, "hunter2"),
+        ({"api_key": "ordinary-secret-value"}, "ordinary-secret-value"),
+        ({"token": "short-secret"}, "short-secret"),
+        ({"nested": {"client_secret": "abc123"}}, "abc123"),
+        ({"clientSecret": "camel-client-secret"}, "camel-client-secret"),
+        ({"accessToken": "camel-access-token"}, "camel-access-token"),
+        ({"refreshToken": "camel-refresh-token"}, "camel-refresh-token"),
+        ({"authToken": "camel-auth-token"}, "camel-auth-token"),
+        ({"authorizationHeader": "Basic ordinary-value"}, "Basic ordinary-value"),
+        ({"passwordValue": "camel-password"}, "camel-password"),
+        ({"APIKeyValue": "acronym-api-key"}, "acronym-api-key"),
+        ({"privateAPIKey": "nested-acronym-key"}, "nested-acronym-key"),
+        ({"PRIVATEKEY": "uppercase-private-key"}, "uppercase-private-key"),
+    ],
+)
+def test_credential_named_metadata_redacts_ordinary_values(metadata, plain_secret):
+    mgr = _manager(static={**AGADOR_DEFAULTS, "extensions": metadata})
+    session = _cached_session()
+    mgr.add_source_message(session, "user", "safe content")
+
+    serialized = repr(session.messages[0]["metadata"])
+    assert plain_secret not in serialized
+    assert "redacted-metadata" in serialized
+
+
+def test_credential_reference_metadata_remains_usable_without_secret_values():
+    mgr = _manager(
+        static={
+            **AGADOR_DEFAULTS,
+            "extensions": {
+                "apiKeyPath": "infisical://project/path",
+                "secretReference": "infisical:n8n/prod/homeassistant",
+                "tokenCount": 12,
+            },
+        }
+    )
+    session = _cached_session()
+    mgr.add_source_message(session, "user", "safe content")
+
+    extensions = session.messages[0]["metadata"]["extensions"]
+    assert extensions["apiKeyPath"] == "infisical://project/path"
+    assert extensions["secretReference"] == "infisical:n8n/prod/homeassistant"
+    assert extensions["tokenCount"] == 12
+
+
+def test_non_json_metadata_values_fail_closed_before_sdk_serialization():
+    mgr = _manager(static={**AGADOR_DEFAULTS, "extensions": {"custom": object()}})
+    session = _cached_session()
+    mgr.add_source_message(session, "user", "safe content")
+
+    assert session.messages[0]["metadata"]["extensions"]["custom"] == "«redacted-metadata»"
+
+
+def test_loaded_synced_messages_reconstruct_sdk_metadata():
+    mgr = _manager()
+    existing = SimpleNamespace(
+        peer_id="stable-human",
+        content="loaded",
+        created_at=datetime(2026, 8, 18, 12, 0, tzinfo=timezone.utc),
+        metadata={"schema": "agador.provenance/v1", "event_id": "existing-event"},
+    )
+    mgr._get_or_create_peer = MagicMock(return_value=MagicMock())
+    mgr._get_or_create_honcho_session = MagicMock(return_value=(MagicMock(), [existing]))
+
+    loaded = mgr.get_or_create("loaded-session")
+    assert loaded.messages[0]["metadata"] == existing.metadata
+    assert loaded.messages[0]["created_at"] == existing.created_at
+    assert loaded.messages[0]["_synced"] is True

--- a/tests/honcho_plugin/test_provenance.py
+++ b/tests/honcho_plugin/test_provenance.py
@@ -10,7 +10,11 @@ import pytest
 
 from plugins.memory.honcho import HonchoMemoryProvider
 from plugins.memory.honcho.client import HonchoClientConfig
-from plugins.memory.honcho.session import HonchoSession, HonchoSessionManager
+from plugins.memory.honcho.session import (
+    DeliveryState,
+    HonchoSession,
+    HonchoSessionManager,
+)
 
 
 AGADOR_DEFAULTS = {
@@ -112,7 +116,7 @@ def test_exact_normative_metadata_and_sdk_created_at_for_both_roles():
     mgr.add_source_message(session, "assistant", "hi")
     created, sdk_session = _wire_flush(mgr, session)
 
-    assert mgr._flush_session(session) is True
+    assert mgr._flush_session(session).state is DeliveryState.DELIVERED
     assert len(created) == 2
     user, assistant = created
     for item in created:
@@ -154,8 +158,8 @@ def test_failed_flush_retry_preserves_event_ids_metadata_and_created_at():
     mgr.add_source_message(session, "user", "retry me")
     created, _ = _wire_flush(mgr, session, fail_first=True)
 
-    assert mgr._flush_session(session) is False
-    assert mgr._flush_session(session) is True
+    assert mgr._flush_session(session).state is DeliveryState.FAILED
+    assert mgr._flush_session(session).state is DeliveryState.DELIVERED
     assert len(created) == 2
     assert created[0].metadata == created[1].metadata
     assert created[0].created_at == created[1].created_at
@@ -315,7 +319,7 @@ def test_metadata_secrets_are_force_redacted_before_sdk_boundary(monkeypatch):
     mgr.add_source_message(session, "user", "conversation content is not changed")
     created, _ = _wire_flush(mgr, session)
 
-    assert mgr._flush_session(session) is True
+    assert mgr._flush_session(session).state is DeliveryState.DELIVERED
     serialized = repr(created[0].metadata)
     assert secret not in serialized
     assert secret_key not in serialized

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -263,8 +263,9 @@ class TestConcludeToolDispatch:
         )
         provider._sync_thread.join(timeout=1.0)
 
-        assert session.add_message.call_args_list[0].args == ("user", "hello")
-        assert session.add_message.call_args_list[1].args == ("assistant", "Visible answer")
+        calls = provider._manager.add_source_message.call_args_list
+        assert calls[0].args == (session, "user", "hello")
+        assert calls[1].args == (session, "assistant", "Visible answer")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/memory/test_honcho_config_schema.py
+++ b/tests/plugins/memory/test_honcho_config_schema.py
@@ -52,6 +52,7 @@ def test_declares_the_new_field_kinds():
     assert by_key["saveMessages"].kind == KIND_BOOL
     assert by_key["dialecticMaxChars"].kind == KIND_NUMBER
     assert by_key["userPeerAliases"].kind == KIND_JSON
+    assert by_key["messageMetadata"].kind == KIND_JSON
     assert by_key["recallMode"].allowed_values() == {"hybrid", "context", "tools"}
     assert by_key["observationMode"].allowed_values() == {"directional", "unified"}
 

--- a/tests/test_honcho_client_config.py
+++ b/tests/test_honcho_client_config.py
@@ -11,6 +11,39 @@ from plugins.memory.honcho.client import HonchoClientConfig
 from plugins.memory.honcho import HonchoMemoryProvider
 
 
+def test_message_metadata_parses_from_root_and_host_override(tmp_path):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({
+        "messageMetadata": {"schema": "root/v1", "authority": "root"},
+        "hosts": {
+            "hermes": {
+                "messageMetadata": {
+                    "schema": "agador.provenance/v1",
+                    "authority": "user",
+                    "extensions": {"agador": {"policy": "synthetic"}},
+                }
+            }
+        },
+    }))
+
+    cfg = HonchoClientConfig.from_global_config(config_path=config_path, host="hermes")
+
+    assert cfg.message_metadata == {
+        "schema": "agador.provenance/v1",
+        "authority": "user",
+        "extensions": {"agador": {"policy": "synthetic"}},
+    }
+
+
+def test_malformed_message_metadata_falls_back_to_empty_mapping(tmp_path):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"messageMetadata": "not-an-object"}))
+
+    cfg = HonchoClientConfig.from_global_config(config_path=config_path, host="hermes")
+
+    assert cfg.message_metadata == {}
+
+
 class TestHonchoClientConfigAutoEnable:
     """Test auto-enable behavior when API key is present."""
 

--- a/tests/test_honcho_startup_fail_open.py
+++ b/tests/test_honcho_startup_fail_open.py
@@ -483,6 +483,12 @@ def test_honcho_sync_turn_same_instance_config_flip_gates_writes():
             manager_calls.append(session_key)
             return SimpleNamespace(add_message=lambda role, content: None)
 
+        def new_source_record_id(self):
+            return "source-record"
+
+        def add_source_message(self, session, role, content, **kwargs):
+            session.add_message(role, content)
+
         def save(self, session):
             write_done.set()
 

--- a/website/docs/user-guide/features/honcho.md
+++ b/website/docs/user-guide/features/honcho.md
@@ -125,6 +125,7 @@ When pointing Hermes at a self-hosted Honcho server, `hermes honcho setup` (and 
 | `recallMode` | `'hybrid'` | `hybrid` (auto-inject + tools), `context` (inject only), `tools` (tools only) |
 | `writeFrequency` | `'async'` | When to flush messages: `async` (background thread), `turn` (sync), `session` (batch on end), or integer N |
 | `saveMessages` | `true` | Whether to persist messages to Honcho API |
+| `messageMetadata` | `{}` | Static JSON defaults merged into provider-native message metadata. Runtime identity, session, timestamp, event, source, channel, and chunk fields always override conflicts; metadata is force-redacted before writes |
 | `observationMode` | `'directional'` | `directional` (all on) or `unified` (shared pool). Override with `observation` object for granular control |
 | `messageMaxChars` | `25000` | Max chars per message sent via `add_messages()`. Chunked if exceeded |
 | `dialecticMaxInputChars` | `10000` | Max chars for dialectic query input to `peer.chat()` |

--- a/website/docs/user-guide/features/honcho.md
+++ b/website/docs/user-guide/features/honcho.md
@@ -134,6 +134,12 @@ When pointing Hermes at a self-hosted Honcho server, `hermes honcho setup` (and 
 | `userPeerAliases` | `{}` | Gateway only. Map of runtime IDs to peers (`{"7654321": "alice"}`). Many-to-one |
 | `runtimePeerPrefix` | `""` | Gateway only. Namespaces unknown runtime IDs (`telegram_7654321`) when no alias matches |
 
+Honcho message writes use the SDK's bounded transport retries. When they are
+exhausted, Hermes stays fail-open, logs a content-free delivery failure, and
+keeps the messages unsynchronized for a later in-process flush. Hermes does not
+currently provide restart-safe durable replay; its canonical session transcript
+remains the source of truth.
+
 **Session strategy** controls how Honcho sessions map to your work:
 - `per-session` — each `hermes` run gets a fresh session. Clean starts, memory via tools. Recommended for new users.
 - `per-directory` — one Honcho session per working directory. Context accumulates across runs.


### PR DESCRIPTION
## Summary
- attach provider-native provenance metadata and UTC `created_at` to Honcho source messages
- preserve stable event/source identities across chunking and in-process retries
- replace bool-only Honcho delivery with immutable `NOOP` / `DELIVERED` / `FAILED` outcomes
- remove the provider's redundant sleep + retry-once/drop path; the Honcho SDK remains the immediate retry layer
- leave terminally failed messages unsynchronized and retryable by a later in-process flush
- serialize manager delivery so async shutdown/flush contention cannot duplicate one local batch
- classify Honcho 2.2.0 timeout/connection errors without logging exception text, headers, URLs, credentials, or message content
- keep restart-safe durable replay out of scope; the canonical Hermes transcript remains the source of truth

## Verification
- exact upstream base: `f94cead3374c8576f701175b59e2772c7bb8ad2d`
- RED proof: direct-delivery contract produced 7 failures before implementation
- sabotage proof: restoring provider retry-once made the one-call regression fail; restored code passed
- exact-head focused Honcho suite: 419 passed
- concurrency proof: 10/10 repeated contention runs passed
- Ruff lint: passed
- new direct-delivery test formatting: passed
- `git diff --check`: passed
- independent spec review: PASS
- independent quality/security re-review: APPROVED
- exact head: `0d2bb3f1efdaaba8e287c28bd3dfe9af8800f0a2`

## Safety and scope
- Honcho remained disabled; no production or synthetic memory was ingested.
- Existing fail-open startup behavior is preserved.
- No SQLite outbox, replay worker, retention system, or failed-write CLI is included.
- Optional restart-safe durable outbox/replay is deferred to BC-65 and must first evaluate server-enforced idempotency and transcript-backed replay.

## Rollback
Revert `0d2bb3f1efdaaba8e287c28bd3dfe9af8800f0a2` to restore the prior provider retry-once/drop behavior while retaining the provenance commit separately.