### PR TITLE
fix(kanban): guard idempotent and workspace claims

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3393,21 +3393,6 @@ def create_task(
             )
         skills_list = cleaned
 
-    # Idempotency check — return the existing task instead of creating a
-    # duplicate. Done BEFORE entering write_txn to keep the fast path fast
-    # and to avoid holding a write lock during the lookup. Race is
-    # acceptable: two concurrent creators with the same key might both
-    # insert, at which point both rows exist but the next lookup stabilises.
-    if idempotency_key:
-        row = conn.execute(
-            "SELECT id FROM tasks WHERE idempotency_key = ? "
-            "AND status != 'archived' "
-            "ORDER BY created_at DESC LIMIT 1",
-            (idempotency_key,),
-        ).fetchone()
-        if row:
-            return row["id"]
-
     now = int(time.time())
 
     # Resolve workspace_path from board-level default_workdir when the
@@ -3438,6 +3423,20 @@ def create_task(
             # compose create_task calls under one outer commit so the
             # dispatcher can never observe a partially constructed graph.
             with write_txn(conn, allow_nested=True):
+                # Check idempotency after BEGIN IMMEDIATE so concurrent
+                # creators serialize before either can insert a duplicate.
+                # Archived rows intentionally do not satisfy the lookup: an
+                # archived request may be created again.
+                if idempotency_key:
+                    row = conn.execute(
+                        "SELECT id FROM tasks WHERE idempotency_key = ? "
+                        "AND status != 'archived' "
+                        "ORDER BY created_at DESC LIMIT 1",
+                        (idempotency_key,),
+                    ).fetchone()
+                    if row:
+                        return row["id"]
+
                 # Determine task status from parent status, unless the caller
                 # parks it directly in blocked for human-ops review or in
                 # triage for a specifier.
@@ -4614,6 +4613,114 @@ def _parents_satisfied(conn: sqlite3.Connection, task_id: str) -> bool:
     ).fetchone() is None
 
 
