### PR TITLE
fix(desktop): MEDIA-delivered .md opens in the preview rail, not as a download link (#84951)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.media-md.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.media-md.test.tsx
@@ -1,0 +1,45 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { isMarkdownDocumentPath, mediaMarkdownHref } from '@/lib/media'
+
+import { MarkdownTextContent } from './markdown-text'
+
+// Regression for #84951: a `.md` delivered via MEDIA has no entry in
+// MEDIA_BY_EXT, so it classified as a generic 'file' and rendered as a
+// download-style link. Markdown is renderable content — it must route to the
+// preview rail (which renders .md with a rendered/source toggle) instead.
+describe('markdown documents delivered via MEDIA', () => {
+  afterEach(cleanup)
+
+  it('classifies markdown extensions as markdown documents', () => {
+    expect(isMarkdownDocumentPath('/tmp/report.md')).toBe(true)
+    expect(isMarkdownDocumentPath('/tmp/notes.markdown')).toBe(true)
+    expect(isMarkdownDocumentPath('C:\\Users\\a\\report.MD')).toBe(true)
+    expect(isMarkdownDocumentPath('/tmp/report.md?x=1')).toBe(true)
+    expect(isMarkdownDocumentPath('/tmp/archive.zip')).toBe(false)
+    expect(isMarkdownDocumentPath('/tmp/clip.mp4')).toBe(false)
+    expect(isMarkdownDocumentPath('/tmp/README')).toBe(false)
+  })
+
+  it('renders a MEDIA .md as a preview attachment, not a download link', async () => {
+    const href = mediaMarkdownHref('/home/user/out/report.md')
+
+    render(<MarkdownTextContent isRunning={false} text={`[report.md](${href})`} />)
+
+    // PreviewAttachment renders an "open preview" toggle button; the old
+    // MediaAttachment 'file' fallback rendered a bare "Open ..." anchor.
+    expect(await screen.findByRole('button')).toBeTruthy()
+    expect(screen.queryByText(/^Loading /)).toBeNull()
+    expect(screen.getByText('report.md')).toBeTruthy()
+  })
+
+  it('still renders a non-markdown MEDIA file through the media fallback', async () => {
+    const href = mediaMarkdownHref('/home/user/out/archive.zip')
+
+    render(<MarkdownTextContent isRunning={false} text={`[archive.zip](${href})`} />)
+
+    expect(await screen.findByText(/archive\.zip/)).toBeTruthy()
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -23,6 +23,7 @@ import { preprocessMarkdown } from '@/lib/markdown-preprocess'
 import {
   downloadGatewayMediaFile,
   isInlineMediaSrc,
+  isMarkdownDocumentPath,
   isRemoteGateway,
   mediaExternalUrl,
   mediaKind,
@@ -255,6 +256,14 @@ function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a
   const mediaPath = mediaPathFromMarkdownHref(href)
 
   if (mediaPath) {
+    // A delivered markdown document is renderable content, not an opaque
+    // download: route it to the preview rail (which renders .md with a
+    // rendered/source toggle) instead of the download-link fallback that
+    // `mediaKind() === 'file'` would produce. (#84951)
+    if (isMarkdownDocumentPath(mediaPath)) {
+      return <PreviewAttachment source="tool-result" target={mediaPath} />
+    }
+
     return <MediaAttachment path={mediaPath} />
   }
 

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -40,6 +40,17 @@ export function mediaKind(path: string): MediaKind {
   return mediaInfo(path)?.kind ?? 'file'
 }
 
+// Markdown is renderable content, not an opaque download: the preview rail
+// already knows how to render a `.md` file (rendered/source toggle), so the
+// MEDIA delivery path routes these to a preview instead of a download link.
+const MARKDOWN_EXTENSIONS = new Set(['md', 'markdown', 'mdown', 'mkd'])
+
+export function isMarkdownDocumentPath(path: string): boolean {
+  const ext = path.split(/[?#]/, 1)[0]?.split('.').pop()?.toLowerCase()
+
+  return ext ? MARKDOWN_EXTENSIONS.has(ext) : false
+}
+
 export function mediaMime(path: string): string {
   return mediaInfo(path)?.mime ?? 'application/octet-stream'
 }


### PR DESCRIPTION
## Summary

A markdown file delivered via MEDIA now opens in the right-rail preview pane instead of degrading to a dead download-style link. Resolves #84951.

Root cause: `.md` has no entry in `MEDIA_BY_EXT`, so `mediaKind()` classified delivered markdown as a generic `'file'` and `MarkdownLink` fell through to the download-anchor fallback.

## Changes

- `lib/media.ts`: `isMarkdownDocumentPath()` — recognizes `md`/`markdown`/`mdown`/`mkd` (case-insensitive, query/hash-safe)
- `assistant-ui/markdown-text.tsx`: `MarkdownLink` routes MEDIA markdown paths to `PreviewAttachment` (source `tool-result`) so they open in the preview rail — where `.md` already renders with a rendered/source toggle and, since #89381, full KaTeX math, tables, images, and links
- `markdown-text.media-md.test.tsx`: 3 tests — extension classification, MEDIA `.md` renders the preview attachment (not a download link), non-markdown MEDIA files keep the existing fallback

The preview rail was the missing delivery seam; no new renderer added (#84951's blueprint suggested extracting a shared markdown component — unnecessary now that #89381 gave the rail the chat-equivalent pipeline).

## Validation

| Check | Result |
|---|---|
| `npx vitest run` media suites | 7/7 passed (3 new) |
| `npm run check:lint` (tsc ×3 + eslint) | 0 errors |

## Infographic

![Delivered .md opens as a document](https://v3b.fal.media/files/b/0aa6e040/BuoQOPOuOMk98Uif8sm-N_JiUjyopl.png)
