### PR TITLE
fix(gateway): preserve history for shared primary profile routes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2091,12 +2091,17 @@ def _profile_runtime_scope(profile_home: "Path"):
     from hermes_cli.env_loader import hydrate_profile_secret_sources
 
     home_token = set_hermes_home_override(str(profile_home))
-    hydrate_profile_secret_sources(Path(profile_home))
-    secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
+    secret_token = None
     try:
-        yield
+        hydrate_profile_secret_sources(Path(profile_home))
+        secret_token = set_secret_scope(
+            build_profile_secret_scope(Path(profile_home))
+        )
+        try:
+            yield
+        finally:
+            reset_secret_scope(secret_token)
     finally:
-        reset_secret_scope(secret_token)
         reset_hermes_home_override(home_token)
 
 
@@ -17740,18 +17745,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._persist_active_agents()
         _run_generation = self._begin_session_run_generation(_quick_key)
 
-        _turn_scope = _nullcontext()
-        if getattr(getattr(self, "config", None), "multiplex_profiles", False):
-            _turn_scope = _profile_runtime_scope(
-                self._resolve_profile_home_for_source(source)
-            )
-
         # Authorization and route stamping above intentionally run in the
         # owning adapter's scope.  Once the turn is claimed, keep the routed
         # scope through post-turn bookkeeping and durable-marker cleanup too;
         # both paths resolve profile-local state after the agent returns.
         _turn_scope_entered = False
         try:
+            _turn_scope = _nullcontext()
+            if getattr(getattr(self, "config", None), "multiplex_profiles", False):
+                _turn_scope = _profile_runtime_scope(
+                    self._resolve_profile_home_for_source(source)
+                )
             with _turn_scope:
                 _turn_scope_entered = True
                 try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2022,7 +2022,7 @@ def _current_max_iterations() -> int:
         return 500
 
 
-from contextlib import contextmanager as _contextmanager
+from contextlib import contextmanager as _contextmanager, nullcontext as _nullcontext
 
 
 # Platforms that bind a host TCP port (HTTP/webhook listeners). In a profile
@@ -17740,64 +17740,75 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._persist_active_agents()
         _run_generation = self._begin_session_run_generation(_quick_key)
 
-        try:
+        _turn_scope = _nullcontext()
+        if getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            _turn_scope = _profile_runtime_scope(
+                self._resolve_profile_home_for_source(source)
+            )
+
+        # Authorization and route stamping above intentionally run in the
+        # owning adapter's scope.  Once the turn is claimed, keep the routed
+        # scope through post-turn bookkeeping and durable-marker cleanup too;
+        # both paths resolve profile-local state after the agent returns.
+        with _turn_scope:
             try:
