### PR TITLE
fix(desktop): keep Home sessions detached

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -91,7 +91,7 @@ function deferred<T>() {
 
 type HarnessHandle = Pick<
   ReturnType<typeof useSessionActions>,
-  'createBackendSessionForSend' | 'selectSidebarItem' | 'startFreshSessionDraft'
+  'createBackendSessionForSend' | 'openNewSessionTile' | 'selectSidebarItem' | 'startFreshSessionDraft'
 >
 
 function storedSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
@@ -2532,6 +2532,57 @@ describe('createBackendSessionForSend workspace target', () => {
     expect(params).toMatchObject({ cwd: '/clicked-workspace' })
   })
 })
+
+describe('openNewSessionTile workspace target', () => {
+  afterEach(() => {
+    cleanup()
+    $projectScope.set(ALL_PROJECTS)
+    $projectTree.set([])
+    $sessionTiles.set([])
+    setCurrentCwd('')
+    vi.restoreAllMocks()
+  })
+
+  it('omits cwd when Home explicitly requests a detached session', async () => {
+    $projectTree.set([
+      {
+        id: 'p_app',
+        label: 'App',
+        path: '/repo/app',
+        repos: [{ groups: [], id: '/repo/app', label: 'app', path: '/repo/app', sessionCount: 0 }],
+        sessionCount: 0
+      }
+    ])
+    $projectScope.set('p_app')
+
+    let createParams: Record<string, unknown> | undefined
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.create') {
+        createParams = params
+
+        return {
+          info: {},
+          session_id: RUNTIME_SESSION_ID,
+          stored_session_id: 'stored-home'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={value => (handle = value)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.openNewSessionTile('center', { cwd: null, listed: false })
+    })
+
+    expect(createParams).not.toHaveProperty('cwd')
+  })
+})
+
 describe('selectSidebarItem', () => {
   it('fronts the workspace pane when navigating to a sidebar route (issue #72602)', async () => {
     const navigate = vi.fn()

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -563,7 +563,8 @@ export function useSessionActions({
         // Fresh tile → the caller's workspace when one was named (the sidebar
         // "+" on a project/worktree lane), else the resolved new-session cwd
         // (project scope → configured default).
-        const params = await desktopSessionCreateParams((options?.cwd || resolveNewSessionCwd()).trim())
+        const cwd = options?.cwd === null ? '' : (options?.cwd || resolveNewSessionCwd()).trim()
+        const params = await desktopSessionCreateParams(cwd)
         const created = await requestGateway<SessionCreateResponse>('session.create', params)
         const stored = created.stored_session_id
 

--- a/apps/desktop/src/app/session/workspace-session-target.test.ts
+++ b/apps/desktop/src/app/session/workspace-session-target.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { $projectScope, $projectTree, ALL_PROJECTS } from '@/store/projects'
 import {
   $currentBranch,
   $currentCwd,
@@ -23,6 +24,8 @@ function deferred<T>() {
 
 describe('startWorkspaceSession', () => {
   afterEach(() => {
+    $projectScope.set(ALL_PROJECTS)
+    $projectTree.set([])
     setCurrentBranch('')
     setCurrentCwd('')
     setNewChatWorkspaceTarget(undefined)
@@ -40,7 +43,7 @@ describe('startWorkspaceSession', () => {
 
     const activeSessionIdRef = { current: null }
 
-    const startFreshSessionDraft = vi.fn((options?: { workspaceTarget: string }) => {
+    const startFreshSessionDraft = vi.fn((options?: { workspaceTarget: null | string }) => {
       setNewChatWorkspaceTarget(options?.workspaceTarget)
       setCurrentCwd(options?.workspaceTarget || '')
     })
@@ -77,5 +80,31 @@ describe('startWorkspaceSession', () => {
     expect($newChatWorkspaceTarget.get()).toBe('/normalized-b')
     expect($currentCwd.get()).toBe('/normalized-b')
     expect($currentBranch.get()).toBe('main')
+  })
+
+  it('keeps a Home session detached instead of inheriting the active project', () => {
+    $projectTree.set([
+      {
+        id: 'p_app',
+        label: 'App',
+        path: '/repo/app',
+        repos: [{ groups: [], id: '/repo/app', label: 'app', path: '/repo/app', sessionCount: 0 }],
+        sessionCount: 0
+      }
+    ])
+    $projectScope.set('p_app')
+
+    const requestGateway = vi.fn()
+    const startFreshSessionDraft = vi.fn()
+
+    startWorkspaceSession({
+      activeSessionIdRef: { current: null },
+      path: null,
+      requestGateway,
+      startFreshSessionDraft
+    })
+
+    expect(startFreshSessionDraft).toHaveBeenCalledWith({ workspaceTarget: null })
+    expect(requestGateway).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/app/session/workspace-session-target.ts
+++ b/apps/desktop/src/app/session/workspace-session-target.ts
@@ -14,7 +14,7 @@ interface WorkspaceSessionOptions {
   onExplicitWorkspace?: (cwd: string) => void
   path: null | string
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
-  startFreshSessionDraft: (options?: { workspaceTarget: string }) => void
+  startFreshSessionDraft: (options?: { workspaceTarget: null | string }) => void
 }
 
 export function startWorkspaceSession({
@@ -25,9 +25,15 @@ export function startWorkspaceSession({
   requestGateway,
   startFreshSessionDraft
 }: WorkspaceSessionOptions): void {
+  if (path === null) {
+    startFreshSessionDraft({ workspaceTarget: null })
+
+    return
+  }
+
   // A worktree lane carries its own path; a project trunk can be path-less, so
   // fall back to the active project's root for that existing controller path.
-  const explicitTarget = path?.trim()
+  const explicitTarget = path.trim()
   const target = explicitTarget || resolveNewSessionCwd()
 
   startFreshSessionDraft(target ? { workspaceTarget: target } : undefined)


### PR DESCRIPTION
## Problem

Clicking the "+" (New session) next to the Home bucket in the desktop sidebar creates the session with an explicit workspace cwd instead of a detached Home session. On a remote/SSH gateway the fallback `os.getcwd()` in the backend (`_completion_cwd`) persists the launch folder, so the session lands under the active project instead of Home. Telegram/gateway sessions stay in Home because they never carry a cwd — only desktop "New session in Home" leaks the project path.

## Fix

- `startWorkspaceSession` now routes a `null` path directly to `startFreshSessionDraft({ workspaceTarget: null })`, keeping the draft detached instead of falling through to `resolveNewSessionCwd()` (which returns the project root when a project scope is active).
- `openNewSessionTile` treats `options.cwd === null` as detached (`` → omitted `cwd` in `session.create`), matching the fresh-draft path.

## Tests

- `workspace-session-target.test.ts`: Home `path: null` emits `{ workspaceTarget: null }` and never calls the gateway.
- `use-session-actions.test.tsx`: `openNewSessionTile("center", { cwd: null })` sends `session.create` with no `cwd` property, even when a project scope is active.

Verified with a live reproduction: desktop "New session in Home" sessions were persisting `cwd=/opt/data/projects/ai-online-business-research` in `state.db`; the fix omits `cwd` so the backend keeps the row null and the tree places the session in Home (NO_PROJECT_ID).