### PR TITLE
feat(cron): native action buttons on Telegram deliveries

### DIFF
--- a/cron/delivery_choices.py
+++ b/cron/delivery_choices.py
@@ -1,0 +1,190 @@
+"""Structured action buttons on cron deliveries (issue #78999).
+
+Cron workers never receive the ``clarify`` toolset — jobs must not block
+waiting for a human. This module is the delivery-time alternative:
+
+1. Parse an optional last-line JSON envelope from the cron final response.
+2. Fall back to a per-job ``delivery_choices`` list.
+3. Register pending buttons (no wait in ``run_job``).
+4. A tap resolves to the choice text so the adapter can inject it as a
+   user turn in the continuable session.
+
+Stale taps (expired, superseded by a newer delivery for the same job)
+fail visibly rather than silently accepting.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+DELIVERY_CHOICES_KEY = "delivery_choices"
+TTL_SECONDS = 6 * 3600
+MAX_CHOICES = 8
+STALE_HINT = "This action expired. Wait for the next preview."
+
+_lock = threading.Lock()
+_entries: dict[str, "DeliveryChoiceEntry"] = {}
+
+
+@dataclass
+class DeliveryChoiceEntry:
+    choices: list[str]
+    job_id: str
+    created_at: float
+    expires_at: float
+
+
+def normalize_delivery_choices(raw: Any) -> Optional[list[str]]:
+    """Return a cleaned choice list, or None when the field is absent/empty."""
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, (list, tuple)):
+        return None
+    choices: list[str] = []
+    for item in raw:
+        text = str(item).strip()
+        if text:
+            choices.append(text)
+        if len(choices) >= MAX_CHOICES:
+            break
+    return choices or None
+
+
+def _parse_envelope_line(line: str) -> Optional[tuple[bool, Optional[list[str]]]]:
+    """Return (True, choices|None) when ``line`` is a delivery_choices object.
+
+    ``choices`` is None when the envelope explicitly lists no buttons.
+    """
+    candidate = (line or "").strip()
+    if not candidate.startswith("{") or not candidate.endswith("}"):
+        return None
+    try:
+        parsed = json.loads(candidate)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, dict) or DELIVERY_CHOICES_KEY not in parsed:
+        return None
+    return True, normalize_delivery_choices(parsed.get(DELIVERY_CHOICES_KEY))
+
+
+def split_delivery_choices(content: str) -> tuple[str, Optional[list[str]], bool]:
+    """Strip a last-line envelope if present.
+
+    Returns ``(visible_text, choices, saw_envelope)``. Invalid JSON, or JSON
+    without ``delivery_choices``, is left untouched so a JSON preview body is
+    never eaten.
+    """
+    if not content:
+        return content, None, False
+    lines = content.splitlines()
+    last_idx = None
+    for i in range(len(lines) - 1, -1, -1):
+        if lines[i].strip():
+            last_idx = i
+            break
+    if last_idx is None:
+        return content, None, False
+    parsed = _parse_envelope_line(lines[last_idx])
+    if parsed is None:
+        return content, None, False
+    _, choices = parsed
+    kept = lines[:last_idx]
+    while kept and not kept[-1].strip():
+        kept.pop()
+    return "\n".join(kept), choices, True
+
+
+def resolve_delivery_choices(
+    content: str,
+    job: Optional[dict] = None,
+) -> tuple[str, Optional[list[str]]]:
+    """Envelope wins; job ``delivery_choices`` is fallback when no envelope."""
+    cleaned, envelope_choices, saw_envelope = split_delivery_choices(content or "")
+    if saw_envelope:
+        return cleaned, envelope_choices
+    return cleaned, normalize_delivery_choices((job or {}).get(DELIVERY_CHOICES_KEY))
+
+
+def new_delivery_id() -> str:
+    return uuid.uuid4().hex[:12]
+
+
+def register_delivery_choices(
+    delivery_id: str,
+    choices: list[str],
+    job_id: str,
+    *,
+    ttl_seconds: int = TTL_SECONDS,
+    now: Optional[float] = None,
+) -> str:
+    """Store pending buttons. Supersedes earlier deliveries for the same job."""
+    cleaned = normalize_delivery_choices(choices)
+    if not cleaned:
+        raise ValueError("delivery_choices must be a non-empty list of strings")
+    ts = time.time() if now is None else now
+    with _lock:
+        _supersede_job_locked(job_id)
+        _entries[delivery_id] = DeliveryChoiceEntry(
+            choices=list(cleaned),
+            job_id=str(job_id or ""),
+            created_at=ts,
+            expires_at=ts + max(1, int(ttl_seconds)),
+        )
+    return delivery_id
+
+
+def resolve_delivery_choice(
+    delivery_id: str,
+    index: int,
+    *,
+    now: Optional[float] = None,
+) -> Optional[str]:
+    """Pop and return the choice text, or None when missing/stale/bad index."""
+    ts = time.time() if now is None else now
+    with _lock:
+        entry = _entries.pop(delivery_id, None)
+        if entry is None:
+            return None
+        if ts >= entry.expires_at:
+            return None
+        if index < 0 or index >= len(entry.choices):
+            return None
+        return entry.choices[index]
+
+
+def peek_delivery_choices(delivery_id: str) -> Optional[list[str]]:
+    with _lock:
+        entry = _entries.get(delivery_id)
+        if entry is None:
+            return None
+        return list(entry.choices)
+
+
+def supersede_job_deliveries(job_id: str) -> int:
+    with _lock:
+        return _supersede_job_locked(job_id)
+
+
+def _supersede_job_locked(job_id: str) -> int:
+    if not job_id:
+        return 0
+    stale = [key for key, entry in _entries.items() if entry.job_id == job_id]
+    for key in stale:
+        _entries.pop(key, None)
+    return len(stale)
+
+
+def clear_delivery_choices() -> None:
+    """Test helper."""
+    with _lock:
+        _entries.clear()

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1797,6 +1797,7 @@ def create_job(
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    delivery_choices: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1854,6 +1855,11 @@ def create_job(
         monitor_url: Optional http(s) URL used as the monitor source instead
                 of a script — fetched with a bounded GET each tick. Same
                 hash-suppression semantics as ``monitor_script``.
+        delivery_choices: Optional fallback action-button labels attached to
+                Telegram/Discord deliveries when the agent's final response
+                does not include a last-line ``{"delivery_choices": [...]}``
+                envelope. Taps become a user turn in the continuable session;
+                the cron worker does not wait. Empty / omitted = text only.
 
     Returns:
         The created job dict
@@ -1890,6 +1896,8 @@ def create_job(
     normalized_monitor_script = normalized_monitor_script or None
     normalized_monitor_url = str(monitor_url).strip() if isinstance(monitor_url, str) else None
     normalized_monitor_url = normalized_monitor_url or None
+    from cron.delivery_choices import normalize_delivery_choices
+    normalized_delivery_choices = normalize_delivery_choices(delivery_choices)
 
     # Monitor-mode validation: exactly one source, and monitor mode only
     # makes sense when there IS an agent to suppress/wake.
@@ -1995,6 +2003,8 @@ def create_job(
     # global cron.mirror_delivery config, default off).
     if normalized_attach is not None:
         job["attach_to_session"] = normalized_attach
+    if normalized_delivery_choices is not None:
+        job["delivery_choices"] = normalized_delivery_choices
 
     with _jobs_lock():
         jobs = load_jobs()
@@ -2100,6 +2110,12 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     _mv = updates[_mon_field]
                     _mv = str(_mv).strip() if isinstance(_mv, str) else None
                     updates[_mon_field] = _mv or None
+
+            if "delivery_choices" in updates:
+                from cron.delivery_choices import normalize_delivery_choices
+                updates["delivery_choices"] = normalize_delivery_choices(
+                    updates.get("delivery_choices")
+                )
 
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2507,6 +2507,63 @@ def _is_channel_dm_topic(
     return is_channel
 
 
+def _send_cron_delivery_choices(
+    adapter,
+    loop,
+    chat_id: str,
+    text: str,
+    choices: list,
+    job: dict,
+    metadata: Optional[dict] = None,
+) -> bool:
+    """Send preview + action buttons without waiting for a tap.
+
+    Returns True only when the adapter accepted the send. Callers fall back
+    to plain-text delivery when this is False. The tap is resolved later by
+    the adapter into a user turn — ``run_job`` must not block on it.
+    """
+    send_fn = getattr(adapter, "send_delivery_choices", None)
+    if not callable(send_fn) or loop is None:
+        return False
+    try:
+        from agent.async_utils import safe_schedule_threadsafe
+        from cron.delivery_choices import new_delivery_id, register_delivery_choices
+
+        delivery_id = new_delivery_id()
+        register_delivery_choices(delivery_id, list(choices), job.get("id", ""))
+        future = safe_schedule_threadsafe(
+            send_fn(
+                str(chat_id),
+                text,
+                list(choices),
+                delivery_id,
+                metadata=metadata,
+            ),
+            loop,
+        )
+        if future is None:
+            return False
+        result = future.result(timeout=60)
+        if isinstance(result, dict):
+            ok = bool(result.get("success"))
+        else:
+            ok = bool(getattr(result, "success", False))
+        if ok:
+            logger.info(
+                "Job '%s': delivered with %d action button(s)",
+                job.get("id", "?"),
+                len(choices),
+            )
+        return ok
+    except Exception as e:
+        logger.warning(
+            "Job '%s': delivery_choices send failed, falling back to text: %s",
+            job.get("id", "?"),
+            e,
+        )
+        return False
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -2518,6 +2575,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
     Returns None on success, or an error string on failure.
     """
