### PR TITLE
fix(agent): cap the ultra reasoning level at the wire vocabulary

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -84,13 +84,21 @@ def _add_prompt_cache_key(
 
 
 def _reasoning_config_for_model(model: str, reasoning_config: dict | None) -> dict | None:
-    """Return the model's wire-compatible reasoning config."""
+    """Return the model's wire-compatible reasoning config.
+
+    Hermes' internal effort set extends the wire vocabulary with ``ultra``
+    (the /reasoning command documents none..xhigh|max|ultra). OpenAI-
+    compatible wires — OpenRouter chief among them — accept exactly
+    max|xhigh|high|medium|low|minimal|none and reject the extension with
+    HTTP 400, so an ``ultra`` configured for an Anthropic default leaks
+    untranslated when a per-job/per-turn override pins a non-Anthropic
+    model on this transport and the whole call fails (#89503). Map the
+    extension to its wire cap for every model on this path; the Anthropic
+    adapter keeps its own richer mapping.
+    """
     if not isinstance(reasoning_config, dict):
         return reasoning_config
-    if (
-        "gpt-5.6" in (model or "").lower()
-        and str(reasoning_config.get("effort") or "").strip().lower() == "ultra"
-    ):
+    if str(reasoning_config.get("effort") or "").strip().lower() == "ultra":
         normalized = dict(reasoning_config)
         normalized["effort"] = "max"
         return normalized

--- a/tests/agent/test_reasoning_effort_wire_translation.py
+++ b/tests/agent/test_reasoning_effort_wire_translation.py
@@ -1,0 +1,54 @@
+"""Wire translation for Hermes' extended reasoning-effort vocabulary (#89503).
+
+Hermes' internal effort set extends the wire vocabulary with ``ultra`` (the
+/reasoning command documents none..xhigh|max|ultra). OpenAI-compatible wires —
+OpenRouter chief among them — accept exactly max|xhigh|high|medium|low|minimal|
+none and reject the extension with HTTP 400:
+
+    reasoning.effort: Invalid option: expected one of "max"|"xhigh"|"high"|
+    "medium"|"low"|"minimal"|"none"
+
+An ``ultra`` configured while the default model was Anthropic worked (the
+Anthropic adapter maps its own levels), but the moment a per-job override
+pinned an OpenRouter model the extension leaked through the OpenAI-compatible
+transport untranslated and every call failed. ``_reasoning_config_for_model``
+is the wire-compat chokepoint for this transport: it must cap the extension
+for every model, not just the one vendor prefix that happened to be fixed
+first.
+"""
+
+from agent.transports.chat_completions import _reasoning_config_for_model
+
+
+class TestUltraEffortWireTranslation:
+    def test_ultra_maps_to_max_for_any_model(self):
+        """The extension level caps at the wire vocabulary for every model —
+        including the OpenRouter vendor prefixes a per-job override pins
+        (#89503's nvidia/ case) and models with no vendor prefix at all."""
+        for model in (
+            "nvidia/nemotron-3.5-lightning:free",
+            "deepseek/deepseek-v4",
+            "qwen/qwen3.5-coder",
+            "some-internal-model",
+        ):
+            out = _reasoning_config_for_model(
+                model, {"enabled": True, "effort": "ultra"}
+            )
+            assert out == {"enabled": True, "effort": "max"}, model
+
+    def test_gpt_56_ultra_still_maps(self):
+        """The original pre-existing mapping (gpt-5.6 + ultra → max) is
+        preserved by the generalized one."""
+        out = _reasoning_config_for_model(
+            "gpt-5.6", {"enabled": True, "effort": "ultra"}
+        )
+        assert out == {"enabled": True, "effort": "max"}
+
+    def test_wire_native_levels_pass_through_untouched(self):
+        for level in ("none", "minimal", "low", "medium", "high", "xhigh", "max"):
+            cfg = {"enabled": True, "effort": level}
+            assert _reasoning_config_for_model("any/model", cfg) == cfg
+
+    def test_non_dict_and_none_pass_through(self):
+        assert _reasoning_config_for_model("m", None) is None
+        assert _reasoning_config_for_model("m", "not-a-dict") == "not-a-dict"


### PR DESCRIPTION
## What does this PR do?

Hermes' internal reasoning-effort vocabulary extends the wire set with `ultra` (the `/reasoning` command documents `none..xhigh|max|ultra`). OpenAI-compatible wires — OpenRouter chief among them — accept exactly `max|xhigh|high|medium|low|minimal|none` and reject the extension with:

```
HTTP 400: reasoning.effort: Invalid option: expected one of "max"|"xhigh"|"high"|
"medium"|"low"|"minimal"|"none"
```

An `ultra` configured while the default model was Anthropic worked fine — the Anthropic adapter maintains its own level mapping — but the moment a cron job pinned a non-Anthropic OpenRouter model (`--model nvidia/... --provider openrouter`), the extension leaked through the OpenAI-compatible transport untranslated and **every call for that job failed** (the issue's control matrix: identical jobs on Anthropic ✅, on the pinned OpenRouter model ❌ 4/4 attempts in under 3s).

The wire-compat chokepoint for this transport (`_reasoning_config_for_model`) previously mapped `ultra → max` only for `gpt-5.6`-family models. This PR generalizes the cap to every model on the OpenAI-compatible path: the extension level maps to its wire cap (`ultra → max`), wire-native levels pass through untouched, and the Anthropic adapter keeps its richer mapping unchanged.

## Related Issue

Fixes #89503

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/transports/chat_completions.py` — `_reasoning_config_for_model` maps `ultra → max` for every model (was: only `gpt-5.6`), with a docstring stating the wire-vocabulary contract and the per-job-override failure shape; both transport call sites inherit the fix.
- `tests/agent/test_reasoning_effort_wire_translation.py` — new suite: `ultra` maps to `max` across vendor prefixes (including the issue's `nvidia/` case) and prefix-less models; the original gpt-5.6 mapping is preserved; every wire-native level passes through untouched; non-dict/None pass through.

## How to Test

```bash
python -m pytest tests/agent/test_reasoning_effort_wire_translation.py -q
# Observed result: 4 passed

python -m pytest tests/hermes_cli/test_openrouter_reasoning_metadata.py tests/agent/test_reasoning_summaries.py tests/agent/test_moa_reasoning_effort.py -q
# Observed result: 41 passed
```

Fail-on-main check: with the transport change stashed, `test_ultra_maps_to_max_for_any_model` fails on main for every non-gpt-5.6 model; the pass-through pins pass on both.

Manual repro from the issue: set the reasoning effort to `ultra` (or any configuration that resolves to it), then run a job pinned to `nvidia/nemotron-3.5-lightning:free` — on main every attempt fails with the HTTP 400 above; with this change the request carries `effort: "max"` and the call proceeds.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments explain intent (why the extension exists, why the wire rejects it, why the cap is universal on this transport)
- [x] Corresponding changes documented via docstring
- [x] Tests added and passing (4 new; adjacent reasoning suites green)
- [x] Single root cause, no unrelated changes
