### PR TITLE
fix(cron): stop leaking the gateway's PYTHONPATH into script jobs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3612,6 +3612,17 @@ def _run_job_script(
                 "errors": "replace",
             }
         env = build_subprocess_env()
+        # A cron script runs as the USER's workload, not as Hermes code: the
+        # gateway's own PYTHONPATH (agent repo + agent-venv site-packages)
+        # must not leak into the child. A wrapper invoking a project venv on
+        # another Python version imports the agent's mismatched site-packages
+        # and dies at import time with a cross-version ModuleNotFoundError
+        # (#89422). The Windows/uv bootstrap below already treats PYTHONPATH
+        # as scheduler-owned (it builds its own overlay), so dropping the
+        # inherited one keeps a single owner for the child's interpreter
+        # environment. PYTHONHOME rides along for the same reason.
+        env.pop("PYTHONPATH", None)
+        env.pop("PYTHONHOME", None)
         env.update(env_overlay)
         # Use the job's workdir as the subprocess cwd when configured,
         # otherwise default to the scripts-dir parent (back-compat).

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -12,6 +12,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import os
 import pathlib
 import subprocess
 from unittest.mock import patch
@@ -105,6 +106,43 @@ def test_run_job_no_agent_success_returns_script_stdout(hermes_env):
     assert error is None
     assert "RAM 92% on host" in final_response
     assert "RAM 92% on host" in doc
+
+
+def test_run_job_no_agent_scrubs_gateway_pythonpath(hermes_env, monkeypatch):
+    """A cron script runs as the USER's workload, not as Hermes code (#89422).
+
+    The gateway process carries its own PYTHONPATH (agent repo + agent-venv
+    site-packages); leaking it into the child made wrappers that invoke a
+    project venv on another Python version import the agent's mismatched
+    site-packages and die at import time with a cross-version
+    ModuleNotFoundError."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    gateway_repo = str(hermes_env / "hermes-agent")
+    gateway_site = str(hermes_env / "hermes-agent" / "venv" / "lib" / "python3.11" / "site-packages")
+    monkeypatch.setenv("PYTHONPATH", os.pathsep.join([gateway_repo, gateway_site]))
+    monkeypatch.setenv("PYTHONHOME", "/opt/agent-python")
+
+    # A python script resolves its own imports: the agent venv must be
+    # invisible to it. Print whether any agent path leaked into sys.path.
+    script_path = hermes_env / "scripts" / "check_path.py"
+    script_path.write_text(
+        "import os, sys\n"
+        "leaked = [p for p in sys.path if "
+        f"{gateway_site!r} in p or {gateway_repo!r} in p]\n"
+        "print('LEAKED:' + ';'.join(leaked) if leaked else 'CLEAN')\n"
+        "print('PYTHONHOME=' + os.environ.get('PYTHONHOME', 'unset'))\n"
+    )
+
+    job = create_job(
+        prompt=None, schedule="every 5m", script="check_path.py", no_agent=True, deliver="local"
+    )
+    success, _doc, final_response, error = run_job(job)
+    assert success is True, error
+    assert "LEAKED" not in final_response
+    assert "CLEAN" in final_response
+    assert "PYTHONHOME=unset" in final_response
 
 
 def test_run_job_no_agent_reloads_dotenv_before_script(hermes_env, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

A `no_agent=True` cron job with a `script:` wrapper runs as the **user's workload**, not as Hermes code — but the scheduler built the child env through `build_subprocess_env()`, whose scrub list covers secrets and profile-home propagation but not interpreter variables. The gateway's own `PYTHONPATH` (agent repo + agent-venv site-packages, visible in `ps eww <gateway-pid>`) was therefore inherited by every script job:

- A `.sh` wrapper invoking a project venv on another Python version (3.13 vs the agent's 3.11) had the agent's mismatched site-packages injected into `sys.path`, importing the wrong-ABI `numpy` and dying at import time with a cross-version `ModuleNotFoundError` whose traceback points at `hermes-agent/venv/...` — bewildering, because the wrapper never mentions Hermes.

This PR drops `PYTHONPATH` and `PYTHONHOME` from the child env in `_run_job_script`, before the scheduler-owned `env_overlay` is applied — so the child's interpreter environment has exactly one owner. The Windows/uv bootstrap path already builds its own PYTHONPATH overlay from scratch, so this only removes the unsolicited inherited copy; agent-driven jobs are untouched (they never go through this script path).

Related open PR #79046 removes one *source* of the pollution (the Windows `_ensure_windows_gateway_venv_imports` mutating `os.environ`); this PR protects the cron-script *consumer* against every source, including the macOS/git-install launch environment from the issue (where `PYTHONPATH` arrives from the gateway's own launch shell, not that Windows function). The two are complementary.

## Related Issue

Fixes #89422

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/scheduler.py` — `_run_job_script` pops `PYTHONPATH`/`PYTHONHOME` from the built child env before applying the scheduler overlay, with a comment stating the user-workload-not-Hermes-code contract and the Windows-overlay consistency argument.
- `tests/cron/test_cron_no_agent.py` — `test_run_job_no_agent_scrubs_gateway_pythonpath`: with a gateway-shaped `PYTHONPATH`/`PYTHONHOME` in the environment, a Python script job's `sys.path` contains no agent paths and `PYTHONHOME` is unset in the child (fails on main: the agent paths leak into `sys.path`).

## How to Test

```bash
python -m pytest tests/cron/test_cron_no_agent.py -q
# Observed result: 19 passed

python -m pytest tests/cron/test_cron_script.py tests/cron/test_script_claim_heartbeat.py -q
# Observed result: 41 passed, 1 skipped
```

Fail-on-main check: with the scheduler change stashed, the scrub test fails (agent paths present in the child's `sys.path`).

Manual repro from the issue: run the gateway, create a `no_agent` script job whose wrapper invokes a project venv on a different Python version importing numpy — on main the job fails with a `ModuleNotFoundError` pointing at hermes-agent's site-packages; with this change the project venv imports cleanly.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments explain intent (user-workload contract, single owner for the child interpreter env)
- [x] Corresponding changes documented via comments
- [x] Tests added and passing (1 new; script-job suites green)
- [x] Single root cause, no unrelated changes
