### PR TITLE
fix(terminal): keep native Windows diagnostics readable

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -116,6 +116,14 @@ class TestIncrementalOutputDecoder:
         assert output.count("\ufffd") == 2
         assert "\u00ff" not in output
 
+    def test_bounded_flush_keeps_one_encoding_for_the_record(self):
+        decoder = _IncrementalOutputDecoder(fallback_encoding="cp1252")
+        first = b"\xff" + b"a" * (decoder._PROBE_LIMIT - 1)
+
+        output = decoder.decode(first) + decoder.decode(b"\xc3\xa9\n", final=True)
+
+        assert output == first.decode("cp1252") + "\u00c3\u00a9\n"
+
     def test_explicit_none_disables_host_fallback(self, monkeypatch):
         from tools.environments import base
 

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -4,9 +4,15 @@ Tests _wrap_command(), _extract_cwd_from_output(), _embed_stdin_heredoc(),
 init_session() failure handling, and the CWD marker contract.
 """
 
+import subprocess
+import sys
 from unittest.mock import MagicMock
 
-from tools.environments.base import BaseEnvironment, _BoundedOutputCollector
+from tools.environments.base import (
+    BaseEnvironment,
+    _BoundedOutputCollector,
+    _IncrementalOutputDecoder,
+)
 
 
 class _TestableEnv(BaseEnvironment):
@@ -49,6 +55,62 @@ class TestBoundedOutputCollector:
         assert len(rendered) <= 120
         assert rendered.endswith("[Command timed out after 1s]")
         assert "[OUTPUT TRUNCATED" in rendered
+
+
+class TestIncrementalOutputDecoder:
+    def test_preserves_utf8_split_across_chunks_with_windows_fallback(self):
+        decoder = _IncrementalOutputDecoder(fallback_encoding="cp936")
+        raw = "MSYS 输出正常\n".encode("utf-8")
+
+        output = decoder.decode(raw[:7]) + decoder.decode(raw[7:10])
+        output += decoder.decode(raw[10:], final=True)
+
+        assert output == "MSYS 输出正常\n"
+
+    def test_decodes_windows_native_codepage_split_across_chunks(self):
+        decoder = _IncrementalOutputDecoder(fallback_encoding="cp936")
+        raw = "找不到名为 no-such-process 的进程。\n".encode("cp936")
+
+        output = "".join(decoder.decode(raw[i : i + 3]) for i in range(0, len(raw), 3))
+        output += decoder.decode(b"", final=True)
+
+        assert output == "找不到名为 no-such-process 的进程。\n"
+        assert "\ufffd" not in output
+
+    def test_selects_encoding_independently_for_mixed_output_lines(self):
+        decoder = _IncrementalOutputDecoder(fallback_encoding="cp936")
+        raw = "UTF-8 工具\n".encode("utf-8") + "本地程序\n".encode("cp936")
+
+        output = decoder.decode(raw, final=True)
+
+        assert output == "UTF-8 工具\n本地程序\n"
+
+    def test_emits_ascii_without_waiting_for_a_newline(self):
+        decoder = _IncrementalOutputDecoder(fallback_encoding="cp936")
+
+        assert decoder.decode(b"ready> ") == "ready> "
+
+    def test_wait_for_process_preserves_native_windows_bytes(self, monkeypatch):
+        from tools.environments import base
+
+        expected = "找不到进程\n"
+        raw_hex = expected.encode("cp936").hex()
+        monkeypatch.setattr(base, "_windows_output_encoding", lambda: "cp936")
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                f"import os; os.write(1, bytes.fromhex('{raw_hex}'))",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+
+        result = _TestableEnv()._wait_for_process(proc, timeout=10)
+
+        assert result["returncode"] == 0
+        assert result["output"] == expected
+        assert "\ufffd" not in result["output"]
 
 
 class TestWrapCommand:

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -100,6 +100,22 @@ class TestIncrementalOutputDecoder:
 
         assert decoder.decode(b"\x00\xff\n") == "\x00\ufffd\n"
 
+    def test_nul_guard_survives_split_chunks(self):
+        decoder = _IncrementalOutputDecoder(fallback_encoding="cp1252")
+
+        output = decoder.decode(b"\x00") + decoder.decode(b"\xff\n", final=True)
+
+        assert output == "\x00\ufffd\n"
+
+    def test_nul_guard_survives_a_bounded_buffer_flush(self):
+        decoder = _IncrementalOutputDecoder(fallback_encoding="cp1252")
+        first = b"\xff\x00" + b"a" * decoder._PROBE_LIMIT
+
+        output = decoder.decode(first) + decoder.decode(b"\xff\n", final=True)
+
+        assert output.count("\ufffd") == 2
+        assert "\u00ff" not in output
+
     def test_explicit_none_disables_host_fallback(self, monkeypatch):
         from tools.environments import base
 

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -90,6 +90,27 @@ class TestIncrementalOutputDecoder:
 
         assert decoder.decode(b"ready> ") == "ready> "
 
+    def test_emits_localized_output_at_a_carriage_return(self):
+        decoder = _IncrementalOutputDecoder(fallback_encoding="cp936")
+
+        assert decoder.decode("处理中\r".encode("cp936")) == "处理中\r"
+
+    def test_nul_record_keeps_utf8_replacement_behavior(self):
+        decoder = _IncrementalOutputDecoder(fallback_encoding="cp1252")
+
+        assert decoder.decode(b"\x00\xff\n") == "\x00\ufffd\n"
+
+    def test_explicit_none_disables_host_fallback(self, monkeypatch):
+        from tools.environments import base
+
+        monkeypatch.setattr(base, "_windows_output_encoding", lambda: "cp936")
+        decoder = _IncrementalOutputDecoder(fallback_encoding=None)
+
+        assert "\ufffd" in decoder.decode("本地程序\n".encode("cp936"))
+
+    def test_base_environment_does_not_guess_remote_output_encoding(self):
+        assert _TestableEnv()._output_fallback_encoding() is None
+
     def test_wait_for_process_preserves_native_windows_bytes(self, monkeypatch):
         from tools.environments import base
 
@@ -106,7 +127,9 @@ class TestIncrementalOutputDecoder:
             stderr=subprocess.STDOUT,
         )
 
-        result = _TestableEnv()._wait_for_process(proc, timeout=10)
+        env = _TestableEnv()
+        env._output_fallback_encoding = lambda: "cp936"
+        result = env._wait_for_process(proc, timeout=10)
 
         assert result["returncode"] == 0
         assert result["output"] == expected

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -373,6 +373,9 @@ def test_reader_loop_reassembles_four_byte_char_split_three_ways(registry, monke
 
 def test_reader_loop_flushes_truncated_multibyte_tail_at_eof(registry, monkeypatch):
     """A sequence truncated by process exit flushes as a single U+FFFD."""
+    from tools.environments import base
+
+    monkeypatch.setattr(base, "_windows_output_encoding", lambda: None)
     session = _run_reader(registry, monkeypatch, [b"ok \xe2\x82"])
     assert session.output_buffer == "ok \ufffd"
 
@@ -381,6 +384,18 @@ def test_reader_loop_still_replaces_genuinely_invalid_bytes(registry, monkeypatc
     """Truly invalid bytes keep the errors="replace" behavior."""
     session = _run_reader(registry, monkeypatch, [b"ok\xffdone\n"])
     assert session.output_buffer == "ok\ufffddone\n"
+
+
+def test_reader_loop_decodes_native_windows_bytes_across_chunks(registry, monkeypatch):
+    from tools.environments import base
+
+    monkeypatch.setattr(base, "_windows_output_encoding", lambda: "cp936")
+    raw = "找不到进程\n".encode("cp936")
+
+    session = _run_reader(registry, monkeypatch, [raw[:3], raw[3:7], raw[7:]])
+
+    assert session.output_buffer == "找不到进程\n"
+    assert "\ufffd" not in session.output_buffer
 
 
 def test_pty_reader_loop_reassembles_multibyte_char_split_across_chunks(registry, monkeypatch):
@@ -411,6 +426,37 @@ def test_pty_reader_loop_reassembles_multibyte_char_split_across_chunks(registry
     registry._pty_reader_loop(session)
 
     assert session.output_buffer == "café\n"
+    assert "\ufffd" not in session.output_buffer
+
+
+def test_pty_reader_loop_decodes_native_windows_bytes(registry, monkeypatch):
+    from tools.environments import base
+
+    class _FakePty:
+        def __init__(self, chunks):
+            self._chunks = list(chunks)
+            self.exitstatus = 0
+
+        def isalive(self):
+            return bool(self._chunks)
+
+        def read(self, _n):
+            return self._chunks.pop(0)
+
+        def wait(self):
+            return 0
+
+    monkeypatch.setattr(base, "_windows_output_encoding", lambda: "cp936")
+    raw = "本地程序\n".encode("cp936")
+    session = _make_session(sid="proc_pty_native")
+    session._pty = _FakePty([raw[:1], raw[1:4], raw[4:]])
+    monkeypatch.setattr(registry, "_check_watch_patterns", lambda _s, _c: None)
+    monkeypatch.setattr(registry, "_emit_output", lambda _s, _c: None)
+    monkeypatch.setattr(registry, "_move_to_finished", lambda _s: None)
+
+    registry._pty_reader_loop(session)
+
+    assert session.output_buffer == "本地程序\n"
     assert "\ufffd" not in session.output_buffer
 
 

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -381,7 +381,10 @@ def test_reader_loop_flushes_truncated_multibyte_tail_at_eof(registry, monkeypat
 
 
 def test_reader_loop_still_replaces_genuinely_invalid_bytes(registry, monkeypatch):
-    """Truly invalid bytes keep the errors="replace" behavior."""
+    """Truly invalid bytes keep the errors="replace" behavior without a fallback."""
+    from tools.environments import base
+
+    monkeypatch.setattr(base, "_windows_output_encoding", lambda: None)
     session = _run_reader(registry, monkeypatch, [b"ok\xffdone\n"])
     assert session.output_buffer == "ok\ufffddone\n"
 

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -101,20 +101,25 @@ class _IncrementalOutputDecoder:
             self._fallback_encoding = None if normalized == "utf-8" else normalized
         self._utf8_decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
         self._buffer = bytearray()
+        self._record_had_nul = False
 
     def _decode_record(self, raw: bytes) -> str:
         try:
             return raw.decode("utf-8", errors="strict")
         except UnicodeDecodeError:
-            if b"\x00" not in raw and self._fallback_encoding:
+            if not self._record_had_nul and b"\x00" not in raw and self._fallback_encoding:
                 return raw.decode(self._fallback_encoding, errors="replace")
             return raw.decode("utf-8", errors="replace")
 
     def _flush_long_buffer(self) -> str:
         raw = bytes(self._buffer)
+        self._record_had_nul = self._record_had_nul or b"\x00" in raw
         try:
             text = raw.decode("utf-8", errors="strict")
         except UnicodeDecodeError as exc:
+            if self._record_had_nul:
+                self._buffer.clear()
+                return raw.decode("utf-8", errors="replace")
             if exc.end == len(raw) and exc.reason == "unexpected end of data" and exc.start:
                 prefix = raw[: exc.start]
                 try:
@@ -151,21 +156,26 @@ class _IncrementalOutputDecoder:
             record = bytes(self._buffer[: boundary + 1])
             del self._buffer[: boundary + 1]
             output.append(self._decode_record(record))
+            self._record_had_nul = False
 
         # An ASCII-only tail is safe to stream without waiting for a newline.
         ascii_end = 0
         while ascii_end < len(self._buffer) and self._buffer[ascii_end] < 0x80:
             ascii_end += 1
         if ascii_end:
-            output.append(bytes(self._buffer[:ascii_end]).decode("ascii"))
+            ascii_raw = bytes(self._buffer[:ascii_end])
+            self._record_had_nul = self._record_had_nul or b"\x00" in ascii_raw
+            output.append(ascii_raw.decode("ascii"))
             del self._buffer[:ascii_end]
 
         if len(self._buffer) >= self._PROBE_LIMIT:
             output.append(self._flush_long_buffer())
 
-        if final and self._buffer:
-            output.append(self._decode_record(bytes(self._buffer)))
-            self._buffer.clear()
+        if final:
+            if self._buffer:
+                output.append(self._decode_record(bytes(self._buffer)))
+                self._buffer.clear()
+            self._record_had_nul = False
 
         return "".join(output)
 

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -8,6 +8,7 @@ or a temp file (local).
 
 import codecs
 import json
+import locale
 import logging
 import os
 import re
@@ -50,6 +51,116 @@ _activity_callback_local = threading.local()
 # enough that the collector never evicts in practice, keeping a single code
 # path for both bounded and unbounded modes.
 _UNBOUNDED_CAPTURE_CHARS = 2**63 - 1
+
+
+def _windows_output_encoding() -> "str | None":
+    """Return the host ANSI codec used by native Windows console programs."""
+    if os.name != "nt":
+        return None
+    try:
+        encoding = locale.getencoding()
+    except (AttributeError, TypeError):
+        encoding = locale.getpreferredencoding(False)
+    try:
+        normalized = codecs.lookup(encoding or "utf-8").name
+    except LookupError:
+        return None
+    return None if normalized == "utf-8" else normalized
+
+
+class _IncrementalOutputDecoder:
+    """Decode UTF-8 shell output with a per-line Windows ANSI fallback.
+
+    Git Bash emits UTF-8 for MSYS tools but passes native Windows child bytes
+    through unchanged.  A single fixed codec therefore cannot represent the
+    stream.  Complete lines are first decoded as strict UTF-8 and only fall
+    back to the host ANSI codec when that fails.  Buffering by line also keeps
+    multibyte sequences intact when pipe reads split them across chunks.
+
+    ASCII is emitted immediately because it is byte-identical in UTF-8 and
+    every supported Windows ANSI code page.  Unterminated non-ASCII output is
+    bounded so an arbitrarily long line cannot grow memory without limit.
+    """
+
+    _PROBE_LIMIT = 4096
+
+    def __init__(self, fallback_encoding: "str | None" = None):
+        self._fallback_encoding = (
+            _windows_output_encoding()
+            if fallback_encoding is None
+            else fallback_encoding
+        )
+        if self._fallback_encoding:
+            try:
+                normalized = codecs.lookup(self._fallback_encoding).name
+            except LookupError:
+                normalized = "utf-8"
+            self._fallback_encoding = None if normalized == "utf-8" else normalized
+        self._utf8_decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+        self._buffer = bytearray()
+
+    def _decode_record(self, raw: bytes) -> str:
+        try:
+            return raw.decode("utf-8", errors="strict")
+        except UnicodeDecodeError:
+            return raw.decode(self._fallback_encoding or "utf-8", errors="replace")
+
+    def _flush_long_buffer(self) -> str:
+        raw = bytes(self._buffer)
+        try:
+            text = raw.decode("utf-8", errors="strict")
+        except UnicodeDecodeError as exc:
+            if exc.end == len(raw) and exc.reason == "unexpected end of data" and exc.start:
+                prefix = raw[: exc.start]
+                try:
+                    text = prefix.decode("utf-8", errors="strict")
+                except UnicodeDecodeError:
+                    pass
+                else:
+                    self._buffer = bytearray(raw[exc.start :])
+                    return text
+
+            decoder = codecs.getincrementaldecoder(self._fallback_encoding)(errors="replace")
+            text = decoder.decode(raw, final=False)
+            pending, _ = decoder.getstate()
+            self._buffer = bytearray(pending)
+            return text
+
+        self._buffer.clear()
+        return text
+
+    def decode(self, data: bytes, final: bool = False) -> str:
+        if not self._fallback_encoding:
+            return self._utf8_decoder.decode(data, final=final)
+
+        self._buffer.extend(data)
+        output: list[str] = []
+
+        while True:
+            try:
+                newline = self._buffer.index(0x0A)
+            except ValueError:
+                break
+            record = bytes(self._buffer[: newline + 1])
+            del self._buffer[: newline + 1]
+            output.append(self._decode_record(record))
+
+        # An ASCII-only tail is safe to stream without waiting for a newline.
+        ascii_end = 0
+        while ascii_end < len(self._buffer) and self._buffer[ascii_end] < 0x80:
+            ascii_end += 1
+        if ascii_end:
+            output.append(bytes(self._buffer[:ascii_end]).decode("ascii"))
+            del self._buffer[:ascii_end]
+
+        if len(self._buffer) >= self._PROBE_LIMIT:
+            output.append(self._flush_long_buffer())
+
+        if final and self._buffer:
+            output.append(self._decode_record(bytes(self._buffer)))
+            self._buffer.clear()
+
+        return "".join(output)
 
 
 class EnvironmentConnectionError(RuntimeError):
@@ -1049,14 +1160,11 @@ class BaseEnvironment(ABC):
         # Any output the grandchild writes after that point goes to an
         # orphaned pipe (harmless — the kernel reaps it when our end closes).
         #
-        # Decoding: we ``os.read()`` raw bytes in fixed-size chunks (4096)
-        # so a single multibyte UTF-8 character can split across reads.  An
-        # incremental decoder buffers partial sequences across chunks, and
-        # ``errors="replace"`` mirrors the baseline ``TextIOWrapper`` (which
-        # was constructed with ``encoding="utf-8", errors="replace"`` on
-        # ``Popen``) so binary or mis-encoded output is preserved with
-        # U+FFFD substitution rather than clobbering the whole buffer.
-        decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+        # Git Bash emits UTF-8 for MSYS tools but passes bytes from native
+        # Windows children through in the host ANSI code page.  Decode raw
+        # chunks with a shared line-aware decoder so both forms survive and
+        # multibyte sequences remain intact across read boundaries.
+        decoder = _IncrementalOutputDecoder()
 
         def _drain_iterable(stream):
             # Fallback path: ``stream`` is not backed by a real OS file

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -68,6 +68,9 @@ def _windows_output_encoding() -> "str | None":
     return None if normalized == "utf-8" else normalized
 
 
+_AUTO_OUTPUT_ENCODING = object()
+
+
 class _IncrementalOutputDecoder:
     """Decode UTF-8 shell output with a per-line Windows ANSI fallback.
 
