### PR TITLE
feat(kanban): dispatcher-side goal-mode clean-exit auto-recovery (t_16a245cc)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8798,6 +8798,219 @@ _PROTOCOL_VIOLATION_FAILURE_LIMIT = 3
 # can only mean "way past the bound" anyway.
 _PROTOCOL_VIOLATION_SCAN_LIMIT = 50
 
+# When a ``goal_mode`` task hits a consecutive run of clean-exit protocol
+# violations, the goal-judge loop is by definition what is failing — the
+# worker keeps exiting cleanly without the model emitting
+# ``kanban_complete`` / ``kanban_block``. Empirically (retro
+# t_16a245cc, observed across GATE-1 / GATE-3 retries on the
+# rob_box_project board) the goal-judge rarely breaks the cycle on its own:
+# it nudges the same model that already failed to emit the terminal tool
+# call. Spawning a single-shot recovery card (goal_mode=False) with
+# explicit terminal-call instructions breaks the loop in one extra
+# dispatch — no manual nudge needed, no waiting for the full breaker trip
+# (which would block the original after 3 violations and strand the work).
+#
+# The threshold is intentionally one less than the breaker trip: at
+# streak=2 the dispatcher spawns recovery + blocks the original, so the
+# 3rd violation (which would have tripped the breaker) never lands — the
+# task is already ``blocked`` and the recovery card is the canonical
+# forward path. Override via env ``HERMES_KANBAN_GOAL_RECOVERY_STREAK``
+# for tests / emergency tunables.
+_GOAL_MODE_RECOVERY_STREAK_LIMIT = int(
+    os.environ.get("HERMES_KANBAN_GOAL_RECOVERY_STREAK", "2") or "2"
+)
+
+# ``created_by`` marker stamped on dispatcher-spawned recovery cards so
+# ``detect_crashed_workers`` can refuse to spawn a recovery-of-recovery
+# (which would loop forever if the recovery worker also exits cleanly).
+# Distinct from the regular ``"system"`` marker used elsewhere so future
+# tooling can filter goal-recovery specifically.
+_GOAL_MODE_RECOVERY_CREATED_BY = "system:goal-mode-recovery"
+
+
+def _spawn_goal_mode_recovery_card(
+    conn: sqlite3.Connection,
+    task_id: str,
+    streak: int,
+) -> Optional[str]:
+    """Spawn a single-shot recovery card for a goal-mode task stuck in a
+    clean-exit protocol-violation loop, and block the original.
+
+    Called from :func:`detect_crashed_workers` once the violation streak
+    crosses :data:`_GOAL_MODE_RECOVERY_STREAK_LIMIT` AND the task has
+    ``goal_mode=True`` AND was not itself spawned by this function (the
+    ``_GOAL_MODE_RECOVERY_CREATED_BY`` marker prevents recovery-of-recovery
+    loops).
+
+    The recovery card inherits the original task's workspace, branch,
+    project, assignee, priority, and ``max_runtime_seconds`` so the worker
+    lands in the same git tree and has the same operational budget. The
+    body is hand-written to break the loop by giving the worker an
+    explicit, terminal-tool-call-only job:
+
+    1. Inspect the original task's git history (``branch_name``) — the
+       worker may have committed everything it needed to.
+    2. ``hermes kanban complete <original_id>`` to close the original.
+    3. ``hermes kanban complete <recovery_id>`` to close itself.
+
+    Returns the recovery card's id, or ``None`` if creation was skipped
+    (already exists via idempotency_key, or ``goal_mode`` was already
+    off — the caller should never invoke us in that case but we guard
+    against it).
+
+    The original task is transitioned to ``blocked`` with
+    ``block_kind="needs_input"`` so the loop counter increments normally
+    and the recovery card (status ``ready``) is dispatched on the next
+    tick. The blocker ``reason`` makes the link to the spawned recovery
+    card visible in the board UI and in the original's event timeline.
+    """
+    row = conn.execute(
+        "SELECT * FROM tasks WHERE id = ?", (task_id,),
+    ).fetchone()
+    if row is None:
+        return None  # task deleted mid-loop, nothing to recover
+    keys = set(row.keys())
+    goal_mode_flag = bool(row["goal_mode"]) if "goal_mode" in keys else False
+    if not goal_mode_flag:
+        # Caller should never invoke us for a non-goal-mode task, but
+        # defend anyway: do NOT spawn, do NOT block.
+        return None
+    if row["created_by"] == _GOAL_MODE_RECOVERY_CREATED_BY:
+        # Recovery-of-recovery guard. The recovery card itself ran
+        # goal_mode=False and still exited cleanly — let it block under
+        # the normal violation-streak rule instead of looping forever.
+        return None
+
+    assignee = row["assignee"]
+    workspace_kind = row["workspace_kind"]
+    workspace_path = row["workspace_path"]
+    branch_name = row["branch_name"]
+    project_id = row["project_id"] if "project_id" in keys else None
+    priority = int(row["priority"]) if row["priority"] is not None else 0
+    max_runtime_seconds = (
+        row["max_runtime_seconds"]
+        if "max_runtime_seconds" in keys
+        and row["max_runtime_seconds"] is not None
+        else None
+    )
+    title = row["title"] or task_id
+    original_body = row["body"] or ""
+    original_body_excerpt = (
+        (original_body[:400] + "…") if len(original_body) > 400
+        else original_body
+    )
+
+    # Idempotency: if a recovery card for this original is already open
+    # (e.g. the dispatcher crashed between spawn and block), do nothing
+    # — the existing card will continue to be the canonical forward
+    # path. Using ``idempotency_key`` (handled in ``create_task``) gives
+    # the same behaviour atomically; we also do an explicit pre-check
+    # so the body we emit reflects whether the work was already done.
+    idempotency_key = f"goal-mode-recovery:{task_id}"
+    existing = conn.execute(
+        "SELECT id FROM tasks WHERE idempotency_key = ? "
+        "AND status != 'archived' LIMIT 1",
+        (idempotency_key,),
+    ).fetchone()
+    if existing is not None:
+        return existing["id"]
+
+    branch_line = (
+        f"\n\n**Original branch:** `{branch_name}`\n"
+        "Inspect `git log <branch>` on this branch in the workspace — "
+        "the previous worker may have committed everything the task "
+        "needed. If the commits cover the body above, you can complete "
+        "the original task immediately without re-doing the work."
+        if branch_name
+        else "\n\nThe original task had no git branch — re-do the work "
+             "in the workspace and push as usual."
+    )
+    body = (
+        f"Auto-recovery for goal-mode task `{task_id}` "
+        f"(streak={streak} consecutive clean-exit protocol violations).\n\n"
+        f"**Original title:** {title}\n\n"
+        f"**Original body (excerpt):**\n"
+        f"```\n{original_body_excerpt}\n```\n"
+        f"{branch_line}\n\n"
+        "**Why this card exists:** the original worker kept exiting "
+        "cleanly (rc=0) without calling `kanban_complete` or "
+        "`kanban_block`. The dispatcher has now blocked the original; "
+        "your job is to close it.\n\n"
+        "**What to do (single-shot — `goal_mode=False`):**\n\n"
+        "1. Run `hermes kanban show " + task_id + "` to re-read the "
+        "original body, comments, and prior attempts.\n"
+        "2. Inspect `git log` on the original branch (see above). If "
+        "the work is already committed, skip to step 4.\n"
+        "3. Otherwise, finish the work in this workspace and push the "
+        "branch.\n"
+        "4. Close the ORIGINAL task: "
+        f"`hermes kanban complete {task_id} "
+        "--summary \"closed via auto-recovery <THIS_ID>\"`\n"
+        "5. Close THIS recovery card: "
+        "`hermes kanban complete <THIS_ID> --summary \"closed "
+        f"original {task_id}\"`\n\n"
+        "**Important:** step 4 is what unblocks the original; step 5 "
+        "is what closes this card. If you only do step 5, the original "
+        "stays blocked and the work is lost. If you skip both, the "
+        "dispatcher will retry this card under the normal violation-"
+        "streak rule (no infinite recovery loops — the original is "
+        "already blocked)."
+    )
+
+    recovery_id = create_task(
+        conn,
+        title=f"recovery (auto, goal-mode): {title}",
+        body=body,
+        assignee=assignee,
+        workspace_kind=workspace_kind,
+        workspace_path=workspace_path,
+        branch_name=branch_name,
+        project_id=project_id,
+        priority=priority,
+        max_runtime_seconds=max_runtime_seconds,
+        goal_mode=False,
+        created_by=_GOAL_MODE_RECOVERY_CREATED_BY,
+        idempotency_key=idempotency_key,
+        initial_status="ready",
+    )
+
+    # Block the original so its violation streak stops accumulating
+    # against the unified breaker. ``needs_input`` is the closest fit:
+    # the original genuinely does need human-readable state ("auto-
+    # recovery spawned") and the loop counter increments normally so a
+    # pathological task that keeps spawning recoveries eventually
+    # escalates to ``triage`` instead of looping forever.
+    block_reason = (
+        f"auto-recovery spawned ({recovery_id}) after "
+        f"{streak} consecutive clean-exit protocol violations; "
+        "see recovery card to close the original"
+    )
+    block_task(
+        conn, task_id,
+        reason=block_reason,
+        kind="needs_input",
+    )
+
+    # Side-channel: dispatch_once / tests pick this up the same way they
+    # pick up ``_last_auto_blocked`` / ``_last_rate_limited``.
+    spawned = list(
+        getattr(_spawn_goal_mode_recovery_card, "_last_spawned", [])
+    )
+    spawned.append({"original": task_id, "recovery": recovery_id})
+    _spawn_goal_mode_recovery_card._last_spawned = spawned  # type: ignore[attr-defined]
+
+    _append_event(
+        conn, task_id, "goal_mode_recovery_spawned",
+        {
+            "recovery_id": recovery_id,
+            "streak": streak,
+            "limit": _GOAL_MODE_RECOVERY_STREAK_LIMIT,
+            "reason": "clean-exit protocol violation loop on goal_mode=True",
+        },
+        run_id=None,
+    )
+    return recovery_id
+
 
 def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
     """Count the task's trailing run of clean-exit protocol violations.
@@ -9080,6 +9293,41 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     if task_override is not None
                     else _PROTOCOL_VIOLATION_FAILURE_LIMIT
                 )
+                # Goal-mode auto-recovery (retro t_16a245cc). When the
+                # task is goal_mode=True AND the streak has crossed the
+                # recovery threshold AND the task isn't itself a recovery
+                # card, spawn a single-shot recovery card and block the
+                # original. The spawned card closes the loop without
+                # waiting for the full breaker trip (which would block
+                # the original after 3 violations and strand the work).
+                # The recovery card has its own idempotency_key + a
+                # ``created_by`` marker so re-runs of this pass are safe
+                # — the recovery-of-recovery guard inside the helper
+                # refuses to spawn a second recovery, so we never loop.
+                # ``streak >= _GOAL_MODE_RECOVERY_STREAK_LIMIT`` may be
+                # true while the breaker would ALSO trip on this tick
+                # (``streak >= violation_limit``); we still ``continue``
+                # afterwards because the recovery helper has already
+                # blocked the task — letting the breaker also run would
+                # emit a redundant ``gave_up`` event and count the
+                # failure against the unified counter.
+                if streak >= _GOAL_MODE_RECOVERY_STREAK_LIMIT:
+                    task_row = conn.execute(
+                        "SELECT goal_mode, created_by FROM tasks WHERE id = ?",
+                        (tid,),
+                    ).fetchone()
+                    if (
+                        task_row is not None
+                        and bool(task_row["goal_mode"])
+                        and task_row["created_by"]
+                            != _GOAL_MODE_RECOVERY_CREATED_BY
+                    ):
+                        recovery_id = _spawn_goal_mode_recovery_card(
+                            conn, tid, streak,
+                        )
+                        if recovery_id is not None:
+                            auto_blocked.append(tid)
+                            continue
                 if streak < violation_limit:
                     # Below budget: the task is already back at ``ready``
                     # (respawn allowed) with ``last_failure_error`` stamped.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8971,7 +8971,6 @@ def _spawn_goal_mode_recovery_card(
         goal_mode=False,
         created_by=_GOAL_MODE_RECOVERY_CREATED_BY,
         idempotency_key=idempotency_key,
-        initial_status="ready",
     )
 
     # Block the original so its violation streak stops accumulating

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1312,6 +1312,21 @@ def _drive_protocol_violation(conn, tid, fake_pid):
     return _drive_worker_exit(conn, tid, fake_pid, 0)
 
 
+@pytest.fixture(autouse=True)
+def _reset_goal_recovery_side_channel():
+    """Reset the module-level ``_last_spawned`` side channel between
+    tests so each test sees a clean slate. The helper stashes spawned
+    recovery card ids on the function object (mirrors how
+    ``detect_crashed_workers`` stashes ``_last_auto_blocked`` /
+    ``_last_rate_limited``), so without this reset, test order would
+    leak into other tests' assertions.
+    """
+    import hermes_cli.kanban_db as _kb
+    _kb._spawn_goal_mode_recovery_card._last_spawned = []  # type: ignore[attr-defined]
+    yield
+    _kb._spawn_goal_mode_recovery_card._last_spawned = []  # type: ignore[attr-defined]
+
+
 def _drive_nonzero_crash(conn, tid, fake_pid):
     """One plain non-zero-exit crash reaper pass for ``tid``.
 
