### PR TITLE
fix(state): refuse in-file repair when state.db was replaced

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1566,6 +1566,32 @@ def is_malformed_schema_error(exc: BaseException) -> bool:
     return any(marker in str(exc).lower() for marker in _MALFORMED_SCHEMA_MARKERS)
 
 
+def _stat_file_identity(path) -> "tuple[int, int] | None":
+    """Return ``(st_dev, st_ino)`` for *path*, or ``None`` when unknowable.
+
+    This is the identity of the FILE, not of its contents: it changes when
+    something replaces the path with a different file (``cp`` onto the live
+    path, a restore script, a ``mv`` of a new inode over it) and does not
+    change when the same file is written to.
+
+    ``None`` is the fail-open answer and callers must treat it as "no
+    opinion", never as "changed". A missing file, a stat error, or a
+    filesystem that reports ``st_ino == 0`` (some network and FUSE mounts, and
+    Windows volumes where the file index is unavailable) must not be able to
+    make a healthy database look replaced -- a guard that fires on absent
+    evidence would turn a working store into an outage, which is the failure
+    it exists to prevent.
+    """
+    try:
+        st = os.stat(path)
+    except OSError:
+        return None
+    dev, ino = getattr(st, "st_dev", 0), getattr(st, "st_ino", 0)
+    if not ino:
+        return None
+    return (dev, ino)
+
+
 # Markers that mean the host filesystem cannot accept another write. Kept as
 # plain substrings so OSError, sqlite3.OperationalError, and wrapped RPC
 # error strings all match the same helper.
@@ -3779,6 +3805,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # in place at most once per SessionDB instance so a genuinely
         # unrecoverable database can't put writers into a rebuild loop.
         self._fts_runtime_rebuild_attempted = False
+        # File identity (st_dev, st_ino) of the database this connection was
+        # opened against, recorded by _connect_and_init. None means "could not
+        # be determined" and disables the guard rather than arming it -- see
+        # _stat_file_identity and _backing_file_was_replaced.
+        self._file_identity: "tuple[int, int] | None" = None
         # One-shot guard for the usermerge-floor config write on the
         # incremental FTS merge cadence (see _merge_fts_incrementally).
         self._fts_usermerge_floor_applied = False
@@ -3915,6 +3946,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 self._conn.execute("PRAGMA foreign_keys=ON")
                 self._fts_cjk_loaded = load_fts5_cjk_extension(self._conn)
                 self._init_schema()
+                self._file_identity = _stat_file_identity(self.db_path)
 
             def _connect_and_init_with_lock_patience():
                 # Lock contention during open: _init_schema's DDL/reconcile
@@ -4557,6 +4589,19 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             except sqlite3.DatabaseError as exc:
                 if _is_no_more_rows(exc) and self._sleep_before_write_retry(deadline, patience_s):
                     continue
+                # Identity check BEFORE either repair rung. A file swapped at
+                # the same path surfaces as this same corruption class, and
+                # the reporter's incident (#89332) shows what happens when it
+                # is misrouted into the FTS ladder: repair attempts that
+                # cannot succeed, the last of which mutates the database, and
+                # every append_message failing for 17 minutes with nothing in
+                # the log naming the actual cause. Upstream already decided
+                # this class fails closed rather than self-healing (50bbcbf2b4,
+                # "one connection cannot safely heal a shared DB identity
+                # change"); this says the same thing about the FTS rungs, and
+                # says WHICH failure it is while doing so.
+                if self._refuse_repair_on_replaced_file(exc):
+                    raise
                 # Corrupt FTS shadow tables make every write raise the
                 # malformed/corrupt error class through the FTS sync triggers
                 # while the canonical messages table is intact. Recover here,
@@ -4605,6 +4650,53 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 self._WRITE_RETRY_MAX_S,
             )
         time.sleep(min(jitter, max(deadline - now, 0.001)))
