### PR TITLE
fix(desktop): sync Bot Mode room previews through profiles

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -192,6 +192,301 @@ const $groupChatWorkspace = atom(null)
 /** Groups whose latest room activity mentions @user — the needs-you badge. */
 const $groupNeedsYou = atom({})
 
+const GROUP_CHAT_SYNC_META_KEY = 'hermes-bots-groups'
+// Gateway ui_meta is capped after Python JSON serialization. Keep a healthy
+// margin below that limit because Python escapes Unicode while JS does not.
+const GROUP_CHAT_SYNC_MAX_BYTES = 48000
+const GROUP_CHAT_SYNC_MESSAGES = 16
+const GROUP_CHAT_SYNC_TEXT_CHARS = 1200
+let groupChatSyncTimer = null
+let groupChatSyncRetryTimer = null
+let groupChatSyncPending = null
+let groupChatSyncInFlight = false
+let groupChatSyncRetryCount = 0
+let groupChatSyncDisposed = false
+
+/** Conservative byte count for the gateway's ensure_ascii JSON encoding.
+ *  Python also inserts separator spaces, so reserve one extra byte per JS
+ *  structural separator on top of escaped Unicode code-point widths. */
+function groupChatGatewayJsonSize(value) {
+  const json = JSON.stringify(value)
+  let bytes = 0
+
+  for (const character of json) {
+    const codePoint = character.codePointAt(0)
+
+    if (codePoint <= 0x7f) {
+      bytes += 1
+      if (character === ',' || character === ':') {
+        bytes += 1
+      }
+    } else {
+      bytes += codePoint <= 0xffff ? 6 : 12
+    }
+  }
+
+  return bytes
+}
+
+/** Compact, display-oriented copy of Desktop's room log for gateway clients.
+ *  The live orchestration state stays in plugin storage; this bounded mirror
+ *  rides the default profile's ui_meta so mobile can show the same messages.
+ *  Newest rooms/messages win when the profile metadata size cap is reached. */
+function groupChatSyncSnapshot(all = $groupChats.get(), deleted = {}) {
+  const ranked = Object.entries(all || {})
+    // Empty runtime tombstones are used to stop an in-flight room after
+    // disband. They are not real rooms and must never reappear on mobile.
+    .filter(([, room]) => room && Array.isArray(room.log) && room.log.length > 0)
+    .sort(([, left], [, right]) => {
+      const leftAt = Number(left.log[left.log.length - 1]?.at || 0)
+      const rightAt = Number(right.log[right.log.length - 1]?.at || 0)
+      return rightAt - leftAt
+    })
+  const rooms = {}
+  const boundedDeleted = Object.fromEntries(
+    Object.entries(deleted)
+      .sort(([, left], [, right]) => Number(right || 0) - Number(left || 0))
+      .slice(0, 64)
+  )
+  const envelope = {
+    version: 1,
+    updatedAt: Date.now(),
+    rooms,
+    ...(Object.keys(boundedDeleted).length ? { deleted: boundedDeleted } : {})
+  }
+
+  for (const [name, room] of ranked) {
+    const log = room.log.slice(-GROUP_CHAT_SYNC_MESSAGES).map(entry => ({
+      from: {
+        kind: entry?.from?.kind === 'member' ? 'member' : 'user',
+        name: String(entry?.from?.name || (entry?.from?.kind === 'member' ? 'Bot' : 'You')).slice(0, 128),
+        ...(entry?.from?.source ? { source: String(entry.from.source).slice(0, 128) } : {})
+      },
+      text: String(entry?.text || '').slice(0, GROUP_CHAT_SYNC_TEXT_CHARS),
+      at: Number(entry?.at || 0),
+      ...(entry?.thread ? { thread: String(entry.thread).slice(0, 128) } : {})
+    }))
+    const compact = {
+      log,
+      members: (Array.isArray(room.members) ? room.members : []).slice(0, GROUP_CHAT_MAX_MEMBERS).map(member => ({
+        name: String(member?.name || '').slice(0, 128),
+        ...(member?.handle ? { handle: String(member.handle).slice(0, 128) } : {}),
+        ...(member?.connectionId ? { connectionId: String(member.connectionId).slice(0, 128) } : {}),
+        ...(member?.connectionKind ? { connectionKind: String(member.connectionKind).slice(0, 64) } : {}),
+        ...(member?.connectionLabel ? { connectionLabel: String(member.connectionLabel).slice(0, 128) } : {}),
+        ...(member?.sourceScoped ? { sourceScoped: true } : {})
+      }))
+    }
+
+    rooms[name] = compact
+    while (compact.log.length > 1 && groupChatGatewayJsonSize(envelope) > GROUP_CHAT_SYNC_MAX_BYTES) {
+      compact.log.shift()
+    }
+    if (groupChatGatewayJsonSize(envelope) > GROUP_CHAT_SYNC_MAX_BYTES) {
+      delete rooms[name]
+    }
+  }
+
+  return envelope
+}
+
+function groupChatSyncEntryKey(entry) {
+  return JSON.stringify([
+    Number(entry?.at || 0),
+    String(entry?.from?.kind || ''),
+    String(entry?.from?.name || ''),
+    String(entry?.from?.source || ''),
+    String(entry?.thread || ''),
+    String(entry?.text || '')
+  ])
+}
+
+function groupChatSyncMemberKey(member) {
+  return JSON.stringify([
+    String(member?.source || ''),
+    String(member?.connectionId || ''),
+    String(member?.connectionLabel || ''),
+    String(member?.handle || ''),
+    String(member?.name || '')
+  ])
+}
+
+/** Merge two bounded projections without treating an absent room/message as
+ *  deletion. Explicit tombstones win until a genuinely newer room message
+ *  recreates the same name. */
+function mergeGroupChatSyncSnapshots(remote, local) {
+  const rooms = {}
+  const deleted = {}
+
+  for (const source of [remote, local]) {
+    for (const [name, at] of Object.entries(source?.deleted || {})) {
+      deleted[name] = Math.max(Number(deleted[name] || 0), Number(at || 0))
+    }
+  }
+
+  for (const source of [remote, local]) {
+    for (const [name, room] of Object.entries(source?.rooms || {})) {
+      if (!room || !Array.isArray(room.log)) {
+        continue
+      }
+      const current = rooms[name] || { log: [], members: [] }
+      const entries = new Map(current.log.map(entry => [groupChatSyncEntryKey(entry), entry]))
+      const members = new Map(current.members.map(member => [groupChatSyncMemberKey(member), member]))
+
+      for (const entry of room.log) {
+        entries.set(groupChatSyncEntryKey(entry), entry)
+      }
+      for (const member of Array.isArray(room.members) ? room.members : []) {
+        members.set(groupChatSyncMemberKey(member), member)
+      }
+      rooms[name] = {
+        log: [...entries.values()].sort((left, right) => {
+          const byTime = Number(left?.at || 0) - Number(right?.at || 0)
+          return byTime || groupChatSyncEntryKey(left).localeCompare(groupChatSyncEntryKey(right))
+        }),
+        members: [...members.values()]
+      }
+    }
+  }
+
+  for (const [name, deletedAt] of Object.entries(deleted)) {
+    const latestMessageAt = Math.max(0, ...(rooms[name]?.log || []).map(entry => Number(entry?.at || 0)))
+    if (Number(deletedAt || 0) >= latestMessageAt) {
+      delete rooms[name]
+    } else {
+      delete deleted[name]
+    }
+  }
+
+  return groupChatSyncSnapshot(rooms, deleted)
+}
+
+function groupChatSyncConnectionId() {
+  return String(host.state.connectionId?.get?.() || host.activeConnectionId?.() || '')
+}
+
+/** Route a sync job back to the gateway that was active when it was queued.
+ *  A foreground switch during debounce must not write the old snapshot into
+ *  the newly active gateway. */
+async function groupChatSyncRequest(job, method, params) {
+  if (job.connectionId && typeof host.profileRoutes === 'function' && typeof host.requestProfile === 'function') {
+    const routes = await host.profileRoutes()
+    const route = (Array.isArray(routes) ? routes : []).find(candidate => {
+      const profile = String(candidate?.targetProfile || candidate?.profile || '')
+      return String(candidate?.connectionId || '') === job.connectionId && profile === 'default'
+    })
+
+    if (route) {
+      return host.requestProfile(route, method, params)
+    }
+  }
+
+  const currentConnectionId = groupChatSyncConnectionId()
+  if (job.connectionId && currentConnectionId && job.connectionId !== currentConnectionId) {
+    throw new Error('Group chat gateway changed before sync')
+  }
+  return host.request(method, params)
+}
+
+async function groupChatRemoteSnapshot(job) {
+  const result = await groupChatSyncRequest(job, 'profiles.list', { include_sessions: false })
+  const profile = (Array.isArray(result?.profiles) ? result.profiles : []).find(row => row?.name === 'default')
+  const snapshot = profile?.ui_meta?.[GROUP_CHAT_SYNC_META_KEY]
+  return snapshot && typeof snapshot === 'object' && !Array.isArray(snapshot) ? snapshot : null
+}
+
+function groupChatSyncBackoff() {
+  return Math.min(30000, 1000 * 2 ** Math.min(groupChatSyncRetryCount, 5))
+}
+
+async function flushGroupChatServerSync() {
+  if (groupChatSyncDisposed || groupChatSyncInFlight || !groupChatSyncPending) {
+    return
+  }
+  const job = groupChatSyncPending
+  groupChatSyncPending = null
+  groupChatSyncInFlight = true
+
+  try {
+    const remote = await groupChatRemoteSnapshot(job)
+    const snapshot = mergeGroupChatSyncSnapshots(remote, job.snapshot)
+    const result = await groupChatSyncRequest(job, 'profiles.configure', {
+      name: 'default',
+      ui_meta: { [GROUP_CHAT_SYNC_META_KEY]: snapshot }
+    })
+
+    if (result?.applied && result.applied.ui_meta !== true) {
+      throw new Error('Gateway rejected group chat ui_meta')
+    }
+
+    const confirmed = await groupChatRemoteSnapshot(job)
+    if (confirmed && Number(confirmed.updatedAt || 0) !== Number(snapshot.updatedAt || 0)) {
+      throw new Error('Group chat ui_meta changed before read-back')
+    }
+    groupChatSyncRetryCount = 0
+  } catch {
+    if (!groupChatSyncDisposed) {
+      groupChatSyncPending ||= job
+      groupChatSyncRetryCount += 1
+      if (typeof setTimeout === 'function' && groupChatSyncRetryTimer === null) {
+        groupChatSyncRetryTimer = setTimeout(() => {
+          groupChatSyncRetryTimer = null
+          void flushGroupChatServerSync()
+        }, groupChatSyncBackoff())
+      }
+    }
+  } finally {
+    groupChatSyncInFlight = false
+    if (groupChatSyncPending && groupChatSyncRetryTimer === null && !groupChatSyncDisposed) {
+      void flushGroupChatServerSync()
+    }
+  }
+}
+
+function stopGroupChatServerSync() {
+  groupChatSyncDisposed = true
+  groupChatSyncPending = null
+  if (groupChatSyncTimer !== null) {
+    clearTimeout(groupChatSyncTimer)
+    groupChatSyncTimer = null
+  }
+  if (groupChatSyncRetryTimer !== null) {
+    clearTimeout(groupChatSyncRetryTimer)
+    groupChatSyncRetryTimer = null
+  }
+}
+
+/** Debounced, pull-merge-write server mirror. Local storage keeps the complete
+ *  orchestration log; ui_meta is a bounded cross-client projection. */
+function scheduleGroupChatServerSync(all = $groupChats.get(), { allowEmpty = false, deletedRooms = [] } = {}) {
+  // Browser shells provide timers; source-level VM tests and older embedded
+  // hosts may not. Room persistence must never break the surrounding gateway
+  // lifecycle when the optional mirror cannot be scheduled.
+  if (typeof setTimeout !== 'function') {
+    return
+  }
+  const deleted = Object.fromEntries(deletedRooms.map(name => [name, Date.now()]))
+  const snapshot = groupChatSyncSnapshot(all, deleted)
+  // A newly installed Desktop has no local room cache. Publishing that empty
+  // state on hydrate/reconnect would erase a valid mirror produced elsewhere.
+  // Only an explicit final-room disband is allowed to clear the projection.
+  if (Object.keys(snapshot.rooms).length === 0 && !allowEmpty) {
+    return
+  }
+  if (groupChatSyncTimer !== null) {
+    clearTimeout(groupChatSyncTimer)
+  }
+  if (groupChatSyncRetryTimer !== null) {
+    clearTimeout(groupChatSyncRetryTimer)
+    groupChatSyncRetryTimer = null
+  }
+  groupChatSyncPending = { snapshot, connectionId: groupChatSyncConnectionId() }
+  groupChatSyncTimer = setTimeout(() => {
+    groupChatSyncTimer = null
+    void flushGroupChatServerSync()
+  }, 350)
+}
+
 function handleSessionsGatewayTransition() {
   $sessionsGatewayGeneration.set($sessionsGatewayGeneration.get() + 1)
   $botSelectedSessions.set({})
@@ -204,6 +499,10 @@ function handleSessionsGatewayTransition() {
   }
 
   $groupChats.set(rooms)
+  // Re-publish the bounded room mirror after reconnects or gateway swaps.
+  // Local plugin storage remains authoritative, so a transient failure here
+  // is harmless and the next gateway transition or room update retries it.
+  scheduleGroupChatServerSync(rooms)
 }
 
 /** Per-bot appearance + display meta, persisted via ctx.storage:
@@ -3523,6 +3822,7 @@ function updateGroupChat(group, mutate) {
   } catch {
     /* storage unavailable — room survives for this window only */
   }
