### PR TITLE
docs(discord): document config.yaml-first mention settings

### DIFF
--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -282,7 +282,7 @@ You can run `hermes gateway` in the background or as a systemd service for persi
 
 ## Configuration Reference
 
-Discord behavior is controlled through two files: **`~/.hermes/.env`** for credentials and env-level toggles, and **`~/.hermes/config.yaml`** for structured settings. Environment variables always take precedence over config.yaml values when both are set.
+Discord behavior is controlled through two files: **`~/.hermes/.env`** for credentials (bot token) and **`~/.hermes/config.yaml`** for structured settings. Secrets stay in `.env`. For `discord.require_mention` and `discord.free_response_channels`, the adapter reads `config.yaml` when the key is set; the matching `DISCORD_*` environment variable is the fallback. That matches [Configuration Precedence](../configuration.md#configuration-precedence) for non-secret settings.
 
 ### Environment Variables (`.env`)
 
@@ -327,7 +327,7 @@ Wiring multiple Hermes profiles to reply to one another in a shared channel — 
 
 ### Config File (`config.yaml`)
 
-The `discord` section in `~/.hermes/config.yaml` mirrors the env vars above. Config.yaml settings are applied as defaults — if the equivalent env var is already set, the env var wins.
+The `discord` section in `~/.hermes/config.yaml` mirrors the env vars above. For `require_mention` and `free_response_channels`, a key present under `discord:` — including defaults written on a fresh install — wins. The matching `DISCORD_*` variable is used only if that config key is unset, which is why a conflicting `.env` entry is ignored.
 
 ```yaml
 # Discord-specific settings

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/discord.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/discord.md
@@ -281,7 +281,7 @@ hermes gateway
 
 ## 配置参考
 
-Discord 行为通过两个文件控制：**`~/.hermes/.env`** 用于凭据和环境级开关，**`~/.hermes/config.yaml`** 用于结构化设置。当两者都设置时，环境变量始终优先于 config.yaml 的值。
+Discord 行为通过两个文件控制：**`~/.hermes/.env`** 用于凭据（机器人 token），**`~/.hermes/config.yaml`** 用于结构化设置。密钥留在 `.env`。对于 `discord.require_mention` 和 `discord.free_response_channels`，适配器在配置键已设置时读取 `config.yaml`；对应的 `DISCORD_*` 环境变量仅作回退。这与[配置优先级](../configuration.md#配置优先级)中非密钥项的规则一致。
 
 ### 环境变量（`.env`）
 
@@ -318,7 +318,7 @@ Discord 行为通过两个文件控制：**`~/.hermes/.env`** 用于凭据和环
 
 ### 配置文件（`config.yaml`）
 
-`~/.hermes/config.yaml` 中的 `discord` 部分与上述环境变量对应。config.yaml 设置作为默认值应用——如果已设置等效的环境变量，则环境变量优先。
+`~/.hermes/config.yaml` 中的 `discord` 部分与上述环境变量对应。对于 `require_mention` 和 `free_response_channels`，只要 `discord:` 下存在该键（包括全新安装写入的默认值），该值即生效；对应的 `DISCORD_*` 变量仅在该配置键未设置时使用，因此会忽略 `.env` 中的冲突项。
 
 ```yaml
 # Discord 特定设置


### PR DESCRIPTION
## What does this PR do?

Fixes the Discord docs to match what the adapter actually does for the two keys in #13685.

On current `main`, `_discord_require_mention` and `_discord_free_response_channels` read `config.extra` first and only fall back to `DISCORD_*` when the config key is unset. Fresh installs write `discord.require_mention: true`, so a conflicting `.env` value is ignored. `configuration.md` already says `config.yaml` wins for non-secret settings. The Discord page still said the opposite.

The issue offered either a code change (env wins) or a docs change (config wins). This PR takes the docs side: `.env` is for secrets, and changing those helpers to env-first would fight that design. Closed PR #13732 was the code-side attempt; it is not revived here.

Open PR #82150 rewrites global precedence toward env-wins and softens one Discord sentence to a link. It does not implement #13685 and leaves the exact “the env var wins” sentence the issue quotes. This PR is scoped to those two mention-gating keys only.

The mention-control comment “env vars win over config.yaml” for `DISCORD_ALLOW_MENTION_*` is left alone — that path still bridges YAML only when the env var is unset.

## Related Issue

Fixes #13685

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [x] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `website/docs/user-guide/messaging/discord.md`: Configuration Reference + Config File sections now say `require_mention` / `free_response_channels` are config-first
- zh-Hans `user-guide/messaging/discord.md`: same two sentences

## How to Test

1. On `main`, confirm the stale lines: “Environment variables always take precedence” and “the env var wins.”
2. Confirm `plugins/platforms/discord/adapter.py` `_discord_require_mention` / `_discord_free_response_channels` still read `config.extra` first.
3. Confirm `website/docs/user-guide/configuration.md` still lists `config.yaml` above `.env` for non-secrets.
4. Confirm the `allow_mentions` snippet still says env vars win.

Docs-only; Python tests are not required. CI Docs Site runs `lint:diagrams` + `build:fast`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (docs-only; Python CI lane will not run)
- [ ] I've added tests for my changes — N/A (docs wording only)
- [x] I've tested on my platform: macOS (darwin 25.5) — wording/grep against current `main`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A — wording-only docs change.