### PR TITLE
fix(computer-use): scale Wayland desktop coordinates

### DIFF
--- a/tests/tools/test_computer_use_cua_backend_linux.py
+++ b/tests/tools/test_computer_use_cua_backend_linux.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import base64
+from io import BytesIO
 from unittest.mock import patch
 
 import pytest
@@ -142,3 +144,298 @@ def test_explicit_app_capture_preserves_filtered_target_order():
     chrome = _normalized_windows(LINUX_LIST_WINDOWS)[1]
 
     assert _select_capture_target([chrome], app_requested=True) == chrome
+
+
+def _desktop_png(width=300, height=150):
+    from PIL import Image
+
+    image = Image.new("RGB", (width, height), "navy")
+    encoded = BytesIO()
+    image.save(encoded, format="PNG")
+    return base64.b64encode(encoded.getvalue()).decode("ascii")
+
+
+class _GenericWaylandSession:
+    capabilities_discovered = True
+
+    def __init__(
+        self,
+        *,
+        pixel_size=(300, 150),
+        logical_size=(200, 100),
+        screen_size_mode="ok",
+        desktop_target=True,
+        windows=None,
+    ):
+        self.png_b64 = _desktop_png(*pixel_size)
+        self.logical_size = logical_size
+        self.screen_size_mode = screen_size_mode
+        self.desktop_target = desktop_target
+        self.windows = windows or []
+        self.calls = []
+
+    def _has_tool(self, name):
+        tools = {
+            "get_desktop_state", "click", "drag", "scroll", "get_window_state",
+        }
+        if self.screen_size_mode != "missing":
+            tools.add("get_screen_size")
+        return name in tools
+
+    def supports_input_property(self, tool, prop):
+        if prop == "target":
+            return self.desktop_target and tool in {"click", "drag", "scroll"}
+        return (tool, prop) in {
+            ("click", "count"),
+            ("scroll", "x"),
+            ("scroll", "y"),
+        }
+
+    def supports_capability(self, capability, tool=None):
+        return False
+
+    def _call_tool_via_cli(self, name, args, timeout):
+        assert name == "list_windows"
+        return self._result(structured={"windows": self.windows})
+
+    @staticmethod
+    def _result(*, structured=None, images=None, data="ok", is_error=False):
+        images = images or []
+        return {
+            "data": data,
+            "images": images,
+            "image_mime_types": ["image/png"] if images else [],
+            "structuredContent": structured or {},
+            "isError": is_error,
+        }
+
+    def call_tool(self, name, args, timeout=30.0):
+        self.calls.append((name, dict(args)))
+        if name == "list_windows":
+            return self._result(structured={"windows": self.windows})
+        if name == "get_desktop_state":
+            return self._result(images=[self.png_b64])
+        if name == "get_screen_size":
+            if self.screen_size_mode == "error":
+                raise RuntimeError("screen size unavailable")
+            if self.screen_size_mode == "malformed":
+                return self._result(
+                    structured={"width": float("nan"), "height": 100},
+                )
+            return self._result(structured={
+                "width": self.logical_size[0],
+                "height": self.logical_size[1],
+            })
+        if name == "get_window_state":
+            return self._result(
+                images=[self.png_b64],
+                structured={"elements": [{
+                    "element_index": 1,
+                    "role": "AXButton",
+                    "label": "Open",
+                    "frame": {"x": 10, "y": 20, "w": 30, "h": 40},
+                }]},
+            )
+        return self._result()
+
+
+@pytest.mark.linux_only
+def test_generic_wayland_desktop_capture_is_visual_only(monkeypatch):
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-1")
+    session = _GenericWaylandSession()
+    backend = CuaDriverBackend()
+    backend._session = session
+
+    capture = backend.capture(mode="som", app="desktop")
+
+    assert (capture.width, capture.height) == (300, 150)
+    assert capture.png_b64 == session.png_b64
+    assert capture.elements == []
+    assert capture.app == "desktop"
+    assert backend._active_desktop_geometry == {
+        "pixel_left": 0.0,
+        "pixel_top": 0.0,
+        "pixel_width": 300.0,
+        "pixel_height": 150.0,
+        "logical_left": 0.0,
+        "logical_top": 0.0,
+        "logical_width": 200.0,
+        "logical_height": 100.0,
+        "scale_x": 1.5,
+        "scale_y": 1.5,
+    }
+    assert [name for name, _ in session.calls] == [
+        "get_desktop_state", "get_screen_size",
+    ]
+
+
+@pytest.mark.linux_only
+@pytest.mark.parametrize(
+    ("pixel_size", "logical_size", "point", "expected", "click_count"),
+    [
+        ((300, 150), (200, 100), (150, 75), (100, 50), 1),
+        ((400, 200), (200, 100), (300, 100), (150, 50), 2),
+    ],
+)
+def test_generic_wayland_desktop_scales_click_and_double_click(
+    monkeypatch, pixel_size, logical_size, point, expected, click_count,
+):
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-1")
+    session = _GenericWaylandSession(
+        pixel_size=pixel_size, logical_size=logical_size,
+    )
+    backend = CuaDriverBackend()
+    backend._session = session
+    backend.capture(mode="som", app="screen")
+
+    clicked = backend.click(x=point[0], y=point[1], click_count=click_count)
+
+    assert clicked.ok is True
+    action, args = session.calls[-1]
+    assert action == "click"
+    assert (args["x"], args["y"]) == expected
+    assert args["target"] == {"kind": "desktop", "display_id": "primary"}
+    assert args.get("count", 1) == click_count
+
+
+@pytest.mark.linux_only
+def test_generic_wayland_desktop_scales_drag_and_scroll(monkeypatch):
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-1")
+    session = _GenericWaylandSession()
+    backend = CuaDriverBackend()
+    backend._session = session
+    backend.capture(mode="som", app="screen")
+
+    dragged = backend.drag(from_xy=(15, 30), to_xy=(285, 135))
+    scrolled = backend.scroll(direction="down", amount=4, x=75, y=45)
+
+    assert dragged.ok is True
+    assert scrolled.ok is True
+    drag_args = session.calls[-2][1]
+    assert {key: drag_args[key] for key in (
+        "from_x", "from_y", "to_x", "to_y", "target",
+    )} == {
+        "from_x": 10,
+        "from_y": 20,
+        "to_x": 190,
+        "to_y": 90,
+        "target": {"kind": "desktop", "display_id": "primary"},
+    }
+    assert (session.calls[-1][1]["x"], session.calls[-1][1]["y"]) == (50, 30)
+
+
+@pytest.mark.linux_only
+@pytest.mark.parametrize("action", ["click", "drag", "scroll"])
+def test_generic_wayland_desktop_rejects_out_of_bounds_pixels(monkeypatch, action):
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-1")
+    session = _GenericWaylandSession()
+    backend = CuaDriverBackend()
+    backend._session = session
+    backend.capture(mode="som", app="screen")
+
+    if action == "click":
+        blocked = backend.click(x=300, y=75)
+    elif action == "drag":
+        blocked = backend.drag(from_xy=(0, 0), to_xy=(-1, 149))
+    else:
+        blocked = backend.scroll(direction="down", x=150, y=float("inf"))
+
+    assert blocked.ok is False
+    assert blocked.code == "desktop_coordinate_mapping_invalid"
+    assert not any(name == action for name, _ in session.calls)
+
+
+@pytest.mark.linux_only
+@pytest.mark.parametrize("screen_size_mode", ["missing", "malformed", "error"])
+def test_generic_wayland_desktop_invalid_screen_size_blocks_pointer_input(
+    monkeypatch, screen_size_mode,
+):
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-1")
+    session = _GenericWaylandSession(screen_size_mode=screen_size_mode)
+    backend = CuaDriverBackend()
+    backend._session = session
+    capture = backend.capture(mode="som", app="screen")
+
+    blocked = backend.click(x=150, y=75)
+
+    assert (capture.width, capture.height) == (300, 150)
+    assert blocked.ok is False
+    assert blocked.code == "desktop_coordinate_mapping_invalid"
+    assert "get_screen_size" in blocked.message
+    assert not any(name == "click" for name, _ in session.calls)
+
+
+@pytest.mark.linux_only
+def test_generic_wayland_desktop_rejects_inconsistent_scale(monkeypatch):
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-1")
+    session = _GenericWaylandSession()
+    backend = CuaDriverBackend()
+    backend._session = session
+    backend.capture(mode="som", app="screen")
+    backend._active_desktop_geometry["scale_x"] = 2.0
+
+    blocked = backend.click(x=150, y=75)
+
+    assert blocked.ok is False
+    assert blocked.code == "desktop_coordinate_mapping_invalid"
+    assert not any(name == "click" for name, _ in session.calls)
+
+
+@pytest.mark.linux_only
+def test_generic_wayland_desktop_requires_advertised_input_target(monkeypatch):
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-1")
+    session = _GenericWaylandSession(desktop_target=False)
+    backend = CuaDriverBackend()
+    backend._session = session
+    backend.capture(mode="som", app="screen")
+
+    blocked = backend.click(x=150, y=75)
+
+    assert blocked.ok is False
+    assert blocked.code == "desktop_target_unsupported"
+    assert "does not advertise desktop targets" in blocked.message
+    assert not any(name == "click" for name, _ in session.calls)
+
+
+@pytest.mark.linux_only
+def test_generic_wayland_normal_app_keeps_semantic_window_route(monkeypatch):
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-1")
+    window = {
+        "app_name": "Terminal",
+        "pid": 4242,
+        "window_id": 99,
+        "title": "Shell",
+        "is_on_screen": True,
+        "z_index": 1,
+    }
+    session = _GenericWaylandSession(windows=[window])
+    backend = CuaDriverBackend()
+    backend._session = session
+
+    capture = backend.capture(mode="som", app="Terminal")
+    clicked = backend.click(element=1)
+
+    assert len(capture.elements) == 1
+    assert capture.elements[0].label == "Open"
+    assert clicked.ok is True
+    assert backend._active_pid == 4242
+    assert backend._active_window_id == 99
+    assert not any(name == "get_desktop_state" for name, _ in session.calls)
+    assert session.calls[-1][0] == "click"
+    assert session.calls[-1][1]["element_index"] == 1

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -42,6 +42,7 @@ import concurrent.futures
 import functools
 import json
 import logging