+def _case_insensitive_filesystem(path: str) -> bool:
+    """Return whether the volume containing ``path`` aliases by case.
+
+    Missing workspace paths cannot be compared with ``samefile`` directly.
+    On macOS, ``pathconf(_PC_CASE_SENSITIVE)`` reports the case policy of the
+    volume containing the nearest existing ancestor. This matters for a
+    mounted case-sensitive volume below a case-insensitive ``/Volumes``
+    namespace: probing the mountpoint's spelling would report the parent
+    namespace instead of the mounted volume. Other platforms retain the
+    bounded samefile probe as a conservative fallback.
+    """
+    probe = os.path.abspath(path)
+    for _ in range(64):
+        if os.path.exists(probe):
+            break
+        parent = os.path.dirname(probe)
+        if parent == probe:
+            return False
+        probe = parent
+
+    if sys.platform == "darwin":
+        try:
+            # Darwin exposes _PC_CASE_SENSITIVE as pathconf name 11. Python's
+            # os.pathconf_names omits Darwin-only names, but the integer API
+            # remains available and returns 1 for case-sensitive volumes.
+            case_sensitive = os.pathconf(probe, 11)
+            if case_sensitive in (0, 1):
+                return case_sensitive == 0
+        except (OSError, ValueError):
+            pass
+
+    for _ in range(64):
+        if os.path.exists(probe):
+            name = os.path.basename(os.path.normpath(probe))
+            alternate_name = name.swapcase()
+            if alternate_name != name:
+                alternate = os.path.join(
+                    os.path.dirname(probe), alternate_name,
+                )
+                try:
+                    return os.path.samefile(probe, alternate)
+                except OSError:
+                    return False
+        parent = os.path.dirname(probe)
+        if parent == probe:
+            break
+        probe = parent
+    return False
+
+
+def _canonical_explicit_workspace(path: Optional[str]) -> Optional[frozenset[tuple]]:
+    """Canonicalize a persistent workspace for collision checks only.
+
+    ``realpath`` deliberately uses ``strict=False`` semantics: a deleted
+    workspace still compares equal by its path, and symlink aliases resolve to
+    the same target. Existing paths also carry their filesystem identity so
+    case aliases compare equal on case-insensitive filesystems without
+    folding paths on case-sensitive filesystems. The stored user path is
+    never rewritten.
+    """
+    if not path:
+        return None
+    try:
+        canonical = os.path.realpath(
+            os.path.abspath(os.path.expanduser(str(path)))
+        )
+    except (OSError, TypeError, ValueError):
+        return None
+    identities: set[tuple] = {("path", canonical)}
+    try:
+        stat = os.stat(canonical)
+    except OSError:
+        stat = None
+    if stat is not None and stat.st_dev and stat.st_ino:
+        identities.add(("inode", int(stat.st_dev), int(stat.st_ino)))
+    elif _case_insensitive_filesystem(canonical):
+        identities.add(("casefolded-path", canonical.casefold()))
+    return frozenset(identities)
+
+
+def _workspace_conflict_task_id(
+    conn: sqlite3.Connection, task_id: str,
+) -> Optional[str]:
+    """Return the active writer occupying a candidate's persistent workspace."""
+    candidate = conn.execute(
+        "SELECT workspace_kind, workspace_path FROM tasks "
+        "WHERE id = ? AND status IN ('ready', 'review') AND claim_lock IS NULL",
+        (task_id,),
+    ).fetchone()
+    if candidate is None or candidate["workspace_kind"] == "scratch":
+        return None
+    candidate_path = _canonical_explicit_workspace(candidate["workspace_path"])
+    if candidate_path is None:
+        return None
+
+    active = conn.execute(
+        "SELECT id, workspace_path FROM tasks "
+        "WHERE id != ? AND status = 'running' AND claim_lock IS NOT NULL "
+        "AND workspace_kind != 'scratch' AND workspace_path IS NOT NULL",
+        (task_id,),
+    ).fetchall()
+    for row in active:
+        active_path = _canonical_explicit_workspace(row["workspace_path"])
+        if active_path is not None and candidate_path & active_path:
+            return row["id"]
+    return None
+
+
 def claim_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4653,6 +4760,15 @@ def claim_task(
             _append_event(
                 conn, task_id, "claim_rejected",
                 {"reason": "parents_not_done"},
+            )
+            return None
+        conflict_task_id = _workspace_conflict_task_id(conn, task_id)
+        if conflict_task_id is not None:
+            _append_event(
+                conn,
+                task_id,
+                "workspace_busy",
+                {"conflicting_task_id": conflict_task_id},
             )
             return None
         # Defensive: if a prior run somehow leaked (invariant violation from
@@ -4774,6 +4890,15 @@ def claim_review_task(
                         "source_status": "review",
                     },
                 )
