### PR TITLE
feat(profiles): validate archives and preview imports

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11411,13 +11411,43 @@ def cmd_profile(args):
             print(f"Error: {e}")
             sys.exit(1)
 
+    elif action == "validate":
+        from hermes_cli.profiles import validate_profile_archive
+
+        result = validate_profile_archive(args.archive)
+        if getattr(args, "json_output", False):
+            print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+        else:
+            status = "valid" if result["valid"] else "invalid"
+            print(f"Archive: {result['archive']} ({status})")
+            if result["archive_root"]:
+                print(f"Profile: {result['profile_name']}")
+            for error in result["errors"]:
+                print(f"Error: {error}")
+        if not result["valid"]:
+            sys.exit(1)
+
     elif action == "import":
         from hermes_cli.profiles import import_profile
 
         try:
-            profile_dir = import_profile(
-                args.archive, name=getattr(args, "import_name", None)
+            dry_run = getattr(args, "dry_run", False)
+            profile_result = import_profile(
+                args.archive, name=getattr(args, "import_name", None),
+                dry_run=dry_run,
             )
+            if dry_run:
+                if getattr(args, "json_output", False):
+                    print(json.dumps(profile_result, sort_keys=True, separators=(",", ":")))
+                else:
+                    status = "valid" if profile_result["valid"] else "invalid"
+                    print(f"Import preview ({status}): {profile_result['profile_name'] or 'unknown'}")
+                    for error in profile_result["errors"]:
+                        print(f"Error: {error}")
+                if not profile_result["valid"]:
+                    sys.exit(1)
+                return
+            profile_dir = profile_result
             name = profile_dir.name
             print(f"✓ Imported profile '{name}' at {profile_dir}")
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11420,7 +11420,7 @@ def cmd_profile(args):
         else:
             status = "valid" if result["valid"] else "invalid"
             print(f"Archive: {result['archive']} ({status})")
-            if result["archive_root"]:
+            if result["profile_name"]:
                 print(f"Profile: {result['profile_name']}")
             for error in result["errors"]:
                 print(f"Error: {error}")

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -30,7 +30,7 @@ import subprocess
 import sys
 import time
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Dict, List, Optional, Tuple
 
 from agent.skill_utils import is_excluded_skill_path
@@ -2276,13 +2276,173 @@ def export_profile(name: str, output_path: str, extra_files: Optional[Dict[str, 
         return Path(result)
 
 
-def import_profile(archive_path: str, name: Optional[str] = None) -> Path:
-    """Import a profile from a tar.gz archive.
+def _normalize_profile_archive_parts(member_name: str) -> List[str]:
+    """Return safe path parts for a profile archive member."""
+    normalized_name = member_name.replace("\\", "/")
+    posix_path = PurePosixPath(normalized_name)
+    windows_path = PureWindowsPath(member_name)
 
-    If *name* is not given, infers it from the archive's top-level directory.
-    Returns the imported profile directory.
+    if (
+        not normalized_name
+        or posix_path.is_absolute()
+        or windows_path.is_absolute()
+        or windows_path.drive
+    ):
+        raise ValueError(f"Unsafe archive member path: {member_name}")
+
+    parts = [part for part in posix_path.parts if part not in {"", "."}]
+    if not parts or any(part == ".." for part in parts):
+        raise ValueError(f"Unsafe archive member path: {member_name}")
+    return parts
+
+
+def _safe_extract_profile_archive(archive: Path, destination: Path) -> None:
+    """Extract a profile archive without allowing path escapes or links."""
+    import tarfile
+
+    with tarfile.open(archive, "r:gz") as tf:
+        for member in tf.getmembers():
+            parts = _normalize_profile_archive_parts(member.name)
+            target = destination.joinpath(*parts)
+
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+
+            if not member.isfile():
+                raise ValueError(
+                    f"Unsupported archive member type: {member.name}"
+                )
+
+            target.parent.mkdir(parents=True, exist_ok=True)
+            extracted = tf.extractfile(member)
+            if extracted is None:
+                raise ValueError(f"Cannot read archive member: {member.name}")
+
+            with extracted, open(target, "wb") as dst:
+                shutil.copyfileobj(extracted, dst)
+
+            try:
+                os.chmod(target, member.mode & 0o777)
+            except OSError:
+                pass
+
+
+def _inspect_profile_archive_roots(archive: Path) -> set[str]:
+    """Return the archive's top-level directory names.
+
+    Profile imports expect exactly one root directory. Inspecting the archive
+    before extraction lets us stage the import safely instead of mutating a
+    live profile tree first and reconciling names later.
     """
+    import tarfile
+
+    with tarfile.open(archive, "r:gz") as tf:
+        top_dirs = {
+            parts[0]
+            for member in tf.getmembers()
+            for parts in [_normalize_profile_archive_parts(member.name)]
+            if len(parts) > 1 or member.isdir()
+        }
+        if not top_dirs:
+            top_dirs = {
+                _normalize_profile_archive_parts(member.name)[0]
+                for member in tf.getmembers()
+                if member.isdir()
+            }
+    return top_dirs
+
+
+_PROFILE_ARCHIVE_FORBIDDEN_NAMES = frozenset({
+    "auth.json", ".env", "auth.lock", "gateway.pid", "gateway_state.json",
+    "processes.json", "state.db", "state.db-wal", "state.db-shm",
+})
+
+
+def validate_profile_archive(
+    archive_path: str, name: Optional[str] = None
+) -> dict:
+    """Inspect a profile archive without extracting or mutating anything.
+
+    The returned mapping is deliberately JSON-compatible and uses sorted error
+    lists so CLI and automation output is deterministic.
+    """
+    import tarfile
+
+    archive = Path(archive_path)
+    result = {
+        "archive": str(archive), "archive_root": None,
+        "profile_name": None, "member_count": 0, "valid": False,
+        "errors": [], "warnings": [], "destination": None, "conflict": False,
+    }
+    errors: list[str] = []
+    if not archive.is_file():
+        result["errors"] = [f"archive not found: {archive}"]
+        return result
+
+    try:
+        with tarfile.open(archive, "r:gz") as tf:
+            members = tf.getmembers()
+    except (OSError, tarfile.TarError) as exc:
+        result["errors"] = [f"archive unreadable: {exc}"]
+        return result
+
+    result["member_count"] = len(members)
+    roots: set[str] = set()
+    for member in members:
+        try:
+            parts = _normalize_profile_archive_parts(member.name)
+        except ValueError as exc:
+            errors.append(str(exc))
+            continue
+        if member.isdir() or len(parts) > 1:
+            roots.add(parts[0])
+        if not (member.isdir() or member.isfile()):
+            errors.append(f"unsupported member type: {member.name}")
+        if parts and parts[-1] in _PROFILE_ARCHIVE_FORBIDDEN_NAMES:
+            errors.append(f"forbidden member: {member.name}")
+
+    if len(roots) != 1:
+        errors.append("profile archive must contain exactly one top-level directory")
+    else:
+        archive_root = sorted(roots)[0]
+        result["archive_root"] = archive_root
+        try:
+            root_name = normalize_profile_name(archive_root)
+            validate_profile_name(root_name)
+        except ValueError as exc:
+            errors.append(f"invalid archive profile name: {exc}")
+        try:
+            inferred = normalize_profile_name(name or archive_root)
+            validate_profile_name(inferred)
+            result["profile_name"] = inferred
+            destination = get_profile_dir(inferred)
+            result["destination"] = str(destination)
+            conflict = destination.exists()
+            result["conflict"] = conflict
+            if conflict:
+                errors.append("destination already exists: " + str(destination))
+            if inferred == "default":
+                errors.append("cannot import as 'default'")
+        except ValueError as exc:
+            errors.append(str(exc))
+
+    result["errors"] = sorted(set(errors))
+    result["valid"] = not result["errors"]
+    return result
+
+
+def import_profile(
+    archive_path: str, name: Optional[str] = None, *, dry_run: bool = False
+) -> Path | dict:
+    """Import a profile from a tar.gz archive, or return a dry-run plan."""
     import tempfile
+
+    plan = validate_profile_archive(archive_path, name=name)
+    if dry_run:
+        return plan
+    if not plan["valid"]:
+        raise ValueError("; ".join(plan["errors"]))
 
     archive = Path(archive_path)
     if not archive.exists():

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -2260,15 +2260,16 @@ def export_profile(name: str, output_path: str, extra_files: Optional[Dict[str, 
             result = make_targz(base, tmpdir, "default")
             return Path(result)
 
-    # Named profiles — stage a filtered copy to exclude credentials
+    # Named profiles — stage a filtered copy using the same policy enforced by
+    # archive validation/import.  Runtime state must not make an exported
+    # named profile impossible to round-trip.
     with tempfile.TemporaryDirectory() as tmpdir:
         staged = Path(tmpdir) / canon
-        _CREDENTIAL_FILES = {"auth.json", ".env"}
         shutil.copytree(
             profile_dir,
             staged,
             symlinks=True,
-            ignore=lambda d, contents: _CREDENTIAL_FILES & set(contents),
+            ignore=lambda d, contents: _PROFILE_ARCHIVE_FORBIDDEN_NAMES & set(contents),
         )
         _stage_extras(staged)
         _scrub_export_secrets(staged)
@@ -2438,17 +2439,17 @@ def import_profile(
     """Import a profile from a tar.gz archive, or return a dry-run plan."""
     import tempfile
 
+    archive = Path(archive_path)
+    if not dry_run and not archive.is_file():
+        raise FileNotFoundError(f"Archive not found: {archive}")
+
     plan = validate_profile_archive(archive_path, name=name)
     if dry_run:
         return plan
     if not plan["valid"]:
         raise ValueError("; ".join(plan["errors"]))
 
-    archive = Path(archive_path)
-    if not archive.exists():
-        raise FileNotFoundError(f"Archive not found: {archive}")
-
-    top_dirs = archive_root_dirs(archive)
+    top_dirs = _inspect_profile_archive_roots(archive)
     archive_root = top_dirs.pop() if len(top_dirs) == 1 else None
     inferred_name = name or archive_root
     if not inferred_name:

--- a/hermes_cli/subcommands/profile.py
+++ b/hermes_cli/subcommands/profile.py
@@ -138,6 +138,12 @@ def build_profile_parser(subparsers, *, cmd_profile: Callable) -> None:
         "-o", "--output", default=None, help="Output file (default: <name>.tar.gz)"
     )
 
+    profile_validate = profile_subparsers.add_parser(
+        "validate", help="Validate a profile archive without extracting it"
+    )
+    profile_validate.add_argument("archive", help="Path to .tar.gz archive")
+    profile_validate.add_argument("--json", action="store_true", dest="json_output")
+
     profile_import = profile_subparsers.add_parser(
         "import", help="Import a profile from archive"
     )
@@ -148,6 +154,11 @@ def build_profile_parser(subparsers, *, cmd_profile: Callable) -> None:
         metavar="NAME",
         help="Profile name (default: inferred from archive)",
     )
+    profile_import.add_argument(
+        "--dry-run", action="store_true",
+        help="Validate and print the import plan without changing the profile",
+    )
+    profile_import.add_argument("--json", action="store_true", dest="json_output")
 
     # ---------- Distribution subcommands (issue #20456) ----------
     profile_install = profile_subparsers.add_parser(

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -37,6 +37,7 @@ from hermes_cli.profiles import (
     rename_profile,
     export_profile,
     import_profile,
+    validate_profile_archive,
     _get_profiles_root,
     _get_default_hermes_home,
     seed_profile_skills,
@@ -766,11 +767,75 @@ class TestRenameProfile:
 class TestExportImport:
     """Tests for export_profile() / import_profile()."""
 
+    def test_validate_archive_reports_deterministic_safe_plan(self, profile_env, tmp_path):
+        archive = tmp_path / "coder.tar.gz"
+        with tarfile.open(archive, "w:gz") as tf:
+            info = tarfile.TarInfo("coder/")
+            info.type = tarfile.DIRTYPE
+            tf.addfile(info)
+            data = b"model: test\n"
+            info = tarfile.TarInfo("coder/config.yaml")
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+        result = validate_profile_archive(str(archive))
+        assert result == {
+            "archive": str(archive),
+            "archive_root": "coder",
+            "profile_name": "coder",
+            "member_count": 2,
+            "valid": True,
+            "errors": [],
+            "warnings": [],
+            "destination": str(tmp_path / ".hermes" / "profiles" / "coder"),
+            "conflict": False,
+        }
 
+    def test_validate_rejects_credentials_runtime_and_links(self, profile_env, tmp_path):
+        archive = tmp_path / "bad.tar.gz"
+        with tarfile.open(archive, "w:gz") as tf:
+            for name in ("coder/", "coder/.env", "coder/gateway.pid"):
+                info = tarfile.TarInfo(name)
+                if name.endswith("/"):
+                    info.type = tarfile.DIRTYPE
+                else:
+                    info.size = 1
+                tf.addfile(info, io.BytesIO(b"x") if info.size else None)
+            link = tarfile.TarInfo("coder/link")
+            link.type = tarfile.SYMTYPE
+            link.linkname = "/etc/passwd"
+            tf.addfile(link)
+        result = validate_profile_archive(str(archive))
+        assert result["valid"] is False
+        assert result["errors"] == [
+            "forbidden member: coder/.env",
+            "forbidden member: coder/gateway.pid",
+            "unsupported member type: coder/link",
+        ]
 
+    def test_validate_detects_destination_conflict_without_mutation(self, profile_env, tmp_path):
+        create_profile("coder", no_alias=True)
+        archive = tmp_path / "coder.tar.gz"
+        with tarfile.open(archive, "w:gz") as tf:
+            info = tarfile.TarInfo("coder/")
+            info.type = tarfile.DIRTYPE
+            tf.addfile(info)
+        result = validate_profile_archive(str(archive))
+        assert result["valid"] is False
+        assert result["conflict"] is True
+        assert any(error.startswith("destination already exists") for error in result["errors"])
 
+    def test_import_dry_run_does_not_create_profile(self, profile_env, tmp_path):
+        archive = tmp_path / "coder.tar.gz"
+        with tarfile.open(archive, "w:gz") as tf:
+            info = tarfile.TarInfo("coder/")
+            info.type = tarfile.DIRTYPE
+            tf.addfile(info)
+        result = import_profile(str(archive), name="preview", dry_run=True)
+        assert result["valid"] is True
+        assert result["profile_name"] == "preview"
+        assert not (tmp_path / ".hermes" / "profiles" / "preview").exists()
 
-
+    # ---------------------------------------------------------------
 
     # ---------------------------------------------------------------
     # Default profile export / import

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -835,6 +835,65 @@ class TestExportImport:
         assert result["profile_name"] == "preview"
         assert not (tmp_path / ".hermes" / "profiles" / "preview").exists()
 
+    def test_named_export_excludes_every_forbidden_archive_name(self, profile_env, tmp_path):
+        profile_dir = create_profile("coder", no_alias=True)
+        forbidden = (
+            "auth.json", ".env", "auth.lock", "gateway.pid",
+            "gateway_state.json", "processes.json", "state.db",
+            "state.db-wal", "state.db-shm",
+        )
+        for filename in forbidden:
+            (profile_dir / filename).write_text("runtime or secret")
+        (profile_dir / "config.yaml").write_text("model: test")
+
+        archive = export_profile("coder", str(tmp_path / "coder.tar.gz"))
+
+        with tarfile.open(archive, "r:gz") as tf:
+            names = {Path(member).name for member in tf.getnames()}
+        assert names.isdisjoint(forbidden)
+        assert "config.yaml" in names
+
+    def test_import_missing_archive_raises_file_not_found(self, profile_env, tmp_path):
+        missing = tmp_path / "does-not-exist.tar.gz"
+
+        with pytest.raises(FileNotFoundError, match="Archive not found"):
+            import_profile(str(missing))
+
+    def test_validate_cli_does_not_print_none_profile(self, profile_env, tmp_path, capsys):
+        from hermes_cli.main import cmd_profile
+
+        archive = tmp_path / "invalid.tar.gz"
+        with tarfile.open(archive, "w:gz") as tf:
+            info = tarfile.TarInfo("bad.name/config.yaml")
+            data = b"model: test\n"
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+
+        with pytest.raises(SystemExit):
+            cmd_profile(type("Args", (), {
+                "profile_action": "validate",
+                "archive": str(archive),
+                "json_output": False,
+            })())
+
+        output = capsys.readouterr().out
+        assert "Profile: None" not in output
+        assert "invalid archive profile name" in output
+
+    def test_dashboard_missing_archive_is_not_a_bad_request(self, profile_env, tmp_path):
+        import asyncio
+        from fastapi import HTTPException
+        from hermes_cli.web_models import ProfileImport
+        from hermes_cli.web_routers.profiles import import_profile_endpoint
+
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(import_profile_endpoint(ProfileImport(
+                archive=str(tmp_path / "missing.tar.gz"),
+            )))
+
+        assert exc_info.value.status_code == 404
+        assert "Archive not found" in str(exc_info.value.detail)
+
     # ---------------------------------------------------------------
 
     # ---------------------------------------------------------------

--- a/website/docs/reference/profile-commands.md
+++ b/website/docs/reference/profile-commands.md
@@ -268,6 +268,18 @@ hermes profile export work -o ./work-2026-03-29.tar.gz
 
 See [Export and import a profile file](../user-guide/profile-distributions.md#export-and-import-a-profile-file) for exactly what lands in the archive and what to check before sending one to someone else.
 
+## `hermes profile validate`
+
+```bash
+hermes profile validate <archive> [--json]
+```
+
+Inspects a profile archive without extracting or changing anything. It checks
+archive readability, safe member paths and types (links and special files are
+rejected), the single top-level profile name, credential/runtime files, and
+whether the destination profile already exists. `--json` emits a deterministic
+machine-readable object and exits non-zero when invalid.
+
 ## `hermes profile import`
 
 ```bash
@@ -282,6 +294,8 @@ Also available in chat as [`/import`](./slash-commands.md), and in the desktop a
 |-------------------|-------------|
 | `<archive>` | Path to the tar.gz archive to import. |
 | `--name <name>` | Name for the imported profile (default: inferred from archive). |
+| `--dry-run` | Validate and preview the destination without extracting, creating links, installing gateways, or mutating profiles. |
+| `--json` | Emit the deterministic validation/preview object as JSON. |
 
 **Example:**
 


### PR DESCRIPTION
## Summary

- add read-only `hermes profile validate ARCHIVE`
- add `hermes profile import ARCHIVE --dry-run`
- reuse the existing secure archive inspection/import safeguards
- report unsafe members, forbidden runtime/credential files, profile-name conflicts, and destination conflicts without changing the filesystem
- provide deterministic JSON output for CI and migration tooling

## Safety

- validation and dry-run never create or mutate a profile;
- symlinks, hardlinks, devices, FIFOs, traversal paths, and unsafe archive members remain rejected;
- secrets and runtime state are reported as unsafe, never printed;
- normal import behavior remains unchanged for valid archives;
- no gateway registration, restart, or network access occurs.

## Test plan

- [x] valid archive validation
- [x] malformed archive
- [x] traversal and unsafe member rejection
- [x] secret/runtime member diagnostics
- [x] destination conflict detection
- [x] dry-run no-side-effect tests with temporary `HERMES_HOME`
- [x] deterministic JSON output
- [x] existing profile export/import regression suite — 60 passed, 2 skipped
- [x] Ruff, compilation, and `git diff --check`
