### PR TITLE
fix(desktop): collapse the docked Bots tab with the sessions sidebar on narrow viewports

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.test.tsx
@@ -1,0 +1,99 @@
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { PANE_TOGGLE_REVEAL_EVENT } from '@/components/pane-shell'
+import { registry } from '@/contrib/registry'
+
+import { group, split } from '../model'
+import { $hiddenTreePanes, $layoutTree, $narrowViewport, declareDefaultTree } from '../store'
+
+import { NarrowOverlays } from './narrow-overlays'
+
+// Ground truth for "the Bots tab is still visible when the sessions sidebar
+// collapses on a narrow window". A collapsible pane DOCKED into the sessions
+// zone (SESSIONS | BOTS) must leave the grid with the zone, and the narrow
+// edge overlay must mirror the zone's tab strip so the docked pane stays
+// reachable — not just the zone's first pane.
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  vi.stubGlobal('ResizeObserver', TestResizeObserver)
+})
+
+const disposers: (() => void)[] = []
+
+const registerPane = (id: string, title: string, data: Record<string, unknown>, body: string) => {
+  disposers.push(
+    registry.register({
+      area: 'panes',
+      data,
+      id,
+      render: () => <div data-testid={`${id}-body`}>{body}</div>,
+      title
+    })
+  )
+}
+
+beforeEach(() => {
+  window.localStorage.clear()
+  $hiddenTreePanes.set(new Set())
+
+  registerPane('sessions', 'sessions', { collapsible: true, placement: 'left', width: '237px' }, 'session rows')
+  registerPane('bots', 'Bots', { collapsible: true, placement: 'left', width: '260px' }, 'bot roster')
+  registerPane('workspace', 'workspace', { placement: 'main', uncloseable: true }, 'chat')
+
+  declareDefaultTree(split('row', [group(['sessions', 'bots']), group(['workspace'])]))
+  $narrowViewport.set(true)
+})
+
+afterEach(() => {
+  cleanup()
+  $narrowViewport.set(false)
+  $layoutTree.set(null)
+  disposers.splice(0).forEach(dispose => dispose())
+})
+
+const revealPane = (id: string) => {
+  act(() => {
+    window.dispatchEvent(new CustomEvent(PANE_TOGGLE_REVEAL_EVENT, { detail: { id, mode: 'open' } }))
+  })
+}
+
+const overlayTab = (paneId: string) => document.querySelector<HTMLElement>(`[data-narrow-overlay-tab="${paneId}"]`)
+
+describe('narrow overlay of a stacked zone', () => {
+  it('mirrors the zone tab strip so every stacked collapsible stays reachable', () => {
+    const { getByTestId, queryByTestId } = render(<NarrowOverlays />)
+
+    revealPane('sessions')
+
+    // Both zone-mates surface as tabs; the revealed pane's body is on screen.
+    expect(overlayTab('sessions')).toBeTruthy()
+    expect(overlayTab('bots')).toBeTruthy()
+    expect(getByTestId('sessions-body')).toBeTruthy()
+    expect(queryByTestId('bots-body')).toBeNull()
+
+    // Clicking the BOTS tab swaps the overlay to the docked pane.
+    fireEvent.pointerDown(overlayTab('bots')!, { button: 0 })
+    expect(getByTestId('bots-body')).toBeTruthy()
+    expect(queryByTestId('sessions-body')).toBeNull()
+  })
+
+  it('keeps the stripless form for a zone with a single collapsible', () => {
+    // Direct set: declareDefaultTree only ADOPTS into an existing tree — it
+    // would keep the beforeEach zone (with bots) instead of replacing it.
+    $layoutTree.set(split('row', [group(['sessions']), group(['workspace'])]))
+
+    const { getByTestId } = render(<NarrowOverlays />)
+
+    revealPane('sessions')
+
+    expect(getByTestId('sessions-body')).toBeTruthy()
+    expect(overlayTab('sessions')).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.tsx
@@ -9,6 +9,7 @@
 import { useStore } from '@nanostores/react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 
+import { PaneTab, PaneTabLabel, PaneTabStrip } from '@/components/ui/pane-tab'
 import { ContribBoundary, ContribRender } from '@/contrib/react/boundary'
 import { useContributions } from '@/contrib/react/use-contributions'
 import type { Contribution } from '@/contrib/types'
@@ -16,7 +17,7 @@ import { ESCAPE_PRIORITY, isTopEscapeLayer, pushEscapeLayer } from '@/lib/escape
 import { cn } from '@/lib/utils'
 
 import { PANE_TOGGLE_REVEAL_EVENT } from '../..'
-import { allPaneIds } from '../model'
+import { allPaneIds, findGroupOfPane } from '../model'
 import { $hiddenTreePanes, $layoutTree, $narrowViewport } from '../store'
 
 import { paneChrome } from './track-model'
@@ -108,6 +109,22 @@ export function NarrowOverlays() {
   const revealed = reveal ? collapsibles.find(p => p.id === reveal.id) : undefined
   const sides = [...new Set(collapsibles.map(sideOf))]
 
+  // The revealed pane's ZONE-mates that also left the grid (the sessions zone
+  // stacks SESSIONS | BOTS): the overlay mirrors the zone's tab strip so a
+  // pane docked into a collapsed zone stays reachable on narrow viewports —
+  // without this, only the zone's first pane ever surfaces again.
+  const zonePanes = (() => {
+    if (!revealed || !tree) {
+      return [revealed].filter((p): p is Contribution => Boolean(p))
+    }
+
+    const zone = findGroupOfPane(tree, revealed.id)
+    const mates = zone ? zone.panes.map(id => collapsibles.find(p => p.id === id)) : []
+    const shown = mates.filter((p): p is Contribution => Boolean(p))
+
+    return shown.length > 0 ? shown : [revealed]
+  })()
+
   return (
     <>
       {/* Hover-intent strips on each edge that has a collapsed pane. */}
@@ -138,6 +155,28 @@ export function NarrowOverlays() {
           // width) instead of a fat fixed 20rem — capped for tiny screens.
           style={{ width: `min(${(revealed.data as { width?: string } | undefined)?.width ?? '18rem'}, 85vw)` }}
         >
+          {/* Zone-mates share the overlay through the zone's own tab strip
+              (SESSIONS | BOTS) — a lone pane keeps the stripless form. */}
+          {zonePanes.length > 1 && (
+            <PaneTabStrip>
+              {zonePanes.map(pane => (
+                <PaneTab
+                  active={pane.id === revealed.id}
+                  aria-selected={pane.id === revealed.id}
+                  data-narrow-overlay-tab={pane.id}
+                  key={pane.id}
+                  onPointerDown={event => {
+                    if (event.button === 0) {
+                      event.preventDefault()
+                      setReveal(current => ({ id: pane.id, pinned: current?.pinned ?? false }))
+                    }
+                  }}
+                >
+                  <PaneTabLabel>{pane.title ?? pane.id}</PaneTabLabel>
+                </PaneTab>
+              ))}
+            </PaneTabStrip>
+          )}
           <ContribBoundary id={revealed.id}>
             {revealed.render && <ContribRender render={revealed.render} />}
           </ContribBoundary>

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -9366,7 +9366,12 @@ export default {
       // An intra-session drag still sticks until the next launch (the
       // invariant runs at adoption time only — see enforceDockedPanes in the
       // tree store).
-      data: { placement: 'left', width: '260px', dock: { pane: 'sessions', pos: 'center', enforce: true } },
+      // collapsible: the pane lives in the sessions zone, so it must LEAVE
+      // the grid with that zone below the sidebar-collapse breakpoint. The
+      // sessions pane collapses alone without this flag. The zone then keeps
+      // a stranded BOTS tab on screen. The narrow edge overlay mirrors the
+      // zone's tab strip, so the pane stays reachable while collapsed.
+      data: { placement: 'left', width: '260px', collapsible: true, dock: { pane: 'sessions', pos: 'center', enforce: true } },
       render: () => jsx(BotsPane, {})
     })
 


### PR DESCRIPTION
## What does this PR do?

On a narrow window, the sessions sidebar collapses, but the "Bots" tab stays on screen. This PR makes the Bots pane collapse with the sidebar. It also keeps the pane reachable after the collapse.

The Bots pane docks into the sessions zone as a SESSIONS | BOTS tab strip. The pane did not declare `collapsible: true`. Below the collapse breakpoint, `paneGone` (`tree-split.tsx:126`) removes only collapsible panes from the grid. The sessions pane left the grid, and the zone kept a stranded BOTS tab.

The flag alone is not sufficient. The narrow edge overlay rendered only one pane, so a collapsed Bots pane became unreachable. The overlay now mirrors the tab strip of the zone when the revealed pane has collapsed zone-mates. A lone pane keeps the stripless overlay form.

## Related Issue

No issue exists for this defect. Ethie reported it directly.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.js` — the Bots pane contribution declares `collapsible: true`.
- `apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.tsx` — the overlay finds the zone of the revealed pane with `findGroupOfPane`. If the zone holds more than one collapsed pane, the overlay renders the zone tabs with `PaneTabStrip` and `PaneTab`. A click on a tab swaps the revealed pane.
- `apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.test.tsx` — new tests that render the real overlay component.

## How to Test

1. Open the desktop app with the hermes-bots plugin enabled.
2. Make the window narrower than the sidebar-collapse breakpoint.
3. Make sure that the BOTS tab is not on screen.
4. Move the pointer to the left edge.
5. Make sure that the overlay shows the SESSIONS | BOTS tab strip.
6. Click the BOTS tab. The overlay shows the bot roster.

Automated proof:

- `npx vitest run src/components/pane-shell` — 118 tests pass, including the 2 new overlay tests.
- `node --test "apps/desktop/src/plugins/hermes-bots/tests/*.test.mjs"` — 270 tests pass.
- `npm run typecheck` — clean on all three tsconfigs.
- `npx eslint` on the touched files — clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the JS test suites for the touched areas and all tests pass (Python tests are not applicable — no Python files changed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
Test Files  24 passed (24)
     Tests  118 passed (118)

ℹ tests 270
ℹ pass 270
ℹ fail 0
```
