### PR TITLE
fix(tests): goal-verdict tests no longer flake when SessionDB init overruns the loop-thread grace window

### DIFF
--- a/tests/gateway/test_goal_verdict_send.py
+++ b/tests/gateway/test_goal_verdict_send.py
@@ -30,6 +30,15 @@ def hermes_home(tmp_path, monkeypatch):
     from hermes_cli import goals
 
     goals._DB_CACHE.clear()
+    # Pre-warm the SessionDB cache from this SYNC context. The tests call
+    # GoalManager.set() on the event-loop thread, where _get_session_db()
+    # refuses to construct SessionDB inline (loop-liveness guard) and only
+    # waits _DB_BOOTSTRAP_LOOP_WAIT_S for a background bootstrap. On a loaded
+    # CI runner the init overruns that window, the goal write is silently
+    # dropped by design, and the continuation path no-ops — the recurring
+    # sends == [] flake. Warming here uses the direct construction path, so
+    # the loop-thread set() always finds a cached DB.
+    goals._get_session_db()
     yield home
     goals._DB_CACHE.clear()
 


### PR DESCRIPTION
## Summary
`tests/gateway/test_goal_verdict_send.py` no longer flakes on loaded CI runners — three hits today (slice 8/12 on two salvage PRs plus main's own push run), always `adapter.sends == []`.

Root cause (reproduced, not log-read): the tests call `GoalManager.set()` on the event-loop thread, where `_get_session_db()` refuses to build SessionDB inline (the loop-liveness guard from the 2026-08-14 crash-loop fix) and waits only 0.25s for the background bootstrap. On a loaded runner the init overruns the window, `set()` degrades to a silent no-op **by design**, the goal never exists, and the continuation path correctly sends nothing — so the #88975 drain-loop de-flake couldn't help; it fixed a different, downstream race.

## Changes
- `tests/gateway/test_goal_verdict_send.py`: the `hermes_home` fixture pre-warms the SessionDB cache from its sync context (direct construction path), so the loop-thread `set()` always finds a cached DB. 9 lines, test-only; production untouched.

## Validation
| | Old fixture | Fixed fixture |
|---|---|---|
| Normal run | 2/2 pass | 2/2 pass |
| Sabotage (0.4s-slow `SessionDB.__init__`, simulating loaded runner) | **1 failed** — exact CI shape (`sends == []`) | **2/2 pass** |

## Infographic

![Flaky test, fixed](https://v3b.fal.media/files/b/0aa6e1de/Svf5ISMBbF2MTzA_HwM6l_FYRBRJRl.png)