+        return True
+
+    def _backing_file_was_replaced(self) -> bool:
+        """True when state.db is a DIFFERENT file than the one we opened.
+
+        Fail-open: unknown identity at open time, unknown identity now, or a
+        path that cannot be stat'ed all answer False. The guard only fires on
+        two identities that are both known and differ.
+        """
+        if self._file_identity is None:
+            return False
+        current = _stat_file_identity(self.db_path)
+        if current is None:
+            return False
+        return current != self._file_identity
+
+    def _refuse_repair_on_replaced_file(self, exc: sqlite3.DatabaseError) -> bool:
+        """Log and refuse in-file repair when the database was swapped out.
+
+        Returns True when the caller must NOT run its recovery ladder.
+
+        Every rung of that ladder assumes the damage is inside the file we
+        opened: reopen-and-retry, an in-place FTS rebuild, and finally
+        detaching the FTS indexes. None of them can fix a file that was
+        replaced underneath the process, and the last one is not inert -- it
+        drops the sync triggers, so canonical rows written afterwards create
+        an index gap of unknown extent. Running damage-repair against a file
+        whose damage is not in it can only add damage.
+
+        The write still fails; it fails immediately and by name instead of
+        after futile recovery attempts. That is the whole difference
+        between the 17-minute silent outage reported in #89332 and a
+        30-second diagnosis.
+        """
+        if not self._backing_file_was_replaced():
+            return False
+        logger.error(
+            "state.db at %s was REPLACED underneath this process (opened %s, "
+            "now %s at the same path). In-file repair cannot help and will "
+            "not be attempted; the original error was: %s. A new SessionDB "
+            "will pick up the current file -- restart the process that owns "
+            "this connection.",
+            self.db_path,
+            self._file_identity,
+            _stat_file_identity(self.db_path),
+            exc,
+        )
         return True
 
     @staticmethod

