### PR TITLE
feat: group chats gain an editable name and room picture (Bot Mode desktop)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -3507,7 +3507,9 @@ function updateGroupChat(group, mutate) {
         stranded: room.stranded || {},
         // Source-qualified member descriptors keep the room whole when the
         // active connection changes and today's local members become remote.
-        members: Array.isArray(room.members) ? room.members : []
+        members: Array.isArray(room.members) ? room.members : [],
+        // Room picture (small data URL, same normalization as bot avatars).
+        image: room.image || null
       }
     }
 
@@ -3563,7 +3565,8 @@ async function disbandGroupChat(group, members) {
           log: room.log,
           watermarks: room.watermarks,
           sessions: room.sessions || {},
-          members: Array.isArray(room.members) ? room.members : []
+          members: Array.isArray(room.members) ? room.members : [],
+          image: room.image || null
         }
       }
     }
@@ -3584,6 +3587,96 @@ async function disbandGroupChat(group, members) {
     const meta = $botMeta.get()[member.name] || {}
     await saveBotMeta(member.name, groupMembershipPatch(meta, group, false))
   }
+}
+
+/** Set or clear a group chat's room picture (small data URL, normalized by
+ *  the same pipeline as bot avatars). Persists with the room record. */
+function setGroupChatImage(group, image) {
+  updateGroupChat(group, room => {
+    room.image = image || null
+    return room
+  })
+}
+
+/** Rename a group chat. The group's NAME is its identity everywhere — the
+ *  room-map key, each local member's ui_meta membership list, and derived
+ *  state — so a rename re-keys all of them. Member gateway sessions are kept
+ *  as-is: stored sids keep resuming, so no history is lost (only a member
+ *  whose sid is later lost falls back to a fresh "Group: <new name>" title
+ *  lookup). Returns the new name, or null when the target name is taken. */
+async function renameGroupChat(oldName, newName, members) {
+  const next = String(newName || '').trim().slice(0, 64)
+
+  if (!next || next === oldName) {
+    return oldName
+  }
+
+  // Renames are explicit user intent: reject a collision honestly instead of
+  // silently suffixing like creation does.
+  const taken = new Set(Object.keys($groupChats.get()))
+
+  for (const meta of Object.values($botMeta.get() || {})) {
+    for (const existing of botGroups(meta)) {
+      taken.add(existing)
+    }
+  }
+
+  taken.delete(oldName)
+
+  if (taken.has(next)) {
+    host.notify({ kind: 'error', message: `A group named “${next}” already exists.` })
+    return null
+  }
+
+  // Move the room record wholesale — log, watermarks, sessions, members,
+  // picture, and runtime flags all belong to the same room under its new name.
+  const all = { ...$groupChats.get() }
+  const room = all[oldName]
+
+  delete all[oldName]
+
+  if (room) {
+    all[next] = room
+  }
+
+  $groupChats.set(all)
+
+  const needs = { ...$groupNeedsYou.get() }
+
+  if (oldName in needs) {
+    needs[next] = needs[oldName]
+    delete needs[oldName]
+    $groupNeedsYou.set(needs)
+  }
+
+  // Local memberships: swap the name inside each member's canonical groups
+  // list (syncs cross-machine via ui_meta). Remote members' seating lives in
+  // the room record we just moved.
+  for (const member of members || []) {
+    if (!member?.name || member.remoteSource) {
+      continue
+    }
+
+    const meta = $botMeta.get()[member.name] || {}
+    const groups = [...new Set(botGroups(meta).map(g => (g === oldName ? next : g)))]
+
+    await saveBotMeta(member.name, { groups, group: groups[0] || null })
+  }
+
+  // Persist the re-keyed map (updateGroupChat writes the whole durable map).
+  updateGroupChat(next, r => r)
+
+  // Follow the open views to the new identity.
+  if ($groupChatWorkspace.get() === oldName) {
+    $groupChatWorkspace.set(next)
+  }
+
+  if (groupChatMainTabs.has(oldName)) {
+    closeGroupChatMainTab(oldName)
+    openGroupChat(next)
+  }
+
+  return next
 }
 
 function appendGroupChatEntry(group, from, text, thread) {
@@ -7429,6 +7522,171 @@ function GroupDialog({ bot, onClose }) {
   })
 }
 
