### PR TITLE
feat(desktop): show a hover close button on pane tabs

### DIFF
--- a/apps/desktop/src/components/ui/pane-tab.test.tsx
+++ b/apps/desktop/src/components/ui/pane-tab.test.tsx
@@ -92,3 +92,46 @@ describe('PaneTab close gestures', () => {
     expect(onPointerDown).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('PaneTab hover close button', () => {
+  it('clicking the ✕ closes without activating or dragging the tab', () => {
+    const onClose = vi.fn()
+    const onActivate = vi.fn()
+    const onPointerDown = vi.fn()
+    render(
+      <PaneTab onClose={onClose} onPointerDown={onPointerDown}>
+        <PaneTabLabel as="button" onClick={onActivate}>
+          tab
+        </PaneTabLabel>
+      </PaneTab>
+    )
+
+    const close = screen.getByRole('button', { name: 'Close' })
+    fireEvent.pointerDown(close, { button: 0 })
+    fireEvent.click(close, { button: 0 })
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(onActivate).not.toHaveBeenCalled()
+    expect(onPointerDown).not.toHaveBeenCalled()
+  })
+
+  it('renders no ✕ without an onClose', () => {
+    render(
+      <PaneTab>
+        <PaneTabLabel>tab</PaneTabLabel>
+      </PaneTab>
+    )
+
+    expect(screen.queryByRole('button', { name: 'Close' })).toBeNull()
+  })
+
+  it('renders no ✕ on a vertical rail tab (middle/⌘-click only there)', () => {
+    const onClose = vi.fn()
+    render(
+      <PaneTab onClose={onClose} vertical>
+        <PaneTabLabel>tab</PaneTabLabel>
+      </PaneTab>
+    )
+
+    expect(screen.queryByRole('button', { name: 'Close' })).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/ui/pane-tab.tsx
+++ b/apps/desktop/src/components/ui/pane-tab.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 
 import { type MenuKit, renderActionItem } from '@/components/ui/actions-menu'
 import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
 import { Tip } from '@/components/ui/tooltip'
 import { translateNow } from '@/i18n'
 import { isMetaClose, middleClickHandlers } from '@/lib/middle-click'
@@ -11,8 +12,12 @@ import { cn } from '@/lib/utils'
 export const PANE_TAB_STRIP_LINE_LEFT = 'shadow-[inset_1px_0_0_var(--ui-stroke-tertiary)]'
 export const PANE_TAB_STRIP_LINE_RIGHT = 'shadow-[inset_-1px_0_0_var(--ui-stroke-tertiary)]'
 
+// `--tab-face` is the tab's EFFECTIVE surface color — what actually sits under
+// the label after every wash lands. The hover close-button gradient fades into
+// it, so the fade is seamless on any theme. Idle hover repaints it below with
+// the same color-mix the darkening wash applies.
 const TAB =
-  'group/tab relative flex shrink-0 items-center border-transparent bg-(--tab-bg) text-[0.6875rem] font-medium [-webkit-app-region:no-drag]'
+  'group/tab relative flex shrink-0 items-center border-transparent bg-(--tab-bg) text-[0.6875rem] font-medium [-webkit-app-region:no-drag] [--tab-face:var(--tab-bg)]'
 
 // Full height: with the strip's rule removed there is no last-pixel row to
 // leave uncovered, so tabs fill the bar and no sliver of gutter shows through.
@@ -31,21 +36,24 @@ const TAB_ACTIVE_UNDERLINE = 'shadow-[inset_0_-2px_0_var(--pane-tab-active-accen
 // Inactive = gutter, defaulting to the shared chrome surface so a strip that
 // sets no vars still matches the sidebar/titlebar instead of falling through to
 // the raw (unmixed) card seed. Hover DARKENS: surfaces this close in value need
-// a darkening wash to register at all.
+// a darkening wash to register at all. `--tab-face` tracks the wash — the same
+// mix flattened onto `--tab-bg` — so the close gradient matches what shows.
 const TAB_IDLE =
-  'text-(--ui-text-tertiary) [--tab-bg:var(--pane-tab-strip-bg,var(--ui-sidebar-surface-background))] hover:shadow-[inset_0_0_0_100vmax_color-mix(in_srgb,#000_var(--ui-tab-hover-darken),transparent)] hover:text-(--ui-text-secondary)'
+  'text-(--ui-text-tertiary) [--tab-bg:var(--pane-tab-strip-bg,var(--ui-sidebar-surface-background))] hover:shadow-[inset_0_0_0_100vmax_color-mix(in_srgb,#000_var(--ui-tab-hover-darken),transparent)] hover:[--tab-face:color-mix(in_srgb,#000_var(--ui-tab-hover-darken),var(--tab-bg))] hover:text-(--ui-text-secondary)'
 
 // A tab riding a multi-tab selection: an accent wash over whatever surface the
 // tab sits on. A background-image gradient (not a shadow) so it stacks cleanly
 // over `--tab-bg` without fighting the active underline / hover shadows.
+// `--tab-face` gets the same wash flattened in, keeping the close fade honest.
 const TAB_SELECTED =
-  '[background-image:linear-gradient(color-mix(in_srgb,var(--ui-accent)_14%,transparent),color-mix(in_srgb,var(--ui-accent)_14%,transparent))] text-foreground'
+  '[background-image:linear-gradient(color-mix(in_srgb,var(--ui-accent)_14%,transparent),color-mix(in_srgb,var(--ui-accent)_14%,transparent))] [--tab-face:color-mix(in_srgb,var(--ui-accent)_14%,var(--tab-bg))] text-foreground'
 
 interface PaneTabProps extends React.ComponentProps<'div'> {
   active?: boolean
   dirty?: boolean
-  /** Close gesture, no hover X (too easy to hit on small tabs): middle-click,
-   *  or ⌘-click as the trackpad-friendly Mac equivalent. */
+  /** Close verb. Horizontal tabs reveal a hover ✕ on the right (a `--tab-face`
+   *  gradient fades it over the label); middle-click and ⌘-click always work,
+   *  and stay the only gestures on vertical rails (no room for a chip ✕). */
   onClose?: () => void
   /** Part of a multi-tab selection (⌥/Ctrl-click, Shift-click) — an accent
    *  wash marks every tab that a drag would carry, Chrome-style. */
@@ -149,6 +157,44 @@ export const PaneTab = React.forwardRef<HTMLDivElement, PaneTabProps>(function P
           )}
         >
           <span className="size-2 rounded-full bg-amber-500 shadow-[0_0_0_2px_var(--tab-bg),0_1px_2px_rgba(0,0,0,0.45)] dark:bg-amber-400" />
+        </span>
+      )}
+      {onClose && !vertical && (
+        // Hover ✕, painted OVER the label's right edge as an overlay (no
+        // layout shift, tab width never jumps on hover). The runway is a tiny
+        // transparent→`--tab-face` gradient, so the button melts into the
+        // tab's effective surface instead of hard-clipping the text under it.
+        // Rendered after the dirty dot: on hover the ✕ takes the dot's spot,
+        // VS Code-style.
+        <span className="pointer-events-none absolute inset-y-0 right-0 flex items-stretch opacity-0 transition-opacity group-hover/tab:pointer-events-auto group-hover/tab:opacity-100">
+          {/* Both pieces re-draw the active underline: they paint over the
+              tab's own last-pixel row, so without it the ✕ would bite a
+              notch out of the accent line on the active tab. */}
+          <span
+            aria-hidden
+            className="w-4 bg-linear-to-r from-transparent to-(--tab-face) group-data-[active=true]/tab:shadow-[inset_0_-2px_0_var(--pane-tab-active-accent,var(--theme-primary))]"
+          />
+          <button
+            aria-label={translateNow('common.close')}
+            className="grid cursor-pointer place-items-center bg-(--tab-face) pr-1.5 pl-0.5 text-(--ui-text-tertiary) outline-none hover:text-foreground group-data-[active=true]/tab:shadow-[inset_0_-2px_0_var(--pane-tab-active-accent,var(--theme-primary))]"
+            onClick={event => {
+              event.preventDefault()
+              event.stopPropagation()
+              onClose()
+            }}
+            onPointerDown={event => {
+              // Claim a plain left press so the shell can't also activate or
+              // drag the tab. Middle/⌘ presses bubble on purpose — the tab's
+              // own close gestures already route them.
+              if (event.button === 0 && !isMetaClose(event)) {
+                event.stopPropagation()
+              }
+            }}
+            tabIndex={-1}
+            type="button"
+          >
+            <Codicon name="close" size="0.6875rem" />
+          </button>
         </span>
       )}
     </div>


### PR DESCRIPTION
## What does this PR do?

Each closeable horizontal pane tab now shows a close button on pointer hover.

Before this change, a tab closed only from the context menu, a middle-click, or a ⌘-click. None of these gestures is visible in the UI.

The button is an overlay on the right edge of the tab. A small gradient fades the button into the tab surface, so a long label fades under it instead of a hard clip.

The gradient reads the `--tab-face` variable. This variable holds the effective surface color of the tab. It tracks the hover wash and the selection wash. As a result, the fade is correct on every theme and skin.

The overlay does not change the tab width. The overlay also draws the accent underline of the active tab again. Without this, the button cuts a notch in the underline.

Vertical rail tabs do not show the button. The middle-click and ⌘-click gestures continue to operate on all tabs.

unhovered
<img width="334" height="94" alt="image" src="https://github.com/user-attachments/assets/12ba4ec7-0481-4822-a5ca-761544e45038" />

hovering active tab
<img width="258" height="66" alt="image" src="https://github.com/user-attachments/assets/d871cd05-3949-448c-81ec-4f067b6221c3" />

hovering inactive tab
<img width="285" height="81" alt="image" src="https://github.com/user-attachments/assets/f3a5af40-6b85-487c-8561-dbcff25b65d1" />

dark theme
<img width="235" height="124" alt="image" src="https://github.com/user-attachments/assets/7b2672a1-df5b-4de4-a05a-3f46b9637943" />
<img width="291" height="106" alt="image" src="https://github.com/user-attachments/assets/528c073a-d0e1-42c9-b30a-ed3b0c9a6430" />

## Related Issue

No issue exists for this change.

### Related work

PRs #69392 and #89243 add a hover close button to the same component. Each of them reserves a permanent slot in the tab, which makes the label area smaller at all times. This PR paints the button over the label and adds the gradient fade. PR #83051 has a much larger scope: close controls with focus recovery across 37 files.

closes #69392 
closes #89243 

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/components/ui/pane-tab.tsx`: add the hover close button, the gradient runway, and the `--tab-face` variable.
- `apps/desktop/src/components/ui/pane-tab.test.tsx`: add three tests for the button.

## How to Test

1. Start the desktop app.
2. Open a second tab in the main zone.
3. Move the pointer over the tab. Make sure that a close button shows on the right edge.
4. Click the button. Make sure that the tab closes and does not activate first.
5. Make sure that a middle-click and a ⌘-click still close a tab.
6. Hover a tab with a long label. Make sure that the label fades under the button.
7. In `apps/desktop`, run `npx vitest run src/components/ui/pane-tab.test.tsx`. All 9 tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — see "Related work" above for the overlaps
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] The change is TypeScript only, so pytest does not apply. The vitest suite, `tsc --noEmit`, and eslint all pass.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, the component comments carry the design notes
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `isMetaClose` keeps the ⌘/Ctrl mapping per OS
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
Test Files  1 passed (1)
     Tests  9 passed (9)
```
