### PR TITLE
feat(desktop): show the scrolled section in read_preview

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-page-extract.test.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-page-extract.test.ts
@@ -67,6 +67,22 @@ describe('preview page viewport extraction', () => {
     expect(result.visible_text).not.toContain('Clipped nested copy')
   })
 
+  it('excludes text clipped by the element that directly owns it', () => {
+    document.body.innerHTML = '<div id="clip" style="overflow: hidden">Direct clipped copy</div>'
+    const clip = document.querySelector('#clip')!
+
+    place(clip, rect(0, 100, 400, 150))
+    vi.spyOn(document, 'createRange').mockReturnValue({
+      detach: vi.fn(),
+      getClientRects: () => [rect(0, 200, 400, 220)],
+      selectNodeContents: vi.fn()
+    } as unknown as Range)
+
+    const result = Function(`return ${PREVIEW_PAGE_EXTRACT_SCRIPT}`)() as ExtractedPreviewPage
+
+    expect(result.visible_text).not.toContain('Direct clipped copy')
+  })
+
   it('hard-caps every variable-length viewport field in the guest payload', () => {
     const headings = Array.from({ length: PREVIEW_VISIBLE_HEADING_LIMIT + 4 }, (_, index) => {
       const heading = document.createElement('h2')

--- a/apps/desktop/src/app/chat/right-rail/preview-page-extract.test.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-page-extract.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  type ExtractedPreviewPage,
+  PREVIEW_PAGE_EXTRACT_SCRIPT,
+  PREVIEW_SELECTION_TEXT_MAX_CHARS,
+  PREVIEW_VISIBLE_HEADING_LIMIT,
+  PREVIEW_VISIBLE_HEADING_TEXT_MAX_CHARS,
+  PREVIEW_VISIBLE_TEXT_MAX_CHARS
+} from './preview-page-extract'
+
+function rect(left: number, top: number, right: number, bottom: number): DOMRect {
+  return {
+    bottom,
+    height: bottom - top,
+    left,
+    right,
+    toJSON: () => ({}),
+    top,
+    width: right - left,
+    x: left,
+    y: top
+  }
+}
+
+function place(element: Element, box: DOMRect): void {
+  element.getBoundingClientRect = () => box
+}
+
+describe('preview page viewport extraction', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 500 })
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 800 })
+    Object.defineProperty(window, 'scrollY', { configurable: true, value: 750 })
+    Object.defineProperty(document.documentElement, 'scrollHeight', { configurable: true, value: 2_500 })
+  })
+
+  it('extracts only viewport-intersecting headings and text, including nested clipping', () => {
+    document.body.innerHTML = `
+      <h2 id="above">Above</h2>
+      <h2 id="visible">Current section</h2>
+      <p id="visible-copy">Visible explanation</p>
+      <div id="scroller" style="overflow: auto"><p id="clipped">Clipped nested copy</p></div>
+    `
+    place(document.querySelector('#above')!, rect(0, -100, 300, -50))
+    place(document.querySelector('#visible')!, rect(0, 20, 300, 60))
+    place(document.querySelector('#visible-copy')!, rect(0, 80, 400, 120))
+    place(document.querySelector('#scroller')!, rect(0, 150, 400, 250))
+    place(document.querySelector('#clipped')!, rect(0, 300, 400, 340))
+    vi.spyOn(window, 'getSelection').mockReturnValue({ toString: () => ' selected words ' } as Selection)
+
+    // Execute the exact JavaScript string sent to webview.executeJavaScript.
+    const result = Function(`return ${PREVIEW_PAGE_EXTRACT_SCRIPT}`)() as ExtractedPreviewPage
+
+    expect(result).toMatchObject({
+      scroll_height: 2_500,
+      scroll_ratio: 0.375,
+      scroll_y: 750,
+      selection_text: 'selected words',
+      viewport_height: 500,
+      visible_headings: [{ level: 2, text: 'Current section' }]
+    })
+    expect(result.visible_text).toContain('Current section')
+    expect(result.visible_text).toContain('Visible explanation')
+    expect(result.visible_text).not.toContain('Above')
+    expect(result.visible_text).not.toContain('Clipped nested copy')
+  })
+
+  it('hard-caps every variable-length viewport field in the guest payload', () => {
+    const headings = Array.from({ length: PREVIEW_VISIBLE_HEADING_LIMIT + 4 }, (_, index) => {
+      const heading = document.createElement('h2')
+
+      heading.textContent = `${index}-${'h'.repeat(PREVIEW_VISIBLE_HEADING_TEXT_MAX_CHARS + 40)}`
+      place(heading, rect(0, 10 + index, 400, 30 + index))
+      document.body.append(heading)
+
+      return heading
+    })
+
+    const paragraph = document.createElement('p')
+
+    paragraph.textContent = 'v'.repeat(PREVIEW_VISIBLE_TEXT_MAX_CHARS + 500)
+    place(paragraph, rect(0, 100, 400, 140))
+    document.body.append(paragraph)
+    vi.spyOn(window, 'getSelection').mockReturnValue({
+      toString: () => 's'.repeat(PREVIEW_SELECTION_TEXT_MAX_CHARS + 500)
+    } as Selection)
+
+    const result = Function(`return ${PREVIEW_PAGE_EXTRACT_SCRIPT}`)() as ExtractedPreviewPage
+
+    expect(headings).toHaveLength(PREVIEW_VISIBLE_HEADING_LIMIT + 4)
+    expect(result.visible_headings).toHaveLength(PREVIEW_VISIBLE_HEADING_LIMIT)
+    expect(result.visible_headings[0]?.text.length).toBe(PREVIEW_VISIBLE_HEADING_TEXT_MAX_CHARS)
+    expect(result.visible_text.length).toBeLessThanOrEqual(PREVIEW_VISIBLE_TEXT_MAX_CHARS)
+    expect(result.selection_text).toHaveLength(PREVIEW_SELECTION_TEXT_MAX_CHARS)
+  })
+})

