### PR TITLE
fix(commandcode): Dashboard/Desktop model picker no longer empty; custom base_url honored for discovery (salvage #88851)

### DIFF
--- a/contributors/emails/sahabatheri@gmail.com
+++ b/contributors/emails/sahabatheri@gmail.com
@@ -1,0 +1,1 @@
+greyvito

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -525,6 +525,31 @@ def get_provider(name: str, *, allow_network: bool = True) -> Optional[ProviderD
             source="hermes",
         )
 
+    # Plugin-registered provider profiles (plugins/model-providers/<name>/).
+    # Providers that ship only as plugin profiles (e.g. commandcode,
+    # tencent-tokenhub) are absent from models.dev and HERMES_OVERLAYS, so
+    # without this fallback they resolve as "Unknown provider" in /model,
+    # --provider, and the model-switch path even though the picker lists them
+    # (CANONICAL_PROVIDERS auto-extends from the same plugin registry).
+    try:
+        from providers import get_provider_profile as _profile
+
+        _prof = _profile(canonical)
+        if _prof is not None:
+            _api_mode_to_transport = {v: k for k, v in TRANSPORT_TO_API_MODE.items()}
+            _transport = _api_mode_to_transport.get(_prof.api_mode, "openai_chat")
+            return ProviderDef(
+                id=canonical,
+                name=_prof.display_name or _prof.name or canonical,
+                transport=_transport,
+                api_key_env_vars=tuple(_prof.env_vars or ()),
+                base_url=_prof.base_url or "",
+                auth_type=_prof.auth_type or "api_key",
+                source="plugin-profile",
+            )
+    except Exception:
+        pass
+
     return None
 
 

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -535,7 +535,13 @@ def get_provider(name: str, *, allow_network: bool = True) -> Optional[ProviderD
         from providers import get_provider_profile as _profile
 
         _prof = _profile(canonical)
-        if _prof is not None:
+        # Only profiles with a concrete endpoint resolve here. Placeholder
+        # profiles like ``custom`` (aliases: ollama/local/vllm) ship with an
+        # empty base_url and are completed by config.yaml custom_providers —
+        # resolving them here would preempt resolve_provider_full's
+        # custom-provider step and collapse keyed IDs
+        # (``custom:local-...``) back to a bare, endpoint-less ``custom``.
+        if _prof is not None and (_prof.base_url or "").strip():
             _api_mode_to_transport = {v: k for k, v in TRANSPORT_TO_API_MODE.items()}
             _transport = _api_mode_to_transport.get(_prof.api_mode, "openai_chat")
             return ProviderDef(

--- a/plugins/model-providers/commandcode/__init__.py
+++ b/plugins/model-providers/commandcode/__init__.py
@@ -79,6 +79,7 @@ class CommandCodeProfile(ProviderProfile):
         self,
         *,
         api_key: str | None = None,
+        base_url: str | None = None,
         timeout: float = 8.0,
     ) -> list[str] | None:
         """Fetch from the public CommandCode /models endpoint."""
@@ -126,6 +127,7 @@ class CommandCodeAnthropicProfile(ProviderProfile):
         self,
         *,
         api_key: str | None = None,
+        base_url: str | None = None,
         timeout: float = 8.0,
     ) -> list[str] | None:
         """Fetch from the public CommandCode /models endpoint.

--- a/plugins/model-providers/commandcode/__init__.py
+++ b/plugins/model-providers/commandcode/__init__.py
@@ -47,14 +47,26 @@ _COMMANDCODE_ANTHROPIC_ENV = ("COMMANDCODE_API_KEY", "COMMANDCODE_ANTHROPIC_BASE
 
 def _fetch_commandcode_models(
     timeout: float = 10.0,
+    base_url: str | None = None,
 ) -> list[str] | None:
     """Fetch the live model list from the CommandCode /models endpoint.
 
     Returns a flat list of model IDs or None on failure.
     No auth required — the public models endpoint is open.
+
+    ``base_url`` overrides the endpoint only when the caller passed a URL
+    that differs from the default ``_COMMANDCODE_BASE`` (a user-configured
+    ``model.base_url`` / ``COMMANDCODE_BASE_URL`` pointing at a proxy or
+    custom deployment). The picker passes base_url unconditionally, falling
+    back to the profile default — equality means "not customised".
     """
+    caller_base = (base_url or "").strip()
+    if caller_base and caller_base.rstrip("/") != _COMMANDCODE_BASE.rstrip("/"):
+        models_url = caller_base.rstrip("/") + "/models"
+    else:
+        models_url = _COMMANDCODE_MODELS_URL
     try:
-        req = urllib.request.Request(_COMMANDCODE_MODELS_URL)
+        req = urllib.request.Request(models_url)
         req.add_header("Accept", "application/json")
         req.add_header("User-Agent", _profile_user_agent())
         with urllib.request.urlopen(req, timeout=timeout) as resp:
@@ -83,7 +95,7 @@ class CommandCodeProfile(ProviderProfile):
         timeout: float = 8.0,
     ) -> list[str] | None:
         """Fetch from the public CommandCode /models endpoint."""
-        return _fetch_commandcode_models(timeout=timeout)
+        return _fetch_commandcode_models(timeout=timeout, base_url=base_url)
 
 
 commandcode = CommandCodeProfile(
@@ -134,7 +146,7 @@ class CommandCodeAnthropicProfile(ProviderProfile):
 
         Filter to Anthropic-family models only (claude-*).
         """
-        all_models = _fetch_commandcode_models(timeout=timeout)
+        all_models = _fetch_commandcode_models(timeout=timeout, base_url=base_url)
         if all_models is None:
             return None
         return [m for m in all_models if m.startswith("claude-")]

--- a/providers/base.py
+++ b/providers/base.py
@@ -207,11 +207,17 @@ class ProviderProfile:
         the provider does not support live model listing.
 
         Resolution order for the endpoint URL:
-          1. self.models_url  (explicit override — use when the models
+          1. base_url + "/models", but ONLY when the caller passed a base_url
+             that differs from this profile's default (a user-configured
+             model.base_url pointing at a proxy/custom endpoint). Callers
+             pass base_url unconditionally — falling back to the profile
+             default when the user configured nothing — so equality with
+             self.base_url means "not customised" and must not shadow
+             models_url.
+          2. self.models_url  (explicit override — use when the models
              endpoint differs from the inference base URL, e.g. OpenRouter
              exposes a public catalog at /api/v1/models while inference is
              at /api/v1)
-          2. base_url (caller override — user-configured model.base_url)
           3. self.base_url + "/models"  (standard OpenAI-compat fallback)
 
         The default implementation sends Bearer auth when api_key is given
@@ -221,12 +227,19 @@ class ProviderProfile:
         Callers must always fall back to the static _PROVIDER_MODELS list
         when this returns None.
         """
-        effective_base = base_url or self.base_url
-        url = (self.models_url or "").strip()
-        if not url:
-            if not effective_base:
-                return None
-            url = effective_base.rstrip("/") + "/models"
+        caller_base = (base_url or "").strip()
+        effective_base = caller_base or self.base_url
+        custom_base = bool(caller_base) and (
+            caller_base.rstrip("/") != (self.base_url or "").rstrip("/")
+        )
+        if custom_base:
+            url = caller_base.rstrip("/") + "/models"
+        else:
+            url = (self.models_url or "").strip()
+            if not url:
+                if not effective_base:
+                    return None
+                url = effective_base.rstrip("/") + "/models"
 
         import json
         import urllib.request

--- a/tests/plugins/model_providers/test_commandcode_profile.py
+++ b/tests/plugins/model_providers/test_commandcode_profile.py
@@ -275,3 +275,93 @@ class TestCommandCodeFetchModelsPickerContract:
         anth = resolve_provider_full("commandcode-anthropic", {}, [])
         assert anth is not None and anth.id == "commandcode-anthropic"
         assert anth.transport == "anthropic_messages"
+
+
+# ── base_url endpoint override ───────────────────────────────────────────────
+
+class TestCommandCodeBaseUrlOverride:
+    """A custom base_url must redirect the catalog fetch; the default must not.
+
+    The picker passes ``base_url`` unconditionally (profile default when the
+    user configured nothing), so only a value differing from the default
+    ``_COMMANDCODE_BASE`` counts as a customised endpoint.
+    """
+
+    def _serve(self, models):
+        import json
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+        from threading import Thread
+
+        class H(BaseHTTPRequestHandler):
+            def do_GET(self):
+                body = json.dumps({"data": models}).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, fmt, *args):
+                pass
+
+        server = HTTPServer(("127.0.0.1", 0), H)
+        Thread(target=server.serve_forever, daemon=True).start()
+        return server, server.server_address[1]
+
+    def test_custom_base_url_redirects_fetch(self, commandcode_profile):
+        server, port = self._serve([{"id": "proxied/model-x"}])
+        try:
+            result = commandcode_profile.fetch_models(
+                api_key="k", base_url=f"http://127.0.0.1:{port}"
+            )
+            assert result == ["proxied/model-x"]
+        finally:
+            server.shutdown()
+
+    def test_custom_base_url_redirects_anthropic_fetch(
+        self, commandcode_anthropic_profile
+    ):
+        server, port = self._serve(
+            [{"id": "claude-sonnet-4-6"}, {"id": "deepseek/deepseek-v4-pro"}]
+        )
+        try:
+            result = commandcode_anthropic_profile.fetch_models(
+                api_key="k", base_url=f"http://127.0.0.1:{port}"
+            )
+            assert result == ["claude-sonnet-4-6"]  # claude-* filter still applies
+        finally:
+            server.shutdown()
+
+    def test_default_base_url_hits_default_endpoint(self, commandcode_profile):
+        """Echoing the profile default back must NOT count as an override."""
+        import sys
+        from unittest.mock import patch as mock_patch
+
+        # The bundled plugin module is registered at discovery time under
+        # ``plugins.model_providers.commandcode`` — resolve via the profile's
+        # own __module__ so the test doesn't depend on discovery mechanics.
+        cc_mod = sys.modules[type(commandcode_profile).__module__]
+
+        captured = {}
+
+        class _FakeResp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self):
+                return b'{"data": [{"id": "m1"}]}'
+
+        def fake_urlopen(req, timeout=0):
+            captured["url"] = req.full_url
+            return _FakeResp()
+
+        with mock_patch.object(
+            cc_mod.urllib.request, "urlopen", side_effect=fake_urlopen
+        ):
+            result = commandcode_profile.fetch_models(
+                api_key="k", base_url=cc_mod._COMMANDCODE_BASE + "/"
+            )
+        assert result == ["m1"]
+        assert captured["url"] == cc_mod._COMMANDCODE_MODELS_URL

--- a/tests/plugins/model_providers/test_commandcode_profile.py
+++ b/tests/plugins/model_providers/test_commandcode_profile.py
@@ -232,3 +232,27 @@ class TestCommandCodeModelFiltering:
         assert "startswith(\"claude-\")" in source or '"claude-" in m' in source, (
             "CommandCodeAnthropicProfile.fetch_models should filter to claude-* models"
         )
+
+
+# ── Picker contract ──────────────────────────────────────────────────────────
+
+class TestCommandCodeFetchModelsPickerContract:
+    """``fetch_models`` must accept the kwargs the model picker passes.
+
+    Regression: the generic live-fetch path in ``hermes_cli/models.py``
+    (``provider_model_ids``) calls ``profile.fetch_models(api_key=...,
+    base_url=...)``. The original CommandCode overrides only accepted
+    ``api_key``/``timeout``, so every picker open raised TypeError, which
+    was swallowed, leaving the provider with zero models.
+    """
+
+    @pytest.mark.parametrize("profile_name", ["commandcode", "commandcode-anthropic"])
+    def test_accepts_base_url_kwarg(self, profile_name):
+        import inspect
+
+        import model_tools  # noqa: F401 — triggers discovery
+        import providers
+
+        profile = providers.get_provider_profile(profile_name)
+        assert profile is not None
+        assert "base_url" in inspect.signature(profile.fetch_models).parameters

--- a/tests/plugins/model_providers/test_commandcode_profile.py
+++ b/tests/plugins/model_providers/test_commandcode_profile.py
@@ -256,3 +256,22 @@ class TestCommandCodeFetchModelsPickerContract:
         profile = providers.get_provider_profile(profile_name)
         assert profile is not None
         assert "base_url" in inspect.signature(profile.fetch_models).parameters
+
+    def test_resolve_provider_full(self):
+        """Both profiles must resolve through the model-switch path.
+
+        Regression: ``resolve_provider_full`` only knew models.dev + overlay
+        providers, so plugin-only providers (commandcode) failed with
+        "Unknown provider" on /model switches even though the picker listed
+        them.
+        """
+        from hermes_cli.providers import resolve_provider_full
+
+        chat = resolve_provider_full("commandcode", {}, [])
+        assert chat is not None and chat.id == "commandcode"
+        assert chat.transport == "openai_chat"
+        assert "COMMANDCODE_API_KEY" in chat.api_key_env_vars
+
+        anth = resolve_provider_full("commandcode-anthropic", {}, [])
+        assert anth is not None and anth.id == "commandcode-anthropic"
+        assert anth.transport == "anthropic_messages"

--- a/tests/providers/test_fetch_models_base_url.py
+++ b/tests/providers/test_fetch_models_base_url.py
@@ -58,6 +58,45 @@ class TestFetchModelsBaseUrlOverride:
         finally:
             server.shutdown()
 
+    def test_custom_base_url_beats_models_url(self):
+        """A caller base_url differing from the profile default overrides
+        models_url — a user-configured proxy must win over the profile's
+        hardcoded catalog endpoint (Discord report: CommandCode picker)."""
+        server, port = _start_server([{"id": "proxy-model-b"}])
+        try:
+            profile = ProviderProfile(
+                name="test",
+                base_url="http://127.0.0.1:1",
+                models_url="http://127.0.0.1:1/models",  # unreachable
+            )
+            result = profile.fetch_models(
+                api_key="test-key",
+                base_url=f"http://127.0.0.1:{port}",
+            )
+            assert result == ["proxy-model-b"]
+        finally:
+            server.shutdown()
+
+    def test_default_base_url_does_not_shadow_models_url(self):
+        """Callers pass base_url unconditionally (profile default when the
+        user configured nothing). Equality with self.base_url means "not
+        customised" and must keep models_url as the endpoint."""
+        server, port = _start_server([{"id": "catalog-model"}])
+        try:
+            profile = ProviderProfile(
+                name="test",
+                base_url="http://127.0.0.1:1",  # inference URL, unreachable
+                models_url=f"http://127.0.0.1:{port}/models",
+            )
+            # Caller echoes the profile default back — models_url must win.
+            result = profile.fetch_models(
+                api_key="test-key",
+                base_url="http://127.0.0.1:1/",  # same default, trailing slash
+            )
+            assert result == ["catalog-model"]
+        finally:
+            server.shutdown()
+
 
 
 


### PR DESCRIPTION
## Summary
CommandCode's Dashboard/Desktop model picker now shows live models, and a user-configured custom `base_url` actually redirects model discovery instead of being silently ignored.

Salvage of #88851 by @greyvito, cherry-picked onto current main with authorship preserved, plus a follow-up that widens the fix to the whole provider class.

Root cause (Discord report by flep, v0.20.4): both CommandCode `fetch_models()` overrides only accepted `api_key`/`timeout`, while the shared picker path (`provider_model_ids` in `hermes_cli/models.py`) calls `fetch_models(api_key=..., base_url=...)`. The TypeError was swallowed → empty picker. The base class and all 8 sibling plugin profiles already accepted `base_url`; CommandCode was the outlier.

## Changes
- `plugins/model-providers/commandcode/__init__.py` (@greyvito): both `fetch_models()` overrides accept `base_url`; (follow-up) `_fetch_commandcode_models()` honors a custom base_url as the endpoint.
- `hermes_cli/providers.py` (@greyvito): `get_provider()` falls back to plugin-registered profiles so plugin-only providers (commandcode) stop resolving as "Unknown provider" in `/model`.
- `providers/base.py` (follow-up, addresses @dansigma's review on #88851): class-wide endpoint precedence — a caller `base_url` that differs from the profile default overrides `models_url`; echoing the default back keeps `models_url` (preserves OpenRouter-style split catalogs, since callers pass base_url unconditionally).
- Tests: picker-contract signatures, `resolve_provider_full` (@greyvito); base-class precedence both ways + CommandCode redirect via live local HTTP server incl. claude-* filter (follow-up).

## Validation
| | Before | After |
|---|---|---|
| Picker `fetch_models(base_url=...)` on CommandCode | TypeError, empty picker | live catalog |
| Custom `model.base_url` proxy | ignored, public catalog fetched | proxy endpoint fetched |
| Default base_url echoed by picker | n/a | still hits `models_url` (no behavior change) |
| Targeted tests | 3 new tests fail on pre-fix code (sabotage run verified) | 111 passed (tests/providers/ + commandcode + custom profile) |

## Infographic

![CommandCode model picker fixed](https://v3b.fal.media/files/b/0aa6df37/98YKIqr-g8DLRBN9BxlAY_S0DC8x7I.png)
