### PR TITLE
feat(desktop): attach files to Bot Mode group chat messages

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -3437,6 +3437,100 @@ function formatGroupChatLine(entry, viewerName) {
   return `${groupSpeakerLabel(entry.from.name)}${suffix}${source}: ${entry.text}`
 }
 
+/** A `MEDIA:/abs/path` token embedded in a group-chat message. The path is the
+ *  ORIGINAL on-disk location (approach A — no copy), so the bot reads it in
+ *  place with read_file / vision_analyze. */
+const GROUP_MEDIA_TOKEN_RE = /MEDIA:(\/[^\s]+|[A-Za-z]:\\[^\s]+)/g
+
+/** Split a message into text runs and MEDIA tokens, preserving order, so the
+ *  renderer can swap tokens for file chips while the stored text stays intact. */
+function parseGroupMediaTokens(text) {
+  const parts = []
+  let last = 0
+  const source = String(text || '')
+
+  for (const match of source.matchAll(GROUP_MEDIA_TOKEN_RE)) {
+    if (match.index > last) {
+      parts.push({ kind: 'text', value: source.slice(last, match.index) })
+    }
+
+    parts.push({ kind: 'media', path: match[1] })
+    last = match.index + match[0].length
+  }
+
+  if (last < source.length) {
+    parts.push({ kind: 'text', value: source.slice(last) })
+  }
+
+  return parts
+}
+
+/** Basename of a path, tolerant of both POSIX and Windows separators. */
+function groupMediaFileName(path) {
+  const p = String(path || '')
+  const idx = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'))
+  return idx >= 0 ? p.slice(idx + 1) : p
+}
+
+/** True when the path's extension looks like an image (for the chip icon). */
+function groupMediaIsImage(path) {
+  return /\.(png|jpe?g|gif|webp|svg|bmp|avif)$/i.test(String(path || ''))
+}
+
+/** Build the `MEDIA:` token string a message carries for one attachment. */
+function groupMediaToken(path) {
+  return `MEDIA:${path}`
+}
+
+/** Render a group-chat message body: `MEDIA:` tokens become clickable file
+ *  chips (approach A — original path, no copy), the rest flows through the
+ *  normal markdown renderer. The stored text is never mutated. */
+function renderGroupChatBody(text) {
+  const parts = parseGroupMediaTokens(text)
+
+  if (parts.length === 1 && parts[0].kind === 'text') {
+    return Streamdown ? jsx(Streamdown, { children: parts[0].value }) : parts[0].value
+  }
+
+  return jsxs('div', {
+    className: 'flex flex-col gap-1',
+    children: parts.map((part, i) => {
+      if (part.kind === 'text') {
+        if (!part.value.trim()) {
+          return null
+        }
+
+        return Streamdown
+          ? jsx(Streamdown, { children: part.value }, `t${i}`)
+          : jsx('span', { children: part.value }, `t${i}`)
+      }
+
+      const name = groupMediaFileName(part.path)
+      const isImage = groupMediaIsImage(part.path)
+
+      return jsx('button', {
+        type: 'button',
+        className:
+          'inline-flex w-fit items-center gap-1.5 rounded-md border border-(--ui-stroke-secondary) bg-(--ui-bg-quaternary) px-2 py-1 text-left text-[0.7rem] text-(--ui-text-secondary) transition-colors hover:bg-(--ui-control-hover-background)',
+        title: `Open ${name}`,
+        onClick: () => {
+          const os = pluginCtx?.os
+          if (os?.revealPath) {
+            void os.revealPath(part.path)
+          } else if (os?.openExternal) {
+            void os.openExternal(`file://${part.path}`)
+          }
+        },
+        children: [
+          jsx(Codicon, { name: isImage ? 'file-media' : 'file', className: 'text-[0.8rem]' }),
+          jsx('span', { className: 'max-w-56 truncate', children: name }),
+          jsx('span', { className: 'text-(--ui-text-quaternary)', children: '열기 ↗' })
+        ]
+      }, `m${i}`)
+    })
+  })
+}
+
 /** The full per-turn payload for one member: participation rules + the room
  *  delta. Rules travel in the turn payload (not SOUL) so every existing bot
  *  can join a group chat without a profile migration. */
