### PR TITLE
fix(gateway): make steer acknowledgments conversational

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -47,8 +47,8 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     "interim_assistant_messages": True,
     "long_running_notifications": True,
     "busy_ack_detail": True,
-    # Whether busy_input_mode=steer sends a visible "Steered into current run"
-    # acknowledgment after successfully injecting the user's mid-turn message.
+    # Whether busy_input_mode=steer sends a visible acknowledgment after
+    # successfully injecting the user's mid-turn message.
     # Disable when the platform should steer silently (the text still lands in
     # the active run; only the confirmation echo is suppressed).
     "busy_steer_ack_enabled": True,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10281,10 +10281,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         status_detail = f" ({', '.join(status_parts)})" if status_parts else ""
         if is_steer_mode:
-            message = (
-                f"⏩ Steered into current run{status_detail}. "
-                f"Your message arrives after the next tool call."
-            )
+            message = f"Still working on your last message{status_detail}—give me a sec."
         elif is_redirect_mode:
             message = (
                 f"↪ Redirected current run{status_detail}. "

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1211,8 +1211,8 @@ DEFAULT_CONFIG = {
         # behavior of showing tool-call summaries inline.
         "resume_skip_tool_only": True,
         "busy_input_mode": "interrupt",  # interrupt | queue | steer
-        # When busy_input_mode="steer", suppress only the visible
-        # "Steered into current run" confirmation bubble by setting this false.
+        # When busy_input_mode="steer", suppress only the visible steer
+        # confirmation bubble by setting this false.
         # The mid-turn steering itself still happens.
         "busy_steer_ack_enabled": True,
         # Classic CLI multiline fallbacks beyond Alt+Enter.

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -218,11 +218,12 @@ class TestBusySessionAck:
         # VERIFY: No queueing — successful steer must NOT replay as next turn
         mock_merge.assert_not_called()
 
-        # VERIFY: Ack mentions steer wording
+        # VERIFY: Ack sounds like a human status update, not transport jargon.
         adapter._send_with_retry.assert_called_once()
         call_kwargs = adapter._send_with_retry.call_args
         content = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
-        assert "Steered" in content or "steer" in content.lower()
+        assert "Still working on your last message—give me a sec." in content
+        assert "Steered into current run" not in content
         assert "Interrupting" not in content
 
     @pytest.mark.asyncio
@@ -260,7 +261,7 @@ class TestBusySessionAck:
         agent.interrupt.assert_not_called()
         assert sk not in adapter._pending_messages
         content = adapter._send_with_retry.call_args.kwargs["content"]
-        assert "Steered" in content
+        assert "Still working on your last message—give me a sec." in content
         assert "Queued" not in content
 
 


### PR DESCRIPTION
## Summary

Replace the transport-jargon busy steer acknowledgment with a natural status update:

> Still working on your last message—give me a sec.

The steer behavior, optional status detail, onboarding hint, and suppression setting are unchanged.

## Verification

- 30 focused gateway/display tests passed
- Ruff passed
- `git diff --check` passed