### PR TITLE
fix(desktop): render LaTeX math in file preview

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -31,7 +31,9 @@ import {
   writeDesktopFileText
 } from '@/lib/desktop-fs'
 import { Check, Pencil, X } from '@/lib/icons'
+import { createMemoizedMathPlugin } from '@/lib/katex-memo'
 import { shikiLanguageForFilename } from '@/lib/markdown-code'
+import { normalizeFilePreviewMath } from '@/lib/markdown-preprocess'
 import { cn } from '@/lib/utils'
 import type { PreviewTarget } from '@/store/preview'
 import { setPreviewDirty } from '@/store/preview-edit'
@@ -43,6 +45,11 @@ const TEXT_PREVIEW_MAX_BYTES = 512 * 1024
 const SOURCE_CHUNK_LINES = 200
 const SOURCE_LINE_PX = 20
 const SOURCE_OVERSCAN_LINES = 400
+
+// Math plugin for the static file preview, configured once at module scope.
+// Mirrors the chat transcript's plugin (`markdown-text.tsx`) — same memoized
+// KaTeX wrapper, with `singleDollarTextMath: true` so `$x$` renders inline.
+const previewMathPlugin = createMemoizedMathPlugin({ singleDollarTextMath: true })
 
 type EmptyStateTone = 'neutral' | 'warning'
 
@@ -370,10 +377,18 @@ const MARKDOWN_COMPONENTS = {
 }
 
 function MarkdownPreview({ text }: { text: string }) {
+  const mathText = useMemo(() => normalizeFilePreviewMath(text), [text])
+
   return (
     <div className="preview-markdown mx-auto max-w-3xl px-4 py-3 text-sm text-foreground" data-selectable-text="true">
-      <Streamdown components={MARKDOWN_COMPONENTS} controls={false} mode="static" parseIncompleteMarkdown={false}>
-        {text}
+      <Streamdown
+        components={MARKDOWN_COMPONENTS}
+        controls={false}
+        mode="static"
+        parseIncompleteMarkdown={false}
+        plugins={{ math: previewMathPlugin }}
+      >
+        {mathText}
       </Streamdown>
     </div>
   )

--- a/apps/desktop/src/lib/file-preview-math.render.test.tsx
+++ b/apps/desktop/src/lib/file-preview-math.render.test.tsx
@@ -1,0 +1,64 @@
+import { render, waitFor } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { Streamdown } from 'streamdown'
+
+import { createMemoizedMathPlugin } from '@/lib/katex-memo'
+import { normalizeFilePreviewMath } from '@/lib/markdown-preprocess'
+
+// This is the exact pipeline the file preview runs: normalizeFilePreviewMath
+// → Streamdown with the memoized math plugin. Rendering here (jsdom) proves the
+// wiring produces KaTeX output, not raw `$..$` source text.
+describe('file-preview math rendering', () => {
+  const mathPlugin = createMemoizedMathPlugin({ singleDollarTextMath: true })
+
+  it('renders inline $..$ math as KaTeX', async () => {
+    const { container } = render(
+      <Streamdown mode="static" plugins={{ math: mathPlugin }}>
+        {normalizeFilePreviewMath('The formula $x^2 + y^2$ here.')}
+      </Streamdown>
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector('.katex')).not.toBeNull()
+    })
+    expect(container.textContent).not.toContain('$x^2')
+  })
+
+  it('renders $$..$$ display math as KaTeX', async () => {
+    const { container } = render(
+      <Streamdown mode="static" plugins={{ math: mathPlugin }}>
+        {normalizeFilePreviewMath('Block:\n\n$$E = mc^2$$')}
+      </Streamdown>
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector('.katex-display') || container.querySelector('.katex')).not.toBeNull()
+    })
+  })
+
+  it('renders \(..\) delimiter math as KaTeX', async () => {
+    const { container } = render(
+      <Streamdown mode="static" plugins={{ math: mathPlugin }}>
+        {normalizeFilePreviewMath('A fraction \\(\\frac{a}{b}\\) inline.')}
+      </Streamdown>
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector('.katex')).not.toBeNull()
+    })
+    expect(container.querySelector('.katex-mathml, .katex-html')).not.toBeNull()
+  })
+
+  it('leaves a literal code-fence \$ alone as code, not math', async () => {
+    const { container } = render(
+      <Streamdown mode="static" plugins={{ math: mathPlugin }}>
+        {normalizeFilePreviewMath('```bash\necho $HOME\n```')}
+      </Streamdown>
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector('.katex')).toBeNull()
+    })
+    expect(container.querySelector('code')?.textContent).toContain('$HOME')
+  })
+})

