### PR TITLE
fix(doctor): preserve explicit Vercel backend diagnostics

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1969,7 +1969,7 @@ def run_doctor(args):
         check_info(f"Install for faster search: {_system_package_install_cmd('ripgrep')}")
     
     # Docker (optional)
-    terminal_env = os.getenv("TERMINAL_ENV", "local")
+    terminal_env = os.getenv("TERMINAL_ENV") or "local"
     try:
         from hermes_constants import is_container as _is_container
         running_in_container = _is_container()

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1983,12 +1983,14 @@ def run_doctor(args):
         # not found" warning. If the user has explicitly chosen
         # TERMINAL_ENV=docker inside the container they likely mounted
         # /var/run/docker.sock, so fall through to the normal check.
-        if terminal_env != "docker":
+        if terminal_env == "local":
             check_info(
                 "Running inside a container — using local terminal backend "
                 "(docker-in-docker is not configured by default)"
             )
-            # Skip to next section; Docker isn't relevant here.
+            # Skip to next section; Docker isn't relevant here. Explicitly
+            # selected backends (Vercel Sandbox, Daytona, SSH, or Docker)
+            # must keep their diagnostics below.
             terminal_env = "local"
     if terminal_env == "docker":
         if _safe_which("docker"):

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -233,6 +233,19 @@ def test_doctor_reports_vercel_backend_diagnostics(monkeypatch, tmp_path):
     assert "snapshot filesystem only" in out
 
 
+def test_doctor_treats_empty_terminal_env_as_local_in_container(monkeypatch):
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    monkeypatch.setattr("hermes_constants.is_container", lambda: True)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    out = buf.getvalue()
+    assert "using local terminal backend" in out
+    assert "docker not found" not in out
+
+
 # ── Memory provider section (doctor should only check the *active* provider) ──
 
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -207,6 +207,7 @@ def test_doctor_reports_vercel_backend_diagnostics(monkeypatch, tmp_path):
     monkeypatch.setenv("VERCEL_TOKEN", "super-secret-value")
     monkeypatch.delenv("VERCEL_PROJECT_ID", raising=False)
     monkeypatch.setenv("VERCEL_TEAM_ID", "team")
+    monkeypatch.setattr("hermes_constants.is_container", lambda: True)
     monkeypatch.setattr(doctor_mod.importlib.util, "find_spec", lambda name: object() if name == "vercel" else None)
 
     fake_model_tools = types.SimpleNamespace(


### PR DESCRIPTION
## Summary

- preserve explicitly selected non-local terminal backends while running `hermes doctor` inside a container
- fix Vercel Sandbox diagnostics being skipped because `TERMINAL_ENV=vercel_sandbox` was rewritten to `local`
- make the regression test deterministic by explicitly simulating a container host

## Root cause

The container-specific Docker fallback treated every backend other than `docker` as the local backend. This silently suppressed diagnostics for explicitly selected Vercel Sandbox, Daytona, and SSH backends.

The fallback now applies only when the selected backend is actually `local`. Explicit backend selections retain their own diagnostics.

## Test plan

- [x] reproduced the failure on clean `origin/main`
- [x] Vercel diagnostic regression test passes
- [x] `tests/hermes_cli/test_doctor.py tests/hermes_cli/test_doctor_live.py` — 80 passed
- [x] Ruff checks
- [x] Python compilation
- [x] `git diff --check`

No Vercel network call is made by the test; credentials remain redacted.
