### PR TITLE
test(gateway): drop a wait that was never synchronising anything

### DIFF
--- a/tests/gateway/test_goal_continuation_drain.py
+++ b/tests/gateway/test_goal_continuation_drain.py
@@ -189,7 +189,19 @@ async def test_runner_goal_hook_enqueues_into_the_key_the_adapter_drains(hermes_
             source=src,
             final_response="partial progress",
         )
-        await asyncio.sleep(0.05)
+        # No wait here, deliberately. `_post_turn_goal_continuation` awaits
+        # every step and ends in a synchronous `_enqueue_fifo`; there is no
+        # create_task / ensure_future / call_soon anywhere in it, so once the
+        # await above returns the enqueue has already happened. The 50ms sleep
+        # this replaces was not too short, it was measuring nothing.
+        #
+        # That matters for reading a CI failure here: `pending keys=[]` cannot
+        # be a lost race against the event loop. It means the hook took a path
+        # that never enqueued -- one of the early returns (no session id,
+        # `mgr.is_active()` false, `should_continue` false, no prompt) or the
+        # `except Exception` around the enqueue, which swallows into a
+        # logger.debug. Waiting longer cannot fix any of those, so do not
+        # "fix" a future flake here by adding a sleep back.
 
     assert adapter_key in adapter._pending_messages, (
         "continuation enqueued under a different key than the adapter "


### PR DESCRIPTION
## What does this PR do?

`tests/gateway/test_goal_continuation_drain.py::test_runner_goal_hook_enqueues_into_the_key_the_adapter_drains`
slept a fixed 50ms between calling the post-turn goal hook and asserting the
enqueue landed. This removes that wait. It does **not** claim to fix the CI
flake, and the rewrite below explains why, because an earlier revision of this
PR did claim exactly that and was wrong.

## What this PR used to say, and why it was wrong

The original version replaced the sleep with a bounded poll, on the stated
theory that "the enqueue does not happen inline, the hook hands off to a task,
so the assertion is racing the event loop".

There is no such handoff. `_post_turn_goal_continuation` contains no
`asyncio.create_task`, no `ensure_future` and no `call_soon`; every step in it
is awaited, and it ends in a synchronous `self._enqueue_fifo(...)`.
`_defer_goal_status_notice_after_delivery`, the one call in there that looks
deferred, either registers an adapter callback and returns or awaits
`_deliver()` directly, and what it delivers is a status notice rather than the
enqueue.

So I measured it instead of arguing about it. Removing the wait **entirely**
(no sleep, no poll) on current `main`:

```
15 runs: pass=15 fail=0
```

If the assertion were racing a spawned task, the zero-wait run is precisely the
one that would fail every time. The 50ms sleep was not too short. It was
measuring nothing.

Credit to @Enough1122, whose review nit ("an event or awaiting the task would be
strictly deterministic") is what sent me back to the code. The answer turned out
to be that there is no task to await, so no production test hook is needed
either.

## What that means for the flake

The CI failure this test produces is:

```
AssertionError: continuation enqueued under a different key than the adapter drains:
pending keys=[] expected=agent:main:slack:channel:C1:1718600000.000100
```

If the enqueue is inline, `pending keys=[]` cannot be a lost race. It means the
hook took a path that never enqueued at all: one of the early returns (no
session id, `mgr.is_active()` false, `should_continue` false, no prompt), or the
`except Exception` wrapped around the enqueue, which swallows the error into a
`logger.debug`. A bounded poll cannot fix any of those. It would wait two
seconds and fail with the same message.

My current suspicion is goals-DB contention upstream of `mgr.is_active()`, since
the test writes a goal via `GoalManager` and then depends on reading it back,
but I have not proven that and am not claiming it here. **Someone should still
open an investigation into the enqueue-path returns**; I did not want the
observed CI failure marked resolved by a change that cannot resolve it.

## Related Issue

None. This came out of a flake observed on unrelated PRs.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/gateway/test_goal_continuation_drain.py`: delete the `await asyncio.sleep(0.05)`
  between the hook call and the assertion, replacing it with a comment that
  records why the hook is already synchronous, and why adding a sleep back would
  be the wrong response to the next failure here.

No production code is touched, and no other test changes.

## How to Test

1. `pytest tests/gateway/test_goal_continuation_drain.py -q` — 2 passed.
2. Repeat the single test to show the wait was not load-bearing:
   `for i in $(seq 1 15); do pytest tests/gateway/...::test_runner_goal_hook_enqueues_into_the_key_the_adapter_drains -q; done`
   gives 15/15 pass with no wait present.
3. Read `_post_turn_goal_continuation` in `gateway/run.py` and grep it for
   `create_task`, `ensure_future`, `call_soon`: none are present, which is the
   static half of the same claim.
4. `ruff check tests/gateway/test_goal_continuation_drain.py` — clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) <!-- N/A: this IS a test change; it removes a wait rather than adding coverage -->
- [x] I've tested on my platform: Windows 11 (Python 3.13)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A <!-- the reasoning lives in the test comment, which is where the next person will look -->
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A <!-- N/A -->
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A <!-- N/A -->
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A <!-- removing a wait cannot be platform-specific, and the test carries no platform gate -->
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A <!-- N/A -->

## Screenshots / Logs

```
$ # wait removed entirely, single test, 15 consecutive runs
15 runs: pass=15 fail=0

$ pytest tests/gateway/test_goal_continuation_drain.py -q
..                                                                       [100%]
2 passed in 1.66s

$ ruff check tests/gateway/test_goal_continuation_drain.py
All checks passed!
```
