### PR TITLE
fix(gateway): keep /context totals accurate after agent reconstruction

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -306,6 +306,18 @@ def _record_codex_app_server_compaction(
             compressor.last_completion_tokens = 0
             compressor.awaiting_real_usage_after_compression = True
 
+    session_db = getattr(agent, "_session_db", None)
+    recorder = getattr(
+        type(session_db) if session_db is not None else None,
+        "increment_successful_compression_count",
+        None,
+    )
+    if callable(recorder):
+        try:
+            recorder(session_db, getattr(agent, "session_id", None) or "")
+        except Exception:
+            logger.debug("codex compaction count persistence failed", exc_info=True)
+
     agent._last_compaction_in_place = False
     try:
         if getattr(agent, "event_callback", None):

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -828,6 +828,7 @@ class GatewaySlashCommandsMixin:
             context_length = getattr(ctx, "context_length", 0) or 0
 
         model_name = _clean_str(getattr(agent, "model", "")) if has_agent else ""
+        durable_totals = None
 
         if not used:
             used = _int_value(getattr(session_entry, "last_prompt_tokens", 0))
@@ -839,6 +840,20 @@ class GatewaySlashCommandsMixin:
                     model_name = _clean_str(row.get("model", ""))
             except Exception:
                 model_name = ""
+
+        if self._session_db:
+            try:
+                await self._session_db.flush_token_counts()
+            except Exception:
+                pass
+            try:
+                totals = await self._session_db.get_compression_lineage_totals(
+                    session_entry.session_id
+                )
+                if isinstance(totals, dict):
+                    durable_totals = totals
+            except Exception:
+                durable_totals = None
 
         if not context_length:
             try:
@@ -893,12 +908,14 @@ class GatewaySlashCommandsMixin:
                 t("gateway.context.headroom", headroom=f"{headroom:,}"),
             ]
 
-            # Full view — compression / throughput need the live agent.
-            if ctx is not None:
+            # Compression/throughput accounting is durable across resident-agent
+            # reconstruction. The live compressor still owns threshold and last-
+            # savings diagnostics, but never the session-wide totals.
+            if durable_totals is not None or ctx is not None:
                 threshold = getattr(ctx, "threshold_tokens", 0) or 0
                 threshold_pct = (getattr(ctx, "threshold_percent", 0) or 0) * 100
                 lines.append("")
-                if threshold > 0:
+                if ctx is not None and threshold > 0:
                     if used >= threshold:
                         lines.append(
                             t(
@@ -916,20 +933,31 @@ class GatewaySlashCommandsMixin:
                                 to_go=f"{threshold - used:,}",
                             )
                         )
-                compressions = getattr(ctx, "compression_count", 0) or 0
+                compressions = (
+                    _int_value(durable_totals.get("successful_compression_count"))
+                    if durable_totals is not None
+                    else _int_value(getattr(ctx, "compression_count", 0))
+                )
                 lines.append(t("gateway.context.compressions", count=compressions))
-                if compressions:
+                if compressions and ctx is not None:
                     savings = getattr(ctx, "_last_compression_savings_pct", None)
                     if savings is not None:
                         lines.append(
                             t("gateway.context.last_savings", savings=f"{savings:.0f}")
                         )
 
-                api_calls = getattr(agent, "session_api_calls", 0) or 0
-                input_tokens = getattr(agent, "session_input_tokens", 0) or 0
-                output_tokens = getattr(agent, "session_output_tokens", 0) or 0
-                reasoning_tokens = getattr(agent, "session_reasoning_tokens", 0) or 0
-                total_tokens = getattr(agent, "session_total_tokens", 0) or 0
+                if durable_totals is not None:
+                    api_calls = _int_value(durable_totals.get("api_call_count"))
+                    input_tokens = _int_value(durable_totals.get("input_tokens"))
+                    output_tokens = _int_value(durable_totals.get("output_tokens"))
+                    reasoning_tokens = _int_value(durable_totals.get("reasoning_tokens"))
+                    total_tokens = _int_value(durable_totals.get("total_tokens"))
+                else:
+                    api_calls = getattr(agent, "session_api_calls", 0) or 0
+                    input_tokens = getattr(agent, "session_input_tokens", 0) or 0
+                    output_tokens = getattr(agent, "session_output_tokens", 0) or 0
+                    reasoning_tokens = getattr(agent, "session_reasoning_tokens", 0) or 0
+                    total_tokens = getattr(agent, "session_total_tokens", 0) or 0
                 lines.append("")
                 lines.append(
                     t("gateway.context.totals_header", calls=api_calls)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5784,7 +5784,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 (total_messages, total_tool_calls, child_session_id),
             )
             updated = conn.execute(
-                "UPDATE sessions SET ended_at = ?, end_reason = 'compression' "
+                "UPDATE sessions SET ended_at = ?, end_reason = 'compression', "
+                "successful_compression_count = "
+                "COALESCE(successful_compression_count, 0) + 1 "
                 "WHERE id = ? AND ended_at IS NULL",
                 (time.time(), parent_session_id),
             )
