### PR TITLE
fix(mcp-catalog): wire api_key auth.env into the stdio child environment

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -569,8 +569,18 @@ def _build_server_config(
         cfg["command"] = _expand_install_dir(t.command or "", install_dir)
         if t.args:
             cfg["args"] = [_expand_install_dir(a, install_dir) for a in t.args]
-        if t.env:
-            cfg["env"] = dict(t.env)
+        env_out: dict = dict(t.env)
+        # auth.env credentials are prompted and persisted to the profile's
+        # .env at install time, but a stdio child only receives what the
+        # generated mcp_servers.<name>.env references — without these
+        # interpolations the server starts credential-less and the
+        # authenticated probe/tool calls fail (#89316). transport.env wins
+        # on key collisions so a manifest can pin a literal default.
+        if entry.auth.type == "api_key":
+            for spec in entry.auth.env:
+                env_out.setdefault(spec.name, f"${{{spec.name}}}")
+        if env_out:
+            cfg["env"] = env_out
     elif t.type == "http":
         cfg["url"] = t.url
         if entry.auth.type == "oauth":

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -201,6 +201,68 @@ class TestManifestParsing:
         assert cfg["url"] == "https://mcp.example.com/sse"
         assert cfg["headers"] == {"Authorization": "Bearer ${MCP_DEMO_API_KEY}"}
 
+    def test_stdio_api_key_auth_env_wired_into_child_env(self, catalog_dir):
+        """stdio + api_key: auth.env credentials must reach the child (#89316).
+
+        The installer prompts for auth.env vars and persists them to the
+        profile .env, but a stdio child only receives what the generated
+        mcp_servers.<name>.env references — without the interpolations the
+        server starts credential-less and authenticated calls fail."""
+        body = _basic_manifest(
+            auth={
+                "type": "api_key",
+                "env": [
+                    {"name": "DEMO_KEY", "prompt": "API key", "secret": True},
+                    {"name": "DEMO_URL", "prompt": "Base URL", "secret": False},
+                ],
+            }
+        )
+        _write_manifest(catalog_dir, "demo", body)
+        from hermes_cli.mcp_catalog import _build_server_config
+
+        cfg = _build_server_config(_entry("demo"), None)
+        assert cfg["env"]["DEMO_KEY"] == "${DEMO_KEY}"
+        assert cfg["env"]["DEMO_URL"] == "${DEMO_URL}"
+
+    def test_stdio_transport_env_wins_over_auth_env(self, catalog_dir):
+        """A transport.env literal for the same name is preserved — the
+        manifest can pin a non-secret default the child should use."""
+        body = _basic_manifest(
+            transport={
+                "type": "stdio",
+                "command": "demo-server",
+                "env": {"DEMO_URL": "https://literal.example.com"},
+            },
+            auth={
+                "type": "api_key",
+                "env": [
+                    {"name": "DEMO_KEY", "prompt": "API key", "secret": True},
+                    {"name": "DEMO_URL", "prompt": "Base URL", "secret": False},
+                ],
+            },
+        )
+        _write_manifest(catalog_dir, "demo", body)
+        from hermes_cli.mcp_catalog import _build_server_config
+
+        cfg = _build_server_config(_entry("demo"), None)
+        assert cfg["env"]["DEMO_URL"] == "https://literal.example.com"
+        assert cfg["env"]["DEMO_KEY"] == "${DEMO_KEY}"
+
+    def test_stdio_oauth_auth_env_not_wired(self, catalog_dir):
+        """OAuth auth.env entries serve the OAuth flow, not the stdio child —
+        only api_key credentials are interpolated into the child env."""
+        body = _basic_manifest(
+            auth={
+                "type": "oauth",
+                "env": [{"name": "DEMO_CLIENT_ID", "prompt": "client id"}],
+            }
+        )
+        _write_manifest(catalog_dir, "demo", body)
+        from hermes_cli.mcp_catalog import _build_server_config
+
+        cfg = _build_server_config(_entry("demo"), None)
+        assert "env" not in cfg
+
     def test_http_api_key_requires_matching_env_declaration(self, catalog_dir):
         """http+api_key manifests must declare the env key the header references.
 


### PR DESCRIPTION
## What does this PR do?

For a catalog entry combining `transport.type: stdio` and `auth.type: api_key`, `hermes mcp install` prompts for the manifest's `auth.env` variables and saves them to the active profile's `.env` — but the generated `mcp_servers.<name>` block only included `transport.env`. When the manifest declares its credentials under `auth.env` without duplicating them under `transport.env`, the stdio child process started with **no environment reference to resolve**: the installer reported the credentials found, while the connect probe and every authenticated tool call failed because the child never received the API key.

This is the stdio counterpart of #70632 (the http side got its `Authorization: Bearer ${...}` header wired long ago, including a parse-time naming contract).

The fix: for stdio + api_key entries, every `auth.env` variable is added to the generated env block as a `${VAR}` interpolation — resolved at spawn time by the MCP loader's existing scope-aware interpolation (profile `.env` with `os.environ` fallback). Scoping rules:

- `transport.env` literals win on key collisions, so a manifest can pin a non-secret default the child should use.
- OAuth `auth.env` entries are untouched — they serve the OAuth flow (client id etc.), not the child process.

## Related Issue

Fixes #89316

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/mcp_catalog.py` — `_build_server_config`'s stdio branch builds the child env from `transport.env` plus `${VAR}` interpolations for each `auth.env` variable (api_key only, `setdefault` so transport literals win), with a comment stating why the references must exist.
- `tests/hermes_cli/test_mcp_catalog.py` — `test_stdio_api_key_auth_env_wired_into_child_env` (auth.env vars appear as `${VAR}`; fails on main with no env block at all), `test_stdio_transport_env_wins_over_auth_env` (collision keeps the literal), `test_stdio_oauth_auth_env_not_wired` (OAuth scope pin).

## How to Test

```bash
python -m pytest tests/hermes_cli/test_mcp_catalog.py -q
# Observed result: 28 passed

python -m pytest tests/hermes_cli/test_copilot_catalog_oauth_fallback.py tests/cli/test_cli_mcp_config_watch.py -q
# Observed result: 8 passed
```

Fail-on-main check: with the catalog change stashed, the two wiring tests fail on main (no env block / no literal-wins behavior); the OAuth scope pin passes on both.

Manual repro from the issue: a stdio catalog manifest declaring credentials under `auth.env` only — after `hermes mcp install`, the generated `mcp_servers.<name>.env` on main is empty of them; with this change it contains `EXAMPLE_API_KEY: ${EXAMPLE_API_KEY}` etc., and the child resolves them from the profile `.env` the installer wrote.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments explain intent (why the child needs the reference, why transport wins, why OAuth is excluded)
- [x] Corresponding changes documented via comments
- [x] Tests added and passing (3 new; catalog suite green)
- [x] Single root cause, no unrelated changes
