### PR TITLE
fix(agent): keep excluded providers out of auxiliary requests

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3944,24 +3944,15 @@ def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str,
 def _inherit_provider_preferences(
     extra_body: Dict[str, Any],
     main_runtime: Dict[str, Any],
-    request_provider: str,
     client: Any,
-    base_url: str,
 ) -> None:
-    """Apply the main routing policy to aggregator aux calls unless overridden."""
+    """Apply the main routing policy to OpenRouter calls unless overridden."""
     provider_preferences = main_runtime.get("provider_preferences")
     if (
         isinstance(provider_preferences, dict)
         and provider_preferences
         and "provider" not in extra_body
-        and not isinstance(
-            client, (AnthropicAuxiliaryClient, AsyncAnthropicAuxiliaryClient)
-        )
-        and (
-            _is_openrouter_client(client)
-            or request_provider == "nous"
-            or base_url_host_matches(base_url, "inference-api.nousresearch.com")
-        )
+        and _is_openrouter_client(client)
     ):
         extra_body["provider"] = copy.deepcopy(provider_preferences)
 
@@ -5106,9 +5097,7 @@ def _call_fallback_candidate_sync(
     _inherit_provider_preferences(
         fallback_extra_body,
         main_runtime or {},
-        destination.provider,
         fb_client,
-        destination.base_url,
     )
     fb_kwargs = _build_call_kwargs(
         destination.provider, destination.model, fallback_messages,
@@ -5156,9 +5145,7 @@ def _call_fallback_candidate_sync(
                 _inherit_provider_preferences(
                     retry_extra_body,
                     main_runtime or {},
-                    retry_destination.provider,
                     retry_client,
-                    retry_destination.base_url,
                 )
                 retry_kwargs = _build_call_kwargs(
                     retry_destination.provider,
@@ -5229,9 +5216,7 @@ async def _call_fallback_candidate_async(
     _inherit_provider_preferences(
         fallback_extra_body,
         main_runtime or {},
-        destination.provider,
         fb_client,
-        destination.base_url,
     )
     fb_kwargs = _build_call_kwargs(
         destination.provider, destination.model, fallback_messages,
@@ -5280,9 +5265,7 @@ async def _call_fallback_candidate_async(
                 _inherit_provider_preferences(
                     retry_extra_body,
                     main_runtime or {},
-                    retry_destination.provider,
                     retry_client,
-                    retry_destination.base_url,
                 )
                 retry_kwargs = _build_call_kwargs(
                     retry_destination.provider,
@@ -9387,7 +9370,7 @@ def _call_llm_impl(
     _base_info = str(getattr(client, "base_url", resolved_base_url) or "")
     primary_extra_body = copy.deepcopy(effective_extra_body)
     _inherit_provider_preferences(
-        primary_extra_body, main_runtime, request_provider, client, _base_info
+        primary_extra_body, main_runtime, client
     )
     if task:
         logger.info("Auxiliary %s: using %s (%s)%s",
@@ -10181,7 +10164,7 @@ async def _async_call_llm_impl(
     _client_base = str(getattr(client, "base_url", "") or "")
     primary_extra_body = copy.deepcopy(effective_extra_body)
     _inherit_provider_preferences(
-        primary_extra_body, main_runtime, request_provider, client, _client_base
+        primary_extra_body, main_runtime, client
     )
     kwargs = _build_call_kwargs(
         request_provider, final_model, messages,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3954,6 +3954,9 @@ def _inherit_provider_preferences(
         isinstance(provider_preferences, dict)
         and provider_preferences
         and "provider" not in extra_body
+        and not isinstance(
+            client, (AnthropicAuxiliaryClient, AsyncAnthropicAuxiliaryClient)
+        )
         and (
             _is_openrouter_client(client)
             or request_provider == "nous"

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5063,6 +5063,7 @@ def _call_fallback_candidate_sync(
     effective_timeout: float,
     effective_extra_body: dict,
     reasoning_config: Optional[dict],
+    main_runtime: Optional[Dict[str, Any]] = None,
 ) -> Optional[Any]:
     """Call one fallback candidate with stale-credential recovery.
 
@@ -5098,11 +5099,19 @@ def _call_fallback_candidate_sync(
         tools,
         destination=destination,
     )
+    fallback_extra_body = copy.deepcopy(effective_extra_body)
+    _inherit_provider_preferences(
+        fallback_extra_body,
+        main_runtime or {},
+        destination.provider,
+        fb_client,
+        destination.base_url,
+    )
     fb_kwargs = _build_call_kwargs(
         destination.provider, destination.model, fallback_messages,
         temperature=temperature, max_tokens=max_tokens,
         tools=fallback_tools, timeout=effective_timeout,
-        extra_body=effective_extra_body, reasoning_config=reasoning_config,
+        extra_body=fallback_extra_body, reasoning_config=reasoning_config,
         base_url=destination.base_url, task=task)
     try:
         return _validate_llm_response(
@@ -5140,13 +5149,21 @@ def _call_fallback_candidate_sync(
                     tools,
                     destination=retry_destination,
                 )
+                retry_extra_body = copy.deepcopy(effective_extra_body)
+                _inherit_provider_preferences(
+                    retry_extra_body,
+                    main_runtime or {},
+                    retry_destination.provider,
+                    retry_client,
+                    retry_destination.base_url,
+                )
                 retry_kwargs = _build_call_kwargs(
                     retry_destination.provider,
                     retry_destination.model,
                     retry_messages,
                     temperature=temperature, max_tokens=max_tokens,
                     tools=retry_tools, timeout=effective_timeout,
-                    extra_body=effective_extra_body,
+                    extra_body=retry_extra_body,
                     reasoning_config=reasoning_config,
                     base_url=retry_destination.base_url, task=task)
                 try:
@@ -5188,6 +5205,7 @@ async def _call_fallback_candidate_async(
     effective_timeout: float,
     effective_extra_body: dict,
     reasoning_config: Optional[dict],
+    main_runtime: Optional[Dict[str, Any]] = None,
 ) -> Optional[Any]:
     """Async mirror of :func:`_call_fallback_candidate_sync`."""
     fb_timeout = _fallback_entry_timeout(task, fb_label)
@@ -5204,11 +5222,19 @@ async def _call_fallback_candidate_async(
         tools,
         destination=destination,
     )
+    fallback_extra_body = copy.deepcopy(effective_extra_body)
+    _inherit_provider_preferences(
+        fallback_extra_body,
+        main_runtime or {},
+        destination.provider,
+        fb_client,
+        destination.base_url,
+    )
     fb_kwargs = _build_call_kwargs(
         destination.provider, destination.model, fallback_messages,
         temperature=temperature, max_tokens=max_tokens,
         tools=fallback_tools, timeout=effective_timeout,
-        extra_body=effective_extra_body, reasoning_config=reasoning_config,
+        extra_body=fallback_extra_body, reasoning_config=reasoning_config,
         base_url=destination.base_url, task=task)
     try:
         return _validate_llm_response(
@@ -5247,13 +5273,21 @@ async def _call_fallback_candidate_async(
                     tools,
                     destination=retry_destination,
                 )
+                retry_extra_body = copy.deepcopy(effective_extra_body)
+                _inherit_provider_preferences(
+                    retry_extra_body,
+                    main_runtime or {},
+                    retry_destination.provider,
+                    retry_client,
+                    retry_destination.base_url,
+                )
                 retry_kwargs = _build_call_kwargs(
                     retry_destination.provider,
                     retry_destination.model,
                     retry_messages,
                     temperature=temperature, max_tokens=max_tokens,
                     tools=retry_tools, timeout=effective_timeout,
-                    extra_body=effective_extra_body,
+                    extra_body=retry_extra_body,
                     reasoning_config=reasoning_config,
                     base_url=retry_destination.base_url, task=task)
                 try:
@@ -9348,8 +9382,9 @@ def _call_llm_impl(
 
     # Log what we're about to do — makes auxiliary operations visible
     _base_info = str(getattr(client, "base_url", resolved_base_url) or "")
+    primary_extra_body = copy.deepcopy(effective_extra_body)
     _inherit_provider_preferences(
-        effective_extra_body, main_runtime, request_provider, client, _base_info
+        primary_extra_body, main_runtime, request_provider, client, _base_info
     )
     if task:
         logger.info("Auxiliary %s: using %s (%s)%s",
@@ -9362,7 +9397,7 @@ def _call_llm_impl(
     kwargs = _build_call_kwargs(
         request_provider, final_model, messages,
         temperature=temperature, max_tokens=max_tokens,
-        tools=tools, timeout=effective_timeout, extra_body=effective_extra_body,
+        tools=tools, timeout=effective_timeout, extra_body=primary_extra_body,
         reasoning_config=reasoning_config,
         base_url=_base_info or resolved_base_url, task=task)
     if extra_headers:
@@ -9876,6 +9911,7 @@ def _call_llm_impl(
                     temperature=temperature, max_tokens=max_tokens,
                     tools=tools, effective_timeout=effective_timeout,
                     effective_extra_body=effective_extra_body,
+                    main_runtime=main_runtime,
                     reasoning_config=reasoning_config)
                 if fb_resp is not None:
                     return fb_resp
@@ -9894,6 +9930,7 @@ def _call_llm_impl(
                         temperature=temperature, max_tokens=max_tokens,
                         tools=tools, effective_timeout=effective_timeout,
                         effective_extra_body=effective_extra_body,
+                        main_runtime=main_runtime,
                         reasoning_config=reasoning_config)
                     if fb_resp is not None:
                         return fb_resp
@@ -10139,13 +10176,14 @@ async def _async_call_llm_impl(
     # endpoint-specific temperature overrides can distinguish
     # api.moonshot.ai vs api.kimi.com/coding even on auto-detected routes.
     _client_base = str(getattr(client, "base_url", "") or "")
+    primary_extra_body = copy.deepcopy(effective_extra_body)
     _inherit_provider_preferences(
-        effective_extra_body, main_runtime, request_provider, client, _client_base
+        primary_extra_body, main_runtime, request_provider, client, _client_base
     )
     kwargs = _build_call_kwargs(
         request_provider, final_model, messages,
         temperature=temperature, max_tokens=max_tokens,
-        tools=tools, timeout=effective_timeout, extra_body=effective_extra_body,
+        tools=tools, timeout=effective_timeout, extra_body=primary_extra_body,
         reasoning_config=reasoning_config,
         base_url=_client_base or resolved_base_url, task=task)
 
@@ -10549,6 +10587,7 @@ async def _async_call_llm_impl(
                     temperature=temperature, max_tokens=max_tokens,
                     tools=tools, effective_timeout=effective_timeout,
                     effective_extra_body=effective_extra_body,
+                    main_runtime=main_runtime,
                     reasoning_config=reasoning_config)
                 if fb_resp is not None:
                     return fb_resp
@@ -10571,6 +10610,7 @@ async def _async_call_llm_impl(
                         temperature=temperature, max_tokens=max_tokens,
                         tools=tools, effective_timeout=effective_timeout,
                         effective_extra_body=effective_extra_body,
+                        main_runtime=main_runtime,
                         reasoning_config=reasoning_config)
                     if fb_resp is not None:
                         return fb_resp

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3390,6 +3390,7 @@ def set_runtime_main(
     auth_mode: str = "",
     session_id: str = "",
     cache_scope: str = "",
+    provider_preferences: Optional[Dict[str, Any]] = None,
 ) -> contextvars.Token:
     """Record the current context's live main runtime for auxiliary routing.
 
@@ -3418,6 +3419,11 @@ def set_runtime_main(
         "auth_mode": (auth_mode or "").strip().lower(),
         "session_id": (session_id or "").strip(),
         "cache_scope": (cache_scope or "").strip(),
+        "provider_preferences": (
+            copy.deepcopy(provider_preferences)
+            if isinstance(provider_preferences, dict)
+            else {}
+        ),
     }
     # Publish authoritative context before updating locked compatibility
     # mirrors; concurrent sessions never read those mirrors at runtime.
@@ -3891,7 +3897,10 @@ _AUTO_PROVIDER_LABELS = {
 }
 
 _MAIN_RUNTIME_FIELDS = ("provider", "model", "base_url", "api_key", "api_mode", "auth_mode")
-_MAIN_RUNTIME_CONTEXT_FIELDS = _MAIN_RUNTIME_FIELDS + ("requested_provider",)
+_MAIN_RUNTIME_CONTEXT_FIELDS = _MAIN_RUNTIME_FIELDS + (
+    "requested_provider",
+    "provider_preferences",
+)
 
 
 def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str, Any]:
@@ -3916,6 +3925,9 @@ def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str,
     normalized: Dict[str, Any] = {}
     for field in _MAIN_RUNTIME_CONTEXT_FIELDS:
         value = main_runtime.get(field)
+        if field == "provider_preferences" and isinstance(value, dict):
+            normalized[field] = copy.deepcopy(value)
+            continue
         # Preserve a callable api_key (Entra ID bearer provider) unchanged.
         if field == "api_key" and callable(value) and not isinstance(value, str):
             normalized[field] = value
@@ -3927,6 +3939,28 @@ def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str,
         if isinstance(identity, str):
             normalized[identity_field] = identity.lower()
     return normalized
+
+
+def _inherit_provider_preferences(
+    extra_body: Dict[str, Any],
+    main_runtime: Dict[str, Any],
+    request_provider: str,
+    client: Any,
+    base_url: str,
+) -> None:
+    """Apply the main routing policy to aggregator aux calls unless overridden."""
+    provider_preferences = main_runtime.get("provider_preferences")
+    if (
+        isinstance(provider_preferences, dict)
+        and provider_preferences
+        and "provider" not in extra_body
+        and (
+            _is_openrouter_client(client)
+            or request_provider == "nous"
+            or base_url_host_matches(base_url, "inference-api.nousresearch.com")
+        )
+    ):
+        extra_body["provider"] = copy.deepcopy(provider_preferences)
 
 
 def _get_provider_chain() -> List[tuple]:
@@ -9314,6 +9348,9 @@ def _call_llm_impl(
 
     # Log what we're about to do — makes auxiliary operations visible
     _base_info = str(getattr(client, "base_url", resolved_base_url) or "")
+    _inherit_provider_preferences(
+        effective_extra_body, main_runtime, request_provider, client, _base_info
+    )
     if task:
         logger.info("Auxiliary %s: using %s (%s)%s",
                      task, request_provider or "auto", final_model or "default",
@@ -10102,6 +10139,9 @@ async def _async_call_llm_impl(
     # endpoint-specific temperature overrides can distinguish
     # api.moonshot.ai vs api.kimi.com/coding even on auto-detected routes.
     _client_base = str(getattr(client, "base_url", "") or "")
+    _inherit_provider_preferences(
+        effective_extra_body, main_runtime, request_provider, client, _client_base
+    )
     kwargs = _build_call_kwargs(
         request_provider, final_model, messages,
         temperature=temperature, max_tokens=max_tokens,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -560,23 +560,43 @@ def _validated_openrouter_provider_sort(raw_sort: Any) -> Optional[str]:
     return None
 
 
+def _provider_preferences_from_values(
+    *,
+    providers_allowed=None,
+    providers_ignored=None,
+    providers_order=None,
+    provider_sort=None,
+    provider_require_parameters=False,
+    provider_data_collection=None,
+) -> Dict[str, Any]:
+    """Build one validated provider-routing object from resolved values."""
+    preferences: Dict[str, Any] = {}
+    if providers_allowed:
+        preferences["only"] = providers_allowed
+    if providers_ignored:
+        preferences["ignore"] = providers_ignored
+    if providers_order:
+        preferences["order"] = providers_order
+    validated_sort = _validated_openrouter_provider_sort(provider_sort)
+    if validated_sort:
+        preferences["sort"] = validated_sort
+    if provider_require_parameters:
+        preferences["require_parameters"] = True
+    if provider_data_collection:
+        preferences["data_collection"] = provider_data_collection
+    return preferences
+
+
 def _provider_preferences_for_agent(agent) -> Dict[str, Any]:
     """Build the validated provider-routing object shared by request paths."""
-    preferences: Dict[str, Any] = {}
-    if agent.providers_allowed:
-        preferences["only"] = agent.providers_allowed
-    if agent.providers_ignored:
-        preferences["ignore"] = agent.providers_ignored
-    if agent.providers_order:
-        preferences["order"] = agent.providers_order
-    provider_sort = _validated_openrouter_provider_sort(agent.provider_sort)
-    if provider_sort:
-        preferences["sort"] = provider_sort
-    if agent.provider_require_parameters:
-        preferences["require_parameters"] = True
-    if agent.provider_data_collection:
-        preferences["data_collection"] = agent.provider_data_collection
-    return preferences
+    return _provider_preferences_from_values(
+        providers_allowed=agent.providers_allowed,
+        providers_ignored=agent.providers_ignored,
+        providers_order=agent.providers_order,
+        provider_sort=agent.provider_sort,
+        provider_require_parameters=agent.provider_require_parameters,
+        provider_data_collection=agent.provider_data_collection,
+    )
 
 
 def _prompt_cache_scope_for_agent(agent) -> "str | None":

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -486,6 +486,7 @@ def build_turn_context(
     # after primary restoration has settled the runtime.
     try:
         from agent.auxiliary_client import set_runtime_main
+        from agent.chat_completion_helpers import _provider_preferences_for_agent
         from agent.prompt_cache_scope import resolve_prompt_cache_scope_safe
         # Rotation-stable prompt-cache scope. Memoized per segment on the
         # agent, so this is a DB walk at most once per segment — except a
@@ -507,6 +508,7 @@ def build_turn_context(
             auth_mode=getattr(agent, "auth_mode", "") or "",
             session_id=getattr(agent, "session_id", "") or "",
             cache_scope=_cache_scope,
+            provider_preferences=_provider_preferences_for_agent(agent),
         )
     except Exception:
         pass

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17966,6 +17966,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         )
                         vision_runtime = dict(runtime_kwargs or {})
                         vision_runtime["model"] = turn_model
+                        from agent.chat_completion_helpers import (
+                            _provider_preferences_from_values,
+                        )
+
+                        provider_routing = getattr(self, "_provider_routing", {}) or {}
+                        vision_runtime["provider_preferences"] = (
+                            _provider_preferences_from_values(
+                                providers_allowed=provider_routing.get("only"),
+                                providers_ignored=provider_routing.get("ignore"),
+                                providers_order=provider_routing.get("order"),
+                                provider_sort=provider_routing.get("sort"),
+                                provider_require_parameters=provider_routing.get(
+                                    "require_parameters", False
+                                ),
+                                provider_data_collection=provider_routing.get(
+                                    "data_collection"
+                                ),
+                            )
+                        )
                     except Exception:
                         logger.debug(
                             "vision enrichment: session runtime resolution failed",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -930,9 +930,10 @@ DEFAULT_CONFIG = {
     # the configured provider is unavailable.
     #
     # extra_body: forwarded verbatim as request body fields on every aux call
-    # for that task. Use this to set provider-specific knobs (independent of
-    # main-agent settings). On OpenRouter you can set provider routing prefs
-    # and the Pareto Code coding-score floor here. Example:
+    # for that task. Use this to set provider-specific knobs. OpenRouter/Nous
+    # auxiliary calls inherit the main agent's provider_routing by default;
+    # an explicit extra_body.provider here overrides it for this task. The
+    # Pareto Code coding-score floor remains task-specific. Example:
     #
     #   auxiliary:
     #     compression:
@@ -946,8 +947,7 @@ DEFAULT_CONFIG = {
     #           - id: pareto-router
     #             min_coding_score: 0.5
     #
-    # Each aux task is independent — main-agent provider_routing and
-    # openrouter.min_coding_score do NOT propagate to aux calls by design.
+    # openrouter.min_coding_score does not propagate to auxiliary calls.
     "auxiliary": {
         # Same-provider retries for a transient transport blip (connection
         # reset / timeout / 5xx / 408) on ANY auxiliary call before falling

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -931,7 +931,8 @@ DEFAULT_CONFIG = {
     #
     # extra_body: forwarded verbatim as request body fields on every aux call
     # for that task. Use this to set provider-specific knobs. OpenRouter/Nous
-    # auxiliary calls inherit the main agent's provider_routing by default;
+    # auxiliary chat-completions calls inherit the main agent's
+    # provider_routing by default;
     # an explicit extra_body.provider here overrides it for this task. The
     # Pareto Code coding-score floor remains task-specific. Example:
     #

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -930,9 +930,8 @@ DEFAULT_CONFIG = {
     # the configured provider is unavailable.
     #
     # extra_body: forwarded verbatim as request body fields on every aux call
-    # for that task. Use this to set provider-specific knobs. OpenRouter/Nous
-    # auxiliary chat-completions calls inherit the main agent's
-    # provider_routing by default;
+    # for that task. Use this to set provider-specific knobs. OpenRouter
+    # auxiliary calls inherit the main agent's provider_routing by default;
     # an explicit extra_body.provider here overrides it for this task. The
     # Pareto Code coding-score floor remains task-specific. Example:
     #

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2280,6 +2280,43 @@ class TestStaleBaseUrlWarning:
 
 
 class TestAuxiliaryTaskExtraBody:
+    def test_nous_native_anthropic_route_omits_openai_provider_routing(self):
+        from agent.auxiliary_client import (
+            AnthropicAuxiliaryClient,
+            _inherit_provider_preferences,
+        )
+
+        client = object.__new__(AnthropicAuxiliaryClient)
+        client.base_url = "https://inference-api.nousresearch.com/v1"
+        extra_body = {}
+
+        _inherit_provider_preferences(
+            extra_body,
+            {"provider_preferences": {"ignore": ["digitalocean"]}},
+            "nous",
+            client,
+            client.base_url,
+        )
+
+        assert "provider" not in extra_body
+
+    def test_nous_chat_completions_route_inherits_provider_routing(self):
+        from agent.auxiliary_client import _inherit_provider_preferences
+
+        client = MagicMock()
+        client.base_url = "https://inference-api.nousresearch.com/v1"
+        extra_body = {}
+
+        _inherit_provider_preferences(
+            extra_body,
+            {"provider_preferences": {"ignore": ["digitalocean"]}},
+            "nous",
+            client,
+            client.base_url,
+        )
+
+        assert extra_body["provider"] == {"ignore": ["digitalocean"]}
+
     def test_sync_call_inherits_main_provider_routing_for_openrouter(self):
         client = MagicMock()
         client.base_url = OPENROUTER_BASE_URL

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2241,6 +2241,95 @@ class TestStaleBaseUrlWarning:
 
 
 class TestAuxiliaryTaskExtraBody:
+    def test_sync_call_inherits_main_provider_routing_for_openrouter(self):
+        client = MagicMock()
+        client.base_url = OPENROUTER_BASE_URL
+        response = MagicMock()
+        client.chat.completions.create.return_value = response
+        provider_preferences = {
+            "only": ["anthropic", "google"],
+            "ignore": ["digitalocean"],
+            "order": ["anthropic", "google"],
+            "sort": "throughput",
+        }
+
+        with patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(client, "deepseek/deepseek-v4-flash"),
+        ):
+            result = call_llm(
+                task="title_generation",
+                provider="openrouter",
+                main_runtime={
+                    "provider": "openrouter",
+                    "provider_preferences": provider_preferences,
+                },
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert result is response
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["extra_body"]["provider"] == provider_preferences
+
+    @pytest.mark.asyncio
+    async def test_async_call_inherits_main_provider_routing_for_openrouter(self):
+        client = MagicMock()
+        client.base_url = OPENROUTER_BASE_URL
+        response = MagicMock()
+        client.chat.completions.create = AsyncMock(return_value=response)
+        provider_preferences = {
+            "ignore": ["streamlake"],
+            "sort": "price",
+        }
+
+        with patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(client, "deepseek/deepseek-v4-flash"),
+        ):
+            result = await async_call_llm(
+                task="title_generation",
+                provider="openrouter",
+                main_runtime={
+                    "provider": "openrouter",
+                    "provider_preferences": provider_preferences,
+                },
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert result is response
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["extra_body"]["provider"] == provider_preferences
+
+    def test_task_provider_routing_overrides_inherited_preferences(self):
+        client = MagicMock()
+        client.base_url = OPENROUTER_BASE_URL
+        response = MagicMock()
+        client.chat.completions.create.return_value = response
+        task_preferences = {"only": ["google"], "sort": "latency"}
+        config = {
+            "auxiliary": {
+                "compression": {"extra_body": {"provider": task_preferences}}
+            }
+        }
+
+        with patch("hermes_cli.config.load_config", return_value=config), patch(
+            "hermes_cli.config.load_config_readonly", return_value=config
+        ), patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(client, "google/gemini-3-flash-preview"),
+        ):
+            call_llm(
+                task="compression",
+                provider="openrouter",
+                main_runtime={
+                    "provider_preferences": {"ignore": ["google"]}
+                },
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["extra_body"]["provider"] == task_preferences
+
     def test_sync_call_merges_task_extra_body_from_config(self):
         client = MagicMock()
         client.base_url = "https://api.example.com/v1"

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1796,6 +1796,45 @@ class TestAuxiliaryFallbackLayering:
         # Main agent fallback should NOT be needed when chain succeeds
         mock_main.assert_not_called()
 
+    def test_inherited_routing_is_projected_per_fallback_destination(self):
+        primary_client = MagicMock()
+        primary_client.base_url = OPENROUTER_BASE_URL
+        rate_err = Exception("Rate limit exceeded")
+        rate_err.status_code = 429
+        primary_client.chat.completions.create.side_effect = rate_err
+
+        fallback_client = MagicMock()
+        fallback_client.base_url = "https://api.anthropic.com/v1"
+        fallback_client.chat.completions.create.return_value = MagicMock(
+            choices=[MagicMock(message=MagicMock(content="fallback"))]
+        )
+
+        with patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(primary_client, "deepseek/deepseek-v4-flash"),
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("openrouter", "deepseek/deepseek-v4-flash", None, None, None),
+        ), patch(
+            "agent.auxiliary_client._try_configured_fallback_chain",
+            return_value=(fallback_client, "claude-haiku-4-5", "anthropic"),
+        ), patch("agent.auxiliary_client._try_main_agent_model_fallback"):
+            result = call_llm(
+                task="compression",
+                main_runtime={
+                    "provider_preferences": {"ignore": ["digitalocean"]}
+                },
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert result.choices[0].message.content == "fallback"
+        primary_kwargs = primary_client.chat.completions.create.call_args.kwargs
+        fallback_kwargs = fallback_client.chat.completions.create.call_args.kwargs
+        assert primary_kwargs["extra_body"]["provider"] == {
+            "ignore": ["digitalocean"]
+        }
+        assert "provider" not in fallback_kwargs.get("extra_body", {})
+
 
     def test_warning_emitted_when_all_fallbacks_exhausted(self, monkeypatch, caplog):
         """When chain AND main model both fail, a user-visible warning fires before re-raise."""

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2293,14 +2293,12 @@ class TestAuxiliaryTaskExtraBody:
         _inherit_provider_preferences(
             extra_body,
             {"provider_preferences": {"ignore": ["digitalocean"]}},
-            "nous",
             client,
-            client.base_url,
         )
 
         assert "provider" not in extra_body
 
-    def test_nous_chat_completions_route_inherits_provider_routing(self):
+    def test_nous_chat_completions_route_omits_provider_routing(self):
         from agent.auxiliary_client import _inherit_provider_preferences
 
         client = MagicMock()
@@ -2310,12 +2308,10 @@ class TestAuxiliaryTaskExtraBody:
         _inherit_provider_preferences(
             extra_body,
             {"provider_preferences": {"ignore": ["digitalocean"]}},
-            "nous",
             client,
-            client.base_url,
         )
 
-        assert extra_body["provider"] == {"ignore": ["digitalocean"]}
+        assert "provider" not in extra_body
 
     def test_sync_call_inherits_main_provider_routing_for_openrouter(self):
         client = MagicMock()

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -210,6 +210,29 @@ def test_returns_turn_context_with_user_message_appended():
     assert ctx.active_system_prompt == "SYSTEM"
 
 
+def test_prologue_binds_validated_provider_routing_for_auxiliary_calls():
+    agent = _FakeAgent()
+    agent.providers_allowed = ["anthropic"]
+    agent.providers_ignored = ["digitalocean"]
+    agent.providers_order = ["anthropic", "google"]
+    agent.provider_sort = "throughput"
+    agent.provider_require_parameters = True
+    agent.provider_data_collection = "deny"
+    set_runtime_main = MagicMock()
+
+    with patch("agent.auxiliary_client.set_runtime_main", set_runtime_main):
+        _build(agent)
+
+    assert set_runtime_main.call_args.kwargs["provider_preferences"] == {
+        "only": ["anthropic"],
+        "ignore": ["digitalocean"],
+        "order": ["anthropic", "google"],
+        "sort": "throughput",
+        "require_parameters": True,
+        "data_collection": "deny",
+    }
+
+
 def test_user_message_preserves_platform_event_timestamp():
     agent = _FakeAgent()
 

--- a/tests/gateway/test_image_input_routing_runtime.py
+++ b/tests/gateway/test_image_input_routing_runtime.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
@@ -43,6 +45,47 @@ def _auto_config() -> dict:
         "agent": {"image_input_mode": "auto"},
         "auxiliary": {"vision": {"provider": "auto", "model": "", "base_url": ""}},
         "model": {"provider": "xiaomi", "default": "mimo-v2.5-pro"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_text_vision_preprocessing_binds_provider_routing(monkeypatch):
+    runner = _make_runner()
+    runner._provider_routing = {
+        "ignore": ["digitalocean"],
+        "order": ["anthropic", "google"],
+        "sort": "throughput",
+    }
+    monkeypatch.setattr(runner, "_decide_image_input_mode", lambda **_: "text")
+    monkeypatch.setattr(
+        runner,
+        "_resolve_session_agent_runtime",
+        lambda **_: (
+            "deepseek/deepseek-v4-flash",
+            {"provider": "openrouter", "base_url": "https://openrouter.ai/api/v1"},
+        ),
+    )
+
+    async def enrich(message, _paths):
+        return message
+
+    monkeypatch.setattr(runner, "_enrich_message_with_vision", enrich)
+    seen = {}
+
+    @contextmanager
+    def capture_runtime(runtime):
+        seen.update(runtime)
+        yield runtime
+
+    monkeypatch.setattr("agent.auxiliary_client.scoped_runtime_main", capture_runtime)
+
+    assert await runner._prepare_inbound_message_text(
+        event=_image_event(), source=_source(), history=[]
+    ) == "look"
+    assert seen["provider_preferences"] == {
+        "ignore": ["digitalocean"],
+        "order": ["anthropic", "google"],
+        "sort": "throughput",
     }
 
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1383,7 +1383,9 @@ The semaphore wraps the entire call including retries and fallbacks, so a single
 
 ### OpenRouter routing & Pareto Code for auxiliary tasks
 
-When an auxiliary task resolves to OpenRouter (either explicitly or via `provider: "main"` while your main agent is on OpenRouter), the main agent's `provider_routing` and `openrouter.min_coding_score` settings **do not propagate** — by design, each auxiliary task is independent. To set OpenRouter provider preferences or use the [Pareto Code router](/integrations/providers#openrouter-pareto-code-router) for a specific aux task, set them per-task via `extra_body`:
+When an auxiliary task resolves to OpenRouter or Nous Portal, it inherits the main agent's validated `provider_routing` settings (`only`, `ignore`, `order`, `sort`, `require_parameters`, and `data_collection`). This keeps provider allow/deny policy consistent across the main conversation, compression, title generation, vision, and other auxiliary requests.
+
+To override provider routing for one auxiliary task, set `extra_body.provider` for that task. The explicit task value replaces the inherited routing object. `openrouter.min_coding_score` remains task-specific, so configure the [Pareto Code router](/integrations/providers#openrouter-pareto-code-router) through `extra_body.plugins`:
 
 ```yaml
 auxiliary:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1383,7 +1383,7 @@ The semaphore wraps the entire call including retries and fallbacks, so a single
 
 ### OpenRouter routing & Pareto Code for auxiliary tasks
 
-When an auxiliary task resolves to OpenRouter or Nous Portal, it inherits the main agent's validated `provider_routing` settings (`only`, `ignore`, `order`, `sort`, `require_parameters`, and `data_collection`). This keeps provider allow/deny policy consistent across the main conversation, compression, title generation, vision, and other auxiliary requests.
+When an auxiliary task resolves to OpenRouter or a Nous Portal chat-completions route, it inherits the main agent's validated `provider_routing` settings (`only`, `ignore`, `order`, `sort`, `require_parameters`, and `data_collection`). This keeps provider allow/deny policy consistent across the main conversation, compression, title generation, vision, and other auxiliary requests. Native Anthropic Messages routes do not accept this OpenAI-wire routing field, so Hermes omits it there.
 
 To override provider routing for one auxiliary task, set `extra_body.provider` for that task. The explicit task value replaces the inherited routing object. `openrouter.min_coding_score` remains task-specific, so configure the [Pareto Code router](/integrations/providers#openrouter-pareto-code-router) through `extra_body.plugins`:
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1383,7 +1383,7 @@ The semaphore wraps the entire call including retries and fallbacks, so a single
 
 ### OpenRouter routing & Pareto Code for auxiliary tasks
 
-When an auxiliary task resolves to OpenRouter or a Nous Portal chat-completions route, it inherits the main agent's validated `provider_routing` settings (`only`, `ignore`, `order`, `sort`, `require_parameters`, and `data_collection`). This keeps provider allow/deny policy consistent across the main conversation, compression, title generation, vision, and other auxiliary requests. Native Anthropic Messages routes do not accept this OpenAI-wire routing field, so Hermes omits it there.
+When an auxiliary task resolves to OpenRouter, it inherits the main agent's validated `provider_routing` settings (`only`, `ignore`, `order`, `sort`, `require_parameters`, and `data_collection`). This keeps provider allow/deny policy consistent across the main conversation, compression, title generation, vision, and other auxiliary requests. Hermes does not inherit this OpenRouter-specific wire field on Nous Portal or native Anthropic Messages requests.
 
 To override provider routing for one auxiliary task, set `extra_body.provider` for that task. The explicit task value replaces the inherited routing object. `openrouter.min_coding_score` remains task-specific, so configure the [Pareto Code router](/integrations/providers#openrouter-pareto-code-router) through `extra_body.plugins`:
 


### PR DESCRIPTION
## What does this PR do?

Auxiliary tasks now preserve the main agent's validated provider routing policy when they use OpenRouter-compatible routes. Users who exclude or constrain upstream providers no longer have title generation, compression, vision, session search, or fallback requests silently routed through providers they explicitly disallowed.

### Symptom

The main conversation honors `provider_routing.only`, `ignore`, `order`, and `sort`, but auxiliary requests omit the top-level `provider` object. OpenRouter can therefore select an excluded upstream for background tasks even though the same policy works on the main request path.

### Impact

OpenRouter users can have auxiliary traffic sent to providers they intentionally excluded for reliability, policy, or data-handling reasons. The affected traffic includes primary and fallback auxiliary calls, plus gateway vision enrichment that runs before a normal agent turn.

### Bug Cause

**Trigger:** `agent/auxiliary_client.py::_call_llm_impl` and `agent/auxiliary_client.py::_async_call_llm_impl` build auxiliary request bodies without the main runtime's validated provider preferences.

**Causal chain:**
1. A user configures `provider_routing` and triggers an auxiliary task.
2. Turn setup binds the main provider, model, and credentials, but not the validated routing object; pre-turn gateway vision enrichment also runs before that binding exists.
3. The auxiliary request reaches an aggregator without a top-level `provider` object, so the aggregator may select an upstream that the user excluded.

**Why it is wrong:** Provider routing is a request-level policy. Applying it only to main conversation requests creates inconsistent routing and silently bypasses explicit allow and deny constraints on auxiliary traffic.

**Working sibling / contrast:** Main conversation and compression request builders already use the validated preferences from `_provider_preferences_for_agent`; direct OpenRouter probes also confirm that request-level `ignore` is honored when Hermes sends it.

**Ruled out:** This is not an OpenRouter routing failure. The reported API comparison changes the selected provider when the same `ignore` object is included, and the regression test reproduces the missing object in-process.

### Fix

- Bind a deep-copied, validated provider-routing object in the context-local main runtime for each turn.
- Inherit that policy on sync and async OpenRouter auxiliary requests, including fallback and refreshed-credential routes.
- Preserve an explicit per-task `extra_body.provider` as the higher-priority override.
- Propagate the policy into gateway vision enrichment before the agent turn begins.
- Omit the OpenRouter-specific routing field from Nous Portal and native Anthropic Messages requests.
- Document the inheritance and override contract.

## Related Issue

Closes #89384

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py` - inherit routing on compatible primary, fallback, retry, sync, and async auxiliary requests while preserving explicit overrides.
- `agent/chat_completion_helpers.py` - expose shared validation from resolved routing values.
- `agent/turn_context.py` - bind validated preferences in context-local runtime state.
- `gateway/run.py` - bind routing for pre-turn vision enrichment.
- `hermes_cli/config_defaults.py` and `website/docs/user-guide/configuration.md` - document inheritance, task overrides, and native-wire boundaries.
- `tests/agent/` and `tests/gateway/` - cover inheritance, route changes, explicit overrides, concurrency isolation, native Anthropic compatibility, and gateway vision propagation.

## How to Test

1. Configure an OpenRouter main provider with `provider_routing.ignore`, then trigger title generation, vision, or another auxiliary task.
2. Confirm compatible auxiliary request bodies contain the same validated `provider` routing object, while Nous Portal and native Anthropic requests omit it and explicit task overrides remain unchanged.
3. Run the focused regression suite:

```bash
scripts/run_tests.sh tests/agent/test_auxiliary_client.py tests/agent/test_turn_context.py tests/agent/test_chat_completion_helpers_provider_sort.py tests/run_agent/test_provider_parity.py tests/providers/test_provider_profiles.py tests/providers/test_profile_wiring.py tests/providers/test_transport_parity.py tests/agent/transports/test_chat_completions.py tests/gateway/test_image_input_routing_runtime.py
```

Result: 356 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` is N/A because this change adds no config key
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because this does not change contributor workflows
- [x] I've considered cross-platform impact; the change is context-local request construction with platform-independent tests
- [x] Tool descriptions and schemas are N/A because no model tool behavior changed