@@ -84,10 +87,10 @@ class _IncrementalOutputDecoder:
 
     _PROBE_LIMIT = 4096
 
-    def __init__(self, fallback_encoding: "str | None" = None):
+    def __init__(self, fallback_encoding=_AUTO_OUTPUT_ENCODING):
         self._fallback_encoding = (
             _windows_output_encoding()
-            if fallback_encoding is None
+            if fallback_encoding is _AUTO_OUTPUT_ENCODING
             else fallback_encoding
         )
         if self._fallback_encoding:
@@ -103,7 +106,9 @@ class _IncrementalOutputDecoder:
         try:
             return raw.decode("utf-8", errors="strict")
         except UnicodeDecodeError:
-            return raw.decode(self._fallback_encoding or "utf-8", errors="replace")
+            if b"\x00" not in raw and self._fallback_encoding:
+                return raw.decode(self._fallback_encoding, errors="replace")
+            return raw.decode("utf-8", errors="replace")
 
     def _flush_long_buffer(self) -> str:
         raw = bytes(self._buffer)
@@ -137,12 +142,14 @@ class _IncrementalOutputDecoder:
         output: list[str] = []
 
         while True:
-            try:
-                newline = self._buffer.index(0x0A)
-            except ValueError:
+            boundary = next(
+                (i for i, byte in enumerate(self._buffer) if byte in (0x0A, 0x0D)),
+                None,
+            )
+            if boundary is None:
                 break
