### PR TITLE
fix(desktop): file preview renders LaTeX math and full markdown (salvage #89337 + #89018)

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-file.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.test.tsx
@@ -1,0 +1,53 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { MarkdownPreview } from './preview-file'
+
+// Behavior tests for the .md file preview renderer: input markdown goes
+// through preprocessMarkdown -> Streamdown (+ KaTeX math plugin) and must
+// come out as real rendered elements, matching what the chat transcript
+// renderer produces. Guards the regression where the preview was a bare
+// Streamdown pass with no math plugin and no table/img/a components.
+describe('MarkdownPreview', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders block and inline math through KaTeX', () => {
+    // KaTeX marks its output; raw "$" delimiters must be gone.
+    const { container } = render(
+      <MarkdownPreview
+        text={'Formula:\n\n$$\nx = \\frac{-b \\pm \\sqrt{b^2-4ac}}{2a}\n$$\n\nInline $a^2 + b^2 = c^2$ too.'}
+      />
+    )
+
+    expect(container.querySelector('.katex')).not.toBeNull()
+    expect(screen.queryByText(/\$\$/)).toBeNull()
+  })
+
+  it('renders GFM tables with header and body cells', () => {
+    const { container } = render(<MarkdownPreview text={'| h1 | h2 |\n| --- | --- |\n| a | b |'} />)
+
+    const table = container.querySelector('table')
+    expect(table).not.toBeNull()
+    expect(table?.querySelector('thead th')?.textContent).toBe('h1')
+    expect(table?.querySelector('tbody td')?.textContent).toBe('a')
+  })
+
+  it('renders images with alt text', () => {
+    const { container } = render(<MarkdownPreview text={'![a chart](https://example.com/chart.png)'} />)
+
+    const img = container.querySelector('img')
+    expect(img?.getAttribute('alt')).toBe('a chart')
+    expect(img?.getAttribute('src')).toBe('https://example.com/chart.png')
+  })
+
+  it('renders external links to open in a new tab safely', () => {
+    const { container } = render(<MarkdownPreview text={'[docs](https://example.com/docs)'} />)
+
+    const anchor = container.querySelector('a')
+    expect(anchor?.getAttribute('href')).toBe('https://example.com/docs')
+    expect(anchor?.getAttribute('target')).toBe('_blank')
+    expect(anchor?.getAttribute('rel')).toBe('noopener noreferrer')
+  })
+})

--- a/apps/desktop/src/app/chat/right-rail/preview-file.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { MarkdownPreview } from './preview-file'
 
 // Behavior tests for the .md file preview renderer: input markdown goes
-// through preprocessMarkdown -> Streamdown (+ KaTeX math plugin) and must
+// through normalizeFilePreviewMath -> Streamdown (+ KaTeX math plugin) and must
 // come out as real rendered elements, matching what the chat transcript
 // renderer produces. Guards the regression where the preview was a bare
 // Streamdown pass with no math plugin and no table/img/a components.

--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -307,7 +307,11 @@ const MD_TAG_CLASSES = {
   ol: 'mb-4 list-decimal pl-6 marker:text-muted-foreground/70 last:mb-0',
   li: 'mt-1 leading-relaxed',
   blockquote: 'mb-4 border-l-2 border-border pl-3 text-muted-foreground italic last:mb-0',
-  pre: 'mb-4 overflow-hidden rounded-lg border border-border bg-card font-mono text-xs leading-relaxed last:mb-0 [&_pre]:m-0 [&_pre]:overflow-x-auto [&_pre]:bg-transparent! [&_pre]:p-3 [&_pre]:font-mono'
+  pre: 'mb-4 overflow-hidden rounded-lg border border-border bg-card font-mono text-xs leading-relaxed last:mb-0 [&_pre]:m-0 [&_pre]:overflow-x-auto [&_pre]:bg-transparent! [&_pre]:p-3 [&_pre]:font-mono',
+  hr: 'my-6 border-border',
+  th: 'px-3 py-2 text-left text-sm font-semibold text-foreground',
+  td: 'px-3 py-2 align-top text-sm leading-relaxed',
+  thead: 'bg-muted/35 text-muted-foreground'
 } as const
 
 function tagged<T extends keyof typeof MD_TAG_CLASSES>(Tag: T) {
@@ -362,6 +366,47 @@ function MarkdownCode({ className, children, ...props }: ComponentProps<'code'>)
   return <RichCodeBlock code={code} fallback={highlighted} language={language} />
 }
 
