### PR TITLE
fix(discord): honor chunk indicator setting

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1227,6 +1227,7 @@ platform_toolsets:
 #   auto_thread: true                # Auto-create thread on @mention (default: true)
 #   free_response_channels: ""       # Channel IDs where no mention is needed
 #   reactions: true                  # Show processing reactions (default: true)
+#   chunk_indicators: true           # Append visible (N/M) labels to split replies
 #   history_backfill: true           # Recover missed channel messages on mention (default: true)
 #   history_backfill_limit: 50       # Max messages to scan backwards (default: 50)
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -7360,12 +7360,22 @@ class BasePlatformAdapter(ABC):
         Default implementation returns content as-is.
         """
         return content
+
+    def split_message(
+        self,
+        content: str,
+        max_length: int = 4096,
+        len_fn: Optional["Callable[[str], int]"] = None,
+    ) -> List[str]:
+        """Split one platform delivery using this adapter's runtime settings."""
+        return self.truncate_message(content, max_length, len_fn=len_fn)
     
     @staticmethod
     def truncate_message(
         content: str,
         max_length: int = 4096,
         len_fn: Optional["Callable[[str], int]"] = None,
+        include_chunk_indicators: bool = True,
     ) -> List[str]:
         """
         Split a long message into chunks, preserving code block boundaries.
@@ -7373,7 +7383,7 @@ class BasePlatformAdapter(ABC):
         When a split falls inside a triple-backtick code block, the fence is
         closed at the end of the current chunk and reopened (with the original
         language tag) at the start of the next chunk.  Multi-chunk responses
-        receive indicators like ``(1/3)``.
+        receive indicators like ``(1/3)`` unless the platform disables them.
 
         Args:
             content: The full message content
@@ -7382,6 +7392,8 @@ class BasePlatformAdapter(ABC):
                      Defaults to ``len`` (Unicode code-points).  Pass
                      ``utf16_len`` for platforms that measure message
                      length in UTF-16 code units (e.g. Telegram).
+            include_chunk_indicators: Append visible ``(N/M)`` labels to
+                                      multi-message responses.
 
         Returns:
             List of message chunks
@@ -7524,7 +7536,7 @@ class BasePlatformAdapter(ABC):
             chunks.append(full_chunk)
 
         # Append chunk indicators when the response spans multiple messages
-        if len(chunks) > 1:
+        if include_chunk_indicators and len(chunks) > 1:
             total = len(chunks)
             chunks = [
                 f"{chunk} ({i + 1}/{total})" for i, chunk in enumerate(chunks)

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -1546,13 +1546,15 @@ class GatewayStreamConsumer:
         those rules with newline-only slicing.  Non-base test doubles and
         legacy adapters retain the historical two-argument call shape.
         """
-        truncate = getattr(self.adapter, "truncate_message", None)
-        if not callable(truncate):
-            return self._split_text_chunks(text, limit, len_fn)
-
         if isinstance(self.adapter, _BasePlatformAdapter):
-            chunks = truncate(text, limit, len_fn=len_fn)
+            split = getattr(self.adapter, "split_message", None)
+            if not callable(split):
+                return self._split_text_chunks(text, limit, len_fn)
+            chunks = split(text, limit, len_fn=len_fn)
         else:
+            truncate = getattr(self.adapter, "truncate_message", None)
+            if not callable(truncate):
+                return self._split_text_chunks(text, limit, len_fn)
             chunks = truncate(text, limit)
         if not isinstance(chunks, (list, tuple)) or not all(
             isinstance(chunk, str) for chunk in chunks

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2310,6 +2310,7 @@ DEFAULT_CONFIG = {
             "max_dispatches": 10,         # Cap on recovered messages dispatched per reconnect
         },
         "reactions": True,             # Add 👀/✅/❌ reactions to messages during processing
+        "chunk_indicators": True,      # Append visible (N/M) labels to split responses
         # Discord Gateway transport health. These settings inspect the active
         # WebSocket's ready/open/heartbeat state; they never use Discord REST as
         # proof that Gateway events are still arriving. Set any value to 0 to

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1057,6 +1057,27 @@ class DiscordAdapter(BasePlatformAdapter):
     # cap are replaced by a short notice.
     MAX_SPLIT_MESSAGES = 8
 
+    def split_message(
+        self,
+        content: str,
+        max_length: int = MAX_MESSAGE_LENGTH,
+        len_fn: Optional[Callable[[str], int]] = None,
+    ) -> List[str]:
+        """Split Discord responses with optional visible ``(N/M)`` labels."""
+        extra = self.config.extra if isinstance(self.config.extra, dict) else {}
+        raw = extra.get("chunk_indicators", True)
+        include_chunk_indicators = (
+            raw
+            if isinstance(raw, bool)
+            else str(raw).strip().lower() in {"true", "1", "yes", "on"}
+        )
+        return self.truncate_message(
+            content,
+            max_length,
+            len_fn=len_fn,
+            include_chunk_indicators=include_chunk_indicators,
+        )
+
     # Auto-disconnect from voice channel after this many seconds of inactivity.
     # Config key: discord.voice_channel_inactivity_timeout_seconds (0 disables)
     VOICE_TIMEOUT = 300
@@ -3512,7 +3533,7 @@ class DiscordAdapter(BasePlatformAdapter):
             # Format and split message if needed
             formatted = self.format_message(content)
             chunks = self._cap_split_chunks(
-                self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+                self.split_message(formatted, self.MAX_MESSAGE_LENGTH)
             )
 
             message_ids = []
@@ -3604,7 +3625,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
         formatted = self.format_message(content)
         chunks = self._cap_split_chunks(
-            self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+            self.split_message(formatted, self.MAX_MESSAGE_LENGTH)
         )
 
         thread_name = _derive_forum_thread_name(content)
@@ -3777,7 +3798,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     return await self._edit_overflow_split(
                         channel, msg, message_id, content,
                     )
-                formatted = self.truncate_message(
+                formatted = self.split_message(
                     formatted, self.MAX_MESSAGE_LENGTH,
                 )[0]
                 _saturated_preview = True
@@ -3809,7 +3830,7 @@ class DiscordAdapter(BasePlatformAdapter):
                             channel, msg, message_id, content,
                         )
                     # Mid-stream: truncate and retry in place (no split).
-                    truncated = self.truncate_message(
+                    truncated = self.split_message(
                         formatted, self.MAX_MESSAGE_LENGTH,
                     )[0]
                     if self._last_overflow_preview.get(_preview_key) == truncated:
@@ -3873,7 +3894,7 @@ class DiscordAdapter(BasePlatformAdapter):
         """
         formatted = self.format_message(content)
         chunks = self._cap_split_chunks(
-            self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+            self.split_message(formatted, self.MAX_MESSAGE_LENGTH)
         )
         if len(chunks) <= 1:
             # Defensive: caller's pre-flight should guarantee >1 chunk, but if
@@ -10392,6 +10413,9 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
             if isinstance(candidate_extra, dict):
                 platform_extra_cfg = candidate_extra
     seeded_extra = {}
+    chunk_indicators_cfg = discord_cfg.get("chunk_indicators")
+    if chunk_indicators_cfg is not None:
+        seeded_extra["chunk_indicators"] = chunk_indicators_cfg
     # Authorization gate keys are ALWAYS seeded into PlatformConfig.extra so
     # every adapter carries its own profile's allow/deny lists (issue #72348).
     # The os.environ writes below remain first-writer-wins for legacy env-only

--- a/tests/gateway/test_discord_edit_message_overflow.py
+++ b/tests/gateway/test_discord_edit_message_overflow.py
@@ -16,6 +16,7 @@ The fix mirrors the proven Telegram contract (and its #48648 lesson):
   in ``message_id`` plus every continuation in ``continuation_message_ids``.
 """
 
+import re
 import sys
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -52,8 +53,14 @@ from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
 MAX = DiscordAdapter.MAX_MESSAGE_LENGTH  # 2000
 
 
-def _make_adapter():
-    return DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+def _make_adapter(*, chunk_indicators=True):
+    return DiscordAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={"chunk_indicators": chunk_indicators},
+        )
+    )
 
 
 def _wire_channel(adapter, *, original_msg, send_side_effect=None):
@@ -186,6 +193,33 @@ class TestSaturatedPreviewDedup:
         result = await adapter.edit_message("555", "42", "x" * 4500, finalize=True)
         assert result.success is True
         assert len(edits) == 3
+
+    @pytest.mark.asyncio
+    async def test_disabled_indicators_keep_saturated_preview_stable(self):
+        adapter = _make_adapter(chunk_indicators=False)
+        edits = []
+        msg = SimpleNamespace(
+            id=42,
+            edit=AsyncMock(side_effect=lambda *, content: edits.append(content)),
+        )
+        channel, sends = _wire_channel(adapter, original_msg=msg)
+
+        result = await adapter.edit_message("555", "42", "x" * 2500, finalize=False)
+        assert result.success is True
+        assert len(edits) == 1
+
+        for grow in (3000, 3500, 4000, 4500):
+            result = await adapter.edit_message("555", "42", "x" * grow, finalize=False)
+            assert result.success is True
+        assert len(edits) == 1
+
+        result = await adapter.edit_message("555", "42", "x" * 4500, finalize=True)
+        assert result.success is True
+        assert len(edits) == 2
+        delivered = edits + [send["content"] for send in sends]
+        assert all(
+            re.search(r"\(\d+/\d+\)\s*$", content) is None for content in delivered
+        )
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/gateway/test_discord_split_cap.py
+++ b/tests/gateway/test_discord_split_cap.py
@@ -9,6 +9,7 @@ with a short notice.
 
 from __future__ import annotations
 
