### PR TITLE
🛡️ Skip directory tokens in walker bare-path branch (t_adc7bb45)

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -423,7 +423,15 @@ def _iter_referenced_shell_scripts(
         if executable.strip("/"):
             if "/" in executable or executable.endswith((".sh", ".bash", ".zsh")):
                 resolved = _resolve_terminal_script_path(executable, cwd)
-                if resolved is not None:
+                # Tokens that resolve to existing directories are not
+                # referenced scripts — yielding them trips the
+                # regular-file check and returns ``unsafe=True`` for any
+                # path-shaped literal in the command body (e.g. a harness
+                # root like ``/tmp/tabjoy-e2e`` or a repo root like
+                # ``/home/hermes/workspace/tabjoy``; t_adc7bb45). Non-regular
+                # files fed to ``sh``/``bash`` directly are still caught
+                # by the shell-executable branch above (#84337 follow-up).
+                if resolved is not None and not resolved.is_dir():
                     yield resolved
 
 

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -494,6 +494,49 @@ class TestTerminalToolGatewayLifecycleGuard:
 
         assert result["exit_code"] == 1
 
+    def test_bare_path_directory_token_does_not_block(self, monkeypatch, tmp_path):
+        """t_adc7bb45: a bare-path token that resolves to an existing directory
+        must be skipped by the walker, not surfaced as a referenced script.
+        Otherwise the harness/repo root literals in command bodies trip
+        ``_read_referenced_script``'s regular-file check and falsely fail closed.
+        The walker is the only layer that yields paths for scanning, so once
+        directories are filtered out, ``_read_referenced_script`` is never
+        called on them and the guard no longer fails closed for harmless
+        path literals in the command body.
+        """
+        from cron.lifecycle_guard import _iter_referenced_shell_scripts
+
+        fake_dir = tmp_path / "harness-root"
+        fake_dir.mkdir()
+
+        # Walker must not yield the directory literal even when it appears as
+        # the executable token (the bare-path branch).
+        yielded = list(
+            _iter_referenced_shell_scripts(str(fake_dir), cwd="/")
+        )
+        assert fake_dir not in yielded, (
+            f"directory token {fake_dir} should be skipped by walker, "
+            f"got {yielded!r}"
+        )
+
+    def test_bare_path_genuine_script_still_yielded(self, monkeypatch, tmp_path):
+        """Counterpart to the directory skip: a bare-path token whose resolved
+        target is a real script still flows through the walker so the
+        recursive scan can detect lifecycle verbs inside it.
+        """
+        from cron.lifecycle_guard import _iter_referenced_shell_scripts
+
+        script = tmp_path / "do-stuff.sh"
+        script.write_text("#!/bin/bash\necho hello\n", encoding="utf-8")
+
+        # Invocation where the script is the executable itself (bare-path).
+        yielded = list(
+            _iter_referenced_shell_scripts(str(script), cwd="/")
+        )
+        assert script in yielded, (
+            f"genuine script {script} should still be yielded, got {yielded!r}"
+        )
+
     def test_quoted_launchctl_submit_text_is_not_blocked(self, monkeypatch):
         import tools.terminal_tool as tt
 


### PR DESCRIPTION
The cron lifecycle walker's bare-path branch used to yield any token containing a slash; tokens like `/tmp/tabjoy-e2e` (harness root) and `/home/hermes/workspace/tabjoy` (repo root) trip the regular-file check in `_read_referenced_script` and return `unsafe=True`, hard-blocking the entire command even though no lifecycle pattern matches.

Fix: skip the yielded path when it resolves to an existing directory. Non-regular files fed directly to `sh`/`bash` (FIFOs, /dev/null, etc.) are still caught by the shell-executable branch above the bare-path branch.

Reproduction: `sh /home/hermes/.hermes/scripts/tabjoy-e2e-preflight.sh` from a cron session (`_HERMES_GATEWAY=1`) now passes. A genuine `.sh` reference still flows through the walker for recursive lifecycle-verb scanning.

Tests: `tests/hermes_cli/test_gateway_restart_loop.py` adds 2 cases (`test_bare_path_directory_token_does_not_block`, `test_bare_path_genuine_script_still_yielded`). Full suite: 133 passed.