+import math
 import os
 import re
 import shutil
@@ -173,16 +174,11 @@ _CUA_DRIVER_ARGS = ["mcp"]  # stdio MCP transport (fallback when the
                             # driver doesn't expose `manifest` — see
                             # `_resolve_mcp_invocation` below)
 
-# Whole-screen / desktop capture. cua-driver is a window-oriented driver —
-# its `get_window_state` / `screenshot` tools capture a single window (by
-# pid + window_id), and there is no MCP tool that captures the entire virtual
-# desktop or an arbitrary monitor as one image. But the OS shell surfaces
-# themselves (the desktop backdrop and the taskbar/menu-bar) are real windows
-# that show up in `list_windows`, so "show me my screen" / "click the taskbar"
-# is reachable by targeting those windows. When `app` is one of these
-# sentinels, capture() resolves to the desktop/shell window instead of an
-# application window.
+# Whole-screen / desktop capture. Current cua-driver builds advertise
+# `get_desktop_state`; older builds remain window-oriented and resolve these
+# sentinels to a desktop/shell window from `list_windows` instead.
 _SCREEN_CAPTURE_SENTINELS = {"screen", "desktop", "fullscreen", "full screen", "all"}
+_PRIMARY_DESKTOP_TARGET = {"kind": "desktop", "display_id": "primary"}
 
 # Known shell/desktop window identifiers across platforms. Matched
 # case-insensitively as a substring against both the window's app_name and
