### PR TITLE
fix(desktop): stop composer text from renaming persisted session tabs

### DIFF
--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -34,6 +34,7 @@ import { transcribeAudio } from '@/hermes'
 import { useI18n } from '@/i18n'
 import type { ChatMessage } from '@/lib/chat-messages'
 import { NEW_SESSION_TITLE, sessionTitle } from '@/lib/chat-runtime'
+import { shouldUseDraftTabTitle } from '@/lib/draft-title'
 import { createComposerAttachmentScope, draftTitleFor } from '@/store/composer'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
 import { $activeGatewayProfile } from '@/store/profile'
@@ -603,7 +604,15 @@ export const watchSessionTiles = paneMirror<SessionTile>({
   ),
   // Until the first turn lists a row there is no title to register, so the tab
   // takes its name from the composer instead — live, without re-registering.
-  tabTitle: storedSessionId => (tileStoredRow(storedSessionId) ? null : <SessionDraftTitle scope={storedSessionId} />),
+  // A listed / titled / already-used row is not a draft even if `$sessions`
+  // momentarily omitted it.
+  tabTitle: storedSessionId => {
+    const stored = tileStoredRow(storedSessionId)
+
+    return shouldUseDraftTabTitle({ listedRow: stored, storedSessionId }) ? (
+      <SessionDraftTitle scope={storedSessionId} />
+    ) : null
+  },
   render: storedSessionId => <SessionTilePane storedSessionId={storedSessionId} />,
   tabWrap: (storedSessionId, tab) => (
     <SessionTabMenu

--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -39,6 +39,7 @@ import { useContributions } from '@/contrib/react/use-contributions'
 import { registry } from '@/contrib/registry'
 import { discoverRuntimePlugins } from '@/contrib/runtime-loader'
 import { NEW_SESSION_TITLE, sessionTitle as storedSessionTitle } from '@/lib/chat-runtime'
+import { shouldUseDraftTabTitle } from '@/lib/draft-title'
 import { Download, FileText, LayoutDashboard, PanelBottom, Terminal, Upload, Zap } from '@/lib/icons'
 import { type KeybindContribution, KEYBINDS_AREA } from '@/lib/keybinds/actions'
 import { TRANSCRIPT_DIRECTIVE_AREA, type TranscriptDirectiveContribution } from '@/lib/transcript-directives'
@@ -58,7 +59,14 @@ import {
 } from '@/store/layout'
 import { runExportProfileFlow, runImportProfileFlow } from '@/store/profile-share'
 import { $reviewOpen, closeReview, openReview, REVIEW_PANE_ID } from '@/store/review'
-import { $currentCwd, $selectedStoredSessionId, $sessions, $yoloActive, sessionMatchesStoredId } from '@/store/session'
+import {
+  $currentCwd,
+  $messagesEmpty,
+  $selectedStoredSessionId,
+  $sessions,
+  $yoloActive,
+  sessionMatchesStoredId
+} from '@/store/session'
 import { watchSessionPins } from '@/store/session-pin-sync'
 import { watchUnreadWriteGuard } from '@/store/session-unread-remote'
 import { $statusbarVisible } from '@/store/statusbar-prefs'
@@ -71,6 +79,7 @@ import { startSessionDrag } from '../chat/session-drag'
 import {
   SessionTileCloseConfirm,
   stackSessionTilesIntoMain,
+  tileStoredRow,
   watchSessionTiles,
   WorkspaceTabMenu
 } from '../chat/session-tile'
@@ -452,14 +461,23 @@ watchUnreadWriteGuard()
 // above, so the pane content never remounts.
 const syncWorkspaceTitle = () => {
   const selected = $selectedStoredSessionId.get()
-  const stored = selected ? $sessions.get().find(s => sessionMatchesStoredId(s, selected)) : null
+  // Same resolver as tiles: recents first, then the project tree. A selected
+  // chat older than the recents page (or a compression tip matched by lineage)
+  // is not a draft — looking only at `$sessions` made typing rename the tab.
+  const stored = selected ? (tileStoredRow(selected) ?? null) : null
+  const hasMessages = Boolean(selected) && !$messagesEmpty.get()
+  const useDraft = shouldUseDraftTabTitle({
+    hasMessages,
+    listedRow: stored,
+    storedSessionId: selected
+  })
 
   registry.register({
     id: 'workspace',
     area: 'panes',
     // The placeholder, not the draft's live name — `tabTitle` below renders
     // that. Keeping it here would re-register the pane on every keystroke.
-    title: stored ? storedSessionTitle(stored) : NEW_SESSION_TITLE,
+    title: stored ? storedSessionTitle(stored) : hasMessages ? 'Untitled session' : NEW_SESSION_TITLE,
     data: {
       // The tab's status dot — the SAME primitive the sidebar row and session
       // tiles render, so the main tab never disagrees with its sidebar row. A
@@ -468,8 +486,9 @@ const syncWorkspaceTitle = () => {
       tabLead: () => <SessionStatusDot session={stored} storedSessionId={selected} />,
       // A draft's name lives in its composer, not in any session row, so the
       // label subscribes to it directly — typing renames the tab without
-      // re-registering the pane.
-      tabTitle: stored ? undefined : () => <SessionDraftTitle scope={selected} />,
+      // re-registering the pane. Persisted chats (listed, titled, or already
+      // holding a transcript) must never take this path.
+      tabTitle: useDraft ? () => <SessionDraftTitle scope={selected} /> : undefined,
       // Pages aren't tab-able: the main zone's bar stands down while one shows.
       headerVeto: $workspaceIsPage.get(),
       placement: 'main',
@@ -484,6 +503,7 @@ const syncWorkspaceTitle = () => {
 
 $selectedStoredSessionId.listen(syncWorkspaceTitle)
 $sessions.listen(syncWorkspaceTitle)
+$messagesEmpty.listen(syncWorkspaceTitle)
 $workspaceIsPage.listen(syncWorkspaceTitle)
 
 // Layout reset collapses every session tile into main as a tab (after the

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -18,6 +18,8 @@ import {
   setSessionsLoading
 } from '@/store/session'
 
+import { $sessionTiles } from '@/store/session-states'
+
 import { useSessionListActions } from './use-session-list-actions'
 
 // Sidebar refresh hygiene: a content-identical refresh (turn complete,
@@ -105,6 +107,7 @@ beforeEach(() => {
   setMessagingPlatformTotals({})
   setMessagingTruncated(false)
   setSessionsLoading(false)
+  $sessionTiles.set([])
 })
 
 afterEach(() => {
@@ -115,6 +118,7 @@ afterEach(() => {
   setMessagingPlatformTotals({})
   setMessagingTruncated(false)
   setSessionsLoading(false)
+  $sessionTiles.set([])
 })
 
 describe('refreshSessions identity + loading hygiene', () => {
@@ -653,5 +657,25 @@ describe('messaging profile scope', () => {
 
     expect(listAllProfileSessions).not.toHaveBeenCalled()
     expect($messagingPlatformTotals.get()).toEqual({ 'work:signal': 12 })
+  })
+})
+
+describe('refreshSessions keeps open tabs', () => {
+  it('keeps an open session tile that aged off the recents page', async () => {
+    // Repro: four tabs open, recents page only returns the newest two.
+    // Without keeping tile ids, the older tabs lose their `$sessions` row and
+    // SessionDraftTitle paints them as "New session" the moment you type.
+    setSessions([row('open-tile', { last_active: 900 }), row('recent', { last_active: 1000 })])
+    $sessionTiles.set([{ storedSessionId: 'open-tile' }])
+    listSidebarSessions.mockResolvedValue(sidebar({ sessions: [row('recent', { last_active: 1000 })] }))
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'default' }))
+
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+
+    expect($sessions.get().map(session => session.id)).toEqual(['recent', 'open-tile'])
+    expect($sessions.get().find(session => session.id === 'open-tile')?.title).toBe('Chat open-tile')
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -35,7 +35,7 @@ import {
   setSessions,
   setSessionsLoading
 } from '@/store/session'
-import { $workingSessionIds, getRecentlySettledSessionIds } from '@/store/session-states'
+import { $sessionTiles, $workingSessionIds, getRecentlySettledSessionIds } from '@/store/session-states'
 
 import { refreshCronJobs as refreshCronJobsStore } from '../../cron/cron-actions'
 
@@ -76,7 +76,11 @@ function sessionsToKeep(scope?: string): Set<string> {
   const keep = new Set<string>([
     ...$workingSessionIds.get(),
     ...$pinnedSessionIds.get(),
-    ...getRecentlySettledSessionIds()
+    ...getRecentlySettledSessionIds(),
+    // Open tabs that aged off the recents page must stay in `$sessions`.
+    // Otherwise `tileStoredRow` / workspace title miss the row and the tab
+    // falls back to SessionDraftTitle — typing then renames every open tab.
+    ...$sessionTiles.get().map(tile => tile.storedSessionId)
   ])
 
   const active = $selectedStoredSessionId.get()

--- a/apps/desktop/src/lib/draft-title.test.ts
+++ b/apps/desktop/src/lib/draft-title.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { deriveDraftTitle, shouldUseDraftTabTitle } from './draft-title'
+
+describe('shouldUseDraftTabTitle', () => {
+  it('names a true new chat after the composer', () => {
+    expect(shouldUseDraftTabTitle({ storedSessionId: null })).toBe(true)
+    expect(shouldUseDraftTabTitle({ storedSessionId: '   ' })).toBe(true)
+  })
+
+  it('never overlays composer text on a listed session with a title', () => {
+    expect(
+      shouldUseDraftTabTitle({
+        storedSessionId: '20260818_212755_f07ce6',
+        listedRow: { title: 'Hermes Desktop-App Sessions-Bug beheben', message_count: 87 }
+      })
+    ).toBe(false)
+  })
+
+  it('never overlays composer text on a listed session that already has messages', () => {
+    expect(
+      shouldUseDraftTabTitle({
+        storedSessionId: '20260818_212029_b9c00b',
+        listedRow: { title: '', message_count: 78 }
+      })
+    ).toBe(false)
+  })
+
+  it('keeps a persisted chat titled even when its recents row is missing', () => {
+    // Compression ancestor / off-page tab: we still have a transcript, so the
+    // tab must not fall back to deriveDraftTitle("die h") / "New session".
+    expect(
+      shouldUseDraftTabTitle({
+        storedSessionId: '20260818_212029_b9c00b',
+        listedRow: null,
+        hasMessages: true
+      })
+    ).toBe(false)
+  })
+
+  it('still live-names an unused + / ⌘T draft', () => {
+    expect(
+      shouldUseDraftTabTitle({
+        storedSessionId: 'draft-unlisted',
+        listedRow: null,
+        hasMessages: false
+      })
+    ).toBe(true)
+  })
+})
+
+describe('deriveDraftTitle', () => {
+  it('takes the first meaningful line', () => {
+    expect(deriveDraftTitle('die h')).toBe('die h')
+  })
+})

--- a/apps/desktop/src/lib/draft-title.ts
+++ b/apps/desktop/src/lib/draft-title.ts
@@ -42,3 +42,34 @@ export function deriveDraftTitle(text: string): string {
 
   return `${kept.replace(/[\s,.;:—-]+$/, '')}…`
 }
+
+/** When a tab may take its name from unsent composer text.
+ *
+ *  Draft titles exist only for a true new chat (no stored id yet) or an unused
+ *  + / ⌘T tab that has never listed a row and has no transcript. The moment a
+ *  session is listed, has a title, or already has messages — including a
+ *  compression ancestor whose recents row vanished — overlaying `deriveDraftTitle`
+ *  makes every open tab look like "New session" / the typed fragment. */
+export function shouldUseDraftTabTitle(opts: {
+  storedSessionId: string | null
+  listedRow?: { message_count?: null | number; title?: null | string } | null
+  hasMessages?: boolean
+}): boolean {
+  const id = opts.storedSessionId?.trim() ?? ''
+
+  if (!id) {
+    return true
+  }
+
+  const row = opts.listedRow
+
+  if (row && ((row.message_count ?? 0) > 0 || Boolean(row.title?.trim()))) {
+    return false
+  }
+
+  if (opts.hasMessages) {
+    return false
+  }
+
+  return true
+}


### PR DESCRIPTION
## Bug Description

Typing in the Desktop composer renamed open session tabs to the typed fragment (`die h` → `DIE H`) or `New session`. The chats were still in `state.db`; the strip just treated a missing recents-page row as an unsent draft.

Fixes #89426

## Root Cause

`SessionDraftTitle` (intentional for true new chats / unused `+` tabs, `c143ec7f0`) mounted whenever the workspace lookup missed `$sessions`. Recents is a page of 50; `sessionsToKeep` did not include other open tile IDs; compression ancestors can also vanish after title transfer. Composer keystrokes then live-renamed every such tab.

## Fix

- `shouldUseDraftTabTitle`: overlay composer text only for a true new chat or an unused `+` tab with no listed row and no transcript.
- Workspace title uses `tileStoredRow` (recents + project tree + lineage), not `$sessions` alone.
- `$messagesEmpty` keeps a selected chat with a transcript off the draft path.
- Open `$sessionTiles` IDs join `sessionsToKeep` so they survive a recents refresh.

Does not revert draft-from-composer for unused new tabs.

## How to Verify

1. Open several existing sessions as tabs, including one older than the recents page.
2. Type in the composer of a persisted chat — its stored title must stay.
3. Open `+` / ⌘T and type — that unused draft may still take its name from the composer.
4. `npx vitest run src/lib/draft-title.test.ts src/app/session/hooks/use-session-list-actions.test.tsx`

## Test Plan

- [x] Added regression test for `shouldUseDraftTabTitle` (listed / titled / has-messages / missing recents row)
- [x] Added refresh test: open tile aged off recents stays in `$sessions`
- [x] Sabotage run: 3 new assertions fail if the guard always returns true
- [x] Existing list-action tests still pass (30/30)
- [ ] Manual verification in a rebuilt Desktop (not in this PR; live app is a different worktree build)

## Risk Assessment

Low — renderer-only. Draft naming for unused `+` tabs is preserved. No backend / DB / title-unique changes. Rollback is revert.
