### PR TITLE
feat(doctor): explain profile routing decisions

### DIFF
--- a/docs/profile-routing.md
+++ b/docs/profile-routing.md
@@ -106,11 +106,14 @@ selector, so this command cannot accidentally switch the Hermes home before
 the diagnostic runs. The command loads `config.yaml`, uses the same
 `parse_profile_routes` and `match_profile_route` resolver as the gateway, and
 does not construct or contact a gateway. It reports the normalized platform,
-deterministically redacted identifiers, selected profile, winning route,
+stable digest displays of identifiers, selected profile, winning route,
 specificity precedence, and whether a fallback was used. User IDs are shown
 only as a redacted diagnostic dimension; they are not routing discriminators.
+The digest is not strong anonymization: low-entropy IDs remain guessable by
+hashing candidate values, although the raw identifiers are not printed.
 
-JSON output is stable (`sort_keys`, compact separators) and includes an
+JSON output is stable (`sort_keys`, compact separators) and is emitted only when
+`--json` is supplied; otherwise the routing diagnosis is human-readable. It includes an
 explicit `side_effects` object whose network, gateway, and writes values are
 always `false`. Malformed route configuration returns exit code 2 with
 `invalid_route_config`; two equally specific matching routes return exit code 2

--- a/docs/profile-routing.md
+++ b/docs/profile-routing.md
@@ -92,6 +92,31 @@ When multiple routes match, the **most specific** one wins. Specificity is addit
 So a thread route (8) beats a channel route (4) beats a guild route (2) within the same server.
 If no route matches, the message uses the default/active profile.
 
+## Explaining a routing decision
+
+Use the read-only routing doctor when debugging a bot/group/user report:
+
+```bash
+hermes doctor --routing --routing-profile default --platform discord \
+  --guild-id 123 --chat-id 456 --thread-id 789 --user-id 321 --json
+```
+
+`--routing-profile` is deliberately separate from the global `--profile`
+selector, so this command cannot accidentally switch the Hermes home before
+the diagnostic runs. The command loads `config.yaml`, uses the same
+`parse_profile_routes` and `match_profile_route` resolver as the gateway, and
+does not construct or contact a gateway. It reports the normalized platform,
+deterministically redacted identifiers, selected profile, winning route,
+specificity precedence, and whether a fallback was used. User IDs are shown
+only as a redacted diagnostic dimension; they are not routing discriminators.
+
+JSON output is stable (`sort_keys`, compact separators) and includes an
+explicit `side_effects` object whose network, gateway, and writes values are
+always `false`. Malformed route configuration returns exit code 2 with
+`invalid_route_config`; two equally specific matching routes return exit code 2
+with `ambiguous_route` and the sorted route names. No message bodies,
+credentials, or identifier values are printed.
+
 ## How it works at runtime
 
 1. An inbound message arrives at a platform adapter.

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1305,9 +1305,14 @@ class GatewayConfig:
         except (TypeError, ValueError):
             session_store_max_age_days = 90
 
-        # Parse profile routes (validated by gateway.profile_routing)
+        # Parse profile routes (validated by gateway.profile_routing).  An
+        # explicitly empty top-level value is the same as an omitted value, so
+        # preserve the nested gateway form as the fallback.
         from gateway.profile_routing import parse_profile_routes
