### PR TITLE
fix(desktop): deny popup creation from webview guests

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -335,6 +335,7 @@ import {
 } from './venv-blocker-scan'
 import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-marketplace'
 import { createWakeIndicatorWindowController } from './wake-indicator-window'
+import { guardUntrustedWebviewWindowOpen } from './webview-security'
 import { readWindowBelow } from './window-below'
 import { installWindowRendererLifecycle } from './window-renderer-lifecycle'
 import { createWindowRevealController } from './window-reveal'
@@ -15393,6 +15394,10 @@ if (!isPrimaryInstance) {
 
 // macOS delivers deep links via 'open-url' — register early (can fire before
 // whenReady; handleDeepLink queues until the renderer is ready).
+app.on('web-contents-created', (_event, contents) => {
+  guardUntrustedWebviewWindowOpen(contents)
+})
+
 app.on('open-url', (event, url) => {
   event.preventDefault()
   handleDeepLink(url)

--- a/apps/desktop/electron/webview-security.test.ts
+++ b/apps/desktop/electron/webview-security.test.ts
@@ -1,0 +1,36 @@
+import type { WebContents } from 'electron'
+import { describe, expect, it, vi } from 'vitest'
+
+import { guardUntrustedWebviewWindowOpen } from './webview-security'
+
+describe('guardUntrustedWebviewWindowOpen', () => {
+  it('installs a deny-only window-open handler on webview guests', () => {
+    const setWindowOpenHandler = vi.fn()
+
+    const contents = {
+      getType: () => 'webview',
+      setWindowOpenHandler
+    }
+
+    expect(guardUntrustedWebviewWindowOpen(contents as unknown as WebContents)).toBe(true)
+    expect(setWindowOpenHandler).toHaveBeenCalledOnce()
+
+    const handler = setWindowOpenHandler.mock.calls[0]?.[0]
+
+    expect(handler?.({ url: 'https://attacker.invalid/popup' })).toEqual({ action: 'deny' })
+  })
+
+  it('does not alter trusted non-webview contents', () => {
+    const setWindowOpenHandler = vi.fn()
+
+    expect(
+      guardUntrustedWebviewWindowOpen(
+        {
+          getType: () => 'window',
+          setWindowOpenHandler
+        } as unknown as WebContents
+      )
+    ).toBe(false)
+    expect(setWindowOpenHandler).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/electron/webview-security.ts
+++ b/apps/desktop/electron/webview-security.ts
@@ -1,0 +1,19 @@
+import type { WebContents } from 'electron'
+
+type GuardableContents = Pick<WebContents, 'getType' | 'setWindowOpenHandler'>
+
+/**
+ * Deny every popup/new-window request created by an untrusted Browser Pane
+ * guest. The renderer deliberately embeds arbitrary web pages in a sandboxed
+ * `<webview>`; Electron CVE-2026-70608 proves the missing `allowpopups`
+ * attribute is not itself a sufficient boundary on affected releases.
+ */
+export function guardUntrustedWebviewWindowOpen(contents: GuardableContents): boolean {
+  if (contents.getType() !== 'webview') {
+    return false
+  }
+
+  contents.setWindowOpenHandler(() => ({ action: 'deny' }))
+
+  return true
+}


### PR DESCRIPTION
## Summary

- deny every popup/new-window request from untrusted Desktop Browser Pane `<webview>` guests
- scope the guard to `WebContents.getType() === "webview"`, leaving main, login, OAuth, HUD, and session windows unchanged
- add a deterministic contract test for guest denial and non-webview pass-through

## Security context

Hermes Desktop's Browser Pane dynamically embeds arbitrary web URLs in a sandboxed Electron `<webview>` without `allowpopups`. On Electron 40.10.2, [CVE-2026-70608 / GHSA-9f4c-93c8-jc8g](https://github.com/advisories/GHSA-9f4c-93c8-jc8g) allows a sandboxed iframe without `allow-popups` to reach the OpenURL/new-window path.

Electron's documented workaround is to return `{ action: "deny" }` from `setWindowOpenHandler` for untrusted content instead of relying on the iframe sandbox. The main Hermes window already denies new windows, but guest webview `WebContents` are distinct and had no handler.

The new global `web-contents-created` hook installs the deny-only handler only on `webview` guests, before Browser Pane content can request a popup.

## Verification

- RED: new contract test failed before the helper existed
- Electron tests: `1433 passed, 2 skipped`
- Desktop UI tests: `4773 passed`
- targeted guard + preview tests: `25 passed`
- independent security review: APPROVE
- Desktop typecheck: pass
- Desktop eslint: pass
- `git diff --check`: pass
- added-line security scan: no secrets, shell execution, eval, unsafe HTML, or external-open path

## Scope

No dependency, lockfile, config, renderer behavior, or normal in-pane navigation changes. Non-webview windows keep their existing handlers and login/OAuth behavior.

## Rebase verification and #82393 boundary — 2026-08-19

Rebased onto current upstream `5dd15872a687` (head `70855bc19584`). Fresh verification: Electron **1451 passed / 2 skipped**, targeted lane **1396 passed / 2 skipped**, typecheck pass, ESLint **0 errors** and no warning introduced by this PR.

The security invariant remains intentionally narrow: every guest `webContents` of type `webview` gets a `setWindowOpenHandler` returning `deny`, closing CVE-2026-70608 on affected Electron versions.

#82393 is still open and adds a separate product behavior: validate a constrained `_blank` target, route it to the OS browser, then return `deny`. These are compatible only if the eventual #82393 handler preserves the no-window invariant and replaces/composes this default guard rather than returning `allow`. I have not copied or subsumed that contributor's 369-line open PR here. The remaining gate is therefore maintainer ordering/reconciliation with #82393, not a conflict with current main.
