### PR TITLE
fix(desktop): tolerate OAuth callback navigation abort

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -225,6 +225,7 @@ import {
 } from './native-oauth'
 import { runNativeLogin } from './native-oauth-login'
 import { loadNativeTokenSet, type NativeTokenStoreIo, persistNativeTokenSet } from './native-token-store'
+import { isExpectedOauthNavigationAbort } from './oauth-navigation'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
 import {
   createParentStartMarkerResolver,
@@ -6908,6 +6909,16 @@ function openOauthLoginWindow(baseUrl, { silent = false } = {}) {
     const normalizedBase = normalizeRemoteBaseUrl(baseUrl)
     const loginUrl = silent ? `${normalizedBase}/` : `${normalizedBase}/login`
     win.loadURL(loginUrl).catch(error => {
+      // Electron can reject the original load with ERR_ABORTED when the OAuth
+      // callback redirects while setting the HttpOnly session cookie. The
+      // navigation abort is expected; keep polling the cookie jar instead of
+      // failing a successful Cloud cascade before the cookie settles.
+      if (isExpectedOauthNavigationAbort(error)) {
+        void checkCookie()
+
+        return
+      }
+
       finish(error instanceof Error ? error : new Error(String(error)))
     })
   })

--- a/apps/desktop/electron/oauth-navigation.test.ts
+++ b/apps/desktop/electron/oauth-navigation.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { isExpectedOauthNavigationAbort } from './oauth-navigation'
+
+describe('isExpectedOauthNavigationAbort', () => {
+  it('treats Electron ERR_ABORTED callback navigation as non-fatal', () => {
+    const error = Object.assign(new Error("ERR_ABORTED (-3) loading 'https://agent.example.com/auth/callback?code=redacted'"), {
+      code: -3
+    })
+
+    expect(isExpectedOauthNavigationAbort(error)).toBe(true)
+  })
+
+  it('does not suppress genuine gateway load failures', () => {
+    expect(isExpectedOauthNavigationAbort(new Error('ERR_NAME_NOT_RESOLVED (-105)'))).toBe(false)
+    expect(isExpectedOauthNavigationAbort(new Error('HTTP 502 from gateway'))).toBe(false)
+  })
+})

--- a/apps/desktop/electron/oauth-navigation.ts
+++ b/apps/desktop/electron/oauth-navigation.ts
@@ -1,0 +1,10 @@
+export function isExpectedOauthNavigationAbort(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false
+  }
+
+  const code = 'code' in error ? Number((error as { code?: unknown }).code) : Number.NaN
+  const message = error instanceof Error ? error.message : String(error)
+
+  return code === -3 || /\bERR_ABORTED\b|\(-3\)/.test(message)
+}


### PR DESCRIPTION
## Summary
- Treats Electron `ERR_ABORTED (-3)` as an expected OAuth callback navigation abort.
- Keeps polling the HttpOnly session cookie instead of failing a successful Hermes Cloud connection.
- Adds focused regression coverage for numeric and message-shaped abort errors.

## Reproduction
Hermes Desktop discovered the hosted agent and completed the ngrok OAuth callback, but `BrowserWindow.loadURL()` rejected with `ERR_ABORTED (-3)` before the cookie poll settled. Desktop reported the Cloud agent as unreachable even though the callback succeeded.

## Verification
Run from `apps/desktop`:

- `npx vitest run --project electron electron/oauth-navigation.test.ts electron/native-oauth-login.test.ts electron/native-oauth.test.ts electron/connection-config.test.ts`
- `npx eslint electron/oauth-navigation.ts electron/oauth-navigation.test.ts electron/main.ts`
- `npx tsc -p tsconfig.electron.json --noEmit`
- Rebuilt the packaged Desktop app and connected successfully to a Hermes Cloud agent.
