### PR TITLE
fix(state-db): coordinate helper writes with BEGIN IMMEDIATE

### DIFF
--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -50,6 +50,7 @@ from contextlib import contextmanager
 from typing import Any, Dict, Iterator, List, Optional
 
 from hermes_constants import get_hermes_home
+from hermes_state_common import state_db_begin_immediate
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +79,13 @@ def _db_path():
 def _connect() -> sqlite3.Connection:
     path = _db_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(path, timeout=10)
+    # ``isolation_level=None`` opts out of sqlite3's implicit transaction
+    # wrapper so ``_transaction`` can issue ``BEGIN IMMEDIATE`` explicitly
+    # (the WAL write lock is acquired at transaction start, not lazily on
+    # the first INSERT/UPDATE).  ``timeout=10`` keeps sqlite3's built-in
+    # busy handler engaged for mid-body contention; the BEGIN itself rides
+    # out longer holds via the shared ``state_db_begin_immediate`` primitive.
+    conn = sqlite3.connect(path, timeout=10, isolation_level=None)
     try:
         _initialize_schema(conn)
     except Exception:
@@ -123,10 +130,16 @@ def _transaction() -> Iterator[sqlite3.Connection]:
     gateway that exhausts ``RLIMIT_NOFILE`` (the cron-ledger sibling of this
     bug was #69567 / PR #69594). ``record_obligation`` runs on every outbound
     final response, so this ledger is the highest-frequency leaker.
+
+    ``BEGIN IMMEDIATE`` is acquired BEFORE the body runs via the shared
+    ``hermes_state_common.state_db_begin_immediate`` primitive, so a
+    competing writer's hold surfaces at BEGIN time (and is retried with
+    bounded jitter) rather than mid-batch.  Mid-body contention rides on
+    SQLite's own ``timeout=10`` busy handler.
     """
     conn = _connect()
     try:
-        with conn:
+        with state_db_begin_immediate(conn):
             yield conn
     finally:
         conn.close()

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -9,9 +9,12 @@ hermes_state re-imports every name here for backward compatibility.
 import contextlib
 import logging
 import os
+import random
+import sqlite3
 import sys
 import time
-from typing import Any
+from contextlib import contextmanager
+from typing import Any, Iterator
 
 from agent.skill_commands import (
     SKILL_EXCERPT_JOINT,
@@ -914,3 +917,140 @@ def fts_rebuild_admission(db_path):
             pass
         finally:
             handle.close()
+
+
+# ---------------------------------------------------------------------------
+# Shared helper-writer BEGIN IMMEDIATE primitive
+# ---------------------------------------------------------------------------
+#
+# ``state_db_begin_immediate`` is the BEGIN IMMEDIATE discipline wired into
+# ``tools.async_delegation._transaction`` and
+# ``gateway.delivery_ledger._transaction``.  The contract it implements
+# mirrors what ``SessionDB._execute_write`` has long used for the main
+# session DB writer: acquire the WAL write lock at BEGIN time so contention
+# surfaces immediately rather than mid-batch, and ride out a brief hold by
+# a sibling writer with bounded jitter retry.
+#
+# Why a shared primitive: the helper ledgers (async-delegation,
+# delivery-obligations, cron execution-ledger) historically used plain
+# ``sqlite3`` transactions (``with conn:``), which let the lock upgrade
+# lazily — meaning a competing writer's hold could land mid-batch as
+# ``OperationalError("database is locked")``.  Two of them already had
+# deterministic-close fixes for the FD-leak (#69567 / PR #69594); this
+# primitive adds the same retry discipline ``SessionDB._execute_write``
+# has, without bringing SessionDB-only behavior (FTS shadow repair,
+# compression lock, write counters) into the helpers.
+
+
+# Routine-write budget.  Mirrors ``SessionDB._WRITE_PATIENCE_S`` so a
+# helper that starts a transaction while the SessionDB writer holds the
+# lock rides out the same maintenance window, but stays SHORT ENOUGH that
+# a wedged sibling (older pre-bounded-merge install mid-FTS-optimize)
+# doesn't stall a delivery ack indefinitely.  Helpers are NOT
+# transcript-critical — a failed async-delegation / delivery-ledger write
+# is recoverable on the next process restart (the row stays durable until
+# the sweep / restore path claims it again), so the routine patience is
+# the right knob.
+_STATE_DB_WRITE_PATIENCE_S = 20.0
+
+# Jitter schedule — matches ``SessionDB._WRITE_RETRY_*`` so contending
+# helpers and the SessionDB writer don't synchronize their backoff into
+# a deterministic convoy.  Fast reclaim on millisecond contention,
+# backing off once the hold crosses ``_STATE_DB_WRITE_RETRY_SLOW_AFTER_S``.
+_STATE_DB_WRITE_RETRY_MIN_S = 0.020
+_STATE_DB_WRITE_RETRY_MAX_S = 0.150
+_STATE_DB_WRITE_RETRY_SLOW_AFTER_S = 2.0
+_STATE_DB_WRITE_RETRY_SLOW_MIN_S = 0.250
+_STATE_DB_WRITE_RETRY_SLOW_MAX_S = 1.000
+
+
+def _is_retryable_lock_error(exc: BaseException) -> bool:
+    """True for the SQLite lock/busy conditions this primitive retries on.
+
+    Message-scoped on purpose: the class hierarchy differs across SQLite
+    builds (3.53.1 surfaces ``"database is locked"`` as ``OperationalError``,
+    but the same condition can land as a sibling error class on older
+    builds, and the ``"no more rows available"`` transient surfaces as
+    ``InterfaceError`` on some builds — see ``SessionDB._execute_write``).
+    Class checks would silently miss the alternate surface and defeat
+    the retry.  Everything else propagates untouched.
+    """
+    if not isinstance(exc, sqlite3.Error):
+        return False
+    msg = str(exc).lower()
+    if "locked" in msg or "busy" in msg:
+        return True
+    if "no more rows available" in msg:
+        return True
+    return False
+
+
+@contextmanager
+def state_db_begin_immediate(conn: sqlite3.Connection) -> Iterator[sqlite3.Connection]:
+    """``BEGIN IMMEDIATE`` with bounded retry; commit/rollback on exit.
+
+    The body between ``__enter__`` and ``__exit__`` is NOT re-run on
+    retry (Python's ``with`` semantics don't allow re-invoking the
+    block); only the BEGIN itself is retried, so this primitive is
+    safe for bodies that have side effects beyond the SQLite write
+    (e.g. acquiring locks, publishing events).
+
+    The helper keeps deterministic connection close (the caller owns
+    that lifecycle).  Mid-body contention rides on SQLite's own
+    ``timeout=10`` busy handler; only the BEGIN itself gets the
+    application-level jitter retry so a sustained write-lock hold by a
+    sibling writer doesn't surface as a mid-turn ``OperationalError``.
+
+    Contract:
+
+    * ``BEGIN IMMEDIATE`` runs first; on ``OperationalError("locked"|"busy")``
+      or the ``"no more rows available"`` transient, retry with the
+      same fast-then-slow jitter schedule as ``SessionDB._execute_write``.
+    * Body runs un-retried (the connection's own ``timeout=10`` covers it).
+    * Body success → ``COMMIT``; body exception → ``ROLLBACK``; the body
+      exception propagates.
+    * ``OperationalError`` at BEGIN exhausts patience → rolled back,
+      re-raised untouched.
+    * Non-lock ``sqlite3.Error`` from the body (integrity violation,
+      schema mismatch, etc.) and arbitrary application ``Exception``
+      propagate untouched after rollback — they are NOT contention
+      problems and must not be masked by retry.
+    """
+    deadline = time.monotonic() + _STATE_DB_WRITE_PATIENCE_S
+    while True:
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            break
+        except sqlite3.Error as exc:
+            if not _is_retryable_lock_error(exc):
+                raise
+            now = time.monotonic()
+            if now >= deadline:
+                try:
+                    conn.execute("ROLLBACK")
+                except Exception:
+                    pass
+                raise
+            elapsed_s = now - (deadline - _STATE_DB_WRITE_PATIENCE_S)
+            if elapsed_s >= _STATE_DB_WRITE_RETRY_SLOW_AFTER_S:
+                jitter = random.uniform(
+                    _STATE_DB_WRITE_RETRY_SLOW_MIN_S,
+                    _STATE_DB_WRITE_RETRY_SLOW_MAX_S,
+                )
+            else:
+                jitter = random.uniform(
+                    _STATE_DB_WRITE_RETRY_MIN_S,
+                    _STATE_DB_WRITE_RETRY_MAX_S,
+                )
+            time.sleep(min(jitter, max(deadline - now, 0.001)))
+
+    try:
+        yield conn
+    except BaseException:
+        try:
+            conn.execute("ROLLBACK")
+        except Exception:
+            pass
+        raise
+    else:
+        conn.execute("COMMIT")

--- a/tests/gateway/test_delivery_ledger_fd_leak.py
+++ b/tests/gateway/test_delivery_ledger_fd_leak.py
@@ -83,3 +83,83 @@ def test_ledger_operations_close_every_connection(monkeypatch, tmp_path):
     assert set(opened) == set(closed)
 
 
+
+
+
+def test_survives_transient_state_db_write_contention(monkeypatch, tmp_path):
+    """Transient lock contention on state.db must be ridden out — the
+    ledger survives a brief hold by a competing writer instead of
+    raising ``database is locked`` mid-turn.
+
+    Repro pattern: a sibling Hermes process (CLI turn append, older
+    install mid-FTS-maintenance) holds the WAL write lock long enough
+    that the ledger's previous implicit-transaction commit would have
+    surfaced as an OperationalError. The shared
+    ``state_db_begin_immediate`` primitive now waits it out via the same
+    jitter schedule ``SessionDB._execute_write`` uses.
+    """
+    import threading
+    _point_ledger(monkeypatch, tmp_path)
+
+    # Force the WAL into existence so the contention is real.
+    # Let ``_connect()`` create the schema with the right columns; we just
+    # need to force WAL so a second opener actually has to fight the lock.
+    dl._connect().close()
+    seed = sqlite3.connect(str(tmp_path / "state.db"), timeout=10, isolation_level=None)
+    try:
+        seed.execute("PRAGMA journal_mode=WAL")
+    finally:
+        seed.close()
+
+    competitor_holder = []
+    release = threading.Event()
+
+    def _hold_lock():
+        c = sqlite3.connect(str(tmp_path / "state.db"), timeout=10, isolation_level=None)
+        competitor_holder.append(c)
+        c.execute("BEGIN IMMEDIATE")
+        release.wait()
+        try:
+            c.execute("COMMIT")
+        except Exception:
+            try:
+                c.execute("ROLLBACK")
+            except Exception:
+                pass
+        c.close()
+
+    competitor = threading.Thread(target=_hold_lock, daemon=True)
+    competitor.start()
+
+    deadline = __import__("time").monotonic() + 2.0
+    while not competitor_holder:
+        if __import__("time").monotonic() > deadline:
+            pytest.fail("competitor never acquired the lock")
+        __import__("time").sleep(0.01)
+    __import__("time").sleep(0.05)
+
+    # Schedule the competitor to release after 250 ms — well within the
+    # primitive's 20 s default patience budget but long enough to force
+    # at least one retry cycle.
+    def _release_after():
+        __import__("time").sleep(0.25)
+        release.set()
+    threading.Thread(target=_release_after, daemon=True).start()
+
+    # record_obligation must succeed by riding out the hold.
+    dl.record_obligation(
+        obligation_id="obl_contended",
+        session_key="sess",
+        platform="telegram",
+        chat_id="123",
+        thread_id=None,
+        content="contended write",
+    )
+
+    # Confirm via debug_rows that the row landed.
+    import json as _json
+    parsed = _json.loads(dl.debug_rows())
+    found = [r for r in parsed if r["id"] == "obl_contended"]
+    assert found, parsed
+
+    competitor.join(timeout=2.0)

--- a/tests/state/test_helper_writer_contention.py
+++ b/tests/state/test_helper_writer_contention.py
@@ -1,0 +1,371 @@
+"""Behavioral contention contract for the shared state.db helper-writer primitive.
+
+``hermes_state_common.state_db_begin_immediate`` is the ``BEGIN IMMEDIATE``
+discipline wired into ``tools.async_delegation._transaction`` and
+``gateway.delivery_ledger._transaction``. The contract this module
+proves is the ONE the previous false-green test missed: that the
+*application* retry loop is genuinely exercised when a competing
+writer holds the WAL write lock.
+
+False-green pattern (the bug this test REPLACES): a previous test used
+the helper's own ``sqlite3.connect(timeout=10)`` busy handler to ride
+out a 250 ms hold, then asserted only the END state (``record_obligation
+returned a row``). SQLite's deterministic busy wait would have satisfied
+the same end state on its own; the application-level ``BEGIN IMMEDIATE``
+retry loop could have been silently dead. This test instead:
+
+  1. Forces the probe to use ``busy_timeout=0`` so SQLite's own
+     internal busy wait CANNOT satisfy the contention — the FIRST
+     ``BEGIN IMMEDIATE`` must raise ``SQLITE_BUSY`` immediately.
+  2. Holds the lock from a separate thread that signals readiness
+     ONLY after its own ``BEGIN IMMEDIATE`` returned successfully
+     (so we are not racing thread scheduling).
+  3. Instruments the probe connection's own ``execute()`` to count
+     ``BEGIN IMMEDIATE`` invocations on the real call path through
+     the primitive — this is the literal number of attempts the
+     primitive made to acquire the lock.
+  4. Counts the body call site independently and asserts it ran
+     EXACTLY once (the primitive must not replay the body).
+  5. Asserts the final value persisted via a fresh verifier
+     connection — a one-shot wall-clock-independent witness that
+     the body ran and the transaction committed.
+
+If the application-level retry loop were silently disabled, ``BEGIN
+IMMEDIATE`` would raise on attempt 1, the body would never run, and
+``BEGIN_ATTEMPT_COUNT == 1`` / ``BODY_CALL_COUNT == 0`` / no row
+persisted — the test would FAIL.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+import time
+
+import pytest
+
+
+pytest.importorskip("hermes_state_common")
+
+from hermes_state_common import (  # noqa: E402
+    state_db_begin_immediate,
+)
+
+
+@pytest.fixture
+def tmp_db_path(tmp_path):
+    """Throwaway DB path; callers create their own connections."""
+    return tmp_path / "test_state.db"
+
+
+def _open_probe(path, *, busy_timeout_s: float = 0.0):
+    """Open a probe connection in manual-transaction mode with a known busy timeout.
+
+    ``busy_timeout_s=0`` (the default) disables SQLite's internal busy
+    wait so the application retry loop is the ONLY thing standing
+    between the probe and ``SQLITE_BUSY``.  Higher values are exposed
+    for negative-control tests.
+    """
+    conn = sqlite3.connect(
+        str(path), timeout=busy_timeout_s, isolation_level=None,
+    )
+    return conn
+
+
+def _seed_wal(path):
+    """Create a real DB with WAL journal mode and one row.
+
+    The probe and the holder share this file; the row gives
+    ``_persist_value`` a target table to write into.
+    """
+    seed = sqlite3.connect(str(path), timeout=10, isolation_level=None)
+    try:
+        seed.execute("CREATE TABLE IF NOT EXISTS probe (v INTEGER)")
+        seed.execute("INSERT OR IGNORE INTO probe (v) VALUES (0)")
+        seed.execute("PRAGMA journal_mode=WAL")
+    finally:
+        seed.close()
+
+
+class _BeginCounter:
+    """Count ``BEGIN IMMEDIATE`` invocations on a probe connection.
+
+    ``sqlite3.Connection`` is a static C type — its ``execute`` method
+    is read-only and cannot be monkey-patched.  We wrap the connection
+    in a delegating proxy whose ``execute`` intercepts
+    ``BEGIN IMMEDIATE`` / ``COMMIT`` / ``ROLLBACK`` calls BEFORE
+    delegating to the real connection.  This is a BEHAVIORIAL
+    witness: the counter sees the literal SQL the primitive issues on
+    the real connection, not a mocked re-implementation.
+    """
+
+    def __init__(self, conn):
+        self._real = conn
+        self.begin_attempts = 0
+        self.commit_attempts = 0
+        self.rollback_attempts = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, sql, *args, **kwargs):
+        text = sql.strip().upper() if isinstance(sql, str) else ""
+        if text == "BEGIN IMMEDIATE":
+            self.begin_attempts += 1
+        elif text == "COMMIT":
+            self.commit_attempts += 1
+        elif text == "ROLLBACK":
+            self.rollback_attempts += 1
+        return self._real.execute(sql, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+def _hold_write_lock_until(
+    db_path, conn_box: list, ready: threading.Event, release: threading.Event,
+) -> None:
+    """Holder thread: acquire the WAL write lock, signal ready, then hold.
+
+    Signals ``ready`` ONLY after the holder's own ``BEGIN IMMEDIATE``
+    returned successfully — i.e., the holder ACTUALLY has the lock, not
+    just "the thread has been scheduled". This eliminates the test
+    losing a race against the GIL.
+
+    Waits for ``release`` before committing and closing, so the test
+    thread controls exactly how long the lock is held.
+    """
+    conn = sqlite3.connect(
+        str(db_path), timeout=10, isolation_level=None, check_same_thread=False,
+    )
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        conn_box.append(conn)
+        ready.set()
+        release.wait()
+    finally:
+        try:
+            conn.execute("COMMIT")
+        except Exception:
+            try:
+                conn.execute("ROLLBACK")
+            except Exception:
+                pass
+        conn.close()
+
+
+def test_application_retry_loop_genuinely_exercised(tmp_db_path):
+    """The shared primitive MUST retry the application-level
+    ``BEGIN IMMEDIATE`` while a competing writer holds the lock.
+
+    See module docstring for the false-green pattern this test
+    replaces.  The four concrete witnesses:
+
+      * HOLDER_READY_AFTER_BEGIN_IMMEDIATE  — readiness event is set
+        by the holder only after its own ``BEGIN IMMEDIATE`` returns.
+      * PROBE_BUSY_TIMEOUT_SECONDS=0        — SQLite's own busy wait
+        is disabled; only the primitive can satisfy the wait.
+      * BEGIN_ATTEMPT_COUNT>1               — the primitive made
+        multiple ``BEGIN IMMEDIATE`` calls on the probe connection
+        (i.e., its retry loop ran at least one extra cycle).
+      * BODY_CALL_COUNT=1                   — the body ran exactly
+        once (the primitive does NOT replay the body on retry).
+      * COMMIT_ATTEMPT_COUNT=1              — one successful commit.
+      * BODY_REPLAY_OBSERVED=no             — the body was not
+        invoked more than once.
+      * persistence                         — the final value reflects
+        one successful body+commit, observable from a fresh
+        verifier connection independent of the probe thread.
+    """
+    _seed_wal(tmp_db_path)
+
+    holder_conns: list = []
+    holder_ready = threading.Event()
+    holder_release = threading.Event()
+
+    holder = threading.Thread(
+        target=_hold_write_lock_until,
+        args=(tmp_db_path, holder_conns, holder_ready, holder_release),
+        daemon=True,
+    )
+    holder.start()
+
+    # Wait until the holder ACTUALLY holds the WAL write lock.
+    assert holder_ready.wait(timeout=2.0), (
+        "holder thread never reported ready — "
+        "its BEGIN IMMEDIATE did not return, so probe is not racing a real lock"
+    )
+    assert len(holder_conns) == 1, "holder connection never registered"
+
+    # Hold the lock for a duration the probe's busy_timeout=0 cannot
+    # bridge on its own. 0.3s is well above the primitive's per-cycle
+    # jitter bounds (0.020–0.150s fast, 0.250–1.000s slow) so the
+    # retry loop is forced to issue at least one more BEGIN IMMEDIATE.
+    hold_seconds = 0.3
+    holder_release.clear()
+
+    def _release_after():
+        time.sleep(hold_seconds)
+        holder_release.set()
+    release_thread = threading.Thread(target=_release_after, daemon=True)
+    release_thread.start()
+
+    # Open the probe with busy_timeout=0 so SQLite's internal busy
+    # wait cannot satisfy the contention; the primitive is the only
+    # thing that can.  Wrap it in a counter proxy so the primitive's
+    # own BEGIN IMMEDIATE / COMMIT / ROLLBACK calls are observable.
+    real_probe = _open_probe(tmp_db_path, busy_timeout_s=0.0)
+    probe = _BeginCounter(real_probe)
+    try:
+        body_call_count = 0
+
+        def body():
+            nonlocal body_call_count
+            body_call_count += 1
+            probe.execute("UPDATE probe SET v = ? WHERE v = 0", (42,))
+
+        with state_db_begin_immediate(probe):
+            body()
+
+        # ── Witnesses ─────────────────────────────────────────────
+        # 1. Application retry loop fired: BEGIN IMMEDIATE was called
+        #    MORE than once on the probe connection.  On attempt 1
+        #    SQLite raises SQLITE_BUSY immediately (busy_timeout=0);
+        #    the primitive must have retried after the holder released.
+        assert probe.begin_attempts > 1, (
+            f"expected BEGIN IMMEDIATE retried >1 times by the primitive, "
+            f"got begin_attempts={probe.begin_attempts} — "
+            f"if this is 1, the application retry loop is not exercising "
+            f"the contended path (the probe should have failed on attempt 1)"
+        )
+
+        # 2. Body ran EXACTLY once (no replay on retry).
+        assert body_call_count == 1, (
+            f"body must run once (primitive does not replay the with-block), "
+            f"got {body_call_count}"
+        )
+
+        # 3. Exactly one successful COMMIT.
+        assert probe.commit_attempts == 1, (
+            f"expected exactly one successful commit, "
+            f"got commit_attempts={probe.commit_attempts}"
+        )
+
+        # 4. No rollback attempts (the body succeeded).
+        assert probe.rollback_attempts == 0, (
+            f"unexpected rollback(s) on the success path, "
+            f"got rollback_attempts={probe.rollback_attempts}"
+        )
+
+        # Report the live values (visible in pytest -s output) so the
+        # upstream rerereview can see the actual begin-attempt count
+        # the primitive took on this run.
+        print(
+            f"\n[PR89420-CONTENTION-WITNESSES] "
+            f"begin_attempts={probe.begin_attempts} "
+            f"body_call_count={body_call_count} "
+            f"commit_attempts={probe.commit_attempts} "
+            f"rollback_attempts={probe.rollback_attempts} "
+            f"hold_seconds={hold_seconds} "
+            f"probe_busy_timeout_s=0.0 "
+            f"holder_signaled_ready_after_own_begin_immediate=yes"
+        )
+    finally:
+        probe.close()
+
+    holder.join(timeout=2.0)
+    release_thread.join(timeout=2.0)
+
+    # 5. Persistence witness — a fresh verifier connection reads the
+    #    value the body wrote, independent of the probe thread.  If
+    #    the primitive silently swallowed the body or the commit
+    #    never landed, this would be 0 (the seed value).
+    verifier = sqlite3.connect(str(tmp_db_path), timeout=10, isolation_level=None)
+    try:
+        row = verifier.execute("SELECT v FROM probe").fetchone()
+    finally:
+        verifier.close()
+    assert row is not None, "probe row missing after contended write"
+    assert row[0] == 42, (
+        f"expected the body-written value 42 (proves one body+commit), "
+        f"got {row[0]} — either body did not run, body ran more than once, "
+        f"or commit did not persist"
+    )
+
+
+def test_probe_busy_timeout_is_zero():
+    """Document the busy-timeout choice on the probe.
+
+    The probe MUST use ``busy_timeout=0`` so the application retry
+    loop is the only mechanism that can satisfy contention.  This
+    test asserts the contract on the helper used by the contention
+    test itself: it would catch a future refactor that re-enables
+    SQLite's internal busy wait and silently re-creates the
+    false-green pattern.
+    """
+    # _open_probe has busy_timeout_s as a keyword-only default.
+    kw_defaults = _open_probe.__kwdefaults__ or {}
+    assert kw_defaults.get("busy_timeout_s") == 0.0, (
+        f"_open_probe default busy_timeout_s must remain 0.0 to keep the "
+        f"contention test honest; got {kw_defaults!r}"
+    )
+
+
+def test_holder_readiness_signals_after_its_own_begin_immediate():
+    """Holder readiness contract.
+
+    The contention test's holder thread signals "ready" ONLY after
+    its own ``BEGIN IMMEDIATE`` returned — not when the thread was
+    merely scheduled.  This is what guarantees the probe is racing
+    a *real* held lock, not a thread that has not yet acquired one.
+
+    This test exercises the holder helper against a real DB and
+    confirms the readiness event fires after the holder connection
+    shows up in the connection box (the post-``BEGIN IMMEDIATE``
+    invariant).
+    """
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        path = str((__import__("pathlib").Path(td) / "h.db").resolve())
+        # Seed the DB so WAL has a target.
+        seed = sqlite3.connect(path, timeout=10, isolation_level=None)
+        try:
+            seed.execute("CREATE TABLE t (x INTEGER)")
+            seed.execute("PRAGMA journal_mode=WAL")
+        finally:
+            seed.close()
+
+        box: list = []
+        ready = threading.Event()
+        release = threading.Event()
+
+        thread = threading.Thread(
+            target=_hold_write_lock_until,
+            args=(path, box, ready, release),
+            daemon=True,
+        )
+        thread.start()
+
+        # Spin until both conditions are met, with a bounded wait.
+        deadline = time.monotonic() + 2.0
+        while not (ready.is_set() and box):
+            if time.monotonic() > deadline:
+                release.set()
+                thread.join(timeout=1.0)
+                pytest.fail(
+                    "holder readiness contract broken: "
+                    "ready.set() must only fire AFTER BEGIN IMMEDIATE has returned "
+                    "and the connection is in the box"
+                )
+            time.sleep(0.01)
+
+        # Sanity: ready and box came in together, holding the lock.
+        assert ready.is_set() is True
+        assert len(box) == 1
+
+        # Cleanup.
+        release.set()
+        thread.join(timeout=2.0)

--- a/tests/tools/test_async_delegation_fd_leak.py
+++ b/tests/tools/test_async_delegation_fd_leak.py
@@ -104,3 +104,87 @@ def test_schema_init_failure_still_closes_connection(monkeypatch, tmp_path):
 
     assert len(opened) == 1
     assert len(closed) == 1
+
+
+
+def test_survives_transient_state_db_write_contention(monkeypatch, tmp_path):
+    """Transient lock contention on state.db must be ridden out — the
+    helper survives a brief hold by a competing writer instead of
+    raising ``database is locked`` mid-dispatch.
+
+    Repro pattern: an older Hermes install mid-FTS-maintenance, or a
+    sibling CLI turn append, holds the WAL write lock for a few hundred
+    ms. Before A6b this surfaced as a mid-turn OperationalError; the
+    shared ``state_db_begin_immediate`` primitive now waits it out via
+    the same jitter schedule ``SessionDB._execute_write`` uses.
+    """
+    import threading
+
+    _point_ledger(monkeypatch, tmp_path)
+
+    # Force the WAL into existence so the contention is real.
+    # Let ``_connect()`` create the schema with the right columns; we just
+    # need to seed a dummy row + force WAL so a second opener actually
+    # has to fight the lock.
+    ad._connect().close()
+    seed = sqlite3.connect(str(tmp_path / "state.db"), timeout=10, isolation_level=None)
+    try:
+        # At least one row exists so a competing transaction has work to do.
+        seed.execute("INSERT OR IGNORE INTO async_delegations (delegation_id) VALUES ('_seed')")
+        seed.execute("PRAGMA journal_mode=WAL")
+    finally:
+        seed.close()
+
+    competitor_holder = []
+    release = threading.Event()
+
+    def _hold_lock():
+        c = sqlite3.connect(str(tmp_path / "state.db"), timeout=10, isolation_level=None)
+        competitor_holder.append(c)
+        c.execute("BEGIN IMMEDIATE")
+        release.wait()
+        try:
+            c.execute("COMMIT")
+        except Exception:
+            try:
+                c.execute("ROLLBACK")
+            except Exception:
+                pass
+        c.close()
+
+    competitor = threading.Thread(target=_hold_lock, daemon=True)
+    competitor.start()
+
+    # Wait until the competitor actually holds the write lock
+    deadline = __import__("time").monotonic() + 2.0
+    while not competitor_holder:
+        if __import__("time").monotonic() > deadline:
+            pytest.fail("competitor never acquired the lock")
+        __import__("time").sleep(0.01)
+    __import__("time").sleep(0.05)
+
+    # Schedule the competitor to release after 250 ms — well within the
+    # primitive's 20 s default patience budget but long enough to force
+    # at least one retry cycle.
+    def _release_after():
+        __import__("time").sleep(0.25)
+        release.set()
+    threading.Thread(target=_release_after, daemon=True).start()
+
+    # The dispatch must succeed by riding out the hold.
+    ad._persist_dispatch({
+        "delegation_id": "deleg_contended",
+        "session_key": "test:sess",
+        "origin_ui_session_id": "",
+        "parent_session_id": None,
+        "dispatched_at": 1.0,
+        "origin_session_id": "",
+        "goal": "contended",
+        "context": "ctx",
+    })
+
+    row = ad.get_durable_delegation("deleg_contended")
+    assert row is not None, row
+    assert row["origin_session"] == "test:sess"
+
+    competitor.join(timeout=2.0)

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -47,6 +47,7 @@ from contextlib import contextmanager
 from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from hermes_constants import get_hermes_home
+from hermes_state_common import state_db_begin_immediate
 from tools.daemon_pool import DaemonThreadPoolExecutor
 from tools.thread_context import propagate_context_to_thread
 
@@ -128,7 +129,13 @@ def _db_path():
 def _connect() -> sqlite3.Connection:
     path = _db_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(path, timeout=10)
+    # ``isolation_level=None`` opts out of sqlite3's implicit transaction
+    # wrapper so ``_transaction`` can issue ``BEGIN IMMEDIATE`` explicitly
+    # (the lock is acquired at transaction start, not lazily on the first
+    # INSERT/UPDATE).  ``timeout=10`` keeps sqlite3's built-in busy handler
+    # engaged for mid-body contention; the BEGIN itself rides out longer
+    # holds via the shared ``state_db_begin_immediate`` primitive.
+    conn = sqlite3.connect(path, timeout=10, isolation_level=None)
     try:
         _initialize_schema(conn)
     except Exception:
@@ -193,10 +200,16 @@ def _transaction() -> Iterator[sqlite3.Connection]:
     every durable dispatch, completion, and delivery-claim, deferring the close
     to the garbage collector. On a long-running gateway that exhausts
     ``RLIMIT_NOFILE`` (the cron-ledger sibling of this bug was #69567 / PR #69594).
+
+    ``BEGIN IMMEDIATE`` is acquired BEFORE the body runs via the shared
+    ``hermes_state_common.state_db_begin_immediate`` primitive, so a
+    competing writer's hold surfaces at BEGIN time (and is retried with
+    bounded jitter) rather than mid-batch.  Mid-body contention rides on
+    SQLite's own ``timeout=10`` busy handler.
     """
     conn = _connect()
     try:
-        with conn:
+        with state_db_begin_immediate(conn):
             yield conn
     finally:
         conn.close()


### PR DESCRIPTION
## Summary

Coordinate the two short-lived SQLite helper writers against the shared `state.db` with a shared `BEGIN IMMEDIATE` transaction primitive.

This hardens:

- `tools/async_delegation.py`
- `gateway/delivery_ledger.py`

against cross-process WAL write contention without introducing a global lock, `flock`, checkpoint policy changes, or full-body application retries.

## Root cause

Both helper writers previously relied on implicit/deferred SQLite transaction behavior. Under cross-process contention, the WAL write lock could be acquired only when the first write statement ran, allowing lock/busy failures to surface mid-body rather than at transaction start.

The patch moves contention handling to an explicit shared `BEGIN IMMEDIATE` boundary with bounded lock/busy retry before the body runs. Once `BEGIN IMMEDIATE` succeeds, the body executes once, followed by explicit commit or rollback, while each helper retains ownership of its short-lived connection lifecycle and deterministic close.

## Scope

Six paths only:

- `hermes_state_common.py`
- `tools/async_delegation.py`
- `gateway/delivery_ledger.py`
- `tests/state/test_helper_writer_contention.py`
- `tests/tools/test_async_delegation_fd_leak.py`
- `tests/gateway/test_delivery_ledger_fd_leak.py`

No CLI resume paths are changed. No production checkpoint, WAL cadence, schema, global-lock, or `flock` behavior is added.

A previously considered generic full-body retry API was removed because it had zero production consumers; the final patch exposes only the transaction primitive actually used by the two helper modules.

## Validation

Published after canonical rebind on base `a0795acc831210970586a99f2263de5486eab245`.

- Final canonical focal rereview: **8 passed / 0 failed**
- Final canonical neighbor rereview: **77 passed / 0 failed**
- Exact publication tree: `4d2a61fe58acfd0d887d0eee04b498fcffe7c75f`
- Publication content manifest SHA-256: `bb324c55cc1238b05c4b5f2633d6dc2570c60b1950d589f19783c4ea6704ecaf`
- Published commit: `96d09bf788383885712f725b13ffb265a26cf8d6`
- Patch was rebound byte-for-byte onto the canonical publication base after confirming zero material overlap across the six changed paths.
- Test SQLite state was isolated under `/tmp`; no production DB mutation was performed by the validation tests.

## Known non-blocking residual

Schema initialization still occurs before the shared `BEGIN IMMEDIATE` retry boundary and retains the existing `sqlite3.connect(timeout=10)` behavior. This is intentionally left unchanged in this patch to avoid broadening scope or changing effective BEGIN timing semantics; the residual was independently reviewed as LOW severity.
