### PR TITLE
fix(gateway): notify sessions of recovery in the same chat/thread that got the shutdown ping (#89396)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1924,6 +1924,18 @@ def _clear_planned_restart_notification() -> None:
     _planned_restart_notification_path().unlink(missing_ok=True)
 
 
+def _session_recovery_notification_path() -> Path:
+    """Marker listing chats/threads that were told the gateway was going down.
+
+    Written by ``_notify_active_sessions_of_shutdown`` (per active session,
+    including threads that are not home channels) and consumed on the next
+    boot by ``_send_session_recovery_notifications`` so every chat/thread
+    that received the shutdown announcement also receives the 'gateway is
+    back' announcement in the same chat/thread (#89396).
+    """
+    return _hermes_home / ".session_recovery_notify.json"
+
+
 # Mark this process as a gateway so cli.py's module-level load_cli_config()
 # knows not to clobber TERMINAL_CWD if lazily imported.
 os.environ["_HERMES_GATEWAY"] = "1"
@@ -10562,15 +10574,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         restart_source = self._restart_command_source if self._restart_requested else None
 
         action = "restarting" if self._restart_requested else "shutting down"
+        # The resume instruction is NOT conditional on the restart branch:
+        # a drain-timeout force-restart (launchd/systemd) or a plain stop
+        # followed by a service-manager restart both land in the
+        # non-restart branch, and the resume machinery runs on the next
+        # boot for both — so the user must know a follow-up message will
+        # resume the interrupted task either way. Previously the
+        # non-restart hint read as terminal, giving the user no reason to
+        # send that follow-up message (#89396).
         hint = (
             "Your current task will be interrupted. "
             "Send any message after restart and I'll try to resume where you left off."
             if self._restart_requested
-            else "Your current task will be interrupted."
+            else (
+                "Your current task will be interrupted. "
+                "Send any message once the gateway is back and I'll try to resume where you left off."
+            )
         )
         msg = f"⚠️ Gateway {action} — {hint}"
 
         notified: set[tuple[str, str, Optional[str]]] = set()
+        # Targets delivered into active sessions' own chats/threads — the
+        # recovery scope for the next boot (#89396).
+        session_notified: set[tuple[str, str, Optional[str]]] = set()
+        session_chat_types: Dict[tuple[str, str, Optional[str]], Optional[str]] = {}
         for session_key in active:
             source = None
             try:
@@ -10634,11 +10661,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     except Exception:
                         pass
 
+                session_chat_type = (
+                    getattr(source, "chat_type", None) if source is not None else None
+                )
                 metadata = self._thread_metadata_for_target(
                     platform,
                     chat_id,
                     thread_id,
-                    chat_type=getattr(source, "chat_type", None) if source is not None else None,
+                    chat_type=session_chat_type,
                     reply_to_message_id=reply_to_message_id,
                     adapter=adapter,
                 )
@@ -10654,6 +10684,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     continue
 
                 notified.add(dedup_key)
+                session_notified.add(dedup_key)
+                session_chat_types[dedup_key] = session_chat_type
                 logger.info(
                     "Sent shutdown notification to active chat %s:%s",
                     platform_str, chat_id,
@@ -10663,6 +10695,38 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "Failed to send shutdown notification to %s:%s: %s",
                     platform_str, chat_id, e,
                 )
+
+        # Persist the per-session targets so the next boot tells the SAME
+        # chats/threads the gateway is back (#89396). Written before the
+        # early returns below so every shutdown flavor (in-chat restart,
+        # drain-suppressed, forced restart) records what was announced.
+        # Best-effort: a lost marker only means a thread isn't told it's
+        # back, and it must never block the shutdown sequence.
+        if session_notified:
+            try:
+                atomic_json_write(
+                    _session_recovery_notification_path(),
+                    {
+                        "shutdown_at": time.time(),
+                        "action": action,
+                        "targets": [
+                            {
+                                "platform": p,
+                                "chat_id": c,
+                                "thread_id": t,
+                                "chat_type": session_chat_types.get((p, c, t)),
+                            }
+                            for (p, c, t) in sorted(session_notified)
+                        ],
+                    },
+                    indent=None,
+                )
+                logger.info(
+                    "Persisted %d session recovery target(s) for next boot",
+                    len(session_notified),
+                )
+            except Exception as e:
+                logger.debug("Failed to persist session recovery marker: %s", e)
 
         if self._restart_requested and restart_source is not None:
             logger.debug("Skipping home-channel shutdown notifications for in-chat restart")
@@ -12979,6 +13043,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
             finally:
                 _clear_planned_restart_notification()
+
+        # Tell every session that was told the gateway was going down that it
+        # is back — mirrors the per-session scope of the shutdown announcement
+        # (#89396). Threads that are not home channels never see the
+        # home-channel broadcast; the marker written at shutdown lists exactly
+        # the chats/threads that received the shutdown ping.
+        await self._send_session_recovery_notifications()
 
         # Automatically continue fresh sessions that were interrupted by the
         # previous gateway restart/shutdown.  The resume_pending flag is cleared
@@ -23971,6 +24042,124 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     exc,
                 )
 
