### PR TITLE
Capabilities view now configures the selected profile on its own gateway (Desktop + Bot Mode)

### DIFF
--- a/apps/desktop/src/app/hooks/use-config-record.ts
+++ b/apps/desktop/src/app/hooks/use-config-record.ts
@@ -1,8 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 
-import { getHermesConfigRecord } from '@/hermes'
+import { getHermesConfigRecord, type ProfileScope, profileScopeKey } from '@/hermes'
 import { queryClient, writeCache } from '@/lib/query-client'
-import { normalizeProfileKey } from '@/store/profile'
 import type { HermesConfigRecord } from '@/types/hermes'
 
 // One shared cache for the whole profile config record (`GET /api/config`).
@@ -14,22 +13,25 @@ import type { HermesConfigRecord } from '@/types/hermes'
 // it pushes personality/cwd/voice/… into the session stores for live chat.
 export const HERMES_CONFIG_KEY = ['hermes-config-record'] as const
 
-// Per-profile cache key. The base key (no profile suffix) is the app-wide
-// active profile, unchanged for every caller that passes nothing. An explicit
-// profile — the Capabilities profile-scope selector configuring ANOTHER
-// profile — gets its own suffixed key so switching the selector refetches and
-// never paints stale cross-profile config (the AGENTS.md scope-in-key rule).
-export const hermesConfigKey = (profile?: null | string) =>
-  profile == null ? HERMES_CONFIG_KEY : ([...HERMES_CONFIG_KEY, normalizeProfileKey(profile)] as const)
+// Per-scope cache key. The base key (no suffix) is the app-wide active
+// profile, unchanged for every caller that passes nothing. An explicit scope —
+// the Capabilities scope selector configuring ANOTHER profile, possibly on
+// another registered gateway — gets its own suffixed key so switching the
+// selector refetches and never paints stale cross-profile config (the
+// AGENTS.md scope-in-key rule). profileScopeKey folds a remote pin's
+// connection id into the suffix, so two gateways' same-named profiles never
+// share a cache row.
+export const hermesConfigKey = (profile?: ProfileScope) =>
+  profile == null ? HERMES_CONFIG_KEY : ([...HERMES_CONFIG_KEY, profileScopeKey(profile)] as const)
 
 // staleTime 0 → serve cache instantly, background-revalidate on every mount.
 // `profile` scopes both the query key and the fetch; omitting it preserves the
 // exact app-wide behavior (base key, `profileScoped(undefined)` fallback).
