### PR TITLE
fix(update): don't retry the Windows update hand-off into a GitHub 429

### DIFF
--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -729,11 +729,34 @@ try {
     Write-HandoffLog "hermes update exit code: $($res.Code)"
 
     if ($res.Code -ne 0 -and $res.Code -ne 2) {
+        # A GitHub rate-limit (HTTP 429) is the one failure where retrying is
+        # actively harmful: the secondary limit is driven by request frequency,
+        # so an immediate second fetch extends the cooldown instead of clearing
+        # it. This repo is a large monorepo, so a single fetch is an expensive
+        # request and back-to-back attempts trip the limit reliably. There is
+        # also nothing for a retry to fix -- the failure is server-side, not the
+        # stale-code-in-memory case the retry below exists for. Bail out and
+        # tell the truth so the next scheduled run picks it up after the window.
+        if ($res.Output -match "(?:HTTP|error:) 429|rate-limited|rate limited|secondary rate") {
+            $finalCode = 4
+            $finalMsg = "Update skipped: GitHub rate-limited the fetch (HTTP 429). This is server-side throttling, not a broken install, and retrying now would extend the cooldown. Nothing was changed; the existing build is untouched. Try again in 10-60 minutes."
+            Write-HandoffLog $finalMsg
+            exit $finalCode
+        }
+
         # One retry for the update-boundary class (fresh code on disk, stale
         # code in memory). Exit 2 ("close all Hermes windows") is not retryable.
         Write-HandoffLog "first attempt failed; retrying once (freshly pulled fix loads on the second run)"
         $res = Invoke-HermesStep $pythonExe $updateArgs "update"
         Write-HandoffLog "retry exit code: $($res.Code)"
+
+        # The retry can independently land in the rate limit.
+        if ($res.Code -ne 0 -and $res.Output -match "(?:HTTP|error:) 429|rate-limited|rate limited|secondary rate") {
+            $finalCode = 4
+            $finalMsg = "Update skipped: GitHub rate-limited the fetch (HTTP 429) on the retry. Nothing was changed; the existing build is untouched. Try again in 10-60 minutes."
+            Write-HandoffLog $finalMsg
+            exit $finalCode
+        }
     }
 
     # -- 4. Truthful completion: don't trust exit 0 -------------------------

--- a/tests/test_desktop_update_windows_rate_limit.py
+++ b/tests/test_desktop_update_windows_rate_limit.py
@@ -1,0 +1,141 @@
+"""Regression: a GitHub rate-limit (HTTP 429) must abort the update, not retry it.
+
+`scripts/desktop-update/windows.ps1` retries `hermes update` once when the first
+attempt exits non-zero and non-2. That retry exists for the update-boundary
+class: the fetch lands fresh code on disk while the already-loaded Python still
+holds the stale module, so running the same command a second time picks up the
+fix. It is the right response to that failure.
+
+It is the wrong response to HTTP 429. GitHub's secondary rate limit is driven by
+request *frequency*, so an immediate second fetch extends the cooldown instead
+of clearing it -- the retry is not merely useless there, it actively delays
+recovery. There is also nothing on disk for the retry to reload: the failure is
+server-side, and the checkout is untouched.
+
+Observed on a Windows install (2026-08-18): the hand-off fetched, took
+`error: RPC failed; HTTP 429`, logged "first attempt failed; retrying once", and
+immediately re-fetched into the same limit. Both attempts failed and the
+cooldown was pushed further out. The checkout was already at origin/main, so the
+update had nothing to pull in the first place.
+
+This test is source-level because Linux CI cannot execute the PowerShell
+hand-off (same constraint as test_desktop_update_windows_python_handoff.py). The
+invariant it guards: a rate-limit detection gate must sit between the first
+attempt's exit-code check and the retry invocation, and the pattern it matches
+must cover the phrasings git and GitHub actually emit without swallowing
+unrelated failures that legitimately deserve the retry.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WINDOWS_PS1 = REPO_ROOT / "scripts" / "desktop-update" / "windows.ps1"
+
+# The exact phrasings git/GitHub emit when the fetch is throttled. Sources:
+# git's curl transport ("RPC failed; HTTP 429"), git's bare remote-rejection
+# line ("The requested URL returned error: 429"), GitHub's remote: banner
+# ("rate-limited due to too many requests"), and the REST-style wording
+# ("secondary rate limit").
+RATE_LIMIT_SAMPLES = (
+    "error: RPC failed; HTTP 429 curl 22 The requested URL returned error: 429",
+    "fatal: unable to access 'https://github.com/x/y.git/': The requested URL returned error: 429",
+    "remote: This request was rate-limited due to too many requests. Reduce the frequency",
+    "You have exceeded a secondary rate limit. Please wait a few minutes",
+)
+
+# Failures that must still reach the retry, plus a decoy that merely contains
+# the digits 429. Matching any of these would suppress a legitimate retry.
+NON_RATE_LIMIT_SAMPLES = (
+    "ModuleNotFoundError: No module named 'hermes_cli'",
+    "Desktop build failed",
+    "error: RPC failed; HTTP 500 curl 22",
+    "copied 429 files successfully",
+)
+
+
+def _read() -> str:
+    return WINDOWS_PS1.read_text(encoding="utf-8")
+
+
+def _rate_limit_patterns(source: str) -> list[str]:
+    """Every regex the script matches $res.Output against to detect throttling."""
+    return re.findall(r'\$res\.Output\s+-match\s+"([^"]*429[^"]*)"', source)
+
+
+def test_rate_limit_gate_exists() -> None:
+    source = _read()
+
+    patterns = _rate_limit_patterns(source)
+    assert patterns, (
+        "scripts/desktop-update/windows.ps1 must test $res.Output for a GitHub "
+        "rate-limit before retrying the update. Without that gate a 429 is "
+        "retried immediately, which extends GitHub's secondary-limit cooldown "
+        "instead of clearing it."
+    )
+
+
+def test_rate_limit_gate_precedes_the_retry() -> None:
+    """The gate is only useful if it can short-circuit before the second fetch."""
+    source = _read()
+
+    retry_marker = "first attempt failed; retrying once"
+    retry_at = source.find(retry_marker)
+    assert retry_at != -1, (
+        "Expected the retry log line in scripts/desktop-update/windows.ps1; the "
+        "hand-off retry structure changed -- update this guard."
+    )
+
+    gate_positions = [
+        m.start()
+        for m in re.finditer(r'\$res\.Output\s+-match\s+"[^"]*429[^"]*"', source)
+    ]
+    assert any(pos < retry_at for pos in gate_positions), (
+        "The rate-limit gate must appear BEFORE the retry invocation so a 429 "
+        "aborts instead of triggering a second doomed fetch."
+    )
+
+
+def test_rate_limit_gate_also_guards_the_retry_result() -> None:
+    """A retry taken for some other reason can itself land in the limit."""
+    source = _read()
+
+    retry_at = source.find("first attempt failed; retrying once")
+    gate_positions = [
+        m.start()
+        for m in re.finditer(r'\$res\.Output\s+-match\s+"[^"]*429[^"]*"', source)
+    ]
+    assert any(pos > retry_at for pos in gate_positions), (
+        "A 429 on the retry itself must also be reported as a rate-limit skip "
+        "rather than falling through to the generic failure path, so the user "
+        "is told to wait instead of re-running immediately."
+    )
+
+
+def test_pattern_matches_real_rate_limit_output() -> None:
+    source = _read()
+    patterns = _rate_limit_patterns(source)
+
+    for sample in RATE_LIMIT_SAMPLES:
+        assert any(re.search(p, sample) for p in patterns), (
+            "No rate-limit pattern in scripts/desktop-update/windows.ps1 matches "
+            f"this real throttled-fetch output:\n  {sample}\n"
+            f"Patterns present: {patterns}"
+        )
+
+
+def test_pattern_does_not_swallow_retryable_failures() -> None:
+    source = _read()
+    patterns = _rate_limit_patterns(source)
+
+    for sample in NON_RATE_LIMIT_SAMPLES:
+        offenders = [p for p in patterns if re.search(p, sample)]
+        assert not offenders, (
+            "A rate-limit pattern in scripts/desktop-update/windows.ps1 matches "
+            f"output that is NOT a rate limit:\n  {sample}\n"
+            f"Offending pattern(s): {offenders}. This would suppress a "
+            "legitimate retry (or mislabel a real failure as throttling)."
+        )


### PR DESCRIPTION
## What does this PR do?

`scripts/desktop-update/windows.ps1` retries `hermes update` once when the first attempt exits non-zero and non-2. That retry targets the update-boundary class: the fetch lands fresh code on disk while the already-loaded Python still holds the stale module, so a second run picks up the fix. It is the right response to that failure.

HTTP 429 is the one failure where it backfires. GitHub's secondary rate limit is driven by request *frequency*, so an immediate second fetch extends the cooldown instead of clearing it. There is also nothing on disk for the retry to reload: the failure is server-side and the checkout is untouched.

Observed on a Windows install (2026-08-18), from `logs/desktop-update-handoff.log`:

```
update| -> Fetching updates...
update| x Failed to fetch updates from origin.
update|   error: RPC failed; HTTP 429 curl 22 The requested URL returned error: 429
hermes update exit code: 1
first attempt failed; retrying once (freshly pulled fix loads on the second run)
```

The retry re-fetched straight into the same limit. Both attempts failed and the cooldown moved further out. The checkout was already at `origin/main`, so the update had nothing to pull in the first place.

This PR gates the retry on the throttle phrasings git and GitHub actually emit, and exits 4 with an honest message instead. The approach is detection-and-abort rather than sleep-and-backoff on purpose: the hand-off is a user-facing update with a progress window, and blocking it for an unknown multi-minute cooldown is worse than telling the truth and letting the next run pick it up.

## Related Issue

No existing issue. I searched open and merged PRs and issues for `rate limit`, `429`, and `desktop-update retry`: the 429 hits are all provider/gateway classification (#60856, #76819, #87080, #88365, #78274) or Discord/Slack/webhook buckets, and the desktop-update retry hits (#85964, #86979, #87293, #84981, #74956) cover self-lock, venv blockers, and marker races. None covers git transport throttling in the hand-off. Happy to file an issue first if you would rather track it that way.

Fixes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `scripts/desktop-update/windows.ps1` (+23): rate-limit gate before the retry invocation, and a second gate on the retry's own result since a retry taken for another reason can independently land in the limit. Both set `$finalCode`/`$finalMsg` and `exit` inside the existing `try`, matching the abort pattern already used for the missing-`python.exe` path, so the `finally` block still writes `.hermes-update-result.json`, releases the marker via `Remove-MarkerIfOwned`, and relaunches the Desktop. Exit 2 stays non-retryable and untouched.
- `tests/test_desktop_update_windows_rate_limit.py` (new, +141): five source-level assertions.

Pattern matched: `(?:HTTP|error:) 429|rate-limited|rate limited|secondary rate`. The `error:` alternative is needed because git's bare remote-rejection line (`The requested URL returned error: 429`) carries no `HTTP` prefix.

## How to Test

1. Source-level tests (these are the CI-runnable proof, since Linux CI cannot execute the PowerShell hand-off, same constraint as `test_desktop_update_windows_python_handoff.py`):
   ```
   pytest tests/test_desktop_update_windows_rate_limit.py -q
   ```
2. Confirm the tests are meaningful rather than tautological: point `WINDOWS_PS1` at the pre-fix script and 4 of the 5 fail (`test_rate_limit_gate_exists`, `..._precedes_the_retry`, `..._also_guards_the_retry_result`, `test_pattern_matches_real_rate_limit_output`); all 5 pass against the fixed script. I verified this both ways.
3. PowerShell syntax parses clean:
   ```
   [System.Management.Automation.Language.Parser]::ParseFile($path,[ref]$null,[ref]$errs)
   ```
4. Regex behavior, verified against real strings: matches all four throttle phrasings (curl `HTTP 429`, bare `error: 429`, GitHub's `remote:` banner, `secondary rate limit`); does **not** match `ModuleNotFoundError`, `Desktop build failed`, `HTTP 500`, or the decoy `copied 429 files successfully`.

Full end-to-end confirmation on the live Windows install is partial and I want to be straight about it: I could not reproduce a 429 on demand (the limit cleared while I worked, and deliberately re-tripping it to prove the branch felt like the wrong thing to do to a shared endpoint). The abort path is verified by the source-level tests and the parse check, not by a live throttled run.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 Enterprise 26100

On `pytest tests/ -q`: left unchecked honestly. `pytest` is not installed in this install's venv and I did not want to mutate a working Hermes install to add it. I drove the new test module directly with the venv interpreter (it is pure `re` + `pathlib`, no pytest-only features) and confirmed 5/5 pass against the fix and 4/5 fail against the pre-fix script. The full suite is unrun on my side; CI will be the first full-suite signal. My change touches one PowerShell script and adds one new test file, so the blast radius on the Python suite should be nil.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A: the rationale lives in the script comment and the test docstring, matching how the surrounding hand-off decisions are documented
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A (no architecture change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility): Windows-only file. `scripts/desktop-update/posix.sh` has the same unconditional retry and the same exposure; I left it alone to keep this PR single-purpose and because I cannot test it. Happy to follow up there if you want parity.
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## Screenshots / Logs

Before (from `logs/desktop-update-handoff.log`, the retry compounding the limit):

```
2026-08-18T10:43:53-05:00 update|   error: RPC failed; HTTP 429 curl 22 The requested URL returned error: 429
2026-08-18T10:43:53-05:00 hermes update exit code: 1
2026-08-18T10:43:53-05:00 first attempt failed; retrying once (freshly pulled fix loads on the second run)
```

After, the log line the gate now writes instead:

```
Update skipped: GitHub rate-limited the fetch (HTTP 429). This is server-side
throttling, not a broken install, and retrying now would extend the cooldown.
Nothing was changed; the existing build is untouched. Try again in 10-60 minutes.
```

### Side note, not part of this PR

While diagnosing, the root cause of *why* this install kept tripping the limit turned out to be fetch cost rather than the updater. `banner.py:332` already documents that an unscoped `git fetch origin` transfers every remote head ("~1,400 on this repo, measured 3.0 s vs 0.55 s scoped") and scopes its command line accordingly, but the installer's stored refspec is still `+refs/heads/*:refs/remotes/origin/*`. So a `--depth 1` install accumulated 1,713 remote-tracking refs and a 381 MB `.git`, and every fetch paid for all of them. Scoping the local refspec to `main` and repacking took it to 137 MB and a 4.1 s fetch.

If installer clones set `remote.origin.fetch` to `+refs/heads/main:refs/remotes/origin/main` to match the fetches the code already performs, that whole class of throttling mostly goes away. Not included here since it is a separate change to a different area; say the word and I will open it separately.
