### PR TITLE
fix(desktop): keep the composer opaque under whole-window glass

### DIFF
--- a/apps/desktop/src/components/chat/composer-dock.ts
+++ b/apps/desktop/src/components/chat/composer-dock.ts
@@ -25,12 +25,13 @@ export const composerDockCard = (edge: 'bottom' | 'top' = 'top') =>
 
 /** Floating composer panel skin — the `/`·`@`·`?` completion drawer and the
  *  attach (`+`) menu. Glassy translucent card, hairline border, full radius,
- *  smallest type, soft nous shadow. Uses an explicit fill (not `--composer-fill`)
- *  so it renders identically whether mounted inside the composer or portaled out
- *  of it. Visual skin only — consumers add their own size/position/padding. */
+ *  smallest type, soft nous shadow. Paints `--composer-panel-fill` (defined on
+ *  :root, not the composer) so it renders identically whether mounted inside
+ *  the composer or portaled out of it — and goes opaque under glass along with
+ *  the bar. Visual skin only — consumers add their own size/position/padding. */
 export const composerPanelCard = cn(
   'rounded-2xl border border-border/65 shadow-nous text-[length:var(--conversation-tool-font-size)]',
-  'bg-[color-mix(in_srgb,var(--dt-card)_72%,transparent)]',
+  'bg-(--composer-panel-fill)',
   composerSurfaceGlass
 )
 

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1698,16 +1698,17 @@ body.guest-pointer-lock :is(webview, iframe) {
   color: var(--ui-text-tertiary) !important;
 }
 
