### PR TITLE
fix(gateway): mark interim commentary deliveries

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2480,6 +2480,12 @@ class SendResult:
     # Server-requested retry delay in seconds (e.g. Telegram FloodWait retry_after).
     # When present, _send_with_retry() honors this instead of its default backoff.
     retry_after: Optional[float] = None
+    # ``None`` preserves the legacy contract: successful sends are assumed to
+    # have reached a user-visible surface. Adapters that intentionally discard
+    # a delivery (for example, route-specific interim commentary suppression)
+    # set this to ``False`` so stream consumers do not record invisible text as
+    # delivered and accidentally suppress a later mandatory final response.
+    delivered: Optional[bool] = None
     # When the adapter had to split an oversized payload across multiple
     # platform messages (e.g. Telegram edit_message overflow split-and-deliver),
     # ``message_id`` is the LAST visible message id (so subsequent edits target

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5334,11 +5334,13 @@ class TurnRunner:
                 return
             if already_streamed or not ctx._status_adapter or not str(display_text or "").strip():
                 return
+            interim_metadata = dict(ctx._status_thread_metadata or {})
+            interim_metadata["interim_assistant_message"] = True
             safe_schedule_threadsafe(
                 ctx._status_adapter.send(
                     ctx._status_chat_id,
                     display_text,
-                    metadata=ctx._status_thread_metadata,
+                    metadata=interim_metadata,
                 ),
                 ctx._loop_for_step,
                 logger=logger,

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -1852,7 +1852,7 @@ class GatewayStreamConsumer:
             # tool..."), not the final response. Setting already_sent would cause
             # the final response to be incorrectly suppressed when there are
             # multiple tool calls. See: https://github.com/NousResearch/hermes-agent/issues/10454
-            if result.success:
+            if result.success and getattr(result, "delivered", None) is not False:
                 # Commentary counts as fresh content — close off any
                 # stale tool bubble above it so the next tool starts a
                 # new bubble below.

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -1836,10 +1836,16 @@ class GatewayStreamConsumer:
         if not text.strip():
             return False
         try:
+            metadata = dict(self.metadata or {})
+            # Mark completed assistant prose explicitly so platform adapters can
+            # distinguish it from mandatory unmarked sends (direct delivery,
+            # recovered finals, clarification, and approval fallbacks). Do not
+            # infer interim intent from a missing ``notify`` marker.
+            metadata["interim_assistant_message"] = True
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=text,
-                metadata=self.metadata,
+                metadata=metadata,
             )
             # Note: do NOT set _already_sent = True here.
             # Commentary messages are interim status updates (e.g. "Using browser

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1024,7 +1024,10 @@ async def _run_with_agent(
     adapter = adapter_cls(platform=platform)
     runner = _make_runner(adapter)
     if stream_consumer_config_error:
+        adapter.stream_consumer_config_error_called = False
+
         def _fail_stream_consumer_config(*args, **kwargs):
+            adapter.stream_consumer_config_error_called = True
             raise RuntimeError("synthetic stream consumer setup failure")
 
         runner._build_stream_consumer_config = _fail_stream_consumer_config
@@ -1207,7 +1210,9 @@ async def test_interim_fallback_send_marks_interim_intent_when_consumer_setup_fa
     )
 
     assert result["final_response"] == "done"
+    assert adapter.stream_consumer_config_error_called is True
     assert [call["content"] for call in adapter.sent] == ["I'll inspect the repo first."]
+    assert adapter.sent[0]["metadata"]["thread_id"] == "17585"
     assert adapter.sent[0]["metadata"]["interim_assistant_message"] is True
 
 

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1006,6 +1006,7 @@ async def _run_with_agent(
     adapter_cls=ProgressCaptureAdapter,
     user_id=None,
     scope_id=None,
+    stream_consumer_config_error=False,
 ):
     if config_data:
         import yaml
