### PR TITLE
fix(profiles): honor per-profile toolset pins and MCP disabled flag at runtime (#89441)

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -426,6 +426,15 @@ def is_enabled(name: str) -> bool:
     cfg = servers.get(name)
     if not cfg:
         return False
+    # ``profiles.configure`` persists per-profile MCP toggles via the
+    # per-server ``disabled`` key; honor it here so the catalog agrees with
+    # the runtime (#89441).
+    disabled = cfg.get("disabled", False)
+    if isinstance(disabled, str):
+        if disabled.lower() in {"true", "1", "yes"}:
+            return False
+    elif disabled:
+        return False
     enabled = cfg.get("enabled", True)
     if isinstance(enabled, str):
         return enabled.lower() in {"true", "1", "yes"}

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2287,8 +2287,10 @@ def enabled_mcp_server_names(config: dict) -> Set[str]:
     Shared by the gateway/CLI platform resolver (``_get_platform_tools``) and
     the cron per-job toolset resolver (``cron.scheduler``) so every path agrees
     on MCP membership. A server is enabled unless its config sets an explicitly
-    falsey ``enabled`` (per ``_parse_enabled_flag``: false/0/no/off) — a missing
-    flag or an unrecognized value is treated as enabled.
+    falsey ``enabled`` (per ``_parse_enabled_flag``: false/0/no/off) or a
+    truthy ``disabled`` — the per-server key ``profiles.configure`` persists
+    profile MCP toggles with (#89441). A missing flag or an unrecognized value
+    is treated as enabled.
 
     Portable Agent Plugins contribute MCP servers in-memory rather than via
     ``config.yaml`` (see ``PluginManager.get_portable_mcp_servers``). Those are
@@ -2302,6 +2304,7 @@ def enabled_mcp_server_names(config: dict) -> Set[str]:
         str(name)
         for name, server_cfg in mcp_servers.items()
         if isinstance(server_cfg, dict)
+        and not _parse_enabled_flag(server_cfg.get("disabled", False), default=False)
         and _parse_enabled_flag(server_cfg.get("enabled", True), default=True)
     }
     try:
@@ -2679,6 +2682,32 @@ def _get_platform_tools(
             name.strip() for name in parse_config_string_list(disabled_toolsets) if name.strip()
         }
         enabled_toolsets -= disabled_set
+
+    # Per-profile toolset pin (tools.enabled_toolsets, written by
+    # `profiles.configure` / the desktop Edit Profile dialog). When set it is
+    # RESTRICTIVE: the profile may only use the toolsets on its pin list, so
+    # intersect the runtime resolution with it. Only toolsets the profile
+    # editor can actually toggle (configurable + plugin) are in scope — MCP
+    # servers are governed by their own per-server enabled/disabled flags and
+    # non-configurable platform toolsets are not offerable in the editor, so
+    # both pass through the pin untouched. An absent/empty pin means an
+    # unpinned profile: current behavior unchanged (#89441). The value may
+    # arrive as a JSON-array string from `hermes config set`, mirroring the
+    # disabled_toolsets handling above.
+    tools_cfg = config.get("tools")
+    if isinstance(tools_cfg, dict):
+        pinned_raw = tools_cfg.get("enabled_toolsets")
+        if pinned_raw:
+            from agent.skill_utils import parse_config_string_list
+
+            pinned_set = {
+                name.strip() for name in parse_config_string_list(pinned_raw) if name.strip()
+            }
+            if pinned_set:
+                pin_scope = configurable_keys | plugin_ts_keys
+                enabled_toolsets = (
+                    enabled_toolsets - pin_scope
+                ) | (enabled_toolsets & pin_scope & pinned_set)
 
     # #38798: if this platform was explicitly configured but every toolset name
     # is invalid (e.g. a migration or hand-edit left `hermes` instead of

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -679,3 +679,52 @@ class TestShippedCatalog:
                     )
 
         assert not problems, "unpinned catalog entries:\n" + "\n".join(problems)
