### PR TITLE
fix(teams-pipeline): transcript webhooks no longer 400 on meeting lookup (salvage #89285, #83452)

### DIFF
--- a/plugins/teams_pipeline/cli.py
+++ b/plugins/teams_pipeline/cli.py
@@ -47,6 +47,11 @@ def register_cli(subparser: argparse.ArgumentParser) -> None:
     fetch_p = subs.add_parser("fetch", aliases=["test"], help="Dry-run meeting artifact resolution")
     fetch_p.add_argument("--meeting-id", default="")
     fetch_p.add_argument("--join-web-url", default="")
+    fetch_p.add_argument(
+        "--organizer-user-id",
+        default="",
+        help="Microsoft Entra user ID for organizer-scoped online meeting lookup",
+    )
     fetch_p.add_argument("--tenant-id", default="")
     fetch_p.add_argument("--call-record-id", default="")
 
@@ -306,6 +311,7 @@ def _cmd_run(args) -> None:
 def _cmd_fetch(args) -> None:
     meeting_id = str(getattr(args, "meeting_id", "") or "").strip() or None
     join_web_url = str(getattr(args, "join_web_url", "") or "").strip() or None
+    organizer_user_id = str(getattr(args, "organizer_user_id", "") or "").strip() or None
     tenant_id = str(getattr(args, "tenant_id", "") or "").strip() or None
     call_record_id = str(getattr(args, "call_record_id", "") or "").strip() or None
     if not meeting_id and not join_web_url:
@@ -319,6 +325,7 @@ def _cmd_fetch(args) -> None:
             meeting_id=meeting_id,
             join_web_url=join_web_url,
             tenant_id=tenant_id,
+            organizer_user_id=organizer_user_id,
         )
     )
     transcript_artifact, transcript_text = _run_async(fetch_preferred_transcript_text(client, meeting_ref))

--- a/plugins/teams_pipeline/meetings.py
+++ b/plugins/teams_pipeline/meetings.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import base64
+import binascii
 import re
 import tempfile
 from pathlib import Path
@@ -88,7 +90,32 @@ def looks_like_transcript_id(value: str, *, odata_type: str | None = None) -> bo
 
     if "calltranscript" in str(odata_type or "").lower():
         return True
-    return "transcript" in str(value or "").lower()
+    text = str(value or "")
+    if "transcript" in text.lower():
+        return True
+    return "transcript" in _decoded_id_hint(text)
+
+
+def _decoded_id_hint(value: str) -> str:
+    """Best-effort base64 decode of a Graph id for artifact-marker sniffing.
+
+    Graph transcript ids are base64url blobs whose *decoded* payload carries a
+    ``...-TranscriptV2`` suffix while the encoded form contains no readable
+    marker (this is exactly the id shape from getAllTranscripts
+    ``resourceData.id``). Returns lowercase decoded text, or "" when the value
+    does not decode.
+    """
+
+    stripped = value.strip()
+    if len(stripped) < 16:
+        return ""
+    padded = stripped + "=" * (-len(stripped) % 4)
+    for decoder in (base64.urlsafe_b64decode, base64.b64decode):
+        try:
+            return decoder(padded).decode("utf-8", "ignore").lower()
+        except (binascii.Error, ValueError):
+            continue
+    return ""
 
 
 def _meeting_path(meeting_ref: TeamsMeetingRef | str) -> str:

--- a/plugins/teams_pipeline/meetings.py
+++ b/plugins/teams_pipeline/meetings.py
@@ -2,13 +2,31 @@
 
 from __future__ import annotations
 
+import re
 import tempfile
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote
+from urllib.parse import quote, unquote
 
 from plugins.teams_pipeline.models import MeetingArtifact, TeamsMeetingRef
 from tools.microsoft_graph_client import MicrosoftGraphAPIError, MicrosoftGraphClient
+
+_USERS_MEETING_RE = re.compile(
+    r"(?i)(?:^|/)users/([^/]+)/onlineMeetings(?:\('([^']+)'\)|/([^/'?]+))"
+)
+_COMM_MEETING_RE = re.compile(
+    r"(?i)(?:^|/)communications/onlineMeetings(?:\('([^']+)'\)|/([^/'?]+))"
+)
+_TRANSCRIPT_RE = re.compile(r"(?i)/transcripts(?:\('([^']+)'\)|/([^/'?]+))")
+_RECORDING_RE = re.compile(r"(?i)/recordings(?:\('([^']+)'\)|/([^/'?]+))")
+_RESOURCE_SENTINELS = frozenset(
+    {
+        "getalltranscripts",
+        "getallrecordings",
+        "transcripts",
+        "recordings",
+    }
+)
 
 
 class TeamsMeetingError(RuntimeError):
