### PR TITLE
feat(gateway): auto-unarchive sessions on inbound user activity

### DIFF
--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -66,6 +66,43 @@ def is_context_overflow_failure_result(agent_result: dict, history_len: int) -> 
     return any(p in err for p in _CONTEXT_OVERFLOW_ERROR_PHRASES) or ("400" in err and history_len > 50)
 
 
+async def _unarchive_session_on_activity(session_db: Any, session_id: str) -> bool:
+    """Resurface an archived session when real user activity arrives (#89325).
+
+    Archiving is a soft hide: the session row keeps every message and inbound
+    delivery still routes to it, but the archived flag hides it from the
+    default session list on every surface (desktop sidebar, TUI, CLI). A
+    conversation that receives a real user message from ANY platform channel
+    must come back — otherwise a chat you are actively using on WhatsApp,
+    BlueBubbles, Photon, Telegram, ... stays hidden on the desktop UI forever
+    while messages pile up invisibly.
+
+    The caller gates this on real (non-internal) inbound only: cron
+    deliveries, background-process completions, and startup-restore replays
+    are system traffic, not user activity, and must not un-archive a session
+    the user deliberately hid. ``unarchive_if_archived`` is the right door here
+    rather than ``unarchive_recoverable_session``: that helper deliberately
+    resurrects only rows archived by a recoverable *accident*
+    (``ws_orphan_reap`` / ``agent_close``) and returns False for a user's own
+    archive — which is precisely the archive this feature is about, since the
+    conversation is no longer dormant once a new message lands in it.
+
+    One statement, no read: this runs on every inbound turn from every
+    platform, so a read to check ``archived`` first would double the cost of
+    the common (nothing-archived) case. ``session_db`` is the async session DB
+    door (``AsyncSessionDB``), which offloads the call to a thread so the event
+    loop never blocks on SQLite. Returns True when the session was archived and
+    is now visible again.
+    """
+    if session_db is None or not session_id:
+        return False
+    try:
+        return bool(await session_db.unarchive_if_archived(session_id))
+    except Exception:
+        logger.debug("auto-unarchive: failed for %s", session_id, exc_info=True)
+        return False
+
+
 class GatewayTurnMixin:
     """Agent-turn execution for GatewayRunner (see module docstring)."""
 
