### PR TITLE
feat(desktop): ⌘⇧E collapses / expands all sidebar projects

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/filter-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/filter-menu.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
+  DropdownMenuShortcut,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
@@ -20,6 +21,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { useI18n } from '@/i18n'
 import { desktopGit } from '@/lib/desktop-git'
+import { useKeybindHint } from '@/lib/keybinds/use-keybind-hint'
 import { cn } from '@/lib/utils'
 import {
   $sidebarCardRows,
@@ -39,7 +41,6 @@ import {
   setSidebarGrouping,
   setSidebarOrdering,
   setSidebarShowArchived,
-  setWorkspaceNodesOpen,
   type SidebarGrouping,
   type SidebarOrdering,
   type SidebarRowMeta,
@@ -57,7 +58,7 @@ import {
   toggleShowAllProfiles
 } from '@/store/profile'
 import { runImportProfileFlow } from '@/store/profile-share'
-import { $projectTree } from '@/store/projects'
+import { $projectTree, projectsAllCollapsed, toggleAllProjectsCollapsed } from '@/store/projects'
 import type { PullRequestBucket } from '@/store/pull-requests'
 import { $unreadFinishedSessionIds, markAllSessionsRead } from '@/store/session'
 import type { SessionStatusBucket } from '@/store/session-dot-state'
@@ -174,7 +175,8 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
   const prAvailable = Boolean(desktopGit()?.review?.prList)
   // Project rows default open, so "all collapsed" means every one of them has
   // been explicitly shut.
-  const projectsCollapsed = projects.length > 0 && projects.every(project => nodeOpen[project.id] === false)
+  const projectsCollapsed = projectsAllCollapsed(projects, nodeOpen)
+  const collapseHint = useKeybindHint('view.toggleProjects')
 
   const groupingLabel = GROUPINGS.find(option => option.id === grouping)?.label
 
@@ -397,15 +399,9 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
             what "collapse all" means here. Their lanes underneath keep their
             own state, so re-opening a project shows it as you left it. */}
         {grouping === 'project' && projects.length > 0 && (
-          <DropdownMenuItem
-            onSelect={() =>
-              setWorkspaceNodesOpen(
-                projects.map(project => project.id),
-                projectsCollapsed
-              )
-            }
-          >
+          <DropdownMenuItem onSelect={toggleAllProjectsCollapsed}>
             {projectsCollapsed ? 'Expand all' : 'Collapse all'}
+            {collapseHint && <DropdownMenuShortcut>{collapseHint}</DropdownMenuShortcut>}
           </DropdownMenuItem>
         )}
         <DropdownMenuItem disabled={unreadIds.length === 0} onSelect={markAllSessionsRead}>

--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -46,7 +46,7 @@ import {
   switchToDefaultProfile,
   toggleShowAllProfiles
 } from '@/store/profile'
-import { openFolderAsProject } from '@/store/projects'
+import { openFolderAsProject, toggleAllProjectsCollapsed } from '@/store/projects'
 import { toggleReview } from '@/store/review'
 import { $selectedStoredSessionId, setModelPickerOpen } from '@/store/session'
 import { reopenLastClosedTile } from '@/store/session-states'
@@ -251,6 +251,8 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
     'view.toggleStatusbar': toggleStatusbarVisible,
     'view.toggleTabStrip': () => void toggleTargetZoneTabStrip(),
     'view.showFiles': showFiles,
+    // ⌘⇧E: fold every sidebar project row shut / open them all back up.
+    'view.toggleProjects': toggleAllProjectsCollapsed,
     'view.showBrowser': openBrowserTab,
     'view.toggleHud': () => toggleHud(hudTargetSessionId()),
     'view.showTerminal': () => togglePaneVisible('terminal'),

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -312,6 +312,7 @@ export const en: Translations = {
       'view.toggleStatusbar': 'Toggle status bar',
       'view.toggleTabStrip': 'Toggle tabs',
       'view.showFiles': 'Show file browser',
+      'view.toggleProjects': 'Collapse / expand all projects',
       'view.showBrowser': 'Open browser',
       'view.toggleHud': 'Toggle HUD mode',
       'hud.snapToPointer': 'Move HUD to pointer (global, while HUD is open)',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -305,6 +305,7 @@ export const zh: Translations = {
       'view.toggleStatusbar': '切换状态栏',
       'view.toggleTabStrip': '切换标签',
       'view.showFiles': '显示文件浏览器',
+      'view.toggleProjects': '收起 / 展开全部项目',
       'view.showBrowser': '打开浏览器',
       'view.showTerminal': '显示终端',
       'view.selectionToComposer': '将选区发送到输入框',

--- a/apps/desktop/src/lib/keybinds/actions.test.ts
+++ b/apps/desktop/src/lib/keybinds/actions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { TRANSLATIONS } from '@/i18n/catalog'
 import { en } from '@/i18n/en'
 
 import { defaultBindings, KEYBIND_ACTIONS, keybindAction } from './actions'
@@ -42,6 +43,19 @@ describe('view.toggleProjects keybind action', () => {
 
   it('has an English label so it renders in the shortcuts panel', () => {
     expect(en.keybinds.actions['view.toggleProjects']).toBe('Collapse / expand all projects')
+  })
+
+  // Locales built with defineLocale inherit missing keys from `en`, but a
+  // locale written as a full literal object does not. Without a label the
+  // shortcuts panel falls back to the raw action id (`view.toggleProjects`),
+  // so assert every shipped locale resolves to real text.
+  it('has a label in every shipped locale', () => {
+    for (const [locale, translations] of Object.entries(TRANSLATIONS)) {
+      const label = translations.keybinds.actions['view.toggleProjects']
+
+      expect(label, `${locale} is missing a view.toggleProjects label`).toBeTruthy()
+      expect(label, `${locale} renders the raw action id`).not.toBe('view.toggleProjects')
+    }
   })
 
   // A duplicate default reads as a permanent conflict in the keybinds panel and

--- a/apps/desktop/src/lib/keybinds/actions.test.ts
+++ b/apps/desktop/src/lib/keybinds/actions.test.ts
@@ -31,3 +31,24 @@ describe('session.archive keybind action', () => {
     expect(matches).toHaveLength(1)
   })
 })
+
+describe('view.toggleProjects keybind action', () => {
+  it('ships bound to the explorer chord under the view category', () => {
+    const action = keybindAction('view.toggleProjects')
+
+    expect(action?.category).toBe('view')
+    expect(defaultBindings()['view.toggleProjects']).toEqual(['mod+shift+e'])
+  })
+
+  it('has an English label so it renders in the shortcuts panel', () => {
+    expect(en.keybinds.actions['view.toggleProjects']).toBe('Collapse / expand all projects')
+  })
+
+  // A duplicate default reads as a permanent conflict in the keybinds panel and
+  // makes one of the two actions unreachable, so the chord has to be unclaimed.
+  it('does not collide with another action default', () => {
+    const owners = KEYBIND_ACTIONS.filter(action => action.defaults.includes('mod+shift+e'))
+
+    expect(owners.map(action => action.id)).toEqual(['view.toggleProjects'])
+  })
+})

--- a/apps/desktop/src/lib/keybinds/actions.ts
+++ b/apps/desktop/src/lib/keybinds/actions.ts
@@ -131,6 +131,11 @@ export const KEYBIND_ACTIONS: readonly KeybindActionMeta[] = [
   // ⌘G — "g" for git; the review pane is the source-control view.
   { id: 'view.toggleReview', category: 'view', defaults: ['mod+g'] },
   { id: 'view.showFiles', category: 'view', defaults: [] },
+  // ⌘⇧E — the explorer mnemonic (VS Code's ⌘⇧E focuses the explorer tree).
+  // Folds every project row in the sidebar shut, or opens them all back up:
+  // the same toggle the filter menu's "Collapse all" / "Expand all" runs, for
+  // a sidebar with more projects than fit on screen.
+  { id: 'view.toggleProjects', category: 'view', defaults: ['mod+shift+e'] },
   // ⌘⇧L — "L" for location, the address-bar chord every browser shares. Plain
   // ⌘L is the terminal's selection shortcut, hence the shift.
   { id: 'view.showBrowser', category: 'view', defaults: ['mod+shift+l'] },

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -2,7 +2,12 @@ import { atom } from 'nanostores'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { NO_PROJECT_ID, type SidebarProjectTree } from '@/app/chat/sidebar/projects/workspace-groups'
-import { $sidebarAgentsGrouped, setSidebarAgentsGrouped } from '@/store/layout'
+import {
+  $sidebarAgentsGrouped,
+  $sidebarWorkspaceNodeOpen,
+  setSidebarAgentsGrouped,
+  setSidebarGrouping
+} from '@/store/layout'
 import { $activeGatewayProfile, setShowAllProfiles } from '@/store/profile'
 import { $currentCwd, $selectedStoredSessionId, $sessions, applyConfiguredDefaultProjectDir } from '@/store/session'
 
@@ -32,6 +37,7 @@ import {
   resolveNewSessionCwd,
   scanAndRecordRepos,
   startWorkInRepo,
+  toggleAllProjectsCollapsed,
   tombstoneSessions
 } from './projects'
 
@@ -913,5 +919,52 @@ describe('tombstone pruning', () => {
     await refreshProjectTree()
 
     expect($removedSessionIds.get().has('sess-1')).toBe(false)
+  })
+})
+
+describe('toggleAllProjectsCollapsed', () => {
+  const project = (id: string): SidebarProjectTree => ({
+    id,
+    label: id,
+    path: `/repos/${id}`,
+    repos: [],
+    sessionCount: 0
+  })
+
+  beforeEach(() => {
+    window.localStorage.clear()
+    $sidebarWorkspaceNodeOpen.set({})
+    $projectTree.set([project('p_a'), project('p_b')])
+    setSidebarGrouping('project')
+  })
+
+  it('collapses every project row when any of them is still open', () => {
+    toggleAllProjectsCollapsed()
+
+    expect($sidebarWorkspaceNodeOpen.get()).toMatchObject({ p_a: false, p_b: false })
+  })
+
+  it('expands them all again once every row is collapsed', () => {
+    $sidebarWorkspaceNodeOpen.set({ p_a: false, p_b: false })
+
+    toggleAllProjectsCollapsed()
+
+    expect($sidebarWorkspaceNodeOpen.get()).toMatchObject({ p_a: true, p_b: true })
+  })
+
+  it('leaves lanes nested under a project untouched, so re-opening restores them', () => {
+    $sidebarWorkspaceNodeOpen.set({ 'p_a/lane': false })
+
+    toggleAllProjectsCollapsed()
+
+    expect($sidebarWorkspaceNodeOpen.get()['p_a/lane']).toBe(false)
+  })
+
+  it('does nothing under a grouping that puts no project rows on screen', () => {
+    setSidebarGrouping('date')
+
+    toggleAllProjectsCollapsed()
+
+    expect($sidebarWorkspaceNodeOpen.get()).toEqual({})
   })
 })

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -14,7 +14,12 @@ import { isMissingRestEndpoint, isMissingRpcMethod } from '@/lib/gateway-rpc'
 import { isUnderPath } from '@/lib/path-compare'
 import { persistentAtom } from '@/lib/persisted'
 import { $gateway, activeGateway, ensureActiveGatewayOpen } from '@/store/gateway'
-import { setSidebarAgentsGrouped } from '@/store/layout'
+import {
+  $sidebarGrouping,
+  $sidebarWorkspaceNodeOpen,
+  setSidebarAgentsGrouped,
+  setWorkspaceNodesOpen
+} from '@/store/layout'
 import { notify } from '@/store/notifications'
 import {
   $activeGatewayProfile,
@@ -46,6 +51,34 @@ export const $activeProjectId = atom<null | string>(null)
 // source of project membership — the desktop no longer derives it.
 export const $projectTree = atom<SidebarProjectTree[]>([])
 export const $projectTreeLoading = atom(false)
+
+// Project rows default OPEN, so "all collapsed" means every one of them has
+// been explicitly shut.
+export function projectsAllCollapsed(
+  projects: readonly { id: string }[],
+  nodeOpen: Record<string, boolean>
+): boolean {
+  return projects.length > 0 && projects.every(project => nodeOpen[project.id] === false)
+}
+
+// Fold every project row shut, or open them all back up — the sidebar's
+// "Collapse all" / "Expand all", shared by the filter menu and the hotkey.
+// Only the project rows fold, and only while grouping by project puts them on
+// screen; under any other grouping there is nothing to fold, so this is a
+// no-op rather than a write the user can't see. Their lanes underneath keep
+// their own state, so re-opening a project shows it as they left it.
+export function toggleAllProjectsCollapsed(): void {
+  const projects = $projectTree.get()
+
+  if ($sidebarGrouping.get() !== 'project' || projects.length === 0) {
+    return
+  }
+
+  setWorkspaceNodesOpen(
+    projects.map(project => project.id),
+    projectsAllCollapsed(projects, $sidebarWorkspaceNodeOpen.get())
+  )
+}
 
 // False when the connected backend predates the projects.* JSON-RPC surface
 // (same semver label, older install). Null until the first probe.


### PR DESCRIPTION
## What

Binds the sidebar's **Collapse all / Expand all** to <kbd>⌘⇧E</kbd> (Ctrl+Shift+E off macOS), and surfaces the hint on the menu row that already runs it.

Today that action is mouse-only: open the filter menu, then click the row. With more projects than fit on screen it's the action you reach for most often and the slowest one to get to.

## The chord

<kbd>⌘⇧E</kbd> is the explorer mnemonic — VS Code's <kbd>⌘⇧E</kbd> focuses the explorer tree — and it was unclaimed in `KEYBIND_ACTIONS`. A test asserts nothing else ships the same default, since a duplicate would read as a permanent conflict in the keybinds panel and make one of the two actions unreachable.

It's a normal rebindable action: it appears in the shortcuts panel under **View**, and the menu hint reads from `useKeybindHint` so a rebind is reflected there rather than hardcoding ⌘⇧E.

## Shape

The toggle moves into `toggleAllProjectsCollapsed` in the projects store, so the menu row and the hotkey run the same code instead of drifting. It keeps every rule the menu already had:

- only the **project** rows fold — sweeping Pinned and Cron shut alongside them is not what "collapse all" means here;
- the lanes underneath keep their own state, so re-opening a project shows it as you left it;
- it's a **no-op** under a grouping that puts no project rows on screen, so the key can't write state you can't see.

No new core tool, no new env var, no new config surface — one row in the existing keybind registry, one handler, one shared store function.

## Proof

Real running desktop (`npm run dev`, driven over CDP), not a mock.

The menu row with its live hint:

![Filter menu showing "Collapse all ⌘⇧E"](https://github.com/user-attachments/assets/b8d337f2-b135-4eaf-98fb-7ead2e1244e8)

Before ⌘⇧E / after ⌘⇧E — and pressing it again restored the expanded state:

| Expanded | After ⌘⇧E |
| --- | --- |
| ![Projects expanded](https://github.com/user-attachments/assets/56c75778-b2d5-4d98-9f71-4e1ea22bb935) | ![Projects collapsed](https://github.com/user-attachments/assets/616cf480-82d8-410d-9dad-7939eafdba41) |

## Tests

Behavior contracts, not snapshots — `store/projects.test.ts` covers collapse, expand-back, nested lanes surviving the fold, and the non-project-grouping no-op; `lib/keybinds/actions.test.ts` covers registration, the English label, and the no-collision invariant.

```
npx vitest run                 # 629 files, 6264 passed | 2 skipped
npx tsc -p . --noEmit          # clean
npx eslint <changed files>     # clean
```

## Related open PRs

I checked for duplicates before opening this: no issue requests it, and no PR (open, merged, or closed) implements a collapse/expand shortcut. Three open PRs touch `filter-menu.tsx`, none overlapping in purpose — #86196 (saved sidebar views) and #88123 (manual session ordering) are independent.

One merge-order note: **#85952** (i18n for the filter menu) edits the same line this PR does, swapping the literals for `f.expandAll` / `f.collapseAll`. The changes are complementary — that PR localizes the label, this one appends a shortcut hint beside it — but whichever merges second takes a one-line conflict. Resolution is to keep their localized label AND the `<DropdownMenuShortcut>` sibling:

```tsx
{projectsCollapsed ? f.expandAll : f.collapseAll}
{collapseHint && <DropdownMenuShortcut>{collapseHint}</DropdownMenuShortcut>}
```

Happy to rebase onto whichever lands first.

> AI was used for the purposes of this PR