--- a/apps/desktop/src/lib/file-preview-math.render.test.tsx
+++ b/apps/desktop/src/lib/file-preview-math.render.test.tsx
@@ -1,6 +1,6 @@
 import { render, waitFor } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
 import { Streamdown } from 'streamdown'
+import { describe, expect, it } from 'vitest'
 
 import { createMemoizedMathPlugin } from '@/lib/katex-memo'
 import { normalizeFilePreviewMath } from '@/lib/markdown-preprocess'
@@ -36,7 +36,7 @@ describe('file-preview math rendering', () => {
     })
   })
 
-  it('renders \(..\) delimiter math as KaTeX', async () => {
+  it('renders delimited math as KaTeX', async () => {
     const { container } = render(
       <Streamdown mode="static" plugins={{ math: mathPlugin }}>
         {normalizeFilePreviewMath('A fraction \\(\\frac{a}{b}\\) inline.')}
@@ -49,7 +49,7 @@ describe('file-preview math rendering', () => {
     expect(container.querySelector('.katex-mathml, .katex-html')).not.toBeNull()
   })
 
-  it('leaves a literal code-fence \$ alone as code, not math', async () => {
+  it('leaves a literal code-fence $ alone as code, not math', async () => {
     const { container } = render(
       <Streamdown mode="static" plugins={{ math: mathPlugin }}>
         {normalizeFilePreviewMath('```bash\necho $HOME\n```')}

--- a/apps/desktop/src/lib/markdown-preprocess.file-preview.test.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.file-preview.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeFilePreviewMath } from '@/lib/markdown-preprocess'
+
+describe('normalizeFilePreviewMath', () => {
+  it('leaves single-dollar inline math untouched', () => {
+    expect(normalizeFilePreviewMath('Price is $x^2 + y^2$ today')).toBe('Price is $x^2 + y^2$ today')
+  })
+
+  it('escapes currency dollar amounts so they are not parsed as math', () => {
+    const output = normalizeFilePreviewMath('Rent $500 and utilities $150.')
+
+    expect(output).toContain('\\$500')
+    expect(output).toContain('\\$150')
+  })
+
+  it('does not escape dollars inside code fences', () => {
+    const input = ['Before', '```bash', 'echo $HOME', 'echo $PATH', '```', 'After'].join('\n')
+
+    expect(normalizeFilePreviewMath(input)).toBe(input)
+  })
+
+  it('does not escape dollars inside inline code spans', () => {
+    expect(normalizeFilePreviewMath('Run `echo $HOME` now')).toBe('Run `echo $HOME` now')
+  })
+
+  it('normalizes latex delimiters to dollar math', () => {
+    // `\(…\)` and `\[…\]` are rewritten to `$…$` / `$$…$$` so remark-math parses them.
+    expect(normalizeFilePreviewMath('A formula \\(x + 1\\) inline.')).toBe('A formula $x + 1$ inline.')
+  })
+
+  it('leaves ```math fences untouched (rehype renders language-math directly)', () => {
+    const input = ['```math', 'E = mc^2', '```'].join('\n')
+
+    expect(normalizeFilePreviewMath(input)).toBe(input)
+  })
+
+  it('does not strip citation markers or autolink urls (chat-only transforms omitted)', () => {
+    const input = 'See [3] and https://example.com'
+
+    const output = normalizeFilePreviewMath(input)
+
+    // A chat message would autolink the URL and strip the [3] citation marker;
+    // a file's prose must stay verbatim.
+    expect(output).toBe(input)
+  })
+
+  it('does not strip reasoning blocks (author content, not model output)', () => {
+    const input = '<reasoning>keep me</reasoning>'
+
+    expect(normalizeFilePreviewMath(input)).toBe(input)
+  })
+})

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -521,3 +521,33 @@ export function preprocessMarkdown(text: string): string {
     .join('')
     .replace(/[ \t]+\n/g, '\n')
 }
+
+/**
+ * Math-only normalization for static file previews. Mirrors the math half of
+ * `preprocessMarkdown` — delimiter normalization (`\(…\)`, `\[…\]`), display
+ * math on its own lines, and currency-dollar escaping — but deliberately skips
+ * the chat-only transforms (reasoning-block stripping, `@session:` ref
+ * linking, preview-target stripping, raw-URL autolinking, citation-marker
+ * stripping). A file's prose is author content, not model output, so those
+ * rewrites must not touch it. Code fences and inline code spans pass through
+ * untouched so `$`, `\(` and `\begin` inside listings are never mangled.
+ *
+ * ` ```math ` fences need no preprocessing: remark/rehype emit them as
+ * `<code class="language-math">` and the memoized rehype-katex wrapper renders
+ * them regardless of this function.
+ */
+export function normalizeFilePreviewMath(text: string): string {
+  return text
+    .split(CODE_FENCE_SPLIT_RE)
+    .map(part => {
+      if (/^(?:```|~~~)/.test(part)) {
+        return part
+      }
+
+      return part
+        .split(INLINE_CODE_SPLIT_RE)
+        .map(segment => (segment.startsWith('`') ? segment : normalizeProseMath(segment)))
+        .join('')
+    })
+    .join('')
+}


### PR DESCRIPTION
## Problem

The right-rail **file preview** rendered Markdown through bare `Streamdown` with **no plugins and no math preprocessing**, so LaTeX (`$...$`, `\(...\)`, `$$...$$`, `\[...\]`) stayed as raw source text. The chat transcript already renders these correctly — the preview just never got the same two pieces it needs.

## Root cause

`chp/src/app/chat/right-rail/preview-file.tsx` (`MarkdownPreview`) passes no `plugins` and feeds text straight to `Streamdown`. The chat surface (`markdown-text.tsx`) renders math via `createMemoizedMathPlugin` + `preprocessMarkdown`; the preview used neither.

## Fix

Two files, +47/−2:

1. **`apps/desktop/src/lib/markdown-preprocess.ts`** — add `normalizeFilePreviewMath()`, a math-only normalizer. It mirrors the math half of `preprocessMarkdown` (delimiter normalization, display-math on its own lines, currency-dollar escaping) but **deliberately skips the chat-only transforms** — reasoning-block stripping, `@session:` linking, preview-target stripping, raw-URL autolinking, citation-marker stripping — because a file's prose is author content, not model output. Code fences and inline code spans pass through untouched, so `$HOME` in a bash block stays literal and `\(` inside a listing is never mangled.

2. **`apps/desktop/src/app/chat/right-rail/preview-file.tsx`** — module-scope `createMemoizedMathPlugin({ singleDollarTextMath: true })`, passed as `plugins={{ math }}` to `Streamdown`, with text preprocessed through `normalizeFilePreviewMath` before render.

## Tests

- `markdown-preprocess.file-preview.test.ts` — 8 unit tests: currency escaping, delimiter normalization, fence/inline-code preservation, verbatim citations/URLs/reasoning blocks.
- `file-preview-math.render.test.tsx` — 4 DOM tests proving the exact preview pipeline emits `.katex` for `$x^2$`, `$$E=mc^2$$`, and `\(...\)` math, and leaves a code-fence `$HOME` as code.

## Notes

- KaTeX CSS was already loaded globally (`styles.css` imports `katex/dist/katex.min.css`), so no stylesheet change was needed.
- The multi-line `$$...$$` hugging-delimiter case (tracked in #44589) is orthogonal — this PR covers single-line inline/display math and `\(...\)`/`\[...\]` delimiters.
- No upstream files other than the two above are touched.