### PR TITLE
perf(desktop): Bot Mode wakes paint instantly — paint-first hydration + durable transcript cache (#89206 class)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -80,6 +80,7 @@ import {
 } from '@/store/session-states'
 import { broadcastSessionsChanged } from '@/store/session-sync'
 import { forgetSessionUnread } from '@/store/session-unread'
+import { dropTranscriptTail, loadTranscriptTail, saveTranscriptTail } from '@/store/transcript-tail-cache'
 import { isWatchWindow } from '@/store/windows'
 import type { SessionCreateResponse, SessionMessage, SessionResumeResponse, UsageStats } from '@/types/hermes'
 
@@ -986,6 +987,9 @@ export function useSessionActions({
               setBusy(running)
               setAwaitingResponse(running)
               syncSessionStateToView(cachedRuntimeId, activatedState)
+              // Durable tail refresh — same post-reconcile contract as the
+              // cold path's save below.
+              saveTranscriptTail(storedSessionId, activatedState.messages)
 
               return
             }
@@ -1026,6 +1030,36 @@ export function useSessionActions({
         setMessages([])
       }
 
+      // Instant paint from the durable tail cache: a cold resume (fresh app
+      // launch, reaped/respawned backend) otherwise shows a loader until the
+      // REST prefetch lands — which on a cold multi-profile boot waits behind
+      // a backend spawn. Painting the persisted tail here makes the wake
+      // visually complete at ~0ms (and satisfies the paint-first hydration
+      // wait). The paint is DISPLAY-ONLY: reconciliation below must treat the
+      // view as empty (see cachedTailPaint), because grafting the REST tail
+      // onto a stale cached tail would duplicate or misorder rows — the
+      // authoritative transcript REPLACES the cached paint when it lands.
+      // Same-selected re-resumes skip it — their transcript is already live.
+      let cachedTailPaint: ChatMessage[] | null = null
+
+      if (!resumedSameSelectedSession && $messages.get().length === 0) {
+        const cachedTail = loadTranscriptTail(storedSessionId)
+
+        if (cachedTail && selectedStoredSessionIdRef.current === storedSessionId) {
+          cachedTailPaint = cachedTail
+          setMessages(cachedTail)
+        }
+      }
+
+      // The reconciler's notion of "what was already on screen": a durable
+      // cached paint is provisional, not history — report empty so the
+      // authoritative transcript replaces it wholesale.
+      const viewMessagesForReconcile = (): ChatMessage[] => {
+        const current = $messages.get()
+
+        return cachedTailPaint !== null && current === cachedTailPaint ? [] : current
+      }
+
       // A history load is not a live turn. Do not mark the incoming session
       // busy — running ≠ loading, and a leftover true locked the composer.
       busyRef.current = false
@@ -1055,8 +1089,8 @@ export function useSessionActions({
         const watchWindow = isWatchWindow()
 
         let localSnapshot = resumedSameSelectedSession
-          ? preserveLocalPendingTurnMessages($messages.get(), resumeStartMessages)
-          : $messages.get()
+          ? preserveLocalPendingTurnMessages(viewMessagesForReconcile(), resumeStartMessages)
+          : viewMessagesForReconcile()
 
         let prefetchApplied = false
         let prefetchedStoredSessionId: string | null = null
@@ -1117,8 +1151,8 @@ export function useSessionActions({
 
         if (prefetchedResult) {
           const previousMessages = resumedSameSelectedSession
-            ? preserveLocalPendingTurnMessages($messages.get(), resumeStartMessages)
-            : $messages.get()
+            ? preserveLocalPendingTurnMessages(viewMessagesForReconcile(), resumeStartMessages)
+            : viewMessagesForReconcile()
 
           // Tail page + previously backfilled prefix (same-session re-resume).
           const graftedPrefetch = graftRefreshedTailOntoBackfill(
@@ -1132,7 +1166,7 @@ export function useSessionActions({
           prefetchedStoredSessionId = prefetchedResult.session_id || storedSessionId
         }
 
-        const currentMessages = $messages.get()
+        const currentMessages = viewMessagesForReconcile()
 
         // Keep the local snapshot when resume would only reshuffle runtime
         // projection. When the REST prefetch already hydrated the transcript,
@@ -1237,6 +1271,15 @@ export function useSessionActions({
         // is safer than surfacing the in-flight turn alone). Recovery only
         // ever appends, so this matches the final transcript's emptiness.
         if (sessionShouldHaveTranscript(stored) && preferredMessages.length === 0) {
+          // Roll back a provisional cached-tail paint and drop its entry: the
+          // authoritative sources say this session has no transcript, so the
+          // cache no longer reflects backend truth and must not survive to
+          // mislead the retry (or the next wake).
+          if (cachedTailPaint !== null && $messages.get() === cachedTailPaint) {
+            setMessages([])
+            dropTranscriptTail(storedSessionId)
+          }
+
           setActiveSessionId(null)
           activeSessionIdRef.current = null
           setResumeFailedSessionId(storedSessionId)
@@ -1295,6 +1338,12 @@ export function useSessionActions({
         if (!chatMessageArraysEquivalent($messages.get(), messagesForView)) {
           setMessages(messagesForView)
         }
+
+        // Refresh the durable tail cache with the authoritative transcript so
+        // the NEXT wake of this session paints instantly (fresh launch,
+        // reaped backend). Post-reconcile only — never persist an optimistic
+        // or in-flight-recovered projection ahead of backend truth.
+        saveTranscriptTail(storedSessionId, messagesForView)
       } catch (err) {
         if (!isCurrentResume()) {
           return
@@ -1318,8 +1367,8 @@ export function useSessionActions({
           }
 
           const previousMessages = resumedSameSelectedSession
-            ? preserveLocalPendingTurnMessages($messages.get(), resumeStartMessages)
-            : $messages.get()
+            ? preserveLocalPendingTurnMessages(viewMessagesForReconcile(), resumeStartMessages)
+            : viewMessagesForReconcile()
 
           // Resume failed, so there is no live projection — the journal is the
           // only carrier of a crashed turn's progress on this path.
@@ -1347,7 +1396,7 @@ export function useSessionActions({
         // instead of toasting an error and hot-looping the bounded retry on a
         // permanently-dead id. (Booting straight into a no-longer-existent
         // last-session id is the common trigger.)
-        if ($messages.get().length === 0 && isSessionGoneError(fallbackError)) {
+        if (viewMessagesForReconcile().length === 0 && isSessionGoneError(fallbackError)) {
           // A 404 is only trustworthy from the backend that OWNS the session.
           // A cross-profile open (Bots pane) races the gateway swap, so both
           // lookups can land on a backend that never heard of the id (#88540).
@@ -1391,9 +1440,12 @@ export function useSessionActions({
           return
         }
 
-        if ($messages.get().length === 0) {
+        if (viewMessagesForReconcile().length === 0) {
           // Arm the self-heal ONLY when the window is still empty: the gateway
           // resume rejected AND the REST fallback failed to paint a transcript.
+          // A durable cached-tail paint counts as EMPTY here — it's provisional
+          // display, not proof of a live transcript, and must not mask the
+          // stranded state from the retry machinery.
           // That is the exact stranded state the loader latches on
           // (messagesEmpty && !activeSessionId), and matches $resumeFailedSessionId's
           // documented contract. If the REST fallback DID paint history, the
@@ -1692,6 +1744,8 @@ export function useSessionActions({
         }
 
         await deleteSession(storedSessionId, removed?.profile)
+        // A deleted session's cached tail must not resurrect on a recycled id.
+        dropTranscriptTail(storedSessionId)
         // Only after the RPC lands — the optimistic eviction above can roll
         // back, and a rolled-back row must keep its watermark/marker.
         forgetSessionUnread(removedIds, removed?.profile)

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -260,9 +260,23 @@ function waitForFocusedSessionHydration({
       const profileMatches = normalizeProfileKey($activeGatewayProfile.get()) === profile
       const sessionMatches = $selectedStoredSessionId.get() === storedSessionId
       const runtimeReady = Boolean($activeSessionId.get())
-      const historyReady = !expectHistory || Boolean($messages.get().length)
+      const historyPainted = Boolean($messages.get().length)
 
-      if (profileMatches && sessionMatches && runtimeReady && historyReady) {
+      // Paint-first hydration: for a history-bearing chat, the wake is DONE
+      // the moment the persisted transcript is painted on the right session —
+      // the REST prefetch delivers it seconds after the profile backend's
+      // HTTP comes up, while the full runtime resume (agent build, MCP
+      // discovery, skill load) keeps warming in the background and binds the
+      // composer when it lands. Gating on runtimeReady serialized the wake
+      // behind that whole boot: on a cold multi-profile start the 20s budget
+      // regularly lost the race on slower machines and surfaced as "errors
+      // waking up bots" even though the transcript had been available almost
+      // immediately. Only an expected-EMPTY chat still waits for the runtime
+      // — with no transcript to paint, a bound runtime is the only proof the
+      // surface is real rather than a stuck loader.
+      const hydrated = expectHistory ? historyPainted : runtimeReady
+
+      if (profileMatches && sessionMatches && hydrated) {
         finish()
       }
     }
@@ -464,9 +478,16 @@ export const host = {
     const profile = (options.profile ?? '').trim()
     const targetProfile = normalizeProfileKey(profile || $activeGatewayProfile.get())
     const expectHistory = options.expectHistory ?? false
+    // Wake-path phase timings. Logged ONLY on a hydration timeout (bridged
+    // into desktop.log via the renderer-console tap), so a support bundle
+    // pinpoints WHERE the budget went — profile activation vs hydration —
+    // instead of leaving us to infer it from process spawn timestamps.
+    const wakeStartedAt = Date.now()
+    let profileActiveAt = wakeStartedAt
 
     if (profile && profile !== $activeGatewayProfile.get()) {
       await ensureGatewayProfile(profile)
+      profileActiveAt = Date.now()
 
       if (options.keepAllProfilesScope !== false) {
         setShowAllProfiles(true)
@@ -533,6 +554,15 @@ export const host = {
         error instanceof Error &&
         error.message.startsWith('Timed out loading ')
       ) {
+        console.warn('[bot-wake] hydration timed out', {
+          hydrationWaitMs: Date.now() - profileActiveAt,
+          profile: targetProfile,
+          profileActivationMs: profileActiveAt - wakeStartedAt,
+          runtimeBound: Boolean($activeSessionId.get()),
+          selectionSettled: $selectedStoredSessionId.get() === storedSessionId,
+          storedSessionId,
+          transcriptPainted: $messages.get().length > 0
+        })
         // Reuse the core stranded-session surface: it renders the explicit
         // error and Retry button, and the normal resume path clears the latch.
         setResumeExhaustedSessionId(storedSessionId)

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -391,6 +391,45 @@ describe('profile-aware plugin session opens', () => {
     expect($gatewaySwapTarget.get()).toBeNull()
   })
 
+  it('resolves a history-bearing wake on transcript paint without waiting for the runtime (paint-first)', async () => {
+    vi.mocked(ensureGatewayProfile).mockImplementationOnce(async (target: null | string | undefined) => {
+      $activeGatewayProfile.set(target || 'default')
+    })
+
+    setMockAtom($selectedStoredSessionId, null)
+    setMockAtom($activeSessionId, null)
+    setMockAtom($messages, [])
+
+    let resolved = false
+
+    const opening = host
+      .openSession('slow-runtime-chat', {
+        profile: 'hyoseob',
+        awaitHydration: true,
+        expectHistory: true,
+        hydrationTimeoutMs: 1_000
+      })
+      .then(() => {
+        resolved = true
+      })
+
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(resolved).toBe(false)
+
+    // The REST prefetch paints the persisted transcript while the runtime
+    // resume (agent build, MCP discovery, skill load) is still warming — the
+    // exact cold-boot shape where the runtime takes 30s+ on slow machines.
+    // The wake must complete on the paint; the runtime binds in background.
+    setMockAtom($selectedStoredSessionId, 'slow-runtime-chat')
+    setMockAtom($messages, [{ id: 'painted-history', parts: [], role: 'assistant' }] as never)
+
+    await opening
+    expect(resolved).toBe(true)
+    expect($activeSessionId.get()).toBeNull()
+    expect($gatewaySwapTarget.get()).toBeNull()
+  })
+
   it('accepts an explicitly empty Bot Chat once its main runtime is bound', async () => {
     $activeGatewayProfile.set('hyoseob')
 

--- a/apps/desktop/src/store/gateway-switch.ts
+++ b/apps/desktop/src/store/gateway-switch.ts
@@ -24,6 +24,7 @@ import {
 } from '@/store/session'
 import { resetSessionPinMirror } from '@/store/session-pin-sync'
 import { clearAllSessionStates } from '@/store/session-states'
+import { clearTranscriptTails } from '@/store/transcript-tail-cache'
 
 // True while a soft gateway-mode apply is mid-flight (wipe → re-dial). Lets the
 // boot hook suppress the backend-exit toast and keeps the cold-boot CONNECTING
@@ -85,6 +86,11 @@ export function wipeSessionListsForGatewaySwitch(): void {
   // Artifacts are keyed by sessions on the previous backend, so both the
   // registry and any rail tab pointing into it go with them.
   clearArtifactRegistry()
+
+  // Cached transcript tails belong to the PREVIOUS backend's sessions; a
+  // different backend can recycle stored ids, and painting another machine's
+  // conversation under a same-named id is worse than a loader. Wipe them.
+  clearTranscriptTails()
 
   // Narrowed: account/marketplace/onboarding caches are global, not gateway-
   // scoped, so a mode swap must not refetch them.

--- a/apps/desktop/src/store/transcript-tail-cache.test.ts
+++ b/apps/desktop/src/store/transcript-tail-cache.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import type { ChatMessage } from '@/lib/chat-messages'
+
+import {
+  clearTranscriptTails,
+  dropTranscriptTail,
+  loadTranscriptTail,
+  saveTranscriptTail
+} from './transcript-tail-cache'
+
+const msg = (id: string, chars = 10): ChatMessage =>
+  ({ id, parts: [{ text: 'x'.repeat(chars), type: 'text' }], role: 'assistant' }) as never
+
+beforeEach(() => {
+  window.localStorage.clear()
+})
+
+afterEach(() => {
+  window.localStorage.clear()
+})
+
+describe('transcript tail cache', () => {
+  it('round-trips a session tail keyed by stored id', () => {
+    saveTranscriptTail('sess-a', [msg('1'), msg('2')])
+
+    const loaded = loadTranscriptTail('sess-a')
+
+    expect(loaded).toHaveLength(2)
+    expect(loaded?.[0].id).toBe('1')
+    expect(loadTranscriptTail('sess-other')).toBeNull()
+  })
+
+  it('persists only the bounded tail of a long transcript', () => {
+    const long = Array.from({ length: 200 }, (_, index) => msg(`m${index}`))
+    saveTranscriptTail('sess-long', long)
+
+    const loaded = loadTranscriptTail('sess-long')
+
+    expect(loaded).toHaveLength(40)
+    expect(loaded?.[0].id).toBe('m160')
+    expect(loaded?.[39].id).toBe('m199')
+  })
+
+  it('falls back to a shorter tail rather than caching an oversized entry', () => {
+    // ~40 x 30KB ≈ 1.2MB > 256KB cap; 8 x 30KB ≈ 240KB fits.
+    const heavy = Array.from({ length: 40 }, (_, index) => msg(`h${index}`, 30_000))
+    saveTranscriptTail('sess-heavy', heavy)
+
+    const loaded = loadTranscriptTail('sess-heavy')
+
+    expect(loaded).toHaveLength(8)
+    expect(loaded?.[7].id).toBe('h39')
+  })
+
+  it('ignores empty saves and blank ids', () => {
+    saveTranscriptTail('', [msg('1')])
+    saveTranscriptTail('sess-empty', [])
+
+    expect(loadTranscriptTail('')).toBeNull()
+    expect(loadTranscriptTail('sess-empty')).toBeNull()
+  })
+
+  it('self-evicts a corrupt entry instead of returning garbage', () => {
+    window.localStorage.setItem('hermes.transcript-tail.v1:sess-bad', '{not json')
+
+    expect(loadTranscriptTail('sess-bad')).toBeNull()
+    expect(window.localStorage.getItem('hermes.transcript-tail.v1:sess-bad')).toBeNull()
+  })
+
+  it('drops a deleted session and wipes everything on a gateway re-home', () => {
+    saveTranscriptTail('sess-1', [msg('a')])
+    saveTranscriptTail('sess-2', [msg('b')])
+
+    dropTranscriptTail('sess-1')
+    expect(loadTranscriptTail('sess-1')).toBeNull()
+    expect(loadTranscriptTail('sess-2')).not.toBeNull()
+
+    clearTranscriptTails()
+    expect(loadTranscriptTail('sess-2')).toBeNull()
+  })
+
+  it('LRU-evicts the oldest sessions past the entry cap', () => {
+    for (let index = 0; index < 55; index += 1) {
+      saveTranscriptTail(`sess-${index}`, [msg(`m${index}`)])
+    }
+
+    // 50-entry cap: the first five saved are evicted, the newest survive.
+    expect(loadTranscriptTail('sess-0')).toBeNull()
+    expect(loadTranscriptTail('sess-4')).toBeNull()
+    expect(loadTranscriptTail('sess-5')).not.toBeNull()
+    expect(loadTranscriptTail('sess-54')).not.toBeNull()
+  })
+})

--- a/apps/desktop/src/store/transcript-tail-cache.ts
+++ b/apps/desktop/src/store/transcript-tail-cache.ts
@@ -1,0 +1,209 @@
+import type { ChatMessage } from '@/lib/chat-messages'
+
+// ── Durable transcript-tail cache (#89206 "feels instant" layer) ────────────
+// The in-memory warm cache (sessionStateByRuntimeIdRef) makes same-window
+// re-opens instant, but dies with the window — so every app launch, backend
+// reap, or profile respawn pays a full network round-trip before ANYTHING
+// paints, and on a cold multi-profile boot that round-trip sits behind a
+// backend spawn. This cache persists a bounded tail of each stored session's
+// transcript in localStorage: a wake paints the cached tail at ~0ms, the
+// paint-first hydration completes immediately, and the REST prefetch /
+// runtime resume reconcile the authoritative transcript when they land
+// (the existing reconcilers already treat painted content as "previous").
+//
+// Scope and bounds:
+//   - TAIL ONLY (last TAIL_MESSAGES), size-capped per entry; oversized
+//     messages evict the entry rather than truncating a message mid-parts.
+//   - LRU across MAX_ENTRIES sessions; corrupt entries self-evict.
+//   - Same trust domain as state.db on the same disk — no new exposure.
+//   - Keyed by stored session id (durable identity), never runtime id.
+
+const PREFIX = 'hermes.transcript-tail.v1:'
+const INDEX_KEY = 'hermes.transcript-tail.v1-index'
+const TAIL_MESSAGES = 40
+const MAX_ENTRY_BYTES = 256 * 1024
+const MAX_ENTRIES = 50
+
+interface CacheEntry {
+  messages: ChatMessage[]
+  savedAt: number
+}
+
+function storage(): Storage | null {
+  try {
+    return window.localStorage
+  } catch {
+    return null
+  }
+}
+
+function readIndex(store: Storage): string[] {
+  try {
+    const raw = store.getItem(INDEX_KEY)
+    const parsed = raw ? JSON.parse(raw) : []
+
+    return Array.isArray(parsed) ? parsed.filter(id => typeof id === 'string') : []
+  } catch {
+    return []
+  }
+}
+
+function writeIndex(store: Storage, ids: string[]): void {
+  try {
+    store.setItem(INDEX_KEY, JSON.stringify(ids))
+  } catch {
+    // Quota — drop the index; entries become orphaned and are rewritten lazily.
+  }
+}
+
+function touchIndex(store: Storage, storedSessionId: string): void {
+  const ids = readIndex(store).filter(id => id !== storedSessionId)
+  ids.push(storedSessionId)
+
+  while (ids.length > MAX_ENTRIES) {
+    const evicted = ids.shift()
+
+    if (evicted) {
+      try {
+        store.removeItem(PREFIX + evicted)
+      } catch {
+        // best effort
+      }
+    }
+  }
+
+  writeIndex(store, ids)
+}
+
+/** Persist the tail of a session's transcript. No-op on empty/oversized. */
+export function saveTranscriptTail(storedSessionId: string, messages: ChatMessage[]): void {
+  const id = (storedSessionId ?? '').trim()
+  const store = storage()
+
+  if (!store || !id || !Array.isArray(messages) || messages.length === 0) {
+    return
+  }
+
+  const entry: CacheEntry = { messages: messages.slice(-TAIL_MESSAGES), savedAt: Date.now() }
+
+  let serialized: string
+
+  try {
+    serialized = JSON.stringify(entry)
+  } catch {
+    return // non-serializable parts (live handles) — skip, never throw
+  }
+
+  if (serialized.length > MAX_ENTRY_BYTES) {
+    // Retry with a shorter tail before giving up; a session dominated by a
+    // few huge tool results still caches its recent turns.
+    const shorter: CacheEntry = { messages: messages.slice(-8), savedAt: entry.savedAt }
+
+    try {
+      serialized = JSON.stringify(shorter)
+    } catch {
+      return
+    }
+
+    if (serialized.length > MAX_ENTRY_BYTES) {
+      return
+    }
+  }
+
+  try {
+    store.setItem(PREFIX + id, serialized)
+    touchIndex(store, id)
+  } catch {
+    // Quota exceeded — evict everything and retry once (small cache >> stale cache).
+    try {
+      clearTranscriptTails()
+      store.setItem(PREFIX + id, serialized)
+      touchIndex(store, id)
+    } catch {
+      // Storage genuinely unavailable; instant paint just won't happen.
+    }
+  }
+}
+
+/** Cached tail for a stored session, or null. Corrupt entries self-evict. */
+export function loadTranscriptTail(storedSessionId: string): ChatMessage[] | null {
+  const id = (storedSessionId ?? '').trim()
+  const store = storage()
+
+  if (!store || !id) {
+    return null
+  }
+
+  let raw: null | string = null
+
+  try {
+    raw = store.getItem(PREFIX + id)
+  } catch {
+    return null
+  }
+
+  if (!raw) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as CacheEntry
+
+    if (!parsed || !Array.isArray(parsed.messages) || parsed.messages.length === 0) {
+      throw new Error('empty')
+    }
+
+    return parsed.messages
+  } catch {
+    try {
+      store.removeItem(PREFIX + id)
+    } catch {
+      // best effort
+    }
+
+    return null
+  }
+}
+
+/** Drop one session's cached tail (session deleted / cache poisoned). */
+export function dropTranscriptTail(storedSessionId: string): void {
+  const id = (storedSessionId ?? '').trim()
+  const store = storage()
+
+  if (!store || !id) {
+    return
+  }
+
+  try {
+    store.removeItem(PREFIX + id)
+    writeIndex(
+      store,
+      readIndex(store).filter(entry => entry !== id)
+    )
+  } catch {
+    // best effort
+  }
+}
+
+/** Wipe the whole cache (connection/mode re-home, quota recovery). */
+export function clearTranscriptTails(): void {
+  const store = storage()
+
+  if (!store) {
+    return
+  }
+
+  for (const id of readIndex(store)) {
+    try {
+      store.removeItem(PREFIX + id)
+    } catch {
+      // best effort
+    }
+  }
+
+  try {
+    store.removeItem(INDEX_KEY)
+  } catch {
+    // best effort
+  }
+}

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -18975,7 +18975,11 @@ def start_server(
             if headless:
                 # No SPA, and the JSON-RPC/WS endpoints are auth-gated — don't
                 # advertise a paste-and-connect URL, just announce the bind.
-                print(f"  Hermes backend listening on {host}:{actual_port}")
+                # flush: on a piped stdout (Desktop spawn) this line is
+                # block-buffered and can surface MINUTES after the flushed
+                # READY sentinel above, which reads as a slow boot in
+                # support bundles when the backend was actually up.
+                print(f"  Hermes backend listening on {host}:{actual_port}", flush=True)
             else:
                 print(f"  Hermes Web UI → http://{host}:{actual_port}")
             _maybe_open_browser(host, actual_port, open_browser, initial_profile)


### PR DESCRIPTION
## Summary

Bot Mode wake is now instant-feeling and spawn-proof, without raising any timeout — two layers:

1. **Paint-first hydration**: a history-bearing chat counts as hydrated the moment its persisted transcript is painted; the full runtime resume (agent build, MCP discovery, skill load) warms in background and binds the composer when ready.
2. **Durable transcript-tail cache**: a bounded tail (40 msgs / 256KB / 50-session LRU, localStorage, keyed by durable stored id) of every reconciled transcript persists across app launches and backend reaps — a cold wake paints at ~0ms before any network I/O, then the REST prefetch/runtime resume replace it with authoritative content. Display-only: reconciliation and failure latches treat the cached paint as empty, so it can never mask a stranded resume or graft onto stale rows; deletes drop entries, gateway re-homes wipe the cache.

Root cause (zero trust's third bundle, on `ae6578af` with both prior #89206 fixes present): cold profile backends on slower Windows machines take 47–120s to fully boot, and the wake path's fixed budgets (20s hydration + ~15s resume retries) raced the whole boot and lost — "errors waking up BOTS" while the backend came up healthy moments later. The transcript itself was available seconds in via the REST prefetch; the wait was serialized behind the slowest part of boot for no user-visible benefit.

## Changes

- `apps/desktop/src/sdk/index.ts` — `waitForFocusedSessionHydration`: paint-first predicate (`expectHistory ? transcriptPainted : runtimeReady`). Expected-empty chats still wait for the runtime (nothing to paint; a bound runtime is the only proof the surface is real). On timeout, a `[bot-wake]` phase breakdown (activation ms, hydration ms, unmet conditions) is logged to the renderer console → desktop.log, so the next support bundle names the slow phase directly.
- `hermes_cli/web_server.py` — flush the headless "listening" line; block-buffered on Desktop's piped stdout it surfaced minutes late, inflating apparent boot times in support bundles (part of the 120s "gap" in this bundle was this artifact).
- `apps/desktop/src/sdk/profile-routing.test.ts` — paint-first regression test (slow-runtime shape).

## Validation

| Check | Result |
|---|---|
| Sabotage: restore runtime-gated wait | paint-first test FAILS by timing out (field shape) |
| `profile-routing.test.ts` | 15/15 |
| transcript-tail-cache tests (incl. sabotage: cache disabled fails 5/7) | 7/7 |
| session hooks + sdk full | 654/654 |
| sdk + session hooks + router suites | 654/654 |
| hermes-bots plugin tests | 270/270 |
| `npm run check:lint` (3 tsconfigs + eslint) | 0 errors |
| `tests/hermes_cli/test_web_server.py` | failures pre-existing on main (env-dependent; verified identical with change stashed) |

Third and final layer of the #89206 wake-failure class (gate fix #89394, routing fix #89475).

## Infographic

![Bots wake paint-first](https://v3b.fal.media/files/b/0aa6e246/vk8zsFaXPPmqevvWM5s4L_54TFilVH.png)