-                _agent_result = await self._handle_message_with_agent(
-                    event, source, _quick_key, _run_generation
-                )
-            except TurnLeaseTimeoutError as exc:
-                # This is a rejected message, not a completed agent turn. Return
-                # before the /goal judge below so it cannot consume the resend
-                # notice and enqueue a synthetic continuation loop.
-                logger.error(
-                    "Rejecting turn for routing key %s on session %s after "
-                    "turn-lease timeout; transcript load was not started and "
-                    "the user must resend",
-                    _quick_key,
-                    exc.session_id,
-                )
-                return (
-                    "⏳ Another turn is still running on this session. To "
-                    "protect the transcript, this message was not processed. "
-                    "Wait for the active turn to finish, then resend it."
-                )
-            try:
-                await self._run_post_turn_hooks(
-                    agent_result=_agent_result,
-                    source=source,
-                    is_internal=is_internal,
-                    event=event,
-                )
-            except Exception as _goal_exc:
-                logger.debug("post-turn hook failed: %s", _goal_exc)
-            return _agent_result
-        finally:
-            # MoA one-shot restore must run on EVERY exit path, not just
-            # success. The restore data lives on the per-turn event object
-            # (_moa_restore_override), which is discarded once the event goes
-            # out of scope — so if _handle_message_with_agent raises, a restore
-            # in the try block would be skipped and the MoA override would leak
-            # permanently (every later message silently fans out through MoA).
-            # Putting it in finally guarantees the revert on success, exception,
-            # and interrupt alike.
-            self._restore_moa_one_shot(event, _quick_key)
-            self._restore_pending_one_turn_model_override(_quick_key)
-            # Normal completion/exception/interrupt owns and clears this exact
-            # durable marker.  SIGKILL/OOM skips finally, leaving the marker for
-            # the next unclean startup's recovery pass.
-            await self._clear_durable_active_turn(event)
-            # Unconditional release covers every exit path. _release_running_agent_state
-            # is idempotent (pop-on-absent is harmless) and, called without a
-            # run_generation guard, always clears the slot regardless of which
-            # generation it holds. This evicts the zombie left when session_reset
-            # bumps the generation (N -> N+1) mid-flight: gen-N's guarded release
-            # inside _run_agent returns False, and the old sentinel-only check here
-            # missed the leftover real agent — locking the session out forever (#28686).
-            self._release_running_agent_state(_quick_key)
-            # Turn lease (#64934): release THIS turn's lease token — keyed by
-            # (routing key, run generation) so this unwind can only ever free
-            # the lease its own turn acquired, never a newer turn's.
-            self._release_turn_lease(_quick_key, _run_generation)
+                try:
+                    _agent_result = await self._handle_message_with_agent(
+                        event, source, _quick_key, _run_generation
+                    )
+                except TurnLeaseTimeoutError as exc:
+                    # This is a rejected message, not a completed agent turn. Return
+                    # before the /goal judge below so it cannot consume the resend
+                    # notice and enqueue a synthetic continuation loop.
+                    logger.error(
+                        "Rejecting turn for routing key %s on session %s after "
+                        "turn-lease timeout; transcript load was not started and "
+                        "the user must resend",
+                        _quick_key,
+                        exc.session_id,
+                    )
+                    return (
+                        "⏳ Another turn is still running on this session. To "
+                        "protect the transcript, this message was not processed. "
+                        "Wait for the active turn to finish, then resend it."
+                    )
+                try:
+                    await self._run_post_turn_hooks(
+                        agent_result=_agent_result,
+                        source=source,
+                        is_internal=is_internal,
+                        event=event,
+                    )
+                except Exception as _goal_exc:
+                    logger.debug("post-turn hook failed: %s", _goal_exc)
+                return _agent_result
+            finally:
+                # MoA one-shot restore must run on EVERY exit path, not just
+                # success. The restore data lives on the per-turn event object
+                # (_moa_restore_override), which is discarded once the event goes
+                # out of scope — so if _handle_message_with_agent raises, a restore
+                # in the try block would be skipped and the MoA override would leak
+                # permanently (every later message silently fans out through MoA).
+                # Putting it in finally guarantees the revert on success, exception,
+                # and interrupt alike.
+                self._restore_moa_one_shot(event, _quick_key)
+                self._restore_pending_one_turn_model_override(_quick_key)
+                # Normal completion/exception/interrupt owns and clears this exact
+                # durable marker.  SIGKILL/OOM skips finally, leaving the marker for
+                # the next unclean startup's recovery pass.
+                await self._clear_durable_active_turn(event)
+                # Unconditional release covers every exit path. _release_running_agent_state
+                # is idempotent (pop-on-absent is harmless) and, called without a
+                # run_generation guard, always clears the slot regardless of which
+                # generation it holds. This evicts the zombie left when session_reset
+                # bumps the generation (N -> N+1) mid-flight: gen-N's guarded release
+                # inside _run_agent returns False, and the old sentinel-only check here
+                # missed the leftover real agent — locking the session out forever (#28686).
+                self._release_running_agent_state(_quick_key)
+                # Turn lease (#64934): release THIS turn's lease token — keyed by
+                # (routing key, run generation) so this unwind can only ever free
+                # the lease its own turn acquired, never a newer turn's.
+                self._release_turn_lease(_quick_key, _run_generation)
 
     def _restore_moa_one_shot(self, event: "MessageEvent", quick_key: str) -> None:
         """Revert a ``/moa <prompt>`` one-shot model override after its turn.
@@ -18566,6 +18577,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
 
         profile_home = self._resolve_profile_home_for_source(source)
+        if Path(get_hermes_home()) == Path(profile_home):
+            return await self._handle_message_with_agent_inner(
+                event, source, _quick_key, run_generation
+            )
         with _profile_runtime_scope(profile_home):
             return await self._handle_message_with_agent_inner(
                 event, source, _quick_key, run_generation

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17750,65 +17750,66 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # owning adapter's scope.  Once the turn is claimed, keep the routed
         # scope through post-turn bookkeeping and durable-marker cleanup too;
         # both paths resolve profile-local state after the agent returns.
-        with _turn_scope:
-            try:
+        _turn_scope_entered = False
+        try:
+            with _turn_scope:
+                _turn_scope_entered = True
                 try:
-                    _agent_result = await self._handle_message_with_agent(
-                        event, source, _quick_key, _run_generation
-                    )
-                except TurnLeaseTimeoutError as exc:
-                    # This is a rejected message, not a completed agent turn. Return
-                    # before the /goal judge below so it cannot consume the resend
-                    # notice and enqueue a synthetic continuation loop.
-                    logger.error(
-                        "Rejecting turn for routing key %s on session %s after "
-                        "turn-lease timeout; transcript load was not started and "
-                        "the user must resend",
-                        _quick_key,
-                        exc.session_id,
-                    )
-                    return (
-                        "⏳ Another turn is still running on this session. To "
-                        "protect the transcript, this message was not processed. "
-                        "Wait for the active turn to finish, then resend it."
-                    )
-                try:
-                    await self._run_post_turn_hooks(
-                        agent_result=_agent_result,
-                        source=source,
-                        is_internal=is_internal,
-                        event=event,
-                    )
-                except Exception as _goal_exc:
-                    logger.debug("post-turn hook failed: %s", _goal_exc)
-                return _agent_result
-            finally:
-                # MoA one-shot restore must run on EVERY exit path, not just
-                # success. The restore data lives on the per-turn event object
-                # (_moa_restore_override), which is discarded once the event goes
-                # out of scope — so if _handle_message_with_agent raises, a restore
-                # in the try block would be skipped and the MoA override would leak
-                # permanently (every later message silently fans out through MoA).
-                # Putting it in finally guarantees the revert on success, exception,
-                # and interrupt alike.
+                    try:
+                        _agent_result = await self._handle_message_with_agent(
+                            event, source, _quick_key, _run_generation
+                        )
+                    except TurnLeaseTimeoutError as exc:
+                        # This is a rejected message, not a completed agent turn. Return
+                        # before the /goal judge below so it cannot consume the resend
+                        # notice and enqueue a synthetic continuation loop.
+                        logger.error(
+                            "Rejecting turn for routing key %s on session %s after "
+                            "turn-lease timeout; transcript load was not started and "
+                            "the user must resend",
+                            _quick_key,
+                            exc.session_id,
+                        )
+                        return (
+                            "⏳ Another turn is still running on this session. To "
+                            "protect the transcript, this message was not processed. "
+                            "Wait for the active turn to finish, then resend it."
+                        )
+                    try:
+                        await self._run_post_turn_hooks(
+                            agent_result=_agent_result,
+                            source=source,
+                            is_internal=is_internal,
+                            event=event,
+                        )
+                    except Exception as _goal_exc:
+                        logger.debug("post-turn hook failed: %s", _goal_exc)
+                    return _agent_result
+                finally:
+                    # MoA one-shot restore must run on EVERY exit path, not just
+                    # success. The restore data lives on the per-turn event object
+                    # (_moa_restore_override), which is discarded once the event goes
+                    # out of scope — so if _handle_message_with_agent raises, a restore
+                    # in the try block would be skipped and the MoA override would leak
+                    # permanently (every later message silently fans out through MoA).
+                    # Putting it in finally guarantees the revert on success, exception,
+                    # and interrupt alike.
+                    self._restore_moa_one_shot(event, _quick_key)
+                    self._restore_pending_one_turn_model_override(_quick_key)
+                    # Normal completion/exception/interrupt owns and clears this exact
+                    # durable marker.  SIGKILL/OOM skips finally, leaving the marker for
+                    # the next unclean startup's recovery pass.
+                    await self._clear_durable_active_turn(event)
+        finally:
+            # A context manager can fail before yielding. Restore one-shot state
+            # on that path too, but avoid doing so twice after a normal entry.
+            if not _turn_scope_entered:
                 self._restore_moa_one_shot(event, _quick_key)
                 self._restore_pending_one_turn_model_override(_quick_key)
-                # Normal completion/exception/interrupt owns and clears this exact
-                # durable marker.  SIGKILL/OOM skips finally, leaving the marker for
-                # the next unclean startup's recovery pass.
-                await self._clear_durable_active_turn(event)
-                # Unconditional release covers every exit path. _release_running_agent_state
-                # is idempotent (pop-on-absent is harmless) and, called without a
-                # run_generation guard, always clears the slot regardless of which
-                # generation it holds. This evicts the zombie left when session_reset
-                # bumps the generation (N -> N+1) mid-flight: gen-N's guarded release
-                # inside _run_agent returns False, and the old sentinel-only check here
-                # missed the leftover real agent — locking the session out forever (#28686).
-                self._release_running_agent_state(_quick_key)
-                # Turn lease (#64934): release THIS turn's lease token — keyed by
-                # (routing key, run generation) so this unwind can only ever free
-                # the lease its own turn acquired, never a newer turn's.
-                self._release_turn_lease(_quick_key, _run_generation)
+            # These process-local claims must be released even if profile-scope
+            # setup or durable cleanup raises.
+            self._release_running_agent_state(_quick_key)
+            self._release_turn_lease(_quick_key, _run_generation)
 
     def _restore_moa_one_shot(self, event: "MessageEvent", quick_key: str) -> None:
         """Revert a ``/moa <prompt>`` one-shot model override after its turn.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18546,8 +18546,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
         return source
 