+/** Compact picture controls shared by group-chat creation and settings:
+ *  a live preview (image, else the organization glyph), Upload / Generate /
+ *  Remove. Reuses the bot-avatar pipeline (device picker, 256px normalize,
+ *  image.generate probe) so room pictures cost the same as bot avatars. */
+function GroupImageControls({ image, onImage, seedName, seedMembers }) {
+  const imagen = useValue($imagenAvailable)
+  const [busy, setBusy] = useState(false)
+
+  if (imagen === null) {
+    void probeImagen()
+  }
+
+  const upload = async () => {
+    const raw = await pickImageFromDevice()
+
+    if (raw) {
+      onImage(await normalizeAvatarImage(raw))
+    }
+  }
+
+  const generate = async () => {
+    if (busy) {
+      return
+    }
+
+    setBusy(true)
+
+    try {
+      const who = [seedName, seedMembers?.length ? `a team of ${seedMembers.join(', ')}` : '']
+        .filter(Boolean)
+        .join(' — ')
+      const res = await host.request('image.generate', {
+        prompt:
+          `Group chat icon for an AI agent team called "${who || 'a bot team'}". ` +
+          'Friendly minimal emblem, bold flat vector style, solid color background, centered, no text.',
+        aspect_ratio: 'square'
+      })
+
+      if (!res?.success) {
+        throw new Error(res?.error || 'generation failed')
+      }
+
+      const img = res.image_data || res.image
+
+      if (img) {
+        onImage(await normalizeAvatarImage(img))
+      }
+    } catch (err) {
+      host.notifyError(err, 'Group picture generation failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return jsxs('div', {
+    className: 'flex items-center gap-2',
+    children: [
+      jsx('div', {
+        className:
+          'flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-full bg-(--chrome-action-hover)',
+        children: image
+          ? jsx('img', { src: image, alt: '', className: 'size-full object-cover' })
+          : jsx(Codicon, { name: 'organization', className: 'text-(--ui-text-tertiary)' })
+      }),
+      jsx(Button, { type: 'button', variant: 'secondary', size: 'sm', onClick: upload, children: 'Upload' }),
+      imagen
+        ? jsx(Button, {
+            type: 'button',
+            variant: 'secondary',
+            size: 'sm',
+            disabled: busy,
+            onClick: generate,
+            children: busy ? 'Generating…' : 'Generate'
+          })
+        : null,
+      image
+        ? jsx(Button, { type: 'button', variant: 'ghost', size: 'sm', onClick: () => onImage(null), children: 'Remove' })
+        : null
+    ]
+  })
+}
+
+/** Edit an existing group chat's name and picture. Renames re-key the room
+ *  and every local member's membership (renameGroupChat); the picture rides
+ *  the room record. Both apply on Save so a cancelled dialog changes nothing. */
+function GroupChatSettingsDialog({ group, members, open, onClose, onRenamed }) {
+  const rooms = useValue($groupChats)
+  const current = (rooms[group] || {}).image || null
+  const [name, setName] = useState(group)
+  const [image, setImage] = useState(current)
+
+  useEffect(() => {
+    if (open) {
+      setName(group)
+      setImage(current)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, group])
+
+  const save = async () => {
+    const finalName = await renameGroupChat(group, name, members)
+
+    if (finalName === null) {
+      return // collision — dialog stays open for a different name
+    }
+
+    if (image !== current) {
+      setGroupChatImage(finalName, image)
+    }
+
+    onClose()
+
+    if (finalName !== group) {
+      onRenamed?.(finalName)
+    }
+  }
+
+  return jsx(Dialog, {
+    open,
+    onOpenChange: value => {
+      if (!value) {
+        onClose()
+      }
+    },
+    children: jsxs(DialogContent, {
+      className: 'max-w-sm',
+      children: [
+        jsxs(DialogHeader, {
+          children: [
+            jsx(DialogTitle, { children: 'Group settings' }),
+            jsx(DialogDescription, {
+              children: 'Rename the group or set a room picture. Members and history are kept.'
+            })
+          ]
+        }),
+        jsx(GroupImageControls, {
+          image,
+          onImage: setImage,
+          seedName: name.trim() || group,
+          seedMembers: (members || []).map(b => b.name)
+        }),
+        jsx('form', {
+          onSubmit: event => {
+            event.preventDefault()
+            void save()
+          },
+          children: jsx(Input, {
+            'aria-label': 'Group name',
+            autoFocus: true,
+            maxLength: 64,
+            value: name,
+            onChange: event => setName(event.target.value)
+          })
+        }),
+        jsxs(DialogFooter, {
+          children: [
+            jsx(Button, { variant: 'secondary', onClick: onClose, children: 'Cancel' }),
+            jsx(Button, { disabled: !name.trim(), onClick: () => void save(), children: 'Save' })
+          ]
+        })
+      ]
+    })
+  })
+}
+
 /** Discord-style group chat creation: pick 2+ bots via checkboxes (with
  *  search), name the group, create. Assignment appends to each local bot's
  *  group membership list, so the room appears in the roster and syncs
@@ -7438,6 +7696,7 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
   const [query, setQuery] = useState('')
   const [checked, setChecked] = useState({})
   const [name, setName] = useState('')
+  const [image, setImage] = useState(null)
 
   // Reset per open so a cancelled draft doesn't leak into the next one.
   useEffect(() => {
@@ -7445,6 +7704,7 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
       setQuery('')
       setChecked({})
       setName('')
+      setImage(null)
     }
   }, [open])
 
@@ -7499,6 +7759,11 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
 
     updateGroupChat(groupName, room => {
       room.members = roomMembers
+
+      if (image) {
+        room.image = image
+      }
+
       return room
     })
 
@@ -7603,18 +7868,29 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
                 })
           })
         }),
-        jsx('form', {
-          onSubmit: event => {
-            event.preventDefault()
-            create()
-          },
-          children: jsx(Input, {
-            'aria-label': 'Group name',
-            maxLength: 64,
-            placeholder,
-            value: name,
-            onChange: event => setName(event.target.value)
-          })
+        jsxs('div', {
+          className: 'grid gap-2',
+          children: [
+            jsx(GroupImageControls, {
+              image,
+              onImage: setImage,
+              seedName: name.trim() || (selected.length ? placeholder : ''),
+              seedMembers: selected.map(bot => displayName(bot, botRosterMeta(bot, allMeta)))
+            }),
+            jsx('form', {
+              onSubmit: event => {
+                event.preventDefault()
+                create()
+              },
+              children: jsx(Input, {
+                'aria-label': 'Group name',
+                maxLength: 64,
+                placeholder,
+                value: name,
+                onChange: event => setName(event.target.value)
+              })
+            })
+          ]
         }),
         jsxs(DialogFooter, {
           children: [
@@ -7830,6 +8106,7 @@ function GroupChatWorkspace({ group, members, onBack }) {
   const room = rooms[group] || { log: [], running: false }
   const [draft, setDraft] = useState('')
   const [confirmDisband, setConfirmDisband] = useState(false)
+  const [settingsOpen, setSettingsOpen] = useState(false)
   // Click-to-disambiguate: which log entry is showing its speaker's full
   // @handle (the roster's name-device form when names collide across
   // connections). Naturally every speaker just shows its display name.
@@ -7852,6 +8129,14 @@ function GroupChatWorkspace({ group, members, onBack }) {
         onClick: () => (onBack ? onBack() : $groupChatWorkspace.set(null)),
         children: 'Back'
       }),
+      // Room picture (set via Group settings) leads the title when present.
+      room.image
+        ? jsx('img', {
+            src: room.image,
+            alt: '',
+            className: 'size-6 shrink-0 rounded-full object-cover ring-1 ring-(--ui-stroke-secondary)'
+          })
+        : null,
       jsx('div', {
         className: 'min-w-0 flex-1 truncate text-sm font-semibold',
         children: `${group} — group chat`
@@ -7875,6 +8160,14 @@ function GroupChatWorkspace({ group, members, onBack }) {
       jsx('span', {
         className: 'shrink-0 text-[0.65rem] text-(--ui-text-quaternary)',
         children: `${members.length} bots`
+      }),
+      jsx(Button, {
+        variant: 'ghost',
+        size: 'sm',
+        className: 'shrink-0 text-(--ui-text-tertiary) hover:text-foreground',
+        title: `Group settings — rename ${group} or set a room picture`,
+        onClick: () => setSettingsOpen(true),
+        children: jsx(Codicon, { name: 'gear' })
       }),
       jsx(Button, {
         variant: 'ghost',
@@ -8180,6 +8473,12 @@ function GroupChatWorkspace({ group, members, onBack }) {
           ]
         })
       }),
+      jsx(GroupChatSettingsDialog, {
+        group,
+        members,
+        open: settingsOpen,
+        onClose: () => setSettingsOpen(false)
+      }),
       jsx(ConfirmDialog, {
         open: confirmDisband,
         title: 'Disband group chat?',
@@ -8293,11 +8592,18 @@ function GroupRow({ group, members, needsYou, onOpen }) {
       'hover:bg-(--chrome-action-hover)'
     ),
     children: [
-      // Composite avatar: up to three member faces fanned like Discord's
-      // group-DM icon; a bare glyph when the room has no seated members.
+      // Room picture when the user set one; else a composite avatar of up to
+      // three member faces fanned like Discord's group-DM icon; a bare glyph
+      // when the room has no seated members.
       jsx('div', {
         className: 'flex w-[34px] shrink-0 items-center justify-center',
-        children: faces.length
+        children: room.image
+          ? jsx('img', {
+              src: room.image,
+              alt: '',
+              className: 'size-7 rounded-full object-cover ring-2 ring-(--ui-bg-primary,#111)'
+            })
+          : faces.length
           ? jsx('div', {
               className: 'flex items-center -space-x-2.5',
               children: faces.map(member => {
@@ -8905,6 +9211,7 @@ export default {
                   sessions: room.sessions && typeof room.sessions === 'object' ? room.sessions : {},
                   stranded: room.stranded && typeof room.stranded === 'object' ? room.stranded : {},
                   members: Array.isArray(room.members) ? room.members : [],
+                  image: typeof room.image === 'string' && room.image ? room.image : null,
                   epoch: 0,
                   running: false
                 }

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat-identity-edit.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat-identity-edit.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+// Group chats have an editable identity: a name (renameable after creation)
+// and a room picture (settable during creation and later via Group settings).
+// Source-contract style, like the sibling group-chat tests.
+
+test('source contract: creation dialog offers a room picture', () => {
+  // Shared picture controls (upload / generate / remove) mount in the create
+  // dialog, and a chosen image lands on the freshly created room record.
+  assert.match(pluginSource, /function GroupImageControls\(/)
+  assert.match(pluginSource, /if \(image\) \{\s*\n\s*room\.image = image/)
+})
+
+test('source contract: settings dialog edits name and picture after creation', () => {
+  assert.match(pluginSource, /function GroupChatSettingsDialog\(/)
+  assert.match(pluginSource, /function renameGroupChat\(/)
+  assert.match(pluginSource, /function setGroupChatImage\(/)
+  // The room header exposes the entry point.
+  assert.match(pluginSource, /Group settings — rename \$\{group\} or set a room picture/)
+})
+
+test('source contract: rename re-keys the room AND local memberships, keeps sessions', () => {
+  // The room record moves wholesale under the new key (sessions included, so
+  // members keep resuming their per-group sessions by stored sid).
+  assert.match(pluginSource, /const room = all\[oldName\]\s*\n\s*\n?\s*delete all\[oldName\]/)
+  // Local members' canonical groups lists swap old → new via ui_meta.
+  assert.match(pluginSource, /botGroups\(meta\)\.map\(g => \(g === oldName \? next : g\)\)/)
+  // Collisions are rejected, not silently suffixed — rename is explicit intent.
+  assert.match(pluginSource, /taken\.delete\(oldName\)/)
+})
+
+test('source contract: room picture persists and hydrates with the room record', () => {
+  // Durable writes carry image; hydration restores only a real string.
+  assert.match(pluginSource, /image: room\.image \|\| null/)
+  assert.match(pluginSource, /image: typeof room\.image === 'string' && room\.image \? room\.image : null/)
+})
+
+test('source contract: room picture shows in the roster row and room header', () => {
+  // Roster row: picture wins over the fanned member faces when set.
+  assert.match(pluginSource, /children: room\.image\s*\n\s*\? jsx\('img', \{/)
+  // Header: picture leads the title.
+  assert.match(pluginSource, /Room picture \(set via Group settings\) leads the title when present/)
+})


### PR DESCRIPTION
## Summary
Bot Mode group chats now have an editable identity: set a room picture during creation, and rename the group or change its picture any time after via a new Group settings dialog. Previously the name was fixed at creation forever and rooms had no picture at all.

## Changes
- `plugin.js` — `CreateGroupChatDialog`: optional room picture via shared `GroupImageControls` (Upload from device or `image.generate`, same 256px normalize pipeline as bot avatars); a chosen image lands on the fresh room record.
- `plugin.js` — room header: gear button opens `GroupChatSettingsDialog` (rename + set/replace/remove picture). Changes apply on Save; cancel changes nothing.
- `plugin.js` — `renameGroupChat()`: re-keys the room record wholesale (log, watermarks, sessions, members, picture), swaps old→new in every local member's canonical ui_meta groups list, migrates the needs-you badge, follows open views (in-panel workspace atom and main-window tab) to the new name, and rejects name collisions instead of silently suffixing. Stored member sessions keep resuming by sid — no history lost.
- `plugin.js` — persistence: `image` rides the durable `group-chats` record in both write paths and hydrates on window load.
- `plugin.js` — rendering: room picture wins over the fanned member-face pile in the roster row and leads the title in the room header.
- `tests/group-chat-identity-edit.test.mjs` — 5 source-contract tests covering creation picture, settings dialog, rename re-keying, persistence, and rendering.

## Validation
| | Before | After |
|---|---|---|
| `node --check plugin.js` | — | pass |
| `node --test tests/*.test.mjs` | 261 pass | 266 pass, 0 fail |

## Infographic

![Group chats: editable name and picture](https://v3b.fal.media/files/b/0aa6dd2f/MAARLTEI1DX_EeMLF7nZK_91R04CpM.png)
