### PR TITLE
fix(terminal): decode non-UTF-8 command output in the host codepage

### DIFF
--- a/tests/tools/test_terminal_ansi_codepage_fallback.py
+++ b/tests/tools/test_terminal_ansi_codepage_fallback.py
@@ -1,0 +1,337 @@
+"""Terminal output must not be destroyed by decoding ANSI-codepage bytes as UTF-8 (#89442).
+
+Git Bash forwards a native Windows child's bytes without transcoding them, so on
+a CJK install a ``powershell.exe`` error arrives as GBK inside a stream whose
+MSYS tools write UTF-8. ``_wait_for_process`` decoded the whole stream strictly
+as UTF-8 with ``errors="replace"``, which turned every one of those bytes into
+U+FFFD *at decode time* - the original bytes were gone and the agent read a wall
+of replacement characters instead of the message it needed.
+
+The contract these tests pin, in order of how much it matters:
+
+1. **Output that is valid UTF-8 decodes exactly as before.** The fallback is
+   consulted only for byte sequences that strict UTF-8 rejects, which are
+   already lost today. This change can recover text; it must not be able to
+   corrupt text that was previously fine.
+2. Decoding is per line, not per read. Legacy multi-byte encodings are not
+   self-synchronising, so a fallback decode over an arbitrary byte range can
+   split a two-byte GBK character. ``TestChunkBoundaries`` is that proof.
+3. A backend that cannot know its writer's codepage keeps the old decoder. The
+   default on ``BaseEnvironment`` is None, and only ``LocalEnvironment`` - where
+   the writer is genuinely a child of this process - overrides it.
+"""
+
+import codecs
+import locale
+import os
+from unittest.mock import MagicMock
+
+from tools.environments.base import (
+    BaseEnvironment,
+    _system_ansi_encoding,
+    _Utf8WithFallbackDecoder,
+)
+from tools.environments.local import LocalEnvironment
+
+GBK_LINE = "找不到名为no-such-process的进程".encode("gbk")
+UTF8_LINE = "réponse: 找不到".encode("utf-8")
+
+
+class _TestableEnv(BaseEnvironment):
+    """Concrete subclass so base-class methods can be exercised directly."""
+
+    def __init__(self, cwd="/tmp", timeout=10):
+        super().__init__(cwd=cwd, timeout=timeout)
+
+    def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None):
+        raise NotImplementedError("Use mock")
+
+    def cleanup(self):
+        pass
+
+
+class TestValidUtf8IsUntouched:
+    """The load-bearing half. If any of these break, the change is a net loss."""
+
+    def test_ascii_is_unchanged(self):
+        d = _Utf8WithFallbackDecoder("cp936")
+        assert d.decode(b"hello world\n") == "hello world\n"
+
+    def test_multibyte_utf8_is_unchanged(self):
+        d = _Utf8WithFallbackDecoder("cp936")
+        assert d.decode(UTF8_LINE + b"\n") == UTF8_LINE.decode("utf-8") + "\n"
+
+    def test_utf8_that_is_also_valid_in_the_fallback_still_decodes_as_utf8(self):
+        """The ordering matters, not just the outcome.
+
+        A short UTF-8 sequence is usually *also* decodable as cp936, into
+        different characters. Trying the fallback first, or on any error rather
+        than only on a UTF-8 error, would silently mojibake ordinary Chinese
+        output - a regression far worse than the bug.
+        """
+        text = "中文"
+        raw = text.encode("utf-8")
+        assert raw.decode("cp936", errors="ignore") != text  # premise of the test
+        d = _Utf8WithFallbackDecoder("cp936")
+        assert d.decode(raw + b"\n") == text + "\n"
+
+    def test_a_pure_utf8_stream_matches_the_old_decoder_exactly(self):
+        """Byte-for-byte agreement with the decoder this replaces."""
+        payload = ("hello\n" + "réponse 中文\n" + "tail без переноса").encode("utf-8")
+        baseline = codecs.getincrementaldecoder("utf-8")(errors="replace")
+        old = baseline.decode(payload) + baseline.decode(b"", final=True)
+
+        d = _Utf8WithFallbackDecoder("cp936")
+        new = d.decode(payload) + d.decode(b"", final=True)
+
+        assert new == old
+
+
+class TestTheFallbackRecoversText:
+
+    def test_a_gbk_line_is_recovered(self):
+        d = _Utf8WithFallbackDecoder("cp936")
+        out = d.decode(GBK_LINE + b"\n")
+        assert out == GBK_LINE.decode("gbk") + "\n"
+        assert "�" not in out
+
+    def test_the_reported_powershell_shape(self):
+        """The exact interleaving from #89442: MSYS line, then a native error."""
+        d = _Utf8WithFallbackDecoder("cp936")
+        stream = b"$ Stop-Process\n" + GBK_LINE + b"\r\n" + b"done\n"
+        out = d.decode(stream) + d.decode(b"", final=True)
+        assert out == "$ Stop-Process\n" + GBK_LINE.decode("gbk") + "\r\n" + "done\n"
+
+    def test_without_the_fallback_the_same_bytes_are_destroyed(self):
+        """Pins the bug itself, so a revert of the wiring is visible here."""
+        baseline = codecs.getincrementaldecoder("utf-8")(errors="replace")
+        out = baseline.decode(GBK_LINE + b"\n")
+        assert "�" in out
+        assert "找不到" not in out
+
+
+class TestChunkBoundaries:
+    """A 4096-byte read can split a character. Neither encoding may be damaged."""
+
+    def test_a_utf8_character_split_across_reads_survives(self):
+        raw = "中".encode("utf-8")
+        d = _Utf8WithFallbackDecoder("cp936")
+        first = d.decode(raw[:2])
+        second = d.decode(raw[2:] + b"\n")
+        assert first + second == "中\n"
+
+    def test_a_gbk_character_split_across_reads_survives(self):
+        """The case a per-chunk fallback cannot get right.
+
+        GBK is two bytes per character with no lead/continuation distinction,
+        so decoding an arbitrary byte range picks up half a character. Holding
+        the line together is what makes this work.
+        """
+        raw = "进程".encode("gbk")
+        assert len(raw) == 4
+        d = _Utf8WithFallbackDecoder("cp936")
+        out = d.decode(raw[:1]) + d.decode(raw[1:3]) + d.decode(raw[3:] + b"\n")
+        assert out == "进程\n"
+
+    def test_a_line_split_across_many_reads_survives(self):
+        d = _Utf8WithFallbackDecoder("cp936")
+        payload = GBK_LINE + b"\n"
+        out = "".join(d.decode(payload[i:i + 1]) for i in range(len(payload)))
+        assert out == GBK_LINE.decode("gbk") + "\n"
+
+
+class TestBufferingContract:
+
+    def test_an_unterminated_tail_is_held_until_final(self):
+        d = _Utf8WithFallbackDecoder("cp936")
+        assert d.decode(b"no newline yet") == ""
+        assert d.decode(b"", final=True) == "no newline yet"
+
+    def test_final_flush_recovers_an_unterminated_fallback_line(self):
+        """``printf`` without a trailing newline is ordinary, not exotic."""
+        d = _Utf8WithFallbackDecoder("cp936")
+        assert d.decode(GBK_LINE) == ""
+        assert d.decode(b"", final=True) == GBK_LINE.decode("gbk")
+
+    def test_a_bare_carriage_return_is_a_boundary(self):
+        """Progress output redraws with CR and would otherwise buffer to the cap."""
+        d = _Utf8WithFallbackDecoder("cp936")
+        assert d.decode(b"50%\r") == "50%\r"
+
+    def test_output_with_no_boundary_is_flushed_at_the_cap(self):
+        """A program that never emits a newline must not pin memory."""
+        d = _Utf8WithFallbackDecoder("cp936")
+        blob = b"x" * (_Utf8WithFallbackDecoder._MAX_BUFFERED_BYTES + 10)
+        out = d.decode(blob)
+        assert out == blob.decode("ascii")
+        assert d.decode(b"", final=True) == ""
+
+    def test_nothing_is_emitted_twice(self):
+        d = _Utf8WithFallbackDecoder("cp936")
+        first = d.decode(b"one\ntwo\n")
+        second = d.decode(b"", final=True)
+        assert first == "one\ntwo\n"
+        assert second == ""
+
+
+class TestItStillFailsSafe:
+
+    def test_binary_with_a_nul_byte_keeps_the_replacement_behaviour(self):
+        """Legacy codepages are byte-dense, so binary would come back as mojibake.
+
+        cp1252 in particular decodes almost anything. A NUL is the cheap
+        discriminator: no text encoding in use emits an interior NUL, and
+        binary blobs almost always contain one.
+        """
+        d = _Utf8WithFallbackDecoder("cp1252")
+        out = d.decode(b"\x00\xff\xfe\n")
+        assert out == b"\x00\xff\xfe\n".decode("utf-8", errors="replace")
+        assert "�" in out
+
+    def test_an_unknown_fallback_codec_degrades_to_replacement(self):
+        d = _Utf8WithFallbackDecoder("not-a-real-codec")
+        out = d.decode(GBK_LINE + b"\n")
+        assert "�" in out
+
+    def test_bytes_invalid_in_both_encodings_degrade_to_replacement(self):
+        """cp936 rejects a lone 0x80, so neither decode can succeed."""
+        d = _Utf8WithFallbackDecoder("cp936")
+        out = d.decode(b"\x80\n")
+        assert out == b"\x80\n".decode("utf-8", errors="replace")
+
+
+class TestSystemAnsiEncoding:
+
+    def test_a_utf8_host_has_no_fallback(self, monkeypatch):
+        """None is what makes this provably a no-op almost everywhere."""
+        monkeypatch.setattr(locale, "getencoding", lambda: "utf-8")
+        assert _system_ansi_encoding() is None
+
+    def test_utf8_aliases_are_normalised(self, monkeypatch):
+        monkeypatch.setattr(locale, "getencoding", lambda: "UTF8")
+        assert _system_ansi_encoding() is None
+
+    def test_a_cjk_host_reports_its_codepage(self, monkeypatch):
+        monkeypatch.setattr(locale, "getencoding", lambda: "cp936")
+        assert _system_ansi_encoding() == codecs.lookup("cp936").name
+
+    def test_an_unknown_encoding_name_is_no_fallback(self, monkeypatch):
+        monkeypatch.setattr(locale, "getencoding", lambda: "nonsense-codec")
+        assert _system_ansi_encoding() is None
+
+    def test_an_empty_encoding_name_is_no_fallback(self, monkeypatch):
+        monkeypatch.setattr(locale, "getencoding", lambda: "")
+        assert _system_ansi_encoding() is None
+
+    def test_a_raising_locale_is_no_fallback(self, monkeypatch):
+        def _boom():
+            raise RuntimeError("locale is unavailable")
+
+        monkeypatch.setattr(locale, "getencoding", _boom)
+        assert _system_ansi_encoding() is None
+
+
+class TestBackendScope:
+
+    def test_the_base_default_is_no_fallback(self):
+        """Remote backends must not guess a container's codepage from this host."""
+        assert _TestableEnv()._output_fallback_encoding() is None
+
+    def test_local_has_no_fallback_off_windows(self, monkeypatch):
+        """On POSIX the shell and its children agree on the locale, so a
+        non-UTF-8 line is far likelier to be binary than to be locale text."""
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", False)
+        monkeypatch.setattr(locale, "getencoding", lambda: "cp936")
+        env = LocalEnvironment.__new__(LocalEnvironment)
+        assert env._output_fallback_encoding() is None
+
+    def test_local_uses_the_ansi_codepage_on_windows(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        monkeypatch.setattr(locale, "getencoding", lambda: "cp936")
+        env = LocalEnvironment.__new__(LocalEnvironment)
+        assert env._output_fallback_encoding() == codecs.lookup("cp936").name
+
+    def test_local_on_a_utf8_windows_host_has_no_fallback(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        monkeypatch.setattr(locale, "getencoding", lambda: "utf-8")
+        env = LocalEnvironment.__new__(LocalEnvironment)
+        assert env._output_fallback_encoding() is None
+
+
+def _proc_emitting(payload: bytes):
+    """A ProcessHandle whose stdout is a real pipe holding *payload*.
+
+    A real fd rather than a mock: ``_wait_for_process`` resolves ``fileno()``
+    and ``os.read()``s it, and a MagicMock ``fileno()`` sends the drain down the
+    iterator fallback instead of the byte path under test.
+    """
+    read_fd, write_fd = os.pipe()
+    os.write(write_fd, payload)
+    os.close(write_fd)
+    proc = MagicMock()
+    proc.poll.return_value = 0
+    proc.returncode = 0
+    proc.stdout = os.fdopen(read_fd, "rb", buffering=0)
+    # Real handles only carry this when _pipe_stdin recorded a failure; a bare
+    # MagicMock would auto-create it and append a bogus "[stdin write failed]".
+    proc._hermes_stdin_errors = []
+    return proc
+
+
+class TestEndToEndThroughTheDrain:
+    """The wiring, exercised through ``_wait_for_process`` itself."""
+
+    def test_a_backend_with_a_fallback_recovers_the_message(self):
+        env = _TestableEnv()
+        env._output_fallback_encoding = lambda: "cp936"
+        proc = _proc_emitting(GBK_LINE + b"\n")
+        try:
+            result = env._wait_for_process(proc, timeout=5)
+        finally:
+            proc.stdout.close()
+        assert GBK_LINE.decode("gbk") in result["output"]
+        assert "�" not in result["output"]
+
+    def test_a_backend_without_one_is_unchanged(self):
+        env = _TestableEnv()
+        proc = _proc_emitting(GBK_LINE + b"\n")
+        try:
+            result = env._wait_for_process(proc, timeout=5)
+        finally:
+            proc.stdout.close()
+        assert "�" in result["output"]
+
+    def test_utf8_output_is_identical_with_and_without_a_fallback(self):
+        payload = "réponse 中文\nsecond line\n".encode("utf-8")
+
+        plain = _TestableEnv()
+        proc_a = _proc_emitting(payload)
+        try:
+            without = plain._wait_for_process(proc_a, timeout=5)["output"]
+        finally:
+            proc_a.stdout.close()
+
+        fallback = _TestableEnv()
+        fallback._output_fallback_encoding = lambda: "cp936"
+        proc_b = _proc_emitting(payload)
+        try:
+            with_fb = fallback._wait_for_process(proc_b, timeout=5)["output"]
+        finally:
+            proc_b.stdout.close()
+
+        assert with_fb == without
+
+    def test_a_raising_hook_cannot_fail_the_command(self):
+        """Resolving an encoding is not worth losing a command's output over."""
+        env = _TestableEnv()
+
+        def _boom():
+            raise RuntimeError("no locale here")
+
+        env._output_fallback_encoding = _boom
+        proc = _proc_emitting(b"still here\n")
+        try:
+            result = env._wait_for_process(proc, timeout=5)
+        finally:
+            proc.stdout.close()
+        assert "still here" in result["output"]

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -8,6 +8,7 @@ or a temp file (local).
 
 import codecs
 import json
+import locale
 import logging
 import os
 import re
@@ -359,6 +360,102 @@ def _pipe_stdin(proc: subprocess.Popen, data: str) -> None:
     thread = threading.Thread(target=_write, daemon=True)
     proc._hermes_stdin_thread = thread
     thread.start()
+
+
+class _Utf8WithFallbackDecoder:
+    """Incremental decoder that decodes UTF-8 and retries failures in *fallback*.
+
+    Git Bash on Windows is a byte pipe, not a transcoder: MSYS tools
+    (``ls``, ``grep``, ...) write UTF-8, while native Windows programs
+    (``powershell.exe``, ``taskkill``, ``pnpm``) write the system ANSI
+    codepage. A single command's output can contain both. Decoding the whole
+    stream as UTF-8 with ``errors="replace"`` turns every ANSI byte into
+    U+FFFD, and because ``replace`` is applied at decode time the original
+    bytes are gone -- the agent is left reading a wall of replacement
+    characters instead of the error message it needs (#89442).
+
+    The invariant that keeps this safe: **output that is valid UTF-8 decodes
+    exactly as it did before.** The fallback is only consulted for bytes that
+    strict UTF-8 rejects, which today are already lost to U+FFFD. So this can
+    recover text, and cannot corrupt text that was previously fine.
+
+    Decoding is per LINE rather than per 4096-byte read. A line is the unit
+    that has a single origin (one program wrote it), and multi-byte legacy
+    encodings are not self-synchronising, so a fallback decode of an
+    arbitrary byte range can split a two-byte GBK character and produce
+    mojibake. Buffering costs nothing here: ``_wait_for_process`` renders the
+    collected output only after the drain thread joins, so nothing observes
+    the stream mid-command.
+    """
+
+    #: Flush an unterminated buffer once it gets this large, so a program that
+    #: never emits a newline (a progress spinner, ``head -c`` of a blob) cannot
+    #: pin bytes in memory or land them all in the tail of a bounded capture.
+    _MAX_BUFFERED_BYTES = 32768
+
+    #: ``\n`` and ``\r``. CR is a boundary too: progress output redraws with a
+    #: bare CR and would otherwise buffer to the cap.
+    _BOUNDARIES = (0x0A, 0x0D)
+
+    def __init__(self, fallback: str) -> None:
+        self._fallback = fallback
+        self._buf = bytearray()
+
+    def decode(self, chunk: bytes, final: bool = False) -> str:
+        if chunk:
+            self._buf.extend(chunk)
+        parts = []
+        cut = 0
+        for i, byte in enumerate(self._buf):
+            if byte in self._BOUNDARIES:
+                parts.append(self._decode_unit(bytes(self._buf[cut:i + 1])))
+                cut = i + 1
+        if cut:
+            del self._buf[:cut]
+        if self._buf and (final or len(self._buf) >= self._MAX_BUFFERED_BYTES):
+            parts.append(self._decode_unit(bytes(self._buf)))
+            self._buf.clear()
+        return "".join(parts)
+
+    def _decode_unit(self, raw: bytes) -> str:
+        try:
+            return raw.decode("utf-8")
+        except UnicodeDecodeError:
+            pass
+        # A NUL byte means this is binary, not text in some other codepage.
+        # Legacy codepages are byte-dense (cp1252 decodes almost anything), so
+        # without this a `cat` of a binary file would come back as mojibake
+        # instead of the U+FFFD it produces today. Text encodings in actual use
+        # never emit an interior NUL, so this costs nothing on the real case.
+        if b"\x00" not in raw:
+            try:
+                return raw.decode(self._fallback)
+            except (UnicodeDecodeError, LookupError):
+                pass
+        return raw.decode("utf-8", errors="replace")
+
+
+def _system_ansi_encoding() -> "str | None":
+    """Return the host's locale encoding, or None when it is already UTF-8.
+
+    ``locale.getencoding()`` rather than ``getpreferredencoding()``: the latter
+    reports ``utf-8`` whenever Python UTF-8 mode is on, which says nothing
+    about what a *native child process* will write to the pipe.
+
+    None means "no fallback", which makes the decoder provably a no-op on the
+    UTF-8 hosts that are the overwhelming majority.
+    """
+    try:
+        name = locale.getencoding()
+    except Exception:
+        return None
+    if not name:
+        return None
+    try:
+        canonical = codecs.lookup(name).name
+    except LookupError:
+        return None
+    return None if canonical == "utf-8" else canonical
 
 
 def _popen_bash(
@@ -846,6 +943,19 @@ class BaseEnvironment(ABC):
         """
         return shlex.quote(path)
 
+    def _output_fallback_encoding(self) -> "str | None":
+        """Encoding to retry a line in when it is not valid UTF-8.
+
+        None (the default) keeps the historical behaviour exactly: strict-UTF-8
+        with U+FFFD substitution. Remote backends inherit that on purpose --
+        their bytes come from a container or a host whose codepage this process
+        cannot observe, so guessing from the *local* locale would be a fabricated
+        answer. Only :class:`~tools.environments.local.LocalEnvironment`
+        overrides it, because there the writer really is a child of this
+        process. See #89442.
+        """
+        return None
+
     def _wrap_command(self, command: str, cwd: str) -> str:
         """Build the full bash script that sources snapshot, cd's, runs command,
         re-dumps env vars, and emits CWD markers."""
@@ -1056,7 +1166,24 @@ class BaseEnvironment(ABC):
         # was constructed with ``encoding="utf-8", errors="replace"`` on
         # ``Popen``) so binary or mis-encoded output is preserved with
         # U+FFFD substitution rather than clobbering the whole buffer.
-        decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+        #
+        # Note that reading the fd directly means the ``Popen`` text wrapper is
+        # bypassed entirely: the raw bytes reach us intact, and this decoder --
+        # not ``Popen``'s ``encoding=`` -- is what decides how they are read.
+        # Backends that can name a fallback codepage for non-UTF-8 lines say so
+        # via ``_output_fallback_encoding``; everything else keeps the strict
+        # UTF-8 decoder unchanged.
+        _fallback = None
+        try:
+            _fallback = self._output_fallback_encoding()
+        except Exception:
+            # Resolving an encoding must never be able to fail a command.
+            _fallback = None
+        decoder = (
+            _Utf8WithFallbackDecoder(_fallback)
+            if _fallback
+            else codecs.getincrementaldecoder("utf-8")(errors="replace")
+        )
 
         def _drain_iterable(stream):
             # Fallback path: ``stream`` is not backed by a real OS file

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -15,7 +15,11 @@ from collections.abc import Mapping
 from pathlib import Path
 
 from hermes_constants import get_process_hermes_home
-from tools.environments.base import BaseEnvironment, _pipe_stdin
+from tools.environments.base import (
+    BaseEnvironment,
+    _pipe_stdin,
+    _system_ansi_encoding,
+)
 from hermes_cli._subprocess_compat import windows_hide_flags
 
 _IS_WINDOWS = platform.system() == "Windows"
@@ -1776,6 +1780,21 @@ class LocalEnvironment(BaseEnvironment):
     def _quote_shell_path(self, path: str) -> str:
         """Rewrite native/mixed Windows paths before quoting for Git Bash."""
         return _quote_bash_path(path)
+
+    def _output_fallback_encoding(self) -> "str | None":
+        """Retry non-UTF-8 output lines in the host's ANSI codepage (#89442).
+
+        Only on Windows, and only when that codepage is not already UTF-8.
+        Commands run through the bundled Git Bash, which forwards a native
+        child's bytes without transcoding them, so on a CJK install a
+        ``powershell.exe`` error arrives as GBK inside an otherwise-UTF-8
+        stream. POSIX hosts are excluded because there the shell and its
+        children agree on the locale, so a non-UTF-8 line is far more likely
+        to be binary than to be text in the locale encoding.
+        """
+        if not _IS_WINDOWS:
+            return None
+        return _system_ansi_encoding()
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,


### PR DESCRIPTION
## What does this PR do?

The terminal tool's output drain decoded every byte strictly as UTF-8 with `errors="replace"`. Git Bash is a byte pipe rather than a transcoder, so on a CJK Windows install a `powershell.exe` error arrives as GBK inside a stream whose MSYS tools write UTF-8 — and `replace` is applied *at decode time*, so those bytes are gone. The agent reads a wall of U+FFFD instead of the error message it needs.

This retries a line that strict UTF-8 rejects in the host's locale encoding.

The invariant that makes it safe: **output that is valid UTF-8 decodes exactly as it did before.** The fallback is only ever consulted for byte sequences UTF-8 rejects, which are already lost to U+FFFD today. So this can recover text and cannot corrupt text that was previously fine — `test_a_pure_utf8_stream_matches_the_old_decoder_exactly` asserts byte-for-byte agreement with the decoder it replaces.

## Related Issue

Refs #89442

One correction to that report, because it points at the wrong lines and the difference is load-bearing.

The issue's root cause is that `text=True, encoding="utf-8"` on `Popen` decodes at the pipe level and "the original bytes are discarded". That is not what happens on this path. `_wait_for_process` resolves `proc.stdout.fileno()` and `os.read()`s the descriptor directly, bypassing the `TextIOWrapper` entirely — the raw bytes arrive intact, and the decision is made by the drain's *own* `codecs.getincrementaldecoder("utf-8")(errors="replace")` a few lines later. The suggested remedy ("collect raw bytes, then decode with sniffing") is therefore already half-built in-tree; only the decoder choice was hardcoded.

That makes this a much smaller change than the issue implies: no `Popen` argument changes, no `chcp`, no shell wrapping. The three sites named in the issue (`local.py:863`, `:929`, and `_popen_bash`) are the Mandatory-ASLR probe, the bash-startup probe, and the SDK-backend spawn helper — none of them is the tool output path, and all are left alone.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**`tools/environments/base.py`**

- `_Utf8WithFallbackDecoder` — same `decode(chunk, final=False)` shape as the incremental decoder it stands in for. Tries strict UTF-8 first; only on `UnicodeDecodeError` does it retry in the fallback; anything that fails both ends on the original `errors="replace"` path.
- `_system_ansi_encoding()` — `locale.getencoding()`, canonicalised through `codecs.lookup`, returning `None` when it is already UTF-8.
- `BaseEnvironment._output_fallback_encoding()` — new hook, returns `None`.
- `_wait_for_process` — picks the decoder from that hook. `None` keeps the exact previous object, so the untouched case is untouched by construction rather than by inspection.

**`tools/environments/local.py`**

- `LocalEnvironment._output_fallback_encoding()` — the host codepage, on Windows only.

### Three judgment calls, stated rather than buried

**Decode per line, not per read.** Legacy multi-byte encodings are not self-synchronising: GBK is two bytes per character with no lead/continuation distinction, so a fallback decode over an arbitrary 4096-byte read boundary can split a character and produce mojibake. A line is the unit that has a single origin — one program wrote it. This costs nothing in latency because `_wait_for_process` renders the collected output only after the drain thread joins; nothing observes the stream mid-command. An unterminated buffer is flushed at 32 KiB, and a bare CR is a boundary too so progress output does not accumulate.

**Opt-in per backend, defaulting to off.** The hook returns `None` on `BaseEnvironment`, so docker / ssh / daytona / modal keep the old decoder. Their bytes come from a container or a remote host whose codepage this process cannot observe, and answering from the *local* locale would be a fabricated answer. Only `LocalEnvironment` overrides it, because there the writer really is a child of this process. It is further gated on Windows: on POSIX the shell and its children agree on the locale, so a non-UTF-8 line there is far likelier to be binary than to be locale text.

**A unit containing NUL stays on the replacement path.** This is the one place the change could plausibly make something worse. Legacy codepages are byte-dense — cp1252 decodes almost anything — so without a guard, `cat` of a binary file would come back as mojibake instead of the U+FFFD it produces today. No text encoding in real use emits an interior NUL, so the guard is free on the case that matters. It is not a complete binary detector, and I have not tried to make it one: the honest scope is "recover text that was destroyed", not "classify every stream".

## How to Test

```bash
pytest tests/tools/test_terminal_ansi_codepage_fallback.py -q     # 32 passed
```

Behavioural throughout — real `os.pipe()` file descriptors driven through `_wait_for_process` itself for the wiring, and real `bytes`/`codecs` for the decoder. No mocking at the boundary under test.

**Mutation proof** — every property is independently load-bearing:

| Reverted | Tests that fail |
|---|---|
| the wiring (always use the old strict decoder) | 1 — `test_a_backend_with_a_fallback_recovers_the_message` |
| try the fallback first instead of only on a UTF-8 error | 2 — incl. `test_a_pure_utf8_stream_matches_the_old_decoder_exactly` |
| the NUL guard | 1 — `test_binary_with_a_nul_byte_keeps_the_replacement_behaviour` |
| decode per read instead of per line | 13 — the whole `TestChunkBoundaries` and `TestBufferingContract` groups |
| the `None`-on-UTF-8-host short circuit | 3 — incl. `test_local_on_a_utf8_windows_host_has_no_fallback` |
| `LocalEnvironment`'s Windows gate | 1 — `test_local_has_no_fallback_off_windows` |
| the base default returning a fallback | 2 — incl. `test_a_backend_without_one_is_unchanged` |

**Baseline** — every environment/terminal test file (`tests/tools/test_base_environment.py`, `test_local_*.py`, `test_terminal_*.py`, `test_ssh_environment.py`, `test_docker_environment.py`, `test_daytona_environment.py`, `test_managed_modal_environment.py`, `test_approved_command_clean_slate.py`), `-q -p no:randomly`, run **serially**, with and without the change:

| | Result |
|---|---|
| without the change (stashed) | `34 failed, 443 passed, 13 skipped` |
| with the change | `34 failed, 475 passed, 13 skipped` |

The **failing sets are identical** — I diffed the two `FAILED` lists and they match line for line. They are pre-existing on this machine and unrelated: the docker/daytona/ssh suites want daemons and remote hosts that are not present, and several terminal tests assume a POSIX shell. The delta is exactly the 32 new tests.

## Overlap with open PRs

Nothing open touches this decoder. The neighbours are worth naming because the topic looks crowded from a title search:

| PR | What it is | Relationship |
|---|---|---|
| **#87162**, **#87181** (open) | pin the Browser-Use CLI's pipes to UTF-8 | Same *class* of bug, different process. Both fix a subprocess wrapper in `tools/browser_use_cli.py`; neither touches `tools/environments/`. |
| **#82494**, **#86636**, **#80186** (open) | U+FFFD / CJK heuristics in binary detection for `read_file` | `tools/file_operations`, deciding whether a *file* is binary. This decides how a *pipe* is decoded. No shared code. |
| **#42775** (open) | "Windows compatibility, path resolution, and encoding issues" | Touches `acp_adapter/` and two test files only. |

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — see the Overlap table
- [x] My PR contains **only** changes related to this fix (one commit, rebased on `main`)
- [x] I've run the environment/terminal slices with and without the change, serially (see How to Test). I did **not** run `pytest tests/ -q` wholesale: on Windows `tests/hermes_cli/` can't be collected (`test_doctor_journal_modes.py` calls `os.geteuid`), so a full-suite number from here would be meaningless. CI runs it.
- [x] I've added tests for my changes — 32, with the mutation proof above
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — docstrings only; each of the three judgment calls above is documented at the line that implements it
- [x] N/A — no config keys added or changed. The fallback is derived from the host locale, so there is nothing to configure and nothing to migrate
- [x] N/A — no architecture or workflow change. `_output_fallback_encoding` is an internal hook on an existing abstract base, defaulting to the previous behaviour
- [x] I've considered cross-platform impact — this is the cross-platform change. POSIX is excluded at `LocalEnvironment`, a UTF-8 host gets `None` from `_system_ansi_encoding` and therefore the byte-identical old decoder, and remote backends are excluded at the base class. `scripts/check-windows-footguns.py` passes on all three files
- [x] N/A — no tool description or schema change