+    from cron.delivery_choices import resolve_delivery_choices
+
+    content, delivery_choices = resolve_delivery_choices(content, job)
+
     targets = _resolve_delivery_targets(job)
     if not targets:
         deliver_value = _normalize_deliver_value(job.get("deliver", "local"))
@@ -2883,139 +2944,152 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 if text_to_send:
                     from agent.async_utils import safe_schedule_threadsafe
 
-                    router = DeliveryRouter(config, adapters)
-                    route_target = DeliveryTarget(
-                        platform=platform,
-                        chat_id=str(chat_id),
-                        thread_id=route_thread_id,
-                        is_explicit=True,
-                    )
-                    # Pass thread routing via the target (not a bare metadata
-                    # "thread_id"): the router only applies its Telegram DM-topic
-                    # detection when "thread_id"/"message_thread_id" are absent
-                    # from metadata, deriving the routing from target.thread_id
-                    # or the explicit direct_messages_topic_id above.
-                    future = safe_schedule_threadsafe(
-                        router._deliver_to_platform(
-                            route_target,
-                            text_to_send,
-                            route_metadata,
-                        ),
+                    if delivery_choices and _send_cron_delivery_choices(
+                        runtime_adapter,
                         loop,
-                    )
-                    if future is None:
-                        adapter_ok = False
-                        target_errors.append("live adapter event loop scheduling failed")
+                        str(chat_id),
+                        text_to_send,
+                        delivery_choices,
+                        job,
+                        route_metadata,
+                    ):
+                        # Buttons went out with the preview. Do not also send
+                        # the same text via DeliveryRouter (would duplicate).
+                        pass
                     else:
