### PR TITLE
fix(teams): deliver documents via file consent cards

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -750,6 +750,73 @@ def check_teams_requirements() -> bool:
     return ensure_and_bind("platform.teams", _import, globals(), prompt=False)
 
 
+# Bot Framework file consent (document delivery in personal chat).
+#
+# Teams rejects a data: URI attachment for anything that is not an image
+# (HTTP 400), so send_document silently failed for .xlsx/.pdf/.csv while
+# the accompanying text claimed a file was attached. The supported path
+# for a bot to deliver a file in a personal chat is the file consent
+# card: the user accepts, Teams returns a pre-authorized upload URL into
+# that user's OneDrive, and the bot PUTs the bytes there. No Graph
+# permissions are involved.
+#
+# The pending map lives on disk rather than in memory because the card
+# may be sent from a short-lived `hermes send` process while the consent
+# invoke always lands in the long-lived gateway process. The context
+# echoed back through the client carries only an opaque token — never a
+# path — so a tampered or replayed invoke cannot make the bot upload an
+# arbitrary local file.
+#
+# Consent is personal-scope only. Group chats and channels have no
+# consent flow; they keep the attachment path (which still cannot carry
+# documents). The tenant Teams app manifest must set
+# `bots[].supportsFiles: true` or Allow fails with "This card action is
+# not supported".
+
+_FILE_CONSENT_CONTENT_TYPE = "application/vnd.microsoft.teams.card.file.consent"
+_FILE_INFO_CONTENT_TYPE = "application/vnd.microsoft.teams.card.file.info"
+_FILE_CONSENT_TTL_SECONDS = 24 * 60 * 60
+_FILE_CONSENT_MAX_BYTES = 250 * 1024 * 1024
+
+
+def _file_consent_store() -> str:
+    home = os.environ.get("HERMES_HOME") or os.path.expanduser("~/.hermes")
+    return os.path.join(home, "pending_file_consents.json")
+
+
+def _load_file_consents() -> Dict[str, Any]:
+    try:
+        with open(_file_consent_store(), "r") as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else {}
+    except FileNotFoundError:
+        return {}
+    except Exception as exc:
+        logger.debug("[teams] Could not read file-consent store: %s", exc)
+        return {}
+
+
+def _write_file_consents(entries: Dict[str, Any]) -> None:
+    import time
+
+    path = _file_consent_store()
+    cutoff = time.time() - _FILE_CONSENT_TTL_SECONDS
+    fresh = {
+        key: rec
+        for key, rec in entries.items()
+        if isinstance(rec, dict) and float(rec.get("ts", 0) or 0) > cutoff
+    }
+    tmp = f"{path}.tmp"
+    try:
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        with open(tmp, "w") as fh:
+            json.dump(fresh, fh)
+        os.replace(tmp, path)
+        os.chmod(path, 0o600)
+    except Exception as exc:
+        logger.warning("[teams] Could not persist file-consent store: %s", exc)
+
+
 class TeamsAdapter(BasePlatformAdapter):
     """Microsoft Teams adapter using the microsoft-teams-apps SDK."""
 
@@ -832,6 +899,13 @@ class TeamsAdapter(BasePlatformAdapter):
                 ctx: ActivityContext[AdaptiveCardInvokeActivity],
             ) -> InvokeResponse[AdaptiveCardActionMessageResponse]:
                 return await self._on_card_action(ctx)
+
+            # Completes a document offered by send_document. The invoke
+            # always arrives here, in the gateway, even when another
+            # process sent the card — hence the on-disk pending map.
+            @self._app.on_file_consent
+            async def _handle_file_consent(ctx) -> None:
+                await self._on_file_consent(ctx)
 
             # initialize() calls register_route() on the bridge, which adds
             # POST /api/messages to aiohttp_app automatically
@@ -1374,6 +1448,183 @@ class TeamsAdapter(BasePlatformAdapter):
             media_label="voice",
         )
 