@@ -205,6 +201,14 @@ _NON_APP_WINDOW_TITLE_PREFIXES = (
     "gnome-shell",
     "GNOME Shell",
 )
+
+
+def _finite_number(value: Any) -> Optional[float]:
+    """Return a finite real value while rejecting booleans and malformed data."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    number = float(value)
+    return number if math.isfinite(number) else None
 
 
 # Env var cua-driver reads to gate its anonymous usage telemetry (PostHog).
@@ -2200,6 +2204,7 @@ class _CuaDriverSession:
     # out of this set because a lost response does not prove they failed.
     _TRANSPORT_REPLAY_SAFE_TOOLS = frozenset({
         "get_cursor_position",
+        "get_desktop_state",
         "get_displays",
         "get_screen_size",
         "get_window_state",
@@ -2541,6 +2546,8 @@ class CuaDriverBackend(ComputerUseBackend):
         # Sticky context — updated by capture(), used by action tools.
         self._active_pid: Optional[int] = None
         self._active_window_id: Optional[int] = None
+        self._active_desktop_display_id: Optional[str] = None
+        self._active_desktop_geometry: Optional[Dict[str, float]] = None
         self._last_app: Optional[str] = None  # last app name targeted via capture/focus_app
         # Exact identity for capture_after. App names may be generic on Linux
         # (for example, multiple unrelated Qt windows can say Qt6Application).
@@ -2704,6 +2711,8 @@ class CuaDriverBackend(ComputerUseBackend):
         """Forget a capture/focus target so a failed lookup cannot misroute input."""
         self._active_pid = None
         self._active_window_id = None
+        self._active_desktop_display_id = None
+        self._active_desktop_geometry = None
         self._last_app = None
         self._last_target = None
         self._snapshot_tokens = {}
@@ -2720,6 +2729,229 @@ class CuaDriverBackend(ComputerUseBackend):
             app="",
             window_title=message,
             png_bytes_len=0,
+        )
+
+    def _wayland_desktop_capture_available(self, app: Optional[str]) -> bool:
+        """Whether a screen sentinel should use cua-driver's desktop route."""
+        is_wayland_screen = bool(
+            sys.platform == "linux"
+            and os.environ.get("WAYLAND_DISPLAY")
+            and isinstance(app, str)
+            and app.strip().lower() in _SCREEN_CAPTURE_SENTINELS
+        )
+        if not is_wayland_screen:
+            return False
+
+        # A backend may be used before start(), leaving tool discovery cold.
+        # One legacy-safe read starts the lazy session and fills capabilities.
+        if not self._session.capabilities_discovered:
+            try:
+                self._call_capture_tool(
+                    "list_windows",
+                    {"on_screen_only": True, "session": self._session_id},
+                )
+            except Exception as exc:
+                logger.debug(
+                    "cua-driver Wayland desktop capability preflight failed: %s",
+                    exc,
+                )
+                return False
+
+        return self._session._has_tool("get_desktop_state")
+
+    def _capture_wayland_desktop(self, mode: str, app: str) -> CaptureResult:
+        """Capture primary-display pixels and record their logical CUA mapping."""
+        out = self._call_capture_tool(
+            "get_desktop_state",
+            {"session": self._session_id},
+        )
+        png_b64, image_mime_type = _image_from_tool_result(out)
+        if not png_b64:
+            return self._failed_capture(
+                mode,
+                "<cua-driver get_desktop_state returned no screenshot>",
+            )
+
+        width = height = 0
+        try:
+            raw = base64.b64decode(png_b64, validate=False)
+            png_bytes_len = len(raw)
+            width, height = _image_dimensions_from_bytes(raw)
+        except Exception:
+            png_bytes_len = len(png_b64) * 3 // 4
+
+        geometry: Optional[Dict[str, float]] = None
+        if self._session._has_tool("get_screen_size"):
+            try:
+                screen_out = self._call_capture_tool(
+                    "get_screen_size",
+                    {"session": self._session_id},
+                )
+            except Exception as exc:
+                logger.debug("cua-driver get_screen_size failed: %s", exc)
+                screen_out = {}
+            raw_screen = screen_out.get("structuredContent")
+            screen = raw_screen if isinstance(raw_screen, dict) else {}
+            logical_width = _finite_number(screen.get("width"))
+            logical_height = _finite_number(screen.get("height"))
+            if (
+                width > 0
+                and height > 0
+                and logical_width is not None
+                and logical_width > 0
+                and logical_height is not None
+                and logical_height > 0
+            ):
+                scale_x = width / logical_width
+                scale_y = height / logical_height
+                if (
+                    math.isfinite(scale_x)
+                    and scale_x > 0
+                    and math.isfinite(scale_y)
+                    and scale_y > 0
+                ):
+                    geometry = {
+                        "pixel_left": 0.0,
+                        "pixel_top": 0.0,
+                        "pixel_width": float(width),
+                        "pixel_height": float(height),
+                        "logical_left": 0.0,
+                        "logical_top": 0.0,
+                        "logical_width": logical_width,
+                        "logical_height": logical_height,
+                        "scale_x": scale_x,
+                        "scale_y": scale_y,
+                    }
+
+        self._active_pid = None
+        self._active_window_id = None
+        self._active_desktop_display_id = _PRIMARY_DESKTOP_TARGET["display_id"]
+        self._active_desktop_geometry = geometry
+        self._last_app = app
+        self._last_target = None
+        self._snapshot_tokens = {}
+        return CaptureResult(
+            mode=mode,
+            width=width,
+            height=height,
+            png_b64=png_b64,
+            elements=[],
+            app=app,
+            window_title="Desktop (primary)",
+            png_bytes_len=png_bytes_len,
+            image_mime_type=image_mime_type,
+        )
+
+    def _desktop_input_target(self, tool: str) -> Optional[Dict[str, str]]:
+        """Return the sticky desktop target only when its schema advertises it."""
+        display_id = self._active_desktop_display_id
+        if not display_id or not self._session.supports_input_property(tool, "target"):
+            return None
+        return {"kind": "desktop", "display_id": display_id}
+
+    def _translate_wayland_desktop_point(
+        self,
+        x: Any,
+        y: Any,
+    ) -> Optional[Tuple[Any, Any]]:
+        """Map an in-bounds screenshot-pixel point to logical CUA coordinates."""
+        geometry = self._active_desktop_geometry
+        pixel_x = _finite_number(x)
+        pixel_y = _finite_number(y)
+        if not isinstance(geometry, dict) or pixel_x is None or pixel_y is None:
+            return None
+
+        values = {
+            key: _finite_number(geometry.get(key))
+            for key in (
+                "pixel_left",
+                "pixel_top",
+                "pixel_width",
+                "pixel_height",
+                "logical_left",
+                "logical_top",
+                "logical_width",
+                "logical_height",
+                "scale_x",
+                "scale_y",
+            )
+        }
+        if any(value is None for value in values.values()):
+            return None
+        pixel_left = values["pixel_left"]
+        pixel_top = values["pixel_top"]
+        pixel_width = values["pixel_width"]
+        pixel_height = values["pixel_height"]
+        logical_left = values["logical_left"]
+        logical_top = values["logical_top"]
+        logical_width = values["logical_width"]
+        logical_height = values["logical_height"]
+        scale_x = values["scale_x"]
+        scale_y = values["scale_y"]
+        assert None not in (
+            pixel_left,
+            pixel_top,
+            pixel_width,
+            pixel_height,
+            logical_left,
+            logical_top,
+            logical_width,
+            logical_height,
+            scale_x,
+            scale_y,
+        )
+        if not (
+            pixel_width > 0
+            and pixel_height > 0
+            and logical_width > 0
+            and logical_height > 0
+            and scale_x > 0
+            and scale_y > 0
+            and math.isclose(pixel_width / logical_width, scale_x)
+            and math.isclose(pixel_height / logical_height, scale_y)
+            and pixel_left <= pixel_x < pixel_left + pixel_width
+            and pixel_top <= pixel_y < pixel_top + pixel_height
+        ):
+            return None
+
+        logical_x = logical_left + ((pixel_x - pixel_left) / scale_x)
+        logical_y = logical_top + ((pixel_y - pixel_top) / scale_y)
+        if not (
+            logical_left <= logical_x < logical_left + logical_width
+            and logical_top <= logical_y < logical_top + logical_height
+        ):
+            return None
+
+        def _clean(value: float) -> Any:
+            rounded = round(value, 6)
+            return int(rounded) if rounded.is_integer() else rounded
+
+        return _clean(logical_x), _clean(logical_y)
+
+    @staticmethod
+    def _desktop_coordinate_mapping_invalid(action: str) -> ActionResult:
+        return ActionResult(
+            ok=False,
+            action=action,
+            code="desktop_coordinate_mapping_invalid",
+            message=(
+                "Desktop pointer input was blocked because the latest capture "
+                "does not provide a valid in-bounds screenshot-pixel to "
+                "logical-coordinate mapping. Capture the desktop again with a "
+                "cua-driver that advertises valid get_screen_size dimensions."
+            ),
+        )
+
+    @staticmethod
+    def _desktop_input_unsupported(action: str) -> ActionResult:
+        return ActionResult(
+            ok=False,
+            action=action,
+            code="desktop_target_unsupported",
+            message=(
+                f"The connected cua-driver {action} schema does not advertise "
+                "desktop targets. Capture and act through a window instead."
+            ),
         )
 
     def _call_capture_tool(self, name: str, args: Dict[str, Any]) -> Dict[str, Any]:
@@ -2907,6 +3139,8 @@ class CuaDriverBackend(ComputerUseBackend):
                 "z_index": 0,
             }]
         else:
+            if self._wayland_desktop_capture_available(app):
+                return self._capture_wayland_desktop(mode, app or "screen")
             try:
                 windows = self._load_windows()
             except Exception:
@@ -2983,6 +3217,8 @@ class CuaDriverBackend(ComputerUseBackend):
         )
         self._active_pid = target["pid"]
         self._active_window_id = target["window_id"]
+        self._active_desktop_display_id = None
+        self._active_desktop_geometry = None
         # Tokens belong to the prior window snapshot. Disarm them before any
         # capture call so an exception cannot pair old tokens with this target.
         self._snapshot_tokens = {}
@@ -3309,8 +3545,50 @@ class CuaDriverBackend(ComputerUseBackend):
     ) -> ActionResult:
         pid = self._active_pid
         if pid is None:
-            return ActionResult(ok=False, action="click",
-                                message="No active window — call capture() first.")
+            if not getattr(self, "_active_desktop_display_id", None):
+                return ActionResult(ok=False, action="click",
+                                    message="No active window — call capture() first.")
+
+            button_norm = (button or "left").lower()
+            if button_norm not in {"left", "right", "middle"}:
+                return ActionResult(
+                    ok=False,
+                    action="click",
+                    message=f"unknown button {button!r} — expected left, right, middle.",
+                )
+            if element is not None:
+                return ActionResult(
+                    ok=False,
+                    action="click",
+                    message="Desktop capture has no element indices; use x/y coordinates.",
+                )
+            if x is None or y is None:
+                return ActionResult(
+                    ok=False,
+                    action="click",
+                    message="click requires x/y after desktop capture.",
+                )
+            translated = self._translate_wayland_desktop_point(x, y)
+            if translated is None:
+                return self._desktop_coordinate_mapping_invalid("click")
+            target = self._desktop_input_target("click")
+            if target is None:
+                return self._desktop_input_unsupported("click")
+            args: Dict[str, Any] = {
+                "button": button_norm,
+                "x": translated[0],
+                "y": translated[1],
+                "target": target,
+            }
+            if click_count == 2:
+                if not self._session.supports_input_property("click", "count"):
+                    return self._desktop_input_unsupported("double_click")
+                args["count"] = 2
+            if modifiers:
+                args["modifier"] = modifiers
+            return self._run_input_action(
+                "click", args, delivery_mode, bring_to_front,
+            )
 
         # Choose tool by click_count only — single-vs-double — and pass the
         # button through to `click`'s `button` enum (Surface 5 of
