### PR TITLE
fix(auxiliary): never hand a probe-mode stub to a real consumer

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -128,11 +128,26 @@ _aux_probe_state = threading.local()
 class _AuxProbeClientStub:
     """Non-functional placeholder returned while `aux_probe_mode` is active."""
 
-    __slots__ = ("api_key", "base_url")
+    # `close` and the wrapper-introspection attributes are REAL members, not
+    # __getattr__ fall-throughs. Teardown and cache-eviction code legitimately
+    # probes these with getattr(obj, name, default) / hasattr, which is a
+    # protocol that requires AttributeError — and this class raises
+    # RuntimeError by design. Without real members, a stub reaching any
+    # best-effort cleanup path turns it into a hard failure instead of a
+    # no-op (#compression abort: "used as a real client (attribute 'close')").
+    # Exposing them here keeps the loud failure for genuine client USE
+    # (.chat, .messages, …) while making the stub inert to inspection.
+    __slots__ = ("api_key", "base_url", "_real_client", "_client")
 
     def __init__(self, api_key: str = "", base_url: str = "") -> None:
         self.api_key = api_key
         self.base_url = base_url
+        self._real_client = None
+        self._client = None
+
+    def close(self) -> None:
+        """No-op: a stub owns no transport, so there is nothing to release."""
+        return None
 
     def __getattr__(self, name: str) -> Any:
         # Loud failure if a probe stub ever leaks into a runtime call path
@@ -7802,6 +7817,17 @@ def _get_cached_client(
         task=task,
     )
     if client is not None:
+        if isinstance(client, _AuxProbeClientStub):
+            # Availability probe: never publish a stub into the shared cache.
+            # This is the SAME invariant _store_cached_client enforces, but
+            # this function writes `_client_cache` directly (below), so the
+            # guard has to be restated here or the invariant has a hole: a
+            # check_fn probing under aux_probe_mode() would seed the cache
+            # with a stub, and the next REAL consumer (context compression,
+            # title generation, vision) would get it on a cache hit and blow
+            # up with "used as a real client". Probes are cheap to redo; a
+            # poisoned cache entry persists for the life of the process.
+            return client, model or default_model
         # For async clients, remember which loop they were created on so we
         # can detect stale entries later.
         bound_loop = current_loop

--- a/tests/agent/test_aux_probe_stub_never_cached.py
+++ b/tests/agent/test_aux_probe_stub_never_cached.py
@@ -1,0 +1,111 @@
+"""Probe stubs must never reach a runtime consumer via the client cache.
+
+Regression coverage for the compression abort:
+
+    Compression aborted: 984 messages preserved
+    Reason: _AuxProbeClientStub used as a real client (attribute 'close');
+            aux_probe_mode is for availability checks only
+
+`aux_probe_mode()` makes client constructors return a lightweight
+`_AuxProbeClientStub` so tool-gating check_fns can answer "is this provider
+resolvable?" without paying for real SDK construction. The stub is explicitly
+documented as never-cached. `_store_cached_client` enforced that, but
+`_get_cached_client` writes `_client_cache` directly and did not — so a
+check_fn probing under probe mode could seed the cache, and the next real
+consumer (context compression) got a non-functional stub on the cache hit.
+
+These are behaviour contracts, not snapshots: they assert the invariant
+("a probe never publishes into the cache"; "a stub is inert to teardown
+inspection but loud on real use") rather than freezing any particular
+cache key, provider list, or call count.
+"""
+
+import pytest
+
+import agent.auxiliary_client as ac
+from agent.auxiliary_client import _AuxProbeClientStub, aux_probe_mode
+
+
+@pytest.fixture(autouse=True)
+def _clean_client_cache():
+    """Each test owns the cache; never leak entries across tests."""
+    with ac._client_cache_lock:
+        saved = dict(ac._client_cache)
+        ac._client_cache.clear()
+    try:
+        yield
+    finally:
+        with ac._client_cache_lock:
+            ac._client_cache.clear()
+            ac._client_cache.update(saved)
+
+
+@pytest.fixture
+def stub_resolver(monkeypatch):
+    """resolve_provider_client returns a stub in probe mode, a real object otherwise.
+
+    Mirrors the real constructors (`_create_openai_client`,
+    `_try_anthropic_native`, …), which all branch on `_aux_probe_active()`.
+    """
+    sentinel = object()
+
+    def fake_resolve(provider, model, async_mode, **kwargs):
+        if ac._aux_probe_active():
+            return _AuxProbeClientStub(api_key="k", base_url="https://example.invalid"), model
+        return sentinel, model
+
+    monkeypatch.setattr(ac, "resolve_provider_client", fake_resolve)
+    return sentinel
+
+
+def test_probe_does_not_publish_stub_into_client_cache(stub_resolver):
+    """A probe-mode resolution must leave the shared cache stub-free."""
+    with aux_probe_mode():
+        client, _ = ac._get_cached_client("anthropic", model="m")
+
+    assert isinstance(client, _AuxProbeClientStub), "probe should still get its stub"
+    cached = [entry[0] for entry in ac._client_cache.values()]
+    assert not any(isinstance(c, _AuxProbeClientStub) for c in cached), (
+        "a probe stub was published into the shared client cache; the next "
+        "real consumer would receive a non-functional client"
+    )
+
+
+def test_runtime_consumer_after_probe_gets_a_real_client(stub_resolver):
+    """The bug: probe first, then a real consumer on the same key."""
+    with aux_probe_mode():
+        ac._get_cached_client("anthropic", model="m")
+
+    client, _ = ac._get_cached_client("anthropic", model="m")
+
+    assert client is stub_resolver
+    assert not isinstance(client, _AuxProbeClientStub), (
+        "runtime consumer (e.g. context compression) received a probe stub "
+        "from the cache — compression would abort instead of summarizing"
+    )
+
+
+def test_stub_is_inert_to_teardown_inspection():
+    """Best-effort cleanup paths must not explode on a stub.
+
+    `getattr(client, "close", None)` relies on AttributeError to fall back to
+    the default; the stub raises RuntimeError from __getattr__, so `close`
+    must exist as a real no-op member.
+    """
+    stub = _AuxProbeClientStub()
+
+    assert callable(getattr(stub, "close", None))
+    assert stub.close() is None
+    ac._close_cached_client(stub)          # must not raise
+    ac._evict_cached_client_instance(stub)  # must not raise
+
+
+def test_stub_still_fails_loudly_when_used_as_a_real_client():
+    """The guard rail stays: genuine client USE must raise, not silently no-op."""
+    stub = _AuxProbeClientStub()
+
+    with pytest.raises(RuntimeError, match="used as a real client"):
+        stub.chat.completions.create()
+
+    with pytest.raises(RuntimeError, match="used as a real client"):
+        stub.messages.create()