@@ -1883,6 +1920,13 @@ class GatewayTurnMixin:
         ``(_PreparedTurn, env_tokens)``; a ``str`` first element is a reply to send instead of
         running (history unreadable); ``None`` drops the turn (inbound text rejected)."""
         from gateway.run import _load_gateway_config
+        # Auto-unarchive on real user activity (#89325): archiving is a soft hide, so a conversation
+        # that receives a message from any channel (WhatsApp, BlueBubbles, Photon, Telegram, ...) must
+        # resurface in the default session list. Internal/system events (cron deliveries,
+        # background-process completions, startup-restore replays) are not user activity — they keep
+        # the archive flag, matching the touch_activity gate used at session resolution above.
+        if not getattr(event, "internal", False):
+            await _unarchive_session_on_activity(self._session_db, session_entry.session_id)
         _was_auto_reset, _is_new_session = await self._hmwa_open_session(session_entry, session_key, source)
         context = build_session_context(source, self.config, session_entry)
         # Session context variables for tools (task-local, concurrency-safe)

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -835,6 +835,50 @@ class SessionSessionsMixin:
         """Soft-hide (or unhide) a session and its compression lineage; messages are kept."""
         return self._set_lineage_column("archived", session_id, int(archived))
 
+    def unarchive_if_archived(self, session_id: str) -> bool:
+        """Clear ``archived`` across the lineage in ONE statement, and only when it is set.
+
+        Purpose-built for the inbound-activity path (#89325): un-hiding a deliberately
+        archived conversation there must not cost a read *plus* a write on every inbound
+        turn — the caller would have to read the row to check first — and an unconditional
+        lineage update would write on every message even when nothing is archived.
+        Returns True only when an archived row was actually made visible again.
+        """
+        if not session_id:
+            return False
+        return self._write_rowcount(
+            """
+            WITH RECURSIVE
+              ancestors(id) AS (
+                SELECT ?
+                UNION
+                SELECT parent.id
+                FROM ancestors a
+                JOIN sessions child ON child.id = a.id
+                JOIN sessions parent ON parent.id = child.parent_session_id
+                WHERE parent.end_reason = 'compression'
+              ),
+              descendants(id) AS (
+                SELECT ?
+                UNION
+                SELECT child.id
+                FROM descendants d
+                JOIN sessions parent ON parent.id = d.id
+                JOIN sessions child ON child.parent_session_id = parent.id
+                WHERE parent.end_reason = 'compression'
+              ),
+              lineage(id) AS (
+                SELECT id FROM ancestors
+                UNION
+                SELECT id FROM descendants
+              )
+            UPDATE sessions
+            SET archived = 0
+            WHERE id IN (SELECT id FROM lineage) AND archived != 0
+            """,
+            (session_id, session_id),
+        ) > 0
+
     # Accidental end reasons recovery treats as resumable (also interpolated into
     # the recovery/promotion SQL so literals cannot drift).
     RECOVERABLE_END_REASONS = _RECOVERABLE_END_REASONS

--- a/tests/gateway/test_89325_auto_unarchive_on_activity.py
+++ b/tests/gateway/test_89325_auto_unarchive_on_activity.py
@@ -1,0 +1,220 @@
+"""Tests for auto-unarchive on inbound activity (#89325).
+
+Archiving is a soft hide: the session row keeps every message and inbound
+delivery still routes to it, but the archived flag hides it from the default
+session list on every surface. A conversation that receives a real user
+message from any platform channel must come back — otherwise a chat you are
+actively using on WhatsApp, BlueBubbles, Photon, Telegram, ... stays hidden
+on the desktop UI forever while messages pile up invisibly.
+
+Internal/system events (cron deliveries, background-process completions,
+startup-restore replays, plugin injections) are NOT user activity and must
+keep the archive flag — otherwise background traffic drags chats the user
+deliberately hid back into the main list.
+"""
+
+import sys
+import types
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+import gateway.run_turn as gateway_run_turn
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource
+from hermes_state import AsyncSessionDB, SessionDB
+
+
+# ---------------------------------------------------------------------------
+# Helper under test — real DB
+# ---------------------------------------------------------------------------
+
+def _make_db(tmp_path):
+    """Real SessionDB + async door on an isolated temp file."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    return AsyncSessionDB(db)
+
+
+def _create_session(db: SessionDB, session_id: str = "sess-1") -> str:
+    """Create a session row directly (bypassing the async door)."""
+    db.create_session(session_id=session_id, source="test")
+    return session_id
+
+
+@pytest.mark.asyncio
+async def test_unarchives_archived_session(tmp_path):
+    db = _make_db(tmp_path)
+    session_id = _create_session(db._db)
+    db._db.set_session_archived(session_id, True)
+    assert db._db.get_session(session_id)["archived"] == 1
+
+    result = await gateway_run_turn._unarchive_session_on_activity(db, session_id)
+
+    assert result is True
+    assert db._db.get_session(session_id)["archived"] == 0
+
+
+@pytest.mark.asyncio
+async def test_leaves_unarchived_session_alone(tmp_path):
+    db = _make_db(tmp_path)
+    session_id = _create_session(db._db)
+    assert db._db.get_session(session_id)["archived"] == 0
+
+    result = await gateway_run_turn._unarchive_session_on_activity(db, session_id)
+
+    assert result is False
+    assert db._db.get_session(session_id)["archived"] == 0
+
+
+@pytest.mark.asyncio
+async def test_missing_session_is_noop(tmp_path):
+    db = _make_db(tmp_path)
+    result = await gateway_run_turn._unarchive_session_on_activity(db, "sess-nope")
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_none_db_is_noop(tmp_path):
+    result = await gateway_run_turn._unarchive_session_on_activity(None, "sess-1")
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_empty_session_id_is_noop(tmp_path):
+    db = _make_db(tmp_path)
+    result = await gateway_run_turn._unarchive_session_on_activity(db, "")
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Wiring in _handle_message_with_agent
+# ---------------------------------------------------------------------------
+
+def _bootstrap(monkeypatch, tmp_path):
+    """Minimal GatewayRunner setup shared by the wiring tests."""
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    config = GatewayConfig()
+    runner = gateway_run.GatewayRunner(config)
+    runner.adapters = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._handle_active_session_busy_message = AsyncMock(return_value=False)
+    runner._session_db = MagicMock()
+    runner._recover_telegram_topic_thread_id = lambda _source: None
+    runner._cache_session_source = lambda _key, _source: None
+    runner._is_session_run_current = lambda _key, _gen: True
+    runner._begin_session_run_generation = lambda _key: 1
+    runner._reply_anchor_for_event = lambda _event: None
+    runner._get_guild_id = lambda _event: None
+    runner._should_send_voice_reply = lambda *_a, **_kw: False
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    # Telegram topic lane check — must be False for the plain DM path.
+    runner._is_telegram_topic_lane = lambda _source: False
+
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:telegram:group:-1001:12345",
+        session_id="sess-wired",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.has_platform_message_id.return_value = False
+    runner.session_store.update_session = MagicMock()
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"}
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100_000,
+    )
+    return runner
+
+
+def _event(*, internal: bool = False):
+    return MessageEvent(
+        text="hello world",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            chat_type="group",
+            user_id="12345",
+        ),
+        message_id="msg-42",
+        internal=internal,
+    )
+
+
+def _source():
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        user_id="12345",
+    )
+
+
+@pytest.mark.asyncio
+async def test_user_message_unarchives_session(monkeypatch, tmp_path):
+    runner = _bootstrap(monkeypatch, tmp_path)
+    unarchive = AsyncMock(return_value=True)
+    monkeypatch.setattr(gateway_run_turn, "_unarchive_session_on_activity", unarchive)
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "Hello!",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    unarchive.assert_awaited_once()
+    args = unarchive.await_args.args
+    assert args[0] is runner._session_db
+    assert args[1] == "sess-wired"
+
+
+@pytest.mark.asyncio
+async def test_internal_event_keeps_session_archived(monkeypatch, tmp_path):
+    runner = _bootstrap(monkeypatch, tmp_path)
+    unarchive = AsyncMock(return_value=False)
+    monkeypatch.setattr(gateway_run_turn, "_unarchive_session_on_activity", unarchive)
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "Hello!",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    await runner._handle_message_with_agent(
+        _event(internal=True),
+        _source(),
+        "agent:main:telegram:group:-1001:12345",
+        1,
+    )
+
+    unarchive.assert_not_awaited()


