### PR TITLE
fix(cron): hold fires through a provider quota window instead of failing on every tick

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -3456,6 +3456,40 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                             needs_save = True
                             break
 
+                # Provider quota hold (#89376): a failure that carried a
+                # provider quota window (scheduler's _apply_quota_hold) parked
+                # this job until the window reopens. Skip the fire and park
+                # next_run_at at the hold boundary — the stale-collapse logic
+                # above then collapses any missed occurrences, so the job
+                # resumes its cadence after the window WITHOUT burst-firing.
+                _quota_hold = job.get("quota_hold_until")
+                if isinstance(_quota_hold, (int, float)) and _quota_hold > 0:
+                    _hold_dt = _ensure_aware(
+                        datetime.fromtimestamp(_quota_hold)
+                    )
+                    if _hold_dt > now:
+                        _parked = _hold_dt.isoformat()
+                        job["next_run_at"] = _parked
+                        for rj in raw_jobs:
+                            if rj["id"] == job["id"]:
+                                rj["next_run_at"] = _parked
+                                needs_save = True
+                                break
+                        logger.info(
+                            "Job '%s' held until %s (provider quota window)",
+                            job.get("name", job.get("id", "?")),
+                            _parked,
+                        )
+                        continue
+                    # Window over: clear the marker so it cannot pin a
+                    # future recovery after an operator-driven model change.
+                    job.pop("quota_hold_until", None)
+                    for rj in raw_jobs:
+                        if rj["id"] == job["id"]:
+                            rj.pop("quota_hold_until", None)
+                            needs_save = True
+                            break
+
                 due.append(job)
         except Exception:
             logger.exception(

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6134,6 +6134,57 @@ def _run_with_fire_claim_heartbeat(job: dict, run) -> bool:
         heartbeat_thread.join(timeout=1.0)
 
 
+# A provider quota window surfacing in a job failure message. Anchored on the
+# Codex quota-exhaustion wording ("quota exhausted (429); retry after <N>s"),
+# which both token-endpoint and usage-endpoint raises share, so an ordinary
+# "retry after" hint from some unrelated subsystem cannot trip the hold.
+_QUOTA_RETRY_AFTER_RE = re.compile(
+    r"quota exhausted \(429\); retry after (\d+)s", re.IGNORECASE
+)
+# Below this the window is shorter than most sub-hourly cadences anyway.
+_QUOTA_HOLD_MIN_SECONDS = 300.0
+# Slack on top of the provider's window so a fire at the boundary does not
+# land inside a clock-skewed still-closed window.
+_QUOTA_HOLD_SLACK_SECONDS = 30.0
+
+
+def _quota_hold_seconds_from_failure(error_text: str) -> Optional[float]:
+    """Extract a deferrable provider quota window from a job failure (#89376).
+
+    Returns whole seconds to hold the job's fires, or None when the failure
+    is not a quota-window rejection (or the window is too short to matter).
+    AuthError carries the same value structurally as
+    ``retry_after_seconds``; this text channel is the surviving signal once
+    run-level exception wrapping has stringified the cause chain.
+    """
+    m = _QUOTA_RETRY_AFTER_RE.search(error_text or "")
+    if not m:
+        return None
+    try:
+        seconds = float(m.group(1))
+    except ValueError:
+        return None
+    return seconds if seconds >= _QUOTA_HOLD_MIN_SECONDS else None
+
+
+def _apply_quota_hold(job: dict, hold_seconds: float) -> None:
+    """Persist a quota hold so get_due_jobs skips fires until the window ends."""
+    hold_until = time.time() + hold_seconds + _QUOTA_HOLD_SLACK_SECONDS
+    try:
+        from cron.jobs import update_job
+
+        update_job(job["id"], {"quota_hold_until": hold_until})
+        logger.warning(
+            "Job '%s': provider quota window (%.0fs) — holding fires until the "
+            "window reopens instead of failing on every cadence tick (#89376)",
+            job.get("id"), hold_seconds,
+        )
+    except Exception as exc:
+        logger.debug(
+            "Failed persisting quota hold for job %s: %s", job.get("id"), exc
+        )
+
+
 def run_one_job(
     job: dict,
     *,
@@ -6551,6 +6602,10 @@ def _run_one_job_body(
             mark_kwargs["expected_fire_owner"] = fire_owner
         if blocked_config:
             mark_kwargs["status"] = "blocked_config"
+        if not success:
+            _hold_s = _quota_hold_seconds_from_failure(error or "")
+            if _hold_s is not None:
+                _apply_quota_hold(job, _hold_s)
         marked = mark_job_run(job["id"], success, error, **mark_kwargs)
         if fire_owner is not None and not marked:
             finish_execution(
@@ -6632,6 +6687,9 @@ def _run_one_job_body(
                     mark_kwargs["expected_fire_owner"] = fire_owner
                 if isinstance(e, Exception):
                     mark_kwargs["delivery_error"] = delivery_error
+                _hold_s = _quota_hold_seconds_from_failure(_err_text)
+                if _hold_s is not None:
+                    _apply_quota_hold(job, _hold_s)
                 mark_job_run(job["id"], False, _err_text, **mark_kwargs)
         except Exception as record_err:
             # Never let bookkeeping mask the original interruption.

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -928,11 +928,17 @@ class AuthError(RuntimeError):
         provider: str = "",
         code: Optional[str] = None,
         relogin_required: bool = False,
+        retry_after_seconds: Optional[float] = None,
     ) -> None:
         super().__init__(message)
         self.provider = provider
         self.code = code
         self.relogin_required = relogin_required
+        # Upstream quota/rate-limit hint (whole seconds until the window
+        # reopens) when the provider sent one. Structured so schedulers can
+        # defer without parsing the message (#89376); None means "retry
+        # later, duration unknown".
+        self.retry_after_seconds = retry_after_seconds
 
 
 def is_rate_limited_auth_error(error: Exception) -> bool:
@@ -3927,6 +3933,7 @@ def refresh_codex_oauth_pure(
             provider="openai-codex",
             code=CODEX_RATE_LIMITED_CODE,
             relogin_required=False,
+            retry_after_seconds=float(retry_after) if retry_after is not None else None,
         )
 
     if response.status_code != 200:
@@ -4180,6 +4187,7 @@ def resolve_codex_runtime_credentials(
                 provider="openai-codex",
                 code=CODEX_RATE_LIMITED_CODE,
                 relogin_required=False,
+                retry_after_seconds=float(remaining) if remaining >= 0 else None,
             )
         if read_error is not None:
             raise read_error

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1102,6 +1102,56 @@ class TestClaimDispatch:
         assert load_jobs() == []  # cleaned up
 
 
+class TestQuotaHoldWindow:
+    """A provider quota window parks the job's fires until it reopens (#89376).
+
+    The scheduler stamps ``quota_hold_until`` (epoch seconds) when a job
+    failure carried an upstream quota window. While the window is open the
+    job must not fire on every cadence tick; next_run_at is parked at the
+    hold boundary so the stale-collapse logic collapses missed occurrences
+    instead of burst-firing when the window ends."""
+
+    def test_open_window_parks_next_run(self, tmp_cron_dir):
+        now_dt = datetime.now(timezone.utc)
+        past = (now_dt - timedelta(minutes=5)).isoformat()
+        hold_until = (now_dt + timedelta(hours=10)).timestamp()
+        save_jobs([{
+            "id": "q1",
+            "name": "quota-held",
+            "enabled": True,
+            "schedule": {"kind": "cron", "expr": "11,41 * * * *"},
+            "next_run_at": past,
+            "quota_hold_until": hold_until,
+        }])
+
+        due = get_due_jobs()
+
+        assert all(j["id"] != "q1" for j in due), "held job must not fire"
+        persisted = load_jobs()[0]
+        parked = datetime.fromisoformat(persisted["next_run_at"])
+        # Parked at the hold boundary (not the original past instant).
+        assert abs(parked.timestamp() - hold_until) < 60
+
+    def test_expired_window_fires_and_clears_marker(self, tmp_cron_dir):
+        now_dt = datetime.now(timezone.utc)
+        past = (now_dt - timedelta(minutes=5)).isoformat()
+        expired_hold = (now_dt - timedelta(hours=1)).timestamp()
+        save_jobs([{
+            "id": "q2",
+            "name": "quota-released",
+            "enabled": True,
+            "schedule": {"kind": "cron", "expr": "11,41 * * * *"},
+            "next_run_at": past,
+            "quota_hold_until": expired_hold,
+        }])
+
+        due = get_due_jobs()
+
+        assert any(j["id"] == "q2" for j in due), "expired hold must fire"
+        persisted = load_jobs()[0]
+        assert "quota_hold_until" not in persisted, "expired marker cleared"
+
+
 class TestLateEnvRepointScopesStore:
     """A HERMES_HOME set AFTER cron.jobs import must scope the store even
     without use_cron_store(): fixtures that patch the environment too late

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2608,3 +2608,29 @@ class TestFailureStreakNudge:
         from cron.scheduler import _failure_streak_nudge
         with patch("cron.scheduler.load_config", side_effect=RuntimeError("boom")):
             assert "failed 3 runs" in _failure_streak_nudge(self._job(2))
+
+
+class TestQuotaHoldFromFailure:
+    """_quota_hold_seconds_from_failure gates the scheduler's quota hold (#89376)."""
+
+    def test_codex_quota_message_yields_window(self):
+        from cron.scheduler import _quota_hold_seconds_from_failure
+
+        msg = (
+            "Codex provider quota exhausted (429); retry after 123518s. "
+            "Credentials are still valid."
+        )
+        assert _quota_hold_seconds_from_failure(msg) == 123518.0
+
+    def test_short_window_ignored(self):
+        from cron.scheduler import _quota_hold_seconds_from_failure
+
+        msg = "Codex provider quota exhausted (429); retry after 90s."
+        assert _quota_hold_seconds_from_failure(msg) is None
+
+    def test_unrelated_retry_after_ignored(self):
+        from cron.scheduler import _quota_hold_seconds_from_failure
+
+        assert _quota_hold_seconds_from_failure("HTTP 429: retry after 60s") is None
+        assert _quota_hold_seconds_from_failure("") is None
+        assert _quota_hold_seconds_from_failure(None) is None

--- a/tests/hermes_cli/test_auth_codex_quota_probe.py
+++ b/tests/hermes_cli/test_auth_codex_quota_probe.py
@@ -281,3 +281,22 @@ def test_pool_probe_not_fired_for_non_quota_exhaustion(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# AuthError.retry_after_seconds — structured quota window (#89376)
+# ---------------------------------------------------------------------------
+
+def test_auth_error_retry_after_seconds_default_and_explicit():
+    default = auth_mod.AuthError("boom", code="x")
+    assert default.retry_after_seconds is None
+
+    err = auth_mod.AuthError(
+        "Codex provider quota exhausted (429); retry after 123518s. "
+        "Credentials are still valid.",
+        code=auth_mod.CODEX_RATE_LIMITED_CODE,
+        relogin_required=False,
+        retry_after_seconds=123518.0,
+    )
+    assert auth_mod.is_rate_limited_auth_error(err) is True
+    assert err.retry_after_seconds == 123518.0
+
+


### PR DESCRIPTION
## What does this PR do?

When a cron job's failure carries an upstream quota window — Codex's `429; retry after 123518s. Credentials are still valid.` — the scheduler ignored the duration and kept firing on the job's normal cadence, failing identically every tick for the entire window (in the issue: every 30 minutes for ~34 hours). The provider had already told us exactly how long to wait.

This PR makes the scheduler honor that window:

- **Detection** (`cron/scheduler.py`): both failure-recording paths in `run_one_job` (the normal `mark_job_run` path and the `BaseException` handler) check the failure text for the quota-exhaustion wording with an explicit window. The regex is anchored on `quota exhausted (429); retry after <N>s` — the exact wording both Codex raises share — so an unrelated "retry after" hint from any other subsystem cannot trip the hold. Windows under five minutes are ignored (shorter than most sub-hourly cadences anyway).
- **Hold**: a matching failure stamps `quota_hold_until` (epoch seconds + 30s slack) on the job via the existing `update_job` persistence, with a one-line warning naming the window.
- **Effect** (`cron/jobs.py`): `get_due_jobs` skips a held job and parks its `next_run_at` at the hold boundary. When the window reopens, the existing stale-collapse logic collapses the missed occurrences and the job fires once — no burst-fire, no perpetual-defer. The first scan after expiry clears the marker so it cannot pin a later recovery after an operator-driven model change.
- **Structure** (`hermes_cli/auth.py`): `AuthError` gains `retry_after_seconds`, populated by both Codex quota raises, so future callers get the window without parsing the message (the scheduler's text channel survives run-level exception wrapping, which is why both exist).

Manual `/pause`-style semantics are untouched: this is an automatic, self-clearing, provider-driven hold only.

## Related Issue

Fixes #89376

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/auth.py` — `AuthError.retry_after_seconds` field (default None); both Codex quota raises populate it.
- `cron/scheduler.py` — `_QUOTA_RETRY_AFTER_RE` + `_quota_hold_seconds_from_failure` (anchor/gate) and `_apply_quota_hold` (persist via `update_job`, one-shot warning); wired into both failure-recording paths of `run_one_job`.
- `cron/jobs.py` — `_get_due_jobs_locked` honors `quota_hold_until`: park `next_run_at` at the boundary while held, clear the marker once expired.
- `tests/cron/test_scheduler.py` — quota-window parse: full window extracted, short window ignored, unrelated `retry after` ignored.
- `tests/cron/test_jobs.py` — `TestQuotaHoldWindow`: open window parks `next_run_at` and suppresses the fire; expired window fires and clears the marker.
- `tests/hermes_cli/test_auth_codex_quota_probe.py` — `retry_after_seconds` default and explicit value, with the rate-limit classification intact.

## How to Test

```bash
python -m pytest tests/cron/ -q
# Observed result: 810 passed, 1 skipped

python -m pytest tests/hermes_cli/test_auth_codex_quota_probe.py tests/hermes_cli/test_auth_codex_provider.py -q
# Observed result: 15 passed
```

Fail-on-main check: with the three source files stashed, all five new behavioral tests fail on main (no hold / no marker handling / no field).

Manual repro from the issue: with an exhausted Codex quota and a sub-hourly job, on main each tick logs the identical quota failure; with this change the first failure records the hold and subsequent ticks log `held until ... (provider quota window)` until the window reopens, then normal cadence resumes with a single catch-up fire.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments explain intent (why the regex is anchored, why the marker self-clears, why the hold parks next_run_at)
- [x] Corresponding changes documented via comments
- [x] Tests added and passing (6 new; full cron suite + Codex auth suites green)
- [x] Single root cause, no unrelated changes
