### PR TITLE
fix(ui): clear TUI and Desktop lint warnings

### DIFF
--- a/apps/desktop/src/app/chat/composer/at-folder-navigation.test.tsx
+++ b/apps/desktop/src/app/chat/composer/at-folder-navigation.test.tsx
@@ -31,17 +31,17 @@ function folderItem(path: string): Unstable_TriggerItem {
 }
 
 function setup(initialText: string) {
-  const editor = document.createElement('div')
+  const editor = globalThis.document.createElement('div')
   editor.contentEditable = 'true'
   // The real composer marks its editor with this slot; `composerPlainText`
   // keys off it to decide whether a DIV contributes a trailing newline.
   // Without it the harness would silently diverge from production text.
   editor.dataset.slot = RICH_INPUT_SLOT
-  document.body.append(editor)
+  globalThis.document.body.append(editor)
   renderComposerContents(editor, initialText)
 
   // Caret at the end, which is where a typed trigger always leaves it.
-  const range = document.createRange()
+  const range = globalThis.document.createRange()
   range.selectNodeContents(editor)
   range.collapse(false)
   const sel = window.getSelection()

--- a/apps/desktop/src/app/chat/composer/directive-actions.test.tsx
+++ b/apps/desktop/src/app/chat/composer/directive-actions.test.tsx
@@ -16,11 +16,11 @@ vi.mock('@/app/open-session', () => ({ openSession: (...args: unknown[]) => open
 /** A live contenteditable holding real chips, with the watcher bound to it —
  *  the same pair both composers mount. */
 function mountEditor(chips: { kind: string; value: string }[]) {
-  const editor = document.createElement('div')
+  const editor = globalThis.document.createElement('div')
 
   editor.contentEditable = 'true'
   editor.append(...chips.map(chip => refChipElement(chip.kind, `\`${chip.value}\``)))
-  document.body.append(editor)
+  globalThis.document.body.append(editor)
 
   render(
     <I18nProvider configClient={null} initialLocale="en">
@@ -41,12 +41,14 @@ function hover(node: Element) {
 
 /** The reference the visible action pill points at, or null when there is none. */
 function pillValue() {
-  return document.querySelector('[data-slot="composer-directive-action"]')?.getAttribute('data-value') ?? null
+  return (
+    globalThis.document.querySelector('[data-slot="composer-directive-action"]')?.getAttribute('data-value') ?? null
+  )
 }
 
 afterEach(() => {
   cleanup()
-  document.body.replaceChildren()
+  globalThis.document.body.replaceChildren()
   closeRightRail()
   delete desktopWindow.hermesDesktop
   openSession.mockReset()
@@ -122,7 +124,7 @@ describe('ComposerDirectiveActions', () => {
     const chip = chips(editor, 'url')[0]!
 
     hover(chip)
-    fireEvent.pointerOut(chip, { relatedTarget: document.body })
+    fireEvent.pointerOut(chip, { relatedTarget: globalThis.document.body })
     fireEvent.mouseEnter(screen.getByRole('button').parentElement!)
     vi.advanceTimersByTime(500)
 
@@ -133,7 +135,7 @@ describe('ComposerDirectiveActions', () => {
     // The edit composer's editor isn't reliably in the DOM when the effect
     // first runs; a document listener that reads the editor lazily works
     // regardless — this is the whole reason it binds to document, not editor.
-    const editor = document.createElement('div')
+    const editor = globalThis.document.createElement('div')
 
     editor.contentEditable = 'true'
     editor.append(refChipElement('url', '`https://late.example`'))
@@ -145,7 +147,7 @@ describe('ComposerDirectiveActions', () => {
     )
 
     // Editor attached AFTER mount.
-    document.body.append(editor)
+    globalThis.document.body.append(editor)
     hover(editor.querySelector('[data-ref-kind="url"]')!)
 
     expect(pillValue()).toBe('https://late.example')

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-branch.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-branch.ts
@@ -30,7 +30,7 @@ export function useComposerBranch({ clearDraft, cwd, draftRef }: UseComposerBran
       scope.attachments.clear()
       requestStartWorkSession(path, text)
     },
-    [clearDraft, draftRef]
+    [clearDraft, draftRef, scope.attachments]
   )
 
   // Branch off into a NEW worktree (base = branch name, or current HEAD). A

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
@@ -228,8 +228,11 @@ export function useComposerDraft({
     }
   }, [appendExternalText, inputDisabled, paintDraft, target])
 
-  const stashAt = (scope: string | null, text = draftRef.current, attachments = attachmentScope.$attachments.get()) =>
-    stashSessionDraft(scope, text, attachments)
+  const stashAt = useCallback(
+    (scope: string | null, text = draftRef.current, attachments = attachmentScope.$attachments.get()) =>
+      stashSessionDraft(scope, text, attachments),
+    [attachmentScope.$attachments]
+  )
 
   const loadIntoComposer = (text: string, attachments: ComposerAttachment[]) => {
     // Diagnostic breadcrumb for #59305-class reports: identifies WHAT kind of
@@ -340,7 +343,7 @@ export function useComposerDraft({
       unsubscribe()
       window.clearTimeout(draftPersistTimerRef.current)
     }
-  }, [composerRuntime, queueEditRef])
+  }, [composerRuntime, queueEditRef, stashAt])
 
   const insertText = (text: string) => {
     const base = draftRef.current
@@ -482,7 +485,7 @@ export function useComposerDraft({
       window.removeEventListener('pagehide', flushPendingDraftPersist)
       flushPendingDraftPersist()
     }
-  }, [syncDraftFromEditor])
+  }, [stashAt, syncDraftFromEditor])
 
   return {
     activeQueueSessionKeyRef,

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-esc-cancel.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-esc-cancel.test.tsx
@@ -11,7 +11,7 @@ function Harness({ busy, onCancel }: { busy: boolean; onCancel: () => void }) {
 
 afterEach(() => {
   cleanup()
-  document.body.innerHTML = ''
+  globalThis.document.body.innerHTML = ''
 })
 
 describe('useComposerEscCancel', () => {
@@ -39,9 +39,9 @@ describe('useComposerEscCancel', () => {
 
     // OverlayView stamps `data-overlay-surface` on its root — the same signal
     // the type-to-focus path uses to stand down while an overlay is open.
-    const overlay = document.createElement('div')
+    const overlay = globalThis.document.createElement('div')
     overlay.setAttribute('data-overlay-surface', '')
-    document.body.appendChild(overlay)
+    globalThis.document.body.appendChild(overlay)
 
     fireEvent.keyDown(window, { key: 'Escape' })
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
@@ -28,7 +28,7 @@ function renderSubmitHook({
   text = ''
 }: SubmitHarnessOptions = {}) {
   const draftRef = { current: text }
-  const editor = document.createElement('div')
+  const editor = globalThis.document.createElement('div')
   editor.dataset.slot = 'composer-rich-input'
   editor.textContent = text
   const editorRef = { current: editor }

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-undo.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-undo.test.tsx
@@ -22,13 +22,13 @@ function mountUndo(editorRef: RefObject<HTMLDivElement | null>, onSync: () => st
 }
 
 function makeEditor(text: string) {
-  const editor = document.createElement('div')
+  const editor = globalThis.document.createElement('div')
   editor.contentEditable = 'true'
   // jsdom only focuses a contentEditable div when it's explicitly focusable;
   // the real editor is reachable via the composer's focus bus.
   editor.tabIndex = 0
-  editor.append(document.createTextNode(text))
-  document.body.append(editor)
+  editor.append(globalThis.document.createTextNode(text))
+  globalThis.document.body.append(editor)
 
   const ref = createRef<HTMLDivElement>() as RefObject<HTMLDivElement | null>
   ref.current = editor
@@ -37,7 +37,7 @@ function makeEditor(text: string) {
 }
 
 const caretAtEnd = (editor: HTMLElement) => {
-  const range = document.createRange()
+  const range = globalThis.document.createRange()
   const selection = window.getSelection()!
   range.selectNodeContents(editor)
   range.collapse(false)
@@ -54,7 +54,7 @@ describe('useComposerUndo', () => {
 
     // Bank, then simulate the Range-based paste that Chromium never records.
     api.current!.recordUndoPoint()
-    editor.append(document.createTextNode(' PASTED'))
+    editor.append(globalThis.document.createTextNode(' PASTED'))
     expect(editor.textContent).toBe('before PASTED')
 
     api.current!.undo()
@@ -79,7 +79,7 @@ describe('useComposerUndo', () => {
 
     expect(
       api.current!.withUndoPoint(() => {
-        editor.append(document.createTextNode('!'))
+        editor.append(globalThis.document.createTextNode('!'))
 
         return true
       })
@@ -100,7 +100,7 @@ describe('useComposerUndo', () => {
     const { api, view } = mountUndo(ref, () => editor.textContent || '')
 
     api.current!.recordUndoPoint()
-    editor.append(document.createTextNode(' extra'))
+    editor.append(globalThis.document.createTextNode(' extra'))
 
     // What Electron's Edit menu `{ role: 'undo' }` produces.
     const event = new InputEvent('beforeinput', { bubbles: true, cancelable: true, inputType: 'historyUndo' })
@@ -122,7 +122,7 @@ describe('useComposerUndo', () => {
     const { api, view } = mountUndo(ref, () => editor.textContent || '')
 
     api.current!.recordUndoPoint()
-    editor.append(document.createTextNode(' changed'))
+    editor.append(globalThis.document.createTextNode(' changed'))
 
     const event = new InputEvent('beforeinput', { bubbles: true, cancelable: true, inputType: 'historyUndo' })
     other.dispatchEvent(event)
@@ -144,7 +144,7 @@ describe('useComposerUndo', () => {
     const editUndo = mountUndo(editRef, () => edit.textContent || '')
 
     mainUndo.api.current!.recordUndoPoint()
-    main.append(document.createTextNode(' typed'))
+    main.append(globalThis.document.createTextNode(' typed'))
 
     // Undoing in the edit composer must not touch the main composer's text.
     editUndo.api.current!.undo()
@@ -167,7 +167,7 @@ describe('useComposerUndo', () => {
     const { api, view } = mountUndo(ref, () => editor.textContent || '')
 
     api.current!.recordUndoPoint()
-    editor.append(document.createTextNode(' edited'))
+    editor.append(globalThis.document.createTextNode(' edited'))
     api.current!.resetUndoHistory()
 
     expect(api.current!.undo()).toBe(false)

--- a/apps/desktop/src/app/chat/composer/status-stack/preview-row.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/preview-row.test.tsx
@@ -30,7 +30,7 @@ describe('PreviewStatusRow', () => {
     fireEvent.pointerMove(screen.getByText('preview.html'), { pointerType: 'mouse' })
     await screen.findByRole('tooltip')
 
-    const content = document.querySelector<HTMLElement>('[data-slot="tooltip-content"]')
+    const content = globalThis.document.querySelector<HTMLElement>('[data-slot="tooltip-content"]')
     const label = content?.firstElementChild?.firstElementChild
 
     expect(content).not.toBeNull()

--- a/apps/desktop/src/app/chat/right-rail/preview-artifact.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-artifact.test.tsx
@@ -51,8 +51,8 @@ describe('ArtifactPreview', () => {
 
     await renderArtifact(artifactId)
 
-    expect(document.querySelector('svg')).not.toBeNull()
-    expect(document.querySelector('svg script')).toBeNull()
+    expect(globalThis.document.querySelector('svg')).not.toBeNull()
+    expect(globalThis.document.querySelector('svg script')).toBeNull()
   })
 
   it('offers only the source view for code, which has nothing to render', async () => {

--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -224,7 +224,7 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
 
       return { attachments: synced, sessionId: liveSessionId }
     },
-    [requestGateway, scope.attachments]
+    [readState, requestGateway, scope.attachments]
   )
 
   // The REAL submit pipeline with tile seams: session always exists, and the

--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.test.tsx
@@ -29,8 +29,8 @@ let container: HTMLDivElement | null = null
 let windowStateCallback: ((payload: { isMinimized?: boolean; isVisible?: boolean }) => void) | null = null
 
 function render(ui: ReactNode) {
-  container = document.createElement('div')
-  document.body.append(container)
+  container = globalThis.document.createElement('div')
+  globalThis.document.body.append(container)
   root = createRoot(container)
 
   act(() => {
@@ -51,8 +51,11 @@ function cleanup() {
 }
 
 function setVisibility(hidden: boolean) {
-  Object.defineProperty(document, 'hidden', { configurable: true, value: hidden })
-  Object.defineProperty(document, 'visibilityState', { configurable: true, value: hidden ? 'hidden' : 'visible' })
+  Object.defineProperty(globalThis.document, 'hidden', { configurable: true, value: hidden })
+  Object.defineProperty(globalThis.document, 'visibilityState', {
+    configurable: true,
+    value: hidden ? 'hidden' : 'visible'
+  })
 }
 
 function installWindowStateBridge() {
@@ -147,7 +150,7 @@ describe('PersistentTerminal rect tracking', () => {
   beforeEach(() => {
     ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
     setVisibility(false)
-    vi.spyOn(document, 'hasFocus').mockReturnValue(true)
+    vi.spyOn(globalThis.document, 'hasFocus').mockReturnValue(true)
     installWindowStateBridge()
     resizeObserverCallback = null
     mutationObserverCallback = null
@@ -341,7 +344,7 @@ describe('PersistentTerminal rect tracking', () => {
 
   it('does not schedule an initial frame when mounted while unfocused', () => {
     const raf = installRaf()
-    vi.mocked(document.hasFocus).mockReturnValue(false)
+    vi.mocked(globalThis.document.hasFocus).mockReturnValue(false)
     vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue(rect(10, 20, 200, 100))
 
     render(<Harness />)

--- a/apps/desktop/src/app/right-sidebar/terminal/rail.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/rail.test.tsx
@@ -25,7 +25,7 @@ describe('TerminalRail', () => {
     fireEvent.pointerMove(screen.getByRole('tab', { name: '1. PowerShell' }), { pointerType: 'mouse' })
     await screen.findByRole('tooltip')
 
-    const content = document.querySelector<HTMLElement>('[data-slot="tooltip-content"]')
+    const content = globalThis.document.querySelector<HTMLElement>('[data-slot="tooltip-content"]')
     const label = content?.firstElementChild?.firstElementChild
 
     expect(content).not.toBeNull()

--- a/apps/desktop/src/app/session/hooks/use-message-stream/delta-flush.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/delta-flush.test.tsx
@@ -69,7 +69,7 @@ describe('useMessageStream delta flush scheduling', () => {
     vi.spyOn(performance, 'now').mockReturnValue(100)
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1)
     vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined)
-    vi.spyOn(document, 'hasFocus').mockReturnValue(false)
+    vi.spyOn(globalThis.document, 'hasFocus').mockReturnValue(false)
   })
 
   afterEach(() => {
@@ -322,7 +322,7 @@ describe('useMessageStream composed with the real useSessionStateCache', () => {
     vi.spyOn(performance, 'now').mockReturnValue(100)
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1)
     vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined)
-    vi.spyOn(document, 'hasFocus').mockReturnValue(false)
+    vi.spyOn(globalThis.document, 'hasFocus').mockReturnValue(false)
   })
 
   afterEach(() => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -199,35 +199,35 @@ function Harness({
     }
   })
 
+  const { cancelRun, editMessage, reloadFromMessage, restoreToMessage, redirectPrompt, steerPrompt, submitText } =
+    actions
+
   useEffect(() => {
     onReady({
       activeSessionIdRef,
-      cancelRun: (...args: Parameters<typeof actions.cancelRun>) =>
-        act(async () => actions.cancelRun(...args)) as Promise<void>,
-      editMessage: (...args: Parameters<typeof actions.editMessage>) =>
-        act(async () => actions.editMessage(...args)) as Promise<void>,
-      reloadFromMessage: (...args: Parameters<typeof actions.reloadFromMessage>) =>
-        act(async () => actions.reloadFromMessage(...args)) as Promise<void>,
-      restoreToMessage: (...args: Parameters<typeof actions.restoreToMessage>) =>
-        act(async () => actions.restoreToMessage(...args)) as Promise<void>,
-      redirectPrompt: (...args: Parameters<typeof actions.redirectPrompt>) =>
-        act(async () => actions.redirectPrompt(...args)) as Promise<boolean>,
-      steerPrompt: (...args: Parameters<typeof actions.steerPrompt>) =>
-        act(async () => actions.steerPrompt(...args)) as Promise<boolean>,
-      submitTextRaw: actions.submitText,
-      submitText: (...args: Parameters<typeof actions.submitText>) =>
-        act(async () => actions.submitText(...args)) as Promise<boolean>
+      cancelRun: (...args: Parameters<typeof cancelRun>) => act(async () => cancelRun(...args)) as Promise<void>,
+      editMessage: (...args: Parameters<typeof editMessage>) => act(async () => editMessage(...args)) as Promise<void>,
+      reloadFromMessage: (...args: Parameters<typeof reloadFromMessage>) =>
+        act(async () => reloadFromMessage(...args)) as Promise<void>,
+      restoreToMessage: (...args: Parameters<typeof restoreToMessage>) =>
+        act(async () => restoreToMessage(...args)) as Promise<void>,
+      redirectPrompt: (...args: Parameters<typeof redirectPrompt>) =>
+        act(async () => redirectPrompt(...args)) as Promise<boolean>,
+      steerPrompt: (...args: Parameters<typeof steerPrompt>) =>
+        act(async () => steerPrompt(...args)) as Promise<boolean>,
+      submitTextRaw: submitText,
+      submitText: (...args: Parameters<typeof submitText>) => act(async () => submitText(...args)) as Promise<boolean>
     })
   }, [
-    actions.cancelRun,
-    actions.editMessage,
-    actions.reloadFromMessage,
-    actions.restoreToMessage,
-    actions.redirectPrompt,
-    actions.steerPrompt,
-    actions.submitText,
     activeSessionIdRef,
-    onReady
+    cancelRun,
+    editMessage,
+    onReady,
+    redirectPrompt,
+    reloadFromMessage,
+    restoreToMessage,
+    steerPrompt,
+    submitText
   ])
 
   return null

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -216,7 +216,7 @@ export function useStatusbarItems({
   // a second per-session copy of the same fact. Re-derives whenever the cwd or
   // the tree changes; null (no named project) falls back to the cwd leaf below.
   const projectTree = useStore($projectTree)
-  const projectName = useMemo(() => projectNameForCwd(currentCwd), [currentCwd, projectTree])
+  const projectName = useMemo(() => projectNameForCwd(currentCwd, projectTree), [currentCwd, projectTree])
 
   const sessionStartedAt = primaryFocused
     ? primarySessionStartedAt

--- a/apps/desktop/src/app/skills/index.test.tsx
+++ b/apps/desktop/src/app/skills/index.test.tsx
@@ -273,7 +273,7 @@ describe('SkillsView toolset management', () => {
     render(<EmbeddedHubPicker installedNames={new Set(['web-research'])} profile={null} />)
 
     // The picker is expanded by default — the hub iframe is live on mount.
-    expect(document.querySelector('iframe')).toBeTruthy()
+    expect(globalThis.document.querySelector('iframe')).toBeTruthy()
 
     await act(async () => {
       window.dispatchEvent(
@@ -297,7 +297,7 @@ describe('SkillsView toolset management', () => {
     // eagerly mounted hub is exactly the Capabilities lag bug.
     await renderSkills() // ?tab=toolsets
     await screen.findByRole('switch', { name: 'Turn Web Search toolset off' })
-    expect(document.querySelector('iframe')).toBeNull()
+    expect(globalThis.document.querySelector('iframe')).toBeNull()
     cleanup()
 
     // Embedded mode drives tabs through local state (the route hooks are
@@ -313,7 +313,7 @@ describe('SkillsView toolset management', () => {
       )
     })
 
-    const iframe = document.querySelector('iframe')
+    const iframe = globalThis.document.querySelector('iframe')
     expect(iframe).toBeTruthy()
     expect(iframe!.closest('section')!.classList.contains('hidden')).toBe(false)
 
@@ -323,7 +323,7 @@ describe('SkillsView toolset management', () => {
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /Tools/ }))
     })
-    const kept = document.querySelector('iframe')
+    const kept = globalThis.document.querySelector('iframe')
     expect(kept).toBeTruthy()
     expect(kept!.closest('section')!.classList.contains('hidden')).toBe(true)
   })

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -196,8 +196,8 @@ describe('ClarifyTool settled view', () => {
 
     expect(screen.getByText('Which deployment target?')).toBeTruthy()
     expect(screen.getByText('staging')).toBeTruthy()
-    expect(document.querySelector('[data-clarify-settled]')).toBeTruthy()
-    expect(document.querySelector('[data-clarify-answer]')?.textContent).toBe('staging')
+    expect(globalThis.document.querySelector('[data-clarify-settled]')).toBeTruthy()
+    expect(globalThis.document.querySelector('[data-clarify-answer]')?.textContent).toBe('staging')
   })
 
   it('labels an empty response as Skipped', () => {
@@ -235,7 +235,7 @@ describe('ClarifyTool settled view', () => {
 
       // The skip label renders AND the original options are still on screen.
       expect(screen.getByText('Skipped')).toBeTruthy()
-      const group = document.querySelector('[data-clarify-late-choices]')
+      const group = globalThis.document.querySelector('[data-clarify-late-choices]')
       expect(group).toBeTruthy()
       expect(screen.getByText('staging')).toBeTruthy()
       expect(screen.getByText('prod')).toBeTruthy()
@@ -264,7 +264,7 @@ describe('ClarifyTool settled view', () => {
       />
     )
 
-    expect(document.querySelector('[data-clarify-late-choices]')).toBeNull()
+    expect(globalThis.document.querySelector('[data-clarify-late-choices]')).toBeNull()
   })
 
   it('does not render late choices for a free-text (no-choice) skip', () => {
@@ -278,7 +278,7 @@ describe('ClarifyTool settled view', () => {
       />
     )
 
-    expect(document.querySelector('[data-clarify-late-choices]')).toBeNull()
+    expect(globalThis.document.querySelector('[data-clarify-late-choices]')).toBeNull()
   })
 })
 
@@ -349,11 +349,11 @@ describe('ClarifyTool keyboard navigation', () => {
     const other = screen.getByPlaceholderText(/Other/)
 
     fireEvent.keyDown(window, { key: '3' })
-    expect(document.activeElement).toBe(other)
+    expect(globalThis.document.activeElement).toBe(other)
 
     fireEvent.change(other, { target: { value: 'canary' } })
     fireEvent.keyDown(window, { key: 'ArrowUp' })
-    expect(document.activeElement).toBe(other)
+    expect(globalThis.document.activeElement).toBe(other)
     expect((other as HTMLTextAreaElement).value).toBe('canary')
   })
 
@@ -410,7 +410,7 @@ describe('ClarifyTool pending marker', () => {
     // `clarifyCardOwnsKey` reads the count off this marker to yield only the
     // shortcuts the card renders (A..N + "Other", 1-9, Enter) and let every
     // other printable through to the composer.
-    const card = document.querySelector('[data-clarify-choices]')
+    const card = globalThis.document.querySelector('[data-clarify-choices]')
 
     expect(card).toBeTruthy()
     expect(Number(card?.getAttribute('data-clarify-choices'))).toBeGreaterThan(0)
@@ -445,6 +445,6 @@ describe('ClarifyTool pending marker', () => {
     )
 
     // No shortcuts → nothing to protect → composer type-to-focus stays live.
-    expect(document.querySelector('[data-clarify-choices]')).toBeNull()
+    expect(globalThis.document.querySelector('[data-clarify-choices]')).toBeNull()
   })
 })

--- a/apps/desktop/src/components/assistant-ui/markdown-text.filelinks.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.filelinks.test.tsx
@@ -22,15 +22,12 @@ describe('MarkdownLink filesystem hrefs', () => {
     // that's the view-time door, not a dead <a>.
     await screen.findByText('report.md')
     expect(screen.getByRole('button', { name: 'Open preview' })).toBeTruthy()
-    expect(document.querySelector('a[href="/home/user/report.md"]')).toBeNull()
+    expect(globalThis.document.querySelector('a[href="/home/user/report.md"]')).toBeNull()
   })
 
   it('routes file:// and ~/ links the same way', async () => {
     render(
-      <MarkdownTextContent
-        isRunning={false}
-        text={'See [notes](file:///srv/data/notes.txt) and [todo](~/todo.md)'}
-      />
+      <MarkdownTextContent isRunning={false} text={'See [notes](file:///srv/data/notes.txt) and [todo](~/todo.md)'} />
     )
 
     await screen.findByText('notes.txt')
@@ -57,6 +54,6 @@ describe('MarkdownLink filesystem hrefs', () => {
     // (they keep Streamdown's pre-existing handling) — neither gains a
     // preview affordance.
     expect(screen.queryByRole('button', { name: 'Open preview' })).toBeNull()
-    expect(document.querySelector('a[href="#section-2"]')).not.toBeNull()
+    expect(globalThis.document.querySelector('a[href="#section-2"]')).not.toBeNull()
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/double-click-reaction.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/double-click-reaction.test.tsx
@@ -71,22 +71,22 @@ afterEach(() => {
 
 describe('isTapbackDoubleClick', () => {
   it('claims a plain double-click on message body', () => {
-    expect(isTapbackDoubleClick({ detail: 2, target: document.createElement('span') })).toBe(true)
+    expect(isTapbackDoubleClick({ detail: 2, target: globalThis.document.createElement('span') })).toBe(true)
   })
 
   it('ignores a triple-click, so selecting a paragraph does not re-toggle', () => {
-    expect(isTapbackDoubleClick({ detail: 3, target: document.createElement('span') })).toBe(false)
+    expect(isTapbackDoubleClick({ detail: 3, target: globalThis.document.createElement('span') })).toBe(false)
   })
 
   it('leaves double-click alone where it already means something', () => {
-    const code = document.createElement('pre')
-    const inner = document.createElement('code')
+    const code = globalThis.document.createElement('pre')
+    const inner = globalThis.document.createElement('code')
 
     code.append(inner)
 
     expect(isTapbackDoubleClick({ detail: 2, target: inner })).toBe(false)
-    expect(isTapbackDoubleClick({ detail: 2, target: document.createElement('a') })).toBe(false)
-    expect(isTapbackDoubleClick({ detail: 2, target: document.createElement('button') })).toBe(false)
+    expect(isTapbackDoubleClick({ detail: 2, target: globalThis.document.createElement('a') })).toBe(false)
+    expect(isTapbackDoubleClick({ detail: 2, target: globalThis.document.createElement('button') })).toBe(false)
   })
 })
 

--- a/apps/desktop/src/components/assistant-ui/thread/duplicate-stall-indicator.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/duplicate-stall-indicator.test.tsx
@@ -230,8 +230,8 @@ describe('StreamStallIndicator tail gating (#68634)', () => {
     expect(indicators.length).toBe(1)
     // The surviving row belongs to the placeholder, while the real running
     // bubble's stall row stays silent.
-    expect(document.querySelectorAll('[data-slot="aui_response-loading"]').length).toBe(1)
-    expect(document.querySelectorAll('[data-slot="aui_stream-stall"]').length).toBe(0)
+    expect(globalThis.document.querySelectorAll('[data-slot="aui_response-loading"]').length).toBe(1)
+    expect(globalThis.document.querySelectorAll('[data-slot="aui_stream-stall"]').length).toBe(0)
   })
 
   // Outside compaction, the placeholder uses the plain loading label and the
@@ -254,7 +254,7 @@ describe('StreamStallIndicator tail gating (#68634)', () => {
       vi.advanceTimersByTime(5_000)
     })
 
-    expect(document.querySelectorAll('[data-slot="aui_response-loading"]').length).toBe(1)
-    expect(document.querySelectorAll('[data-slot="aui_stream-stall"]').length).toBe(0)
+    expect(globalThis.document.querySelectorAll('[data-slot="aui_response-loading"]').length).toBe(1)
+    expect(globalThis.document.querySelectorAll('[data-slot="aui_stream-stall"]').length).toBe(0)
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/user-message-text.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-text.test.tsx
@@ -20,14 +20,14 @@ describe('a sent reference renders as the chip the composer showed', () => {
 
     expect(screen.queryByTitle('https://github.com/NousResearch/hermes-agent/pull/74790')).not.toBeNull()
     // The whole reference is one node — no bare `@url:` text left behind.
-    expect(document.body.textContent).not.toContain('@url:')
+    expect(globalThis.document.body.textContent).not.toContain('@url:')
   })
 
   it('chips a backtick-quoted @file: path with spaces', () => {
     render(<UserMessageText text="see @file:`apps/desktop/my notes.md` please" />)
 
     expect(screen.queryByTitle('apps/desktop/my notes.md')).not.toBeNull()
-    expect(document.body.textContent).not.toContain('@file:')
+    expect(globalThis.document.body.textContent).not.toContain('@file:')
   })
 
   it('chips every kind that travels in message text', () => {
@@ -41,7 +41,7 @@ describe('a sent reference renders as the chip the composer showed', () => {
   it('still renders a genuine code span as code', () => {
     render(<UserMessageText text="run `npm test` first" />)
 
-    const code = document.querySelector('[data-slot="aui_user-inline-code"]')
+    const code = globalThis.document.querySelector('[data-slot="aui_user-inline-code"]')
 
     expect(code?.textContent).toBe('npm test')
   })
@@ -49,13 +49,13 @@ describe('a sent reference renders as the chip the composer showed', () => {
   it('renders code and a reference side by side', () => {
     render(<UserMessageText text="run `npm test` on @file:`apps/desktop/a b.ts` now" />)
 
-    expect(document.querySelector('[data-slot="aui_user-inline-code"]')?.textContent).toBe('npm test')
+    expect(globalThis.document.querySelector('[data-slot="aui_user-inline-code"]')?.textContent).toBe('npm test')
     expect(screen.queryByTitle('apps/desktop/a b.ts')).not.toBeNull()
   })
 
   it('leaves a fenced block alone', () => {
     render(<UserMessageText text={'before\n```ts\nconst x = 1\n```\nafter'} />)
 
-    expect(document.querySelector('[data-slot="aui_user-fence"]')?.textContent).toBe('const x = 1\n')
+    expect(globalThis.document.querySelector('[data-slot="aui_user-fence"]')?.textContent).toBe('const x = 1\n')
   })
 })

--- a/apps/desktop/src/components/chat/activity-timer.test.tsx
+++ b/apps/desktop/src/components/chat/activity-timer.test.tsx
@@ -19,7 +19,7 @@ describe('useElapsedSeconds', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
-    vi.spyOn(document, 'hasFocus').mockReturnValue(true)
+    vi.spyOn(globalThis.document, 'hasFocus').mockReturnValue(true)
     __resetElapsedTimerRegistryForTests()
   })
 
@@ -77,7 +77,7 @@ describe('useElapsedSeconds', () => {
 
   it('pauses UI ticks without focus and catches up immediately on return', () => {
     render(<Probe active timerKey="tool:background" />)
-    vi.mocked(document.hasFocus).mockReturnValue(false)
+    vi.mocked(globalThis.document.hasFocus).mockReturnValue(false)
     window.dispatchEvent(new Event('blur'))
 
     act(() => {
@@ -85,7 +85,7 @@ describe('useElapsedSeconds', () => {
     })
     expect(screen.getByTestId('elapsed').textContent).toBe('0')
 
-    vi.mocked(document.hasFocus).mockReturnValue(true)
+    vi.mocked(globalThis.document.hasFocus).mockReturnValue(true)
     act(() => window.dispatchEvent(new Event('focus')))
     expect(screen.getByTestId('elapsed').textContent).toBe('5')
   })
@@ -95,7 +95,7 @@ describe('useMeasuredDuration', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
-    vi.spyOn(document, 'hasFocus').mockReturnValue(true)
+    vi.spyOn(globalThis.document, 'hasFocus').mockReturnValue(true)
     __resetElapsedTimerRegistryForTests()
   })
 
@@ -175,7 +175,7 @@ describe('useMeasuredDuration', () => {
 
   it('records the real finish time even if the UI clock was paused', () => {
     const probe = render(<DurationProbe active timerKey="reasoning:background" />)
-    vi.mocked(document.hasFocus).mockReturnValue(false)
+    vi.mocked(globalThis.document.hasFocus).mockReturnValue(false)
     window.dispatchEvent(new Event('blur'))
 
     act(() => {

--- a/apps/desktop/src/components/chat/image-generation-placeholder.test.tsx
+++ b/apps/desktop/src/components/chat/image-generation-placeholder.test.tsx
@@ -9,8 +9,8 @@ let container: HTMLDivElement | null = null
 let windowStateCallback: ((payload: { isMinimized?: boolean; isVisible?: boolean }) => void) | null = null
 
 function render() {
-  container = document.createElement('div')
-  document.body.append(container)
+  container = globalThis.document.createElement('div')
+  globalThis.document.body.append(container)
   root = createRoot(container)
 
   act(() => {
@@ -86,7 +86,7 @@ function installWindowStateBridge() {
 describe('DiffusionCanvas scheduling', () => {
   beforeEach(() => {
     ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
-    vi.spyOn(document, 'hasFocus').mockReturnValue(true)
+    vi.spyOn(globalThis.document, 'hasFocus').mockReturnValue(true)
     installWindowStateBridge()
     vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
       setTransform: vi.fn()
@@ -169,7 +169,7 @@ function installDrawableContext() {
 describe('DiffusionCanvas frame budget', () => {
   beforeEach(() => {
     ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
-    vi.spyOn(document, 'hasFocus').mockReturnValue(true)
+    vi.spyOn(globalThis.document, 'hasFocus').mockReturnValue(true)
     installWindowStateBridge()
   })
 
@@ -213,8 +213,8 @@ describe('DiffusionCanvas frame budget', () => {
 
     act(() => {
       for (let i = 0; i < 3; i++) {
-        const el = document.createElement('div')
-        document.body.append(el)
+        const el = globalThis.document.createElement('div')
+        globalThis.document.body.append(el)
         containers.push(el)
         const r = createRoot(el)
         roots.push(r)
@@ -237,8 +237,8 @@ describe('DiffusionCanvas frame budget', () => {
     }
 
     // Counter released on unmount — a fresh mount animates again.
-    const el = document.createElement('div')
-    document.body.append(el)
+    const el = globalThis.document.createElement('div')
+    globalThis.document.body.append(el)
     const r = createRoot(el)
 
     act(() => {

--- a/apps/desktop/src/components/desktop-install-overlay.test.tsx
+++ b/apps/desktop/src/components/desktop-install-overlay.test.tsx
@@ -75,7 +75,7 @@ function whenPresent(text: string): Promise<HTMLElement> {
       }
     })
 
-    observer.observe(document.body, { childList: true, subtree: true, characterData: true })
+    observer.observe(globalThis.document.body, { childList: true, subtree: true, characterData: true })
   })
 }
 

--- a/apps/desktop/src/components/find-bar.test.tsx
+++ b/apps/desktop/src/components/find-bar.test.tsx
@@ -93,11 +93,11 @@ function drainListeners() {
  * tests for the same pattern).
  */
 function plantSurface(id = 'surface') {
-  const root = document.createElement('div')
+  const root = globalThis.document.createElement('div')
 
   root.setAttribute('data-chat-surface', '')
   root.id = id
-  document.body.appendChild(root)
+  globalThis.document.body.appendChild(root)
 
   return root
 }
@@ -111,7 +111,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup()
-  document.body.innerHTML = ''
+  globalThis.document.body.innerHTML = ''
   resetStore()
   drainListeners()
   vi.restoreAllMocks()
@@ -383,13 +383,13 @@ describe('find-in-page store', () => {
     // The scoped walker must only wrap matches inside the surface the bar
     // was opened against.
     const foreground = plantSurface('foreground')
-    const hidden = document.createElement('div')
+    const hidden = globalThis.document.createElement('div')
 
     hidden.setAttribute('data-pane-hidden', '')
     hidden.setAttribute('data-chat-surface', '')
     hidden.id = 'background'
     hidden.textContent = 'needle in background chat needle'
-    document.body.appendChild(hidden)
+    globalThis.document.body.appendChild(hidden)
 
     foreground.textContent = 'needle in foreground chat needle'
 
@@ -412,12 +412,12 @@ describe('find-in-page store', () => {
     // opened after the pane flips to chat-B searches chat-B. The previous
     // bar's highlights are already cleared by closeFindBar().
     const surfaceA = plantSurface('a')
-    const surfaceB = document.createElement('div')
+    const surfaceB = globalThis.document.createElement('div')
 
     surfaceB.setAttribute('data-chat-surface', '')
     surfaceB.id = 'b'
     surfaceB.textContent = 'target-b needle'
-    document.body.appendChild(surfaceB)
+    globalThis.document.body.appendChild(surfaceB)
 
     surfaceA.textContent = 'target-a needle'
 
@@ -447,11 +447,11 @@ describe('find-in-page store', () => {
     // while the viewed surface contains the text. The scope must re-resolve
     // to the now-foreground surface.
     const surfaceA = plantSurface('a')
-    const surfaceB = document.createElement('div')
+    const surfaceB = globalThis.document.createElement('div')
 
     surfaceB.setAttribute('data-chat-surface', '')
     surfaceB.id = 'b'
-    document.body.appendChild(surfaceB)
+    globalThis.document.body.appendChild(surfaceB)
 
     surfaceA.textContent = 'needle in A'
     surfaceB.textContent = 'needle in B needle'

--- a/apps/desktop/src/components/pane-shell/tree/renderer/floating-panes.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/floating-panes.test.tsx
@@ -19,8 +19,8 @@ let container: HTMLDivElement | null = null
 let disposers: (() => void)[] = []
 
 function render(ui: ReactNode) {
-  container = document.createElement('div')
-  document.body.append(container)
+  container = globalThis.document.createElement('div')
+  globalThis.document.body.append(container)
   root = createRoot(container)
 
   act(() => {
@@ -28,7 +28,7 @@ function render(ui: ReactNode) {
   })
 }
 
-const card = () => document.querySelector<HTMLElement>('[data-floating-pane="hud"]')
+const card = () => globalThis.document.querySelector<HTMLElement>('[data-floating-pane="hud"]')
 
 const grab = () => card()!.querySelector('header')!
 
@@ -97,7 +97,7 @@ describe('FloatingPanes (live DOM)', () => {
     expect(el.style.left).toBe('1204px')
     expect(el.style.top).toBe('46px')
     expect(el.style.width).toBe('224px')
-    expect(document.querySelector('[data-testid="hud-body"]')?.textContent).toBe('live')
+    expect(globalThis.document.querySelector('[data-testid="hud-body"]')?.textContent).toBe('live')
   })
 
   it('renders nothing for a non-floating placement', () => {
@@ -184,7 +184,7 @@ describe('FloatingPanes (live DOM)', () => {
       toggle.click()
     })
 
-    expect(document.querySelector('[data-testid="hud-body"]')).toBeNull()
+    expect(globalThis.document.querySelector('[data-testid="hud-body"]')).toBeNull()
     expect(card()!.style.height).toBe('')
     expect(chevron().className).toContain('codicon-chevron-up')
   })
@@ -203,6 +203,6 @@ describe('FloatingPanes (live DOM)', () => {
 
     render(<FloatingPanes />)
 
-    expect(document.querySelectorAll('[data-floating-pane]').length).toBe(2)
+    expect(globalThis.document.querySelectorAll('[data-floating-pane]').length).toBe(2)
   })
 })

--- a/apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.test.tsx
@@ -64,7 +64,8 @@ const revealPane = (id: string) => {
   })
 }
 
-const overlayTab = (paneId: string) => document.querySelector<HTMLElement>(`[data-narrow-overlay-tab="${paneId}"]`)
+const overlayTab = (paneId: string) =>
+  globalThis.document.querySelector<HTMLElement>(`[data-narrow-overlay-tab="${paneId}"]`)
 
 describe('narrow overlay of a stacked zone', () => {
   it('mirrors the zone tab strip so every stacked collapsible stays reachable', () => {

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tool-panel-close.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tool-panel-close.test.tsx
@@ -77,7 +77,7 @@ const zoneAt = (index: number) => {
   return (node.type === 'split' ? node.children[index] : node) as never
 }
 
-const tabEl = (paneId: string) => document.querySelector<HTMLElement>(`[data-tree-tab="${paneId}"]`)
+const tabEl = (paneId: string) => globalThis.document.querySelector<HTMLElement>(`[data-tree-tab="${paneId}"]`)
 
 describe('right-clicking a tool panel tab', () => {
   it('offers Close when logs is STACKED with the terminal', async () => {

--- a/apps/desktop/src/components/pet/pet-sprite.test.tsx
+++ b/apps/desktop/src/components/pet/pet-sprite.test.tsx
@@ -38,8 +38,8 @@ let windowStateCallback: ((payload: { isMinimized?: boolean; isVisible?: boolean
 let drawImage: ReturnType<typeof vi.fn>
 
 function render(ui: ReactNode) {
-  container = document.createElement('div')
-  document.body.append(container)
+  container = globalThis.document.createElement('div')
+  globalThis.document.body.append(container)
   root = createRoot(container)
 
   act(() => {
@@ -60,8 +60,11 @@ function cleanup() {
 }
 
 function setVisibility(hidden: boolean) {
-  Object.defineProperty(document, 'hidden', { configurable: true, value: hidden })
-  Object.defineProperty(document, 'visibilityState', { configurable: true, value: hidden ? 'hidden' : 'visible' })
+  Object.defineProperty(globalThis.document, 'hidden', { configurable: true, value: hidden })
+  Object.defineProperty(globalThis.document, 'visibilityState', {
+    configurable: true,
+    value: hidden ? 'hidden' : 'visible'
+  })
 }
 
 function installWindowStateBridge() {
@@ -124,7 +127,7 @@ describe('PetSprite RAF scheduling', () => {
     vi.useFakeTimers()
     setVisibility(false)
     Object.defineProperty(window, 'devicePixelRatio', { configurable: true, value: 1 })
-    vi.spyOn(document, 'hasFocus').mockReturnValue(true)
+    vi.spyOn(globalThis.document, 'hasFocus').mockReturnValue(true)
     installWindowStateBridge()
     vi.stubGlobal(
       'Image',

--- a/apps/desktop/src/components/pet/pixel-egg-sprite.test.tsx
+++ b/apps/desktop/src/components/pet/pixel-egg-sprite.test.tsx
@@ -8,8 +8,8 @@ let root: Root | null = null
 let container: HTMLDivElement | null = null
 
 function render(mode: 'bounce' | 'hatch', onDone?: () => void) {
-  container = document.createElement('div')
-  document.body.append(container)
+  container = globalThis.document.createElement('div')
+  globalThis.document.body.append(container)
   root = createRoot(container)
 
   act(() => {

--- a/apps/desktop/src/components/pet/use-pet-roam.test.tsx
+++ b/apps/desktop/src/components/pet/use-pet-roam.test.tsx
@@ -14,8 +14,8 @@ let container: HTMLDivElement | null = null
 let windowStateCallback: ((payload: { isMinimized?: boolean; isVisible?: boolean }) => void) | null = null
 
 function render(ui: ReactNode) {
-  container = document.createElement('div')
-  document.body.append(container)
+  container = globalThis.document.createElement('div')
+  globalThis.document.body.append(container)
   root = createRoot(container)
 
   act(() => {
@@ -36,8 +36,11 @@ function cleanup() {
 }
 
 function setVisibility(hidden: boolean) {
-  Object.defineProperty(document, 'hidden', { configurable: true, value: hidden })
-  Object.defineProperty(document, 'visibilityState', { configurable: true, value: hidden ? 'hidden' : 'visible' })
+  Object.defineProperty(globalThis.document, 'hidden', { configurable: true, value: hidden })
+  Object.defineProperty(globalThis.document, 'visibilityState', {
+    configurable: true,
+    value: hidden ? 'hidden' : 'visible'
+  })
 }
 
 function installWindowStateBridge() {
@@ -90,7 +93,7 @@ describe('usePetRoam RAF scheduling', () => {
     ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
     vi.useFakeTimers()
     setVisibility(false)
-    vi.spyOn(document, 'hasFocus').mockReturnValue(true)
+    vi.spyOn(globalThis.document, 'hasFocus').mockReturnValue(true)
     installWindowStateBridge()
     vi.spyOn(Math, 'random').mockReturnValue(0)
     vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({

--- a/apps/desktop/src/components/ui/dialog-dismiss-repro.test.tsx
+++ b/apps/desktop/src/components/ui/dialog-dismiss-repro.test.tsx
@@ -39,7 +39,7 @@ describe('REPRO: dismissing an open Select inside a Dialog', () => {
     // setTimeout(0) — flush it first.
     await flushTimers()
 
-    const overlay = document.querySelector('[data-slot="dialog-overlay"]') as HTMLElement
+    const overlay = globalThis.document.querySelector('[data-slot="dialog-overlay"]') as HTMLElement
     expect(overlay).toBeTruthy()
     expect(screen.getByText('Option A')).toBeTruthy()
 
@@ -76,7 +76,7 @@ describe('REPRO: dismissing an open Select inside a Dialog', () => {
 
     await flushTimers()
 
-    const overlay = document.querySelector('[data-slot="dialog-overlay"]') as HTMLElement
+    const overlay = globalThis.document.querySelector('[data-slot="dialog-overlay"]') as HTMLElement
     fireEvent.pointerDown(overlay, { button: 0 })
     fireEvent.pointerUp(overlay, { button: 0 })
     fireEvent.click(overlay, { button: 0 })

--- a/apps/desktop/src/components/ui/glyph-spinner.test.tsx
+++ b/apps/desktop/src/components/ui/glyph-spinner.test.tsx
@@ -144,24 +144,24 @@ describe('GlyphSpinner', () => {
     const status = screen.getByRole('status', { name: 'Loading' })
     expect(vi.getTimerCount()).toBe(1)
 
-    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'hidden' })
+    Object.defineProperty(globalThis.document, 'visibilityState', { configurable: true, value: 'hidden' })
 
     try {
-      act(() => document.dispatchEvent(new Event('visibilitychange')))
+      act(() => globalThis.document.dispatchEvent(new Event('visibilitychange')))
       expect(vi.getTimerCount()).toBe(0)
 
       const frozen = status.textContent
       act(() => vi.advanceTimersByTime(800))
       expect(status.textContent).toBe(frozen)
 
-      Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' })
-      act(() => document.dispatchEvent(new Event('visibilitychange')))
+      Object.defineProperty(globalThis.document, 'visibilityState', { configurable: true, value: 'visible' })
+      act(() => globalThis.document.dispatchEvent(new Event('visibilitychange')))
       expect(vi.getTimerCount()).toBe(1)
 
       act(() => vi.advanceTimersByTime(80))
       expect(status.textContent).not.toBe(frozen)
     } finally {
-      Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' })
+      Object.defineProperty(globalThis.document, 'visibilityState', { configurable: true, value: 'visible' })
     }
   })
 })

--- a/apps/desktop/src/i18n/context.test.tsx
+++ b/apps/desktop/src/i18n/context.test.tsx
@@ -217,14 +217,14 @@ describe('I18nProvider', () => {
     )
 
     expect(screen.getByTestId('locale').textContent).toBe('ar')
-    expect(document.documentElement.dir).toBe('rtl')
-    expect(document.documentElement.lang).toBe('ar')
+    expect(globalThis.document.documentElement.dir).toBe('rtl')
+    expect(globalThis.document.documentElement.lang).toBe('ar')
 
     fireEvent.click(screen.getByRole('button', { name: 'switch' }))
 
     await waitFor(() => expect(screen.getByTestId('locale').textContent).toBe('en'))
-    expect(document.documentElement.dir).toBe('ltr')
-    expect(document.documentElement.lang).toBe('en')
+    expect(globalThis.document.documentElement.dir).toBe('ltr')
+    expect(globalThis.document.documentElement.lang).toBe('en')
   })
 
   it('rolls back the visible locale when saving fails', async () => {

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -255,6 +255,7 @@ function applyActive(profile: string, activationEpoch: number): boolean {
   // truth for "which profile is the active gateway on" — every eviction /
   // fallback path funnels through applyActive, so the published profile can
   // never linger on a backend that is no longer selected (#89206).
+
   const routeProfile =
     g.activeKey === g.primaryProfile ? g.primaryProfile : (g.secondaries.get(g.activeKey)?.profile ?? g.primaryProfile)
 

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -224,6 +224,13 @@ describe('projectNameForCwd', () => {
     expect(projectNameForCwd('/repos/website/src/app')).toBe('Website')
   })
 
+  it('can derive from an explicit reactive project-tree snapshot', () => {
+    const projects = [treeNode({ id: 'p_live', label: 'Live project', path: '/repos/live' })]
+
+    expect(projectNameForCwd('/repos/live/src', projects)).toBe('Live project')
+    expect($projectTree.get()).toEqual([])
+  })
+
   it('matches nested repo and worktree paths, not just the project root', () => {
     $projectTree.set([
       treeNode({

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -264,7 +264,7 @@ export function projectIdForCwd(cwd: string): null | string {
 // cwd-leaf label — matching the backend `_project_info_for_cwd`, which
 // only resolves projects.db rows, so the desktop and TUI name the same session
 // identically without threading a second per-session copy through session.info.
-export function projectNameForCwd(cwd: string): null | string {
+export function projectNameForCwd(cwd: string, projects: SidebarProjectTree[] = $projectTree.get()): null | string {
   const target = (cwd || '').trim()
 
   if (!target) {
@@ -274,7 +274,7 @@ export function projectNameForCwd(cwd: string): null | string {
   let best: null | string = null
   let bestLen = -1
 
-  for (const project of $projectTree.get()) {
+  for (const project of projects) {
     if (project.isAuto || project.isNoProject) {
       continue
     }

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -418,8 +418,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
       newSession,
       resetSession,
       resetVisibleHistory,
-      resumeById,
-      trimTail
+      resumeById
     ]
   )
 }

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -817,6 +817,7 @@ export function TextInput({
   const cbChange = useRef(onChange)
   const cbSubmit = useRef(onSubmit)
   const cbPaste = useRef(onPaste)
+  const commitSelectionRef = useRef<null | ((next: string, nextCur: number) => void)>(null)
   cbChange.current = onChange
   cbSubmit.current = onSubmit
   cbPaste.current = onPaste
@@ -981,7 +982,10 @@ export function TextInput({
             return
           }
 
-          commit(vRef.current.slice(0, current.start) + vRef.current.slice(current.end), current.start)
+          commitSelectionRef.current?.(
+            vRef.current.slice(0, current.start) + vRef.current.slice(current.end),
+            current.start
+          )
         })
       },
       end: selected?.end ?? curRef.current,
@@ -1142,6 +1146,8 @@ export function TextInput({
       }
     }
   }
+
+  commitSelectionRef.current = commit
 
   const swap = (from: typeof undo, to: typeof redo) => {
     const entry = from.current.pop()


### PR DESCRIPTION
## Summary

- remove the two remaining TUI hook-dependency warnings without effect churn or stale async cut callbacks
- qualify the 120 lint-reported test DOM accesses as `globalThis.document`, preserving the deliberate `no-restricted-globals` guard
- complete six real Desktop hook dependency contracts instead of suppressing them
- derive the status-bar project name from the subscribed project-tree snapshot and cover that path with a regression test
- clean the remaining Desktop formatting warning

## Why

The warning baseline was:

- TUI: 2 `react-hooks/exhaustive-deps` warnings
- Desktop: 120 `no-restricted-globals`, 6 `react-hooks/exhaustive-deps`, and 1 formatting warning

The bare-`document` rule is intentional and remains unchanged. The hook fixes preserve stable subscriptions while removing stale-closure risks. In particular, the asynchronous clipboard cut continuation now calls the latest commit function through a ref rather than capturing a render-scoped function or forcing the selection registration effect to run on every render.

## Verification

- `npm run check --workspace ui-tui` — passed; 158 files, 1,672 tests passed, 1 skipped
- `npm run lint --workspace apps/desktop -- --max-warnings=0` — passed
- `npm run typecheck --workspace apps/desktop` — passed
- focused Desktop behavior tests — 5 files / 170 tests passed
- `npm run build --workspace apps/desktop` — passed
- full Desktop UI suite — 521 files / 4,825 tests passed
- `git diff --check` — passed