@@ -27,9 +45,65 @@ class TeamsMeetingPermissionError(TeamsMeetingError):
     """Raised when Graph access is denied for the requested resource."""
 
 
+def parse_graph_meeting_resource(resource: str) -> dict[str, str | None]:
+    """Parse organizer, meeting, and artifact ids from a Graph resource or @odata.id."""
+
+    text = str(resource or "").strip()
+    organizer_user_id: str | None = None
+    meeting_id: str | None = None
+    transcript_id: str | None = None
+    recording_id: str | None = None
+
+    users_match = _USERS_MEETING_RE.search(text)
+    if users_match:
+        organizer_user_id = unquote(users_match.group(1) or "").strip() or None
+        meeting_id = unquote(users_match.group(2) or users_match.group(3) or "").strip() or None
+
+    if not meeting_id:
+        comm_match = _COMM_MEETING_RE.search(text)
+        if comm_match:
+            meeting_id = unquote(comm_match.group(1) or comm_match.group(2) or "").strip() or None
+
+    if meeting_id and meeting_id.lower() in _RESOURCE_SENTINELS:
+        meeting_id = None
+
+    transcript_match = _TRANSCRIPT_RE.search(text)
+    if transcript_match:
+        transcript_id = unquote(transcript_match.group(1) or transcript_match.group(2) or "").strip() or None
+
+    recording_match = _RECORDING_RE.search(text)
+    if recording_match:
+        recording_id = unquote(recording_match.group(1) or recording_match.group(2) or "").strip() or None
+
+    return {
+        "organizer_user_id": organizer_user_id,
+        "meeting_id": meeting_id,
+        "transcript_id": transcript_id,
+        "recording_id": recording_id,
+    }
+
+
+def looks_like_transcript_id(value: str, *, odata_type: str | None = None) -> bool:
+    """True when a Graph id is a callTranscript artifact rather than an onlineMeeting."""
+
+    if "calltranscript" in str(odata_type or "").lower():
+        return True
+    return "transcript" in str(value or "").lower()
+
+
 def _meeting_path(meeting_ref: TeamsMeetingRef | str) -> str:
-    meeting_id = meeting_ref.meeting_id if isinstance(meeting_ref, TeamsMeetingRef) else str(meeting_ref)
-    return f"/communications/onlineMeetings/{quote(meeting_id, safe='')}"
+    if isinstance(meeting_ref, TeamsMeetingRef):
+        meeting_id = meeting_ref.meeting_id
+        organizer_user_id = meeting_ref.organizer_user_id
+    else:
+        meeting_id = str(meeting_ref)
+        organizer_user_id = None
+    encoded_meeting_id = quote(meeting_id, safe="")
+    if organizer_user_id:
+        return (
+            f"/users/{quote(organizer_user_id, safe='')}/onlineMeetings/{encoded_meeting_id}"
+        )
+    return f"/communications/onlineMeetings/{encoded_meeting_id}"
 
 
 def _wrap_graph_error(exc: MicrosoftGraphAPIError, *, missing_message: str) -> TeamsMeetingError:
@@ -62,7 +136,12 @@ def _parse_thread_id(payload: dict[str, Any]) -> str | None:
     return payload.get("threadId")
 
 