+function MarkdownTable({ className, ...rest }: ComponentProps<'table'>) {
+  return (
+    <div className="mb-4 w-full overflow-x-auto rounded-lg border border-border last:mb-0">
+      <table
+        className={cn(
+          'm-0 w-full min-w-[18rem] border-collapse [&_tr]:border-b [&_tr]:border-border last:[&_tr]:border-0',
+          className
+        )}
+        {...rest}
+      />
+    </div>
+  )
+}
+
+function MarkdownImage({ alt, src, ...rest }: ComponentProps<'img'>) {
+  return (
+    <img
+      alt={alt ?? ''}
+      className="my-3 max-h-96 w-auto max-w-full rounded-lg border border-border object-contain shadow-sm"
+      src={src}
+      {...rest}
+    />
+  )
+}
+
+function MarkdownLink({ children, className, href, ...rest }: ComponentProps<'a'>) {
+  const isExternal = /^https?:\/\//i.test(href || '')
+
+  return (
+    <a
+      className={cn('text-foreground underline underline-offset-2 hover:text-primary', className)}
+      href={href}
+      rel={isExternal ? 'noopener noreferrer' : undefined}
+      target={isExternal ? '_blank' : undefined}
+      {...rest}
+    >
+      {children}
+    </a>
+  )
+}
+
 const MARKDOWN_COMPONENTS = {
   h1: tagged('h1'),
   h2: tagged('h2'),
@@ -373,7 +418,14 @@ const MARKDOWN_COMPONENTS = {
   li: tagged('li'),
   blockquote: tagged('blockquote'),
   pre: tagged('pre'),
-  code: MarkdownCode
+  code: MarkdownCode,
+  hr: tagged('hr'),
+  table: MarkdownTable,
+  th: tagged('th'),
+  td: tagged('td'),
+  thead: tagged('thead'),
+  img: MarkdownImage,
+  a: MarkdownLink
 }
 
 function MarkdownPreview({ text }: { text: string }) {

--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -31,7 +31,9 @@ import {
   writeDesktopFileText
 } from '@/lib/desktop-fs'
 import { Check, Pencil, X } from '@/lib/icons'
+import { createMemoizedMathPlugin } from '@/lib/katex-memo'
 import { shikiLanguageForFilename } from '@/lib/markdown-code'
+import { normalizeFilePreviewMath } from '@/lib/markdown-preprocess'
 import { cn } from '@/lib/utils'
 import type { PreviewTarget } from '@/store/preview'
 import { setPreviewDirty } from '@/store/preview-edit'
@@ -43,6 +45,11 @@ const TEXT_PREVIEW_MAX_BYTES = 512 * 1024
 const SOURCE_CHUNK_LINES = 200
 const SOURCE_LINE_PX = 20
 const SOURCE_OVERSCAN_LINES = 400
+
+// Math plugin for the static file preview, configured once at module scope.
+// Mirrors the chat transcript's plugin (`markdown-text.tsx`) — same memoized
+// KaTeX wrapper, with `singleDollarTextMath: true` so `$x$` renders inline.
+const previewMathPlugin = createMemoizedMathPlugin({ singleDollarTextMath: true })
 
 type EmptyStateTone = 'neutral' | 'warning'
 
@@ -370,10 +377,18 @@ const MARKDOWN_COMPONENTS = {
 }
 
 function MarkdownPreview({ text }: { text: string }) {
+  const mathText = useMemo(() => normalizeFilePreviewMath(text), [text])
+
   return (
     <div className="preview-markdown mx-auto max-w-3xl px-4 py-3 text-sm text-foreground" data-selectable-text="true">
-      <Streamdown components={MARKDOWN_COMPONENTS} controls={false} mode="static" parseIncompleteMarkdown={false}>
-        {text}
+      <Streamdown
+        components={MARKDOWN_COMPONENTS}
+        controls={false}
+        mode="static"
+        parseIncompleteMarkdown={false}
+        plugins={{ math: previewMathPlugin }}
+      >
+        {mathText}
       </Streamdown>
     </div>
   )

--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -428,7 +428,7 @@ const MARKDOWN_COMPONENTS = {
   a: MarkdownLink
 }
 
-function MarkdownPreview({ text }: { text: string }) {
+export function MarkdownPreview({ text }: { text: string }) {
   const mathText = useMemo(() => normalizeFilePreviewMath(text), [text])
 
   return (

--- a/apps/desktop/src/lib/file-preview-math.render.test.tsx
+++ b/apps/desktop/src/lib/file-preview-math.render.test.tsx
@@ -1,0 +1,64 @@
+import { render, waitFor } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { Streamdown } from 'streamdown'
+
+import { createMemoizedMathPlugin } from '@/lib/katex-memo'
+import { normalizeFilePreviewMath } from '@/lib/markdown-preprocess'
+
+// This is the exact pipeline the file preview runs: normalizeFilePreviewMath
+// → Streamdown with the memoized math plugin. Rendering here (jsdom) proves the
+// wiring produces KaTeX output, not raw `$..$` source text.
+describe('file-preview math rendering', () => {
+  const mathPlugin = createMemoizedMathPlugin({ singleDollarTextMath: true })
+
+  it('renders inline $..$ math as KaTeX', async () => {
+    const { container } = render(
+      <Streamdown mode="static" plugins={{ math: mathPlugin }}>
+        {normalizeFilePreviewMath('The formula $x^2 + y^2$ here.')}
+      </Streamdown>
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector('.katex')).not.toBeNull()
+    })
+    expect(container.textContent).not.toContain('$x^2')
+  })
+
+  it('renders $$..$$ display math as KaTeX', async () => {
+    const { container } = render(
+      <Streamdown mode="static" plugins={{ math: mathPlugin }}>
+        {normalizeFilePreviewMath('Block:\n\n$$E = mc^2$$')}
+      </Streamdown>
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector('.katex-display') || container.querySelector('.katex')).not.toBeNull()
+    })
+  })
+
+  it('renders \(..\) delimiter math as KaTeX', async () => {
+    const { container } = render(
+      <Streamdown mode="static" plugins={{ math: mathPlugin }}>
+        {normalizeFilePreviewMath('A fraction \\(\\frac{a}{b}\\) inline.')}
+      </Streamdown>
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector('.katex')).not.toBeNull()
+    })
+    expect(container.querySelector('.katex-mathml, .katex-html')).not.toBeNull()
+  })
+
+  it('leaves a literal code-fence \$ alone as code, not math', async () => {
+    const { container } = render(
+      <Streamdown mode="static" plugins={{ math: mathPlugin }}>
+        {normalizeFilePreviewMath('```bash\necho $HOME\n```')}
+      </Streamdown>
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector('.katex')).toBeNull()
+    })
+    expect(container.querySelector('code')?.textContent).toContain('$HOME')
+  })
+})

