### PR TITLE
fix(deps): patch Node and Electron security advisories

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -37,7 +37,7 @@ min-release-age-exclude[]=brace-expansion
 # js-yaml 4.3.1 includes fixes for GHSA-5p4m-2wfm-xmqj. remove when > 2wks old (rel 2026-07-31)
 min-release-age-exclude[]=js-yaml
 
-# nanoid 3.3.17 includes fixes for GHSA-2v37-7h3g-55p8. remove when > 2wks old (rel 2026-08-03)
+# nanoid 3.3.18 includes fixes for GHSA-2v37-7h3g-55p8. remove when > 2wks old (rel 2026-08-07)
 min-release-age-exclude[]=nanoid
 
 # mermaid 11.16.1 includes fixes for 5 GHSAs. remove when > 2wks old (rel 2026-08-04)

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -169,7 +169,7 @@
     "bippy": "0.5.43",
     "concurrently": "10.0.4",
     "cross-env": "10.1.0",
-    "electron": "40.10.2",
+    "electron": "41.10.3",
     "electron-builder": "26.15.3",
     "esbuild": "0.28.1",
     "jsdom": "29.1.1",
@@ -182,7 +182,7 @@
     "wait-on": "9.0.10"
   },
   "build": {
-    "electronVersion": "40.10.2",
+    "electronVersion": "41.10.3",
     "appId": "com.nousresearch.hermes",
     "productName": "Hermes",
     "executableName": "Hermes",

--- a/apps/desktop/scripts/packaged-app-layout.mjs
+++ b/apps/desktop/scripts/packaged-app-layout.mjs
@@ -1,0 +1,3 @@
+export function resolveLinuxUnpackedDirName(arch) {
+  return arch === 'x64' ? 'linux-unpacked' : `linux-${arch}-unpacked`
+}

--- a/apps/desktop/scripts/packaged-app-layout.test.mjs
+++ b/apps/desktop/scripts/packaged-app-layout.test.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { resolveLinuxUnpackedDirName } from './packaged-app-layout.mjs'
+
+test('uses electron-builder default directory on Linux x64', () => {
+  assert.equal(resolveLinuxUnpackedDirName('x64'), 'linux-unpacked')
+})
+
+test('includes architecture in electron-builder Linux ARM64 directory', () => {
+  assert.equal(resolveLinuxUnpackedDirName('arm64'), 'linux-arm64-unpacked')
+})

--- a/apps/desktop/scripts/test-desktop.mjs
+++ b/apps/desktop/scripts/test-desktop.mjs
@@ -5,6 +5,7 @@ import { spawn, spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import { listPackage } from '@electron/asar'
 
+import { resolveLinuxUnpackedDirName } from './packaged-app-layout.mjs'
 import PACKAGE_JSON from '../package.json' with { type: 'json' }
 
 const MODE = process.argv[2] || 'help'
@@ -38,8 +39,8 @@ const APP = (() => {
       unpackedDistIndex: path.join(unpacked, 'resources', 'app.asar.unpacked', 'dist', 'index.html')
     }
   }
-  // linux unpacked layout matches windows but with different binary name
-  const unpacked = path.join(RELEASE_ROOT, 'linux-unpacked')
+  // electron-builder uses an architecture suffix for non-x64 Linux output.
+  const unpacked = path.join(RELEASE_ROOT, resolveLinuxUnpackedDirName(ARCH))
   return {
     appPath: unpacked,
     binary: path.join(unpacked, 'Hermes'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -152,7 +152,7 @@
         "bippy": "0.5.43",
         "concurrently": "10.0.4",
         "cross-env": "10.1.0",
-        "electron": "40.10.2",
+        "electron": "41.10.3",
         "electron-builder": "26.15.3",
         "esbuild": "0.28.1",
         "jsdom": "29.1.1",
@@ -171,57 +171,6 @@
         "get-windows": "9.3.0"
       }
     },
-    "apps/desktop/node_modules/@electron/get": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
-      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "env-paths": "^2.2.0",
-        "fs-extra": "^8.1.0",
-        "got": "^11.8.5",
-        "progress": "^2.0.3",
-        "semver": "^6.2.0",
-        "sumchecker": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "global-agent": "^3.0.0"
-      }
-    },
-    "apps/desktop/node_modules/electron": {
-      "version": "40.10.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-40.10.2.tgz",
-      "integrity": "sha512-Xj3Hy0Imbu4g0gDIW55w/jJYz94nMO2JRSGYA3LyAn5SwaERCelgZrA21vfH+Bi//SWAWQXddHsMwCqauyMT8g==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@electron/get": "^2.0.0",
-        "@types/node": "^24.9.0",
-        "extract-zip": "^2.0.1"
-      },
-      "bin": {
-        "electron": "cli.js"
-      },
-      "engines": {
-        "node": ">= 12.20.55"
-      }
-    },
-    "apps/desktop/node_modules/electron/node_modules/@types/node": {
-      "version": "24.13.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
-      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.18.0"
-      }
-    },
     "apps/desktop/node_modules/ignore": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