+import re
 import sys
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -16,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.config import PlatformConfig
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
 
 
 def _ensure_discord_mock():
@@ -39,15 +41,24 @@ def _ensure_discord_mock():
 
 _ensure_discord_mock()
 
-from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+from plugins.platforms.discord.adapter import (  # noqa: E402
+    DiscordAdapter,
+    _apply_yaml_config,
+)
 
 
 MAX = DiscordAdapter.MAX_MESSAGE_LENGTH
 CAP = DiscordAdapter.MAX_SPLIT_MESSAGES
 
 
-def _make_adapter():
-    return DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+def _make_adapter(*, chunk_indicators=False):
+    return DiscordAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={"chunk_indicators": chunk_indicators},
+        )
+    )
 
 
 def _huge_content(chars: int = 60_000) -> str:
@@ -56,6 +67,33 @@ def _huge_content(chars: int = 60_000) -> str:
 
 
 class TestCapSplitChunks:
+    def test_default_config_preserves_chunk_indicators(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        assert DEFAULT_CONFIG["discord"]["chunk_indicators"] is True
+
+    def test_yaml_config_seeds_chunk_indicator_setting(self):
+        seeded = _apply_yaml_config({}, {"chunk_indicators": False})
+
+        assert seeded == {"chunk_indicators": False}
+
+    def test_disabled_chunk_indicators_are_not_rendered(self):
+        adapter = _make_adapter(chunk_indicators=False)
+
+        chunks = adapter.split_message("word " * 1000, MAX)
+
+        assert len(chunks) > 1
+        assert all(re.search(r"\(\d+/\d+\)\s*$", chunk) is None for chunk in chunks)
+
+    def test_stream_split_respects_disabled_chunk_indicators(self):
+        adapter = _make_adapter(chunk_indicators=False)
+        consumer = GatewayStreamConsumer(adapter, "555", StreamConsumerConfig())
+
+        chunks = consumer._truncate_for_stream("word " * 1000, MAX, len)
+
+        assert len(chunks) > 1
+        assert all(re.search(r"\(\d+/\d+\)\s*$", chunk) is None for chunk in chunks)
+
     def test_below_cap_unchanged(self):
         adapter = _make_adapter()
         chunks = ["a", "b", "c"]
@@ -74,6 +112,40 @@ class TestCapSplitChunks:
 
 
 class TestSendCap:
+    @pytest.mark.asyncio
+    async def test_standalone_send_respects_disabled_indicators(self, monkeypatch):
+        from gateway.config import Platform
+        from gateway.platform_registry import platform_registry
+        from tools.send_message_tool import _send_to_platform
+
+        sender = AsyncMock(return_value={"success": True, "message_id": "1"})
+        entry = SimpleNamespace(max_message_length=MAX, standalone_sender_fn=sender)
+        original_get = platform_registry.get
+
+        def fake_get(name):
+            return entry if name == "discord" else original_get(name)
+
+        monkeypatch.setattr(platform_registry, "get", fake_get)
+        pconfig = SimpleNamespace(
+            enabled=True,
+            token="***",
+            extra={"chunk_indicators": False},
+        )
+
+        result = await _send_to_platform(
+            Platform.DISCORD,
+            pconfig,
+            "ch",
+            "word " * 1000,
+        )
+
+        assert result["success"] is True
+        assert sender.await_count >= 3
+        assert all(
+            re.search(r"\(\d+/\d+\)\s*$", call.args[2]) is None
+            for call in sender.await_args_list
+        )
+
     @pytest.mark.asyncio
     async def test_send_caps_split_flood(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -95,6 +167,9 @@ class TestSendCap:
         assert result.success is True
         assert len(sends) == CAP
         assert "Response truncated" in sends[-1]
+        assert all(
+            re.search(r"\(\d+/\d+\)\s*$", content) is None for content in sends
+        )
 
 
 class TestForumCap:
@@ -127,6 +202,10 @@ class TestForumCap:
         # 1 starter message + at most (CAP - 1) follow-up chunks.
         assert len(thread_sends) <= CAP - 1
         assert "Response truncated" in thread_sends[-1]
+        assert all(
+            re.search(r"\(\d+/\d+\)\s*$", content) is None
+            for content in thread_sends
+        )
 
 
 class TestEditOverflowCap:
@@ -154,3 +233,7 @@ class TestEditOverflowCap:
         assert len(edits) == 1
         assert len(sends) <= CAP - 1
         assert "Response truncated" in (sends[-1] if sends else edits[-1])
+        assert all(
+            re.search(r"\(\d+/\d+\)\s*$", content) is None
+            for content in edits + sends
+        )

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -927,7 +927,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
 
     Long messages are automatically chunked to fit within platform limits
     using the same smart-splitting algorithm as the gateway adapters
-    (preserves code-block boundaries, adds part indicators).
+    (preserves code-block boundaries and honors platform indicator settings).
     """
     from gateway.config import Platform
 
@@ -996,7 +996,21 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     max_len = _MAX_LENGTHS.get(platform)
     if max_len:
         _len_fn = utf16_len if platform == Platform.TELEGRAM else None
-        chunks = BasePlatformAdapter.truncate_message(message, max_len, len_fn=_len_fn)
+        _include_chunk_indicators = True
+        if platform == Platform.DISCORD:
+            _extra = pconfig.extra if isinstance(getattr(pconfig, "extra", None), dict) else {}
+            _raw = _extra.get("chunk_indicators", True)
+            _include_chunk_indicators = (
+                _raw
+                if isinstance(_raw, bool)
+                else str(_raw).strip().lower() in {"true", "1", "yes", "on"}
+            )
+        chunks = BasePlatformAdapter.truncate_message(
+            message,
+            max_len,
+            len_fn=_len_fn,
+            include_chunk_indicators=_include_chunk_indicators,
+        )
     else:
         chunks = [message]
 

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -337,6 +337,7 @@ discord:
   free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
   auto_thread: true               # Auto-create threads on @mention
   reactions: true                 # Add emoji reactions during processing
+  chunk_indicators: true          # Append visible (N/M) labels to split replies
   ignored_channels: []            # Channel IDs where bot never responds
   no_thread_channels: []          # Channel IDs where bot responds without threading
   history_backfill: true          # Prepend recent channel scrollback on mention (default: true)
@@ -420,6 +421,12 @@ Controls whether the bot adds emoji reactions to messages as visual feedback:
 - ❌ added if an error occurs during processing
 
 Disable this if you find the reactions distracting or if the bot's role doesn't have the **Add Reactions** permission.
+
+#### `discord.chunk_indicators`
+
+**Type:** boolean — **Default:** `true`
+
+Controls whether replies split across Discord's 2,000-character message limit end with visible labels such as `(1/3)`. Set this to `false` for clean multipart replies that copy and paste as continuous text.
 
 #### `discord.ignored_channels`
 


### PR DESCRIPTION
## What does this PR do?

Discord accepted `discord.chunk_indicators: false` in user configuration, but dropped the value before adapter construction. The shared splitter therefore appended `(N/M)` to every multipart Discord response.

This PR carries the setting into the Discord adapter and applies it to normal sends, forum posts, streaming previews, and finalized overflow delivery. The default remains `true`, preserving existing behavior for users who have not configured it. Setting `discord.chunk_indicators: false` hides the labels without changing chunk order or content delivery.

## Related Issue

No issue. Reproduced in a live Discord gateway and covered by regression tests.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add an instance-aware `split_message()` path while preserving the public static `truncate_message()` API.
- Route Discord send, forum, edit, and streaming overflow paths through the configured splitter.
- Pass `discord.chunk_indicators` into `PlatformConfig.extra` with a backward-compatible default of `true`.
- Cover disabled, enabled, missing-setting, static-call, edit-overflow, and streaming behavior.
- Document the setting in `cli-config.yaml.example` and the Discord guide.

## How to Test

1. Set `discord.chunk_indicators: false`, send a Discord response longer than 2,000 characters, and confirm no message ends with `(N/M)`.
2. Set the value to `true` or remove it, then confirm multipart responses retain their labels.
3. Run the focused suites listed below.

## Test Results

- `21 passed`: reply-mode, Discord split-cap, and Discord edit-overflow tests.
- `151 passed, 1 skipped`: stream-consumer and platform-base tests.
- `47 passed`: Discord connect, free-response, and slash-command tests.
- `3 passed`: the media tests that fail only when the entire `test_discord_*.py` glob shares polluted Discord module mocks.
- `compileall` and `git diff --check` passed.
- Independent pre-push review found no security concerns or logic errors.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-neutral Python/config change
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Manual splitter probe:

```text
configured=None  chunks=3  labels=True
configured=False chunks=3  labels=False
configured=True  chunks=3  labels=True
```
