### PR TITLE
fix(hindsight): include exception type in tool errors + add timeout guidance

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -72,7 +72,7 @@ _DEFAULT_API_URL = "https://api.hindsight.vectorize.io"
 _DEFAULT_LOCAL_URL = "http://localhost:8888"
 # Keep in sync with tools/lazy_deps.py ("memory.hindsight") and plugin.yaml.
 _MIN_CLIENT_VERSION = "0.6.1"
-_DEFAULT_TIMEOUT = 120  # seconds — cloud API can take 30-40s per request
+_DEFAULT_TIMEOUT = 120  # seconds — cloud API can take 30-40s per request. Override per-profile via timeout key in ~/.hermes/hindsight/config.json
 _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
 # ``metadata.source`` stamped on retained memories — OPT-IN, empty by default.
 # AGENTS.md forbids shipping third-party attribution tags on-by-default until a
@@ -2195,8 +2195,11 @@ class HindsightMemoryProvider(MemoryProvider):
                 logger.debug("Tool hindsight_retain: success")
                 return json.dumps({"result": "Memory stored successfully."})
             except Exception as e:
+                msg = f"Failed to store memory: {type(e).__name__}: {e}"
+                if isinstance(e, TimeoutError):
+                    msg += " The server may have completed the operation despite the client timeout. Do not blindly retry — verify the fact was stored via recall before retrying to avoid duplicates. See hindsight-retain-timeout-workaround.md for REST fallback."
                 logger.warning("hindsight_retain failed: %s", e, exc_info=True)
-                return tool_error(f"Failed to store memory: {e}")
+                return tool_error(msg)
 
         elif tool_name == "hindsight_recall":
             query = args.get("query", "")
@@ -2223,7 +2226,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 return json.dumps({"result": "\n".join(lines)})
             except Exception as e:
                 logger.warning("hindsight_recall failed: %s", e, exc_info=True)
-                return tool_error(f"Failed to search memory: {e}")
+                return tool_error(f"Failed to search memory: {type(e).__name__}: {e}")
 
         elif tool_name == "hindsight_reflect":
             query = args.get("query", "")
@@ -2241,7 +2244,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 return json.dumps({"result": resp.text or "No relevant memories found."})
             except Exception as e:
                 logger.warning("hindsight_reflect failed: %s", e, exc_info=True)
-                return tool_error(f"Failed to reflect: {e}")
+                return tool_error(f"Failed to reflect: {type(e).__name__}: {e}")
 
         return tool_error(f"Unknown tool: {tool_name}")
 


### PR DESCRIPTION
## Changes
- All 3 Hindsight tool error handlers now include exception type: `{type(e).__name__}: {e}` instead of bare `{e}`
- Retain handler adds TimeoutError-specific guidance text
- Comment on `_DEFAULT_TIMEOUT` updated to reference config.json override path

## Why
`str(TimeoutError())` returns empty string, so timeout errors appeared as `"Failed to store memory: "` with no useful diagnostic. This makes the exception type visible and provides retry guidance.

## Scope
Isolated change — 1 file, 7 insertions, 4 deletions. No config, no dependency bumps, no unrelated commits. Based on current upstream main.

## Verification
- `py_compile` passes
- `grep -n "type(e).__name__" plugins/memory/hindsight/__init__.py` returns 3 matches