-            record = bytes(self._buffer[: newline + 1])
-            del self._buffer[: newline + 1]
+            record = bytes(self._buffer[: boundary + 1])
+            del self._buffer[: boundary + 1]
             output.append(self._decode_record(record))
 
         # An ASCII-only tail is safe to stream without waiting for a newline.
@@ -957,6 +964,10 @@ class BaseEnvironment(ABC):
         """
         return shlex.quote(path)
 
+    def _output_fallback_encoding(self) -> "str | None":
+        """Return a trustworthy fallback codec for this backend's output."""
+        return None
+
     def _wrap_command(self, command: str, cwd: str) -> str:
         """Build the full bash script that sources snapshot, cd's, runs command,
         re-dumps env vars, and emits CWD markers."""
@@ -1164,7 +1175,9 @@ class BaseEnvironment(ABC):
         # Windows children through in the host ANSI code page.  Decode raw
         # chunks with a shared line-aware decoder so both forms survive and
         # multibyte sequences remain intact across read boundaries.
-        decoder = _IncrementalOutputDecoder()
+        decoder = _IncrementalOutputDecoder(
+            fallback_encoding=self._output_fallback_encoding()
+        )
 
         def _drain_iterable(stream):
             # Fallback path: ``stream`` is not backed by a real OS file

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -102,41 +102,47 @@ class _IncrementalOutputDecoder:
         self._utf8_decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
         self._buffer = bytearray()
         self._record_had_nul = False
