### PR TITLE
feat(cli): surface all free tool-capable models in OpenRouter picker (#89150)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1831,7 +1831,8 @@ def fetch_openrouter_models(
 
     # Surface all remaining free tool-capable models from the live catalog (#89150).
     # Allows free-tier users to discover all available free models without
-    # dumping the entire 400+ paid catalog.
+    # dumping the entire 400+ paid catalog. Sorted alphabetically for stable ordering.
+    extra_free: list[str] = []
     for mid, live_item in live_by_id.items():
         if mid in seen_ids:
             continue
@@ -1839,8 +1840,11 @@ def fetch_openrouter_models(
             continue
         if not _openrouter_model_supports_tools(live_item):
             continue
-        curated.append((mid, "free"))
+        extra_free.append(mid)
         seen_ids.add(mid)
+
+    for mid in sorted(extra_free):
+        curated.append((mid, "free"))
 
     if not curated:
         return list(_openrouter_catalog_cache or fallback)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1809,6 +1809,7 @@ def fetch_openrouter_models(
         }
 
     curated: list[tuple[str, str]] = []
+    seen_ids: set[str] = set()
     silent_default = get_preferred_silent_default_model("openrouter")
     for preferred_id in preferred_ids:
         live_item = live_by_id.get(preferred_id)
@@ -1826,6 +1827,20 @@ def fetch_openrouter_models(
         else:
             desc = "free" if _openrouter_model_is_free(live_item.get("pricing")) else ""
         curated.append((preferred_id, desc))
+        seen_ids.add(preferred_id)
+
+    # Surface all remaining free tool-capable models from the live catalog (#89150).
+    # Allows free-tier users to discover all available free models without
+    # dumping the entire 400+ paid catalog.
+    for mid, live_item in live_by_id.items():
+        if mid in seen_ids:
+            continue
+        if not _openrouter_model_is_free(live_item.get("pricing")):
+            continue
+        if not _openrouter_model_supports_tools(live_item):
+            continue
+        curated.append((mid, "free"))
+        seen_ids.add(mid)
 
     if not curated:
         return list(_openrouter_catalog_cache or fallback)

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -101,6 +101,54 @@ class TestFetchOpenRouterModels:
         # Image-only model advertised supported_parameters WITHOUT tools → must be dropped.
         assert "google/gemini-3-pro-image-preview" not in ids
 
+    def test_surfaces_all_live_free_models_with_tool_support(self, monkeypatch):
+        """Live free models with tool support should be included in the picker even if not in curated list (#89150)."""
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return (
+                    b'{"data":['
+                    b'{"id":"anthropic/claude-opus-4.6","pricing":{"prompt":"0.000015","completion":"0.000075"},'
+                    b'"supported_parameters":["temperature","tools"]},'
+                    b'{"id":"openai/gpt-oss-20b:free","pricing":{"prompt":"0","completion":"0"},'
+                    b'"supported_parameters":["temperature","tools"]},'
+                    b'{"id":"meta-llama/llama-free-no-tools:free","pricing":{"prompt":"0","completion":"0"},'
+                    b'"supported_parameters":["temperature"]},'
+                    b'{"id":"expensive/model-not-curated","pricing":{"prompt":"0.01","completion":"0.02"},'
+                    b'"supported_parameters":["tools"]}'
+                    b']}'
+                )
+
+        monkeypatch.setattr(
+            _models_mod,
+            "OPENROUTER_MODELS",
+            [
+                ("anthropic/claude-opus-4.6", ""),
+            ],
+        )
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        with (
+            patch("hermes_cli.model_catalog.get_curated_openrouter_models", return_value=[]),
+            patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()),
+        ):
+            models = fetch_openrouter_models(force_refresh=True)
+
+        model_dict = dict(models)
+        # Curated paid model present
+        assert "anthropic/claude-opus-4.6" in model_dict
+        # Uncurated free model WITH tools present and marked 'free'
+        assert "openai/gpt-oss-20b:free" in model_dict
+        assert model_dict["openai/gpt-oss-20b:free"] == "free"
+        # Free model WITHOUT tools excluded
+        assert "meta-llama/llama-free-no-tools:free" not in model_dict
+        # Uncurated paid model excluded
+        assert "expensive/model-not-curated" not in model_dict
+
 
 
 class TestOpenRouterToolSupportHelper:


### PR DESCRIPTION
## What does this PR do?

Surfaces all live OpenRouter models that are **free** (`pricing.prompt == 0` and `pricing.completion == 0`) and support **tool calling** (`_openrouter_model_supports_tools(item)`) in the model picker (`fetch_openrouter_models()`), in addition to the curated list.

Previously, `fetch_openrouter_models()` only included models present in the curated manifest, causing usable free tool-capable models in the live OpenRouter catalog to be hidden from the picker.

## Related Issue

Fixes #89150

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/models.py`: After populating the curated OpenRouter models, iterate through all live catalog models and append any remaining free models with tool-calling capabilities with the `"free"` badge.
- `tests/hermes_cli/test_models.py`: Added `test_surfaces_all_live_free_models_with_tool_support` to verify that uncurated live free models with tool support are properly surfaced, while non-tool or paid uncurated models remain excluded.

## How to Test

1. Run unit tests: `pytest tests/hermes_cli/test_models.py -k test_surfaces_all_live_free_models_with_tool_support`
2. Test live model fetching with OpenRouter API to verify free models are present in the returned list.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(scope):`, `fix(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11
