### PR TITLE
feat(skills): add Speko as an outbound AI call provider in the telephony skill

### DIFF
--- a/optional-skills/productivity/telephony/SKILL.md
+++ b/optional-skills/productivity/telephony/SKILL.md
@@ -7,7 +7,7 @@ license: MIT
 platforms: [linux, macos, windows]
 metadata:
   hermes:
-    tags: [telephony, phone, sms, mms, voice, twilio, bland.ai, vapi, calling, texting]
+    tags: [telephony, phone, sms, mms, voice, twilio, bland.ai, vapi, speko, calling, texting]
     related_skills: [maps, google-workspace, agentmail]
     category: productivity
 ---
@@ -24,7 +24,7 @@ It ships with a helper script, `scripts/telephony.py`, that can:
 - poll inbound SMS for that number with no webhook server required
 - make direct Twilio calls using TwiML `<Say>` or `<Play>`
 - import the owned Twilio number into Vapi
-- place outbound AI calls through Bland.ai or Vapi
+- place outbound AI calls through Bland.ai, Vapi, or Speko
 
 ## What this solves
 
@@ -100,6 +100,18 @@ Why:
 - easiest way to play a custom MP3
 - pairs well with Hermes `text_to_speech` plus a public file host or tunnel
 
+### 5) "The call is not in English" or "one provider keeps degrading mid-call"
+Use **Speko**.
+
+Why:
+- it picks the STT / LLM / TTS stack per language from its own provider benchmarks, so a
+  Spanish or Hindi call does not need a hand-tuned stack
+- it fails over to the runner-up provider when one degrades during the call
+- it provisions its own numbers, so there is no Twilio import step
+
+Tradeoff:
+- one more account to hold, and outbound calls need a number provisioned in Speko first
+
 ## Files and persistent state
 
 The skill persists telephony state in two places:
@@ -113,7 +125,11 @@ Used for long-lived provider credentials and owned-number IDs, for example:
 - `BLAND_API_KEY`
 - `VAPI_API_KEY`
 - `VAPI_PHONE_NUMBER_ID`
-- `PHONE_PROVIDER` (AI call provider: bland or vapi)
+- `SPEKO_API_KEY`
+- `SPEKO_PHONE_NUMBER`
+- `SPEKO_AGENT_ID` (optional — reuse a saved Speko agent instead of an ad-hoc prompt)
+- `SPEKO_LANGUAGE`
+- `PHONE_PROVIDER` (AI call provider: bland, vapi, or speko)
 
 ### `~/.hermes/telephony_state.json`
 Used for skill-only state that should survive across sessions, for example:
@@ -216,6 +232,27 @@ If you already know the Vapi phone number ID, save it directly:
 ```bash
 python "$SCRIPT" save-vapi your_vapi_api_key --phone-number-id vapi_phone_number_id_here
 ```
+
+### Speko — routed AI calls, multilingual, own numbers
+
+Sign up at:
+- https://platform.speko.ai
+
+Save the API key:
+
+```bash
+python "$SCRIPT" save-speko your_speko_api_key
+```
+
+List the numbers the Speko account owns, and save one as the outbound caller ID:
+
+```bash
+python "$SCRIPT" speko-numbers
+python "$SCRIPT" save-speko your_speko_api_key --phone-number "+14155550123" --language en
+```
+
+If the account owns exactly one outbound-capable number, `ai-call --provider speko` uses it
+without any `--from-number`. With several, pass `--from-number` or save a default.
 
 ## Diagnose current state
 