@@ -6317,6 +6319,26 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
 
         self._execute_write(_do)
+
+    def increment_successful_compression_count(self, session_id: str) -> int:
+        """Record one successful externally-owned compaction boundary."""
+        if not session_id:
+            return 0
+        self._insert_session_row(session_id, "unknown")
+
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET successful_compression_count = "
+                "COALESCE(successful_compression_count, 0) + 1 WHERE id = ?",
+                (session_id,),
+            )
+            row = conn.execute(
+                "SELECT successful_compression_count FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            return max(0, int(row[0] or 0)) if row is not None else 0
+
+        return int(self._execute_write(_do))
 
     # ──────────────────────────────────────────────────────────────────────
     # Compression locks
@@ -10081,13 +10103,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # the archived rows are still on disk but not part of the live count.
             if model_config_patch is None:
                 conn.execute(
-                    "UPDATE sessions SET message_count = ?, tool_call_count = ? WHERE id = ?",
+                    "UPDATE sessions SET message_count = ?, tool_call_count = ?, "
+                    "successful_compression_count = "
+                    "COALESCE(successful_compression_count, 0) + 1 WHERE id = ?",
                     (inserted, tool_calls_total, session_id),
                 )
             else:
                 conn.execute(
                     "UPDATE sessions SET message_count = ?, tool_call_count = ?, "
-                    "model_config = ? WHERE id = ?",
+                    "model_config = ?, successful_compression_count = "
+                    "COALESCE(successful_compression_count, 0) + 1 WHERE id = ?",
                     (inserted, tool_calls_total, patched_model_config, session_id),
                 )
             return inserted
@@ -11329,6 +11354,52 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 # requested session itself was compacted.
                 continue
         return lineage if session_id in lineage else [session_id]
+
+    def get_compression_lineage_totals(self, session_id: str) -> Dict[str, int]:
+        """Return durable usage and compaction totals for one logical session.
+
+        Physical session rows rotate at compression boundaries.  Aggregate the
+        canonical compression lineage only; explicit branches, delegates, and
+        reset-created children must keep independent accounting scopes.
+        """
+        columns = (
+            "successful_compression_count",
+            "api_call_count",
+            "input_tokens",
+            "output_tokens",
+            "cache_read_tokens",
+            "cache_write_tokens",
+            "reasoning_tokens",
+        )
+        totals = {column: 0 for column in columns}
+        lineage = list(dict.fromkeys(self.get_compression_lineage(session_id)))
+        if not lineage:
+            totals["total_tokens"] = 0
+            return totals
+
+        placeholders = ",".join("?" for _ in lineage)
+        select = ", ".join(
+            f"COALESCE(SUM(COALESCE({column}, 0)), 0) AS {column}"
+            for column in columns
+        )
+        with self._read_ctx() as conn:
+            row = conn.execute(
+                f"SELECT {select} FROM sessions WHERE id IN ({placeholders})",
+                lineage,
+            ).fetchone()
+        if row is not None:
+            totals.update({column: max(0, int(row[column] or 0)) for column in columns})
+        totals["total_tokens"] = sum(
+            totals[column]
+            for column in (
+                "input_tokens",
+                "output_tokens",
+                "cache_read_tokens",
+                "cache_write_tokens",
+                "reasoning_tokens",
+            )
+        )
+        return totals
 
     def clear_messages(self, session_id: str) -> None:
         """Delete all messages for a session and reset its counters."""

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -11355,7 +11355,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 continue
         return lineage if session_id in lineage else [session_id]
 
-    def get_compression_lineage_totals(self, session_id: str) -> Dict[str, int]:
+    def get_compression_lineage_totals(
+        self, session_id: str
+    ) -> Optional[Dict[str, int]]:
         """Return durable usage and compaction totals for one logical session.
 
         Physical session rows rotate at compression boundaries.  Aggregate the
@@ -11374,8 +11376,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         totals = {column: 0 for column in columns}
         lineage = list(dict.fromkeys(self.get_compression_lineage(session_id)))
         if not lineage:
-            totals["total_tokens"] = 0
-            return totals
+            return None
 
         placeholders = ",".join("?" for _ in lineage)
         select = ", ".join(
@@ -11396,7 +11397,6 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "output_tokens",
                 "cache_read_tokens",
                 "cache_write_tokens",
-                "reasoning_tokens",
             )
         )
         return totals

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -307,6 +307,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     compression_failure_error TEXT,
     compression_fallback_streak INTEGER NOT NULL DEFAULT 0,
     compression_ineffective_count INTEGER NOT NULL DEFAULT 0,
+    successful_compression_count INTEGER NOT NULL DEFAULT 0,
     profile_name TEXT,
     rewind_count INTEGER NOT NULL DEFAULT 0,
     archived INTEGER NOT NULL DEFAULT 0,

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -559,7 +559,7 @@ async def test_context_command_reports_durable_totals_without_resident_agent(tmp
     assert "Compressions this session: 4" in result
     assert "cumulative across 27 API calls" in result
     assert "Input 110,000 · Output 9,000 · Reasoning 6,000" in result
-    assert "Total billed: 197,000" in result
+    assert "Total billed: 191,000" in result
     assert "Full compression and throughput stats available" not in result
 
 
@@ -631,6 +631,27 @@ async def test_context_command_prefers_durable_totals_after_agent_reconstruction
     assert "Input 800,000 · Output 70,000 · Reasoning 20,000" in result
     assert "Total billed: 1,400,000" in result
     assert "cumulative across 2 API calls" not in result
+
+
+@pytest.mark.asyncio
+async def test_context_command_uses_resident_totals_when_durable_row_is_missing():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-not-persisted",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    runner._running_agents[session_entry.session_key] = _stub_agent()
+    runner._session_db._db.get_compression_lineage_totals.return_value = None
+
+    result = await runner._handle_context_command(_make_event("/context"))
+
+    assert "Compressions this session: 2" in result
+    assert "cumulative across 47 API calls" in result
+    assert "Total billed: 3,158,641" in result
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -516,6 +516,53 @@ async def test_context_command_keeps_configured_window_without_resident_agent():
     assert context_lookup.call_args.kwargs["config_context_length"] == 262_144
 
 
+@pytest.mark.asyncio
+async def test_context_command_reports_durable_totals_without_resident_agent(tmp_path):
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-durable",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    session_entry.last_prompt_tokens = 40_000
+    runner = _make_runner(session_entry)
+    db = SessionDB(db_path=tmp_path / "state.db")
+    runner._session_db = AsyncSessionDB(db)
+    try:
+        db.create_session(
+            "sess-durable",
+            source="telegram",
+            model="openai/gpt-test",
+        )
+        db.update_token_counts(
+            "sess-durable",
+            input_tokens=110_000,
+            output_tokens=9_000,
+            cache_read_tokens=70_000,
+            cache_write_tokens=2_000,
+            reasoning_tokens=6_000,
+            api_call_count=27,
+        )
+        for _ in range(4):
+            db.increment_successful_compression_count("sess-durable")
+
+        with patch(
+            "agent.model_metadata.get_model_context_length",
+            return_value=200_000,
+        ):
+            result = await runner._handle_context_command(_make_event("/context"))
+    finally:
+        db.close()
+
+    assert "Compressions this session: 4" in result
+    assert "cumulative across 27 API calls" in result
+    assert "Input 110,000 · Output 9,000 · Reasoning 6,000" in result
+    assert "Total billed: 197,000" in result
+    assert "Full compression and throughput stats available" not in result
+
+
 def _stub_agent(**overrides) -> SimpleNamespace:
     """Build a stub agent with the attributes _handle_context_command reads."""
     props = dict(
@@ -538,6 +585,52 @@ def _stub_agent(**overrides) -> SimpleNamespace:
     )
     props.update(overrides)
     return SimpleNamespace(**props)
+
+
+@pytest.mark.asyncio
+async def test_context_command_prefers_durable_totals_after_agent_reconstruction():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-reconstructed",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    runner._running_agents[session_entry.session_key] = _stub_agent(
+        session_api_calls=2,
+        session_input_tokens=300,
+        session_output_tokens=40,
+        session_reasoning_tokens=5,
+        session_total_tokens=345,
+        context_compressor=SimpleNamespace(
+            last_prompt_tokens=47_231,
+            context_length=200_000,
+            threshold_tokens=100_000,
+            threshold_percent=0.5,
+            compression_count=0,
+            _last_compression_savings_pct=None,
+        ),
+    )
+    runner._session_db._db.get_compression_lineage_totals.return_value = {
+        "successful_compression_count": 6,
+        "api_call_count": 91,
+        "input_tokens": 800_000,
+        "output_tokens": 70_000,
+        "cache_read_tokens": 500_000,
+        "cache_write_tokens": 10_000,
+        "reasoning_tokens": 20_000,
+        "total_tokens": 1_400_000,
+    }
+
+    result = await runner._handle_context_command(_make_event("/context"))
+
+    assert "Compressions this session: 6" in result
+    assert "cumulative across 91 API calls" in result
+    assert "Input 800,000 · Output 70,000 · Reasoning 20,000" in result
+    assert "Total billed: 1,400,000" in result
+    assert "cumulative across 2 API calls" not in result
 
 
 @pytest.mark.asyncio

--- a/tests/run_agent/test_codex_app_server_compaction.py
+++ b/tests/run_agent/test_codex_app_server_compaction.py
@@ -180,3 +180,26 @@ def test_codex_native_boundary_clears_stale_hermes_fallback_streak():
     assert _record_codex_app_server_compaction(agent, turn) is True
     assert compressor._fallback_compression_streak == 0
     assert compressor._verify_compaction_cleared_threshold is True
+
+
+def test_codex_native_boundary_persists_successful_compression(tmp_path):
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("hermes-session-1", source="cli")
+        agent = DummyAgent(
+            TurnResult(thread_id="thread-1", turn_id="compact-turn-1")
+        )
+        agent._session_db = db
+        turn = TurnResult(
+            thread_id="thread-1",
+            turn_id="compact-turn-1",
+            compacted=True,
+        )
+
+        assert _record_codex_app_server_compaction(agent, turn) is True
+
+        assert db.get_session("hermes-session-1")["successful_compression_count"] == 1
+    finally:
+        db.close()

--- a/tests/state/test_compression_accounting.py
+++ b/tests/state/test_compression_accounting.py
@@ -1,0 +1,172 @@
+"""Durable accounting for successful context compression boundaries."""
+
+import pytest
+
+from hermes_state import SessionCompressionInProgressError, SessionDB
+
+
+SUMMARY = [
+    {"role": "user", "content": "compressed summary"},
+    {"role": "assistant", "content": "continuation"},
+]
+
+
+@pytest.fixture
+def db(tmp_path):
+    store = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        yield store
+    finally:
+        store.close()
+
+
+def _seed_session(db: SessionDB, session_id: str) -> None:
+    db.create_session(session_id, source="test")
+    db.append_message(session_id, "user", "original question")
+    db.append_message(session_id, "assistant", "original answer")
+
+
+def test_in_place_commit_increments_successful_compression_atomically(db: SessionDB) -> None:
+    _seed_session(db, "session")
+
+    db.archive_and_compact("session", SUMMARY)
+    db.archive_and_compact("session", SUMMARY)
+
+    assert db.get_session("session")["successful_compression_count"] == 2
+
+
+def test_failed_in_place_commit_does_not_increment_successful_compression(
+    db: SessionDB,
+) -> None:
+    _seed_session(db, "session")
+    assert db.try_acquire_compression_lock("session", "winner") is True
+
+    with pytest.raises(SessionCompressionInProgressError):
+        db.archive_and_compact(
+            "session",
+            SUMMARY,
+            lock_holder="loser",
+        )
+
+    assert db.get_session("session")["successful_compression_count"] == 0
+
+
+def test_rotated_commit_counts_on_compression_parent(db: SessionDB) -> None:
+    _seed_session(db, "parent")
+    assert db.try_acquire_compression_lock("parent", "winner") is True
+
+    db.publish_compression_child(
+        parent_session_id="parent",
+        child_session_id="child",
+        source="test",
+        messages=SUMMARY,
+        compression_lock_holder="winner",
+    )
+
+    assert db.get_session("parent")["successful_compression_count"] == 1
+    assert db.get_session("child")["successful_compression_count"] == 0
+
+
+def test_failed_rotated_commit_does_not_increment_successful_compression(
+    db: SessionDB,
+    monkeypatch,
+) -> None:
+    _seed_session(db, "parent")
+    assert db.try_acquire_compression_lock("parent", "winner") is True
+
+    def fail_handoff(*_args, **_kwargs):
+        raise RuntimeError("handoff failed")
+
+    monkeypatch.setattr(db, "_insert_message_rows", fail_handoff)
+    with pytest.raises(RuntimeError, match="handoff failed"):
+        db.publish_compression_child(
+            parent_session_id="parent",
+            child_session_id="child",
+            source="test",
+            messages=SUMMARY,
+            compression_lock_holder="winner",
+        )
+
+    assert db.get_session("parent")["successful_compression_count"] == 0
+    assert db.get_session("child") is None
+
+
+def test_lineage_totals_sum_each_compression_segment_once(db: SessionDB) -> None:
+    _seed_session(db, "parent")
+    db.update_token_counts(
+        "parent",
+        input_tokens=100,
+        output_tokens=20,
+        cache_read_tokens=30,
+        cache_write_tokens=4,
+        reasoning_tokens=5,
+        api_call_count=2,
+    )
+    assert db.try_acquire_compression_lock("parent", "winner") is True
+    db.publish_compression_child(
+        parent_session_id="parent",
+        child_session_id="child",
+        source="test",
+        messages=SUMMARY,
+        compression_lock_holder="winner",
+    )
+    db.update_token_counts(
+        "child",
+        input_tokens=50,
+        output_tokens=10,
+        cache_read_tokens=7,
+        cache_write_tokens=1,
+        reasoning_tokens=3,
+        api_call_count=1,
+    )
+    db.archive_and_compact("child", SUMMARY)
+
+    assert db.get_compression_lineage_totals("child") == {
+        "successful_compression_count": 2,
+        "api_call_count": 3,
+        "input_tokens": 150,
+        "output_tokens": 30,
+        "cache_read_tokens": 37,
+        "cache_write_tokens": 5,
+        "reasoning_tokens": 8,
+        "total_tokens": 230,
+    }
+
+
+def test_reset_child_starts_a_fresh_accounting_scope(db: SessionDB) -> None:
+    _seed_session(db, "old")
+    db.update_token_counts("old", input_tokens=100, api_call_count=2)
+    db.end_session("old", "session_reset")
+    db.create_session(
+        "fresh",
+        source="test",
+        parent_session_id="old",
+        model_config={"_reset_from": "old"},
+    )
+    db.update_token_counts("fresh", input_tokens=7, api_call_count=1)
+
+    totals = db.get_compression_lineage_totals("fresh")
+
+    assert totals["api_call_count"] == 1
+    assert totals["input_tokens"] == 7
+    assert totals["successful_compression_count"] == 0
+
+
+def test_explicit_branch_does_not_inherit_compression_parent_totals(
+    db: SessionDB,
+) -> None:
+    _seed_session(db, "parent")
+    db.update_token_counts("parent", input_tokens=100, api_call_count=2)
+    db.end_session("parent", "compression")
+    db.create_session(
+        "branch",
+        source="test",
+        parent_session_id="parent",
+        model_config={"_branched_from": "parent"},
+    )
+    db.update_token_counts("branch", input_tokens=9, api_call_count=1)
+
+    totals = db.get_compression_lineage_totals("branch")
+
+    assert totals["api_call_count"] == 1
+    assert totals["input_tokens"] == 9

--- a/tests/state/test_compression_accounting.py
+++ b/tests/state/test_compression_accounting.py
@@ -129,8 +129,12 @@ def test_lineage_totals_sum_each_compression_segment_once(db: SessionDB) -> None
         "cache_read_tokens": 37,
         "cache_write_tokens": 5,
         "reasoning_tokens": 8,
-        "total_tokens": 230,
+        "total_tokens": 222,
     }
+
+
+def test_missing_session_has_no_durable_totals(db: SessionDB) -> None:
+    assert db.get_compression_lineage_totals("missing") is None
 
 
 def test_reset_child_starts_a_fresh_accounting_scope(db: SessionDB) -> None:


### PR DESCRIPTION
## What does this PR do?

Gateway `/context` now reports session-wide compression and usage totals accurately after its resident agent is evicted, reconstructed, or restarted. The totals come from durable SessionDB accounting across the canonical compression lineage, preventing operators from seeing counters reset to zero or a small owner-lifetime value while the logical conversation continues.

### Symptom

For one uninterrupted logical gateway conversation, repeated `/context` output can show compression counts dropping from a positive value to zero and API-call totals restarting from a small value after agent reconstruction, even though the durable session rows retain the full history.

### Impact

Gateway operators receive misleading context and throughput diagnostics for long-running conversations. This can hide accumulated compression activity and substantially underreport API and token usage after cache eviction or restart.

### Bug Cause

**Trigger:** `gateway/slash_commands.py` / `GatewaySlashCommandsMixin._handle_context_command` reads counters from the current resident `AIAgent` and `ContextCompressor` instances.

**Causal chain:**
1. A gateway conversation accumulates API calls and successful context compressions.
2. Cache eviction, restart, or reconstruction replaces the resident Python objects, whose owner-lifetime counters initialize at zero.
3. `/context` labels those reset counters as cumulative session totals, so the displayed values no longer match the durable logical conversation.

**Why it is wrong:** The presentation scope is the logical session, but the previous accounting source was the lifetime of one resident object. Successful compressions also lacked a durable positive counter.

**Working sibling / contrast:** SessionDB already persists per-physical-session API and token deltas, and its compression lineage follows only real compression continuation edges. Explicit reset, branch, and delegate children remain separate accounting scopes.

**Ruled out:** Token persistence itself is not resetting. Durable session rows retain the larger values; the undercount occurs when `/context` ignores them after resident-agent reconstruction.

### Fix

Persist successful compression commits atomically for in-place, rotated, and Codex app-server compaction paths. Aggregate API, token, and compression totals across the canonical compression lineage, while preserving resident-only threshold and last-savings diagnostics. Fall back to resident counters when no durable row exists so newly constructed agents are not incorrectly shown as zero.

## Related Issue

Closes #89318

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state_common.py` - add the durable successful-compression counter to the session schema.
- `hermes_state.py` - record successful commits and aggregate logical-session totals without crossing reset or branch boundaries.
- `agent/codex_runtime.py` - persist successful externally owned Codex compactions.
- `gateway/slash_commands.py` - render durable totals with a safe resident fallback and live-only diagnostics.
- `tests/gateway/test_status_command.py` - cover reconstructed and non-resident `/context` output plus missing-row fallback.
- `tests/state/test_compression_accounting.py` - cover lineage aggregation, reset isolation, repeated success, and failed-commit behavior.
- `tests/run_agent/test_codex_app_server_compaction.py` - cover Codex compaction persistence.

## How to Test

1. Create physical session rows connected by compression continuation and record usage on each segment.
2. Reconstruct or remove the resident agent, then invoke `/context` and verify that compression, API-call, and token totals remain cumulative.
3. Run the focused gateway, state-accounting, schema, and Codex compaction tests. The related clean gates completed with 65 passing tests; the post-review regression gate completed with 12 passing tests and ruff passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all related clean gates pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; no user-facing configuration or workflow changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; no contributor workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; no model tool schema changed
