### PR TITLE
fix(desktop): read input value before setState updater in MCP catalog env form

### DIFF
--- a/apps/desktop/src/app/skills/mcp-tab.tsx
+++ b/apps/desktop/src/app/skills/mcp-tab.tsx
@@ -1660,12 +1660,16 @@ function McpCatalog({
                         </span>
                         <Input
                           className="h-7 text-xs"
-                          onChange={event =>
+                          onChange={event => {
+                            // Read synchronously: currentTarget is null once the
+                            // updater runs after event dispatch.
+                            const value = event.currentTarget.value
+
                             setEnvDrafts(prev => ({
                               ...prev,
-                              [entry.name]: { ...prev[entry.name], [env.name]: event.currentTarget.value }
+                              [entry.name]: { ...prev[entry.name], [env.name]: value }
                             }))
-                          }
+                          }}
                           type="password"
                           value={draft[env.name] ?? ''}
                         />


### PR DESCRIPTION
## What does this PR do?

Fixes a 100%-reproducible crash of the workspace pane when typing into an MCP catalog entry's env input (currently only the n8n entry exposes such fields — "n8n instance URL" / "n8n API key"). Every keystroke threw `Cannot read properties of null (reading 'value')` and the ContribBoundary replaced the pane with "workspace" failed to render.

The onChange handler read `event.currentTarget.value` inside the `setEnvDrafts` updater. React runs state updaters after event dispatch has finished, and `currentTarget` is only defined during dispatch — so the updater dereferences null. The fix reads the value synchronously in the handler and passes it into the updater.

## Related Issue

Fixes #89352

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/skills/mcp-tab.tsx`: hoist `event.currentTarget.value` out of the `setEnvDrafts` updater in the catalog env input's onChange.

## How to Test

1. Capabilities → MCP → Catalog, expand the n8n entry
2. Type into "n8n instance URL"
3. Before: pane crashes on the first keystroke; after: text appears normally and install proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)