### PR TITLE
fix(kanban): block clean exits missing terminal events before claim reclamation

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -122,7 +122,9 @@ VALID_INITIAL_STATUSES = {"running", "blocked"}
 # ``BLOCK_RECURRENCE_LIMIT``) escalates them to ``triage`` if a cron keeps
 # unblocking them only to have the worker re-block for the same reason.
 # ``None`` = legacy/un-typed block (treated as a generic human blocker).
-VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
+VALID_BLOCK_KINDS = {
+    "dependency", "needs_input", "capability", "transient", "worker_protocol",
+}
 
 # After a task has been blocked, unblocked, and re-blocked this many times for
 # the same (truly-blocked) reason, the unblock-loop breaker stops trusting the
@@ -8778,75 +8780,308 @@ def _error_fingerprint(error_text: str) -> str:
     return fp.lower().strip()
 
 
-# Empirically ~96% of "clean exit without a terminal tool call" tasks complete
-# on a later run (a goal-mode finalize nudge, or the model simply emitting the
-# tool call next time), so a protocol violation is NOT deterministic — give it a
-# bounded retry before the breaker trips instead of blocking on the first hit.
-#
-# The budget is a violation-only STREAK, not a share of the unified
-# ``consecutive_failures`` counter: it counts consecutive clean-exit protocol
-# violations (derived from run history by ``_protocol_violation_streak``), so
-# earlier timeouts / nonzero exits neither consume nor extend it, and a
-# below-budget violation does not tick the unified counter either. A per-task
-# ``max_retries`` overrides this bound — the same "task override wins"
-# precedence ``_record_task_failure`` documents for every other failure kind.
-_PROTOCOL_VIOLATION_FAILURE_LIMIT = 3
-
-# How far back to walk a task's closed runs when counting the violation
-# streak. The streak trips at a handful of violations, so anything beyond a
-# few dozen rows (violations interleaved with neutral rate-limited requeues)
-# can only mean "way past the bound" anyway.
-_PROTOCOL_VIOLATION_SCAN_LIMIT = 50
+_MISSING_TERMINAL_REASON = (
+    "Worker exited successfully without kanban_complete or kanban_block; "
+    "dispatcher auto-blocked the task."
+)
+_STALE_RUNNING_REASON = (
+    "Worker is no longer running and no terminal event was observed; "
+    "one-time stale-task reaper auto-blocked the task."
+)
 
 
-def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
-    """Count the task's trailing run of clean-exit protocol violations.
+def _missing_terminal_payload(
+    *,
+    trigger: str,
+    exit_kind: str,
+    exit_code: Optional[int],
+    worker_pid: Optional[int],
+    last_heartbeat_at: Optional[int],
+) -> dict:
+    """Build the allowlisted, secret-safe Control A event payload."""
+    return {
+        "reason_code": "worker_exited_without_terminal_event",
+        "reason": (
+            _MISSING_TERMINAL_REASON
+            if exit_kind == "clean_exit"
+            else _STALE_RUNNING_REASON
+        ),
+        "kind": "worker_protocol",
+        "auto_blocked": True,
+        "trigger": trigger,
+        "terminal_event_observed": False,
+        "exit_kind": exit_kind,
+        "exit_code": exit_code,
+        "worker_pid": worker_pid,
+        "last_heartbeat_at": last_heartbeat_at,
+    }
 
-    Walks the task's closed runs newest-first — including the violation run
-    ``detect_crashed_workers`` just closed — and counts how many in a row were
-    clean-exit protocol violations:
 
-    * ``rate_limited`` runs are neutral and skipped: a quota wall says nothing
-      about the task, exactly as it is neutral for the unified
-      ``consecutive_failures`` counter.
-    * Any other closed run (completed, plain crash, timeout, spawn failure,
-      reclaim, …) breaks the streak, so the bounded retry budget counts ONLY
-      protocol violations — mixed failure kinds can neither consume nor
-      extend it.
+def _auto_block_missing_terminal_event_in_txn(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    expected_run_id: Optional[int],
+    expected_pid: int,
+    expected_claim_lock: Optional[str],
+    last_heartbeat_at: Optional[int],
+    exit_kind: str,
+    exit_code: Optional[int],
+    trigger: str,
+) -> Optional[int]:
+    """CAS one observed dead-worker run to ``blocked`` inside a write txn.
 
