### PR TITLE
feat(weixin): prioritize final replies over transient progress

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1242,6 +1242,10 @@ class WeixinAdapter(BasePlatformAdapter):
             or os.getenv("WEIXIN_SPLIT_MULTILINE_MESSAGES"),
             default=False,
         )
+        self._final_response_priority = _coerce_bool(
+            extra.get("final_response_priority"),
+            default=False,
+        )
 
         # Text debounce batching (mirrors Telegram adapter pattern).
         # iLink delivers messages individually, so rapid multi-message
@@ -1913,6 +1917,26 @@ class WeixinAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
+        if (
+            self._final_response_priority
+            and isinstance(metadata, dict)
+            and metadata.get("transient_progress") is True
+        ):
+            logger.debug(
+                "[%s] final-response priority suppressed transient progress for %s",
+                self.name,
+                _safe_id(chat_id),
+            )
+            # ``success=True`` acknowledges an intentional no-op so generic
+            # progress callers do not retry it.  The machine-readable flag is
+            # the delivery-ledger contract: no platform message was created.
+            return SendResult(
+                success=True,
+                raw_response={
+                    "suppressed": True,
+                    "reason": "transient_progress",
+                },
+            )
         if not self._send_session or not self._token:
             return SendResult(success=False, error="Not connected")
         context_token = self._token_store.get(self._account_id, chat_id)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -530,6 +530,15 @@ def _non_conversational_metadata(
     return merged
 
 
+def _transient_progress_metadata(
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Mark non-final progress so transport adapters can preserve final quota."""
+    merged = dict(metadata or {})
+    merged["transient_progress"] = True
+    return merged
+
+
 def _seed_hygiene_system_prompt(
     agent: Any,
     session_row: Optional[Dict[str, Any]],
@@ -5294,6 +5303,9 @@ class TurnRunner:
                         chat_id=ctx.source.chat_id,
                         config=_consumer_cfg,
                         metadata=ctx._status_thread_metadata,
+                        commentary_metadata=_transient_progress_metadata(
+                            ctx._status_thread_metadata
+                        ),
                         on_new_message=(
                             (lambda: ctx.progress_queue.put(("__reset__",)))
                             if ctx.progress_queue is not None
@@ -5338,7 +5350,9 @@ class TurnRunner:
                 ctx._status_adapter.send(
                     ctx._status_chat_id,
                     display_text,
-                    metadata=ctx._status_thread_metadata,
+                    metadata=_transient_progress_metadata(
+                        ctx._status_thread_metadata
+                    ),
                 ),
                 ctx._loop_for_step,
                 logger=logger,
@@ -5725,7 +5739,12 @@ class TurnRunner:
                 ctx._status_adapter.send(
                     ctx._status_chat_id,
                     message,
-                    metadata=_non_conversational_metadata(ctx._status_thread_metadata, platform=ctx.source.platform),
+                    metadata=_transient_progress_metadata(
+                        _non_conversational_metadata(
+                            ctx._status_thread_metadata,
+                            platform=ctx.source.platform,
+                        )
+                    ),
                 ),
                 ctx._loop_for_step,
                 logger=logger,
@@ -27362,6 +27381,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         chat_id=source.chat_id,
                         config=_consumer_cfg,
                         metadata=_thread_metadata,
+                        commentary_metadata=_transient_progress_metadata(
+                            _thread_metadata
+                        ),
                         on_before_finalize=_pause_typing_before_finalize,
                         initial_reply_to_id=event_message_id,
                         run_still_current=_run_still_current,
@@ -28102,6 +28124,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # reply anchor; carry it so progress joins that thread.
             _progress_metadata = {"reply_to_message_id": event_message_id}
         _progress_metadata = _non_conversational_metadata(_progress_metadata, platform=source.platform)
+        _progress_metadata = _transient_progress_metadata(_progress_metadata)
         if _native_slack_task_cards:
             # chat.startStream in channels requires the recipient team/user
             # pair; harmless extras elsewhere, so stamp them whenever known.
@@ -28521,7 +28544,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         _notify_res = await _notify_adapter.send(
                             source.chat_id,
                             _heartbeat_text,
-                            metadata=_non_conversational_metadata(_status_thread_metadata, platform=source.platform),
+                            metadata=_transient_progress_metadata(
+                                _non_conversational_metadata(
+                                    _status_thread_metadata,
+                                    platform=source.platform,
+                                )
+                            ),
                         )
                         if getattr(_notify_res, "success", False) and getattr(
                             _notify_res, "message_id", None

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -199,11 +199,15 @@ class GatewayStreamConsumer:
         on_before_finalize: Optional[Callable[[], Any]] = None,
         initial_reply_to_id: Optional[str] = None,
         run_still_current: Optional[Callable[[], bool]] = None,
+        commentary_metadata: Optional[dict] = None,
     ):
         self.adapter = adapter
         self.chat_id = chat_id
         self.cfg = config or StreamConsumerConfig()
         self.metadata = metadata
+        self.commentary_metadata = (
+            commentary_metadata if commentary_metadata is not None else metadata
+        )
         # Fired whenever a fresh content bubble is created on the platform
         # (first-send of a new message, commentary, overflow chunk, or
         # fallback continuation). The gateway uses this to linearize the
@@ -1839,14 +1843,22 @@ class GatewayStreamConsumer:
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=text,
-                metadata=self.metadata,
+                metadata=self.commentary_metadata,
             )
             # Note: do NOT set _already_sent = True here.
             # Commentary messages are interim status updates (e.g. "Using browser
             # tool..."), not the final response. Setting already_sent would cause
             # the final response to be incorrectly suppressed when there are
             # multiple tool calls. See: https://github.com/NousResearch/hermes-agent/issues/10454
-            if result.success:
+            raw_response = getattr(result, "raw_response", None)
+            # Some transports intentionally acknowledge a suppressed progress
+            # send as success to prevent retries.  That is not delivery: never
+            # let it enter the commentary ledger used to suppress final replies.
+            suppressed = (
+                isinstance(raw_response, dict)
+                and raw_response.get("suppressed") is True
+            )
+            if result.success and not suppressed:
                 # Commentary counts as fresh content — close off any
                 # stale tool bubble above it so the next tool starts a
                 # new bubble below.
@@ -1855,7 +1867,7 @@ class GatewayStreamConsumer:
                 # an interim "preview" actually carried the final response, vs.
                 # unrelated commentary delivered during a session split (#14238).
                 self._delivered_commentary_texts.append(text)
-            return result.success
+            return bool(result.success and not suppressed)
         except Exception as e:
             logger.error("Commentary send error: %s", e)
             return False

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -529,6 +529,7 @@ async def test_run_agent_progress_uses_event_message_id_for_slack_dm(monkeypatch
     expected_metadata = {
         "thread_id": "1234567890.000001",
         "message_id": "1234567890.000001",
+        "transient_progress": True,
     }
     assert adapter.sent[0]["metadata"] == expected_metadata
     assert all(call["metadata"] == expected_metadata for call in adapter.typing)

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -25,6 +25,22 @@ def test_stream_send_metadata_carries_original_reply_anchor():
     }
 
 
+def test_legacy_positional_on_new_message_callback_is_preserved():
+    callback = MagicMock()
+    metadata = {"thread_id": "topic-1"}
+
+    consumer = GatewayStreamConsumer(
+        MagicMock(),
+        "chat-1",
+        StreamConsumerConfig(),
+        metadata,
+        callback,
+    )
+
+    assert consumer._on_new_message is callback
+    assert consumer.commentary_metadata is metadata
+
+
 # ── _clean_for_display unit tests ────────────────────────────────────────
 
 
@@ -830,6 +846,43 @@ class TestInterimCommentaryMessages:
         sent_texts = [call[1]["content"] for call in adapter.send.call_args_list]
         assert sent_texts == ["I'll inspect the repository first.", "Done."]
         assert consumer.final_response_sent is True
+
+    @pytest.mark.asyncio
+    async def test_commentary_metadata_is_transient_but_final_metadata_is_not(self):
+        adapter = MagicMock()
+        adapter.send = AsyncMock(side_effect=[
+            SimpleNamespace(success=True, message_id="msg_1"),
+            SimpleNamespace(success=True, message_id="msg_2"),
+        ])
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5),
+            metadata={"thread_id": "topic-1"},
+            commentary_metadata={
+                "thread_id": "topic-1",
+                "transient_progress": True,
+            },
+        )
+
+        consumer.on_commentary("I'll inspect the repository first.")
+        consumer.on_delta("Done.")
+        consumer.finish()
+
+        await consumer.run()
+
+        commentary_call, final_call = adapter.send.call_args_list
+        assert commentary_call.kwargs["metadata"] == {
+            "thread_id": "topic-1",
+            "transient_progress": True,
+        }
+        assert final_call.kwargs["metadata"] == {
+            "thread_id": "topic-1",
+            "notify": True,
+        }
 
 
 class TestCancelledConsumerSetsFlags:

--- a/tests/gateway/test_transient_progress_metadata.py
+++ b/tests/gateway/test_transient_progress_metadata.py
@@ -1,0 +1,18 @@
+"""Stable metadata contract for transport-level transient progress."""
+
+from gateway.run import _transient_progress_metadata
+
+
+def test_transient_progress_metadata_preserves_routing_fields():
+    metadata = _transient_progress_metadata({"thread_id": "topic-1"})
+
+    assert metadata == {"thread_id": "topic-1", "transient_progress": True}
+
+
+def test_transient_progress_metadata_does_not_mutate_input():
+    routing = {"thread_id": "topic-1"}
+
+    metadata = _transient_progress_metadata(routing)
+
+    assert routing == {"thread_id": "topic-1"}
+    assert metadata is not routing

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -14,6 +14,7 @@ from gateway.platforms.base import SendResult
 from gateway.platforms.base import MessageEvent, MessageType
 from gateway.platforms import weixin
 from gateway.platforms.weixin import ContextTokenStore, WeixinAdapter
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
 from tools.send_message_tool import _parse_target_ref, _send_to_platform
 
 
@@ -269,6 +270,160 @@ class TestWeixinChunkDelivery:
         # rest of the current chunk and follow-up sends fail fast.
         assert send_message_mock.await_count == 2
         assert sleep_mock.await_count == 1
+
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_final_response_priority_drops_transient_progress_before_send(
+        self, send_message_mock
+    ):
+        adapter = WeixinAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="test-token",
+                extra={
+                    "account_id": "test-account",
+                    "final_response_priority": True,
+                },
+            )
+        )
+        adapter._send_session = object()
+        adapter._token_store.get = lambda account_id, chat_id: "ctx-token"
+        send_message_mock.return_value = {}
+
+        result = asyncio.run(
+            adapter.send(
+                "wxid_test123",
+                "tool progress",
+                metadata={"transient_progress": True},
+            )
+        )
+
+        assert result.success is True
+        assert send_message_mock.await_count == 0
+        assert result.raw_response == {
+            "suppressed": True,
+            "reason": "transient_progress",
+        }
+
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_final_response_priority_keeps_final_delivery(self, send_message_mock):
+        adapter = WeixinAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="test-token",
+                extra={
+                    "account_id": "test-account",
+                    "final_response_priority": True,
+                },
+            )
+        )
+        adapter._send_session = object()
+        adapter._token_store.get = lambda account_id, chat_id: "ctx-token"
+        send_message_mock.return_value = {}
+
+        result = asyncio.run(adapter.send("wxid_test123", "final answer"))
+
+        assert result.success is True
+        assert send_message_mock.await_count == 1
+
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_suppressed_stream_commentary_does_not_claim_final_delivery(
+        self, send_message_mock
+    ):
+        adapter = WeixinAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="test-token",
+                extra={
+                    "account_id": "test-account",
+                    "final_response_priority": True,
+                },
+            )
+        )
+        adapter._send_session = object()
+        adapter._token_store.get = lambda account_id, chat_id: "ctx-token"
+        send_message_mock.return_value = {}
+
+        async def scenario():
+            consumer = GatewayStreamConsumer(
+                adapter,
+                "wxid_test123",
+                StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5),
+                metadata={"thread_id": "topic-1"},
+                commentary_metadata={
+                    "thread_id": "topic-1",
+                    "transient_progress": True,
+                },
+            )
+            consumer.on_commentary("same as final")
+            consumer.finish()
+            await consumer.run()
+
+            assert consumer.has_delivered_text("same as final") is False
+
+            final_result = await adapter.send(
+                "wxid_test123",
+                "same as final",
+                metadata={"thread_id": "topic-1"},
+            )
+            assert final_result.success is True
+
+        asyncio.run(scenario())
+
+        assert send_message_mock.await_count == 1
+
+    @pytest.mark.parametrize(
+        "metadata",
+        [
+            None,
+            {},
+            {"transient_progress": False},
+            {"transient_progress": 1},
+            {"transient_progress": "true"},
+            ["not-a-metadata-dict"],
+        ],
+    )
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_final_response_priority_only_suppresses_exact_boolean_true(
+        self, send_message_mock, metadata
+    ):
+        adapter = WeixinAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="test-token",
+                extra={
+                    "account_id": "test-account",
+                    "final_response_priority": True,
+                },
+            )
+        )
+        adapter._send_session = object()
+        adapter._token_store.get = lambda account_id, chat_id: "ctx-token"
+        send_message_mock.return_value = {}
+
+        result = asyncio.run(
+            adapter.send("wxid_test123", "must be delivered", metadata=metadata)
+        )
+
+        assert result.success is True
+        assert send_message_mock.await_count == 1
+
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_transient_progress_is_sent_when_priority_mode_disabled(
+        self, send_message_mock
+    ):
+        adapter = self._connected_adapter()
+        send_message_mock.return_value = {}
+
+        result = asyncio.run(
+            adapter.send(
+                "wxid_test123",
+                "tool progress",
+                metadata={"transient_progress": True},
+            )
+        )
+
+        assert result.success is True
+        assert send_message_mock.await_count == 1
 
 
 class TestWeixinOutboundMedia:

--- a/website/docs/user-guide/messaging/weixin.md
+++ b/website/docs/user-guide/messaging/weixin.md
@@ -103,6 +103,7 @@ The adapter will restore saved credentials, connect to the iLink API, and begin 
 - **Context token persistence** — disk-backed reply continuity across restarts
 - **Markdown formatting** — preserves Markdown, including headers, tables, and code blocks, so WeChat clients that support Markdown can render it natively
 - **Smart message chunking** — messages stay as a single bubble when under the limit; only oversized payloads split at logical boundaries
+- **Optional final-response priority** — suppresses tool progress, interim commentary, background-review notifications, and long-running heartbeats before iLink delivery while preserving final replies and lifecycle/actionable messages
 - **Typing indicators** — shows "typing…" status in the WeChat client while the agent processes
 - **SSRF protection** — outbound media URLs are validated before download
 - **Message deduplication** — 5-minute sliding window prevents double-processing
@@ -123,6 +124,7 @@ Set these in `config.yaml` under `platforms.weixin.extra`:
 | `allow_from` | `[]` | User IDs allowed for DMs (when dm_policy=allowlist) |
 | `group_allow_from` | `[]` | Group IDs allowed (when group_policy=allowlist) |
 | `split_multiline_messages` | `false` | When `true`, split multi-line replies into multiple chat messages (legacy behavior). When `false`, keep multi-line replies as one message unless they exceed the length limit. |
+| `final_response_priority` | `false` | When `true`, drop only outbound messages marked by the gateway as `transient_progress` before calling iLink: tool progress, interim commentary (including the streaming-consumer path), background-review notifications, and long-running heartbeats. Final replies, lifecycle statuses, and actionable warning/approval/clarify messages remain deliverable. Useful when iLink send quotas are tight or a shared Desktop/Weixin session emits frequent progress. |
 | `text_batch_delay_seconds` | `3.0` | Quiet period (seconds) before a buffered burst of rapid text messages is flushed as one combined request. iLink delivers messages individually, so this debounce avoids one agent invocation per fragment. Set `0` to dispatch each message immediately. |
 | `text_batch_split_delay_seconds` | `5.0` | Extended flush delay used when the latest fragment is near the split threshold (long messages iLink may have chunked). |
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/weixin.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/weixin.md
@@ -103,6 +103,7 @@ hermes gateway
 - **上下文 token 持久化** — 基于磁盘的回复连续性，重启后仍可保持
 - **Markdown 格式化** — 保留 Markdown 格式（包括标题、表格和代码块），支持 Markdown 的微信客户端可原生渲染
 - **智能消息分块** — 未超出长度限制时保持单条消息气泡；仅超长内容在逻辑边界处拆分
+- **可选的最终回复优先** — 在调用 iLink 前抑制工具进度、中间说明、后台审查通知和长任务心跳，同时保留最终回复、生命周期状态和需要操作的消息
 - **正在输入提示** — 代理处理消息时在微信客户端显示"正在输入…"状态
 - **SSRF 防护** — 下载前验证外发媒体 URL
 - **消息去重** — 5 分钟滑动窗口防止重复处理
@@ -123,6 +124,7 @@ hermes gateway
 | `allow_from` | `[]` | 允许发送私信的用户 ID（当 dm_policy=allowlist 时生效） |
 | `group_allow_from` | `[]` | 允许的群组 ID（当 group_policy=allowlist 时生效） |
 | `split_multiline_messages` | `false` | 为 `true` 时，将多行回复拆分为多条消息（旧版行为）；为 `false` 时，多行回复保持为单条消息，除非超出长度限制。 |
+| `final_response_priority` | `false` | 为 `true` 时，仅在调用 iLink 前丢弃被网关标记为 `transient_progress` 的出站消息：工具进度、中间说明（包括 streaming consumer 路径）、后台审查通知和长任务心跳。最终回复、生命周期状态以及可操作的警告/审批/澄清消息仍会正常投递。适用于 iLink 发送额度紧张，或 Desktop/Weixin 共享会话频繁产生进度消息的场景。 |
 
 ## 访问策略
 


### PR DESCRIPTION
## Summary

- add an opt-in `platforms.weixin.extra.final_response_priority` transport gate
- mark tool progress, interim commentary (including `GatewayStreamConsumer`), background-review notifications, and Weixin fallback heartbeats as `transient_progress`
- preserve final replies and the existing lifecycle/status/approval/clarify/error metadata paths
- distinguish an intentionally suppressed progress send from a message that actually reached the platform, so delivery reconciliation can never suppress an identical final reply
- document the option in the English and Simplified Chinese Weixin guides

## Why

Weixin/iLink cannot edit ordinary chat bubbles and has a tight send budget. In a shared Desktop/Weixin session, routine progress can consume that budget before the canonical final reply is ready. The adapter needs an explicit, opt-in boundary that drops only messages the gateway has classified as transient, before connection checks or any iLink call.

This complements #89180, which suppresses periodic cross-process lease-wait refreshes on non-editing chat adapters. It does not duplicate or modify that lease-refresh logic.

## Delivery semantics

- The option defaults to `false`; existing Weixin behavior is unchanged.
- Suppression requires `metadata` to be a dictionary and `metadata["transient_progress"] is True`. Values such as `False`, `1`, or `"true"` are not suppressed.
- A suppressed send returns `success=True` to acknowledge an intentional no-op and prevent generic progress retries, plus `raw_response.suppressed=true` to state that no platform message was created.
- `GatewayStreamConsumer` excludes suppressed commentary from its delivered-text ledger. If commentary text is later reused as the final reply, the final still reaches iLink.
- Existing positional `GatewayStreamConsumer` construction remains compatible; the new optional metadata argument is appended after all existing parameters.

## Tests

Local Windows verification:

```text
280 passed, 2 deselected
81 passed, 1 xfailed (existing suppression/duplicate-reply matrix)
```

The two deselected cases are pre-existing Windows `Path.as_uri()` backslash-encoding assertions unrelated to this change. Focused regressions cover:

- adapter call counts for enabled/disabled priority mode
- exact-boolean metadata boundaries, including non-dict input
- streamed commentary metadata vs final metadata
- suppressed commentary followed by an identical final reply
- legacy positional constructor compatibility
- Slack/thread routing metadata preservation

Related: #89166, #21126
Complements: #89180