+  scheduleGroupChatServerSync(all)
 
   return next
 }
@@ -3581,6 +3881,7 @@ async function disbandGroupChat(group, members) {
   } catch {
     /* storage unavailable — the atom reset above still empties the room */
   }
+  scheduleGroupChatServerSync($groupChats.get(), { allowEmpty: true, deletedRooms: [group] })
 
   // Remove this membership last. saveBotMeta never throws (local storage +
   // best-effort profiles.configure per member), so a flaky gateway can't
@@ -4040,6 +4341,13 @@ function sendToGroupChat(group, members, text, thread) {
   const target = thread || mintGroupThreadId()
 
   $groupNeedsYou.set({ ...$groupNeedsYou.get(), [group]: false })
+  // Refresh the durable room roster on every send. This backfills rooms made
+  // by older Desktop builds and keeps the gateway mirror complete even when
+  // members overlap across multiple groups.
+  updateGroupChat(group, room => {
+    room.members = durableGroupChatMembers(members)
+    return room
+  })
   appendGroupChatEntry(group, { kind: 'user', name: 'You' }, trimmed, target)
 
   const wasRunning = ($groupChats.get()[group] || {}).running === true
@@ -9104,6 +9412,7 @@ export default {
   description: 'Bot Mode — a one-chat-per-agent roster with avatars, routines, group chats, and bot-to-bot messaging. Ships with the app; disable here if unwanted.',
   register(ctx) {
     pluginCtx = ctx
+    groupChatSyncDisposed = false
     startFaceClock()
     // Disabling the plugin (or a hot reload) must actually stop the clock —
     // before this, the rAF loop + 1Hz document scan ran until app restart.
@@ -9235,6 +9544,7 @@ export default {
             }
 
             $groupChats.set({ ...rooms, ...$groupChats.get() })
+            scheduleGroupChatServerSync($groupChats.get())
           }
         })
         .catch(() => undefined)