@@ -1364,6 +1379,252 @@ def test_protocol_violation_budget_not_consumed_by_other_failures(kanban_home):
         assert len(gave_up) == 1
         assert (gave_up[0].payload or {}).get("protocol_violations") == \
             _kb._PROTOCOL_VIOLATION_FAILURE_LIMIT
+    finally:
+        conn.close()
+
+
+def test_goal_mode_clean_exit_spawns_recovery_card(kanban_home, monkeypatch):
+    """A goal_mode=True task that hits the clean-exit violation streak
+    must spawn a single-shot recovery card (goal_mode=False) and block
+    the original — instead of looping the original through three more
+    clean-exit cycles until the unified breaker trips (retro
+    t_16a245cc).
+
+    Covers the dispatcher-side fix for the observed pattern on
+    t_ba114e5c (GATE-1) and t_f19de2f1 (GATE-3) where the goal-judge
+    loop nudged the same model that had already failed to emit
+    kanban_complete / kanban_block, yielding 13/14 crashed runs with
+    rc=0. After this fix, the second consecutive violation spawns
+    recovery + blocks the original; the third violation (which would
+    have tripped the breaker) never lands because the task is already
+    blocked.
+    """
+    import hermes_cli.kanban_db as _kb
+    # Pin the recovery streak to 2 (the default) so the test asserts the
+    # documented behaviour, not whatever env the caller has set.
+    monkeypatch.setenv("HERMES_KANBAN_GOAL_RECOVERY_STREAK", "2")
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="GATE-1 acceptance",
+            assignee="worker",
+            goal_mode=True,
+            body="Acceptance: gate validates the JSON contract.",
+            workspace_kind="worktree",
+            workspace_path="/tmp/fake-worktree",
+            branch_name="z-devops/t_16a245cc-fixture",
+        )
+
+        # 1st violation: streak == 1, below threshold, original stays
+        # ``ready`` for retry — no recovery card yet.
+        _drive_protocol_violation(conn, tid, 992001)
+        task = kb.get_task(conn, tid)
+        assert task.status == "ready", (
+            "first violation must still retry, not spawn recovery"
+        )
+        assert (
+            getattr(
+                _kb._spawn_goal_mode_recovery_card,
+                "_last_spawned",  # type: ignore[attr-defined]
+            )
+        ) == [], "no recovery card should be spawned yet"
+
+        # 2nd violation: streak == 2, hits recovery threshold, recovery
+        # card spawned + original blocked.
+        _drive_protocol_violation(conn, tid, 992002)
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked", (
+            f"after 2nd violation the original must be blocked, "
+            f"got {task.status!r}"
+        )
+        spawned = list(
+            getattr(_kb._spawn_goal_mode_recovery_card, "_last_spawned", [])
+        )
+        assert len(spawned) == 1, (
+            f"exactly one recovery card expected, got {len(spawned)}"
+        )
+        recovery_id = spawned[-1]["recovery"]
+        assert spawned[-1]["original"] == tid
+
+        # The recovery card has the right shape: goal_mode=False,
+        # assignee inherited, branch inherited, and the body points the
+        # worker at closing the original.
+        recovery = kb.get_task(conn, recovery_id)
+        assert recovery is not None, "recovery card must exist"
+        assert recovery.goal_mode is False, (
+            "recovery card must be single-shot (goal_mode=False) — "
+            "goal-judge is exactly what was looping the original"
+        )
+        assert recovery.assignee == "worker"
+        assert recovery.workspace_kind == "worktree"
+        assert recovery.branch_name == "z-devops/t_16a245cc-fixture"
+        assert recovery.status == "ready", (
+            "recovery card must be dispatched immediately, not queued"
+        )
+        assert "recovery" in (recovery.title or "").lower()
+        assert "auto" in (recovery.title or "").lower(), (
+            "title must include 'auto' marker so users can filter "
+            "dispatcher-spawned recovery cards in the board UI"
+        )
+        assert (
+            recovery.created_by
+            == _kb._GOAL_MODE_RECOVERY_CREATED_BY
+        ), "recovery created_by marker is the recovery-of-recovery guard"
+        assert f"`{tid}`" in (recovery.body or ""), (
+            "recovery body must reference the original task id"
+        )
+        assert "kanban complete" in (recovery.body or "").lower(), (
+            "recovery body must instruct the worker to call "
+            "kanban_complete on the original"
+        )
+
+        # Recovery event recorded on the original.
+        recovery_events = [
+            e for e in kb.list_events(conn, tid)
+            if e.kind == "goal_mode_recovery_spawned"
+        ]
+        assert len(recovery_events) == 1
+        payload = recovery_events[0].payload or {}
+        assert payload.get("recovery_id") == recovery_id
+        assert payload.get("streak") == 2
+
+        # A redundant 3rd violation must NOT spawn a second recovery
+        # card (idempotency_key) — the original is already blocked, so
+        # the helper's idempotency pre-check returns the existing
+        # recovery id without writing a second card.
+        result = _kb._spawn_goal_mode_recovery_card(conn, tid, streak=3)
+        assert result == recovery_id, (
+            "a 3rd violation must NOT spawn another recovery "
+            "(idempotency), got a different recovery id"
+        )
+        spawned2 = list(
+            getattr(_kb._spawn_goal_mode_recovery_card, "_last_spawned", [])
+        )
+        assert len(spawned2) == 1, (
+            f"a 3rd violation must NOT append to _last_spawned "
+            f"(idempotency), got {len(spawned2)}"
+        )
+        # Original has a single ``gave_up``? No — we blocked it via
+        # ``block_task`` (needs_input), not via the unified breaker. So
+        # there should be NO ``gave_up`` event on the original.
+        gave_up = [
+            e for e in kb.list_events(conn, tid) if e.kind == "gave_up"
+        ]
+        assert gave_up == [], (
+            f"recovery already blocked the original via block_task; "
+            f"the unified breaker must not have been called, but "
+            f"gave_up events landed: {gave_up}"
+        )
+    finally:
+        conn.close()
+
+
+def test_goal_mode_recovery_skips_non_goal_mode_tasks(kanban_home, monkeypatch):
+    """The recovery helper must not block / spawn for non-goal-mode
+    tasks — those follow the existing violation-streak + breaker
+    flow unchanged (the original retro's regression boundary).
+    """
+    import hermes_cli.kanban_db as _kb
+    monkeypatch.setenv("HERMES_KANBAN_GOAL_RECOVERY_STREAK", "2")
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn, title="plain task", assignee="worker",
+            goal_mode=False,
+        )
+
+        # Three clean-exit violations: streak walks 1 → 2 → 3.
+        # At streak == 2 the helper MUST NOT spawn recovery (goal_mode
+        # off), so the 3rd violation trips the breaker as it always did.
+        _drive_protocol_violation(conn, tid, 993001)
+        _drive_protocol_violation(conn, tid, 993002)
+        # Helper invoked directly — should return None for goal_mode=False.
+        result = _kb._spawn_goal_mode_recovery_card(conn, tid, streak=2)
+        assert result is None, (
+            "non-goal-mode tasks must NOT spawn a recovery card"
+        )
+
+        _drive_protocol_violation(conn, tid, 993003)
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked", (
+            "non-goal-mode tasks must still trip the breaker on streak==3"
+        )
+        # No recovery event on the original.
+        recovery_events = [
+            e for e in kb.list_events(conn, tid)
+            if e.kind == "goal_mode_recovery_spawned"
+        ]
+        assert recovery_events == [], (
+            "non-goal-mode tasks must NOT emit goal_mode_recovery_spawned"
+        )
+    finally:
+        conn.close()
+
+
+def test_goal_mode_recovery_idempotent_on_repeat_dispatch(kanban_home, monkeypatch):
+    """Re-running detect_crashed_workers on a task whose recovery card
+    is already open must NOT spawn a second recovery card — the
+    idempotency_key on the recovery card keeps it singleton.
+    """
+    import hermes_cli.kanban_db as _kb
+    monkeypatch.setenv("HERMES_KANBAN_GOAL_RECOVERY_STREAK", "2")
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn, title="repeat", assignee="worker", goal_mode=True,
+        )
+        _drive_protocol_violation(conn, tid, 994001)
+        _drive_protocol_violation(conn, tid, 994002)
+        spawned_first = list(
+            getattr(_kb._spawn_goal_mode_recovery_card, "_last_spawned", [])
+        )
+        assert len(spawned_first) == 1
+        recovery_id = spawned_first[-1]["recovery"]
+
+        # Force another violation pass (task is blocked, but we can
+        # still invoke the helper directly to test idempotency).
+        result = _kb._spawn_goal_mode_recovery_card(conn, tid, streak=2)
+        assert result == recovery_id, (
+            "second invocation must return the existing recovery id "
+            "(idempotency_key), not spawn a second card"
+        )
+        spawned_second = list(
+            getattr(_kb._spawn_goal_mode_recovery_card, "_last_spawned", [])
+        )
+        assert len(spawned_second) == 1, (
+            "second invocation must not append to _last_spawned"
+        )
+    finally:
+        conn.close()
+
+
+def test_goal_mode_recovery_skips_recovery_of_recovery(kanban_home, monkeypatch):
+    """A recovery card itself has goal_mode=False, but if its worker
+    ALSO exits cleanly the dispatcher must not spawn another recovery
+    (infinite-loop guard). The helper refuses via the ``created_by``
+    marker — verify the helper returns ``None`` for a recovery card.
+    """
+    import hermes_cli.kanban_db as _kb
+    monkeypatch.setenv("HERMES_KANBAN_GOAL_RECOVERY_STREAK", "2")
+    conn = kb.connect()
+    try:
+        # Direct-create a recovery card (bypassing the dispatcher) so
+        # we can drive the recovery-of-recovery case deterministically.
+        recovery_id = kb.create_task(
+            conn,
+            title="recovery (auto, goal-mode): fake original",
+            assignee="worker",
+            goal_mode=False,
+            created_by=_kb._GOAL_MODE_RECOVERY_CREATED_BY,
+            workspace_kind="scratch",
+        )
+        result = _kb._spawn_goal_mode_recovery_card(
+            conn, recovery_id, streak=2
+        )
+        assert result is None, (
+            "recovery-of-recovery must be refused (created_by marker)"
+        )
     finally:
         conn.close()
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -424,6 +424,22 @@ streak — and a per-task `max_retries` overrides the bound. This usually means
 the model wrote a plain-text answer and exited without using the Kanban tool
 surface.
 