+            return None
+        conflict_task_id = _workspace_conflict_task_id(conn, task_id)
+        if conflict_task_id is not None:
+            _append_event(
+                conn,
+                task_id,
+                "workspace_busy",
+                {"conflicting_task_id": conflict_task_id},
+            )
             return None
         cur = conn.execute(
             """
@@ -8049,6 +8174,9 @@ class DispatchResult:
     subsequent tick when the assignee has capacity. Separate bucket so
     telemetry / dashboards can show "this profile is busy" vs
     "task is genuinely stuck"."""
+    workspace_busy: list[tuple[str, str]] = field(default_factory=list)
+    """Tasks deferred because an active writer holds the same canonical
+    persistent workspace, as ``(task_id, conflicting_task_id)`` pairs."""
     crashed: list[str] = field(default_factory=list)
     """Task ids reclaimed because their worker PID disappeared."""
     auto_blocked: list[str] = field(default_factory=list)
@@ -10215,17 +10343,20 @@ def _dispatch_once_locked(
                         {"reason": guard_reason},
                     )
             continue
+        workspace_conflict = _workspace_conflict_task_id(conn, row["id"])
+        if workspace_conflict is not None:
+            result.workspace_busy.append((row["id"], workspace_conflict))
         if dry_run:
-            result.spawned.append((row["id"], row_assignee, ""))
-            spawned += 1
-            # Increment per-profile counter even in dry_run so the cap
-            # check sees the would-be spawn on subsequent iterations.
-            # Without this, dry_run reports every task as spawnable and
-            # under-reports the capped subset (#21582).
-            if _per_profile_cap is not None and row_assignee:
-                _per_profile_running[row_assignee] = (
-                    _per_profile_running.get(row_assignee, 0) + 1
-                )
+            if workspace_conflict is None:
+                result.spawned.append((row["id"], row_assignee, ""))
+                # Increment per-profile counter even in dry_run so the cap
+                # check sees the would-be spawn on subsequent iterations.
+                # Without this, dry_run reports every task as spawnable and
+                # under-reports the capped subset (#21582).
+                if _per_profile_cap is not None and row_assignee:
+                    _per_profile_running[row_assignee] = (
+                        _per_profile_running.get(row_assignee, 0) + 1
+                    )
             continue
         claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
@@ -10328,6 +10459,18 @@ def _dispatch_once_locked(
             profile_exists = None  # type: ignore[assignment]
         if profile_exists is not None and not profile_exists(row["assignee"]):
             result.skipped_nonspawnable.append(row["id"])
+            continue
+        workspace_conflict = _workspace_conflict_task_id(conn, row["id"])
+        if workspace_conflict is not None:
+            result.workspace_busy.append((row["id"], workspace_conflict))
+            if not dry_run:
+                with write_txn(conn):
+                    _append_event(
+                        conn,
+                        row["id"],
+                        "workspace_busy",
+                        {"conflicting_task_id": workspace_conflict},
+                    )
             continue
         if _per_profile_cap is not None:
             current = _per_profile_running.get(row["assignee"], 0)

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -7,6 +7,7 @@ import os
 import sqlite3
 import subprocess
 import sys
+import threading
 import time
 import types
 import unittest.mock
@@ -170,6 +171,540 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
 # Task creation + status inference
 # ---------------------------------------------------------------------------
 
+def test_concurrent_idempotent_creators_return_one_non_archived_task(
+    kanban_home, monkeypatch,
+):
+    """Concurrent creators must converge on one task inside the write txn."""
+    ready = threading.Barrier(2)
+    original_new_task_id = kb._new_task_id
+
+    def synchronized_new_task_id():
+        ready.wait(timeout=5)
+        return original_new_task_id()
+
+    monkeypatch.setattr(kb, "_new_task_id", synchronized_new_task_id)
+
+    def create_one():
+        conn = kb.connect()
+        try:
+            return kb.create_task(
+                conn,
+                title="same request",
+                assignee="worker",
+                tenant="tenant-a",
+                idempotency_key="request-123",
+            )
+        finally:
+            conn.close()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        task_ids = list(pool.map(lambda _unused: create_one(), range(2)))
+
+    assert task_ids[0] == task_ids[1]
+    with kb.connect() as conn:
+        assert conn.execute(
+            "SELECT COUNT(*) FROM tasks WHERE idempotency_key = ? "
+            "AND status != 'archived'",
+            ("request-123",),
+        ).fetchone()[0] == 1
+
+
+def test_archived_idempotency_key_can_be_created_again(kanban_home):
+    with kb.connect() as conn:
+        first = kb.create_task(
+            conn,
+            title="archived request",
+            assignee="worker",
+            idempotency_key="archive-and-retry",
+        )
+        assert kb.claim_task(conn, first, claimer="writer:first") is not None
+        assert kb.complete_task(conn, first, result="done") is True
+        assert kb.archive_task(conn, first) is True
+
+        second = kb.create_task(
+            conn,
+            title="retried request",
+            assignee="worker",
+            idempotency_key="archive-and-retry",
+        )
+        assert second != first
+        second_task = kb.get_task(conn, second)
+        assert second_task is not None
+        assert second_task.status == "ready"
+
+
+# ---------------------------------------------------------------------------
+# Claim / workspace isolation
+# ---------------------------------------------------------------------------
+def test_claim_defers_second_writer_on_same_explicit_workspace(
+    kanban_home, tmp_path,
+):
+    shared = tmp_path / "shared-workspace"
+    shared.mkdir()
+
+    with kb.connect() as conn:
+        first = kb.create_task(
+            conn,
+            title="first writer",
+            assignee="worker",
+            workspace_kind="dir",
+            workspace_path=str(shared),
+        )
+        second = kb.create_task(
+            conn,
+            title="second writer",
+            assignee="worker",
+            workspace_kind="dir",
+            workspace_path=str(shared),
+        )
+
+        assert kb.claim_task(conn, first, claimer="writer:first") is not None
+        assert kb.claim_task(conn, second, claimer="writer:second") is None
+        second_task = kb.get_task(conn, second)
+        assert second_task is not None
+        assert second_task.status == "ready"
+        assert second_task.consecutive_failures == 0
+        events = kb.list_events(conn, second)
+        busy = [event for event in events if event.kind == "workspace_busy"]
+        assert len(busy) == 1
+        assert busy[0].payload == {"conflicting_task_id": first}
+
+
+def test_case_aliases_conflict_on_case_insensitive_filesystem(
+    kanban_home, tmp_path,
+):
+    target = tmp_path / "CaseProbe"
+    target.mkdir()
+    alias = tmp_path / "caseprobe"
+    if not os.path.exists(alias):
+        pytest.skip("filesystem is case-sensitive")
+    assert os.path.samefile(target, alias)
+
+    with kb.connect() as conn:
+        first = kb.create_task(
+            conn,
+            title="case-sensitive spelling",
+            workspace_kind="dir",
+            workspace_path=str(target),
+        )
+        second = kb.create_task(
+            conn,
+            title="case-alias spelling",
+            workspace_kind="dir",
+            workspace_path=str(alias),
+        )
+
+        assert kb.claim_task(conn, first, claimer="writer:first") is not None
+        assert kb.claim_task(conn, second, claimer="writer:second") is None
+        second_task = kb.get_task(conn, second)
+        assert second_task is not None
+        assert second_task.status == "ready"
+
+
+def test_deleted_case_aliases_conflict_on_case_insensitive_filesystem(
+    kanban_home, tmp_path,
+):
+    target = tmp_path / "DeletedCaseProbe"
+    target.mkdir()
+    alias = tmp_path / "deletedcaseprobe"
+    if not os.path.exists(alias):
+        pytest.skip("filesystem is case-sensitive")
+    assert os.path.samefile(target, alias)
+    target.rmdir()
+    assert not target.exists()
+    assert not alias.exists()
+
+    with kb.connect() as conn:
+        first = kb.create_task(
+            conn,
+            title="deleted case-sensitive spelling",
+            workspace_kind="dir",
+            workspace_path=str(target),
+        )
+        second = kb.create_task(
+            conn,
+            title="deleted case-alias spelling",
+            workspace_kind="dir",
+            workspace_path=str(alias),
+        )
+
+        assert kb.claim_task(conn, first, claimer="writer:first") is not None
+        assert kb.claim_task(conn, second, claimer="writer:second") is None
+        second_task = kb.get_task(conn, second)
+        assert second_task is not None
+        assert second_task.status == "ready"
+
+
+def test_dispatch_reports_workspace_busy_without_claiming_second_writer(
+    kanban_home, tmp_path, monkeypatch,
+):
+    shared = tmp_path / "shared-workspace"
+    shared.mkdir()
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda _name: True)
+
+    with kb.connect() as conn:
+        first = kb.create_task(
+            conn,
+            title="first writer",
+            assignee="worker",
+            workspace_kind="dir",
+            workspace_path=str(shared),
+        )
+        second = kb.create_task(
+            conn,
+            title="second writer",
+            assignee="worker",
+            workspace_kind="dir",
+            workspace_path=str(shared),
+        )
+        assert kb.claim_task(conn, first, claimer="writer:first") is not None
+
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda *_args, **_kwargs: pytest.fail(
+                "workspace-busy task must not spawn"
+            ),
+        )
+
+        assert result.workspace_busy == [(second, first)]
+        second_task = kb.get_task(conn, second)
+        assert second_task is not None
+        assert second_task.status == "ready"
+
+
+def test_direct_review_claim_defers_on_busy_workspace(kanban_home, tmp_path):
+    shared = tmp_path / "shared-review-workspace"
+    shared.mkdir()
+
+    with kb.connect() as conn:
+        writer = kb.create_task(
+            conn,
+            title="first writer",
+            assignee="worker",
+            workspace_kind="dir",
+            workspace_path=str(shared),
+        )
+        review = kb.create_task(
+            conn,
+            title="review task",
+            assignee="critic",
+            workspace_kind="dir",
+            workspace_path=str(shared),
+        )
+        conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (review,))
+
+        assert kb.claim_task(conn, writer, claimer="writer:first") is not None
+        assert kb.claim_review_task(conn, review, claimer="critic:review") is None
+
+        review_task = kb.get_task(conn, review)
+        assert review_task is not None
+        assert review_task.status == "review"
+        assert review_task.consecutive_failures == 0
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_runs WHERE task_id = ?", (review,)
+        ).fetchone()[0] == 0
+        busy = [
+            event for event in kb.list_events(conn, review)
+            if event.kind == "workspace_busy"
+        ]
+        assert len(busy) == 1
+        assert busy[0].payload == {"conflicting_task_id": writer}
+
+
+def test_review_dispatch_defers_on_busy_workspace_without_spawning(
+    kanban_home, tmp_path, monkeypatch,
+):
+    shared = tmp_path / "shared-review-workspace"
+    shared.mkdir()
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda _name: True)
+
+    with kb.connect() as conn:
+        writer = kb.create_task(
+            conn,
+            title="first writer",
+            assignee="worker",
+            workspace_kind="dir",
+            workspace_path=str(shared),
+        )
+        review = kb.create_task(
+            conn,
+            title="review task",
+            assignee="critic",
+            workspace_kind="dir",
+            workspace_path=str(shared),
+        )
+        conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (review,))
+        assert kb.claim_task(conn, writer, claimer="writer:first") is not None
+
+        spawned: list[str] = []
+
+        def spawn(task, _workspace):
+            spawned.append(task.id)
+            return 12345
+
+        result = kb.dispatch_once(conn, spawn_fn=spawn)
+
+        assert result.workspace_busy == [(review, writer)]
+        assert spawned == []
+        review_task = kb.get_task(conn, review)
+        assert review_task is not None
+        assert review_task.status == "review"
+        assert review_task.consecutive_failures == 0
+
+
+def test_review_dispatch_claims_after_writer_completion(
+    kanban_home, tmp_path, monkeypatch,
+):
+    shared = tmp_path / "shared-review-workspace"
+    shared.mkdir()
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda _name: True)
+
+    with kb.connect() as conn:
+        writer = kb.create_task(
+            conn,
+            title="first writer",
+            assignee="worker",
+            workspace_kind="dir",
+            workspace_path=str(shared),
+        )
+        review = kb.create_task(
+            conn,
+            title="review task",
+            assignee="critic",
+            workspace_kind="dir",
+            workspace_path=str(shared),
+        )
+        conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (review,))
+        assert kb.claim_task(conn, writer, claimer="writer:first") is not None
+        assert kb.complete_task(conn, writer, result="done") is True
+
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda task, _workspace: 12345,
+        )
+
+        assert result.workspace_busy == []
+        assert result.spawned == [(review, "critic", str(shared))]
+        review_task = kb.get_task(conn, review)
+        assert review_task is not None
+        assert review_task.status == "running"
+
+
+def test_case_sensitive_existing_missing_and_deleted_variants_remain_distinct(
+    kanban_home, tmp_path,
+):
+    existing = tmp_path / "CaseProbe"
+    existing.mkdir()
+    existing_alias = tmp_path / "caseprobe"
+    if os.path.exists(existing_alias):
+        pytest.skip("filesystem is case-insensitive")
+
+    missing = tmp_path / "MissingCaseProbe"
+    missing_alias = tmp_path / "missingcaseprobe"
+    deleted = tmp_path / "DeletedCaseProbe"
+    deleted.mkdir()
+    deleted_alias = tmp_path / "deletedcaseprobe"
+    deleted.rmdir()
+    assert not deleted.exists()
+    assert not deleted_alias.exists()
+
+    with kb.connect() as conn:
+        existing_task = kb.create_task(
+            conn,
+            title="existing case-sensitive spelling",
+            workspace_kind="dir",
+            workspace_path=str(existing),
+        )
+        existing_alias_task = kb.create_task(
+            conn,
+            title="existing case-distinct spelling",
+            workspace_kind="dir",
+            workspace_path=str(existing_alias),
+        )
+        missing_task = kb.create_task(
+            conn,
+            title="missing case-sensitive spelling",
+            workspace_kind="dir",
+            workspace_path=str(missing),
+        )
+        missing_alias_task = kb.create_task(
+            conn,
+            title="missing case-distinct spelling",
+            workspace_kind="dir",
+            workspace_path=str(missing_alias),
+        )
+        deleted_task = kb.create_task(
+            conn,
+            title="deleted case-sensitive spelling",
+            workspace_kind="dir",
+            workspace_path=str(deleted),
+        )
+        deleted_alias_task = kb.create_task(
+            conn,
+            title="deleted case-distinct spelling",
+            workspace_kind="dir",
+            workspace_path=str(deleted_alias),
+        )
+
+        for task_id in (
+            existing_task,
+            existing_alias_task,
+            missing_task,
+            missing_alias_task,
+            deleted_task,
+            deleted_alias_task,
+        ):
+            assert kb.claim_task(conn, task_id, claimer=f"writer:{task_id}") is not None
+
+
+def test_workspace_alias_and_deleted_paths_still_conflict(
+    kanban_home, tmp_path,
+):
+    target = tmp_path / "target"
+    target.mkdir()
+    alias = tmp_path / "alias"
+    alias.symlink_to(target, target_is_directory=True)
+    deleted = tmp_path / "deleted"
+
+    with kb.connect() as conn:
+        first = kb.create_task(
+            conn,
+            title="symlink target",
+            workspace_kind="dir",
+            workspace_path=str(target),
+        )
+        second = kb.create_task(
+            conn,
+            title="symlink alias",
+            workspace_kind="dir",
+            workspace_path=str(alias),
+        )
+        assert kb.claim_task(conn, first, claimer="writer:first") is not None
+        assert kb.claim_task(conn, second, claimer="writer:second") is None
+
+        third = kb.create_task(
+            conn,
+            title="deleted workspace",
+            workspace_kind="dir",
+            workspace_path=str(deleted),
+        )
+        fourth = kb.create_task(
+            conn,
+            title="same deleted workspace",
+            workspace_kind="dir",
+            workspace_path=str(deleted),
+        )
+        assert kb.claim_task(conn, third, claimer="writer:third") is not None
+        assert not deleted.exists()
+        assert kb.claim_task(conn, fourth, claimer="writer:fourth") is None
+
+
+def test_different_workspaces_and_boards_remain_claimable(
+    kanban_home, tmp_path,
+):
+    first_workspace = tmp_path / "first"
+    second_workspace = tmp_path / "second"
+    first_workspace.mkdir()
+    second_workspace.mkdir()
+
+    with kb.connect() as conn:
+        first = kb.create_task(
+            conn,
+            title="first workspace",
+            workspace_kind="dir",
+            workspace_path=str(first_workspace),
+        )
+        second = kb.create_task(
+            conn,
+            title="second workspace",
+            workspace_kind="dir",
+            workspace_path=str(second_workspace),
+        )
+        assert kb.claim_task(conn, first, claimer="writer:first") is not None
+        assert kb.claim_task(conn, second, claimer="writer:second") is not None
+
+    board_a = tmp_path / "board-a.db"
+    board_b = tmp_path / "board-b.db"
+    kb.init_db(board_a)
+    kb.init_db(board_b)
+    with kb.connect(board_a) as conn_a, kb.connect(board_b) as conn_b:
+        task_a = kb.create_task(
+            conn_a,
+            title="board a",
+            workspace_kind="dir",
+            workspace_path=str(first_workspace),
+            idempotency_key="same-key-on-each-board",
+        )
+        task_b = kb.create_task(
+            conn_b,
+            title="board b",
+            workspace_kind="dir",
+            workspace_path=str(first_workspace),
+            idempotency_key="same-key-on-each-board",
+        )
+        assert task_a != task_b
+        assert kb.claim_task(conn_a, task_a, claimer="writer:a") is not None
+        assert kb.claim_task(conn_b, task_b, claimer="writer:b") is not None
+
+
+def test_completed_writer_releases_workspace_for_dependent_critic(
+    kanban_home, tmp_path,
+):
+    shared = tmp_path / "shared-workspace"
+    shared.mkdir()
+
+    with kb.connect() as conn:
+        writer = kb.create_task(
+            conn,
+            title="implementation",
+            assignee="worker",
+            workspace_kind="dir",
+            workspace_path=str(shared),
+        )
+        critic = kb.create_task(
+            conn,
+            title="independent verification",
+            assignee="critic",
+            workspace_kind="dir",
+            workspace_path=str(shared),
+            parents=[writer],
+        )
+        assert kb.claim_task(conn, writer, claimer="writer:implementation") is not None
+        assert kb.complete_task(conn, writer, result="implementation complete") is True
+        critic_task = kb.get_task(conn, critic)
+        assert critic_task is not None
+        assert critic_task.status == "ready"
+        assert kb.claim_task(conn, critic, claimer="critic:verification") is not None
+
+
+# ---------------------------------------------------------------------------
+# Test isolation
+# ---------------------------------------------------------------------------
+def test_kanban_smoke_uses_temp_board_without_touching_live_board(tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    live_board = Path(os.path.expanduser("~")) / ".hermes" / "kanban.db"
+    before = (
+        (live_board.exists(), live_board.stat().st_size, live_board.stat().st_mtime_ns)
+        if live_board.exists()
+        else (False, None, None)
+    )
+
+    kb.init_db()
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="isolated smoke")
+        assert kb.get_task(conn, task_id) is not None
+
+    temp_board = kb.kanban_db_path().resolve()
+    assert temp_board.is_relative_to(home.resolve())
+    after = (
+        (live_board.exists(), live_board.stat().st_size, live_board.stat().st_mtime_ns)
+        if live_board.exists()
+        else (False, None, None)
+    )
+    assert after == before
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This is the independently accepted throughput-guardrail candidate, rebased mechanically onto current `origin/main` without hand-editing the frozen diff.

