### PR TITLE
fix(kanban): inherit canonical project for worker children

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1134,3 +1134,69 @@ def test_attach_url_happy_path_public_host(worker_env, default_url_guard, monkey
         assert Path(atts[0].stored_path).read_bytes() == payload
     finally:
         conn.close()
+
+
+def test_create_worktree_child_inherits_root_project(worker_env):
+    """A worktree child keeps the canonical project of its worker task."""
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import projects_db as pdb
+    from tools import kanban_tools as kt
+
+    repo = os.path.join(os.environ["HERMES_HOME"], "repo")
+    os.mkdir(repo)
+    with pdb.connect_closing() as project_conn:
+        project_id = pdb.create_project(
+            project_conn, name="Root project", primary_path=repo
+        )
+
+    conn = kb.connect()
+    try:
+        conn.execute(
+            "UPDATE tasks SET project_id=?, workspace_kind=? WHERE id=?",
+            (project_id, "worktree", worker_env),
+        )
+        conn.commit()
+        assert kb.get_task(conn, worker_env).project_id == project_id
+    finally:
+        conn.close()
+
+    out = kt._handle_create({
+        "title": "child",
+        "assignee": "child-worker",
+        "parents": [worker_env],
+        "workspace_kind": "worktree",
+    })
+    created = json.loads(out)
+    assert created["project_id"] == project_id, out
+
+
+def test_create_child_rejects_different_project_id(worker_env):
+    """A worker cannot silently switch a child to another project."""
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import projects_db as pdb
+    from tools import kanban_tools as kt
+
+    repo = os.path.join(os.environ["HERMES_HOME"], "repo")
+    os.mkdir(repo)
+    with pdb.connect_closing() as project_conn:
+        project_id = pdb.create_project(
+            project_conn, name="Root project", primary_path=repo
+        )
+
+    conn = kb.connect()
+    try:
+        conn.execute("UPDATE tasks SET project_id=? WHERE id=?", (project_id, worker_env))
+        conn.commit()
+    finally:
+        conn.close()
+
+    out = kt._handle_create({
+        "title": "child",
+        "assignee": "child-worker",
+        "parents": [worker_env],
+        "workspace_kind": "worktree",
+        "project_id": "other-project",
+    })
+    created = json.loads(out)
+    assert "error" in created, out
+    assert "canonical project" in created["error"], out

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1388,7 +1388,7 @@ def _handle_create(args: dict, **kw) -> str:
     workspace_path = args.get("workspace_path")
     project_id = args.get("project") or args.get("project_id")
     project_source_task_id = None
-    _inherit_project = workspace_kind is None and workspace_path is None
+    _inherit_project = workspace_path is None
     if workspace_kind is None:
         workspace_kind = "scratch"
     triage, bool_error = _parse_bool_arg(args, "triage")
@@ -1426,11 +1426,16 @@ def _handle_create(args: dict, **kw) -> str:
             # A project link is safe to inherit because ``create_task`` turns
             # it into a fresh per-task worktree. Never inherit the parent's
             # literal workspace kind/path; directory sharing must be explicit.
-            if _inherit_project and project_id is None:
+            if _inherit_project:
                 _self_tid = os.environ.get("HERMES_KANBAN_TASK")
                 if _self_tid:
                     _self_task = kb.get_task(conn, _self_tid)
                     if _self_task is not None and _self_task.project_id:
+                        if project_id is not None and project_id != _self_task.project_id:
+                            return tool_error(
+                                "project_id does not match the worker task's "
+                                "canonical project"
+                            )
                         project_id = _self_task.project_id
                         project_source_task_id = _self_task.id
             new_tid = kb.create_task(


### PR DESCRIPTION
## Summary

- inherit the spawning worker task project when `kanban_create` explicitly requests `workspace_kind=worktree`
- reject a caller-provided child project that differs from the worker task canonical project
- add regression coverage for both inheritance and mismatch rejection

## Root cause

`kanban_create` only inherited the worker project when both `workspace_kind` and `workspace_path` were omitted. Orchestrator agents commonly set `workspace_kind=worktree` explicitly, which disabled project inheritance and allowed children to be created without the canonical project context.

## Verification

- RED: both new regression tests failed before the fix
- GREEN: both pass after the fix
- `scripts/run_tests.sh tests/tools/test_kanban_tools.py -q` — 34 passed
- focused regressions — 2 passed
- Ruff — pass
- `git diff --check` — pass

## Related work

This is complementary to #67631. That PR hardens cross-profile project routes, but its `kanban_create` inheritance condition still applies only when workspace fields are omitted. This change covers the explicit `workspace_kind=worktree` path on current `main`.
