### PR TITLE
fix(gateway): stop reporting quota exhaustion as an auth failure in chat

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6522,9 +6522,14 @@ class APIServerAdapter(BasePlatformAdapter):
                     # /v1/runs has its own branch in its executor.
                     logger.warning("Provider authentication failed for session=%s: %s",
                                    session_id or "", exc)
+                    # Quota exhaustion is not an auth failure (#89401) — the
+                    # reply must not send the operator to re-authenticate
+                    # valid credentials.
+                    from hermes_cli.auth import format_resolution_failure_reply
+
                     return (
                         {
-                            "final_response": f"⚠️ Provider authentication failed: {exc}",
+                            "final_response": format_resolution_failure_reply(exc),
                             "messages": [],
                             "api_calls": 0,
                             "tools": [],
@@ -7012,7 +7017,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 # failure, instead of falling through to the generic
                 # except-Exception branch below.
                 logger.warning("Provider authentication failed for run=%s: %s", run_id, exc)
-                error_msg = f"⚠️ Provider authentication failed: {exc}"
+                # Quota exhaustion is not an auth failure (#89401).
+                from hermes_cli.auth import format_resolution_failure_reply
+
+                error_msg = format_resolution_failure_reply(exc)
                 self._set_run_status(
                     run_id,
                     "failed",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5233,8 +5233,13 @@ class TurnRunner:
                 model, runtime_kwargs.get("provider"), ctx.session_key or "",
             )
         except Exception as exc:
+            # Quota exhaustion is not an auth failure (#89401): the chat
+            # reply must not send the operator to re-authenticate valid
+            # credentials — the log side already distinguishes (#32790).
+            from hermes_cli.auth import format_resolution_failure_reply
+
             return {
-                "final_response": f"⚠️ Provider authentication failed: {exc}",
+                "final_response": format_resolution_failure_reply(exc),
                 "messages": [],
                 "api_calls": 0,
                 "tools": [],

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -963,6 +963,34 @@ def _parse_retry_after_seconds(headers: Any) -> Optional[int]:
     return None if seconds is None else int(seconds)
 
 
+def format_resolution_failure_reply(exc: Exception) -> str:
+    """User-facing reply for a provider-resolution failure (#89401).
+
+    Resolution failures surface to chat wrapped as "Provider authentication
+    failed: <cause>" — but a quota/rate-limit AuthError is not a credential
+    problem, and #32790's log-side distinction must reach the chat reply too,
+    or operators re-authenticate working credentials. Walks the cause chain
+    because the resolution layer re-raises the AuthError inside a RuntimeError.
+    """
+    seen: set[int] = set()
+    cur: Optional[Exception] = exc
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        if isinstance(cur, AuthError) and is_rate_limited_auth_error(cur):
+            window = getattr(cur, "retry_after_seconds", None)
+            suffix = f" — retry after {int(window)}s" if window else ""
+            return (
+                "⏱️ Provider quota exhausted"
+                f"{suffix}. The configured credentials are still valid; "
+                "try again after the quota window reopens."
+            )
+        cur = (
+            getattr(cur, "__cause__", None)
+            or getattr(cur, "__context__", None)
+        )
+    return f"⚠️ Provider authentication failed: {exc}"
+
+
 def format_auth_error(error: Exception) -> str:
     """Map auth failures to concise user-facing guidance."""
     if not isinstance(error, AuthError):

--- a/tests/gateway/test_local_model_connection_reply.py
+++ b/tests/gateway/test_local_model_connection_reply.py
@@ -61,3 +61,52 @@ class TestGatewayConnectionErrorReply:
         assert "rate-limiting" in _gateway_provider_error_reply(
             "rate limited after 3 retries"
         ).lower()
+
+
+class TestQuotaMislabelReply:
+    """Quota exhaustion must not reach chat as an auth failure (#89401).
+
+    The resolution layer wraps the quota AuthError inside a RuntimeError and
+    the caller prefixes "Provider authentication failed:" — which the reply
+    classifier then matched, sending operators to re-authenticate valid
+    credentials. format_resolution_failure_reply distinguishes them at the
+    source; the classifier then routes the quota wording to the rate-limit
+    reply instead of the auth reply."""
+
+    def _quota_runtime_error(self):
+        from hermes_cli.auth import AuthError, CODEX_RATE_LIMITED_CODE
+
+        inner = AuthError(
+            "Codex provider quota exhausted (429); retry after 116168s. "
+            "Credentials are still valid.",
+            provider="openai-codex",
+            code=CODEX_RATE_LIMITED_CODE,
+            relogin_required=False,
+        )
+        wrapped = RuntimeError(str(inner))
+        wrapped.__cause__ = inner
+        return wrapped
+
+    def test_quota_resolution_failure_is_not_auth(self):
+        from hermes_cli.auth import format_resolution_failure_reply
+
+        reply = format_resolution_failure_reply(self._quota_runtime_error())
+        assert "quota" in reply.lower()
+        assert "credentials are still valid" in reply
+        assert "authentication" not in reply.lower()
+
+    def test_genuine_auth_failure_keeps_auth_reply(self):
+        from hermes_cli.auth import format_resolution_failure_reply
+
+        reply = format_resolution_failure_reply(RuntimeError("invalid api key"))
+        assert "authentication" in reply.lower()
+
+    def test_quota_reply_classifies_as_rate_limit_not_auth(self):
+        # End to end: the quota-worded resolution reply must fall through the
+        # classifier to the rate-limit bucket, never the auth bucket.
+        from hermes_cli.auth import format_resolution_failure_reply
+
+        reply = format_resolution_failure_reply(self._quota_runtime_error())
+        classified = _gateway_provider_error_reply(reply)
+        assert "rate-limiting" in classified.lower()
+        assert "authentication" not in classified.lower()


### PR DESCRIPTION
## What does this PR do?

When the Codex quota is exhausted (429), chat surfaces reply **"⚠️ Provider authentication failed. Check the configured credentials"** — while the gateway log correctly says `Primary provider rate-limited (429) … Credentials are still valid`. The reported incident sent an operator to re-run device-code logins across nine profiles and restart four gateways before anyone noticed the logs disagreed with the chat message. The credentials were valid the entire time.

The chain: the resolution layer catches the quota `AuthError` (already correctly classified — `is_rate_limited_auth_error`, #32790's log-side fix) and re-raises it inside a `RuntimeError`; the turn-runner and api_server reply sites prefix **every** resolution failure with `⚠️ Provider authentication failed:`; the gateway reply classifier then matches that prefix into the auth bucket. #32790's distinction never reaches the chat reply.

This PR adds `format_resolution_failure_reply(exc)` next to the existing auth-error formatting family: it walks the cause chain for a rate-limited `AuthError` and answers with quota wording — credentials are still valid, retry after the window (including the structured `retry_after_seconds` when present) — while genuine auth failures keep the existing wording and remediation unchanged. Applied at the three resolution-failure reply sites:

- `gateway/run.py` — the turn runner's `_resolve_session_agent_runtime` failure reply.
- `gateway/platforms/api_server.py` — both the session-chat surface and the `/v1/runs` failure status.

End to end, the quota wording then falls through `_gateway_provider_error_reply` into the rate-limit bucket ("provider is rate-limiting requests…") instead of the auth bucket — no re-authentication prompt.

## Related Issue

Fixes #89401

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/auth.py` — new `format_resolution_failure_reply(exc)`: cause-chain walk for a rate-limited AuthError → quota wording (with the structured window suffix when `retry_after_seconds` is present); otherwise the existing auth-failure wording, verbatim.
- `gateway/run.py` — the turn-runner resolution-failure reply uses the new formatter.
- `gateway/platforms/api_server.py` — both the session-chat resolution-failure reply and the `/v1/runs` failure status use it.
- `tests/gateway/test_local_model_connection_reply.py` — `TestQuotaMislabelReply`: a quota AuthError wrapped in a RuntimeError (the real resolution shape) produces quota wording with no "authentication"; a genuine auth failure keeps the auth wording; end to end, the quota reply classifies into the rate-limit bucket, never the auth bucket.

## How to Test

```bash
python -m pytest tests/gateway/test_local_model_connection_reply.py -q
# Observed result: 9 passed

python -m pytest tests/gateway/test_api_server_runs.py tests/gateway/test_telegram_noise_filter.py -q
# Observed result: 156 passed (existing auth-failure assertions unchanged)
```

Fail-on-main check: with the three source files stashed, the three new tests fail on main (formatter absent / quota mislabeled).

Manual repro from the issue: with an exhausted Codex quota and no usable fallback, a Slack turn on main replies "⚠️ Provider authentication failed. Check the configured credentials"; with this change the reply is quota wording (or the classifier's rate-limit short form), and the logs' "credentials are still valid" finally matches what the user is told.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments explain intent (why the cause chain is walked, why the classifier then does the right thing)
- [x] Corresponding changes documented via comments
- [x] Tests added and passing (3 new; reply-classifier and api_server suites green)
- [x] Single root cause, no unrelated changes