+        return delivered
+
+    async def _send_session_recovery_notifications(self) -> set[tuple[str, str, Optional[str]]]:
+        """Tell every shutdown-notified session that the gateway is back.
+
+        Mirrors the per-session scope of ``_notify_active_sessions_of_shutdown``
+        (#89396): the shutdown announcement went into each active session's own
+        chat/thread, so the recovery announcement must too — a thread that is
+        not the platform home channel would otherwise never hear that the
+        gateway came back. The marker written at shutdown lists exactly the
+        chats/threads that received the shutdown ping.
+
+        Targets answered by a more specific delivery on this boot are skipped
+        so no chat gets the same news twice:
+        - the chat that initiated /restart (``.restart_notify.json``) — it
+          gets a precise reply from ``_send_restart_notification``;
+        - home channels on a planned restart — they get the broadcast from
+          ``_send_home_channel_startup_notifications``.
+
+        Best-effort like the shutdown side: send failures are logged and
+        swallowed; the marker is consumed regardless.
+        """
+        marker_path = _session_recovery_notification_path()
+        if not marker_path.exists():
+            return set()
+        try:
+            data = json.loads(marker_path.read_text(encoding="utf-8"))
+        except Exception as e:
+            logger.warning(
+                "Failed to read session recovery marker %s: %s", marker_path, e
+            )
+            marker_path.unlink(missing_ok=True)
+            return set()
+
+        message = "♻️ Gateway online — Hermes is back and ready."
+        delivered: set[tuple[str, str, Optional[str]]] = set()
+        skipped: set[tuple[str, str, Optional[str]]] = set()
+
+        try:
+            # The /restart initiator is answered by _send_restart_notification.
+            restart_path = _hermes_home / ".restart_notify.json"
+            if restart_path.exists():
+                restart_data = json.loads(restart_path.read_text(encoding="utf-8"))
+                if restart_data.get("platform") and restart_data.get("chat_id"):
+                    skipped.add(
+                        (
+                            restart_data["platform"],
+                            str(restart_data["chat_id"]),
+                            str(restart_data["thread_id"])
+                            if restart_data.get("thread_id")
+                            else None,
+                        )
+                    )
+            # Home channels get the planned-restart broadcast.
+            if _planned_restart_notification_pending():
+                for platform, platform_cfg in self.config.platforms.items():
+                    home = platform_cfg.home_channel
+                    if home and home.chat_id:
+                        skipped.add(
+                            (
+                                platform.value,
+                                str(home.chat_id),
+                                str(home.thread_id) if home.thread_id else None,
+                            )
+                        )
+        except Exception:
+            # Dedup is best-effort; the worst case is a duplicate message.
+            logger.debug("Session recovery dedup scan failed", exc_info=True)
+
+        for entry in data.get("targets") or []:
+            platform_str = entry.get("platform")
+            chat_id = entry.get("chat_id")
+            if not platform_str or not chat_id:
+                continue
+            thread_id = entry.get("thread_id")
+            target = (platform_str, str(chat_id), str(thread_id) if thread_id else None)
+            if target in skipped or target in delivered:
+                continue
+            try:
+                platform = Platform(platform_str)
+                adapter = self.adapters.get(platform)
+                if not adapter:
+                    continue
+                platform_cfg = self.config.platforms.get(platform)
+                if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
+                    logger.info(
+                        "Session recovery notification suppressed: %s has gateway_restart_notification=false",
+                        platform_str,
+                    )
+                    continue
+                metadata = self._thread_metadata_for_target(
+                    platform,
+                    chat_id,
+                    thread_id,
+                    chat_type=entry.get("chat_type"),
+                    adapter=adapter,
+                )
+                result = await adapter.send(chat_id, message, metadata=metadata)
+                if result is not None and getattr(result, "success", True) is False:
+                    logger.warning(
+                        "Session recovery notification to %s:%s was not delivered: %s",
+                        platform_str,
+                        chat_id,
+                        getattr(result, "error", "send returned success=False"),
+                    )
+                    continue
+                delivered.add(target)
+                logger.info(
+                    "Sent session recovery notification to %s:%s",
+                    platform_str, chat_id,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Session recovery notification to %s:%s failed: %s",
+                    platform_str, chat_id, e,
+                )
+
+        marker_path.unlink(missing_ok=True)
         return delivered
 
     async def _send_session_db_warning_notifications(self) -> None:

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -387,7 +387,8 @@ async def test_shutdown_notifications_use_cached_live_thread_source_when_origin_
 
     adapter.send.assert_awaited_once_with(
         "parent-42",
-        "⚠️ Gateway shutting down — Your current task will be interrupted.",
+        "⚠️ Gateway shutting down — Your current task will be interrupted. "
+        "Send any message once the gateway is back and I'll try to resume where you left off.",
         metadata={"thread_id": "topic-7"},
     )
 