-    async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
-        """Inner handler that runs under the _running_agents sentinel guard."""
+    async def _handle_message_with_agent(
+        self, event, source, _quick_key: str, run_generation: int
+    ):
+        """Run the routed session lifecycle in the selected profile scope.
+
+        Primary adapters enter through the default profile so authorization and
+        platform secrets remain owned by that adapter.  Route stamping happens
+        during that ingress path, but session creation and transcript loading
+        happen here, before ``_run_agent`` applies its narrower agent scope.  A
+        multiplexed turn therefore has to switch scopes at this boundary so
+        every session-store access and the eventual agent use the same DB.
+
+        Single-profile gateways keep the existing unscoped path unchanged.
+        """
+        if not getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            return await self._handle_message_with_agent_inner(
+                event, source, _quick_key, run_generation
+            )
+
+        profile_home = self._resolve_profile_home_for_source(source)
+        with _profile_runtime_scope(profile_home):
+            return await self._handle_message_with_agent_inner(
+                event, source, _quick_key, run_generation
+            )
+
+    async def _handle_message_with_agent_inner(
+        self, event, source, _quick_key: str, run_generation: int
+    ):
+        """Execute one turn after its profile storage scope has been selected."""
         _msg_start_time = time.time()
         _platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
         _msg_preview = (event.text or "")[:80].replace("\n", " ")