-def _normalize_meeting_ref(payload: dict[str, Any], *, tenant_id: str | None = None) -> TeamsMeetingRef:
+def _normalize_meeting_ref(
+    payload: dict[str, Any],
+    *,
+    tenant_id: str | None = None,
+    organizer_user_id: str | None = None,
+) -> TeamsMeetingRef:
     metadata = {
         key: payload.get(key)
         for key in ("subject", "startDateTime", "endDateTime", "createdDateTime")
@@ -73,7 +152,7 @@ def _normalize_meeting_ref(payload: dict[str, Any], *, tenant_id: str | None = N
         metadata["participants"] = participants
     return TeamsMeetingRef(
         meeting_id=str(payload.get("id") or "").strip(),
-        organizer_user_id=_parse_organizer_user_id(payload),
+        organizer_user_id=organizer_user_id or _parse_organizer_user_id(payload),
         join_web_url=payload.get("joinWebUrl"),
         calendar_event_id=payload.get("calendarEventId"),
         thread_id=_parse_thread_id(payload),
@@ -140,21 +219,42 @@ async def resolve_meeting_reference(
     meeting_id: str | None = None,
     join_web_url: str | None = None,
     tenant_id: str | None = None,
+    organizer_user_id: str | None = None,
 ) -> TeamsMeetingRef:
+    if meeting_id and looks_like_transcript_id(meeting_id):
+        if join_web_url:
+            meeting_id = None
+        else:
+            raise TeamsMeetingError(
+                "Refusing to GET /communications/onlineMeetings/{id} with a transcript id. "
+                "Graph v1.0 does not support that id format; use the organizer-scoped meeting "
+                "id from the notification @odata.id, or a join URL."
+            )
     if meeting_id:
         try:
-            payload = await client.get_json(_meeting_path(meeting_id))
+            payload = await client.get_json(
+                _meeting_path(
+                    TeamsMeetingRef(meeting_id=meeting_id, organizer_user_id=organizer_user_id)
+                )
+            )
         except MicrosoftGraphAPIError as exc:
             raise _wrap_graph_error(exc, missing_message=f"Teams meeting not found: {meeting_id}") from exc
         if not isinstance(payload, dict) or not payload.get("id"):
             raise TeamsMeetingNotFoundError(f"Teams meeting not found: {meeting_id}")
-        return _normalize_meeting_ref(payload, tenant_id=tenant_id)
+        return _normalize_meeting_ref(
+            payload,
+            tenant_id=tenant_id,
+            organizer_user_id=organizer_user_id,
+        )
 
     if join_web_url:
         escaped_join_url = join_web_url.replace("'", "''")
+        lookup_path = "/communications/onlineMeetings"
+        if organizer_user_id:
+            lookup_path = f"/users/{quote(organizer_user_id, safe='')}/onlineMeetings"
         try:
             payload = await client.get_json(
-                "/communications/onlineMeetings",
+                lookup_path,
                 params={"$filter": f"JoinWebUrl eq '{escaped_join_url}'"},
             )
         except MicrosoftGraphAPIError as exc:
@@ -165,7 +265,11 @@ async def resolve_meeting_reference(
         candidates = payload.get("value") if isinstance(payload, dict) else None
         if not isinstance(candidates, list) or not candidates:
             raise TeamsMeetingNotFoundError(f"Teams meeting not found for join URL: {join_web_url}")
-        return _normalize_meeting_ref(candidates[0], tenant_id=tenant_id)
+        return _normalize_meeting_ref(
+            candidates[0],
+            tenant_id=tenant_id,
+            organizer_user_id=organizer_user_id,
+        )
 
     raise ValueError("Either meeting_id or join_web_url is required.")
 

--- a/plugins/teams_pipeline/pipeline.py
+++ b/plugins/teams_pipeline/pipeline.py
@@ -24,6 +24,8 @@ from plugins.teams_pipeline.meetings import (
     enrich_meeting_with_call_record,
     fetch_preferred_transcript_text,
     list_recording_artifacts,
+    looks_like_transcript_id,
+    parse_graph_meeting_resource,
     resolve_meeting_reference,
 )
 from plugins.teams_pipeline.models import (
@@ -299,13 +301,7 @@ class TeamsMeetingPipeline:
         if existing_job is not None:
             return existing_job
         resource_data = notification.get("resourceData") or {}
-        meeting_id = (
-            resource_data.get("id")
-            or notification.get("meetingId")
-            or _extract_meeting_id_from_resource(str(notification.get("resource") or ""))
-            or notification.get("resource")
-            or event_id
-        )
+        meeting_id, organizer_user_id, extra_metadata = _meeting_ids_from_notification(notification)
         job = TeamsMeetingPipelineJob(
             job_id=f"teams-job-{uuid.uuid4().hex[:12]}",
             event_id=event_id,
@@ -314,11 +310,13 @@ class TeamsMeetingPipeline:
             status="received",
             meeting_ref=TeamsMeetingRef(
                 meeting_id=str(meeting_id),
+                organizer_user_id=organizer_user_id,
                 tenant_id=resource_data.get("tenantId") or notification.get("tenantId"),
                 metadata={
                     "notification": dict(notification),
                     "join_web_url": resource_data.get("joinWebUrl"),
                     "call_record_id": resource_data.get("callRecordId") or notification.get("callRecordId"),
+                    **extra_metadata,
                 },
             ),
         )
@@ -347,7 +345,12 @@ class TeamsMeetingPipeline:
                 meeting_id=meeting_ref.meeting_id,
                 join_web_url=meeting_ref.join_web_url or meeting_ref.metadata.get("join_web_url"),
                 tenant_id=meeting_ref.tenant_id,
+                organizer_user_id=meeting_ref.organizer_user_id,
             )
+            if meeting_ref.metadata:
+                resolved_meeting.metadata = {**meeting_ref.metadata, **resolved_meeting.metadata}
+            if not resolved_meeting.organizer_user_id:
+                resolved_meeting.organizer_user_id = meeting_ref.organizer_user_id
             job.meeting_ref = resolved_meeting
             job = self._persist_job(job, meeting_ref=resolved_meeting.to_dict())
 
@@ -613,17 +616,97 @@ def _collect_participants(meeting_ref: TeamsMeetingRef) -> list[str]:
     return result
 
 
+def _odata_field(payload: dict[str, Any], name: str) -> Any:
+    return payload.get(f"@{name}") or payload.get(name)
+
+
+def _organizer_user_id_from_payload(payload: dict[str, Any]) -> str | None:
+    organizer = payload.get("meetingOrganizer") or payload.get("organizer")
+    if isinstance(organizer, dict):
+        identity = organizer.get("identity")
+        user = organizer.get("user")
+        if user is None and isinstance(identity, dict):
+            user = identity.get("user")
+        if isinstance(user, dict) and user.get("id"):
+            return str(user["id"]).strip() or None
+    return (
+        str(payload.get("organizerUserId") or payload.get("organizer_user_id") or "").strip() or None
+    )
+
+
+def _resource_data_id_is_artifact(notification: dict[str, Any], resource_data: dict[str, Any]) -> bool:
+    odata_type = str(_odata_field(resource_data, "odata.type") or "")
+    if "calltranscript" in odata_type.lower() or "callrecording" in odata_type.lower():
+        return True
+    resource = str(notification.get("resource") or "").lower()
+    if "getalltranscripts" in resource or "getallrecordings" in resource:
+        return True
+    if "/transcripts" in resource or "/recordings" in resource:
+        return True
+    return looks_like_transcript_id(str(resource_data.get("id") or ""), odata_type=odata_type)
+
+
+def _meeting_ids_from_notification(notification: dict[str, Any]) -> tuple[str, str | None, dict[str, Any]]:
+    resource_data = notification.get("resourceData") or {}
+    if not isinstance(resource_data, dict):
+        resource_data = {}
+
+    parsed_paths = [
+        parse_graph_meeting_resource(str(_odata_field(resource_data, "odata.id") or "")),
+        parse_graph_meeting_resource(str(notification.get("resource") or "")),
+        parse_graph_meeting_resource(str(resource_data.get("transcriptContentUrl") or "")),
+    ]
+
+    organizer_user_id = next(
+        (parsed["organizer_user_id"] for parsed in parsed_paths if parsed.get("organizer_user_id")),
+        None,
+    ) or _organizer_user_id_from_payload(resource_data) or _organizer_user_id_from_payload(notification)
+
+    meeting_id = next(
+        (parsed["meeting_id"] for parsed in parsed_paths if parsed.get("meeting_id")),
+        None,
+    ) or (
+        str(resource_data.get("meetingId") or notification.get("meetingId") or "").strip() or None
+    )
+
+    transcript_id = next(
+        (parsed["transcript_id"] for parsed in parsed_paths if parsed.get("transcript_id")),
+        None,
+    )
+    recording_id = next(
+        (parsed["recording_id"] for parsed in parsed_paths if parsed.get("recording_id")),
+        None,
+    )
+
+    resource_data_id = str(resource_data.get("id") or "").strip() or None
+    if resource_data_id and not _resource_data_id_is_artifact(notification, resource_data):
+        meeting_id = meeting_id or resource_data_id
+    elif resource_data_id and not transcript_id and looks_like_transcript_id(
+        resource_data_id, odata_type=str(_odata_field(resource_data, "odata.type") or "")
+    ):
+        transcript_id = resource_data_id
+
+    meeting_id = (
+        meeting_id
+        or _extract_meeting_id_from_resource(str(notification.get("resource") or ""))
+        or transcript_id
+        or recording_id
+        or TeamsPipelineStore.build_notification_receipt_key(notification)
+    )
+
+    extra_metadata = {
+        key: value
+        for key, value in {
+            "transcript_id": transcript_id,
+            "recording_id": recording_id,
+        }.items()
+        if value
+    }
+    return str(meeting_id), organizer_user_id, extra_metadata
+
+
 def _extract_meeting_id_from_resource(resource: str) -> str | None:
-    if not resource:
-        return None
-    parts = [part for part in resource.split("/") if part]
-    if not parts:
-        return None
-    if "onlineMeetings" in parts:
-        index = parts.index("onlineMeetings")
-        if index + 1 < len(parts):
-            return parts[index + 1]
-    return parts[-1]
+    return parse_graph_meeting_resource(resource).get("meeting_id")
 
 
 def _build_summary_prompt(

--- a/tests/plugins/test_teams_pipeline_meetings.py
+++ b/tests/plugins/test_teams_pipeline_meetings.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from plugins.teams_pipeline.meetings import resolve_meeting_reference
+
+
+class FakeGraphClient:
+    def __init__(self, payload):
+        self.payload = payload
+        self.calls = []
+
+    async def get_json(self, path, *, params=None):
+        self.calls.append((path, params))
+        return self.payload
+
+
+@pytest.mark.anyio
+async def test_join_url_can_use_organizer_scoped_graph_lookup():
+    client = FakeGraphClient({"value": [{"id": "meeting-1", "joinWebUrl": "https://teams.microsoft.com/meet/code"}]})
+
+    meeting = await resolve_meeting_reference(
+        client,
+        join_web_url="https://teams.microsoft.com/meet/code",
+        organizer_user_id="organizer-1",
+    )
+
+    assert meeting.meeting_id == "meeting-1"
+    assert meeting.organizer_user_id == "organizer-1"
+    assert client.calls == [
+        (
+            "/users/organizer-1/onlineMeetings",
+            {"$filter": "JoinWebUrl eq 'https://teams.microsoft.com/meet/code'"},
+        )
+    ]

--- a/tests/plugins/test_teams_pipeline_plugin.py
+++ b/tests/plugins/test_teams_pipeline_plugin.py
@@ -11,9 +11,15 @@ import pytest
 from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from plugins.teams_pipeline import register
+from plugins.teams_pipeline.meetings import (
+    TeamsMeetingError,
+    looks_like_transcript_id,
+    parse_graph_meeting_resource,
+    resolve_meeting_reference,
+)
+from plugins.teams_pipeline.models import MeetingArtifact
 from plugins.teams_pipeline.pipeline import TeamsMeetingPipeline
 from plugins.teams_pipeline.store import TeamsPipelineStore
-from plugins.teams_pipeline.models import MeetingArtifact
 
 
 class FakeGraphClient:
@@ -21,11 +27,14 @@ class FakeGraphClient:
         self.downloaded = False
 
 
-async def _transcript_meeting_resolver(client, *, meeting_id=None, join_web_url=None, tenant_id=None):
+async def _transcript_meeting_resolver(
+    client, *, meeting_id=None, join_web_url=None, tenant_id=None, organizer_user_id=None
+):
     from plugins.teams_pipeline.models import TeamsMeetingRef
 
     return TeamsMeetingRef(
         meeting_id=str(meeting_id),
+        organizer_user_id=organizer_user_id,
         tenant_id=tenant_id,
         metadata={"subject": "Weekly Sync", "participants": [{"displayName": "Ada"}]},
     )
@@ -422,3 +431,122 @@ class TestTeamsMeetingPipeline:
         assert len(store.list_jobs()) == 1
         receipt_key = TeamsPipelineStore.build_notification_receipt_key(notification)
         assert store.has_notification_receipt(receipt_key) is True
+
+
+def test_parse_graph_meeting_resource_reads_quoted_users_transcript_path():
+    parsed = parse_graph_meeting_resource(
+        "users/org-1/onlineMeetings('MSo-meeting')/transcripts('ktViz-transcript-TranscriptV2=')"
+    )
+
+    assert parsed["organizer_user_id"] == "org-1"
+    assert parsed["meeting_id"] == "MSo-meeting"
+    assert parsed["transcript_id"] == "ktViz-transcript-TranscriptV2="
+    assert parsed["recording_id"] is None
+
+
+def test_parse_graph_meeting_resource_ignores_get_all_transcripts_sentinel():
+    parsed = parse_graph_meeting_resource("communications/onlineMeetings/getAllTranscripts")
+
+    assert parsed["meeting_id"] is None
+    assert parsed["organizer_user_id"] is None
+    assert parsed["transcript_id"] is None
+
+
+def test_looks_like_transcript_id_detects_graph_call_transcripts():
+    assert looks_like_transcript_id(
+        "ktVizInGAAAA-TranscriptV2=",
+        odata_type="#Microsoft.Graph.callTranscript",
+    )
+    assert looks_like_transcript_id("abcTranscriptV2=")
+    assert not looks_like_transcript_id("MSo-meeting")
+
+
+def test_create_job_from_get_all_transcripts_uses_meeting_id_not_transcript_id(tmp_path):
+    store = TeamsPipelineStore(tmp_path / "teams-store.json")
+    pipeline = TeamsMeetingPipeline(graph_client=FakeGraphClient(), store=store)
+    transcript_id = "ktVizInGAAAAi_B6lATZRTE5Om1lZXRpbmdfTranscriptV2="
+
+    job = pipeline.create_job_from_notification(
+        {
+            "id": "notif-tx",
+            "changeType": "created",
+            "resource": "communications/onlineMeetings/getAllTranscripts",
+            "resourceData": {
+                "id": transcript_id,
+                "@odata.type": "#Microsoft.Graph.callTranscript",
+                "@odata.id": (
+                    "users/976f4b31-fd01-4e0b-9178-29cc40c14438/"
+                    f"onlineMeetings('MSo-meeting-id')/transcripts('{transcript_id}')"
+                ),
+            },
+            "tenantId": "tenant-1",
+        }
+    )
+
+    assert job.meeting_ref is not None
+    assert job.meeting_ref.meeting_id == "MSo-meeting-id"
+    assert job.meeting_ref.organizer_user_id == "976f4b31-fd01-4e0b-9178-29cc40c14438"
+    assert job.meeting_ref.meeting_id != transcript_id
+    assert job.meeting_ref.metadata.get("transcript_id") == transcript_id
+
+
+def test_create_job_from_users_resource_path_without_odata_id(tmp_path):
+    store = TeamsPipelineStore(tmp_path / "teams-store.json")
+    pipeline = TeamsMeetingPipeline(graph_client=FakeGraphClient(), store=store)
+
+    job = pipeline.create_job_from_notification(
+        {
+            "id": "notif-resource-path",
+            "changeType": "created",
+            "resource": "users/org-2/onlineMeetings('MSo-from-resource')/transcripts('tx-99')",
+            "resourceData": {
+                "id": "tx-99",
+                "@odata.type": "#Microsoft.Graph.callTranscript",
+            },
+        }
+    )
+
+    assert job.meeting_ref is not None
+    assert job.meeting_ref.meeting_id == "MSo-from-resource"
+    assert job.meeting_ref.organizer_user_id == "org-2"
+    assert job.meeting_ref.metadata.get("transcript_id") == "tx-99"
+
+
+@pytest.mark.anyio
+async def test_resolve_meeting_reference_uses_organizer_scoped_graph_path():
+    class RecordingGraphClient:
+        def __init__(self) -> None:
+            self.paths: list[str] = []
+
+        async def get_json(self, path, *, params=None, headers=None):
+            self.paths.append(path)
+            return {
+                "id": "MSo-meeting-id",
+                "subject": "Standup",
+                "organizer": {"identity": {"user": {"id": "org-1"}}},
+            }
+
+    client = RecordingGraphClient()
+    meeting_ref = await resolve_meeting_reference(
+        client,
+        meeting_id="MSo-meeting-id",
+        organizer_user_id="org-1",
+        tenant_id="tenant-1",
+    )
+
+    assert client.paths == ["/users/org-1/onlineMeetings/MSo-meeting-id"]
+    assert meeting_ref.meeting_id == "MSo-meeting-id"
+    assert meeting_ref.organizer_user_id == "org-1"
+
+
+@pytest.mark.anyio
+async def test_resolve_meeting_reference_refuses_transcript_id_without_join_url():
+    class BoomGraphClient:
+        async def get_json(self, path, *, params=None, headers=None):
+            raise AssertionError(f"Graph should not be called, got {path}")
+
+    with pytest.raises(TeamsMeetingError, match="transcript id"):
+        await resolve_meeting_reference(
+            BoomGraphClient(),
+            meeting_id="ktVizInGAAAA-TranscriptV2=",
+        )

--- a/tests/plugins/test_teams_pipeline_plugin.py
+++ b/tests/plugins/test_teams_pipeline_plugin.py
@@ -461,6 +461,24 @@ def test_looks_like_transcript_id_detects_graph_call_transcripts():
     assert not looks_like_transcript_id("MSo-meeting")
 
 
+def test_looks_like_transcript_id_detects_base64_encoded_marker():
+    # Real-world getAllTranscripts resourceData.id shape: base64url blob whose
+    # DECODED payload ends in "-TranscriptV2" while the encoded form has no
+    # readable marker (from a field report, Aug 2026).
+    import base64
+
+    encoded = base64.urlsafe_b64encode(
+        b"...meeting_ABC@thread.v2#55d6e479-2db7-4297-8590-98f6011a9613-1787004872-TranscriptV2"
+    ).decode().rstrip("=") + "="
+    assert "transcript" not in encoded.lower()
+    assert looks_like_transcript_id(encoded)
+    # Meeting ids (base64 of "0#...#0**19:meeting_...@thread.v2") must NOT match.
+    meeting_encoded = base64.b64encode(
+        b"0#af8b854e-e592-4d5a-b04c-6e63a3b502e7#0**19:meeting_ABC@thread.v2"
+    ).decode()
+    assert not looks_like_transcript_id(meeting_encoded)
+
+
 def test_create_job_from_get_all_transcripts_uses_meeting_id_not_transcript_id(tmp_path):
     store = TeamsPipelineStore(tmp_path / "teams-store.json")
     pipeline = TeamsMeetingPipeline(graph_client=FakeGraphClient(), store=store)


### PR DESCRIPTION
## Summary
Webhook-driven Teams meeting jobs no longer fail with `400 Unexpected id format`: Graph `getAllTranscripts` notifications put the transcript artifact id in `resourceData.id`, and the pipeline was using it as the onlineMeeting id in `GET /communications/onlineMeetings/{id}`. The pipeline now parses the real meeting id and organizer from the notification's `@odata.id`/`resource` path and resolves via the organizer-scoped `/users/{organizer}/onlineMeetings/{meetingId}` endpoint.

Salvages #89285 (@xxxigm) and #83452 (@kyssta-exe, earliest organizer-scoped submission — fixes #83422's CLI `/meet/` short-URL path) onto current main, with both authors' commits preserved.

## Changes
- `plugins/teams_pipeline/meetings.py`: parse meeting/organizer/artifact ids from Graph resource paths; organizer-scoped `_meeting_path` and join-URL lookup; refuse GET with transcript-shaped ids (clear error instead of Graph 400); base64-decode hint so encoded `...-TranscriptV2` ids (the exact field-report shape, invisible to the substring check) are detected (follow-up commit)
- `plugins/teams_pipeline/pipeline.py`: `create_job_from_notification` derives meeting id + organizer from `@odata.id`/`resource`/`transcriptContentUrl` instead of trusting `resourceData.id`; carries organizer + transcript/recording ids in job metadata
- `plugins/teams_pipeline/cli.py`: `fetch --organizer-user-id` for organizer-scoped dry runs (from #83452)
- tests: notification parsing, organizer-scoped resolution, transcript-id refusal, base64-marker detection

## Validation
| | Before | After |
|---|---|---|
| getAllTranscripts webhook job | `400 Unexpected id format`, job failed | resolves meeting via organizer-scoped path |
| encoded transcript id (field report) | passed heuristic, hit Graph 400 | flagged, refused with actionable error |
| targeted suites | — | 20/20 passed |

E2E: replayed the reporter's exact notification id shape (debug bundle 9033babf) through `_meeting_ids_from_notification` — documented, organizer-scoped, and degraded (no `@odata.id`) shapes all resolve or refuse correctly.

## Infographic

![Teams meeting pipeline fix](https://v3b.fal.media/files/b/0aa6dd98/LJFnoARRk3Yh5eNCHkDxH_gSxFBOD4.png)