+
+
+# ---------------------------------------------------------------------------
+# is_enabled honors the per-server `disabled` key (#89441)
+# ---------------------------------------------------------------------------
+
+
+def _servers_with(**server_cfg) -> dict:
+    return {"srv": {"command": "npx", **server_cfg}}
+
+
+def test_is_enabled_disabled_true_off_without_enabled_key():
+    """profiles.configure persists per-profile MCP toggles via `disabled`; a
+    server with `disabled: true` (and no `enabled` key) must be OFF."""
+    import hermes_cli.mcp_catalog as mc
+
+    with patch.object(mc, "installed_servers", return_value=_servers_with(disabled=True)):
+        assert mc.is_enabled("srv") is False
+
+
+def test_is_enabled_disabled_string_true_off():
+    import hermes_cli.mcp_catalog as mc
+
+    with patch.object(mc, "installed_servers", return_value=_servers_with(disabled="true")):
+        assert mc.is_enabled("srv") is False
+
+
+def test_is_enabled_enabled_false_still_off():
+    """`enabled: false` keeps working — the new key is additive."""
+    import hermes_cli.mcp_catalog as mc
+
+    with patch.object(mc, "installed_servers", return_value=_servers_with(enabled=False)):
+        assert mc.is_enabled("srv") is False
+
+
+def test_is_enabled_no_flags_on():
+    import hermes_cli.mcp_catalog as mc
+
+    with patch.object(mc, "installed_servers", return_value=_servers_with()):
+        assert mc.is_enabled("srv") is True
+
+
+def test_is_enabled_disabled_false_and_enabled_true_on():
+    import hermes_cli.mcp_catalog as mc
+
+    with patch.object(
+        mc, "installed_servers", return_value=_servers_with(disabled=False, enabled=True)
+    ):
+        assert mc.is_enabled("srv") is True

--- a/tests/hermes_cli/test_mcp_tools_config.py
+++ b/tests/hermes_cli/test_mcp_tools_config.py
@@ -73,3 +73,20 @@ def test_empty_tools_server_skipped(capsys):
     assert len(checklist_calls) == 0
     captured = capsys.readouterr()
     assert "no tools found" in captured.out
+
+
+def test_server_enabled_honors_disabled_flag():
+    """#89441: the runtime MCP gates must treat `disabled: true` as OFF even
+    when `enabled` is unset (the per-server key profiles.configure writes),
+    and `enabled: false` must keep working."""
+    from tools.mcp_tool import _server_enabled
+
+    assert _server_enabled({"command": "npx"}) is True
+    assert _server_enabled({"command": "npx", "enabled": True}) is True
+    assert _server_enabled({"command": "npx", "disabled": False}) is True
+    assert _server_enabled({"command": "npx", "disabled": False, "enabled": True}) is True
+
+    assert _server_enabled({"command": "npx", "enabled": False}) is False
+    assert _server_enabled({"command": "npx", "disabled": True}) is False
+    assert _server_enabled({"command": "npx", "disabled": "true"}) is False
+    assert _server_enabled({"command": "npx", "enabled": True, "disabled": True}) is False

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1083,6 +1083,142 @@ def test_agent_disabled_toolsets_python_literal_string_form_still_wins():
     assert not (_RECENTLY_SHIPPED_TOOLSETS & enabled)
 
 