+        self._record_encoding = None
 
     def _decode_record(self, raw: bytes) -> str:
+        if self._record_had_nul or b"\x00" in raw:
+            return raw.decode("utf-8", errors="replace")
+        if self._record_encoding:
+            return raw.decode(self._record_encoding, errors="replace")
         try:
             return raw.decode("utf-8", errors="strict")
         except UnicodeDecodeError:
-            if not self._record_had_nul and b"\x00" not in raw and self._fallback_encoding:
+            if self._fallback_encoding:
                 return raw.decode(self._fallback_encoding, errors="replace")
             return raw.decode("utf-8", errors="replace")
 
     def _flush_long_buffer(self) -> str:
         raw = bytes(self._buffer)
         self._record_had_nul = self._record_had_nul or b"\x00" in raw
-        try:
-            text = raw.decode("utf-8", errors="strict")
-        except UnicodeDecodeError as exc:
-            if self._record_had_nul:
+        if self._record_had_nul:
+            self._record_encoding = "utf-8"
+        elif not self._record_encoding:
+            try:
+                text = raw.decode("utf-8", errors="strict")
+            except UnicodeDecodeError as exc:
+                if exc.end == len(raw) and exc.reason == "unexpected end of data" and exc.start:
+                    try:
+                        raw[: exc.start].decode("utf-8", errors="strict")
+                    except UnicodeDecodeError:
+                        pass
+                    else:
+                        self._record_encoding = "utf-8"
+                if not self._record_encoding:
+                    self._record_encoding = self._fallback_encoding
+            else:
+                self._record_encoding = "utf-8"
                 self._buffer.clear()