@@ -413,3 +414,161 @@ async def test_shutdown_notifications_are_fully_muted_when_flag_disabled():
     adapter.send.assert_not_awaited()
 
 
+# ── per-session recovery notifications (#89396) ─────────────────────────
+#
+# Shutdown is announced per active session (into each chat/thread); recovery
+# must mirror that scope instead of only reaching home channels.
+
+
+@pytest.mark.asyncio
+async def test_shutdown_persists_recovery_marker_for_active_session_thread(
+    tmp_path, monkeypatch
+):
+    """The shutdown ping into a non-home thread is recorded for the next boot."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="parent-42", chat_type="group", thread_id="topic-7")
+    session_key = build_session_key(source)
+    runner._running_agents[session_key] = object()
+    runner.session_store._entries[session_key] = MagicMock(origin=source)
+    runner._cache_session_source(session_key, source)
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="shutdown"))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    marker = tmp_path / ".session_recovery_notify.json"
+    assert marker.exists()
+    data = json.loads(marker.read_text())
+    assert data["targets"] == [
+        {
+            "platform": "telegram",
+            "chat_id": "parent-42",
+            "thread_id": "topic-7",
+            "chat_type": "group",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_recovery_mirrors_shutdown_scope_for_non_home_threads(tmp_path, monkeypatch):
+    """Every chat/thread told 'shutting down' is told 'back online' on next boot."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="m"))
+
+    thread_source = make_restart_source(chat_id="parent-42", chat_type="group", thread_id="topic-7")
+    home_source = make_restart_source(chat_id="home-42", chat_type="dm")
+    for src in (thread_source, home_source):
+        key = build_session_key(src)
+        runner._running_agents[key] = object()
+        runner.session_store._entries[key] = MagicMock(origin=src)
+        runner._cache_session_source(key, src)
+
+    await runner._notify_active_sessions_of_shutdown()
+    shutdown_chats = {call.args[0] for call in adapter.send.await_args_list}
+    assert shutdown_chats == {"parent-42", "home-42"}
+
+    # Next boot: recovery reaches the same chats (thread included). The home
+    # channel is reached too here because no planned-restart broadcast marker
+    # exists — the plain-stop scenario the issue calls out.
+    adapter.send.reset_mock()
+    delivered = await runner._send_session_recovery_notifications()
+
+    assert delivered == {
+        ("telegram", "parent-42", "topic-7"),
+        ("telegram", "home-42", None),
+    }
+    thread_sends = [
+        call for call in adapter.send.await_args_list if call.args[0] == "parent-42"
+    ]
+    assert len(thread_sends) == 1
+    assert thread_sends[0].args[1] == "♻️ Gateway online — Hermes is back and ready."
+    assert thread_sends[0].kwargs["metadata"] == {"thread_id": "topic-7"}
+    assert not (tmp_path / ".session_recovery_notify.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_session_recovery_skips_home_channel_and_restart_initiator(tmp_path, monkeypatch):
+    """Recovery must not double-deliver to targets answered by other notifications."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="back"))
+    marker = tmp_path / ".session_recovery_notify.json"
+    marker.write_text(
+        json.dumps(
+            {
+                "targets": [
+                    # Home channel that was also an active session: the
+                    # planned-restart broadcast answers it.
+                    {"platform": "telegram", "chat_id": "home-42", "thread_id": None},
+                    # /restart initiator: _send_restart_notification answers it.
+                    {
+                        "platform": "telegram",
+                        "chat_id": "restart-chat",
+                        "thread_id": "topic-9",
+                    },
+                    # Plain thread: only recovery reaches it.
+                    {
+                        "platform": "telegram",
+                        "chat_id": "plain-thread",
+                        "thread_id": "topic-1",
+                    },
+                ]
+            }
+        )
+    )
+    (tmp_path / ".restart_notify.json").write_text(
+        json.dumps({"platform": "telegram", "chat_id": "restart-chat", "thread_id": "topic-9"})
+    )
+    (tmp_path / ".restart_pending.json").write_text("{}")
+
+    delivered = await runner._send_session_recovery_notifications()
+
+    assert delivered == {("telegram", "plain-thread", "topic-1")}
+    adapter.send.assert_awaited_once()
+    assert adapter.send.await_args.args[:2] == (
+        "plain-thread",
+        "♻️ Gateway online — Hermes is back and ready.",
+    )
+    assert not marker.exists()
+
+
+@pytest.mark.asyncio
+async def test_session_recovery_respects_gateway_restart_notification_flag(
+    tmp_path, monkeypatch
+):
+    """A platform with gateway_restart_notification=false gets no recovery pings."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification = False
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="back"))
+    marker = tmp_path / ".session_recovery_notify.json"
+    marker.write_text(
+        json.dumps(
+            {
+                "targets": [
+                    {"platform": "telegram", "chat_id": "parent-42", "thread_id": "topic-7"},
+                ]
+            }
+        )
+    )
+
+    delivered = await runner._send_session_recovery_notifications()
+
+    assert delivered == set()
+    adapter.send.assert_not_awaited()
+    assert not marker.exists()


