### PR TITLE
fix(desktop): own SSH serve after wrapper exec and watch lock/log

### DIFF
--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { exec as execCallback, spawn } from 'node:child_process'
-import { chmod, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { promisify } from 'node:util'
@@ -469,6 +469,54 @@ test.skipIf(process.platform === 'win32')(
     }
   }
 )
+
+test('cleanupStale keeps lock and log when OWNED kill fails', async () => {
+  const killFail = new Error('kill refused')
+  const ssh = fakeSsh([
+    [/print\("OWNED"/, 'OWNED\n'],
+    [/kill 9\b/, killFail]
+  ])
+
+  await assert.rejects(
+    () =>
+      cleanupStale(ssh, OWNERSHIP_ID, {
+        pid: 9,
+        spawnNonce: SPAWN_NONCE,
+        hermesPath: '/x/hermes',
+        logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE)
+      }),
+    (err: { kind?: string }) => err.kind === 'transient-transport-error'
+  )
+  assert.ok(ssh.calls.some(c => /kill 9\b/.test(c)))
+  assert.ok(!ssh.calls.some(c => /rm -f/.test(c)), 'OWNED kill-fail must not drop lock or log')
+})
+
+test('buildSpawnCommand exports lock and log paths when spawn nonce is set', () => {
+  const logPath = spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE)
+  const cmd = buildSpawnCommand('/x/hermes', 'work', {
+    logPath,
+    spawnNonce: SPAWN_NONCE,
+    tokenFilePath: spawnTokenPath(OWNERSHIP_ID, SPAWN_NONCE)
+  })
+
+  assert.match(cmd, /HERMES_SSH_LOCKFILE=/)
+  assert.match(cmd, /HERMES_SSH_LOGFILE=/)
+  assert.match(cmd, /backend\.lock\.json/)
+  assert.match(cmd, /--ssh-owner-nonce/)
+})
+
+test('buildSpawnCommand does not export lock env without spawn nonce', () => {
+  const cmd = buildSpawnCommand('/x/hermes', 'work', { logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE) })
+  assert.doesNotMatch(cmd, /HERMES_SSH_LOCKFILE/)
+  assert.doesNotMatch(cmd, /HERMES_SSH_LOGFILE/)
+})
+
+test('remote-lifecycle embeds ssh_pid_owned.py verbatim', async () => {
+  const here = path.dirname(new URL(import.meta.url).pathname)
+  const py = await readFile(path.join(here, 'ssh_pid_owned.py'), 'utf8')
+  const ts = await readFile(path.join(here, 'remote-lifecycle.ts'), 'utf8')
+  assert.ok(ts.includes(py), 'pidIsOurDashboard must embed ssh_pid_owned.py verbatim')
+})
 
 test('cleanupStale kills ONLY a provably-ours pid, always drops the lockfile', async () => {
   const notOurs = fakeSsh([[/print\("OWNED"/, 'FOREIGN\n']])

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -397,6 +397,118 @@ async function remotePidAlive(ssh, pid) {
   }
 }
 
+const SSH_PID_OWNED_PY = `"""Classify Desktop SSH dashboard argv. Stdlib only. Embedded by remote-lifecycle.ts."""
+
+from __future__ import annotations
+
+import os
+import shlex
+
+
+def _wrapper_exec_targets(hermes_path):
+    try:
+        with open(hermes_path, encoding="utf-8") as handle:
+            text = handle.read()
+    except OSError:
+        return []
+    lines = text.splitlines()
+    if not lines or not lines[0].startswith("#!"):
+        return []
+    interp = lines[0][2:].strip()
+    if not interp:
+        return []
+    name = os.path.basename(interp.split()[-1])
+    if name not in {"sh", "bash"}:
+        return []
+    exec_line = ""
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("exec"):
+            exec_line = stripped
+    if not exec_line:
+        return []
+    try:
+        parts = shlex.split(exec_line)
+    except ValueError:
+        return []
+    if len(parts) != 4 or parts[0] != "exec" or parts[-1] != "$@":
+        return []
+    return [os.path.expanduser(parts[1]), os.path.expanduser(parts[2])]
+
+
+def classify_dashboard_argv(
+    args,
+    expected,
+    nonce,
+    hermes_home="",
+    token_path="",
+    profile="",
+    allow_spawn_proof=True,
+    include_repo_hermes_entry=True,
+    resolve_wrapper=True,
+):
+    expected = os.path.expanduser(expected or "")
+    hermes_home = os.path.expanduser(hermes_home) if hermes_home else ""
+    expected_token = os.path.expanduser(token_path) if token_path else ""
+    expected_profile = profile or ""
+    expected_entries = {expected} if expected else set()
+    if hermes_home:
+        expected_entries.add(
+            os.path.join(hermes_home, "hermes-agent", "venv", "bin", "hermes")
+        )
+        if include_repo_hermes_entry:
+            expected_entries.add(os.path.join(hermes_home, "hermes-agent", "hermes"))
+    if resolve_wrapper and expected:
+        expected_entries.update(_wrapper_exec_targets(expected))
+    try:
+        serve = args.index("serve")
+        owner = args.index("--ssh-owner-nonce", serve + 1)
+        token = args.index("--ssh-session-token-file", serve + 1) if expected_token else -1
+        isolated = args.index("--isolated", serve + 1)
+        profile_arg = args.index("--profile") if expected_profile else -1
+        serve_count = args.count("serve")
+        owner_count = args.count("--ssh-owner-nonce")
+        token_count = args.count("--ssh-session-token-file")
+        isolated_count = args.count("--isolated")
+        profile_count = args.count("--profile")
+        direct = bool(args) and args[0] in expected_entries
+        python_entry = (
+            len(args) > 1
+            and args[1] in expected_entries
+            and os.path.basename(args[0]).startswith("python")
+        )
+        token_ok = (not expected_token) or args[token + 1] == expected_token
+        isolated_ok = isolated_count == 1 and isolated > serve
+        if expected_profile:
+            profile_ok = (
+                profile_count == 1
+                and profile_arg < serve
+                and args[profile_arg + 1] == expected_profile
+            )
+        else:
+            profile_ok = profile_count == 0
+        spawn_proof = (
+            bool(allow_spawn_proof)
+            and bool(expected_token)
+            and owner_count == 1
+            and token_count == 1
+            and token_ok
+            and profile_ok
+        )
+        ok = (
+            (direct or python_entry or spawn_proof)
+            and serve_count == 1
+            and isolated_ok
+            and owner_count == 1
+            and args[owner + 1] == nonce
+            and token_ok
+            and profile_ok
+        )
+    except (ValueError, IndexError):
+        ok = False
+    return "OWNED" if ok else "FOREIGN"
+`
+
 // A pid is "provably ours" only if its remote cmdline carries our dashboard
 // args — never kill a pid we can't positively identify as our dashboard.
 async function pidIsOurDashboard(
@@ -413,18 +525,16 @@ async function pidIsOurDashboard(
   }
 
   try {
+    // SSH_PID_OWNED_PY is the exact sibling file. Extra lines only read
+    // argv and print OWNED/FOREIGN so packaged Desktop still ships one script.
     const script =
+      SSH_PID_OWNED_PY +
       'import os,shlex,subprocess,sys\n' +
       `pid=${Number(pid)}\n` +
       `expected=os.path.expanduser(${shq(hermesPath)})\n` +
-      // The installer-facing launcher is intentionally preserved for invocation
-      // (#74411), but it may `exec python <install-dir>/hermes`, leaving neither
-      // launcher nor HERMES_HOME-derived entrypoint in argv. The ownership-scoped
-      // token path + random nonce + exact profile below are the alternative proof.
+      // #74411 keeps hermesPath as the launcher; expected entries plus spawn_proof
+      // identify the post-exec python + hermes-agent/hermes argv shape.
       `hermes_home=os.path.expanduser(${shq(hermesHome)}) if ${shq(hermesHome)} else ""\n` +
-      'expected_entries={expected}\n' +
-      'if hermes_home:\n' +
-      ' expected_entries.add(os.path.join(hermes_home,"hermes-agent","venv","bin","hermes"))\n' +
       `expected_token=os.path.expanduser(${shq(ownershipId ? spawnTokenPath(ownershipId, spawnNonce) : '')})\n` +
       `expected_profile=${shq(profile)}\n` +
       `nonce=${shq(spawnNonce)}\n` +
@@ -438,28 +548,7 @@ async function pidIsOurDashboard(
       '  # pid already gone — a dead process is FOREIGN, not a transport error\n' +
       '  print("FOREIGN");sys.exit(0)\n' +
       ' args=shlex.split(line)\n' +
-      'ok=False\n' +
-      'try:\n' +
-      ' serve=args.index("serve")\n' +
-      ' owner=args.index("--ssh-owner-nonce",serve+1)\n' +
-      ' token=args.index("--ssh-session-token-file",serve+1) if expected_token else -1\n' +
-      ' isolated=args.index("--isolated",serve+1)\n' +
-      ' profile_arg=args.index("--profile") if expected_profile else -1\n' +
-      ' serve_count=args.count("serve")\n' +
-      ' owner_count=args.count("--ssh-owner-nonce")\n' +
-      ' token_count=args.count("--ssh-session-token-file")\n' +
-      ' isolated_count=args.count("--isolated")\n' +
-      ' profile_count=args.count("--profile")\n' +
-      ' direct=args[0] in expected_entries\n' +
-      ' python_entry=len(args)>1 and args[1] in expected_entries and os.path.basename(args[0]).startswith("python")\n' +
-      ' token_ok=not expected_token or args[token+1]==expected_token\n' +
-      ' isolated_ok=isolated_count==1 and isolated>serve\n' +
-      ' profile_ok=(profile_count==1 and profile_arg<serve and args[profile_arg+1]==expected_profile) if expected_profile else profile_count==0\n' +
-      ' spawn_proof=bool(expected_token) and owner_count==1 and token_count==1 and token_ok and profile_ok\n' +
-      ' ok=(direct or python_entry or spawn_proof) and serve_count==1 and isolated_ok and owner_count==1 and args[owner+1]==nonce and token_ok and profile_ok\n' +
-      'except (ValueError,IndexError):pass\n' +
-      'print("OWNED" if ok else "FOREIGN")'
-
+      'print("OWNED" if classify_dashboard_argv(args,expected,nonce,hermes_home=hermes_home,token_path=expected_token,profile=expected_profile)=="OWNED" else "FOREIGN")'
     const out = await ssh.exec(`python3 -c ${shq(script)}`)
 
     return String(out || '').trim() === 'OWNED'
@@ -528,10 +617,14 @@ function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
   const tokenArg = tokenFilePath ? ` --ssh-session-token-file ${expandRemotePath(tokenFilePath)}` : ''
   const ownerArg = opts.spawnNonce ? ` --ssh-owner-nonce ${validateSpawnNonce(opts.spawnNonce)}` : ''
   const subCmd = `serve --isolated --host 127.0.0.1 --port 0${tokenArg}${ownerArg}`
+  const lockEnv =
+    opts.spawnNonce && opts.logPath
+      ? ` HERMES_SSH_LOCKFILE=${expandRemotePath(String(opts.logPath).replace(/[^/]+$/, 'backend.lock.json'))} HERMES_SSH_LOGFILE=${logPath}`
+      : ''
 
   const dashCmd =
     `ulimit -n ${REMOTE_NOFILE_SOFT_LIMIT} 2>/dev/null || true; ` +
-    `exec env HERMES_DESKTOP=1 ${hermes} ${profileArgs}${subCmd}`
+    `exec env HERMES_DESKTOP=1${lockEnv} ${hermes} ${profileArgs}${subCmd}`
 
   return (
     `mkdir -p "$(dirname ${logPath})" && ` +

--- a/apps/desktop/electron/ssh_pid_owned.py
+++ b/apps/desktop/electron/ssh_pid_owned.py
@@ -1,0 +1,110 @@
+"""Classify Desktop SSH dashboard argv. Stdlib only. Embedded by remote-lifecycle.ts."""
+
+from __future__ import annotations
+
+import os
+import shlex
+
+
+def _wrapper_exec_targets(hermes_path):
+    try:
+        with open(hermes_path, encoding="utf-8") as handle:
+            text = handle.read()
+    except OSError:
+        return []
+    lines = text.splitlines()
+    if not lines or not lines[0].startswith("#!"):
+        return []
+    interp = lines[0][2:].strip()
+    if not interp:
+        return []
+    name = os.path.basename(interp.split()[-1])
+    if name not in {"sh", "bash"}:
+        return []
+    exec_line = ""
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("exec"):
+            exec_line = stripped
+    if not exec_line:
+        return []
+    try:
+        parts = shlex.split(exec_line)
+    except ValueError:
+        return []
+    if len(parts) != 4 or parts[0] != "exec" or parts[-1] != "$@":
+        return []
+    return [os.path.expanduser(parts[1]), os.path.expanduser(parts[2])]
+
+
+def classify_dashboard_argv(
+    args,
+    expected,
+    nonce,
+    hermes_home="",
+    token_path="",
+    profile="",
+    allow_spawn_proof=True,
+    include_repo_hermes_entry=True,
+    resolve_wrapper=True,
+):
+    expected = os.path.expanduser(expected or "")
+    hermes_home = os.path.expanduser(hermes_home) if hermes_home else ""
+    expected_token = os.path.expanduser(token_path) if token_path else ""
+    expected_profile = profile or ""
+    expected_entries = {expected} if expected else set()
+    if hermes_home:
+        expected_entries.add(
+            os.path.join(hermes_home, "hermes-agent", "venv", "bin", "hermes")
+        )
+        if include_repo_hermes_entry:
+            expected_entries.add(os.path.join(hermes_home, "hermes-agent", "hermes"))
+    if resolve_wrapper and expected:
+        expected_entries.update(_wrapper_exec_targets(expected))
+    try:
+        serve = args.index("serve")
+        owner = args.index("--ssh-owner-nonce", serve + 1)
+        token = args.index("--ssh-session-token-file", serve + 1) if expected_token else -1
+        isolated = args.index("--isolated", serve + 1)
+        profile_arg = args.index("--profile") if expected_profile else -1
+        serve_count = args.count("serve")
+        owner_count = args.count("--ssh-owner-nonce")
+        token_count = args.count("--ssh-session-token-file")
+        isolated_count = args.count("--isolated")
+        profile_count = args.count("--profile")
+        direct = bool(args) and args[0] in expected_entries
+        python_entry = (
+            len(args) > 1
+            and args[1] in expected_entries
+            and os.path.basename(args[0]).startswith("python")
+        )
+        token_ok = (not expected_token) or args[token + 1] == expected_token
+        isolated_ok = isolated_count == 1 and isolated > serve
+        if expected_profile:
+            profile_ok = (
+                profile_count == 1
+                and profile_arg < serve
+                and args[profile_arg + 1] == expected_profile
+            )
+        else:
+            profile_ok = profile_count == 0
+        spawn_proof = (
+            bool(allow_spawn_proof)
+            and bool(expected_token)
+            and owner_count == 1
+            and token_count == 1
+            and token_ok
+            and profile_ok
+        )
+        ok = (
+            (direct or python_entry or spawn_proof)
+            and serve_count == 1
+            and isolated_ok
+            and owner_count == 1
+            and args[owner + 1] == nonce
+            and token_ok
+            and profile_ok
+        )
+    except (ValueError, IndexError):
+        ok = False
+    return "OWNED" if ok else "FOREIGN"

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -18716,6 +18716,108 @@ def _start_parent_death_watchdog() -> None:
     threading.Thread(target=_loop, daemon=True, name="serve-parent-watchdog").start()
 
 
+def _ssh_lock_watchdog_decision(
+    *,
+    seen_lock: bool,
+    lock_exists: bool,
+    lock_readable: bool,
+    lock_nonce: Optional[str],
+    our_nonce: str,
+    log_nlink: Optional[int],
+    missing_polls: int,
+) -> tuple[str, bool, int]:
+    """Decide whether the SSH lock/log watchdog should wait, continue, or exit."""
+    if lock_exists:
+        if not lock_readable:
+            return "continue", True, 0
+        if lock_nonce != our_nonce:
+            return "exit", True, 0
+        if log_nlink == 0:
+            return "exit", True, 0
+        return "continue", True, 0
+    if not seen_lock:
+        return "wait", False, 0
+    missing_polls += 1
+    if missing_polls >= 2:
+        return "exit", True, missing_polls
+    return "continue", True, missing_polls
+
+
+def _ssh_lock_snapshot(lock_path: str) -> tuple[bool, bool, Optional[str]]:
+    try:
+        with open(lock_path, encoding="utf-8") as handle:
+            raw = handle.read()
+    except FileNotFoundError:
+        return False, False, None
+    except OSError:
+        return True, False, None
+    try:
+        parsed = json.loads(raw)
+        nonce = parsed.get("spawnNonce") if isinstance(parsed, dict) else None
+        if not isinstance(nonce, str):
+            return True, False, None
+        return True, True, nonce
+    except (TypeError, ValueError):
+        return True, False, None
+
+
+def _ssh_log_is_unlinked(fd: int) -> bool:
+    try:
+        return os.fstat(fd).st_nlink == 0
+    except OSError:
+        return False
+
+
+def _start_ssh_lock_watchdog() -> None:
+    """Exit this isolated serve when Desktop drops our lock or unlinks the log.
+
+    Armed only when ``--ssh-owner-nonce`` was set. Missing lock at startup is
+    not an exit: Desktop writes the lock after spawn. No parent-pid, no
+    process-lifetime cutoff, no process-group kill.
+    """
+    our_nonce = _SSH_OWNER_NONCE
+    if not our_nonce:
+        return
+    lock_path = os.environ.get("HERMES_SSH_LOCKFILE") or ""
+    log_path = os.environ.get("HERMES_SSH_LOGFILE") or ""
+    if not lock_path:
+        return
+    try:
+        poll = max(0.5, float(os.environ.get("HERMES_SERVE_WATCHDOG_POLL_S", "2.0")))
+    except (TypeError, ValueError):
+        poll = 2.0
+
+    def _loop() -> None:
+        seen = False
+        missing = 0
+        log_fd: Optional[int] = None
+        while True:
+            exists, readable, nonce = _ssh_lock_snapshot(lock_path)
+            nlink: Optional[int] = None
+            if log_path:
+                try:
+                    if log_fd is None and os.path.exists(log_path):
+                        log_fd = os.open(log_path, os.O_RDONLY)
+                    if log_fd is not None:
+                        nlink = os.fstat(log_fd).st_nlink
+                except OSError:
+                    nlink = None
+            action, seen, missing = _ssh_lock_watchdog_decision(
+                seen_lock=seen,
+                lock_exists=exists,
+                lock_readable=readable,
+                lock_nonce=nonce,
+                our_nonce=our_nonce,
+                log_nlink=nlink,
+                missing_polls=missing,
+            )
+            if action == "exit":
+                os._exit(0)
+            time.sleep(poll)
+
+    threading.Thread(target=_loop, daemon=True, name="serve-ssh-lock-watchdog").start()
+
+
 def _demo() -> None:
     assert _is_serve_orphaned(999999999, pid_exists=lambda _pid: False) is True
     assert _is_serve_orphaned(42, pid_exists=lambda _pid: True) is False
@@ -18957,6 +19059,7 @@ def start_server(
             # tui_gateway/slash_worker.py::_start_parent_death_watchdog. No-op
             # for standalone `hermes serve` (no HERMES_PARENT_PID env).
             _start_parent_death_watchdog()
+            _start_ssh_lock_watchdog()
 
             actual_port = _read_bound_port(server, fallback=port)
             app.state.bound_port = actual_port

--- a/tests/hermes_cli/test_ssh_lock_watchdog.py
+++ b/tests/hermes_cli/test_ssh_lock_watchdog.py
@@ -1,0 +1,190 @@
+"""TDD for Desktop SSH lock/log watchdog (D6)."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import re
+import threading
+from pathlib import Path
+
+from hermes_cli import web_server
+
+
+def test_watchdog_start_is_noop_without_owner_nonce(monkeypatch):
+    monkeypatch.setattr(web_server, "_SSH_OWNER_NONCE", None)
+    started = []
+    monkeypatch.setattr(
+        threading,
+        "Thread",
+        lambda *args, **kwargs: started.append(kwargs) or (_ for _ in ()).throw(AssertionError("thread")),
+    )
+    web_server._start_ssh_lock_watchdog()
+    assert started == []
+
+
+def test_watchdog_waits_for_missing_lock_and_does_not_exit():
+    action, seen, missing = web_server._ssh_lock_watchdog_decision(
+        seen_lock=False,
+        lock_exists=False,
+        lock_readable=False,
+        lock_nonce=None,
+        our_nonce="0123456789abcdef",
+        log_nlink=1,
+        missing_polls=0,
+    )
+    assert action == "wait"
+    assert seen is False
+    assert missing == 0
+
+
+def test_watchdog_still_waits_after_many_absent_polls():
+    action, seen, missing = web_server._ssh_lock_watchdog_decision(
+        seen_lock=False,
+        lock_exists=False,
+        lock_readable=False,
+        lock_nonce=None,
+        our_nonce="0123456789abcdef",
+        log_nlink=1,
+        missing_polls=80,
+    )
+    assert action == "wait"
+    assert seen is False
+
+
+def test_watchdog_exits_after_two_missing_polls_once_seen():
+    first, seen, missing = web_server._ssh_lock_watchdog_decision(
+        seen_lock=True,
+        lock_exists=False,
+        lock_readable=False,
+        lock_nonce=None,
+        our_nonce="0123456789abcdef",
+        log_nlink=1,
+        missing_polls=0,
+    )
+    assert first == "continue"
+    assert seen is True
+    assert missing == 1
+
+    second, seen, missing = web_server._ssh_lock_watchdog_decision(
+        seen_lock=True,
+        lock_exists=False,
+        lock_readable=False,
+        lock_nonce=None,
+        our_nonce="0123456789abcdef",
+        log_nlink=1,
+        missing_polls=missing,
+    )
+    assert second == "exit"
+    assert missing == 2
+
+
+def test_watchdog_exits_when_lock_nonce_differs():
+    action, seen, missing = web_server._ssh_lock_watchdog_decision(
+        seen_lock=True,
+        lock_exists=True,
+        lock_readable=True,
+        lock_nonce="fedcba9876543210",
+        our_nonce="0123456789abcdef",
+        log_nlink=1,
+        missing_polls=0,
+    )
+    assert action == "exit"
+    assert seen is True
+    assert missing == 0
+
+
+def test_watchdog_exits_when_log_nlink_is_zero():
+    action, _, _ = web_server._ssh_lock_watchdog_decision(
+        seen_lock=True,
+        lock_exists=True,
+        lock_readable=True,
+        lock_nonce="0123456789abcdef",
+        our_nonce="0123456789abcdef",
+        log_nlink=0,
+        missing_polls=0,
+    )
+    assert action == "exit"
+
+
+def test_watchdog_keeps_serving_when_lock_unreadable():
+    action, seen, missing = web_server._ssh_lock_watchdog_decision(
+        seen_lock=True,
+        lock_exists=True,
+        lock_readable=False,
+        lock_nonce=None,
+        our_nonce="0123456789abcdef",
+        log_nlink=1,
+        missing_polls=3,
+    )
+    assert action == "continue"
+    assert seen is True
+    assert missing == 0
+
+
+def test_watchdog_matching_lock_resets_missing_polls():
+    action, seen, missing = web_server._ssh_lock_watchdog_decision(
+        seen_lock=True,
+        lock_exists=True,
+        lock_readable=True,
+        lock_nonce="0123456789abcdef",
+        our_nonce="0123456789abcdef",
+        log_nlink=1,
+        missing_polls=1,
+    )
+    assert action == "continue"
+    assert seen is True
+    assert missing == 0
+
+
+def test_watchdog_observes_unlinked_log_nlink(tmp_path: Path):
+    log_path = tmp_path / "0123456789abcdef.log"
+    log_path.write_text("ready\n", encoding="utf-8")
+    fd = os.open(log_path, os.O_RDONLY)
+    try:
+        os.unlink(log_path)
+        assert os.fstat(fd).st_nlink == 0
+        assert web_server._ssh_log_is_unlinked(fd) is True
+    finally:
+        os.close(fd)
+
+
+def test_watchdog_reads_spawn_nonce_from_lock_file(tmp_path: Path):
+    lock_path = tmp_path / "backend.lock.json"
+    lock_path.write_text(json.dumps({"spawnNonce": "0123456789abcdef"}), encoding="utf-8")
+    exists, readable, nonce = web_server._ssh_lock_snapshot(str(lock_path))
+    assert exists is True
+    assert readable is True
+    assert nonce == "0123456789abcdef"
+
+
+def test_watchdog_unreadable_lock_snapshot(tmp_path: Path):
+    lock_path = tmp_path / "backend.lock.json"
+    lock_path.write_text("{not-json", encoding="utf-8")
+    exists, readable, nonce = web_server._ssh_lock_snapshot(str(lock_path))
+    assert exists is True
+    assert readable is False
+    assert nonce is None
+
+
+def test_watchdog_contract_has_no_age_pkill_or_parent_pid():
+    source = inspect.getsource(web_server._start_ssh_lock_watchdog)
+    source += inspect.getsource(web_server._ssh_lock_watchdog_decision)
+    body = "\n".join(
+        line for line in source.splitlines() if not line.strip().startswith(('"', "'", "#"))
+    )
+    lowered = body.lower()
+    assert "hermes_parent_pid" not in lowered
+    assert "pkill" not in lowered
+    assert "killpg" not in lowered
+    assert re.search(r"\bage\b", lowered) is None
+    assert "serve-ssh-lock-watchdog" in source
+    assert "os._exit" in source
+    signature = inspect.signature(web_server._start_ssh_lock_watchdog)
+    assert list(signature.parameters) == []
+
+
+def test_watchdog_poll_default_is_two_seconds():
+    source = inspect.getsource(web_server._start_ssh_lock_watchdog)
+    assert "2.0" in source or "2" in source

--- a/tests/hermes_cli/test_ssh_pid_owned.py
+++ b/tests/hermes_cli/test_ssh_pid_owned.py
@@ -1,0 +1,322 @@
+"""Execute the Desktop SSH argv classifier. No /proc, no mocked OWNED strings."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLASSIFIER_PATH = REPO_ROOT / "apps" / "desktop" / "electron" / "ssh_pid_owned.py"
+
+HOME = "/home/u"
+HERMES_HOME = f"{HOME}/.hermes"
+WRAPPER = f"{HOME}/.local/bin/hermes"
+PYTHON = f"{HERMES_HOME}/hermes-agent/venv/bin/python"
+REPO_HERMES = f"{HERMES_HOME}/hermes-agent/hermes"
+VENV_HERMES = f"{HERMES_HOME}/hermes-agent/venv/bin/hermes"
+NONCE = "0123456789abcdef"
+OWNERSHIP_ID = "0123456789abcdef0123456789abcdef"
+TOKEN = f"{HERMES_HOME}/desktop-ssh/{OWNERSHIP_ID}/{NONCE}.token"
+PROFILE = "cto"
+
+
+def this_host_args(**over: object) -> list[str]:
+    args = [
+        str(over.get("argv0", PYTHON)),
+        str(over.get("argv1", REPO_HERMES)),
+        "--profile",
+        str(over.get("profile", PROFILE)),
+        "serve",
+        "--isolated",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "0",
+        "--ssh-session-token-file",
+        str(over.get("token", TOKEN)),
+        "--ssh-owner-nonce",
+        str(over.get("nonce", NONCE)),
+    ]
+    if over.get("drop_isolated"):
+        args.remove("--isolated")
+    return args
+
+
+def classify_legacy_4arg(args: list[str], expected: str, nonce: str) -> str:
+    """HEAD / running Desktop 4-arg rule (direct || python_entry vs hermesPath)."""
+    try:
+        serve = args.index("serve")
+        owner = args.index("--ssh-owner-nonce", serve + 1)
+        direct = args[0] == expected
+        python_entry = (
+            len(args) > 1
+            and args[1] == expected
+            and os.path.basename(args[0]).startswith("python")
+        )
+        ok = (
+            (direct or python_entry)
+            and "--isolated" in args[serve + 1 :]
+            and args[owner + 1] == nonce
+        )
+    except (ValueError, IndexError):
+        ok = False
+    return "OWNED" if ok else "FOREIGN"
+
+
+def load_classifier():
+    spec = importlib.util.spec_from_file_location("ssh_pid_owned", CLASSIFIER_PATH)
+    if spec is None or spec.loader is None:
+        raise FileNotFoundError(CLASSIFIER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_this_host_shape_is_foreign_under_old_4arg_rule():
+    assert (
+        classify_legacy_4arg(this_host_args(), WRAPPER, NONCE) == "FOREIGN"
+    ), "python + hermes-agent/hermes must be FOREIGN when expected is the wrapper path"
+
+
+def test_classify_dashboard_argv_exists():
+    module = load_classifier()
+    assert callable(module.classify_dashboard_argv)
+
+
+def test_this_host_shape_is_owned_without_spawn_proof():
+    module = load_classifier()
+    result = module.classify_dashboard_argv(
+        this_host_args(),
+        WRAPPER,
+        NONCE,
+        hermes_home=HERMES_HOME,
+        token_path="",
+        profile=PROFILE,
+        allow_spawn_proof=False,
+    )
+    assert result == "OWNED"
+
+
+def test_this_host_wrong_nonce_is_foreign():
+    module = load_classifier()
+    result = module.classify_dashboard_argv(
+        this_host_args(nonce="fedcba9876543210"),
+        WRAPPER,
+        NONCE,
+        hermes_home=HERMES_HOME,
+        token_path=TOKEN,
+        profile=PROFILE,
+    )
+    assert result == "FOREIGN"
+
+
+def test_this_host_without_isolated_is_foreign():
+    module = load_classifier()
+    result = module.classify_dashboard_argv(
+        this_host_args(drop_isolated=True),
+        WRAPPER,
+        NONCE,
+        hermes_home=HERMES_HOME,
+        token_path=TOKEN,
+        profile=PROFILE,
+    )
+    assert result == "FOREIGN"
+
+
+def test_direct_hermes_path_is_owned():
+    module = load_classifier()
+    args = [WRAPPER, "--profile", PROFILE, "serve", "--isolated", "--ssh-owner-nonce", NONCE]
+    assert (
+        module.classify_dashboard_argv(
+            args, WRAPPER, NONCE, hermes_home=HERMES_HOME, profile=PROFILE
+        )
+        == "OWNED"
+    )
+
+
+def test_python_plus_hermes_path_is_owned():
+    module = load_classifier()
+    args = [
+        PYTHON,
+        WRAPPER,
+        "--profile",
+        PROFILE,
+        "serve",
+        "--isolated",
+        "--ssh-owner-nonce",
+        NONCE,
+    ]
+    assert (
+        module.classify_dashboard_argv(
+            args, WRAPPER, NONCE, hermes_home=HERMES_HOME, profile=PROFILE
+        )
+        == "OWNED"
+    )
+
+
+def test_wrapper_exec_targets_are_owned_without_spawn_proof(tmp_path: Path):
+    module = load_classifier()
+    wrapper = tmp_path / "hermes"
+    script = tmp_path / "custom-hermes"
+    script.write_text("# entry\n", encoding="utf-8")
+    wrapper.write_text(
+        f'#!/usr/bin/env bash\nexec "{PYTHON}" "{script}" "$@"\n',
+        encoding="utf-8",
+    )
+    wrapper.chmod(0o755)
+    args = [
+        PYTHON,
+        str(script),
+        "--profile",
+        PROFILE,
+        "serve",
+        "--isolated",
+        "--ssh-owner-nonce",
+        NONCE,
+    ]
+    assert (
+        module.classify_dashboard_argv(
+            args,
+            str(wrapper),
+            NONCE,
+            hermes_home="/unrelated/hermes-home",
+            profile=PROFILE,
+            allow_spawn_proof=False,
+        )
+        == "OWNED"
+    )
+
+
+def test_unrelated_python_is_foreign():
+    module = load_classifier()
+    args = [
+        "/usr/bin/python3",
+        "/opt/other/app.py",
+        "serve",
+        "--isolated",
+        "--ssh-owner-nonce",
+        NONCE,
+    ]
+    assert (
+        module.classify_dashboard_argv(
+            args, WRAPPER, NONCE, hermes_home=HERMES_HOME, profile=""
+        )
+        == "FOREIGN"
+    )
+
+
+def test_nonce_and_isolated_without_entry_or_spawn_proof_is_foreign():
+    module = load_classifier()
+    args = this_host_args()
+    assert (
+        module.classify_dashboard_argv(
+            args,
+            WRAPPER,
+            NONCE,
+            hermes_home="",
+            token_path="",
+            profile=PROFILE,
+            allow_spawn_proof=False,
+            include_repo_hermes_entry=False,
+            resolve_wrapper=False,
+        )
+        == "FOREIGN"
+    )
+
+
+def test_sabotage_dropping_repo_hermes_entry_fails_this_host_without_spawn_proof():
+    module = load_classifier()
+    result = module.classify_dashboard_argv(
+        this_host_args(),
+        WRAPPER,
+        NONCE,
+        hermes_home=HERMES_HOME,
+        token_path="",
+        profile=PROFILE,
+        allow_spawn_proof=False,
+        include_repo_hermes_entry=False,
+        resolve_wrapper=True,
+    )
+    assert result == "FOREIGN"
+
+
+def test_sabotage_dropping_only_wrapper_resolve_fails_wrapper_fixture(tmp_path: Path):
+    module = load_classifier()
+    wrapper = tmp_path / "hermes"
+    script = tmp_path / "custom-hermes"
+    script.write_text("# entry\n", encoding="utf-8")
+    wrapper.write_text(
+        f'#!/usr/bin/env bash\nexec "{PYTHON}" "{script}" "$@"\n',
+        encoding="utf-8",
+    )
+    args = [
+        PYTHON,
+        str(script),
+        "--profile",
+        PROFILE,
+        "serve",
+        "--isolated",
+        "--ssh-owner-nonce",
+        NONCE,
+    ]
+    result = module.classify_dashboard_argv(
+        args,
+        str(wrapper),
+        NONCE,
+        hermes_home="/unrelated/hermes-home",
+        profile=PROFILE,
+        allow_spawn_proof=False,
+        resolve_wrapper=False,
+    )
+    assert result == "FOREIGN"
+
+
+def test_existing_venv_entrypoint_stays_owned_without_new_repo_entry():
+    module = load_classifier()
+    args = [
+        PYTHON,
+        VENV_HERMES,
+        "--profile",
+        PROFILE,
+        "serve",
+        "--isolated",
+        "--ssh-owner-nonce",
+        NONCE,
+    ]
+    assert (
+        module.classify_dashboard_argv(
+            args,
+            WRAPPER,
+            NONCE,
+            hermes_home=HERMES_HOME,
+            profile=PROFILE,
+            allow_spawn_proof=False,
+            include_repo_hermes_entry=False,
+        )
+        == "OWNED"
+    )
+
+
+def test_spawn_proof_still_owns_this_host_when_new_entries_disabled():
+    module = load_classifier()
+    result = module.classify_dashboard_argv(
+        this_host_args(),
+        WRAPPER,
+        NONCE,
+        hermes_home=HERMES_HOME,
+        token_path=TOKEN,
+        profile=PROFILE,
+        allow_spawn_proof=True,
+        include_repo_hermes_entry=False,
+        resolve_wrapper=False,
+    )
+    assert result == "OWNED"
+
+
+def test_remote_lifecycle_embeds_classifier_source():
+    ts = (REPO_ROOT / "apps" / "desktop" / "electron" / "remote-lifecycle.ts").read_text(
+        encoding="utf-8"
+    )
+    py = CLASSIFIER_PATH.read_text(encoding="utf-8")
+    assert py in ts, "pidIsOurDashboard must embed ssh_pid_owned.py verbatim"


### PR DESCRIPTION
## Bug Description

Desktop SSH `setsid`-detaches `serve --isolated` on purpose. After `#74411`, `locateHermes` keeps the installer wrapper (`~/.local/bin/hermes`). The wrapper `exec`s `venv/bin/python` + `{hermesHome}/hermes-agent/hermes`, so live argv no longer matches the recorded `hermesPath`.

The running Desktop 4-arg checker (`direct || python_entry` vs `hermesPath`) then classifies that process **FOREIGN**. `cleanupStale` unlinks lock+log without kill. The next connect respawns. On one host this left 23 isolated serves / 22 deleted-log corpses.

`origin/main` already owns the same argv via `spawn_proof` (token path + nonce + profile). Its `python_entry` is still false: expected entries only add `{hermesHome}/hermes-agent/venv/bin/hermes`, not `{hermesHome}/hermes-agent/hermes`. Identification must not rest on a single untested pillar.

## Root Cause

1. Wrapper argv is python + repo `hermes`, not the launcher path and not the venv console script.
2. Classifier tests mocked the string `OWNED`/`FOREIGN` and never executed the predicate against this-host argv.
3. Isolated serve has no lock/log watchdog, so a FOREIGN drop on the Desktop client leaves a detached corpse.

## Fix

- Extract stdlib-only `classify_dashboard_argv` to `apps/desktop/electron/ssh_pid_owned.py`.
- `pidIsOurDashboard` embeds that exact source (packaged Desktop still ships one script). A test asserts embed == file.
- Keep `spawn_proof`. Add expected entries:
  - `{hermesHome}/hermes-agent/hermes`
  - wrapper `exec "python" "…/hermes"` targets parsed from a `#!` bash/sh `hermesPath`
- Do **not** accept nonce + `--isolated` with no entry match and no spawn_proof.
- Do **not** change `locateHermes` (wrapper stays the invocation path).
- `cleanupStale` still drops lock on FOREIGN+alive. OWNED + kill-fail still throws before drop (new pin).
- When `--ssh-owner-nonce` is set, `buildSpawnCommand` exports `HERMES_SSH_LOCKFILE` / `HERMES_SSH_LOGFILE`. Remote `serve` starts `serve-ssh-lock-watchdog`: wait for lock, then missing lock ×2 / nonce mismatch / log `st_nlink==0` → `os._exit(0)`. Unreadable lock keeps serving. No parent-pid, no age, no pkill.

## How to Verify

1. Old 4-arg rule vs this-host argv (python + `hermes-agent/hermes` + serve --isolated + nonce) is FOREIGN. Recorded in `tests/hermes_cli/test_ssh_pid_owned.py`.
2. Same fixture is OWNED on the new classifier with `allow_spawn_proof=False`.
3. Sabotage: drop only the new repo-hermes entry, spawn_proof off → this-host test fails (`FOREIGN`).
4. Watchdog fixtures: lock-gone after first sighting exits; nlink==0 exits; unreadable lock does not.
5. `vitest run --project electron electron/remote-lifecycle.test.ts` — 75 passed.

## Test Plan

- [x] Added executable classifier fixtures (no `/proc`, no mocked OWNED strings)
- [x] Recorded RED: this-host FOREIGN under old 4-arg
- [x] GREEN: this-host OWNED without spawn_proof
- [x] Sabotage: drop new entry → this-host GREEN test fails
- [x] Watchdog tests green
- [x] Existing `remote-lifecycle.test.ts` still green (75/75)
- [ ] CI on this PR (live checks, not hoped)

## Risk Assessment

Medium — identification + isolated-serve exit path.

- False OWNED would let Desktop SIGTERM a foreign process. Fail-closed: nonce+isolated alone is FOREIGN.
- False FOREIGN still drops lock (intentional, D5) and respawns; the watchdog is what stops a new corpse before the Electron client is rebuilt.
- Watchdog only arms when `--ssh-owner-nonce` is set.

Does not merge. Does not drain existing corpses. Desktop client must be rebuilt for the TS half (D8).
