### PR TITLE
fix(bot-mode): group room preview shows the bot handle, not @default

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -4256,7 +4256,11 @@ function previewKind(preview) {
   }
   const match = text.match(A2A_RE)
   if (match) {
-    return { fromBot: (match[1] || match[2] || '').trim().toLowerCase() || null }
+    // The captured name is whatever the delivery prefix carried — a raw
+    // profile name. Map it the way every other surface does so the primary
+    // profile reads @hermes, never @default (#89484).
+    const sender = (match[1] || match[2] || '').trim().toLowerCase()
+    return { fromBot: sender ? botHandle(sender) : null }
   }
   return { fromBot: null }
 }
@@ -8637,8 +8641,12 @@ function GroupRow({ group, members, needsYou, onOpen }) {
   const log = Array.isArray(room.log) ? room.log : []
   const last = log.length ? log[log.length - 1] : null
   const lastAt = groupLastActivity(room)
+  // Room previews speak the same handle vocabulary as the roster, mentions
+  // and the group prompt: the primary profile is @hermes, not @default.
+  const lastFrom = last?.from?.name || ''
+  const lastHandle = botHandle(lastFrom || 'bot', members.find(member => member?.name === lastFrom))
   const preview = last
-    ? `${last.from?.kind === 'user' ? 'You' : `@${last.from?.name || 'bot'}`}: ${stripPreviewMarkdown(last.text) || '…'}`
+    ? `${last.from?.kind === 'user' ? 'You' : `@${lastHandle}`}: ${stripPreviewMarkdown(last.text) || '…'}`
     : 'No messages yet — say hi to the room'
   const faces = members.slice(0, 3)
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -714,3 +714,11 @@ test('source contract: group chat message bodies opt back into selectable text',
   const src = groupChatWorkspaceSource()
   assert.match(src, /'data-selectable-text':\s*'true'/)
 })
+
+test('group room preview renders the bot HANDLE, not the raw profile name', () => {
+  // #89484: the room line read "@default: …" while the bot answers to
+  // @hermes, so users concluded mention routing was broken.
+  assert.match(pluginSource, /const lastHandle = botHandle\(lastFrom \|\| 'bot', members\.find\(/)
+  assert.match(pluginSource, /\? `\$\{last\.from\?\.kind === 'user' \? 'You' : `@\$\{lastHandle\}`\}/)
+  assert.doesNotMatch(pluginSource, /`@\$\{last\.from\?\.name \|\| 'bot'\}`/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/roster-preview.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/roster-preview.test.mjs
@@ -209,3 +209,13 @@ test('render: BotRow previews the pinned canonical chat, not an unrelated latest
   assert.match(text, /pinned chat content/)
   assert.doesNotMatch(text, /unrelated scratch content/)
 })
+
+test('previewKind: the primary profile surfaces as @hermes, never @default', () => {
+  // botHandle() exists so "the word 'default' never surfaces in the UI"; the
+  // bot-to-bot badge was rendering the raw captured profile name (#89484).
+  assert.equal(fromBotOf("Message from agent 'default': deploy is green"), 'hermes')
+})
+
+test('previewKind: a named profile keeps its own handle', () => {
+  assert.equal(fromBotOf("Message from agent 'ops': deploy is green"), 'ops')
+})

--- a/contributors/emails/johnsonafuye@gmail.com
+++ b/contributors/emails/johnsonafuye@gmail.com
@@ -1,0 +1,2 @@
+johnsonAyo
+# PR for #89484 (desktop: group room preview uses botHandle)


### PR DESCRIPTION
## What does this PR do?

`botHandle()` exists so that, per its own comment, "the word 'default' never surfaces in the UI" — it presents the primary profile as `hermes`. Roster rows, mention resolution and the group-chat prompt all route through it. Two preview paths did not, and rendered the raw profile name instead:

1. **`GroupRow`'s room preview** built `` `@${last.from?.name}` `` directly, so a group room read `@default: …`
2. **`previewKind()`** returned the raw captured name from the bot-to-bot delivery prefix, so the `🤖 @<name>` badge and tooltip could show `@default` too

The mismatch is presentation-only, but it reads as a routing bug: the room says a message came from `@default`, while `@default` is not a handle the mention resolver accepts — so users reasonably conclude bot-to-bot addressing is broken when it is working correctly.

Both paths now map through `botHandle()`. `GroupRow` passes the matching member so a bot with a custom handle keeps it; `previewKind` maps the lowercased sender name, leaving every non-primary profile untouched.

## Related Issue

Fixes #89484

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.js` — `previewKind()` maps the captured sender through `botHandle()`
- `apps/desktop/src/plugins/hermes-bots/plugin.js` — `GroupRow` resolves `lastHandle` via `botHandle(lastFrom, member)` and renders that
- `apps/desktop/src/plugins/hermes-bots/tests/roster-preview.test.mjs` — primary profile resolves to `hermes`; a named profile keeps its own handle
- `apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs` — source-shape assertion for the render path, matching that file's existing convention

## How to Test

1. Create a group chat containing the primary (`default`) bot
2. Say something in the room and let the bot reply
3. Look at the group's row in the Bots roster

**Before:** `@default: Hi @user — hello! …`
**After:** `@hermes: Hi @user — hello! …`

A room whose last message came from a *named* profile is unchanged — it already showed that profile's real handle (e.g. `@andrew`), and the added test guards that.

Reproduced on macOS 27.0 arm64 against `main`, which also confirms the original Windows 11 report cross-platform. Two rooms side by side showed `@andrew:` (correct) and `@default:` (wrong) simultaneously, which isolates the mapping as the only difference.

```
node --test src/plugins/hermes-bots/tests/*.test.mjs
# 273 pass, 0 fail
```

Both new assertions fail against the pre-fix source (verified by reverting `plugin.js` and re-running: 2 failures, 49 pass).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the plugin test suite and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 27.0 arm64 (issue reported on Windows 11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing docs describe this string)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — presentation-only, no platform-specific code
- [x] I've updated tool descriptions/schemas — N/A