@@ -3362,8 +3640,38 @@ class CuaDriverBackend(ComputerUseBackend):
     ) -> ActionResult:
         pid = self._active_pid
         if pid is None:
-            return ActionResult(ok=False, action="drag",
-                                message="No active window — call capture() first.")
+            if not getattr(self, "_active_desktop_display_id", None):
+                return ActionResult(ok=False, action="drag",
+                                    message="No active window — call capture() first.")
+            if from_element is not None or to_element is not None:
+                return ActionResult(
+                    ok=False,
+                    action="drag",
+                    message="Desktop capture has no element indices; use coordinates.",
+                )
+            if from_xy is None or to_xy is None:
+                return ActionResult(
+                    ok=False,
+                    action="drag",
+                    message="drag requires coordinate pairs after desktop capture.",
+                )
+            translated_from = self._translate_wayland_desktop_point(*from_xy)
+            translated_to = self._translate_wayland_desktop_point(*to_xy)
+            if translated_from is None or translated_to is None:
+                return self._desktop_coordinate_mapping_invalid("drag")
+            target = self._desktop_input_target("drag")
+            if target is None:
+                return self._desktop_input_unsupported("drag")
+            args: Dict[str, Any] = {
+                "from_x": translated_from[0],
+                "from_y": translated_from[1],
+                "to_x": translated_to[0],
+                "to_y": translated_to[1],
+                "target": target,
+            }
+            return self._run_input_action(
+                "drag", args, delivery_mode, bring_to_front,
+            )
         args: Dict[str, Any] = {"pid": pid}
         if from_element is not None and to_element is not None:
             if self._active_window_id is None:
@@ -3398,8 +3706,38 @@ class CuaDriverBackend(ComputerUseBackend):
     ) -> ActionResult:
         pid = self._active_pid
         if pid is None:
-            return ActionResult(ok=False, action="scroll",
-                                message="No active window — call capture() first.")
+            if not getattr(self, "_active_desktop_display_id", None):
+                return ActionResult(ok=False, action="scroll",
+                                    message="No active window — call capture() first.")
+            if element is not None:
+                return ActionResult(
+                    ok=False,
+                    action="scroll",
+                    message="Desktop capture has no element indices; use coordinates.",
+                )
+            if x is None or y is None:
+                return self._desktop_coordinate_mapping_invalid("scroll")
+            translated = self._translate_wayland_desktop_point(x, y)
+            if translated is None:
+                return self._desktop_coordinate_mapping_invalid("scroll")
+            target = self._desktop_input_target("scroll")
+            if target is None:
+                return self._desktop_input_unsupported("scroll")
+            if not (
+                self._session.supports_input_property("scroll", "x")
+                and self._session.supports_input_property("scroll", "y")
+            ):
+                return self._desktop_input_unsupported("scroll")
+            args: Dict[str, Any] = {
+                "direction": direction,
+                "amount": max(1, min(50, amount)),
+                "target": target,
+                "x": translated[0],
+                "y": translated[1],
+            }
+            return self._run_input_action(
+                "scroll", args, delivery_mode, bring_to_front,
+            )
         args: Dict[str, Any] = {
             "pid": pid,
             "direction": direction,


### PR DESCRIPTION
## Summary

Adds a safe desktop-only Wayland fallback for explicit `capture(app="screen"|"desktop")` when Cua Driver advertises `get_desktop_state`, including pixel-to-logical-coordinate mapping for follow-up desktop actions.

## Why

On native Wayland, Cua Driver can capture a real desktop even when window enumeration does not expose usable native windows. The wrapper previously stayed on its legacy window route. A naïve desktop fallback is unsafe on HiDPI/fractional displays: the screenshot is in pixels while CUA desktop pointer input expects logical points.

## Behavior

- On Linux Wayland and explicit screen sentinels, use `get_desktop_state` only when the driver advertises the desktop API.
- Fetch `get_screen_size`, retain validated image-pixel → logical-point scale, and reject malformed/inconsistent mappings.
- Route coordinate click, double-click, drag, and scroll via `{kind: "desktop", display_id: "primary"}` after validated conversion and screenshot-bounds checks.
- Desktop captures are explicitly visual-only: no synthetic semantic elements.
- Older drivers and normal window/X11/macOS/Windows paths retain their prior behavior.

## Validation

- `python -m pytest tests/tools/test_computer_use_cua_backend_linux.py -q` → 18 passed
- `python -m pytest tests/tools/test_computer_use*.py -q` → 303 passed
- `ruff check tools/computer_use/cua_backend.py tests/tools/test_computer_use_cua_backend_linux.py` → passed
- `python -m py_compile tools/computer_use/cua_backend.py` → passed
- Live Omarchy/Hyprland smoke through this worktree adapter: `capture(app="screen")` → `1920×1080`, PNG present, no semantic elements.

## Scope

This intentionally does **not** claim native Wayland app discovery or semantic AT-SPI capture. A separately validated Hyprland-specific visual app-crop layer is being held as a dependent follow-up so this portable safety fix can be reviewed independently.

Related: #62697, #74969, #74987.