-    Violation runs are recognized by the ``protocol_violation`` marker that
-    ``detect_crashed_workers`` stamps into the run metadata; the violation
-    error text is matched as a fallback for runs recorded before the marker
-    existed.
+    The exact run, pid, and claim are part of the compare-and-swap guard. A
+    concurrent terminal transition or reaper therefore makes this a no-op.
+    Returns the linked run id on success, otherwise ``None``.
     """
-    streak = 0
+    payload = _missing_terminal_payload(
+        trigger=trigger,
+        exit_kind=exit_kind,
+        exit_code=exit_code,
+        worker_pid=expected_pid,
+        last_heartbeat_at=last_heartbeat_at,
+    )
+    cur = conn.execute(
+        """
+        UPDATE tasks
+           SET status = 'blocked',
+               claim_lock = NULL,
+               claim_expires = NULL,
+               worker_pid = NULL,
+               block_kind = 'worker_protocol',
+               block_recurrences = CASE
+                   WHEN block_kind = 'worker_protocol'
+                   THEN block_recurrences + 1 ELSE 1 END,
+               last_failure_error = ?
+         WHERE id = ?
+           AND status = 'running'
+           AND current_run_id IS ?
+           AND worker_pid = ?
+           AND claim_lock IS ?
+           AND NOT EXISTS (
+               SELECT 1 FROM task_events
+                WHERE task_id = ?
+                  AND run_id IS ?
+                  AND kind IN ('completed', 'blocked')
+           )
+        """,
+        (
+            payload["reason"], task_id, expected_run_id,
+            expected_pid, expected_claim_lock, task_id, expected_run_id,
+        ),
+    )
+    if cur.rowcount != 1:
+        return None
+
+    run_id = _end_run(
+        conn,
+        task_id,
+        outcome="blocked",
+        status="blocked",
+        error=payload["reason"],
+        metadata=dict(payload),
+    )
+    if run_id is None:
+        run_id = _synthesize_ended_run(
+            conn,
+            task_id,
+            outcome="blocked",
+            error=payload["reason"],
+            metadata=dict(payload),
+        )
+    _append_event(conn, task_id, "blocked", payload, run_id=run_id)
+    return run_id
+
+
+def _fire_missing_terminal_hooks(
+    task_id: str,
+    *,
+    assignee: Optional[str],
+    run_id: Optional[int],
+    worker_pid: int,
+    exit_kind: str,
+    exit_code: Optional[int],
+) -> None:
+    """Notify lifecycle observers only after the database transaction commits."""
+    board = get_current_board()
+    if _kanban_observer_consumed("kanban_task_blocked"):
+        _fire_kanban_lifecycle_hook(
+            "kanban_task_blocked",
+            task_id,
+            board=board,
+            assignee=assignee,
+            run_id=run_id,
+            reason=_missing_terminal_payload(
+                trigger="missing_terminal_event",
+                exit_kind=exit_kind,
+                exit_code=exit_code,
+                worker_pid=worker_pid,
+                last_heartbeat_at=None,
+            )["reason"],
+        )
+    if _kanban_observer_consumed("on_kanban_worker_exited"):
+        _fire_kanban_lifecycle_hook(
+            "on_kanban_worker_exited",
+            task_id,
+            board=board,
+            assignee=assignee,
+            run_id=run_id,
+            worker_pid=worker_pid,
+            exit_kind=exit_kind,
+            exit_code=exit_code,
+            outcome="blocked",
+            retry_status="blocked",
+        )
+
+
+def _auto_block_missing_terminal_event(
+    conn: sqlite3.Connection,
+    **observed,
+) -> Optional[int]:
+    """Transactional wrapper used by explicit reapers and race tests."""
+    assignee_row = conn.execute(
+        "SELECT assignee FROM tasks WHERE id = ?", (observed["task_id"],),
+    ).fetchone()
+    with write_txn(conn):
+        run_id = _auto_block_missing_terminal_event_in_txn(conn, **observed)
+    if run_id is not None:
+        _fire_missing_terminal_hooks(
+            observed["task_id"],
+            assignee=assignee_row["assignee"] if assignee_row else None,
+            run_id=run_id,
+            worker_pid=observed["expected_pid"],
+            exit_kind=observed["exit_kind"],
+            exit_code=observed["exit_code"],
+        )
+    return run_id
+
+
+def preview_stale_running_workers(conn: sqlite3.Connection) -> list[dict]:
+    """Read-only preview for the one-time Control A stale-running backfill.
+
+    The forward dispatcher path handles known clean exits. This explicit
+    preview additionally includes dead workers whose exit status is no longer
+    available after a dispatcher restart (``unknown``). Known non-zero,
+    signaled, and rate-limited exits remain on their existing branches.
+    """
     rows = conn.execute(
-        "SELECT outcome, error, metadata FROM task_runs "
-        "WHERE task_id = ? AND ended_at IS NOT NULL "
-        "ORDER BY id DESC LIMIT ?",
-        (task_id, _PROTOCOL_VIOLATION_SCAN_LIMIT),
+        "SELECT id, worker_pid, claim_lock, started_at, assignee, "
+        "last_heartbeat_at, current_run_id FROM tasks "
+        "WHERE status = 'running' AND worker_pid IS NOT NULL ORDER BY id"
     ).fetchall()
+    host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
+    preview: list[dict] = []
     for row in rows:
-        outcome = row["outcome"] or ""
-        if outcome == "rate_limited":
+        lock = row["claim_lock"] or ""
+        if not lock.startswith(host_prefix):
             continue
-        if outcome == "crashed":
-            is_violation = False
-            raw_meta = row["metadata"]
-            if raw_meta:
-                try:
-                    is_violation = bool(
-                        json.loads(raw_meta).get("protocol_violation")
-                    )
-                except (ValueError, TypeError):
-                    is_violation = False
-            if not is_violation:
-                is_violation = "protocol violation" in (row["error"] or "")
-            if is_violation:
-                streak += 1
+        started_at = row["started_at"]
+        if started_at is not None:
+            grace = _resolve_crash_grace_seconds()
+            if time.time() - started_at < grace:
                 continue
-        break
-    return streak
+        pid = int(row["worker_pid"])
+        if _pid_alive(pid):
+            continue
+        exit_kind, exit_code = _classify_worker_exit(pid)
+        if exit_kind not in {"clean_exit", "unknown"}:
+            continue
+        preview.append({
+            "task_id": row["id"],
+            "expected_run_id": row["current_run_id"],
+            "expected_pid": pid,
+            "expected_claim_lock": row["claim_lock"],
+            "last_heartbeat_at": row["last_heartbeat_at"],
+            "exit_kind": exit_kind,
+            "exit_code": exit_code,
+            "worker_pid": pid,
+            "assignee": row["assignee"],
+        })
+    return preview
+
+
+def reap_stale_running_workers(conn: sqlite3.Connection) -> list[str]:
+    """Run the explicitly-invoked, idempotent Control A stale-task backfill."""
+    touched: list[str] = []
+    for row in preview_stale_running_workers(conn):
+        observed = {
+            "task_id": row["task_id"],
+            "expected_run_id": row["expected_run_id"],
+            "expected_pid": row["expected_pid"],
+            "expected_claim_lock": row["expected_claim_lock"],
+            "last_heartbeat_at": row["last_heartbeat_at"],
+            "exit_kind": row["exit_kind"],
+            "exit_code": row["exit_code"],
+            "trigger": "stale_running_backfill",
+        }
+        if _auto_block_missing_terminal_event(conn, **observed) is not None:
+            touched.append(row["task_id"])
+    return touched
+
+
+def _auto_block_clean_exits_before_recovery(
+    conn: sqlite3.Connection,
+) -> list[str]:
+    """Block only known-clean dead workers before recovery erases evidence.
+
+    This narrow pre-pass exists solely for the missing-terminal protocol case.
+    Non-zero, signaled, unknown, and rate-limited exits are deliberately left
+    untouched so TTL/orphan/stale recovery retains its historical precedence;
+    normal crash detection handles any survivors afterward.
+    """
+    auto_blocked: list[str] = []
+    hook_payloads: list[dict] = []
+    with write_txn(conn):
+        rows = conn.execute(
+            "SELECT id, worker_pid, claim_lock, started_at, assignee, "
+            "last_heartbeat_at, current_run_id FROM tasks "
+            "WHERE status = 'running' AND worker_pid IS NOT NULL"
+        ).fetchall()
+        host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
+        for row in rows:
+            lock = row["claim_lock"] or ""
+            if not lock.startswith(host_prefix):
+                continue
+            started_at = row["started_at"]
+            if started_at is not None:
+                grace = _resolve_crash_grace_seconds()
+                if time.time() - started_at < grace:
+                    continue
+            pid = int(row["worker_pid"])
+            if _pid_alive(pid):
+                continue
+            kind, code = _classify_worker_exit(pid)
+            if kind != "clean_exit":
+                continue
+            run_id = _auto_block_missing_terminal_event_in_txn(
+                conn,
+                task_id=row["id"],
+                expected_run_id=row["current_run_id"],
+                expected_pid=pid,
+                expected_claim_lock=row["claim_lock"],
+                last_heartbeat_at=row["last_heartbeat_at"],
+                exit_kind=kind,
+                exit_code=code,
+                trigger="missing_terminal_event",
+            )
+            if run_id is None:
+                continue
+            auto_blocked.append(row["id"])
+            hook_payloads.append({
+                "task_id": row["id"],
+                "assignee": row["assignee"],
+                "run_id": run_id,
+                "worker_pid": pid,
+                "exit_kind": kind,
+                "exit_code": code,
+            })
+
+    for hook_fields in hook_payloads:
+        hook_fields = dict(hook_fields)
+        task_id = hook_fields.pop("task_id")
+        _fire_missing_terminal_hooks(task_id, **hook_fields)
+    return auto_blocked
 
 
 def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
@@ -8879,21 +9114,21 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     """
     crashed: list[str] = []
     rate_limited: list[str] = []
