### PR TITLE
fix(gateway): prevent cross-profile session recovery via peer-tuple fallback when multiplexing

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1550,16 +1550,35 @@ class SessionStore:
         requested_session_key: str,
         recovered: Dict[str, Any],
     ) -> bool:
-        """Prevent non-multiplexed gateways from reviving another profile's row."""
-        if getattr(self.config, "multiplex_profiles", False):
-            return True
+        """Prevent gateways from reviving another profile's session row.
 
+        When multiplexing is enabled, the peer-tuple fallback in
+        ``find_latest_gateway_session_for_peer`` does not include the profile
+        namespace, so a recovered row could belong to a different profile.
+        This gate checks that the recovered session's profile namespace is
+        compatible with the requested session key.
+
+        When multiplexing is disabled, checks against the active profile name
+        to prevent non-multiplexed gateways from reviving another profile's row.
+        """
         recovered_key = str(recovered.get("session_key") or "")
         if not recovered_key or recovered_key == requested_session_key:
             return True
 
         recovered_profile = self._profile_from_session_key(recovered_key)
         if recovered_profile is None:
+            return True
+
+        if getattr(self.config, "multiplex_profiles", False):
+            # Multiplexed: the peer-tuple fallback in
+            # find_latest_gateway_session_for_peer can return rows from
+            # another profile. Compare the profile namespace encoded in the
+            # session keys rather than the active profile name, because the
+            # active profile is a process-level setting that may not reflect
+            # the routed profile for this specific event.
+            requested_profile = self._profile_from_session_key(requested_session_key)
+            if requested_profile and recovered_profile != requested_profile:
+                return False
             return True
 
         return recovered_profile == self._active_profile_name()
@@ -1743,8 +1762,7 @@ class SessionStore:
         ):
             logger.warning(
                 "Gateway session DB recovery ignored %s for %s because "
-                "multiplex_profiles is disabled and the row belongs to a "
-                "different profile",
+                "the row belongs to a different profile namespace",
                 recovered.get("session_key"),
                 session_key,
             )
@@ -1803,8 +1821,7 @@ class SessionStore:
         ):
             logger.warning(
                 "Gateway session DB recovery ignored %s for %s because "
-                "multiplex_profiles is disabled and the row belongs to a "
-                "different profile",
+                "the row belongs to a different profile namespace",
                 recovered.get("session_key"),
                 session_key,
             )

--- a/tests/gateway/test_multiplex_phase0.py
+++ b/tests/gateway/test_multiplex_phase0.py
@@ -265,3 +265,80 @@ class TestSessionStoreUnmultiplexedRecovery:
         assert recovered.session_id == "sess-coder"
         assert recovered.session_key == "agent:main:telegram:dm:99"
         assert store._db.reopened == ["sess-coder"]
+
+
+class TestSessionStoreMultiplexedRecovery:
+    """When multiplexing is on, the peer-tuple fallback in the DB must not
+    recover a session belonging to another profile namespace."""
+
+    def _store(self, tmp_path, **cfg_kw):
+        config = GatewayConfig(**cfg_kw)
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._loaded = True
+        return store
+
+    def test_rejects_other_profile_via_peer_fallback(self, tmp_path):
+        """Multiplexed: a row with a different profile namespace is rejected."""
+        row = {
+            "id": "sess-coder",
+            "started_at": 1700000000,
+            "session_key": "agent:coder:telegram:dm:99",
+        }
+        store = self._store(tmp_path, multiplex_profiles=True)
+        store._db = _RecoveringDB(row)
+        source = _src(chat_id="99", chat_type="dm")
+
+        # Requesting key for the 'default' profile, but the recovered row is 'coder'.
+        recovered = store._recover_session_from_db(
+            session_key="agent:main:telegram:dm:99",
+            source=source,
+            now=datetime.fromtimestamp(1700000001),
+        )
+
+        assert recovered is None
+        assert store._db.reopened == []
+
+    def test_allows_same_profile_via_peer_fallback(self, tmp_path):
+        """Multiplexed: a row with the same profile namespace is accepted."""
+        row = {
+            "id": "sess-coder",
+            "started_at": 1700000000,
+            "session_key": "agent:coder:telegram:dm:99",
+        }
+        store = self._store(tmp_path, multiplex_profiles=True)
+        store._db = _RecoveringDB(row)
+        source = _src(chat_id="99", chat_type="dm")
+
+        recovered = store._recover_session_from_db(
+            session_key="agent:coder:telegram:dm:99",
+            source=source,
+            now=datetime.fromtimestamp(1700000001),
+        )
+
+        assert recovered is not None
+        assert recovered.session_id == "sess-coder"
+        assert recovered.session_key == "agent:coder:telegram:dm:99"
+        assert store._db.reopened == ["sess-coder"]
+
+    def test_allows_legacy_key_when_multiplexed(self, tmp_path):
+        """Multiplexed: a legacy (agent:main) row is still accessible when
+        the requested key is also legacy (default profile)."""
+        row = {
+            "id": "sess-legacy",
+            "started_at": 1700000000,
+            "session_key": "agent:main:telegram:dm:99",
+        }
+        store = self._store(tmp_path, multiplex_profiles=True)
+        store._db = _RecoveringDB(row)
+        source = _src(chat_id="99", chat_type="dm")
+
+        recovered = store._recover_session_from_db(
+            session_key="agent:main:telegram:dm:99",
+            source=source,
+            now=datetime.fromtimestamp(1700000001),
+        )
+
+        assert recovered is not None
+        assert recovered.session_id == "sess-legacy"
+        assert store._db.reopened == ["sess-legacy"]


### PR DESCRIPTION
## Problem

When `multiplex_profiles` is enabled, the peer-tuple fallback in `find_latest_gateway_session_for_peer` matches on `source`, `user_id`, `chat_id`, `chat_type` and `thread_id` — none of which include the profile namespace. This allows a recovered session row from profile B to be adopted by an event routed to profile A.

Previously `_recovered_row_allowed_for_active_profile` returned `True` unconditionally when multiplexing was enabled, bypassing the profile namespace check entirely.

## Fix

The gate now compares the profile namespace encoded in the requested session key against the recovered row's session key, rejecting cross-namespace recovery:

- When multiplexing is enabled: compare the profile namespace from the requested key against the recovered key
- When multiplexing is disabled: existing behavior preserved (check against active profile name)
- When the recovered key has no profile namespace (legacy `agent:main`): allowed through (backward compatible)

The warning message at both call sites is updated to reflect the general case ("profile namespace mismatch") rather than assuming `multiplex_profiles` is disabled.

## Tests

- `test_rejects_other_profile_via_peer_fallback` — multiplexed, different profile namespace → rejected
- `test_allows_same_profile_via_peer_fallback` — multiplexed, same profile namespace → accepted
- `test_allows_legacy_key_when_multiplexed` — multiplexed, legacy `agent:main` key → accepted

## Related

Part of the class closure for #88715 (Multiplex: profile identity is late-bound across transport, session, storage, and control paths).