@@ -368,6 +405,28 @@ python "$SCRIPT" ai-call "+15551230000" "You are calling to make a dinner reserv
 python "$SCRIPT" ai-status <call_id> --provider vapi
 ```
 
+### I. Outbound AI phone call with Speko (non-English or routed)
+
+No number import step — the call goes out on a number the Speko account already owns:
+
+```bash
+python "$SCRIPT" ai-call "+15551230000" "Llama a la clinica, confirma la cita del martes por la tarde y pregunta si hay que llegar antes." --provider speko --language es
+```
+
+Check the result. Once the call has ended this also returns Speko's own call summary,
+outcome, structured data, and the full transcript:
+
+```bash
+python "$SCRIPT" ai-status <session_id> --provider speko
+```
+
+To run the call as a saved Speko agent (voice, tools, and knowledge base already attached)
+instead of an ad-hoc prompt:
+
+```bash
+python "$SCRIPT" save-speko your_speko_api_key --agent-id agent_abc123
+```
+
 ## Suggested agent procedure
 
 When the user asks for a call or text:
@@ -395,6 +454,14 @@ Those would require more infrastructure than a pure optional skill.
 - `twilio-inbox` polls the REST API; it is not instant push delivery.
 - Vapi outbound calling still depends on having a valid imported number.
 - Bland is easiest, but not always the best-sounding.
+- Speko needs a number provisioned in the Speko account before any outbound call; the
+  helper says so explicitly instead of failing at dial time.
+- `--max-duration` is a Bland/Vapi option; Speko ignores it. Bound the call in the task
+  prompt instead.
+- Reading a Speko call back within a second or two of dialing can fail while the session is
+  still being created — retry `ai-status` rather than treating it as a lost call.
+- Speko's post-call analysis echoes the dialed number back inside `structured_data`. That
+  payload is passed through as-is, so safety rule 4 above still applies when summarizing it.
 - Do not store arbitrary third-party phone numbers in Hermes memory.
 
 ## Verification checklist
@@ -408,6 +475,7 @@ After setup, you should be able to do all of the following with just this skill:
 5. poll inbound texts for the owned number later
 6. place a direct Twilio call
 7. place an AI call via Bland or Vapi
+8. place an AI call via Speko and read its summary and transcript with `ai-status`
 
 ## References
 
@@ -416,3 +484,5 @@ After setup, you should be able to do all of the following with just this skill:
 - Twilio voice: https://www.twilio.com/docs/voice/api/call-resource
 - Vapi docs: https://docs.vapi.ai/
 - Bland.ai: https://app.bland.ai/
+- Speko phone agents: https://docs.speko.ai/guides/phone-agents
+- Speko dial endpoint: https://docs.speko.ai/api-reference/sessions-phone

--- a/optional-skills/productivity/telephony/scripts/telephony.py
+++ b/optional-skills/productivity/telephony/scripts/telephony.py
@@ -8,7 +8,7 @@ Capabilities:
 - Send SMS / MMS via Twilio
 - Poll inbound SMS for an owned Twilio number using only this script + state
 - Import a Twilio number into Vapi and persist the returned Vapi phone_number_id
-- Make outbound AI voice calls via Bland.ai or Vapi
+- Make outbound AI voice calls via Bland.ai, Vapi, or Speko
 
 This file intentionally uses Python stdlib HTTP clients so the skill can run in a
 minimal environment with no extra pip installs.
@@ -35,6 +35,7 @@ from typing import Any
 TWILIO_API_BASE = "https://api.twilio.com/2010-04-01/Accounts"
 VAPI_API_BASE = "https://api.vapi.ai"
 BLAND_API_BASE = "https://api.bland.ai/v1"
+SPEKO_API_BASE = "https://api.speko.dev/v1"
 
 BLAND_DEFAULT_VOICE = "mason"
 BLAND_DEFAULT_MODEL = "enhanced"
@@ -53,6 +54,7 @@ VAPI_DEFAULT_VOICE_ID = "cjVigY5qzO86Huf0OWal"  # ElevenLabs "Eric"
 VAPI_DEFAULT_MODEL = "gpt-4o"
 TWILIO_DEFAULT_TTS_VOICE = "Polly.Joanna"
 DEFAULT_AI_PROVIDER = "bland"
+SPEKO_DEFAULT_LANGUAGE = "en"
 STATE_VERSION = 1
 
 
@@ -448,6 +450,64 @@ def _bland_api_key() -> str:
         "BLAND_API_KEY",
         ("telephony", "bland", "api_key"),
         ("phone", "bland", "api_key"),
+    )
+
+
+def _speko_api_key() -> str:
+    return _env_or_config(
+        "SPEKO_API_KEY",
+        ("telephony", "speko", "api_key"),
+        ("phone", "speko", "api_key"),
+    )
+
+
+def _speko_from_number() -> str:
+    state = _load_state()
+    speko_state = state.get("speko", {}) if isinstance(state.get("speko"), dict) else {}
+    return _env_or_config(
+        "SPEKO_PHONE_NUMBER",
+        ("telephony", "speko", "phone_number"),
+        ("phone", "speko", "phone_number"),
+        default=str(speko_state.get("phone_number", "")),
+    )
+
+
+def _speko_agent_id() -> str:
+    state = _load_state()
+    speko_state = state.get("speko", {}) if isinstance(state.get("speko"), dict) else {}
+    return _env_or_config(
+        "SPEKO_AGENT_ID",
+        ("telephony", "speko", "agent_id"),
+        ("phone", "speko", "agent_id"),
+        default=str(speko_state.get("agent_id", "")),
+    )
+
+
+def _speko_language() -> str:
+    return _env_or_config(
+        "SPEKO_LANGUAGE",
+        ("telephony", "speko", "language"),
+        ("phone", "speko", "language"),
+        default=SPEKO_DEFAULT_LANGUAGE,
+    )
+
+
+def _speko_request(method: str, path: str, *, json_body: dict[str, Any] | None = None) -> Any:
+    """Call the Speko REST API.
+
+    Returns whatever the endpoint answers with: most routes reply with an object,
+    but ``GET /phone-numbers`` replies with a bare array.
+    """
+    api_key = _speko_api_key()
+    if not api_key:
+        raise TelephonyError(
+            f"Speko is not configured. Use 'save-speko' or set SPEKO_API_KEY in {_env_path()}."
+        )
+    return _json_request(
+        method,
+        f"{SPEKO_API_BASE}{path}",
+        headers={"Authorization": f"Bearer {api_key}"},
+        json_body=json_body,
     )
 
 
@@ -968,6 +1028,121 @@ def _vapi_status(call_id: str) -> dict[str, Any]:
     }
 
 
+def _speko_owned_numbers() -> list[dict[str, Any]]:
+    """List the phone numbers the Speko organization owns (bare array response)."""
+    payload = _speko_request("GET", "/phone-numbers")
+    numbers = payload if isinstance(payload, list) else (payload or {}).get("phone_numbers", [])
+    return [n for n in numbers if isinstance(n, dict)]
+
+
+def _speko_resolve_from_number(explicit: str | None = None) -> str:
+    candidate = (explicit or _speko_from_number()).strip()
+    if candidate:
+        return _normalize_phone(candidate)
+    outbound = [
+        n
+        for n in _speko_owned_numbers()
+        if str(n.get("direction", "both")) in {"both", "outbound"} and n.get("e164")
+    ]
+    if not outbound:
+        raise TelephonyError(
+            "Speko has no outbound-capable phone number. Provision one in the Speko "
+            "dashboard (Phone numbers -> Buy or import), then re-run 'save-speko' with "
+            "--phone-number."
+        )
+    if len(outbound) > 1:
+        options = ", ".join(_mask_phone(str(n["e164"])) for n in outbound)
+        raise TelephonyError(
+            f"Speko owns several outbound numbers ({options}). Pass --from-number or save a "
+            "default with 'save-speko --phone-number'."
+        )
+    return _normalize_phone(str(outbound[0]["e164"]))
+
+
+def _speko_call(
+    phone_number: str,
+    task: str,
+    *,
+    voice: str | None = None,
+    first_sentence: str | None = None,
+    from_identifier: str | None = None,
+    agent_id: str | None = None,
+    language: str | None = None,
+) -> dict[str, Any]:
+    normalized = _normalize_phone(phone_number)
+    from_number = _speko_resolve_from_number(from_identifier)
+    agent = (agent_id if agent_id is not None else _speko_agent_id()).strip()
+    body: dict[str, Any] = {"to": normalized, "from": from_number, "systemPrompt": task}
+    if agent:
+        body["agentId"] = agent
+    else:
+        body["intent"] = {"language": (language or _speko_language()).strip()}
+    if voice:
+        body["voice"] = voice
+    if first_sentence:
+        body["firstMessage"] = first_sentence
+
+    payload = _speko_request("POST", "/sessions/phone", json_body=body)
+    session_id = str(payload.get("sessionId") or "")
+    if not session_id:
+        raise TelephonyError(f"Speko returned no sessionId: {payload}")
+    return {
+        "success": True,
+        "provider": "speko",
+        "call_id": session_id,
+        "status": payload.get("status"),
+        "agent_id": agent,
+        "language": body.get("intent", {}).get("language", ""),
+        "to_phone_number_masked": _mask_phone(normalized),
+        "from_phone_number_masked": _mask_phone(from_number),
+        "message": "AI call queued with Speko.",
+    }
+
+
+def _speko_transcript(report: dict[str, Any]) -> str:
+    entries = (report.get("transcript") or {}).get("entries") or []
+    lines = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        text = str(entry.get("text") or "").strip()
+        if text:
+            lines.append(f"{entry.get('source', 'unknown')}: {text}")
+    return "\n".join(lines)
+
+
+def _speko_status(session_id: str) -> dict[str, Any]:
+    try:
+        call = _speko_request("GET", f"/calls/{urllib.parse.quote(session_id)}")
+    except TelephonyError as exc:
+        raise TelephonyError(
+            f"Could not read Speko call {session_id}: {exc}. A call that was only just "
+            "dialed may not be readable yet — retry in a few seconds."
+        ) from exc
+    result = {
+        "success": True,
+        "provider": "speko",
+        "call_id": session_id,
+        "status": call.get("status"),
+        "language": call.get("language"),
+        "duration_seconds": call.get("duration_seconds"),
+        "ended_at": call.get("ended_at"),
+        "recording_status": call.get("recording_status"),
+    }
+    if call.get("status") == "ended":
+        try:
+            report = _speko_request("GET", f"/calls/{urllib.parse.quote(session_id)}/report")
+        except TelephonyError:
+            report = {}
+        if report:
+            result["summary"] = report.get("summary")
+            result["outcome"] = report.get("outcome")
+            result["transcript"] = _speko_transcript(report)
+            result["structured_data"] = report.get("structured_data")
+            result["cost_micro_usd"] = report.get("cost_micro_usd")
+    return result
+
+
 def _provider_decision_tree() -> list[dict[str, str]]:
     return [
         {
@@ -984,6 +1159,11 @@ def _provider_decision_tree() -> list[dict[str, str]]:
             "need": "I want premium conversational voice quality for AI calls, ideally on my own number.",
             "use": "Twilio + Vapi",
             "why": "Buy/import the number with Twilio, then import it into Vapi for better voices and more flexible assistants.",
+        },
+        {
+            "need": "I need the call in a language other than English, or provider failover mid-call.",
+            "use": "Speko",
+            "why": "Speko picks the STT/LLM/TTS stack per language from its own benchmarks and fails over to the runner-up provider when one degrades, so non-English calls do not need a hand-tuned stack.",
         },
         {
             "need": "I want to call with a prerecorded/custom voice message generated elsewhere.",
@@ -1018,6 +1198,7 @@ def diagnose() -> dict[str, Any]:
 
     bland_key = _bland_api_key()
     vapi_key = _vapi_api_key()
+    speko_key = _speko_api_key()
     vapi_phone_id = _vapi_phone_number_id() or str(vapi_state.get("phone_number_id", ""))
 
     return {
@@ -1065,12 +1246,19 @@ def diagnose() -> dict[str, Any]:
                     default=VAPI_DEFAULT_MODEL,
                 ),
             },
+            "speko": {
+                "configured": bool(speko_key),
+                "phone_number": _speko_from_number(),
+                "agent_id": _speko_agent_id(),
+                "language": _speko_language(),
+            },
         },
         "decision_tree": _provider_decision_tree(),
         "notes": [
             "Twilio is the best path for owning a durable phone number, texting, and polling inbound SMS.",
             "Bland is the easiest path for outbound AI calls only.",
             "Vapi is best when you want better AI voice quality, usually backed by a Twilio-owned number.",
+            "Speko is best for non-English calls and for automatic failover across speech providers; it provisions its own numbers, so no Twilio import step.",
             "VoIP numbers are not guaranteed to work for every third-party 2FA flow.",
         ],
     }
@@ -1145,6 +1333,64 @@ def save_vapi(
     return result
 
 
+def save_speko(
+    api_key: str,
+    *,
+    phone_number: str = "",
+    agent_id: str = "",
+    language: str = SPEKO_DEFAULT_LANGUAGE,
+) -> dict[str, Any]:
+    updates = {
+        "SPEKO_API_KEY": api_key.strip(),
+        "SPEKO_LANGUAGE": language.strip() or SPEKO_DEFAULT_LANGUAGE,
+        "PHONE_PROVIDER": "speko",
+    }
+    normalized = _normalize_phone(phone_number) if phone_number.strip() else ""
+    if normalized:
+        updates["SPEKO_PHONE_NUMBER"] = normalized
+    if agent_id.strip():
+        updates["SPEKO_AGENT_ID"] = agent_id.strip()
+    env_file = _upsert_env_file(updates)
+
+    state = _load_state()
+    speko_state = state.get("speko", {}) if isinstance(state.get("speko"), dict) else {}
+    if normalized:
+        speko_state["phone_number"] = normalized
+    if agent_id.strip():
+        speko_state["agent_id"] = agent_id.strip()
+    if speko_state:
+        state["speko"] = speko_state
+        _save_state(state)
+
+    return {
+        "success": True,
+        "provider": "speko",
+        "saved_env_keys": sorted(updates),
+        "env_path": str(env_file),
+        "phone_number_masked": _mask_phone(normalized) if normalized else "",
+        "message": f"Speko configuration saved to {env_file}.",
+    }
+
+
+def speko_numbers() -> dict[str, Any]:
+    numbers = _speko_owned_numbers()
+    return {
+        "success": True,
+        "provider": "speko",
+        "count": len(numbers),
+        "numbers": [
+            {
+                "phone_number": str(n.get("e164") or ""),
+                "phone_number_masked": _mask_phone(str(n.get("e164") or "")),
+                "direction": n.get("direction"),
+                "source": n.get("source"),
+                "agent_id": n.get("agentId") or n.get("agent_id") or "",
+            }
+            for n in numbers
+        ],
+    }
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Hermes telephony helper")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -1167,6 +1413,14 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--voice-provider", default=VAPI_DEFAULT_VOICE_PROVIDER)
     p.add_argument("--voice-id", default=VAPI_DEFAULT_VOICE_ID)
     p.add_argument("--model", default=VAPI_DEFAULT_MODEL)
+
+    p = sub.add_parser("save-speko", help="Save Speko settings to the Hermes .env file")
+    p.add_argument("api_key")
+    p.add_argument("--phone-number", default="", help="Outbound caller ID owned in Speko")
+    p.add_argument("--agent-id", default="", help="Reuse a saved Speko agent instead of an ad-hoc prompt")
+    p.add_argument("--language", default=SPEKO_DEFAULT_LANGUAGE)
+
+    sub.add_parser("speko-numbers", help="List phone numbers owned in Speko")
 
     p = sub.add_parser("twilio-search", help="Search Twilio numbers available for purchase")
     p.add_argument("--country", default="US")
@@ -1214,17 +1468,19 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--phone-number", default="")
     p.add_argument("--save-env", action="store_true")
 
-    p = sub.add_parser("ai-call", help="Place an outbound AI voice call via Bland.ai or Vapi")
+    p = sub.add_parser("ai-call", help="Place an outbound AI voice call via Bland.ai, Vapi, or Speko")
     p.add_argument("to_number")
     p.add_argument("task")
-    p.add_argument("--provider", choices=["bland", "vapi"], default="")
+    p.add_argument("--provider", choices=["bland", "vapi", "speko"], default="")
     p.add_argument("--voice", default="")
     p.add_argument("--first-sentence", default="")
     p.add_argument("--max-duration", type=int, default=3)
+    p.add_argument("--from-number", default="", help="Caller ID (Speko only; Bland/Vapi use their own)")
+    p.add_argument("--language", default="", help="Call language (Speko only, e.g. es, de, hi)")
 
-    p = sub.add_parser("ai-status", help="Check an AI call status via Bland.ai or Vapi")
+    p = sub.add_parser("ai-status", help="Check an AI call status via Bland.ai, Vapi, or Speko")
     p.add_argument("call_id")
-    p.add_argument("--provider", choices=["bland", "vapi"], default="")
+    p.add_argument("--provider", choices=["bland", "vapi", "speko"], default="")
     p.add_argument("--analyze", default="")
 
     return parser
@@ -1236,6 +1492,15 @@ def _dispatch(args: argparse.Namespace) -> dict[str, Any]:
         return diagnose()
     if cmd == "save-twilio":
         return save_twilio(args.account_sid, args.auth_token, phone_number=args.phone_number, phone_sid=args.phone_sid)
+    if cmd == "save-speko":
+        return save_speko(
+            args.api_key,
+            phone_number=args.phone_number,
+            agent_id=args.agent_id,
+            language=args.language,
+        )
+    if cmd == "speko-numbers":
+        return speko_numbers()
     if cmd == "save-bland":
         return save_bland(args.api_key, voice=args.voice)
     if cmd == "save-vapi":
@@ -1310,8 +1575,17 @@ def _dispatch(args: argparse.Namespace) -> dict[str, Any]:
                 first_sentence=args.first_sentence or None,
                 max_duration=args.max_duration,
             )
+        if provider == "speko":
+            return _speko_call(
+                args.to_number,
+                args.task,
+                voice=args.voice or None,
+                first_sentence=args.first_sentence or None,
+                from_identifier=args.from_number or None,
+                language=args.language or None,
+            )
         raise TelephonyError(
-            f"Unsupported AI call provider '{provider}'. Use --provider bland or --provider vapi, "
+            f"Unsupported AI call provider '{provider}'. Use --provider bland, vapi, or speko, "
             f"or set PHONE_PROVIDER in {_env_path()}."
         )
     if cmd == "ai-status":
@@ -1320,8 +1594,10 @@ def _dispatch(args: argparse.Namespace) -> dict[str, Any]:
             return _vapi_status(args.call_id)
         if provider == "bland":
             return _bland_status(args.call_id, analyze=args.analyze or None)
+        if provider == "speko":
+            return _speko_status(args.call_id)
         raise TelephonyError(
-            f"Unsupported AI call provider '{provider}'. Use --provider bland or --provider vapi, "
+            f"Unsupported AI call provider '{provider}'. Use --provider bland, vapi, or speko, "
             f"or set PHONE_PROVIDER in {_env_path()}."
         )
     raise TelephonyError(f"Unknown command: {cmd}")

--- a/tests/skills/test_telephony_skill.py
+++ b/tests/skills/test_telephony_skill.py
@@ -132,3 +132,185 @@ def test_diagnose_includes_decision_tree_and_saved_state(tmp_path: Path, monkeyp
     assert result["providers"]["bland"]["configured"] is True
     assert result["providers"]["vapi"]["phone_number_id"] == "vapi-abc"
     assert any(item["use"] == "Twilio" for item in result["decision_tree"])
+
+
+def test_save_speko_writes_env_and_state(tmp_path: Path, monkeypatch):
+    mod = load_module()
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    result = mod.save_speko(
+        "sk-speko-test",
+        phone_number="+1 (415) 555-0123",
+        agent_id="agent_abc123",
+        language="es",
+    )
+
+    env_text = (tmp_path / ".hermes" / ".env").read_text(encoding="utf-8")
+    state = json.loads((tmp_path / ".hermes" / "telephony_state.json").read_text(encoding="utf-8"))
+
+    assert result["success"] is True
+    assert "SPEKO_API_KEY=sk-speko-test" in env_text
+    assert "SPEKO_PHONE_NUMBER=+14155550123" in env_text
+    assert "SPEKO_AGENT_ID=agent_abc123" in env_text
+    assert "SPEKO_LANGUAGE=es" in env_text
+    assert "PHONE_PROVIDER=speko" in env_text
+    assert state["speko"]["phone_number"] == "+14155550123"
+    assert state["speko"]["agent_id"] == "agent_abc123"
+
+
+def _capture_speko(mod, response):
+    calls = []
+
+    def fake_request(method, path, *, json_body=None):
+        calls.append({"method": method, "path": path, "json_body": json_body})
+        return response(path) if callable(response) else response
+
+    mod._speko_request = fake_request
+    return calls
+
+
+def test_speko_call_is_agentless_when_no_agent_saved(tmp_path: Path, monkeypatch):
+    mod = load_module()
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setenv("SPEKO_PHONE_NUMBER", "+14155550123")
+    calls = _capture_speko(mod, {"sessionId": "sess_1", "status": "dialing"})
+
+    result = mod._speko_call(
+        "+1 555 123 0000",
+        "Confirm the Tuesday appointment.",
+        first_sentence="Hi, this is Ava.",
+        language="es",
+    )
+
+    body = calls[0]["json_body"]
+    assert calls[0]["path"] == "/sessions/phone"
+    assert body["to"] == "+15551230000"
+    assert body["from"] == "+14155550123"
+    assert body["systemPrompt"] == "Confirm the Tuesday appointment."
+    assert body["firstMessage"] == "Hi, this is Ava."
+    assert body["intent"] == {"language": "es"}
+    assert "agentId" not in body
+    assert result["call_id"] == "sess_1"
+    assert result["provider"] == "speko"
+    assert "5551230000" not in json.dumps(result)
+
+
+def test_speko_call_uses_saved_agent_instead_of_intent(tmp_path: Path, monkeypatch):
+    mod = load_module()
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setenv("SPEKO_PHONE_NUMBER", "+14155550123")
+    monkeypatch.setenv("SPEKO_AGENT_ID", "agent_abc123")
+    calls = _capture_speko(mod, {"sessionId": "sess_2", "status": "dialing"})
+
+    mod._speko_call("+15551230000", "Ask about Wednesday instead.")
+
+    body = calls[0]["json_body"]
+    assert body["agentId"] == "agent_abc123"
+    assert "intent" not in body
+
+
+def test_speko_call_resolves_the_only_outbound_number(tmp_path: Path, monkeypatch):
+    mod = load_module()
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    calls = _capture_speko(
+        mod,
+        lambda path: (
+            [{"e164": "+14155550123", "direction": "both"}]
+            if path == "/phone-numbers"
+            else {"sessionId": "sess_3", "status": "dialing"}
+        ),
+    )
+
+    mod._speko_call("+15551230000", "Say hello.")
+
+    assert calls[0]["path"] == "/phone-numbers"
+    assert calls[1]["json_body"]["from"] == "+14155550123"
+
+
+def test_speko_call_refuses_to_guess_between_numbers(tmp_path: Path, monkeypatch):
+    mod = load_module()
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _capture_speko(
+        mod,
+        [
+            {"e164": "+14155550123", "direction": "both"},
+            {"e164": "+14155550124", "direction": "outbound"},
+        ],
+    )
+
+    try:
+        mod._speko_call("+15551230000", "Say hello.")
+    except mod.TelephonyError as exc:
+        assert "several outbound numbers" in str(exc)
+    else:  # pragma: no cover - the call must not proceed
+        raise AssertionError("expected TelephonyError when several numbers are owned")
+
+
+def test_speko_status_flattens_report_transcript(tmp_path: Path, monkeypatch):
+    mod = load_module()
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setenv("SPEKO_API_KEY", "sk-speko-test")
+    _capture_speko(
+        mod,
+        lambda path: (
+            {
+                "session_id": "sess_4",
+                "summary": "Appointment confirmed for Tuesday.",
+                "outcome": "completed",
+                "transcript": {
+                    "entries": [
+                        {"source": "agent", "text": "Hi, calling to confirm Tuesday."},
+                        {"source": "user", "text": "Tuesday works."},
+                        {"source": "agent", "text": "   "},
+                    ]
+                },
+            }
+            if path.endswith("/report")
+            else {"status": "ended", "duration_seconds": 42, "language": "en"}
+        ),
+    )
+
+    result = mod._speko_status("sess_4")
+
+    assert result["status"] == "ended"
+    assert result["duration_seconds"] == 42
+    assert result["outcome"] == "completed"
+    assert result["transcript"] == (
+        "agent: Hi, calling to confirm Tuesday.\nuser: Tuesday works."
+    )
+
+
+def test_speko_status_explains_a_call_that_cannot_be_read_yet(tmp_path: Path, monkeypatch):
+    mod = load_module()
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    def fake_request(method, path, *, json_body=None):
+        raise mod.TelephonyError("HTTP 500 from /calls/sess_5")
+
+    mod._speko_request = fake_request
+
+    try:
+        mod._speko_status("sess_5")
+    except mod.TelephonyError as exc:
+        assert "retry in a few seconds" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected TelephonyError for an unreadable call")
+
+
+def test_diagnose_reports_speko_readiness(tmp_path: Path, monkeypatch):
+    mod = load_module()
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / ".env").write_text(
+        "SPEKO_API_KEY=sk-speko-test\nSPEKO_PHONE_NUMBER=+14155550123\nPHONE_PROVIDER=speko\n",
+        encoding="utf-8",
+    )
+
+    result = mod.diagnose()
+
+    assert result["ai_call_provider"] == "speko"
+    assert result["providers"]["speko"]["configured"] is True
+    assert result["providers"]["speko"]["phone_number"] == "+14155550123"
+    assert result["providers"]["speko"]["language"] == "en"
+    assert any(item["use"] == "Speko" for item in result["decision_tree"])


### PR DESCRIPTION
## What does this PR do?

The `telephony` optional skill already routes outbound AI calls across Bland.ai and Vapi, and its decision tree tells the agent which one to pick. This adds **Speko** as a third option for the two cases the existing pair handles awkwardly:

- **the call is not in English** — Speko selects the STT / LLM / TTS stack per language from its own provider benchmarks, so a Spanish or Hindi call doesn't need a hand-tuned stack;
- **one speech provider degrades mid-call** — Speko fails over to the runner-up provider inside the call.

It also skips the number-import step: Speko provisions its own numbers, so there is no Twilio → Vapi hop before the first call.

Nothing in core changes. This is confined to the skill's helper script, its SKILL.md, and its test file — same shape as the existing Bland and Vapi paths, reusing this script's own `_json_request`, `_env_or_config`, `_normalize_phone` and `_mask_phone` helpers, stdlib only, no new dependencies.

**Disclosure:** I work at Speko, on the team that built this integration.

## Related Issue

No existing issue or PR — I searched issues and PRs (open and closed) for `speko` and for telephony-provider work before starting; there were no hits and no duplicate in flight.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `optional-skills/productivity/telephony/scripts/telephony.py`
  - `save-speko` (api key, optional caller ID, optional saved agent id, language) and `speko-numbers`
  - `ai-call --provider speko` — sends an ad-hoc `systemPrompt` + `intent.language`, or `agentId` when a Speko agent is saved
  - `ai-status --provider speko` — call status, then (once the call has ended) Speko's own summary, outcome, structured data, and a flattened `speaker: text` transcript
  - `diagnose` reports Speko readiness alongside Twilio / Bland / Vapi, plus a new decision-tree branch
  - `ai-call` gains `--from-number` and `--language` (Speko-only; documented as such)
  - caller ID resolves from a saved number, or from the account when exactly **one** outbound-capable number is owned; with several it raises and asks rather than guessing, and with none it says to provision one instead of failing at dial time
- `optional-skills/productivity/telephony/SKILL.md` — decision-tree branch 5, provider setup section, workflow I, three pitfalls, a verification-checklist item, tags, references
- `tests/skills/test_telephony_skill.py` — 8 new tests (no network; the API layer is stubbed)

## How to Test

```bash
SCRIPT=optional-skills/productivity/telephony/scripts/telephony.py

