### PR TITLE
feat(telegram): enrich normalized reaction events

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4101,47 +4101,81 @@ class TelegramAdapter(BasePlatformAdapter):
         """Normalize a ``message_reaction`` update (event_type ``reaction``).
 
         Reaction (the motivating use case: a plugin that re-renders or reacts to
-        a message when the user reacts to it) is normalized to the fields a
-        plugin consumes: ``emojis`` (standard unicode), ``custom_emoji_ids``
-        (custom reaction emojis — PTB exposes ``custom_emoji_id`` with no
-        ``.emoji``), ``chat_id``, ``message_id``, ``thread_id``.
+        a message when the user reacts to it) is normalized to bounded event,
+        actor, timestamp, and reaction-state fields without exposing SDK objects.
         """
         mr = getattr(update, "message_reaction", None)
         if mr is None:
             return None
         chat = getattr(mr, "chat", None)
+        actor = getattr(mr, "user", None) or getattr(mr, "actor_chat", None)
+        old_reaction = getattr(mr, "old_reaction", None) or []
         new_reaction = getattr(mr, "new_reaction", None) or []
-        if not isinstance(new_reaction, (list, tuple)):
-            return None
-        chat_id = getattr(chat, "id", None) if chat is not None else None
-        message_id = getattr(mr, "message_id", None)
-        if (
-            isinstance(chat_id, bool)
-            or not isinstance(chat_id, (str, int))
-            or isinstance(message_id, bool)
-            or not isinstance(message_id, (str, int))
+        if not isinstance(old_reaction, (list, tuple)) or not isinstance(
+            new_reaction, (list, tuple)
         ):
             return None
-        emojis: List[str] = []
-        custom_emoji_ids: List[str] = []
-        for r in new_reaction[:64]:
-            emoji = getattr(r, "emoji", None)
-            if isinstance(emoji, str) and emoji:
-                emojis.append(emoji[:64])
-            custom_id = getattr(r, "custom_emoji_id", None)
-            if (
-                not isinstance(custom_id, bool)
-                and isinstance(custom_id, (str, int))
-            ):
-                custom_emoji_ids.append(str(custom_id)[:128])
+
+        def _bounded_identifier(value: Any) -> Optional[str]:
+            if isinstance(value, bool) or not isinstance(value, (str, int)):
+                return None
+            normalized = str(value).strip()
+            return normalized[:128] if normalized else None
+
+        update_id = _bounded_identifier(getattr(update, "update_id", None))
+        actor_id = _bounded_identifier(getattr(actor, "id", None))
+        chat_id = _bounded_identifier(
+            getattr(chat, "id", None) if chat is not None else None
+        )
+        message_id = _bounded_identifier(getattr(mr, "message_id", None))
+        if None in (update_id, actor_id, chat_id, message_id):
+            return None
+
+        actor_name = None
+        for attribute in ("username", "full_name", "title"):
+            candidate = getattr(actor, attribute, None)
+            if isinstance(candidate, str) and candidate.strip():
+                actor_name = candidate.strip()[:256]
+                break
+
+        occurred_at = None
+        event_date = getattr(mr, "date", None)
+        if isinstance(event_date, datetime):
+            if event_date.tzinfo is None:
+                event_date = event_date.replace(tzinfo=timezone.utc)
+            occurred_at = event_date.isoformat()[:64]
+
+        def _reaction_parts(reactions: list | tuple) -> tuple[List[str], List[str]]:
+            emojis: List[str] = []
+            custom_ids: List[str] = []
+            for reaction in reactions[:64]:
+                emoji = getattr(reaction, "emoji", None)
+                if isinstance(emoji, str) and emoji:
+                    emojis.append(emoji[:64])
+                custom_id = getattr(reaction, "custom_emoji_id", None)
+                if (
+                    not isinstance(custom_id, bool)
+                    and isinstance(custom_id, (str, int))
+                ):
+                    custom_ids.append(str(custom_id)[:128])
+            return emojis, custom_ids
+
+        old_emojis, old_custom_emoji_ids = _reaction_parts(old_reaction)
+        emojis, custom_emoji_ids = _reaction_parts(new_reaction)
         return {
             "platform": "telegram",
             "event_type": "reaction",
             "payload": {
+                "update_id": update_id,
+                "actor_id": actor_id,
+                "actor_name": actor_name,
+                "occurred_at": occurred_at,
+                "old_emojis": old_emojis,
+                "old_custom_emoji_ids": old_custom_emoji_ids,
                 "emojis": emojis,
                 "custom_emoji_ids": custom_emoji_ids,
-                "chat_id": str(chat_id)[:128],
-                "message_id": str(message_id)[:128],
+                "chat_id": chat_id,
+                "message_id": message_id,
                 # Reactions don't carry thread_id; do not guess it or expose an
                 # adapter object as a routing escape hatch.
                 "thread_id": None,

--- a/tests/gateway/test_gateway_platform_event_hook.py
+++ b/tests/gateway/test_gateway_platform_event_hook.py
@@ -7,7 +7,7 @@ Covers the normalized-envelope pattern that replaces raw-SDK handler args:
   performs the authoritative post-auth check before invoking plugins
 * ``TelegramAdapter._normalize_platform_event`` maps an inbound PTB update to a
   stable ``{platform, event_type, payload}`` envelope (no raw SDK objects),
-  including custom-emoji reactions
+  including update/actor identity and old/new custom-emoji reaction sets
 * ``_on_platform_update`` fires ``gateway_platform_event`` with that envelope,
   gated on the same authorization decision as inbound gateway traffic
   (unauthorized reactions never fire), and swallows errors so the observer
@@ -19,6 +19,7 @@ Covers the normalized-envelope pattern that replaces raw-SDK handler args:
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timezone
 import json
 import sys
 from contextlib import nullcontext
@@ -101,13 +102,30 @@ def _reaction(*, emoji=None, custom_emoji_id=None):
     return r
 
 
-def _reaction_update(reactions, chat_id: object = 123, message_id: object = 456):
+def _reaction_update(
+    reactions,
+    chat_id: object = 123,
+    message_id: object = 456,
+    *,
+    old_reactions=(),
+    update_id: object = 789,
+    actor_id: object = 777,
+    actor_name: object = "Alice",
+    occurred_at: object = datetime(2026, 8, 11, 18, 0, tzinfo=timezone.utc),
+):
     """A PTB Update stand-in carrying a message_reaction with ``reactions``."""
     update = MagicMock()
+    update.update_id = update_id
     update.message_reaction = MagicMock()
     update.message_reaction.chat.id = chat_id
     update.message_reaction.message_id = message_id
+    update.message_reaction.old_reaction = list(old_reactions)
     update.message_reaction.new_reaction = list(reactions)
+    update.message_reaction.user.id = actor_id
+    update.message_reaction.user.username = actor_name
+    update.message_reaction.user.full_name = actor_name
+    update.message_reaction.actor_chat = None
+    update.message_reaction.date = occurred_at
     return update
 
 
@@ -229,6 +247,12 @@ class TestNormalizePlatformEvent:
             "platform": "telegram",
             "event_type": "reaction",
             "payload": {
+                "update_id": "789",
+                "actor_id": "777",
+                "actor_name": "Alice",
+                "occurred_at": "2026-08-11T18:00:00+00:00",
+                "old_emojis": [],
+                "old_custom_emoji_ids": [],
                 "emojis": ["\U0001F44E"],
                 "custom_emoji_ids": [],
                 "chat_id": "123",
@@ -260,6 +284,53 @@ class TestNormalizePlatformEvent:
         assert event["payload"]["emojis"] == ["\U0001F44D", "\U0001F525"]
         assert event["payload"]["custom_emoji_ids"] == ["555"]
 
+    def test_old_and_new_reaction_sets_are_both_preserved(self):
+        a = _adapter()
+        update = _reaction_update(
+            [_reaction(emoji="\U0001F525")],
+            old_reactions=[
+                _reaction(emoji="\U0001F44D"),
+                _reaction(custom_emoji_id="old-custom"),
+            ],
+        )
+
+        event = a._normalize_platform_event(update)
+        assert event is not None
+        payload = event["payload"]
+
+        assert payload["old_emojis"] == ["\U0001F44D"]
+        assert payload["old_custom_emoji_ids"] == ["old-custom"]
+        assert payload["emojis"] == ["\U0001F525"]
+
+    def test_actor_chat_identity_is_preserved_for_anonymous_admin(self):
+        a = _adapter()
+        update = _reaction_update([_reaction(emoji="\U0001F44D")])
+        update.message_reaction.user = None
+        update.message_reaction.actor_chat = SimpleNamespace(
+            id=888,
+            username=None,
+            full_name=None,
+            title="Moderators",
+        )
+
+        event = a._normalize_platform_event(update)
+
+        assert event is not None
+        assert event["payload"]["actor_id"] == "888"
+        assert event["payload"]["actor_name"] == "Moderators"
+
+    def test_naive_reaction_timestamp_is_assumed_utc(self):
+        a = _adapter()
+        update = _reaction_update(
+            [_reaction(emoji="\U0001F44D")],
+            occurred_at=datetime(2026, 8, 11, 18, 0),
+        )
+
+        event = a._normalize_platform_event(update)
+
+        assert event is not None
+        assert event["payload"]["occurred_at"] == "2026-08-11T18:00:00+00:00"
+
     def test_malformed_values_never_escape_as_live_objects(self):
         a = _adapter()
         update = _reaction_update(
@@ -279,6 +350,13 @@ class TestNormalizePlatformEvent:
             [_reaction(emoji="x" * 100, custom_emoji_id="9" * 200) for _ in range(100)],
             chat_id="c" * 200,
             message_id="m" * 200,
+            old_reactions=[
+                _reaction(emoji="y" * 100, custom_emoji_id="8" * 200)
+                for _ in range(100)
+            ],
+            update_id="u" * 200,
+            actor_id="a" * 200,
+            actor_name="n" * 400,
         )
 
         event = a._normalize_platform_event(update)
@@ -287,10 +365,29 @@ class TestNormalizePlatformEvent:
         payload = event["payload"]
         assert len(payload["emojis"]) == 64
         assert len(payload["custom_emoji_ids"]) == 64
+        assert len(payload["old_emojis"]) == 64
+        assert len(payload["old_custom_emoji_ids"]) == 64
         assert all(len(value) == 64 for value in payload["emojis"])
         assert all(len(value) == 128 for value in payload["custom_emoji_ids"])
+        assert all(len(value) == 64 for value in payload["old_emojis"])
+        assert all(len(value) == 128 for value in payload["old_custom_emoji_ids"])
+        assert len(payload["update_id"]) == 128
+        assert len(payload["actor_id"]) == 128
+        assert len(payload["actor_name"]) == 256
         assert len(payload["chat_id"]) == 128
         assert len(payload["message_id"]) == 128
+
+    def test_malformed_reaction_identity_or_state_returns_none(self):
+        a = _adapter()
+        assert a._normalize_platform_event(
+            _reaction_update([_reaction(emoji="x")], update_id=True)
+        ) is None
+        assert a._normalize_platform_event(
+            _reaction_update([_reaction(emoji="x")], actor_id=object())
+        ) is None
+        update = _reaction_update([_reaction(emoji="x")])
+        update.message_reaction.old_reaction = object()
+        assert a._normalize_platform_event(update) is None
 
     def test_non_reaction_update_returns_none(self):
         """Unsupported update types return None until a concrete contract exists."""
@@ -650,6 +747,12 @@ class TestFixturePluginObservationPath:
             "platform": "telegram",
             "event_type": "reaction",
             "payload": {
+                "update_id": "789",
+                "actor_id": "777",
+                "actor_name": "Alice",
+                "occurred_at": "2026-08-11T18:00:00+00:00",
+                "old_emojis": [],
+                "old_custom_emoji_ids": [],
                 "emojis": ["\U0001F44D"],
                 "custom_emoji_ids": [],
                 "chat_id": "123",

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -936,7 +936,7 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 | [`on_session_end`](/user-guide/features/hooks#on_session_end) | End of every `run_conversation` call + CLI exit | `session_id: str, completed: bool, interrupted: bool, model: str, platform: str` | ignored |
 | [`on_session_finalize`](/user-guide/features/hooks#on_session_finalize) | CLI/gateway tears down an active session | `session_id: str \| None, platform: str` | ignored |
 | [`on_session_reset`](/user-guide/features/hooks#on_session_reset) | Gateway swaps in a new session key (`/new`, `/reset`) | `session_id: str, platform: str` | ignored |
-| [`gateway_platform_event`](/user-guide/features/hooks#gateway_platform_event) | An authorized platform-native event is normalized at the gateway boundary (Telegram reactions currently) | `platform: str, event_type: str, payload: dict` | ignored |
+| [`gateway_platform_event`](/user-guide/features/hooks#gateway_platform_event) | An authorized platform-native event is normalized at the gateway boundary (Telegram reactions include update/actor identity and old/new state) | `platform: str, event_type: str, payload: dict` | ignored |
 | `kanban_task_claimed` | A kanban task is claimed (dispatcher process, before the worker spawns) | `task_id: str, board: str \| None, assignee: str \| None, run_id: int \| None, profile_name: str` | ignored |
 | `kanban_task_completed` | A kanban task completes (worker process) | `task_id, board, assignee, run_id, profile_name, summary: str \| None` | ignored |
 | `kanban_task_blocked` | A kanban task is blocked (worker process) | `task_id, board, assignee, run_id, profile_name, reason: str \| None` | ignored |

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -1253,7 +1253,7 @@ Every payload is additive and event-specific; there is no monolithic gateway pay
 
 | `event_type` | Platforms | Payload fields |
 |--------------|-----------|----------------|
-| `reaction` | telegram | `emojis: list[str]`, `custom_emoji_ids: list[str]`, `chat_id: str`, `message_id: str`, `thread_id: str \| None` (Telegram reaction updates carry no topic id, so currently always `None`). |
+| `reaction` | telegram | `update_id: str`, `actor_id: str`, `actor_name: str \| None`, `occurred_at: str \| None` (ISO 8601), `old_emojis: list[str]`, `old_custom_emoji_ids: list[str]`, `emojis: list[str]`, `custom_emoji_ids: list[str]`, `chat_id: str`, `message_id: str`, `thread_id: str \| None` (Telegram reaction updates carry no topic id, so currently always `None`). |
 | `message_edited` | telegram, discord | `chat_id: str`, `message_id: str`, `thread_id: str \| None`, `text: str \| None` (edited text or caption, bounded; `None` for media-only edits or when uncached), `edited_at: str \| None` (ISO 8601). |
 | `message_deleted` | discord | `chat_id: str`, `message_id: str`, `thread_id: str \| None`, `author_id: str \| None`. Discord's delete event does not identify the deleter; the authorized source is the deleted message's author, and uncached deletions never fire. |
 | `thread_created` | discord | `thread_id: str`, `parent_chat_id: str \| None`, `name: str \| None`, `owner_id: str \| None`. |


### PR DESCRIPTION
## Summary

Follow-up to #82063: enrich the already-authorized, normalized Telegram `gateway_platform_event` reaction payload with the identity and state needed by deterministic consumers.

- add bounded `update_id`, `actor_id`, optional `actor_name`, and optional ISO `occurred_at`
- preserve both old and new standard/custom reaction sets
- keep every exposed value primitive, JSON-safe, and bounded
- fail closed on malformed update/actor/chat/message identity or malformed reaction state
- document the additive reaction payload contract

## Why

The current payload contains only the new reaction snapshot. A durable feedback consumer needs the Telegram update identity for idempotency, the authorized actor identity for attribution, the event timestamp, and both old/new sets to distinguish additions, removals, and replacement reactions without receiving raw PTB objects.

This is a clean port of my earlier extension commit `ee9948619e` onto current `main`; that old commit was built on Paolo Antinori's pre-merge observer branch and no longer cherry-picks after #82063/#84989. The new patch preserves the current profile-scoped post-auth dispatch, identity bounds, rebuild behavior, and normalized-envelope design instead of reviving the old branch.

## Compatibility and security

The contract is additive for existing plugin consumers. Reaction events still pass through the existing routed-profile authorization boundary before plugin dispatch. No SDK object, bot handle, raw update, or adapter reference enters the payload.

## Verification

- `uv run pytest -q tests/gateway/test_gateway_platform_event_hook.py` — 38 passed
- reaction/profile/auth/thread regression set — 71 passed
- `uv run ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_gateway_platform_event_hook.py` — passed
- `python3 -m compileall -q ...` — passed
- independent exact-diff fail-closed review — passed
