### PR TITLE
fix(config): warn when a custom provider base_url has no path

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1410,6 +1410,24 @@ def _normalize_custom_provider_entry(
             parsed = urlparse(candidate)
             if parsed.scheme and parsed.netloc:
                 base_url = candidate
+                # A scheme+host with no path is a classic silent-404 shape:
+                # transports append their own API path to base_url, so a bare
+                # domain can point the request at a nonexistent path while the
+                # server serves /v1/chat/completions. Surfaced here because
+                # the failing request reports a bare-looking endpoint and
+                # nothing else hints at the path mismatch (#89334). Kept
+                # direction-neutral: some transports strip a trailing /v1
+                # (see #37403), so the warning names both failure shapes
+                # instead of prescribing one fix.
+                if parsed.path in ("", "/") and not re.search(r"\{[^}]+\}", candidate):
+                    _warn_once_per_provider(
+                        provider_key, f"bare-base-url:{candidate}",
+                        "providers.%s: base_url '%s' has no path — transports "
+                        "append their own API path to it, and both a missing "
+                        "and a doubled '/v1' 404; verify the endpoint path "
+                        "against your provider's docs",
+                        provider_key or "?", candidate,
+                    )
                 break
             else:
                 logger.warning(

--- a/tests/hermes_cli/test_custom_provider_normalize_no_mutate.py
+++ b/tests/hermes_cli/test_custom_provider_normalize_no_mutate.py
@@ -48,6 +48,53 @@ def test_providers_dict_roundtrip_leaves_cached_config_untouched():
     assert config == snapshot
 
 
+def test_bare_base_url_warns_about_missing_v1_prefix(caplog):
+    """A scheme+host-only base_url is the silent-404 shape: OpenAI-compatible
+    clients append /chat/completions to base_url, so the request misses the
+    server's /v1/chat/completions (#89334). The normalizer must say so once."""
+    import logging
+
+    import hermes_cli.config as config_mod
+
+    entry = {"base_url": "https://api.example.com", "key_env": "MY_KEY"}
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.config"):
+        out = config_mod._normalize_custom_provider_entry(entry, provider_key="dots")
+    assert out is not None
+    assert any(
+        "has no path" in r.getMessage() for r in caplog.records
+    ), "bare base_url must warn about the missing /v1 prefix"
+
+
+def test_base_url_with_path_does_not_warn(caplog):
+    import logging
+
+    import hermes_cli.config as config_mod
+
+    entry = {"base_url": "https://api.example.com/v1", "key_env": "MY_KEY"}
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.config"):
+        out = config_mod._normalize_custom_provider_entry(entry, provider_key="dots")
+    assert out is not None
+    assert not any(
+        "has no path" in r.getMessage() for r in caplog.records
+    )
+
+
+def test_bare_base_url_placeholder_does_not_warn(caplog):
+    """Env-ref/template URLs are expanded at runtime; the path may come from
+    the expansion, so the bare check must not fire on them."""
+    import logging
+
+    import hermes_cli.config as config_mod
+
+    entry = {"base_url": "https://api-{region}.example.com", "key_env": "MY_KEY"}
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.config"):
+        out = config_mod._normalize_custom_provider_entry(entry, provider_key="dots")
+    assert out is not None
+    assert not any(
+        "has no path" in r.getMessage() for r in caplog.records
+    )
+
+
 def test_normalized_models_mapping_is_not_shared_with_input():
     entry = {
         "base_url": "https://x.example/v1",


### PR DESCRIPTION
## What does this PR do?

A custom provider configured with a scheme+host-only `base_url` (e.g. `https://api.example.com`) fails with a bare `HTTP 404` and no further hint — transports append their own API path to `base_url`, so the request can land on a nonexistent path while the server serves `/v1/chat/completions`. The error report shows the bare endpoint, and users are left suspecting auth headers, request formats, or the provider type (#89334's reporter tested three provider types and two auth-header spellings before filing).

The provider-entry normalizer now emits a one-shot warning when a resolved `base_url` has no path:

```
providers.dots: base_url 'https://api.example.com' has no path — transports
append their own API path to it, and both a missing and a doubled '/v1' 404;
verify the endpoint path against your provider's docs
```

The wording is deliberately direction-neutral: #37403 (open) documents the *double*-`/v1` failure where a trailing `/v1` must be stripped, while this issue is the *missing*-`/v1` shape — prescribing "add /v1" here would mislead users on transports that append their own. Naming both shapes keeps the diagnostic correct either way. Placeholder/template URLs (`${VAR}`, `{region}`) are exempt — their path may arrive from runtime expansion (#14457's precedent).

No resolution semantics change: the entry still resolves exactly as before; only the missing diagnostic appears. (Related config confusion in the report — `api_key_header` — already warns through the existing unknown-keys path, and `api_key_env` is a documented alias for `key_env`.)

## Related Issue

Fixes #89334

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/config.py` — in `_normalize_custom_provider_entry`'s URL resolution, a valid scheme+host with an empty/`/` path emits the one-shot warning (via the existing `_warn_once_per_provider` dedup, so no warning storms on repeated config loads), with a comment explaining the two 404 shapes and the #37403 interplay.
- `tests/hermes_cli/test_custom_provider_normalize_no_mutate.py` — `test_bare_base_url_warns_about_missing_v1_prefix` (fails on main: no warning), `test_base_url_with_path_does_not_warn`, `test_bare_base_url_placeholder_does_not_warn`.

## How to Test

```bash
python -m pytest tests/hermes_cli/test_custom_provider_normalize_no_mutate.py tests/hermes_cli/test_api_mode_aliases.py tests/hermes_cli/test_custom_provider_extra_headers.py -q
# Observed result: 44 passed

python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -q
# Observed result: 59 passed
```

Fail-on-main check: with the config change stashed, the bare-base_url warning test fails (no record); the two scoping pins pass on both.

Manual repro from the issue: a `providers.dots` entry with `base_url: https://note3-prev-api.askdiandian.com` — on main, `hermes chat -q test` 404s with only the bare endpoint in the error report; with this change the config load surfaces the path warning pointing at the fix (adding `/v1` for an OpenAI-compatible chat-completions server).

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments explain intent (why the warning is direction-neutral, why placeholders are exempt)
- [x] Corresponding changes documented via comments
- [x] Tests added and passing (3 new; provider normalize/resolution suites green)
- [x] Single root cause, no unrelated changes
