### PR TITLE
fix(model_metadata): parse llama.cpp exceed_context_size_error for context-limit recovery

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1578,6 +1578,13 @@ def parse_context_limit_from_error(error_msg: str) -> Optional[int]:
     patterns = [
         r'max_model_len\s*(?:is\s*)?[:=(]?\s*(\d{4,})',  # vLLM: "max_model_len 32768", "=32768", ": 32768", "(32768)", "is 32768"
         r'maximum model length\s*(?:is\s*)?[:=(]?\s*(\d{4,})',  # vLLM alt: "maximum model length 131072", "... is 131072"
+        # llama.cpp exceed_context_size_error: "request (33056 tokens) exceeds
+        # the available context size (32768 tokens), try increasing it".  The
+        # limit sits behind a paren, which the generic context pattern below
+        # cannot cross (same delimiter class the vLLM patterns above fix) —
+        # and the leading "request (33056 tokens)" must NOT be captured, so
+        # anchor on the "available context size" phrasing specifically.
+        r'available context size\s*\(?\s*(\d{4,})\s*tokens?\)?',
         r'(?:max(?:imum)?|limit)\s*(?:context\s*)?(?:length|size|window)?\s*(?:is|of|:)?\s*(\d{4,})',
         r'context\s*(?:length|size|window)\s*(?:is|of|:)?\s*(\d{4,})',
         r'(\d{4,})\s*(?:token)?\s*(?:context|limit)',

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1298,6 +1298,37 @@ class TestParseContextLimitFromError:
         fell through to None."""
         assert parse_context_limit_from_error(msg) == expected
 
+    @pytest.mark.parametrize("msg,expected", [
+        # llama.cpp exceed_context_size_error, message field only.  Must
+        # return the LIMIT (32768), never the request size (33056) that
+        # appears first in the message.
+        ("request (33056 tokens) exceeds the available context size "
+         "(32768 tokens), try increasing it", 32768),
+        # Same error as the full stringified JSON body a client may surface.
+        ('{"error":{"code":400,"message":"request (33056 tokens) exceeds '
+         'the available context size (32768 tokens), try increasing it",'
+         '"type":"exceed_context_size_error","n_prompt_tokens":33056,'
+         '"n_ctx":32768}}', 32768),
+    ])
+    def test_llamacpp_exceed_context_size_error(self, msg, expected):
+        """llama.cpp's exceed_context_size_error puts the limit behind a
+        paren ("available context size (32768 tokens)"), which the generic
+        context pattern could not cross — the parser returned None, so
+        overflow recovery kept a wrong catalog-guessed window (e.g. 131072
+        for a server enforcing 32768) and compression never converged
+        ("Cannot compress further")."""
+        assert parse_context_limit_from_error(msg) == expected
+
+    def test_get_context_length_from_llamacpp_error_adopts_lower_limit(self):
+        from agent.model_metadata import get_context_length_from_provider_error
+        msg = ("request (33056 tokens) exceeds the available context size "
+               "(32768 tokens), try increasing it")
+        # Catalog guessed 131072 for a llama.cpp server enforcing 32768: the
+        # provider-reported lower limit must be adopted.
+        assert get_context_length_from_provider_error(msg, 131072) == 32768
+        # Guard unchanged: never raise the window from an error message.
+        assert get_context_length_from_provider_error(msg, 16384) is None
+
     def test_get_context_length_from_vllm_max_model_len_error(self):
         from agent.model_metadata import get_context_length_from_provider_error
 


### PR DESCRIPTION

## What does this PR do?

Teaches `parse_context_limit_from_error` to read llama.cpp's `exceed_context_size_error`, whose message reports the real window behind a parenthesis:

```
request (33056 tokens) exceeds the available context size (32768 tokens), try increasing it
```

The generic context pattern cannot cross the `(`, so the parser returned `None`, overflow recovery kept the (wrong, larger) resolved window, the compressor saw no overflow by its own accounting and removed nothing, and the session died permanently with `Context length exceeded (N tokens). Cannot compress further.` This is the same delimiter class the vLLM `max_model_len` patterns already handle; the new pattern is anchored on the "available context size" phrasing specifically so the leading `request (N tokens)` figure can never be captured.

With the limit parsed, the existing recovery path adopts the provider-reported window, persists it via `save_context_length`, and compression converges, so the fix is self-healing on first contact with the wall for every llama.cpp-backed endpoint, including setups where the window cannot be probed up front (for example llama.cpp behind llama-swap, where the swap-level `/v1/models` has no context metadata and resolution falls back to a catalog guess).

## Related Issue

Fixes #89502

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py`: one new pattern in `parse_context_limit_from_error`, placed with the other delimiter-hardened patterns, with a comment documenting the exact llama.cpp message shape and the anchoring rationale.
- `tests/agent/test_model_metadata.py`: three new cases in `TestParseContextLimitFromError`: the message-only form, the full stringified JSON error body, and a `get_context_length_from_provider_error` check that the lower reported limit is adopted while the never-raise guard stays intact.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_model_metadata.py` (108 passed here).
2. Unit repro of the bug: on main, `parse_context_limit_from_error("request (33056 tokens) exceeds the available context size (32768 tokens), try increasing it")` returns `None`; on this branch it returns `32768`, and `get_context_length_from_provider_error(msg, 131072)` returns `32768` (and still `None` for a current window of `16384`, preserving the never-raise-from-error guard).
3. Live repro: serve a model with llama.cpp `-c 32768` behind llama-swap (probe-down endpoint, so Hermes resolves a larger catalog window), run a session past 32k request tokens. On main the turn dies with "Cannot compress further" and every later turn fails the same way; with this fix, recovery logs the provider limit, persists it, compresses, and the session continues. Verified live on the setup described in the linked issue.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the full suite via `scripts/run_tests.sh` (CI-parity runner): 32,215 passed. My environment shows 2,429 pre-existing failures (missing provider keys/services); I ran the identical suite on clean `origin/main` and the failing-file set is byte-identical (2,429 failures, same 426 files), so this change introduces zero new failures. The affected files pass completely: `tests/agent/test_model_metadata.py` (108/108) and `tests/test_ctx_halving_fix.py` (14/14).
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 26.04 LTS, Python 3.11.15

### Documentation & Housekeeping

- [x] Docstrings/comments updated where relevant (pattern comment documents the message shape) — other docs N/A
- [x] No config keys changed — N/A
- [x] No architecture/workflow changes — N/A
- [x] Cross-platform impact considered: pure regex addition, no platform surface
- [x] No tool behavior changes — N/A