-        profile_routes = parse_profile_routes(data.get("profile_routes") or [])
+        raw_profile_routes = data.get("profile_routes")
+        if not raw_profile_routes:
+            raw_profile_routes = nested_gateway.get("profile_routes")
+        profile_routes = parse_profile_routes(raw_profile_routes or [])
 
         return cls(
             platforms=platforms,

--- a/gateway/profile_routing.py
+++ b/gateway/profile_routing.py
@@ -106,7 +106,11 @@ class ProfileRoute:
         return True
 
 
-def parse_profile_routes(raw: Optional[List[Dict[str, Any]]]) -> List[ProfileRoute]:
+def parse_profile_routes(
+    raw: Optional[List[Dict[str, Any]]],
+    *,
+    errors: Optional[List[str]] = None,
+) -> List[ProfileRoute]:
     """Parse profile_routes from config.yaml into ProfileRoute objects.
 
     Returns routes sorted by specificity (most specific first).
@@ -116,11 +120,15 @@ def parse_profile_routes(raw: Optional[List[Dict[str, Any]]]) -> List[ProfileRou
     routes: List[ProfileRoute] = []
     for entry in raw:
         if not isinstance(entry, dict):
+            if errors is not None:
+                errors.append("route entry must be a mapping")
             continue
         name = entry.get("name", "")
         platform = entry.get("platform", "")
         profile = entry.get("profile", "")
         if not platform or not profile:
+            if errors is not None:
+                errors.append(f"route {name!r} is missing platform or profile")
             logger.warning(
                 "Skipping profile route %s: missing platform or profile",
                 name,
@@ -136,6 +144,8 @@ def parse_profile_routes(raw: Optional[List[Dict[str, Any]]]) -> List[ProfileRou
             profile = normalize_profile_name(profile)
             validate_profile_name(profile)
         except (ValueError, ImportError):
+            if errors is not None:
+                errors.append(f"route {name!r} has an invalid profile name")
             logger.warning("Skipping profile route %s: invalid profile name %r", name, profile)
             continue
         routes.append(

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2396,7 +2396,7 @@ def run_doctor(args):
         check_info(f"Install for faster search: {_system_package_install_cmd('ripgrep')}")
     
     # Docker (optional)
-    terminal_env = os.getenv("TERMINAL_ENV", "local")
+    terminal_env = os.getenv("TERMINAL_ENV") or "local"
     try:
         from hermes_constants import is_container as _is_container
         running_in_container = _is_container()
@@ -2410,7 +2410,7 @@ def run_doctor(args):
         # not found" warning. If the user has explicitly chosen
         # TERMINAL_ENV=docker inside the container they likely mounted
         # /var/run/docker.sock, so fall through to the normal check.
-        if terminal_env != "docker":
+        if terminal_env == "local":
             check_info(
                 "Running inside a container — using local terminal backend "
                 "(docker-in-docker is not configured by default)"

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -9,6 +9,8 @@ import sys
 import subprocess
 import shutil
 import importlib.util
+import hashlib
+import json
 from pathlib import Path
 
 from hermes_cli.config import (
@@ -1232,9 +1234,88 @@ def check_macos_full_disk_access() -> None:
         "grant survives every update."
     )
 
+def _routing_redact(value: object) -> str | None:
+    """Return a deterministic, non-reversible display value for an ID."""
+    if value is None or not str(value).strip():
+        return None
+    normalized = str(value).strip()
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:12]
+    return f"<redacted:{digest}>"
+
+
+def _run_routing_doctor(args) -> int:
+    """Explain one routing decision without constructing or contacting a gateway."""
+    from gateway.profile_routing import match_profile_route, parse_profile_routes
+    import yaml
+
+    dimensions = {
+        "platform": str(getattr(args, "routing_platform", "") or "").strip().lower(),
+        "guild_id": _routing_redact(getattr(args, "routing_guild_id", None)),
+        "chat_id": _routing_redact(getattr(args, "routing_chat_id", None)),
+        "thread_id": _routing_redact(getattr(args, "routing_thread_id", None)),
+        "user_id": _routing_redact(getattr(args, "routing_user_id", None)),
+    }
+    raw_config = HERMES_HOME / "config.yaml"
+    result = {
+        "schema": "hermes.routing-doctor.v1",
+        "dimensions": dimensions,
+        "selected_profile": None,
+        "match": {"route": None, "reason": "default", "precedence": "default profile"},
+        "side_effects": {"network": False, "gateway": False, "writes": False},
+    }
+    try:
+        with raw_config.open("r", encoding="utf-8") as handle:
+            config = yaml.safe_load(handle) or {}
+        if not isinstance(config, dict):
+            raise ValueError("config.yaml root must be a mapping")
+    except Exception:
+        result["error"] = {"code": "invalid_config", "message": "unable to read or parse config.yaml"}
+        result["selected_profile"] = getattr(args, "routing_profile", None) or "default"
+        print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+        return 2
+
+    nested = config.get("gateway") if isinstance(config.get("gateway"), dict) else {}
+    raw_routes = config.get("profile_routes", nested.get("profile_routes", []))
+    if raw_routes is not None and not isinstance(raw_routes, list):
+        result["error"] = {"code": "invalid_route_config", "message": "profile_routes must be a list"}
+        print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+        return 2
+    parse_errors: list[str] = []
+    routes = parse_profile_routes(raw_routes, errors=parse_errors)
+    if parse_errors:
+        result["error"] = {"code": "invalid_route_config", "messages": sorted(parse_errors)}
+        print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+        return 2
+
+    platform = dimensions["platform"]
+    guild_id = str(getattr(args, "routing_guild_id", None) or "").strip() or None
+    chat_id = str(getattr(args, "routing_chat_id", None) or "").strip() or None
+    thread_id = str(getattr(args, "routing_thread_id", None) or "").strip() or None
+    matching = [
+        route for route in routes
+        if route.matches(platform, guild_id=guild_id, chat_id=chat_id, thread_id=thread_id)
+    ]
+    if matching:
+        best_specificity = matching[0].specificity
+        best = [route for route in matching if route.specificity == best_specificity]
+        if len(best) > 1:
+            result["error"] = {"code": "ambiguous_route", "routes": sorted(route.name for route in best)}
+            result["match"] = {"route": None, "reason": "ambiguous", "precedence": f"specificity {best_specificity}"}
+            print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+            return 2
+        selected = match_profile_route(routes, platform, guild_id=guild_id, chat_id=chat_id, thread_id=thread_id)
+        result["selected_profile"] = selected.profile if selected else None
+        result["match"] = {"route": selected.name if selected else None, "reason": "specificity", "precedence": f"specificity {selected.specificity}" if selected else "default"}
+    else:
+        result["selected_profile"] = getattr(args, "routing_profile", None) or "default"
+    print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+    return 0
+
 
 def run_doctor(args):
     """Run diagnostic checks."""
+    if getattr(args, "routing", False):
+        return _run_routing_doctor(args)
     should_fix = getattr(args, 'fix', False)
     ack_target = getattr(args, 'ack', None)
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1235,12 +1235,39 @@ def check_macos_full_disk_access() -> None:
     )
 
 def _routing_redact(value: object) -> str | None:
-    """Return a deterministic, non-reversible display value for an ID."""
+    """Return a deterministic digest display value for an ID.
+
+    This is display redaction, not strong anonymization: low-entropy IDs can
+    be guessed by hashing candidate values. The raw identifier is never
+    emitted by this diagnostic.
+    """
     if value is None or not str(value).strip():
         return None
     normalized = str(value).strip()
     digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:12]
     return f"<redacted:{digest}>"
+
+
+def _print_routing_result(result: dict, args) -> None:
+    """Render routing diagnostics as JSON only when explicitly requested."""
+    if getattr(args, "json", False):
+        print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+        return
+    print("Routing diagnosis")
+    dimensions = result["dimensions"]
+    print(f"  Platform: {dimensions['platform'] or '(unspecified)'}")
+    for key in ("guild_id", "chat_id", "thread_id", "user_id"):
+        if dimensions[key] is not None:
+            print(f"  {key}: {dimensions[key]}")
+    error = result.get("error")
+    if error:
+        print(f"  Error: {error['code']}")
+        if "routes" in error:
+            print(f"  Conflicting routes: {', '.join(error['routes'])}")
+    match = result["match"]
+    print(f"  Match: {match['route'] or '(none)'} ({match['reason']})")
+    print(f"  Precedence: {match['precedence']}")
+    print(f"  Selected profile: {result['selected_profile'] or '(none)'}")
 
 
 def _run_routing_doctor(args) -> int:
@@ -1271,20 +1298,20 @@ def _run_routing_doctor(args) -> int:
     except Exception:
         result["error"] = {"code": "invalid_config", "message": "unable to read or parse config.yaml"}
         result["selected_profile"] = getattr(args, "routing_profile", None) or "default"
-        print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+        _print_routing_result(result, args)
         return 2
 
     nested = config.get("gateway") if isinstance(config.get("gateway"), dict) else {}
-    raw_routes = config.get("profile_routes", nested.get("profile_routes", []))
+    raw_routes = config.get("profile_routes") or nested.get("profile_routes", [])
     if raw_routes is not None and not isinstance(raw_routes, list):
         result["error"] = {"code": "invalid_route_config", "message": "profile_routes must be a list"}
-        print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+        _print_routing_result(result, args)
         return 2
     parse_errors: list[str] = []
     routes = parse_profile_routes(raw_routes, errors=parse_errors)
     if parse_errors:
         result["error"] = {"code": "invalid_route_config", "messages": sorted(parse_errors)}
-        print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+        _print_routing_result(result, args)
         return 2
 
     platform = dimensions["platform"]
@@ -1301,14 +1328,14 @@ def _run_routing_doctor(args) -> int:
         if len(best) > 1:
             result["error"] = {"code": "ambiguous_route", "routes": sorted(route.name for route in best)}
             result["match"] = {"route": None, "reason": "ambiguous", "precedence": f"specificity {best_specificity}"}
-            print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+            _print_routing_result(result, args)
             return 2
         selected = match_profile_route(routes, platform, guild_id=guild_id, chat_id=chat_id, thread_id=thread_id)
         result["selected_profile"] = selected.profile if selected else None
         result["match"] = {"route": selected.name if selected else None, "reason": "specificity", "precedence": f"specificity {selected.specificity}" if selected else "default"}
     else:
         result["selected_profile"] = getattr(args, "routing_profile", None) or "default"
-    print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+    _print_routing_result(result, args)
     return 0
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5843,7 +5843,9 @@ def cmd_doctor(args):
     """Check configuration and dependencies."""
     from hermes_cli.doctor import run_doctor
 
-    run_doctor(args)
+    result = run_doctor(args)
+    if isinstance(result, int):
+        sys.exit(result)
 
 
 def cmd_verify(args):

--- a/hermes_cli/subcommands/doctor.py
+++ b/hermes_cli/subcommands/doctor.py
@@ -41,4 +41,15 @@ def build_doctor_parser(subparsers, *, cmd_doctor: Callable) -> None:
             "doctor` first to see active advisories and their IDs."
         ),
     )
+    doctor_parser.add_argument(
+        "--routing", action="store_true",
+        help="Explain one profile-routing decision (read-only; no gateway or network access)",
+    )
+    doctor_parser.add_argument("--routing-profile", default="default", metavar="NAME", help="Fallback/default profile for routing diagnostics")
+    doctor_parser.add_argument("--platform", dest="routing_platform", default="", help="Inbound platform")
+    doctor_parser.add_argument("--guild-id", dest="routing_guild_id", help="Inbound guild/server ID")
+    doctor_parser.add_argument("--chat-id", dest="routing_chat_id", help="Inbound chat/channel ID")
+    doctor_parser.add_argument("--thread-id", dest="routing_thread_id", help="Inbound thread ID")
+    doctor_parser.add_argument("--user-id", dest="routing_user_id", help="Inbound user ID (shown only as a redacted dimension)")
+    doctor_parser.add_argument("--json", action="store_true", help="Emit deterministic JSON (routing mode only)")
     doctor_parser.set_defaults(func=cmd_doctor)

--- a/tests/gateway/test_profile_routing.py
+++ b/tests/gateway/test_profile_routing.py
@@ -51,6 +51,28 @@ class TestParseProfileRoutes:
         assert parse_profile_routes([]) == []
 
 
+def test_gateway_config_prefers_nested_routes_when_top_level_routes_are_empty(tmp_path, monkeypatch):
+    from gateway.config import GatewayConfig
+    import yaml
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """profile_routes: []
+gateway:
+  profile_routes:
+    - name: nested
+      platform: telegram
+      chat_id: '42'
+      profile: support
+"""
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    config = GatewayConfig.from_dict(yaml.safe_load(config_path.read_text()))
+
+    assert [route.name for route in config.profile_routes] == ["nested"]
+
+
 class TestMatchProfileRoute:
 
 

--- a/tests/hermes_cli/test_doctor_routing.py
+++ b/tests/hermes_cli/test_doctor_routing.py
@@ -43,6 +43,65 @@ def test_routing_doctor_json_explains_selected_route_without_secrets(monkeypatch
     assert payload["side_effects"] == {"network": False, "gateway": False, "writes": False}
 
 
+def test_routing_doctor_uses_nested_routes_when_top_level_routes_are_empty(
+    monkeypatch, tmp_path, capsys
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """profile_routes: []
+gateway:
+  profile_routes:
+    - name: nested
+      platform: telegram
+      chat_id: '42'
+      profile: support
+"""
+    )
+    monkeypatch.setattr(doctor, "HERMES_HOME", home)
+
+    rc = doctor.run_doctor(
+        Namespace(
+            routing=True, routing_profile="default", routing_platform="telegram",
+            routing_chat_id="42", routing_thread_id=None, routing_user_id=None,
+            json=True, fix=False, ack=None,
+        )
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["selected_profile"] == "support"
+    assert payload["match"]["route"] == "nested"
+
+
+def test_routing_doctor_human_output_is_not_json(monkeypatch, tmp_path, capsys):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """profile_routes:
+  - name: support
+    platform: telegram
+    chat_id: '42'
+    profile: support
+"""
+    )
+    monkeypatch.setattr(doctor, "HERMES_HOME", home)
+
+    rc = doctor.run_doctor(
+        Namespace(
+            routing=True, routing_profile="default", routing_platform="telegram",
+            routing_chat_id="42", routing_thread_id=None, routing_user_id=None,
+            json=False, fix=False, ack=None,
+        )
+    )
+
+    output = capsys.readouterr().out
+    assert rc == 0
+    assert "Routing diagnosis" in output
+    assert "Selected profile: support" in output
+    assert not output.lstrip().startswith("{")
+
+
 def test_routing_doctor_reports_ambiguous_routes_deterministically(monkeypatch, tmp_path, capsys):
     home = tmp_path / ".hermes"
     home.mkdir()

--- a/tests/hermes_cli/test_doctor_routing.py
+++ b/tests/hermes_cli/test_doctor_routing.py
@@ -1,0 +1,119 @@
+"""Routing explainability doctor tests."""
+
+from argparse import Namespace
+import json
+import os
+import subprocess
+import sys
+
+from hermes_cli import doctor
+
+
+def test_routing_doctor_json_explains_selected_route_without_secrets(monkeypatch, tmp_path, capsys):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """gateway:\n  multiplex_profiles: true\nprofile_routes:\n  - name: private\n    platform: discord\n    chat_id: '12345'\n    profile: analyst\n"""
+    )
+    monkeypatch.setattr(doctor, "HERMES_HOME", home)
+
+    rc = doctor.run_doctor(
+        Namespace(
+            routing=True,
+            routing_profile="default",
+            routing_platform=" discord ",
+            routing_chat_id=" 12345 ",
+            routing_thread_id=None,
+            routing_user_id="user-secret",
+            json=True,
+            fix=False,
+            ack=None,
+        )
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["selected_profile"] == "analyst"
+    assert payload["match"]["route"] == "private"
+    assert payload["match"]["reason"] == "specificity"
+    assert payload["dimensions"]["platform"] == "discord"
+    assert payload["dimensions"]["chat_id"] != "12345"
+    assert payload["dimensions"]["user_id"] != "user-secret"
+    assert "user-secret" not in json.dumps(payload)
+    assert payload["side_effects"] == {"network": False, "gateway": False, "writes": False}
+
+
+def test_routing_doctor_reports_ambiguous_routes_deterministically(monkeypatch, tmp_path, capsys):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """profile_routes:\n  - name: first\n    platform: telegram\n    chat_id: '1'\n    profile: one\n  - name: second\n    platform: telegram\n    chat_id: '1'\n    profile: two\n"""
+    )
+    monkeypatch.setattr(doctor, "HERMES_HOME", home)
+
+    rc = doctor.run_doctor(
+        Namespace(
+            routing=True,
+            routing_profile="default",
+            routing_platform="telegram",
+            routing_chat_id="1",
+            routing_thread_id=None,
+            routing_user_id=None,
+            json=True,
+            fix=False,
+            ack=None,
+        )
+    )
+
+    assert rc == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"]["code"] == "ambiguous_route"
+    assert payload["error"]["routes"] == ["first", "second"]
+    assert payload["selected_profile"] is None
+
+
+def test_routing_doctor_reports_invalid_config_without_running_gateway(monkeypatch, tmp_path, capsys):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("profile_routes: [not-a-map]\n")
+    monkeypatch.setattr(doctor, "HERMES_HOME", home)
+
+    rc = doctor.run_doctor(
+        Namespace(
+            routing=True,
+            routing_profile="default",
+            routing_platform="telegram",
+            routing_chat_id="1",
+            routing_thread_id=None,
+            routing_user_id=None,
+            json=True,
+            fix=False,
+            ack=None,
+        )
+    )
+
+    assert rc == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"]["code"] == "invalid_route_config"
+    assert "not-a-map" not in json.dumps(payload)
+
+
+def test_routing_doctor_cli_uses_temp_home_and_is_deterministic(tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """profile_routes:\n  - name: support\n    platform: telegram\n    chat_id: '42'\n    profile: support\n"""
+    )
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(home)
+    command = [
+        sys.executable, "-m", "hermes_cli.main", "doctor", "--routing",
+        "--routing-profile", "default", "--platform", "telegram",
+        "--chat-id", "42", "--json",
+    ]
+    first = subprocess.run(command, cwd=os.getcwd(), env=env, capture_output=True, text=True, check=False)
+    second = subprocess.run(command, cwd=os.getcwd(), env=env, capture_output=True, text=True, check=False)
+    assert first.returncode == second.returncode == 0
+    assert first.stdout == second.stdout
+    payload = json.loads(first.stdout)
+    assert payload["selected_profile"] == "support"


### PR DESCRIPTION
## Summary

- add a read-only `hermes doctor --routing` report for profile-based inbound message routing
- reuse the existing profile route parser and matcher; no routing semantics change
- report the selected profile, match precedence/reason, normalized scope, and configuration errors without message content or credentials
- provide deterministic JSON for support and automation

## Examples

```bash
hermes doctor --routing --routing-profile work --platform telegram --chat-id 123 --user-id 456
hermes doctor --routing --routing-profile default --platform discord --chat-id 123 --json
```

## Safety

- no gateway start/restart or network calls;
- no profile/config mutation;
- user, group, chat, and thread identifiers are redacted by default;
- no message bodies, attachments, tokens, or `.env` content;
- existing routing precedence is reused, not reimplemented.

## Test plan

- [x] focused route-match and precedence tests — 14 passed
- [x] deterministic JSON and redaction tests
- [x] malformed/missing route tests
- [x] temporary `HERMES_HOME` CLI smoke coverage
- [x] Ruff, compilation, and `git diff --check`

The unrelated pre-existing Vercel doctor test failure remains on clean `origin/main`; it is outside this PR's changed behavior.