@@ -3460,7 +3554,8 @@ function buildGroupChatTurnPrompt({ groupName, members, viewer, deltaLines }) {
     '- Reply with ONE conversational message ONLY if you have something new worth adding: build on what was just said, claim or hand off work, answer a question aimed at you, or report a real result. Keep chatter short (1-3 sentences) — but when you are delivering a result, an answer the user asked for, or substantive work, give it at full quality and length; never thin out real content to fit the room.',
     '- If you have nothing new to add, reply with exactly "(pass)". Passing is good — it lets the conversation settle.',
     '- Mention a teammate as @name to pull them in; mention @user only for a judgment call or a result the user needs. Do not repeat points already made.',
-    '- Never reveal content from your private 1:1 chats. Your reply text goes to the room verbatim — no preamble, no meta-commentary.'
+    '- Never reveal content from your private 1:1 chats. Your reply text goes to the room verbatim — no preamble, no meta-commentary.',
+    '- If a message contains a `MEDIA:` token, it is a file attachment: read that file with read_file (or vision_analyze for images) before replying, and treat it as part of the message.'
   ].join('\n')
 }
 
@@ -7842,6 +7937,33 @@ function GroupChatWorkspace({ group, members, onBack }) {
   const [openThreads, setOpenThreads] = useState({})
   const [replyThread, setReplyThread] = useState(null)
   const [replyDrafts, setReplyDrafts] = useState({})
+  // Pending attachments for the MAIN composer (approach A: original paths, no
+  // copy). Each entry is the absolute path the user picked; on submit they are
+  // rendered as `MEDIA:` tokens ahead of the typed text.
+  const [pendingAttachments, setPendingAttachments] = useState([])
+  const fileInputRef = useRef(null)
+
+  const pickAttachments = async () => {
+    const bridge = typeof window !== 'undefined' ? window.hermesDesktop : null
+
+    if (!bridge?.selectPaths) {
+      host.notify({ kind: 'error', message: 'File picking is unavailable in this build.' })
+      return
+    }
+
+    try {
+      const paths = await bridge.selectPaths({ multiple: true })
+      if (Array.isArray(paths) && paths.length) {
+        setPendingAttachments(prev => [...prev, ...paths])
+      }
+    } catch {
+      host.notify({ kind: 'error', message: 'Could not pick files.' })
+    }
+  }
+
+  const removePendingAttachment = path => {
+    setPendingAttachments(prev => prev.filter(p => p !== path))
+  }
 
   const header = jsxs('div', {
     className: 'flex items-center gap-2 px-2.5 pt-2.5 pb-2',
@@ -7895,16 +8017,22 @@ function GroupChatWorkspace({ group, members, onBack }) {
 
   const submit = () => {
     const text = draft.trim()
+    const attachments = pendingAttachments.map(groupMediaToken).join('\n')
 
-    if (!text) {
+    if (!text && !attachments) {
       return
     }
 
+    // Attachments ride as `MEDIA:` tokens ahead of the typed text. The stored
+    // message stays a plain string; the renderer swaps tokens for file chips.
+    const fullText = attachments ? `${attachments}\n${text}`.trim() : text
+
     setDraft('')
+    setPendingAttachments([])
     // Main composer = START A NEW THREAD with the whole group (Slack shape).
     // Full descriptors ride into the turn loop: remote members keep their
     // connection fields so their turns route to their own machines.
-    const minted = sendToGroupChat(group, memberDescriptors(), text)
+    const minted = sendToGroupChat(group, memberDescriptors(), fullText)
 
     if (minted) {
       setOpenThreads(prev => ({ ...prev, [minted]: true }))
@@ -8006,7 +8134,7 @@ function GroupChatWorkspace({ group, members, onBack }) {
                           jsx('div', {
                             className:
                               'text-xs text-(--ui-text-secondary) [&_p]:mb-1 [&_p:last-child]:mb-0 [&_ul]:mb-1 [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:mb-1 [&_ol]:list-decimal [&_ol]:pl-4 [&_pre]:overflow-x-auto',
-                            children: Streamdown ? jsx(Streamdown, { children: entry.text }) : entry.text
+                            children: renderGroupChatBody(entry.text)
                           })
                         ]
                       })
@@ -8162,21 +8290,64 @@ function GroupChatWorkspace({ group, members, onBack }) {
       }),
       jsx('div', {
         className: 'border-t border-(--ui-stroke-secondary) p-2',
-        children: jsxs('form', {
-          className: 'flex items-center gap-1.5',
-          onSubmit: event => {
-            event.preventDefault()
-            submit()
-          },
+        children: jsxs('div', {
+          className: 'flex flex-col gap-1.5',
           children: [
-            jsx(GroupMentionInput, {
-              'aria-label': `Message ${group}`,
-              placeholder: `New thread in ${group}… (@name to direct, @everyone for all)`,
-              members,
-              value: draft,
-              onChange: setDraft
-            }),
-            jsx(Button, { type: 'submit', size: 'sm', disabled: !draft.trim(), children: 'New Thread' })
+            pendingAttachments.length
+              ? jsx('div', {
+                  className: 'flex flex-wrap items-center gap-1.5',
+                  children: pendingAttachments.map(path =>
+                    jsxs('span', {
+                      className:
+                        'inline-flex items-center gap-1 rounded-md border border-(--ui-stroke-secondary) bg-(--ui-bg-quaternary) px-1.5 py-0.5 text-[0.7rem] text-(--ui-text-secondary)',
+                      children: [
+                        jsx(Codicon, {
+                          name: groupMediaIsImage(path) ? 'file-media' : 'file',
+                          className: 'text-[0.7rem]'
+                        }),
+                        jsx('span', { className: 'max-w-40 truncate', children: groupMediaFileName(path) }),
+                        jsx('button', {
+                          type: 'button',
+                          className: 'ml-0.5 text-(--ui-text-quaternary) hover:text-foreground',
+                          title: 'Remove attachment',
+                          onClick: () => removePendingAttachment(path),
+                          children: jsx(Codicon, { name: 'close', className: 'text-[0.7rem]' })
+                        })
+                      ]
+                    }, path)
+                  )
+                }, 'pending-attachments')
+              : null,
+            jsxs('form', {
+              className: 'flex items-center gap-1.5',
+              onSubmit: event => {
+                event.preventDefault()
+                submit()
+              },
+              children: [
+                jsx(Button, {
+                  type: 'button',
+                  variant: 'ghost',
+                  size: 'sm',
+                  title: 'Attach files',
+                  onClick: pickAttachments,
+                  children: jsx(Codicon, { name: 'add' })
+                }),
+                jsx(GroupMentionInput, {
+                  'aria-label': `Message ${group}`,
+                  placeholder: `New thread in ${group}… (@name to direct, @everyone for all)`,
+                  members,
+                  value: draft,
+                  onChange: setDraft
+                }),
+                jsx(Button, {
+                  type: 'submit',
+                  size: 'sm',
+                  disabled: !draft.trim() && !pendingAttachments.length,
+                  children: 'New Thread'
+                })
+              ]
+            })
           ]
         })
       }),


### PR DESCRIPTION
## Summary

Adds a **+ button** to the Bot Mode group-chat composer so the user can attach local files (images, PDFs, etc.) to a message. Attachments are sent as `MEDIA:` path tokens embedded in the message text; bots read the referenced file in place with `read_file` / `vision_analyze`, and the renderer swaps each token for a clickable file chip.

This PR implements **Approach A** (original-path reference) and includes the full **Approach B** design (copy to a managed folder) as a documented follow-up.

## Approach A — original-path reference (implemented in this PR)

The message stays a **plain string** — no backend / message-model change. The stored text is never mutated; only the presentation layer turns `MEDIA:` tokens into chips.

```
+ button → selectPaths() → MEDIA:/abs/path\n<typed text> → sendToGroupChat(text)
```

- **Zero copy** — the bot reads the file in place from its original location.
- **Minimal blast radius** — one plugin file, no electron/preload/IPC changes, no message-model migration.
- **Limitation** — the path is a live reference: if the user moves/deletes the file, the chip breaks, and remote bots on other machines cannot resolve a local path.

## Approach B — copy to a managed folder (design, not in this PR)

Attachments are copied into a managed folder under the Hermes home at attach time, so they survive the original file being moved/deleted and can be shared with remote bots.

### Data flow

```
+ button → selectPaths() → copyFile IPC → ~/.hermes/group-attachments/<group>/<thread>/<basename>
→ message text carries MEDIA:<managed-path> → bots read the managed copy
```

### Folder layout

```
~/.hermes/group-attachments/
  <group-name>/
    <thread-id>/
      <basename>          # collision-safe: timestamp-prefixed when the name exists
```

### New IPC surface (electron)

- `main.ts` — `ipcMain.handle('fs:copyGroupAttachment', …)`: copies the picked file into the managed folder, returns the new absolute path. Rejects on a size cap (e.g. 50 MB) and on path traversal.
- `preload.ts` — expose `copyGroupAttachment({ group, thread, sourcePath }) → Promise<string>`.
- `global.d.ts` — type the new bridge method.

### Renderer changes (plugin.js)

- `pickAttachments` calls the copy IPC instead of keeping the original path; pending chips show the managed path.
- Garbage collection: when `trimGroupChatLog` drops a thread, orphaned files are swept by a later cleanup pass (out of scope for the first B PR).

### Trade-offs

| | A (this PR) | B (design) |
|---|---|---|
| Copy | none — original path | copy into managed folder |
| Survives original moved/deleted | ❌ | ✅ |
| Remote bots (other machines) | ❌ (path is local) | ✅ (managed folder is shareable) |
| Disk usage | 0 | 1 copy per attachment |
| Electron/IPC changes | none | `main.ts` + `preload.ts` + `global.d.ts` |
| Message model | plain string | plain string |

### Why B is not in this PR

- B needs electron main/preload changes — a bigger blast radius that deserves its own E2E validation on all platforms.
- A ships the complete user-facing pipeline first; B can land as a follow-up **without breaking A** — the token format is identical, only the path source changes (original path → managed path).

## Changes

- `apps/desktop/src/plugins/hermes-bots/plugin.js` (single file):
  - `parseGroupMediaTokens` / `groupMediaFileName` / `groupMediaIsImage` / `groupMediaToken` helpers
  - turn prompt instructs bots: *"If a message contains a `MEDIA:` token, read that file with read_file (or vision_analyze for images) before replying"*
  - composer `+` button + pending-attachment preview (filename + remove)
  - `submit()` injects `MEDIA:` tokens ahead of the typed text
  - `renderGroupChatBody` renders tokens as file chips (icon + filename + "열기 ↗"), click opens via `ctx.os.revealPath`

## Why this shape

- **Minimal blast radius** — one plugin file, no electron/preload/IPC changes, no message-model migration.
- **No dead affordance** — the + button, token injection, bot instruction, and chip rendering ship together as one complete pipeline.
- **Backward compatible** — messages without `MEDIA:` tokens render exactly as before.

## Future work (suggested, not in this PR)

- **Approach B** — see the full design above.
- **Inline image thumbnails**: render image chips with a thumbnail via `readFileDataUrl` (currently icon-only to keep the first PR light).
- **File size on the chip**: needs a `statFile` IPC; omitted for now.

## Validation

- `npm run build` succeeds (7.4s); new bundle `index-B9tO_xsi.js` contains the `MEDIA:` token logic and the earlier `data-selectable-text` fix.