### PR DESCRIPTION
## Summary
Shutdown notifications are delivered **per active session** (into the exact chat/thread the user was talking in), but the "back online" recovery notification is delivered **per home channel only**. A thread that is not the home channel gets told the gateway went down and is never told it came back — the conversation simply ends with a warning and no resolution.

## Root Cause
- `_notify_active_sessions_of_shutdown()` iterates `_snapshot_running_agents()`, resolves each session's origin, and delivers the shutdown message into that session's own chat/thread.
- `_send_home_channel_startup_notifications()` iterates configured platform home channels instead — a different iteration source, so a different recipient set. No mechanism records which sessions were told about the shutdown, so recovery can't mirror the shutdown scope.

## Change
- `gateway/run.py`:
  - New marker file `~/.hermes/.session_recovery_notify.json` written by `_notify_active_sessions_of_shutdown()` **before** its early returns (in-chat restart, drain-suppressed, and forced-restart branches all covered) — best-effort, never blocks shutdown. Records the dedup-key targets actually delivered per-session plus per-target chat type.
  - New `_send_session_recovery_notifications()`: on next boot, sends `"♻️ Gateway online — Hermes is back and ready."` to every recorded session target in the same chat/thread, re-checking the `gateway_restart_notification` config gate and mirroring shutdown-side send semantics (`_thread_metadata_for_target` + `adapter.send`). Dedups against targets already answered on this boot (the `/restart` initiator via `.restart_notify.json`; home channels when a planned-restart broadcast is pending via `.restart_pending.json`). The marker is consumed regardless, even when malformed.
  - `_start()` calls `_send_session_recovery_notifications()` right after the home-channel broadcast block.
  - Secondary fix from the issue: the non-restart shutdown hint now includes the resume instruction (`"…Send any message once the gateway is back and I'll try to resume where you left off."`), covering the drain-timeout → launchd force-restart path that previously presented a deliberate, recoverable restart as an unexplained termination. The restart-branch wording is kept byte-identical (pinned by `test_restart_resume_pending.py`).

## Verification
- New tests in `tests/gateway/test_restart_notification.py`: shutdown persists a recovery marker for an active session thread; recovery mirrors shutdown scope for non-home threads (shutdown-set == recovery-set invariant, thread metadata preserved); recovery skips home channel and restart initiator (no double-delivery); recovery respects the `gateway_restart_notification` flag.
- `test_restart_notification.py` + `test_gateway_shutdown.py`: **25 passed**
- `test_shutdown_cache_cleanup.py` + `test_cron_interrupt_notification.py` + `test_restart_resume_pending.py` + `test_startup_restart_race.py`: **45 passed**
- `py_compile gateway/run.py`: OK

## Notes
- Marker is consumed on the next boot, matching existing `.restart_notify.json` semantics. Crash path: no shutdown notification → no marker → no recovery (unchanged, correct).
- Relay-fronted platforms: shutdown-side pings never reach relay-fronted sessions today (pre-existing `self.adapters.get(platform)` limitation), so recovery inherits the same scope — recovery send mirrors shutdown-side semantics rather than the transport/relay path used by the home-channel broadcast.

Closes #89396