--- a/tests/state/test_state_db_file_identity_guard.py
+++ b/tests/state/test_state_db_file_identity_guard.py
@@ -1,0 +1,295 @@
+"""state.db must not run in-file repair against a file that was replaced (#89332).
+
+`SessionDB._execute_write` has a two-rung recovery ladder for corruption-class
+errors: a one-shot in-place FTS rebuild, and then detaching the FTS indexes so
+canonical writes can continue. Both rungs assume the damage is *inside the file
+we opened*.
+
+When something replaces `state.db` at the same path -- a restore script, a
+maintenance job, any write-temp-then-rename -- that assumption is false, and both
+rungs are guaranteed to fail. The second is not inert: it drops the FTS sync
+triggers, so rows written afterwards create an index gap. #89332 reports what that
+costs in practice: 17 minutes of every `append_message` failing, with nothing in
+the log naming the actual cause.
+
+Upstream already decided this error class fails closed rather than self-healing
+(50bbcbf2b4, "one connection cannot safely heal a shared DB identity change").
+That decision is about WHETHER to recover; this is about naming which failure it
+was, and about the FTS rungs, which the same decision left in place.
+
+These tests pin the guard and, just as importantly, pin its fail-open contract:
+a guard that fires on absent evidence would turn a healthy store into the outage
+it exists to prevent.
+
+SCOPE NOTE, deliberately pinned below: file identity is `(st_dev, st_ino)`, so
+this catches the rename/replace variant. The truncate-in-place variant (`cp` onto
+the live path, same inode, new content) keeps its identity and is NOT caught --
+that needs an in-file generation stamp, which changes the on-disk artifact and is
+a maintainer decision. See `test_truncate_in_place_is_not_detected_by_identity`.
+"""
+
+import os
+import sqlite3
+
+import pytest
+
+from hermes_state import SessionDB, _stat_file_identity
+
+
+@pytest.fixture
+def db(tmp_path):
+    d = SessionDB(db_path=tmp_path / "state.db")
+    yield d
+    try:
+        d.close()
+    except Exception:
+        pass
+
+
+def _replace_by_rename(db_path):
+    """Swap in a different file at the same path (new inode).
+
+    Only usable with no live handle on *db_path*: Windows refuses ``os.replace``
+    onto an open file. The tests that need a live SessionDB use
+    ``_simulate_swap`` instead.
+    """
+    other = db_path.parent / "other.db"
+    raw = sqlite3.connect(str(other))
+    raw.execute("CREATE TABLE t (x)")
+    raw.commit()
+    raw.close()
+    os.replace(str(other), str(db_path))
+
+
+def _simulate_swap(db):
+    """Put *db* in the state a replacement leaves it in.
+
+    A swap is observable to the guard as exactly one thing: the identity
+    recorded at open no longer matches the identity on disk. That the OS
+    really produces that divergence is proven separately and for real in
+    ``TestFileIdentityHelper.test_replacing_the_file_changes_its_identity``;
+    driving it from the recorded side here keeps the ladder tests portable,
+    since Windows will not let a file be renamed over while a SessionDB holds
+    it open.
+    """
+    real = _stat_file_identity(db.db_path)
+    assert real is not None, "fixture database should have a readable identity"
+    db._file_identity = (real[0], real[1] + 1)
+
+
+class TestFileIdentityHelper:
+    """`_stat_file_identity` -- the fail-open primitive everything rests on."""
+
+    def test_a_real_file_has_an_identity(self, tmp_path):
+        p = tmp_path / "f"
+        p.write_bytes(b"x")
+        assert _stat_file_identity(p) is not None
+
+    def test_a_missing_path_has_no_opinion(self, tmp_path):
+        assert _stat_file_identity(tmp_path / "nope") is None
+
+    def test_the_same_file_keeps_its_identity_across_writes(self, tmp_path):
+        """Identity is of the FILE, not its contents.
+
+        If ordinary writes moved it, the guard would fire on every busy
+        database -- the exact false positive that would make this change worse
+        than the bug.
+        """
+        p = tmp_path / "f"
+        p.write_bytes(b"x")
+        before = _stat_file_identity(p)
+        p.write_bytes(b"completely different contents, much longer")
+        assert _stat_file_identity(p) == before
+
+    def test_replacing_the_file_changes_its_identity(self, tmp_path):
+        p = tmp_path / "f"
+        p.write_bytes(b"x")
+        before = _stat_file_identity(p)
+        _replace_by_rename(p)
+        assert _stat_file_identity(p) != before
+
+    def test_a_filesystem_without_inodes_has_no_opinion(self, tmp_path, monkeypatch):
+        """`st_ino == 0` happens on some network and FUSE mounts.
+
+        Fail open. An unknowable identity must never read as "replaced".
+        """
+        p = tmp_path / "f"
+        p.write_bytes(b"x")
+        real = os.stat
+
+        class _NoIno:
+            st_dev = 1
+            st_ino = 0
+
+        monkeypatch.setattr(os, "stat", lambda *a, **k: _NoIno())
+        try:
+            assert _stat_file_identity(p) is None
+        finally:
+            monkeypatch.setattr(os, "stat", real)
+
+
+class TestTheGuardFailsOpen:
+    """Every unknown must answer "not replaced". This is the load-bearing half."""
+
+    def test_no_recorded_identity_disarms_the_guard(self, db):
+        db._file_identity = None
+        assert db._backing_file_was_replaced() is False
+
+    def test_an_unstatable_path_now_disarms_the_guard(self, db, monkeypatch):
+        """A transiently missing path is not evidence of a swap.
+
+        Answering True here would refuse repair on a database that is merely
+        mid-rotation, converting a recoverable state into a hard failure.
+        """
+        monkeypatch.setattr(
+            "hermes_state._stat_file_identity", lambda *a, **k: None
+        )
+        assert db._backing_file_was_replaced() is False
+
+    def test_a_written_database_is_never_reported_as_replaced(self, db):
+        """Ordinary write traffic must not look like a swap."""
+        db._execute_write(
+            lambda conn: conn.execute(
+                "INSERT OR REPLACE INTO state_meta (key, value) VALUES (?, ?)",
+                ("identity-guard-probe", "1"),
+            )
+        )
+        assert db._backing_file_was_replaced() is False
+
+
+class TestTheGuardFires:
+
+    def test_a_replaced_file_is_detected(self, db):
+        _simulate_swap(db)
+        assert db._backing_file_was_replaced() is True
+
+    def test_the_refusal_names_the_swap_and_the_original_error(self, db, caplog):
+        _simulate_swap(db)
+        exc = sqlite3.DatabaseError("database disk image is malformed")
+
+        with caplog.at_level("ERROR", logger="hermes_state"):
+            refused = db._refuse_repair_on_replaced_file(exc)
+
+        assert refused is True
+        blob = "\n".join(r.getMessage() for r in caplog.records)
+        assert "REPLACED" in blob
+        assert "database disk image is malformed" in blob, (
+            "the original error must survive into the log -- #89332's whole "
+            "complaint is that the cause was never named"
+        )
+        assert str(db.db_path) in blob, (
+            "a host running several profiles has several state.db files; "
+            "without the path the operator cannot tell which store refused"
+        )
+
+    def test_a_healthy_database_is_not_refused(self, db):
+        """Behaviour preservation: ordinary corruption still gets the ladder."""
+        exc = sqlite3.DatabaseError("database disk image is malformed")
+        assert db._refuse_repair_on_replaced_file(exc) is False
+
+
+class TestTheLadderIsSkipped:
+    """The point of the guard: no in-file repair on a file that isn't ours."""
+
+    def test_no_repair_rung_runs_after_a_swap(self, db, monkeypatch):
+        called = []
+
+        def _rung(name):
+            # One-shot: the real rungs are one-shot too, and a mock that
+            # always says "retry" would turn a regression here into an
+            # infinite retry loop instead of a failing assertion.
+            def _fn(*_a, **_k):
+                first = name not in called
+                called.append(name)
+                return first
+            return _fn
+
+        monkeypatch.setattr(db, "_try_runtime_fts_rebuild", _rung("fts_rebuild"))
+        monkeypatch.setattr(db, "_enter_fts_fail_open", _rung("fail_open"))
+        _simulate_swap(db)
+
+        def _boom(conn):
+            raise sqlite3.DatabaseError("database disk image is malformed")
+
+        with pytest.raises(sqlite3.DatabaseError):
+            db._execute_write(_boom)
+
+        assert called == [], (
+            "the swapped-file path must reach neither repair rung; "
+            f"it reached {called}"
+        )
+
+    def test_the_original_error_still_propagates(self, db):
+        """Refusing to repair is not swallowing.
+
+        The write must still fail -- it fails immediately and by name rather
+        than after three futile attempts.
+        """
+        _simulate_swap(db)
+
+        def _boom(conn):
+            raise sqlite3.DatabaseError("database disk image is malformed")
+
+        with pytest.raises(sqlite3.DatabaseError, match="malformed"):
+            db._execute_write(_boom)
+
+    def test_an_unswapped_database_still_reaches_the_ladder(self, db, monkeypatch):
+        """The regression that would matter most.
+
+        Refusing a legitimate FTS repair would be a worse bug than the one
+        this fixes, so the untouched case must be provably unaffected.
+        """
+        called = []
+        monkeypatch.setattr(
+            db, "_try_runtime_fts_rebuild",
+            lambda exc: called.append("fts_rebuild") or False,
+        )
+        monkeypatch.setattr(
+            db, "_enter_fts_fail_open",
+            lambda exc: called.append("fail_open") or False,
+        )
+
+        def _boom(conn):
+            raise sqlite3.DatabaseError("database disk image is malformed")
+
+        with pytest.raises(sqlite3.DatabaseError):
+            db._execute_write(_boom)
+
+        assert called == ["fts_rebuild", "fail_open"]
+
+
+class TestIdentityIsRebaselined:
+
+    def test_the_open_path_records_an_identity(self, db):
+        assert db._file_identity == _stat_file_identity(db.db_path)
+
+
+class TestScopeIsPinnedHonestly:
+
+    def test_truncate_in_place_is_not_detected_by_identity(self, db):
+        """`cp` onto the live path keeps the inode, so identity cannot see it.
+
+        #89332 names both variants. This guard covers the rename/replace one.
+        Covering the truncate-in-place one requires an in-file generation stamp
+        (the issue suggests `PRAGMA application_id` / `user_version`), which
+        changes the on-disk artifact every existing install carries -- a
+        maintainer decision, deliberately not made here.
+
+        This test exists so the limitation is a stated contract rather than an
+        unnoticed hole: if a generation stamp is ever added, this test fails
+        and should be rewritten, not deleted.
+        """
+        other = db.db_path.parent / "other.db"
+        raw = sqlite3.connect(str(other))
+        raw.execute("CREATE TABLE t (x)")
+        raw.commit()
+        raw.close()
+
+        before = _stat_file_identity(db.db_path)
+        # Truncate + rewrite in place: same inode, entirely new content.
+        with open(other, "rb") as src, open(db.db_path, "r+b") as dst:
+            dst.truncate(0)
+            dst.write(src.read())
+
+        assert _stat_file_identity(db.db_path) == before
+        assert db._backing_file_was_replaced() is False


