### PR TITLE
feat(desktop): live-preview themes from the palette highlight

### DIFF
--- a/apps/desktop/src/app/command-palette/highlight-watcher.test.tsx
+++ b/apps/desktop/src/app/command-palette/highlight-watcher.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * The regression that motivates this file: cmdk calls the root
+ * `onValueChange` only in controlled mode (a set `value` prop). The palette
+ * is uncontrolled, so a highlight preview wired to that prop never fires.
+ * The watcher must read the cmdk store instead, which works in both modes.
+ */
+
+import { render } from '@testing-library/react'
+import { Command } from 'cmdk'
+import { describe, expect, it, vi } from 'vitest'
+
+import { HighlightWatcher } from './highlight-watcher'
+
+// cmdk observes group headings with a ResizeObserver, which jsdom lacks.
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+
+Element.prototype.scrollIntoView = function scrollIntoView() {}
+
+const palette = (onValue: (value: string) => void, onRootValueChange?: (value: string) => void) => (
+  <Command onValueChange={onRootValueChange}>
+    <HighlightWatcher onValue={onValue} />
+    <Command.List>
+      <Command.Item value="alpha">Alpha</Command.Item>
+      <Command.Item value="beta">Beta</Command.Item>
+    </Command.List>
+  </Command>
+)
+
+describe('HighlightWatcher', () => {
+  it('reports the highlight from the cmdk store in uncontrolled mode', () => {
+    const onValue = vi.fn()
+
+    render(palette(onValue))
+
+    // cmdk auto-highlights the first item on mount.
+    expect(onValue).toHaveBeenCalledWith('alpha')
+  })
+
+  it('covers the gap: the root onValueChange stays silent in uncontrolled mode', () => {
+    const onValue = vi.fn()
+    const onRootValueChange = vi.fn()
+
+    render(palette(onValue, onRootValueChange))
+
+    // The store-based watcher fires. The prop the first implementation used
+    // does not. If cmdk starts to fire it in uncontrolled mode, the watcher
+    // becomes removable — this assertion is the signal.
+    expect(onValue).toHaveBeenCalledWith('alpha')
+    expect(onRootValueChange).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/command-palette/highlight-watcher.tsx
+++ b/apps/desktop/src/app/command-palette/highlight-watcher.tsx
@@ -1,0 +1,31 @@
+/**
+ * Reports the cmdk highlight to the palette.
+ *
+ * cmdk calls the root `onValueChange` only in controlled mode (when the
+ * `value` prop is set). This palette is uncontrolled, so that prop never
+ * fires. This watcher subscribes to the cmdk store with `useCommandState`,
+ * which works in both modes, and reports each highlight change.
+ */
+
+import { useCommandState } from 'cmdk'
+import { useEffect, useRef } from 'react'
+
+interface HighlightWatcherProps {
+  /** Receives the cmdk value of each newly highlighted row. */
+  onValue: (value: string) => void
+}
+
+export function HighlightWatcher({ onValue }: HighlightWatcherProps): null {
+  const value = useCommandState(state => state.value)
+
+  // Pin the callback so the effect fires on highlight changes only. The
+  // parent passes a fresh closure on every render.
+  const onValueRef = useRef(onValue)
+  onValueRef.current = onValue
+
+  useEffect(() => {
+    onValueRef.current(value)
+  }, [value])
+
+  return null
+}

--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -1424,11 +1424,23 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
     [clearThemePreview, itemByValue]
   )
 
-  // A preview lives only while its rows show. If the page changes or the
-  // palette retires, give the paint back to the committed appearance.
+  // A preview lives only while its rows show. If the page changes, give the
+  // paint back to the committed appearance.
   useEffect(() => {
     clearThemePreview()
   }, [page, clearThemePreview])
+
+  // Clear at close START, not at unmount. The body stays mounted through the
+  // whole exit animation (see CommandPalette), so an unmount clear would
+  // revert the theme only after the fade. The unmount return is the backstop
+  // for a body that dies without a close (a remount on reopen).
+  const paletteOpen = useStore($commandPaletteOpen)
+
+  useEffect(() => {
+    if (!paletteOpen) {
+      clearThemePreview()
+    }
+  }, [paletteOpen, clearThemePreview])
 
   useEffect(() => clearThemePreview, [clearThemePreview])
 

--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -128,6 +128,11 @@ interface PaletteItem {
   /** Label shown while ⌘/⌃ is held — previews the modifier-variant action. */
   modLabel?: string
   /**
+   * Runs when the row becomes the cmdk highlight (arrow keys or hover). When
+   * a row has no onHighlight, a highlight on it clears the live preview.
+   */
+  onHighlight?: () => void
+  /**
    * When set, ⌘/⌃-select (or ⌘-Enter) opens a new tab and ⇧⌘-select pops a
    * window — matching sidebar session rows. Plain select stays in-place.
    * Receives the last selector event so the modifiers can be read.
@@ -549,7 +554,10 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
   const projectTree = useStore($projectTree)
   const dismissedAutoProjects = useStore($dismissedAutoProjectIds)
   const navigate = useNavigate()
-  const { availableThemes, mode, resolvedMode, setMode, setTheme, themeName } = useTheme()
+
+  const { availableThemes, clearThemePreview, mode, previewTheme, resolvedMode, setMode, setTheme, themeName } =
+    useTheme()
+
   const [search, setSearch] = useState('')
   const [page, setPage] = useState<string | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
@@ -1100,21 +1108,32 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
     // can't render the current light/dark mode, flip to the one it supports.
     result.push({
       heading: t.settings.appearance.themeTitle,
-      items: availableThemes.map(theme => ({
-        active: themeName === theme.name,
-        icon: Palette,
-        id: `search-theme-${theme.name}`,
-        keepOpen: true,
-        keywords: ['theme', 'appearance', 'color', 'skin', theme.name, theme.description],
-        label: theme.label,
-        run: () => {
-          setTheme(theme.name)
+      items: availableThemes.map(theme => {
+        // Same mode fixup as run(): if a theme cannot render the current
+        // light/dark, preview (and commit) in the one mode it supports.
+        const previewMode = themeSupportsMode(theme.name, resolvedMode)
+          ? resolvedMode
+          : resolvedMode === 'dark'
+            ? 'light'
+            : 'dark'
 
-          if (!themeSupportsMode(theme.name, resolvedMode)) {
-            setMode(resolvedMode === 'dark' ? 'light' : 'dark')
+        return {
+          active: themeName === theme.name,
+          icon: Palette,
+          id: `search-theme-${theme.name}`,
+          keepOpen: true,
+          keywords: ['theme', 'appearance', 'color', 'skin', theme.name, theme.description],
+          label: theme.label,
+          onHighlight: () => previewTheme(theme.name, previewMode),
+          run: () => {
+            setTheme(theme.name)
+
+            if (!themeSupportsMode(theme.name, resolvedMode)) {
+              setMode(previewMode)
+            }
           }
         }
-      }))
+      })
     })
 
     // Switch light/dark/system directly (typing "dark" shouldn't require the
@@ -1210,6 +1229,7 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
     goSession,
     mcpServers,
     mode,
+    previewTheme,
     resolvedMode,
     search,
     sessions,
@@ -1318,6 +1338,7 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
                 keepOpen: true,
                 keywords: ['theme', 'appearance', 'palette', groupMode, theme.label, theme.description ?? ''],
                 label: theme.label,
+                onHighlight: () => previewTheme(theme.name, groupMode),
                 run: () => {
                   setTheme(theme.name)
                   setMode(groupMode)
@@ -1365,13 +1386,49 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
         groups: settingsPageGroups
       }
     }),
-    [availableThemes, mode, resolvedMode, setMode, setTheme, settingsPageGroups, t, themeName]
+    [availableThemes, mode, previewTheme, resolvedMode, setMode, setTheme, settingsPageGroups, t, themeName]
   )
 
   const activePage = page ? subPages[page] : null
   const unrankedGroups = activePage ? activePage.groups : groups
   const visibleGroups = useMemo(() => rankGroups(unrankedGroups, search), [unrankedGroups, search])
   const placeholder = activePage ? activePage.placeholder : t.commandCenter.searchPlaceholder
+
+  // cmdk reports the highlighted row (arrows or hover) via the root's
+  // onValueChange. Resolve it back to its PaletteItem so preview-capable rows
+  // (the theme pickers) can paint live. Any other highlight clears the preview.
+  const itemByValue = useMemo(() => {
+    const map = new Map<string, PaletteItem>()
+
+    for (const group of visibleGroups) {
+      for (const item of group.items) {
+        map.set(paletteValue(item), item)
+      }
+    }
+
+    return map
+  }, [visibleGroups])
+
+  const handleHighlight = useCallback(
+    (value: string) => {
+      const item = itemByValue.get(value)
+
+      if (item?.onHighlight) {
+        item.onHighlight()
+      } else {
+        clearThemePreview()
+      }
+    },
+    [clearThemePreview, itemByValue]
+  )
+
+  // A preview lives only while its rows show. If the page changes or the
+  // palette retires, give the paint back to the committed appearance.
+  useEffect(() => {
+    clearThemePreview()
+  }, [page, clearThemePreview])
+
+  useEffect(() => clearThemePreview, [clearThemePreview])
 
   const handleSelect = (item: PaletteItem) => {
     if (item.to) {
@@ -1423,7 +1480,7 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
         }}
       >
         <DialogPrimitive.Title className="sr-only">{t.commandCenter.paletteTitle}</DialogPrimitive.Title>
-        <Command className="bg-transparent" loop shouldFilter={false}>
+        <Command className="bg-transparent" loop onValueChange={handleHighlight} shouldFilter={false}>
           {activePage && (
             <button
               className="flex w-full items-center gap-1.5 border-b border-border px-3 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:text-foreground"

--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -105,6 +105,7 @@ import { type SettingsSearchEntry, settingsSearchTargetQuery } from '../settings
 import { useSettingsSearchCatalog } from '../settings/use-settings-search'
 
 import { usePaletteContributions } from './contrib'
+import { HighlightWatcher } from './highlight-watcher'
 import { MarketplaceThemePage } from './marketplace-theme-page'
 import { PetInlineToggle, PetPalettePage } from './pet-palette-page'
 
@@ -1394,9 +1395,10 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
   const visibleGroups = useMemo(() => rankGroups(unrankedGroups, search), [unrankedGroups, search])
   const placeholder = activePage ? activePage.placeholder : t.commandCenter.searchPlaceholder
 
-  // cmdk reports the highlighted row (arrows or hover) via the root's
-  // onValueChange. Resolve it back to its PaletteItem so preview-capable rows
-  // (the theme pickers) can paint live. Any other highlight clears the preview.
+  // The HighlightWatcher inside <Command> reports the highlighted row (arrows
+  // or hover) from the cmdk store. Resolve it back to its PaletteItem so
+  // preview-capable rows (the theme pickers) can paint live. Any other
+  // highlight clears the preview.
   const itemByValue = useMemo(() => {
     const map = new Map<string, PaletteItem>()
 
@@ -1480,7 +1482,8 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
         }}
       >
         <DialogPrimitive.Title className="sr-only">{t.commandCenter.paletteTitle}</DialogPrimitive.Title>
-        <Command className="bg-transparent" loop onValueChange={handleHighlight} shouldFilter={false}>
+        <Command className="bg-transparent" loop shouldFilter={false}>
+          <HighlightWatcher onValue={handleHighlight} />
           {activePage && (
             <button
               className="flex w-full items-center gap-1.5 border-b border-border px-3 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:text-foreground"

--- a/apps/desktop/src/themes/context.test.tsx
+++ b/apps/desktop/src/themes/context.test.tsx
@@ -2,7 +2,8 @@ import { act, cleanup, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { __resetBackendSkinSync, ingestBackendSkin } from './backend-sync'
-import { ThemeProvider } from './context'
+import { skinPref, ThemeProvider, useTheme } from './context'
+import { midnightTheme } from './presets'
 
 // The live-authoring loop: Hermes writes/edits one skin file and every surface
 // repaints. An in-place edit keeps the NAME — only the palette moves.
@@ -66,5 +67,74 @@ describe('ThemeProvider ← backend skin sync', () => {
       ingestBackendSkin({ name: 'forest', colors: { background: '#001100', ui_text: '#66ff66' } }, { apply: false })
     )
     expect(cssVar('--theme-foreground')).toBe('#ff9f0a')
+  })
+})
+
+describe('ThemeProvider highlight preview', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    __resetBackendSkinSync()
+  })
+
+  afterEach(cleanup)
+
+  // Read the live context so the tests drive the real provider, not a mock.
+  let ctx: ReturnType<typeof useTheme>
+
+  function Probe() {
+    ctx = useTheme()
+
+    return null
+  }
+
+  const renderProbe = () =>
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>
+    )
+
+  it('paints the previewed theme without persisting it', () => {
+    renderProbe()
+
+    const committed = ctx.themeName
+
+    act(() => ctx.previewTheme('midnight', 'dark'))
+
+    expect(cssVar('--theme-foreground')).toBe(midnightTheme.colors.foreground)
+    // The commit surface does not change. The context name and the stored
+    // preference keep their values.
+    expect(ctx.themeName).toBe(committed)
+    expect(skinPref.resolve('default')).toBe(committed)
+  })
+
+  it('clearThemePreview repaints the committed appearance', () => {
+    renderProbe()
+
+    act(() => ctx.previewTheme('midnight', 'dark'))
+    expect(cssVar('--theme-foreground')).toBe(midnightTheme.colors.foreground)
+
+    act(() => ctx.clearThemePreview())
+    expect(cssVar('--theme-foreground')).not.toBe(midnightTheme.colors.foreground)
+  })
+
+  it('a commit replaces the preview and persists', () => {
+    renderProbe()
+
+    act(() => ctx.previewTheme('midnight', 'dark'))
+    act(() => ctx.setTheme('mono'))
+
+    expect(ctx.themeName).toBe('mono')
+    expect(skinPref.resolve('default')).toBe('mono')
+    expect(cssVar('--theme-foreground')).not.toBe(midnightTheme.colors.foreground)
+  })
+
+  it('ignores a preview of an unknown theme', () => {
+    renderProbe()
+
+    const painted = cssVar('--theme-foreground')
+
+    act(() => ctx.previewTheme('does-not-exist', 'dark'))
+    expect(cssVar('--theme-foreground')).toBe(painted)
   })
 })

--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -298,6 +298,13 @@ interface ThemeContextValue {
   availableThemes: Array<{ name: string; label: string; description: string }>
   setTheme: (name: string) => void
   setMode: (mode: ThemeMode) => void
+  /**
+   * Paint a theme with an explicit light/dark, without persistence. This is
+   * the highlight preview for the palette. A commit (`setTheme`) or
+   * `clearThemePreview` repaints the committed appearance.
+   */
+  previewTheme: (name: string, mode: 'light' | 'dark') => void
+  clearThemePreview: () => void
 }
 
 const SKIN_LIST = BUILTIN_THEME_LIST.map(({ name, label, description }) => ({ name, label, description }))
@@ -310,7 +317,9 @@ const ThemeContext = createContext<ThemeContextValue>({
   renderedMode: 'light',
   availableThemes: SKIN_LIST,
   setTheme: () => {},
-  setMode: () => {}
+  setMode: () => {},
+  previewTheme: () => {},
+  clearThemePreview: () => {}
 })
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
@@ -378,19 +387,27 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   const systemDark = useMediaQuery('(prefers-color-scheme: dark)')
   const resolvedMode = resolveMode(mode, systemDark)
 
+  // Transient highlight preview (palette theme picker). It is never
+  // persisted. A commit or an explicit clear returns the paint to the
+  // committed appearance.
+  const [preview, setPreview] = useState<{ name: string; mode: 'light' | 'dark' } | null>(null)
+
+  const paintedName = preview ? preview.name : themeName
+  const paintedMode = preview ? preview.mode : resolvedMode
+
   const activeTheme = useMemo(
-    () => deriveTheme(themeName, resolvedMode),
+    () => deriveTheme(paintedName, paintedMode),
     // deriveTheme resolves its seed through the merged registry, so the theme
     // stores are its reactivity too — an in-place palette edit of the ACTIVE
     // skin (live theme authoring) must repaint, not just a name switch.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [themeName, resolvedMode, userThemes, backendThemes, registryVersion]
+    [paintedName, paintedMode, userThemes, backendThemes, registryVersion]
   )
 
   // What actually gets painted (matches the `.dark` class applyTheme toggles).
-  const renderedMode = useMemo(() => renderedModeFor(activeTheme.colors, resolvedMode), [activeTheme, resolvedMode])
+  const renderedMode = useMemo(() => renderedModeFor(activeTheme.colors, paintedMode), [activeTheme, paintedMode])
 
-  useEffect(() => applyTheme(activeTheme, resolvedMode), [activeTheme, resolvedMode])
+  useEffect(() => applyTheme(activeTheme, paintedMode), [activeTheme, paintedMode])
 
   // Keep the native window appearance pinned to the app theme (vibrancy
   // material, titlebar, new-window pre-paint background).
@@ -402,14 +419,22 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
   const setTheme = useCallback((name: string) => {
     const next = normalizeSkin(name)
+    setPreview(null)
     setThemeNameState(next)
     skinPref.assign(liveProfile(), next)
   }, [])
 
   const setMode = useCallback((next: ThemeMode) => {
+    setPreview(null)
     setModeState(next)
     modePref.assign(liveProfile(), next)
   }, [])
+
+  const previewTheme = useCallback((name: string, previewMode: 'light' | 'dark') => {
+    setPreview(resolveTheme(name) ? { name, mode: previewMode } : null)
+  }, [])
+
+  const clearThemePreview = useCallback(() => setPreview(null), [])
 
   // Drain a backend-driven skin switch (Hermes authoring/activating a skin from a
   // prompt, or `/skin` on another surface). setTheme persists it per profile, so
@@ -427,8 +452,30 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   // (`appearance.toggleMode`) so it shows up in the hotkey map and is rebindable.
 
   const value = useMemo<ThemeContextValue>(
-    () => ({ theme: activeTheme, themeName, mode, resolvedMode, renderedMode, availableThemes, setTheme, setMode }),
-    [activeTheme, themeName, mode, resolvedMode, renderedMode, availableThemes, setTheme, setMode]
+    () => ({
+      theme: activeTheme,
+      themeName,
+      mode,
+      resolvedMode,
+      renderedMode,
+      availableThemes,
+      setTheme,
+      setMode,
+      previewTheme,
+      clearThemePreview
+    }),
+    [
+      activeTheme,
+      themeName,
+      mode,
+      resolvedMode,
+      renderedMode,
+      availableThemes,
+      setTheme,
+      setMode,
+      previewTheme,
+      clearThemePreview
+    ]
   )
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>


### PR DESCRIPTION
## What does this PR do?

The theme rows in the Cmd-K picker applied a theme only on select. This PR paints the highlighted theme immediately. Move the highlight with the arrow keys or the pointer, and the window shows that theme. Select a row to keep it. Move away, close the palette, or leave the page, and the committed theme returns.

The preview reads the cmdk highlight from the cmdk store. cmdk calls the root `onValueChange` only in controlled mode, and this palette is uncontrolled, so a small `HighlightWatcher` child subscribes with `useCommandState` instead. A new optional `onHighlight` callback on `PaletteItem` receives the highlight. The theme context gets `previewTheme(name, mode)` and `clearThemePreview()`. A preview repaints through the same `deriveTheme` and `applyTheme` path as a commit, but it does not touch localStorage or the profile preferences. Other windows do not repaint, and a relaunch boots the committed theme.

The Marketplace install page does not preview. Those themes are not local before an install, so there is nothing to paint.

## Related Issue

No open issue exists for this feature.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/themes/context.tsx` — add `previewTheme` and `clearThemePreview` to the theme context. A transient preview state layers over the committed pick. `setTheme` and `setMode` clear the preview. An unknown theme name is a no-op.
- `apps/desktop/src/app/command-palette/index.tsx` — add the optional `onHighlight` field to `PaletteItem`. Mount a `HighlightWatcher` inside the `<Command>` root to resolve the highlighted value back to its item. The nested theme picker previews in its group's light or dark mode. The root-search theme rows preview with the same mode fixup that their `run()` uses. A highlight on a row without `onHighlight` clears the preview. A page change and the palette unmount also clear it.
- `apps/desktop/src/app/command-palette/highlight-watcher.tsx` — the watcher. It subscribes to the cmdk store with `useCommandState`, which reports the highlight in uncontrolled mode. The root `onValueChange` prop does not.
- `apps/desktop/src/app/command-palette/highlight-watcher.test.tsx` — two tests against a real uncontrolled cmdk root: the watcher fires on the auto-highlight, and the root `onValueChange` prop stays silent. The second assertion signals when cmdk changes this behavior and the watcher becomes removable.
- `apps/desktop/src/themes/context.test.tsx` — four new tests against the real provider: a preview paints without persistence, a clear repaints the committed appearance, a commit replaces the preview and persists, and an unknown name changes nothing.

## How to Test

1. Run the desktop app. Press Cmd-K, open "Change theme…".
2. Move the highlight across the theme rows with the arrow keys or the pointer. The window repaints with each highlighted theme.
3. Press Escape without a select. The committed theme returns, and a relaunch boots the committed theme.
4. Select a theme. The pick persists, the same as before.
5. `cd apps/desktop && npx vitest run src/themes/ src/app/command-palette/` — 9 files, 72 tests pass.
6. `cd apps/desktop && npx tsc -p . --noEmit` and `npx eslint` on the three changed files — clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the JS test suite for the touched area and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
Test Files  9 passed (9)
     Tests  72 passed (72)
```