### PR DESCRIPTION
## Summary

Auto-unarchive a session when real user activity arrives in it, from **any** platform channel (WhatsApp, BlueBubbles, Photon/iMessage, Telegram, Discord, Slack, ...).

Archiving is a soft hide: the session row keeps every message and inbound delivery still routes to it, but the `archived` flag hides it from the default session list on every surface. Today, a chat you archive on the desktop then keep using on another channel stays hidden **forever** — messages pile up invisibly and the only way to see the conversation again is to remember it exists and manually unarchive it. This flips that.

Closes #89325.

## Change

**`gateway/run_turn.py`** — new `_unarchive_session_on_activity(session_db, session_id)` helper, called from `_hmwa_prepare_turn` immediately before `_hmwa_open_session`. That is the same position the original patch used in the pre-decomposition `gateway/run.py`: after session resolution, before the auto-reset flags are consumed. Gated on `getattr(event, "internal", False)` so **only real user messages unarchive** — cron deliveries, background-process completions, and startup-replay events are system traffic and must not drag a deliberately-hidden chat back.

*(Rebased onto current `main`: the gateway decomposition moved `_handle_message_with_agent` into `gateway/run_turn.py` and split the surrounding block into `_hmwa_*` phase helpers, so the hook moved with it. The old `gateway/run.py` hunk is gone because that code no longer lives there.)*

**`hermes_state_sessions.py`** — new `unarchive_if_archived(session_id)`: clears `archived` across the compression lineage in **one** statement, and only when it is actually set.

This hook runs on *every* inbound turn from *every* platform, so the shape matters:
- a read-then-conditional-write costs a second SQLite round-trip on the common path (nothing archived), and
- an unconditional lineage update would write on every message even when nothing changes.

One statement, nothing to read first, no write when there is nothing to clear. It mirrors `set_session_archived`'s lineage walk (so an archived ancestor cannot resurrect the hidden chat on refresh) with `AND archived != 0` as the guard.

**`tests/gateway/test_89325_auto_unarchive_on_activity.py`** — 7 tests: the helper against a real `SessionDB` (unarchives archived / no-op when unarchived / missing session / None db / empty id) plus both wiring polarities (a user message unarchives; an internal event does not).

## One semantic worth settling explicitly

`unarchive_recoverable_session` (added to `main` since this PR was opened) deliberately resurrects only rows archived by a recoverable *accident* (`ws_orphan_reap`, `agent_close`) and returns `False` for a session the user archived deliberately. This feature is the opposite case on purpose: the archive is the user's own, and it is no longer dormant once a new message lands in it — a chat you are actively messaging from WhatsApp is not "hidden", it is stale metadata.

So this uses its own door rather than overloading that helper. If the intent is instead that a user's deliberate archive should survive inbound activity, that is a design call and this PR is the place to make it — happy to fold it into `unarchive_recoverable_session` with a widened reason set if that is the preferred shape.

## Verification

- `tests/gateway/test_89325_auto_unarchive_on_activity.py` — 7 passed, 0 failed.
- `tests/gateway/` + every other test file referencing archive semantics — **8260 passed, 0 failed, 43 skipped** (3 `linux_only` / 4 `windows_only` files skip on macOS and run on the CI lanes).
- An earlier revision of this patch read the row before writing and tripped `test_session_hygiene_forces_in_place_compaction_with_bound_session_db`, which pins the recovery path's `get_session` call site (#79624) at exactly one call. That is what drove the single-statement form — the assertion was right, the extra read was the bug.