+    auto_blocked: list[str] = []
     # Per-crash details collected inside the main txn, used after it
     # closes to run ``_record_task_failure`` (which needs its own
-    # write_txn so can't nest). ``protocol_violation`` flags the
-    # clean-exit-but-still-running case, which is accounted against its
-    # own bounded violation streak instead of the unified failure
-    # counter (see the post-txn loop below).
-    crash_details: list[tuple[str, int, str, bool, str]] = []
-    # (task_id, pid, claimer, protocol_violation, error_text)
+    # write_txn so can't nest). Clean exits are not crashes: they are
+    # atomically blocked in the main transaction and never enter this list.
+    crash_details: list[tuple[str, int, str, str]] = []
+    # (task_id, pid, claimer, error_text)
     # Worker-exit observer payloads (RFC #58548), collected inside the main
     # txn and fired only after every reclaim/accounting txn has committed.
     exited_hook_payloads: list[dict] = []
+    blocked_hook_payloads: list[dict] = []
     with write_txn(conn):
         rows = conn.execute(
-            "SELECT id, worker_pid, claim_lock, started_at, assignee "
-            "FROM tasks "
+            "SELECT id, worker_pid, claim_lock, started_at, assignee, "
+            "last_heartbeat_at, current_run_id FROM tasks "
             "WHERE status = 'running' AND worker_pid IS NOT NULL"
         ).fetchall()
         host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
@@ -8917,32 +9152,32 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
             kind, code = _classify_worker_exit(pid)
             rate_limited_exit = False
             if kind == "clean_exit":
-                # Worker subprocess returned 0 but its task is still
-                # ``running`` in the DB — it exited without calling
-                # ``kanban_complete`` / ``kanban_block``. Overwhelmingly the
-                # work itself succeeded and only the paperwork was skipped, so
-                # a retry usually completes; the corrective sentence below is
-                # surfaced to the retry worker via the prior-attempt error in
-                # ``build_worker_context`` (guidance approach from #61817).
-                protocol_violation = True
-                error_text = (
-                    "worker exited cleanly (rc=0) without calling "
-                    "kanban_complete or kanban_block — protocol violation. "
-                    "If the prior run already did the work, verify it and "
-                    "report the result via kanban_complete; a run that ends "
-                    "without a terminal kanban call counts as failed no "
-                    "matter what it did."
+                # A clean exit with no terminal transition is a protocol
+                # failure, not a crash. Block atomically on the first
+                # observation so the board cannot advertise retryable work
+                # that the worker has already abandoned.
+                run_id = _auto_block_missing_terminal_event_in_txn(
+                    conn,
+                    task_id=row["id"],
+                    expected_run_id=row["current_run_id"],
+                    expected_pid=pid,
+                    expected_claim_lock=row["claim_lock"],
+                    last_heartbeat_at=row["last_heartbeat_at"],
+                    exit_kind=kind,
+                    exit_code=code,
+                    trigger="missing_terminal_event",
                 )
-                event_kind = "protocol_violation"
-                event_payload = {
-                    "pid": pid,
-                    "claimer": row["claim_lock"],
-                    "exit_code": code,
-                    # Durable marker for _protocol_violation_streak: _end_run
-                    # copies this payload into the run metadata, which is how
-                    # the violation-only retry budget is derived later.
-                    "protocol_violation": True,
-                }
+                if run_id is not None:
+                    auto_blocked.append(row["id"])
+                    blocked_hook_payloads.append({
+                        "task_id": row["id"],
+                        "assignee": row["assignee"],
+                        "run_id": run_id,
+                        "worker_pid": pid,
+                        "exit_kind": kind,
+                        "exit_code": code,
+                    })
+                continue
             elif kind == "rate_limited":
                 # Worker bailed because the provider rate-limited / exhausted
                 # quota (EX_TEMPFAIL sentinel). This is NOT a task failure —
@@ -8951,7 +9186,6 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 # quota window clears, and crucially do NOT count a failure
                 # (skip ``_record_task_failure``) so a long quota window can't
                 # trip the circuit breaker and permanently block the card.
-                protocol_violation = False
                 rate_limited_exit = True
                 error_text = (
                     f"pid {pid} exited rate-limited (quota wall) — "
@@ -8964,7 +9198,6 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     "exit_code": code,
                 }
             else:
-                protocol_violation = False
                 if kind == "nonzero_exit":
                     error_text = f"pid {pid} exited with code {code}"
                 elif kind == "signaled":
@@ -9024,93 +9257,21 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     )
                     rate_limited.append(row["id"])
                 else:
-                    if protocol_violation:
-                        # Stamp the failure error now: a below-budget
-                        # violation never reaches ``_record_task_failure``
-                        # (which stamps this column for every other failure
-                        # kind), yet the board UI and the retry worker's
-                        # context still need the violation message + the
-                        # corrective guidance it carries.
-                        conn.execute(
-                            "UPDATE tasks SET last_failure_error = ? "
-                            "WHERE id = ?",
-                            (error_text[:500], row["id"]),
-                        )
                     crashed.append(row["id"])
                     crash_details.append(
-                        (row["id"], pid, row["claim_lock"],
-                         protocol_violation, error_text)
+                        (row["id"], pid, row["claim_lock"], error_text)
                     )
