### PR TITLE
fix(cli): suppress spurious 'Unknown toolsets' warning for plugin toolsets validated before registration

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5071,8 +5071,23 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # Validate each toolset — MCP server names are resolved via
             # live registry aliases (registered during discover_mcp_tools),
             # but discovery hasn't run yet at this point, so exclude them.
+            # Same for plugin toolsets (e.g. "a2a", "spotify"): they're
+            # registered at plugin load time, which happens after this
+            # constructor runs, so "a2a" would otherwise be reported as
+            # unknown even though it loads fine moments later.
             mcp_names = set((CLI_CONFIG.get("mcp_servers") or {}).keys())
-            invalid = [t for t in toolsets if not validate_toolset(t) and t not in mcp_names]
+            plugin_ts_names = {
+                name
+                for names in (CLI_CONFIG.get("known_plugin_toolsets") or {}).values()
+                for name in (names or [])
+            }
+            invalid = [
+                t
+                for t in toolsets
+                if not validate_toolset(t)
+                and t not in mcp_names
+                and t not in plugin_ts_names
+            ]
             if invalid:
                 self._console_print(f"[bold red]Warning: Unknown toolsets: {', '.join(invalid)}[/]")
         


### PR DESCRIPTION
## Summary

`cli.py` prints a spurious `Warning: Unknown toolsets: a2a` (and `spotify`) on startup even though those plugin toolsets load and work correctly moments later.

## Root cause

The `HermesCLI` constructor validates the enabled-toolset list via `validate_toolset()` **before** plugin toolset registration runs. Plugin toolsets like `a2a` / `spotify` are registered at plugin load time (after this constructor), so they look unknown at this early point.

The existing code already excludes MCP server names from the check for exactly this reason (MCP names resolve later during discovery). Plugin toolsets are the same class of "resolves later" name, but weren't excluded.

## Fix

Mirror the MCP-name exclusion: also skip toolset names recorded in config's `known_plugin_toolsets` (a platform → list-of-names map written by the `hermes tools` save flow — see `hermes_cli/tools_config.py`).

```python
mcp_names = set((CLI_CONFIG.get("mcp_servers") or {}).keys())
plugin_ts_names = {
    name
    for names in (CLI_CONFIG.get("known_plugin_toolsets") or {}).values()
    for name in (names or [])
}
invalid = [
    t
    for t in toolsets
    if not validate_toolset(t)
    and t not in mcp_names
    and t not in plugin_ts_names
]
```

## Verification

- `python3 -c "import ast; ast.parse(open('cli.py').read())"` → clean.
- Confirmed `a2a` is present in `known_plugin_toolsets` on a live config, so the warning is suppressed.
- Confirmed the toolset is genuinely functional (not a masking of a real error): `✓ a2a connected` in gateway.log and the `a2a_*` tools present in the session catalog.

## Notes

- This is a source fix; it does not survive `hermes update` (by design — it's an upstream change).
- Related to #89199 (same startup-ordering bug class, different symptom).
