### PR TITLE
feat(desktop): create a project from the session Move-to-project submenu

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/project-dialog.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/project-dialog.test.tsx
@@ -1,6 +1,9 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type * as Nanostores from 'nanostores'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { notify, notifyError } from '@/store/notifications'
+import { closeProjectDialog, createProject, moveSessionToProject } from '@/store/projects'
 
 import { ProjectDialog } from './project-dialog'
 
@@ -23,6 +26,8 @@ vi.mock('@/i18n', () => ({
           ideaLabel: 'Idea',
           ideaPlaceholder: 'What are you building?',
           ideaShuffle: 'Shuffle ideas',
+          moveFailed: 'Could not move session',
+          movedTo: (name: string) => `Moved to ${name}`,
           namePlaceholder: 'Project name',
           noFolders: 'No folders yet',
           primaryBadge: 'Primary',
@@ -42,7 +47,12 @@ const { $projectDialog } = vi.hoisted(() => {
   const { atom } = require('nanostores') as typeof Nanostores
 
   return {
-    $projectDialog: atom<{ mode: 'create' | 'rename' | 'add-folder'; name?: string; projectId?: string } | null>({
+    $projectDialog: atom<{
+      mode: 'create' | 'rename' | 'add-folder'
+      name?: string
+      projectId?: string
+      moveSessionAfter?: { profile?: null | string; sessionId: string }
+    } | null>({
       mode: 'create'
     })
   }
@@ -54,11 +64,13 @@ vi.mock('@/store/projects', () => ({
   closeProjectDialog: vi.fn(),
   createProject: vi.fn(),
   generateProjectIdea: vi.fn(),
+  moveSessionToProject: vi.fn(),
   pickProjectFolder: vi.fn(async () => '/Users/test/my-folder'),
   renameProject: vi.fn()
 }))
 
 vi.mock('@/store/notifications', () => ({
+  notify: vi.fn(),
   notifyError: vi.fn()
 }))
 
@@ -69,6 +81,13 @@ vi.mock('@/lib/project-idea-templates', () => ({
 const tipTrigger = (el: HTMLElement) => el.closest('[data-slot="tooltip-trigger"]')
 
 describe('ProjectDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(createProject).mockResolvedValue(null)
+    vi.mocked(moveSessionToProject).mockResolvedValue(undefined)
+    $projectDialog.set({ mode: 'create' })
+  })
+
   it('wraps the "shuffle idea" button in a Tip', () => {
     render(<ProjectDialog />)
 
@@ -83,5 +102,66 @@ describe('ProjectDialog', () => {
 
     const button = await screen.findByRole('button', { name: 'Remove folder' })
     expect(tipTrigger(button)).toBeTruthy()
+  })
+
+  // Fill the create form (name + one folder via the mocked picker) and submit.
+  async function submitCreate() {
+    render(<ProjectDialog />)
+
+    fireEvent.change(screen.getByPlaceholderText('Project name'), { target: { value: 'Demo' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add folder' }))
+    // The picker resolves async; wait for the folder to land so Create enables.
+    await screen.findByRole('button', { name: 'Remove folder' })
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+  }
+
+  it('creates with use: true when not opened from the move menu', async () => {
+    await submitCreate()
+
+    await waitFor(() =>
+      expect(createProject).toHaveBeenCalledWith({
+        folders: ['/Users/test/my-folder'],
+        idea: undefined,
+        name: 'Demo',
+        use: true
+      })
+    )
+    expect(moveSessionToProject).not.toHaveBeenCalled()
+    expect(closeProjectDialog).toHaveBeenCalled()
+  })
+
+  it('creates with use: false and moves the session into the new project', async () => {
+    vi.mocked(createProject).mockResolvedValue({ id: 'p_new', name: 'Demo' } as never)
+    $projectDialog.set({
+      mode: 'create',
+      moveSessionAfter: { profile: 'work', sessionId: 'sess-1' }
+    })
+
+    await submitCreate()
+
+    await waitFor(() =>
+      expect(createProject).toHaveBeenCalledWith({
+        folders: ['/Users/test/my-folder'],
+        idea: undefined,
+        name: 'Demo',
+        use: false
+      })
+    )
+    expect(moveSessionToProject).toHaveBeenCalledWith('sess-1', 'p_new', 'work')
+    expect(notify).toHaveBeenCalledWith({ durationMs: 2_000, kind: 'success', message: 'Moved to Demo' })
+    expect(closeProjectDialog).toHaveBeenCalled()
+  })
+
+  it('keeps the created project and closes when the move fails', async () => {
+    vi.mocked(createProject).mockResolvedValue({ id: 'p_new', name: 'Demo' } as never)
+    vi.mocked(moveSessionToProject).mockRejectedValue(new Error('move boom'))
+    $projectDialog.set({ mode: 'create', moveSessionAfter: { sessionId: 'sess-1' } })
+
+    await submitCreate()
+
+    await waitFor(() => expect(moveSessionToProject).toHaveBeenCalled())
+    expect(createProject).toHaveBeenCalled()
+    expect(notifyError).toHaveBeenCalledWith(expect.any(Error), 'Could not move session')
+    expect(closeProjectDialog).toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/project-dialog.tsx
+++ b/apps/desktop/src/app/chat/sidebar/project-dialog.tsx
@@ -18,13 +18,14 @@ import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
 import { type ProjectIdeaTemplate, randomIdeaTemplates } from '@/lib/project-idea-templates'
 import { cn } from '@/lib/utils'
-import { notifyError } from '@/store/notifications'
+import { notify, notifyError } from '@/store/notifications'
 import {
   $projectDialog,
   addProjectFolder,
   closeProjectDialog,
   createProject,
   generateProjectIdea,
+  moveSessionToProject,
   pickProjectFolder,
   renameProject
 } from '@/store/projects'
@@ -124,7 +125,25 @@ export function ProjectDialog() {
     // A project owns sessions by folder (cwd-prefix), so creation requires at
     // least one — a folder-less project couldn't hold a session anyway.
     if (mode === 'create' && trimmed && folders.length) {
-      await runSubmit(() => createProject({ folders, idea: idea.trim() || undefined, name: trimmed, use: true }))
+      // When the dialog was opened from the session menu's Move-to-project →
+      // New project item, keep the app's active scope where the user is
+      // (use: false) and re-home the session once the project exists.
+      const move = state?.moveSessionAfter
+
+      await runSubmit(async () => {
+        const created = await createProject({ folders, idea: idea.trim() || undefined, name: trimmed, use: !move })
+
+        if (created && move) {
+          try {
+            await moveSessionToProject(move.sessionId, created.id, move.profile)
+            notify({ durationMs: 2_000, kind: 'success', message: p.movedTo(created.name || created.id) })
+          } catch (err) {
+            // The project exists regardless; surface the failed move and let
+            // runSubmit close the dialog (a create failure keeps it open).
+            notifyError(err, p.moveFailed)
+          }
+        }
+      })
     }
   }
 

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
@@ -1,10 +1,27 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { atom } from 'nanostores'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import type * as Nanostores from 'nanostores'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { openProjectCreateMove } from '@/store/projects'
 
 import { SessionActionsMenu, SessionContextMenu } from './session-actions-menu'
 
 afterEach(cleanup)
+
+// $projectDialog is a real nanostore atom in the app; recreate it here so the
+// openProjectCreateMove mock can drive it faithfully (vi.mock factories are
+// hoisted, so the atom must exist before the factory runs).
+const { $projectDialog } = vi.hoisted(() => {
+  const { atom } = require('nanostores') as typeof Nanostores
+
+  return {
+    $projectDialog: atom<null | {
+      mode: 'create'
+      moveSessionAfter?: { profile?: null | string; sessionId: string }
+    }>(null)
+  }
+})
 
 // Exercises the real SessionActionsMenu end-to-end (no DropdownMenu mock) so
 // a broken asChild composition on the kebab trigger fails here — the menu
@@ -41,6 +58,7 @@ vi.mock('@/i18n', () => ({
           moveNoProjects: 'No other projects',
           movedTo: (name: string) => `Moved to ${name}`,
           moveToProject: 'Move to project',
+          newButton: 'New project',
           noColor: 'No color'
         },
         row: {
@@ -76,8 +94,12 @@ vi.mock('@/lib/session-export', () => ({ exportSession: vi.fn() }))
 vi.mock('@/store/gateway', () => ({ activeGateway: vi.fn(() => null) }))
 vi.mock('@/store/notifications', () => ({ notify: vi.fn(), notifyError: vi.fn() }))
 vi.mock('@/store/projects', () => ({
+  $projectDialog,
   $projectTree: atom<unknown[]>([]),
   moveSessionToProject: vi.fn(),
+  openProjectCreateMove: vi.fn((sessionId: string, profile?: null | string) => {
+    $projectDialog.set({ mode: 'create', moveSessionAfter: { profile, sessionId } })
+  }),
   projectIdForCwd: vi.fn(() => null),
   projectRootCwd: vi.fn(() => '')
 }))
@@ -121,6 +143,10 @@ function renderMenu() {
 }
 
 describe('SessionActionsMenu', () => {
+  beforeEach(() => {
+    $projectDialog.set(null)
+  })
+
   it('opens the dropdown on click without a tooltip on the kebab', async () => {
     renderMenu()
 
@@ -284,5 +310,59 @@ describe('SessionActionsMenu', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
     expect(await screen.findByText('Session deleted')).toBeTruthy()
     expect(onDelete).toHaveBeenCalledTimes(1)
+  })
+
+  // Opens the kebab menu, then the Move-to-project submenu (its trigger is a
+  // menuitem; clicking it toggles the Radix sub open).
+  async function openMoveToProjectSubmenu() {
+    const trigger = screen.getByRole('button', { name: 'Session actions' })
+    fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.pointerUp(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.click(trigger)
+
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Move to project' }))
+  }
+
+  it('renders the New project item in Move to project even with no other targets', async () => {
+    renderMenu()
+    await openMoveToProjectSubmenu()
+
+    expect(await screen.findByRole('menuitem', { name: 'New project' })).toBeTruthy()
+
+    // The empty-state hint still shows below it, disabled.
+    const noProjects = screen.getByRole('menuitem', { name: 'No other projects' })
+    expect(noProjects.getAttribute('aria-disabled')).toBe('true')
+  })
+
+  it('opens the create dialog with the row as the move-after target', async () => {
+    renderMenu()
+    await openMoveToProjectSubmenu()
+
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'New project' }))
+
+    expect(openProjectCreateMove).toHaveBeenCalledWith('s1', undefined)
+    expect($projectDialog.get()).toEqual({
+      mode: 'create',
+      moveSessionAfter: { profile: undefined, sessionId: 's1' }
+    })
+  })
+
+  it('forwards the row profile to the create opener', async () => {
+    render(
+      <SessionActionsMenu profile="work" sessionId="s1" title="My session">
+        <button aria-label="Session actions" type="button">
+          ⋮
+        </button>
+      </SessionActionsMenu>
+    )
+    await openMoveToProjectSubmenu()
+
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'New project' }))
+
+    expect(openProjectCreateMove).toHaveBeenCalledWith('s1', 'work')
+    expect($projectDialog.get()).toEqual({
+      mode: 'create',
+      moveSessionAfter: { profile: 'work', sessionId: 's1' }
+    })
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -31,7 +31,13 @@ import { PROFILE_SWATCHES } from '@/lib/profile-color'
 import { exportSession } from '@/lib/session-export'
 import { activeGateway } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
-import { $projectTree, moveSessionToProject, projectIdForCwd, projectRootCwd } from '@/store/projects'
+import {
+  $projectTree,
+  moveSessionToProject,
+  openProjectCreateMove,
+  projectIdForCwd,
+  projectRootCwd
+} from '@/store/projects'
 import {
   $activeSessionId,
   $connection,
@@ -149,7 +155,17 @@ function SessionColorSwatches({ sessionId }: { sessionId: string }) {
 // project's root — the fix for a chat created in the wrong folder. The current
 // owner and folderless projects (the Home bucket) are excluded: there is
 // nothing to move into.
-function MoveToProjectItems({ kit, sessionId, profile }: { kit: MenuKit; sessionId: string; profile?: string }) {
+function MoveToProjectItems({
+  kit,
+  onOpenCreateProject,
+  sessionId,
+  profile
+}: {
+  kit: MenuKit
+  onOpenCreateProject: () => void
+  sessionId: string
+  profile?: string
+}) {
   const { t } = useI18n()
   const p = t.sidebar.projects
   const tree = useStore($projectTree)
@@ -158,25 +174,33 @@ function MoveToProjectItems({ kit, sessionId, profile }: { kit: MenuKit; session
   const currentProjectId = cwd ? projectIdForCwd(cwd) : null
   const targets = tree.filter(node => node.id !== currentProjectId && !node.isNoProject && projectRootCwd(node))
 
-  if (targets.length === 0) {
-    return <kit.Item disabled>{p.moveNoProjects}</kit.Item>
-  }
-
   return (
     <>
-      {targets.map(node => (
-        <kit.Item
-          key={node.id}
-          onSelect={() => {
-            triggerHaptic('selection')
-            moveSessionToProject(sessionId, node.id, profile)
-              .then(() => notify({ durationMs: 2_000, kind: 'success', message: p.movedTo(node.label) }))
-              .catch(err => notifyError(err, p.moveFailed))
-          }}
-        >
-          {node.label}
-        </kit.Item>
-      ))}
+      <kit.Item
+        onSelect={() => {
+          triggerHaptic('selection')
+          onOpenCreateProject()
+        }}
+      >
+        {p.newButton}
+      </kit.Item>
+      {targets.length === 0 ? (
+        <kit.Item disabled>{p.moveNoProjects}</kit.Item>
+      ) : (
+        targets.map(node => (
+          <kit.Item
+            key={node.id}
+            onSelect={() => {
+              triggerHaptic('selection')
+              moveSessionToProject(sessionId, node.id, profile)
+                .then(() => notify({ durationMs: 2_000, kind: 'success', message: p.movedTo(node.label) }))
+                .catch(err => notifyError(err, p.moveFailed))
+            }}
+          >
+            {node.label}
+          </kit.Item>
+        ))
+      )}
     </>
   )
 }
@@ -487,7 +511,17 @@ function useSessionActions({
           <span>{t.sidebar.projects.moveToProject}</span>
         </kit.SubTrigger>
         <kit.SubContent>
-          <MoveToProjectItems kit={kit} profile={profile} sessionId={sessionId} />
+          <MoveToProjectItems
+            kit={kit}
+            onOpenCreateProject={() => {
+              // Same guard as Rename: keep Radix from restoring focus to the
+              // row trigger when the menu closes, or the dialog input loses it.
+              suppressCloseFocusRef.current = true
+              openProjectCreateMove(sessionId, profile)
+            }}
+            profile={profile}
+            sessionId={sessionId}
+          />
         </kit.SubContent>
       </kit.Sub>
       {tabItems.length > 0 && (

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -8,6 +8,7 @@ import { $currentCwd, $selectedStoredSessionId, $sessions, applyConfiguredDefaul
 
 import {
   $activeProjectId,
+  $projectDialog,
   $projects,
   $projectScope,
   $projectsRpcAvailable,
@@ -23,6 +24,7 @@ import {
   exitProjectScope,
   fetchProjectSessions,
   openProjectCreate,
+  openProjectCreateMove,
   pickProjectFolder,
   projectIdForCwd,
   projectNameForCwd,
@@ -490,6 +492,43 @@ describe('projects RPC capability', () => {
 
     openProjectCreate()
 
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'warning', message: 'sidebar.projects.staleBackend' })
+    )
+  })
+})
+
+describe('openProjectCreateMove', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    $projectDialog.set(null)
+    $projectsRpcAvailable.set(null)
+  })
+
+  it('opens the create dialog with the session pinned as the move-after target', () => {
+    openProjectCreateMove('sess-1', 'work')
+
+    expect($projectDialog.get()).toEqual({
+      mode: 'create',
+      moveSessionAfter: { profile: 'work', sessionId: 'sess-1' }
+    })
+  })
+
+  it('passes an absent profile through (local-profile rows)', () => {
+    openProjectCreateMove('sess-1')
+
+    expect($projectDialog.get()).toEqual({
+      mode: 'create',
+      moveSessionAfter: { profile: undefined, sessionId: 'sess-1' }
+    })
+  })
+
+  it('honors the stale-backend guard like openProjectCreate', () => {
+    $projectsRpcAvailable.set(false)
+
+    openProjectCreateMove('sess-1')
+
+    expect($projectDialog.get()).toBeNull()
     expect(notify).toHaveBeenCalledWith(
       expect.objectContaining({ kind: 'warning', message: 'sidebar.projects.staleBackend' })
     )

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -1132,21 +1132,42 @@ export interface ProjectDialogState {
   mode: 'add-folder' | 'create' | 'rename'
   projectId?: string
   name?: string
+  /** When set, a successful create also re-homes this session into the new
+   *  project (the Move-to-project submenu's "New project" flow). */
+  moveSessionAfter?: { profile?: null | string; sessionId: string }
 }
 
 export const $projectDialog = atom<null | ProjectDialogState>(null)
 
-export function openProjectCreate(): void {
+// A backend that predates the projects.* RPC surface cannot create projects;
+// warn once per attempt instead of opening a dialog that is doomed to fail.
+function projectsCreateBlocked(): boolean {
   if ($projectsRpcAvailable.get() === false) {
     notify({
       kind: 'warning',
       message: translateNow('sidebar.projects.staleBackend')
     })
 
+    return true
+  }
+
+  return false
+}
+
+export function openProjectCreate(): void {
+  if (projectsCreateBlocked()) {
     return
   }
 
   $projectDialog.set({ mode: 'create' })
+}
+
+export function openProjectCreateMove(sessionId: string, profile?: null | string): void {
+  if (projectsCreateBlocked()) {
+    return
+  }
+
+  $projectDialog.set({ mode: 'create', moveSessionAfter: { sessionId, profile } })
 }
 
 export function openProjectRename(project: { id: string; name: string }): void {


### PR DESCRIPTION
## Summary

The session context menu's **Move to project** submenu only lists existing projects. To move a session into a project that doesn't exist yet, the user must leave the session list, create the project from the sidebar, come back, reopen the menu, and repeat the move. This PR adds a **New project** item at the top of the submenu: it opens the existing New Project dialog (name + folder picker) and, on confirm, creates the project and moves the session into it in one step — no navigation away from the session list.

Closes #89434.

## Changes

- `store/projects.ts` — `ProjectDialogState` gains an optional `moveSessionAfter: { sessionId, profile? }` payload. The stale-backend guard in `openProjectCreate` is extracted into a shared `projectsCreateBlocked()` helper, and a new `openProjectCreateMove(sessionId, profile?)` opener uses the same guard.
- `project-dialog.tsx` — in create mode with `moveSessionAfter` set, creation uses `use: false` (the app's active scope stays where the user is, unlike the sidebar flow's `use: true`), then moves the session into the new project and shows the existing "Moved to …" toast. If the move fails after the create succeeds, the project remains (it exists on the backend) and a move-specific error toast surfaces while the dialog closes; a failed create keeps the dialog open as before.
- `session-actions-menu.tsx` — `MoveToProjectItems` always renders **New project** first, including when there are no movable targets (the disabled "No other projects" hint still follows). The item sets the same Radix focus-restore suppression flag as the Rename item, so focus lands in the dialog input instead of the row trigger.

## Tests

- Menu (`session-actions-menu.test.tsx`): the item renders with an empty project tree (empty-state hint preserved); selecting it opens the create dialog with the row pinned as the move-after target; profile forwarding.
- Dialog (`project-dialog.test.tsx`): plain create still uses `use: true`; the move flow uses `use: false` and moves after create with the success toast; a move failure keeps the created project, closes the dialog, and toasts the move-specific error.
- Store (`projects.test.ts`): `openProjectCreateMove` atom state, absent-profile handling, and stale-backend guard parity with `openProjectCreate`.

The three touched test files pass locally: 47/47.

## Notes

- No i18n changes — the submenu reuses the existing "New project" label already used by the sidebar button.
- **Open question:** the item keeps the plain "New project" label (no ellipsis) to match the existing Rename item, which also opens a dialog. Flagging it here in case the convention should become an ellipsis for dialog-opening items project-wide.
