### PR TITLE
chore: attribution mappings unblock vadelma-agent's five open PRs

### DIFF
--- a/contributors/emails/taneli.mielikainen@iki.fi
+++ b/contributors/emails/taneli.mielikainen@iki.fi
@@ -1,0 +1,1 @@
+tmielika

--- a/contributors/emails/vadelma-agent@users.noreply.github.com
+++ b/contributors/emails/vadelma-agent@users.noreply.github.com
@@ -1,0 +1,1 @@
+vadelma-agent

--- a/contributors/emails/vadelma@agenttiklubi.org
+++ b/contributors/emails/vadelma@agenttiklubi.org
@@ -1,0 +1,1 @@
+vadelma-agent


### PR DESCRIPTION
## Summary
The check-attribution gate now passes for vadelma-agent's five open PRs (#70667, #72671, #67934, #86255, #89194) — their commit emails were unmapped, which turned #86255's CI red on `check contributors / check-attribution`.

## Changes
- contributors/emails/vadelma@agenttiklubi.org → vadelma-agent
- contributors/emails/vadelma-agent@users.noreply.github.com → vadelma-agent (bare noreply form, not auto-resolved by CI)
- contributors/emails/taneli.mielikainen@iki.fi → tmielika (co-author on the same PRs)

## Validation
| | Before | After |
|---|---|---|
| `audit_pr_attribution.py` on #86255's commits | missing: vadelma@agenttiklubi.org | ✅ all mapped |

## Infographic

![Contributor attribution mapped](https://v3b.fal.media/files/b/0aa6ddb5/cla2p-DHt8j-4nFO8Vo6t_hg4KcMD4.png)