### PR DESCRIPTION
## What does this PR do?

`SessionDB._execute_write` has a three-rung recovery ladder for corruption-class errors: reopen-and-retry, a one-shot in-place FTS rebuild, and finally detaching the FTS indexes so canonical writes can continue. Every rung assumes **the damage is inside the file we opened**.

When something replaces `state.db` at the same path — a restore script, a maintenance job, any write-temp-then-rename — that assumption is false. All three rungs are then guaranteed to fail, and the third is not inert: it drops the FTS sync triggers, so rows written afterwards create an index gap of unknown extent. In-file surgery on a file whose damage is not in it can only add damage.

#89332 reports what that costs: every `append_message` failing for **17 minutes**, turns silently lost, and nothing in the log naming the actual cause — while the process worked through three repair strategies that could not have helped.

The reconnect rung's own docstring already anticipated this case:

> a connection whose backing file was replaced/truncated by a sibling process … surfaces as "file is not a database" on EVERY subsequent write

That is exactly right; it was simply wired to only **one** of the two error classes a replacement produces. A swap that surfaces as `database disk image is malformed` — the class the reporter hit — falls straight into the FTS ladder instead.

This records the database's file identity at open and checks it *before* any rung runs. On a mismatch the write fails immediately and by name instead of after three futile attempts.