# 1. no key configured -> a clear pointer, not a traceback
python "$SCRIPT" speko-numbers

# 2. configure, then list what the account owns (numbers come back masked)
python "$SCRIPT" save-speko "$SPEKO_API_KEY"
python "$SCRIPT" speko-numbers

# 3. readiness + the new decision-tree branch
python "$SCRIPT" diagnose

# 4. malformed destination is rejected locally, before anything is dialed (exit 1)
python "$SCRIPT" ai-call "not-a-number" "Confirm the appointment." --provider speko

# 5. place the call, then read it back
python "$SCRIPT" ai-call "+15551230000" "Llama a la clinica y confirma la cita del martes." --provider speko --language es
python "$SCRIPT" ai-status <session_id> --provider speko
```

What I ran against the live API on this branch:

- `speko-numbers` → `200`, one owned number, returned masked (`***-***-8143`), `direction: both`
- `diagnose` → `providers.speko.configured: true`, Speko branch present in `decision_tree`
- `ai-status <ended call id> --provider speko` → `status: ended`, `duration_seconds: 70`, `recording_status: ready`, plus the call summary, `outcome`, `structured_data` and the flattened four-turn transcript
- `ai-call not-a-number ... --provider speko` → `{"success": false, "error": "Phone number must be E.164 format …"}`, exit 1, no request sent
- the dial body itself: posted the exact body this code builds with an invalid `to`, and the API's only complaint was `to` — confirming it accepts the agentless `intent` + `systemPrompt` shape; a bogus `agentId` returns `404 AGENT_NOT_FOUND`

**I did not dial a real person for this PR** — there was no consenting recipient on the other end — so step 5 above is verified as far as the request contract and the read-back path, not as a completed conversation. The `ai-status` output quoted above is from a real earlier Speko call on the same account.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run the tests — via the canonical runner on the affected tree: `scripts/run_tests.sh tests/skills/ -q` → **38 files, 1593 passed, 0 failed** (12 of those in `test_telephony_skill.py`, 8 of them new; `test_authoring_standards.py` 1196 passed). Also clean: `ruff check` on both changed Python files, `scripts/check-windows-footguns.py --all` (983 files), and `uv lock --check`. Happy to run any other slice you want to see.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation — SKILL.md carries the setup, the workflow, and the pitfalls
- [x] N/A — `cli-config.yaml.example`: this skill reads `$HERMES_HOME/.env` and `telephony.*` / `phone.*` config paths that already exist; no new top-level config keys
- [x] N/A — no architecture or workflow change
- [x] Cross-platform: stdlib only (`urllib`, `json`, `pathlib`), no POSIX-only primitives, so the skill's existing `platforms: [linux, macos, windows]` still holds
- [x] N/A — no tool description or schema change

## For New Skills

N/A — this extends an existing official optional skill rather than adding one.