### PR DESCRIPTION
## The bug

`aux_probe_mode()` makes auxiliary client constructors return a lightweight `_AuxProbeClientStub`, so tool-gating `check_fn`s can answer *"is this provider resolvable?"* without paying for the `openai` import plus httpx/SSL construction on the CLI startup path. The stub is documented as never-cached, and `_store_cached_client()` enforces that:

```python
def _store_cached_client(cache_key, client, default_model, *, bound_loop=None):
    if isinstance(client, _AuxProbeClientStub):
        # Probe stubs must never enter the cache — a runtime caller would
        # receive a non-functional client on the next cache hit.
        return
```

`_get_cached_client()` writes `_client_cache` directly, and did not.

So `check_vision_requirements()` — which runs under `aux_probe_mode()` during tool gating at startup — seeded the cache with a stub. The next real consumer resolving the same key got the stub on a cache hit and died on first attribute access:

```
Compression aborted: 984 messages preserved
Reason: _AuxProbeClientStub used as a real client (attribute 'close');
        aux_probe_mode is for availability checks only
```

Compression fails safe, so no history was lost — but it could not succeed again for the life of the process. It only reproduces on conversations long enough to trigger compaction, which is why it survived to now.

## Two fixes

**1. Plug the cache hole.** `_get_cached_client()` returns probe stubs without publishing them — the same invariant `_store_cached_client()` already had, restated at the second cache-write site.

**2. Make the stub inert to inspection.** `__getattr__` raised `RuntimeError` for *every* attribute, which breaks the `getattr(obj, name, default)` protocol — that idiom needs `AttributeError` to fall back to the default. Any best-effort teardown (`_close_cached_client`, `_evict_cached_client_instance`) therefore turned into a hard failure instead of a no-op. `close()` is now a real no-op and `_real_client`/`_client` are real members.

Genuine misuse (`.chat`, `.messages`) still raises loudly — that guard rail is what catches the next leak, so it stays.

## Verification

Reproduced first, fixed second, then mutation-checked the tests against a stub-free `origin/main` worktree:

- **Source fix reverted** → 3 of 4 new tests fail with the exact reported `RuntimeError`
- **Fix applied** → all 4 pass

Real path, end to end: running `check_vision_requirements()` leaves **1 stub** in the cache before the fix and **0** after; a subsequent compression resolve then returns a real `AnthropicAuxiliaryClient` instead of the stub.

Full auxiliary/compression suite: **1826 passed**. The 7 pre-existing failures are byte-identical on a stashed baseline — verified, not assumed.

Per the contribution rubric, the tests assert the *invariant* (a probe never publishes into the cache; a stub is inert to inspection but loud on real use) rather than freezing any cache key, provider list, or call count.
