### PR TITLE
fix(gateway): prevent duplicate guardrail halt delivery

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7230,7 +7230,6 @@ def run_conversation(
                         if agent.stream_delta_callback:
                             try:
                                 agent.stream_delta_callback(final_response)
-                                agent.stream_delta_callback(None)
                             except Exception:
                                 pass
                     break

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -423,3 +423,8 @@ def test_guardrail_halt_emits_final_response_through_stream_delta_callback():
     assert halt_text in text_deltas, (
         f"halt message was never streamed; callback only saw {deltas!r}"
     )
+    assert deltas[-1] == halt_text, (
+        "guardrail halt text is final turn content; a trailing None would be "
+        "misinterpreted by gateway streaming as a tool/segment boundary and "
+        "allow the normal final-send path to deliver the same text again"
+    )


### PR DESCRIPTION
## Summary

Fixes #46731 by preventing a streamed tool-guardrail halt explanation from being delivered twice on Telegram.

This is the focused replacement requested in the issue's August 3 consolidation note. It reapplies the guardrail portion of closed PR #46743 and preserves the original author of that work.

## Root cause

`agent/conversation_loop.py` emits the synthesized guardrail explanation through `stream_delta_callback(final_response)` so SSE/TUI clients do not see a silent stream close. It then emitted `stream_delta_callback(None)`.

For gateway clients, however, `None` means **tool/segment boundary**, not turn completion. `GatewayStreamConsumer` finalized the explanation as an interim segment and reset its final-delivery flags. The outer gateway later called the normal completion path, saw no confirmed final delivery, and sent the same response again.

The durable transcript contained one assistant message and one model turn; the duplication was entirely in delivery.

## Fix

- Keep emitting the synthesized halt text for SSE/TUI visibility.
- Remove the trailing boundary callback and let the gateway's existing outer `finish()` signal close the stream.
- Extend the existing runtime regression to require the halt text itself to be the final callback delta.

## Reproduction evidence

Observed on Telegram with `loop_web_search_cap`:

- one inbound user message;
- one agent turn and one persisted assistant response;
- the streamed guardrail explanation appeared once;
- the normal gateway final-send path delivered the identical text again.

The new assertion fails on current `main` because the last callback is `None`, then passes with this patch.

## Verification

```text
scripts/run_tests.sh \
  tests/run_agent/test_tool_call_guardrail_runtime.py \
  tests/gateway/test_duplicate_reply_suppression.py \
  tests/gateway/test_stream_consumer_fresh_final.py -q

29 passed, 0 failed
```

Additional checks:

- `ruff check` on both changed files: passed
- `compileall` on both changed files: passed
- `git diff --check`: passed

## Scope

This PR fixes delivery duplication only. It does not change the search-cap threshold or the wording issue tracked by #85746 / #85768.