+**Goal-mode auto-recovery (retro t_16a245cc):** When a `goal_mode=true` task
+hits a streak of clean-exit protocol violations, the dispatcher spawns a
+**single-shot recovery card** with `goal_mode=false` and an explicit
+"close the original" body, then blocks the original with `needs_input` so the
+violation counter stops accumulating. The threshold defaults to 2 violations
+(override via `HERMES_KANBAN_GOAL_RECOVERY_STREAK`) — one less than the
+breaker trip — so the recovery card is the canonical forward path before the
+unified breaker ever trips. The recovery card inherits the original's
+`assignee`, `branch_name`, `workspace_kind`, and `project_id` so the worker
+lands in the same git tree. `idempotency_key="goal-mode-recovery:<original>"`
+keeps re-runs of the dispatcher safe (no duplicate recovery cards), and a
+`created_by="system:goal-mode-recovery"` marker refuses recovery-of-recovery
+so the helper cannot loop on itself. The recovery card emits a
+`goal_mode_recovery_spawned` event on the original with `recovery_id`,
+`streak`, and `limit` for board-UI wiring.
+
 The lifecycle plus the load-bearing reference details (workspace kinds, deliverable `artifacts`, claiming created cards) ship in that system-prompt block, so every worker has them regardless of which profile it runs under — no per-profile skill setup required.
 
 ### Pinning extra skills to a specific task


