### PR TITLE
feat(browser): drive Electron desktop apps over CDP — hermes browser attach + session registry + escalation nudge (#89270)

### DIFF
--- a/hermes_cli/browser_attach.py
+++ b/hermes_cli/browser_attach.py
@@ -195,12 +195,9 @@ def load_registry() -> Dict[str, Dict[str, Any]]:
 
 
 def _write_registry(sessions: Dict[str, Dict[str, Any]]) -> None:
-    path = registry_path()
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    tmp = f"{path}.tmp"
-    with open(tmp, "w", encoding="utf-8") as fh:
-        json.dump({"sessions": sessions}, fh, indent=2)
-    os.replace(tmp, path)
+    from utils import atomic_json_write
+
+    atomic_json_write(registry_path(), {"sessions": sessions})
 
 
 def save_session_endpoint(name: str, cdp_url: str, app: str) -> None:
@@ -256,8 +253,8 @@ def _terminate_app(pid: int, timeout: float = 10.0) -> bool:
         # can skip their before-quit handlers.
         import subprocess
 
-        bundle = _bundle_path(exe_path) if (exe_path := _exe_of(proc)) else None
-        app_name = os.path.basename(bundle)[: -len(".app")] if bundle else proc.name()
+        exe_path = _exe_of(proc)
+        app_name = app_display_name(exe_path, proc.name()) if exe_path else proc.name()
         try:
             subprocess.run(
                 ["osascript", "-e", f'quit app "{app_name}"'],

--- a/hermes_cli/browser_attach.py
+++ b/hermes_cli/browser_attach.py
@@ -34,7 +34,7 @@ import re
 import time
 from typing import Any, Dict, List, Optional
 
-from hermes_cli.browser_connect import find_free_debug_port, is_browser_debug_ready
+from hermes_cli.browser_connect import discover_local_cdp_url, find_free_debug_port
 from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
@@ -105,15 +105,17 @@ def is_electron_child(cmdline: List[str]) -> bool:
 
 def app_display_name(exe_path: str, fallback: str) -> str:
     """Human name for the app: the ``.app`` bundle on macOS, else the binary."""
-    for part in reversed(exe_path.split(os.sep)):
-        if part.endswith(".app"):
-            return part[: -len(".app")]
-    return fallback
+    bundle = _bundle_path(exe_path)
+    return os.path.basename(bundle)[: -len(".app")] if bundle else fallback
 
 
 def session_slug(name: str) -> str:
-    """Registry/session-safe slug (matches browser_exec's session grammar)."""
-    slug = re.sub(r"[^A-Za-z0-9_-]+", "-", name).strip("-").lower()
+    """Registry/session-safe slug (matches browser_exec's session grammar).
+
+    browser_exec's ``_SESSION_RE`` requires an alphanumeric FIRST char, so
+    strip leading/trailing underscores as well as dashes.
+    """
+    slug = re.sub(r"[^A-Za-z0-9_-]+", "-", name).strip("-_").lower()
     return slug[:64] or "app"
 
 
@@ -131,7 +133,7 @@ def scan_electron_apps() -> List[Dict[str, Any]]:
     import psutil
 
     found: List[Dict[str, Any]] = []
-    seen_exes: Dict[str, int] = {}
+    seen_exes: set = set()
     for proc in psutil.process_iter(["pid", "name", "exe", "cmdline"]):
         try:
             info = proc.info
@@ -144,13 +146,13 @@ def scan_electron_apps() -> List[Dict[str, Any]]:
             # One entry per app binary: the first (lowest-pid) main wins.
             if exe in seen_exes:
                 continue
-            seen_exes[exe] = info["pid"]
+            seen_exes.add(exe)
             port = debug_port_from_cmdline(cmdline)
             cdp_url: Optional[str] = None
             if port:
-                candidate = f"http://127.0.0.1:{port}"
-                if is_browser_debug_ready(candidate, timeout=0.5):
-                    cdp_url = candidate
+                # Dual-stack probe: an IPv4-loopback squatter can push the
+                # relaunched app's debug listener onto [::1] only.
+                cdp_url = discover_local_cdp_url(port, timeout=0.5)
             found.append(
                 {
                     "pid": info["pid"],
@@ -255,14 +257,29 @@ def _terminate_app(pid: int, timeout: float = 10.0) -> bool:
 
         exe_path = _exe_of(proc)
         app_name = app_display_name(exe_path, proc.name()) if exe_path else proc.name()
+        quit_sent = False
         try:
-            subprocess.run(
-                ["osascript", "-e", f'quit app "{app_name}"'],
-                capture_output=True,
-                timeout=5,
+            quit_sent = (
+                subprocess.run(
+                    ["osascript", "-e", f'quit app "{app_name}"'],
+                    capture_output=True,
+                    timeout=5,
+                ).returncode
+                == 0
             )
         except Exception as e:
             logger.debug("osascript quit failed (falling back to terminate): %s", e)
+        if quit_sent:
+            # Give the AppleEvent quit a grace window before SIGTERM —
+            # terminating immediately defeats the graceful quit and can
+            # skip the app's before-quit handlers (the point of osascript).
+            try:
+                proc.wait(timeout=5)
+                return True
+            except psutil.NoSuchProcess:
+                return True
+            except psutil.TimeoutExpired:
+                pass
     try:
         if proc.is_running():
             proc.terminate()
@@ -329,10 +346,12 @@ def relaunch_with_debug_port(
         logger.warning("could not stop %s (pid %d)", app["name"], app["pid"])
         return None
     _spawn_with_debug_port(app["exe"], port)
-    url = f"http://127.0.0.1:{port}"
     deadline = time.monotonic() + wait_s
     while time.monotonic() < deadline:
-        if is_browser_debug_ready(url, timeout=0.5):
+        # Dual-stack: the relaunched app may bind [::1] only (see
+        # discover_local_cdp_url) — probe both loopbacks each pass.
+        url = discover_local_cdp_url(port, timeout=0.5)
+        if url:
             return url
         time.sleep(0.3)
     return None

--- a/hermes_cli/browser_attach.py
+++ b/hermes_cli/browser_attach.py
@@ -1,0 +1,341 @@
+"""Attach Hermes browser sessions to running Electron/Chromium desktop apps.
+
+Driving a desktop Electron app (Obsidian, Slack, VS Code, Discord, ...) over
+CDP is far more reliable than OS-level input synthesis: Chromium drops
+synthetic pointer events into occluded, unfocused renderers, while a CDP
+attach gives exact DOM-level control with zero focus steal.
+
+This module owns the three pieces that make that a one-command flow:
+
+* **Electron discovery** — scan running processes for Electron *main*
+  processes (``resources/app.asar`` next to the executable, no ``--type=``
+  child marker) and read any ``--remote-debugging-port`` they were launched
+  with.
+* **The named-session CDP registry** — ``$HERMES_HOME/browser-sessions.json``
+  maps a browser_exec session name to the app's CDP endpoint, so ONE named
+  session drives the app while the default session keeps browsing the web.
+* **The relaunch flow** — for a detected app that does not expose a CDP
+  port, offer to quit and relaunch it with ``--remote-debugging-port``.
+
+Consent model: CDP into a live desktop app exposes everything the app can
+see (Slack DMs, vault contents, editor buffers) — the same power class as
+cua-driver's gated ``existing_profile`` attach. The agent therefore never
+opens a debug port itself: ``hermes browser attach`` is user-invoked, and
+the relaunch confirmation is the consent moment.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import platform
+import re
+import time
+from typing import Any, Dict, List, Optional
+
+from hermes_cli.browser_connect import find_free_debug_port, is_browser_debug_ready
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+_REGISTRY_FILENAME = "browser-sessions.json"
+
+_DEBUG_PORT_RE = re.compile(r"--remote-debugging-port=(\d+)")
+
+# Chromium child processes carry --type=renderer/gpu-process/utility/...;
+# the main process never does. This is the cheapest main-vs-child split.
+_CHILD_TYPE_RE = re.compile(r"--type=\w")
+
+
+# ── Electron detection ─────────────────────────────────────────────
+
+
+def electron_resource_roots(exe_path: str) -> List[str]:
+    """Return the candidate ``resources/`` directories for an executable.
+
+    Electron ships the packaged app as ``resources/app.asar`` (or an
+    unpacked ``resources/app/`` tree) next to the binary on Windows/Linux,
+    and under ``Contents/Resources/`` on macOS (the binary lives in
+    ``Contents/MacOS/``).
+    """
+    exe_dir = os.path.dirname(exe_path)
+    roots = [os.path.join(exe_dir, "resources")]
+    if os.path.basename(exe_dir) == "MacOS":
+        roots.append(os.path.join(os.path.dirname(exe_dir), "Resources"))
+    return roots
+
+
+def is_electron_executable(exe_path: str) -> bool:
+    """True when ``exe_path`` looks like a packaged Electron app binary.
+
+    Signature: ``app.asar`` (packaged) or ``app/package.json`` (unpacked)
+    under the executable's resources root. Real browsers (Chrome, Brave,
+    Edge) ship neither, so they are excluded automatically.
+    """
+    if not exe_path:
+        return False
+    for root in electron_resource_roots(exe_path):
+        if os.path.isfile(os.path.join(root, "app.asar")):
+            return True
+        if os.path.isfile(os.path.join(root, "app", "package.json")):
+            return True
+    return False
+
+
+def debug_port_from_cmdline(cmdline: List[str]) -> Optional[int]:
+    """Extract ``--remote-debugging-port=N`` from a process command line."""
+    for arg in cmdline or []:
+        m = _DEBUG_PORT_RE.search(str(arg))
+        if m:
+            try:
+                port = int(m.group(1))
+            except ValueError:
+                continue
+            # Port 0 means "OS-assigned" and is not probeable from here.
+            if port > 0:
+                return port
+    return None
+
+
+def is_electron_child(cmdline: List[str]) -> bool:
+    """True for renderer/gpu/utility children (``--type=...`` marker)."""
+    return any(_CHILD_TYPE_RE.search(str(arg)) for arg in cmdline or [])
+
+
+def app_display_name(exe_path: str, fallback: str) -> str:
+    """Human name for the app: the ``.app`` bundle on macOS, else the binary."""
+    for part in reversed(exe_path.split(os.sep)):
+        if part.endswith(".app"):
+            return part[: -len(".app")]
+    return fallback
+
+
+def session_slug(name: str) -> str:
+    """Registry/session-safe slug (matches browser_exec's session grammar)."""
+    slug = re.sub(r"[^A-Za-z0-9_-]+", "-", name).strip("-").lower()
+    return slug[:64] or "app"
+
+
+def scan_electron_apps() -> List[Dict[str, Any]]:
+    """Enumerate running Electron *main* processes.
+
+    Returns entries of shape::
+
+        {"pid", "name", "exe", "debug_port" (int|None), "cdp_url" (str|None)}
+
+    ``cdp_url`` is set only when the advertised port answered a CDP
+    discovery probe. Best-effort by design: unreadable processes (access
+    denied, zombies) are skipped silently.
+    """
+    import psutil
+
+    found: List[Dict[str, Any]] = []
+    seen_exes: Dict[str, int] = {}
+    for proc in psutil.process_iter(["pid", "name", "exe", "cmdline"]):
+        try:
+            info = proc.info
+            exe = info.get("exe") or ""
+            cmdline = info.get("cmdline") or []
+            if not exe or is_electron_child(cmdline):
+                continue
+            if not is_electron_executable(exe):
+                continue
+            # One entry per app binary: the first (lowest-pid) main wins.
+            if exe in seen_exes:
+                continue
+            seen_exes[exe] = info["pid"]
+            port = debug_port_from_cmdline(cmdline)
+            cdp_url: Optional[str] = None
+            if port:
+                candidate = f"http://127.0.0.1:{port}"
+                if is_browser_debug_ready(candidate, timeout=0.5):
+                    cdp_url = candidate
+            found.append(
+                {
+                    "pid": info["pid"],
+                    "name": app_display_name(exe, info.get("name") or "app"),
+                    "exe": exe,
+                    "debug_port": port,
+                    "cdp_url": cdp_url,
+                }
+            )
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            continue
+        except Exception as e:  # pragma: no cover — defensive per-proc guard
+            logger.debug("electron scan: skipping process: %s", e)
+            continue
+    return sorted(found, key=lambda a: a["name"].lower())
+
+
+# ── Named-session CDP registry ─────────────────────────────────────
+
+
+def registry_path() -> str:
+    return str(get_hermes_home() / _REGISTRY_FILENAME)
+
+
+def load_registry() -> Dict[str, Dict[str, Any]]:
+    """Return ``{session_name: {cdp_url, app, attached_at}}`` (never raises)."""
+    try:
+        with open(registry_path(), "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        sessions = data.get("sessions")
+        if isinstance(sessions, dict):
+            return {
+                str(k): v
+                for k, v in sessions.items()
+                if isinstance(v, dict) and v.get("cdp_url")
+            }
+    except FileNotFoundError:
+        pass
+    except Exception as e:
+        logger.warning("browser session registry unreadable (%s): %s", registry_path(), e)
+    return {}
+
+
+def _write_registry(sessions: Dict[str, Dict[str, Any]]) -> None:
+    path = registry_path()
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = f"{path}.tmp"
+    with open(tmp, "w", encoding="utf-8") as fh:
+        json.dump({"sessions": sessions}, fh, indent=2)
+    os.replace(tmp, path)
+
+
+def save_session_endpoint(name: str, cdp_url: str, app: str) -> None:
+    sessions = load_registry()
+    sessions[name] = {
+        "cdp_url": cdp_url,
+        "app": app,
+        "attached_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+    }
+    _write_registry(sessions)
+
+
+def remove_session_endpoint(name: str) -> bool:
+    sessions = load_registry()
+    if name not in sessions:
+        return False
+    del sessions[name]
+    _write_registry(sessions)
+    return True
+
+
+def resolve_session_endpoint(name: str) -> Optional[str]:
+    """CDP URL registered for a browser_exec session name, or None."""
+    entry = load_registry().get(name)
+    if not entry:
+        return None
+    url = str(entry.get("cdp_url") or "").strip()
+    return url or None
+
+
+# ── Relaunch with a debug port ─────────────────────────────────────
+
+
+def _exe_of(proc) -> Optional[str]:
+    """Best-effort executable path of a psutil process (None if denied)."""
+    try:
+        return proc.exe()
+    except Exception:
+        return None
+
+
+def _terminate_app(pid: int, timeout: float = 10.0) -> bool:
+    """Gracefully stop an app's main process (children follow). True on exit."""
+    import psutil
+
+    try:
+        proc = psutil.Process(pid)
+    except psutil.NoSuchProcess:
+        return True
+    if platform.system() == "Darwin":
+        # Ask the app to quit properly first — Electron apps persist state
+        # (open vaults, drafts) on graceful AppleEvent quit; SIGTERM alone
+        # can skip their before-quit handlers.
+        import subprocess
+
+        bundle = _bundle_path(exe_path) if (exe_path := _exe_of(proc)) else None
+        app_name = os.path.basename(bundle)[: -len(".app")] if bundle else proc.name()
+        try:
+            subprocess.run(
+                ["osascript", "-e", f'quit app "{app_name}"'],
+                capture_output=True,
+                timeout=5,
+            )
+        except Exception as e:
+            logger.debug("osascript quit failed (falling back to terminate): %s", e)
+    try:
+        if proc.is_running():
+            proc.terminate()
+        proc.wait(timeout=timeout)
+        return True
+    except psutil.NoSuchProcess:
+        return True
+    except psutil.TimeoutExpired:
+        try:
+            proc.kill()
+            proc.wait(timeout=3)
+            return True
+        except Exception:
+            return False
+    except Exception as e:
+        logger.debug("terminate failed for pid %d: %s", pid, e)
+        return not psutil.pid_exists(pid)
+
+
+def _spawn_with_debug_port(exe: str, port: int) -> None:
+    """Relaunch the app binary with the debug flag, detached from us."""
+    import subprocess
+
+    from hermes_cli.browser_connect import _detach_kwargs
+
+    system = platform.system()
+    if system == "Darwin":
+        bundle = _bundle_path(exe)
+        if bundle:
+            subprocess.Popen(
+                ["open", "-a", bundle, "--args", f"--remote-debugging-port={port}"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            return
+    subprocess.Popen(
+        [exe, f"--remote-debugging-port={port}"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        **_detach_kwargs(system),
+    )
+
+
+def _bundle_path(exe: str) -> Optional[str]:
+    """``.../Foo.app`` prefix of a macOS bundle executable path, or None."""
+    parts = exe.split(os.sep)
+    for i, part in enumerate(parts):
+        if part.endswith(".app"):
+            return os.sep.join(parts[: i + 1])
+    return None
+
+
+def relaunch_with_debug_port(
+    app: Dict[str, Any], port: Optional[int] = None, wait_s: float = 25.0
+) -> Optional[str]:
+    """Quit ``app`` and relaunch it exposing CDP. Returns the live URL or None.
+
+    Chromium's single-instance lock means the running instance must fully
+    exit before the relaunch, or the new invocation just forwards to the old
+    process and exits without opening the port.
+    """
+    port = port or find_free_debug_port()
+    if not _terminate_app(app["pid"]):
+        logger.warning("could not stop %s (pid %d)", app["name"], app["pid"])
+        return None
+    _spawn_with_debug_port(app["exe"], port)
+    url = f"http://127.0.0.1:{port}"
+    deadline = time.monotonic() + wait_s
+    while time.monotonic() < deadline:
+        if is_browser_debug_ready(url, timeout=0.5):
+            return url
+        time.sleep(0.3)
+    return None

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -451,6 +451,7 @@ from hermes_cli.subcommands.logout import build_logout_parser
 from hermes_cli.subcommands.auth import build_auth_parser
 from hermes_cli.subcommands.status import build_status_parser
 from hermes_cli.subcommands.pause import build_pause_parser
+from hermes_cli.subcommands.browser import build_browser_parser
 from hermes_cli.subcommands.webhook import build_webhook_parser
 from hermes_cli.subcommands.hooks import build_hooks_parser
 from hermes_cli.subcommands.doctor import build_doctor_parser
@@ -11432,7 +11433,7 @@ def _build_provider_choices() -> list[str]:
 # to parse.
 _BUILTIN_SUBCOMMANDS = frozenset(
     {
-        "acp", "approvals", "auth", "backup", "bundles", "checkpoints", "claw", "completion",
+        "acp", "approvals", "auth", "backup", "browser", "bundles", "checkpoints", "claw", "completion",
         "computer-use",
         "config", "console", "cron", "curator", "dashboard", "serve", "debug", "doctor",
         "dump", "egress", "fallback", "gateway", "hooks", "import", "import-agent", "insights",
@@ -12508,6 +12509,7 @@ def main():
     # pause / resume commands  (parser built in hermes_cli/subcommands/pause.py)
     # =========================================================================
     build_pause_parser(subparsers)
+    build_browser_parser(subparsers)
 
     # =========================================================================
     # cron command  (parser built in hermes_cli/subcommands/cron.py)

--- a/hermes_cli/subcommands/browser.py
+++ b/hermes_cli/subcommands/browser.py
@@ -83,8 +83,11 @@ def _cmd_attach(args: argparse.Namespace) -> int:
             return 1
 
     target = apps[0]
-    if len(apps) > 1 and not requested:
-        print("Running Electron apps:")
+    if len(apps) > 1:
+        # Always show the picker on ambiguity — a filter can legitimately
+        # match several apps ('code' → 'Code' and 'Code - Insiders'), and
+        # silently taking the first would attach to the wrong one.
+        print("Matching Electron apps:" if requested else "Running Electron apps:")
         for i, app in enumerate(apps, 1):
             state = f"CDP live on {app['cdp_url']}" if app["cdp_url"] else (
                 f"debug port {app['debug_port']} (not answering)" if app["debug_port"]

--- a/hermes_cli/subcommands/browser.py
+++ b/hermes_cli/subcommands/browser.py
@@ -1,0 +1,183 @@
+"""``hermes browser`` subcommand — attach browser sessions to desktop apps.
+
+``hermes browser attach`` scans running processes for Electron apps, probes
+for exposed CDP endpoints, and registers one under a named browser_exec
+session so the agent can drive the app with exact DOM control (no focus
+steal). For a detected app that does not expose CDP, it offers the
+relaunch-with-``--remote-debugging-port`` itself — the confirmation prompt
+is the user's consent moment, which is why this lives behind a user-invoked
+CLI command rather than an agent tool.
+
+Related: the in-session ``/browser connect`` flow (live Chrome for the
+built-in browser tools) — this command is its desktop-app sibling and
+feeds ``browser_exec`` named sessions instead of the global override.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+
+def cmd_browser(args: argparse.Namespace) -> int:
+    action = getattr(args, "browser_action", None)
+    if action == "attach":
+        return _cmd_attach(args)
+    if action == "list":
+        return _cmd_list()
+    if action == "detach":
+        return _cmd_detach(args)
+    print("Usage: hermes browser attach|list|detach  (see --help)")
+    return 2
+
+
+def _cmd_list() -> int:
+    from hermes_cli.browser_attach import load_registry
+
+    sessions = load_registry()
+    if not sessions:
+        print("No attached browser sessions. Run `hermes browser attach` to add one.")
+        return 0
+    print("Attached browser sessions (browser_exec session → app):")
+    for name, entry in sorted(sessions.items()):
+        print(f"  {name:20s} {entry.get('app', '?'):24s} {entry.get('cdp_url', '')}")
+    return 0
+
+
+def _cmd_detach(args: argparse.Namespace) -> int:
+    from hermes_cli.browser_attach import remove_session_endpoint
+
+    name = getattr(args, "session", None) or ""
+    if not name:
+        print("Usage: hermes browser detach <session-name>")
+        return 2
+    if remove_session_endpoint(name):
+        print(f"Detached session '{name}'.")
+        return 0
+    print(f"No attached session named '{name}'. `hermes browser list` shows them.")
+    return 1
+
+
+def _cmd_attach(args: argparse.Namespace) -> int:
+    from hermes_cli.browser_attach import (
+        relaunch_with_debug_port,
+        save_session_endpoint,
+        scan_electron_apps,
+        session_slug,
+    )
+
+    print("Scanning for running Electron apps…")
+    apps = scan_electron_apps()
+    if not apps:
+        print(
+            "No running Electron apps found.\n"
+            "Start the app you want to drive, then re-run `hermes browser attach`.\n"
+            "(For a regular web browser, use `/browser connect` inside a session.)"
+        )
+        return 1
+
+    requested = (getattr(args, "app", None) or "").strip().lower()
+    if requested:
+        apps = [a for a in apps if requested in a["name"].lower()]
+        if not apps:
+            print(f"No running Electron app matches '{requested}'.")
+            return 1
+
+    target = apps[0]
+    if len(apps) > 1 and not requested:
+        print("Running Electron apps:")
+        for i, app in enumerate(apps, 1):
+            state = f"CDP live on {app['cdp_url']}" if app["cdp_url"] else (
+                f"debug port {app['debug_port']} (not answering)" if app["debug_port"]
+                else "no debug port"
+            )
+            print(f"  {i}. {app['name']:24s} pid {app['pid']:<8d} {state}")
+        try:
+            choice = input(f"Attach to which app? [1-{len(apps)}] ").strip()
+            target = apps[int(choice) - 1]
+        except (ValueError, IndexError, EOFError, KeyboardInterrupt):
+            print("Cancelled.")
+            return 1
+
+    session = getattr(args, "session", None) or session_slug(target["name"])
+
+    cdp_url = target["cdp_url"]
+    if not cdp_url:
+        if getattr(args, "no_relaunch", False):
+            print(
+                f"{target['name']} is running without a CDP debug port.\n"
+                f"Relaunch it manually with --remote-debugging-port=<port> and retry."
+            )
+            return 1
+        print(
+            f"{target['name']} is running but does not expose a CDP debug port.\n"
+            f"Attaching requires QUITTING and RELAUNCHING it with "
+            f"--remote-debugging-port.\n"
+            f"Note: this exposes everything the app can access (messages, files,\n"
+            f"vault contents) to local debugger connections while it runs."
+        )
+        try:
+            answer = input(f"Quit and relaunch {target['name']} now? [y/N] ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            answer = ""
+        if answer not in ("y", "yes"):
+            print("Cancelled — app left untouched.")
+            return 1
+        print(f"Relaunching {target['name']} with a debug port…")
+        cdp_url = relaunch_with_debug_port(target)
+        if not cdp_url:
+            print(
+                f"{target['name']} did not come back up with a reachable CDP "
+                "endpoint. Check that it fully quit (background/tray instances "
+                "block the single-instance lock) and retry."
+            )
+            return 1
+
+    save_session_endpoint(session, cdp_url, target["name"])
+    print(
+        f"✓ Attached: browser_exec session '{session}' → {target['name']} ({cdp_url})\n"
+        f"  The agent drives it with: browser_exec(code=…, session='{session}')\n"
+        f"  Detach with: hermes browser detach {session}"
+    )
+    return 0
+
+
+def build_browser_parser(subparsers) -> None:
+    """Attach the ``browser`` subcommand to ``subparsers``."""
+    browser_parser = subparsers.add_parser(
+        "browser",
+        help="Attach browser sessions to desktop Electron apps over CDP",
+        description=(
+            "Attach a named browser_exec session to a running desktop\n"
+            "Electron/Chromium app (Obsidian, Slack, VS Code, ...) over the\n"
+            "Chrome DevTools Protocol, for exact DOM-level control without\n"
+            "focus steal. For connecting a regular web browser to the\n"
+            "built-in browser tools, use `/browser connect` inside a session."
+        ),
+    )
+    browser_sub = browser_parser.add_subparsers(dest="browser_action")
+
+    attach = browser_sub.add_parser(
+        "attach",
+        help="Scan for Electron apps and attach a session to one",
+    )
+    attach.add_argument(
+        "app",
+        nargs="?",
+        help="App name filter (e.g. 'obsidian'). Omit to pick from a list.",
+    )
+    attach.add_argument(
+        "--session",
+        help="browser_exec session name to register (default: the app's name)",
+    )
+    attach.add_argument(
+        "--no-relaunch",
+        action="store_true",
+        help="Never offer to quit/relaunch the app; only attach to an already-exposed port",
+    )
+
+    browser_sub.add_parser("list", help="List attached app sessions")
+
+    detach = browser_sub.add_parser("detach", help="Remove an attached session")
+    detach.add_argument("session", nargs="?", help="Session name to remove")
+
+    browser_parser.set_defaults(func=cmd_browser)

--- a/hermes_cli/subcommands/browser.py
+++ b/hermes_cli/subcommands/browser.py
@@ -98,7 +98,7 @@ def _cmd_attach(args: argparse.Namespace) -> int:
             print("Cancelled.")
             return 1
 
-    session = getattr(args, "session", None) or session_slug(target["name"])
+    session = session_slug(getattr(args, "session", None) or target["name"])
 
     cdp_url = target["cdp_url"]
     if not cdp_url:

--- a/skills/autonomous-ai-agents/drive-electron-apps/SKILL.md
+++ b/skills/autonomous-ai-agents/drive-electron-apps/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: drive-electron-apps
+description: "Use when driving an Electron/desktop Chromium app (Obsidian, Slack, VS Code…). Attach over CDP for exact DOM control with zero focus steal."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [macos, windows, linux]
+metadata:
+  hermes:
+    tags: [electron, cdp, desktop, automation, browser]
+    category: desktop
+    related_skills: [computer-use]
+---
+
+# Drive Electron Desktop Apps over CDP
+
+Electron apps (Obsidian, Slack, VS Code, Discord, Notion, Figma desktop, …)
+are Chromium renderers in a desktop shell. Chromium **drops synthetic
+pointer events into occluded, unfocused renderers**, which is why
+`computer_use` background clicks often come back `suspected_noop` on these
+apps. The higher-fidelity route is a **CDP attach**: the user exposes the
+app's DevTools protocol port, you drive the DOM directly through
+`browser_exec` — exact selectors, real JS, zero focus steal, no window
+flash.
+
+## The one-command flow
+
+```
+hermes browser attach            # USER runs this, not you
+```
+
+It scans running processes for Electron apps, finds or provisions a CDP
+endpoint, and registers it as a named `browser_exec` session. Then you
+drive the app with:
+
+```
+browser_exec(code="print(page_info())", session="obsidian")
+```
+
+Everything `browser_exec` offers works against the app: `js()`, `cdp()`,
+`fill_input()`, the workspace, screenshots.
+
+`hermes browser list` shows attached sessions; `hermes browser detach
+<name>` removes one.
+
+## Consent — hard rule
+
+A CDP attach exposes **everything the app can access** (Slack DMs, vault
+contents, editor buffers, tokens in localStorage) to local debugger
+connections. That grant belongs to the user:
+
+- **Never** relaunch the user's app with `--remote-debugging-port` yourself
+  via terminal, and never open debug ports on their apps.
+- If no endpoint is attached, **ask the user to run `hermes browser
+  attach`**. Its relaunch confirmation prompt is the consent moment.
+- Same doctrine as cua-driver's `grant_existing_profile` gate — this route
+  is the desktop-app equivalent and gets the same respect.
+
+## When to use which tool
+
+- **Endpoint attached** (session exists in `hermes browser list`, or the
+  user says so) → `browser_exec(session=…)` is the preferred way to drive
+  that app's UI.
+- **No endpoint, quick task** → `computer_use` background ladder first; it
+  often works (AX-routed input reaches many Electron controls). Do NOT
+  predict failure from the app being Electron — escalate only on returned
+  signals (`suspected_noop`, refusals), per the computer-use skill.
+- **Escalation arrives with `alternative: "cdp_attach"`** → that is the
+  runtime telling you the renderer refused background input and the target
+  is Electron. Ask the user to run `hermes browser attach`, then switch to
+  `browser_exec`.
+- **App state that lives in files** (Obsidian notes, VS Code settings.json)
+  → file tools remain better than any UI automation.
+
+## Detecting Electron yourself (when scanning is unavailable)
+
+- `resources/app.asar` (or `resources/app/package.json`) next to the
+  executable — on macOS under `Foo.app/Contents/Resources/`.
+- Child processes carrying `--type=renderer` / `--type=gpu-process`.
+- A crashpad handler child process.
+- Real browsers (Chrome, Brave, Edge) ship none of these — they are NOT
+  Electron and already have first-class routes.
+
+## Relaunch recipe (for reference — the attach command does this)
+
+Chromium's **single-instance lock** means the app must FULLY quit first
+(including tray/background instances), or the new invocation forwards to
+the old process and exits without opening the port.
+
+- macOS: quit the app (AppleEvent), then
+  `open -a <App> --args --remote-debugging-port=<port>`
+- Windows/Linux: quit, then `<exe> --remote-debugging-port=<port>`
+- Pick a free port that is NOT 9222 (9222 belongs to the `/browser
+  connect` debug-Chrome flow; colliding steals its slot).
+- Verify with `curl http://127.0.0.1:<port>/json/version`.
+
+## Target picking
+
+`GET /json/list` on the endpoint enumerates targets. Drive entries with
+`"type": "page"`; skip `devtools://`, `chrome-extension://`, and
+service-worker targets. Multi-window apps expose one page target per
+window — match on `title`/`url`. With `browser_exec` this is mostly
+handled for you; `ensure_real_tab()` recovers from landing on an internal
+target.
+
+## Framework input patterns (the part that saves you an hour)
+
+Electron apps are mostly React/Vue with controlled inputs — DOM
+`element.value = x` does NOT register with the framework's state.
+
+**React controlled input — use the native value setter, then fire the event:**
+
+```python
+js("""(() => {
+  const el = document.querySelector('input[aria-label="Search"]');
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype, 'value').set;
+  setter.call(el, 'my query');
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+})()""")
+```
+
+For `<textarea>`, use `HTMLTextAreaElement.prototype`. For
+contenteditable surfaces (Slack/Discord composers), prefer focusing the
+element and using `cdp('Input.insertText', text='…')` — it goes through
+the real input pipeline.
+
+**Radix/Headless-UI menus (Slack, Linear, many Electron apps): the menu
+closes on focus loss between evals — do open + click in ONE `js()` call:**
+
+```python
+js("""(() => {
+  document.querySelector('[data-state][aria-haspopup]').click();
+  const item = [...document.querySelectorAll('[role="menuitem"]')]
+    .find(e => e.textContent.includes('Settings'));
+  if (item) item.click();
+  return item ? 'clicked' : 'menu item not found';
+})()""")
+```
+
+**Keyboard shortcuts** that the app binds globally: dispatch via
+`cdp('Input.dispatchKeyEvent', …)` rather than DOM KeyboardEvent — apps
+often listen at the Electron/webContents level.
+
+## Pitfalls
+
+- **Electron rejects `Target.createTarget` ("Not supported")** — you cannot
+  open new tabs in an app the way you can in Chrome. `new_tab()` fails;
+  Hermes routes app sessions onto the harness's attach-to-existing-page
+  path automatically, but anything that tries to create a target will
+  error. Work within the app's existing page target(s).
+- **Don't `goto_url()` in an app session** — that would navigate the app's
+  own window away from its UI (Obsidian is `app://obsidian.md/index.html`).
+  Work within the existing target; `page_info()` + `js()` are your
+  primitives.
+- Many Electron apps expose a global app object (`window.app` in Obsidian)
+  — often far richer than DOM scraping. One `js()` call against it beats
+  ten selector queries; explore it with
+  `js("Object.keys(window.app ?? {}).join()")` first.
+- The app's window is a real window on the user's desktop: DOM clicks via
+  CDP don't steal focus, but anything that opens NATIVE surfaces (file
+  dialogs, context menus, notifications) leaves CDP's reach — hand those
+  to `computer_use`.
+- Some apps gate DevTools in production builds; if `/json` never answers
+  after a debug-port relaunch, the app may strip the switch — report that
+  honestly instead of retrying.
+- The registry entry outlives the app process: if the app was restarted
+  WITHOUT the debug port, the session's endpoint is dead. Symptom:
+  browser_exec connection errors. Fix: user re-runs `hermes browser attach`.

--- a/tests/hermes_cli/test_browser_attach.py
+++ b/tests/hermes_cli/test_browser_attach.py
@@ -1,0 +1,200 @@
+"""Tests for hermes_cli.browser_attach — Electron discovery + session registry."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from hermes_cli import browser_attach as ba
+
+
+# ── Electron detection ─────────────────────────────────────────────
+
+
+class TestIsElectronExecutable:
+    def test_app_asar_next_to_binary(self, tmp_path):
+        exe = tmp_path / "MyApp" / "myapp"
+        resources = tmp_path / "MyApp" / "resources"
+        resources.mkdir(parents=True)
+        (resources / "app.asar").write_bytes(b"")
+        exe.parent.mkdir(exist_ok=True)
+        exe.write_bytes(b"")
+        assert ba.is_electron_executable(str(exe)) is True
+
+    def test_unpacked_app_package_json(self, tmp_path):
+        exe = tmp_path / "MyApp" / "myapp"
+        app_dir = tmp_path / "MyApp" / "resources" / "app"
+        app_dir.mkdir(parents=True)
+        (app_dir / "package.json").write_text("{}")
+        exe.write_bytes(b"")
+        assert ba.is_electron_executable(str(exe)) is True
+
+    def test_macos_bundle_layout(self, tmp_path):
+        macos_dir = tmp_path / "Obsidian.app" / "Contents" / "MacOS"
+        resources = tmp_path / "Obsidian.app" / "Contents" / "Resources"
+        macos_dir.mkdir(parents=True)
+        resources.mkdir(parents=True)
+        (resources / "app.asar").write_bytes(b"")
+        exe = macos_dir / "Obsidian"
+        exe.write_bytes(b"")
+        assert ba.is_electron_executable(str(exe)) is True
+
+    def test_plain_binary_is_not_electron(self, tmp_path):
+        exe = tmp_path / "bin" / "vim"
+        exe.parent.mkdir()
+        exe.write_bytes(b"")
+        assert ba.is_electron_executable(str(exe)) is False
+
+    def test_empty_path(self):
+        assert ba.is_electron_executable("") is False
+
+
+class TestCmdlineParsing:
+    def test_debug_port_extracted(self):
+        assert ba.debug_port_from_cmdline(["/x/app", "--remote-debugging-port=9333"]) == 9333
+
+    def test_port_zero_rejected(self):
+        assert ba.debug_port_from_cmdline(["/x/app", "--remote-debugging-port=0"]) is None
+
+    def test_no_port(self):
+        assert ba.debug_port_from_cmdline(["/x/app", "--flag"]) is None
+
+    def test_child_detected_by_type_flag(self):
+        assert ba.is_electron_child(["/x/app", "--type=renderer"]) is True
+        assert ba.is_electron_child(["/x/app", "--type=gpu-process"]) is True
+
+    def test_main_process_is_not_child(self):
+        assert ba.is_electron_child(["/x/app", "--remote-debugging-port=1"]) is False
+
+
+class TestNames:
+    def test_display_name_from_bundle(self):
+        assert (
+            ba.app_display_name("/Applications/Obsidian.app/Contents/MacOS/Obsidian", "x")
+            == "Obsidian"
+        )
+
+    def test_display_name_fallback(self):
+        assert ba.app_display_name("/usr/lib/slack/slack", "slack") == "slack"
+
+    def test_session_slug_sanitizes(self):
+        assert ba.session_slug("Visual Studio Code") == "visual-studio-code"
+
+    def test_session_slug_empty_fallback(self):
+        assert ba.session_slug("///") == "app"
+
+
+# ── Registry round-trip ────────────────────────────────────────────
+
+
+@pytest.fixture
+def registry_home(tmp_path, monkeypatch):
+    monkeypatch.setattr(ba, "registry_path", lambda: str(tmp_path / "browser-sessions.json"))
+    return tmp_path
+
+
+class TestRegistry:
+    def test_round_trip(self, registry_home):
+        ba.save_session_endpoint("obsidian", "http://127.0.0.1:9333", "Obsidian")
+        assert ba.resolve_session_endpoint("obsidian") == "http://127.0.0.1:9333"
+        sessions = ba.load_registry()
+        assert sessions["obsidian"]["app"] == "Obsidian"
+
+    def test_missing_file_is_empty(self, registry_home):
+        assert ba.load_registry() == {}
+        assert ba.resolve_session_endpoint("nope") is None
+
+    def test_corrupt_file_is_empty(self, registry_home):
+        with open(ba.registry_path(), "w") as fh:
+            fh.write("{not json")
+        assert ba.load_registry() == {}
+
+    def test_entries_without_url_dropped(self, registry_home):
+        with open(ba.registry_path(), "w") as fh:
+            json.dump({"sessions": {"bad": {"app": "X"}, "good": {"cdp_url": "http://h:1"}}}, fh)
+        assert set(ba.load_registry()) == {"good"}
+
+    def test_remove(self, registry_home):
+        ba.save_session_endpoint("s1", "http://127.0.0.1:1", "A")
+        assert ba.remove_session_endpoint("s1") is True
+        assert ba.remove_session_endpoint("s1") is False
+        assert ba.resolve_session_endpoint("s1") is None
+
+    def test_atomic_write_leaves_no_tmp(self, registry_home):
+        ba.save_session_endpoint("s1", "http://127.0.0.1:1", "A")
+        assert not os.path.exists(ba.registry_path() + ".tmp")
+
+
+# ── browser_exec backend resolution honors the registry ───────────
+
+
+class TestResolveBackendRegistry:
+    def _patch_browser_tool(self, monkeypatch):
+        import tools.browser_use_cli as bu_cli
+
+        monkeypatch.setattr(
+            "tools.browser_tool._get_cdp_override", lambda: "", raising=False
+        )
+        monkeypatch.setattr(
+            "tools.browser_tool._get_cloud_provider", lambda: None, raising=False
+        )
+        return bu_cli
+
+    def test_named_session_uses_registry(self, registry_home, monkeypatch):
+        bu_cli = self._patch_browser_tool(monkeypatch)
+        ba.save_session_endpoint("obsidian", "http://127.0.0.1:9333", "Obsidian")
+        env: dict = {"BU_NAME": "obsidian"}
+        assert bu_cli._resolve_backend_cdp(env, "t1", session_name="obsidian") is None
+        assert env["BU_CDP_URL"] == "http://127.0.0.1:9333"
+        # App session is private: no own-tab preamble tab leaked into the app.
+        assert env.get(bu_cli._PRIVATE_BROWSER_SENTINEL) == "1"
+        # Electron rejects Target.createTarget, which the harness's named-
+        # daemon path calls — app sessions must run the default-name daemon
+        # isolated via a per-session harness home instead.
+        assert "BU_NAME" not in env
+        assert env["BH_HOME"].endswith(os.path.join("app-sessions", "obsidian"))
+
+    def test_ws_endpoint_uses_ws_env(self, registry_home, monkeypatch):
+        bu_cli = self._patch_browser_tool(monkeypatch)
+        ba.save_session_endpoint("app", "ws://127.0.0.1:9333/devtools/browser/x", "App")
+        env: dict = {}
+        assert bu_cli._resolve_backend_cdp(env, "t1", session_name="app") is None
+        assert env["BU_CDP_WS"] == "ws://127.0.0.1:9333/devtools/browser/x"
+
+    def test_unregistered_session_falls_through(self, registry_home, monkeypatch):
+        bu_cli = self._patch_browser_tool(monkeypatch)
+        env: dict = {}
+        assert bu_cli._resolve_backend_cdp(env, "t1", session_name="other") is None
+        assert "BU_CDP_URL" not in env and "BU_CDP_WS" not in env
+
+    def test_unnamed_call_ignores_registry(self, registry_home, monkeypatch):
+        bu_cli = self._patch_browser_tool(monkeypatch)
+        ba.save_session_endpoint("obsidian", "http://127.0.0.1:9333", "Obsidian")
+        env: dict = {}
+        assert bu_cli._resolve_backend_cdp(env, "t1") is None
+        assert "BU_CDP_URL" not in env
+
+    def test_explicit_env_wins_over_registry(self, registry_home, monkeypatch):
+        bu_cli = self._patch_browser_tool(monkeypatch)
+        ba.save_session_endpoint("obsidian", "http://127.0.0.1:9333", "Obsidian")
+        env = {"BU_CDP_URL": "http://127.0.0.1:1111"}
+        assert bu_cli._resolve_backend_cdp(env, "t1", session_name="obsidian") is None
+        assert env["BU_CDP_URL"] == "http://127.0.0.1:1111"
+
+    def test_registry_outranks_global_override(self, registry_home, monkeypatch):
+        import tools.browser_use_cli as bu_cli
+
+        monkeypatch.setattr(
+            "tools.browser_tool._get_cdp_override",
+            lambda: "http://127.0.0.1:9222",
+            raising=False,
+        )
+        monkeypatch.setattr(
+            "tools.browser_tool._get_cloud_provider", lambda: None, raising=False
+        )
+        ba.save_session_endpoint("obsidian", "http://127.0.0.1:9333", "Obsidian")
+        env: dict = {}
+        assert bu_cli._resolve_backend_cdp(env, "t1", session_name="obsidian") is None
+        assert env["BU_CDP_URL"] == "http://127.0.0.1:9333"

--- a/tests/hermes_cli/test_browser_attach.py
+++ b/tests/hermes_cli/test_browser_attach.py
@@ -85,6 +85,15 @@ class TestNames:
     def test_session_slug_empty_fallback(self):
         assert ba.session_slug("///") == "app"
 
+    def test_session_slug_always_matches_browser_exec_grammar(self):
+        # browser_exec rejects sessions not matching _SESSION_RE (alnum
+        # first char) — a slug that fails it would be registered but
+        # unreachable, silent dead state.
+        from tools.browser_use_cli import _SESSION_RE
+
+        for raw in ("_private app", "-dash", "My Obsidian", "app!", "日本語アプリ"):
+            assert _SESSION_RE.match(ba.session_slug(raw)), raw
+
 
 # ── Registry round-trip ────────────────────────────────────────────
 

--- a/tests/tools/test_computer_use_electron_escalation.py
+++ b/tests/tools/test_computer_use_electron_escalation.py
@@ -1,0 +1,103 @@
+"""Tests for the Electron cdp_attach branch of _enrich_escalation."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.computer_use.backend import ActionResult
+from tools.computer_use import tool as cu_tool
+
+
+def _res(escalation=None, meta=None, **kw):
+    return ActionResult(
+        ok=kw.pop("ok", False),
+        action="click",
+        message="",
+        meta=meta or {},
+        escalation=escalation,
+        **kw,
+    )
+
+
+FOREGROUND = {"recommended": "foreground", "reason": "occluded renderer"}
+
+
+class TestElectronEscalationBranch:
+    def test_electron_pid_gets_cdp_attach_alternative(self, monkeypatch):
+        monkeypatch.setattr(cu_tool, "_is_electron_pid", lambda pid: pid == 4242)
+        out = cu_tool._enrich_escalation(_res(dict(FOREGROUND), meta={"pid": 4242}))
+        assert out["recommended"] == "foreground"  # driver verdict untouched
+        assert out["alternative"] == "cdp_attach"
+        assert "hermes browser attach" in out["alternative_hint"]
+
+    def test_non_electron_pid_unchanged(self, monkeypatch):
+        monkeypatch.setattr(cu_tool, "_is_electron_pid", lambda pid: False)
+        esc = dict(FOREGROUND)
+        out = cu_tool._enrich_escalation(_res(esc, meta={"pid": 77}))
+        assert out == FOREGROUND
+        assert "alternative" not in out
+
+    def test_no_pid_in_meta_skips_silently(self, monkeypatch):
+        called = []
+        monkeypatch.setattr(
+            cu_tool, "_is_electron_pid", lambda pid: called.append(pid) or False
+        )
+        out = cu_tool._enrich_escalation(_res(dict(FOREGROUND), meta={}))
+        assert "alternative" not in out
+        assert called == [None]
+
+    def test_non_foreground_recommendation_untouched(self, monkeypatch):
+        monkeypatch.setattr(cu_tool, "_is_electron_pid", lambda pid: True)
+        esc = {"recommended": "px", "reason": "x"}
+        assert cu_tool._enrich_escalation(_res(dict(esc), meta={"pid": 1})) == esc
+
+    def test_typed_page_branch_wins_for_browser_windows(self, monkeypatch):
+        # A real browser window (chrome_widgetwin_1) with page input keeps the
+        # existing typed-page alternative even if the pid also looks Electron
+        # (Electron embeds Chromium and shares the window class on Windows).
+        monkeypatch.setattr(cu_tool, "_is_electron_pid", lambda pid: True)
+        out = cu_tool._enrich_escalation(
+            _res(
+                dict(FOREGROUND),
+                meta={
+                    "pid": 1,
+                    "target_class": "Chrome_WidgetWin_1",
+                    "event_kind": "text_input",
+                },
+            )
+        )
+        assert out["alternative"] == "page"
+
+    def test_none_escalation_passthrough(self):
+        assert cu_tool._enrich_escalation(_res(None)) is None
+
+
+class TestIsElectronPid:
+    def test_rejects_non_ints(self):
+        assert cu_tool._is_electron_pid(None) is False
+        assert cu_tool._is_electron_pid("42") is False
+        assert cu_tool._is_electron_pid(True) is False
+        assert cu_tool._is_electron_pid(-1) is False
+
+    def test_dead_pid_is_false(self):
+        # A pid that (almost certainly) doesn't exist → psutil raises → False.
+        assert cu_tool._is_electron_pid(2**22 + 12345) is False
+
+    def test_electron_layout_detected(self, tmp_path, monkeypatch):
+        exe = tmp_path / "app" / "myapp"
+        res_dir = tmp_path / "app" / "resources"
+        res_dir.mkdir(parents=True)
+        (res_dir / "app.asar").write_bytes(b"")
+        exe.write_bytes(b"")
+
+        class FakeProc:
+            def __init__(self, pid):
+                pass
+
+            def exe(self):
+                return str(exe)
+
+        import psutil
+
+        monkeypatch.setattr(psutil, "Process", FakeProc)
+        assert cu_tool._is_electron_pid(1234) is True

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -379,6 +379,23 @@ def install_cli(timeout_s: int = 600) -> Tuple[bool, str]:
     return True, f"browser-use CLI installed ({found[0]})"
 
 
+def _app_session_harness_home(session_name: str) -> str:
+    """Per-app-session harness home (isolates daemon socket/log/pid).
+
+    App-attached sessions run the harness under the DEFAULT daemon name
+    (the named-daemon path calls Target.createTarget, which Electron
+    rejects), so isolation between app sessions — and from the real
+    default web daemon — comes from giving each one its own BH_HOME.
+    """
+    from pathlib import Path
+
+    from hermes_constants import get_hermes_home
+
+    path = Path(get_hermes_home()) / "cache" / "browser-use" / "app-sessions" / session_name
+    path.mkdir(parents=True, exist_ok=True)
+    return str(path)
+
+
 def _workspace_dir(task_id: Optional[str]) -> Optional[str]:
     """Stable per-task scratch dir that persists across browser_exec calls"""
     existing = os.environ.get("BH_AGENT_WORKSPACE")
@@ -456,6 +473,9 @@ def _resolve_backend_cdp(
 
     1. ``BU_CDP_WS`` / ``BU_CDP_URL`` already in the environment — explicit
        user/operator override, passed through untouched.
+    1b. A named-session endpoint registered by ``hermes browser attach``
+       (``$HERMES_HOME/browser-sessions.json``) — pins THIS session to a
+       desktop app's CDP port without affecting other sessions.
     2. ``BROWSER_CDP_URL`` env / ``browser.cdp_url`` config override — the
        ``/browser connect`` path, same precedence the built-in tools honor.
     3. A configured cloud browser provider (Browserbase, Firecrawl, Nous
@@ -476,6 +496,37 @@ def _resolve_backend_cdp(
     """
     if env.get("BU_CDP_WS") or env.get("BU_CDP_URL"):
         return None
+
+    # A named session registered via `hermes browser attach` is pinned to
+    # that app's CDP endpoint (Electron desktop apps: Obsidian, Slack, …).
+    # It outranks the global override on purpose: the registry entry is
+    # per-session and user-created, so the default session keeps browsing
+    # the web while this one drives the app.
+    if session_name:
+        try:
+            from hermes_cli.browser_attach import resolve_session_endpoint
+
+            registered = resolve_session_endpoint(session_name)
+        except Exception as e:
+            logger.debug("browser session registry lookup failed: %s", e)
+            registered = None
+        if registered:
+            env["BU_CDP_URL" if registered.startswith(("http://", "https://")) else "BU_CDP_WS"] = registered
+            # The app's browser belongs to this session alone — no sibling
+            # daemon to collide with, and an own-tab preamble would open a
+            # visible blank window inside the user's app.
+            env[_PRIVATE_BROWSER_SENTINEL] = "1"
+            # Electron apps reject Target.createTarget ("Not supported"),
+            # and the harness's NAMED-daemon path creates a dedicated tab
+            # with exactly that call — fatal on attach. The default-name
+            # daemon attaches to the first real page instead, which is
+            # precisely right for an app (its window IS the page). Keep
+            # per-session isolation by giving each app session its own
+            # harness home (BH_HOME namespaces the daemon's socket, log,
+            # and pid) rather than a daemon name.
+            env.pop("BU_NAME", None)
+            env["BH_HOME"] = _app_session_harness_home(session_name)
+            return None
 
     try:
         from tools.browser_tool import (
@@ -700,7 +751,11 @@ _HEADER_BASE = (
     "call, so progress survives timeouts. For an isolated concurrent "
     "browser session (parallel tasks that must not share tabs), pass "
     "session=<name> (never BU_NAME env syntax) and reuse the same name on "
-    "every related call."
+    "every related call. A session attached to a desktop Electron/Chromium "
+    "app via `hermes browser attach` (user-run) drives that app's UI over "
+    "CDP with exact DOM control and zero focus steal — for driving desktop "
+    "Electron apps, prefer that over computer_use when an endpoint is "
+    "attached."
 )
 
 _HEADER_VISION = (

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -464,6 +464,11 @@ def _native_screenshot_result(result: Dict[str, Any], path: str) -> Optional[Dic
         return None
 
 
+def _set_cdp_env(env: dict, url: str) -> None:
+    """Export a CDP endpoint under the env var the harness expects."""
+    env["BU_CDP_URL" if url.startswith(("http://", "https://")) else "BU_CDP_WS"] = url
+
+
 def _resolve_backend_cdp(
     env: dict, task_id: Optional[str], session_name: str = ""
 ) -> Optional[str]:
@@ -511,7 +516,7 @@ def _resolve_backend_cdp(
             logger.debug("browser session registry lookup failed: %s", e)
             registered = None
         if registered:
-            env["BU_CDP_URL" if registered.startswith(("http://", "https://")) else "BU_CDP_WS"] = registered
+            _set_cdp_env(env, registered)
             # The app's browser belongs to this session alone — no sibling
             # daemon to collide with, and an own-tab preamble would open a
             # visible blank window inside the user's app.
@@ -543,7 +548,7 @@ def _resolve_backend_cdp(
     except Exception:
         override = ""
     if override:
-        env["BU_CDP_URL" if override.startswith(("http://", "https://")) else "BU_CDP_WS"] = override
+        _set_cdp_env(env, override)
         return None
 
     try:
@@ -588,7 +593,7 @@ def _resolve_backend_cdp(
             "CDP endpoint, so Browser Use mode cannot drive it. Switch to "
             "the built-in browser tools for this provider."
         )
-    env["BU_CDP_URL" if cdp.startswith(("http://", "https://")) else "BU_CDP_WS"] = cdp
+    _set_cdp_env(env, cdp)
     # A provider browser keyed bu-named-<name> is exclusive to this session —
     # the own-tab preamble is unnecessary there (it would just leak a blank
     # tab into a browser nobody else touches).

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -3951,5 +3951,18 @@ class CuaDriverBackend(ComputerUseBackend):
             meta.update(data)
         if isinstance(structured, dict):
             meta.update(structured)
-        return _action_result_from(name, ok, message, meta, structured,
-                                   requested_delivery=args.get("delivery_mode"))
+        res = _action_result_from(name, ok, message, meta, structured,
+                                  requested_delivery=args.get("delivery_mode"))
+        # When the driver recommends escalating, carry the acting target's
+        # pid so the wrapper's escalation enrichment can classify the app
+        # (e.g. Electron → suggest the CDP-attach alternative). Additive and
+        # escalation-only: success payloads stay byte-identical, and a
+        # driver-supplied pid is never overwritten.
+        if (
+            res.escalation is not None
+            and isinstance(res.meta, dict)
+            and "pid" not in res.meta
+            and self._active_pid
+        ):
+            res.meta["pid"] = self._active_pid
+        return res

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -3951,18 +3951,15 @@ class CuaDriverBackend(ComputerUseBackend):
             meta.update(data)
         if isinstance(structured, dict):
             meta.update(structured)
-        res = _action_result_from(name, ok, message, meta, structured,
-                                  requested_delivery=args.get("delivery_mode"))
         # When the driver recommends escalating, carry the acting target's
         # pid so the wrapper's escalation enrichment can classify the app
-        # (e.g. Electron → suggest the CDP-attach alternative). Additive and
-        # escalation-only: success payloads stay byte-identical, and a
-        # driver-supplied pid is never overwritten.
-        if (
-            res.escalation is not None
-            and isinstance(res.meta, dict)
-            and "pid" not in res.meta
-            and self._active_pid
-        ):
-            res.meta["pid"] = self._active_pid
-        return res
+        # (e.g. Electron → suggest the CDP-attach alternative). Decided
+        # BEFORE building the result — mutating res.meta afterwards would
+        # rely on _action_result_from aliasing the dict, an undocumented
+        # contract. Additive and escalation-only: success payloads stay
+        # byte-identical, and a driver-supplied pid is never overwritten.
+        esc = structured.get("escalation", meta.get("escalation"))
+        if isinstance(esc, dict) and "pid" not in meta and self._active_pid:
+            meta["pid"] = self._active_pid
+        return _action_result_from(name, ok, message, meta, structured,
+                                   requested_delivery=args.get("delivery_mode"))

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -1044,15 +1044,39 @@ _TYPED_BROWSER_WINDOW_CLASSES = {
 }
 
 
+def _is_electron_pid(pid: Any) -> bool:
+    """True when ``pid``'s executable looks like a packaged Electron app.
+
+    Runs ONLY on the escalation path (never on success), so the process
+    lookup costs nothing in the common case. Any failure — bad pid, process
+    gone, psutil missing, access denied — quietly reports False: this feeds
+    an advisory hint, never a decision.
+    """
+    if isinstance(pid, bool) or not isinstance(pid, int) or pid <= 0:
+        return False
+    try:
+        import psutil
+
+        from hermes_cli.browser_attach import is_electron_executable
+
+        return is_electron_executable(psutil.Process(pid).exe() or "")
+    except Exception:
+        return False
+
+
 def _enrich_escalation(res: ActionResult) -> Optional[Dict[str, Any]]:
-    """Return the driver's escalation dict, adding a typed-page alternative.
+    """Return the driver's escalation dict, adding wrapper-known alternatives.
 
     Purely additive: never changes the driver's `recommended` rung, only
-    appends `alternative`/`alternative_hint` when the refused target is a
-    known browser window class and the refused event is page-directed input
-    (typing/keys into page content). The model can then try the
-    `cua_browser_*` route — trusted input, no window flash — before a
-    foreground escalation, per the documented ladder ordering.
+    appends `alternative`/`alternative_hint` when the wrapper knows a
+    higher-fidelity route the driver cannot see:
+
+    * a known browser window class receiving page-directed input → the
+      typed `cua_browser_*` route (trusted input, no window flash);
+    * an Electron app whose renderer refused background input → a CDP
+      attach via the user-run `hermes browser attach` (exact DOM control,
+      zero focus steal). Reaction-only, per the ladder doctrine: the check
+      runs strictly on a returned escalation, never as a prediction.
     """
     escalation = res.escalation
     if not isinstance(escalation, dict):
@@ -1061,21 +1085,36 @@ def _enrich_escalation(res: ActionResult) -> Optional[Dict[str, Any]]:
         return escalation
     meta = res.meta or {}
     target_class = str(meta.get("target_class") or "").lower()
-    if target_class not in _TYPED_BROWSER_WINDOW_CLASSES:
-        return escalation
-    if meta.get("event_kind") not in {"text_input", "key_press"}:
-        return escalation
-    enriched = dict(escalation)
-    enriched["alternative"] = "page"
-    enriched["alternative_hint"] = (
-        "target is a browser window: if the input goes into PAGE content "
-        "(not browser chrome or a native dialog), the typed cua_browser_* "
-        "route can deliver it without any window flash — bind with "
-        "cua_browser_state (exact pid/window_id), then cua_browser_type. "
-        "Use foreground only for chrome/native surfaces or if typed binding "
-        "is unavailable."
-    )
-    return enriched
+    if (
+        target_class in _TYPED_BROWSER_WINDOW_CLASSES
+        and meta.get("event_kind") in {"text_input", "key_press"}
+    ):
+        enriched = dict(escalation)
+        enriched["alternative"] = "page"
+        enriched["alternative_hint"] = (
+            "target is a browser window: if the input goes into PAGE content "
+            "(not browser chrome or a native dialog), the typed cua_browser_* "
+            "route can deliver it without any window flash — bind with "
+            "cua_browser_state (exact pid/window_id), then cua_browser_type. "
+            "Use foreground only for chrome/native surfaces or if typed binding "
+            "is unavailable."
+        )
+        return enriched
+    if _is_electron_pid(meta.get("pid")):
+        enriched = dict(escalation)
+        enriched["alternative"] = "cdp_attach"
+        enriched["alternative_hint"] = (
+            "target is an Electron app: its unfocused renderer refused "
+            "background input, and a CDP attach is a higher-fidelity rung "
+            "than foreground — exact DOM control with zero focus steal. "
+            "Ask the USER to run `hermes browser attach` (it may relaunch "
+            "the app with a debug port — their consent, not yours), then "
+            "drive it via browser_exec(session=<name>). The "
+            "drive-electron-apps skill has the full playbook. Foreground "
+            "remains valid if the user prefers not to attach."
+        )
+        return enriched
+    return escalation
 
 
 # Default cap for the AX `elements` array returned by capture. Dense UIs


### PR DESCRIPTION
Implements the full plan from #89357 in one PR — all three layers plus the CLI affordance, E2E-verified against a live Electron app.

## Real-world impact (WHO / WHEN / WHY)

**WHO:** anyone asking the agent to drive a desktop Electron app — "organize my Obsidian vault", "post this in Slack", "toggle this VS Code setting".
**WHEN:** today the model reaches for `computer_use`, background input gets dropped by the unfocused Chromium renderer (`suspected_noop`), and the only escalation is `foreground` — a visible focus steal that disrupts the user mid-work.
**WHY:** a CDP attach gives exact DOM-level control with zero focus steal. The transport already worked (`BROWSER_CDP_URL` → browser_exec), but it was global-only (attaching an app hijacked ALL web browsing) and nothing made it discoverable at planning time, task-match time, or the failure point.

## What this adds

**1. `hermes browser attach` / `list` / `detach`** (new CLI command; `hermes_cli/browser_attach.py` + `hermes_cli/subcommands/browser.py`)
- Scans running processes for Electron *main* processes (`resources/app.asar` signature — packaged, unpacked, and macOS bundle layouts; `--type=` children excluded), probes advertised debug ports for live CDP.
- Registers the endpoint under a named browser_exec session in `$HERMES_HOME/browser-sessions.json` (written via the existing `utils.atomic_json_write`).
- For a detected app with no exposed port: offers the quit-and-relaunch with `--remote-debugging-port=<free port ≠ 9222>` itself, waiting on the existing dual-stack readiness probe.
- **Consent model:** CDP into a live app exposes everything it can access (DMs, vault contents, tokens) — same power class as cua-driver's gated `existing_profile` attach. The agent never opens debug ports; this command is user-invoked and its relaunch confirmation is the consent moment. The skill instructs the model to ask the user to run it, never to relaunch apps via terminal.

**2. Named-session registry resolution in `browser_exec`** (`tools/browser_use_cli.py`)
- A session registered by the attach command pins THAT session to the app's endpoint; the default session (and any other name) keeps browsing the web normally. Precedence: explicit `BU_CDP_*` env > session registry > global `/browser connect` override > cloud provider.
- **Electron CDP quirk, found E2E:** Electron rejects `Target.createTarget` (`Not supported`), and the harness's named-daemon path fatally calls exactly that to mint its dedicated tab. App sessions therefore run the harness's default-name path (attach-to-existing-page — correct for an app, whose window IS the page), isolated per session via `BH_HOME` (the harness's own home var — no new `HERMES_*` env surface).

**3. Failure-point nudge** (`tools/computer_use/tool.py`, `tools/computer_use/cua_backend.py`)
- `_enrich_escalation()` gains a second additive branch mirroring the existing typed-page one: when the driver recommends `foreground` and the acting pid's executable carries the Electron signature, the escalation payload adds `alternative: "cdp_attach"` + a hint naming `hermes browser attach` and the skill. The driver's `recommended` is never changed; detection runs only on the escalation path (zero cost on success); typed-page branch takes precedence for real browser windows.
- The cua backend threads the acting pid into escalation meta additively (only when an escalation is present, never overwriting a driver-supplied pid).
- This is **reaction-only**, per the shipped ladder doctrine ("never predict from the app being Electron") — many Electron controls DO accept background AX input, and nothing here changes rung ordering.

**4. Bundled skill `drive-electron-apps`** + **one schema sentence**
- Skill: detection recipe, per-platform relaunch (incl. the single-instance-lock pitfall), target picking from `/json/list`, React native-value-setter / Radix one-eval / `Input.insertText` patterns, the `window.app` tip, consent rules, and when computer_use remains the right tool.
- Schema: one sentence on the `browser_exec` header pointing at the attach flow. Note: the header was A/B benchmarked and pinned (Aug 2026, comment at `tools/browser_use_cli.py:768`) — this addition is outside that benchmark's coverage, flagging per that comment's intent. The description is computed at tool-definition time, so it remains byte-stable for the life of a conversation (no cache break).

## Verification (all real output, macOS)

- **Live E2E:** `hermes browser attach obsidian` against running Obsidian 1.10.6 → relaunch-free attach to its exposed port; `browser_exec(code=…, session='obsidian')` returned the real DOM title and full `window.app` access (vault name, file count, active file). Slack/Discord/Bitwarden/ChatGPT correctly detected as Electron; `--no-relaunch` refusal path, interactive detach/list, and a `--session "My Obsidian"` slug round-trip all exercised live.
- **Isolation proof:** unnamed sessions and unregistered named sessions leave the env untouched (no `BU_CDP_*`, no `BH_HOME`); explicit `BU_CDP_URL` env still wins over the registry.
- **Tests:** 161 passed — the full existing `test_browser_use_cli.py` + `test_computer_use_delivery_ladder.py` + browser-connect suites, plus new: registry round-trip/precedence, Electron detection across the three layouts, cmdline parsing, escalation-branch contract (driver verdict never overridden, typed-page precedence, silent skip without pid).
- **Mutation checks:** disabling the escalation branch fails its 2 guard tests; disabling the registry consult fails 3 precedence tests; both restored green.
- **`_BUILTIN_SUBCOMMANDS` ↔ argparse parity** contract test green with the new `browser` command; ruff clean.

## Review gates run

`/simplify-code` (3 parallel reviewers on the full diff): reuse HIGH (hand-rolled atomic write → `utils.atomic_json_write`) and quality HIGH (third inline `.app`-name derivation → module's own `app_display_name`) both verified and folded as the second commit; efficiency reviewer dismissed its candidates with call-frequency evidence (registry read is opt-in per named session, consistent with existing per-call config reads in the same function). `hermes-pr-review` Phase 2 checks (dispatch-site completeness — static + dynamic schema paths both carry the note; wiring parity; E2E re-run post-cleanup) on the full final diff.

Closes the Phase 1–3 checkboxes of #89357.

