### PR TITLE
fix(desktop): Bot Mode group chat text is selectable and copyable again

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -29,6 +29,7 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
   ConfirmDialog,
+  CopyButton,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -7978,7 +7979,7 @@ function GroupChatWorkspace({ group, members, onBack }) {
 
                   return jsxs('div', {
                     className: cn(
-                      'flex items-start gap-2',
+                      'group flex items-start gap-2',
                       isUser ? 'rounded-md bg-(--chrome-action-hover) px-2 py-1.5' : 'px-2 py-1'
                     ),
                     children: [
@@ -7998,7 +7999,7 @@ function GroupChatWorkspace({ group, members, onBack }) {
                         className: 'min-w-0 flex-1',
                         children: [
                           jsxs('div', {
-                            className: 'flex items-baseline gap-2',
+                            className: 'flex items-center gap-2',
                             children: [
                               isUser
                                 ? jsx('span', {
@@ -8016,7 +8017,19 @@ function GroupChatWorkspace({ group, members, onBack }) {
                               jsx('span', {
                                 className: 'text-[0.625rem] text-(--ui-text-quaternary)',
                                 children: relativeTime(entry.at)
-                              })
+                              }),
+                              entry.text.trim()
+                                ? jsx('div', {
+                                    className:
+                                      'ml-auto shrink-0 opacity-0 pointer-events-none group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100',
+                                    children: jsx(CopyButton, {
+                                      appearance: 'icon',
+                                      buttonSize: 'icon',
+                                      stopPropagation: true,
+                                      text: entry.text
+                                    })
+                                  })
+                                : null
                             ]
                           }),
                           jsx('div', {

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -8035,6 +8035,7 @@ function GroupChatWorkspace({ group, members, onBack }) {
                           jsx('div', {
                             className:
                               'text-xs text-(--ui-text-secondary) [&_p]:mb-1 [&_p:last-child]:mb-0 [&_ul]:mb-1 [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:mb-1 [&_ol]:list-decimal [&_ol]:pl-4 [&_pre]:overflow-x-auto',
+                            'data-selectable-text': 'true',
                             children: Streamdown ? jsx(Streamdown, { children: entry.text }) : entry.text
                           })
                         ]

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -8035,6 +8035,8 @@ function GroupChatWorkspace({ group, members, onBack }) {
                           jsx('div', {
                             className:
                               'text-xs text-(--ui-text-secondary) [&_p]:mb-1 [&_p:last-child]:mb-0 [&_ul]:mb-1 [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:mb-1 [&_ol]:list-decimal [&_ol]:pl-4 [&_pre]:overflow-x-auto',
+                            // The app shell sets user-select: none globally; message bodies opt
+                            // back in so drag-select and ⌘C work in group chat logs.
                             'data-selectable-text': 'true',
                             children: Streamdown ? jsx(Streamdown, { children: entry.text }) : entry.text
                           })

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -706,3 +706,11 @@ test('source contract: group chat log lines expose CopyButton on the entry body'
   assert.doesNotMatch(src, /readAloud/)
   assert.doesNotMatch(src, /ActionBarPrimitive\.Reload/)
 })
+
+test('source contract: group chat message bodies opt back into selectable text', () => {
+  // styles.css sets user-select: none app-wide and re-enables it only for
+  // [data-selectable-text="true"] surfaces. Without this opt-in on the entry
+  // body, drag-select and Cmd/Ctrl+C are dead in group chat logs.
+  const src = groupChatWorkspaceSource()
+  assert.match(src, /'data-selectable-text':\s*'true'/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -683,3 +683,26 @@ test('source contract: thread UI — folded rows, per-thread reply box, new-thre
   assert.match(pluginSource, /children: 'New Thread'/)
   assert.match(pluginSource, /const markKey = `\$\{thread\}::\$\{memberKey\}`/)
 })
+
+function groupChatWorkspaceSource() {
+  const start = pluginSource.indexOf('function GroupChatWorkspace')
+  const end = pluginSource.indexOf('function closeGroupChatMainTab')
+  assert.ok(start >= 0, 'GroupChatWorkspace is defined')
+  assert.ok(end > start, 'closeGroupChatMainTab follows GroupChatWorkspace')
+  return pluginSource.slice(start, end)
+}
+
+test('source contract: group chat log lines expose CopyButton on the entry body', () => {
+  const src = groupChatWorkspaceSource()
+  assert.match(pluginSource, /CopyButton/)
+  assert.match(src, /CopyButton/)
+  assert.match(src, /text:\s*entry\.text/)
+  assert.match(src, /stopPropagation:\s*true/)
+  assert.match(src, /appearance:\s*['"]icon['"]/)
+  assert.match(src, /buttonSize:\s*['"]icon['"]/)
+  assert.match(src, /['"]group /)
+  assert.doesNotMatch(src, /playSpeechText/)
+  assert.doesNotMatch(src, /RefreshCw/)
+  assert.doesNotMatch(src, /readAloud/)
+  assert.doesNotMatch(src, /ActionBarPrimitive\.Reload/)
+})

--- a/contributors/emails/lazy-idler@users.noreply.github.com
+++ b/contributors/emails/lazy-idler@users.noreply.github.com
@@ -1,0 +1,1 @@
+lazy-idler


### PR DESCRIPTION
## Summary

Text in Bot Mode group chat rooms is selectable and copyable again — drag-select / Cmd-C work on message bodies, and every line gets a hover Copy button. Fixes the "unable to copy text in Group chat" report from Discord.

Root cause: the desktop shell sets `user-select: none` app-wide (styles.css) and re-enables it only for surfaces marked `data-selectable-text="true"`. The group chat log body never received that opt-in, so all selection was dead on the surface.

## Changes

- `apps/desktop/src/plugins/hermes-bots/plugin.js`: `data-selectable-text="true"` on the group chat entry body — the root-cause fix, salvaged from #89374 with @lazy-idler's authorship preserved; hover/focus-reveal `CopyButton` on each expanded line copying `entry.text`, salvaged from #89327 with @HarishDarko's authorship preserved.
- `apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs`: source-contract tests for the CopyButton wiring (from #89327) and the selectable-text opt-in (ours, proven to fail without the fix).

## Validation

| | Before | After |
|---|---|---|
| `node --test group-chat.test.mjs` | 33 pass | 35 pass |
| Selectable-text test w/o fix (sabotage run) | — | fails as expected |

Credit: @lazy-idler (#89374) for the root-cause selectable-text fix, @HarishDarko (#89327) for the CopyButton affordance.

## Infographic

![Group chat text is selectable again](https://v3b.fal.media/files/b/0aa6dd92/letuTH5-MqkzrBK_9VugY_RDlWfZf2.png)
