### PR TITLE
feat(webhook): Add Gitea/Forgejo webhook support (rebased from #66895)

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -738,6 +738,8 @@ class WebhookAdapter(BasePlatformAdapter):
         event_type = (
             request.headers.get("X-GitHub-Event", "")
             or request.headers.get("X-GitLab-Event", "")
+            or request.headers.get("X-Gitea-Event", "")
+            or request.headers.get("X-Forgejo-Event", "")
             or payload.get("event_type", "")
             or payload.get("type", "")
             or "unknown"
@@ -1128,6 +1130,16 @@ class WebhookAdapter(BasePlatformAdapter):
                 secret.encode(), body, hashlib.sha256
             ).hexdigest()
             return _hmac_str_equal(gitea_sig, expected)
+
+        # Forgejo: X-Forgejo-Signature = <hex HMAC-SHA256 of body>
+        # Forgejo is a Gitea fork and uses the same signature format.
+        # Like Gitea, it sends the raw hex digest without a prefix.
+        forgejo_sig = request.headers.get("X-Forgejo-Signature", "")
+        if forgejo_sig:
+            expected = hmac.new(
+                secret.encode(), body, hashlib.sha256
+            ).hexdigest()
+            return _hmac_str_equal(forgejo_sig, expected)
 
         # Generic V2: X-Webhook-Signature-V2 = <hex HMAC-SHA256 of "<timestamp>.<body>">
         #             X-Webhook-Timestamp = <unix seconds> (required for V2)

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -1117,6 +1117,15 @@ class WebhookAdapter(BasePlatformAdapter):
         if gl_token:
             return _hmac_str_equal(gl_token, secret)
 
+        # Gitea: X-Gitea-Signature = <hex HMAC-SHA256 of body>
+        # Gitea sends the raw hex digest (no sha256= prefix like GitHub)
+        gitea_sig = request.headers.get("X-Gitea-Signature", "")
+        if gitea_sig:
+            expected = hmac.new(
+                secret.encode(), body, hashlib.sha256
+            ).hexdigest()
+            return _hmac_str_equal(gitea_sig, expected)
+
         # Generic V2: X-Webhook-Signature-V2 = <hex HMAC-SHA256 of "<timestamp>.<body>">
         #             X-Webhook-Timestamp = <unix seconds> (required for V2)
         # Checked independently of (and before) legacy V1 below — a sender

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -1118,7 +1118,10 @@ class WebhookAdapter(BasePlatformAdapter):
             return _hmac_str_equal(gl_token, secret)
 
         # Gitea: X-Gitea-Signature = <hex HMAC-SHA256 of body>
-        # Gitea sends the raw hex digest (no sha256= prefix like GitHub)
+        # Gitea sends the raw hex digest (no sha256= prefix like GitHub).
+        # Modern Gitea also sends X-Hub-Signature-256 (GitHub-compatible),
+        # which is validated by the GitHub branch above; this branch is a
+        # fallback for Gitea configs that send X-Gitea-Signature alone.
         gitea_sig = request.headers.get("X-Gitea-Signature", "")
         if gitea_sig:
             expected = hmac.new(

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -99,6 +99,15 @@ def _github_signature(body: bytes, secret: str) -> str:
     ).hexdigest()
 
 
+def _gitea_signature(body: bytes, secret: str) -> str:
+    """Compute X-Gitea-Signature (plain HMAC-SHA256 hex) for *body*.
+    
+    Gitea sends the raw hex digest without the 'sha256=' prefix
+    that GitHub uses. This is the same format as X-Webhook-Signature.
+    """
+    return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
 def _generic_signature(body: bytes, secret: str) -> str:
     """Compute X-Webhook-Signature (plain HMAC-SHA256 hex) for *body*."""
     return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
@@ -131,6 +140,37 @@ class TestValidateSignature:
     """Tests for WebhookAdapter._validate_signature."""
 
 
+    def test_validate_gitea_signature_valid(self):
+        """Valid X-Gitea-Signature (raw hex) is accepted.
+        
+        Gitea sends HMAC-SHA256 as raw hex without 'sha256=' prefix.
+        Modern Gitea also sends X-Hub-Signature-256 (GitHub-compatible),
+        but this test covers the Gitea-specific header fallback.
+        """
+        adapter = _make_adapter()
+        body = b'{"action": "opened"}'
+        secret = "webhook-secret-42"
+        sig = _gitea_signature(body, secret)
+        req = _mock_request(headers={"X-Gitea-Signature": sig})
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_gitea_signature_invalid(self):
+        """Wrong X-Gitea-Signature is rejected."""
+        adapter = _make_adapter()
+        body = b'{"action": "opened"}'
+        secret = "webhook-secret-42"
+        req = _mock_request(headers={"X-Gitea-Signature": "deadbeef"})
+        assert adapter._validate_signature(req, body, secret) is False
+
+    def test_validate_gitea_signature_wrong_body_rejected(self):
+        """X-Gitea-Signature computed for wrong body is rejected."""
+        adapter = _make_adapter()
+        secret = "webhook-secret-42"
+        # Compute sig for one body, send another
+        sig = _gitea_signature(b'{"action": "closed"}', secret)
+        req = _mock_request(headers={"X-Gitea-Signature": sig})
+        assert adapter._validate_signature(req, b'{"action": "opened"}', secret) is False
+
     def test_validate_no_signature_with_secret_rejects(self):
         """Secret configured but no recognised signature header → reject."""
         adapter = _make_adapter()
@@ -148,6 +188,7 @@ class TestValidateSignature:
         for header in (
             "X-Hub-Signature-256",
             "X-Gitlab-Token",
+            "X-Gitea-Signature",
             "X-Webhook-Signature",
             "linear-signature",
         ):

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -171,6 +171,35 @@ class TestValidateSignature:
         req = _mock_request(headers={"X-Gitea-Signature": sig})
         assert adapter._validate_signature(req, b'{"action": "opened"}', secret) is False
 
+    def test_validate_forgejo_signature_valid(self):
+        """Valid X-Forgejo-Signature (raw hex) is accepted.
+        
+        Forgejo is a Gitea fork and uses the same signature format:
+        HMAC-SHA256 as raw hex without 'sha256=' prefix.
+        """
+        adapter = _make_adapter()
+        body = b'{"action": "opened"}'
+        secret = "webhook-secret-42"
+        sig = _gitea_signature(body, secret)  # Same format as Gitea
+        req = _mock_request(headers={"X-Forgejo-Signature": sig})
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_forgejo_signature_invalid(self):
+        """Wrong X-Forgejo-Signature is rejected."""
+        adapter = _make_adapter()
+        body = b'{"action": "opened"}'
+        secret = "webhook-secret-42"
+        req = _mock_request(headers={"X-Forgejo-Signature": "deadbeef"})
+        assert adapter._validate_signature(req, body, secret) is False
+
+    def test_validate_forgejo_signature_wrong_body_rejected(self):
+        """X-Forgejo-Signature computed for wrong body is rejected."""
+        adapter = _make_adapter()
+        secret = "webhook-secret-42"
+        sig = _gitea_signature(b'{"action": "closed"}', secret)
+        req = _mock_request(headers={"X-Forgejo-Signature": sig})
+        assert adapter._validate_signature(req, b'{"action": "opened"}', secret) is False
+
     def test_validate_no_signature_with_secret_rejects(self):
         """Secret configured but no recognised signature header → reject."""
         adapter = _make_adapter()
@@ -189,6 +218,7 @@ class TestValidateSignature:
             "X-Hub-Signature-256",
             "X-Gitlab-Token",
             "X-Gitea-Signature",
+            "X-Forgejo-Signature",
             "X-Webhook-Signature",
             "linear-signature",
         ):
