### PR TITLE
docs(teams-pipeline): fetch --organizer-user-id is now documented (follow-up to #89382)

### DIFF
--- a/skills/productivity/teams-meeting-pipeline/SKILL.md
+++ b/skills/productivity/teams-meeting-pipeline/SKILL.md
@@ -70,6 +70,7 @@ hermes teams-pipeline subscriptions         # current Graph webhook subscription
 hermes teams-pipeline run <job-id>          # replay a stored job (re-summarize, re-deliver)
 hermes teams-pipeline fetch --meeting-id <id>   # dry-run: resolve meeting + transcript without persisting
 hermes teams-pipeline fetch --join-web-url "<url>"   # dry-run by join URL
+hermes teams-pipeline fetch --join-web-url "<url>" --organizer-user-id <id>   # organizer-scoped lookup (required for /meet/ short URLs)
 ```
 
 ### Subscription management

--- a/website/docs/guides/operate-teams-meeting-pipeline.md
+++ b/website/docs/guides/operate-teams-meeting-pipeline.md
@@ -159,7 +159,14 @@ hermes teams-pipeline run <job-id>
 ```bash
 hermes teams-pipeline fetch --meeting-id <meeting-id>
 hermes teams-pipeline fetch --join-web-url "<join-url>"
+hermes teams-pipeline fetch --join-web-url "<join-url>" --organizer-user-id <entra-user-id>
 ```
+
+Pass `--organizer-user-id` (the organizer's Microsoft Entra user ID) to resolve
+through the organizer-scoped `/users/{id}/onlineMeetings` Graph path. This is
+required for Teams `/meet/` short URLs, which Graph rejects on the
+`/communications/onlineMeetings` endpoint. Webhook-driven jobs derive the
+organizer automatically from the notification's `@odata.id`.
 
 ## Routine Runbook
 

--- a/website/docs/user-guide/skills/bundled/productivity/productivity-teams-meeting-pipeline.md
+++ b/website/docs/user-guide/skills/bundled/productivity/productivity-teams-meeting-pipeline.md
@@ -81,6 +81,7 @@ hermes teams-pipeline subscriptions         # current Graph webhook subscription
 hermes teams-pipeline run <job-id>          # replay a stored job (re-summarize, re-deliver)
 hermes teams-pipeline fetch --meeting-id <id>   # dry-run: resolve meeting + transcript without persisting
 hermes teams-pipeline fetch --join-web-url "<url>"   # dry-run by join URL
+hermes teams-pipeline fetch --join-web-url "<url>" --organizer-user-id <id>   # organizer-scoped lookup (required for /meet/ short URLs)
 ```
 
 ### Subscription management


### PR DESCRIPTION
## Summary
Docs now cover the `fetch --organizer-user-id` flag that shipped in #89382 — the operator runbook, the bundled-skill docs page, and the bundled SKILL.md all show the organizer-scoped lookup and note that Teams `/meet/` short URLs require it (webhook-driven jobs derive the organizer automatically from `@odata.id`).

## Changes
- `website/docs/guides/operate-teams-meeting-pipeline.md`: new fetch example + short explanation of when the flag is needed
- `website/docs/user-guide/skills/bundled/productivity/productivity-teams-meeting-pipeline.md`: command-reference line
- `skills/productivity/teams-meeting-pipeline/SKILL.md`: same line in the bundled skill

## Validation
Docs-only, 9 insertions; command syntax matches `plugins/teams_pipeline/cli.py` (`--organizer-user-id` on the `fetch` subparser).

## Infographic

![Organizer-scoped lookup docs update](https://v3b.fal.media/files/b/0aa6deec/1tYBLfEDNo2SegWQ7oOli_0WpF78On.png)
