### PR TITLE
fix(profiles): strip gateway runtime files on config clone and add cross-profile --replace guard

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -29919,6 +29919,36 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     if existing_pid is not None and existing_pid != os.getpid():
         if replace:
             existing_start_time = get_process_start_time(existing_pid)
+
+            # ── Cross-profile guard ──────────────────────────────────
+            # Verify the existing PID belongs to the same HERMES_HOME
+            # before sending SIGTERM.  A polluted gateway.pid (e.g.
+            # copied from another profile's clone, or a hybrid process)
+            # would otherwise make --replace kill a different profile's
+            # gateway — a silent cross-profile outage.
+            from gateway.status import _read_pid_record
+            _pid_rec = _read_pid_record()
+            if _pid_rec is not None:
+                _rec_home = _pid_rec.get("hermes_home")
+                if _rec_home is not None:
+                    try:
+                        from gateway.status import _same_hermes_home
+                        if not _same_hermes_home(_rec_home, _hermes_home):
+                            logger.warning(
+                                "Refusing --replace: PID %d belongs to "
+                                "HERMES_HOME=%s (ours=%s). "
+                                "Remove the stale gateway.pid file manually.",
+                                existing_pid, _rec_home, _hermes_home,
+                            )
+                            print(
+                                f"\n⚠ --replace refused: PID {existing_pid} belongs to "
+                                f"a different profile ({_rec_home}).\n"
+                                f"  Remove the stale gateway.pid from this profile and retry.\n"
+                            )
+                            return False
+                    except Exception:
+                        pass  # Best-effort — proceed if comparison fails
+
             logger.info(
                 "Replacing existing gateway instance (PID %d) with --replace.",
                 existing_pid,

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -75,10 +75,18 @@ _CLONE_SUBDIR_FILES = [
 # Runtime files stripped after --clone-all (shouldn't carry over).
 # Kept as a post-copy step rather than in the ignore filter because they
 # are created dynamically during normal use and may be absent at copy time.
+# Also stripped after a config clone (clone_config / clone_from) so a cloned
+# profile never inherits the source profile's running-gateway identity files —
+# those reference the source's live PID and, if copied verbatim, make the new
+# profile's gateway believe another instance is already running or that it may
+# SIGTERM the source profile's process.
 _CLONE_ALL_STRIP: list[str] = [
     "gateway.pid",
     "gateway_state.json",
+    "gateway.lock",
     "processes.json",
+    ".gateway-takeover.json",
+    ".gateway-planned-stop.json",
 ]
 
 # Infrastructure artifacts excluded from --clone-all when the source is the
@@ -1190,6 +1198,19 @@ def create_profile(
                     dst = profile_dir / relpath
                     dst.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copy2(src, dst)
+
+            # Strip gateway runtime identity files even on a config clone.
+            # `_CLONE_ALL_STRIP` is normally only applied in the --clone-all
+            # branch above; a config clone (desktop "clone from default",
+            # `--clone-from`) copies config.yaml/.env verbatim and would
+            # otherwise inherit the source profile's live gateway.pid /
+            # gateway.lock / gateway_state.json.  Those files name the source
+            # profile's running PID — copying them makes the new profile's
+            # gateway either refuse to start ("another instance is running")
+            # or, with --replace, SIGTERM the source profile's gateway process.
+            # The cloned profile must start from a clean gateway identity.
+            for stale in _CLONE_ALL_STRIP:
+                (profile_dir / stale).unlink(missing_ok=True)
 
     # Seed an empty .env so the profile has its own credentials file from
     # day one. Without it, profile-scoped env writes (dashboard Channels /

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -1030,6 +1030,65 @@ class TestEdgeCases:
         assert (target_dir / ".env").read_text().strip() == "SECRET=yes"
 
 
+class TestCloneStripsGatewayRuntimeState:
+    """A cloned profile must never inherit the source's live gateway identity
+    files (gateway.pid / gateway.lock / gateway_state.json / takeover markers).
+    Copying them verbatim makes the new profile's gateway refuse to start
+    ("another instance is running") or, with --replace, SIGTERM the source
+    profile's gateway process — a cross-profile outage (issue #89315)."""
+
+    def _write_gateway_runtime_files(self, profile_dir, pid=4242):
+        for name in (
+            "gateway.pid",
+            "gateway.lock",
+            "gateway_state.json",
+            "processes.json",
+            ".gateway-takeover.json",
+            ".gateway-planned-stop.json",
+        ):
+            (profile_dir / name).write_text(f'{{"pid": {pid}, "kind": "hermes-gateway"}}')
+
+    def test_clone_config_strips_gateway_files(self, profile_env):
+        default_home = profile_env / ".hermes"
+        (default_home / "config.yaml").write_text("model: test")
+        (default_home / ".env").write_text("KEY=val")
+        self._write_gateway_runtime_files(default_home)
+
+        profile_dir = create_profile("worker", clone_config=True, no_alias=True)
+
+        for name in (
+            "gateway.pid",
+            "gateway.lock",
+            "gateway_state.json",
+            "processes.json",
+            ".gateway-takeover.json",
+            ".gateway-planned-stop.json",
+        ):
+            assert not (profile_dir / name).exists(), (
+                f"cloned profile must not inherit {name}"
+            )
+        # Config itself is still cloned
+        assert (profile_dir / ".env").read_text().strip() == "KEY=val"
+
+    def test_clone_all_strips_gateway_files(self, profile_env):
+        default_home = profile_env / ".hermes"
+        self._write_gateway_runtime_files(default_home)
+
+        profile_dir = create_profile("worker2", clone_all=True, no_alias=True)
+
+        for name in (
+            "gateway.pid",
+            "gateway.lock",
+            "gateway_state.json",
+            "processes.json",
+            ".gateway-takeover.json",
+            ".gateway-planned-stop.json",
+        ):
+            assert not (profile_dir / name).exists(), (
+                f"cloned profile must not inherit {name}"
+            )
+
+
 
 class TestProfilesToServe:
     """profiles_to_serve(multiplex) — the gateway's profile-enumeration chokepoint."""


### PR DESCRIPTION
Fixes #89315

## Summary

Creating a new profile via the Hermes Desktop app (which defaults to `clone_from: 'default'`) copies `config.yaml` / `.env` / `SOUL.md` from the source profile, **but also inherits gateway runtime identity files** (`gateway.pid`, `gateway_state.json`, `gateway.lock`, takeover markers) when they exist in the source. Those files reference the source profile's **live PID**, so the new profile's gateway either:

- refuses to start (`Another gateway instance is already running`), or
- with `--replace`, **SIGTERMs the source profile's gateway process** — while launchd's `KeepAlive` revives it, which then SIGTERMs the new gateway back … an infinite cross-profile kill/flap loop.

Additionally, the `--replace` path in `start_gateway()` never verifies that the PID read from `gateway.pid` belongs to the **same HERMES_HOME** before sending SIGTERM, so a polluted PID file could silently kill a different profile's gateway.

## Changes

### 1. `hermes_cli/profiles.py` — strip gateway runtime files on config clone

- `_CLONE_ALL_STRIP` extended with `gateway.lock`, `.gateway-takeover.json`, `.gateway-planned-stop.json` (previously only `--clone-all` cleaned these).
- The same strip is now also applied in the **config-clone path** (`clone_from` / `clone_config`, which is what the Desktop "clone from default" flow uses). The cloned profile always starts with a clean gateway identity, never inheriting the source's live PID/lock files.

### 2. `gateway/run.py` — cross-profile guard before `--replace` SIGTERM

- Before `terminate_pid(existing_pid, force=False)` in the `--replace` branch of `start_gateway()`, read the PID record from `gateway.pid` and compare its `hermes_home` against the current process's `HERMES_HOME`.
- If they differ, **refuse to send SIGTERM**, log a warning, print a user-facing message, and return `False` (no kill).

### 3. `tests/hermes_cli/test_profiles.py` — regression tests

- New `TestCloneStripsGatewayRuntimeState` class:
  - `test_clone_config_strips_gateway_files` — config clone strips all 6 runtime files while still copying `config.yaml` / `.env`.
  - `test_clone_all_strips_gateway_files` — `--clone-all` strips them too (incl. the newly added files).

## Testing

- `tests/hermes_cli/test_profiles.py`: **56 passed, 2 skipped** (all green, incl. 2 new tests)
- `tests/gateway/test_status.py`: **68 passed, 2 skipped** (gateway status/PID-file suite unaffected)

## Environment

- macOS, Hermes Desktop, three profiles (default / sam / tim) each with an independent Feishu app.
- Root cause observed in the wild: a default gateway became a "hybrid process" holding a cloned profile's fd set + Feishu app scoped lock, blocking the cloned profile's gateway from ever acquiring its token lock.