### PR TITLE
fix(desktop): make group-chat message text selectable

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -8006,6 +8006,7 @@ function GroupChatWorkspace({ group, members, onBack }) {
                           jsx('div', {
                             className:
                               'text-xs text-(--ui-text-secondary) [&_p]:mb-1 [&_p:last-child]:mb-0 [&_ul]:mb-1 [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:mb-1 [&_ol]:list-decimal [&_ol]:pl-4 [&_pre]:overflow-x-auto',
+                            'data-selectable-text': 'true',
                             children: Streamdown ? jsx(Streamdown, { children: entry.text }) : entry.text
                           })
                         ]


### PR DESCRIPTION
## Problem

Group-chat message bodies in the `hermes-bots` desktop plugin render without the `data-selectable-text` attribute, so they inherit the app-wide `body { user-select: none }` rule and cannot be drag-selected or copied.

1:1 chat messages already carry the equivalent marker (`[data-slot='aui_assistant-message-content']`), so this aligns group chat with that existing behavior.

## Root cause

In `apps/desktop/src/plugins/hermes-bots/plugin.js`, the message body wrapper `div` (the `Streamdown`/text renderer) is missing `data-selectable-text="true"`. The global stylesheet (`apps/desktop/src/styles.css`) only re-enables `user-select: text` for elements carrying that attribute (or the `aui_*` slots), so group-chat text stays unselectable.

## Fix

Add `'data-selectable-text': 'true'` to the message body wrapper, matching the 1:1 chat pattern.

```diff
                           jsx('div', {
                             className:
                               'text-xs text-(--ui-text-secondary) [&_p]:mb-1 [&_p:last-child]:mb-0 [&_ul]:mb-1 [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:mb-1 [&_ol]:list-decimal [&_ol]:pl-4 [&_pre]:overflow-x-auto',
+                            'data-selectable-text': 'true',
                             children: Streamdown ? jsx(Streamdown, { children: entry.text }) : entry.text
                           })
```

## Verification

- Confirmed the message body wrapper is the only group-chat text node missing the attribute (1:1 chat uses `aui_assistant-message-content`).
- After the change, group-chat message text is drag-selectable and copyable, matching 1:1 chat behavior.