### PR TITLE
docs(tts): add Speko as a TTS + STT command-provider example

### DIFF
--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -323,6 +323,41 @@ tts:
 
 Credentials come from your shell environment (`VOLCENGINE_APP_ID` / `VOLCENGINE_ACCESS_TOKEN`) or `~/.doubao-speech/config.yaml`. Pick a voice by adding `--voice zh-female-warm` (or any other alias from `doubao-speech list-voices`) to the command. `doubao-speech` also bundles streaming ASR — see the [STT section below](#example-doubao--volcengine-asr) for Hermes integration. Source and full docs: [github.com/Hypnus-Yuan/doubao-speech](https://github.com/Hypnus-Yuan/doubao-speech).
 
+#### Example: Speko (routed TTS)
+
+[Speko](https://speko.ai) is a hosted router in front of many speech vendors: it benchmarks them per
+language and sends each request to whichever currently scores best, failing over to the runner-up
+when one degrades. Useful for a language whose best TTS vendor you would rather not track by hand.
+Nothing to install — `curl`, `jq`, and `ffmpeg` are enough:
+
+```bash
+export SPEKO_API_KEY="your-speko-api-key"   # platform.speko.ai -> API keys
+```
+
+```yaml
+tts:
+  provider: speko
+  providers:
+    speko:
+      type: command
+      command: >-
+        jq -Rs '{{text: ., intent: {{language: "en"}}, sampleRate: 24000}}' {input_path}
+        | curl -sS -X POST https://api.speko.dev/v1/synthesize
+        -H "Authorization: Bearer $SPEKO_API_KEY" -H "Content-Type: application/json"
+        --data-binary @-
+        | ffmpeg -hide_banner -loglevel error -f s16le -ar 24000 -ac 1 -i pipe:0 -y {output_path}
+      output_format: wav
+      env_passthrough: [SPEKO_API_KEY]
+      timeout: 60
+```
+
+`/v1/synthesize` answers with **headerless PCM** (`audio/pcm;rate=24000`, echoed in the
+`X-Speko-Audio-Format` header) rather than a container — that is what the `ffmpeg` step is for, and
+why `sampleRate` is pinned so the `-ar` flag stays correct. Change `language` inside the `intent`
+object to route the request elsewhere (`es`, `hi`, `ar`, …), or add `"voice": "<voice-id>"` from
+`GET /v1/voices` to pin one voice; add `voice_compatible: true` for Telegram voice bubbles. The
+transcription direction takes the same key — see [Speko under `stt.providers`](#example-speko-routed-stt).
+
 #### Placeholders
 
 Your command template can reference these placeholders. Hermes substitutes them at render time and shell-quotes each value for the surrounding context (bare / single-quoted / double-quoted), so paths with spaces and other shell-sensitive characters are safe.
@@ -562,6 +597,35 @@ stt:
 
 This complements the legacy `HERMES_LOCAL_STT_COMMAND` escape hatch via the built-in `local_command` path. Unlike the shell-driven command-provider registry, the legacy template is tokenized into argv and runs without implicit shell interpretation. Use `stt.providers.<name>` when you want **multiple** shell-driven STT engines, a name you can pick via `stt.provider`, or anything that needs per-provider `language` / `model` / `timeout`.
 
+#### Example: Speko (routed STT)
+
+The same [Speko](https://speko.ai) key drives the transcription direction — one hosted endpoint that
+routes to whichever STT vendor its benchmarks rank best for the language, with failover:
+
+```yaml
+stt:
+  provider: speko
+  language: en
+  providers:
+    speko:
+      type: command
+      command: >-
+        ffmpeg -hide_banner -loglevel error -i {input_path} -ac 1 -ar 24000 -f wav pipe:1
+        | curl -sS -X POST https://api.speko.dev/v1/transcribe
+        -H "Authorization: Bearer $SPEKO_API_KEY" -H "Content-Type: audio/wav"
+        -H 'x-speko-intent: {{"language": "{language}"}}' --data-binary @-
+        | grep '^data:' | tail -n1 | sed 's/^data: //' | jq -r .text > {output_path}
+      format: txt
+      env_passthrough: [SPEKO_API_KEY]
+      timeout: 120
+```
+
+Two details make that pipeline shape necessary. `/v1/transcribe` takes raw audio bytes with the
+routing intent in an `x-speko-intent` header, and it answers with **server-sent events** rather than
+JSON, so the transcript is the `text` field of the final `data:` line — hence the tail. And an Opus
+voice note posted as-is returns `200` with an *empty* transcript, so the incoming file is normalised
+to mono 24 kHz WAV first, which is what makes Telegram / WhatsApp / Discord voice messages work.
+
 #### STT placeholders
 
 Your command template can reference these placeholders. Hermes substitutes them at render time and shell-quotes each value for the surrounding context (bare / single-quoted / double-quoted), so paths with spaces are safe.
@@ -597,6 +661,7 @@ For `format: json` / `srt` / `vtt`, Hermes returns the raw file content as the `
 | `format`        | `txt`   | One of `txt` / `json` / `srt` / `vtt`. Sets the extension of `{output_path}`.                       |
 | `language`      | `en`    | Forwarded to `{language}`. Defaults to `stt.language` then `en`.                                     |
 | `model`         | empty   | Forwarded to `{model}`. The `model=` argument to `transcribe_audio()` overrides this.                |
+| `env_passthrough` | empty | Variable names copied back from the parent environment into the scrubbed child env — needed when the template reads its own API key. Same key as on the [TTS side](#custom-command-providers). |
 
 #### STT command-provider behavior notes
 


### PR DESCRIPTION
## What does this PR do?

Adds a worked **Speko** example to both command-provider surfaces in `features/tts.md` — `tts.providers.<name>` and `stt.providers.<name>` — in the same shape as the existing Doubao example. Speko is a hosted router in front of many speech vendors: it benchmarks them per language and sends each request to whichever currently scores best, failing over to the runner-up when one degrades. So it's a fit for the case those sections already describe: a language whose best TTS/STT vendor you'd rather not track by hand. One API key covers both directions, and there's nothing to install — `curl`, `jq` and `ffmpeg` are enough.

Docs only. No code, no new dependency, no core change.

The reason it's worth a worked example rather than a link: both endpoints do something a naive template gets wrong, and each fails in a way that doesn't look like a template bug.

- **`/v1/synthesize` answers with headerless PCM** (`audio/pcm;rate=24000`, echoed in `X-Speko-Audio-Format`), not a container. Point `output_format: mp3` at it and you get a file no player opens — hence the `ffmpeg` step, and hence pinning `sampleRate` so `-ar` stays correct.
- **`/v1/transcribe` answers with server-sent events**, not JSON, so the transcript is the `text` field of the final `data:` line. And an Opus voice note posted as-is comes back **`200` with an empty transcript** — no error to read — so the input is normalised to mono 24 kHz WAV first. That's what makes Telegram / WhatsApp / Discord voice messages work, since they arrive as Opus.

It also adds the missing **`env_passthrough`** row to the STT command-provider optional-keys table. The key *is* honored there — `tools/transcription_tools.py:695` mirrors `tools/tts_tool.py:1165` — but only the TTS side documented it, so a curl-style STT template loses its API key to the secret scrub with nothing in the docs to explain why. That gap applies to any hosted STT provider, not just this one.

## Related Issue

None — docs addition. I searched issues and PRs for `speko` first; no hits.

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `website/docs/user-guide/features/tts.md`
  - `#### Example: Speko (routed TTS)` under **Custom command providers**
  - `#### Example: Speko (routed STT)` under **STT custom command providers**
  - `env_passthrough` row added to the STT command-provider optional-keys table

## How to Test

Both YAML blocks are verified rather than illustrative. I parsed them straight out of the committed markdown, rendered the `command` templates through the repo's own renderers, and ran the rendered strings against the live API:

```python
# rendered via tools.tts_tool._render_command_tts_template
jq -Rs '{text: ., intent: {language: "en"}, sampleRate: 24000}' /tmp/in.txt | curl -sS -X POST https://api.speko.dev/v1/synthesize -H "Authorization: Bearer $SPEKO_API_KEY" -H "Content-Type: application/json" --data-binary @- | ffmpeg -hide_banner -loglevel error -f s16le -ar 24000 -ac 1 -i pipe:0 -y /tmp/out.wav

# rendered via tools.transcription_tools._render_command_stt_template
ffmpeg -hide_banner -loglevel error -i /tmp/voice.ogg -ac 1 -ar 24000 -f wav pipe:1 | curl -sS -X POST https://api.speko.dev/v1/transcribe -H "Authorization: Bearer $SPEKO_API_KEY" -H "Content-Type: audio/wav" -H 'x-speko-intent: {"language": "en"}' --data-binary @- | grep '^data:' | tail -n1 | sed 's/^data: //' | jq -r .text > /tmp/tr.txt
```

Results: the TTS command produced a playable 2.4 s WAV (`ffprobe`: `pcm_s16le, 24000 Hz, 1 channel`); re-encoding that to Opus and feeding it to the STT command returned the original sentence. The doubled braces in the YAML survive the renderers intact, and `{language}` substitutes into the intent header — that's why the templates are written with `{{` / `}}`, per the placeholder rules already documented in both sections.

Negative controls behind the two warnings in the prose: the same Opus file posted without the `ffmpeg` hop returns `200` with `{"text":""}`, and `/v1/synthesize` without the `ffmpeg` hop writes headerless PCM that `ffprobe` will not open.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this documentation addition
- [x] Docs checks run locally: `ascii-guard lint --exclude-code-blocks docs` → 409 files, 0 errors; `npm run build:fast` in `website/` → `[SUCCESS] Generated static files`, exit 0, no broken anchor for the new in-page cross-link (the only broken links reported are the pre-existing `/docs/llms.txt` and `/docs/llms-full.txt` on the index page). I deliberately did **not** commit regenerated `website/docs/user-guide/skills/**` pages — running the generators locally rewrites ~51 unrelated pages (`python3` → `python` in other skills' code blocks), and those pages are refreshed in maintainer sweeps, not per-PR.
- [x] N/A — no tests: this adds no code path
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] This *is* the documentation update
- [x] N/A — `cli-config.yaml.example`: no new config keys; `tts.providers.<name>` / `stt.providers.<name>` and `env_passthrough` all already exist
- [x] N/A — no architecture or workflow change
- [x] Cross-platform: the templates need `curl`, `jq` and `ffmpeg` on `PATH`; on Windows they want a shell wrapper, the same caveat the surrounding sections already carry for shell-driven templates
- [x] N/A — no tool description or schema change

**Disclosure:** I work at Speko, on the team that built this integration. Related, separate PR: #89406 adds Speko as an outbound-call provider in the `telephony` optional skill.