@@ -230,13 +179,6 @@
       "engines": {
         "node": ">= 4"
       }
-    },
-    "apps/desktop/node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
-      "license": "MIT"
     },
     "apps/shared": {
       "name": "@hermes/shared",
@@ -1366,6 +1308,16 @@
         "react": ">=16.8.0"
       }
     },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.5.tgz",
+      "integrity": "sha512-+bqFCP98pLI0Tt0XQo1TmlXtwjWchISndDOxCkEcIuUgXWpBnLyRI+2DU+mesvnMMX6L1XDqYNA0lXNDHd/yiA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
     "node_modules/@electron/asar": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
@@ -1495,6 +1447,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.1.0.tgz",
+      "integrity": "sha512-3kSBtG8ObcTVfXanm5vVJ6UnBLEVmVsRk1M+vGqCuMBV+XLCbJYuWQful+yIy0GQDsSlK0kHEriEHn7SPk4EnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
+        "progress": "^2.0.3",
+        "semver": "^7.6.3",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "optionalDependencies": {
+        "undici": "^7.24.4"
+      }
+    },
+    "node_modules/@electron/get/node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@electron/get/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@electron/notarize": {
@@ -6525,17 +6524,6 @@
       "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "license": "MIT"
     },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.64.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.64.0.tgz",
@@ -9580,6 +9568,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/electron": {
+      "version": "41.10.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.10.3.tgz",
+      "integrity": "sha512-MJuSODPw8siv/I8JjhctW/cS/XNldwI4gLRyyWZx6QkoZJUDgbEvitp7IVOnGrHENTQb6Udo+zMpKhFnhlIhdg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 22.12.0"
+      }
+    },
     "node_modules/electron-builder": {
       "version": "26.15.3",
       "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.3.tgz",
@@ -9956,6 +9963,23 @@
       "engines": {
         "node": ">=6 <7 || >=8"
       }
+    },
+    "node_modules/electron/node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/electron/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
@@ -10492,27 +10516,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10773,21 +10776,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
       }
     },
     "node_modules/fs.realpath": {
@@ -15076,13 +15064,6 @@
         "url": "https://github.com/sponsors/jet2jet"
       }
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -16485,9 +16466,9 @@
       }
     },
     "node_modules/sanitize-html/node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -18325,9 +18306,9 @@
       }
     },
     "node_modules/vite/node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -18940,19 +18921,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
-      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "mermaid": "11.16.1",
     "dompurify": "3.4.13",
     "ip-address": "10.3.1",
-    "nanoid@^3": "3.3.17",
+    "nanoid@^3": "3.3.18",
     "nanoid@^6": "6.0.0",
     "js-yaml@^4": "4.3.1",
     "undici@^6": "6.28.0",
@@ -67,7 +67,7 @@
     "esbuild@0.28.1": true,
     "node-pty@1.1.0": true,
     "electron-winstaller@5.4.0": true,
-    "electron@40.10.2": true,
+    "electron@41.10.3": true,
     "fsevents@2.3.2": true,
     "fsevents@2.3.3": true,
     "get-windows@9.3.0": true


### PR DESCRIPTION
## Summary

- raise the Nano ID v3 override from 3.3.17 to 3.3.18 for GHSA-2v37-7h3g-55p8
- move Electron from 40.10.2 to 41.10.3, the lowest release line that fixes both current Electron advisories
- replace Electron's vulnerable legacy `extract-zip` path with the fixed internal extractor pulled by Electron 41
- teach the Linux desktop bundle validator about electron-builder's `linux-arm64-unpacked` directory
- add a regression test for x64 and ARM64 Linux unpacked-directory names

## Why

`npm audit --workspace web` and `npm audit --workspace ui-tui` reported the Nano ID advisory through Vite/PostCSS. A complete workspace audit also found two Electron advisories plus `extract-zip` path traversal. Electron 40.10.6 fixes only one of the Electron advisories; 41.10.3 is the minimal release that covers both.

The verification run exposed a pre-existing ARM64-only validator bug: electron-builder correctly emitted `release/linux-arm64-unpacked`, while `scripts/test-desktop.mjs` hard-coded `release/linux-unpacked`.

## Verification

- `npm audit --workspaces=false` — 0 vulnerabilities
- `npm audit --workspace web` — 0 vulnerabilities
- `npm audit --workspace ui-tui` — 0 vulnerabilities
- `npm audit` — 0 vulnerabilities
- `npm run build --workspace web` — passed
- `npm run check --workspace ui-tui` — 158 files passed, 1,672 tests passed, 1 skipped; existing lint warnings only
- desktop `check:lint`, UI tests, and Electron-platform tests — passed before the ARM64 bundle-path assertion
- `node --test apps/desktop/scripts/packaged-app-layout.test.mjs` — 2 passed
- `HERMES_DESKTOP_SKIP_BUILD=1 npm run test:desktop:all --workspace apps/desktop` — passed against the Electron 41.10.3 ARM64 package
- `./node_modules/.bin/electron --no-sandbox --version` — v41.10.3
