### PR TITLE
fix(whatsapp): strip :<device> suffix in normalizeWhatsAppId (fixes @mention & reply-to-bot in groups)

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -205,7 +205,11 @@ function trackSentMessageId(sent) {
 
 function normalizeWhatsAppId(value) {
   if (!value) return '';
-  return String(value).replace(':', '@');
+  // Strip the :<device> suffix (e.g. 447999674698:14@s.whatsapp.net -> ...@s.whatsapp.net)
+  // so bot/mention/quoted ids compare consistently. The old .replace(':','@') produced a
+  // malformed '...@14@lid', which never matched the bot's own id (breaking @mention and
+  // reply-to-bot detection in groups).
+  return String(value).replace(/:\d+@/, '@').replace(/:\d+$/, '');
 }
 
 function redactWhatsAppId(value) {


### PR DESCRIPTION
### Problem
`normalizeWhatsAppId` does `String(value).replace(':', '@')`, which turns a device-qualified id like `116342762025117:14@lid` into a **malformed** `116342762025117@14@lid`.

The bot's own ids (`sock.user.id` / `sock.user.lid`, used to build `botIds`) carry the `:<device>` suffix, while inbound `mentionedJid` and `contextInfo.participant` (the quoted message's author) do **not**. After the mangling the two never compare equal, so:
- `@mention` of the bot isn't detected, and
- **reply-to-bot** (quoting a bot message to re-engage it) isn't detected

…in groups with `require_mention`, meaning the bot silently ignores messages that clearly address it.

Observed values (debug): `quotedParticipant = 116342762025117@lid` vs `botIds = [447999674698@14@s.whatsapp.net, 116342762025117@14@lid]` → no match.

### Fix
Strip the `:<device>` suffix so every id form (`@s.whatsapp.net`, `@lid`, with or without `:<device>`) normalizes consistently:

```js
return String(value).replace(/:\d+@/, '@').replace(/:\d+$/, '');
```

After this, `116342762025117:14@lid` and `116342762025117@lid` both normalize to `116342762025117@lid`, so `_message_mentions_bot` / `_message_is_reply_to_bot` match correctly.