### PR DESCRIPTION
## Problem (retro t_16a245cc, 18.08.2026)

Goal-mode cards in clean-exit protocol-violation loops are never auto-recovered: a worker returns 0 but never calls `kanban_complete` / `kanban_block`, the goal judge nudges the same model that already failed to emit the terminal tool call, and no recovery card ever spawns. Result: 13/14 runs on `t_ba114e5c` (GATE-1) and 13/14 on `t_f19de2f1` (GATE-3) crashed identically with "worker exited cleanly (rc=0) without calling kanban_complete or kanban_block — protocol violation". The unified breaker only trips after 3 consecutive crashes, which means every goal-mode card in this state burns 3 wasted dispatches and then dies.

This is a recovery gap between the existing bounded retry (PR #61817, 2 violations before breaker) and the goal-judge failure mode. The judge itself is the failing party, so adding another nudge budget on the same loop does not help — the recovery must happen OUT of the loop.

## Fix

`_spawn_goal_mode_recovery_card` in `hermes_cli/kanban_db.py` is called from the post-`detect_crashed_workers` accounting pass when a violation lands and the streak crosses `_GOAL_MODE_RECOVERY_STREAK_LIMIT` (default 2, env `HERMES_KANBAN_GOAL_RECOVERY_STREAK`):

- If `goal_mode=True` AND the streak ≥ limit AND the task is not itself a recovery card:
  - Spawn a fresh recovery card with `goal_mode=False` (single-shot, no judge loop), inheriting assignee / branch / workspace / project / priority / max_runtime from the original.
  - Block the original with `block_kind=needs_input`, reason `auto-recovery spawned (<recovery_id>) after <streak> violations`.
  - Emit a `goal_mode_recovery_spawned` event with the recovery id and streak for board-UI wiring.
  - Skip the breaker call — the original is already blocked, so the 3rd violation never lands and the breaker can't double-count it.

At streak=2 the dispatcher already de-escalates (original blocked), so the breaker (which would trip at streak=3) never fires. That preserves the work via a single fresh dispatch and skips the failed 3rd slot. The recovery card is the canonical forward path; the breaker stays as the fallback for non-goal-mode tasks.

### Safety

- **`idempotency_key="goal-mode-recovery:<original>"`** — dispatcher re-runs return the existing recovery id; no duplicate cards across reap storms.
- **`created_by="system:goal-mode-recovery"` marker** — a `detect_crashed_workers` re-run that sees a recovery task in violation streak refuses to spawn a recovery-of-recovery (would loop forever). Recovery cards fall back to the normal unified breaker on their own second violation.
- **Per-task `max_retries` override** already respected (same precedence as every other failure kind).
- **Env tunables** `HERMES_KANBAN_GOAL_RECOVERY_STREAK` for emergency tuning; default 2 (one less than the breaker trip).

### Recovery-card shape

The single-shot body tells the worker exactly what to do, in 5 numbered steps, written in our channel format (matches existing recovery cards e.g. PR-merge conflict, deploy-recovery, gate-fail):

> 1. Run `hermes kanban show <original_id>` to re-read the body.
> 2. Inspect `git log` on the original branch — prior commits may already cover the work.
> 3. If not, finish the work in this workspace and push the branch.
> 4. Close the ORIGINAL: `hermes kanban complete <original_id> --summary "closed via auto-recovery <recovery_id>"`.
> 5. Close THIS recovery card: `hermes kanban complete <recovery_id> --summary "closed original <original_id>"`.

`branch_name` and `body excerpt` of the original are baked in; assignee inherits from the card row.

## Tests (in `tests/hermes_cli/test_kanban_core_functionality.py`)

| Test | What it proves |
|------|----------------|
| `test_goal_mode_clean_exit_spawns_recovery_card` | Full dispatcher flow: 1st violation retries, 2nd violation spawns recovery + blocks original, recovery card shape (`goal_mode=False`, assignee inherited, branch inherited, body references original + `kanban_complete` instructions), `goal_mode_recovery_spawned` event recorded, 3rd call is idempotent and does NOT emit `gave_up` (breaker was skipped). |
| `test_goal_mode_recovery_skips_non_goal_mode_tasks` | Non-goal-mode tasks still trip the breaker on `streak==3` unchanged. |
| `test_goal_mode_recovery_idempotent_on_repeat_dispatch` | Second invocation returns the existing recovery id (`idempotency_key` enforcement), no double-spawn. |
| `test_goal_mode_recovery_skips_recovery_of_recovery` | Recovery-of-recovery refused via `created_by` marker. |

All four pass; existing `test_kanban_core_functionality.py` suite (24 tests) still green; sibling files `test_kanban_goal_mode.py` / `test_kanban_review_surfaces.py` / `test_kanban_db.py` all pass (43 passed, 1 skipped, 0 regressions in touched areas).

## Acceptance

- [x] Code in `hermes_cli/kanban_db.py` (`_spawn_goal_mode_recovery_card`, `_GOAL_MODE_RECOVERY_STREAK_LIMIT`, docstring on the helper and the dispatcher hook).
- [x] Unit tests: 4 new tests cover the full dispatcher flow + idempotency + recovery-of-recovery guard.
- [x] Docs: `website/docs/user-guide/features/kanban.md` — new "Goal-mode auto-recovery" paragraph under "Dispatcher-side recovery".
- [ ] Live: next `goal_mode=True` card that hits a clean-exit loop (PR #1418 / issue #1422 class) — the recovery card spawns automatically within 2 crashes, breaking the loop with one extra dispatch.

## Related

- SOUL.md "Recovery pattern"
- SOUL.md "Worker in goal-mode: finalisation rules"
- Hermes Multi-Agent-2 video (Namreg): R1XR card as recovery-pattern
- ADR-0014 (agent-flow SSoT)
- ADR-0022 (GATE-1/2/3 — this retro card's automation target)
- PR #61817 (one instructed retry before breaker — the bounded retry that this card sits ON TOP OF; this card breaks the loop earlier when goal-mode judges are the failing party)
- PR #49875 (open, separate fix for `goal_mode clean exit no longer triggers protocol_violation` — orthogonal concern: that PR reclassifies intent-worker turns as expected exits; this PR handles the case where reclassification did NOT save us)
- Currently-dying cards from this pattern: `t_ba114e5c`, `t_f19de2f1`
- Prior retro cards: `t_16325ddd` (push force-with-lease safety), `t_a0fac345` (triage dedup), `t_de6bea69` (user-unlabel respect)