### PR TITLE
feat(desktop): add copy on Bot Mode group chat messages

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -29,6 +29,7 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
   ConfirmDialog,
+  CopyButton,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -7962,7 +7963,7 @@ function GroupChatWorkspace({ group, members, onBack }) {
 
                   return jsxs('div', {
                     className: cn(
-                      'flex items-start gap-2',
+                      'group flex items-start gap-2',
                       isUser ? 'rounded-md bg-(--chrome-action-hover) px-2 py-1.5' : 'px-2 py-1'
                     ),
                     children: [
@@ -7982,7 +7983,7 @@ function GroupChatWorkspace({ group, members, onBack }) {
                         className: 'min-w-0 flex-1',
                         children: [
                           jsxs('div', {
-                            className: 'flex items-baseline gap-2',
+                            className: 'flex items-center gap-2',
                             children: [
                               isUser
                                 ? jsx('span', {
@@ -8000,7 +8001,19 @@ function GroupChatWorkspace({ group, members, onBack }) {
                               jsx('span', {
                                 className: 'text-[0.625rem] text-(--ui-text-quaternary)',
                                 children: relativeTime(entry.at)
-                              })
+                              }),
+                              entry.text.trim()
+                                ? jsx('div', {
+                                    className:
+                                      'ml-auto shrink-0 opacity-0 pointer-events-none group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100',
+                                    children: jsx(CopyButton, {
+                                      appearance: 'icon',
+                                      buttonSize: 'icon',
+                                      stopPropagation: true,
+                                      text: entry.text
+                                    })
+                                  })
+                                : null
                             ]
                           }),
                           jsx('div', {

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -683,3 +683,26 @@ test('source contract: thread UI — folded rows, per-thread reply box, new-thre
   assert.match(pluginSource, /children: 'New Thread'/)
   assert.match(pluginSource, /const markKey = `\$\{thread\}::\$\{memberKey\}`/)
 })
+
+function groupChatWorkspaceSource() {
+  const start = pluginSource.indexOf('function GroupChatWorkspace')
+  const end = pluginSource.indexOf('function closeGroupChatMainTab')
+  assert.ok(start >= 0, 'GroupChatWorkspace is defined')
+  assert.ok(end > start, 'closeGroupChatMainTab follows GroupChatWorkspace')
+  return pluginSource.slice(start, end)
+}
+
+test('source contract: group chat log lines expose CopyButton on the entry body', () => {
+  const src = groupChatWorkspaceSource()
+  assert.match(pluginSource, /CopyButton/)
+  assert.match(src, /CopyButton/)
+  assert.match(src, /text:\s*entry\.text/)
+  assert.match(src, /stopPropagation:\s*true/)
+  assert.match(src, /appearance:\s*['"]icon['"]/)
+  assert.match(src, /buttonSize:\s*['"]icon['"]/)
+  assert.match(src, /['"]group /)
+  assert.doesNotMatch(src, /playSpeechText/)
+  assert.doesNotMatch(src, /RefreshCw/)
+  assert.doesNotMatch(src, /readAloud/)
+  assert.doesNotMatch(src, /ActionBarPrimitive\.Reload/)
+})


### PR DESCRIPTION
## What does this PR do?

Bot Mode group rooms (`Open chat` on a group) render a custom log and had no copy control. Sessions chat already has Copy on assistant messages via `CopyButton`.

This adds the same `CopyButton` to each expanded group-chat line (your messages and bot messages). Hover the row to reveal it. Click copies the message body only, not the speaker name or timestamp.

Read aloud and Refresh are intentionally not included. A group room is several bots taking turns in separate `Group: …` sessions, so regenerate can land on a turn another bot has already continued. Users can already talk in the room or 1:1. Per-line TTS is a weak fit for overlapping short turns.

## Related Issue

N/A — no existing issue or PR for this (searched open PRs/issues for Bot Mode copy / read aloud / refresh).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes a bug)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.js` — import SDK `CopyButton`; hover/focus-reveal copy on each `renderEntry` header row; `stopPropagation` so copy does not toggle the speaker handle; skip empty bodies.
- `apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs` — source-contract test that GroupChatWorkspace wires `CopyButton` to `entry.text` and does not add refresh/TTS.

No new plugin SDK exports. Canonical 1:1 Bot Chats already use the Sessions thread and already have copy.

## How to Test

1. From `apps/desktop`: `node --test src/plugins/hermes-bots/tests/group-chat.test.mjs` (34 passed, including the new contract).
2. Desktop: Bots tab → open a group chat → expand a thread → hover a user line and a bot line → Copy → paste. Confirm the clipboard is the message body only. Confirm no refresh or read-aloud controls. Clicking Copy must not toggle the bot `@handle`.
3. Folded thread summaries do not show copy until opened (the full line is not on screen).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(desktop):`, `test(desktop):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (N/A — desktop plugin JS only; ran `node --test src/plugins/hermes-bots/tests/*.test.mjs`. 4 pre-existing Windows failures in mention-handoff/routine-prompt spawn `sh` and fail the same on unmodified main)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (plugin tests). Interactive Desktop hover-copy not run in this environment.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (reuses Electron `clipboard.writeText` via existing `CopyButton`)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Plugin test run: 34/34 pass on `group-chat.test.mjs`.

Made with [Cursor](https://cursor.com)