-                return raw.decode("utf-8", errors="replace")
-            if exc.end == len(raw) and exc.reason == "unexpected end of data" and exc.start:
-                prefix = raw[: exc.start]
-                try:
-                    text = prefix.decode("utf-8", errors="strict")
-                except UnicodeDecodeError:
-                    pass
-                else:
-                    self._buffer = bytearray(raw[exc.start :])
-                    return text
+                return text
 
-            decoder = codecs.getincrementaldecoder(self._fallback_encoding)(errors="replace")
-            text = decoder.decode(raw, final=False)
-            pending, _ = decoder.getstate()
-            self._buffer = bytearray(pending)
-            return text
-
-        self._buffer.clear()
+        decoder = codecs.getincrementaldecoder(self._record_encoding)(errors="replace")
+        text = decoder.decode(raw, final=False)
+        pending, _ = decoder.getstate()
+        self._buffer = bytearray(pending)
         return text
 
     def decode(self, data: bytes, final: bool = False) -> str:
@@ -157,6 +163,7 @@ class _IncrementalOutputDecoder:
             del self._buffer[: boundary + 1]
             output.append(self._decode_record(record))
             self._record_had_nul = False
+            self._record_encoding = None
 
         # An ASCII-only tail is safe to stream without waiting for a newline.
         ascii_end = 0
