### PR TITLE
fix(cli): use Chromium's namespace sandbox when userns is available instead of requiring setuid chrome-sandbox + sudo

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7628,6 +7628,37 @@ def _desktop_linux_needs_no_sandbox() -> bool:
         return False
 
 
+def _desktop_linux_userns_sandbox_available() -> bool:
+    """Return True when Chromium's unprivileged user-namespace sandbox works.
+
+    When an unprivileged process can create a user namespace, Chromium uses the
+    namespace sandbox and never consults the setuid ``chrome-sandbox`` helper,
+    so requiring the helper to be root-owned 4755 (and prompting for sudo) is
+    unnecessary. Probe the real capability with ``unshare`` instead of reading
+    distro-specific sysctls: the probe fails closed on hosts where user
+    namespaces are disabled or AppArmor-restricted, which then follow the
+    existing setuid-helper path.
+    """
+    if sys.platform != "linux":
+        return False
+    unshare = shutil.which("unshare")
+    if not unshare:
+        return False
+    try:
+        return (
+            subprocess.run(
+                [unshare, "--user", "--map-root-user", "true"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=5,
+                check=False,
+            ).returncode
+            == 0
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
 def _desktop_linux_sandbox_helper_is_regular_file(packaged_executable: Path) -> bool:
     """Return True when ``chrome-sandbox`` exists as a regular file."""
     if sys.platform != "linux":
@@ -7664,6 +7695,10 @@ def _desktop_linux_sandbox_fixup(packaged_executable: Path) -> bool:
         return False
 
     if sandbox_lstat.st_uid == 0 and stat.S_IMODE(sandbox_lstat.st_mode) == 0o4755:
+        return True
+
+    if _desktop_linux_userns_sandbox_available():
+        print("✓ Using Chromium's user-namespace sandbox (setuid helper not needed).")
         return True
 
     sudo = shutil.which("sudo")

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -243,6 +243,10 @@ linux_gate() {
   sb="$unpacked/chrome-sandbox"
   if [ ! -e "$sb" ]; then GATE=relaunch; return; fi
   if [ -u "$sb" ] && [ "$(stat -c %u "$sb" 2>/dev/null)" = "0" ]; then GATE=relaunch; return; fi
+  # Namespace sandbox usable => Electron never consults the setuid helper,
+  # so a non-root chrome-sandbox does not block relaunch (mirrors the
+  # _desktop_linux_userns_sandbox_available() probe in hermes_cli/main.py).
+  if unshare --user --map-root-user true 2>/dev/null; then GATE=relaunch; return; fi
 
   case "${ELECTRON_DISABLE_SANDBOX:-}" in 1|true|TRUE|True) GATE=relaunch; return ;; esac
   [ "$SANDBOX_FALLBACK" -eq 1 ] && { GATE=relaunch; return; }

--- a/tests/hermes_cli/test_linux_sandbox_fixup.py
+++ b/tests/hermes_cli/test_linux_sandbox_fixup.py
@@ -1,0 +1,116 @@
+"""Tests for the Linux desktop sandbox-helper fixup and the userns probe.
+
+``_desktop_linux_sandbox_fixup`` historically demanded a root-owned 4755
+``chrome-sandbox`` on every Linux host and shelled out to ``sudo`` to get it
+— which fails silently when the desktop entry launches ``hermes desktop``
+without a TTY (#88032, #51327), and blocked the updater's relaunch gate
+(#58593). On hosts where unprivileged user namespaces work, Chromium uses
+its namespace sandbox and never consults the setuid helper, so the fixup now
+probes for that capability first and skips the sudo path entirely.
+"""
+
+from __future__ import annotations
+
+import stat
+import subprocess
+import sys
+from unittest.mock import patch
+
+from hermes_cli import main as cli_main
+
+
+class TestDesktopLinuxUsernsSandboxAvailable:
+    def test_false_on_non_linux(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "darwin")
+        assert cli_main._desktop_linux_userns_sandbox_available() is False
+
+    def test_false_when_unshare_is_missing(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        with patch.object(cli_main.shutil, "which", return_value=None):
+            assert cli_main._desktop_linux_userns_sandbox_available() is False
+
+    def test_true_when_probe_succeeds(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        with patch.object(cli_main.shutil, "which", return_value="/usr/bin/unshare"), \
+             patch.object(cli_main.subprocess, "run") as run:
+            run.return_value.returncode = 0
+            assert cli_main._desktop_linux_userns_sandbox_available() is True
+        probe = run.call_args.args[0]
+        assert probe[0] == "/usr/bin/unshare"
+        assert "--user" in probe
+
+    def test_false_when_probe_fails(self, monkeypatch):
+        """EPERM from the kernel (userns disabled or AppArmor-restricted)."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        with patch.object(cli_main.shutil, "which", return_value="/usr/bin/unshare"), \
+             patch.object(cli_main.subprocess, "run") as run:
+            run.return_value.returncode = 1
+            assert cli_main._desktop_linux_userns_sandbox_available() is False
+
+    def test_false_when_probe_raises(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        with patch.object(cli_main.shutil, "which", return_value="/usr/bin/unshare"), \
+             patch.object(
+                 cli_main.subprocess,
+                 "run",
+                 side_effect=subprocess.TimeoutExpired(cmd="unshare", timeout=5),
+             ):
+            assert cli_main._desktop_linux_userns_sandbox_available() is False
+
+
+class TestDesktopLinuxSandboxFixup:
+    def _fake_packaged_app(self, tmp_path):
+        """Unpacked-app layout with a non-root, non-setuid chrome-sandbox."""
+        unpacked = tmp_path / "linux-unpacked"
+        unpacked.mkdir()
+        exe = unpacked / "Hermes"
+        exe.write_text("", encoding="utf-8")
+        sandbox = unpacked / "chrome-sandbox"
+        sandbox.write_text("", encoding="utf-8")
+        sandbox.chmod(0o755)
+        return exe
+
+    def test_userns_host_skips_sudo_and_succeeds(self, monkeypatch, tmp_path):
+        """A user-owned helper must not trigger sudo when userns works.
+
+        This is the .desktop-launch regression: no TTY means sudo cannot
+        prompt, so reaching the sudo path at all kills the launch.
+        """
+        monkeypatch.setattr(sys, "platform", "linux")
+        exe = self._fake_packaged_app(tmp_path)
+        with patch.object(
+                 cli_main, "_desktop_linux_userns_sandbox_available", return_value=True
+             ), \
+             patch.object(cli_main.subprocess, "run") as run:
+            assert cli_main._desktop_linux_sandbox_fixup(exe) is True
+        run.assert_not_called()
+
+    def test_restricted_host_without_sudo_still_fails(self, monkeypatch, tmp_path):
+        """The pre-existing strict path is preserved when userns is unusable."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        exe = self._fake_packaged_app(tmp_path)
+        with patch.object(
+                 cli_main, "_desktop_linux_userns_sandbox_available", return_value=False
+             ), \
+             patch.object(cli_main.shutil, "which", return_value=None):
+            assert cli_main._desktop_linux_sandbox_fixup(exe) is False
+
+    def test_root_owned_setuid_helper_short_circuits(self, monkeypatch, tmp_path):
+        """A correctly configured helper wins before the userns probe runs."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        exe = self._fake_packaged_app(tmp_path)
+        real_lstat = (exe.parent / "chrome-sandbox").lstat()
+
+        class _RootSetuidStat:
+            st_mode = stat.S_IFREG | 0o4755
+            st_uid = 0
+
+            def __getattr__(self, name):
+                return getattr(real_lstat, name)
+
+        with patch.object(cli_main.Path, "lstat", return_value=_RootSetuidStat()), \
+             patch.object(
+                 cli_main, "_desktop_linux_userns_sandbox_available"
+             ) as probe:
+            assert cli_main._desktop_linux_sandbox_fixup(exe) is True
+        probe.assert_not_called()


### PR DESCRIPTION
## What & why

On Linux, `hermes desktop` refuses to launch unless `chrome-sandbox` in the unpacked Electron app is root-owned with mode 4755, and shells out to `sudo chown/chmod` to make it so. Two failure modes follow:

1. **Silent death from the `.desktop` entry** (#88032, #51327): a desktop-icon launch has no TTY, so `sudo` cannot prompt, the fixup fails, and the launcher exits without ever showing a window or an error.
2. **Every update re-breaks the app** (#58593): each rebuild recreates `chrome-sandbox` owned by the user, and the update hand-off's `linux_gate` in `scripts/desktop-update/posix.sh` then refuses to auto-relaunch ("its sandbox helper needs root ownership"), so the app stays dead until the user runs something from a terminal.

The setuid helper is only Chromium's **fallback** sandbox: on hosts where unprivileged user namespaces work (default Arch, Fedora, most non-hardened distros), Chromium uses the namespace sandbox and never consults `chrome-sandbox`. Requiring root ownership there demands a privilege Chromium won't use — and `posix.sh` already acknowledges this for the *absent*-helper case ("chrome-sandbox ABSENT is fine (namespace-sandbox build; nothing to block on)"); this PR makes the *present-but-user-owned* case consistent with that.

## How

- New `_desktop_linux_userns_sandbox_available()` in `hermes_cli/main.py`: probes the real capability with `unshare --user --map-root-user true` (5s timeout, fails closed on any error, missing binary, or non-Linux).
- `_desktop_linux_sandbox_fixup()` returns success **before the sudo path** when the probe passes. An already root-owned 4755 helper still short-circuits first, and restricted hosts (userns disabled, or Ubuntu 23.10+ AppArmor `apparmor_restrict_unprivileged_userns=1` — where the probe fails with EPERM) keep the existing sudo → `--no-sandbox`-fallback behavior unchanged.
- `linux_gate()` in `scripts/desktop-update/posix.sh` gets the same probe, so the post-update auto-relaunch fires on userns-capable hosts.

Sandboxing stays fully enabled in both regimes; this never adds `--no-sandbox`.

## How to test

Repro (Arch or any userns-enabled distro): run a Hermes update or `chown $USER apps/desktop/release/linux-unpacked/chrome-sandbox`, then launch Hermes from the desktop entry. Before: nothing opens (launcher exits after the silent sudo failure). After: launcher prints `✓ Using Chromium's user-namespace sandbox (setuid helper not needed).` and the app starts; `hermes update` auto-relaunches the app instead of ending with "Reopen Hermes to finish".

- `pytest tests/hermes_cli/test_linux_sandbox_fixup.py -v` — 8 new tests covering the probe (success/failure/missing-unshare/exception/non-Linux) and the fixup (skips sudo on userns hosts, preserves the strict path on restricted hosts, root-owned helper still short-circuits).
- `pytest tests/hermes_cli/test_gui_command.py tests/hermes_cli/test_relaunch.py tests/hermes_cli/test_linux_desktop_entry.py` — 50 passed, 11 skipped, no regressions.
- Manually verified end-to-end on the affected setup (below): with a user-owned `chrome-sandbox`, `hermes desktop` now launches with no sudo prompt, window maps, zygote processes run under the namespace sandbox.

## Platforms tested

Arch Linux (kernel 7.1.8-arch1-3, Hyprland/Wayland), `kernel.unprivileged_userns_clone=1`, Hermes v0.20.4 checkout. Ubuntu-AppArmor and userns-disabled paths are covered by unit tests (probe fails closed → behavior identical to before this change).

Fixes #88032
Fixes #51327
Fixes #58593