-                        send_result = None
-                        timeout_handled = False
-                        try:
-                            send_result = future.result(timeout=60)
-                        except TimeoutError:
-                            # #38922: a slow confirmation does NOT necessarily
-                            # mean the send failed — but we must distinguish two
-                            # cases via future.cancel()'s return value:
-                            #
-                            #   cancel() == False -> the coroutine was already
-                            #     running on the gateway loop when the timeout
-                            #     fired; the request is in flight on the wire and
-                            #     cannot be un-sent.  Re-sending via standalone
-                            #     would be a guaranteed DUPLICATE, so treat it as
-                            #     delivered (assume-delivered).
-                            #
-                            #   cancel() == True -> the scheduled callback never
-                            #     started executing (loop wedged/backlogged for
-                            #     the full 60s), so nothing was sent.  We MUST
-                            #     fall through to the standalone path or the
-                            #     message is silently dropped (worse than a
-                            #     duplicate).
-                            cancelled = future.cancel()
-                            if cancelled:
-                                msg = (
-                                    f"live adapter send to {platform_name}:{chat_id} "
-                                    "timed out before the coroutine was dispatched"
-                                )
-                                logger.warning(
-                                    "Job '%s': %s, falling back to standalone",
-                                    job["id"], msg,
-                                )
-                                target_errors.append(msg)
-                                adapter_ok = False  # fall through to standalone path
-                                timeout_handled = True
-                            else:
-                                timed_out = True
-                                timeout_handled = True
-                                logger.warning(
-                                    "Job '%s': live adapter send to %s:%s timed out "
-                                    "after 60s; already dispatched (in flight), "
-                                    "assuming delivered (skipping standalone fallback "
-                                    "to avoid duplicate)",
-                                    job["id"], platform_name, chat_id,
-                                )
-                        except Exception as ex:
-                            # A real send error (not a slow confirmation) — fall
-                            # through to the standalone path so the message is
-                            # still delivered.
-                            target_errors.append(f"live adapter send failed: {ex}")
-                            raise
-
-                        if timeout_handled:
-                            # The timeout branch above already decided the
-                            # outcome (assume-delivered if in flight, or
-                            # adapter_ok=False to fall through if never
-                            # dispatched).  send_result is None, so skip the
-                            # confirmation/thread-fallback inspection below.
-                            pass
+                        router = DeliveryRouter(config, adapters)
+                        route_target = DeliveryTarget(
+                            platform=platform,
+                            chat_id=str(chat_id),
+                            thread_id=route_thread_id,
+                            is_explicit=True,
+                        )
+                        # Pass thread routing via the target (not a bare metadata
+                        # "thread_id"): the router only applies its Telegram DM-topic
+                        # detection when "thread_id"/"message_thread_id" are absent
+                        # from metadata, deriving the routing from target.thread_id
+                        # or the explicit direct_messages_topic_id above.
+                        future = safe_schedule_threadsafe(
+                            router._deliver_to_platform(
+                                route_target,
+                                text_to_send,
+                                route_metadata,
+                            ),
+                            loop,
+                        )
+                        if future is None:
+                            adapter_ok = False
+                            target_errors.append("live adapter event loop scheduling failed")
                         else:
-                            # _deliver_to_platform returns either a SendResult
-                            # (.success attr) or, when the silence-narration
-                            # filter drops the message, a plain dict
-                            # {"success": True, "delivered": False, ...}.
-                            # Normalize both shapes so a getattr default doesn't
-                            # misread a dict, and so a None / success-less object
-                            # is NOT counted as delivered (#47056).
-                            if isinstance(send_result, dict):
-                                send_success = bool(send_result.get("success", False))
-                                send_raw_response = send_result.get("raw_response")
-                            else:
-                                send_success = _confirm_adapter_delivery(send_result)
-                                send_raw_response = getattr(send_result, "raw_response", None)
-
-                            if not send_success:
-                                if isinstance(send_result, dict):
-                                    err = send_result.get("error", "unknown")
-                                    shape = "dict"
-                                elif send_result is not None:
-                                    err = getattr(send_result, "error", None)
-                                    shape = type(send_result).__name__
-                                else:
-                                    err = "no response from adapter"
-                                    shape = "None"
-                                msg = (
-                                    f"live adapter send to {platform_name}:{chat_id} "
-                                    f"returned unconfirmed result ({shape}, error={err})"
-                                )
-                                if transport is not None and transport.is_relay:
-                                    logger.warning("Job '%s': %s", job["id"], msg)
-                                else:
+                            send_result = None
+                            timeout_handled = False
+                            try:
+                                send_result = future.result(timeout=60)
+                            except TimeoutError:
+                                # #38922: a slow confirmation does NOT necessarily
+                                # mean the send failed — but we must distinguish two
+                                # cases via future.cancel()'s return value:
+                                #
+                                #   cancel() == False -> the coroutine was already
+                                #     running on the gateway loop when the timeout
+                                #     fired; the request is in flight on the wire and
+                                #     cannot be un-sent.  Re-sending via standalone
+                                #     would be a guaranteed DUPLICATE, so treat it as
+                                #     delivered (assume-delivered).
+                                #
+                                #   cancel() == True -> the scheduled callback never
+                                #     started executing (loop wedged/backlogged for
+                                #     the full 60s), so nothing was sent.  We MUST
+                                #     fall through to the standalone path or the
+                                #     message is silently dropped (worse than a
+                                #     duplicate).
+                                cancelled = future.cancel()
+                                if cancelled:
+                                    msg = (
+                                        f"live adapter send to {platform_name}:{chat_id} "
+                                        "timed out before the coroutine was dispatched"
+                                    )
                                     logger.warning(
                                         "Job '%s': %s, falling back to standalone",
                                         job["id"], msg,
                                     )
