### PR TITLE
fix(state): warn when an existing database's journal_mode is flipped to WAL

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1021,6 +1021,31 @@ def sqlite_source_id() -> str:
     return str(row[0])
 
 
+def _database_has_content(conn: sqlite3.Connection) -> bool:
+    """Return whether the database file already holds pages.
+
+    Used to tell an EXISTING database apart from a brand-new one before
+    rewriting its journal mode. ``PRAGMA page_count`` is a header read, so
+    this costs nothing and takes no lock.
+
+    Fail-quiet: any error, or a database we cannot measure, answers False.
+    The only caller uses this to decide whether to emit a warning, and a
+    warning that fires when the answer is unknown would fire on every fresh
+    database -- precisely the case where there is provably no operator choice
+    being overwritten.
+    """
+    try:
+        row = conn.execute("PRAGMA page_count").fetchone()
+    except sqlite3.Error:
+        return False
+    if not row or row[0] is None:
+        return False
+    try:
+        return int(row[0]) > 0
+    except (TypeError, ValueError):
+        return False
+
+
 def resolve_journal_mode() -> str:
     """Return the configured journal mode (``wal`` or ``delete``).
 
@@ -1160,6 +1185,21 @@ def apply_wal_with_fallback(
             )
         return actual
 
+    # Decide BEFORE the flip whether it would silently overwrite a mode
+    # somebody chose. Both inputs are only readable while the file is still
+    # in its original state: `current_mode` is the probe above, and
+    # page_count distinguishes an existing database from a fresh one.
+    #
+    # A 0-page database has no prior choice to overwrite, and every caller
+    # reaches this before creating any schema (SessionDB._connect_and_init
+    # applies WAL, then _init_schema), so brand-new databases land here empty
+    # and stay quiet.
+    _upgrading_existing_db = (
+        current_mode is not None
+        and current_mode != "wal"
+        and _database_has_content(conn)
+    )
+
     try:
         # ``PRAGMA journal_mode=WAL`` is a query-that-sets: it RETURNS the
         # resulting journal mode. Network filesystems that refuse WAL by
@@ -1173,6 +1213,8 @@ def apply_wal_with_fallback(
         row = conn.execute("PRAGMA journal_mode=WAL").fetchone()
         mode = str(row[0]).strip().lower() if row and row[0] is not None else ""
         if mode == "wal":
+            if _upgrading_existing_db:
+                _log_journal_mode_upgrade_once(db_label, current_mode)
             _apply_wal_size_limit(conn)
             _apply_macos_checkpoint_barrier(conn)
             _enforce_macos_synchronous_full(conn)
@@ -1222,6 +1264,11 @@ def apply_wal_with_fallback(
                     else ""
                 )
                 if mode == "wal":
+                    # Same flip, later door: a transient EIO cleared and the
+                    # switch went through. The header rewrite is identical, so
+                    # the signal must be too.
+                    if _upgrading_existing_db:
+                        _log_journal_mode_upgrade_once(db_label, current_mode)
                     _apply_wal_size_limit(conn)
                     _apply_macos_checkpoint_barrier(conn)
                     _enforce_macos_synchronous_full(conn)
@@ -1373,6 +1420,12 @@ def _wal_reset_repair_hint() -> str:
     )
 
 
+# Dedup state for _log_journal_mode_upgrade_once, mirroring the
+# _wal_fallback_warned_* pair below it.
+_journal_upgrade_warned_paths: set = set()
+_journal_upgrade_warned_lock = threading.Lock()
+
+
 def _log_wal_reset_bug_once(
     db_label: str,
     *,
@@ -1412,6 +1465,47 @@ def _log_wal_reset_bug_once(
         sqlite3.sqlite_version,
         action,
         repair_hint,
+    )
+
+
+def _log_journal_mode_upgrade_once(db_label: str, previous_mode: str) -> None:
+    """Log a single WARNING per (process, db_label) about a non-WAL -> WAL flip.
+
+    ``PRAGMA journal_mode`` is a property of the FILE, not of the connection:
+    switching an existing database to WAL rewrites its header and outlives the
+    process that did it. Operators do set it directly on the file -- that was
+    the documented mitigation for the SQLite 3.50.4 WAL-reset bug -- and
+    nothing here told them the next open would silently put it back.
+
+    WARNING, not ERROR, and deliberately so. The reverse move is logged at
+    ERROR by ``_log_wal_fallback_once`` because dropping to DELETE is a real
+    loss of concurrency; this direction is normally the desirable one (see
+    ``hermes_cli/managed_uv._default_live_venv``, which treats a database
+    stuck on DELETE as a bug worth repairing on update). The problem is not
+    the change, it is that the change was invisible: an operator who chose
+    DELETE deliberately had no way to learn their choice had been overwritten,
+    or which lever makes it stick. So this says what happened and names the
+    durable setting, without claiming a degradation that is not there.
+
+    Deduped per process per ``db_label`` like its siblings: kanban opens a
+    fresh connection per operation, so an undeduped line here would be a log
+    flood rather than a signal.
+    """
+    with _journal_upgrade_warned_lock:
+        if db_label in _journal_upgrade_warned_paths:
+            return
+        _journal_upgrade_warned_paths.add(db_label)
+    logger.warning(
+        "%s: on-disk journal_mode was %s and has been switched to WAL. This "
+        "rewrites the database header and persists after this process exits. "
+        "If %s was a deliberate choice (for example the mitigation for the "
+        "SQLite WAL-reset bug, or a WAL-unsafe filesystem), setting it with "
+        "PRAGMA on the file will not survive -- every open re-applies the "
+        "configured mode. Set `database.journal_mode: delete` in config.yaml "
+        "to make it stick. This message fires once per process per database.",
+        db_label,
+        previous_mode,
+        previous_mode,
     )
 
 

--- a/tests/test_journal_mode_upgrade_warning.py
+++ b/tests/test_journal_mode_upgrade_warning.py
@@ -1,0 +1,358 @@
+"""An existing database's journal mode must not be rewritten silently (#89293).
+
+``PRAGMA journal_mode`` is a property of the FILE. Switching an existing
+database to WAL rewrites its header and outlives the process that did it.
+
+``apply_wal_with_fallback`` already treats on-disk WAL as authoritative and
+refuses to live-downgrade it. The mirror case had no protection at all: an
+on-disk DELETE database was flipped to WAL by the *default* configured value,
+with no log line -- so an operator who set DELETE on the file (the documented
+mitigation for the SQLite 3.50.4 WAL-reset bug) had no way to learn their
+choice had been overwritten, or that ``database.journal_mode`` is the lever
+that makes it stick.
+
+#89293 is the field report: after upgrading past the vulnerable SQLite,
+``is_sqlite_wal_reset_vulnerable()`` stopped short-circuiting to DELETE and
+4 of 5 databases silently returned to WAL.
+
+This is a LOG-ONLY change. Half of these tests exist to prove that: the return
+value, the resulting header, and the never-live-downgrade rule are all pinned
+unchanged, and the brand-new-database case must stay silent or the warning
+would fire on every fresh install.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+import yaml
+
+
+def _write_config(monkeypatch: pytest.MonkeyPatch, tmp_path, config: object) -> None:
+    home = tmp_path / "hermes-home"
+    home.mkdir(exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    (home / "config.yaml").write_text(yaml.safe_dump(config), encoding="utf-8")
+
+
+def _configure_mode(monkeypatch: pytest.MonkeyPatch, tmp_path, mode: object) -> None:
+    _write_config(monkeypatch, tmp_path, {"database": {"journal_mode": mode}})
+
+
+def _disable_vulnerable_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "hermes_state.is_sqlite_wal_reset_vulnerable",
+        lambda **kwargs: False,
+    )
+
+
+def _make_delete_db_with_content(path) -> None:
+    """Create a real, non-empty database left in journal_mode=DELETE."""
+    conn = sqlite3.connect(str(path))
+    try:
+        assert conn.execute("PRAGMA journal_mode=DELETE").fetchone()[0].lower() == "delete"
+        conn.execute("CREATE TABLE t (x)")
+        conn.execute("INSERT INTO t VALUES (1)")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture(autouse=True)
+def _reset_dedup():
+    """Order-independence: the warning is deduped per process per db_label."""
+    import hermes_state
+
+    hermes_state._journal_upgrade_warned_paths.clear()
+    yield
+    hermes_state._journal_upgrade_warned_paths.clear()
+
+
+class TestTheContentProbe:
+    """``_database_has_content`` is what keeps fresh installs quiet."""
+
+    def test_a_brand_new_database_has_no_content(self, tmp_path):
+        from hermes_state import _database_has_content
+
+        conn = sqlite3.connect(str(tmp_path / "new.db"))
+        try:
+            assert _database_has_content(conn) is False
+        finally:
+            conn.close()
+
+    def test_a_database_with_a_table_has_content(self, tmp_path):
+        from hermes_state import _database_has_content
+
+        path = tmp_path / "used.db"
+        _make_delete_db_with_content(path)
+        conn = sqlite3.connect(str(path))
+        try:
+            assert _database_has_content(conn) is True
+        finally:
+            conn.close()
+
+    def test_an_unreadable_probe_answers_no_content(self, tmp_path):
+        """Fail-quiet.
+
+        Answering True on an error would emit the warning for a database we
+        could not measure, which includes every fresh one.
+        """
+        from hermes_state import _database_has_content
+
+        conn = sqlite3.connect(":memory:")
+        try:
+            conn.close()
+            assert _database_has_content(conn) is False
+        finally:
+            pass
+
+
+class TestTheWarningFires:
+
+    def test_an_existing_delete_database_warns_when_flipped(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        from hermes_state import apply_wal_with_fallback
+
+        _configure_mode(monkeypatch, tmp_path, "wal")
+        _disable_vulnerable_gate(monkeypatch)
+        path = tmp_path / "existing-delete.db"
+        _make_delete_db_with_content(path)
+
+        conn = sqlite3.connect(str(path))
+        try:
+            with caplog.at_level("WARNING", logger="hermes_state"):
+                assert apply_wal_with_fallback(conn, db_label="state.db") == "wal"
+        finally:
+            conn.close()
+
+        blob = "\n".join(r.getMessage() for r in caplog.records)
+        assert "state.db" in blob
+        assert "delete" in blob.lower()
+
+    def test_the_warning_names_the_setting_that_makes_it_stick(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """The whole point.
+
+        Telling an operator their mode changed, without telling them which
+        lever survives an open, leaves them doing the same PRAGMA again.
+        """
+        from hermes_state import apply_wal_with_fallback
+
+        _configure_mode(monkeypatch, tmp_path, "wal")
+        _disable_vulnerable_gate(monkeypatch)
+        path = tmp_path / "existing-delete.db"
+        _make_delete_db_with_content(path)
+
+        conn = sqlite3.connect(str(path))
+        try:
+            with caplog.at_level("WARNING", logger="hermes_state"):
+                apply_wal_with_fallback(conn, db_label="state.db")
+        finally:
+            conn.close()
+
+        blob = "\n".join(r.getMessage() for r in caplog.records)
+        assert "database.journal_mode" in blob, (
+            "the warning must name the config key, not just report the change"
+        )
+
+    def test_the_flip_still_happens(self, monkeypatch, tmp_path):
+        """Log-only: WAL is still applied, and it still persists.
+
+        Staying on DELETE is itself treated as a defect elsewhere in the tree
+        (managed_uv repairs it on update, citing ~2600x slower appends), so
+        this must warn about the change without preventing it.
+        """
+        from hermes_state import apply_wal_with_fallback
+
+        _configure_mode(monkeypatch, tmp_path, "wal")
+        _disable_vulnerable_gate(monkeypatch)
+        path = tmp_path / "existing-delete.db"
+        _make_delete_db_with_content(path)
+
+        conn = sqlite3.connect(str(path))
+        try:
+            assert apply_wal_with_fallback(conn, db_label="state.db") == "wal"
+            assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+        finally:
+            conn.close()
+
+    def test_it_fires_once_per_process_per_database(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """kanban opens a connection per operation; undeduped this is a flood."""
+        from hermes_state import apply_wal_with_fallback
+
+        _configure_mode(monkeypatch, tmp_path, "wal")
+        _disable_vulnerable_gate(monkeypatch)
+
+        with caplog.at_level("WARNING", logger="hermes_state"):
+            for name in ("a", "b"):
+                path = tmp_path / f"{name}.db"
+                _make_delete_db_with_content(path)
+                conn = sqlite3.connect(str(path))
+                try:
+                    apply_wal_with_fallback(conn, db_label="same-label.db")
+                finally:
+                    conn.close()
+
+        hits = [r for r in caplog.records if "same-label.db" in r.getMessage()]
+        assert len(hits) == 1, f"expected one deduped warning, got {len(hits)}"
+
+    def test_a_second_database_gets_its_own_warning(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """#89293 saw four databases flip. Dedup is per label, not global."""
+        from hermes_state import apply_wal_with_fallback
+
+        _configure_mode(monkeypatch, tmp_path, "wal")
+        _disable_vulnerable_gate(monkeypatch)
+
+        with caplog.at_level("WARNING", logger="hermes_state"):
+            for label in ("state.db", "kanban.db"):
+                path = tmp_path / f"{label}"
+                _make_delete_db_with_content(path)
+                conn = sqlite3.connect(str(path))
+                try:
+                    apply_wal_with_fallback(conn, db_label=label)
+                finally:
+                    conn.close()
+
+        blob = "\n".join(r.getMessage() for r in caplog.records)
+        assert "state.db" in blob and "kanban.db" in blob
+
+
+class TestTheWarningStaysQuiet:
+    """Every one of these would be a false positive shipped to every user."""
+
+    def test_a_brand_new_database_is_silent(self, monkeypatch, tmp_path, caplog):
+        """The load-bearing guard.
+
+        A fresh file reports journal_mode=delete (SQLite's default) and is
+        about to be switched to WAL, which looks identical to the reported
+        bug from `current_mode` alone. Only page_count tells them apart, and
+        every opener applies WAL before creating any schema -- so without
+        this guard the warning fires on every first run of every install.
+        """
+        from hermes_state import apply_wal_with_fallback
+
+        _configure_mode(monkeypatch, tmp_path, "wal")
+        _disable_vulnerable_gate(monkeypatch)
+
+        conn = sqlite3.connect(str(tmp_path / "fresh.db"))
+        try:
+            with caplog.at_level("WARNING", logger="hermes_state"):
+                assert apply_wal_with_fallback(conn, db_label="fresh.db") == "wal"
+        finally:
+            conn.close()
+
+        assert not [r for r in caplog.records if "fresh.db" in r.getMessage()]
+
+    def test_an_existing_wal_database_is_silent(self, monkeypatch, tmp_path, caplog):
+        """No flip happens: the probe returns early. Nothing to report."""
+        from hermes_state import apply_wal_with_fallback
+
+        _configure_mode(monkeypatch, tmp_path, "wal")
+        _disable_vulnerable_gate(monkeypatch)
+        path = tmp_path / "already-wal.db"
+        conn = sqlite3.connect(str(path))
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("CREATE TABLE t (x)")
+            conn.commit()
+            with caplog.at_level("WARNING", logger="hermes_state"):
+                assert apply_wal_with_fallback(conn, db_label="already-wal.db") == "wal"
+        finally:
+            conn.close()
+
+        assert not [r for r in caplog.records if "already-wal.db" in r.getMessage()]
+
+    def test_configured_delete_is_silent(self, monkeypatch, tmp_path, caplog):
+        """The operator used the durable lever. There is nothing to tell them."""
+        from hermes_state import apply_wal_with_fallback
+
+        _configure_mode(monkeypatch, tmp_path, "delete")
+        _disable_vulnerable_gate(monkeypatch)
+        path = tmp_path / "configured-delete.db"
+        _make_delete_db_with_content(path)
+
+        conn = sqlite3.connect(str(path))
+        try:
+            with caplog.at_level("WARNING", logger="hermes_state"):
+                assert apply_wal_with_fallback(conn, db_label="configured-delete.db") == "delete"
+            assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "delete"
+        finally:
+            conn.close()
+
+        assert not [
+            r for r in caplog.records if "configured-delete.db" in r.getMessage()
+        ]
+
+    def test_the_wal_reset_vulnerable_path_is_silent(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """That branch returns before any flip, so it must not warn.
+
+        It is also the branch that KEPT #89293's databases on DELETE before
+        the SQLite upgrade -- warning here would blame the guard that was
+        doing its job.
+        """
+        from hermes_state import apply_wal_with_fallback
+
+        _configure_mode(monkeypatch, tmp_path, "wal")
+        monkeypatch.setattr(
+            "hermes_state.is_sqlite_wal_reset_vulnerable",
+            lambda **kwargs: True,
+        )
+        path = tmp_path / "vulnerable.db"
+        _make_delete_db_with_content(path)
+
+        conn = sqlite3.connect(str(path))
+        try:
+            with caplog.at_level("WARNING", logger="hermes_state"):
+                apply_wal_with_fallback(conn, db_label="vulnerable.db")
+        finally:
+            conn.close()
+
+        assert not [
+            r
+            for r in caplog.records
+            if "database.journal_mode" in r.getMessage()
+        ]
+
+
+class TestTheExistingContractIsUnchanged:
+    """Behaviour preservation for the rules this change sits next to."""
+
+    def test_on_disk_wal_is_still_never_live_downgraded(self, monkeypatch, tmp_path):
+        from hermes_state import apply_wal_with_fallback
+
+        _configure_mode(monkeypatch, tmp_path, "delete")
+        path = tmp_path / "existing-wal.db"
+        conn = sqlite3.connect(str(path))
+        try:
+            assert conn.execute("PRAGMA journal_mode=WAL").fetchone()[0].lower() == "wal"
+            monkeypatch.setattr(
+                "hermes_state.is_sqlite_wal_reset_vulnerable",
+                lambda **kwargs: True,
+            )
+            assert apply_wal_with_fallback(conn, db_label="existing-wal.db") == "wal"
+            assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+        finally:
+            conn.close()
+
+    def test_default_config_still_yields_wal_on_a_fresh_database(
+        self, monkeypatch, tmp_path
+    ):
+        from hermes_state import apply_wal_with_fallback
+
+        _configure_mode(monkeypatch, tmp_path, "wal")
+        _disable_vulnerable_gate(monkeypatch)
+        conn = sqlite3.connect(str(tmp_path / "default.db"))
+        try:
+            assert apply_wal_with_fallback(conn, db_label="default.db") == "wal"
+            assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+        finally:
+            conn.close()


### PR DESCRIPTION
## What does this PR do?

`apply_wal_with_fallback()` treats an on-disk WAL database as authoritative and says so twice:

> Never downgrades to DELETE if the on-disk DB header reports WAL

> Existing on-disk WAL databases were returned above and are **never live-downgraded**.

The mirror case has no protection at all. When the on-disk mode is DELETE and the configured mode is `wal`, the function flips the database to WAL and logs nothing. `journal_mode` is a property of the **file**, so that rewrites the header and persists after the process exits.

That matters because setting the mode directly on the file is a thing operators actually do — it was the documented mitigation for the SQLite 3.50.4 WAL-reset bug. There is a config key that makes the choice durable (`database.journal_mode`, #68545), but nothing tells an operator it exists at the moment their PRAGMA is being undone.

This adds a single deduped WARNING on that flip. It is **log-only**: the flip still happens, the return value is unchanged, and the never-live-downgrade rule is untouched.

## Related Issue

Refs #89293

Item 1 of that report ("**journal_mode silently reverted to WAL after upgrade**", 4 of 5 databases) is this code path, and the reporter's own suggested remedy is what this implements:

> An upgrade should preserve the operator's explicit journal_mode choice (**or at least warn when re-enabling WAL after the operator deliberately disabled it**).

The "after upgrade" framing is exact, and the mechanism is worth stating because it explains why this went unnoticed for so long. Before the upgrade the deployment linked SQLite 3.50.4, so `is_sqlite_wal_reset_vulnerable()` was true and `apply_wal_with_fallback` short-circuited into `_apply_delete_for_wal_reset_bug` — which kept DELETE and never reached the flip. Upgrading to 3.53.1 turned that gate off, and the flip path went live on every database routed through this helper. `response_store.db` stayed DELETE because it is the one store that does not route through it.

This does **not** close #89293. That report is a four-part causal chain (oversized DB → cron lock storm → restart inside the lock window → WAL-reset amplifier); the other parts belong to #84277, #89088 and #88604, which the reporter already cites. This is item 1 only.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**`hermes_state.py`**

- `_database_has_content(conn)` — module-level helper, `PRAGMA page_count > 0`. A header read; no lock, no cost. Fail-quiet: any error answers `False`.
- `_log_journal_mode_upgrade_once(db_label, previous_mode)` — mirrors the existing `_log_wal_fallback_once` / `_log_wal_reset_bug_once` idiom (module-level set + lock, deduped per process per `db_label`), with its own `_journal_upgrade_warned_paths` / `_journal_upgrade_warned_lock` pair.
- `apply_wal_with_fallback` — computes `_upgrading_existing_db` **before** the pragma (both inputs are only readable while the file is still in its original state), and emits the warning at both points where the switch actually succeeds: the normal path and the `disk i/o error` retry path.

### Two judgment calls, stated rather than buried

**WARNING, not ERROR.** The reverse direction is ERROR (`_log_wal_fallback_once`) because dropping to DELETE is a real loss of concurrency. This direction is normally the *desirable* one — `managed_uv._default_live_venv` treats a database stuck on DELETE as a bug worth repairing on update, citing ~2600x slower `state.db` appends. So the message reports a change and names the durable lever without claiming a degradation that is not there. That is also why this does not *prevent* the flip: preventing it would fight a deliberate design decision, and the reporter did not ask for that.

**The `page_count` guard is the load-bearing half.** A brand-new database reports `journal_mode=delete` (SQLite's default) and is about to be switched to WAL — from `current_mode` alone that is indistinguishable from the reported bug. Every opener applies WAL *before* creating schema (`SessionDB._connect_and_init` calls `apply_wal_with_fallback`, then `_init_schema`), so without this guard the warning would fire on the first run of every install. Four of the fourteen tests exist for this one condition.

**`tests/test_journal_mode_upgrade_warning.py`** — new, 14 tests.

## How to Test

```bash
pytest tests/test_journal_mode_upgrade_warning.py -q     # 14 passed
```

All behavioural — real `sqlite3` on tmp files and `caplog`, matching `test_journal_mode_config.py`'s existing idiom (`_configure_mode` / `_disable_vulnerable_gate`). No mocking at the boundary under test.

**Mutation proof** — every property is independently load-bearing:

| Reverted | Tests that fail |
|---|---|
| the warning call removed from the flip | 4 — every "warns" test |
| `page_count` guard removed (treat all as existing) | 1 — `test_a_brand_new_database_is_silent` |
| dedup removed | 1 — `test_it_fires_once_per_process_per_database` |
| `database.journal_mode` dropped from the message | 1 — `test_the_warning_names_the_setting_that_makes_it_stick` |
| also warn on the configured-`delete` path | 1 — `test_configured_delete_is_silent` |

**Baseline** — `pytest tests/test_journal_mode_config.py tests/test_hermes_state_wal_fallback.py tests/test_sqlite_wal_reset_gate.py tests/test_wal_checkpoint_strategy.py tests/test_conftest_wal_gate.py tests/state/ tests/test_hermes_state.py -q -p no:randomly`, run **serially**, with and without the change:

| | Result |
|---|---|
| without the change (stashed) | `1 failed, 395 passed` |
| with the change | `1 failed, 395 passed` |

Byte-identical, as a log-only change should be. The one failure is pre-existing and unrelated — `tests/test_hermes_state.py::TestFTS5Search::test_search_projection_skips_context_enrichment_queries` (`assert 0 == 1`); it fails the same way on a clean `9664e386f`. The 14 new tests are additional to those counts.

## Overlap with open PRs

`hermes_state.py` is busy and the journal-mode area especially so, so I read the neighbours rather than assuming:

| PR | What it is | Relationship |
|---|---|---|
| **#85609** (open) | warns when a configured `journal_mode=delete` is overridden by an existing on-disk WAL | **The exact mirror of this, and the closest neighbour.** Both warning sites there are gated on `configured == "delete"`; this one only fires when the configured mode is `wal`. Theirs covers "your config lost to the file", this covers "the file lost to a default you never set" — which is the case where the operator never touched config at all. Disjoint conditions, no shared line. |
| **#87044**, **#87612** (open) | represent an indeterminate journal-mode probe as `None`/`delete` so the WAL read pool is not enabled on an unconfirmed WAL | Different question (what `_wal_active` should be when the probe fails). Neither adds or removes a journal-mode switch. |
| **#84277** (open) | PASSIVE instead of TRUNCATE for all `state.db` checkpoints | Cause ② / ③ of #89293's chain, and the reporter cites it as such. Different function, different failure. |

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — see the Overlap table; #85609 in particular is the mirror case and is called out explicitly
- [x] My PR contains **only** changes related to this fix (one commit, rebased on `main`)
- [x] I've run the journal-mode and state-store slices with and without the change, serially (see How to Test). I did **not** run `pytest tests/ -q` wholesale: on Windows `tests/hermes_cli/` can't be collected (`test_doctor_journal_modes.py` calls `os.geteuid`), so a full-suite number from here would be meaningless. CI runs it.
- [x] I've added tests for my changes — 14, with the mutation proof above
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — docstrings only; both new helpers document why the warning is WARNING rather than ERROR and why the content probe fails quiet
- [x] N/A — no config keys added or changed. `database.journal_mode` already exists (#68545); this change only names it in a message
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact — `PRAGMA page_count` is a portable header read, and the change adds no filesystem assumptions. The macOS/NFS paths (`_apply_macos_checkpoint_barrier`, `_enforce_macos_synchronous_full`, the silent-refusal branch) are untouched and still run in the same order
- [x] N/A — no tool description or schema change
