### PR TITLE
docs(auxiliary): document one-shot cache eviction priority

### DIFF
--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1381,6 +1381,24 @@ auxiliary:
 
 The semaphore wraps the entire call including retries and fallbacks, so a single slow call counts only once toward the limit.
 
+### Prioritizing one-shot auxiliary cache entries for eviction
+
+One-shot tasks such as context compression produce KV/radix-cache prefixes that are unlikely to be reused. When an inference engine supports priority-based cache eviction, set its request-specific priority field through the task's `extra_body` so those entries are evicted before long-lived agent and subagent prefixes:
+
+```yaml
+auxiliary:
+  compression:
+    extra_body:
+      priority: -1000
+```
+
+This field is **inference-engine-specific**; Hermes forwards it but does not normalize its meaning:
+
+- **SGLang:** start the engine with `--radix-eviction-policy priority`. SGLang then evicts the lowest-priority radix-cache nodes first, so a negative value such as `-1000` makes compression entries easier to evict than entries using the default priority. See NVIDIA Dynamo's [SGLang guide for agentic workloads](https://docs.nvidia.com/dynamo/v1.0.2/user-guides/agents/sg-lang-for-agentic-workloads#priority-based-kv-cache-eviction).
+- **vLLM:** `priority` controls request scheduling, not KV-cache eviction; lower values are handled earlier, and nonzero values require priority scheduling to be enabled. Do not use the SGLang example as an eviction setting for vLLM. See the [vLLM OpenAI-compatible server reference](https://docs.vllm.ai/en/v0.13.0/serving/openai_compatible_server/).
+
+Check your inference engine's request schema before adding other `extra_body` fields.
+
 ### OpenRouter routing & Pareto Code for auxiliary tasks
 
 When an auxiliary task resolves to OpenRouter (either explicitly or via `provider: "main"` while your main agent is on OpenRouter), the main agent's `provider_routing` and `openrouter.min_coding_score` settings **do not propagate** — by design, each auxiliary task is independent. To set OpenRouter provider preferences or use the [Pareto Code router](/integrations/providers#openrouter-pareto-code-router) for a specific aux task, set them per-task via `extra_body`:


### PR DESCRIPTION
## What does this PR do?

Documents how operators can mark one-shot auxiliary request cache entries for earlier eviction without changing Hermes runtime behavior. The guide now explains that `auxiliary.<task>.extra_body` forwards engine-specific request fields and distinguishes SGLang cache eviction priority from vLLM request scheduling priority.

## Related Issue

Closes #89462

## Type of Change

- [x] Documentation update

## Changes Made

- `website/docs/user-guide/configuration.md` - add a compression example for SGLang priority-based radix-cache eviction, the required server flag, and a vLLM compatibility warning with official references.

## How to Test

1. Build the English documentation site:

```bash
cd website
npx -y npm@11.17.0 run build:fast
```

2. Confirm the configuration guide renders the YAML example and both engine-specific notes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this documentation update (no unrelated commits)
- [x] I've run the relevant Docusaurus build and it passes

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` is N/A because this documents an existing passthrough field
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no architecture or workflow changed
- [x] Cross-platform impact is N/A because this is documentation-only
- [x] Tool descriptions and schemas are N/A because tool behavior did not change
