### PR TITLE
fix(gateway): deduplicate replayed restart events

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20821,60 +20821,81 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
 
     def _is_stale_restart_redelivery(self, event: MessageEvent) -> bool:
-        """Return True if this /restart is a Telegram re-delivery we already handled.
+        """Return True when a chat /restart event was already processed.
 
-        The previous gateway wrote ``.restart_last_processed.json`` with the
-        triggering platform + update_id when it processed the /restart.  If
-        we now see a /restart on the same platform with an update_id <= that
-        recorded value, it is a redelivery when this process booted from that
-        restart. Otherwise the marker must still be recent (< 5 minutes).
+        Every adapter may expose a stable ``message_id``.  An exact match with
+        the durable restart marker is unambiguous across gateway processes and
+        prevents startup sync/replay from executing the same destructive
+        command twice (notably Matrix initial sync).
 
-        Only applies to Telegram today (the only platform that exposes a
-        numeric cross-session update ordering); other platforms return False.
+        Telegram additionally exposes a numeric ``platform_update_id``.  Keep
+        the older same-or-lower update ordering guard and its bounded fallback
+        for PTB shutdown-ACK failures where no stable message marker survived.
         """
         if event is None or event.source is None:
             return False
-        if event.platform_update_id is None:
-            return False
         if event.source.platform is None:
             return False
-        # Only Telegram populates platform_update_id currently; be explicit
-        # so future platforms aren't accidentally gated by this check.
         try:
             platform_value = event.source.platform.value
         except Exception:
             return False
-        if platform_value != "telegram":
-            return False
 
+        marker_path = _hermes_home / ".restart_last_processed.json"
         try:
-            marker_path = _hermes_home / ".restart_last_processed.json"
-            if not marker_path.exists():
-                # Belt-and-suspenders for when the dedup marker goes missing
-                # (manually cleaned up, or the previous cycle's write failed).
-                # Without a marker the update_id comparison below can't run, so
-                # a redelivered /restart would sail through and re-restart the
-                # gateway — an infinite loop (issue #18528).
-                #
-                # Suppress ONLY when we can independently confirm we just came
-                # out of a restart cycle: this process booted from a
-                # chat-originated /restart (_booted_from_restart) AND is still
-                # within a short post-boot window. This never swallows a
-                # genuine first /restart on a fresh boot (no restart marker on
-                # boot → flag stays False). Consume the flag one-shot so a
-                # legitimate /restart sent later in the same session is honored.
-                if (
-                    getattr(self, "_booted_from_restart", False)
-                    and time.time() - getattr(self, "_startup_time", 0.0) < 60
-                ):
-                    self._booted_from_restart = False
-                    return True
-                return False
-            data = json.loads(marker_path.read_text(encoding="utf-8"))
+            marker_exists = marker_path.exists()
+            data = (
+                json.loads(marker_path.read_text(encoding="utf-8"))
+                if marker_exists
+                else None
+            )
         except Exception:
             return False
 
-        if data.get("platform") != platform_value:
+        if isinstance(data, dict) and data.get("platform") == platform_value:
+            recorded_message_id = data.get("message_id")
+            event_message_id = getattr(event, "message_id", None)
+            if (
+                isinstance(recorded_message_id, str)
+                and recorded_message_id
+                and isinstance(event_message_id, str)
+                and event_message_id == recorded_message_id
+            ):
+                # The immutable platform event itself is the idempotency key.
+                # Consume the boot hint when present; exact-ID matching does
+                # not need a wall-clock trust window.
+                if getattr(self, "_booted_from_restart", False):
+                    self._booted_from_restart = False
+                return True
+
+        # Only Telegram has ordered update IDs.  Other platforms are safely
+        # handled by exact event/message ID above.
+        if platform_value != "telegram" or event.platform_update_id is None:
+            return False
+
+        if not marker_exists:
+            # Belt-and-suspenders for when the dedup marker goes missing
+            # (manually cleaned up, or the previous cycle's write failed).
+            # Without a marker the update_id comparison below can't run, so
+            # a redelivered /restart would sail through and re-restart the
+            # gateway — an infinite loop (issue #18528).
+            #
+            # Suppress ONLY when we can independently confirm we just came
+            # out of a restart cycle: this process booted from a
+            # chat-originated /restart (_booted_from_restart) AND is still
+            # within a short post-boot window. This never swallows a
+            # genuine first /restart on a fresh boot (no restart marker on
+            # boot → flag stays False). Consume the flag one-shot so a
+            # legitimate /restart sent later in the same session is honored.
+            if (
+                getattr(self, "_booted_from_restart", False)
+                and time.time() - getattr(self, "_startup_time", 0.0) < 60
+            ):
+                self._booted_from_restart = False
+                return True
+            return False
+
+        if not isinstance(data, dict) or data.get("platform") != platform_value:
             return False
         recorded_uid = data.get("update_id")
         if not isinstance(recorded_uid, int):

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1603,8 +1603,10 @@ class GatewaySlashCommandsMixin:
         """Handle /restart command - drain active work, then restart the gateway."""
         from gateway.run import _hermes_home
         # Defensive idempotency check: if the previous gateway process
-        # recorded this same /restart (same platform + update_id) and the new
-        # process is seeing it *again*, this is a re-delivery caused by PTB's
+        # recorded this same /restart (same platform + immutable message/event
+        # ID, or Telegram update_id) and the new process is seeing it *again*,
+        # this is a platform startup re-delivery. Telegram commonly does this
+        # when PTB's
         # graceful-shutdown `get_updates` ACK failing on the way out ("Error
         # while calling `get_updates` one more time to mark all fetched
         # updates. Suppressing error to ensure graceful shutdown. When
@@ -1615,9 +1617,10 @@ class GatewaySlashCommandsMixin:
         # again.
         if self._is_stale_restart_redelivery(event):
             logger.info(
-                "Ignoring redelivered /restart (platform=%s, update_id=%s) — "
+                "Ignoring redelivered /restart (platform=%s, message_id=%s, update_id=%s) — "
                 "already processed by a previous gateway instance.",
                 event.source.platform.value if event.source and event.source.platform else "?",
+                event.message_id,
                 event.platform_update_id,
             )
             return ""
@@ -1665,16 +1668,19 @@ class GatewaySlashCommandsMixin:
         except Exception as e:
             logger.debug("Failed to write restart notify file: %s", e)
 
-        # Record the triggering platform + update_id in a dedicated dedup
-        # marker.  Unlike .restart_notify.json (which gets unlinked once the
-        # new gateway sends the "gateway restarted" notification), this
-        # marker persists so the new gateway can still detect a delayed
-        # /restart redelivery from Telegram.  Overwritten on every /restart.
+        # Record the triggering platform + immutable message/event ID in a
+        # dedicated dedup marker. Telegram also records its ordered update_id.
+        # Unlike .restart_notify.json (which gets unlinked once the new gateway
+        # sends the "gateway restarted" notification), this marker persists so
+        # the new gateway can detect a delayed platform replay of the same
+        # /restart event. Overwritten on every /restart.
         try:
             dedup_data = {
                 "platform": event.source.platform.value if event.source.platform else None,
                 "requested_at": time.time(),
             }
+            if event.message_id:
+                dedup_data["message_id"] = str(event.message_id)
             if event.platform_update_id is not None:
                 dedup_data["update_id"] = event.platform_update_id
             await asyncio.to_thread(

--- a/tests/gateway/test_restart_redelivery_dedup.py
+++ b/tests/gateway/test_restart_redelivery_dedup.py
@@ -26,6 +26,23 @@ def _make_restart_event(update_id: int | None = 100) -> MessageEvent:
     )
 
 
+def _make_matrix_restart_event(message_id: str) -> MessageEvent:
+    from gateway.config import Platform
+    from gateway.session import SessionSource
+
+    return MessageEvent(
+        text="/restart",
+        message_type=MessageType.COMMAND,
+        source=SessionSource(
+            platform=Platform.MATRIX,
+            chat_id="!home:example.org",
+            chat_type="dm",
+            user_id="@alice:example.org",
+        ),
+        message_id=message_id,
+    )
+
+
 @pytest.mark.asyncio
 async def test_redelivered_restart_with_older_update_id_is_ignored(tmp_path, monkeypatch):
     """update_id strictly LESS than the recorded one is also a redelivery."""
@@ -163,4 +180,57 @@ async def test_marker_missing_but_booted_from_restart_ignores_redelivery(tmp_pat
     # One-shot: the flag is consumed so a later legitimate /restart is honored.
     assert runner._booted_from_restart is False
 
+
+@pytest.mark.asyncio
+async def test_matrix_restart_same_event_id_is_ignored_after_restart(tmp_path, monkeypatch):
+    """Matrix initial-sync replay of the exact triggering event is idempotent."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+
+    marker = tmp_path / ".restart_last_processed.json"
+    marker.write_text(json.dumps({
+        "platform": "matrix",
+        "message_id": "$restart-event",
+        "requested_at": time.time() - 5,
+    }))
+
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+    runner._booted_from_restart = True
+
+    result = await runner._handle_restart_command(
+        _make_matrix_restart_event("$restart-event")
+    )
+
+    assert result == ""
+    runner.request_restart.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_matrix_restart_different_event_id_is_honored(tmp_path, monkeypatch):
+    """A new Matrix command is not swallowed merely because restart was recent."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+
+    marker = tmp_path / ".restart_last_processed.json"
+    marker.write_text(json.dumps({
+        "platform": "matrix",
+        "message_id": "$old-restart-event",
+        "requested_at": time.time() - 5,
+    }))
+
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+    runner._booted_from_restart = True
+
+    result = await runner._handle_restart_command(
+        _make_matrix_restart_event("$new-restart-event")
+    )
+
+    assert "Restarting gateway" in result
+    runner.request_restart.assert_called_once()
+
+    persisted = json.loads(marker.read_text())
+    assert persisted["platform"] == "matrix"
+    assert persisted["message_id"] == "$new-restart-event"
 


### PR DESCRIPTION
## Summary

Prevent a chat-originated `/restart` from executing twice when a platform replays the same immutable message event after the gateway comes back.

Matrix can re-deliver the triggering event during the replacement process's initial sync. The existing restart guard only handled Telegram's numeric `platform_update_id`, so the replayed Matrix event was queued during startup restore, drained, and executed as a second restart.

## Changes

- Persist the triggering `MessageEvent.message_id` alongside the platform in `.restart_last_processed.json` before requesting shutdown.
- Treat an exact `platform + message_id` match as an already-processed restart event across gateway processes.
- Preserve Telegram's existing same-or-lower `platform_update_id` behavior and missing-marker fallback.
- Include the message ID in the redelivery log record.
- Add regressions proving:
  - the exact same Matrix event ID is ignored after restart;
  - a different Matrix event ID still triggers a legitimate restart;
  - the accepted new command replaces the durable marker with its own event ID.

## Reproduction evidence

One Matrix `!restart` event produced:

1. the first planned restart;
2. replacement gateway initial sync;
3. `Queued inbound message during gateway startup restore`;
4. `Drained 1 inbound message(s) queued during startup restore`;
5. a second planned restart approximately six seconds after the first.

The Matrix room contained only one user restart event ID, ruling out a client double-send.

## Verification

On the exact source base used for the patch:

```text
74 passed, 2 skipped
```

Suites included the focused restart-redelivery module and adjacent startup, service-detection, resume-pending, after-turn, drain, and notification restart tests.

After activation, a real Matrix `!restart` produced exactly one user command event, one “Restarting gateway” event, one replacement PID, and one “Gateway restarted successfully” event, with no second restart.