-    # Outside the main txn: account each crashed task and maybe trip the
-    # breaker (the retried task transitions to blocked with a ``gave_up`` event
-    # on top of the event we already emitted).
-    #
-    # Protocol-violation crashes (clean exit, no terminal tool call) get a
-    # BOUNDED retry, not an immediate trip: empirically ~96% of these tasks
-    # complete on a later run (a goal-mode finalize nudge, or the model simply
-    # emitting kanban_complete/kanban_block next time), so blocking on the first
-    # occurrence just churned them through the respawn cycle. The retry budget
-    # is a violation-only streak (``_protocol_violation_streak``): earlier
-    # timeouts / nonzero exits neither consume nor extend it, and a
-    # below-budget violation does not tick the unified
-    # ``consecutive_failures`` counter, so the two budgets stay independent.
-    # A per-task ``max_retries`` overrides the violation bound with the same
-    # top precedence it has for every other failure kind. Systemic same-error
-    # crashes still trip immediately.
-    auto_blocked: list[str] = []
+    # Outside the main txn: account real crashes and maybe trip the breaker
+    # (the retried task transitions to blocked with a ``gave_up`` event on top
+    # of the crash event already emitted). Clean protocol exits were already
+    # blocked atomically above and never enter the crash counter.
     if crash_details:
         # Fingerprint errors to detect systemic failures.
         _fp_counts: dict[str, int] = {}
-        for _, _, _, _, err_text in crash_details:
+        for _, _, _, err_text in crash_details:
             fp = _error_fingerprint(err_text)
             _fp_counts[fp] = _fp_counts.get(fp, 0) + 1