--- a/apps/desktop/src/app/chat/right-rail/preview-page-extract.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-page-extract.ts
@@ -1,0 +1,167 @@
+export interface PreviewViewportHeading {
+  level: number
+  text: string
+}
+
+export interface ExtractedPreviewPage {
+  scroll_height: number
+  scroll_ratio: number
+  scroll_y: number
+  selection_text?: string
+  text: string
+  viewport_height: number
+  visible_headings: PreviewViewportHeading[]
+  visible_text: string
+}
+
+export const PREVIEW_VISIBLE_HEADING_LIMIT = 8
+export const PREVIEW_VISIBLE_HEADING_TEXT_MAX_CHARS = 200
+export const PREVIEW_VISIBLE_TEXT_MAX_CHARS = 6_000
+export const PREVIEW_SELECTION_TEXT_MAX_CHARS = 2_000
+
+/**
+ * Runs inside the preview guest. Keep this function self-contained: the
+ * renderer serializes it below and sends it through webview.executeJavaScript.
+ */
+export function extractPreviewPage(): ExtractedPreviewPage {
+  const visibleHeadingLimit = 8
+  const visibleHeadingTextMaxChars = 200
+  const visibleTextMaxChars = 6_000
+  const selectionTextMaxChars = 2_000
+  const body = document.body
+  const root = document.documentElement
+  const scrollingElement = document.scrollingElement ?? root
+  const viewportHeight = Math.max(0, window.innerHeight || root?.clientHeight || 0)
+  const viewportWidth = Math.max(0, window.innerWidth || root?.clientWidth || 0)
+  const rawScrollY = window.scrollY || scrollingElement?.scrollTop || 0
+
+  const scrollHeight = Math.max(
+    viewportHeight,
+    scrollingElement?.scrollHeight || 0,
+    root?.scrollHeight || 0,
+    body?.scrollHeight || 0
+  )
+
+  const maxScrollY = Math.max(0, scrollHeight - viewportHeight)
+  const scrollY = Math.min(Math.max(0, Number.isFinite(rawScrollY) ? rawScrollY : 0), maxScrollY)
+  const scrollRatio = maxScrollY > 0 ? scrollY / maxScrollY : 0
+
+  const intersectsViewport = (rect: DOMRect, element: Element): boolean => {
+    let left = Math.max(0, rect.left)
+    let right = Math.min(viewportWidth, rect.right)
+    let top = Math.max(0, rect.top)
+    let bottom = Math.min(viewportHeight, rect.bottom)
+
+    if (right <= left || bottom <= top || rect.width <= 0 || rect.height <= 0) {
+      return false
+    }
+
+    for (let ancestor = element.parentElement; ancestor && ancestor !== body; ancestor = ancestor.parentElement) {
+      const style = window.getComputedStyle(ancestor)
+
+      if (style.display === 'none' || style.visibility === 'hidden') {
+        return false
+      }
+
+      const clips = `${style.overflow} ${style.overflowX} ${style.overflowY}`
+
+      if (/auto|clip|hidden|scroll/.test(clips)) {
+        const ancestorRect = ancestor.getBoundingClientRect()
+
+        left = Math.max(left, ancestorRect.left)
+        right = Math.min(right, ancestorRect.right)
+        top = Math.max(top, ancestorRect.top)
+        bottom = Math.min(bottom, ancestorRect.bottom)
+
+        if (right <= left || bottom <= top) {
+          return false
+        }
+      }
+    }
+
+    return true
+  }
+
+  const elementIsVisible = (element: Element): boolean => {
+    const style = window.getComputedStyle(element)
+
+    return style.display !== 'none' && style.visibility !== 'hidden' && intersectsViewport(element.getBoundingClientRect(), element)
+  }
+
+  const visibleHeadings = body
+    ? Array.from(body.querySelectorAll<HTMLElement>('h1,h2,h3,h4,h5,h6'))
+        .filter(elementIsVisible)
+        .slice(0, visibleHeadingLimit)
+        .map(element => ({
+          level: Number(element.tagName.slice(1)),
+          text: (element.innerText || element.textContent || '').trim().slice(0, visibleHeadingTextMaxChars)
+        }))
+        .filter(heading => heading.text.length > 0)
+    : []
+
+  const visibleTextParts: string[] = []
+  let visibleTextLength = 0
+
+  if (body) {
+    const walker = document.createTreeWalker(body, NodeFilter.SHOW_TEXT)
+    let node: Node | null
+
+    while (visibleTextLength < visibleTextMaxChars && (node = walker.nextNode())) {
+      const parent = node.parentElement
+      const value = (node.nodeValue || '').replace(/\s+/g, ' ').trim()
+
+      if (!parent || !value || parent.closest('script,style,noscript,template')) {
+        continue
+      }
+
+      const style = window.getComputedStyle(parent)
+
+      if (style.display === 'none' || style.visibility === 'hidden') {
+        continue
+      }
+
+      const range = document.createRange()
+      range.selectNodeContents(node)
+      const rects = typeof range.getClientRects === 'function' ? Array.from(range.getClientRects()) : []
+
+      const isVisible = (rects.length ? rects : [parent.getBoundingClientRect()]).some(rect =>
+        intersectsViewport(rect, parent)
+      )
+
+      range.detach?.()
+
+      if (!isVisible) {
+        continue
+      }
+
+      const separatorLength = visibleTextParts.length ? 1 : 0
+      const remaining = visibleTextMaxChars - visibleTextLength - separatorLength
+
+      if (remaining <= 0) {
+        break
+      }
+
+      const part = value.slice(0, remaining)
+
+      visibleTextParts.push(part)
+      visibleTextLength += separatorLength + part.length
+    }
+  }
+
+  const selection = String(window.getSelection?.() || '')
+    .trim()
+    .slice(0, selectionTextMaxChars)
+
+  return {
+    scroll_height: scrollHeight,
+    scroll_ratio: Math.min(1, Math.max(0, scrollRatio)),
+    scroll_y: scrollY,
+    ...(selection ? { selection_text: selection } : {}),
+    text: body ? (typeof body.innerText === 'string' ? body.innerText : body.textContent || '') : '',
+    viewport_height: viewportHeight,
+    visible_headings: visibleHeadings,
+    visible_text: visibleTextParts.join('\n')
+  }
+}
+
+export const PREVIEW_PAGE_EXTRACT_SCRIPT = `(${extractPreviewPage.toString()})()`