-/* ── Composer fill — ONE var painted by the surface AND anything docked to it
-   (slash·@ popover, `?` help). State ladder sets the var; consumers just paint
-   `background: var(--composer-fill)`, so every state matches by construction.
-   The :has() rule is last on purpose: while a completion drawer is open it
-   beats focus/scroll and forces an OPAQUE fill (both mix endpoints solid) —
-   translucent glass can never match across the two layers because they sample
-   different backdrops. */
+/* ── Composer fill — ONE var painted by the surface and everything docked to
+   it (status stack, queue, floating pills). The state ladder sets the var;
+   consumers just paint `background: var(--composer-fill)`, so every state
+   matches by construction. The floating panels (slash·@ drawer, `?` help,
+   attach menu) paint --composer-panel-fill instead — defined on :root, not
+   the composer, so a portaled panel resolves the same value as a docked one
+   (see composerPanelCard in composer-dock.ts). */
 :root {
   /* Fallback for drawers outside the main composer (e.g. edit-message). */
   --composer-fill: color-mix(in srgb, var(--dt-card) 90%, var(--dt-background));
+  --composer-panel-fill: color-mix(in srgb, var(--dt-card) 72%, transparent);
 }
 
 [data-slot='composer-root'] {
@@ -1716,6 +1717,29 @@ body.guest-pointer-lock :is(webview, iframe) {
 
 [data-slot='composer-root'][data-thread-scrolled-up] {
   --composer-fill: color-mix(in srgb, var(--dt-card) 48%, transparent);
+}
+
+/* Under whole-window glass the composer is CHROME, not field. The translucent
+   rungs above are tuned for a bar floating over the app's own (opaque)
+   transcript; when the window itself is glass their transparency reaches the
+   desktop wallpaper instead, and the type-in line — the one place the user is
+   always reading — ends up on moving imagery. Pin the opaque card at every
+   intensity and in every state, the same value the HUD resolves to (and the
+   HUD already forces its completion drawer opaque for the same reason: two
+   half-lit surfaces stacked on a third are unreadable however the numbers are
+   tuned). The docked stack paints --composer-fill and the floating panels
+   paint --composer-panel-fill, so the whole group goes solid together.
+   Sidebar scope is exempt: its content column is repainted full opaque by the
+   <body> gradient (see the Finder-shape rule), so the bar sits over the
+   transcript exactly as the ladder assumes. The surface's backdrop-blur is
+   unaffected and harmless — an opaque fill leaves nothing to blur (see
+   composer-dock.ts). */
+:root[data-hermes-glass]:not([data-hermes-glass-scope='sidebar']) {
+  --composer-panel-fill: var(--dt-card);
+}
+
+:root[data-hermes-glass]:not([data-hermes-glass-scope='sidebar']) [data-slot='composer-root'] {
+  --composer-fill: var(--dt-card);
 }
 
 /* Tool/thinking blocks now live at message-text alignment (no leading


### PR DESCRIPTION
## What does this PR do?

#88744 shipped Glass: the field surfaces thin over the vibrancy material and the desktop shows through the window. The composer kept its own translucent fill ladder from before glass existed: 72% of the card at rest, 48% when the thread is scrolled up. That ladder was tuned for a bar floating over the app's own opaque transcript. Under whole-window glass the transparency reaches the desktop wallpaper instead, and the type-in line (the one place the user is always reading) sits on moving imagery.

Measured live at glass 100%, window scope: the composer fill computes `color(srgb … / 0.72)` with `blur(12px) saturate(1.12)` over the raw wallpaper.

The bar is chrome, not field. This pins `--composer-fill` to the solid card while whole-window glass is active, the same value the HUD already resolves for the same reason (its comment: "it IS the interface"). One var rung in the existing state ladder, so everything docked to the bar (status stack, queue, floating pills, scroll-to-bottom) goes solid together by construction.

| composer fill | glass off | whole-window glass |
|---|---|---|
| before | 72% card over the transcript | 72% card over the wallpaper |
| after | 72% card over the transcript (unchanged) | solid card |

## Changes made

- `apps/desktop/src/styles.css`: one new rung after the scrolled-up state. `:root[data-hermes-glass]:not([data-hermes-glass-scope='sidebar'])` pins `--composer-fill` (on the composer root) and `--composer-panel-fill` (on `:root`) to `var(--dt-card)`. Sidebar scope is exempt on purpose: the Finder-shape body gradient repaints the content column fully opaque, so the bar sits over the transcript exactly as the ladder assumes. Also rewrites the fill-ladder header comment, which still described a drawer-open `:has()` rung that eed78d6eb removed.
- `apps/desktop/src/components/chat/composer-dock.ts`: `composerPanelCard` (the `/`·`@`·`?` completion drawer and attach menu) hardcoded the same 72% mix inline so it could render identically when portaled out of the composer. It now paints a shared `--composer-panel-fill` defined on `:root`: same portal-safe resolution, and the glass pin moves the panels together with the bar. The no-glass value is unchanged (`color-mix(in srgb, var(--dt-card) 72%, transparent)`).

The surface's backdrop-blur classes are untouched: over an opaque fill there is nothing to blur, and stripping them belongs to #69130 if that lands.

## Related issues

- #69130 (backdrop-blur typing lag): adjacent, not addressed here; this PR neither adds nor removes blur.
- #80228 (content scrolls under the floating composer on Windows): different surface, unaffected. The pin is scoped to `data-hermes-glass`, which only macOS sets.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] 🎯 New skill (bundled or hub)

## How to Test

1. macOS, Settings → Appearance: Glass, intensity up, scope Window. The transcript field shows the wallpaper; the composer stays a solid card in both color modes, at rest and scrolled up.
2. Type `/`: the completion drawer is solid too, matching the bar it is docked to.
3. Scope Sidebar: the content column is opaque (body gradient), and the composer keeps its normal translucent ladder over it.
4. Glass off (Clear, or slider at 0): everything identical to today, including the drawer's 72% translucent panel.
5. Windows/Linux: no `data-hermes-glass`, no change.

Verified live in the dev renderer (macOS 26.5, dark and light): drove the store over CDP, read computed fills at every fork (window scope pinned opaque; sidebar scope translucent; no glass translucent; drawer opaque under glass and translucent without), and pixel-diffed window captures with the pin neutralized vs active. The diff is confined to the composer strip (54% of its pixels shift) while the transcript region above is pixel-identical (mean 0.00/255).

Desktop gate: `tsc --noEmit` clean, eslint clean, `vitest --project ui` 4773 passed (513 files).

## Screenshots

Light, glass 100%, window scope. Before (72% fill, wallpaper texture inside the bar):

![before, light](https://raw.githubusercontent.com/SHL0MS/hermes-agent/assets/glass-opaque-composer/light-unpinned.png)

After (solid card):

![after, light](https://raw.githubusercontent.com/SHL0MS/hermes-agent/assets/glass-opaque-composer/light-pinned.png)

Dark, before:

![before, dark](https://raw.githubusercontent.com/SHL0MS/hermes-agent/assets/glass-opaque-composer/dark-unpinned.png)

Dark, after:

![after, dark](https://raw.githubusercontent.com/SHL0MS/hermes-agent/assets/glass-opaque-composer/dark-pinned.png)

Completion drawer under glass, solid with the bar:

![drawer under glass](https://raw.githubusercontent.com/SHL0MS/hermes-agent/assets/glass-opaque-composer/light-drawer-pinned.png)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A (renderer CSS/skin only, no Python changes). Desktop gate run instead: `tsc --noEmit` clean, eslint clean, `vitest --project ui` 4773 passed.
- [x] I've added tests for my changes — no behavior seam to test: two CSS custom-property rungs and a class-string swap, no component logic changed. Verified by computed-style reads at every mode/scope fork and pixel diffs (above).
- [x] I've tested on my platform: macOS 26.5 (Tahoe), Apple Silicon

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (no docs reference the composer fill; the in-code ladder comment carries the contract and is updated here)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the pin is scoped to `data-hermes-glass`, set only on macOS; the panel-fill var refactor resolves to the identical value everywhere else
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
