### PR TITLE
fix(curator): forward configured fallback chains

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1839,6 +1839,26 @@ def _resolve_review_model(cfg: Dict[str, Any]) -> tuple[str, str]:
     return b.provider, b.model
 
 
+def _resolve_review_fallback_chain(cfg: Dict[str, Any]) -> Optional[List[Dict[str, Any]]]:
+    """Resolve the curator slot's fallback chain, then the global chain.
+
+    A configured per-task chain intentionally takes precedence over the
+    top-level chain; an explicit empty list therefore disables fallback for
+    the curator rather than silently re-enabling global providers.
+    """
+    try:
+        from hermes_cli.fallback_config import get_fallback_chain
+
+        aux = cfg.get("auxiliary", {}) if isinstance(cfg.get("auxiliary"), dict) else {}
+        task = aux.get("curator", {}) if isinstance(aux.get("curator"), dict) else {}
+        if "fallback_chain" in task:
+            return get_fallback_chain({"fallback_model": task.get("fallback_chain")})
+        return get_fallback_chain(cfg)
+    except Exception:
+        logger.debug("Curator fallback-chain resolution failed", exc_info=True)
+        return None
+
+
 def _run_llm_review(prompt: str) -> Dict[str, Any]:
     """Spawn an AIAgent fork to run the curator review prompt.
 
@@ -1884,6 +1904,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
     _api_mode = None
     _resolved_provider = None
     _credential_pool = None
+    _fallback_chain = None
     _request_overrides: Dict[str, Any] = {}
     _max_tokens = None
     _acp_command = None
@@ -1893,6 +1914,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         from hermes_cli.config import load_config_readonly
         from hermes_cli.runtime_provider import resolve_runtime_provider
         _cfg = load_config_readonly()
+        _fallback_chain = _resolve_review_fallback_chain(_cfg)
         _binding = _resolve_review_runtime(_cfg)
         _provider, _model_name = _binding.provider, _binding.model
         _rp = resolve_runtime_provider(
@@ -1929,6 +1951,8 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         if isinstance(_acp_command, str) and _acp_command:
             _agent_kwargs["acp_command"] = _acp_command
             _agent_kwargs["acp_args"] = _acp_args or []
+        if _fallback_chain is not None:
+            _agent_kwargs["fallback_model"] = _fallback_chain
         review_agent = AIAgent(
             model=_model_name,
             provider=_resolved_provider,

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -665,6 +665,29 @@ def test_review_model_auxiliary_curator_partial_override_falls_back(curator_env)
     )
 
 
+def test_review_fallback_chain_prefers_curator_slot(curator_env):
+    curator = curator_env["curator"]
+    cfg = {
+        "fallback_providers": [{"provider": "openrouter", "model": "global"}],
+        "auxiliary": {
+            "curator": {
+                "fallback_chain": [{"provider": "nous", "model": "curator"}],
+            },
+        },
+    }
+    assert curator._resolve_review_fallback_chain(cfg) == [
+        {"provider": "nous", "model": "curator"},
+    ]
+
+
+def test_review_fallback_chain_uses_global_when_slot_is_unset(curator_env):
+    curator = curator_env["curator"]
+    cfg = {"fallback_providers": [{"provider": "openrouter", "model": "global"}]}
+    assert curator._resolve_review_fallback_chain(cfg) == [
+        {"provider": "openrouter", "model": "global"},
+    ]
+
+
 
 
 
@@ -744,7 +767,16 @@ def test_review_fork_forwards_runtime_pool_and_overrides(curator_env, monkeypatc
     )
     monkeypatch.setattr(
         "hermes_cli.config.load_config_readonly",
-        lambda: {"model": {"provider": "custom:hyper-charm", "default": "glm-5.2"}},
+        lambda: {
+            "model": {"provider": "custom:hyper-charm", "default": "glm-5.2"},
+            "auxiliary": {
+                "curator": {
+                    "fallback_chain": [
+                        {"provider": "openrouter", "model": "fallback-model"},
+                    ],
+                },
+            },
+        },
     )
     monkeypatch.setattr(
         "hermes_cli.runtime_provider.resolve_runtime_provider",
@@ -757,6 +789,9 @@ def test_review_fork_forwards_runtime_pool_and_overrides(curator_env, monkeypatc
     assert meta.get("error") is None, meta.get("error")
     assert captured["kwargs"]["credential_pool"] is fake_pool
     assert captured["kwargs"]["request_overrides"] == fake_overrides
+    assert captured["kwargs"]["fallback_model"] == [
+        {"provider": "openrouter", "model": "fallback-model"},
+    ]
 
 
 def test_review_fork_uses_runtime_model_and_output_cap(curator_env, monkeypatch):


### PR DESCRIPTION
## Summary
- resolve `auxiliary.curator.fallback_chain` for curator review forks
- prefer the curator-specific chain while preserving the global fallback chain when the slot is unset
- forward the effective chain into `AIAgent` and add regression tests

## Root cause
The curator review resolved its provider and model but constructed `AIAgent` without `fallback_model`, so configured per-task and global fallback providers were never available to curator reviews.

## Validation
- targeted curator fallback/runtime tests: 7 passed
- Python compilation passed

Fixes #78371