@@ -176,6 +183,7 @@ class _IncrementalOutputDecoder:
                 output.append(self._decode_record(bytes(self._buffer)))
                 self._buffer.clear()
             self._record_had_nul = False
+            self._record_encoding = None
 
         return "".join(output)
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -15,7 +15,7 @@ from collections.abc import Mapping
 from pathlib import Path
 
 from hermes_constants import get_process_hermes_home
-from tools.environments.base import BaseEnvironment, _pipe_stdin
+from tools.environments.base import BaseEnvironment, _pipe_stdin, _windows_output_encoding
 from hermes_cli._subprocess_compat import windows_hide_flags
 
 _IS_WINDOWS = platform.system() == "Windows"
@@ -1776,6 +1776,10 @@ class LocalEnvironment(BaseEnvironment):
     def _quote_shell_path(self, path: str) -> str:
         """Rewrite native/mixed Windows paths before quoting for Git Bash."""
         return _quote_bash_path(path)
+
+    def _output_fallback_encoding(self) -> "str | None":
+        """Return the local Windows ANSI codec used by native child programs."""
+        return _windows_output_encoding()
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -29,7 +29,6 @@ Usage:
     process_registry.kill(session.id)
 """
 
-import codecs
 import json
 import logging
 import os
@@ -43,6 +42,7 @@ import uuid
 from pathlib import Path
 
 _IS_WINDOWS = platform.system() == "Windows"
+from tools.environments.base import _IncrementalOutputDecoder
 from tools.environments.local import _find_shell, _resolve_safe_cwd, _sanitize_subprocess_env
 from hermes_cli._subprocess_compat import windows_hide_flags
 from dataclasses import dataclass, field
@@ -1335,14 +1335,9 @@ class ProcessRegistry:
         lazy reconcile in poll()/wait() remains the safety net.
         """
         first_chunk = True
