### PR TITLE
feat(discord): add plugin-owned reaction actions

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -360,6 +360,11 @@ VALID_HOOKS: Set[str] = {
     #       payload contracts; no inert VALID_HOOKS surface is registered
     #       ahead of implementation.
     "gateway_platform_event",
+    # Discord outbound shortcut reactions. Fired only when a plugin subscribes
+    # and a user reacts to a bot-authored Discord message. Best-effort return
+    # actions may ask the Discord adapter to send a follow-up or add/remove a
+    # reaction; callbacks are isolated so they cannot break Discord delivery.
+    "on_discord_reaction_add",
     # Slash-command dispatch observer (#64204, observer-first per #64182
     # ground rule 3). Fired when a recognized slash command is about to be
     # dispatched, BEFORE the handler runs, on both the interactive CLI

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -140,6 +140,23 @@ try:
 except ImportError:
     from ffmpeg_utils import resolve_ffmpeg_executable
 
+try:
+    from .reaction_actions import dispatch_raw_reaction_add
+    from .reaction_delivery import attach_manifest_actions_live
+    from .reaction_manifest import (
+        extract_reaction_manifest,
+        manifest_actions,
+        manifest_discord_messages,
+    )
+except ImportError:
+    from reaction_actions import dispatch_raw_reaction_add  # type: ignore
+    from reaction_delivery import attach_manifest_actions_live  # type: ignore
+    from reaction_manifest import (  # type: ignore
+        extract_reaction_manifest,
+        manifest_actions,
+        manifest_discord_messages,
+    )
+
 from gateway.config import Platform, PlatformConfig
 
 from gateway.platforms.helpers import (
@@ -1399,6 +1416,10 @@ class DiscordAdapter(BasePlatformAdapter):
             @self._client.event
             async def on_message(message: DiscordMessage):
                 await adapter_self._dispatch_discord_message(message)
+
+            @self._client.event
+            async def on_raw_reaction_add(payload):
+                await dispatch_raw_reaction_add(adapter_self, payload, discord_module=discord)
 
             @self._client.event
             async def on_message_edit(before: DiscordMessage, after: DiscordMessage):
@@ -3443,7 +3464,11 @@ class DiscordAdapter(BasePlatformAdapter):
         """
         if not self._client:
             return SendResult(success=False, error="Not connected")
-        if not (content or "").strip():
+
+        send_content, discord_manifest = extract_reaction_manifest(content or "")
+        discord_manifest_messages = manifest_discord_messages(discord_manifest)
+
+        if not (send_content or "").strip() and not discord_manifest_messages:
             logger.warning(
                 "[%s] Dropped empty message to chat=%s (caller bug). Call site:\n%s",
                 self.name,
@@ -3462,7 +3487,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 self._record_discord_response,
                 reply_to=reply_to,
                 result=result,
-                content=content,
+                content=send_content,
                 final=bool(metadata and metadata.get("notify")),
             )
             return result
@@ -3492,61 +3517,85 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Forum channels reject channel.send() — create a thread post instead.
             if self._is_forum_parent(channel):
-                result = await self._send_to_forum(channel, content)
+                forum_content = send_content
+                if not forum_content.strip() and discord_manifest_messages:
+                    forum_content = "\n\n".join(
+                        item["content"] for item in discord_manifest_messages if item["content"].strip()
+                    )
+                result = await self._send_to_forum(channel, forum_content)
                 await asyncio.to_thread(
                     self._record_discord_response,
                     reply_to=reply_to,
                     result=result,
-                    content=content,
+                    content=forum_content,
                     final=final_delivery,
                 )
                 return result
 
-            # Format and split message if needed
-            formatted = self.format_message(content)
-            chunks = self._cap_split_chunks(
-                self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
-            )
-
             message_ids = []
+            sent_messages: list[dict[str, Any]] = []
+            warnings: list[str] = []
             # Build the reference from ids — no fetch_message round trip.
             reference = self._reply_reference_for_send(reply_to, channel)
 
-            for i, chunk in enumerate(chunks):
-                if self._reply_to_mode == "all":
-                    chunk_reference = reference
-                else:  # "first" (default) or "off"
-                    chunk_reference = reference if i == 0 else None
-                try:
-                    msg = await channel.send(
-                        content=chunk,
-                        reference=chunk_reference,
-                    )
-                except Exception as e:
-                    err_text = str(e)
-                    if (
-                        chunk_reference is not None
-                        and (
-                            (
-                                "error code: 50035" in err_text
-                                and "Cannot reply to a system message" in err_text
-                            )
-                            or "error code: 10008" in err_text
-                        )
-                    ):
-                        logger.warning(
-                            "[%s] Reply target %s rejected the reply reference; retrying send without reply reference",
-                            self.name,
-                            reply_to,
-                        )
-                        reference = None
+            async def _send_chunks(message_text: str, *, action_entries=None) -> list[dict[str, Any]]:
+                nonlocal reference
+                formatted = self.format_message(message_text)
+                chunks = self._cap_split_chunks(
+                    self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+                )
+                local_sent: list[dict[str, Any]] = []
+                for chunk in chunks:
+                    message_number = len(message_ids)
+                    if self._reply_to_mode == "all":
+                        chunk_reference = reference
+                    else:  # "first" (default) or "off"
+                        chunk_reference = reference if message_number == 0 else None
+                    try:
                         msg = await channel.send(
                             content=chunk,
-                            reference=None,
+                            reference=chunk_reference,
                         )
-                    else:
-                        raise
-                message_ids.append(str(msg.id))
+                    except Exception as e:
+                        err_text = str(e)
+                        if (
+                            chunk_reference is not None
+                            and (
+                                (
+                                    "error code: 50035" in err_text
+                                    and "Cannot reply to a system message" in err_text
+                                )
+                                or "error code: 10008" in err_text
+                            )
+                        ):
+                            logger.warning(
+                                "[%s] Reply target %s rejected the reply reference; retrying send without reply reference",
+                                self.name,
+                                reply_to,
+                            )
+                            reference = None
+                            msg = await channel.send(
+                                content=chunk,
+                                reference=None,
+                            )
+                        else:
+                            raise
+                    message_ids.append(str(msg.id))
+                    record = {"content": chunk, "message": msg, "message_id": str(msg.id)}
+                    sent_messages.append(record)
+                    local_sent.append(record)
+                if action_entries:
+                    warnings.extend(await attach_manifest_actions_live(self, action_entries, local_sent))
+                return local_sent
+
+            if discord_manifest_messages:
+                for item in discord_manifest_messages:
+                    if item["content"].strip():
+                        await _send_chunks(item["content"], action_entries=item.get("actions", []))
+                warnings.extend(await attach_manifest_actions_live(self, manifest_actions(discord_manifest), sent_messages))
+            else:
+                await _send_chunks(send_content)
+                warnings.extend(await attach_manifest_actions_live(self, manifest_actions(discord_manifest), sent_messages))
 
             # Track the last message we sent in this channel for history
             # backfill — avoids a full channel.history() scan on hot paths.
@@ -3554,19 +3603,22 @@ class DiscordAdapter(BasePlatformAdapter):
                 _target_id = thread_id or chat_id
                 if nonconversational:
                     self._nonconversational_messages.mark_many(message_ids)
-                elif not _looks_like_nonconversational_history_message(content):
+                elif not _looks_like_nonconversational_history_message(send_content):
                     self._last_self_message_id[_target_id] = message_ids[-1]
 
+            raw_response: Dict[str, Any] = {"message_ids": message_ids}
+            if warnings:
+                raw_response["warnings"] = warnings
             result = SendResult(
                 success=True,
                 message_id=message_ids[0] if message_ids else None,
-                raw_response={"message_ids": message_ids}
+                raw_response=raw_response,
             )
             await asyncio.to_thread(
                 self._record_discord_response,
                 reply_to=reply_to,
                 result=result,
-                content=content,
+                content=send_content,
                 final=final_delivery,
             )
             return result
@@ -3578,7 +3630,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 self._record_discord_response,
                 reply_to=reply_to,
                 result=result,
-                content=content,
+                content=send_content,
                 final=bool(metadata and metadata.get("notify")),
             )
             return result

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -83,6 +83,7 @@ _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS = 30.0
 # every slash command — not just the overflow ones. We keep the desired set
 # at or below this limit at registration time.
 _DISCORD_MAX_APP_COMMANDS = 100
+_AGENT_REACTION_MEMORY = 1024
 _DISCORD_SELECT_FIELD_LIMIT = 100
 _DISCORD_BUTTON_LABEL_LIMIT = 80
 _DISCORD_ELLIPSIS = "\u2026"
@@ -1178,6 +1179,10 @@ class DiscordAdapter(BasePlatformAdapter):
         # history backfill to skip the full scan on hot paths.  Falls back to
         # scanning channel.history() on cache miss (cold start / restart).
         self._last_self_message_id: Dict[str, str] = {}
+        # Reaction helpers default to the message that triggered the active
+        # turn. Store both a thread and its parent for auto-threaded turns.
+        self._last_inbound_by_chat: Dict[str, str] = {}
+        self._agent_reactions: Dict[Tuple[str, str], str] = {}
         # Persistent set of bot-authored lifecycle/status message IDs that
         # should not act as conversational history boundaries after restart.
         self._nonconversational_messages = _DiscordNonConversationalMessageTracker()
@@ -3350,6 +3355,86 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.debug("[%s] add_reaction failed (%s): %s", self.name, emoji, e)
             return False
 
+    def _record_inbound_reaction_target(self, event: MessageEvent) -> None:
+        """Remember an inbound message as the default reaction target."""
+        source = getattr(event, "source", None)
+        message_id = str(
+            getattr(event, "message_id", "")
+            or getattr(getattr(event, "raw_message", None), "id", "")
+            or ""
+        )
+        if not message_id:
+            return
+        for chat_key in (getattr(source, "chat_id", None), getattr(source, "parent_chat_id", None)):
+            if chat_key:
+                self._last_inbound_by_chat[str(chat_key)] = message_id
+
+    async def _fetch_reaction_target(self, chat_id: str, message_id: str) -> Optional[Any]:
+        """Fetch a reaction target, trying a thread's parent when needed."""
+        if not self._client:
+            return None
+        try:
+            channel_id, target_id = int(chat_id), int(message_id)
+        except (TypeError, ValueError):
+            return None
+        channel = self._client.get_channel(channel_id)
+        if channel is None:
+            try:
+                channel = await self._client.fetch_channel(channel_id)
+            except Exception as exc:
+                logger.debug("[%s] reaction channel fetch failed: %s", self.name, exc)
+                return None
+        for candidate in (channel, self._thread_parent_channel(channel)):
+            fetch_message = getattr(candidate, "fetch_message", None)
+            if not callable(fetch_message):
+                continue
+            try:
+                message = await fetch_message(target_id)
+            except Exception as exc:
+                logger.debug("[%s] reaction message fetch failed: %s", self.name, exc)
+                continue
+            if message is not None:
+                return message
+        return None
+
+    def _resolve_reaction_target_id(self, chat_id: str, message_id: Optional[str]) -> Optional[str]:
+        target = message_id or self._last_inbound_by_chat.get(str(chat_id))
+        return str(target) if target else None
+
+    async def add_reaction(
+        self, chat_id: str, emoji: str, message_id: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Add an explicit plugin/adapter reaction to a delivered Discord message."""
+        target = self._resolve_reaction_target_id(chat_id, message_id)
+        if not target:
+            return {"success": False, "error": "no message to react to — pass message_id"}
+        message = await self._fetch_reaction_target(chat_id, target)
+        if message is None:
+            return {"success": False, "error": f"message {target} not found in chat {chat_id}"}
+        if not await self._add_reaction(message, emoji):
+            return {"success": False, "error": "reaction failed (see gateway debug log)"}
+        self._agent_reactions[(str(chat_id), target)] = emoji
+        while len(self._agent_reactions) > _AGENT_REACTION_MEMORY:
+            self._agent_reactions.pop(next(iter(self._agent_reactions)))
+        return {"success": True, "message_id": target}
+
+    async def remove_reaction(
+        self, chat_id: str, message_id: Optional[str] = None, emoji: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Remove an explicit bot reaction, defaulting to the remembered emoji."""
+        target = self._resolve_reaction_target_id(chat_id, message_id)
+        if not target:
+            return {"success": False, "error": "no message to unreact — pass message_id"}
+        reaction = emoji or self._agent_reactions.get((str(chat_id), target))
+        if not reaction:
+            return {"success": False, "error": f"no reaction of ours to retract on message {target}"}
+        message = await self._fetch_reaction_target(chat_id, target)
+        if message is None:
+            return {"success": False, "error": f"message {target} not found in chat {chat_id}"}
+        if not await self._remove_reaction(message, reaction):
+            return {"success": False, "error": "unreact failed (see gateway debug log)"}
+        self._agent_reactions.pop((str(chat_id), target), None)
+        return {"success": True, "message_id": target}
     async def _remove_reaction(self, message: Any, emoji: str) -> bool:
         """Remove the bot's own emoji reaction from a Discord message."""
         if not message or not hasattr(message, "remove_reaction") or not self._client or not self._client.user:
@@ -3368,6 +3453,7 @@ class DiscordAdapter(BasePlatformAdapter):
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add an in-progress reaction and record durable handling state."""
         message = event.raw_message
+        self._record_inbound_reaction_target(event)
         acked = False
         if self._reactions_enabled() and hasattr(message, "add_reaction"):
             acked = await self._add_reaction(message, "👀")

--- a/plugins/platforms/discord/reaction_actions.py
+++ b/plugins/platforms/discord/reaction_actions.py
@@ -1,0 +1,210 @@
+"""Plugin-owned Discord reaction action hooks.
+
+This module keeps the optional ``on_discord_reaction_add`` surface out of the
+large Discord adapter file. The adapter still owns Discord SDK setup and core
+authorization helpers; this module owns the plugin hook contract and the small
+set of best-effort side effects callbacks may request.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+def reaction_action_hooks_subscribed() -> bool:
+    try:
+        from hermes_cli.lifecycle import has_hook
+
+        return has_hook("on_discord_reaction_add")
+    except Exception:
+        return False
+
+
+def raw_reaction_authorized(
+    adapter: Any,
+    payload: Any,
+    channel: Any,
+    user_id: str,
+    *,
+    discord_module: Any,
+) -> bool:
+    """Apply Discord channel/user gates before plugin hook dispatch."""
+    is_dm = isinstance(channel, discord_module.DMChannel)
+    channel_keys: Optional[set[str]] = None
+    guild = getattr(channel, "guild", None)
+
+    if not is_dm:
+        parent_channel_id = adapter._get_parent_channel_id(channel)
+        channel_keys = adapter._discord_channel_keys_from_channel(channel, parent_channel_id)
+
+        allowed = adapter._get_allowed_channels()
+        if allowed and "*" not in allowed and not (channel_keys & allowed):
+            logger.debug(
+                "[%s] Ignoring reaction in non-allowed channel: %s",
+                adapter.name,
+                channel_keys,
+            )
+            return False
+
+        ignored = adapter._get_ignored_channels()
+        if "*" in ignored or (channel_keys & ignored):
+            logger.debug(
+                "[%s] Ignoring reaction in ignored channel: %s",
+                adapter.name,
+                channel_keys,
+            )
+            return False
+
+        if guild is None:
+            guild_id = getattr(payload, "guild_id", None)
+            if guild_id is not None and adapter._client is not None:
+                get_guild = getattr(adapter._client, "get_guild", None)
+                if callable(get_guild):
+                    try:
+                        guild = get_guild(int(guild_id))
+                    except Exception:
+                        guild = None
+
+    author = getattr(payload, "member", None)
+    return adapter._is_allowed_user(
+        user_id,
+        author=author,
+        guild=guild,
+        is_dm=is_dm,
+        channel_ids=channel_keys if not is_dm else None,
+    )
+
+
+async def dispatch_raw_reaction_add(
+    adapter: Any,
+    payload: Any,
+    *,
+    discord_module: Any,
+) -> None:
+    """Dispatch user-added Discord reactions to subscribed plugins."""
+    if not adapter._client or not reaction_action_hooks_subscribed():
+        return
+    user_id = str(getattr(payload, "user_id", "") or "")
+    bot_user = getattr(adapter._client, "user", None)
+    if bot_user is not None and user_id == str(getattr(bot_user, "id", "")):
+        return
+
+    try:
+        channel_id = str(getattr(payload, "channel_id", "") or "")
+        message_id = str(getattr(payload, "message_id", "") or "")
+        guild_id_raw = getattr(payload, "guild_id", None)
+        guild_id = str(guild_id_raw) if guild_id_raw is not None else None
+        emoji = str(getattr(payload, "emoji", "") or "")
+        if not channel_id or not message_id or not user_id or not emoji:
+            return
+
+        channel = adapter._client.get_channel(int(channel_id))
+        if channel is None:
+            channel = await adapter._client.fetch_channel(int(channel_id))
+        if channel is None or not hasattr(channel, "fetch_message"):
+            return
+        if not raw_reaction_authorized(
+            adapter,
+            payload,
+            channel,
+            user_id,
+            discord_module=discord_module,
+        ):
+            return
+        message = await channel.fetch_message(int(message_id))
+        if message is None:
+            return
+
+        author = getattr(message, "author", None)
+        if author is not None and not getattr(author, "bot", False):
+            return
+
+        results = await asyncio.to_thread(
+            invoke_discord_reaction_hook,
+            emoji=emoji,
+            user_id=user_id,
+            channel_id=channel_id,
+            message_id=message_id,
+            guild_id=guild_id,
+            message_content=getattr(message, "content", ""),
+            message_author_id=str(getattr(author, "id", "") or "") if author is not None else None,
+        )
+        for result in results:
+            await apply_reaction_hook_result(adapter, result, channel, message, payload)
+    except Exception:
+        logger.debug("[%s] Discord reaction action hook failed", adapter.name, exc_info=True)
+
+
+def invoke_discord_reaction_hook(**payload: Any) -> list[Any]:
+    from hermes_cli.lifecycle import invoke_hook
+
+    return invoke_hook("on_discord_reaction_add", **payload)
+
+
+async def apply_reaction_hook_result(
+    adapter: Any,
+    result: Any,
+    channel: Any,
+    message: Any,
+    payload: Any,
+) -> None:
+    """Apply optional best-effort Discord side effects returned by plugins."""
+    if isinstance(result, list):
+        for item in result:
+            await apply_reaction_hook_result(adapter, item, channel, message, payload)
+        return
+    if not isinstance(result, dict):
+        return
+    actions = result.get("actions")
+    if isinstance(actions, list):
+        for item in actions:
+            await apply_reaction_hook_result(adapter, item, channel, message, payload)
+        return
+
+    action = str(result.get("action", "")).strip().lower()
+    if action == "send_message":
+        text = result.get("content", result.get("message", ""))
+        if isinstance(text, str) and text.strip() and hasattr(channel, "send"):
+            await channel.send(content=text)
+    elif action in {"add_reaction", "add_bot_reaction"}:
+        emoji = result.get("emoji")
+        if isinstance(emoji, str) and emoji.strip():
+            await adapter._add_reaction(message, emoji)
+    elif action == "remove_bot_reaction":
+        emoji = result.get("emoji")
+        if isinstance(emoji, str) and emoji.strip():
+            await adapter._remove_reaction(message, emoji)
+    elif action == "remove_user_reaction" and hasattr(message, "remove_reaction"):
+        emoji = result.get("emoji") or str(getattr(payload, "emoji", "") or "")
+        user = await resolve_reaction_payload_user(adapter, payload)
+        if isinstance(emoji, str) and emoji.strip() and user is not None:
+            try:
+                await message.remove_reaction(emoji, user)
+            except Exception:
+                logger.debug("[%s] remove_user_reaction failed", adapter.name, exc_info=True)
+
+
+async def resolve_reaction_payload_user(adapter: Any, payload: Any) -> Any:
+    member = getattr(payload, "member", None)
+    if member is not None:
+        return member
+    user_id = getattr(payload, "user_id", None)
+    if user_id is None or not adapter._client:
+        return None
+    get_user = getattr(adapter._client, "get_user", None)
+    if callable(get_user):
+        user = get_user(int(user_id))
+        if user is not None:
+            return user
+    fetch_user = getattr(adapter._client, "fetch_user", None)
+    if callable(fetch_user):
+        try:
+            return await fetch_user(int(user_id))
+        except Exception:
+            return None
+    return None

--- a/plugins/platforms/discord/reaction_delivery.py
+++ b/plugins/platforms/discord/reaction_delivery.py
@@ -1,0 +1,299 @@
+"""Discord reaction manifest delivery helpers."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Awaitable, Callable
+from urllib.parse import quote
+
+from agent.secret_scope import get_secret
+from gateway.platforms.base import BasePlatformAdapter
+
+try:
+    from .reaction_manifest import (
+        choose_reaction_message_index,
+        extract_reaction_manifest,
+        manifest_actions,
+        manifest_discord_messages,
+    )
+except ImportError:
+    from reaction_manifest import (  # type: ignore
+        choose_reaction_message_index,
+        extract_reaction_manifest,
+        manifest_actions,
+        manifest_discord_messages,
+    )
+
+
+StandaloneSender = Callable[..., Awaitable[dict[str, Any]]]
+CaptionSplit = Callable[..., tuple[str | None, str]]
+
+
+def discord_reaction_route_emoji(emoji: str) -> str:
+    """Return the URL path segment Discord expects for a reaction emoji."""
+    import re
+
+    emoji = (emoji or "").strip()
+    custom = re.fullmatch(r"<a?:([^:<>]+):(\d+)>", emoji)
+    if custom:
+        emoji = f"{custom.group(1)}:{custom.group(2)}"
+    return quote(emoji, safe="")
+
+
+async def add_manifest_reaction_with_retry(
+    pconfig: Any,
+    chat_id: str,
+    message_id: str,
+    emoji: str,
+    *,
+    max_attempts: int = 3,
+) -> str | None:
+    """Best-effort REST reaction add for out-of-process Discord sends."""
+    try:
+        import aiohttp
+    except ImportError:
+        return "Discord reaction add skipped: aiohttp not installed"
+
+    token = (getattr(pconfig, "token", None) or "").strip()
+    if not token:
+        token = (get_secret("DISCORD_BOT_TOKEN", "") or "").strip()
+    if not token:
+        return "Discord reaction add skipped: DISCORD_BOT_TOKEN is not set"
+
+    try:
+        from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp
+
+        proxy_url = resolve_proxy_url(platform_env_var="DISCORD_PROXY")
+        session_kwargs, request_kwargs = proxy_kwargs_for_aiohttp(proxy_url)
+    except Exception:
+        session_kwargs, request_kwargs = {}, {}
+
+    route_emoji = discord_reaction_route_emoji(emoji)
+    url = (
+        "https://discord.com/api/v10/channels/"
+        f"{chat_id}/messages/{message_id}/reactions/{route_emoji}/@me"
+    )
+    headers = {"Authorization": f"Bot {token}"}
+
+    for attempt in range(max_attempts):
+        try:
+            async with aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=15),
+                **session_kwargs,
+            ) as session:
+                async with session.put(url, headers=headers, **request_kwargs) as resp:
+                    if resp.status in {200, 204}:
+                        return None
+                    if resp.status == 429 and attempt < max_attempts - 1:
+                        retry_after = None
+                        try:
+                            body = await resp.json()
+                            retry_after = float(body.get("retry_after"))
+                        except Exception:
+                            for header in ("Retry-After", "X-RateLimit-Reset-After"):
+                                try:
+                                    retry_after = float(resp.headers.get(header))
+                                    break
+                                except Exception:
+                                    continue
+                        if retry_after is None:
+                            retry_after = 1.0
+                        await asyncio.sleep(max(0.0, min(retry_after, 10.0)))
+                        continue
+                    try:
+                        body = await resp.text()
+                    except Exception:
+                        body = ""
+                    detail = f": {body[:200]}" if body else ""
+                    return (
+                        "Discord reaction add failed "
+                        f"for message {message_id} emoji {emoji} ({resp.status}){detail}"
+                    )
+        except Exception as exc:
+            if attempt < max_attempts - 1:
+                await asyncio.sleep(0.5)
+                continue
+            return (
+                "Discord reaction add failed "
+                f"for message {message_id} emoji {emoji}: {type(exc).__name__}: {exc}"
+            )
+    return f"Discord reaction add failed for message {message_id} emoji {emoji}"
+
+
+async def attach_manifest_actions_standalone(
+    pconfig: Any,
+    chat_id: str,
+    actions: list[dict[str, Any]],
+    sent_messages: list[dict[str, Any]],
+) -> list[str]:
+    warnings = []
+    for action in actions:
+        index = choose_reaction_message_index(action, sent_messages)
+        if index is None:
+            continue
+        sent = sent_messages[index]
+        message_id = sent.get("message_id")
+        emoji = action.get("emoji")
+        if not message_id or not isinstance(emoji, str) or not emoji.strip():
+            continue
+        warning = await add_manifest_reaction_with_retry(
+            pconfig,
+            chat_id,
+            str(message_id),
+            emoji,
+        )
+        if warning:
+            warnings.append(warning)
+    return warnings
+
+
+async def attach_manifest_actions_live(
+    adapter: Any,
+    actions: list[dict[str, Any]],
+    sent_messages: list[dict[str, Any]],
+) -> list[str]:
+    """Best-effort outbound reaction shortcuts for sent Discord messages."""
+    warnings: list[str] = []
+    for action in actions:
+        index = choose_reaction_message_index(action, sent_messages)
+        if index is None:
+            continue
+        message = sent_messages[index].get("message")
+        emoji = action.get("emoji")
+        if not message or not isinstance(emoji, str) or not emoji.strip():
+            continue
+        if not await adapter._add_reaction(message, emoji):
+            message_id = getattr(message, "id", sent_messages[index].get("message_id", "unknown"))
+            warnings.append(f"Failed to add Discord reaction {emoji} to message {message_id}")
+    return warnings
+
+
+def merge_warnings(result: Any, warnings: list[str]) -> Any:
+    if warnings and isinstance(result, dict):
+        existing = result.get("warnings")
+        if isinstance(existing, list):
+            result["warnings"] = [*existing, *warnings]
+        elif existing:
+            result["warnings"] = [existing, *warnings]
+        else:
+            result["warnings"] = warnings
+    return result
+
+
+async def send_standalone_discord_with_manifest(
+    *,
+    pconfig: Any,
+    chat_id: str,
+    message: str,
+    thread_id: str | None,
+    media_files: list[tuple[str, bool]],
+    max_len: int | None,
+    default_caption_limit: int,
+    caption_split: CaptionSplit,
+    standalone_sender_fn: StandaloneSender,
+) -> dict[str, Any]:
+    """Send Discord text/media through the standalone sender with manifests."""
+    send_content, discord_manifest = extract_reaction_manifest(message)
+    discord_manifest_messages = manifest_discord_messages(discord_manifest)
+
+    if discord_manifest_messages and not media_files:
+        last_result = None
+        sent_messages = []
+        warnings = []
+        for item in discord_manifest_messages:
+            item_chunks = BasePlatformAdapter.truncate_message(
+                item["content"],
+                max_len or default_caption_limit,
+            )
+            item_sent = []
+            for chunk in item_chunks:
+                if not chunk.strip():
+                    continue
+                result = await standalone_sender_fn(
+                    pconfig,
+                    chat_id,
+                    chunk,
+                    thread_id=thread_id,
+                    media_files=[],
+                )
+                if isinstance(result, dict) and result.get("error"):
+                    return result
+                last_result = result
+                message_id = result.get("message_id") if isinstance(result, dict) else None
+                if message_id:
+                    record = {"content": chunk, "message_id": message_id}
+                    item_sent.append(record)
+                    sent_messages.append(record)
+            warnings.extend(
+                await attach_manifest_actions_standalone(
+                    pconfig,
+                    chat_id,
+                    item.get("actions", []),
+                    item_sent,
+                )
+            )
+        warnings.extend(
+            await attach_manifest_actions_standalone(
+                pconfig,
+                chat_id,
+                manifest_actions(discord_manifest),
+                sent_messages,
+            )
+        )
+        if last_result is None:
+            last_result = {"error": "Discord reaction manifest did not contain deliverable text"}
+        return merge_warnings(last_result, warnings)
+
+    caption, _ = caption_split(
+        send_content,
+        media_files,
+        max_caption_len=(max_len or default_caption_limit),
+    )
+    if caption is not None:
+        result = await standalone_sender_fn(
+            pconfig,
+            chat_id,
+            "",
+            thread_id=thread_id,
+            media_files=media_files,
+            caption=caption,
+        )
+        if isinstance(result, dict) and result.get("error"):
+            return result
+        sent_messages = []
+        message_id = result.get("message_id") if isinstance(result, dict) else None
+        if message_id:
+            sent_messages.append({"content": caption, "message_id": message_id})
+        warnings = await attach_manifest_actions_standalone(
+            pconfig,
+            chat_id,
+            manifest_actions(discord_manifest),
+            sent_messages,
+        )
+        return merge_warnings(result, warnings)
+
+    chunks = BasePlatformAdapter.truncate_message(send_content, max_len) if max_len else [send_content]
+    last_result = None
+    sent_messages = []
+    for i, chunk in enumerate(chunks):
+        is_last = i == len(chunks) - 1
+        result = await standalone_sender_fn(
+            pconfig,
+            chat_id,
+            chunk,
+            thread_id=thread_id,
+            media_files=media_files if is_last else [],
+        )
+        if isinstance(result, dict) and result.get("error"):
+            return result
+        last_result = result
+        message_id = result.get("message_id") if isinstance(result, dict) else None
+        if message_id:
+            sent_messages.append({"content": chunk, "message_id": message_id})
+    warnings = await attach_manifest_actions_standalone(
+        pconfig,
+        chat_id,
+        manifest_actions(discord_manifest),
+        sent_messages,
+    )
+    return merge_warnings(last_result, warnings)

--- a/plugins/platforms/discord/reaction_delivery.py
+++ b/plugins/platforms/discord/reaction_delivery.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any, Awaitable, Callable
-from urllib.parse import quote
 
 from agent.secret_scope import get_secret
 from gateway.platforms.base import BasePlatformAdapter
+
+try:
+    from .reaction_requests import ReactionError, add_reaction_request
+except ImportError:
+    from reaction_requests import ReactionError, add_reaction_request  # type: ignore
 
 try:
     from .reaction_manifest import (
@@ -27,17 +31,6 @@ except ImportError:
 
 StandaloneSender = Callable[..., Awaitable[dict[str, Any]]]
 CaptionSplit = Callable[..., tuple[str | None, str]]
-
-
-def discord_reaction_route_emoji(emoji: str) -> str:
-    """Return the URL path segment Discord expects for a reaction emoji."""
-    import re
-
-    emoji = (emoji or "").strip()
-    custom = re.fullmatch(r"<a?:([^:<>]+):(\d+)>", emoji)
-    if custom:
-        emoji = f"{custom.group(1)}:{custom.group(2)}"
-    return quote(emoji, safe="")
 
 
 async def add_manifest_reaction_with_retry(
@@ -68,11 +61,11 @@ async def add_manifest_reaction_with_retry(
     except Exception:
         session_kwargs, request_kwargs = {}, {}
 
-    route_emoji = discord_reaction_route_emoji(emoji)
-    url = (
-        "https://discord.com/api/v10/channels/"
-        f"{chat_id}/messages/{message_id}/reactions/{route_emoji}/@me"
-    )
+    try:
+        request = add_reaction_request(chat_id, message_id, emoji)
+    except ReactionError as exc:
+        return f"Discord reaction add skipped for message {message_id} emoji {emoji}: {exc}"
+    url = f"https://discord.com/api/v10{request['path']}"
     headers = {"Authorization": f"Bot {token}"}
 
     for attempt in range(max_attempts):

--- a/plugins/platforms/discord/reaction_manifest.py
+++ b/plugins/platforms/discord/reaction_manifest.py
@@ -1,0 +1,132 @@
+"""Discord outbound reaction manifest helpers.
+
+The marker is emitted by profile/plugin code, but Discord delivery is the
+first shared layer that can safely strip it before message splitting.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Iterable
+
+
+REACTION_ACTIONS_MARKER = "[HERMES_REACTION_ACTIONS]"
+
+
+def _valid_action(value: Any) -> bool:
+    return isinstance(value, dict) and isinstance(value.get("emoji"), str) and bool(value["emoji"].strip())
+
+
+def _normalized_actions(values: Any) -> list[dict[str, Any]]:
+    if not isinstance(values, list):
+        return []
+    return [dict(item) for item in values if _valid_action(item)]
+
+
+def manifest_actions(manifest: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Return valid top-level action entries from a parsed manifest."""
+    if not isinstance(manifest, dict):
+        return []
+    return _normalized_actions(manifest.get("actions"))
+
+
+def manifest_discord_messages(manifest: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Return normalized Discord message sections from a parsed manifest."""
+    if not isinstance(manifest, dict):
+        return []
+    raw_messages = manifest.get("discord_messages")
+    if not isinstance(raw_messages, list):
+        return []
+
+    messages: list[dict[str, Any]] = []
+    for item in raw_messages:
+        if not isinstance(item, dict):
+            continue
+        content = item.get("content", item.get("text", item.get("message", "")))
+        if content is None:
+            content = ""
+        content = str(content)
+        actions = _normalized_actions(item.get("actions"))
+        if content.strip() or actions:
+            messages.append({"content": content, "actions": actions})
+    return messages
+
+
+def _has_valid_manifest(manifest: Any) -> bool:
+    return isinstance(manifest, dict) and (
+        bool(manifest_actions(manifest)) or bool(manifest_discord_messages(manifest))
+    )
+
+
+def extract_reaction_manifest(text: str) -> tuple[str, dict[str, Any] | None]:
+    """Strip and parse a Discord reaction manifest from *text*.
+
+    Invalid manifests deliberately fail open by returning the original text.
+    That keeps accidental user-visible text visible instead of silently
+    deleting content we did not understand.
+    """
+    if REACTION_ACTIONS_MARKER not in text:
+        return text, None
+
+    marker_index = text.find(REACTION_ACTIONS_MARKER)
+    before = text[:marker_index]
+    after_marker = text[marker_index + len(REACTION_ACTIONS_MARKER):]
+    parse_source = after_marker.lstrip()
+    leading_ws = len(after_marker) - len(parse_source)
+    try:
+        manifest, parsed_len = json.JSONDecoder().raw_decode(parse_source)
+    except Exception:
+        return text, None
+
+    if not _has_valid_manifest(manifest):
+        return text, None
+
+    consumed = leading_ws + parsed_len
+    cleaned = before + after_marker[consumed:]
+    return cleaned.rstrip(), manifest
+
+
+def choose_reaction_message_index(
+    action: dict[str, Any],
+    sent_messages: Iterable[dict[str, Any]],
+) -> int | None:
+    """Choose which sent Discord message should receive *action*."""
+    messages = list(sent_messages)
+    if not messages:
+        return None
+
+    explicit_index = action.get("message_index")
+    if isinstance(explicit_index, int) and 0 <= explicit_index < len(messages):
+        return explicit_index
+
+    anchors = [
+        value
+        for key in ("anchor", "target_text", "section", "target")
+        for value in [action.get(key)]
+        if isinstance(value, str) and value.strip()
+    ]
+    for anchor in anchors:
+        anchor_lower = anchor.casefold()
+        for index, message in enumerate(messages):
+            if anchor_lower in str(message.get("content", "")).casefold():
+                return index
+
+    action_text = " ".join(
+        str(action.get(key, ""))
+        for key in ("emoji", "kind", "type", "action", "label")
+    ).casefold()
+    section_hint = None
+    if "search" in action_text or "\U0001f50e" in action_text:
+        section_hint = "search queries:"
+    elif "dismiss" in action_text:
+        section_hint = "dismiss shortcuts:"
+
+    if section_hint:
+        for index, message in enumerate(messages):
+            if section_hint in str(message.get("content", "")).casefold():
+                return index
+
+    for index, message in enumerate(messages):
+        if str(message.get("content", "")).strip():
+            return index
+    return 0

--- a/plugins/platforms/discord/reaction_requests.py
+++ b/plugins/platforms/discord/reaction_requests.py
@@ -24,10 +24,10 @@ def validate_emoji(emoji: str) -> str:
         raise ReactionError("emoji must be a non-empty string")
     if emoji.strip() != emoji:
         raise ReactionError("emoji must not have surrounding whitespace")
-    if _FORBIDDEN.search(emoji):
-        raise ReactionError(f"emoji {emoji!r} contains forbidden characters")
     if _CUSTOM_EMOJI_RE.fullmatch(emoji) or _KEYCAP_EMOJI_RE.fullmatch(emoji):
         return emoji
+    if _FORBIDDEN.search(emoji):
+        raise ReactionError(f"emoji {emoji!r} contains forbidden characters")
 
     codepoints = list(emoji)
     if any(char.isascii() and char.isalnum() for char in codepoints):

--- a/plugins/platforms/discord/reaction_requests.py
+++ b/plugins/platforms/discord/reaction_requests.py
@@ -9,9 +9,10 @@ from urllib.parse import quote
 
 
 MAX_REACTION_PAGE = 100
-_CUSTOM_EMOJI_RE = re.compile(r"^[A-Za-z0-9_]{2,32}:[0-9]{15,20}$")
+_CUSTOM_EMOJI_RE = re.compile(r"^[A-Za-z0-9_]{2,32}:[1-9][0-9]{14,19}$")
 _KEYCAP_EMOJI_RE = re.compile(r"^[0-9#*]\ufe0f?\u20e3$")
 _FORBIDDEN = re.compile(r"[\s/@#]|@everyone|@here")
+_SNOWFLAKE_RE = re.compile(r"^[1-9][0-9]*$")
 
 
 class ReactionError(ValueError):
@@ -45,9 +46,9 @@ def encode_emoji_path(emoji: str) -> str:
 
 
 def _base_path(channel_id: str, message_id: str) -> str:
-    if not str(channel_id).isdigit():
+    if not _SNOWFLAKE_RE.fullmatch(str(channel_id)):
         raise ReactionError(f"channel_id must be a snowflake, got {channel_id!r}")
-    if not str(message_id).isdigit():
+    if not _SNOWFLAKE_RE.fullmatch(str(message_id)):
         raise ReactionError(f"message_id must be a snowflake, got {message_id!r}")
     return f"/channels/{channel_id}/messages/{message_id}"
 
@@ -70,12 +71,17 @@ def remove_user_reaction_request(
     channel_id: str, message_id: str, emoji: str, user_id: str
 ) -> dict[str, Any]:
     """Build the request to remove another user's reaction."""
-    if not str(user_id).isdigit():
+    if not _SNOWFLAKE_RE.fullmatch(str(user_id)):
         raise ReactionError(f"user_id must be a snowflake, got {user_id!r}")
     return _request(
         "DELETE",
         f"{_base_path(channel_id, message_id)}/reactions/{encode_emoji_path(emoji)}/{user_id}",
     )
+
+
+def remove_all_reactions_request(channel_id: str, message_id: str) -> dict[str, Any]:
+    """Build the request to remove all reactions from a message."""
+    return _request("DELETE", f"{_base_path(channel_id, message_id)}/reactions")
 
 
 def list_reactions_request(

--- a/plugins/platforms/discord/reaction_requests.py
+++ b/plugins/platforms/discord/reaction_requests.py
@@ -1,0 +1,95 @@
+"""Validated Discord REST v10 reaction request builders for the platform plugin."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import Any
+from urllib.parse import quote
+
+
+MAX_REACTION_PAGE = 100
+_CUSTOM_EMOJI_RE = re.compile(r"^[A-Za-z0-9_]{2,32}:[0-9]{15,20}$")
+_KEYCAP_EMOJI_RE = re.compile(r"^[0-9#*]\ufe0f?\u20e3$")
+_FORBIDDEN = re.compile(r"[\s/@#]|@everyone|@here")
+
+
+class ReactionError(ValueError):
+    """Raised when a Discord reaction request is invalid."""
+
+
+def validate_emoji(emoji: str) -> str:
+    """Return a validated Unicode or ``name:id`` Discord reaction emoji."""
+    if not isinstance(emoji, str) or not emoji:
+        raise ReactionError("emoji must be a non-empty string")
+    if emoji.strip() != emoji:
+        raise ReactionError("emoji must not have surrounding whitespace")
+    if _FORBIDDEN.search(emoji):
+        raise ReactionError(f"emoji {emoji!r} contains forbidden characters")
+    if _CUSTOM_EMOJI_RE.fullmatch(emoji) or _KEYCAP_EMOJI_RE.fullmatch(emoji):
+        return emoji
+
+    codepoints = list(emoji)
+    if any(char.isascii() and char.isalnum() for char in codepoints):
+        raise ReactionError(
+            f"{emoji!r} is not a recognized emoji; use a Unicode emoji or custom 'name:id'"
+        )
+    if any(unicodedata.category(char).startswith("S") for char in codepoints):
+        return emoji
+    raise ReactionError(f"{emoji!r} is not a recognized emoji")
+
+
+def encode_emoji_path(emoji: str) -> str:
+    """Percent-encode a validated emoji for a Discord REST URL path."""
+    return quote(validate_emoji(emoji), safe="")
+
+
+def _base_path(channel_id: str, message_id: str) -> str:
+    if not str(channel_id).isdigit():
+        raise ReactionError(f"channel_id must be a snowflake, got {channel_id!r}")
+    if not str(message_id).isdigit():
+        raise ReactionError(f"message_id must be a snowflake, got {message_id!r}")
+    return f"/channels/{channel_id}/messages/{message_id}"
+
+
+def _request(method: str, path: str, *, query: dict[str, str] | None = None) -> dict[str, Any]:
+    return {"method": method, "path": path, "payload": None, "query": query or {}}
+
+
+def add_reaction_request(channel_id: str, message_id: str, emoji: str) -> dict[str, Any]:
+    """Build the request to add the bot's own reaction."""
+    return _request("PUT", f"{_base_path(channel_id, message_id)}/reactions/{encode_emoji_path(emoji)}/@me")
+
+
+def remove_own_reaction_request(channel_id: str, message_id: str, emoji: str) -> dict[str, Any]:
+    """Build the request to remove the bot's own reaction."""
+    return _request("DELETE", f"{_base_path(channel_id, message_id)}/reactions/{encode_emoji_path(emoji)}/@me")
+
+
+def remove_user_reaction_request(
+    channel_id: str, message_id: str, emoji: str, user_id: str
+) -> dict[str, Any]:
+    """Build the request to remove another user's reaction."""
+    if not str(user_id).isdigit():
+        raise ReactionError(f"user_id must be a snowflake, got {user_id!r}")
+    return _request(
+        "DELETE",
+        f"{_base_path(channel_id, message_id)}/reactions/{encode_emoji_path(emoji)}/{user_id}",
+    )
+
+
+def list_reactions_request(
+    channel_id: str, message_id: str, emoji: str, *, limit: int = 25
+) -> dict[str, Any]:
+    """Build the request to list users reacting with an emoji."""
+    if isinstance(limit, bool):
+        raise ReactionError("limit must be an integer")
+    try:
+        limit = int(limit)
+    except (TypeError, ValueError) as exc:
+        raise ReactionError("limit must be an integer") from exc
+    return _request(
+        "GET",
+        f"{_base_path(channel_id, message_id)}/reactions/{encode_emoji_path(emoji)}",
+        query={"limit": str(max(1, min(limit, MAX_REACTION_PAGE)))},
+    )

--- a/tests/gateway/test_discord_reactions.py
+++ b/tests/gateway/test_discord_reactions.py
@@ -175,6 +175,25 @@ async def test_adapter_add_reaction_targets_explicit_message(adapter):
 
 
 @pytest.mark.asyncio
+async def test_reaction_action_without_message_id_targets_latest_inbound_message(
+    adapter, monkeypatch
+):
+    """The lifecycle hook must preserve the default target used by plugin actions."""
+    monkeypatch.setenv("DISCORD_REACTIONS", "false")
+    monkeypatch.setattr(adapter, "_record_discord_processing_start", lambda *args, **kwargs: None)
+    inbound = _reaction_target(556)
+    channel = _ReactionChannel(123, {556: inbound})
+    adapter._client.get_channel = lambda channel_id: channel if channel_id == 123 else None
+
+    await adapter.on_processing_start(_make_event("556", SimpleNamespace()))
+
+    result = await adapter.add_reaction("123", "🟢")
+
+    assert result == {"success": True, "message_id": "556"}
+    inbound.add_reaction.assert_awaited_once_with("🟢")
+
+
+@pytest.mark.asyncio
 async def test_adapter_reaction_uses_thread_parent_and_ignores_lifecycle_toggle(adapter, monkeypatch):
     monkeypatch.setenv("DISCORD_REACTIONS", "false")
     message = _reaction_target(777)

--- a/tests/gateway/test_discord_reactions.py
+++ b/tests/gateway/test_discord_reactions.py
@@ -40,7 +40,9 @@ def _ensure_discord_mock():
 
 _ensure_discord_mock()
 
+from plugins.platforms.discord import adapter as discord_adapter_module  # noqa: E402
 from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+from plugins.platforms.discord.reaction_actions import dispatch_raw_reaction_add  # noqa: E402
 
 
 class FakeTree:
@@ -59,6 +61,7 @@ class FakeTree:
 def adapter():
     config = PlatformConfig(enabled=True, token="***")
     adapter = DiscordAdapter(config)
+    adapter._allowed_user_ids = {"42"}
     adapter._client = SimpleNamespace(
         tree=FakeTree(),
         get_channel=lambda _id: None,
@@ -140,3 +143,198 @@ async def test_reactions_disabled_via_env(adapter, monkeypatch):
     adapter.send.assert_awaited_once()
 
 
+# ---------------------------------------------------------------------------
+# on_discord_reaction_add plugin hook (raw reaction events)
+# ---------------------------------------------------------------------------
+
+
+def _make_reaction_payload(user_id=42, member=None, emoji="\u2705"):
+    return SimpleNamespace(
+        user_id=user_id,
+        channel_id="123",
+        message_id="456",
+        guild_id=None,
+        emoji=emoji,
+        member=member,
+    )
+
+
+async def _dispatch_reaction(adapter, payload):
+    await dispatch_raw_reaction_add(
+        adapter,
+        payload,
+        discord_module=discord_adapter_module.discord,
+    )
+
+
+def _fake_reaction_channel(message, *, channel_id=123, name="email-important"):
+    return SimpleNamespace(
+        id=channel_id,
+        name=name,
+        fetch_message=AsyncMock(return_value=message),
+        send=AsyncMock(),
+    )
+
+
+def _fake_bot_message(content="bot message"):
+    return SimpleNamespace(
+        author=SimpleNamespace(id=99999, bot=True),
+        content=content,
+        add_reaction=AsyncMock(),
+        remove_reaction=AsyncMock(),
+    )
+
+
+def _install_reaction_hook(monkeypatch, results):
+    """Point the adapter's in-function imports at controllable fakes."""
+    import hermes_cli.lifecycle as lifecycle
+
+    monkeypatch.setattr(
+        lifecycle, "has_hook", lambda name: name == "on_discord_reaction_add"
+    )
+    invoke = MagicMock(return_value=results)
+    monkeypatch.setattr(
+        lifecycle, "invoke_hook", lambda name, **payload: invoke(**payload)
+    )
+    return invoke
+
+
+def _client_with_channel(channel, *, get_user=None):
+    return SimpleNamespace(
+        user=SimpleNamespace(id=99999, name="HermesBot"),
+        get_channel=lambda _id: channel,
+        fetch_channel=AsyncMock(),
+        get_user=get_user,
+    )
+
+
+@pytest.mark.asyncio
+async def test_raw_reaction_add_no_hook_subscribed_does_nothing(adapter, monkeypatch):
+    import hermes_cli.lifecycle as lifecycle
+
+    monkeypatch.setattr(lifecycle, "has_hook", lambda name: False)
+    fetch_channel = AsyncMock()
+    adapter._client = SimpleNamespace(
+        user=SimpleNamespace(id=99999, name="HermesBot"),
+        get_channel=lambda _id: None,
+        fetch_channel=fetch_channel,
+    )
+
+    await _dispatch_reaction(adapter, _make_reaction_payload())
+
+    fetch_channel.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_raw_reaction_add_bot_self_reaction_ignored(adapter, monkeypatch):
+    _install_reaction_hook(monkeypatch, [])
+    fetch_channel = AsyncMock()
+    adapter._client = SimpleNamespace(
+        user=SimpleNamespace(id=99999, name="HermesBot"),
+        get_channel=lambda _id: None,
+        fetch_channel=fetch_channel,
+    )
+
+    await _dispatch_reaction(adapter, _make_reaction_payload(user_id=99999))
+
+    fetch_channel.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_raw_reaction_add_user_on_bot_message_invokes_hook(adapter, monkeypatch):
+    invoke = _install_reaction_hook(monkeypatch, [])
+    channel = _fake_reaction_channel(_fake_bot_message())
+    adapter._client = _client_with_channel(channel)
+
+    await _dispatch_reaction(adapter, _make_reaction_payload())
+
+    invoke.assert_called_once()
+    kwargs = invoke.call_args.kwargs
+    assert kwargs["emoji"] == "\u2705"
+    assert kwargs["user_id"] == "42"
+    assert kwargs["channel_id"] == "123"
+    assert kwargs["message_id"] == "456"
+    assert kwargs["message_content"] == "bot message"
+    assert kwargs["message_author_id"] == "99999"
+
+
+@pytest.mark.asyncio
+async def test_raw_reaction_add_non_allowed_channel_does_not_fetch_message(
+    adapter, monkeypatch
+):
+    invoke = _install_reaction_hook(monkeypatch, [])
+    channel = _fake_reaction_channel(_fake_bot_message(), channel_id=123)
+    adapter._client = _client_with_channel(channel)
+    adapter._allowed_user_ids = set()
+    monkeypatch.setattr(adapter, "_get_allowed_channels", lambda: {"999"})
+    monkeypatch.setattr(adapter, "_get_ignored_channels", lambda: set())
+
+    await _dispatch_reaction(adapter, _make_reaction_payload())
+
+    invoke.assert_not_called()
+    channel.fetch_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_raw_reaction_add_allowed_channel_invokes_without_user_allowlist(
+    adapter, monkeypatch
+):
+    invoke = _install_reaction_hook(monkeypatch, [])
+    channel = _fake_reaction_channel(_fake_bot_message(), channel_id=123)
+    adapter._client = _client_with_channel(channel)
+    adapter._allowed_user_ids = set()
+    monkeypatch.setattr(adapter, "_get_allowed_channels", lambda: {"123"})
+    monkeypatch.setattr(adapter, "_get_ignored_channels", lambda: set())
+
+    await _dispatch_reaction(adapter, _make_reaction_payload())
+
+    invoke.assert_called_once()
+    channel.fetch_message.assert_awaited_once_with(456)
+
+
+@pytest.mark.asyncio
+async def test_raw_reaction_add_ignored_channel_does_not_fetch_message(
+    adapter, monkeypatch
+):
+    invoke = _install_reaction_hook(monkeypatch, [])
+    channel = _fake_reaction_channel(_fake_bot_message(), channel_id=123)
+    adapter._client = _client_with_channel(channel)
+    monkeypatch.setattr(adapter, "_get_allowed_channels", lambda: {"123"})
+    monkeypatch.setattr(adapter, "_get_ignored_channels", lambda: {"123"})
+
+    await _dispatch_reaction(adapter, _make_reaction_payload())
+
+    invoke.assert_not_called()
+    channel.fetch_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_raw_reaction_add_hook_send_message_sends_followup(adapter, monkeypatch):
+    _install_reaction_hook(
+        monkeypatch,
+        [{"action": "send_message", "content": "follow-up!"}],
+    )
+    channel = _fake_reaction_channel(_fake_bot_message())
+    adapter._client = _client_with_channel(channel)
+
+    await _dispatch_reaction(adapter, _make_reaction_payload())
+
+    channel.send.assert_awaited_once_with(content="follow-up!")
+
+
+@pytest.mark.asyncio
+async def test_raw_reaction_add_hook_remove_user_reaction_removes_when_resolvable(
+    adapter, monkeypatch
+):
+    member = SimpleNamespace(id=42, name="Jezza")
+    _install_reaction_hook(
+        monkeypatch,
+        [{"action": "remove_user_reaction", "emoji": "\u2705"}],
+    )
+    message = _fake_bot_message()
+    channel = _fake_reaction_channel(message)
+    adapter._client = _client_with_channel(channel)
+
+    await _dispatch_reaction(adapter, _make_reaction_payload(member=member))
+
+    message.remove_reaction.assert_awaited_once_with("\u2705", member)

--- a/tests/gateway/test_discord_reactions.py
+++ b/tests/gateway/test_discord_reactions.py
@@ -143,6 +143,64 @@ async def test_reactions_disabled_via_env(adapter, monkeypatch):
     adapter.send.assert_awaited_once()
 
 
+class _ReactionChannel:
+    def __init__(self, channel_id, messages=None, parent=None):
+        self.id = int(channel_id)
+        self._messages = messages or {}
+        self.parent = parent
+
+    async def fetch_message(self, message_id):
+        message = self._messages.get(int(message_id))
+        if message is None:
+            raise RuntimeError("Unknown Message")
+        return message
+
+
+def _reaction_target(message_id):
+    return SimpleNamespace(
+        id=int(message_id), add_reaction=AsyncMock(), remove_reaction=AsyncMock()
+    )
+
+
+@pytest.mark.asyncio
+async def test_adapter_add_reaction_targets_explicit_message(adapter):
+    message = _reaction_target(555)
+    channel = _ReactionChannel(123, {555: message})
+    adapter._client.get_channel = lambda channel_id: channel if channel_id == 123 else None
+
+    result = await adapter.add_reaction("123", "🟢", message_id="555")
+
+    assert result == {"success": True, "message_id": "555"}
+    message.add_reaction.assert_awaited_once_with("🟢")
+
+
+@pytest.mark.asyncio
+async def test_adapter_reaction_uses_thread_parent_and_ignores_lifecycle_toggle(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REACTIONS", "false")
+    message = _reaction_target(777)
+    parent = _ReactionChannel(123, {777: message})
+    thread = _ReactionChannel(888, parent=parent)
+    adapter._client.get_channel = lambda channel_id: {123: parent, 888: thread}.get(channel_id)
+
+    result = await adapter.add_reaction("888", "🔴", message_id="777")
+
+    assert result == {"success": True, "message_id": "777"}
+    message.add_reaction.assert_awaited_once_with("🔴")
+
+
+@pytest.mark.asyncio
+async def test_adapter_remove_reaction_removes_bot_own_tracked_emoji(adapter):
+    message = _reaction_target(555)
+    channel = _ReactionChannel(123, {555: message})
+    adapter._client.get_channel = lambda channel_id: channel if channel_id == 123 else None
+
+    await adapter.add_reaction("123", "🟢", message_id="555")
+    result = await adapter.remove_reaction("123", message_id="555")
+
+    assert result == {"success": True, "message_id": "555"}
+    message.remove_reaction.assert_awaited_once_with("🟢", adapter._client.user)
+
+
 # ---------------------------------------------------------------------------
 # on_discord_reaction_add plugin hook (raw reaction events)
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -151,6 +151,63 @@ async def test_send_retries_without_reference_when_reply_target_is_deleted():
     assert send_calls[2]["reference"] is None
 
 
+@pytest.mark.asyncio
+async def test_send_strips_reaction_manifest_and_adds_action_reaction(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    sent_msg = SimpleNamespace(id=1001, add_reaction=AsyncMock())
+    channel = SimpleNamespace(id=555, send=AsyncMock(return_value=sent_msg))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    manifest = {"actions": [{"emoji": "\u2705", "action": "dismiss"}]}
+
+    result = await adapter.send(
+        "555",
+        "Dismiss shortcuts:\n1. archive"
+        f" [HERMES_REACTION_ACTIONS] {json.dumps(manifest)}",
+    )
+
+    assert result.success is True
+    assert channel.send.await_args.kwargs["content"] == "Dismiss shortcuts:\n1. archive"
+    sent_msg.add_reaction.assert_awaited_once_with("\u2705")
+
+
+@pytest.mark.asyncio
+async def test_send_reaction_manifest_messages_send_explicit_parts(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    sent_msgs = [
+        SimpleNamespace(id=1001, add_reaction=AsyncMock()),
+        SimpleNamespace(id=1002, add_reaction=AsyncMock()),
+    ]
+    channel = SimpleNamespace(id=555, send=AsyncMock(side_effect=sent_msgs))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    manifest = {
+        "discord_messages": [
+            {"content": "Search queries:", "actions": [{"emoji": "\U0001f50e"}]},
+            {"content": "Dismiss shortcuts:", "actions": [{"emoji": "\u2705"}]},
+        ]
+    }
+
+    result = await adapter.send(
+        "555",
+        f"fallback [HERMES_REACTION_ACTIONS] {json.dumps(manifest)}",
+    )
+
+    assert result.success is True
+    assert [call.kwargs["content"] for call in channel.send.await_args_list] == [
+        "Search queries:",
+        "Dismiss shortcuts:",
+    ]
+    sent_msgs[0].add_reaction.assert_awaited_once_with("\U0001f50e")
+    sent_msgs[1].add_reaction.assert_awaited_once_with("\u2705")
+
+
 # ---------------------------------------------------------------------------
 # Forum channel tests
 # ---------------------------------------------------------------------------
@@ -416,5 +473,4 @@ async def test_send_file_attachment_forum_uses_files_kwarg(tmp_path, monkeypatch
     thread_kwargs = forum_channel.create_thread.await_args.kwargs
     assert thread_kwargs.get("file") is None
     assert isinstance(thread_kwargs.get("files"), list) and len(thread_kwargs["files"]) == 1
-
 

--- a/tests/plugins/platforms/test_discord_reaction_manifest.py
+++ b/tests/plugins/platforms/test_discord_reaction_manifest.py
@@ -1,0 +1,66 @@
+import json
+
+from plugins.platforms.discord.reaction_manifest import (
+    REACTION_ACTIONS_MARKER,
+    choose_reaction_message_index,
+    extract_reaction_manifest,
+    manifest_actions,
+    manifest_discord_messages,
+)
+
+
+def test_extract_reaction_manifest_absent_returns_original_text():
+    text, manifest = extract_reaction_manifest("plain message")
+
+    assert text == "plain message"
+    assert manifest is None
+
+
+def test_extract_reaction_manifest_invalid_json_fails_open():
+    original = f"hello {REACTION_ACTIONS_MARKER} {{not json"
+
+    text, manifest = extract_reaction_manifest(original)
+
+    assert text == original
+    assert manifest is None
+
+
+def test_extract_reaction_manifest_actions_strips_valid_marker():
+    payload = {"actions": [{"emoji": "\u2705", "action": "dismiss"}]}
+
+    text, manifest = extract_reaction_manifest(
+        "Dismiss shortcuts\n"
+        f"{REACTION_ACTIONS_MARKER} {json.dumps(payload)}"
+    )
+
+    assert text == "Dismiss shortcuts"
+    assert manifest_actions(manifest) == payload["actions"]
+
+
+def test_extract_reaction_manifest_discord_messages_without_top_level_actions():
+    payload = {
+        "discord_messages": [
+            {"content": "Search queries", "actions": [{"emoji": "\U0001f50e"}]},
+            {"text": "Dismiss shortcuts", "actions": [{"emoji": "\u2705"}]},
+        ]
+    }
+
+    text, manifest = extract_reaction_manifest(
+        f"fallback {REACTION_ACTIONS_MARKER} {json.dumps(payload)}"
+    )
+
+    assert text == "fallback"
+    assert manifest_discord_messages(manifest) == [
+        {"content": "Search queries", "actions": [{"emoji": "\U0001f50e"}]},
+        {"content": "Dismiss shortcuts", "actions": [{"emoji": "\u2705"}]},
+    ]
+
+
+def test_choose_reaction_message_index_prefers_action_anchor():
+    sent = [
+        {"content": "Search queries:\n1. find receipts", "message_id": "1"},
+        {"content": "Dismiss shortcuts:\n2. archive", "message_id": "2"},
+    ]
+
+    assert choose_reaction_message_index({"emoji": "\u2705", "anchor": "Dismiss shortcuts:"}, sent) == 1
+    assert choose_reaction_message_index({"emoji": "\U0001f50e", "action": "search"}, sent) == 0

--- a/tests/plugins/platforms/test_discord_reaction_requests.py
+++ b/tests/plugins/platforms/test_discord_reaction_requests.py
@@ -1,0 +1,41 @@
+"""Tests for plugin-owned Discord reaction REST request builders."""
+
+import pytest
+
+from plugins.platforms.discord.reaction_requests import (
+    MAX_REACTION_PAGE,
+    ReactionError,
+    add_reaction_request,
+    encode_emoji_path,
+    list_reactions_request,
+    remove_own_reaction_request,
+    validate_emoji,
+)
+
+
+def test_unicode_and_keycap_emoji_paths_are_encoded():
+    assert encode_emoji_path("👍") == "%F0%9F%91%8D"
+    assert encode_emoji_path("1️⃣") == "1%EF%B8%8F%E2%83%A3"
+
+
+def test_custom_emoji_path_is_encoded():
+    assert encode_emoji_path("hermes:123456789012345678") == "hermes%3A123456789012345678"
+
+
+@pytest.mark.parametrize("emoji", [" hello", "hello", "<@123>", "x@everyone", "bad:12"])
+def test_invalid_emoji_is_rejected(emoji):
+    with pytest.raises(ReactionError):
+        validate_emoji(emoji)
+
+
+def test_add_and_remove_own_request_shapes():
+    assert add_reaction_request("111", "222", "👍") == {
+        "method": "PUT", "path": "/channels/111/messages/222/reactions/%F0%9F%91%8D/@me", "payload": None, "query": {}
+    }
+    assert remove_own_reaction_request("111", "222", "👍")["method"] == "DELETE"
+
+
+def test_list_limit_is_clamped_and_invalid_values_raise_reaction_error():
+    assert list_reactions_request("111", "222", "👍", limit=999)["query"] == {"limit": str(MAX_REACTION_PAGE)}
+    with pytest.raises(ReactionError):
+        list_reactions_request("111", "222", "👍", limit="not-a-number")

--- a/tests/plugins/platforms/test_discord_reaction_requests.py
+++ b/tests/plugins/platforms/test_discord_reaction_requests.py
@@ -8,7 +8,9 @@ from plugins.platforms.discord.reaction_requests import (
     add_reaction_request,
     encode_emoji_path,
     list_reactions_request,
+    remove_all_reactions_request,
     remove_own_reaction_request,
+    remove_user_reaction_request,
     validate_emoji,
 )
 
@@ -24,6 +26,11 @@ def test_custom_emoji_path_is_encoded():
     assert encode_emoji_path("hermes:123456789012345678") == "hermes%3A123456789012345678"
 
 
+def test_custom_emoji_zero_prefixed_snowflake_is_rejected():
+    with pytest.raises(ReactionError):
+        validate_emoji("hermes:000000000000000")
+
+
 @pytest.mark.parametrize("emoji", [" hello", "hello", "<@123>", "x@everyone", "bad:12"])
 def test_invalid_emoji_is_rejected(emoji):
     with pytest.raises(ReactionError):
@@ -35,6 +42,37 @@ def test_add_and_remove_own_request_shapes():
         "method": "PUT", "path": "/channels/111/messages/222/reactions/%F0%9F%91%8D/@me", "payload": None, "query": {}
     }
     assert remove_own_reaction_request("111", "222", "👍")["method"] == "DELETE"
+
+
+def test_remove_user_and_all_request_shapes():
+    assert remove_user_reaction_request("111", "222", "👍", "333") == {
+        "method": "DELETE",
+        "path": "/channels/111/messages/222/reactions/%F0%9F%91%8D/333",
+        "payload": None,
+        "query": {},
+    }
+    assert remove_all_reactions_request("111", "222") == {
+        "method": "DELETE",
+        "path": "/channels/111/messages/222/reactions",
+        "payload": None,
+        "query": {},
+    }
+
+
+@pytest.mark.parametrize(
+    ("field", "args"),
+    [
+        ("channel_id", ("0111", "222")),
+        ("message_id", ("111", "0222")),
+        ("user_id", ("111", "222", "👍", "0333")),
+    ],
+)
+def test_zero_prefixed_snowflakes_are_rejected(field, args):
+    with pytest.raises(ReactionError, match=field):
+        if field == "user_id":
+            remove_user_reaction_request(*args)
+        else:
+            remove_all_reactions_request(*args)
 
 
 def test_list_limit_is_clamped_and_invalid_values_raise_reaction_error():

--- a/tests/plugins/platforms/test_discord_reaction_requests.py
+++ b/tests/plugins/platforms/test_discord_reaction_requests.py
@@ -16,6 +16,8 @@ from plugins.platforms.discord.reaction_requests import (
 def test_unicode_and_keycap_emoji_paths_are_encoded():
     assert encode_emoji_path("👍") == "%F0%9F%91%8D"
     assert encode_emoji_path("1️⃣") == "1%EF%B8%8F%E2%83%A3"
+    assert encode_emoji_path("#️⃣") == "%23%EF%B8%8F%E2%83%A3"
+    assert encode_emoji_path("*️⃣") == "%2A%EF%B8%8F%E2%83%A3"
 
 
 def test_custom_emoji_path_is_encoded():

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -383,6 +383,21 @@ class TestSendMessageTool:
         assert leaked not in result["error"]
         assert "access_token=***" in result["error"]
 
+    def test_discord_reactions_are_not_model_callable(self):
+        result = json.loads(
+            send_message_tool(
+                {
+                    "action": "react",
+                    "target": "discord:123",
+                    "emoji": "👍",
+                    "message_id": "456",
+                }
+            )
+        )
+
+        assert "error" in result
+        assert "Discord reactions are plugin-owned" in result["error"]
+
 
 class TestSendTelegramMediaDelivery:
     def test_sends_photo_with_caption_for_media_tag(self, tmp_path, monkeypatch):

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -490,6 +490,146 @@ class TestSendToPlatformChunking:
         for call in send.await_args_list:
             assert len(call.args[2]) <= 2020  # each chunk fits the limit
 
+    def test_discord_without_manifest_does_not_add_manifest_reactions(self, monkeypatch):
+        send = AsyncMock(return_value={"success": True, "message_id": "1"})
+        add_reaction = AsyncMock(return_value=None)
+        monkeypatch.setattr(
+            "plugins.platforms.discord.reaction_delivery.add_manifest_reaction_with_retry",
+            add_reaction,
+        )
+
+        with _patch_discord_sender(send):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.DISCORD,
+                    SimpleNamespace(enabled=True, token="***", extra={}),
+                    "ch",
+                    "plain Discord message",
+                )
+            )
+
+        assert result["success"] is True
+        send.assert_awaited_once_with(
+            "***",
+            "ch",
+            "plain Discord message",
+            thread_id=None,
+            media_files=[],
+        )
+        add_reaction.assert_not_awaited()
+
+    def test_discord_invalid_manifest_remains_visible(self, monkeypatch):
+        sent_messages = []
+
+        async def mock_send(token, chat_id, message, thread_id=None, media_files=None):
+            sent_messages.append(message)
+            return {"success": True, "message_id": "1"}
+
+        add_reaction = AsyncMock(return_value=None)
+        monkeypatch.setattr(
+            "plugins.platforms.discord.reaction_delivery.add_manifest_reaction_with_retry",
+            add_reaction,
+        )
+        original = "visible [HERMES_REACTION_ACTIONS] {not json"
+
+        with _patch_discord_sender(AsyncMock(side_effect=mock_send)):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.DISCORD,
+                    SimpleNamespace(enabled=True, token="***", extra={}),
+                    "ch",
+                    original,
+                )
+            )
+
+        assert result["success"] is True
+        assert sent_messages == [original]
+        add_reaction.assert_not_awaited()
+
+    def test_discord_manifest_is_stripped_before_chunking_and_reacts(self, monkeypatch):
+        call_log = []
+
+        async def mock_send(token, chat_id, message, thread_id=None, media_files=None):
+            message_id = f"msg-{len(call_log)}"
+            call_log.append({"message": message, "message_id": message_id})
+            return {"success": True, "message_id": message_id}
+
+        add_reaction = AsyncMock(return_value=None)
+        monkeypatch.setattr(
+            "plugins.platforms.discord.reaction_delivery.add_manifest_reaction_with_retry",
+            add_reaction,
+        )
+        manifest = {
+            "actions": [
+                {"emoji": "\u2705", "action": "dismiss", "anchor": "Dismiss shortcuts:"}
+            ]
+        }
+        message = (
+            ("A " * 1100)
+            + "\nDismiss shortcuts:\n1. archive\n"
+            + f"[HERMES_REACTION_ACTIONS] {json.dumps(manifest)}"
+        )
+
+        with _patch_discord_sender(AsyncMock(side_effect=mock_send)):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.DISCORD,
+                    SimpleNamespace(enabled=True, token="tok", extra={}),
+                    "ch",
+                    message,
+                )
+            )
+
+        assert result["success"] is True
+        assert len(call_log) >= 2
+        assert all("[HERMES_REACTION_ACTIONS]" not in call["message"] for call in call_log)
+        target_message_id = next(
+            call["message_id"]
+            for call in call_log
+            if "Dismiss shortcuts:" in call["message"]
+        )
+        add_reaction.assert_awaited_once()
+        assert add_reaction.await_args.args[1:] == ("ch", target_message_id, "\u2705")
+
+    def test_discord_manifest_messages_send_explicit_parts(self, monkeypatch):
+        sent_messages = []
+
+        async def mock_send(token, chat_id, message, thread_id=None, media_files=None):
+            message_id = f"msg-{len(sent_messages)}"
+            sent_messages.append({"message": message, "message_id": message_id})
+            return {"success": True, "message_id": message_id}
+
+        add_reaction = AsyncMock(return_value=None)
+        monkeypatch.setattr(
+            "plugins.platforms.discord.reaction_delivery.add_manifest_reaction_with_retry",
+            add_reaction,
+        )
+        manifest = {
+            "discord_messages": [
+                {"content": "Search queries:", "actions": [{"emoji": "\U0001f50e"}]},
+                {"content": "Dismiss shortcuts:", "actions": [{"emoji": "\u2705"}]},
+            ]
+        }
+
+        with _patch_discord_sender(AsyncMock(side_effect=mock_send)):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.DISCORD,
+                    SimpleNamespace(enabled=True, token="tok", extra={}),
+                    "ch",
+                    f"fallback [HERMES_REACTION_ACTIONS] {json.dumps(manifest)}",
+                )
+            )
+
+        assert result["success"] is True
+        assert [call["message"] for call in sent_messages] == [
+            "Search queries:",
+            "Dismiss shortcuts:",
+        ]
+        assert [call.args[3] for call in add_reaction.await_args_list] == [
+            "\U0001f50e",
+            "\u2705",
+        ]
 
     def test_slack_pre_escaped_entities_not_double_escaped(self, monkeypatch):
         """Pre-escaped HTML entities survive tool-layer formatting without double-escaping."""

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -990,7 +990,7 @@ class TestSendTelegramThreadIdMapping:
 
         # Create a test file
         test_file = tmp_path / "doc.txt"
-        test_file.write_text("test content")
+        test_file.write_text("test content", encoding="utf-8")
 
         asyncio.run(
             _send_telegram(

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -79,6 +79,7 @@ _CAPTIONABLE_EXTS = _IMAGE_EXTS | _VIDEO_EXTS | {
     ".pdf", ".doc", ".docx", ".txt", ".md", ".csv", ".xlsx", ".zip",
 }
 
+
 # Per-platform native caption length limits (characters). Text longer than
 # the limit can't ride on the media bubble and stays a separate body message.
 # Telegram's photo/video caption cap is 1024; WhatsApp and Discord are far
@@ -1014,44 +1015,25 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     # historically went straight to the HTTP path; we preserve that by
     # explicitly invoking the registry hook here so behavior is unchanged.
     if platform == Platform.DISCORD:
+        from plugins.platforms.discord.reaction_delivery import (
+            send_standalone_discord_with_manifest,
+        )
         from gateway.platform_registry import platform_registry
+
         entry = platform_registry.get("discord")
         if entry is None or entry.standalone_sender_fn is None:
             return {"error": "Discord plugin not registered or missing standalone_sender_fn"}
-        # MEDIA:<path> caption: single captionable file + short text rides as
-        # the media message content instead of a separate message before the
-        # attachment (single enforced decision in _media_caption_split). Cap on
-        # the platform's own message limit so the caption is always deliverable.
-        _dc_caption, _ = _media_caption_split(
-            message, media_files,
-            max_caption_len=(max_len or _DEFAULT_CAPTION_LIMIT),
+        return await send_standalone_discord_with_manifest(
+            pconfig=pconfig,
+            chat_id=chat_id,
+            message=message,
+            thread_id=thread_id,
+            media_files=media_files,
+            max_len=max_len,
+            default_caption_limit=_DEFAULT_CAPTION_LIMIT,
+            caption_split=_media_caption_split,
+            standalone_sender_fn=entry.standalone_sender_fn,
         )
-        if _dc_caption is not None:
-            result = await entry.standalone_sender_fn(
-                pconfig,
-                chat_id,
-                "",
-                thread_id=thread_id,
-                media_files=media_files,
-                caption=_dc_caption,
-            )
-            if isinstance(result, dict) and result.get("error"):
-                return result
-            return result
-        last_result = None
-        for i, chunk in enumerate(chunks):
-            is_last = (i == len(chunks) - 1)
-            result = await entry.standalone_sender_fn(
-                pconfig,
-                chat_id,
-                chunk,
-                thread_id=thread_id,
-                media_files=media_files if is_last else [],
-            )
-            if isinstance(result, dict) and result.get("error"):
-                return result
-            last_result = result
-        return last_result
 
     # --- Matrix: route ALL sends through the native adapter so text is
     # encrypted in E2EE rooms too (issue: text-only sends arrived with a red

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -222,7 +222,7 @@ SEND_MESSAGE_SCHEMA = {
             "action": {
                 "type": "string",
                 "enum": ["send", "list", "react", "unreact"],
-                "description": "Action to perform. 'send' (default) sends a message. 'list' returns all available channels/contacts across connected platforms. 'react' attaches an emoji reaction to a message (platforms that support it, e.g. photon/iMessage tapbacks). 'unreact' retracts a previously-added reaction."
+                "description": "Action to perform. 'send' (default) sends a message. 'list' returns all available channels/contacts across connected platforms. 'react' attaches an emoji reaction to a message (platforms that support it, e.g. photon/iMessage tapbacks; Discord reactions are plugin-owned through hooks/manifests). 'unreact' retracts a previously-added reaction."
             },
             "target": {
                 "type": "string",
@@ -293,6 +293,11 @@ def _handle_react(args, remove=False):
 
     parts = target.split(":", 1)
     platform_name = parts[0].strip().lower()
+    if platform_name == "discord":
+        return tool_error(
+            "Discord reactions are plugin-owned; use Discord reaction hooks or "
+            "reaction manifests instead of send_message react/unreact."
+        )
     target_ref = parts[1].strip() if len(parts) > 1 else None
     chat_id = None
     prepare_send_message_platforms()

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -944,6 +944,8 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 
 Most hooks are fire-and-forget observers — their return values are ignored. The exceptions are `pre_llm_call`, which can inject context into the conversation; `pre_tool_call`, which can return a block/approve directive; and `on_discord_reaction_add`, whose return value can request best-effort Discord side effects on the reacted message.
 
+Discord reaction behavior is plugin-owned: use reaction hooks, outbound manifests, and adapter delivery helpers rather than adding direct core Discord tool actions.
+
 All callbacks should accept `**kwargs` for forward compatibility. If a hook callback crashes, it's logged and skipped. Other hooks and the agent continue normally.
 
 The kanban lifecycle hooks fire **after** the board DB change commits, so a callback always sees durable state and can never hold the SQLite write lock. Because kanban workers run as separate `hermes -p <profile> chat -q` subprocesses, `kanban_task_claimed` fires in the **dispatcher** process while `kanban_task_completed` / `kanban_task_blocked` fire in the **worker** process — hook in the dispatcher to observe every transition centrally, or in the worker for per-task in-session context.

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -937,11 +937,12 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 | [`on_session_finalize`](/user-guide/features/hooks#on_session_finalize) | CLI/gateway tears down an active session | `session_id: str \| None, platform: str` | ignored |
 | [`on_session_reset`](/user-guide/features/hooks#on_session_reset) | Gateway swaps in a new session key (`/new`, `/reset`) | `session_id: str, platform: str` | ignored |
 | [`gateway_platform_event`](/user-guide/features/hooks#gateway_platform_event) | An authorized platform-native event is normalized at the gateway boundary (Telegram reactions currently) | `platform: str, event_type: str, payload: dict` | ignored |
+| [`on_discord_reaction_add`](/user-guide/features/hooks#on_discord_reaction_add) | An authorized user reacts to a bot-authored Discord message | `emoji: str, user_id: str, channel_id: str, message_id: str, guild_id: str \| None, message_content: str, message_author_id: str \| None` | optional best-effort Discord action dict(s) |
 | `kanban_task_claimed` | A kanban task is claimed (dispatcher process, before the worker spawns) | `task_id: str, board: str \| None, assignee: str \| None, run_id: int \| None, profile_name: str` | ignored |
 | `kanban_task_completed` | A kanban task completes (worker process) | `task_id, board, assignee, run_id, profile_name, summary: str \| None` | ignored |
 | `kanban_task_blocked` | A kanban task is blocked (worker process) | `task_id, board, assignee, run_id, profile_name, reason: str \| None` | ignored |
 
-Most hooks are fire-and-forget observers — their return values are ignored. The exceptions are `pre_llm_call`, which can inject context into the conversation, and `pre_tool_call`, which can return a block/approve directive.
+Most hooks are fire-and-forget observers — their return values are ignored. The exceptions are `pre_llm_call`, which can inject context into the conversation; `pre_tool_call`, which can return a block/approve directive; and `on_discord_reaction_add`, whose return value can request best-effort Discord side effects on the reacted message.
 
 All callbacks should accept `**kwargs` for forward compatibility. If a hook callback crashes, it's logged and skipped. Other hooks and the agent continue normally.
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -1315,6 +1315,8 @@ Side-effect failures are logged at debug level and do not crash the gateway. The
 
 Plugins or profile code can attach reaction actions to outbound Discord messages by appending a reaction manifest to text delivered through `send_message`, cron, kanban, MCP delivery, or other send paths. The Discord sender strips the marker before message splitting, sends any Discord-specific message sections, then adds the configured bot reactions to the delivered Discord messages:
 
+Discord reactions are exposed through plugin hooks/manifests and adapter delivery helpers, not as direct core Discord tool actions.
+
 ```text
 Decision summary for today.
 [HERMES_REACTION_ACTIONS]{

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -463,6 +463,7 @@ Payload fields below are the exact event-specific fields supplied by each call s
 | `subagent_stop` | Observer | Child exit; return ignored. | `parent_session_id`, `parent_turn_id`, `child_session_id`, `child_role`, `child_summary`, `child_status`, `tool_call_history`, `duration_ms` | Summary and redacted tool-history metadata may reveal project structure. |
 | `pre_gateway_dispatch` | Directive/control | Incoming non-internal message before auth/pairing/dispatch; first valid `skip`, `rewrite`, or `allow` controls flow. | `event`, `gateway`, `session_store` | Extremely privileged in-process objects expose inbound user/routing data and host handles. |
 | `gateway_platform_event` | Observer | After the gateway's profile-scoped authorization succeeds, when a supported platform-native event is normalized at the gateway boundary (Telegram: reactions, message edits; Discord: message edits/deletes, thread created/renamed); return ignored. | `platform`, `event_type`, `payload` (event-type-specific dict — see the per-event contracts below) | Normalized plain-dict envelope only; raw SDK objects, adapter handles, and bot clients are never exposed. |
+| [`on_discord_reaction_add`](#on_discord_reaction_add) | Platform action hook | After an authorized user adds a reaction to a bot-authored Discord message; bot self-reactions and non-bot-authored messages are ignored. | `emoji`, `user_id`, `channel_id`, `message_id`, `guild_id`, `message_content`, `message_author_id` | Discord ids plus the bot message content. No raw Discord SDK objects, adapter handles, or bot clients are exposed. |
 | `pre_command` | Observer | Recognized slash command about to be dispatched, before the handler runs, on CLI and gateway cold-path dispatch; return ignored in v1 (directive-shaped dicts are logged at debug). Gateway running-agent intercept commands (`/stop`, `/approve` during an active run) are deliberately excluded — control-plane escape hatches must stay outside plugin reach. | `surface` (`"cli"` \| `"gateway"`), `command` (canonical name), `alias_used`, `args_raw`, `session_key`, `platform` | `args_raw` may contain user content or secrets typed after the command. |
 | `pre_approval_request` | Observer | Before prompted or smart approval; return ignored. | `command`, `description`, `pattern_key`, `pattern_keys`, `session_key`, `surface`, `turn_id`, `tool_call_id` | Command may contain secrets; smart observer preparation force-redacts, but surfaces do not all have identical redaction. |
 | `post_approval_response` | Observer | After a decision, timeout, or gateway notification failure; return ignored. | `command`, `description`, `pattern_key`, `pattern_keys`, `session_key`, `surface`, `turn_id`, `tool_call_id`, `choice`; smart path may add `decided_by` | Same command sensitivity plus decision metadata. |
@@ -1262,6 +1263,75 @@ Every payload is additive and event-specific; there is no monolithic gateway pay
 The bot's own progressive message edits (streaming) never fire `message_edited` on Discord — bot-authored events are dropped at the fire-site.
 
 This hook is observer-only: it does **not** add raw-event access or adapter access. **Raw SDK payload access is deliberately not shipped** — adapter SDK objects change shape without notice and would become un-evolvable API surface; where genuinely needed it requires its own explicit capability (`gateway.raw_events`) with a "no stability guarantee" label and its own design (tracked in #64228). For *acting* on a platform (adding a reaction, renaming a thread), use the capability-gated `ctx.platform_actions` facade documented in the [plugins guide](plugins.md#platform-actions) — it is gated off by default behind the `gateway.platform_actions` capability. `PluginContext.dispatch_tool()` can only call tools registered in the tool registry; `send_message` is intentionally not registered there (its transport is reserved for explicit CLI, cron, kanban, and MCP delivery paths). A future outbound-delivery contract must first provide stable delivered content/handles across all adapters; this slice does not pre-register an inert `gateway_message_delivered` hook.
+
+---
+
+### `on_discord_reaction_add`
+
+Fires when a subscribed plugin needs to handle user reactions on bot-authored Discord messages. This is intentionally narrower than [`gateway_platform_event`](#gateway_platform_event): it is for plugin-owned Discord reaction actions, not for routing every raw Discord reaction into the agent.
+
+The Discord adapter applies the same profile-level Discord gates before dispatching this hook:
+
+- the reacting user must pass the configured Discord user/role policy
+- the channel must pass `discord.allowed_channels` / `discord.ignored_channels`
+- bot self-reactions are ignored
+- the target message must be authored by a bot
+
+```python
+def handle_decision(emoji, user_id, channel_id, message_id, message_content, **kwargs):
+    if emoji == "✅":
+        return {
+            "actions": [
+                {"action": "remove_user_reaction", "emoji": emoji},
+                {"action": "add_reaction", "emoji": "☑️"},
+                {"action": "send_message", "content": f"Recorded approval from <@{user_id}>."},
+            ]
+        }
+
+def register(ctx):
+    ctx.register_hook("on_discord_reaction_add", handle_decision)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `emoji` | `str` | The reaction emoji as rendered by Discord. |
+| `user_id` | `str` | Discord id of the user who added the reaction. |
+| `channel_id` | `str` | Discord channel id where the reaction happened. |
+| `message_id` | `str` | Discord id of the reacted-to bot message. |
+| `guild_id` | `str \| None` | Discord guild id, or `None` for DMs. |
+| `message_content` | `str` | Current content of the reacted-to bot message. |
+| `message_author_id` | `str \| None` | Discord id of the message author, if available. |
+
+Callbacks may return a single action dict, a list of action dicts, or `{"actions": [...]}`. Supported best-effort actions are:
+
+| Action | Fields | Effect |
+|--------|--------|--------|
+| `send_message` | `content` or `message` | Sends a follow-up message in the same channel. |
+| `add_reaction` / `add_bot_reaction` | `emoji` | Adds a bot reaction to the reacted-to message. |
+| `remove_bot_reaction` | `emoji` | Removes the bot's reaction from the reacted-to message. |
+| `remove_user_reaction` | `emoji` optional | Removes the reacting user's emoji from the reacted-to message; defaults to the triggering emoji. |
+
+Side-effect failures are logged at debug level and do not crash the gateway. The hook receives plain strings only; raw Discord SDK objects, adapter handles, and the bot client are deliberately not part of the stable contract.
+
+Plugins or profile code can attach reaction actions to outbound Discord messages by appending a reaction manifest to text delivered through `send_message`, cron, kanban, MCP delivery, or other send paths. The Discord sender strips the marker before message splitting, sends any Discord-specific message sections, then adds the configured bot reactions to the delivered Discord messages:
+
+```text
+Decision summary for today.
+[HERMES_REACTION_ACTIONS]{
+  "actions": [
+    {"emoji": "✅", "anchor": "Decision summary"},
+    {"emoji": "🗑️", "anchor": "Decision summary"}
+  ],
+  "discord_messages": [
+    {
+      "content": "Decision summary for today.",
+      "actions": [{"emoji": "✅"}, {"emoji": "🗑️"}]
+    }
+  ]
+}
+```
+
+The manifest is valid only when it contains at least one top-level `actions` entry or one `discord_messages` entry with content or actions. `emoji` is the only required action field; optional fields such as `message_index`, `anchor`, `target_text`, `section`, or `target` help Hermes choose which delivered message should receive the reaction when a send is split into multiple Discord messages. Invalid manifests fail open: the original text is sent unchanged so Hermes does not silently delete user-visible content it could not parse.
 
 ---
 

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -421,6 +421,8 @@ Controls whether the bot adds emoji reactions to messages as visual feedback:
 
 Disable this if you find the reactions distracting or if the bot's role doesn't have the **Add Reactions** permission.
 
+Plugin hooks and reaction manifests can still request explicit outbound reactions; these are delivery helpers, not direct core Discord tool actions.
+
 #### `discord.ignored_channels`
 
 **Type:** string or list — **Default:** `[]`

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -927,5 +927,3 @@ Leave `everyone` and `roles` at `false` unless you know exactly why you need the
 :::
 
 For more information on securing your Hermes Agent deployment, see the [Security Guide](../security.md).
-
-


### PR DESCRIPTION
## Summary

A lightweight plugin action interface for Discord-delivered messages.

This grew out of profile/plugin workflows that need lightweight reaction affordances on Discord-delivered messages, without baking those workflow semantics into core.

This lets plugins and profile code attach hidden reaction manifests to outbound Discord messages. The Discord sender strips the manifest before delivery, adds the requested reactions to the delivered bot messages, and dispatches authorized user reactions to `on_discord_reaction_add`.

The core does not decide what a reaction means. One plugin could make ✅ mean “approve,” another could make 🗑️ mean “dismiss,” and yet another plugin could make 📅 mean “create follow-up event.”

## What changed

- Adds Discord reaction manifest parsing for outbound sends.
- Adds shared Discord REST v10 reaction request builders and validation.
- Covers add own reaction, remove own reaction, remove user reaction, remove all reactions, and list reaction users request shapes.
- Adds `on_discord_reaction_add` for authorized reactions on bot-authored Discord messages.
- Adds plugin/adapter delivery helpers for best-effort bot reaction add/remove.
- Keeps raw Discord SDK objects out of the plugin contract.
- Applies Discord channel/user gates before invoking reaction hooks.
- Supports best-effort hook return actions: `send_message`, `add_reaction`, `remove_bot_reaction`, and `remove_user_reaction`.
- Keeps Discord reactions plugin-owned; direct Discord `react` / `unreact` actions are not exposed through the core Discord tool or generic model-callable `send_message` reaction path.
- Documents the hook and manifest format.

## Convergence and attribution

This PR incorporates the goals and design pressure from adjacent Discord reaction PRs while keeping the final surface plugin-owned rather than adding direct core Discord tool actions.

Related work credited:

- #67008 by @Kyzcreig: proposed direct Discord `react` / `unreact` actions.
- #79074 by @vel007-ai: proposed agent-facing adapter reaction helpers with Photon-style parity.
- #86419 by @andrexibiza: proposed Discord REST v10 outbound reaction request helpers.

The converged shape is: reaction hooks, outbound manifests, shared request builders, and adapter delivery helpers, without exposing direct Discord `react` / `unreact` actions through core model-callable tools.

`remove_all_reactions_request` is included in the shared request-builder layer for REST coverage and future use, but it is intentionally not exposed as an `on_discord_reaction_add` hook action in this PR. Hook actions remain scoped to adding/removing bot reactions and removing the triggering/user reaction. Clearing all reactions is broader and may remove user context, so exposing it should be a separate explicit policy decision.

## Related issues

This also partially enables the goals in these issue-only requests, without hard-coding reaction meanings into core:

- #29026 by @YuiSuki7: broad Discord reaction support for quick feedback signals.
- #46855 by @poppap: inbound Discord reactions as confirmation/input signals.

This PR intentionally does not close those issues by itself, because confirmation semantics such as “✅ means approve” remain plugin/profile-owned policy built on top of the hook.

## Compatibility / Risk

This is additive and opt-in. Existing Discord behavior is unchanged unless a plugin registers `on_discord_reaction_add` or outbound Discord content includes a valid `[HERMES_REACTION_ACTIONS]` manifest. Invalid manifests fail open and remain visible.

The hook receives only stable plain-string fields, and normal Discord channel/user authorization gates run before dispatch.

## Tests

- `uv run --extra all --extra dev pytest tests/plugins/platforms/test_discord_reaction_manifest.py tests/plugins/platforms/test_discord_reaction_requests.py tests/gateway/test_discord_send.py tests/gateway/test_discord_reactions.py tests/tools/test_send_message_tool.py -q`
- `uv run --extra all --extra dev python -m ruff check plugins/platforms/discord/reaction_requests.py tests/plugins/platforms/test_discord_reaction_requests.py tools/send_message_tool.py tests/tools/test_send_message_tool.py`
