### PR TITLE
fix(matrix): clear stale inbound sessions on device reset

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1476,7 +1476,7 @@ class MatrixAdapter(BasePlatformAdapter):
         return True
 
     async def _reset_crypto_store_if_device_changed(
-        self, crypto_store: Any, device_id: str
+        self, crypto_store: Any, crypto_db: Any, device_id: str
     ) -> bool:
         """Reset the local Olm account when the access token's device changed.
 
@@ -1504,6 +1504,16 @@ class MatrixAdapter(BasePlatformAdapter):
             device_id,
         )
         await crypto_store.delete()
+        # mautrix 0.21's PgCryptoStore.delete() removes the account, Olm
+        # sessions and outbound Megolm sessions, but leaves inbound Megolm
+        # sessions behind. Those rows are pickled with the old device-derived
+        # key and raise BAD_ACCOUNT_KEY after a device change, including while
+        # sending to an encrypted room. They belong to the old device and must
+        # be removed as part of the same reset.
+        await crypto_db.execute(
+            "DELETE FROM crypto_megolm_inbound_session WHERE account_id=$1",
+            crypto_store.account_id,
+        )
         return True
 
     async def _migrate_legacy_crypto_pickle(
@@ -1938,7 +1948,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
                     if client.device_id:
                         _store_was_reset = await self._reset_crypto_store_if_device_changed(
-                            crypto_store, client.device_id
+                            crypto_store, crypto_db, client.device_id
                         )
                         await crypto_store.put_device_id(client.device_id)
                     else:

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -227,6 +227,7 @@ def _make_fake_mautrix():
             db = MagicMock()
             db.start = AsyncMock()
             db.stop = AsyncMock()
+            db.execute = AsyncMock()
             return db
 
     mautrix_util_async_db.Database = Database
@@ -2944,18 +2945,27 @@ class TestMatrixDispatchSyncIsolation:
 
 class TestCryptoStoreResetOnDeviceChange:
     @pytest.mark.asyncio
-    async def test_reset_when_device_id_changed(self, caplog):
+    async def test_resets_store_when_device_changed(self, caplog):
         import logging
         adapter = _make_adapter()
         store = MagicMock()
+        store.account_id = "@bot:example.org"
         store.get_device_id = AsyncMock(return_value="OLDDEVICE")
         store.delete = AsyncMock()
+        crypto_db = MagicMock()
+        crypto_db.execute = AsyncMock()
 
         with caplog.at_level(logging.WARNING):
-            reset = await adapter._reset_crypto_store_if_device_changed(store, "NEWDEVICE")
+            reset = await adapter._reset_crypto_store_if_device_changed(
+                store, crypto_db, "NEWDEVICE"
+            )
 
         assert reset is True
         store.delete.assert_awaited_once()
+        crypto_db.execute.assert_awaited_once_with(
+            "DELETE FROM crypto_megolm_inbound_session WHERE account_id=$1",
+            "@bot:example.org",
+        )
         assert "OLDDEVICE" in caplog.text and "NEWDEVICE" in caplog.text
 
     @pytest.mark.asyncio
@@ -2964,9 +2974,14 @@ class TestCryptoStoreResetOnDeviceChange:
         store = MagicMock()
         store.get_device_id = AsyncMock(return_value="SAMEDEVICE")
         store.delete = AsyncMock()
+        crypto_db = MagicMock()
+        crypto_db.execute = AsyncMock()
 
-        assert await adapter._reset_crypto_store_if_device_changed(store, "SAMEDEVICE") is False
+        assert await adapter._reset_crypto_store_if_device_changed(
+            store, crypto_db, "SAMEDEVICE"
+        ) is False
         store.delete.assert_not_awaited()
+        crypto_db.execute.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_no_reset_on_fresh_store(self):
@@ -2974,9 +2989,14 @@ class TestCryptoStoreResetOnDeviceChange:
         store = MagicMock()
         store.get_device_id = AsyncMock(return_value=None)
         store.delete = AsyncMock()
+        crypto_db = MagicMock()
+        crypto_db.execute = AsyncMock()
 
-        assert await adapter._reset_crypto_store_if_device_changed(store, "NEWDEVICE") is False
+        assert await adapter._reset_crypto_store_if_device_changed(
+            store, crypto_db, "NEWDEVICE"
+        ) is False
         store.delete.assert_not_awaited()
+        crypto_db.execute.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_no_reset_without_device_id(self):
@@ -2984,9 +3004,14 @@ class TestCryptoStoreResetOnDeviceChange:
         store = MagicMock()
         store.get_device_id = AsyncMock(return_value="OLDDEVICE")
         store.delete = AsyncMock()
+        crypto_db = MagicMock()
+        crypto_db.execute = AsyncMock()
 
-        assert await adapter._reset_crypto_store_if_device_changed(store, "") is False
+        assert await adapter._reset_crypto_store_if_device_changed(
+            store, crypto_db, ""
+        ) is False
         store.delete.assert_not_awaited()
+        crypto_db.execute.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_connect_resets_store_when_token_device_differs_from_config(


### PR DESCRIPTION
## Summary
- Clear inbound Megolm sessions when Matrix resets the local crypto store after a device change.
- Avoid retained sessions encrypted with the old device-derived pickle key causing `BAD_ACCOUNT_KEY`.

## Test plan
- `uv run --extra dev pytest -q tests/gateway/test_matrix.py::TestCryptoStoreResetOnDeviceChange::test_resets_store_when_device_changed tests/gateway/test_matrix.py::TestCryptoStoreResetOnDeviceChange::test_no_reset_when_device_id_same tests/gateway/test_matrix.py::TestCryptoStoreResetOnDeviceChange::test_no_reset_on_fresh_store tests/gateway/test_matrix.py::TestCryptoStoreResetOnDeviceChange::test_no_reset_without_device_id`
- `uv run --extra dev ruff check plugins/platforms/matrix/adapter.py tests/gateway/test_matrix.py`