-                                target_errors.append(msg)
-                                adapter_ok = False  # fall through to standalone path
-                            elif (
-                                send_raw_response
-                                and thread_id
-                                and send_raw_response.get("thread_fallback")
-                            ):
-                                requested_thread_id = send_raw_response.get("requested_thread_id") or thread_id
-                                msg = (
-                                    f"configured thread_id {requested_thread_id} for "
-                                    f"{platform_name}:{chat_id} was not found; delivered without thread_id"
-                                )
-                                logger.warning("Job '%s': %s", job["id"], msg)
-                                delivery_errors.append(msg)
+                                    target_errors.append(msg)
+                                    adapter_ok = False  # fall through to standalone path
+                                    timeout_handled = True
+                                else:
+                                    timed_out = True
+                                    timeout_handled = True
+                                    logger.warning(
+                                        "Job '%s': live adapter send to %s:%s timed out "
+                                        "after 60s; already dispatched (in flight), "
+                                        "assuming delivered (skipping standalone fallback "
+                                        "to avoid duplicate)",
+                                        job["id"], platform_name, chat_id,
+                                    )
+                            except Exception as ex:
+                                # A real send error (not a slow confirmation) — fall
+                                # through to the standalone path so the message is
+                                # still delivered.
+                                target_errors.append(f"live adapter send failed: {ex}")
+                                raise
+
+                            if timeout_handled:
+                                # The timeout branch above already decided the
+                                # outcome (assume-delivered if in flight, or
+                                # adapter_ok=False to fall through if never
+                                # dispatched).  send_result is None, so skip the
+                                # confirmation/thread-fallback inspection below.
+                                pass
+                            else:
+                                # _deliver_to_platform returns either a SendResult
+                                # (.success attr) or, when the silence-narration
+                                # filter drops the message, a plain dict
+                                # {"success": True, "delivered": False, ...}.
+                                # Normalize both shapes so a getattr default doesn't
+                                # misread a dict, and so a None / success-less object
+                                # is NOT counted as delivered (#47056).
+                                if isinstance(send_result, dict):
+                                    send_success = bool(send_result.get("success", False))
+                                    send_raw_response = send_result.get("raw_response")
+                                else:
+                                    send_success = _confirm_adapter_delivery(send_result)
+                                    send_raw_response = getattr(send_result, "raw_response", None)
+
+                                if not send_success:
+                                    if isinstance(send_result, dict):
+                                        err = send_result.get("error", "unknown")
+                                        shape = "dict"
+                                    elif send_result is not None:
+                                        err = getattr(send_result, "error", None)
+                                        shape = type(send_result).__name__
+                                    else:
+                                        err = "no response from adapter"
+                                        shape = "None"
+                                    msg = (
+                                        f"live adapter send to {platform_name}:{chat_id} "
+                                        f"returned unconfirmed result ({shape}, error={err})"
+                                    )
+                                    if transport is not None and transport.is_relay:
+                                        logger.warning("Job '%s': %s", job["id"], msg)
+                                    else:
+                                        logger.warning(
+                                            "Job '%s': %s, falling back to standalone",
+                                            job["id"], msg,
+                                        )
+                                    target_errors.append(msg)
+                                    adapter_ok = False  # fall through to standalone path
+                                elif (
+                                    send_raw_response
+                                    and thread_id
+                                    and send_raw_response.get("thread_fallback")
+                                ):
+                                    requested_thread_id = send_raw_response.get("requested_thread_id") or thread_id
+                                    msg = (
+                                        f"configured thread_id {requested_thread_id} for "
+                                        f"{platform_name}:{chat_id} was not found; delivered without thread_id"
+                                    )
+                                    logger.warning("Job '%s': %s", job["id"], msg)
+                                    delivery_errors.append(msg)
 
                 # Send extracted media files as native attachments via the live
                 # adapter, using the same DM-topic-aware routing as the text send

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -388,6 +388,7 @@ class CronJobCreate(BaseModel):
     enabled_toolsets: Optional[List[str]] = None
     workdir: Optional[str] = None
     no_agent: bool = False
