### PR TITLE
fix(memory): show Hindsight status on gateway surfaces

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1820,10 +1820,14 @@ def init_agent(
                         "platform": platform or "cli",
                         "hermes_home": str(get_hermes_home()),
                         "agent_context": "primary",
+                        # Providers may emit status from background workers after
+                        # gateway/TUI construction has finished.  _emit_status
+                        # resolves the surface callback at emission time, so this
+                        # remains valid when that callback is bound later.
+                        "status_callback": agent._emit_status,
                     }
                     if _init_kwargs["platform"] == "cli":
                         _init_kwargs["warning_callback"] = agent._emit_warning
-                        _init_kwargs["status_callback"] = agent._emit_status
                     # Thread session title for memory provider scoping
                     # (e.g. honcho uses this to derive chat-scoped session keys)
                     if agent._session_db:
@@ -1859,10 +1863,6 @@ def init_agent(
                         _init_kwargs["agent_workspace"] = "hermes"
                     except Exception:
                         pass
-                    # NOTE: status_callback (for the deterministic retain
-                    # indicator) is wired above, CLI-only — gateway status is
-                    # delivered on a different path (see the platform=="cli"
-                    # block), and the indicator no-ops when it's absent.
                     agent._memory_manager.initialize_all(**_init_kwargs)
                     _ra().logger.info("Memory provider '%s' activated", _mem_provider_name)
                 else:

--- a/tests/run_agent/test_memory_provider_init.py
+++ b/tests/run_agent/test_memory_provider_init.py
@@ -93,7 +93,7 @@ def test_close_shuts_down_memory_provider():
     agent._memory_manager.shutdown_all.assert_called_once()
 
 
-def test_aiagent_forwards_user_id_alt_to_memory_provider():
+def test_aiagent_forwards_gateway_identity_and_late_bound_status_bridge():
     provider = RecordingMemoryProvider()
     cfg = {"memory": {"provider": "recording"}, "agent": {}}
 
@@ -125,7 +125,13 @@ def test_aiagent_forwards_user_id_alt_to_memory_provider():
     assert provider.init_kwargs["user_id_alt"] == "union-id"
     assert provider.init_kwargs["platform"] == "feishu"
     assert "warning_callback" not in provider.init_kwargs
-    assert "status_callback" not in provider.init_kwargs
+    assert callable(provider.init_kwargs["status_callback"])
+
+    status_events = []
+    agent.status_callback = lambda kind, text: status_events.append((kind, text))
+    provider.init_kwargs["status_callback"]("saving to memory")
+
+    assert status_events == [("lifecycle", "saving to memory")]
 
 
 class CoreShadowProvider:


### PR DESCRIPTION
## What does this PR do?

Hindsight retain and recall indicators now reach desktop, TUI, and gateway sessions instead of appearing only in the classic CLI. Memory operations already succeeded on those surfaces, but users received no lifecycle feedback; this change routes provider status through the existing late-bound agent status bridge while preserving CLI-only warning behavior.

### Symptom

With Hindsight enabled, non-CLI sessions retain and recall memory successfully but never render the configured provider status indicators.

### Impact

Desktop, TUI, and messaging gateway users cannot tell when Hindsight is saving to or recalling from memory. The missing feedback makes successful background memory activity appear inactive or stalled.

### Bug Cause

**Trigger:** `agent/agent_init.py` / memory provider initialization when `platform != "cli"`

**Causal chain:**
1. A non-CLI agent initializes an external memory provider such as Hindsight.
2. Provider initialization omits `status_callback` because it is added only inside the CLI branch.
3. Hindsight's asynchronous indicator path has no callback and silently skips the lifecycle update, even though the session binds `agent.status_callback` later.

**Why it is wrong:** Status delivery is surface-neutral and already supported by `AIAgent._emit_status`, which resolves the current surface callback at emission time. Restricting that bridge to CLI initialization prevents providers from using the established gateway and TUI status path.

**Working sibling / contrast:** Core recall status already calls `AIAgent._emit_status`, so late-bound gateway and TUI callbacks receive those lifecycle events.

**Ruled out:** Memory persistence and recall are not failing. The provider operations complete successfully, and the indicator-focused Hindsight tests pass; only callback propagation is missing.

### Fix

Pass `agent._emit_status` to initialized memory providers on every surface. Keep `warning_callback` CLI-only, and cover the non-CLI path with a regression test that binds the surface callback after agent construction and verifies the provider bridge resolves it at emission time.

## Related Issue

Closes #89400

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_init.py` - provide the late-bound status bridge to memory providers on every surface while retaining CLI-only warnings.
- `tests/run_agent/test_memory_provider_init.py` - verify non-CLI identity propagation and late-bound provider status delivery.

## How to Test

1. Initialize an agent with a recording memory provider and a non-CLI platform.
2. Bind the agent surface status callback after construction and invoke the provider's stored status callback.
3. Confirm the lifecycle event reaches the late-bound surface callback.
4. Run the focused regression and indicator suites:

```bash
scripts/run_tests.sh tests/run_agent/test_memory_provider_init.py tests/gateway/test_telegram_noise_filter.py -q
scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py -q -k 'TestRecallStatus or TestRetainIndicator'
```

The first command passed 138 tests. The indicator-focused Hindsight command passed 13 tests. Phase B also replayed the regression against the base revision, where it failed because `status_callback` was absent, and confirmed all 5 tests in the updated memory-provider initialization file pass on this branch.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all targeted tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A - no user-facing configuration or API changed
- [x] `cli-config.yaml.example` update: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered - the callback bridge is platform-neutral and the regression uses a non-CLI platform
- [x] Tool description/schema update: N/A - no model tool behavior changed
