### PR TITLE
fix(agent): keep auxiliary task base_url when provider is auto or unset

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8004,8 +8004,9 @@ def _resolve_task_provider_model(
 
     if task:
         # Config.yaml is the primary source for per-task overrides.
-        if cfg_base_url and cfg_api_key:
-            # Both base_url and api_key explicitly set → custom endpoint.
+        if cfg_base_url and (cfg_api_key or cfg_provider in (None, "auto")):
+            # A base_url without a named provider is a custom endpoint; local
+            # OpenAI-compatible servers may not require an API key.
             return "custom", resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode
         if cfg_base_url and cfg_provider and cfg_provider != "auto":
             # base_url set without api_key but with a known provider — use

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -261,7 +261,108 @@ class TestResolveTaskProviderModel:
         assert resolved_provider == "anthropic"
         assert model is None
 
+    def test_task_base_url_without_api_key_keeps_custom_endpoint(self):
+        """auxiliary.<task>.model + base_url (no provider, no api_key) must
+        still route to that endpoint.
 
+        #89445: local/OpenAI-compatible servers such as Ollama often have no
+        API key. The resolver currently requires *both* base_url and api_key
+        before returning custom, otherwise it falls through to auto and
+        *drops* the configured base_url. Requests then hit the main provider
+        (e.g. Nous Portal) instead of the documented custom endpoint.
+        """
+        task_config = {
+            "model": "qwen3.6:27b",
+            "base_url": "http://127.0.0.1:11434/v1",
+        }
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value=task_config,
+        ):
+            resolved_provider, model, base_url, api_key, api_mode = (
+                _resolve_task_provider_model(task="title_generation")
+            )
+
+        assert resolved_provider == "custom"
+        assert model == "qwen3.6:27b"
+        assert base_url == "http://127.0.0.1:11434/v1"
+        assert api_key is None
+        assert api_mode is None
+
+    def test_task_base_url_with_provider_auto_keeps_custom_endpoint(self):
+        """provider: auto plus a task-level base_url must not discard the URL.
+
+        #89445 variant 3: users set provider: auto hoping it means
+        \"auto-detect *except* honor my endpoint\". Today auto is treated as
+        \"inherit / auto-detect\" and the fallthrough returns
+        (auto, model, None, None).
+        """
+        task_config = {
+            "provider": "auto",
+            "model": "qwen3.6:27b",
+            "base_url": "http://127.0.0.1:11434/v1",
+        }
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value=task_config,
+        ):
+            resolved_provider, model, base_url, api_key, api_mode = (
+                _resolve_task_provider_model(task="title_generation")
+            )
+
+        assert resolved_provider == "custom"
+        assert model == "qwen3.6:27b"
+        assert base_url == "http://127.0.0.1:11434/v1"
+        assert api_key is None
+        assert api_mode is None
+
+    @pytest.mark.parametrize("provider", ["openrouter", "zai"])
+    def test_task_named_provider_with_base_url_preserves_provider(self, provider):
+        """A named provider's endpoint must retain provider-specific routing."""
+        task_config = {
+            "provider": provider,
+            "model": "provider-model",
+            "base_url": "https://provider.example/v1",
+        }
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value=task_config,
+        ):
+            resolved_provider, model, base_url, api_key, api_mode = (
+                _resolve_task_provider_model(task="title_generation")
+            )
+
+        assert resolved_provider == provider
+        assert resolved_provider != "custom"
+        assert model == "provider-model"
+        assert base_url == "https://provider.example/v1"
+        assert api_key is None
+        assert api_mode is None
+
+    @pytest.mark.parametrize("provider", [None, "auto"])
+    def test_task_base_url_with_api_key_uses_custom_endpoint(self, provider):
+        """A keyed endpoint without a named provider is explicitly custom."""
+        task_config = {
+            "model": "custom-model",
+            "base_url": "https://custom.example/v1",
+            "api_key": "custom-secret",
+        }
+        if provider is not None:
+            task_config["provider"] = provider
+
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value=task_config,
+        ):
+            resolved_provider, model, base_url, api_key, api_mode = (
+                _resolve_task_provider_model(task="title_generation")
+            )
+
+        assert resolved_provider == "custom"
+        assert model == "custom-model"
+        assert base_url == "https://custom.example/v1"
+        assert api_key == "custom-secret"
+        assert api_mode is None
 
 
 


### PR DESCRIPTION
## What does this PR do?

`auxiliary.<task>.base_url` was dropped when the task had no API key and provider was missing or `auto`. Those calls then used the auto chain (the main provider, e.g. Nous Portal) instead of the configured OpenAI-compatible endpoint.

This keeps the URL and routes as `custom` when provider is missing/`auto`. Named-provider + `base_url` is unchanged.

This does **not** claim a fix for reporter variant 2 (`provider: custom` + `base_url`). On current main that resolver path already keeps the URL; the downstream Nous routing could not be reproduced.

## Related Issue

Addresses #89445

This fixes the missing/auto-provider variants reported there.
The `provider: custom` variant is not claimed as fixed because its
downstream routing behavior could not be reproduced on current main.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`: `_resolve_task_provider_model` treats `base_url` without a named provider as custom even when `api_key` is empty
- `tests/agent/test_auxiliary_client.py`: four-case matrix (missing provider, `auto`, named provider, keyed custom)

## How to Test

1. `uv run pytest tests/agent/test_auxiliary_client.py::TestResolveTaskProviderModel -q`
2. Configure only `auxiliary.title_generation.model` + `base_url` (no API key) and confirm the request hits that endpoint, not Nous.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (Linux)

### Documentation & Housekeeping

- [x] N/A — no new config keys or docs required