### PR TITLE
feat(usage): show CommandCode account limits in /usage

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -17,6 +17,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_ACCOUNT_USAGE_NOTICE_BANDS: tuple[tuple[float, str, int], ...] = (
+    (75.0, "warn", 75),
+    (90.0, "warn", 90),
+    (100.0, "error", 100),
+)
+
 
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
@@ -110,7 +116,7 @@ def render_account_usage_lines(snapshot: Optional[AccountUsageSnapshot], *, mark
             base = f"{window.label}: {remaining}% remaining ({used}% used)"
         if window.reset_at:
             base += f" • resets {_format_reset(window.reset_at)}"
-        elif window.detail:
+        if window.detail:
             base += f" • {window.detail}"
         lines.append(base)
     for detail in snapshot.details:
@@ -118,6 +124,69 @@ def render_account_usage_lines(snapshot: Optional[AccountUsageSnapshot], *, mark
     if snapshot.unavailable_reason:
         lines.append(f"Unavailable: {snapshot.unavailable_reason}")
     return lines
+
+
+def new_account_usage_notice_latch() -> dict[str, Any]:
+    """Return state for provider-window notice reconciliation."""
+    return {"active": set(), "bands": {}}
+
+
+def _account_usage_notice_key(provider: str, label: str) -> str:
+    slug = "".join(ch.lower() if ch.isalnum() else "-" for ch in label).strip("-")
+    while "--" in slug:
+        slug = slug.replace("--", "-")
+    return f"account_usage.{provider}.{slug or 'window'}"
+
+
+def evaluate_account_usage_notices(
+    snapshot: AccountUsageSnapshot,
+    latch: dict[str, Any],
+) -> tuple[list[Any], list[str]]:
+    """Reconcile sticky warnings for provider windows at 75/90/100 percent."""
+    from agent.credits_tracker import AgentNotice
+
+    active: set[str] = latch.setdefault("active", set())
+    bands: dict[str, int] = latch.setdefault("bands", {})
+    seen: set[str] = set()
+    to_show: list[AgentNotice] = []
+    to_clear: list[str] = []
+
+    for window in snapshot.windows:
+        if window.used_percent is None or not _is_finite_num(window.used_percent):
+            continue
+        key = _account_usage_notice_key(snapshot.provider, window.label)
+        seen.add(key)
+        used = max(0.0, float(window.used_percent))
+        current: Optional[tuple[float, str, int]] = None
+        for band in _ACCOUNT_USAGE_NOTICE_BANDS:
+            if used >= band[0]:
+                current = band
+        target = current[2] if current else None
+        if bands.get(key) == target:
+            continue
+        if key in active:
+            to_clear.append(key)
+            active.discard(key)
+        if current is not None:
+            level = current[1]
+            glyph = "✕" if level == "error" else "⚠"
+            text = f"{glyph} {snapshot.provider} {window.label} is {used:.0f}% used"
+            if window.reset_at:
+                text += f" · resets {_format_reset(window.reset_at)}"
+            to_show.append(
+                AgentNotice(text=text, level=level, kind="sticky", key=key, id=key)
+            )
+            active.add(key)
+            bands[key] = target
+        else:
+            bands.pop(key, None)
+
+    for key in list(active):
+        if key.startswith(f"account_usage.{snapshot.provider}.") and key not in seen:
+            to_clear.append(key)
+            active.discard(key)
+            bands.pop(key, None)
+    return to_show, to_clear
 
 
 def _fmt_usd(d: float) -> str:
@@ -897,6 +966,17 @@ def fetch_account_usage(
             return _fetch_anthropic_account_usage()
         if normalized == "openrouter":
             return _fetch_openrouter_account_usage(base_url, api_key)
+        from providers import get_provider_profile
+
+        profile = get_provider_profile(normalized)
+        if profile is not None:
+            snapshot = profile.fetch_account_usage(
+                api_key=api_key,
+                base_url=base_url,
+                timeout=9.0,
+            )
+            return snapshot if isinstance(snapshot, AccountUsageSnapshot) else None
     except Exception:
+        logger.debug("account usage fetch failed for %s", normalized, exc_info=True)
         return None
     return None

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1004,7 +1004,7 @@ def init_agent(
     agent._account_usage_notice_latch = None
     agent._account_usage_refresh_lock = threading.Lock()
     agent._account_usage_refresh_inflight = False
-    agent._account_usage_refreshed_at = 0.0
+    agent._account_usage_refreshed_at = None
 
     # OpenRouter response cache hit counter — incremented when
     # X-OpenRouter-Cache-Status: HIT is seen in streaming response headers.

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1001,6 +1001,10 @@ def init_agent(
     from agent.credits_tracker import new_credits_latch
 
     agent._credits_latch = new_credits_latch()
+    agent._account_usage_notice_latch = None
+    agent._account_usage_refresh_lock = threading.Lock()
+    agent._account_usage_refresh_inflight = False
+    agent._account_usage_refreshed_at = 0.0
 
     # OpenRouter response cache hit counter — incremented when
     # X-OpenRouter-Cache-Status: HIT is seen in streaming response headers.

--- a/agent/credits_tracker.py
+++ b/agent/credits_tracker.py
@@ -797,8 +797,11 @@ def _hydrate_seed_state(agent, state) -> None:
 
 
 def seed_credits_at_session_start(agent) -> bool:
-    """Hydrate agent._credits_state from /api/oauth/account (or a dev fixture) and
-    fire the notice policy, so depletion / usage-band warnings show at session OPEN.
+    """Start provider credit/window hydration at session open.
+
+    Nous hydrates ``agent._credits_state`` from its account endpoint (or a dev
+    fixture). CommandCode schedules its provider-account refresh hook. Both are
+    fail-open and fire the relevant notice policy without delaying readiness.
 
     Shared by (a) the TUI/desktop agent build (fires at "ready", before any message)
     and (b) the first-turn conversation setup (fallback for plain CLI / when the
@@ -809,7 +812,16 @@ def seed_credits_at_session_start(agent) -> bool:
     fail-open error). Never raises — credits must never block session startup.
     """
     try:
-        if getattr(agent, "provider", "") != "nous":
+        provider = str(getattr(agent, "provider", "") or "").lower()
+        if provider in {
+            "commandcode",
+            "commandcode-chat",
+            "commandcode-anthropic",
+            "commandcode-claude",
+        }:
+            refresh = getattr(agent, "_refresh_account_usage_notices", None)
+            return bool(refresh()) if callable(refresh) else False
+        if provider != "nous":
             return False
         # Idempotent: don't re-seed if state already exists (seed or live header).
         if getattr(agent, "_credits_state", None) is not None:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3877,6 +3877,14 @@ OPTIONAL_ENV_VARS = {
         "category": "provider",
         "advanced": True,
     },
+    "COMMANDCODE_SESSION_COOKIE": {
+        "description": "CommandCode web session cookie for /usage account limits",
+        "prompt": "CommandCode session cookie (Cookie header or session token)",
+        "url": "https://commandcode.ai/",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
     "OPENCODE_ZEN_BASE_URL": {
         "description": "OpenCode Zen base URL override",
         "prompt": "OpenCode Zen base URL (leave empty for default)",

--- a/plugins/model-providers/commandcode/__init__.py
+++ b/plugins/model-providers/commandcode/__init__.py
@@ -28,7 +28,11 @@ from __future__ import annotations
 
 import json
 import logging
+import math
+import os
 import urllib.request
+from datetime import datetime, timezone
+from typing import Any
 
 from providers import register_provider
 from providers.base import ProviderProfile, _profile_user_agent
@@ -38,6 +42,24 @@ logger = logging.getLogger(__name__)
 # ── Shared constants ──────────────────────────────────────────────────────────
 _COMMANDCODE_BASE = "https://api.commandcode.ai/provider/v1"
 _COMMANDCODE_MODELS_URL = f"{_COMMANDCODE_BASE}/models"
+_COMMANDCODE_BILLING_BASE = "https://api.commandcode.ai/internal/billing"
+_COMMANDCODE_CREDITS_URL = f"{_COMMANDCODE_BILLING_BASE}/credits"
+_COMMANDCODE_SUBSCRIPTIONS_URL = f"{_COMMANDCODE_BILLING_BASE}/subscriptions"
+_COMMANDCODE_SESSION_COOKIES = (
+    "__Secure-commandcode_prod_.session_token",
+    "commandcode_prod_.session_token",
+    "__Host-commandcode_prod_.session_token",
+    "__Host-better-auth.session_token",
+    "__Secure-better-auth.session_token",
+    "better-auth.session_token",
+)
+_COMMANDCODE_PLANS: dict[str, tuple[str, float]] = {
+    "individual-go": ("Go", 10.0),
+    "individual-goat": ("GOAT", 70.0),
+    "individual-pro": ("Pro", 30.0),
+    "individual-max": ("Max", 150.0),
+    "individual-ultra": ("Ultra", 300.0),
+}
 # Both profiles authenticate with the same key; each carries its own base-URL
 # override var so each renders its own card on the desktop Keys tab (rows are
 # keyed by env var, and the shared API key attributes to the first profile).
@@ -70,6 +92,154 @@ def _fetch_commandcode_models(
         return None
 
 
+def _commandcode_cookie_header(raw: str | None) -> str | None:
+    """Extract only a recognized session cookie from a pasted Cookie header."""
+    text = str(raw or "").strip()
+    if not text or any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in text):
+        return None
+    if "=" not in text and ";" not in text:
+        return f"__Secure-better-auth.session_token={text}"
+    pairs: dict[str, tuple[str, str]] = {}
+    for chunk in text.split(";"):
+        name, separator, value = chunk.strip().partition("=")
+        if separator and name.strip() and value.strip():
+            pairs[name.strip().lower()] = (name.strip(), value.strip())
+    for expected in _COMMANDCODE_SESSION_COOKIES:
+        match = pairs.get(expected.lower())
+        if match:
+            return f"{match[0]}={match[1]}"
+    return None
+
+
+def _commandcode_number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+def _commandcode_datetime(value: Any) -> datetime | None:
+    number = _commandcode_number(value)
+    if number is not None and number > 0:
+        if number > 10_000_000_000:
+            number /= 1000
+        return datetime.fromtimestamp(number, tz=timezone.utc)
+    text = str(value or "").strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _commandcode_get_json(url: str, cookie_header: str, timeout: float) -> dict[str, Any]:
+    req = urllib.request.Request(url)
+    req.add_header("Cookie", cookie_header)
+    req.add_header("Accept", "application/json, text/plain, */*")
+    req.add_header("Origin", "https://commandcode.ai")
+    req.add_header("Referer", "https://commandcode.ai/")
+    req.add_header("User-Agent", _profile_user_agent())
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        payload = json.loads(resp.read().decode())
+    if not isinstance(payload, dict):
+        raise ValueError("CommandCode billing response must be an object")
+    return payload
+
+
+def _commandcode_usage_window(value: Any, label: str):
+    from agent.account_usage import AccountUsageWindow
+
+    if not isinstance(value, dict):
+        return None
+    cap = _commandcode_number(value.get("cap"))
+    used = _commandcode_number(value.get("used"))
+    if cap is None or cap <= 0 or used is None or used < 0:
+        return None
+    return AccountUsageWindow(
+        label=label,
+        used_percent=max(0.0, min(100.0, used / cap * 100.0)),
+        reset_at=_commandcode_datetime(value.get("resetAt")),
+        detail=f"${used:.2f} of ${cap:.2f} used",
+    )
+
+
+def _fetch_commandcode_account_usage(timeout: float = 15.0):
+    from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
+
+    cookie_header = _commandcode_cookie_header(os.getenv("COMMANDCODE_SESSION_COOKIE"))
+    if not cookie_header:
+        return None
+    credits_timeout = max(0.5, min(timeout, 7.0))
+    credits_payload = _commandcode_get_json(
+        _COMMANDCODE_CREDITS_URL, cookie_header, credits_timeout
+    )
+    credits = credits_payload.get("credits")
+    if not isinstance(credits, dict):
+        return None
+    monthly_remaining = _commandcode_number(credits.get("monthlyCredits"))
+    if monthly_remaining is None or monthly_remaining < 0:
+        return None
+
+    subscription: dict[str, Any] = {}
+    subscription_timeout = min(2.0, max(0.0, timeout - credits_timeout))
+    if subscription_timeout > 0:
+        try:
+            sub_payload = _commandcode_get_json(
+                _COMMANDCODE_SUBSCRIPTIONS_URL, cookie_header, subscription_timeout
+            )
+            if sub_payload.get("success") is True and isinstance(sub_payload.get("data"), dict):
+                subscription = sub_payload["data"]
+        except Exception:
+            logger.debug("CommandCode subscription enrichment failed", exc_info=True)
+
+    windows: list[AccountUsageWindow] = []
+    limits = credits_payload.get("windowLimits")
+    if not isinstance(limits, dict):
+        limits = credits.get("windowLimits")
+    if isinstance(limits, dict):
+        for key, label in (("fiveHour", "5-hour limit"), ("weekly", "Weekly limit")):
+            window = _commandcode_usage_window(limits.get(key), label)
+            if window is not None:
+                windows.append(window)
+
+    plan_id = str(subscription.get("planId") or "").strip().lower()
+    plan = _COMMANDCODE_PLANS.get(plan_id)
+    period_end = _commandcode_datetime(subscription.get("currentPeriodEnd"))
+    if plan and 0 <= monthly_remaining <= plan[1]:
+        monthly_used = plan[1] - monthly_remaining
+        windows.append(
+            AccountUsageWindow(
+                label="Monthly credits",
+                used_percent=monthly_used / plan[1] * 100.0,
+                reset_at=period_end,
+                detail=f"${monthly_remaining:.2f} of ${plan[1]:.2f} remaining",
+            )
+        )
+
+    details: list[str] = []
+    if not plan:
+        details.append(f"Monthly credits remaining: ${monthly_remaining:.2f}")
+    purchased = _commandcode_number(credits.get("purchasedCredits"))
+    if purchased is not None and purchased > 0:
+        details.append(f"Purchased credits: ${purchased:.2f}")
+    return AccountUsageSnapshot(
+        provider="commandcode",
+        source="billing_cookie_api",
+        fetched_at=datetime.now(timezone.utc),
+        title="CommandCode limits",
+        plan=plan[0] if plan else None,
+        windows=tuple(windows),
+        details=tuple(details),
+    )
+
+
 # ── Chat Completions profile ──────────────────────────────────────────────────
 
 class CommandCodeProfile(ProviderProfile):
@@ -83,6 +253,15 @@ class CommandCodeProfile(ProviderProfile):
     ) -> list[str] | None:
         """Fetch from the public CommandCode /models endpoint."""
         return _fetch_commandcode_models(timeout=timeout)
+
+    def fetch_account_usage(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 15.0,
+    ):
+        return _fetch_commandcode_account_usage(timeout=timeout)
 
 
 commandcode = CommandCodeProfile(
@@ -136,6 +315,15 @@ class CommandCodeAnthropicProfile(ProviderProfile):
         if all_models is None:
             return None
         return [m for m in all_models if m.startswith("claude-")]
+
+    def fetch_account_usage(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 15.0,
+    ):
+        return _fetch_commandcode_account_usage(timeout=timeout)
 
 
 commandcode_anthropic = CommandCodeAnthropicProfile(

--- a/providers/base.py
+++ b/providers/base.py
@@ -252,3 +252,19 @@ class ProviderProfile:
         except Exception as exc:
             logger.debug("fetch_models(%s): %s", self.name, exc)
             return None
+
+    def fetch_account_usage(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 15.0,
+    ) -> Any | None:
+        """Return an ``AccountUsageSnapshot`` for this provider, when supported.
+
+        Account billing is optional provider surface. The default deliberately
+        performs no I/O; provider profiles with a documented account endpoint
+        may override this hook while the shared ``/usage`` command remains
+        provider-agnostic.
+        """
+        return None

--- a/run_agent.py
+++ b/run_agent.py
@@ -4191,7 +4191,8 @@ class AIAgent:
             now = time.monotonic()
             if getattr(self, "_account_usage_refresh_inflight", False):
                 return False
-            if now - getattr(self, "_account_usage_refreshed_at", 0.0) < 300.0:
+            refreshed_at = getattr(self, "_account_usage_refreshed_at", None)
+            if refreshed_at is not None and now - refreshed_at < 300.0:
                 return False
             self._account_usage_refresh_inflight = True
             self._account_usage_refreshed_at = now

--- a/run_agent.py
+++ b/run_agent.py
@@ -4080,6 +4080,10 @@ class AIAgent:
         EVALUATION/EMIT is a SEPARATE block that WARNS on failure (R1-M2): a bug in the
         depletion-notice path must not vanish silently under the parse swallow.
         """
+        # Providers without response-side billing headers refresh account-window
+        # notices in a daemon thread. The TTL/in-flight gates keep this call cheap.
+        self._refresh_account_usage_notices()
+
         # Dev test fixture (HERMES_DEV_CREDITS_FIXTURE): inject a chosen notice state
         # each turn for repeatable testing, bypassing real headers. Throwaway scaffolding.
         try:
@@ -4155,6 +4159,75 @@ class AIAgent:
 
         # Threshold notices — shared with the cold-start seed (see _emit_credits_notices).
         self._emit_credits_notices()
+
+    def _refresh_account_usage_notices(self) -> bool:
+        """Refresh CommandCode rolling-window notices without blocking a turn."""
+        provider = str(getattr(self, "provider", "") or "").strip().lower()
+        if provider not in {
+            "commandcode",
+            "commandcode-chat",
+            "commandcode-anthropic",
+            "commandcode-claude",
+        }:
+            return False
+        if not os.environ.get("COMMANDCODE_SESSION_COOKIE"):
+            return False
+        if (
+            getattr(self, "notice_callback", None) is None
+            and getattr(self, "notice_clear_callback", None) is None
+        ) or not self._credits_notices_enabled():
+            return False
+
+        import threading
+        import time
+
+        lock = getattr(self, "_account_usage_refresh_lock", None)
+        if lock is None:
+            lock = self._account_usage_refresh_lock = threading.Lock()
+        with lock:
+            now = time.monotonic()
+            if getattr(self, "_account_usage_refresh_inflight", False):
+                return False
+            if now - getattr(self, "_account_usage_refreshed_at", 0.0) < 300.0:
+                return False
+            self._account_usage_refresh_inflight = True
+            self._account_usage_refreshed_at = now
+
+        def _refresh() -> None:
+            try:
+                from agent.account_usage import (
+                    evaluate_account_usage_notices,
+                    fetch_account_usage,
+                    new_account_usage_notice_latch,
+                )
+
+                snapshot = fetch_account_usage(
+                    provider,
+                    base_url=getattr(self, "base_url", None),
+                    api_key=getattr(self, "api_key", None),
+                )
+                if snapshot is None:
+                    return
+                latch = getattr(self, "_account_usage_notice_latch", None)
+                if latch is None:
+                    latch = self._account_usage_notice_latch = new_account_usage_notice_latch()
+                to_show, to_clear = evaluate_account_usage_notices(snapshot, latch)
+                for key in to_clear:
+                    self._emit_notice_clear(key)
+                for notice in to_show:
+                    self._emit_notice(notice)
+            except Exception:
+                logger.debug("provider account usage notice refresh failed", exc_info=True)
+            finally:
+                with lock:
+                    self._account_usage_refresh_inflight = False
+
+        threading.Thread(
+            target=_refresh,
+            name="account-usage-refresh",
+            daemon=True,
+        ).start()
+        return True
 
     def _emit_credits_notices(self) -> None:
         """Run the threshold policy on the current credits state and emit notices.

--- a/run_agent.py
+++ b/run_agent.py
@@ -4169,13 +4169,16 @@ class AIAgent:
             "commandcode-anthropic",
             "commandcode-claude",
         }:
+            self._clear_account_usage_notices()
             return False
         if not os.environ.get("COMMANDCODE_SESSION_COOKIE"):
+            self._clear_account_usage_notices()
             return False
         if (
             getattr(self, "notice_callback", None) is None
             and getattr(self, "notice_clear_callback", None) is None
         ) or not self._credits_notices_enabled():
+            self._clear_account_usage_notices()
             return False
 
         import threading
@@ -4207,15 +4210,30 @@ class AIAgent:
                     api_key=getattr(self, "api_key", None),
                 )
                 if snapshot is None:
+                    self._clear_account_usage_notices()
                     return
-                latch = getattr(self, "_account_usage_notice_latch", None)
-                if latch is None:
-                    latch = self._account_usage_notice_latch = new_account_usage_notice_latch()
-                to_show, to_clear = evaluate_account_usage_notices(snapshot, latch)
-                for key in to_clear:
-                    self._emit_notice_clear(key)
-                for notice in to_show:
-                    self._emit_notice(notice)
+                with lock:
+                    # A fallback/model switch or cookie removal can race the
+                    # network request. Never publish the old provider's result
+                    # after the current runtime has left that account.
+                    if (
+                        str(getattr(self, "provider", "") or "").strip().lower()
+                        != provider
+                        or not os.environ.get("COMMANDCODE_SESSION_COOKIE")
+                        or not self._credits_notices_enabled()
+                    ):
+                        return
+                    latch = getattr(self, "_account_usage_notice_latch", None)
+                    if latch is None:
+                        latch = self._account_usage_notice_latch = (
+                            new_account_usage_notice_latch()
+                        )
+                    to_show, to_clear = evaluate_account_usage_notices(snapshot, latch)
+                    # Keep clear/show ordering serialized with lifecycle cleanup.
+                    for key in to_clear:
+                        self._emit_notice_clear(key)
+                    for notice in to_show:
+                        self._emit_notice(notice)
             except Exception:
                 logger.debug("provider account usage notice refresh failed", exc_info=True)
             finally:
@@ -4228,6 +4246,23 @@ class AIAgent:
             daemon=True,
         ).start()
         return True
+
+    def _clear_account_usage_notices(self) -> bool:
+        """Clear provider-account sticky notices and discard their latch."""
+        import threading
+
+        lock = getattr(self, "_account_usage_refresh_lock", None)
+        if lock is None:
+            lock = self._account_usage_refresh_lock = threading.Lock()
+        with lock:
+            latch = getattr(self, "_account_usage_notice_latch", None)
+            if not isinstance(latch, dict):
+                return False
+            active = list(latch.get("active", ()))
+            self._account_usage_notice_latch = None
+            for key in active:
+                self._emit_notice_clear(key)
+        return bool(active)
 
     def _emit_credits_notices(self) -> None:
         """Run the threshold policy on the current credits state and emit notices.

--- a/tests/plugins/model_providers/test_commandcode_profile.py
+++ b/tests/plugins/model_providers/test_commandcode_profile.py
@@ -232,3 +232,118 @@ class TestCommandCodeModelFiltering:
         assert "startswith(\"claude-\")" in source or '"claude-" in m' in source, (
             "CommandCodeAnthropicProfile.fetch_models should filter to claude-* models"
         )
+
+
+class TestCommandCodeAccountUsage:
+    def test_cookie_header_sends_only_recognized_session_cookie(self):
+        from plugins.model_providers.commandcode import _commandcode_cookie_header
+
+        raw = "analytics=do-not-send; __Secure-commandcode_prod_.session_token=abc==; other=secret"
+        assert (
+            _commandcode_cookie_header(raw)
+            == "__Secure-commandcode_prod_.session_token=abc=="
+        )
+        assert _commandcode_cookie_header("bare-token") == (
+            "__Secure-better-auth.session_token=bare-token"
+        )
+        assert _commandcode_cookie_header("analytics=only") is None
+        assert _commandcode_cookie_header("token\r\nInjected: yes") is None
+
+    def test_fetch_account_usage_maps_windows_monthly_plan_and_alias(
+        self, monkeypatch
+    ):
+        import sys
+
+        from agent.account_usage import fetch_account_usage
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("commandcode")
+        assert profile is not None
+        module = sys.modules[profile.__class__.__module__]
+
+        calls = []
+
+        def fake_get(url, cookie_header, timeout):
+            calls.append((url, cookie_header, timeout))
+            if url.endswith("/credits"):
+                return {
+                    "credits": {
+                        "monthlyCredits": 7.5,
+                        "purchasedCredits": 2,
+                        "premiumMonthlyCredits": 0,
+                        "opensourceMonthlyCredits": 0,
+                    },
+                    "windowLimits": {
+                        "fiveHour": {
+                            "cap": "4",
+                            "used": "3",
+                            "resetAt": 1_900_000_000,
+                        },
+                        "weekly": {
+                            "cap": 20,
+                            "used": 5,
+                            "resetAt": 1_900_500_000_000,
+                        },
+                    },
+                }
+            return {
+                "success": True,
+                "data": {
+                    "planId": "individual-pro",
+                    "status": "active",
+                    "currentPeriodEnd": "2030-03-01T00:00:00.000Z",
+                },
+            }
+
+        monkeypatch.setenv(
+            "COMMANDCODE_SESSION_COOKIE",
+            "analytics=no; __Secure-commandcode_prod_.session_token=valid; unrelated=no",
+        )
+        monkeypatch.setattr(module, "_commandcode_get_json", fake_get)
+
+        snapshot = fetch_account_usage("commandcode-claude")
+
+        assert snapshot is not None
+        assert snapshot.provider == "commandcode"
+        assert snapshot.plan == "Pro"
+        assert [window.label for window in snapshot.windows] == [
+            "5-hour limit",
+            "Weekly limit",
+            "Monthly credits",
+        ]
+        assert snapshot.windows[0].used_percent == 75.0
+        assert snapshot.windows[1].used_percent == 25.0
+        assert snapshot.windows[2].used_percent == 75.0
+        assert snapshot.windows[2].detail == "$7.50 of $30.00 remaining"
+        assert snapshot.details == ("Purchased credits: $2.00",)
+        assert all(
+            cookie == "__Secure-commandcode_prod_.session_token=valid"
+            for _, cookie, _ in calls
+        )
+
+    def test_fetch_account_usage_requires_session_cookie(self, monkeypatch):
+        import sys
+
+        from agent.account_usage import fetch_account_usage
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("commandcode")
+        assert profile is not None
+        module = sys.modules[profile.__class__.__module__]
+
+        monkeypatch.delenv("COMMANDCODE_SESSION_COOKIE", raising=False)
+        monkeypatch.setattr(
+            module,
+            "_commandcode_get_json",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("billing endpoint must not be called")
+            ),
+        )
+        assert fetch_account_usage("commandcode") is None
+
+    def test_session_cookie_is_catalogued_as_secret(self):
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+
+        entry = OPTIONAL_ENV_VARS["COMMANDCODE_SESSION_COOKIE"]
+        assert entry["password"] is True
+        assert entry["category"] == "provider"

--- a/tests/run_agent/test_commandcode_account_usage_notices.py
+++ b/tests/run_agent/test_commandcode_account_usage_notices.py
@@ -60,6 +60,60 @@ def test_commandcode_notice_refresh_requires_cookie_and_consumer(monkeypatch):
     assert agent._refresh_account_usage_notices() is False
 
 
+def test_commandcode_notice_clears_when_provider_changes(monkeypatch):
+    agent = _bare_commandcode_agent()
+    shown = []
+    cleared = []
+    agent.notice_callback = shown.append
+    agent.notice_clear_callback = cleared.append
+    snapshot = AccountUsageSnapshot(
+        provider="commandcode",
+        source="test",
+        fetched_at=datetime.now(timezone.utc),
+        windows=(AccountUsageWindow(label="5-hour limit", used_percent=91),),
+    )
+
+    monkeypatch.setenv("COMMANDCODE_SESSION_COOKIE", "session-token")
+    monkeypatch.setattr("threading.Thread", _ImmediateThread)
+    monkeypatch.setattr(
+        "agent.account_usage.fetch_account_usage", lambda *args, **kwargs: snapshot
+    )
+
+    assert agent._refresh_account_usage_notices() is True
+    agent.provider = "openrouter"
+    assert agent._refresh_account_usage_notices() is False
+    assert cleared == ["account_usage.commandcode.5-hour-limit"]
+
+
+def test_commandcode_notice_clears_when_refresh_becomes_unavailable(monkeypatch):
+    agent = _bare_commandcode_agent()
+    shown = []
+    cleared = []
+    agent.notice_callback = shown.append
+    agent.notice_clear_callback = cleared.append
+    snapshots = [
+        AccountUsageSnapshot(
+            provider="commandcode",
+            source="test",
+            fetched_at=datetime.now(timezone.utc),
+            windows=(AccountUsageWindow(label="Weekly limit", used_percent=91),),
+        ),
+        None,
+    ]
+
+    monkeypatch.setenv("COMMANDCODE_SESSION_COOKIE", "session-token")
+    monkeypatch.setattr("threading.Thread", _ImmediateThread)
+    monkeypatch.setattr(
+        "agent.account_usage.fetch_account_usage",
+        lambda *args, **kwargs: snapshots.pop(0),
+    )
+
+    assert agent._refresh_account_usage_notices() is True
+    agent._account_usage_refreshed_at = 0.0
+    assert agent._refresh_account_usage_notices() is True
+    assert cleared == ["account_usage.commandcode.weekly-limit"]
+
+
 def test_commandcode_cold_start_routes_to_account_usage_refresh():
     from agent.credits_tracker import seed_credits_at_session_start
 

--- a/tests/run_agent/test_commandcode_account_usage_notices.py
+++ b/tests/run_agent/test_commandcode_account_usage_notices.py
@@ -22,6 +22,7 @@ def _bare_commandcode_agent():
     agent.notice_callback = None
     agent.notice_clear_callback = None
     agent._credits_notices_enabled = lambda: True
+    agent._account_usage_refreshed_at = None
     return agent
 
 
@@ -39,6 +40,7 @@ def test_commandcode_notice_refresh_is_backgrounded_and_ttl_cached(monkeypatch):
     )
 
     monkeypatch.setenv("COMMANDCODE_SESSION_COOKIE", "session-token")
+    monkeypatch.setattr("time.monotonic", lambda: 100.0)
     monkeypatch.setattr("threading.Thread", _ImmediateThread)
     monkeypatch.setattr("agent.account_usage.fetch_account_usage", lambda *args, **kwargs: snapshot)
 
@@ -109,7 +111,7 @@ def test_commandcode_notice_clears_when_refresh_becomes_unavailable(monkeypatch)
     )
 
     assert agent._refresh_account_usage_notices() is True
-    agent._account_usage_refreshed_at = 0.0
+    agent._account_usage_refreshed_at -= 301.0
     assert agent._refresh_account_usage_notices() is True
     assert cleared == ["account_usage.commandcode.weekly-limit"]
 

--- a/tests/run_agent/test_commandcode_account_usage_notices.py
+++ b/tests/run_agent/test_commandcode_account_usage_notices.py
@@ -1,0 +1,78 @@
+from datetime import datetime, timezone
+
+from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
+from run_agent import AIAgent
+
+
+class _ImmediateThread:
+    def __init__(self, *, target, name, daemon):
+        self.target = target
+        self.name = name
+        self.daemon = daemon
+
+    def start(self):
+        self.target()
+
+
+def _bare_commandcode_agent():
+    agent = object.__new__(AIAgent)
+    agent.provider = "commandcode"
+    agent.base_url = "https://api.commandcode.ai/provider/v1"
+    agent.api_key = "api-key-is-not-used-for-billing"
+    agent.notice_callback = None
+    agent.notice_clear_callback = None
+    agent._credits_notices_enabled = lambda: True
+    return agent
+
+
+def test_commandcode_notice_refresh_is_backgrounded_and_ttl_cached(monkeypatch):
+    agent = _bare_commandcode_agent()
+    shown = []
+    cleared = []
+    agent.notice_callback = shown.append
+    agent.notice_clear_callback = cleared.append
+    snapshot = AccountUsageSnapshot(
+        provider="commandcode",
+        source="test",
+        fetched_at=datetime.now(timezone.utc),
+        windows=(AccountUsageWindow(label="5-hour limit", used_percent=91),),
+    )
+
+    monkeypatch.setenv("COMMANDCODE_SESSION_COOKIE", "session-token")
+    monkeypatch.setattr("threading.Thread", _ImmediateThread)
+    monkeypatch.setattr("agent.account_usage.fetch_account_usage", lambda *args, **kwargs: snapshot)
+
+    assert agent._refresh_account_usage_notices() is True
+    assert [notice.key for notice in shown] == [
+        "account_usage.commandcode.5-hour-limit"
+    ]
+    assert cleared == []
+    assert agent._refresh_account_usage_notices() is False
+    assert len(shown) == 1
+
+
+def test_commandcode_notice_refresh_requires_cookie_and_consumer(monkeypatch):
+    agent = _bare_commandcode_agent()
+    monkeypatch.delenv("COMMANDCODE_SESSION_COOKIE", raising=False)
+    assert agent._refresh_account_usage_notices() is False
+
+    monkeypatch.setenv("COMMANDCODE_SESSION_COOKIE", "session-token")
+    assert agent._refresh_account_usage_notices() is False
+
+
+def test_commandcode_cold_start_routes_to_account_usage_refresh():
+    from agent.credits_tracker import seed_credits_at_session_start
+
+    class FakeAgent:
+        provider = "commandcode-anthropic"
+
+        def __init__(self):
+            self.calls = 0
+
+        def _refresh_account_usage_notices(self):
+            self.calls += 1
+            return True
+
+    agent = FakeAgent()
+    assert seed_credits_at_session_start(agent) is True
+    assert agent.calls == 1

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -3,7 +3,9 @@ from datetime import datetime, timezone
 from agent.account_usage import (
     AccountUsageSnapshot,
     AccountUsageWindow,
+    evaluate_account_usage_notices,
     fetch_account_usage,
+    new_account_usage_notice_latch,
     render_account_usage_lines,
 )
 
@@ -201,3 +203,49 @@ def test_fetch_account_usage_openrouter_omits_quota_window_when_key_has_no_limit
     assert snapshot.windows == ()
     assert "Credits balance: $74.50" in snapshot.details
     assert "API key usage: $25.50 total • $1.25 today • $4.50 this week • $18.00 this month" in snapshot.details
+
+
+def test_account_usage_notices_emit_on_band_changes_and_clear_on_recovery():
+    latch = new_account_usage_notice_latch()
+
+    def snapshot(used):
+        return AccountUsageSnapshot(
+            provider="commandcode",
+            source="test",
+            fetched_at=datetime.now(timezone.utc),
+            windows=(AccountUsageWindow(label="5-hour limit", used_percent=used),),
+        )
+
+    show, clear = evaluate_account_usage_notices(snapshot(74), latch)
+    assert show == [] and clear == []
+    show, clear = evaluate_account_usage_notices(snapshot(75), latch)
+    assert [notice.key for notice in show] == ["account_usage.commandcode.5-hour-limit"]
+    assert show[0].level == "warn" and clear == []
+    show, clear = evaluate_account_usage_notices(snapshot(80), latch)
+    assert show == [] and clear == []
+    show, clear = evaluate_account_usage_notices(snapshot(91), latch)
+    assert [notice.key for notice in show] == ["account_usage.commandcode.5-hour-limit"]
+    assert clear == ["account_usage.commandcode.5-hour-limit"]
+    show, clear = evaluate_account_usage_notices(snapshot(20), latch)
+    assert show == []
+    assert clear == ["account_usage.commandcode.5-hour-limit"]
+
+
+def test_render_account_usage_lines_keeps_reset_and_credit_detail():
+    reset = datetime.fromtimestamp(1_900_000_000, tz=timezone.utc)
+    snapshot = AccountUsageSnapshot(
+        provider="commandcode",
+        source="test",
+        fetched_at=datetime.now(timezone.utc),
+        windows=(
+            AccountUsageWindow(
+                label="Monthly credits",
+                used_percent=25,
+                reset_at=reset,
+                detail="$22.50 of $30.00 remaining",
+            ),
+        ),
+    )
+    line = render_account_usage_lines(snapshot)[2]
+    assert "resets" in line
+    assert "$22.50 of $30.00 remaining" in line

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -39,7 +39,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Xiaomi MiMo** | `XIAOMI_API_KEY` in `~/.hermes/.env` (provider: `xiaomi`, aliases: `mimo`, `xiaomi-mimo`) |
 | **Tencent TokenHub** | `TOKENHUB_API_KEY` in `~/.hermes/.env` (provider: `tencent-tokenhub`, aliases: `tencent`, `tokenhub`, `tencentmaas`) |
 | **OpenCode Zen** | `OPENCODE_ZEN_API_KEY` in `~/.hermes/.env` (provider: `opencode-zen`) |
-| **CommandCode** | `COMMANDCODE_API_KEY` in `~/.hermes/.env` (provider: `commandcode`, alias: `commandcode-chat`; Claude models via `commandcode-anthropic`, alias: `commandcode-claude`). Works with GOAT/Pro/Max/Provider plans (not the $1 Go plan — no API access). |
+| **CommandCode** | `COMMANDCODE_API_KEY` in `~/.hermes/.env` (provider: `commandcode`, alias: `commandcode-chat`; Claude models via `commandcode-anthropic`, alias: `commandcode-claude`). Works with GOAT/Pro/Max/Provider plans (not the $1 Go plan — no API access). To show provider-side credits and rolling windows in `/usage`, also set the secret `COMMANDCODE_SESSION_COOKIE` to the signed-in web session token or a copied `Cookie` header; Hermes sends only the recognized CommandCode session cookie. |
 | **OpenCode Go** | `OPENCODE_GO_API_KEY` in `~/.hermes/.env` (provider: `opencode-go`) |
 | **DeepSeek** | `DEEPSEEK_API_KEY` in `~/.hermes/.env` (provider: `deepseek`) |
 | **Hugging Face** | `HF_TOKEN` in `~/.hermes/.env` (provider: `huggingface`, aliases: `hf`) |


### PR DESCRIPTION
## What does this PR do?

CommandCode users can now see provider-side monthly credits and rolling 5-hour and weekly limits in the existing `/usage` output. Optional background notices also warn when a configured account crosses existing usage thresholds, so long-running sessions can react before reaching a provider limit. The feature uses the provider profile extension point and is inactive unless a CommandCode web session cookie is configured.

### Motivation

`/usage` currently reports local token and Nous credit data for CommandCode sessions but cannot show the provider account limits that govern those sessions. Users running long agent tasks therefore have no in-session view of their monthly balance or rolling-window consumption.

### Behavior

When `COMMANDCODE_SESSION_COOKIE` is configured, CLI and gateway `/usage` surfaces include the CommandCode plan, monthly remaining credits, and any available 5-hour or weekly usage windows with reset times. A pasted Cookie header is reduced to one recognized CommandCode or better-auth session cookie before any request is sent; unrelated cookies are never forwarded. Missing credentials, malformed responses, and unavailable billing endpoints degrade silently to the existing usage view.

With `display.credits_notices` enabled, CommandCode window notices refresh asynchronously at session startup and response boundaries. Refreshes are TTL-cached and deduplicated by threshold band, and stale notices are cleared when the provider, account availability, or notice setting changes. Automatic browser-cookie extraction is intentionally out of scope.

### Implementation

The provider profile interface now offers an optional account-usage hook, implemented by CommandCode against its billing credits and subscription endpoints. CommandCode responses are normalized into the existing `AccountUsageSnapshot` and `AccountUsageWindow` model, so shared CLI and gateway renderers need no provider-specific branch. The agent schedules bounded background refreshes and reuses the existing credit-notice policy and latch semantics.

## Related Issue

Closes #89373

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `providers/base.py` and `agent/account_usage.py` - add optional provider-profile account usage dispatch.
- `plugins/model-providers/commandcode/__init__.py` - sanitize session cookies, fetch billing data, and map plan, monthly credit, and rolling-window details.
- `run_agent.py`, `agent/agent_init.py`, and `agent/credits_tracker.py` - refresh and reconcile non-blocking CommandCode threshold notices.
- `hermes_cli/config_defaults.py` and `website/docs/integrations/providers.md` - register and document the password-masked session secret.
- Targeted account-usage, CommandCode provider, notice lifecycle, and gateway tests - cover mapping, sanitization, dispatch, scheduling, deduplication, and stale-notice cleanup.

## How to Test

1. Configure `COMMANDCODE_SESSION_COOKIE` with a CommandCode web session token or Cookie header, select a CommandCode provider, and run `/usage`.
2. Confirm monthly credits and available 5-hour and weekly windows render with reset details; remove the cookie or switch providers and confirm stale provider notices clear.
3. Run the relevant automated suite:

```bash
scripts/run_tests.sh tests/test_account_usage.py tests/agent/test_account_usage.py tests/plugins/model_providers/test_commandcode_profile.py tests/run_agent/test_commandcode_account_usage_notices.py tests/run_agent/test_credits_notices_toggle.py tests/agent/test_credits_cold_start.py tests/agent/test_credits_tracker.py tests/agent/test_credits_policy.py tests/agent/test_credits_view.py tests/agent/test_nous_credits_snapshot.py tests/agent/test_nous_credits_gauge.py tests/gateway/test_usage_command.py
```

Result: 155 passed on the reviewed tip. Ruff checks and `git diff --check` also passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run the repository test entry point on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested the changed behavior with the targeted suite on Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` is N/A because this adds a secret environment variable, not a config key
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no contributor workflow changes
- [x] I've considered cross-platform impact; the implementation uses Python standard-library HTTP and platform-neutral session configuration
- [x] Tool descriptions and schemas are N/A because no model tool changed
