### PR TITLE
feat: allow free-response Discord messages to create threads

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1632,6 +1632,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["allowed_topics"] = platform_cfg["allowed_topics"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
+                if "auto_thread_free_response" in platform_cfg:
+                    bridged["auto_thread_free_response"] = platform_cfg["auto_thread_free_response"]
                 if "mention_patterns" in platform_cfg:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if "exclusive_bot_mentions" in platform_cfg:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6718,6 +6718,15 @@ class DiscordAdapter(BasePlatformAdapter):
             return {part.strip() for part in s.split(",") if part.strip()}
         return set()
 
+    def _discord_auto_thread_free_response(self) -> bool:
+        """Whether free-response channel messages should auto-create threads."""
+        raw = self.config.extra.get("auto_thread_free_response")
+        if raw is None:
+            raw = self._gate_env("DISCORD_AUTO_THREAD_FREE_RESPONSE")
+        if isinstance(raw, bool):
+            return raw
+        return str(raw or "").strip().lower() in {"true", "1", "yes"}
+
     def _raw_mentioned_user_ids(self, message: Any) -> set:
         """Extract Discord user-mention IDs directly from raw message content.
 
@@ -8073,6 +8082,8 @@ class DiscordAdapter(BasePlatformAdapter):
         #   discord.allowed_channels: If set, bot ONLY responds in these channels (whitelist)
         #   discord.no_thread_channels: Channel IDs where bot responds directly without creating thread
         #   discord.auto_thread: Auto-create thread on @mention in channels (default: true)
+        #   discord.auto_thread_free_response: Also auto-create threads for
+        #       messages admitted by free_response_channels (default: false)
 
         thread_id = None
         parent_channel_id = None
@@ -8159,7 +8170,13 @@ class DiscordAdapter(BasePlatformAdapter):
         auto_threaded_channel = None
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels = self._get_no_thread_channels()
-            skip_thread = bool(channel_keys & no_thread_channels) or is_free_channel
+            # Free-response channels historically reply inline.  Keep that
+            # default, but allow an explicit opt-in for thread-first workflows
+            # where every admitted message should become its own conversation.
+            auto_thread_free_response = self._discord_auto_thread_free_response()
+            skip_thread = bool(channel_keys & no_thread_channels) or (
+                is_free_channel and not auto_thread_free_response
+            )
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:

--- a/tests/e2e/test_discord_adapter.py
+++ b/tests/e2e/test_discord_adapter.py
@@ -12,6 +12,7 @@ import pytest
 
 from tests.e2e.conftest import (
     BOT_USER_ID,
+    CHANNEL_ID,
     E2E_MESSAGE_SETTLE_DELAY,
     get_response_text,
     make_discord_message,
@@ -105,6 +106,21 @@ class TestAutoThreadingPreservesCommand:
         response = get_response_text(discord_adapter)
         assert response is not None
         assert "/new" in response
+
+    async def test_free_response_channel_can_opt_into_auto_threads(
+        self, discord_adapter, monkeypatch
+    ):
+        """Free-response ingress can retain thread-first behavior explicitly."""
+        monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+        discord_adapter.config.extra["free_response_channels"] = [str(CHANNEL_ID)]
+        discord_adapter.config.extra["auto_thread_free_response"] = True
+        fake_thread = make_fake_thread(thread_id=90002, name="free-response")
+        msg = make_discord_message(content="message without a mention")
+        msg.create_thread = AsyncMock(return_value=fake_thread)
+
+        await dispatch(discord_adapter, msg)
+
+        msg.create_thread.assert_awaited_once()
 
 
 class TestRepliedToMediaDispatch:

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -300,7 +300,8 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `DISCORD_THREAD_REQUIRE_MENTION` | No | `false` | When `true`, the in-thread mention shortcut is disabled — threads are gated the same as channels, requiring `@mention` even after the bot has already participated. Use this when multiple bots share a thread and you want each to fire only on explicit `@mention`. |
 | `DISCORD_FREE_RESPONSE_CHANNELS` | No | — | Comma-separated channel IDs where the bot responds without requiring an `@mention`, even when `DISCORD_REQUIRE_MENTION` is `true`. |
 | `DISCORD_IGNORE_NO_MENTION` | No | `true` | When `true`, the bot stays silent if a message `@mentions` other users but does **not** mention the bot. Prevents the bot from jumping into conversations directed at other people. Only applies in server channels, not DMs. |
-| `DISCORD_AUTO_THREAD` | No | `true` | When `true`, automatically creates a new thread for every `@mention` in a text channel, so each conversation is isolated (similar to Slack behavior). Messages already inside threads or DMs are unaffected. |
+| `DISCORD_AUTO_THREAD` | No | `true` | When `true`, automatically creates a new thread for every admitted message in a text channel, subject to `no_thread_channels` and the free-response threading compatibility setting. |
+| `DISCORD_AUTO_THREAD_FREE_RESPONSE` | No | `false` | When `true`, also auto-creates a thread for messages admitted by `free_response_channels`. Defaults to `false` to preserve inline free-response behavior. |
 | `DISCORD_ALLOW_BOTS` | No | `"none"` | Controls how the bot handles messages from other Discord bots. `"none"` — ignore all other bots. `"mentions"` — only accept bot messages that `@mention` Hermes. `"all"` — accept all bot messages. |
 | `DISCORD_REACTIONS` | No | `true` | When `true`, the bot adds emoji reactions to messages during processing (👀 when starting, ✅ on success, ❌ on error). Set to `false` to disable reactions entirely. |
 | `DISCORD_IGNORED_CHANNELS` | No | — | Comma-separated channel IDs where the bot **never** responds, even when `@mentioned`. Takes priority over all other channel settings. |
@@ -335,6 +336,7 @@ discord:
   require_mention: true           # Require @mention in server channels
   thread_require_mention: false   # If true, require @mention in threads too (multi-bot threads)
   free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
+  auto_thread_free_response: false # Thread every message in free-response channels
   auto_thread: true               # Auto-create threads on @mention
   reactions: true                 # Add emoji reactions during processing
   ignored_channels: []            # Channel IDs where bot never responds
@@ -400,7 +402,7 @@ discord:
 
 If a thread's parent channel is in this list, the thread also becomes mention-free.
 
-Free-response channels also **skip auto-threading** — the bot replies inline rather than spinning off a new thread per message. This keeps the channel usable as a lightweight chat surface. If you want threading behavior, don't list the channel as free-response (use normal `@mention` flow instead).
+Free-response channels **skip auto-threading by default** — the bot replies inline rather than spinning off a new thread per message. Set `discord.auto_thread_free_response: true` (or `DISCORD_AUTO_THREAD_FREE_RESPONSE=true`) to opt into thread-first behavior while retaining mention-free ingress.
 
 #### `discord.auto_thread`
 
@@ -408,7 +410,7 @@ Free-response channels also **skip auto-threading** — the bot replies inline r
 
 When enabled, every `@mention` in a regular text channel automatically creates a new thread for the conversation. This keeps the main channel clean and gives each conversation its own isolated session history. Once a thread is created, subsequent messages in that thread don't require `@mention` — the bot knows it's already participating. Set [`thread_require_mention`](#discordthread_require_mention) to `true` to disable this in-thread shortcut for multi-bot setups.
 
-Messages sent in existing threads or DMs are unaffected by this setting. Channels listed in `discord.free_response_channels` or `discord.no_thread_channels` also bypass auto-threading and get inline replies instead.
+Messages already inside threads or DMs are unaffected by this setting. Channels listed in `discord.no_thread_channels` bypass auto-threading. Free-response channels bypass it unless `discord.auto_thread_free_response` is enabled.
 
 #### `discord.reactions`
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR do?

Adds an opt-in thread-first mode for Discord free-response channels.

Previously, `free_response_channels` allowed Hermes to respond without an `@mention`, but responses were posted inline in the channel. This made it difficult to keep separate conversations organized.

This PR adds `discord.auto_thread_free_response`. When enabled alongside `free_response_channels`, each top-level message creates a separate Discord thread and Hermes responds inside that thread. Subsequent messages within the thread continue the conversation without requiring another mention.

Existing inline free-response behavior remains unchanged by default, so this is backward-compatible.

## Related Issue

No related issue. This PR introduces a new opt-in Discord messaging feature.

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `discord.auto_thread_free_response` configuration support.
- Added `DISCORD_AUTO_THREAD_FREE_RESPONSE` environment-variable support.
- Updated `gateway/config.py` to bridge the new Discord setting into the platform adapter configuration.
- Updated `plugins/platforms/discord/adapter.py` to:
  - preserve inline replies by default;
  - create a separate thread for each admitted top-level message when the opt-in is enabled;
  - continue handling subsequent messages inside the created thread without requiring an `@mention`;
  - preserve existing `no_thread_channels` and auto-thread behavior.
- Added an end-to-end test covering free-response messages that create threads.
- Updated `website/docs/user-guide/messaging/discord.md` with configuration and behavior details.

## How to Test

1. Configure a Discord channel as free-response and enable thread-first mode:

   ```yaml
   discord:
     free_response_channels:
       - "CHANNEL_ID"
     auto_thread_free_response: true
   ```

2. Start or restart the Hermes gateway and post a normal message in the configured Discord channel without mentioning Hermes.

3. Confirm that Hermes creates a new Discord thread on the message and responds inside that thread.

4. Send a follow-up message inside the created thread without mentioning Hermes. Confirm that Hermes continues the same conversation.

5. Send another top-level message in the configured channel. Confirm that Hermes creates a separate thread for it.

Focused automated verification:

```text
8 passed in 3.16s
```

## Checklist

### Code

- [ ] I've read the [Contributing Guide](@url:`https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md`)
- [x] My commit messages follow [Conventional Commits](@url:`https://www.conventionalcommits.org/`) (`feat(scope):`, `fix(scope):`, etc.)
- [ ] I searched for [existing PRs](@url:`https://github.com/NousResearch/hermes-agent/pulls`) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Hermes gateway / Discord)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](@url:`https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility`) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

Not applicable; this PR does not add a skill.

## Screenshots / Logs

Focused Discord adapter test output:

```text
........                                                                 [100%]
8 passed in 3.16s
```

Manual verification on Discord confirmed the intended behavior:

- a top-level message in the configured channel creates a new thread;
- Hermes responds inside that thread;
- subsequent messages inside the thread continue without an `@mention`;
- another top-level message creates a separate thread.

--- Context Warnings ---

The URL extraction warnings were retained from the supplied template; they do not affect this PR description.