+    delivery_choices: Optional[List[str]] = None
 
 
 class CronJobUpdate(BaseModel):

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12386,6 +12386,8 @@ def _normalize_dashboard_cron_updates(
         normalized["context_from"] = _cron_string_list(normalized["context_from"])
     if "enabled_toolsets" in normalized:
         normalized["enabled_toolsets"] = _cron_string_list(normalized["enabled_toolsets"])
+    if "delivery_choices" in normalized:
+        normalized["delivery_choices"] = _cron_string_list(normalized["delivery_choices"])
     return normalized
 
 
@@ -12738,6 +12740,7 @@ def _create_cron_job_sync(body: CronJobCreate, profile: Optional[str] = None):
             enabled_toolsets=_cron_string_list(body.enabled_toolsets),
             workdir=_cron_optional_text(body.workdir),
             no_agent=no_agent,
+            delivery_choices=_cron_string_list(body.delivery_choices) or None,
         )
     except HTTPException:
         raise

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6347,6 +6347,66 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning("[%s] send_clarify failed: %s", self.name, _redact_telegram_error_text(e))
             return SendResult(success=False, error=_redact_telegram_error_text(e))
 
+    async def send_delivery_choices(
+        self,
+        chat_id: str,
+        text: str,
+        choices: list,
+        delivery_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a cron delivery with fixed-choice buttons (no Other, no wait).
+
+        Callbacks use ``cd:<delivery_id>:<idx>`` and inject the choice text as
+        a user turn. Distinct from ``send_clarify`` (``cl:``) which blocks a
+        live agent tool call.
+        """
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        if not choices:
+            return SendResult(success=False, error="No delivery choices")
+
+        try:
+            from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
+            thread_id = self._metadata_thread_id(metadata)
+            kwargs: Dict[str, Any] = {
+                "chat_id": normalize_telegram_chat_id(chat_id),
+                "text": text,
+                **self._link_preview_kwargs(),
+            }
+            rows = []
+            for idx, label in enumerate(choices):
+                button_label = str(label)[:64]
+                rows.append([
+                    InlineKeyboardButton(
+                        button_label,
+                        callback_data=f"cd:{delivery_id}:{idx}",
+                    )
+                ])
+            kwargs["reply_markup"] = InlineKeyboardMarkup(rows)
+
+            reply_to_id = self._reply_to_message_id_for_send(None, metadata)
+            kwargs["reply_to_message_id"] = reply_to_id
+            kwargs.update(
+                self._thread_kwargs_for_send(
+                    chat_id,
+                    thread_id,
+                    metadata,
+                    reply_to_message_id=reply_to_id,
+                )
+            )
+
+            msg = await self._send_message_with_thread_fallback(**kwargs)
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.warning(
+                "[%s] send_delivery_choices failed: %s",
+                self.name,
+                _redact_telegram_error_text(e),
+            )
+            return SendResult(success=False, error=_redact_telegram_error_text(e))
+
     async def send_model_picker(
         self,
         chat_id: str,
@@ -7233,6 +7293,108 @@ class TelegramAdapter(BasePlatformAdapter):
                         await self._send_message_with_thread_fallback(**send_kwargs)
                 except Exception as exc:
                     logger.error("[%s] slash-confirm callback failed: %s", self.name, exc, exc_info=True)
+            return
+
+        # --- Cron delivery-choice callbacks (cd:delivery_id:idx) ---
+        if data.startswith("cd:"):
+            parts = data.split(":", 2)
+            if len(parts) == 3:
+                delivery_id = parts[1]
+                choice_token = parts[2]
+
+                caller_id = str(getattr(query.from_user, "id", ""))
+                if not self._is_callback_user_authorized(
+                    caller_id,
+                    chat_id=query_chat_id,
+                    chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                    thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                    user_name=query_user_name,
+                ):
+                    await query.answer(text="⛔ You are not authorized to answer this prompt.")
+                    return
+
+                user_display = getattr(query.from_user, "first_name", "User")
+                try:
+                    idx = int(choice_token)
+                except (ValueError, TypeError):
+                    await query.answer(text="Invalid choice.")
+                    return
+
+                from cron.delivery_choices import STALE_HINT, resolve_delivery_choice
+
+                resolved_text = resolve_delivery_choice(delivery_id, idx)
+                if resolved_text is None:
+                    await query.answer(text=STALE_HINT)
+                    try:
+                        await query.edit_message_reply_markup(reply_markup=None)
+                    except Exception:
+                        pass
+                    try:
+                        await query.edit_message_text(
+                            text=(
+                                f"{query.message.text or ''}\n\n"
+                                f"<i>{_html.escape(STALE_HINT)}</i>"
+                            ),
+                            parse_mode=ParseMode.HTML,
+                            reply_markup=None,
+                        )
+                    except Exception:
+                        pass
+                    return
+
+                await query.answer(text=f"✓ {resolved_text[:60]}")
+                try:
+                    await query.edit_message_text(
+                        text=(
+                            f"{_html.escape(query.message.text or '')}\n\n"
+                            f"<b>{_html.escape(user_display)}:</b> "
+                            f"{_html.escape(resolved_text)}"
+                        ),
+                        parse_mode=ParseMode.HTML,
+                        reply_markup=None,
+                    )
+                except Exception:
+                    try:
+                        await query.edit_message_reply_markup(reply_markup=None)
+                    except Exception:
+                        pass
+
+                chat_type_raw = str(query_chat_type or "").lower()
+                chat_type = "dm" if chat_type_raw in {"private", "dm"} else "group"
+                try:
+                    from gateway.config import Platform
+                    from gateway.platforms.base import MessageEvent, MessageType
+                    from gateway.session import SessionSource
+
+                    event = MessageEvent(
+                        text=resolved_text,
+                        message_type=MessageType.TEXT,
+                        source=SessionSource(
+                            platform=Platform.TELEGRAM,
+                            chat_id=str(query_chat_id or ""),
+                            chat_type=chat_type,
+                            user_id=caller_id,
+                            user_name=user_display,
+                            thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                        ),
+                        user_id=caller_id,
+                        user_name=user_display,
+                    )
+                    await self.handle_message(event)
+                    logger.info(
+                        "Telegram cron delivery button injected as user turn "
+                        "(id=%s, choice=%r, user=%s)",
+                        delivery_id,
+                        resolved_text,
+                        user_display,
+                    )
+                except Exception as exc:
+                    logger.error(
+                        "[%s] cron delivery-choice inject failed: %s",
+                        self.name,
+                        exc,
+                        exc_info=True,
+                    )
             return
 
         # --- Clarify callbacks (cl:clarify_id:idx | cl:clarify_id:other) ---

--- a/tests/cron/test_delivery_choices.py
+++ b/tests/cron/test_delivery_choices.py
@@ -1,0 +1,140 @@
+"""Unit tests for cron delivery-time action buttons (#78999)."""
+
+from __future__ import annotations
+
+import unittest
+
+from cron.delivery_choices import (
+    STALE_HINT,
+    clear_delivery_choices,
+    normalize_delivery_choices,
+    register_delivery_choices,
+    resolve_delivery_choice,
+    resolve_delivery_choices,
+    split_delivery_choices,
+    supersede_job_deliveries,
+)
+
+
+class TestNormalizeDeliveryChoices(unittest.TestCase):
+    def test_none_and_empty(self):
+        self.assertIsNone(normalize_delivery_choices(None))
+        self.assertIsNone(normalize_delivery_choices([]))
+        self.assertIsNone(normalize_delivery_choices(["", "  "]))
+
+    def test_strips_and_caps(self):
+        self.assertEqual(
+            normalize_delivery_choices([" vis bilag ", "skip"]),
+            ["vis bilag", "skip"],
+        )
+        many = [str(i) for i in range(20)]
+        self.assertEqual(len(normalize_delivery_choices(many)), 8)
+
+    def test_single_string(self):
+        self.assertEqual(normalize_delivery_choices("only"), ["only"])
+
+
+class TestSplitEnvelope(unittest.TestCase):
+    def test_plain_text_untouched(self):
+        text, choices, saw = split_delivery_choices("Vercel 163,32 DKK")
+        self.assertEqual(text, "Vercel 163,32 DKK")
+        self.assertIsNone(choices)
+        self.assertFalse(saw)
+
+    def test_strips_last_line_envelope(self):
+        body = "Preview line\n\n{\"delivery_choices\": [\"vis bilag\", \"spring over\"]}"
+        text, choices, saw = split_delivery_choices(body)
+        self.assertEqual(text, "Preview line")
+        self.assertEqual(choices, ["vis bilag", "spring over"])
+        self.assertTrue(saw)
+
+    def test_json_preview_without_key_untouched(self):
+        body = '{"amount": 163.32, "account": 7320}'
+        text, choices, saw = split_delivery_choices(body)
+        self.assertEqual(text, body)
+        self.assertIsNone(choices)
+        self.assertFalse(saw)
+
+    def test_invalid_json_untouched(self):
+        body = "hello\n{not json}"
+        text, choices, saw = split_delivery_choices(body)
+        self.assertEqual(text, body)
+        self.assertFalse(saw)
+
+    def test_empty_envelope_still_strips(self):
+        body = "Preview\n{\"delivery_choices\": []}"
+        text, choices, saw = split_delivery_choices(body)
+        self.assertEqual(text, "Preview")
+        self.assertIsNone(choices)
+        self.assertTrue(saw)
+
+
+class TestResolveDeliveryChoices(unittest.TestCase):
+    def test_envelope_wins_over_job(self):
+        job = {"delivery_choices": ["job-a", "job-b"]}
+        text, choices = resolve_delivery_choices(
+            "Hi\n{\"delivery_choices\": [\"vis bilag\"]}",
+            job,
+        )
+        self.assertEqual(text, "Hi")
+        self.assertEqual(choices, ["vis bilag"])
+
+    def test_job_fallback_when_no_envelope(self):
+        job = {"delivery_choices": ["vis bilag", "spring over"]}
+        text, choices = resolve_delivery_choices("Hi", job)
+        self.assertEqual(text, "Hi")
+        self.assertEqual(choices, ["vis bilag", "spring over"])
+
+    def test_empty_envelope_does_not_fall_back(self):
+        job = {"delivery_choices": ["vis bilag"]}
+        text, choices = resolve_delivery_choices(
+            "Hi\n{\"delivery_choices\": []}",
+            job,
+        )
+        self.assertEqual(text, "Hi")
+        self.assertIsNone(choices)
+
+    def test_local_job_without_choices(self):
+        text, choices = resolve_delivery_choices("silent", {"deliver": "local"})
+        self.assertEqual(text, "silent")
+        self.assertIsNone(choices)
+
+
+class TestPendingStore(unittest.TestCase):
+    def setUp(self):
+        clear_delivery_choices()
+
+    def tearDown(self):
+        clear_delivery_choices()
+
+    def test_register_and_resolve(self):
+        register_delivery_choices("d1", ["vis bilag", "spring over"], "job-1")
+        self.assertEqual(resolve_delivery_choice("d1", 0), "vis bilag")
+        self.assertIsNone(resolve_delivery_choice("d1", 1))
+
+    def test_stale_after_ttl(self):
+        register_delivery_choices(
+            "d1", ["a"], "job-1", ttl_seconds=10, now=100.0
+        )
+        self.assertIsNone(resolve_delivery_choice("d1", 0, now=111.0))
+        self.assertTrue(STALE_HINT)
+
+    def test_new_delivery_supersedes_old(self):
+        register_delivery_choices("old", ["a"], "job-1")
+        register_delivery_choices("new", ["b"], "job-1")
+        self.assertIsNone(resolve_delivery_choice("old", 0))
+        self.assertEqual(resolve_delivery_choice("new", 0), "b")
+
+    def test_other_job_untouched(self):
+        register_delivery_choices("a", ["one"], "job-a")
+        register_delivery_choices("b", ["two"], "job-b")
+        self.assertEqual(supersede_job_deliveries("job-a"), 1)
+        self.assertEqual(resolve_delivery_choice("b", 0), "two")
+
+    def test_bad_index(self):
+        register_delivery_choices("d1", ["only"], "job-1")
+        self.assertIsNone(resolve_delivery_choice("d1", 3))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2254,6 +2254,34 @@ class TestCronDeliveryMirror:
         assert "Cronjob Response:" not in mirrored_text
         assert "To stop or manage this job" not in mirrored_text
 
+    def test_delivery_strips_choices_envelope_from_mirror(self):
+        """Last-line delivery_choices JSON is not shown to the user."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})), \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            job = {
+                "id": "test-job",
+                "name": "bank-queue",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+                "attach_to_session": True,
+            }
+            _deliver_result(
+                job,
+                'Vercel 163,32\n{"delivery_choices": ["vis bilag", "spring over"]}',
+            )
+
+        mirrored_text = mirror_mock.call_args[0][2]
+        assert "Vercel 163,32" in mirrored_text
+        assert "delivery_choices" not in mirrored_text
+
 
     # --- origin-scoping (mirror only into the conversation that created the job) ---
 

--- a/tests/gateway/test_telegram_cron_delivery_choices.py
+++ b/tests/gateway/test_telegram_cron_delivery_choices.py
@@ -1,0 +1,121 @@
+"""Telegram cron delivery-choice buttons (#78999)."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from cron.delivery_choices import (  # noqa: E402
+    clear_delivery_choices,
+    register_delivery_choices,
+)
+from gateway.config import PlatformConfig  # noqa: E402
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+
+
+def _make_adapter():
+    config = PlatformConfig(enabled=True, token="test-token", extra={})
+    adapter = TelegramAdapter(config)
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    adapter._send_message_with_thread_fallback = AsyncMock(
+        return_value=MagicMock(message_id=99)
+    )
+    adapter._is_callback_user_authorized = MagicMock(return_value=True)
+    adapter.handle_message = AsyncMock()
+    return adapter
+
+
+def _callback_update(data: str, text: str = "preview"):
+    query = MagicMock()
+    query.data = data
+    query.message.text = text
+    query.message.chat_id = 123
+    query.message.chat.type = "private"
+    query.message.message_thread_id = None
+    query.from_user.id = 7
+    query.from_user.first_name = "Stefan"
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+    query.edit_message_reply_markup = AsyncMock()
+    update = MagicMock()
+    update.callback_query = query
+    return update, query
+
+
+class TestSendDeliveryChoices(unittest.IsolatedAsyncioTestCase):
+    async def test_renders_preview_text(self):
+        adapter = _make_adapter()
+        result = await adapter.send_delivery_choices(
+            "123",
+            "Preview body",
+            ["vis bilag", "spring over"],
+            "deliv1",
+        )
+        self.assertTrue(result.success)
+        kwargs = adapter._send_message_with_thread_fallback.await_args.kwargs
+        self.assertEqual(kwargs["text"], "Preview body")
+        self.assertIsNotNone(kwargs.get("reply_markup"))
+
+
+class TestDeliveryChoiceCallback(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        clear_delivery_choices()
+
+    def tearDown(self):
+        clear_delivery_choices()
+
+    async def test_tap_injects_choice_as_user_turn(self):
+        register_delivery_choices("d1", ["vis bilag", "spring over"], "job-1")
+        adapter = _make_adapter()
+        update, query = _callback_update("cd:d1:0")
+        await adapter._handle_callback_query(update, None)
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        self.assertEqual(event.text, "vis bilag")
+        query.answer.assert_awaited()
+
+    async def test_stale_tap_is_visible_and_does_not_inject(self):
+        adapter = _make_adapter()
+        update, query = _callback_update("cd:missing:0")
+        await adapter._handle_callback_query(update, None)
+        adapter.handle_message.assert_not_awaited()
+        answer_text = query.answer.await_args.kwargs.get("text") or ""
+        if not answer_text and query.answer.await_args.args:
+            answer_text = query.answer.await_args.args[0]
+        self.assertIn("expired", answer_text.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1201,6 +1201,7 @@ def cronjob(
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    delivery_choices: Optional[List[str]] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
 ) -> str:
@@ -1301,6 +1302,7 @@ def cronjob(
                     attach_to_session=attach_to_session,
                     monitor_script=_normalize_optional_job_value(monitor_script),
                     monitor_url=_normalize_optional_job_value(monitor_url),
+                    delivery_choices=delivery_choices or None,
                 )
             except CronSchedulerRegistrationError as exc:
                 _partial = exc.to_dict()
@@ -1567,6 +1569,8 @@ def cronjob(
                 updates["enabled_toolsets"] = enabled_toolsets or None
             if attach_to_session is not None:
                 updates["attach_to_session"] = bool(attach_to_session)
+            if delivery_choices is not None:
+                updates["delivery_choices"] = delivery_choices or None
             if workdir is not None:
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
@@ -1736,6 +1740,11 @@ Scheduling from cron-run sessions is disabled by default and enabled via cron.al
             "attach_to_session": {
                 "type": "boolean",
                 "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
+            },
+            "delivery_choices": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional fallback action-button labels for Telegram (and other adapters that implement send_delivery_choices). Attached to the cron delivery itself — the worker does not call clarify and does not wait. A tap becomes a user turn in the continuable session. The agent's final response may instead end with a last-line {\"delivery_choices\": [...]} envelope (that wins). On update, pass an empty array to clear. No effect when deliver='local'."
             },
         },
         "required": ["action"]

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -449,6 +449,32 @@ explicit other-chat deliveries) are never made continuable. The mirror is
 written as a labelled user turn (`[Cron delivery: <task name>]`), which keeps
 the conversation history alternation-safe across all model providers.
 
+### Action buttons on a cron delivery
+
+Cron workers never receive the `clarify` tool — a scheduled job has nobody to
+wait for, and blocking the run would stall the ticker. To put **native buttons
+on the cron message itself**, end the agent's final response with a last-line
+JSON envelope:
+
+```json
+{"delivery_choices": ["vis bilag", "lav konteringspreview", "spring over"]}
+```
+
+The scheduler strips that line before send and, on Telegram (and any adapter
+that implements `send_delivery_choices`), attaches one button per label. A tap
+becomes a user turn in the continuable session — the same as if the user typed
+the label. The cron worker does **not** wait.
+
+A per-job `delivery_choices` list is the fallback when the model forgets the
+envelope. `deliver: local` and an empty list stay plain text. A newer delivery
+for the same job, or a tap older than 6 hours, fails visibly
+("This action expired. Wait for the next preview.") instead of silently
+accepting.
+
+This is the preferred form of [issue #78999](https://github.com/NousResearch/hermes-agent/issues/78999).
+It is not `cron.allow_clarify` (mid-run wait) and not a journal of button
+clicks outside the agent turn.
+
 #### Flat, in-channel continuation (Slack)
 
 The thread-preferred behaviour above mints a dedicated thread on every


### PR DESCRIPTION
## What does this PR do?

Cron workers never receive the `clarify` toolset, so scheduled jobs cannot render approval-style buttons today. This implements the preferred form of #78999: structured choices at **delivery time**, no wait in `run_job`, tap becomes a user turn in the continuable session.

A last-line envelope:

```json
{"delivery_choices": ["vis bilag", "lav konteringspreview", "spring over"]}
```

is stripped from the visible message. A per-job `delivery_choices` list is the fallback when the model omits the envelope. Telegram attaches one inline button per label (`cd:` callbacks, no "Other"). Stale taps (superseded by a newer delivery for the same job, or older than 6 hours) fail visibly.

This is not `cron.allow_clarify` (mid-run block) and not journal buttons written to `button_responses.jsonl`.

## Related Issue

Fixes #78999

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `cron/delivery_choices.py` — envelope parse, job fallback, pending store
- `cron/scheduler.py` — strip envelope; send buttons via `adapter.send_delivery_choices` without waiting for a tap
- `cron/jobs.py`, `tools/cronjob_tools.py`, `hermes_cli/web_models.py`, `hermes_cli/web_server.py` — optional `delivery_choices` field
- `plugins/platforms/telegram/adapter.py` — `send_delivery_choices` + `cd:` callback injects `MessageEvent`
- `website/docs/user-guide/features/cron.md` — Action buttons section
- Tests: `tests/cron/test_delivery_choices.py`, `tests/gateway/test_telegram_cron_delivery_choices.py`, envelope-strip case in `tests/cron/test_scheduler.py`

## How to Test

1. `PYTHONPATH=. python3.11 -m pytest tests/cron/test_delivery_choices.py tests/cron/test_scheduler.py::TestCronDeliveryMirror tests/gateway/test_telegram_cron_delivery_choices.py -q` — 25 passed
2. Create a Telegram-delivered continuable cron job with `delivery_choices: ["Approve", "Skip"]` (or have the agent end with the JSON envelope)
3. Confirm the cron message has buttons, a tap continues the session with that label, and a second delivery expires the first job's buttons

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs (nearest: #38731 journal buttons, #74113 cron.allow_clarify, #82727 action_buttons without cron delivery)
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass (focused files above: 25 passed; full suite not run in this environment)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (unit + adapter mocks)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/features/cron.md`)
- [x] cli-config.yaml.example — N/A (job field, not a config key)
- [x] CONTRIBUTING.md / AGENTS.md — N/A
- [x] Cross-platform: pure Python, Telegram adapter only for native buttons; other platforms keep plain text
- [x] cronjob tool schema updated


Made with [Cursor](https://cursor.com)