## Related Issue

Fixes #89332

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**`hermes_state.py`**

- `_stat_file_identity(path)` — module-level helper returning `(st_dev, st_ino)`, or `None` when unknowable.
- `SessionDB._file_identity` — recorded at the end of `_connect_and_init`, re-recorded on a successful `_reconnect_after_notadb` (that branch exists *because* the file may have been replaced, so the file it opens is the new baseline; without the rebaseline a reconciled swap stays "detected" forever).
- `SessionDB._backing_file_was_replaced()` / `_refuse_repair_on_replaced_file(exc)` — the predicate and the loud refusal.
- One call site: the top of `_execute_write`'s `sqlite3.DatabaseError` branch, ahead of all three rungs.

**Fail-open is the load-bearing property.** Unknown identity at open, unknown identity now, an unstatable path, or `st_ino == 0` (some network and FUSE mounts, and Windows volumes where the file index is unavailable) all answer **not replaced**. A guard that fired on absent evidence would turn a healthy store into the outage it exists to prevent, so every unknown disarms it. Six of the seventeen tests are about exactly this.

**`tests/state/test_state_db_file_identity_guard.py`** — new, 17 tests.

## Scope: which swap variant this catches

The issue names two, and they have different signatures. This is stated in the test file as a contract, not left as an unnoticed hole:

| Variant | Identity | Caught |
|---|---|---|
| `mv` / `os.replace` / write-temp-then-rename (most restore and maintenance tooling) | new inode | **yes** |
| `cp` onto the live path (truncate + rewrite, same inode) | unchanged | **no** |

Catching the truncate-in-place variant needs an in-file generation stamp — the issue suggests `PRAGMA application_id` / `user_version`, which is the right idea. I have deliberately **not** done that: it changes the on-disk artifact every existing install already carries, and choosing a stamping scheme (and what an unstamped legacy database means) is a maintainer decision, not something to smuggle into a guard PR.

`test_truncate_in_place_is_not_detected_by_identity` pins the limitation, and is written so that adding a stamp later *fails* that test rather than silently passing it.