-        # Incremental decoder: raw pipe reads can split a multibyte UTF-8
-        # character across two read1() chunks. A stateless per-chunk
-        # ``bytes.decode(errors="replace")`` turns both halves into U+FFFD
-        # mojibake. The incremental decoder holds the partial sequence until
-        # the continuation bytes arrive — same treatment the foreground path
-        # already has in ``tools/environments/base.py::_wait_for_process``.
-        # (Ported from openclaw/openclaw#112325.)
-        decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+        # Share the foreground decoder: preserve split UTF-8 sequences and
+        # native Windows ANSI output passed through by Git Bash.
+        decoder = _IncrementalOutputDecoder()
 
         def _append_chunk(chunk: str):
             nonlocal first_chunk
@@ -1504,10 +1499,9 @@ class ProcessRegistry:
     def _pty_reader_loop(self, session: ProcessSession):
         """Background thread: read output from a PTY process."""
         pty = session._pty
-        # PTY reads can split a multibyte UTF-8 character across chunks just
-        # like pipe reads — hold partial sequences until the rest arrives.
-        # (Ported from openclaw/openclaw#112325.)
-        decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+        # Byte-returning PTYs need the same mixed UTF-8/native-Windows policy
+        # as pipe readers. pywinpty may return str, which is already decoded.
+        decoder = _IncrementalOutputDecoder()
 
         def _append_text(text: str):
             with session._lock:


### PR DESCRIPTION
## What does this PR do?

Windows users whose native programs emit the system ANSI code page now receive readable localized terminal output instead of irreversible U+FFFD replacement characters. The terminal still preserves UTF-8 output from MSYS tools, including streams where multibyte characters cross pipe-read boundaries.

### Symptom

On a zh-CN Windows host using code page 936, localized output from a native program invoked through Git Bash was decoded as UTF-8 with replacement enabled. The terminal result contained replacement characters instead of the original message.

### Impact

Affected Windows users lose diagnostic text from native commands, so error messages can become unreadable before the agent receives them. The verified failure affects foreground local execution and the equivalent raw-byte background reader path.

### Bug Cause

**Trigger:** `tools/environments/base.py:1164` / `BaseEnvironment._wait_for_process` when Git Bash forwards bytes from a native Windows child.

**Causal chain:**
1. A native Windows child writes localized output using the host ANSI code page while MSYS programs in the same shell continue to emit UTF-8.
2. Foreground, background, and byte-returning PTY readers feed all raw chunks to UTF-8-only incremental decoders.
3. Invalid UTF-8 byte sequences are replaced with U+FFFD before terminal output reaches the agent.

**Why it is wrong:** Git Bash can carry both UTF-8 MSYS output and native Windows code-page output, so one fixed UTF-8 decoder cannot represent every valid stream.

**Working sibling / contrast:** UTF-8 output from MSYS tools already decodes correctly and must remain unchanged; pywinpty string output is already decoded by its provider and does not need byte decoding.

**Ruled out:** The native process does not emit damaged text. Captured raw bytes decode correctly as code page 936, which isolates the loss to Hermes' raw-byte decoding step.

### Fix

Add a shared bounded incremental decoder that prefers strict UTF-8 for each complete record and falls back to the host Windows ANSI codec only when UTF-8 is invalid. Use it for foreground pipes, background process pipes, and byte-returning PTYs so mixed encodings and multibyte sequences split across chunks are preserved without changing already-decoded string output.

## Related Issue

Closes #89442

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/base.py` - detect the native Windows output codec, add bounded mixed-encoding incremental decoding, and use it for foreground raw-byte output.
- `tools/process_registry.py` - share the decoder across background pipe and byte-returning PTY readers.
- `tests/tools/test_base_environment.py` - cover UTF-8, code page 936, mixed records, prompt output, foreground execution, and chunk boundaries.
- `tests/tools/test_process_registry.py` - cover native Windows bytes and split multibyte sequences in background and PTY readers.

## How to Test

1. On Windows 11 with ANSI code page 936, invoke a native PowerShell command that emits a localized error through the local terminal backend and confirm the text is readable with no U+FFFD characters.
2. Run an MSYS command that emits UTF-8 CJK text and confirm it remains unchanged.
3. Start the native-output command in the background and confirm ProcessRegistry returns readable output with no replacement characters.
4. Automated verification already run: 14 focused decoder, foreground, background, PTY, and timeout-output tests passed; Ruff passed for the changed files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, zh-CN, ANSI code page 936

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, no user-facing configuration changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, no configuration keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A, no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, the terminal tool contract is unchanged