--- a/apps/desktop/src/lib/file-preview-math.render.test.tsx
+++ b/apps/desktop/src/lib/file-preview-math.render.test.tsx
@@ -1,6 +1,6 @@
 import { render, waitFor } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
 import { Streamdown } from 'streamdown'
+import { describe, expect, it } from 'vitest'
 
 import { createMemoizedMathPlugin } from '@/lib/katex-memo'
 import { normalizeFilePreviewMath } from '@/lib/markdown-preprocess'
@@ -36,7 +36,7 @@ describe('file-preview math rendering', () => {
     })
   })
 
-  it('renders \(..\) delimiter math as KaTeX', async () => {
+  it('renders delimited math as KaTeX', async () => {
     const { container } = render(
       <Streamdown mode="static" plugins={{ math: mathPlugin }}>
         {normalizeFilePreviewMath('A fraction \\(\\frac{a}{b}\\) inline.')}
@@ -49,7 +49,7 @@ describe('file-preview math rendering', () => {
     expect(container.querySelector('.katex-mathml, .katex-html')).not.toBeNull()
   })
 
-  it('leaves a literal code-fence \$ alone as code, not math', async () => {
+  it('leaves a literal code-fence $ alone as code, not math', async () => {
     const { container } = render(
       <Streamdown mode="static" plugins={{ math: mathPlugin }}>
         {normalizeFilePreviewMath('```bash\necho $HOME\n```')}

--- a/apps/desktop/src/lib/markdown-preprocess.file-preview.test.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.file-preview.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeFilePreviewMath } from '@/lib/markdown-preprocess'
+
+describe('normalizeFilePreviewMath', () => {
+  it('leaves single-dollar inline math untouched', () => {
+    expect(normalizeFilePreviewMath('Price is $x^2 + y^2$ today')).toBe('Price is $x^2 + y^2$ today')
+  })
+
+  it('escapes currency dollar amounts so they are not parsed as math', () => {
+    const output = normalizeFilePreviewMath('Rent $500 and utilities $150.')
+
+    expect(output).toContain('\\$500')
+    expect(output).toContain('\\$150')
+  })
+
+  it('does not escape dollars inside code fences', () => {
+    const input = ['Before', '```bash', 'echo $HOME', 'echo $PATH', '```', 'After'].join('\n')
+
+    expect(normalizeFilePreviewMath(input)).toBe(input)
+  })
+
+  it('does not escape dollars inside inline code spans', () => {
+    expect(normalizeFilePreviewMath('Run `echo $HOME` now')).toBe('Run `echo $HOME` now')
+  })
+
+  it('normalizes latex delimiters to dollar math', () => {
+    // `\(…\)` and `\[…\]` are rewritten to `$…$` / `$$…$$` so remark-math parses them.
+    expect(normalizeFilePreviewMath('A formula \\(x + 1\\) inline.')).toBe('A formula $x + 1$ inline.')
+  })
+
+  it('leaves ```math fences untouched (rehype renders language-math directly)', () => {
+    const input = ['```math', 'E = mc^2', '```'].join('\n')
+
+    expect(normalizeFilePreviewMath(input)).toBe(input)
+  })
+
+  it('does not strip citation markers or autolink urls (chat-only transforms omitted)', () => {
+    const input = 'See [3] and https://example.com'
+
+    const output = normalizeFilePreviewMath(input)
+
+    // A chat message would autolink the URL and strip the [3] citation marker;
+    // a file's prose must stay verbatim.
+    expect(output).toBe(input)
+  })
+
+  it('does not strip reasoning blocks (author content, not model output)', () => {
+    const input = '<reasoning>keep me</reasoning>'
+
+    expect(normalizeFilePreviewMath(input)).toBe(input)
+  })
+})

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -521,3 +521,33 @@ export function preprocessMarkdown(text: string): string {
     .join('')
     .replace(/[ \t]+\n/g, '\n')
 }
+
+/**
+ * Math-only normalization for static file previews. Mirrors the math half of
+ * `preprocessMarkdown` — delimiter normalization (`\(…\)`, `\[…\]`), display
+ * math on its own lines, and currency-dollar escaping — but deliberately skips
+ * the chat-only transforms (reasoning-block stripping, `@session:` ref
+ * linking, preview-target stripping, raw-URL autolinking, citation-marker
+ * stripping). A file's prose is author content, not model output, so those
+ * rewrites must not touch it. Code fences and inline code spans pass through
+ * untouched so `$`, `\(` and `\begin` inside listings are never mangled.
+ *
+ * ` ```math ` fences need no preprocessing: remark/rehype emit them as
+ * `<code class="language-math">` and the memoized rehype-katex wrapper renders
+ * them regardless of this function.
+ */
+export function normalizeFilePreviewMath(text: string): string {
+  return text
+    .split(CODE_FENCE_SPLIT_RE)
+    .map(part => {
+      if (/^(?:```|~~~)/.test(part)) {
+        return part
+      }
+
+      return part
+        .split(INLINE_CODE_SPLIT_RE)
+        .map(segment => (segment.startsWith('`') ? segment : normalizeProseMath(segment)))
+        .join('')
+    })
+    .join('')
+}

--- a/contributors/emails/46404230+peetteerr@users.noreply.github.com
+++ b/contributors/emails/46404230+peetteerr@users.noreply.github.com
@@ -1,0 +1,1 @@
+peetteerr


### PR DESCRIPTION
## Summary

The desktop right-rail file preview now renders LaTeX math (`$x^2$`, `$$...$$`, `\(...\)`, `\[...\]`) as real KaTeX output instead of raw source, and gains the table/image/link/hr components the chat transcript already had. Salvages #89337 (@thebizfixer) and #89018 (@peetteerr, first submitter) — the two PRs fixed the same math gap independently on the same day.

Root cause: `MarkdownPreview` was a bare `Streamdown` pass — no math plugin, no preprocessing — while the chat surface uses `createMemoizedMathPlugin` + preprocessing.

## Changes

- `apps/desktop/src/lib/markdown-preprocess.ts`: new `normalizeFilePreviewMath()` — the math half of `preprocessMarkdown` (delimiter normalization, currency-dollar escaping, code fences/inline code untouched), deliberately skipping chat-only transforms (reasoning stripping, citation stripping, autolinking) since file content is author prose, not model output (@thebizfixer)
- `apps/desktop/src/app/chat/right-rail/preview-file.tsx`: wire memoized KaTeX plugin + the normalizer into `MarkdownPreview` (@thebizfixer); add `MarkdownTable`/`MarkdownImage`/`MarkdownLink`/`hr`/`th`/`td`/`thead` components from #89018 (@peetteerr)
- Conflict resolution keeps @thebizfixer's math-only normalizer over #89018's full `preprocessMarkdown` (which would apply chat-only rewrites to author content); @peetteerr's component work and behavior tests land intact on top

## Validation

| Check | Result |
|---|---|
| `npx vitest run` (3 test files) | 16/16 passed |
| `npm run check:lint` (tsc ×3 + eslint, same as CI) | 0 errors |
| `scripts/audit_pr_attribution.py --fix` | all emails mapped |

Both contributors' authorship preserved via cherry-pick.

## Infographic

![File preview renders real math](https://v3b.fal.media/files/b/0aa6dd93/ARxhGSRQtw4lL12pADNfZ_P6NPBfB1.png)