-export const useHermesConfigRecord = (profile?: null | string) =>
+export const useHermesConfigRecord = (profile?: ProfileScope) =>
   useQuery({
     queryKey: hermesConfigKey(profile),
     // null/undefined both mean "no override" → fetch with undefined so
-    // profileScoped falls back to the app-wide active profile (passing null
+    // capabilityScoped falls back to the app-wide active profile (passing null
     // would wrongly target the primary backend).
     queryFn: () => getHermesConfigRecord(profile ?? undefined),
     staleTime: 0
@@ -39,8 +41,8 @@ export const useHermesConfigRecord = (profile?: null | string) =>
 // write the suffixed per-profile cache instead — keeps the selector's optimistic
 // write-through landing on the same key its query reads.
 export const setHermesConfigCache = writeCache<HermesConfigRecord>(HERMES_CONFIG_KEY)
-export const hermesConfigCacheWriter = (profile?: null | string) =>
+export const hermesConfigCacheWriter = (profile?: ProfileScope) =>
   writeCache<HermesConfigRecord>(hermesConfigKey(profile))
 
-export const invalidateHermesConfig = (profile?: null | string) =>
+export const invalidateHermesConfig = (profile?: ProfileScope) =>
   queryClient.invalidateQueries({ queryKey: hermesConfigKey(profile) })

--- a/apps/desktop/src/app/learning/archive-skill-confirm-dialog.tsx
+++ b/apps/desktop/src/app/learning/archive-skill-confirm-dialog.tsx
@@ -1,5 +1,5 @@
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
-import { deleteLearningNode } from '@/hermes'
+import { deleteLearningNode, type ProfileScope } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
 import { notify } from '@/store/notifications'
 
@@ -9,7 +9,7 @@ export function notifySkillArchived(t: Translations): void {
   notify({ kind: 'success', message: t.skills.skillArchivedMessage, title: t.skills.skillArchivedTitle })
 }
 
-export async function archiveLearningSkill(id: string, profile?: null | string): Promise<void> {
+export async function archiveLearningSkill(id: string, profile?: ProfileScope): Promise<void> {
   const res = await deleteLearningNode(id, profile)
 
   if (!res.ok) {
@@ -34,7 +34,7 @@ interface ArchiveSkillConfirmDialogProps {
   open: boolean
   /** Capabilities profile-scope override — archive against THIS profile's
    *  backend; undefined/null keeps the app-wide active profile. */
-  profile?: null | string
+  profile?: ProfileScope
   skillId: string
   skillName: string
 }

--- a/apps/desktop/src/app/settings/toolset-config-panel.tsx
+++ b/apps/desktop/src/app/settings/toolset-config-panel.tsx
@@ -10,6 +10,7 @@ import {
   getToolsetConfig,
   getToolsetModels,
   pollOAuthSession,
+  type ProfileScope,
   revealEnvVar,
   runToolsetPostSetup,
   selectToolsetModel,
@@ -43,7 +44,7 @@ interface ToolsetConfigPanelProps {
   /** Capabilities profile-scope override: configure THIS profile instead of the
    *  app-wide active one. Omitted (every other caller) → app-wide active
    *  profile, so behavior is unchanged. Threaded into every fetch below. */
-  profile?: null | string
+  profile?: ProfileScope
 }
 
 /** Toolsets whose backends expose a selectable model catalog (mirrors the
@@ -101,7 +102,7 @@ interface EnvVarFieldProps {
   isSet: boolean
   onSaved: (key: string) => void
   onCleared: (key: string) => void
-  profile?: null | string
+  profile?: ProfileScope
 }
 
 function EnvVarField({ envVar, isSet, onSaved, onCleared, profile }: EnvVarFieldProps) {
@@ -249,7 +250,7 @@ interface PostSetupRunnerProps {
   /** Refresh the parent config after the install finishes (a backend may now
    *  report itself configured). */
   onComplete?: () => void
-  profile?: null | string
+  profile?: ProfileScope
 }
 
 /**
@@ -388,7 +389,7 @@ interface ModelCatalogPickerProps {
   /** True when this provider is the one written to config — selecting a model
    *  only makes sense for the active backend. */
   isActiveBackend: boolean
-  profile?: null | string
+  profile?: ProfileScope
 }
 
 /**

--- a/apps/desktop/src/app/skills/embedded-hub-picker.tsx
+++ b/apps/desktop/src/app/skills/embedded-hub-picker.tsx
@@ -2,6 +2,7 @@ import { useStore } from '@nanostores/react'
 import { memo, type PointerEvent as ReactPointerEvent, useEffect, useRef, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
+import type { ProfileScope } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { Loader2 } from '@/lib/icons'
 import { useStoreSelector } from '@/lib/use-session-slice'
@@ -53,7 +54,7 @@ interface EmbeddedHubPickerProps {
   installedNames: ReadonlySet<string>
   /** Capabilities profile-scope override — installs land in THIS profile;
    *  undefined/null targets the app-wide active profile. */
-  profile?: null | string
+  profile?: ProfileScope
 }
 
 /** The Skills Hub browser for the Skills tab: a resizable iframe of the live

--- a/apps/desktop/src/app/skills/index.test.tsx
+++ b/apps/desktop/src/app/skills/index.test.tsx
@@ -355,4 +355,63 @@ describe('SkillsView toolset management', () => {
     // consumed by ModelSettings' deep-link highlight. Never an external URL.
     await waitFor(() => expect(navigateSpy).toHaveBeenCalledWith('/settings?tab=config:model&aux=vision'))
   })
+
+  it('fixedConnection pins every read to the target connection', async () => {
+    // Bot Mode's remote-target door: a bot on another registered gateway gets
+    // the live surface pointed at ITS backend — the reads must carry the
+    // (connection, profile) pin, not a bare profile name that would resolve
+    // against the ACTIVE gateway (the wrong-machine bug).
+    const { SkillsView } = await import('./index')
+    await act(async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/skills']}>
+            <SkillsView embedded fixedConnection="homelab" fixedProfile="inbox-bot" />
+          </MemoryRouter>
+        </QueryClientProvider>
+      )
+    })
+
+    await waitFor(() => expect(getSkills).toHaveBeenCalled())
+    expect(getSkills.mock.calls[0][0]).toEqual({ connectionId: 'homelab', profile: 'inbox-bot' })
+    expect(getToolsets.mock.calls[0][0]).toEqual({ connectionId: 'homelab', profile: 'inbox-bot' })
+    // Pinned scope → no roster/profiles fetch, selector hidden.
+    expect(getProfiles).not.toHaveBeenCalled()
+  })
+
+  it('offers (connection, profile) scope rows on multi-connection desktops', async () => {
+    // With a v2 registry holding >1 connection, the scope selector lists the
+    // union agent roster — profile + owning device — instead of the local
+    // profiles list, so a selection identifies WHICH gateway's capabilities
+    // are being configured.
+    const connections = {
+      list: vi.fn().mockResolvedValue({
+        version: 2,
+        primary: 'local',
+        secureTokenStorage: true,
+        connections: [
+          { id: 'local', kind: 'local', label: 'This device', tokenSet: false, tokenPreview: null },
+          { id: 'homelab', kind: 'remote', label: 'Homelab', tokenSet: true, tokenPreview: '…' }
+        ]
+      })
+    }
+    const getAgentRoster = vi.fn().mockResolvedValue({
+      agents: [
+        { connectionId: 'local', connectionKind: 'local', connectionLabel: 'This device', profile: 'default', handle: 'default' },
+        { connectionId: 'homelab', connectionKind: 'remote', connectionLabel: 'Homelab', profile: 'inbox-bot', handle: 'inbox-bot-homelab' }
+      ],
+      sources: []
+    })
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = { connections, getAgentRoster }
+
+    try {
+      await renderSkills()
+
+      await waitFor(() => expect(getAgentRoster).toHaveBeenCalled())
+      // The selector paints roster rows labeled profile — device.
+      expect(await screen.findByText('default — This device (current)')).toBeTruthy()
+    } finally {
+      delete (window as { hermesDesktop?: unknown }).hermesDesktop
+    }
+  })
 })

--- a/apps/desktop/src/app/skills/index.tsx
+++ b/apps/desktop/src/app/skills/index.tsx
@@ -11,6 +11,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { CountSkeleton } from '@/components/ui/skeleton'
+import type { DesktopRosterAgent } from '@/global'
 import {
   editLearningNode,
   getLearningNode,
@@ -19,6 +20,8 @@ import {
   getSkills,
   getToolsets,
   getUsageAnalytics,
+  type ProfileScope,
+  profileScopeKey,
   setSkillEnabled,
   setToolsetEnabled
 } from '@/hermes'
@@ -29,7 +32,7 @@ import { queryClient } from '@/lib/query-client'
 import { invalidateSlashCompletions } from '@/lib/slash-completion-cache'
 import { normalize } from '@/lib/text'
 import { useStoreSelector } from '@/lib/use-session-slice'
-import { $gateway } from '@/store/gateway'
+import { $gateway, activeGatewayConnectionId } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import type { SkillInfo, ToolsetInfo } from '@/types/hermes'
@@ -87,7 +90,7 @@ const toolCallsCache = new Map<string, { at: number; value: Record<string, numbe
 
 async function loadToolCalls(
   scopeKey: string,
-  scopeProfile: null | string,
+  scopeProfile: ProfileScope,
   force = false
 ): Promise<Record<string, number>> {
   const cached = toolCallsCache.get(scopeKey)
@@ -191,10 +194,17 @@ interface SkillsViewProps extends React.ComponentProps<'section'> {
    *  every tab reads/writes THAT profile. This is the plugin door — Bot Mode
    *  renders the real Capabilities surface pinned to a bot. */
   fixedProfile?: string
+  /** Pin the view to a REGISTERED gateway connection alongside `fixedProfile`:
+   *  every read/write routes to that machine's backend instead of the active
+   *  gateway. `''`/`'local'` mean the local pool. This is Bot Mode's
+   *  remote-target door — a bot living on another registered gateway gets the
+   *  live surface pointed at ITS backend. Ignored without `fixedProfile`. */
+  fixedConnection?: string
 }
 
 export function SkillsView({
   embedded = false,
+  fixedConnection,
   fixedProfile,
   setStatusbarItemGroup: _setStatusbarItemGroup,
   ...props
@@ -222,15 +232,38 @@ export function SkillsView({
     setHubMounted(true)
   }
 
-  // Capabilities profile-scope selector: which profile's Tools/MCP config we're
-  // editing. Defaults to the app-wide active profile; overriding it here lets
-  // the user configure ANY profile's toolsets/MCP without switching the whole
-  // app into that profile. null = the active profile (unchanged behavior).
-  // A `fixedProfile` pins the scope outright (selector hidden).
+  // Capabilities scope selector: which profile's Skills/Tools/MCP config we're
+  // editing — and on WHICH gateway. A profile belongs to one gateway, so on a
+  // multi-connection desktop the selector offers every (connection, profile)
+  // pair from the union agent roster and an explicit pick routes every
+  // read/write to that machine's backend. Defaults to the app-wide active
+  // profile (unchanged behavior). A `fixedProfile` (+ optional
+  // `fixedConnection`) pins the scope outright (selector hidden).
   const activeProfile = useStore($activeGatewayProfile)
-  const [scopeOverride, setScopeOverride] = useState<null | string>(null)
-  const scopeProfile = fixedProfile ?? scopeOverride ?? activeProfile ?? null
-  const scopeKey = normalizeProfileKey(scopeProfile)
+  const [scopeOverride, setScopeOverride] = useState<null | string | { connectionId: string; profile: string }>(null)
+
+  const scopeProfile: ProfileScope = useMemo(
+    () =>
+      fixedProfile
+        ? fixedConnection
+          ? { connectionId: fixedConnection, profile: fixedProfile }
+          : fixedProfile
+        : (scopeOverride ?? activeProfile ?? null),
+    [activeProfile, fixedConnection, fixedProfile, scopeOverride]
+  )
+
+  const scopeKey = profileScopeKey(scopeProfile)
+
+  // The registry connection an explicit override pins — null for the ambient
+  // active-profile path and for fixed-profile pins without a connection.
+  const scopeConnectionId =
+    scopeProfile && typeof scopeProfile === 'object' ? ((scopeProfile.connectionId ?? '').trim() || 'local') : null
+
+  // Scoped to a DIFFERENT backend than the window's active gateway? The MCP
+  // tab's live-reload RPC rides the active gateway socket, which would reload
+  // the wrong machine — withhold it for cross-backend scopes.
+  const crossBackendScope =
+    scopeConnectionId !== null && scopeConnectionId !== (activeGatewayConnectionId() ?? 'local')
 
   const { data: profilesData } = useQuery({
     queryKey: ['capabilities-profiles'],
@@ -241,6 +274,29 @@ export function SkillsView({
   })
 
   const profiles = profilesData?.profiles ?? []
+
+  // v2 multi-connection registry: cheap local IPC to learn whether more than
+  // one gateway is registered. Only then is the (heavier) union agent roster
+  // fetched to feed the selector — single-connection setups keep the exact
+  // legacy profiles list. Both feature-detected for older Electron mains.
+  const registryBridge = window.hermesDesktop?.connections
+  const rosterBridge = window.hermesDesktop?.getAgentRoster
+
+  const { data: registryData } = useQuery({
+    queryKey: ['capabilities-connections-registry'],
+    queryFn: () => registryBridge!.list(),
+    staleTime: 60_000,
+    enabled: !fixedProfile && Boolean(registryBridge) && Boolean(rosterBridge)
+  })
+
+  const multiConnection = (registryData?.connections.length ?? 0) > 1
+
+  const { data: rosterData } = useQuery({
+    queryKey: ['capabilities-agent-roster'],
+    queryFn: () => rosterBridge!(),
+    staleTime: 60_000,
+    enabled: !fixedProfile && multiConnection
+  })
 
   const {
     data: skills,
@@ -621,12 +677,24 @@ export function SkillsView({
   // scope's skill (a save/archive would hit the new one). Reset both here —
   // this handler is the only way the scope changes besides an app profile
   // switch, which useOnProfileSwitch already covers.
+  //
+  // Selector option values are `connectionId::profile` on multi-connection
+  // desktops (the roster path) and bare profile names otherwise, so one
+  // handler decodes both.
   const changeScope = (value: string) => {
-    if (value === (scopeProfile ?? '')) {
+    const sep = value.indexOf('::')
+
+    // Roster picks (`connectionId::profile`) stay objects — a `local::` pick
+    // must PIN the local pool even while a remote gateway is active. Legacy
+    // bare-name picks stay strings so cache keys and routing are unchanged.
+    const next: ProfileScope =
+      sep >= 0 ? { connectionId: value.slice(0, sep), profile: value.slice(sep + 2) } : value
+
+    if (profileScopeKey(next) === scopeKey) {
       return
     }
 
-    setScopeOverride(value)
+    setScopeOverride(next as string | { connectionId: string; profile: string })
     toolCallsEpoch.current += 1
     setToolCalls(null)
     skillEditorEpoch.current += 1
@@ -635,22 +703,61 @@ export function SkillsView({
     setArchiveTarget(null)
   }
 
-  // Profile-scope selector, shown above EVERY Capabilities tab (Skills, Tools,
-  // MCP, Browse Hub). Lets the user configure ANY profile's capabilities
-  // without switching the whole app. Only meaningful with >1 profile; hidden
-  // otherwise to avoid clutter.
+  // Scope-selector rows. Multi-connection desktops list every reachable
+  // (connection, profile) agent from the union roster — the selected profile
+  // is configured ON ITS OWN GATEWAY. Otherwise the legacy per-profile list.
+  const scopeOptions: { key: string; label: string; value: string }[] = useMemo(() => {
+    if (multiConnection && rosterData?.agents?.length) {
+      const activeId = activeGatewayConnectionId() ?? 'local'
+
+      return rosterData.agents.map((agent: DesktopRosterAgent) => ({
+        key: `${agent.connectionId}::${agent.profile}`,
+        label:
+          agent.connectionId === activeId
+            ? `${agent.profile} — ${agent.connectionLabel} (current)`
+            : `${agent.profile} — ${agent.connectionLabel}`,
+        value: `${agent.connectionId}::${agent.profile}`
+      }))
+    }
+
+    return (profilesData?.profiles ?? []).map(p => ({
+      key: p.name,
+      label: p.is_default ? 'Hermes (default)' : p.name,
+      value: p.name
+    }))
+  }, [multiConnection, profilesData, rosterData])
+
+  // The selector's current value must match one option's value exactly. On the
+  // roster path an ambient (non-override) scope is the active gateway's
+  // profile, which lives at `activeConnectionId::profile`.
+  const scopeSelectValue = useMemo(() => {
+    if (scopeProfile && typeof scopeProfile === 'object') {
+      return `${(scopeProfile.connectionId ?? '').trim() || 'local'}::${scopeProfile.profile ?? ''}`
+    }
+
+    if (multiConnection && rosterData?.agents?.length) {
+      return `${activeGatewayConnectionId() ?? 'local'}::${normalizeProfileKey(scopeProfile)}`
+    }
+
+    return scopeProfile ?? ''
+  }, [multiConnection, rosterData, scopeProfile])
+
+  // Scope selector, shown above EVERY Capabilities tab (Skills, Tools, MCP,
+  // Browse Hub). Lets the user configure ANY profile's capabilities — on any
+  // registered gateway — without switching the whole app. Only meaningful
+  // with >1 option; hidden otherwise to avoid clutter.
   const profileScopeSelector =
-    profiles.length > 1 ? (
+    scopeOptions.length > 1 ? (
       <div className="flex items-center gap-2 border-b border-(--ui-stroke-secondary) px-3 py-2">
         <span className="text-[0.7rem] font-medium text-(--ui-text-tertiary)">{t.skills.configuringProfile}</span>
-        <Select onValueChange={changeScope} value={scopeProfile ?? ''}>
+        <Select onValueChange={changeScope} value={scopeSelectValue}>
           <SelectTrigger className="h-7 w-56 text-xs">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {profiles.map(p => (
-              <SelectItem key={p.name} value={p.name}>
-                {p.is_default ? 'Hermes (default)' : p.name}
+            {scopeOptions.map(option => (
+              <SelectItem key={option.key} value={option.value}>
+                {option.label}
               </SelectItem>
             ))}
           </SelectContent>
@@ -684,7 +791,12 @@ export function SkillsView({
         <div className="flex min-h-0 flex-1 flex-col">
           <div className={mode === 'skills' ? 'min-h-40 flex-1 overflow-hidden' : 'min-h-0 flex-1'}>
             {mode === 'mcp' ? (
-              <McpTab gateway={gateway} key={`mcp-${scopeKey}`} profile={scopeProfile} />
+              // The gateway instance backs ONLY the live `reload.mcp` RPC, and
+              // it is the ACTIVE gateway's socket — for a scope pinned to a
+              // different backend that RPC would hot-reload the wrong
+              // machine's MCP servers, so it is withheld (config edits still
+              // apply on that backend's next session).
+              <McpTab gateway={crossBackendScope ? null : gateway} key={`mcp-${scopeKey}`} profile={scopeProfile} />
             ) : (skillsFailed || toolsetsFailed) && (!skills || !toolsets) ? (
               <PanelEmpty
                 action={
@@ -847,6 +959,14 @@ export function SkillsView({
   )
 }
 
+// Feature-detection flag for plugins (Bot Mode): TRUE means this build's
+// SkillsView routes `fixedConnection` to the pinned connection's backend.
+// Older builds export SkillsView WITHOUT the prop — passing it there would
+// silently read/write the ACTIVE gateway under the remote bot's profile name,
+// which is exactly the wrong-machine bug the prop exists to prevent. A static
+// property is probe-able without rendering.
+SkillsView.supportsFixedConnection = true as const
+
 // Shared inspector header — mirrors Messaging's PlatformDetail so Skills and
 // Tools share one title/description block and tab switches don't jump.
 function DetailHeader({
@@ -919,7 +1039,7 @@ function SkillDetail({
 }: {
   onArchive: () => void
   onEdit: () => void
-  profile?: null | string
+  profile?: ProfileScope
   skill: SkillInfo
 }) {
   const { t } = useI18n()
@@ -931,7 +1051,7 @@ function SkillDetail({
   // provenance, scoped to the Capabilities profile selector. The row list only
   // carries name/description; the pane shows the whole thing.
   const contentQuery = useQuery({
-    queryKey: ['skill-content', skill.name, normalizeProfileKey(profile)],
+    queryKey: ['skill-content', skill.name, profileScopeKey(profile)],
     queryFn: () => getSkillContent(skill.name, profile),
     staleTime: 60_000
   })
@@ -1000,7 +1120,7 @@ function ToolsetDetail({
   toolset: ToolsetInfo
   toolCalls: Record<string, number>
   onConfiguredChange: () => void
-  profile?: null | string
+  profile?: ProfileScope
 }) {
   const { t } = useI18n()
   const navigate = useNavigate()
@@ -1050,7 +1170,7 @@ function ToolsetDetail({
       {toolset.name === 'computer_use' && <ComputerUsePanel onConfiguredChange={onConfiguredChange} />}
       {toolset.name === 'terminal' && <TerminalBackendPanel onConfiguredChange={onConfiguredChange} />}
       <ToolsetConfigPanel
-        key={`${toolset.name}:${normalizeProfileKey(profile)}`}
+        key={`${toolset.name}:${profileScopeKey(profile)}`}
         onConfiguredChange={onConfiguredChange}
         profile={profile}
         toolset={toolset.name}

--- a/apps/desktop/src/app/skills/mcp-tab.tsx
+++ b/apps/desktop/src/app/skills/mcp-tab.tsx
@@ -26,6 +26,8 @@ import {
   installMcpCatalogEntry,
   type McpCatalogEntry,
   type McpTestResult,
+  type ProfileScope,
+  profileScopeKey,
   saveMcpServers,
   testMcpServer
 } from '@/hermes'
@@ -130,7 +132,7 @@ interface ServerCost {
 const MCP_USAGE_TTL_MS = 10 * 60_000
 const mcpUsageCache = new Map<string, { at: number; value: Record<string, number> }>()
 
-async function loadMcpUsage(scopeKey: string, scopeProfile: null | string): Promise<null | Record<string, number>> {
+async function loadMcpUsage(scopeKey: string, scopeProfile: ProfileScope): Promise<null | Record<string, number>> {
   const cached = mcpUsageCache.get(scopeKey)
 
   if (cached && Date.now() - cached.at < MCP_USAGE_TTL_MS) {
@@ -367,7 +369,7 @@ function scanServerBlocks(text: string): ServerBlock[] {
   return blocks
 }
 
-export function McpTab({ gateway, profile }: { gateway: HermesGateway | null; profile?: null | string }) {
+export function McpTab({ gateway, profile }: { gateway: HermesGateway | null; profile?: ProfileScope }) {
   const { t } = useI18n()
   const m = t.settings.mcp
   const activeSessionId = useStore($activeSessionId)
@@ -379,7 +381,7 @@ export function McpTab({ gateway, profile }: { gateway: HermesGateway | null; pr
   // profile's servers (AGENTS.md scope-in-key). When no override is passed this
   // resolves to $activeGatewayProfile, so behavior is identical to before.
   const appProfile = useStore($activeGatewayProfile)
-  const scopeProfileKey = normalizeProfileKey(profile ?? appProfile)
+  const scopeProfileKey = profile != null ? profileScopeKey(profile) : normalizeProfileKey(appProfile)
 
   // Shared config cache (see use-config-record): revisiting the tab paints the
   // cached record instantly; mutations write through `setConfig` and stay
@@ -1551,7 +1553,7 @@ function McpCatalog({
   entries: McpCatalogEntry[]
   loading: boolean
   onInstalled: () => void
-  profile?: null | string
+  profile?: ProfileScope
 }) {
   const { t } = useI18n()
   const m = t.settings.mcp

--- a/apps/desktop/src/hermes-capability-scope.test.ts
+++ b/apps/desktop/src/hermes-capability-scope.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  getHermesConfigRecord,
+  getMcpCatalog,
+  getSkillContent,
+  getSkills,
+  getToolsets,
+  getUsageAnalytics,
+  installSkillFromHub,
+  profileScopeKey,
+  saveMcpServers,
+  setApiRequestConnection,
+  setApiRequestProfile,
+  setSkillEnabled,
+  setToolsetEnabled
+} from './hermes'
+
+// Contract: the Capabilities surface (skills / toolsets / MCP / hub / config)
+// can be scoped to a (connection, profile) pair — a profile belongs to ONE
+// gateway, so its skills/tools/MCP must be read from and written to THAT
+// machine's backend. Three shapes:
+//   - no scope         → ambient profile + ambient registry connection tag
+//   - string scope     → explicit profile, ambient connection tag
+//   - object scope     → explicit (connection, profile) pin; 'local' pins the
+//                        local pool and DROPS the ambient connection tag
+describe('capability helpers are connection-scoped', () => {
+  const api = vi.fn(async (_req: { connectionId?: string; path: string; profile?: string }) => ({}) as never)
+
+  beforeEach(() => {
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = { api }
+    api.mockClear()
+  })
+
+  afterEach(() => {
+    setApiRequestProfile(null)
+    setApiRequestConnection(null)
+    delete (window as { hermesDesktop?: unknown }).hermesDesktop
+  })
+
+  const last = () => api.mock.calls.at(-1)?.[0] as { connectionId?: string; profile?: string }
+
+  it('omits both scopes when none are active (single-source users unaffected)', () => {
+    void getSkills()
+    expect(last()).not.toHaveProperty('profile')
+    expect(last()).not.toHaveProperty('connectionId')
+  })
+
+  it('carries the ambient registry connection on the legacy string/ambient path', () => {
+    // A window activated onto a registered remote gateway must read THAT
+    // machine's skills — not the local pool's (the ambient-tag half).
+    setApiRequestProfile('research')
+    setApiRequestConnection('gw-tailscale')
+
+    void getSkills()
+    void getToolsets()
+    void getHermesConfigRecord()
+    void getMcpCatalog()
+    void getUsageAnalytics(30)
+
+    for (const call of api.mock.calls) {
+      expect((call[0] as { connectionId?: string }).connectionId).toBe('gw-tailscale')
+      expect(call[0].profile).toBe('research')
+    }
+  })
+
+  it('string scopes override the profile but keep the ambient connection', () => {
+    setApiRequestProfile('research')
+    setApiRequestConnection('gw-tailscale')
+
+    void getSkills('coder')
+
+    expect(last().profile).toBe('coder')
+    expect(last().connectionId).toBe('gw-tailscale')
+  })
+
+  it('object scopes pin every read and write to the named connection', () => {
+    void getSkills({ connectionId: 'homelab', profile: 'inbox-bot' })
+    void getToolsets({ connectionId: 'homelab', profile: 'inbox-bot' })
+    void getSkillContent('arxiv', { connectionId: 'homelab', profile: 'inbox-bot' })
+    void setSkillEnabled('arxiv', false, { connectionId: 'homelab', profile: 'inbox-bot' })
+    void setToolsetEnabled('browser', true, { connectionId: 'homelab', profile: 'inbox-bot' })
+    void saveMcpServers({}, { connectionId: 'homelab', profile: 'inbox-bot' })
+    void installSkillFromHub('official/research/arxiv', { connectionId: 'homelab', profile: 'inbox-bot' })
+
+    for (const call of api.mock.calls) {
+      expect((call[0] as { connectionId?: string }).connectionId).toBe('homelab')
+      expect(call[0].profile).toBe('inbox-bot')
+    }
+  })
+
+  it("a 'local' pin routes to the local pool even while a remote gateway is active", () => {
+    setApiRequestProfile('research')
+    setApiRequestConnection('gw-tailscale')
+
+    void getSkills({ connectionId: 'local', profile: 'coder' })
+
+    expect(last().profile).toBe('coder')
+    expect(last()).not.toHaveProperty('connectionId')
+  })
+
+  it('profileScopeKey keeps legacy keys byte-identical and namespaces remote pins', () => {
+    expect(profileScopeKey()).toBe('default')
+    expect(profileScopeKey(null)).toBe('default')
+    expect(profileScopeKey('coder')).toBe('coder')
+    expect(profileScopeKey({ connectionId: 'local', profile: 'coder' })).toBe('coder')
+    expect(profileScopeKey({ connectionId: 'homelab', profile: 'coder' })).toBe('homelab::coder')
+    expect(profileScopeKey({ connectionId: 'homelab' })).toBe('homelab::default')
+  })
+})

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -294,6 +294,53 @@ function connectionScoped(): { connectionId?: string } {
   return _apiConnectionId ? { connectionId: _apiConnectionId } : {}
 }
 
+// ── Capability scope: (connection, profile) routing for the Capabilities
+// surface (skills / toolsets / MCP / hub / env / toolset config) ────────────
+//
+// A profile is not a machine-global name — it belongs to ONE gateway. The
+// Capabilities surface can be pointed at any (connection, profile) pair
+// (SkillsView's scope selector, Bot Mode's fixedProfile/fixedConnection), so
+// its REST helpers accept either the legacy string form or an explicit scope
+// object:
+//
+//   - `undefined` / string → the legacy profile path, PLUS the active registry
+//     connection tag (connectionScoped, same contract the cron helpers adopted
+//     in #87882). Without the tag, a window activated onto a registered remote
+//     gateway read the LOCAL pool's skills/tools/MCP — the wrong machine.
+//   - `{ connectionId, profile }` → explicit pin. `''`/`'local'` connection
+//     ids mean the local pool and deliberately DROP the ambient connection
+//     tag, so a local-profile pick made while a remote gateway is active still
+//     routes to the local machine.
+export type ProfileScope = null | string | { connectionId?: null | string; profile?: null | string }
+
+function capabilityScoped(scope?: ProfileScope): { connectionId?: string; profile?: string } {
+  if (scope && typeof scope === 'object') {
+    const profile = (scope.profile ?? '').trim()
+    const connectionId = (scope.connectionId ?? '').trim()
+
+    return {
+      ...(profile ? { profile } : {}),
+      ...(connectionId && connectionId !== 'local' ? { connectionId } : {})
+    }
+  }
+
+  return { ...profileScoped(scope), ...connectionScoped() }
+}
+
+/** Stable cache-key for a capability scope: `profile` for the local/legacy
+ *  path, `connectionId::profile` for an explicit remote pin. Mirrors
+ *  normalizeProfileKey for plain strings so existing keys stay byte-identical. */
+export function profileScopeKey(scope?: ProfileScope): string {
+  if (scope && typeof scope === 'object') {
+    const profile = (scope.profile ?? '').trim() || 'default'
+    const connectionId = (scope.connectionId ?? '').trim()
+
+    return connectionId && connectionId !== 'local' ? `${connectionId}::${profile}` : profile
+  }
+
+  return (scope ?? '').trim() || 'default'
+}
+
 /** Registry connection id that connection-scoped WS calls should target
  *  (null → the local pool). Read-only twin of setApiRequestConnection. */
 export function getApiRequestConnection(): null | string {
@@ -951,9 +998,9 @@ export function getHermesConfig(profile?: string): Promise<HermesConfig> {
   })
 }
 
-export function getHermesConfigRecord(profile?: null | string): Promise<HermesConfigRecord> {
+export function getHermesConfigRecord(profile?: ProfileScope): Promise<HermesConfigRecord> {
   return window.hermesDesktop.api<HermesConfigRecord>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: '/api/config'
   })
 }
@@ -1010,9 +1057,9 @@ export function getEnvVars(profile?: null | string): Promise<Record<string, EnvV
   })
 }
 
-export function setEnvVar(key: string, value: string, profile?: null | string): Promise<{ ok: boolean }> {
+export function setEnvVar(key: string, value: string, profile?: ProfileScope): Promise<{ ok: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean }>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: '/api/env',
     method: 'PUT',
     body: { key, value }
@@ -1072,18 +1119,18 @@ export function deleteCustomEndpoint(id: string): Promise<CustomEndpointsRespons
   })
 }
 
-export function deleteEnvVar(key: string, profile?: null | string): Promise<{ ok: boolean }> {
+export function deleteEnvVar(key: string, profile?: ProfileScope): Promise<{ ok: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean }>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: '/api/env',
     method: 'DELETE',
     body: { key }
   })
 }
 
-export function revealEnvVar(key: string, profile?: null | string): Promise<{ key: string; value: string }> {
+export function revealEnvVar(key: string, profile?: ProfileScope): Promise<{ key: string; value: string }> {
   return window.hermesDesktop.api<{ key: string; value: string }>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: '/api/env/reveal',
     method: 'POST',
     body: { key }
@@ -1105,9 +1152,9 @@ export function disconnectOAuthProvider(providerId: string): Promise<{ ok: boole
   })
 }
 
-export function startOAuthLogin(providerId: string, profile?: null | string): Promise<OAuthStartResponse> {
+export function startOAuthLogin(providerId: string, profile?: ProfileScope): Promise<OAuthStartResponse> {
   return window.hermesDesktop.api<OAuthStartResponse>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: `/api/providers/oauth/${encodeURIComponent(providerId)}/start`,
     method: 'POST',
     body: {}
@@ -1126,10 +1173,10 @@ export function submitOAuthCode(providerId: string, sessionId: string, code: str
 export function pollOAuthSession(
   providerId: string,
   sessionId: string,
-  profile?: null | string
+  profile?: ProfileScope
 ): Promise<OAuthPollResponse> {
   return window.hermesDesktop.api<OAuthPollResponse>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: `/api/providers/oauth/${encodeURIComponent(providerId)}/poll/${encodeURIComponent(sessionId)}`
   })
 }
@@ -1165,9 +1212,9 @@ export function getMemoryProviderOAuthStatus(
   })
 }
 
-export function getSkills(profile?: null | string): Promise<SkillInfo[]> {
+export function getSkills(profile?: ProfileScope): Promise<SkillInfo[]> {
   return window.hermesDesktop.api<SkillInfo[]>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: '/api/skills'
   })
 }
@@ -1176,10 +1223,10 @@ export function getSkills(profile?: null | string): Promise<SkillInfo[]> {
  *  learned — backing the Capabilities detail pane's full-skill view. */
 export function getSkillContent(
   name: string,
-  profile?: null | string
+  profile?: ProfileScope
 ): Promise<{ content: string; name: string; path: string }> {
   return window.hermesDesktop.api<{ content: string; name: string; path: string }>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: `/api/skills/content?name=${encodeURIComponent(name)}`
   })
 }
@@ -1200,16 +1247,16 @@ export interface LearningNodeDetail {
   ok: boolean
 }
 
-export function getLearningNode(id: string, profile?: null | string): Promise<LearningNodeDetail> {
+export function getLearningNode(id: string, profile?: ProfileScope): Promise<LearningNodeDetail> {
   return window.hermesDesktop.api<LearningNodeDetail>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: `/api/learning/node?id=${encodeURIComponent(id)}`
   })
 }
 
-export function deleteLearningNode(id: string, profile?: null | string): Promise<{ message: string; ok: boolean }> {
+export function deleteLearningNode(id: string, profile?: ProfileScope): Promise<{ message: string; ok: boolean }> {
   return window.hermesDesktop.api<{ message: string; ok: boolean }>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: '/api/learning/node',
     method: 'DELETE',
     body: { id }
@@ -1219,10 +1266,10 @@ export function deleteLearningNode(id: string, profile?: null | string): Promise
 export function editLearningNode(
   id: string,
   content: string,
-  profile?: null | string
+  profile?: ProfileScope
 ): Promise<{ message: string; ok: boolean }> {
   return window.hermesDesktop.api<{ message: string; ok: boolean }>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: '/api/learning/node',
     method: 'PUT',
     body: { content, id }
@@ -1232,10 +1279,10 @@ export function editLearningNode(
 export function setSkillEnabled(
   name: string,
   enabled: boolean,
-  profile?: null | string
+  profile?: ProfileScope
 ): Promise<{ ok: boolean; name: string; enabled: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean; name: string; enabled: boolean }>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: '/api/skills/toggle',
     method: 'PUT',
     body: { name, enabled }
@@ -1264,9 +1311,9 @@ export interface McpOAuthFlow {
 
 /** Connect to the server, list its tools, disconnect. Slow (spawns/handshakes
  *  for real) — well past the 15s default fetch timeout. */
-export function testMcpServer(name: string, profile?: null | string): Promise<McpTestResult> {
+export function testMcpServer(name: string, profile?: ProfileScope): Promise<McpTestResult> {
   return window.hermesDesktop.api<McpTestResult>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: `/api/mcp/servers/${encodeURIComponent(name)}/test`,
     method: 'POST',
     timeoutMs: 60_000
@@ -1278,10 +1325,10 @@ export function testMcpServer(name: string, profile?: null | string): Promise<Mc
  *  re-enables (dropping `enabled: false`), and removed nested fields persist. */
 export function saveMcpServers(
   servers: Record<string, Record<string, unknown>>,
-  profile?: null | string
+  profile?: ProfileScope
 ): Promise<{ ok: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean }>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: '/api/mcp/servers',
     method: 'PUT',
     body: { servers }
@@ -1289,18 +1336,18 @@ export function saveMcpServers(
 }
 
 /** Start an MCP OAuth flow and return the authorization URL. */
-export function authMcpServer(name: string, profile?: null | string): Promise<McpOAuthFlow> {
+export function authMcpServer(name: string, profile?: ProfileScope): Promise<McpOAuthFlow> {
   return window.hermesDesktop.api<McpOAuthFlow>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: `/api/mcp/servers/${encodeURIComponent(name)}/auth`,
     method: 'POST',
     timeoutMs: 60_000
   })
 }
 
-export function getMcpOAuthFlow(flowId: string, profile?: null | string): Promise<McpOAuthFlow> {
+export function getMcpOAuthFlow(flowId: string, profile?: ProfileScope): Promise<McpOAuthFlow> {
   return window.hermesDesktop.api<McpOAuthFlow>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: `/api/mcp/oauth/flows/${encodeURIComponent(flowId)}`
   })
 }
@@ -1320,9 +1367,9 @@ export function cancelMcpOAuthFlow(flowId: string, profile?: null | string): Pro
 // panels configure ANY profile without swapping the app-wide active profile.
 // Omitting it (every pre-existing caller) means `profileScoped(undefined)`
 // falls back to the app-wide `_apiProfile`, so behavior is byte-identical.
-export function getToolsets(profile?: null | string): Promise<ToolsetInfo[]> {
+export function getToolsets(profile?: ProfileScope): Promise<ToolsetInfo[]> {
   return window.hermesDesktop.api<ToolsetInfo[]>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: '/api/tools/toolsets'
   })
 }
@@ -1330,19 +1377,19 @@ export function getToolsets(profile?: null | string): Promise<ToolsetInfo[]> {
 export function setToolsetEnabled(
   name: string,
   enabled: boolean,
-  profile?: null | string
+  profile?: ProfileScope
 ): Promise<{ ok: boolean; name: string; enabled: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean; name: string; enabled: boolean }>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: `/api/tools/toolsets/${encodeURIComponent(name)}`,
     method: 'PUT',
     body: { enabled }
   })
 }
 
-export function getToolsetConfig(name: string, profile?: null | string): Promise<ToolsetConfig> {
+export function getToolsetConfig(name: string, profile?: ProfileScope): Promise<ToolsetConfig> {
   return window.hermesDesktop.api<ToolsetConfig>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: `/api/tools/toolsets/${encodeURIComponent(name)}/config`
   })
 }
@@ -1350,12 +1397,12 @@ export function getToolsetConfig(name: string, profile?: null | string): Promise
 export function getToolsetModels(
   name: string,
   provider?: string,
-  profile?: null | string
+  profile?: ProfileScope
 ): Promise<ToolsetModelsResponse> {
   const suffix = provider ? `?provider=${encodeURIComponent(provider)}` : ''
 
   return window.hermesDesktop.api<ToolsetModelsResponse>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: `/api/tools/toolsets/${encodeURIComponent(name)}/models${suffix}`
   })
 }
@@ -1364,10 +1411,10 @@ export function selectToolsetModel(
   name: string,
   model: string,
   provider?: string,
-  profile?: null | string
+  profile?: ProfileScope
 ): Promise<{ ok: boolean; name: string; model: string }> {
   return window.hermesDesktop.api<{ ok: boolean; name: string; model: string }>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: `/api/tools/toolsets/${encodeURIComponent(name)}/model`,
     method: 'PUT',
     body: { model, provider }
@@ -1392,10 +1439,10 @@ export function selectToolsetProvider(
   name: string,
   provider: string,
   capability?: 'search' | 'extract',
-  profile?: null | string
+  profile?: ProfileScope
 ): Promise<SelectToolsetProviderResponse> {
   return window.hermesDesktop.api<SelectToolsetProviderResponse>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: `/api/tools/toolsets/${encodeURIComponent(name)}/provider`,
     method: 'PUT',
     body: capability ? { provider, capability } : { provider }
@@ -1405,10 +1452,10 @@ export function selectToolsetProvider(
 export function runToolsetPostSetup(
   name: string,
   key: string,
-  profile?: null | string
+  profile?: ProfileScope
 ): Promise<ActionResponse & { key: string }> {
   return window.hermesDesktop.api<ActionResponse & { key: string }>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: `/api/tools/toolsets/${encodeURIComponent(name)}/post-setup`,
     method: 'POST',
     body: { key }
@@ -1781,9 +1828,9 @@ export function importProfileArchive(
   })
 }
 
-export function getUsageAnalytics(days = 30, profile?: null | string): Promise<AnalyticsResponse> {
+export function getUsageAnalytics(days = 30, profile?: ProfileScope): Promise<AnalyticsResponse> {
   return window.hermesDesktop.api<AnalyticsResponse>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: `/api/analytics/usage?days=${Math.max(1, Math.floor(days))}`
   })
 }
@@ -1917,9 +1964,9 @@ export function checkHermesUpdate(force = false): Promise<BackendUpdateCheckResp
   })
 }
 
-export function getActionStatus(name: string, lines = 200, profile?: null | string): Promise<ActionStatusResponse> {
+export function getActionStatus(name: string, lines = 200, profile?: ProfileScope): Promise<ActionStatusResponse> {
   return window.hermesDesktop.api<ActionStatusResponse>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: `/api/actions/${encodeURIComponent(name)}/status?lines=${Math.max(1, lines)}`
   })
 }
@@ -2007,27 +2054,27 @@ export function scanSkillHub(identifier: string, profile?: null | string): Promi
   })
 }
 
-export function installSkillFromHub(identifier: string, profile?: null | string): Promise<ActionResponse> {
+export function installSkillFromHub(identifier: string, profile?: ProfileScope): Promise<ActionResponse> {
   return window.hermesDesktop.api<ActionResponse>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: '/api/skills/hub/install',
     method: 'POST',
     body: { identifier }
   })
 }
 
-export function uninstallSkillFromHub(name: string, profile?: null | string): Promise<ActionResponse> {
+export function uninstallSkillFromHub(name: string, profile?: ProfileScope): Promise<ActionResponse> {
   return window.hermesDesktop.api<ActionResponse>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: '/api/skills/hub/uninstall',
     method: 'POST',
     body: { name }
   })
 }
 
-export function updateSkillsFromHub(profile?: null | string): Promise<ActionResponse> {
+export function updateSkillsFromHub(profile?: ProfileScope): Promise<ActionResponse> {
   return window.hermesDesktop.api<ActionResponse>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: '/api/skills/hub/update',
     method: 'POST',
     body: {}
@@ -2084,9 +2131,9 @@ export function setMcpServerEnabled(name: string, enabled: boolean): Promise<{ o
   })
 }
 
-export function getMcpCatalog(profile?: null | string): Promise<McpCatalogResponse> {
+export function getMcpCatalog(profile?: ProfileScope): Promise<McpCatalogResponse> {
   return window.hermesDesktop.api<McpCatalogResponse>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: '/api/mcp/catalog'
   })
 }
@@ -2104,10 +2151,10 @@ export function getGhAuthStatus(refresh = false): Promise<{ available: boolean; 
 export function installMcpCatalogEntry(
   name: string,
   env: Record<string, string> = {},
-  profile?: null | string
+  profile?: ProfileScope
 ): Promise<{ ok: boolean; name?: string; pid?: number; action?: string; background?: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean; name?: string; pid?: number; action?: string; background?: boolean }>({
-    ...profileScoped(profile),
+    ...capabilityScoped(profile),
     path: '/api/mcp/catalog/install',
     method: 'POST',
     body: { name, env, enable: true },

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -67,6 +67,12 @@ import { jsx, jsxs } from 'react/jsx-runtime'
 const { McpTab, ToolsetConfigPanel } = sdk
 // Keep optional exports feature-detected; test harnesses may strip the SDK namespace.
 const SkillsView = typeof sdk === 'undefined' ? undefined : sdk.SkillsView
+// TRUE only on builds whose SkillsView routes `fixedConnection` to the pinned
+// registry connection's backend. Older builds export SkillsView WITHOUT the
+// prop — rendering it for a remote-target draft there would read/write the
+// ACTIVE gateway's skills under the remote bot's name (the wrong machine),
+// so those builds keep the staged checklists for remote targets.
+const skillsViewRoutesConnections = Boolean(SkillsView && SkillsView.supportsFixedConnection)
 const Streamdown = typeof sdk === 'undefined' ? undefined : sdk.Streamdown
 // Budgeted render loop (fps cap + observability pause + dormancy + teardown).
 // Feature-detected: older desktops fall back to the hand-rolled clock below.
@@ -5930,7 +5936,8 @@ function CreateAgentDialog({ open, onClose, roster }) {
                       setTargetConnection(value === (activeConnectionId || 'local') ? '' : value)
                       // The capability catalog and clone list belong to the
                       // target backend — refetch for the new home. The live
-                      // Capabilities tab only exists for the active gateway.
+                      // Capabilities tab re-pins to it via fixedConnection on
+                      // builds that route it (staged checklists otherwise).
                       setCaps(null)
                       setCapsFailed(false)
                       setAdvTab('general')
@@ -6008,10 +6015,13 @@ function CreateAgentDialog({ open, onClose, roster }) {
                       // Newer desktops export the whole Capabilities surface —
                       // one live tab replaces the three staged checklists.
                       // The live Capabilities surface (SkillsView) binds to
-                      // the ACTIVE gateway's backend — a remote-target draft
-                      // lives elsewhere, so it keeps the staged checklists
-                      // (their catalog reads already route to the target).
-                      children: (SkillsView && !remoteTarget
+                      // the ACTIVE gateway's backend unless this build routes
+                      // fixedConnection (skillsViewRoutesConnections) — then a
+                      // remote-target draft gets the live surface pinned to
+                      // ITS machine. Builds without that routing keep the
+                      // staged checklists for remote targets (their catalog
+                      // reads already route to the target).
+                      children: (SkillsView && (!remoteTarget || skillsViewRoutesConnections)
                         ? [
                             ['general', 'General'],
                             ['capabilities', 'Capabilities']
@@ -6154,9 +6164,15 @@ function CreateAgentDialog({ open, onClose, roster }) {
                                 style: { height: 440, minHeight: 280, resize: 'vertical', overflow: 'auto' },
                                 // The REAL core Capabilities surface (skills +
                                 // one-click hub installs + tools + MCP), pinned
-                                // to the just-created profile. Writes land
+                                // to the just-created profile — and, for a
+                                // remote-target draft, to the target machine's
+                                // backend via fixedConnection. Writes land
                                 // immediately — no staging needed.
-                                children: jsx(SkillsView, { embedded: true, fixedProfile: createdForCaps })
+                                children: jsx(SkillsView, {
+                                  embedded: true,
+                                  fixedProfile: createdForCaps,
+                                  ...(remoteTarget ? { fixedConnection: targetConnection } : {})
+                                })
                               })
                       : capsFailed
                         ? jsx('div', {

--- a/apps/desktop/src/plugins/hermes-bots/tests/embed-skills-view.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/embed-skills-view.test.mjs
@@ -26,7 +26,15 @@ test('New Agent gains a Capabilities tab that materializes the profile first', (
   // …and opening it creates the profile through the same lazy door MCP setup uses.
   assert.match(source, /id === 'capabilities'/)
   assert.match(source, /ensureAgentCreated\(\)\s*\n?\s*\.then\(created => created && setCreatedForCaps\(created\)\)/)
-  assert.match(source, /jsx\(SkillsView, \{ embedded: true, fixedProfile: createdForCaps \}\)/)
+  assert.match(source, /jsx\(SkillsView, \{\s*embedded: true,\s*fixedProfile: createdForCaps,/)
+})
+
+test('remote-target drafts pin the live surface to the target connection', () => {
+  // Builds whose SkillsView routes fixedConnection get the live Capabilities
+  // tab for remote targets too — pinned to the target machine's backend.
+  assert.match(source, /skillsViewRoutesConnections = Boolean\(SkillsView && SkillsView\.supportsFixedConnection\)/)
+  assert.match(source, /SkillsView && \(!remoteTarget \|\| skillsViewRoutesConnections\)/)
+  assert.match(source, /\.\.\.\(remoteTarget \? \{ fixedConnection: targetConnection \} : \{\}\)/)
 })
 
 test('older-build fallback keeps the checklist UI intact', () => {

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -575,7 +575,10 @@ export type { TitlebarTool } from '@/app/shell/titlebar-controls'
  *  lists, full-skill detail pane, embedded hub picker with one-click
  *  installs). For plugin dialogs pass `embedded` (tab state stays local —
  *  never touches the page router) and `fixedProfile` to pin every tab to one
- *  bot's backend; the internal profile selector hides itself. Bot Mode's
+ *  bot's backend; the internal profile selector hides itself. Add
+ *  `fixedConnection` (registry connection id) to pin a bot living on another
+ *  registered gateway — probe `SkillsView.supportsFixedConnection` first;
+ *  builds without it would route the pin to the ACTIVE gateway. Bot Mode's
  *  Advanced section is the reference consumer. */
 export { SkillsView } from '@/app/skills'
 /** THE full MCP tab core Settings renders — per-server enable + OAuth sign-in

--- a/apps/desktop/src/store/hub-actions.ts
+++ b/apps/desktop/src/store/hub-actions.ts
@@ -1,6 +1,6 @@
 import { atom, map } from 'nanostores'
 
-import { getActionStatus, installSkillFromHub, uninstallSkillFromHub, updateSkillsFromHub } from '@/hermes'
+import { getActionStatus, installSkillFromHub, type ProfileScope, uninstallSkillFromHub, updateSkillsFromHub } from '@/hermes'
 import { queryClient } from '@/lib/query-client'
 import { invalidateSlashCompletions } from '@/lib/slash-completion-cache'
 import { upsertDesktopActionTask } from '@/store/activity'
@@ -70,7 +70,7 @@ async function runHubAction(
   key: string,
   kind: HubActionKind,
   spawn: () => Promise<{ name: string }>,
-  profile?: null | string
+  profile?: ProfileScope
 ): Promise<void> {
   const epoch = _hubEpoch
   const switched = () => _hubEpoch !== epoch
@@ -137,15 +137,15 @@ async function runHubAction(
   }
 }
 
-export function installHubSkill(identifier: string, profile?: null | string): Promise<void> {
+export function installHubSkill(identifier: string, profile?: ProfileScope): Promise<void> {
   return runHubAction(identifier, 'install', () => installSkillFromHub(identifier, profile), profile)
 }
 
-export function uninstallHubSkill(identifier: string, name: string, profile?: null | string): Promise<void> {
+export function uninstallHubSkill(identifier: string, name: string, profile?: ProfileScope): Promise<void> {
   return runHubAction(identifier, 'uninstall', () => uninstallSkillFromHub(name, profile), profile)
 }
 
-export function updateHubSkills(profile?: null | string): Promise<void> {
+export function updateHubSkills(profile?: ProfileScope): Promise<void> {
   return runHubAction(UPDATE_ALL_KEY, 'update', () => updateSkillsFromHub(profile), profile)
 }
 

--- a/website/docs/user-guide/bot-mode.md
+++ b/website/docs/user-guide/bot-mode.md
@@ -49,7 +49,7 @@ With a single connection (the common case) the picker is hidden and the Bot is c
 Remote-creation notes:
 
 - **Clone source** is a profile of the *target* machine (its `default`) — a remote box doesn't have your local profiles to clone.
-- The live Capabilities tab binds to your active gateway, so a remote-target draft uses the staged Skills/Tools/MCP checklists instead; both read the target machine's catalog.
+- The live Capabilities tab pins to the target machine's backend, so skills, tools, and MCP servers you configure during creation land on the machine the Bot will live on. (Older desktop builds fall back to staged Skills/Tools/MCP checklists for remote targets; both read the target machine's catalog.)
 - Cancelling the dialog discards the draft profile on whichever machine it was created.
 
 **Edit Profile** (right-click a Bot) reopens the same surface on the live profile any time: avatar, title, description, model pin, skills, toolsets, MCP servers, and the full SOUL.md.

--- a/website/docs/user-guide/multi-connection-desktop.md
+++ b/website/docs/user-guide/multi-connection-desktop.md
@@ -167,6 +167,14 @@ Switching agents is the same gesture as switching profiles:
   list, with per-profile tags.
 - Hovering an agent pre-warms its backend so the switch doesn't pay a cold
   boot.
+- The **Capabilities** page (Skills / Tools / MCP) grows a matching scope: its
+  **Configuring** selector lists every `(profile, device)` agent from the
+  union roster, and picking one reads and writes **that machine's** skills,
+  toolsets, and MCP servers — no gateway switch. Hub installs, env keys, and
+  MCP setup all land on the selected agent's backend. (One caveat: the MCP
+  tab's *hot-reload into a live session* button only appears for agents on
+  the gateway your window is connected to; edits on other machines apply on
+  their next session.)
 
 ## Updating every instance at once
 


### PR DESCRIPTION
## Summary
The desktop Capabilities view (Skills / Tools / MCP) now reads and writes the **selected profile's own gateway** — a profile is not a machine-global name, and scoping the page to a profile that lives on another registered connection previously edited the ACTIVE gateway's skills/tools/MCP under that profile's name (the wrong machine, silently).

## Changes
- `src/hermes.ts`: capability REST helpers (skills, skill content, toggles, toolsets, toolset config/models/providers, MCP servers/catalog/OAuth, hub install/uninstall/update, env vars, learning nodes, analytics, action status, provider OAuth) accept a `ProfileScope` — legacy `string` profile, or an explicit `{ connectionId, profile }` pin. The ambient path now also carries the active registry connection tag (same contract the cron helpers adopted in #87882), so a window activated onto a remote gateway reads that machine, not the local pool. New `profileScopeKey()` folds a pin's connection id into cache keys.
- `src/app/skills/index.tsx` (SkillsView): the **Configuring** scope selector lists `(profile, device)` rows from the union agent roster on multi-connection desktops (feature-detected, registry fetched only when >1 connection); an explicit pick routes every tab to that machine. New `fixedConnection` prop pins the whole view to a registered connection — the plugin door — with a probe-able `SkillsView.supportsFixedConnection` static so older builds can be told apart.
- MCP tab: the live `reload.mcp` RPC is withheld for cross-backend scopes (it rides the active gateway socket and would hot-reload the wrong machine); config edits still land on the scoped backend.
- Bot Mode plugin: remote-target New Agent drafts now render the live Capabilities tab pinned via `fixedConnection` instead of falling back to staged checklists — gated on `supportsFixedConnection` so older desktops keep the fallback.
- `use-config-record` / `hub-actions` / `toolset-config-panel` / `embedded-hub-picker` / archive dialog: props widened to `ProfileScope`; per-scope cache keys are connection-namespaced so two gateways' same-named profiles never share a row.
- Docs: `multi-connection-desktop.md` (Capabilities scoping section), `bot-mode.md` (remote-creation note updated).

## Validation
| | Before | After |
|---|---|---|
| Scope a remote-owned profile | reads/writes ACTIVE gateway | pinned to owning connection (`connectionId` on every call) |
| Ambient scope on a remote-activated window | local pool | active registry connection tag carried |
| `local::` pick while remote active | n/a | pins local pool, drops ambient tag |
| Bot Mode remote draft | staged checklists only | live SkillsView pinned to target |

- `tsc -p .`, `tsc -p tsconfig.electron.json`, `tsc -p tsconfig.e2e.json`, `eslint src/ electron/`: 0 errors
- New `src/hermes-capability-scope.test.ts` (6 contract tests) + 2 new SkillsView component tests (fixedConnection pin, roster selector) — pass
- `vitest run src/app/settings src/app/learning src/store src/app/skills src/hermes*`: 1290+ tests pass
- Bot Mode source-shape tests: 262/262 pass

## Infographic

![Capabilities, on the right machine](https://v3b.fal.media/files/b/0aa6dc98/c_6bON8VbeBfLfgFKO09w_K5YyYfFg.png)