- Moves idempotency lookup inside `BEGIN IMMEDIATE` so concurrent creators atomically converge on one non-archived task; archived keys remain reusable.
- Adds persistent-workspace identity checks for direct claims and dispatch, including symlink aliases, deleted paths, filesystem inodes, and bounded case-insensitive fallback semantics.
- Defers review claims and review dispatch when a running writer owns the same canonical workspace, returning `workspace_busy` telemetry without spawning, creating a run, or mutating failure state.
- Keeps temporary-board isolation covered through a temporary `HERMES_HOME` smoke path.

## RED / GREEN behavior

- RED contract: concurrent same-key creates could race into duplicate non-archived rows, and concurrent writer/reviewer claims could both proceed against one persistent workspace.
- GREEN behavior: idempotent creators serialize under the write transaction; a second writer or reviewer remains queued with a durable `workspace_busy` event and the conflicting task id; distinct workspaces, boards, and case-sensitive spellings remain independently claimable.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py` — 43 passed, 2 host skips, 0 failed.
- Related Kanban DB/dispatch/worktree/project/core suite (13 files via `scripts/run_tests.sh`) — 146 passed, 3 host skips, 0 failed.
- `ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py` — passed.
- `python -m compileall -q hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py` — passed.
- `git diff --cached --check` and `git diff --check origin/main...HEAD` — passed; only the two declared paths changed.
- Court Jester doctor/analyze/lint/execute — passed. Court Jester verify was exit 3 / inconclusive because its isolated harness lacks pytest and classifies intentional invalid-board-slug `ValueError`s as crashes; replay reproduced that verifier finding with exit 0. Court Jester CI was inconclusive only on execute while reporting 0 crashes and 0 property violations.

The real case-insensitive APFS, case-sensitive APFS, deleted-path, concurrent-claim, temporary-board, and review-dispatch probes were independently accepted by Critic before publication.

## Residual risk / follow-up

A bounded, nonblocking P2 remains for direct/API worktree claims while a worktree task still stores a shared repo anchor before the dispatcher materializes its per-task checkout: direct callers may conservatively serialize distinct derived targets during that short window. The normal dispatcher path resolves and persists the per-task target before iterating. No tenant/privacy, security, corruption, data-loss, or customer-commitment impact was found.

## Commit / scope

- Base: `31f62d76af068abde3c699f91190e8ded07fd05b`
- Head: `ae8f03ec9b960bf71ccb7d3520057b0b3763e6ae`
- Changed paths: `hermes_cli/kanban_db.py`, `tests/hermes_cli/test_kanban_db.py`
- Frozen source dirty-diff fingerprint: `1cdec35028454209fb69394345262edff355da219f67cb74bb9a013b8a91137a`