@@ -1022,6 +1023,11 @@ async def _run_with_agent(
 
     adapter = adapter_cls(platform=platform)
     runner = _make_runner(adapter)
+    if stream_consumer_config_error:
+        def _fail_stream_consumer_config(*args, **kwargs):
+            raise RuntimeError("synthetic stream consumer setup failure")
+
+        runner._build_stream_consumer_config = _fail_stream_consumer_config
     gateway_run = importlib.import_module("gateway.run")
     if config_data and "streaming" in config_data:
         runner.config.streaming = StreamingConfig.from_dict(config_data["streaming"])
@@ -1181,6 +1187,28 @@ async def test_display_streaming_does_not_enable_gateway_streaming(monkeypatch, 
     assert result.get("already_sent") is not True
     assert adapter.edits == []
     assert [call["content"] for call in adapter.sent] == ["I'll inspect the repo first."]
+    assert adapter.sent[0]["metadata"]["interim_assistant_message"] is True
+
+
+@pytest.mark.asyncio
+async def test_interim_fallback_send_marks_interim_intent_when_consumer_setup_fails(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        CommentaryAgent,
+        session_id="sess-interim-fallback-metadata",
+        config_data={
+            "display": {"interim_assistant_messages": True},
+            "streaming": {"enabled": False},
+        },
+        stream_consumer_config_error=True,
+    )
+
+    assert result["final_response"] == "done"
+    assert [call["content"] for call in adapter.sent] == ["I'll inspect the repo first."]
+    assert adapter.sent[0]["metadata"]["interim_assistant_message"] is True
 
 
 class TransformedStreamAgent:

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -839,6 +839,32 @@ class TestInterimCommentaryMessages:
         assert final_metadata == {"thread_id": "thread_7", "notify": True}
         assert consumer.final_response_sent is True
 
+    @pytest.mark.asyncio
+    async def test_suppressed_commentary_is_not_recorded_as_visible_delivery(self):
+        adapter = MagicMock()
+        adapter.send = AsyncMock(
+            return_value=SimpleNamespace(
+                success=True,
+                message_id="suppressed",
+                delivered=False,
+            )
+        )
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        new_messages = []
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            StreamConsumerConfig(),
+            on_new_message=lambda: new_messages.append(True),
+        )
+
+        result = await consumer._send_commentary("Final answer")
+
+        assert result is True
+        assert consumer.has_delivered_text("Final answer") is False
+        assert consumer._delivered_commentary_texts == []
+        assert new_messages == []
+
 
 class TestCancelledConsumerSetsFlags:
     """Cancellation must set final_response_sent when already_sent is True.

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -819,6 +819,7 @@ class TestInterimCommentaryMessages:
             adapter,
             "chat_123",
             StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5),
+            metadata={"thread_id": "thread_7"},
         )
 
         consumer.on_commentary("I'll inspect the repository first.")
@@ -829,6 +830,13 @@ class TestInterimCommentaryMessages:
 
         sent_texts = [call[1]["content"] for call in adapter.send.call_args_list]
         assert sent_texts == ["I'll inspect the repository first.", "Done."]
+        commentary_metadata = adapter.send.call_args_list[0].kwargs["metadata"]
+        assert commentary_metadata == {
+            "thread_id": "thread_7",
+            "interim_assistant_message": True,
+        }
+        final_metadata = adapter.send.call_args_list[1].kwargs["metadata"]
+        assert final_metadata == {"thread_id": "thread_7", "notify": True}
         assert consumer.final_response_sent is True
 
 


### PR DESCRIPTION
## Problem

`GatewayStreamConsumer._send_commentary()` delivers completed interim assistant prose through `adapter.send()` with only the source/thread metadata. Platform adapters therefore cannot distinguish this delivery from mandatory unmarked sends such as direct delivery, recovered finals, clarification prompts, or approval fallbacks.

This is observable on asynchronous work surfaces: an interim line such as “I’ll attach the charts” can become a permanent recording comment before the tool runs.

## Fix

Add the explicit semantic marker `interim_assistant_message: true` to a copied metadata dictionary for completed commentary deliveries.

The change:

- preserves all original source/thread metadata;
- does not mutate the consumer’s stored metadata;
- does not overload missing `notify` as lifecycle intent;
- is backward-compatible because adapters ignore unknown metadata keys;
- gives external platform plugins a reliable, generic suppression/routing signal.

## Tests

- Updated the commentary/final stream regression test to assert:
  - commentary carries original thread metadata plus `interim_assistant_message: true`;
  - final delivery carries original thread metadata plus `notify: true`.
- `tests/gateway/test_stream_consumer.py`: **65 passed, 1 skipped**.
- External Basecamp plugin compatibility suite against this worktree: **448 passed, 31 subtests passed**.
