### PR TITLE
fix(config): deprecated TERMINAL_CWD warning fires on programmatic env values

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2187,6 +2187,26 @@ def print_config_warnings(config: Optional[Dict[str, Any]] = None) -> None:
     sys.stderr.write("\n".join(lines) + "\n\n")
 
 
+def _dotenv_cwd_keys() -> set:
+    """Return {MESSAGING_CWD, TERMINAL_CWD} keys actually set (uncommented) in .env."""
+    keys: set = set()
+    try:
+        from hermes_constants import get_hermes_home
+
+        env_path = get_hermes_home() / ".env"
+        if not env_path.exists():
+            return keys
+        for line in env_path.read_text(errors="replace").splitlines():
+            stripped = line.strip()
+            if stripped.startswith("MESSAGING_CWD="):
+                keys.add("MESSAGING_CWD")
+            elif stripped.startswith("TERMINAL_CWD="):
+                keys.add("TERMINAL_CWD")
+    except Exception:
+        pass
+    return keys
+
+
 def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> None:
     """Warn if MESSAGING_CWD or TERMINAL_CWD is set in .env instead of config.yaml.
 
@@ -2195,6 +2215,18 @@ def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> Non
     """
     messaging_cwd = os.environ.get("MESSAGING_CWD")
     terminal_cwd_env = os.environ.get("TERMINAL_CWD")
+
+    # Only warn when the var actually comes from .env.  TERMINAL_CWD is also
+    # set programmatically (session cwd restore, worktree launch, gateway cwd
+    # resolution), and warning on those in-process values is a false positive.
+    if messaging_cwd or terminal_cwd_env:
+        env_keys = _dotenv_cwd_keys()
+        if "MESSAGING_CWD" not in env_keys:
+            messaging_cwd = None
+        if "TERMINAL_CWD" not in env_keys:
+            terminal_cwd_env = None
+    if not messaging_cwd and not terminal_cwd_env:
+        return
 
     if config is None:
         try:

--- a/tests/hermes_cli/test_deprecated_cwd_warning.py
+++ b/tests/hermes_cli/test_deprecated_cwd_warning.py
@@ -1,10 +1,17 @@
 """Tests for warn_deprecated_cwd_env_vars() migration warning."""
 
 
+def _make_env(tmp_path, monkeypatch, content: str):
+    """Point HERMES_HOME at a temp dir containing the given .env content."""
+    (tmp_path / ".env").write_text(content)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+
 class TestDeprecatedCwdWarning:
     """Warn when MESSAGING_CWD or TERMINAL_CWD is set in .env."""
 
-    def test_messaging_cwd_triggers_warning(self, monkeypatch, capsys):
+    def test_messaging_cwd_triggers_warning(self, tmp_path, monkeypatch, capsys):
+        _make_env(tmp_path, monkeypatch, "MESSAGING_CWD=/some/path\n")
         monkeypatch.setenv("MESSAGING_CWD", "/some/path")
         monkeypatch.delenv("TERMINAL_CWD", raising=False)
 
@@ -16,8 +23,11 @@ class TestDeprecatedCwdWarning:
         assert "deprecated" in captured.err.lower()
         assert "config.yaml" in captured.err
 
-
-    def test_both_deprecated_vars_warn(self, monkeypatch, capsys):
+    def test_both_deprecated_vars_warn(self, tmp_path, monkeypatch, capsys):
+        _make_env(
+            tmp_path, monkeypatch,
+            "MESSAGING_CWD=/msg/path\nTERMINAL_CWD=/term/path\n",
+        )
         monkeypatch.setenv("MESSAGING_CWD", "/msg/path")
         monkeypatch.setenv("TERMINAL_CWD", "/term/path")
 
@@ -27,3 +37,16 @@ class TestDeprecatedCwdWarning:
         captured = capsys.readouterr()
         assert "MESSAGING_CWD" in captured.err
         assert "TERMINAL_CWD" in captured.err
+
+    def test_programmatic_env_var_does_not_warn(self, tmp_path, monkeypatch, capsys):
+        # TERMINAL_CWD in the process env but NOT in .env (set by session
+        # restore / worktree launch / gateway) must not trigger the warning.
+        _make_env(tmp_path, monkeypatch, "# TERMINAL_CWD=.\n")
+        monkeypatch.setenv("TERMINAL_CWD", "/term/path")
+        monkeypatch.delenv("MESSAGING_CWD", raising=False)
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+        warn_deprecated_cwd_env_vars(config={})
+
+        captured = capsys.readouterr()
+        assert captured.err == ""


### PR DESCRIPTION
## Symptom

Every CLI/gateway launch prints:

```
⚠ Deprecated .env settings detected:
  ⚠ TERMINAL_CWD=... found in .env — this is deprecated.
```

even when `~/.hermes/.env` only contains the commented-out template line (`# TERMINAL_CWD=.`).

## Cause

`warn_deprecated_cwd_env_vars()` reads `os.environ` and assumes the value came from .env. But TERMINAL_CWD is also set programmatically in several places — session cwd restore (`cli.py`), worktree launch (`hermes_cli/main.py`, `cli_commands_mixin.py`), gateway cwd resolution (`gateway/run.py`), TUI config writes (`tui_gateway/server.py`). Any of those leaves the var in the process env and the warning fires on every subsequent launch, telling the user to remove a line that isn't there.

## Fix

Cross-check `~/.hermes/.env` for an actual uncommented `TERMINAL_CWD=` / `MESSAGING_CWD=` line before warning. In-process values stay silent.

Adds a regression test for the programmatic case; the two existing warn-path tests updated to write a real .env into a temp `HERMES_HOME` (they previously passed only because the env-var-only assumption was baked in).

## Verification

```
tests/hermes_cli/test_deprecated_cwd_warning.py — 3 passed
```