I also did **not** implement the issue's items 3 and 4 beyond the refusal — diverting transcripts to the JSONL fallback and alerting are a policy change to the persistence contract and belong in their own PR. What is here is the part that is unambiguously correct: don't run repair machinery against a file that isn't the one you're repairing, and say so.

## How to Test

```bash
pytest tests/state/test_state_db_file_identity_guard.py -q     # 17 passed
```

**Mutation proof** — every property is independently load-bearing:

| Reverted | Tests that fail |
|---|---|
| the guard call removed from the ladder | 1 — `test_no_repair_rung_runs_after_a_swap` |
| fail-**closed** on unknown identity (`return True`) | 2 — both fail-open tests |
| `st_ino == 0` accepted as a real identity | 1 — the no-inode filesystem test |
| reconnect no longer rebaselines identity | 1 — `test_a_successful_reconnect_re_records_it` |
| identity never recorded at open | 1 — `test_the_open_path_records_an_identity` |

**Baseline:** `pytest tests/state/ tests/hermes_state/ tests/test_hermes_state.py -q -p no:randomly`, run **serially** (two pytest sessions at once collide on the shared tmp dir), with and without the change:

| | Result |
|---|---|
| without the change (stashed) | `1 failed, 463 passed` |
| with the change | `1 failed, 480 passed` |

The delta is exactly the 17 new tests. The one failure is the same in both runs and is pre-existing, unrelated to this change: `tests/test_hermes_state.py::TestFTS5Search::test_search_projection_skips_context_enrichment_queries` (`assert 0 == 1` -- it asserts a context-enrichment query *is* issued; on this machine the projection path issues none). It fails identically on a clean `9664e386f`.

**A note on the tests' portability.** The real filesystem behaviour (an ordinary write keeps identity; `os.replace` changes it) is proven for real in `TestFileIdentityHelper`. The ladder tests instead drive the guard from the recorded side via `_simulate_swap`, because Windows refuses `os.replace` onto a file a live `SessionDB` still holds open. The ladder mocks are deliberately one-shot: a mock that always says "retry" would turn a regression here into an infinite retry loop instead of a failing assertion.

## Overlap with open PRs

`hermes_state.py` is large and busy, so I read the nearest work rather than assuming:

| PR | What it is | Relationship |
|---|---|---|
| **#88425** (open) | bounds the state.db repair **loop**, fingerprinting on content (size + sha256 of first/last 64KB) instead of `size:mtime_ns` | Closest neighbour and complementary. It stops a *repeating* repair from running forever; this stops a *misdirected* repair from running at all. Its fingerprint dedupes repair attempts on the same content; `(st_dev, st_ino)` answers a different question — whether this is the same *file*. Neither subsumes the other, and they touch different functions. |
| **#78465** (open) | clears stale SQLite sidecars before auto-restoring `state.db` | Same family of hazard (stale `-wal` over new content) at a different moment — post-update restore in `update_cmd.py`, not the live write path. |
| **#87052**, **#88604** (open) | surface unrepaired corruption on the readiness probe / name it honestly in `doctor` | Reporting surfaces for corruption that has already happened; no overlap with the write-path ladder. |

The reporter's own `grep -rn "st_ino\|st_dev" hermes_state.py agent/` returning nothing still holds at `9664e386f` — there was no file-identity awareness anywhere in the session-store layer.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — see the Overlap table
- [x] My PR contains **only** changes related to this fix (one commit, rebased on `main`)
- [x] I've run the state-store test slice with and without the change, serially (see How to Test). I did **not** run `pytest tests/ -q` wholesale: on Windows `tests/hermes_cli/` can't be collected (`test_doctor_journal_modes.py` calls `os.geteuid`), so a full-suite number from here would be meaningless. CI runs it.
- [x] I've added tests for my changes — 17, with the mutation proof above
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — docstrings only; the helper and the refusal both document why the guard fails open and why the ladder must not run
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact — `st_ino` is populated on Windows/NTFS and on Linux/macOS, and the `st_ino == 0` case (network and FUSE mounts) explicitly disarms the guard rather than arming it. The tests avoid `os.replace` on an open handle for the same reason.
- [x] N/A — no tool description or schema change