@@ -410,6 +440,161 @@ class TestEventFilter:
                 headers={"X-GitHub-Event": "pull_request"},
             )
             assert resp.status == 202
+
+    @pytest.mark.asyncio
+    async def test_event_filter_rejects_non_matching(self):
+        """Non-matching event type returns 200 with status=ignored."""
+        routes = {
+            "gh": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["pull_request"],
+                "prompt": "test",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/gh",
+                json={"action": "opened"},
+                headers={"X-GitHub-Event": "push"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["status"] == "ignored"
+
+    @pytest.mark.asyncio
+    async def test_event_filter_empty_allows_all(self):
+        """No events list → accept any event type."""
+        routes = {
+            "all": {
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "got it",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/all",
+                json={"action": "any"},
+                headers={"X-GitHub-Event": "whatever"},
+            )
+            assert resp.status == 202
+
+    @pytest.mark.asyncio
+    async def test_event_filter_accepts_payload_type_field(self):
+        """Svix-style payloads often use a top-level `type` event field."""
+        routes = {
+            "svix": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["message.received"],
+                "prompt": "got it",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/svix",
+                json={"type": "message.received"},
+            )
+            assert resp.status == 202
+
+    @pytest.mark.asyncio
+    async def test_event_filter_accepts_gitea_event(self):
+        """Gitea X-Gitea-Event header is recognized for event filtering."""
+        routes = {
+            "gitea": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["issues"],
+                "prompt": "Issue: {action}",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/gitea",
+                json={"action": "opened"},
+                headers={"X-Gitea-Event": "issues"},
+            )
+            assert resp.status == 202
+
+    @pytest.mark.asyncio
+    async def test_event_filter_rejects_gitea_non_matching(self):
+        """Gitea non-matching event type returns 200 with status=ignored."""
+        routes = {
+            "gitea": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["issues"],
+                "prompt": "test",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/gitea",
+                json={"action": "opened"},
+                headers={"X-Gitea-Event": "push"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["status"] == "ignored"
+
+    @pytest.mark.asyncio
+    async def test_event_filter_accepts_forgejo_event(self):
+        """Forgejo X-Forgejo-Event header is recognized for event filtering."""
+        routes = {
+            "forgejo": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["pull_request"],
+                "prompt": "PR: {action}",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/forgejo",
+                json={"action": "opened"},
+                headers={"X-Forgejo-Event": "pull_request"},
+            )
+            assert resp.status == 202
+
+    @pytest.mark.asyncio
+    async def test_event_filter_rejects_forgejo_non_matching(self):
+        """Forgejo non-matching event type returns 200 with status=ignored."""
+        routes = {
+            "forgejo": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["pull_request"],
+                "prompt": "test",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/forgejo",
+                json={"action": "opened"},
+                headers={"X-Forgejo-Event": "issues"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["status"] == "ignored"
 
 
 # ===================================================================


### PR DESCRIPTION
This is a **rebased copy of #66895** (feat(webhook): Add Gitea webhook signature validation support) by **MISAKIGA** — all code and test work credit goes to them. We simply want this fix merged, as the original PR has been stalled for a month.

## Why this PR exists

- **Original:** #66895 — *feat(webhook): Add Gitea webhook signature validation support*
  - Author: **MISAKIGA**
  - Opened 2026-07-18, head `MISAKIGA:fix/add-gitea-webhook-signature-support` at `715f139cb4`
  - Currently `mergeable_state: dirty` (conflicts with `main`), no activity since 2026-07-18
- Prior closed PR: #83723 (same Forgejo/Gitea event-header problem, narrower fix) was closed in favor of #66895.

The author's original commits are cherry-picked **verbatim** onto current `main`
(authorship preserved — all three commits are `MISAKIGA`'s), with
conflicts resolved:

- `715f139cb4` feat(webhook): Add complete Gitea/Forgejo webhook support
- `ac97a43957` test(webhook): Add Gitea signature validation tests
- `d5a2f46493` feat(webhook): Add Gitea webhook signature validation support

## What it does

Adds full Gitea/Forgejo webhook support to `gateway/platforms/webhook.py` (+24 lines):

- Event-type detection for `X-Gitea-Event` / `X-Forgejo-Event` headers
- Signature validation for `X-Gitea-Signature` / `X-Forgejo-Signature` (bare-hex HMAC-SHA256, the format Gitea/Forgejo actually send)

Plus regression tests (+226 lines in `tests/gateway/test_webhook_adapter.py`).

## Verification

- **All 49 tests pass** in `tests/gateway/test_webhook_adapter.py` on this branch (baseline on pristine `main`: 34 tests pass)
- No test-suite deletions: diff is purely additive
- Rebase conflict resolution: only test-file hunk placement (their base was July main); the webhook.py change applied cleanly

## Request to maintainers

Either merge this, or — if you'd prefer the original — please ask @MISAKIGA to rebase #66895. We're happy to close this the moment the original lands; we're not trying to displace the author's credit, just get a month-old working fix merged.

Related: #83723, #66895, #18041, #66893