-        for tid, pid, claimer, protocol_violation, error_text in crash_details:
-            if protocol_violation:
-                streak = _protocol_violation_streak(conn, tid)
-                trow = conn.execute(
-                    "SELECT max_retries FROM tasks WHERE id = ?", (tid,),
-                ).fetchone()
-                if trow is None:
-                    continue  # task deleted mid-loop
-                task_override = (
-                    trow["max_retries"] if "max_retries" in trow.keys() else None
-                )
-                violation_limit = (
-                    int(task_override)
-                    if task_override is not None
-                    else _PROTOCOL_VIOLATION_FAILURE_LIMIT
-                )
-                if streak < violation_limit:
-                    # Below budget: the task is already back at ``ready``
-                    # (respawn allowed) with ``last_failure_error`` stamped.
-                    # Deliberately no ``_record_task_failure`` call — a
-                    # below-budget violation must not consume the unified
-                    # failure budget, just as other failure kinds don't
-                    # consume this one.
-                    continue
-                # Streak reached the bound: trip the breaker. ``force_trip``
-                # skips the threshold resolution inside
-                # ``_record_task_failure`` because the decision — including
-                # the per-task ``max_retries`` override — was already made
-                # against the violation streak above.
-                tripped = _record_task_failure(
-                    conn, tid,
-                    error=error_text,
-                    outcome="crashed",
-                    failure_limit=violation_limit,
-                    force_trip=True,
-                    release_claim=False,
-                    end_run=False,
-                    event_payload_extra={
-                        "pid": pid,
-                        "claimer": claimer,
-                        "protocol_violations": streak,
-                        "protocol_violation_limit": violation_limit,
-                    },
-                )
-                if tripped:
-                    auto_blocked.append(tid)
-                continue
+        for tid, pid, claimer, error_text in crash_details:
             fp = _error_fingerprint(error_text)
             is_systemic = _fp_counts.get(fp, 0) >= 3
             tripped = _record_task_failure(
@@ -9132,7 +9293,12 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # Same side-channel for rate-limited requeues — these did NOT count a
     # failure and are NOT crashes, so they stay out of the ``crashed`` return.
     detect_crashed_workers._last_rate_limited = rate_limited  # type: ignore[attr-defined]
-    # Worker-lifecycle observer (RFC #58548): exit events are tick-derived
+    # Missing-terminal hooks are fired only after the atomic block commits.
+    for hook_fields in blocked_hook_payloads:
+        hook_fields = dict(hook_fields)
+        task_id = hook_fields.pop("task_id")
+        _fire_missing_terminal_hooks(task_id, **hook_fields)
+    # Worker-lifecycle observer (RFC #58548): other exit events are tick-derived
     # from this reclaim pass — fired only now, after the main reclaim txn
     # AND the breaker accounting above have committed, so subscribers always
     # observe fully durable board state.
@@ -9196,13 +9362,9 @@ def _record_task_failure(
       3. ``DEFAULT_FAILURE_LIMIT``
 
     ``force_trip=True`` trips the breaker unconditionally, skipping the
-    counter-vs-threshold comparison (the resolution order above is then
-    only reported in the ``gave_up`` payload, not re-evaluated). Callers
-    use it when they have already applied their own bounded-retry policy
-    — e.g. the clean-exit protocol-violation streak in
-    ``detect_crashed_workers``, which resolves the per-task
-    ``max_retries`` override against the violation streak itself. The
-    failure is still counted into ``consecutive_failures``.
+    counter-vs-threshold comparison. Callers use it only when an independent
+    bounded-failure policy has already made the blocking decision. The failure
+    is still counted into ``consecutive_failures``.
     """
     if failure_limit is None:
         failure_limit = DEFAULT_FAILURE_LIMIT
@@ -9905,11 +10067,13 @@ def _dispatch_once_locked(
     """Run one dispatcher tick.
 
     Steps:
-      1. Reclaim stale running tasks (TTL expired).
-      2. Reclaim stale running tasks (no recent heartbeat).
-      3. Reclaim crashed running tasks (host-local PID no longer alive).
-      3. Promote todo -> ready where all parents are done.
-      4. For each ready task with an assignee, atomically claim and call
+      1. Classify only known-clean exited workers before stale-claim recovery
+         can erase their run/PID evidence.
+      2. Preserve the existing recovery order: TTL reclaim, orphan recovery,
+         then stale-heartbeat recovery.
+      3. Run normal crash detection for surviving non-clean exits.
+      4. Promote todo -> ready where all parents are done.
+      5. For each ready task with an assignee, atomically claim and call
          ``spawn_fn(task, workspace_path, board) -> Optional[int]``. The
          return value (if any) is recorded as ``worker_pid`` so subsequent
          ticks can detect crashes before the TTL expires.
@@ -9942,6 +10106,11 @@ def _dispatch_once_locked(
     reap_worker_zombies()
 
     result = DispatchResult()
+    # Control A's only pre-recovery exception is a known clean exit without a
+    # terminal event. All non-clean exit kinds retain the historical recovery
+    # precedence below and reach normal crash detection only if still running.
+    result.auto_blocked.extend(_auto_block_clean_exits_before_recovery(conn))
+
     result.reclaimed = release_stale_claims(conn)
     if reconcile_orphans:
         # Orphaned-card reconciliation: requeue 'running' cards whose claim
@@ -9951,6 +10120,7 @@ def _dispatch_once_locked(
     result.stale = detect_stale_running(
         conn, stale_timeout_seconds=stale_timeout_seconds,
     )
+
     result.crashed = detect_crashed_workers(conn)
     # detect_crashed_workers stashes protocol-violation auto-blocks on
     # itself so the public list-return stays stable. Pull them into the
@@ -9968,6 +10138,7 @@ def _dispatch_once_locked(
     )
     if _crash_rate_limited:
         result.rate_limited.extend(_crash_rate_limited)
+
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -312,8 +312,10 @@ VALID_HOOKS: Set[str] = {
     #   exit_kind: "clean_exit" | "rate_limited" | "nonzero_exit"
     #              | "signaled" | "unknown",
     #   exit_code: int | None,
-    #   outcome: "crashed" | "rate_limited",
-    #   retry_status: str  (the phase the task was released back to).
+    #   outcome: "blocked" | "crashed" | "rate_limited",
+    #   retry_status: str  (the durable task phase after exit handling).
+    # ``blocked`` is emitted when Control A observes a clean worker exit with
+    # no terminal kanban event, including the explicit stale-running backfill.
     "on_kanban_worker_exited",
     # on_kanban_worker_stale_claim fires when release_stale_claims reclaims
     # a TTL-expired claim, after the reclaim txn commits. Live-PID claim

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1320,52 +1320,489 @@ def _drive_nonzero_crash(conn, tid, fake_pid):
     return _drive_worker_exit(conn, tid, fake_pid, 256)
 
 
-def test_protocol_violation_budget_not_consumed_by_other_failures(kanban_home):
-    """Mixed failure kinds must not consume the violation retry budget.
-
-    Regression for the #61233 review finding: expressed as a plain
-    ``failure_limit`` over the unified ``consecutive_failures`` counter, the
-    violation budget was consumed by earlier timeouts / nonzero exits. As a
-    violation-only streak, a prior real crash must not eat violation
-    retries, and below-budget violations must leave the unified counter
-    untouched (so the two budgets stay independent).
-    """
+def test_clean_exit_without_terminal_event_blocks_immediately(kanban_home):
+    """A clean worker exit without a terminal event blocks on first detection."""
     import hermes_cli.kanban_db as _kb
+
     conn = kb.connect()
     try:
-        tid = kb.create_task(conn, title="mixed", assignee="worker")
+        tid = kb.create_task(
+            conn, title="missing terminal", assignee="worker", max_retries=99,
+        )
+        crashed = _drive_protocol_violation(conn, tid, 991001)
 
-        # One real crash: unified counter ticks to 1 (below
-        # DEFAULT_FAILURE_LIMIT=2 — task stays ready).
-        _drive_nonzero_crash(conn, tid, 991000)
-        task = kb.get_task(conn, tid)
-        assert task.status == "ready"
-        assert task.consecutive_failures == 1
-
-        # Two violations after it: streak 1 and 2 — both retry, unified
-        # counter untouched. (Pre-fix: the crash consumed the budget and the
-        # violations blocked well before three of them happened.)
-        for i, pid in enumerate((991001, 991002)):
-            _drive_protocol_violation(conn, tid, pid)
-            task = kb.get_task(conn, tid)
-            assert task.status == "ready", (
-                f"violation {i + 1} after a crash must still retry, "
-                f"got {task.status}"
-            )
-            assert task.consecutive_failures == 1, (
-                "below-budget violations must not tick the unified counter"
-            )
-
-        # Third consecutive violation: streak hits the bound — blocked.
-        _drive_protocol_violation(conn, tid, 991003)
         task = kb.get_task(conn, tid)
         assert task.status == "blocked"
-        gave_up = [e for e in kb.list_events(conn, tid) if e.kind == "gave_up"]
-        assert len(gave_up) == 1
-        assert (gave_up[0].payload or {}).get("protocol_violations") == \
-            _kb._PROTOCOL_VIOLATION_FAILURE_LIMIT
+        assert task.block_kind == "worker_protocol"
+        assert task.consecutive_failures == 0
+        assert tid not in crashed
+        assert tid in getattr(_kb.detect_crashed_workers, "_last_auto_blocked", [])
+
+        events = kb.list_events(conn, tid)
+        assert not [e for e in events if e.kind in {"protocol_violation", "gave_up"}]
+        blocked = [e for e in events if e.kind == "blocked"]
+        assert len(blocked) == 1
+        payload = blocked[0].payload or {}
+        assert set(payload) == {
+            "reason_code", "reason", "kind", "auto_blocked", "trigger",
+            "terminal_event_observed", "exit_kind", "exit_code",
+            "worker_pid", "last_heartbeat_at",
+        }
+        assert payload == {
+            "reason_code": "worker_exited_without_terminal_event",
+            "reason": (
+                "Worker exited successfully without kanban_complete or "
+                "kanban_block; dispatcher auto-blocked the task."
+            ),
+            "kind": "worker_protocol",
+            "auto_blocked": True,
+            "trigger": "missing_terminal_event",
+            "terminal_event_observed": False,
+            "exit_kind": "clean_exit",
+            "exit_code": 0,
+            "worker_pid": 991001,
+            "last_heartbeat_at": payload["last_heartbeat_at"],
+        }
+        assert payload["last_heartbeat_at"] is None or isinstance(
+            payload["last_heartbeat_at"], int,
+        )
+
+        runs = kb.list_runs(conn, tid)
+        assert len(runs) == 1
+        assert runs[0].outcome == "blocked"
+        assert runs[0].status == "blocked"
+        assert blocked[0].run_id == runs[0].id
     finally:
         conn.close()
+
+
+def test_missing_terminal_autoblock_is_idempotent(kanban_home):
+    """Repeated reaper passes cannot duplicate the dispatcher block event."""
+    import hermes_cli.kanban_db as _kb
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="idempotent", assignee="worker")
+        _drive_protocol_violation(conn, tid, 991002)
+
+        assert _kb.detect_crashed_workers(conn) == []
+        blocked = [e for e in kb.list_events(conn, tid) if e.kind == "blocked"]
+        assert len(blocked) == 1
+        assert len(kb.list_runs(conn, tid)) == 1
+    finally:
+        conn.close()
+
+
+def test_clean_exit_payload_preserves_existing_heartbeat(kanban_home):
+    """A real worker heartbeat remains visible on the auto-block event."""
+    import hermes_cli.kanban_db as _kb
+
+    conn = kb.connect()
+    original_alive = _kb._pid_alive
+    try:
+        tid = kb.create_task(conn, title="heartbeat preserved", assignee="worker")
+        assert kb.claim_task(conn, tid)
+        _kb._set_worker_pid(conn, tid, 991004)
+        assert kb.heartbeat_worker(conn, tid)
+        observed = kb.get_task(conn, tid)
+        assert observed is not None
+        assert isinstance(observed.last_heartbeat_at, int)
+
+        _kb._record_worker_exit(991004, 0)
+        _kb._pid_alive = lambda _pid: False
+        _kb.detect_crashed_workers(conn)
+
+        blocked = [e for e in kb.list_events(conn, tid) if e.kind == "blocked"]
+        assert len(blocked) == 1
+        assert (blocked[0].payload or {})["last_heartbeat_at"] == \
+            observed.last_heartbeat_at
+    finally:
+        _kb._pid_alive = original_alive
+        conn.close()
+
+
+def test_nonzero_worker_exit_keeps_existing_retry_behavior(kanban_home):
+    """Control A must not change the non-zero crash branch."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="real crash", assignee="worker")
+        crashed = _drive_nonzero_crash(conn, tid, 991003)
+
+        task = kb.get_task(conn, tid)
+        assert tid in crashed
+        assert task.status == "ready"
+        assert task.block_kind is None
+        assert task.consecutive_failures == 1
+        assert not [e for e in kb.list_events(conn, tid) if e.kind == "blocked"]
+        assert [e for e in kb.list_events(conn, tid) if e.kind == "crashed"]
+    finally:
+        conn.close()
+
+
+def test_stale_running_backfill_preview_is_read_only_and_exact(kanban_home):
+    """Backfill preview finds dead running workers without mutating the board."""
+    import hermes_cli.kanban_db as _kb
+
+    conn = kb.connect()
+    original_alive = _kb._pid_alive
+    try:
+        host = _kb._claimer_id().split(":", 1)[0]
+        stale = kb.create_task(conn, title="stale", assignee="worker")
+        live = kb.create_task(conn, title="live", assignee="worker")
+        assert kb.claim_task(conn, stale, claimer=f"{host}:stale")
+        assert kb.claim_task(conn, live, claimer=f"{host}:live")
+        _kb._set_worker_pid(conn, stale, 991010)
+        _kb._set_worker_pid(conn, live, 991011)
+        _kb._pid_alive = lambda pid: pid == 991011
+
+        preview = _kb.preview_stale_running_workers(conn)
+        assert [row["task_id"] for row in preview] == [stale]
+        assert preview[0]["worker_pid"] == 991010
+        assert preview[0]["exit_kind"] == "unknown"
+        assert preview[0]["exit_code"] is None
+        assert kb.get_task(conn, stale).status == "running"
+        assert kb.get_task(conn, live).status == "running"
+    finally:
+        _kb._pid_alive = original_alive
+        conn.close()
+
+
+def test_stale_running_backfill_uses_same_contract_and_is_idempotent(kanban_home):
+    """The explicit one-time backfill blocks stale tasks once with honest values."""
+    import hermes_cli.kanban_db as _kb
+
+    conn = kb.connect()
+    original_alive = _kb._pid_alive
+    try:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="stale", assignee="worker")
+        assert kb.claim_task(conn, tid, claimer=f"{host}:stale")
+        _kb._set_worker_pid(conn, tid, 991020)
+        _kb._pid_alive = lambda _pid: False
+
+        touched = _kb.reap_stale_running_workers(conn)
+        assert touched == [tid]
+        assert _kb.reap_stale_running_workers(conn) == []
+
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+        assert task.block_kind == "worker_protocol"
+        blocked = [e for e in kb.list_events(conn, tid) if e.kind == "blocked"]
+        assert len(blocked) == 1
+        payload = blocked[0].payload or {}
+        assert set(payload) == {
+            "reason_code", "reason", "kind", "auto_blocked", "trigger",
+            "terminal_event_observed", "exit_kind", "exit_code",
+            "worker_pid", "last_heartbeat_at",
+        }
+        assert payload["reason_code"] == "worker_exited_without_terminal_event"
+        assert payload["trigger"] == "stale_running_backfill"
+        assert payload["exit_kind"] == "unknown"
+        assert payload["exit_code"] is None
+        assert payload["worker_pid"] == 991020
+    finally:
+        _kb._pid_alive = original_alive
+        conn.close()
+
+
+@pytest.mark.parametrize(
+    ("label", "raw_status"),
+    [
+        pytest.param("nonzero_exit", 7 << 8, id="nonzero-exit"),
+        pytest.param("signaled", 9, id="signaled"),
+        pytest.param("unknown", None, id="unknown"),
+        pytest.param(
+            "rate_limited",
+            kb.KANBAN_RATE_LIMIT_EXIT_CODE << 8,
+            id="rate-limited",
+        ),
+    ],
+)
+def test_expired_nonclean_exit_keeps_recovery_precedence(
+    kanban_home,
+    label,
+    raw_status,
+):
+    """Expired non-clean exits keep the base TTL-reclaim behavior."""
+    import hermes_cli.kanban_db as _kb
+
+    pid_by_kind = {
+        "nonzero_exit": 991040,
+        "signaled": 991041,
+        "unknown": 991042,
+        "rate_limited": 991043,
+    }
+    pid = pid_by_kind[label]
+    conn = kb.connect()
+    original_alive = _kb._pid_alive
+    try:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(
+            conn,
+            title=f"expired {label}",
+            assignee="worker",
+            max_retries=99,
+        )
+        assert kb.claim_task(conn, tid, claimer=f"{host}:expired-{label}")
+        _kb._set_worker_pid(conn, tid, pid)
+        _kb._recent_worker_exits.pop(pid, None)
+        if raw_status is not None:
+            _kb._record_worker_exit(pid, raw_status)
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+            (int(time.time()) - 1, tid),
+        )
+        conn.commit()
+        _kb._pid_alive = lambda _pid: False
+
+        result = _kb.dispatch_once(
+            conn,
+            spawn_fn=lambda *_args, **_kwargs: None,
+            max_spawn=0,
+            reconcile_orphans=False,
+        )
+
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "ready"
+        assert task.block_kind is None
+        assert task.consecutive_failures == 0
+        assert result.reclaimed == 1
+        assert tid not in result.crashed
+        assert tid not in result.rate_limited
+        assert tid not in result.auto_blocked
+        events = kb.list_events(conn, tid)
+        assert len([event for event in events if event.kind == "reclaimed"]) == 1
+        assert not [
+            event for event in events
+            if event.kind in {"crashed", "rate_limited", "gave_up", "blocked"}
+        ]
+    finally:
+        _kb._recent_worker_exits.pop(pid, None)
+        _kb._pid_alive = original_alive
+        conn.close()
+
+
+def test_foreign_host_candidates_skip_liveness_and_classification(
+    kanban_home,
+    monkeypatch,
+):
+    """Foreign-host candidates are rejected before local PID inspection."""
+    import hermes_cli.kanban_db as _kb
+
+    conn = kb.connect()
+    task_ids = []
+    try:
+        pids = (991050, 991051)
+        for label, pid in zip(("clean", "unknown"), pids):
+            tid = kb.create_task(conn, title=f"foreign {label}", assignee="worker")
+            task_ids.append(tid)
+            assert kb.claim_task(conn, tid, claimer=f"foreign-host:{label}")
+            _kb._set_worker_pid(conn, tid, pid)
+        _kb._record_worker_exit(pids[0], 0)
+        _kb._recent_worker_exits.pop(pids[1], None)
+
+        def forbidden(*_args, **_kwargs):
+            raise AssertionError("foreign-host PID must not be inspected")
+
+        monkeypatch.setattr(_kb, "_pid_alive", forbidden)
+        monkeypatch.setattr(_kb, "_classify_worker_exit", forbidden)
+
+        assert _kb.preview_stale_running_workers(conn) == []
+        prepass = getattr(_kb, "_auto_block_clean_exits_before_recovery")
+        assert prepass(conn) == []
+        assert _kb.detect_crashed_workers(conn) == []
+        for tid in task_ids:
+            task = kb.get_task(conn, tid)
+            assert task is not None
+            assert task.status == "running"
+    finally:
+        for pid in (991050, 991051):
+            _kb._recent_worker_exits.pop(pid, None)
+        conn.close()
+
+
+def test_live_recycled_pid_skips_autoblock_and_signal(
+    kanban_home,
+    monkeypatch,
+):
+    """A live PID wins over stale clean-exit evidence without signaling."""
+    import hermes_cli.kanban_db as _kb
+
+    conn = kb.connect()
+    pid = 991052
+    signal_attempts = []
+    try:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="recycled pid", assignee="worker")
+        assert kb.claim_task(conn, tid, claimer=f"{host}:recycled")
+        _kb._set_worker_pid(conn, tid, pid)
+        _kb._record_worker_exit(pid, 0)
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+            (int(time.time()) - 1, tid),
+        )
+        conn.commit()
+
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+
+        def forbidden_termination(*args, **kwargs):
+            signal_attempts.append((args, kwargs))
+            raise AssertionError("live/recycled PID must not be signaled")
+
+        monkeypatch.setattr(_kb, "_terminate_reclaimed_worker", forbidden_termination)
+
+        result = _kb.dispatch_once(
+            conn,
+            spawn_fn=lambda *_args, **_kwargs: None,
+            max_spawn=0,
+            reconcile_orphans=False,
+        )
+
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "running"
+        assert task.worker_pid == pid
+        assert result.reclaimed == 0
+        assert tid not in result.auto_blocked
+        assert signal_attempts == []
+        events = kb.list_events(conn, tid)
+        assert len([event for event in events if event.kind == "claim_extended"]) == 1
+        assert not [event for event in events if event.kind == "blocked"]
+    finally:
+        _kb._recent_worker_exits.pop(pid, None)
+        conn.close()
+
+
+def test_dispatch_observes_clean_exit_before_expired_claim_reclaim(kanban_home):
+    """An expired claim cannot hide a clean missing-terminal exit from Control A."""
+    import hermes_cli.kanban_db as _kb
+
+    conn = kb.connect()
+    original_alive = _kb._pid_alive
+    try:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="expired clean exit", assignee="worker")
+        assert kb.claim_task(conn, tid, claimer=f"{host}:expired")
+        _kb._set_worker_pid(conn, tid, 991026)
+        _kb._record_worker_exit(991026, 0)
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+            (int(time.time()) - 1, tid),
+        )
+        conn.commit()
+        _kb._pid_alive = lambda _pid: False
+
+        result = _kb.dispatch_once(
+            conn,
+            spawn_fn=lambda *_args, **_kwargs: None,
+            max_spawn=0,
+            reconcile_orphans=False,
+        )
+
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
+        assert task.block_kind == "worker_protocol"
+        assert tid in result.auto_blocked
+        assert result.reclaimed == 0
+        assert not [e for e in kb.list_events(conn, tid) if e.kind == "reclaimed"]
+        assert len([e for e in kb.list_events(conn, tid) if e.kind == "blocked"]) == 1
+    finally:
+        _kb._pid_alive = original_alive
+        conn.close()
+
+
+def test_autoblock_skips_run_with_existing_terminal_event(kanban_home):
+    """An observed terminal event wins even if task state is momentarily stale."""
+    import hermes_cli.kanban_db as _kb
+
+    conn = kb.connect()
+    try:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="terminal race", assignee="worker")
+        assert kb.claim_task(conn, tid, claimer=f"{host}:race")
+        _kb._set_worker_pid(conn, tid, 991025)
+        observed = kb.get_task(conn, tid)
+        assert observed is not None
+        with _kb.write_txn(conn):
+            _kb._append_event(
+                conn, tid, "completed", {"result_len": 0},
+                run_id=observed.current_run_id,
+            )
+
+        blocked_run = _kb._auto_block_missing_terminal_event(
+            conn,
+            task_id=tid,
+            expected_run_id=observed.current_run_id,
+            expected_pid=991025,
+            expected_claim_lock=observed.claim_lock,
+            last_heartbeat_at=observed.last_heartbeat_at,
+            exit_kind="clean_exit",
+            exit_code=0,
+            trigger="missing_terminal_event",
+        )
+        assert blocked_run is None
+        assert kb.get_task(conn, tid).status == "running"
+        assert not [e for e in kb.list_events(conn, tid) if e.kind == "blocked"]
+    finally:
+        conn.close()
+
+
+def test_autoblock_compare_and_swap_allows_only_one_writer(kanban_home):
+    """Two contenders for the same observed run produce one transition/event."""
+    import hermes_cli.kanban_db as _kb
+
+    setup = kb.connect()
+    try:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(setup, title="race", assignee="worker")
+        task = kb.claim_task(setup, tid, claimer=f"{host}:race")
+        assert task is not None
+        _kb._set_worker_pid(setup, tid, 991030)
+        observed = kb.get_task(setup, tid)
+        expected = {
+            "task_id": tid,
+            "expected_run_id": observed.current_run_id,
+            "expected_pid": 991030,
+            "expected_claim_lock": observed.claim_lock,
+            "last_heartbeat_at": observed.last_heartbeat_at,
+            "exit_kind": "clean_exit",
+            "exit_code": 0,
+            "trigger": "missing_terminal_event",
+        }
+    finally:
+        setup.close()
+
+    barrier = threading.Barrier(2)
+    results = []
+    errors = []
+
+    def contender():
+        conn = kb.connect()
+        try:
+            barrier.wait()
+            results.append(_kb._auto_block_missing_terminal_event(conn, **expected))
+        except Exception as exc:  # pragma: no cover - assertion reports detail
+            errors.append(exc)
+        finally:
+            conn.close()
+
+    threads = [threading.Thread(target=contender) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert not errors
+    assert sorted(bool(result) for result in results) == [False, True]
+    verify = kb.connect()
+    try:
+        assert kb.get_task(verify, tid).status == "blocked"
+        assert len([e for e in kb.list_events(verify, tid) if e.kind == "blocked"]) == 1
+        assert len(kb.list_runs(verify, tid)) == 1
+    finally:
+        verify.close()
 
 
 

--- a/tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py
+++ b/tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py
@@ -122,6 +122,69 @@ def test_crash_reclaim_fires_worker_exited(kanban_home, captured_hooks, monkeypa
     assert "profile_name" in kw
     assert "board" in kw
 
+
+@pytest.mark.parametrize("path", ["dispatcher", "backfill"])
+def test_missing_terminal_hooks_fire_after_committed_block(
+    kanban_home, monkeypatch, path,
+):
+    """Both Control A paths notify observers only after the block commits."""
+    mgr = get_plugin_manager()
+    saved = {k: list(v) for k, v in mgr._hooks.items()}
+    fired: list[tuple[str, dict, str, int]] = []
+
+    def _capture(hook_name):
+        def callback(**kw):
+            # A fresh connection proves the transition and event were committed
+            # before either observer ran.
+            c2 = sqlite3.connect(kb.kanban_db_path())
+            try:
+                row = c2.execute(
+                    "SELECT status FROM tasks WHERE id = ?", (kw["task_id"],)
+                ).fetchone()
+                event_count = c2.execute(
+                    "SELECT COUNT(*) FROM task_events "
+                    "WHERE task_id = ? AND kind = 'blocked'",
+                    (kw["task_id"],),
+                ).fetchone()[0]
+            finally:
+                c2.close()
+            fired.append((hook_name, kw, row[0], event_count))
+        return callback
+
+    for hook in ("kanban_task_blocked", "on_kanban_worker_exited"):
+        mgr._hooks.setdefault(hook, []).append(_capture(hook))
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title=path, assignee="worker")
+        assert kb.claim_task(conn, tid)
+        pid = 98766 if path == "dispatcher" else 98767
+        kb._set_worker_pid(conn, tid, pid)
+        monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+        if path == "dispatcher":
+            kb._record_worker_exit(pid, 0)
+            kb.detect_crashed_workers(conn)
+        else:
+            assert kb.reap_stale_running_workers(conn) == [tid]
+    finally:
+        conn.close()
+        mgr._hooks = saved
+
+    assert [entry[0] for entry in fired] == [
+        "kanban_task_blocked", "on_kanban_worker_exited",
+    ]
+    assert all(
+        status == "blocked" and count == 1
+        for _, _, status, count in fired
+    )
+    worker_kw = fired[1][1]
+    assert worker_kw["outcome"] == "blocked"
+    assert worker_kw["retry_status"] == "blocked"
+    assert worker_kw["exit_kind"] == (
+        "clean_exit" if path == "dispatcher" else "unknown"
+    )
+
+
 def test_stale_claim_reclaim_fires_hook(kanban_home, captured_hooks):
     """A TTL-expired reclaim fires the stale-claim observer post-commit."""
     conn = kb.connect()


### PR DESCRIPTION
## What does this PR do?

When a Kanban worker exits `rc=0` without calling `kanban_complete` or `kanban_block`, the task should be blocked so the board stops showing it as an active delegation. Today the dispatcher instead routes this through the generic protocol-violation retry path, and the task keeps appearing active until the failure budget is exhausted.

This adds a narrow clean-only pre-pass (`_auto_block_clean_exits_before_recovery`) that runs **before** claim-TTL reclamation, orphan reconciliation, and stale-heartbeat recovery. A zero-exit-without-terminal-event is blocked on first observation with a typed `worker_protocol` block kind. Nonzero, signaled, unknown, and rate-limited exits keep their existing TTL/orphan/stale recovery precedence unchanged.

The ordering is the substantive point. Placing the clean-exit block *before* `release_stale_claims` closes a gap where an expired claim reclaims a long-running task to `ready` before the clean exit is ever classified, so the block would otherwise never fire for exactly the long-running tasks that hit it most.

## Related Issue

Addresses #27924 (currently `needs-repro`); the added `test_dispatch_observes_clean_exit_before_expired_claim_reclaim` is a deterministic reproduction. Related: #46593, #27178, #44812.

I'm aware of #70072 and #73264, which target the same rc=0-without-terminal condition with a different design (a new `completed_pending_review` status plus `missing_exit_signal` diagnostics and dashboard surfaces, triggered after repeated exits). This PR is deliberately smaller: it blocks on first occurrence, adds no new status or dashboard/locale surface, touches 4 files, and fixes the claim-reclamation ordering that those two PRs leave in place. Happy to align with whichever direction maintainers prefer, or to fold the ordering fix into one of them if that's cleaner.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py`: add `_auto_block_clean_exits_before_recovery` clean-only pre-pass; run it before reclamation in `_dispatch_once_locked`; add `worker_protocol` to `VALID_BLOCK_KINDS`; host-scoped and live-PID-conservative like existing recovery.
- `hermes_cli/plugins.py`: add `blocked` to the `on_kanban_worker_exited` outcome enum; lifecycle hooks fire only after the blocking transaction commits.
- `tests/hermes_cli/test_kanban_core_functionality.py` and `tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py`: coverage for first-exit blocking, clean-exit precedence over expired-claim reclamation, preserved ordering for the four non-clean exit classes, host scoping, live/recycled PID skip, CAS/idempotency, terminal-event race, and post-commit hooks.

## How to Test

```
scripts/run_tests.sh
```

Or focused:

```
pytest tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py -q
```

The four expired-claim regression tests were written to fail against a naive "reorder everything" fix and pass only with the narrow clean-only pre-pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (see #70072 / #73264 note above)
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (see note below)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (self-hosted)

> **Note on the full-suite checkbox:** the focused kanban suites pass (45 tests). Against the full suite at this base commit there are 83 pre-existing failures unrelated to this change, all in optional-provider/media/sandbox areas. A differential run (base vs. this branch, same environment) shows 83 failures on both sides: zero introduced and zero removed by this PR.

### Documentation & Housekeeping

- [x] Docstrings updated for the new function; no README/`docs/` change needed (N/A)
- [x] No config keys added (N/A)
- [x] No architecture/workflow change to `CONTRIBUTING.md`/`AGENTS.md` (N/A)
- [x] Considered cross-platform impact; change is host/PID/claim logic already guarded per-platform
- [x] No tool schema change (N/A)
