### PR TITLE
fix(whatsapp): restore history sync so group messages decrypt (#11951)

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -409,6 +409,11 @@ async function startSocket() {
     printQRInTerminal: false,
     browser: ['Hermes Agent', 'Chrome', '120.0'],
     syncFullHistory: false,
+    // Baileys 7.x: with syncFullHistory:false and NO shouldSyncHistoryMessage, ALL
+    // history sync is disabled (INITIAL_BOOTSTRAP/RECENT/ON_DEMAND), so LID mappings
+    // and group participation never arrive and group messages fail to decrypt (#11951).
+    // Allow every sync type except FULL (syncType 2).
+    shouldSyncHistoryMessage: (msg) => (msg && msg.syncType) !== 2,
     markOnlineOnConnect: false,
     // Required for Baileys 7.x: without this, incoming messages that need
     // E2EE session re-establishment are silently dropped (msg.message === null)


### PR DESCRIPTION
### Problem
`bridge.js` sets `syncFullHistory: false` but provides **no** `shouldSyncHistoryMessage` callback. In Baileys 7.x this disables **all** history sync (INITIAL_BOOTSTRAP, RECENT, ON_DEMAND), not just the full-history download. Without those sync types the client never receives **LID↔PN mappings** or **group participation** data.

Symptoms (real deployment, Baileys 7.0.0-rc13, groups using `@lid` addressing):
- inbound **group** messages fail to decrypt: `SessionError: No session record` / `No session found to decrypt message` (GroupCipher), `USync fetch yielded no results for pending PNs`
- DMs work; groups effectively never route.

This is the same root cause discussed in #11951 (closed but the code in `main` still has no callback).

### Fix
Add a `shouldSyncHistoryMessage` callback that allows every sync type **except FULL** (syncType 2), restoring LID/group sync while still avoiding the full-history download.

```js
shouldSyncHistoryMessage: (msg) => (msg && msg.syncType) !== 2,
```

### Verified
On a fresh device re-pair with this callback, the session syncs the group sender-keys (session grows from ~0 to ~2800 files) and group messages decrypt + route correctly.