@@ -9255,6 +9565,7 @@ export default {
 
     if (typeof ctx.onDispose === 'function') {
       ctx.onDispose(() => {
+        stopGroupChatServerSync()
         if (typeof unbindProfileListener === 'function') {
           unbindProfileListener()
         }

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -198,6 +198,7 @@ const GROUP_CHAT_SYNC_META_KEY = 'hermes-bots-groups'
 const GROUP_CHAT_SYNC_MAX_BYTES = 48000
 const GROUP_CHAT_SYNC_MESSAGES = 16
 const GROUP_CHAT_SYNC_TEXT_CHARS = 1200
+const GROUP_CHAT_SYNC_IMAGE_CHARS = 24000
 let groupChatSyncTimer = null
 let groupChatSyncRetryTimer = null
 let groupChatSyncPending = null
@@ -249,7 +250,7 @@ function groupChatSyncSnapshot(all = $groupChats.get(), deleted = {}) {
       .slice(0, 64)
   )
   const envelope = {
-    version: 1,
+    version: 2,
     updatedAt: Date.now(),
     rooms,
     ...(Object.keys(boundedDeleted).length ? { deleted: boundedDeleted } : {})
@@ -257,6 +258,7 @@ function groupChatSyncSnapshot(all = $groupChats.get(), deleted = {}) {
 
   for (const [name, room] of ranked) {
     const log = room.log.slice(-GROUP_CHAT_SYNC_MESSAGES).map(entry => ({
+      ...(entry?.id ? { id: String(entry.id).slice(0, 160) } : {}),
       from: {
         kind: entry?.from?.kind === 'member' ? 'member' : 'user',
         name: String(entry?.from?.name || (entry?.from?.kind === 'member' ? 'Bot' : 'You')).slice(0, 128),
@@ -268,6 +270,7 @@ function groupChatSyncSnapshot(all = $groupChats.get(), deleted = {}) {
     }))
     const compact = {
       log,
+      revision: Math.max(0, Number(room?.syncRevision ?? room?.revision ?? 0)),
       members: (Array.isArray(room.members) ? room.members : []).slice(0, GROUP_CHAT_MAX_MEMBERS).map(member => ({
         name: String(member?.name || '').slice(0, 128),
         ...(member?.handle ? { handle: String(member.handle).slice(0, 128) } : {}),
@@ -275,12 +278,18 @@ function groupChatSyncSnapshot(all = $groupChats.get(), deleted = {}) {
         ...(member?.connectionKind ? { connectionKind: String(member.connectionKind).slice(0, 64) } : {}),
         ...(member?.connectionLabel ? { connectionLabel: String(member.connectionLabel).slice(0, 128) } : {}),
         ...(member?.sourceScoped ? { sourceScoped: true } : {})
-      }))
+      })),
+      ...(typeof room?.image === 'string' && room.image.length <= GROUP_CHAT_SYNC_IMAGE_CHARS
+        ? { image: room.image }
+        : {})
     }
 
     rooms[name] = compact
     while (compact.log.length > 1 && groupChatGatewayJsonSize(envelope) > GROUP_CHAT_SYNC_MAX_BYTES) {
       compact.log.shift()
+    }
+    if (compact.image && groupChatGatewayJsonSize(envelope) > GROUP_CHAT_SYNC_MAX_BYTES) {
+      delete compact.image
     }
     if (groupChatGatewayJsonSize(envelope) > GROUP_CHAT_SYNC_MAX_BYTES) {
       delete rooms[name]
@@ -291,6 +300,9 @@ function groupChatSyncSnapshot(all = $groupChats.get(), deleted = {}) {
 }
 
 function groupChatSyncEntryKey(entry) {
+  if (entry?.id) {
+    return `id:${String(entry.id)}`
+  }
   return JSON.stringify([
     Number(entry?.at || 0),
     String(entry?.from?.kind || ''),
@@ -311,47 +323,76 @@ function groupChatSyncMemberKey(member) {
   ])
 }
 
+function groupChatSyncDeletedRevision(source, value) {
+  return Number(source?.version || 0) >= 2 ? Math.max(0, Number(value || 0)) : 0
+}
+
 /** Merge two bounded projections without treating an absent room/message as
- *  deletion. Explicit tombstones win until a genuinely newer room message
- *  recreates the same name. */
-function mergeGroupChatSyncSnapshots(remote, local) {
+ *  deletion. Gateway revisions order room identity/membership/picture and
+ *  tombstones; stable message ids make concurrent log union idempotent. */
+function mergeGroupChatSyncSnapshots(
+  remote,
+  local,
+  { changedRooms = [], deletedRooms = [], writeRevision = 0 } = {}
+) {
   const rooms = {}
   const deleted = {}
+  const changed = new Set(changedRooms)
 
   for (const source of [remote, local]) {
     for (const [name, at] of Object.entries(source?.deleted || {})) {
-      deleted[name] = Math.max(Number(deleted[name] || 0), Number(at || 0))
+      deleted[name] = Math.max(Number(deleted[name] || 0), groupChatSyncDeletedRevision(source, at))
+    }
+  }
+  for (const name of deletedRooms) {
+    deleted[name] = Math.max(Number(deleted[name] || 0), Number(writeRevision || 0))
+  }
+
+  const roomNames = new Set([...Object.keys(remote?.rooms || {}), ...Object.keys(local?.rooms || {})])
+  for (const name of roomNames) {
+    const remoteRoom = remote?.rooms?.[name]
+    const localRoom = local?.rooms?.[name]
+    if ((!remoteRoom || !Array.isArray(remoteRoom.log)) && (!localRoom || !Array.isArray(localRoom.log))) {
+      continue
+    }
+    const remoteRevision = Math.max(0, Number(remoteRoom?.revision || 0))
+    const localRevision = changed.has(name)
+      ? Math.max(0, Number(writeRevision || 0))
+      : Math.max(0, Number(localRoom?.revision || 0))
+    const entries = new Map()
+    for (const entry of [...(remoteRoom?.log || []), ...(localRoom?.log || [])]) {
+      entries.set(groupChatSyncEntryKey(entry), entry)
+    }
+
+    let members
+    let image
+    if (localRevision > remoteRevision) {
+      members = [...(localRoom?.members || [])]
+      image = localRoom?.image
+    } else if (remoteRevision > localRevision) {
+      members = [...(remoteRoom?.members || [])]
+      image = remoteRoom?.image
+    } else {
+      const byId = new Map()
+      for (const member of [...(remoteRoom?.members || []), ...(localRoom?.members || [])]) {
+        byId.set(groupChatSyncMemberKey(member), member)
+      }
+      members = [...byId.values()]
+      image = Object.prototype.hasOwnProperty.call(localRoom || {}, 'image') ? localRoom.image : remoteRoom?.image
+    }
+    rooms[name] = {
+      log: [...entries.values()].sort((left, right) => {
+        const byTime = Number(left?.at || 0) - Number(right?.at || 0)
+        return byTime || groupChatSyncEntryKey(left).localeCompare(groupChatSyncEntryKey(right))
+      }),
+      members,
+      revision: Math.max(remoteRevision, localRevision),
+      ...(typeof image === 'string' && image ? { image } : {})
     }
   }
 
-  for (const source of [remote, local]) {
-    for (const [name, room] of Object.entries(source?.rooms || {})) {
-      if (!room || !Array.isArray(room.log)) {
-        continue
-      }
-      const current = rooms[name] || { log: [], members: [] }
-      const entries = new Map(current.log.map(entry => [groupChatSyncEntryKey(entry), entry]))
-      const members = new Map(current.members.map(member => [groupChatSyncMemberKey(member), member]))
-
-      for (const entry of room.log) {
-        entries.set(groupChatSyncEntryKey(entry), entry)
-      }
-      for (const member of Array.isArray(room.members) ? room.members : []) {
-        members.set(groupChatSyncMemberKey(member), member)
-      }
-      rooms[name] = {
-        log: [...entries.values()].sort((left, right) => {
-          const byTime = Number(left?.at || 0) - Number(right?.at || 0)
-          return byTime || groupChatSyncEntryKey(left).localeCompare(groupChatSyncEntryKey(right))
-        }),
-        members: [...members.values()]
-      }
-    }
-  }
-
-  for (const [name, deletedAt] of Object.entries(deleted)) {
-    const latestMessageAt = Math.max(0, ...(rooms[name]?.log || []).map(entry => Number(entry?.at || 0)))
-    if (Number(deletedAt || 0) >= latestMessageAt) {
+  for (const [name, deletedRevision] of Object.entries(deleted)) {
+    if (Number(deletedRevision || 0) >= Number(rooms[name]?.revision || 0)) {
       delete rooms[name]
     } else {
       delete deleted[name]
@@ -365,14 +406,26 @@ function mergeGroupChatSyncSnapshots(remote, local) {
  *  state without discarding local session/watermark/runtime fields. Missing
  *  remote rooms/messages are not deletions; only explicit tombstones remove a
  *  room, and a genuinely newer local message wins over a stale tombstone. */
-function mergeRemoteGroupChatSnapshotIntoRooms(remote, current = $groupChats.get()) {
+function mergeRemoteGroupChatSnapshotIntoRooms(
+  remote,
+  current = $groupChats.get(),
+  { preserveRooms = [], deletedRooms = [] } = {}
+) {
   const rooms = { ...(current || {}) }
+  const preserved = new Set(preserveRooms)
+  const locallyDeleted = new Set(deletedRooms)
 
   for (const [name, projected] of Object.entries(remote?.rooms || {})) {
     if (!projected || !Array.isArray(projected.log)) {
       continue
     }
+    if (locallyDeleted.has(name)) {
+      delete rooms[name]
+      continue
+    }
     const existing = rooms[name] || {}
+    const remoteRevision = Math.max(0, Number(projected.revision || 0))
+    const localRevision = Math.max(0, Number(existing.syncRevision || 0))
     const entries = new Map(
       (Array.isArray(existing.log) ? existing.log : []).map(entry => [groupChatSyncEntryKey(entry), entry])
     )
@@ -383,8 +436,13 @@ function mergeRemoteGroupChatSnapshotIntoRooms(remote, current = $groupChats.get
     for (const entry of projected.log) {
       entries.set(groupChatSyncEntryKey(entry), entry)
     }
-    for (const member of Array.isArray(projected.members) ? projected.members : []) {
-      members.set(groupChatSyncMemberKey(member), { ...member, remoteSource: true })
+    if (!preserved.has(name)) {
+      if (remoteRevision > localRevision) {
+        members.clear()
+      }
+      for (const member of Array.isArray(projected.members) ? projected.members : []) {
+        members.set(groupChatSyncMemberKey(member), { ...member, remoteSource: true })
+      }
     }
 
     const log = assignLegacyThreads(
@@ -402,16 +460,28 @@ function mergeRemoteGroupChatSnapshotIntoRooms(remote, current = $groupChats.get
       sessions: existing.sessions && typeof existing.sessions === 'object' ? existing.sessions : {},
       stranded: existing.stranded && typeof existing.stranded === 'object' ? existing.stranded : {},
       members: [...members.values()],
+      image: preserved.has(name)
+        ? existing.image || null
+        : remoteRevision >= localRevision && Object.prototype.hasOwnProperty.call(projected, 'image')
+          ? projected.image || null
+          : existing.image || null,
+      syncRevision: preserved.has(name) ? localRevision : Math.max(remoteRevision, localRevision),
       epoch: Number(existing.epoch || 0),
       running: Boolean(existing.running)
     }
   }
 
   for (const [name, deletedAt] of Object.entries(remote?.deleted || {})) {
-    const latestMessageAt = Math.max(0, ...(rooms[name]?.log || []).map(entry => Number(entry?.at || 0)))
-    if (Number(deletedAt || 0) >= latestMessageAt) {
+    if (preserved.has(name)) {
+      continue
+    }
+    const deletedRevision = groupChatSyncDeletedRevision(remote, deletedAt)
+    if (deletedRevision >= Number(rooms[name]?.syncRevision || 0)) {
       delete rooms[name]
     }
+  }
+  for (const name of locallyDeleted) {
+    delete rooms[name]
   }
 
   return rooms
@@ -429,7 +499,9 @@ function durableGroupChatRooms(all = $groupChats.get()) {
       watermarks: room.watermarks || {},
       sessions: room.sessions || {},
       stranded: room.stranded || {},
-      members: Array.isArray(room.members) ? room.members : []
+      members: Array.isArray(room.members) ? room.members : [],
+      image: room.image || null,
+      syncRevision: Math.max(0, Number(room.syncRevision || 0))
     }
   }
 
@@ -475,18 +547,26 @@ async function groupChatRemoteSnapshot(job) {
   const result = await groupChatSyncRequest(job, 'profiles.list', { include_sessions: false })
   const profile = (Array.isArray(result?.profiles) ? result.profiles : []).find(row => row?.name === 'default')
   const snapshot = profile?.ui_meta?.[GROUP_CHAT_SYNC_META_KEY]
-  return snapshot && typeof snapshot === 'object' && !Array.isArray(snapshot) ? snapshot : null
+  const supportsCas = Boolean(profile && Object.prototype.hasOwnProperty.call(profile, 'ui_meta_revisions'))
+  return {
+    snapshot: snapshot && typeof snapshot === 'object' && !Array.isArray(snapshot) ? snapshot : null,
+    revision: Math.max(0, Number(profile?.ui_meta_revisions?.[GROUP_CHAT_SYNC_META_KEY] || 0)),
+    supportsCas
+  }
 }
 
 /** Pull the shared room projection into this Desktop before it publishes any
  *  local state. This is the receive half of the client-only sync contract. */
 async function pullGroupChatServerState(connectionId = groupChatSyncConnectionId()) {
-  const remote = await groupChatRemoteSnapshot({ connectionId })
+  const { snapshot: remote } = await groupChatRemoteSnapshot({ connectionId })
 
   if (!remote) {
     return false
   }
-  const merged = mergeRemoteGroupChatSnapshotIntoRooms(remote, $groupChats.get())
+  const merged = mergeRemoteGroupChatSnapshotIntoRooms(remote, $groupChats.get(), {
+    preserveRooms: groupChatSyncPending?.changedRooms || [],
+    deletedRooms: groupChatSyncPending?.deletedRooms || []
+  })
   $groupChats.set(merged)
   await persistGroupChatRooms(merged)
   return true
@@ -494,6 +574,25 @@ async function pullGroupChatServerState(connectionId = groupChatSyncConnectionId
 
 function groupChatSyncBackoff() {
   return Math.min(30000, 1000 * 2 ** Math.min(groupChatSyncRetryCount, 5))
+}
+
+function mergeGroupChatSyncJobs(existing, incoming) {
+  if (!existing || existing.connectionId !== incoming.connectionId) {
+    return incoming
+  }
+  return {
+    connectionId: incoming.connectionId,
+    allowEmpty: Boolean(existing.allowEmpty || incoming.allowEmpty),
+    changedRooms: [...new Set([...(existing.changedRooms || []), ...(incoming.changedRooms || [])])],
+    deletedRooms: [...new Set([...(existing.deletedRooms || []), ...(incoming.deletedRooms || [])])]
+  }
+}
+
+function groupChatSyncPayloadEqual(left, right) {
+  return (
+    JSON.stringify(left?.rooms || {}) === JSON.stringify(right?.rooms || {}) &&
+    JSON.stringify(left?.deleted || {}) === JSON.stringify(right?.deleted || {})
+  )
 }
 
 async function flushGroupChatServerSync() {
@@ -505,35 +604,66 @@ async function flushGroupChatServerSync() {
   groupChatSyncInFlight = true
 
   try {
-    const remote = await groupChatRemoteSnapshot(job)
-    if (remote) {
-      const mergedRooms = mergeRemoteGroupChatSnapshotIntoRooms(remote, $groupChats.get())
-      $groupChats.set(mergedRooms)
-      await persistGroupChatRooms(mergedRooms)
-    }
-    const snapshot = mergeGroupChatSyncSnapshots(remote, job.snapshot)
-    const result = await groupChatSyncRequest(job, 'profiles.configure', {
-      name: 'default',
-      ui_meta: { [GROUP_CHAT_SYNC_META_KEY]: snapshot }
+    const remoteState = await groupChatRemoteSnapshot(job)
+    const local = groupChatSyncSnapshot($groupChats.get())
+    const writeRevision = remoteState.revision + 1
+    const snapshot = mergeGroupChatSyncSnapshots(remoteState.snapshot, local, {
+      changedRooms: job.changedRooms,
+      deletedRooms: job.deletedRooms,
+      writeRevision
     })
 
-    if (result?.applied && result.applied.ui_meta !== true) {
-      throw new Error('Gateway rejected group chat ui_meta')
+    // Reconnect/startup reconciliation often discovers that the gateway
+    // already holds the exact merged projection. Avoid advancing a revision
+    // merely because a view reopened.
+    if (!(job.changedRooms || []).length && !(job.deletedRooms || []).length && groupChatSyncPayloadEqual(snapshot, remoteState.snapshot)) {
+      if (remoteState.snapshot) {
+        const mergedRooms = mergeRemoteGroupChatSnapshotIntoRooms(remoteState.snapshot, $groupChats.get(), {
+          preserveRooms: groupChatSyncPending?.changedRooms || [],
+          deletedRooms: groupChatSyncPending?.deletedRooms || []
+        })
+        $groupChats.set(mergedRooms)
+        await persistGroupChatRooms(mergedRooms)
+      }
+      groupChatSyncRetryCount = 0
+      return
     }
 
-    const confirmed = await groupChatRemoteSnapshot(job)
-    if (confirmed && Number(confirmed.updatedAt || 0) !== Number(snapshot.updatedAt || 0)) {
-      throw new Error('Group chat ui_meta changed before read-back')
+    const configureParams = {
+      name: 'default',
+      ui_meta: { [GROUP_CHAT_SYNC_META_KEY]: snapshot }
     }
-    if (confirmed) {
-      const mergedRooms = mergeRemoteGroupChatSnapshotIntoRooms(confirmed, $groupChats.get())
+    if (remoteState.supportsCas) {
+      configureParams.ui_meta_expected_revisions = { [GROUP_CHAT_SYNC_META_KEY]: remoteState.revision }
+    }
+    const result = await groupChatSyncRequest(job, 'profiles.configure', configureParams)
+
+    if (result?.applied?.ui_meta !== true) {
+      throw new Error('Gateway rejected group chat ui_meta')
+    }
+    if (
+      remoteState.supportsCas &&
+      Number(result?.applied?.ui_meta_revisions?.[GROUP_CHAT_SYNC_META_KEY] || 0) !== writeRevision
+    ) {
+      throw new Error('Gateway did not advance group chat ui_meta revision')
+    }
+
+    const confirmedState = await groupChatRemoteSnapshot(job)
+    if (remoteState.supportsCas && confirmedState.revision < writeRevision) {
+      throw new Error('Group chat ui_meta revision missing after read-back')
+    }
+    if (confirmedState.snapshot) {
+      const mergedRooms = mergeRemoteGroupChatSnapshotIntoRooms(confirmedState.snapshot, $groupChats.get(), {
+        preserveRooms: groupChatSyncPending?.changedRooms || [],
+        deletedRooms: groupChatSyncPending?.deletedRooms || []
+      })
       $groupChats.set(mergedRooms)
       await persistGroupChatRooms(mergedRooms)
     }
     groupChatSyncRetryCount = 0
   } catch {
     if (!groupChatSyncDisposed) {
-      groupChatSyncPending ||= job
+      groupChatSyncPending = mergeGroupChatSyncJobs(groupChatSyncPending, job)
       groupChatSyncRetryCount += 1
       if (typeof setTimeout === 'function' && groupChatSyncRetryTimer === null) {
         groupChatSyncRetryTimer = setTimeout(() => {
@@ -565,15 +695,17 @@ function stopGroupChatServerSync() {
 
 /** Debounced, pull-merge-write server mirror. Local storage keeps the complete
  *  orchestration log; ui_meta is a bounded cross-client projection. */
-function scheduleGroupChatServerSync(all = $groupChats.get(), { allowEmpty = false, deletedRooms = [] } = {}) {
+function scheduleGroupChatServerSync(
+  all = $groupChats.get(),
+  { allowEmpty = false, changedRooms = [], deletedRooms = [] } = {}
+) {
   // Browser shells provide timers; source-level VM tests and older embedded
   // hosts may not. Room persistence must never break the surrounding gateway
   // lifecycle when the optional mirror cannot be scheduled.
   if (typeof setTimeout !== 'function') {
     return
   }
-  const deleted = Object.fromEntries(deletedRooms.map(name => [name, Date.now()]))
-  const snapshot = groupChatSyncSnapshot(all, deleted)
+  const snapshot = groupChatSyncSnapshot(all)
   // A newly installed Desktop has no local room cache. Publishing that empty
   // state on hydrate/reconnect would erase a valid mirror produced elsewhere.
   // Only an explicit final-room disband is allowed to clear the projection.
@@ -587,7 +719,12 @@ function scheduleGroupChatServerSync(all = $groupChats.get(), { allowEmpty = fal
     clearTimeout(groupChatSyncRetryTimer)
     groupChatSyncRetryTimer = null
   }
-  groupChatSyncPending = { snapshot, connectionId: groupChatSyncConnectionId() }
+  groupChatSyncPending = mergeGroupChatSyncJobs(groupChatSyncPending, {
+    connectionId: groupChatSyncConnectionId(),
+    allowEmpty,
+    changedRooms,
+    deletedRooms
+  })
   groupChatSyncTimer = setTimeout(() => {
     groupChatSyncTimer = null
     void flushGroupChatServerSync()
@@ -3895,7 +4032,7 @@ function trimGroupChatLog(log, watermarks, limit = GROUP_CHAT_HISTORY_LIMIT * 4)
 }
 
 /** Mutate one group's room state through the atom + persist the durable part. */
-function updateGroupChat(group, mutate) {
+function updateGroupChat(group, mutate, { sync = true } = {}) {
   const all = { ...$groupChats.get() }
   const current = all[group] || { log: [], watermarks: {}, epoch: 0, running: false }
   const next = mutate({ ...current, log: [...current.log], watermarks: { ...current.watermarks } })
@@ -3922,7 +4059,8 @@ function updateGroupChat(group, mutate) {
         // active connection changes and today's local members become remote.
         members: Array.isArray(room.members) ? room.members : [],
         // Room picture (small data URL, same normalization as bot avatars).
-        image: room.image || null
+        image: room.image || null,
+        syncRevision: Math.max(0, Number(room.syncRevision || 0))
       }
     }
 
@@ -3930,7 +4068,9 @@ function updateGroupChat(group, mutate) {
   } catch {
     /* storage unavailable — room survives for this window only */
   }
-  scheduleGroupChatServerSync(all)
+  if (sync) {
+    scheduleGroupChatServerSync(all, { changedRooms: [group] })
+  }
 
   return next
 }
@@ -3980,7 +4120,8 @@ async function disbandGroupChat(group, members) {
           watermarks: room.watermarks,
           sessions: room.sessions || {},
           members: Array.isArray(room.members) ? room.members : [],
-          image: room.image || null
+          image: room.image || null,
+          syncRevision: Math.max(0, Number(room.syncRevision || 0))
         }
       }
     }
@@ -4079,7 +4220,14 @@ async function renameGroupChat(oldName, newName, members) {
   }
 
   // Persist the re-keyed map (updateGroupChat writes the whole durable map).
-  updateGroupChat(next, r => r)
+  updateGroupChat(next, r => r, { sync: false })
+  // A rename is one revisioned state transition: the new identity is updated
+  // and the old identity is tombstoned together, so cold hydration cannot
+  // merge the pre-rename room back into the roster.
+  scheduleGroupChatServerSync($groupChats.get(), {
+    changedRooms: [next],
+    deletedRooms: [oldName]
+  })
 
   // Follow the open views to the new identity.
   if ($groupChatWorkspace.get() === oldName) {
@@ -4094,8 +4242,21 @@ async function renameGroupChat(oldName, newName, members) {
   return next
 }
 
+function groupChatEntryId() {
+  if (globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID()
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+}
+
 function appendGroupChatEntry(group, from, text, thread) {
-  const entry = { at: Date.now(), from, text: String(text).trim(), thread: thread || 'legacy' }
+  const entry = {
+    id: groupChatEntryId(),
+    at: Date.now(),
+    from,
+    text: String(text).trim(),
+    thread: thread || 'legacy'
+  }
 
   updateGroupChat(group, room => {
     room.log.push(entry)
@@ -9645,6 +9806,7 @@ export default {
                   stranded: room.stranded && typeof room.stranded === 'object' ? room.stranded : {},
                   members: Array.isArray(room.members) ? room.members : [],
                   image: typeof room.image === 'string' && room.image ? room.image : null,
+                  syncRevision: Math.max(0, Number(room.syncRevision || 0)),
                   epoch: 0,
                   running: false
                 }

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -361,6 +361,89 @@ function mergeGroupChatSyncSnapshots(remote, local) {
   return groupChatSyncSnapshot(rooms, deleted)
 }
 
+/** Merge the gateway's bounded display projection into Desktop's richer room
+ *  state without discarding local session/watermark/runtime fields. Missing
+ *  remote rooms/messages are not deletions; only explicit tombstones remove a
+ *  room, and a genuinely newer local message wins over a stale tombstone. */
+function mergeRemoteGroupChatSnapshotIntoRooms(remote, current = $groupChats.get()) {
+  const rooms = { ...(current || {}) }
+
+  for (const [name, projected] of Object.entries(remote?.rooms || {})) {
+    if (!projected || !Array.isArray(projected.log)) {
+      continue
+    }
+    const existing = rooms[name] || {}
+    const entries = new Map(
+      (Array.isArray(existing.log) ? existing.log : []).map(entry => [groupChatSyncEntryKey(entry), entry])
+    )
+    const members = new Map(
+      (Array.isArray(existing.members) ? existing.members : []).map(member => [groupChatSyncMemberKey(member), member])
+    )
+
+    for (const entry of projected.log) {
+      entries.set(groupChatSyncEntryKey(entry), entry)
+    }
+    for (const member of Array.isArray(projected.members) ? projected.members : []) {
+      members.set(groupChatSyncMemberKey(member), { ...member, remoteSource: true })
+    }
+
+    const log = assignLegacyThreads(
+      [...entries.values()].sort((left, right) => {
+        const byTime = Number(left?.at || 0) - Number(right?.at || 0)
+        return byTime || groupChatSyncEntryKey(left).localeCompare(groupChatSyncEntryKey(right))
+      })
+    )
+    const bounded = trimGroupChatLog(log, existing.watermarks || {})
+
+    rooms[name] = {
+      ...existing,
+      log: bounded.log,
+      watermarks: bounded.watermarks,
+      sessions: existing.sessions && typeof existing.sessions === 'object' ? existing.sessions : {},
+      stranded: existing.stranded && typeof existing.stranded === 'object' ? existing.stranded : {},
+      members: [...members.values()],
+      epoch: Number(existing.epoch || 0),
+      running: Boolean(existing.running)
+    }
+  }
+
+  for (const [name, deletedAt] of Object.entries(remote?.deleted || {})) {
+    const latestMessageAt = Math.max(0, ...(rooms[name]?.log || []).map(entry => Number(entry?.at || 0)))
+    if (Number(deletedAt || 0) >= latestMessageAt) {
+      delete rooms[name]
+    }
+  }
+
+  return rooms
+}
+
+function durableGroupChatRooms(all = $groupChats.get()) {
+  const durable = {}
+
+  for (const [name, room] of Object.entries(all || {})) {
+    if (!room || !Array.isArray(room.log)) {
+      continue
+    }
+    durable[name] = {
+      log: room.log,
+      watermarks: room.watermarks || {},
+      sessions: room.sessions || {},
+      stranded: room.stranded || {},
+      members: Array.isArray(room.members) ? room.members : []
+    }
+  }
+
+  return durable
+}
+
+function persistGroupChatRooms(all = $groupChats.get()) {
+  try {
+    return Promise.resolve(pluginCtx?.storage?.set?.('group-chats', durableGroupChatRooms(all))).catch(() => undefined)
+  } catch {
+    return Promise.resolve()
+  }
+}
+
 function groupChatSyncConnectionId() {
   return String(host.state.connectionId?.get?.() || host.activeConnectionId?.() || '')
 }
@@ -395,6 +478,20 @@ async function groupChatRemoteSnapshot(job) {
   return snapshot && typeof snapshot === 'object' && !Array.isArray(snapshot) ? snapshot : null
 }
 
+/** Pull the shared room projection into this Desktop before it publishes any
+ *  local state. This is the receive half of the client-only sync contract. */
+async function pullGroupChatServerState(connectionId = groupChatSyncConnectionId()) {
+  const remote = await groupChatRemoteSnapshot({ connectionId })
+
+  if (!remote) {
+    return false
+  }
+  const merged = mergeRemoteGroupChatSnapshotIntoRooms(remote, $groupChats.get())
+  $groupChats.set(merged)
+  await persistGroupChatRooms(merged)
+  return true
+}
+
 function groupChatSyncBackoff() {
   return Math.min(30000, 1000 * 2 ** Math.min(groupChatSyncRetryCount, 5))
 }
@@ -409,6 +506,11 @@ async function flushGroupChatServerSync() {
 
   try {
     const remote = await groupChatRemoteSnapshot(job)
+    if (remote) {
+      const mergedRooms = mergeRemoteGroupChatSnapshotIntoRooms(remote, $groupChats.get())
+      $groupChats.set(mergedRooms)
+      await persistGroupChatRooms(mergedRooms)
+    }
     const snapshot = mergeGroupChatSyncSnapshots(remote, job.snapshot)
     const result = await groupChatSyncRequest(job, 'profiles.configure', {
       name: 'default',
@@ -422,6 +524,11 @@ async function flushGroupChatServerSync() {
     const confirmed = await groupChatRemoteSnapshot(job)
     if (confirmed && Number(confirmed.updatedAt || 0) !== Number(snapshot.updatedAt || 0)) {
       throw new Error('Group chat ui_meta changed before read-back')
+    }
+    if (confirmed) {
+      const mergedRooms = mergeRemoteGroupChatSnapshotIntoRooms(confirmed, $groupChats.get())
+      $groupChats.set(mergedRooms)
+      await persistGroupChatRooms(mergedRooms)
     }
     groupChatSyncRetryCount = 0
   } catch {
@@ -499,10 +606,11 @@ function handleSessionsGatewayTransition() {
   }
 
   $groupChats.set(rooms)
-  // Re-publish the bounded room mirror after reconnects or gateway swaps.
-  // Local plugin storage remains authoritative, so a transient failure here
-  // is harmless and the next gateway transition or room update retries it.
-  scheduleGroupChatServerSync(rooms)
+  // Pull before re-publishing so a reconnect or source swap never lets this
+  // client's stale cache hide a room written by another Desktop/mobile client.
+  void pullGroupChatServerState()
+    .catch(() => false)
+    .then(() => scheduleGroupChatServerSync($groupChats.get()))
 }
 
 /** Per-bot appearance + display meta, persisted via ctx.storage:
@@ -9522,7 +9630,7 @@ export default {
     // and always reset — a loop can't survive a window reload anyway).
     try {
       Promise.resolve(ctx.storage?.get?.('group-chats'))
-        .then(value => {
+        .then(async value => {
           if (value && typeof value === 'object' && !Array.isArray(value)) {
             const rooms = {}
 
@@ -9544,8 +9652,13 @@ export default {
             }
 
             $groupChats.set({ ...rooms, ...$groupChats.get() })
-            scheduleGroupChatServerSync($groupChats.get())
           }
+
+          // Receive before publish. A fresh Desktop with no local room cache
+          // must hydrate the gateway projection instead of merely avoiding an
+          // empty overwrite and then rendering an empty conversation.
+          await pullGroupChatServerState().catch(() => false)
+          scheduleGroupChatServerSync($groupChats.get())
         })
         .catch(() => undefined)
     } catch {

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -95,7 +95,7 @@ function load(turnScript) {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, scheduleGroupChatServerSync, disbandGroupChat, updateGroupChat, $groupChats, $groupNeedsYou, $groupChatWorkspace, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, updateGroupChat, $groupChats, $groupNeedsYou, $groupChatWorkspace, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -451,6 +451,42 @@ test('pull-before-push merge preserves disjoint rooms, messages, and members', (
   assert.equal(JSON.stringify(merged.rooms.Shared.log.map(entry => entry.text)), JSON.stringify(['remote', 'local']))
   assert.equal(JSON.stringify(merged.rooms.Shared.members.map(member => member.name)), JSON.stringify(['research', 'builder']))
   assert.equal(merged.rooms.RemoteOnly.log[0].text, 'kept')
+})
+
+test('gateway projection hydrates a cold Desktop without dropping local runtime fields', () => {
+  const gc = load(() => '(pass)')
+  const merged = gc.mergeRemoteGroupChatSnapshotIntoRooms(
+    {
+      rooms: {
+        Shared: {
+          log: [
+            { from: { kind: 'user', name: 'You' }, text: 'remote question', at: 10, thread: 'thread-1' },
+            { from: { kind: 'member', name: 'research' }, text: 'remote answer', at: 20, thread: 'thread-1' }
+          ],
+          members: [{ name: 'research', connectionId: 'mini', sourceScoped: true }]
+        }
+      }
+    },
+    {
+      Local: {
+        log: [{ from: { kind: 'user', name: 'You' }, text: 'local', at: 5, thread: 'thread-local' }],
+        watermarks: { builder: 1 },
+        sessions: { builder: 'session-1' },
+        members: [{ name: 'builder' }],
+        epoch: 7,
+        running: true
+      }
+    }
+  )
+
+  assert.equal(
+    JSON.stringify(merged.Shared.log.map(entry => entry.text)),
+    JSON.stringify(['remote question', 'remote answer'])
+  )
+  assert.equal(merged.Shared.members[0].remoteSource, true)
+  assert.equal(merged.Local.sessions.builder, 'session-1')
+  assert.equal(merged.Local.epoch, 7)
+  assert.equal(merged.Local.running, true)
 })
 
 test('room deletion tombstone wins over stale history but not a later recreation', () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -8,7 +8,7 @@ const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf
 /** Load the plugin in a vm with a scripted cli.exec so member turns are
  *  deterministic. `turnScript(profile, prompt)` returns the member's reply
  *  text (or throws to simulate a failed turn). */
-function load(turnScript) {
+function load(turnScript, { conflictOnce = false, deferredTimers = false } = {}) {
   const values = new Map()
   const atom = initial => {
     const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
@@ -20,7 +20,10 @@ function load(turnScript) {
   const sessions = new Map()
   const runtimeToStored = new Map()
   const titleToStored = new Map()
+  const sharedUiMeta = {}
+  const uiMetaRevisions = {}
   let sessionSequence = 0
+  let injectedConflict = false
 
   const resolveSession = (profile, target) => {
     const stored = runtimeToStored.get(target) || (sessions.has(target) ? target : titleToStored.get(`${profile}::${target}`))
@@ -29,6 +32,10 @@ function load(turnScript) {
   const context = {
     atom,
     setTimeout: fn => {
+      if (deferredTimers) {
+        setImmediate(fn)
+        return 1
+      }
       fn()
       return 0
     },
@@ -39,6 +46,64 @@ function load(turnScript) {
     host: {
       request: async (method, params) => {
         requests.push({ method, params })
+        if (method === 'profiles.list') {
+          return {
+            profiles: [
+              {
+                name: 'default',
+                ui_meta: { ...sharedUiMeta },
+                ui_meta_revisions: { ...uiMetaRevisions }
+              }
+            ]
+          }
+        }
+        if (method === 'profiles.configure') {
+          if (conflictOnce && !injectedConflict) {
+            injectedConflict = true
+            sharedUiMeta['hermes-bots-groups'] = {
+              version: 2,
+              rooms: {
+                Shared: {
+                  revision: 1,
+                  log: [{ id: 'writer-a:1', from: { kind: 'user', name: 'You' }, text: 'alpha', at: 1 }],
+                  members: [{ name: 'alpha' }]
+                }
+              }
+            }
+            uiMetaRevisions['hermes-bots-groups'] = 1
+            return {
+              applied: {
+                ui_meta: false,
+                ui_meta_conflicts: { 'hermes-bots-groups': { expected: 0, actual: 1 } },
+                ui_meta_revisions: { 'hermes-bots-groups': 1 }
+              }
+            }
+          }
+          const expected = params.ui_meta_expected_revisions || null
+          if (expected) {
+            for (const key of Object.keys(params.ui_meta || {})) {
+              if ((uiMetaRevisions[key] || 0) !== expected[key]) {
+                return {
+                  applied: {
+                    ui_meta: false,
+                    ui_meta_conflicts: {
+                      [key]: { expected: expected[key], actual: uiMetaRevisions[key] || 0 }
+                    }
+                  }
+                }
+              }
+            }
+          }
+          for (const [key, value] of Object.entries(params.ui_meta || {})) {
+            if (value === null) {
+              delete sharedUiMeta[key]
+            } else {
+              sharedUiMeta[key] = value
+            }
+            uiMetaRevisions[key] = (uiMetaRevisions[key] || 0) + 1
+          }
+          return { applied: { ui_meta: true, ui_meta_revisions: { ...uiMetaRevisions } } }
+        }
         if (method === 'session.create') {
           sessionSequence += 1
           const stored = `sid-${params.profile}-${sessionSequence}`
@@ -95,7 +160,7 @@ function load(turnScript) {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, updateGroupChat, $groupChats, $groupNeedsYou, $groupChatWorkspace, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, $groupChats, $groupNeedsYou, $groupChatWorkspace, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -103,7 +168,7 @@ function load(turnScript) {
     storage: { get: () => null, set: (key, value) => storageWrites.set(key, value) },
     register: () => undefined
   })
-  return { ...context.__gc, calls, requests, sessions, storageWrites }
+  return { ...context.__gc, calls, requests, sessions, storageWrites, sharedUiMeta, uiMetaRevisions }
 }
 
 const MEMBERS = [{ name: 'research', title: '' }, { name: 'builder', title: '' }, { name: 'ops', title: 'The Ops' }]
@@ -350,7 +415,7 @@ test('group room messages and members mirror through bounded gateway profile met
   assert.ok(configure, 'room updates are mirrored to the gateway')
   assert.equal(configure.params.name, 'default')
   const envelope = configure.params.ui_meta['hermes-bots-groups']
-  assert.equal(envelope.version, 1)
+  assert.equal(envelope.version, 2)
   assert.equal(envelope.rooms.Research.log[0].text, 'What changed?')
   assert.equal(JSON.stringify(envelope.rooms.Research.members.map(member => member.name)), JSON.stringify(['research', 'builder']))
   assert.ok(gc.groupChatGatewayJsonSize(envelope) <= 48000)
@@ -492,17 +557,176 @@ test('gateway projection hydrates a cold Desktop without dropping local runtime 
 test('room deletion tombstone wins over stale history but not a later recreation', () => {
   const gc = load(() => '(pass)')
   const stale = gc.mergeGroupChatSyncSnapshots(
-    { rooms: { Research: { log: [{ from: { kind: 'user', name: 'You' }, text: 'old', at: 10 }] } } },
-    { rooms: {}, deleted: { Research: 20 } }
+    {
+      version: 2,
+      rooms: { Research: { revision: 1, log: [{ id: 'old', from: { kind: 'user', name: 'You' }, text: 'old', at: 10 }] } }
+    },
+    { version: 2, rooms: {}, deleted: { Research: 2 } }
   )
   assert.equal(stale.rooms.Research, undefined)
-  assert.equal(stale.deleted.Research, 20)
+  assert.equal(stale.deleted.Research, 2)
 
   const recreated = gc.mergeGroupChatSyncSnapshots(stale, {
-    rooms: { Research: { log: [{ from: { kind: 'user', name: 'You' }, text: 'new', at: 30 }] } }
+    version: 2,
+    rooms: { Research: { revision: 3, log: [{ id: 'new', from: { kind: 'user', name: 'You' }, text: 'new', at: 1 }] } }
   })
   assert.equal(recreated.rooms.Research.log[0].text, 'new')
   assert.equal(recreated.deleted, undefined)
+})
+
+test('gateway revisions, not device clocks, order room deletion and recreation', () => {
+  const gc = load(() => '(pass)')
+  const merged = gc.mergeGroupChatSyncSnapshots(
+    {
+      version: 2,
+      rooms: {
+        ClockSkewed: {
+          revision: 8,
+          log: [{ id: 'future-clock', from: { kind: 'user', name: 'You' }, text: 'old', at: 9999999999999 }]
+        }
+      }
+    },
+    { version: 2, rooms: {}, deleted: { ClockSkewed: 9 } }
+  )
+
+  assert.equal(merged.rooms.ClockSkewed, undefined)
+  assert.equal(merged.deleted.ClockSkewed, 9)
+})
+
+test('a conflicting writer can merge the winner and preserve both stable message ids', () => {
+  const gc = load(() => '(pass)')
+  const winner = {
+    version: 2,
+    rooms: {
+      Shared: {
+        revision: 1,
+        log: [{ id: 'writer-a:1', from: { kind: 'user', name: 'You' }, text: 'alpha', at: 100 }],
+        members: [{ name: 'alpha' }]
+      }
+    }
+  }
+  const loserRetry = gc.mergeGroupChatSyncSnapshots(
+    winner,
+    {
+      version: 2,
+      rooms: {
+        Shared: {
+          revision: 0,
+          log: [{ id: 'writer-b:1', from: { kind: 'member', name: 'beta' }, text: 'beta', at: 1 }],
+          members: [{ name: 'beta' }]
+        }
+      }
+    },
+    { changedRooms: ['Shared'], writeRevision: 2 }
+  )
+
+  assert.equal(
+    JSON.stringify(loserRetry.rooms.Shared.log.map(entry => entry.id).sort()),
+    JSON.stringify(['writer-a:1', 'writer-b:1'])
+  )
+  assert.equal(loserRetry.rooms.Shared.revision, 2)
+})
+
+test('sync worker retries a gateway CAS conflict and publishes the merged room', async () => {
+  const gc = load(() => '(pass)', { conflictOnce: true, deferredTimers: true })
+  gc.$groupChats.set({
+    Shared: {
+      log: [{ id: 'writer-b:1', from: { kind: 'member', name: 'beta' }, text: 'beta', at: 2 }],
+      members: [{ name: 'beta' }],
+      watermarks: {},
+      sessions: {},
+      syncRevision: 0
+    }
+  })
+
+  gc.scheduleGroupChatServerSync(gc.$groupChats.get(), { changedRooms: ['Shared'] })
+  for (let i = 0; i < 20 && (gc.uiMetaRevisions['hermes-bots-groups'] || 0) < 2; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  const stored = gc.sharedUiMeta['hermes-bots-groups']
+  assert.equal(gc.uiMetaRevisions['hermes-bots-groups'], 2)
+  assert.equal(
+    JSON.stringify(stored.rooms.Shared.log.map(entry => entry.id).sort()),
+    JSON.stringify(['writer-a:1', 'writer-b:1'])
+  )
+  assert.equal(
+    gc.requests.filter(call => call.method === 'profiles.configure').length,
+    2
+  )
+})
+
+test('read-back does not clobber a newer local room edit queued during an in-flight write', () => {
+  const gc = load(() => '(pass)')
+  const merged = gc.mergeRemoteGroupChatSnapshotIntoRooms(
+    {
+      version: 2,
+      rooms: {
+        Shared: {
+          revision: 5,
+          log: [{ id: 'remote', from: { kind: 'user', name: 'You' }, text: 'remote message', at: 1 }],
+          members: [{ name: 'old-member' }],
+          image: 'data:image/png;base64,old'
+        }
+      }
+    },
+    {
+      Shared: {
+        syncRevision: 4,
+        log: [{ id: 'local', from: { kind: 'user', name: 'You' }, text: 'local message', at: 2 }],
+        members: [{ name: 'new-member' }],
+        image: 'data:image/png;base64,new'
+      }
+    },
+    { preserveRooms: ['Shared'] }
+  )
+
+  assert.equal(JSON.stringify(merged.Shared.members.map(member => member.name)), JSON.stringify(['new-member']))
+  assert.equal(merged.Shared.image, 'data:image/png;base64,new')
+  assert.equal(merged.Shared.syncRevision, 4)
+  assert.equal(
+    JSON.stringify(merged.Shared.log.map(entry => entry.id).sort()),
+    JSON.stringify(['local', 'remote'])
+  )
+})
+
+test('rename publishes a new room plus old-name tombstone and cold hydrate cannot resurrect it', () => {
+  const gc = load(() => '(pass)')
+  const before = {
+    version: 2,
+    rooms: {
+      Old: {
+        revision: 4,
+        log: [{ id: 'turn-1', from: { kind: 'user', name: 'You' }, text: 'history', at: 10 }],
+        members: [{ name: 'research' }],
+        image: 'data:image/png;base64,room'
+      }
+    }
+  }
+  const after = gc.mergeGroupChatSyncSnapshots(
+    before,
+    {
+      version: 2,
+      rooms: {
+        New: {
+          revision: 4,
+          log: before.rooms.Old.log,
+          members: before.rooms.Old.members,
+          image: before.rooms.Old.image
+        }
+      }
+    },
+    { changedRooms: ['New'], deletedRooms: ['Old'], writeRevision: 5 }
+  )
+  const hydrated = gc.mergeRemoteGroupChatSnapshotIntoRooms(after, {})
+
+  assert.equal(after.rooms.Old, undefined)
+  assert.equal(after.deleted.Old, 5)
+  assert.equal(after.rooms.New.revision, 5)
+  assert.equal(after.rooms.New.image, 'data:image/png;base64,room')
+  assert.equal(hydrated.Old, undefined)
+  assert.equal(hydrated.New.log[0].text, 'history')
+  assert.equal(hydrated.New.image, 'data:image/png;base64,room')
 })
 
 test('source contract: workspace + main-window door + prompt rules are wired', () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -16,6 +16,7 @@ function load(turnScript) {
     return slot
   }
   const calls = []
+  const requests = []
   const sessions = new Map()
   const runtimeToStored = new Map()
   const titleToStored = new Map()
@@ -37,6 +38,7 @@ function load(turnScript) {
     document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
     host: {
       request: async (method, params) => {
+        requests.push({ method, params })
         if (method === 'session.create') {
           sessionSequence += 1
           const stored = `sid-${params.profile}-${sessionSequence}`
@@ -93,7 +95,7 @@ function load(turnScript) {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, disbandGroupChat, updateGroupChat, $groupChats, $groupNeedsYou, $groupChatWorkspace, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, scheduleGroupChatServerSync, disbandGroupChat, updateGroupChat, $groupChats, $groupNeedsYou, $groupChatWorkspace, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -101,7 +103,7 @@ function load(turnScript) {
     storage: { get: () => null, set: (key, value) => storageWrites.set(key, value) },
     register: () => undefined
   })
-  return { ...context.__gc, calls, sessions, storageWrites }
+  return { ...context.__gc, calls, requests, sessions, storageWrites }
 }
 
 const MEMBERS = [{ name: 'research', title: '' }, { name: 'builder', title: '' }, { name: 'ops', title: 'The Ops' }]
@@ -331,6 +333,140 @@ test('log trimming keeps watermarks consistent', () => {
   assert.equal(trimmed.length, 96)
   assert.equal(watermarks.research, 150 - 104)
   assert.equal(watermarks.builder, 0)
+})
+
+test('group room messages and members mirror through bounded gateway profile metadata', async () => {
+  const gc = load(() => '(pass)')
+  const members = [
+    { name: 'research', handle: 'research' },
+    { name: 'builder', handle: 'builder' }
+  ]
+  gc.sendToGroupChat('Research', members, 'What changed?')
+  for (let i = 0; i < 200 && (gc.$groupChats.get().Research || {}).running; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  const configure = gc.requests.filter(call => call.method === 'profiles.configure').at(-1)
+  assert.ok(configure, 'room updates are mirrored to the gateway')
+  assert.equal(configure.params.name, 'default')
+  const envelope = configure.params.ui_meta['hermes-bots-groups']
+  assert.equal(envelope.version, 1)
+  assert.equal(envelope.rooms.Research.log[0].text, 'What changed?')
+  assert.equal(JSON.stringify(envelope.rooms.Research.members.map(member => member.name)), JSON.stringify(['research', 'builder']))
+  assert.ok(gc.groupChatGatewayJsonSize(envelope) <= 48000)
+})
+
+test('group gateway mirror is size bounded and favors recent messages', () => {
+  const gc = load(() => '(pass)')
+  const long = 'x'.repeat(5000)
+  const snapshot = gc.groupChatSyncSnapshot({
+    Large: {
+      log: Array.from({ length: 100 }, (_, index) => ({
+        from: { kind: index % 2 ? 'member' : 'user', name: index % 2 ? 'research' : 'You' },
+        text: `${index}:${long}`,
+        at: index
+      }))
+    }
+  })
+
+  assert.ok(gc.groupChatGatewayJsonSize(snapshot) <= 48000)
+  assert.ok(snapshot.rooms.Large.log.length <= 16)
+  assert.match(snapshot.rooms.Large.log.at(-1).text, /^99:/)
+  assert.ok(snapshot.rooms.Large.log.at(-1).text.length <= 1200)
+})
+
+test('group gateway mirror preserves threads and budgets escaped Unicode', () => {
+  const gc = load(() => '(pass)')
+  const snapshot = gc.groupChatSyncSnapshot({
+    Unicode: {
+      log: Array.from({ length: 16 }, (_, index) => ({
+        from: { kind: 'member', name: 'research' },
+        text: `message ${index} ${'🧠'.repeat(1200)}`,
+        at: index,
+        thread: `thread-${index}`
+      }))
+    }
+  })
+
+  assert.ok(gc.groupChatGatewayJsonSize(snapshot) <= 48000)
+  assert.equal(snapshot.rooms.Unicode.log.at(-1).thread, 'thread-15')
+})
+
+test('empty runtime rooms are omitted from the gateway mirror', () => {
+  const gc = load(() => '(pass)')
+  const snapshot = gc.groupChatSyncSnapshot({
+    Disbanded: { log: [], members: [{ name: 'research' }] }
+  })
+
+  assert.deepEqual(Object.keys(snapshot.rooms), [])
+})
+
+test('an empty hydrate cannot erase a shared gateway room mirror', () => {
+  const gc = load(() => '(pass)')
+  const before = gc.requests.length
+
+  gc.scheduleGroupChatServerSync({})
+
+  assert.equal(gc.requests.length, before)
+})
+
+test('an explicit final-room disband may clear the gateway room mirror', async () => {
+  const gc = load(() => '(pass)')
+
+  gc.scheduleGroupChatServerSync({}, { allowEmpty: true, deletedRooms: ['Research'] })
+  await new Promise(resolve => setImmediate(resolve))
+
+  const configure = gc.requests.filter(call => call.method === 'profiles.configure').at(-1)
+  assert.deepEqual(Object.keys(configure.params.ui_meta['hermes-bots-groups'].rooms), [])
+  assert.ok(configure.params.ui_meta['hermes-bots-groups'].deleted.Research > 0)
+})
+
+test('pull-before-push merge preserves disjoint rooms, messages, and members', () => {
+  const gc = load(() => '(pass)')
+  const merged = gc.mergeGroupChatSyncSnapshots(
+    {
+      version: 1,
+      rooms: {
+        Shared: {
+          log: [{ from: { kind: 'user', name: 'You' }, text: 'remote', at: 1, thread: 'one' }],
+          members: [{ name: 'research', handle: 'research' }]
+        },
+        RemoteOnly: {
+          log: [{ from: { kind: 'member', name: 'ops' }, text: 'kept', at: 2 }],
+          members: [{ name: 'ops' }]
+        }
+      }
+    },
+    {
+      version: 1,
+      rooms: {
+        Shared: {
+          log: [{ from: { kind: 'member', name: 'builder' }, text: 'local', at: 3, thread: 'one' }],
+          members: [{ name: 'builder', handle: 'builder' }]
+        }
+      }
+    }
+  )
+
+  assert.equal(JSON.stringify(merged.rooms.Shared.log.map(entry => entry.text)), JSON.stringify(['remote', 'local']))
+  assert.equal(JSON.stringify(merged.rooms.Shared.members.map(member => member.name)), JSON.stringify(['research', 'builder']))
+  assert.equal(merged.rooms.RemoteOnly.log[0].text, 'kept')
+})
+
+test('room deletion tombstone wins over stale history but not a later recreation', () => {
+  const gc = load(() => '(pass)')
+  const stale = gc.mergeGroupChatSyncSnapshots(
+    { rooms: { Research: { log: [{ from: { kind: 'user', name: 'You' }, text: 'old', at: 10 }] } } },
+    { rooms: {}, deleted: { Research: 20 } }
+  )
+  assert.equal(stale.rooms.Research, undefined)
+  assert.equal(stale.deleted.Research, 20)
+
+  const recreated = gc.mergeGroupChatSyncSnapshots(stale, {
+    rooms: { Research: { log: [{ from: { kind: 'user', name: 'You' }, text: 'new', at: 30 }] } }
+  })
+  assert.equal(recreated.rooms.Research.log[0].text, 'new')
+  assert.equal(recreated.deleted, undefined)
 })
 
 test('source contract: workspace + main-window door + prompt rules are wired', () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/session-workspace.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/session-workspace.test.mjs
@@ -108,7 +108,10 @@ test('sessions workspace: a gateway lifecycle change clears selection and reject
   assert.deepEqual(plain(runtime.__sessions.$botSelectedSessions.get()), {})
 
   await runtime.__sessions.openProfileSession('ops', 'stored-123', 0)
-  assert.deepEqual(runtime.calls, [])
+  assert.deepEqual(
+    plain(runtime.calls.map(([method]) => method)),
+    ['profiles.list']
+  )
 })
 
 test('sessions workspace: an in-flight open cannot restore selection after gateway replacement', async () => {
@@ -118,7 +121,8 @@ test('sessions workspace: an in-flight open cannot restore selection after gatew
   })
 
   await runtime.__sessions.openProfileSession('ops', 'stored-123', 0)
-  assert.equal(runtime.calls.length, 1)
+  assert.equal(runtime.calls.filter(([method]) => method === 'openSession').length, 1)
+  assert.equal(runtime.calls.filter(([method]) => method === 'profiles.list').length, 1)
   assert.deepEqual(plain(runtime.__sessions.$botSelectedSessions.get()), {})
 })
 

--- a/tests/tui_gateway/test_profiles_ui_meta_cas.py
+++ b/tests/tui_gateway/test_profiles_ui_meta_cas.py
@@ -1,0 +1,98 @@
+"""Gateway-owned revisions for concurrent profile UI metadata updates.
+
+Clients use ``profiles.list`` to read a shared key and its revision, merge a
+local mutation, then pass that revision back to ``profiles.configure``.  The
+gateway must let exactly one concurrent writer advance the key and make every
+stale writer retry instead of silently replacing somebody else's state.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+import tui_gateway.server as srv
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    return hermes_home
+
+
+def _configure(ui_meta, expected=None):
+    params = {"name": "default", "ui_meta": ui_meta}
+    if expected is not None:
+        params["ui_meta_expected_revisions"] = expected
+    return srv._methods["profiles.configure"]("configure", params)["result"]["applied"]
+
+
+def _default_profile():
+    rows = srv._methods["profiles.list"](
+        "list", {"include_sessions": False}
+    )["result"]["profiles"]
+    return next(row for row in rows if row["name"] == "default")
+
+
+def test_ui_meta_revision_advances_and_stale_compare_and_swap_is_rejected(home):
+    first = _configure({"shared-room": {"messages": ["one"]}})
+    assert first["ui_meta"] is True
+    assert first["ui_meta_revisions"] == {"shared-room": 1}
+
+    second = _configure(
+        {"shared-room": {"messages": ["one", "two"]}},
+        {"shared-room": 1},
+    )
+    assert second["ui_meta"] is True
+    assert second["ui_meta_revisions"] == {"shared-room": 2}
+
+    stale = _configure(
+        {"shared-room": {"messages": ["stale replacement"]}},
+        {"shared-room": 1},
+    )
+    assert stale["ui_meta"] is False
+    assert stale["ui_meta_conflicts"] == {
+        "shared-room": {"expected": 1, "actual": 2}
+    }
+
+    row = _default_profile()
+    assert row["ui_meta"]["shared-room"] == {"messages": ["one", "two"]}
+    assert row["ui_meta_revisions"]["shared-room"] == 2
+
+
+def test_ui_meta_revision_survives_key_deletion(home):
+    _configure({"shared-room": {"messages": ["one"]}})
+    deleted = _configure({"shared-room": None}, {"shared-room": 1})
+
+    assert deleted["ui_meta"] is True
+    assert deleted["ui_meta_revisions"] == {"shared-room": 2}
+    row = _default_profile()
+    assert "shared-room" not in row.get("ui_meta", {})
+    assert row["ui_meta_revisions"]["shared-room"] == 2
+
+    stale_recreate = _configure(
+        {"shared-room": {"messages": ["resurrected"]}},
+        {"shared-room": 1},
+    )
+    assert stale_recreate["ui_meta"] is False
+    assert stale_recreate["ui_meta_conflicts"]["shared-room"]["actual"] == 2
+
+
+def test_two_concurrent_writers_cannot_both_replace_the_same_revision(home):
+    def write(label):
+        return _configure(
+            {"shared-room": {"messages": [label]}},
+            {"shared-room": 0},
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(write, ("alpha", "beta")))
+
+    assert sum(result["ui_meta"] is True for result in results) == 1
+    assert sum(result["ui_meta"] is False for result in results) == 1
+    loser = next(result for result in results if result["ui_meta"] is False)
+    assert loser["ui_meta_conflicts"]["shared-room"]["actual"] == 1
+    assert _default_profile()["ui_meta_revisions"]["shared-room"] == 1

--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -217,12 +217,22 @@ def _(rid, params: dict) -> dict:
                 from pathlib import Path as _Path
 
                 meta_path = _Path(str(p.path)) / "profile.yaml"
+                # Presence of this field feature-detects gateway-owned CAS,
+                # including a brand-new profile whose revision map is empty.
+                row["ui_meta_revisions"] = {}
                 if meta_path.is_file():
                     with open(meta_path, "r", encoding="utf-8") as f:
                         raw_meta = _yaml.safe_load(f) or {}
                     ui_meta = raw_meta.get("ui_meta")
                     if isinstance(ui_meta, dict) and ui_meta:
                         row["ui_meta"] = ui_meta
+                    revisions = raw_meta.get("_ui_meta_revisions")
+                    if isinstance(revisions, dict) and revisions:
+                        row["ui_meta_revisions"] = {
+                            str(key): max(0, int(value))
+                            for key, value in revisions.items()
+                            if isinstance(value, int) and not isinstance(value, bool)
+                        }
             except Exception:
                 pass
 
@@ -667,7 +677,9 @@ def _(rid, params: dict) -> dict:
     ``model`` + ``provider`` (both required together),
     ``disabled_skills`` (list[str], replace semantics),
     ``enabled_toolsets`` (list[str], replace semantics; empty list clears
-    the pin so every toolset is enabled again).
+    the pin so every toolset is enabled again), and
+    ``ui_meta_expected_revisions`` (dict[str, int], optional compare-and-swap
+    preconditions for keys supplied in ``ui_meta``).
 
     Each section is applied independently and best-effort; the result
     reports per-section success so a UI can surface partial failures.
@@ -702,32 +714,73 @@ def _(rid, params: dict) -> dict:
                 else:
                     import yaml as _yaml
 
-                    meta_path = profile_dir / "profile.yaml"
-                    existing = {}
-                    if meta_path.is_file():
-                        try:
-                            with open(meta_path, "r", encoding="utf-8") as f:
-                                loaded = _yaml.safe_load(f) or {}
-                            if isinstance(loaded, dict):
-                                existing = loaded
-                        except Exception:
-                            existing = {}
-                    current = existing.get("ui_meta")
-                    if not isinstance(current, dict):
-                        current = {}
-                    for key, value in incoming.items():
-                        if value is None:
-                            current.pop(key, None)
-                        else:
-                            current[key] = value
-                    if current:
-                        existing["ui_meta"] = current
-                    else:
-                        existing.pop("ui_meta", None)
-                    from utils import atomic_yaml_write
+                    expected = params.get("ui_meta_expected_revisions")
+                    if expected is not None and not isinstance(expected, dict):
+                        raise ValueError("ui_meta_expected_revisions must be an object")
 
-                    atomic_yaml_write(meta_path, existing, sort_keys=False)
-                    applied["ui_meta"] = True
+                    meta_path = profile_dir / "profile.yaml"
+                    with _profile_ui_meta_lock:
+                        existing = {}
+                        if meta_path.is_file():
+                            try:
+                                with open(meta_path, "r", encoding="utf-8") as f:
+                                    loaded = _yaml.safe_load(f) or {}
+                                if isinstance(loaded, dict):
+                                    existing = loaded
+                            except Exception:
+                                existing = {}
+
+                        raw_revisions = existing.get("_ui_meta_revisions")
+                        revisions = dict(raw_revisions) if isinstance(raw_revisions, dict) else {}
+                        revisions = {
+                            str(key): max(0, int(value))
+                            for key, value in revisions.items()
+                            if isinstance(value, int) and not isinstance(value, bool)
+                        }
+                        conflicts = {}
+                        if isinstance(expected, dict):
+                            for key in incoming:
+                                wanted = expected.get(key)
+                                actual = revisions.get(key, 0)
+                                if (
+                                    not isinstance(wanted, int)
+                                    or isinstance(wanted, bool)
+                                    or wanted < 0
+                                    or wanted != actual
+                                ):
+                                    conflicts[key] = {"expected": wanted, "actual": actual}
+
+                        if conflicts:
+                            applied["ui_meta"] = False
+                            applied["ui_meta_conflicts"] = conflicts
+                            applied["ui_meta_revisions"] = {
+                                key: revisions.get(key, 0) for key in incoming
+                            }
+                        else:
+                            current = existing.get("ui_meta")
+                            if not isinstance(current, dict):
+                                current = {}
+                            for key, value in incoming.items():
+                                if value is None:
+                                    current.pop(key, None)
+                                else:
+                                    current[key] = value
+                                revisions[key] = revisions.get(key, 0) + 1
+                            if current:
+                                existing["ui_meta"] = current
+                            else:
+                                existing.pop("ui_meta", None)
+                            # Revisions intentionally survive deletion: a
+                            # stale client must not recreate a removed key by
+                            # presenting the initial revision again.
+                            existing["_ui_meta_revisions"] = revisions
+                            from utils import atomic_yaml_write
+
+                            atomic_yaml_write(meta_path, existing, sort_keys=False)
+                            applied["ui_meta"] = True
+                            applied["ui_meta_revisions"] = {
+                                key: revisions[key] for key in incoming
+                            }
             except Exception:
                 applied["ui_meta"] = False
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -149,6 +149,10 @@ _db = None
 _db_error: str | None = None
 _stdout_lock = threading.Lock()
 _cfg_lock = threading.Lock()
+# Shared profile UI metadata can be updated concurrently by Desktop, mobile,
+# and multiple worker-pool RPCs.  Its compare/check/write transaction needs a
+# dedicated lock rather than the unrelated process-config cache lock.
+_profile_ui_meta_lock = threading.Lock()
 _sessions_lock = threading.RLock()  # reentrant: _close_session_by_id may run under callers that already hold it
 _prompt_lock = threading.Lock()
 _cfg_cache: dict | None = None


### PR DESCRIPTION
## What does this PR do?

Hermes Desktop group-room transcripts currently live only in renderer-local plugin storage. Gateway clients such as Hermes Go can list the same bots and groups through `profiles.list`, but cannot reliably display recent room messages because Desktop did not maintain a shared, bidirectional projection.

This adds a bounded, display-oriented room projection to the default profile's `ui_meta`. It intentionally does **not** move live orchestration state or full archival history into profile metadata.

The gateway now provides a backward-compatible compare-and-swap extension for top-level `ui_meta` keys. Desktop uses it to make pull/merge/write safe under concurrent clients:

- `profiles.list` returns gateway-owned per-key revisions;
- `profiles.configure` accepts optional expected revisions and atomically rejects stale writers;
- Desktop retries conflicts after re-reading and merging stable message IDs;
- gateway revisions, rather than device clocks, order room tombstones and recreation;
- hydrate and persist the gateway projection before a fresh Desktop publishes local state;
- serialize/coalesce writes and preserve edits queued during an in-flight write/read-back;
- target the gateway captured when work was queued;
- preserve source-qualified members, thread IDs, and bounded room pictures;
- rename publishes the new identity and old-name tombstone in one revisioned transition;
- budget for Python `ensure_ascii` JSON encoding and cancel pending work on dispose.

Older gateways are feature-detected and retain the previous best-effort behavior; no configuration key or database migration is required.

## Related Issue

External client report and reproduction: https://github.com/TheTom/hermes-go/issues/5

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.js`
  - publish and receive a compact recent group-room projection;
  - hydrate cold clients before publishing;
  - conflict-retry with stable message IDs and gateway revisions;
  - preserve source-qualified membership, threads, room pictures, rename tombstones, and in-flight local edits;
  - route, serialize, verify, retry, size-bound, and dispose sync work.
- `tui_gateway/methods_profiles.py`, `tui_gateway/server.py`
  - expose per-key UI metadata revisions;
  - atomically compare/check/write/increment under a dedicated lock;
  - keep deletion revisions so stale clients cannot recreate removed keys.
- Desktop and gateway tests
  - cover two-writer conflict repair, clock skew, stable IDs, queued in-flight edits, room rename + cold hydration, image propagation, Unicode sizing, deletion/recreation, and concurrent RPC writers.

## How to Test

1. Connect two Desktop/gateway clients to the same gateway and mutate the same room concurrently; confirm one stale write conflicts, retries, and the final room contains both messages.
2. Create a Bot Mode group and send a message; refresh a gateway client and confirm members, messages, replies, and thread IDs are present.
3. Clear only another Desktop's `hermes.plugin.hermes-bots.group-chats` storage, restart it, and confirm the shared transcript hydrates before publish.
4. Rename a previously synced room, cold-start another client, and confirm only the new identity appears with history and picture intact.
5. Disband a room and confirm its revisioned tombstone removes it without deleting unrelated rooms.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (focused gateway tests run; full CI pending)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS, signed arm64 Desktop build against a remote gateway

### Documentation & Housekeeping

- [x] The internal wire contract is documented in handler docstrings, code, and behavioral tests
- [x] `cli-config.yaml.example` is unchanged because no config keys were added
- [x] No contributor workflow or public tool schema changed
- [x] Cross-platform impact considered: renderer JavaScript plus platform-neutral gateway Python/RPC

## Verification

- `npm --prefix apps/desktop run check:test:plugins` — **281 passed / 0 failed**
- focused gateway/profile suite — **11 passed / 0 failed**
- Ruff and `git diff --check` — passed
- actual stdio gateway concurrency probe — two revision-0 writers produced exactly one revision-1 commit and one explicit stale-write conflict
- signed macOS arm64 Desktop → remote Mac mini gateway → independent JSON-RPC client transport/hydration verification; details in the PR test comment