--- a/apps/desktop/src/app/chat/right-rail/preview-page-extract.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-page-extract.ts
@@ -56,7 +56,7 @@ export function extractPreviewPage(): ExtractedPreviewPage {
       return false
     }
 
-    for (let ancestor = element.parentElement; ancestor && ancestor !== body; ancestor = ancestor.parentElement) {
+    for (let ancestor: Element | null = element; ancestor && ancestor !== body; ancestor = ancestor.parentElement) {
       const style = window.getComputedStyle(ancestor)
 
       if (style.display === 'none' || style.visibility === 'hidden') {

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -28,6 +28,7 @@ import { type ConsoleEntry } from './preview-console-state'
 import { previewConsoleState } from './preview-console-store'
 import { LocalFilePreview, PreviewEmptyState } from './preview-file'
 import { PREVIEW_BROWSER_ATTR, registerPreviewNav } from './preview-nav'
+import { type ExtractedPreviewPage, PREVIEW_PAGE_EXTRACT_SCRIPT } from './preview-page-extract'
 import { registerPreviewPageReader } from './preview-reader'
 
 type PreviewWebview = HTMLElement & {
@@ -401,10 +402,8 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
     return registerPreviewNav(tabId, { back: goBack, forward: goForward, reload: reloadPreview })
   }, [goBack, goForward, isRemoteHtml, isWebPreview, reloadPreview, tabId])
 
-  // Publish the PAGE reader for this tab (the read_preview tool): extract the
-  // rendered page's title + visible text from the webview. innerText (not
-  // textContent) so hidden nodes and script/style bodies stay out, matching
-  // what the user actually sees.
+  // Publish the PAGE reader for this tab (the read_preview tool): extract both
+  // full-page text for pagination and bounded viewport-local context.
   useEffect(() => {
     if (!isWebPreview || !tabId) {
       return
@@ -417,10 +416,11 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
         throw new Error('preview webview is not ready')
       }
 
-      const text = await webview.executeJavaScript('document.body ? document.body.innerText : ""')
+      const extracted = (await webview.executeJavaScript(PREVIEW_PAGE_EXTRACT_SCRIPT)) as ExtractedPreviewPage
 
       return {
-        text: typeof text === 'string' ? text : '',
+        ...extracted,
+        text: typeof extracted?.text === 'string' ? extracted.text : '',
         title: webview.getTitle?.() ?? '',
         url: webview.getURL?.() ?? ''
       }

--- a/apps/desktop/src/app/chat/right-rail/preview-reader.test.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-reader.test.ts
@@ -3,6 +3,12 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { $rightRailActiveTabId, selectRightRailTab } from '@/store/layout'
 import { closeRightRail, openPreview, type PreviewTarget } from '@/store/preview'
 
+import {
+  PREVIEW_SELECTION_TEXT_MAX_CHARS,
+  PREVIEW_VISIBLE_HEADING_LIMIT,
+  PREVIEW_VISIBLE_HEADING_TEXT_MAX_CHARS,
+  PREVIEW_VISIBLE_TEXT_MAX_CHARS
+} from './preview-page-extract'
 import { PREVIEW_READ_MAX_CHARS, readActivePreview, registerPreviewPageReader } from './preview-reader'
 
 function urlTarget(url: string): PreviewTarget {
@@ -74,6 +80,46 @@ describe('readActivePreview (read_preview tool)', () => {
     })
   })
 
+  it('passes bounded viewport context independently of the full-text window', async () => {
+    openPreview(urlTarget('https://example.com/guide'), 'tool-result')
+    register($rightRailActiveTabId.get()!, async () => ({
+      scroll_height: 4_000,
+      scroll_ratio: 99,
+      scroll_y: 1_500,
+      selection_text: 's'.repeat(PREVIEW_SELECTION_TEXT_MAX_CHARS + 20),
+      text: 'abcdefghij',
+      title: 'Guide',
+      url: '',
+      viewport_height: 1_000,
+      visible_headings: Array.from({ length: PREVIEW_VISIBLE_HEADING_LIMIT + 2 }, (_, index) => ({
+        level: index + 1,
+        text: ` ${'h'.repeat(PREVIEW_VISIBLE_HEADING_TEXT_MAX_CHARS + 20)} `
+      })),
+      visible_text: 'v'.repeat(PREVIEW_VISIBLE_TEXT_MAX_CHARS + 20)
+    }))
+
+    const result = await readActivePreview({ count: 4, start: 2 })
+
+    expect(result).toMatchObject({
+      end: 6,
+      scroll_height: 4_000,
+      scroll_ratio: 0.5,
+      scroll_y: 1_500,
+      start: 2,
+      text: 'cdef',
+      total_chars: 10,
+      viewport_height: 1_000
+    })
+    expect(result?.selection_text).toHaveLength(PREVIEW_SELECTION_TEXT_MAX_CHARS)
+    expect(result?.visible_headings).toHaveLength(PREVIEW_VISIBLE_HEADING_LIMIT)
+    expect(result?.visible_headings?.[0]).toEqual({
+      level: 1,
+      text: 'h'.repeat(PREVIEW_VISIBLE_HEADING_TEXT_MAX_CHARS)
+    })
+    expect(result?.visible_headings?.at(-1)?.level).toBe(6)
+    expect(result?.visible_text).toHaveLength(PREVIEW_VISIBLE_TEXT_MAX_CHARS)
+  })
+
   it('caps a single read at PREVIEW_READ_MAX_CHARS even when asked for more', async () => {
     openPreview(urlTarget('https://example.com'), 'tool-result')
     register($rightRailActiveTabId.get()!, async () => ({
@@ -102,11 +148,15 @@ describe('readActivePreview (read_preview tool)', () => {
   it('answers a file tab with its identity and points at read_file', async () => {
     openPreview(fileTarget('/work/notes.md'), 'file-browser')
 
-    expect(await readActivePreview()).toMatchObject({
+    const result = await readActivePreview()
+
+    expect(result).toMatchObject({
       kind: 'file',
       note: expect.stringContaining('read_file') as string,
       path: '/work/notes.md'
     })
+    expect(result).not.toHaveProperty('visible_text')
+    expect(result).not.toHaveProperty('scroll_ratio')
   })
 
   it('reads the tab the user is LOOKING at, not the last one opened', async () => {

--- a/apps/desktop/src/app/chat/right-rail/preview-reader.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-reader.ts
@@ -15,6 +15,14 @@
 import { $rightRailActiveTabId } from '@/store/layout'
 import { $previewTabs } from '@/store/preview'
 
+import {
+  PREVIEW_SELECTION_TEXT_MAX_CHARS,
+  PREVIEW_VISIBLE_HEADING_LIMIT,
+  PREVIEW_VISIBLE_HEADING_TEXT_MAX_CHARS,
+  PREVIEW_VISIBLE_TEXT_MAX_CHARS,
+  type PreviewViewportHeading
+} from './preview-page-extract'
+
 export interface PreviewReadOptions {
   /** Characters to return from `start` (capped at PREVIEW_READ_MAX_CHARS). */
   count?: number
@@ -27,18 +35,32 @@ export interface PreviewReadResult {
   kind: string
   note?: string
   path?: string
+  scroll_height?: number
+  scroll_ratio?: number
+  scroll_y?: number
+  selection_text?: string
   start: number
   text: string
   title: string
   total_chars: number
   url: string
+  viewport_height?: number
+  visible_headings?: PreviewViewportHeading[]
+  visible_text?: string
 }
 
 /** What a pane's page reader extracts — the reader module owns the windowing. */
 interface PreviewPage {
+  scroll_height?: number
+  scroll_ratio?: number
+  scroll_y?: number
+  selection_text?: string
   text: string
   title: string
   url: string
+  viewport_height?: number
+  visible_headings?: PreviewViewportHeading[]
+  visible_text?: string
 }
 
 type PageReader = () => Promise<PreviewPage>
@@ -48,6 +70,42 @@ type PageReader = () => Promise<PreviewPage>
 export const PREVIEW_READ_MAX_CHARS = 24_000
 
 const readers = new Map<string, PageReader>()
+
+function boundedNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.max(0, value) : 0
+}
+
+function viewportContext(page: PreviewPage): Partial<PreviewReadResult> {
+  if (typeof page.visible_text !== 'string') {
+    return {}
+  }
+
+  const viewportHeight = boundedNumber(page.viewport_height)
+  const scrollHeight = Math.max(viewportHeight, boundedNumber(page.scroll_height))
+  const maxScrollY = Math.max(0, scrollHeight - viewportHeight)
+  const scrollY = Math.min(boundedNumber(page.scroll_y), maxScrollY)
+  const selection = typeof page.selection_text === 'string' ? page.selection_text.trim() : ''
+
+  const headings = Array.isArray(page.visible_headings)
+    ? page.visible_headings
+        .slice(0, PREVIEW_VISIBLE_HEADING_LIMIT)
+        .map(heading => ({
+          level: Math.min(6, Math.max(1, Math.trunc(boundedNumber(heading?.level) || 1))),
+          text: typeof heading?.text === 'string' ? heading.text.trim().slice(0, PREVIEW_VISIBLE_HEADING_TEXT_MAX_CHARS) : ''
+        }))
+        .filter(heading => heading.text.length > 0)
+    : []
+
+  return {
+    scroll_height: scrollHeight,
+    scroll_ratio: maxScrollY > 0 ? scrollY / maxScrollY : 0,
+    scroll_y: scrollY,
+    ...(selection ? { selection_text: selection.slice(0, PREVIEW_SELECTION_TEXT_MAX_CHARS) } : {}),
+    viewport_height: viewportHeight,
+    visible_headings: headings,
+    visible_text: page.visible_text.slice(0, PREVIEW_VISIBLE_TEXT_MAX_CHARS)
+  }
+}
 
 /** Register a live preview's page reader; returns an idempotent unregister. */
 export function registerPreviewPageReader(tabId: string, reader: PageReader): () => void {
@@ -90,7 +148,13 @@ export async function readActivePreview(opts: PreviewReadOptions = {}): Promise<
       const page = await reader()
 
       return windowText(
-        { kind: target.kind, path: target.path, title: page.title || target.label, url: page.url || target.url },
+        {
+          kind: target.kind,
+          path: target.path,
+          title: page.title || target.label,
+          url: page.url || target.url,
+          ...viewportContext(page)
+        },
         page.text,
         opts
       )

--- a/tests/tools/test_read_preview_tool.py
+++ b/tests/tools/test_read_preview_tool.py
@@ -28,7 +28,15 @@ def test_empty_answer_means_nothing_open():
 
 
 def test_passes_json_through():
-    payload = {"kind": "url", "url": "https://news.ycombinator.com", "title": "HN", "text": "hello"}
+    payload = {
+        "kind": "url",
+        "url": "https://news.ycombinator.com",
+        "title": "HN",
+        "text": "whole page",
+        "scroll_ratio": 0.5,
+        "visible_headings": [{"level": 2, "text": "Current stories"}],
+        "visible_text": "hello",
+    }
     result = json.loads(rp.read_preview_tool(callback=lambda **_: json.dumps(payload)))
     assert result == payload
 

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -337,10 +337,11 @@ def test_sensitive_prompt_timeout_emits_expiry(capture, event):
         ("sudo.respond", "password"),
         ("clarify.respond", "answer"),
         ("terminal.read.respond", "text"),
+        ("preview.read.respond", "text"),
     ],
 )
 def test_late_prompt_response_is_idempotent(server, method, value_key):
-    """All four blocking bridges tolerate a late reply after their request has
+    """Blocking bridges tolerate a late reply after their request has
     expired — the `*.respond` returns a graceful `{"status": "expired"}` instead
     of the raw 4009 protocol error a client would otherwise surface verbatim."""
     response = server.handle_request(

--- a/tools/read_preview_tool.py
+++ b/tools/read_preview_tool.py
@@ -57,13 +57,16 @@ READ_PREVIEW_SCHEMA = {
         "Read what's currently shown in the in-app browser / preview pane of the "
         "Hermes desktop GUI (the pane open_preview opens beside this chat). Call "
         "with no arguments for the first window of the active tab's content. "
-        "Returns JSON {kind, url, title, text, start, end, total_chars, note?}: "
-        "a URL (Browser) tab's text is the rendered page's visible text — page "
-        "through longer pages with `start`/`count` (character offsets, capped "
-        "per read); a file tab answers identity only (read the file with "
-        "read_file); an artifact tab points back at the conversation. Use after "
-        "open_preview, or whenever the user refers to what's on screen in the "
-        "browser ('what does this page say?')."
+        "Returns JSON {kind, url, title, text, start, end, total_chars, note?, "
+        "scroll_y?, scroll_height?, viewport_height?, scroll_ratio?, "
+        "visible_headings?, visible_text?, selection_text?}. For a URL (Browser) "
+        "tab, `text` is CSS-visible text from the whole rendered page and remains "
+        "pageable with `start`/`count`; when the user refers to 'this', 'here', or "
+        "what they are reading, prefer the bounded viewport-local "
+        "`visible_headings`, `visible_text`, and `selection_text` fields. A file "
+        "tab answers identity only (read the file with read_file); an artifact tab "
+        "points back at the conversation. Use after open_preview, or whenever the "
+        "user refers to what's on screen in the browser."
     ),
     "parameters": {
         "type": "object",

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -185,7 +185,7 @@ messaging, and cron sessions.
 | `read_terminal` | Read what's currently shown in the in-app terminal pane of the Hermes desktop GUI (the embedded shell beside this chat). | — |
 | `close_terminal` | Close the read-only terminal tab for a background process in the Hermes desktop GUI. Does NOT kill the process — only drops the tab/view; use process(action='kill') to stop it. | — |
 | `open_preview` | Open a web URL, localhost dev-server URL, or file path in the preview pane beside the chat in the Hermes desktop app. | — |
-| `read_preview` | Read what's currently shown in the preview pane of the Hermes desktop GUI — the in-app Browser's page text (URL + title + rendered text, pageable with `start`/`count`), or a file/artifact tab's identity. | — |
+| `read_preview` | Read what's currently shown in the preview pane of the Hermes desktop GUI — the in-app Browser's full rendered page text (pageable with `start`/`count`) plus bounded viewport-local headings, text, selection, and scroll position, or a file/artifact tab's identity. | — |
 | `read_window_below` | Identify the OS window directly underneath the Hermes desktop window — app name, title, bounds (metadata only, never pixels). On macOS, other apps' titles appear only when Screen Recording is already granted; the tool never prompts for it. | — |
 | `focus_pane` | Reveal and focus a pane in the Hermes desktop app (chat, files, terminal, review, sessions). | — |
 | `react_to_message` | React to a message with a single emoji, iMessage-tapback style. Opt-in via Settings → Appearance (`display.message_reactions`). | — |


### PR DESCRIPTION
## What does this PR do?

`read_preview` now reports the section visible in the Desktop in-app browser, including bounded viewport text, visible headings, selection text, and normalized scroll metrics. This lets the agent answer references such as "this section" without replacing the existing full-page `text` pagination contract or adding another model tool.

## Related Issue

Closes #89288

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `apps/desktop/src/app/chat/right-rail/preview-page-extract.ts` - extract bounded viewport-local text, headings, selection, and scroll metrics while respecting nested overflow clipping.
- `apps/desktop/src/app/chat/right-rail/preview-pane.tsx` - return the richer page snapshot from the existing webview reader.
- `apps/desktop/src/app/chat/right-rail/preview-reader.ts` - normalize and forward viewport fields without changing full-page `start` and `count` windowing.
- `tools/read_preview_tool.py` - document the additive viewport-aware response contract for the model.
- `tests/` and Desktop tests - cover extraction bounds, clipping, protocol forwarding, and the unchanged pagination behavior.
- `website/docs/reference/tools-reference.md` - document when to use viewport-local fields versus full-page text.

## How to Test

1. In Hermes Desktop, open a long page in the preview rail and scroll to a section with headings.
2. Call `read_preview` and verify that `visible_text` and `visible_headings` match the on-screen section, `scroll_ratio` is clamped to 0-1, and `text` still follows `start` and `count`.
3. Run the focused automated checks:

```bash
scripts/run_tests.sh tests/tools/test_read_preview_tool.py tests/tui_gateway/test_protocol.py
cd apps/desktop
npx vitest run src/app/chat/right-rail/preview-page-extract.test.ts src/app/chat/right-rail/preview-reader.test.ts
npm run typecheck
npx eslint src/app/chat/right-rail/preview-page-extract.ts src/app/chat/right-rail/preview-page-extract.test.ts src/app/chat/right-rail/preview-pane.tsx src/app/chat/right-rail/preview-reader.ts src/app/chat/right-rail/preview-reader.test.ts
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run the focused Python and Desktop test suites listed above and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] Config examples are N/A because this change adds no config keys
- [x] Contributor and architecture guide updates are N/A because this does not change contributor workflows
- [x] I've considered cross-platform impact; the webview extraction is platform-independent and covered by DOM unit tests
- [x] I've updated the tool description for the additive response fields

## Screenshots / Logs

N/A - the feature is exposed through the structured `read_preview` response and is covered by focused protocol and extraction tests.