+# ── Per-profile toolset pin (tools.enabled_toolsets, #89441) ──────────────
+
+
+def _pin_candidates_for_cli() -> tuple:
+    """Configurable toolsets a default ``[hermes-cli]`` resolution enables."""
+    unpinned = _get_platform_tools(
+        {"platform_toolsets": {"cli": ["hermes-cli"]}},
+        "cli",
+        include_default_mcp_servers=False,
+    )
+    configurable = {k for k, _, _ in CONFIGURABLE_TOOLSETS}
+    candidates = sorted(unpinned & configurable)
+    assert candidates, "sanity: cli resolution contains configurable toolsets"
+    return candidates
+
+
+def test_tools_enabled_toolsets_pin_restricts_runtime_resolution():
+    """#89441: profiles.configure persists tools.enabled_toolsets, but the
+    runtime resolver ignored it. When the pin is set it must restrict the
+    resolution to the pinned configurable toolsets."""
+    pin_candidates = _pin_candidates_for_cli()
+    pinned = pin_candidates[: max(1, len(pin_candidates) - 1)]
+    dropped = set(pin_candidates) - set(pinned)
+    assert dropped, "sanity: pin drops at least one configurable toolset"
+
+    config = {"platform_toolsets": {"cli": ["hermes-cli"]}}
+    config["tools"] = {"enabled_toolsets": pinned}
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+
+    assert set(pinned) <= enabled
+    assert not (dropped & enabled)
+
+
+def test_tools_enabled_toolsets_pin_absent_keeps_behavior_unchanged():
+    """No pin (or an empty one — profiles.configure removes the key when the
+    list clears) means the profile is unpinned: resolution must be identical
+    to the pre-fix behavior."""
+    unpinned = _get_platform_tools(
+        {"platform_toolsets": {"cli": ["hermes-cli"]}},
+        "cli",
+        include_default_mcp_servers=False,
+    )
+    assert unpinned
+
+    for pin in (None, [], ""):
+        config = {"platform_toolsets": {"cli": ["hermes-cli"]}}
+        if pin is not None:
+            config["tools"] = {"enabled_toolsets": pin}
+        assert (
+            _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+            == unpinned
+        )
+
+
+def test_tools_enabled_toolsets_pin_json_array_string_form():
+    """The pin may arrive as a JSON-array string from `hermes config set`;
+    it must be parsed like agent.disabled_toolsets (#86661), not treated as
+    a single dead toolset name that filters nothing."""
+    import json as _json
+
+    pin_candidates = _pin_candidates_for_cli()
+    pinned = pin_candidates[: max(1, len(pin_candidates) - 1)]
+    dropped = set(pin_candidates) - set(pinned)
+
+    config = {"platform_toolsets": {"cli": ["hermes-cli"]}}
+    config["tools"] = {"enabled_toolsets": _json.dumps(pinned)}
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+
+    assert set(pinned) <= enabled
+    assert not (dropped & enabled)
+
+
+def test_tools_enabled_toolsets_pin_keeps_mcp_servers_and_platform_native():
+    """The pin only covers configurable + plugin toolsets — MCP servers
+    (governed by their own per-server enabled/disabled flags) and
+    non-configurable platform toolsets (kanban) must pass through a pinned
+    profile untouched, or pinning any toolset would silently kill every MCP
+    server for that profile."""
+    config = {
+        "platform_toolsets": {"cli": ["hermes-cli", "kanban"]},
+        "mcp_servers": {
+            "filesystem": {
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-filesystem"],
+            }
+        },
+        "tools": {"enabled_toolsets": ["terminal"]},
+    }
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=True)
+
+    assert "filesystem" in enabled
+    assert "kanban" in enabled
+    assert "terminal" in enabled
+
+
+def test_mcp_disabled_server_excluded_from_platform_resolution():
+    """#89441: profiles.configure persists per-profile MCP toggles via the
+    per-server ``disabled`` key; runtime resolution must not include the
+    tools of a server toggled off that way (and ``enabled: false`` must
+    keep working)."""
+    config = {
+        "platform_toolsets": {"cli": ["hermes-cli"]},
+        "mcp_servers": {
+            "filesystem": {"command": "npx"},
+            "gitlab": {"command": "npx", "disabled": True},
+            "legacy-off": {"command": "npx", "enabled": False},
+        },
+    }
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=True)
+
+    assert "filesystem" in enabled
+    assert "gitlab" not in enabled
+    assert "legacy-off" not in enabled
+
+
+def test_enabled_mcp_server_names_honors_disabled_flag():
+    """The shared MCP membership resolver must agree with the catalog: a
+    server with ``disabled: true`` and no ``enabled`` key is OFF."""
+    from hermes_cli.tools_config import enabled_mcp_server_names
+
+    names = enabled_mcp_server_names(
+        {
+            "mcp_servers": {
+                "off-server": {"command": "npx", "disabled": True},
+                "off-string": {"command": "npx", "disabled": "true"},
+                "on-server": {"command": "npx"},
+                "on-explicit": {"command": "npx", "enabled": True},
+                "legacy-off": {"command": "npx", "enabled": False},
+            }
+        }
+    )
+
+    assert {"on-server", "on-explicit"} <= names
+    assert not ({"off-server", "off-string", "legacy-off"} & names)
+
+
 @_requires_recently_shipped
 def test_platforms_whose_composite_excludes_it_are_left_narrow():
     """Parity is the justification, so don't widen a deliberately small

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6557,6 +6557,20 @@ def _parse_boolish(value: Any, default: bool = True) -> bool:
     return default
 
 
+def _server_enabled(cfg: dict) -> bool:
+    """Whether a configured MCP server is enabled.
+
+    Honours both ``enabled`` and ``disabled``: the server is ON only when
+    ``enabled`` is truthy (default) AND ``disabled`` is not truthy.
+    ``profiles.configure`` persists per-profile MCP toggles via the
+    per-server ``disabled`` key, so every runtime gate must consult it or
+    the toggle is describe-visible only (#89441).
+    """
+    if _parse_boolish(cfg.get("disabled", False), default=False):
+        return False
+    return _parse_boolish(cfg.get("enabled", True), default=True)
+
+
 def _get_lifecycle_seconds(config: dict, key: str) -> Optional[float]:
     """Return an optional positive lifecycle timeout from top-level/nested config."""
     raw = config.get(key)
@@ -7203,7 +7217,7 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
             # Servers already lazily registered from the schema cache are
             # not re-registered; they connect on first tool use (#56832).
             and k not in _lazy_server_configs
-            and _parse_boolish(v.get("enabled", True), default=True)
+            and _server_enabled(v)
             # Skip a server still serving its post-failure backoff. Without
             # this, a server that fails to connect (and is therefore never
             # recorded in ``_servers``) would be re-spawned on every worker
@@ -7437,7 +7451,7 @@ def discover_mcp_tools() -> List[str]:
                 for name, cfg in servers.items()
                 if name not in _servers
                 and name not in connecting
-                and _parse_boolish(cfg.get("enabled", True), default=True)
+                and _server_enabled(cfg)
             ]
 
         tool_names = register_mcp_servers(servers)
@@ -7508,7 +7522,7 @@ def get_mcp_status() -> List[dict]:
 
     for name, cfg in configured.items():
         transport = cfg.get("transport", "http") if "url" in cfg else "stdio"
-        enabled = _parse_boolish(cfg.get("enabled", True), default=True)
+        enabled = _server_enabled(cfg)
         server = active_servers.get(name)
         if server and server.session is not None:
             entry = {
@@ -7586,7 +7600,7 @@ def probe_mcp_server_tools() -> Dict[str, List[tuple]]:
 
     enabled = {
         k: v for k, v in servers_config.items()
-        if _parse_boolish(v.get("enabled", True), default=True)
+        if _server_enabled(v)
     }
     if not enabled:
         return {}


### PR DESCRIPTION
## Summary
`profiles.configure` persists per-profile toolset pins (`tools.enabled_toolsets`) and per-server MCP `disabled` flags, and `profiles.describe` reads them back — but the runtime never consults either, so the UI shows the state the user chose while the bot's actual toolset ignores it (and the capability fingerprint still bumps, making the symptom read as "I turned off a toolset and the bot still used it").

## Root Cause
- **Toolsets:** runtime toolset resolution (`_get_platform_tools` in `hermes_cli/tools_config.py`) resolves purely from `platform_toolsets.<platform>` + `agent.disabled_toolsets`. The `tools.enabled_toolsets` key written by `profiles.configure` has exactly two readers: `profiles.describe` and the bot-mode capability fingerprint — never the resolver. All runtime callers (`gateway/run.py::_resolve_enabled_toolsets_for_source`, `gateway/platforms/api_server.py`) inherit the gap through `_get_platform_tools`.
- **MCP servers:** `hermes_cli/mcp_catalog.py::is_enabled`, `enabled_mcp_server_names`, and the four runtime gates in `tools/mcp_tool.py` (connection filter, discovery filter, status banner, schema probe) all read only `enabled`. The per-server `disabled` key written by `profiles.configure` is describe-visible only.

## Change
- `hermes_cli/tools_config.py::_get_platform_tools`: after `agent.disabled_toolsets` handling, when `tools.enabled_toolsets` is set (non-empty list; JSON-array-string form parsed like #86661), the resolved set is intersected with the pin — scoped to the pin-able universe (`configurable_keys | plugin keys`, i.e. exactly what the profile editor offers). MCP server names and non-configurable platform toolsets pass through untouched, so pinning a toolset can't silently kill MCP tools. Absent/empty pin keeps byte-identical pre-fix behavior.
- `hermes_cli/mcp_catalog.py::is_enabled` + `enabled_mcp_server_names`: a server is now OFF when `disabled` is truthy (bool or string `"true"/"1"/"yes"`) even without an explicit `enabled` key.
- `tools/mcp_tool.py`: new shared `_server_enabled(cfg)` helper (`enabled` truthy AND `disabled` not truthy) used at all four gates; `enabled: false` semantics unchanged.

## Verification
- 12 new tests (tools_config ×6, mcp_catalog ×5, mcp_tools_config ×1) plus existing coverage:
  - `test_tools_config.py` + `test_mcp_catalog.py` + `test_mcp_tools_config.py`: **89 passed / 0 failed**
  - `tests/tools/test_mcp_tool.py` + `test_mcp_probe.py`: **100 passed / 0 failed**
  - `test_setup_blank_slate.py` + `test_config_set_list_values.py`: **16 passed**
  - `test_tui_gateway_server.py -k profile`: **24 passed**
  - `test_mcp_startup` + `test_mcp_security` + `test_mcp_discovery_timing`: **19 passed**
  - Total across all focused runs: **310 passed / 0 failed**
- Manual end-to-end: pinned profile resolves only pinned toolsets, keeps `filesystem` MCP server, drops a `disabled: true` server; empty pin ≡ unpinned.

## Notes
- The pin is restrictive-only: it can remove toolsets a platform would enable, but cannot add one the platform resolution never enables (that remains `hermes tools`' job) — documented in the code comment.

Closes #89441
