### PR TITLE
fix(copilot): preserve signed thinking and IDE identity on the Messages relay

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -15,7 +15,8 @@ from utils import normalize_proxy_env_vars
 
 from agent.anthropic_credentials import _is_oauth_token
 from agent.anthropic_endpoints import (
-    _base_url_needs_context_1m_beta, _is_azure_anthropic_endpoint, _is_kimi_coding_endpoint,
+    _base_url_needs_context_1m_beta, _is_azure_anthropic_endpoint,
+    _is_github_copilot_anthropic_endpoint, _is_kimi_coding_endpoint,
     _is_minimax_anthropic_endpoint, _is_nous_portal_endpoint, _is_opencode_endpoint,
     _is_third_party_anthropic_endpoint, _model_name_is_kimi_family, _normalize_base_url_text,
     _requires_bearer_auth,
@@ -398,6 +399,15 @@ def build_anthropic_client(api_key, base_url: str = None, timeout: float = None,
     elif style == "oauth":
         headers["user-agent"] = f"claude-code/{_get_claude_code_version()} (external, cli)"
         headers["x-app"] = "cli"
+    if _is_github_copilot_anthropic_endpoint(normalized_base_url):
+        # Copilot authenticates the IDE, not just the token: /v1/messages rejects a request
+        # without Editor-Version ("missing Editor-Version header for IDE auth", HTTP 400).
+        # The OpenAI-wire path gets these from the Copilot profile's default_headers; this
+        # SDK route never sees that profile, so apply the same identity here.
+        from hermes_cli.copilot_auth import copilot_request_headers
+
+        for k, v in copilot_request_headers().items():
+            headers.setdefault(k, v)
     if _is_opencode_endpoint(base_url):
         # OpenCode identifies clients by request headers (like OpenRouter). The OpenAI-wire paths
         # get these from profile.default_headers, but this route never sees the profile.

--- a/agent/anthropic_endpoints.py
+++ b/agent/anthropic_endpoints.py
@@ -139,6 +139,15 @@ def _base_url_needs_context_1m_beta(base_url: str | None) -> bool:
     return "azure.com" in _normalize_base_url_text(base_url).lower()
 
 
+def _is_github_copilot_anthropic_endpoint(base_url: str | None) -> bool:
+    """Return True for GitHub Copilot's Anthropic Messages relay.
+
+    Copilot proxies Claude end to end, including the signed thinking contract,
+    so it takes the native replay path rather than the third-party strip.
+    """
+    return base_url_host_matches(base_url or "", "githubcopilot.com")
+
+
 def _is_minimax_anthropic_endpoint(base_url: str | None) -> bool:
     """MiniMax's Anthropic-compatible endpoints, which reject the fine-grained-tool-streaming and
     context-1m betas (stripped even though MiniMax also uses Bearer auth)."""

--- a/agent/anthropic_message_convert.py
+++ b/agent/anthropic_message_convert.py
@@ -11,7 +11,8 @@ import re
 from typing import Any, Dict, List, Optional, Tuple
 
 from agent.anthropic_endpoints import (
-    _is_deepseek_anthropic_endpoint, _is_kimi_family_endpoint, _is_nous_portal_endpoint,
+    _is_deepseek_anthropic_endpoint, _is_github_copilot_anthropic_endpoint,
+    _is_kimi_family_endpoint, _is_nous_portal_endpoint,
     _is_third_party_anthropic_endpoint, _model_name_is_deepseek_thinking,
 )
 
@@ -560,10 +561,14 @@ def _manage_thinking_signatures(result: List[Dict[str, Any]], base_url: str | No
     (400 "Invalid signature in thinking block"), so on direct Anthropic only the LATEST assistant
     turn keeps signed blocks. Signatures are proprietary: third-party endpoints strip all thinking.
     Kimi replays as-is; DeepSeek needs unsigned blocks round-tripped but rejects signed ones. Nous
-    Portal proxies Claude with sticky sessions and validates the same signatures, so it takes the
+    Portal and GitHub Copilot proxy Claude and validate the same signatures, so both take the
     native path despite not being anthropic.com.
     """
-    is_third_party = _is_third_party_anthropic_endpoint(base_url) and not _is_nous_portal_endpoint(base_url)
+    is_third_party = (
+        _is_third_party_anthropic_endpoint(base_url)
+        and not _is_nous_portal_endpoint(base_url)
+        and not _is_github_copilot_anthropic_endpoint(base_url)
+    )
     is_kimi = _is_kimi_family_endpoint(base_url, model)
     is_deepseek = _is_deepseek_anthropic_endpoint(base_url) or (
         is_third_party and _model_name_is_deepseek_thinking(model)

--- a/contributors/emails/allenliang2022@users.noreply.github.com
+++ b/contributors/emails/allenliang2022@users.noreply.github.com
@@ -1,0 +1,1 @@
+allenliang2022

--- a/tests/agent/test_copilot_anthropic_relay.py
+++ b/tests/agent/test_copilot_anthropic_relay.py
@@ -1,0 +1,155 @@
+"""GitHub Copilot's Anthropic Messages relay: IDE identity and signed thinking.
+
+Copilot proxies Claude end to end over ``/v1/messages``. Two contracts must hold
+on that route, and neither is exercised by the OpenAI-wire Copilot path:
+
+* the relay authenticates the *IDE*, so requests without ``Editor-Version`` are
+  rejected with HTTP 400 ``missing Editor-Version header for IDE auth``;
+* the relay validates Anthropic's signed thinking blocks, so stripping them (the
+  generic third-party behaviour) breaks multi-turn tool loops.
+"""
+import httpx
+import pytest
+
+from agent.anthropic_adapter import build_anthropic_client
+from agent.anthropic_endpoints import _is_github_copilot_anthropic_endpoint
+from agent.anthropic_message_convert import convert_messages_to_anthropic
+
+COPILOT_BASE = "https://api.enterprise.githubcopilot.com"
+
+
+class TestCopilotEndpointDetection:
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://api.githubcopilot.com",
+            COPILOT_BASE,
+            "https://api.business.githubcopilot.com/v1",
+        ],
+    )
+    def test_recognizes_copilot_hosts(self, base_url):
+        assert _is_github_copilot_anthropic_endpoint(base_url) is True
+
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://api.anthropic.com",
+            "https://githubcopilot.com.attacker.test",
+            "https://notgithubcopilot.com",
+            None,
+            "",
+        ],
+    )
+    def test_rejects_other_and_lookalike_hosts(self, base_url):
+        assert _is_github_copilot_anthropic_endpoint(base_url) is False
+
+
+class TestCopilotIdeIdentityHeaders:
+    """The IDE identity must reach the wire, not merely the client kwargs."""
+
+    @staticmethod
+    def _captured_request(base_url):
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["request"] = request
+            return httpx.Response(
+                200,
+                json={
+                    "id": "msg_1",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "claude-opus-test",
+                    "content": [{"type": "text", "text": "ok"}],
+                    "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 1, "output_tokens": 1},
+                },
+            )
+
+        client = build_anthropic_client("test-token", base_url=base_url)
+        client._client = httpx.Client(transport=httpx.MockTransport(handler))
+        client.messages.create(
+            model="claude-opus-test",
+            max_tokens=16,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        return captured["request"]
+
+    def test_editor_version_reaches_the_wire(self):
+        request = self._captured_request(COPILOT_BASE)
+        # Case-insensitive: httpx.Headers normalizes, the relay does not care.
+        assert request.headers.get("editor-version")
+
+    def test_copilot_integration_id_reaches_the_wire(self):
+        request = self._captured_request(COPILOT_BASE)
+        assert request.headers.get("copilot-integration-id")
+
+    def test_non_copilot_endpoint_does_not_get_ide_headers(self):
+        request = self._captured_request("https://api.anthropic.com")
+        assert request.headers.get("editor-version") is None
+        assert request.headers.get("copilot-integration-id") is None
+
+
+class TestCopilotSignedThinkingReplay:
+    """Copilot validates signed thinking; the third-party strip would break it."""
+
+    @staticmethod
+    def _signed_tool_turn():
+        thinking_block = {
+            "type": "thinking",
+            "thinking": "Need the exact contents.",
+            "signature": "signed-thinking",
+        }
+        return [
+            {"role": "user", "content": "Inspect the file"},
+            {
+                "role": "assistant",
+                "content": "I'll inspect it.",
+                "reasoning_details": [thinking_block],
+                "anthropic_content_blocks": [
+                    thinking_block,
+                    {"type": "text", "text": "I'll inspect it."},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": "read_file",
+                        "input": {"path": "a.txt"},
+                    },
+                ],
+                "tool_calls": [
+                    {
+                        "id": "toolu_1",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": '{"path":"a.txt"}'},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "toolu_1",
+                "name": "read_file",
+                "content": "contents",
+            },
+        ]
+
+    def _assistant_blocks(self, base_url):
+        _, converted = convert_messages_to_anthropic(
+            self._signed_tool_turn(), base_url=base_url, model="claude-opus-test"
+        )
+        assistant = next(m for m in converted if m["role"] == "assistant")
+        return assistant["content"]
+
+    def test_copilot_preserves_the_signed_thinking_block(self):
+        blocks = self._assistant_blocks(COPILOT_BASE)
+        thinking = [b for b in blocks if b.get("type") == "thinking"]
+        assert len(thinking) == 1
+        assert thinking[0]["signature"] == "signed-thinking"
+
+    def test_copilot_keeps_the_tool_use_block_alongside_thinking(self):
+        blocks = self._assistant_blocks(COPILOT_BASE)
+        assert [b.get("type") for b in blocks] == ["thinking", "text", "tool_use"]
+
+    def test_generic_third_party_still_strips_signed_thinking(self):
+        """Contrast case: the exemption must be Copilot-specific, not a blanket change."""
+        blocks = self._assistant_blocks("https://api.some-third-party.test")
+        assert not [b for b in blocks if b.get("type") == "thinking"]


### PR DESCRIPTION
GitHub Copilot proxies Claude end to end over `/v1/messages`, but Hermes treats that route as a generic third-party Anthropic endpoint. Two contracts break as a result, and neither is exercised by the OpenAI-wire Copilot path.

### 1. Signed thinking blocks were stripped

Copilot validates Anthropic's signatures the same way the native API does. Stripping them from replayed assistant turns loses multi-turn reasoning continuity and violates the tool-result replay protocol.

### 2. The Messages client carried no IDE identity

Copilot authenticates the editor, not just the token, and rejects requests without `Editor-Version`:

```
anthropic.BadRequestError: bad request: missing Editor-Version header for IDE auth
```

The OpenAI-wire path picks these headers up from the Copilot profile's `default_headers`. The SDK route never sees that profile, so the turn fails before delivery with HTTP 400.

### Why this second failure hid for so long

The transport is chosen per turn from the live catalog's `supported_endpoints`, and the curated offline fallback advertises none. A failed catalog fetch therefore downgrades the route to chat completions — which *does* carry the headers — silently and with no error. The same build alternates between a working and a failing transport depending on catalog availability, so the native route can sit unused for weeks and then fail on its first real request.

I confirmed the routing empirically rather than assuming it: both `api.githubcopilot.com` and `api.enterprise.githubcopilot.com` advertise `["/v1/messages", "/chat/completions"]` for Claude and the router returns `anthropic_messages` for each, while the no-catalog branch returns `chat_completions`.

### Approach

Both fixes reuse the existing endpoint predicate and mirror the adjacent OpenCode / Nous Portal exemptions rather than widening third-party behaviour generally. `headers.setdefault` is used so an explicit caller header always wins.

### Tests

14 new tests in `tests/agent/test_copilot_anthropic_relay.py`:

- IDE headers asserted on the **actual wire request** through a mock transport, not on client kwargs — a kwargs assertion would pass even if the headers never reached the request.
- Signed thinking preserved for Copilot, with a **contrast case** asserting generic third-party endpoints still strip it, so the exemption cannot silently become blanket behaviour.
- Lookalike hosts rejected (`githubcopilot.com.attacker.test`, `notgithubcopilot.com`).

Verified by mutation: removing the header injection turns 2 tests red, removing the signature exemption turns a different 2 red, and restoring both returns 14/14 green. Full local regression across the Anthropic and Copilot suites: 334 passed, 8 skipped.

Rebuilt on current `main` — the earlier revision predated the `anthropic_endpoints.py` / `anthropic_message_convert.py` split, so the change now lands in those modules instead of the old monolithic adapter.

*AI-assisted: implementation and testing were done with agent assistance; all changes were reviewed and verified locally.*