--- a/tests/gateway/test_gateway_command_dispatch_minimal.py
+++ b/tests/gateway/test_gateway_command_dispatch_minimal.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
@@ -183,5 +184,32 @@ async def test_multiplex_claimed_turn_completion_stays_in_routed_scope(
 
     assert result == {"final_response": "", "messages": []}
     assert observed == ["agent", "post-turn", "cleanup"]
+
+
+@pytest.mark.asyncio
+async def test_multiplex_scope_entry_failure_releases_claimed_turn(
+    tmp_path, monkeypatch
+):
+    from gateway import run as run_mod
+
+    runner, _adapter = _make_runner()
+    runner.config.multiplex_profiles = True
+    runner._resolve_profile_home_for_source = (
+        lambda _source: tmp_path / "profiles" / "fitness"
+    )
+    event = _make_event("hello")
+    event.source.profile = "fitness"
+
+    @contextmanager
+    def _failing_scope(_profile_home):
+        raise RuntimeError("scope setup failed")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(run_mod, "_profile_runtime_scope", _failing_scope)
+
+    with pytest.raises(RuntimeError, match="scope setup failed"):
+        await runner._handle_message(event)
+
+    assert runner._running_agents == {}
 
 

--- a/tests/gateway/test_gateway_command_dispatch_minimal.py
+++ b/tests/gateway/test_gateway_command_dispatch_minimal.py
@@ -213,3 +213,75 @@ async def test_multiplex_scope_entry_failure_releases_claimed_turn(
     assert runner._running_agents == {}
 
 
+@pytest.mark.asyncio
+async def test_multiplex_profile_resolution_failure_releases_claimed_turn():
+    runner, _adapter = _make_runner()
+    runner.config.multiplex_profiles = True
+
+    def _fail_resolution(_source):
+        raise RuntimeError("profile resolution failed")
+
+    runner._resolve_profile_home_for_source = _fail_resolution
+    event = _make_event("hello")
+    event.source.profile = "fitness"
+
+    with pytest.raises(RuntimeError, match="profile resolution failed"):
+        await runner._handle_message(event)
+
+    assert runner._running_agents == {}
+
+
+def test_profile_runtime_scope_restores_home_when_secret_hydration_fails(
+    tmp_path, monkeypatch
+):
+    from gateway import run as run_mod
+    from hermes_constants import get_hermes_home
+
+    root = tmp_path / "hermes"
+    profile = root / "profiles" / "fitness"
+    root.mkdir(parents=True)
+    profile.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    def _fail_hydration(_profile_home):
+        raise RuntimeError("hydration failed")
+
+    monkeypatch.setattr(
+        "hermes_cli.env_loader.hydrate_profile_secret_sources",
+        _fail_hydration,
+    )
+
+    with pytest.raises(RuntimeError, match="hydration failed"):
+        with run_mod._profile_runtime_scope(profile):
+            pass
+
+    assert Path(get_hermes_home()) == root
+
+
+def test_profile_runtime_scope_restores_home_when_secret_cleanup_fails(
+    tmp_path, monkeypatch
+):
+    from agent import secret_scope
+    from gateway import run as run_mod
+    from hermes_constants import get_hermes_home
+
+    root = tmp_path / "hermes"
+    profile = root / "profiles" / "fitness"
+    root.mkdir(parents=True)
+    profile.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    original_reset = secret_scope.reset_secret_scope
+
+    def _reset_then_fail(token):
+        original_reset(token)
+        raise RuntimeError("secret cleanup failed")
+
+    monkeypatch.setattr(secret_scope, "reset_secret_scope", _reset_then_fail)
+
+    with pytest.raises(RuntimeError, match="secret cleanup failed"):
+        with run_mod._profile_runtime_scope(profile):
+            assert Path(get_hermes_home()) == profile
+
+    assert Path(get_hermes_home()) == root
+
+

--- a/tests/gateway/test_gateway_command_dispatch_minimal.py
+++ b/tests/gateway/test_gateway_command_dispatch_minimal.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -127,5 +128,60 @@ async def test_idle_queue_sends_payload_as_next_turn(command_text):
     assert captured["key"] == build_session_key(_make_source())
     assert captured["generation"] == 1
     assert runner._running_agents == {}
+
+
+@pytest.mark.asyncio
+async def test_multiplex_claimed_turn_completion_stays_in_routed_scope(
+    tmp_path, monkeypatch
+):
+    """Post-turn hooks and cleanup must not fall back to the adapter owner."""
+    from agent import secret_scope
+    from gateway import run as run_mod
+    from hermes_constants import get_hermes_home
+
+    root = tmp_path / "hermes"
+    profile = root / "profiles" / "fitness"
+    root.mkdir(parents=True)
+    profile.mkdir(parents=True)
+    (root / ".env").write_text("ROUTE_SCOPE_TOKEN=owner\n", encoding="utf-8")
+    (profile / ".env").write_text("ROUTE_SCOPE_TOKEN=routed\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setattr(run_mod, "get_hermes_home", lambda: root)
+
+    runner, _adapter = _make_runner()
+    runner.config.multiplex_profiles = True
+    runner._resolve_profile_home_for_source = lambda _source: profile
+    event = _make_event("hello")
+    event.source.profile = "fitness"
+    observed = []
+
+    def _assert_routed(stage):
+        assert Path(get_hermes_home()) == profile
+        assert secret_scope.get_secret("ROUTE_SCOPE_TOKEN") == "routed"
+        observed.append(stage)
+
+    async def _agent(_event, _source, _key, _generation):
+        _assert_routed("agent")
+        return {"final_response": "", "messages": []}
+
+    async def _post_turn(**_kwargs):
+        _assert_routed("post-turn")
+
+    async def _clear(_event):
+        _assert_routed("cleanup")
+        return True
+
+    runner._handle_message_with_agent = _agent
+    runner._run_post_turn_hooks = _post_turn
+    runner._clear_durable_active_turn = _clear
+
+    secret_scope.set_multiplex_active(True)
+    try:
+        result = await runner._handle_message(event)
+    finally:
+        secret_scope.set_multiplex_active(False)
+
+    assert result == {"final_response": "", "messages": []}
+    assert observed == ["agent", "post-turn", "cleanup"]
 
 

--- a/tests/gateway/test_multiplex_session_db_profile_scope.py
+++ b/tests/gateway/test_multiplex_session_db_profile_scope.py
@@ -16,13 +16,15 @@ row sitting in the root store.
 """
 
 import sqlite3
+import threading
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
 from gateway.config import GatewayConfig
-from gateway.session import SessionStore
+from gateway.session import AsyncSessionStore, SessionSource, SessionStore
 from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 
 
@@ -251,3 +253,81 @@ def test_runner_session_db_follows_the_active_profile_scope(multiplex_homes):
     assert runner._session_db_handles == {}
     assert root_db._db._conn is None
     assert profile_db._db._conn is None
+
+
+@pytest.mark.asyncio
+async def test_shared_primary_routes_session_lifecycle_to_profile_store(
+    multiplex_homes, monkeypatch
+):
+    """Owner-scoped ingress must hand the whole session lifecycle to the route.
+
+    The default adapter still authorizes with its own secrets.  Once routing has
+    selected ``fitness``, however, session creation and both lazy DB properties
+    must resolve against that profile before transcript loading begins.
+    """
+    from agent import secret_scope
+    from gateway import run as run_mod
+    from gateway.config import Platform
+    from gateway.run import GatewayRunner, _SESSION_DB_UNPINNED
+    from hermes_constants import get_hermes_home
+
+    root, profile = multiplex_homes
+    (root / ".env").write_text("ROUTE_SCOPE_TOKEN=owner\n", encoding="utf-8")
+    (profile / ".env").write_text("ROUTE_SCOPE_TOKEN=routed\n", encoding="utf-8")
+    monkeypatch.setattr(run_mod, "get_hermes_home", lambda: root)
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner.session_store = _make_store(root)
+    runner._async_session_store = AsyncSessionStore(runner.session_store)
+    runner._session_db_pinned = _SESSION_DB_UNPINNED
+    runner._session_db_handles = {}
+    runner._session_db_handles_lock = threading.Lock()
+    runner._resolve_profile_home_for_source = lambda _source: profile
+
+    source = SessionSource(
+        platform=Platform.WHATSAPP,
+        chat_id="shared-group",
+        chat_type="group",
+    )
+    event = SimpleNamespace(source=source)
+
+    async def _inner(_event, routed_source, _quick_key, _generation):
+        assert Path(get_hermes_home()) == profile
+        assert secret_scope.get_secret("ROUTE_SCOPE_TOKEN") == "routed"
+        entry = await runner.async_session_store.get_or_create_session(routed_source)
+        assert Path(runner.session_store._db.db_path) == profile / "state.db"
+        assert Path(runner._session_db._db.db_path) == profile / "state.db"
+        history = await runner.async_session_store.load_transcript(entry.session_id)
+        if not history:
+            await runner.async_session_store.append_to_transcript(
+                entry.session_id, {"role": "user", "content": "remember me"}
+            )
+        return entry.session_id, history
+
+    runner._handle_message_with_agent_inner = _inner
+
+    async def _authorized_owner_ingress(routed_event):
+        assert Path(get_hermes_home()) == root
+        assert secret_scope.get_secret("ROUTE_SCOPE_TOKEN") == "owner"
+        routed_event.source.profile = "fitness"
+        return await GatewayRunner._handle_message_with_agent(
+            runner, routed_event, routed_event.source, "route-key", 1
+        )
+
+    runner._handle_message = _authorized_owner_ingress
+    secret_scope.set_multiplex_active(True)
+    try:
+        handler = runner._make_default_profile_message_handler()
+        session_id, first_history = await handler(event)
+        repeated_session_id, second_history = await handler(event)
+    finally:
+        secret_scope.set_multiplex_active(False)
+
+    assert repeated_session_id == session_id
+    assert first_history == []
+    assert [(message["role"], message["content"]) for message in second_history] == [
+        ("user", "remember me")
+    ]
+    assert _session_ids(profile / "state.db") == {session_id}
+    assert _session_ids(root / "state.db") == set()


### PR DESCRIPTION
## What does this PR do?

Shared primary messaging adapters can route a turn to a secondary profile, but the gateway previously loaded that turn history from the adapter owner root store. This change keeps the complete routed turn lifecycle in the selected profile scope while preserving owner-scoped authorization and secrets. Without the fix, follow-up messages lose prior context and can produce incorrect responses even though the transcript was persisted successfully.

### Symptom

A secondary profile served through a shared primary adapter answers the first message, but later messages in the same session reload an empty history. The root `state.db` receives session metadata while the routed profile `state.db` receives the transcript.

### Impact

Users of `gateway.multiplex_profiles` with shared primary adapters can experience same-session amnesia on routed conversations. Follow-up requests that depend on earlier turns may ask for information already provided or act on the wrong context.

### Bug Cause

**Trigger:** `gateway/run.py` / `GatewayRunner._handle_message_with_agent` when a shared primary adapter stamps a secondary `source.profile`.

**Causal chain:**
1. The primary adapter correctly performs ingress authorization and route stamping in its owner profile scope.
2. Session creation and transcript loading begin before the old code enters the routed profile scope, so lazy session DB handles resolve to the owner/root store.
3. The agent later persists messages in the secondary profile store, splitting one conversation across two databases and leaving the next turn with no history.

**Why it is wrong:** Session creation, transcript loading, post-turn bookkeeping, durable-marker cleanup, and agent persistence are one profile-local lifecycle, but the scope boundary previously began too late and ended too early.

**Working sibling / contrast:** Single-profile gateways already use one storage scope for the entire turn and remain on their existing path.

**Ruled out:** Compression is not responsible. The regression reproduces the split with no compression and verifies the exact session and transcript rows in real temporary SQLite stores.

### Fix

The gateway now enters the routed profile scope after owner authorization and route stamping, then retains it through agent execution, post-turn hooks, and durable active-turn cleanup. Regression tests cover a two-turn shared-primary route with distinct owner/routed secrets and stores, plus the post-turn and cleanup scope boundaries.

### Upgrade note

Conversations already split by this bug may start a new routed session after upgrading. Their transcripts remain present in the secondary profile's `state.db`; however, the old routing entry is in the root store while the transcript-side session row lacks the gateway peer metadata required for an unambiguous automatic rebind. This affects only conversations created while the bug was present. New turns stay entirely in the routed profile store.

## Related Issue

Closes #89346

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` - keep multiplexed session handling, post-turn bookkeeping, and durable cleanup in the routed profile scope, and unwind claimed state if profile scope setup fails.
- `tests/gateway/test_multiplex_session_db_profile_scope.py` - verify two routed turns reload history from the secondary profile store while the root store stays empty.
- `tests/gateway/test_gateway_command_dispatch_minimal.py` - verify agent execution, post-turn hooks, and cleanup retain the routed home and secret scope.

## How to Test

1. Run the focused gateway regression suite:

```bash
scripts/run_tests.sh tests/gateway/test_multiplex_session_db_profile_scope.py tests/gateway/test_gateway_command_dispatch_minimal.py tests/gateway/test_active_turn_recovery.py tests/gateway/test_64674_multiplex_primary_token_scope.py -q
```

2. Confirm all 40 tests pass.
3. Run `uv run ruff check gateway/run.py tests/gateway/test_multiplex_session_db_profile_scope.py tests/gateway/test_gateway_command_dispatch_minimal.py` and `git diff --check`.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I ran the relevant repository test entry and all 40 focused tests pass
- [x] I added tests for my changes
- [x] I tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation: N/A - no user-facing configuration or API changed
- [x] `cli-config.yaml.example`: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A - no architecture or workflow contract changed
- [x] Cross-platform impact considered - existing profile ContextVar and path abstractions are used
- [x] Tool descriptions/schemas: N/A - no model tool behavior changed

## Screenshots / Logs

N/A - this is a gateway storage-scope fix covered by deterministic SQLite and lifecycle regression tests.