+    def _is_personal_chat(self, chat_id: str) -> bool:
+        """True when chat_id is a 1:1 (personal-scope) Teams conversation."""
+        ref = self._conv_refs.get(chat_id)
+        conv = getattr(ref, "conversation", None) if ref is not None else None
+        conv_type = getattr(conv, "conversation_type", None)
+        if conv_type:
+            return str(conv_type) == "personal"
+        # No captured reference yet (outbound-first send): group chats and
+        # channels carry thread-scoped ids, personal conversations do not.
+        return not chat_id.startswith("19:")
+
+    def _is_allowed_teams_user(self, ctx: Any) -> bool:
+        """Same default-deny allowlist that guards card actions."""
+        if os.getenv("TEAMS_ALLOW_ALL_USERS", "").strip().lower() in {"1", "true", "yes"}:
+            return True
+        allowed_csv = os.getenv("TEAMS_ALLOWED_USERS", "").strip()
+        if not allowed_csv:
+            return False
+        from_account = getattr(ctx.activity, "from_", None)
+        user_id = getattr(from_account, "aad_object_id", None) or getattr(from_account, "id", "")
+        allowed = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
+        return "*" in allowed or str(user_id) in allowed
+
+    async def _send_file_consent(
+        self,
+        chat_id: str,
+        path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+    ) -> SendResult:
+        """Offer a local file to a personal chat via a file consent card."""
+        import secrets
+        import time
+
+        from microsoft_teams.api import Attachment, MessageActivityInput
+        from microsoft_teams.api.models.file import FileConsentCard
+
+        try:
+            size = os.path.getsize(path)
+        except OSError as exc:
+            return SendResult(success=False, error=f"file not readable: {exc}")
+        if size <= 0:
+            return SendResult(success=False, error="file is empty")
+        if size > _FILE_CONSENT_MAX_BYTES:
+            return SendResult(success=False, error="file exceeds the consent-card size limit")
+
+        name = file_name or os.path.basename(path)
+        token = secrets.token_urlsafe(18)
+
+        entries = _load_file_consents()
+        entries[token] = {
+            "path": os.path.abspath(path),
+            "chat_id": chat_id,
+            "name": name,
+            "size": size,
+            "ts": time.time(),
+        }
+        _write_file_consents(entries)
+
+        card = FileConsentCard(
+            description=caption or name,
+            size_in_bytes=size,
+            accept_context={"token": token},
+            decline_context={"token": token},
+        )
+        attachment = Attachment(
+            content_type=_FILE_CONSENT_CONTENT_TYPE, name=name, content=card
+        )
+        activity = MessageActivityInput().add_attachments(attachment)
+
+        try:
+            conv_ref = self._conv_refs.get(chat_id)
+            if conv_ref:
+                result = await self._app.activity_sender.send(activity, conv_ref)
+            else:
+                result = await self._app.send(chat_id, activity)
+        except Exception as exc:
+            entries = _load_file_consents()
+            entries.pop(token, None)
+            _write_file_consents(entries)
+            logger.error("[teams] file consent offer failed for %s: %s", name, exc, exc_info=True)
+            return SendResult(success=False, error=str(exc), retryable=True)
+
+        logger.info(
+            "[teams] Offered %s (%d bytes) via file consent card to %s", name, size, chat_id
+        )
+        return SendResult(success=True, message_id=getattr(result, "id", None))
+
+    async def _send_file_info_card(self, chat_id: str, upload: Any) -> None:
+        """Post the file card that appears once the upload completes."""
+        try:
+            from microsoft_teams.api import Attachment, MessageActivityInput
+            from microsoft_teams.api.models.file import FileInfoCard
+
+            card = FileInfoCard(
+                unique_id=getattr(upload, "unique_id", None),
+                file_type=getattr(upload, "file_type", None),
+            )
+            attachment = Attachment(
+                content_type=_FILE_INFO_CONTENT_TYPE,
+                content_url=getattr(upload, "content_url", None),
+                name=getattr(upload, "name", None),
+                content=card,
+            )
+            activity = MessageActivityInput().add_attachments(attachment)
+            conv_ref = self._conv_refs.get(chat_id)
+            if conv_ref:
+                await self._app.activity_sender.send(activity, conv_ref)
+            else:
+                await self._app.send(chat_id, activity)
+        except Exception as exc:
+            logger.debug("[teams] Could not send file info card: %s", exc)
+
+    async def _on_file_consent(self, ctx: Any) -> None:
+        """Complete or discard a document offer once the user answers."""
+        value = getattr(ctx.activity, "value", None)
+        context = getattr(value, "context", None) or {}
+        token = context.get("token") if isinstance(context, dict) else None
+        action = getattr(value, "action", None)
+        action_str = str(getattr(action, "value", None) or action or "")
+
+        entries = _load_file_consents()
+        record = entries.pop(token, None) if token else None
+        _write_file_consents(entries)
+
+        if not isinstance(record, dict):
+            logger.warning("[teams] file consent callback with unknown/expired token — ignoring")
+            return
+
+        name = record.get("name") or "file"
+        chat_id = record.get("chat_id") or ""
+
+        if not action_str.endswith("accept"):
+            logger.info("[teams] %s declined by user", name)
+            return
+
+        # Accepting makes the bot read a local file and upload it, so gate
+        # the accept on the same allowlist that guards card actions.
+        if not self._is_allowed_teams_user(ctx):
+            logger.warning("[teams] Unauthorized file consent accept for %s — ignoring", name)
+            return
+
+        upload = getattr(value, "upload_info", None)
+        upload_url = getattr(upload, "upload_url", None)
+        if not upload_url:
+            logger.error("[teams] file consent accept for %s carried no upload URL", name)
+            return
+
+        try:
+            with open(record.get("path", ""), "rb") as fh:
+                data = fh.read()
+        except OSError as exc:
+            logger.error("[teams] file consent accept but %s is unreadable: %s", name, exc)
+            await self.send(chat_id, f"{name} is no longer available on the host.")
+            return
+
+        import httpx
+
+        try:
+            async with httpx.AsyncClient(timeout=300.0) as client:
+                response = await client.put(
+                    upload_url,
+                    content=data,
+                    headers={
+                        "Content-Length": str(len(data)),
+                        "Content-Range": f"bytes 0-{len(data) - 1}/{len(data)}",
+                    },
+                )
+                response.raise_for_status()
+        except Exception as exc:
+            logger.error("[teams] upload failed for %s: %s", name, exc)
+            await self.send(chat_id, f"Upload of {name} failed: {exc}")
+            return
+
+        await self._send_file_info_card(chat_id, upload)
+        logger.info("[teams] Uploaded %s (%d bytes) after consent", name, len(data))
+
     async def send_document(
         self,
         chat_id: str,
@@ -1384,6 +1635,21 @@ class TeamsAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
+        # Teams rejects a data: URI attachment for anything that is not an
+        # image, so a document in personal chat goes out as a file consent
+        # card and _on_file_consent uploads the bytes once accepted. Group
+        # chats and channels have no consent flow, so they keep the old path.
+        is_local = not file_path.startswith(("http://", "https://"))
+        if is_local and self._is_personal_chat(chat_id):
+            result = await self._send_file_consent(
+                chat_id, file_path.removeprefix("file://"), caption, file_name
+            )
+            if result.success:
+                return result
+            logger.warning(
+                "[teams] file consent offer failed (%s); falling back to attachment",
+                result.error,
+            )
         return await self._send_media_attachment(
             chat_id=chat_id,
             source=file_path,

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -64,6 +64,10 @@ def _ensure_teams_mock():
             self._card_action_handler = func
             return func
 
+        def on_file_consent(self, func):
+            self._file_consent_handler = func
+            return func
+
         async def initialize(self):
             pass
 
@@ -100,6 +104,19 @@ def _ensure_teams_mock():
     # Adaptive card response mocks
     microsoft_teams_api_models_adaptive_card.AdaptiveCardActionCardResponse = MagicMock
     microsoft_teams_api_models_adaptive_card.AdaptiveCardActionMessageResponse = MagicMock
+
+    microsoft_teams_api_models_file = types.ModuleType("microsoft_teams.api.models.file")
+
+    class MockFileConsentCard:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class MockFileInfoCard:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    microsoft_teams_api_models_file.FileConsentCard = MockFileConsentCard
+    microsoft_teams_api_models_file.FileInfoCard = MockFileInfoCard
 
     # Invoke response mocks
     class MockInvokeResponse:
@@ -154,6 +171,7 @@ def _ensure_teams_mock():
         "microsoft_teams.common.http.client": microsoft_teams_common_http_client,
         "microsoft_teams.api.models": microsoft_teams_api_models,
         "microsoft_teams.api.models.adaptive_card": microsoft_teams_api_models_adaptive_card,
+        "microsoft_teams.api.models.file": microsoft_teams_api_models_file,
         "microsoft_teams.api.models.invoke_response": microsoft_teams_api_models_invoke_response,
         "microsoft_teams.cards": microsoft_teams_cards,
         "microsoft_teams.apps.http": microsoft_teams_apps_http,
@@ -747,5 +765,151 @@ class TestTeamsMediaAttachments:
         result = await adapter.send_document("19:abc@thread.v2", str(doc))
         assert result.success
         adapter._app.send.assert_awaited_once()
+
+
+def _consent_ctx(token: str, action: str = "accept", user_id: str = "user-1", upload_url: str | None = "https://upload.example/file"):
+    upload = SimpleNamespace(
+        upload_url=upload_url,
+        unique_id="uid-1",
+        file_type="xlsx",
+        content_url="https://share.example/file",
+        name="report.xlsx",
+    )
+    value = SimpleNamespace(
+        context={"token": token},
+        action=action,
+        upload_info=upload,
+    )
+    activity = SimpleNamespace(
+        value=value,
+        from_=SimpleNamespace(aad_object_id=user_id, id=user_id),
+    )
+    return SimpleNamespace(activity=activity)
+
+
+class TestTeamsFileConsent:
+    """Personal-chat send_document uses the Bot Framework file-consent
+    card. Group/channel ids (19:...) keep the attachment path above."""
+
+    def _make_adapter(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+        ))
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+        adapter._app.send = AsyncMock(return_value=MagicMock(id="msg-consent"))
+        adapter._app.activity_sender = MagicMock()
+        adapter._app.activity_sender.send = AsyncMock(return_value=MagicMock(id="msg-consent"))
+        return adapter
+
+    @pytest.mark.asyncio
+    async def test_personal_chat_offers_consent_card(self, tmp_path, monkeypatch):
+        adapter = self._make_adapter(tmp_path, monkeypatch)
+        doc = tmp_path / "report.xlsx"
+        doc.write_bytes(b"PK\x03\x04workbook")
+        result = await adapter.send_document("a:1personal", str(doc), caption="parent codes")
+        assert result.success
+        adapter._app.send.assert_awaited_once()
+        store = json.loads((tmp_path / "pending_file_consents.json").read_text())
+        assert len(store) == 1
+        token, rec = next(iter(store.items()))
+        assert "/" not in token and "\\" not in token
+        assert rec["path"] == str(doc.resolve())
+        assert rec["name"] == "report.xlsx"
+        assert rec["chat_id"] == "a:1personal"
+
+    @pytest.mark.asyncio
+    async def test_empty_file_is_rejected(self, tmp_path, monkeypatch):
+        adapter = self._make_adapter(tmp_path, monkeypatch)
+        empty = tmp_path / "empty.csv"
+        empty.write_bytes(b"")
+        result = await adapter._send_file_consent("a:1personal", str(empty))
+        assert result.success is False
+        assert "empty" in result.error
+
+    @pytest.mark.asyncio
+    async def test_oversized_file_is_rejected(self, tmp_path, monkeypatch):
+        adapter = self._make_adapter(tmp_path, monkeypatch)
+        monkeypatch.setattr(_teams_mod, "_FILE_CONSENT_MAX_BYTES", 4)
+        big = tmp_path / "big.bin"
+        big.write_bytes(b"12345")
+        result = await adapter._send_file_consent("a:1personal", str(big))
+        assert result.success is False
+        assert "size limit" in result.error
+
+    @pytest.mark.asyncio
+    async def test_accept_uploads_and_drops_token(self, tmp_path, monkeypatch):
+        adapter = self._make_adapter(tmp_path, monkeypatch)
+        monkeypatch.setenv("TEAMS_ALLOW_ALL_USERS", "1")
+        doc = tmp_path / "report.xlsx"
+        doc.write_bytes(b"workbook-bytes")
+        offered = await adapter.send_document("a:1personal", str(doc))
+        assert offered.success
+        token = next(iter(json.loads((tmp_path / "pending_file_consents.json").read_text())))
+
+        puts: list[tuple] = []
+
+        class FakeResponse:
+            def raise_for_status(self):
+                return None
+
+        class FakeClient:
+            def __init__(self, *args, **kwargs):
+                async def put(url, content=None, headers=None):
+                    puts.append((url, content, headers))
+                    return FakeResponse()
+
+                self.put = put
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+        monkeypatch.setattr(httpx, "AsyncClient", FakeClient)
+        adapter.send = AsyncMock()
+        await adapter._on_file_consent(_consent_ctx(token))
+        store = json.loads((tmp_path / "pending_file_consents.json").read_text())
+        assert store == {}
+        assert puts and puts[0][0] == "https://upload.example/file"
+        assert puts[0][1] == b"workbook-bytes"
+        adapter.send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_decline_does_not_upload(self, tmp_path, monkeypatch):
+        adapter = self._make_adapter(tmp_path, monkeypatch)
+        doc = tmp_path / "report.xlsx"
+        doc.write_bytes(b"workbook-bytes")
+        await adapter.send_document("a:1personal", str(doc))
+        token = next(iter(json.loads((tmp_path / "pending_file_consents.json").read_text())))
+        adapter.send = AsyncMock()
+        await adapter._on_file_consent(_consent_ctx(token, action="decline"))
+        store = json.loads((tmp_path / "pending_file_consents.json").read_text())
+        assert store == {}
+        adapter.send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unknown_token_is_ignored(self, tmp_path, monkeypatch):
+        adapter = self._make_adapter(tmp_path, monkeypatch)
+        adapter.send = AsyncMock()
+        await adapter._on_file_consent(_consent_ctx("not-a-real-token"))
+        adapter.send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_accept_gated_on_allowlist(self, tmp_path, monkeypatch):
+        adapter = self._make_adapter(tmp_path, monkeypatch)
+        monkeypatch.delenv("TEAMS_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.setenv("TEAMS_ALLOWED_USERS", "allowed-user")
+        doc = tmp_path / "report.xlsx"
+        doc.write_bytes(b"workbook-bytes")
+        await adapter.send_document("a:1personal", str(doc))
+        token = next(iter(json.loads((tmp_path / "pending_file_consents.json").read_text())))
+        adapter.send = AsyncMock()
+        await adapter._on_file_consent(_consent_ctx(token, user_id="other-user"))
+        adapter.send.assert_not_awaited()
+        store = json.loads((tmp_path / "pending_file_consents.json").read_text())
+        assert store == {}
 
 


### PR DESCRIPTION
## What does this PR do?

`send_document` on Teams silently failed for every non-image file. The adapter base64s local files into a `data:` URI attachment; Bot Framework accepts that for images and returns HTTP 400 for everything else (`.xlsx`, `.pdf`, `.csv`, …). The text that went with the file still claimed it was attached.

The supported Bot Framework path for a bot to deliver a document in a **personal** chat is the [file consent card](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/bots-filesv4): the user accepts, Teams returns a pre-authorized upload URL into that user's own OneDrive, and the bot PUTs the bytes there. No Graph permissions are required.

This PR routes local `send_document` calls in personal chats through that flow, and keeps the existing attachment path for group chats / channels (Teams has no consent flow there) and for HTTP(S) URLs.

## Related Issue

No existing issue or PR covers Teams `send_document` / file consent (searched open + closed). Group-chat document delivery remains a platform constraint, not addressed here.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `plugins/platforms/teams/adapter.py`
  - Disk-backed pending map (`$HERMES_HOME/pending_file_consents.json`, mode 0600, 24h TTL) keyed by an opaque token — never a path — so a short-lived `hermes send` and the long-lived gateway can share state, and a tampered invoke cannot upload an arbitrary local file.
  - `_send_file_consent` offers the card; `_on_file_consent` (registered via `@app.on_file_consent`) completes or discards it.
  - Accept is gated on the same `TEAMS_ALLOWED_USERS` / `TEAMS_ALLOW_ALL_USERS` allowlist as card actions.
  - `send_document` uses the consent path for local files in personal chat; group/channel ids (`19:…`) and remote URLs keep the attachment path.
- `tests/gateway/test_teams.py` — personal-chat offer, empty/oversized rejection, accept upload + token drop, decline, unknown token, allowlist gate. Existing group-chat `send_document` test still expects the attachment path.

**Scope note:** consent is personal-chat only. The tenant Teams app manifest must set `bots[].supportsFiles: true` or the Allow button fails with "This card action is not supported by \<bot\>".

## How to Test

1. Targeted: `pytest tests/gateway/test_teams.py -q` (30 passed on this branch).
2. Live: enable Teams, send a local `.xlsx` from a personal chat. A consent card should render; after Allow, the file lands in the recipient's OneDrive and a file-info card appears. Gateway log: `[teams] Uploaded … after consent`.
3. Group/channel send should be unchanged (attachment path; documents still cannot be delivered there).

I did **not** run the full `pytest tests/ -q` suite locally. The install/update tests in this repo rebuild `.venv` and reset the git checkout; targeted tests + CI are the safer split.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(teams):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — targeted `test_teams.py` only; see above
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (targeted tests) + a production Teams tenant (live consent flow)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (adapter docstring + comments)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pending store uses `HERMES_HOME` + `os.replace`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A