### PR TITLE
fix(model-metadata): stop Coding Plan sessions from compressing at the wrong context limit

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1691,11 +1691,38 @@ def check_compression_model_feasibility(agent: Any) -> None:
         _raw_aux_key = getattr(client, "api_key", "")
         aux_api_key = "" if (callable(_raw_aux_key) and not isinstance(_raw_aux_key, str)) else str(_raw_aux_key or "")
 
+        aux_context_config = getattr(
+            agent, "_aux_compression_context_length_config", None
+        )
+        if aux_context_config is None:
+            same_model = str(aux_model).strip().casefold() == str(
+                getattr(agent, "model", "") or ""
+            ).strip().casefold()
+            main_base_url = str(getattr(agent, "base_url", "") or "").rstrip("/")
+            aux_provider = (
+                _aux_cfg_provider
+                if _aux_cfg_provider and _aux_cfg_provider != "auto"
+                else getattr(agent, "provider", "")
+            )
+            same_provider = str(aux_provider or "").casefold() == str(
+                getattr(agent, "provider", "") or ""
+            ).casefold()
+            normalized_aux_url = aux_base_url.rstrip("/")
+            same_endpoint = (
+                normalized_aux_url == main_base_url
+                if normalized_aux_url or main_base_url
+                else same_provider
+            )
+            if same_model and same_endpoint:
+                # The default compression runtime inherits the main model and
+                # endpoint. Preserve its route-scoped explicit context pin too.
+                aux_context_config = getattr(agent, "_config_context_length", None)
+
         aux_context = get_model_context_length(
             aux_model,
             base_url=aux_base_url,
             api_key=aux_api_key,
-            config_context_length=getattr(agent, "_aux_compression_context_length_config", None),
+            config_context_length=aux_context_config,
             # Each model must be resolved with its own provider so that
             # provider-specific paths (e.g. Bedrock static table, OpenRouter API)
             # are invoked for the correct client, not inherited from the main model.

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -76,6 +76,7 @@ from agent.model_metadata import (
     estimate_request_tokens_rough,
 )
 from agent.session_activity import ActivityProvenance, normalize_activity_provenance
+from utils import base_url_identity
 
 logger = logging.getLogger(__name__)
 
@@ -1698,7 +1699,7 @@ def check_compression_model_feasibility(agent: Any) -> None:
             same_model = str(aux_model).strip().casefold() == str(
                 getattr(agent, "model", "") or ""
             ).strip().casefold()
-            main_base_url = str(getattr(agent, "base_url", "") or "").rstrip("/")
+            main_base_url = str(getattr(agent, "base_url", "") or "")
             aux_provider = (
                 _aux_cfg_provider
                 if _aux_cfg_provider and _aux_cfg_provider != "auto"
@@ -1707,10 +1708,11 @@ def check_compression_model_feasibility(agent: Any) -> None:
             same_provider = str(aux_provider or "").casefold() == str(
                 getattr(agent, "provider", "") or ""
             ).casefold()
-            normalized_aux_url = aux_base_url.rstrip("/")
+            main_identity = base_url_identity(main_base_url)
+            aux_identity = base_url_identity(aux_base_url)
             same_endpoint = (
-                normalized_aux_url == main_base_url
-                if normalized_aux_url or main_base_url
+                bool(main_identity and aux_identity and main_identity == aux_identity)
+                if aux_base_url or main_base_url
                 else same_provider
             )
             if same_model and same_endpoint:

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -3120,7 +3120,11 @@ def get_model_context_length(
 
     if effective_provider:
         from agent.models_dev import lookup_models_dev_context
-        ctx = lookup_models_dev_context(effective_provider, model)
+        ctx = lookup_models_dev_context(
+            effective_provider,
+            model,
+            base_url=base_url or "",
+        )
         if ctx:
             # MiniMax M3: models.dev reports 512K but actual context is 1M.
             # Prefer hardcoded catalog over stale probe value.

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -733,7 +733,11 @@ def fetch_models_dev(
 
 
 def lookup_models_dev_context(
-    provider: str, model: str, *, allow_network: bool = False
+    provider: str,
+    model: str,
+    *,
+    base_url: str = "",
+    allow_network: bool = False,
 ) -> Optional[int]:
     """Look up context_length for a provider+model combo in models.dev.
 
@@ -748,6 +752,9 @@ def lookup_models_dev_context(
     ``allow_network`` defaults to False — context-length lookup is a
     hot path (called during every conversation turn) and must never block
     on the network. Pass True only from explicit refresh flows.
+
+    ``base_url`` selects route-specific provider catalogs when one Hermes
+    provider identity fronts multiple products, such as Z.AI Coding Plan.
     """
     # Explicit config override — checked before catalog so it always wins.
     override_ctx = _override_context_window(provider, model)
@@ -758,6 +765,15 @@ def lookup_models_dev_context(
     if not mdev_provider_id:
         return _default_override_context(provider)
 
+    provider_ids = [mdev_provider_id]
+    if (
+        mdev_provider_id == "zai"
+        and "/api/coding/" in str(base_url or "").lower()
+    ):
+        # Z.AI publishes Coding Plan-only models in a separate models.dev
+        # catalog even though Hermes uses one provider identity for both APIs.
+        provider_ids.insert(0, "zai-coding-plan")
+
     # NOTE: keep the zero-argument call on the allow_network path. Dozens
     # of test sites monkeypatch fetch_models_dev with zero-arg lambdas;
     # passing the kwarg unconditionally breaks them all (TypeError).
@@ -766,50 +782,45 @@ def lookup_models_dev_context(
         if allow_network
         else fetch_models_dev(allow_network=False)
     )
-    provider_data = data.get(mdev_provider_id)
-    if not isinstance(provider_data, dict):
-        return _default_override_context(provider)
-
-    models = provider_data.get("models", {})
-    if not isinstance(models, dict):
-        return _default_override_context(provider)
-
-    # Exact match
-    entry = models.get(model)
-    if entry:
-        ctx = _extract_context(entry)
-        if ctx:
-            return ctx
-
-    # Case-insensitive match
     model_lower = model.lower()
-    for mid, mdata in models.items():
-        if mid.lower() == model_lower:
-            ctx = _extract_context(mdata)
-            if ctx:
-                return ctx
+    for provider_id in provider_ids:
+        provider_data = data.get(provider_id)
+        if not isinstance(provider_data, dict):
+            continue
+        models = provider_data.get("models", {})
+        if not isinstance(models, dict):
+            continue
 
-    # Suffix-aware fallback: some providers (e.g. ollama-cloud) store
-    # model IDs with :cloud / -cloud suffixes in models.dev while the
-    # live API returns bare names.  Without this, kimi-k2.6 misses the
-    # kimi-k2.6:cloud entry and falls through to stale OpenRouter metadata
-    # reporting 32768 — tripping the 64k minimum-context guard.
-    # The suffix-stripping in fetch_ollama_cloud_models() handles the
-    # model-picker UX; this handles the context-length lookup path.
-    for suffix in (":cloud", "-cloud"):
-        suffixed_key = model + suffix
-        entry = models.get(suffixed_key)
+        # Exact match
+        entry = models.get(model)
         if entry:
             ctx = _extract_context(entry)
             if ctx:
                 return ctx
-        # Also try case-insensitive
-        suffixed_lower = model_lower + suffix
+
+        # Case-insensitive match
         for mid, mdata in models.items():
-            if mid.lower() == suffixed_lower:
+            if mid.lower() == model_lower:
                 ctx = _extract_context(mdata)
                 if ctx:
                     return ctx
+
+        # Suffix-aware fallback: some providers (e.g. ollama-cloud) store
+        # model IDs with :cloud / -cloud suffixes in models.dev while the
+        # live API returns bare names.
+        for suffix in (":cloud", "-cloud"):
+            suffixed_key = model + suffix
+            entry = models.get(suffixed_key)
+            if entry:
+                ctx = _extract_context(entry)
+                if ctx:
+                    return ctx
+            suffixed_lower = model_lower + suffix
+            for mid, mdata in models.items():
+                if mid.lower() == suffixed_lower:
+                    ctx = _extract_context(mdata)
+                    if ctx:
+                        return ctx
 
     # Catalog miss — a _default override may fill the gap (#84482).
     return _default_override_context(provider)

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -183,6 +183,7 @@ PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "minimax-cn": "minimax-cn",
     "deepseek": "deepseek",
     "alibaba": "alibaba",
+    "alibaba-coding-plan": "alibaba-coding-plan",
     "qwen-oauth": "alibaba",
     "copilot": "github-copilot",
     "ai-gateway": "vercel",
@@ -213,6 +214,8 @@ PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "cohere": "cohere",
     "ollama-cloud": "ollama-cloud",
 }
+
+_CODING_PLAN_CATALOG_SUFFIX = "-coding-plan"
 
 # Reverse mapping: models.dev id → Hermes ids (built lazily; many-to-one,
 # e.g. both "meta" and "meta-ai" may map to the same models.dev id).
@@ -765,15 +768,6 @@ def lookup_models_dev_context(
     if not mdev_provider_id:
         return _default_override_context(provider)
 
-    provider_ids = [mdev_provider_id]
-    if (
-        mdev_provider_id == "zai"
-        and "/api/coding/" in str(base_url or "").lower()
-    ):
-        # Z.AI publishes Coding Plan-only models in a separate models.dev
-        # catalog even though Hermes uses one provider identity for both APIs.
-        provider_ids.insert(0, "zai-coding-plan")
-
     # NOTE: keep the zero-argument call on the allow_network path. Dozens
     # of test sites monkeypatch fetch_models_dev with zero-arg lambdas;
     # passing the kwarg unconditionally breaks them all (TypeError).
@@ -782,6 +776,7 @@ def lookup_models_dev_context(
         if allow_network
         else fetch_models_dev(allow_network=False)
     )
+    provider_ids = _catalog_search_order(mdev_provider_id, base_url, data)
     model_lower = model.lower()
     for provider_id in provider_ids:
         provider_data = data.get(provider_id)
@@ -824,6 +819,35 @@ def lookup_models_dev_context(
 
     # Catalog miss — a _default override may fill the gap (#84482).
     return _default_override_context(provider)
+
+
+def _catalog_search_order(
+    mdev_provider_id: str,
+    base_url: str,
+    data: Dict[str, Any],
+) -> tuple[str, ...]:
+    """Return route-specific models.dev catalogs before the regular catalog.
+
+    Coding Plan products have separate provider entries and provider-specific
+    limits. Match their declared API URL instead of borrowing a sibling merely
+    because the regular catalog missed; the latter would leak subscription-only
+    metadata into a provider's standard API.
+    """
+    if mdev_provider_id.endswith(_CODING_PLAN_CATALOG_SUFFIX):
+        return (mdev_provider_id,)
+
+    requested_url = str(base_url or "").strip().lower().rstrip("/")
+    if requested_url:
+        for provider_id, provider_data in data.items():
+            if not provider_id.endswith(_CODING_PLAN_CATALOG_SUFFIX):
+                continue
+            if not isinstance(provider_data, dict):
+                continue
+            catalog_url = str(provider_data.get("api") or "").strip().lower().rstrip("/")
+            if catalog_url and catalog_url == requested_url:
+                return (provider_id, mdev_provider_id)
+
+    return (mdev_provider_id,)
 
 
 def _default_override_context(provider: str) -> Optional[int]:

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -47,7 +47,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-from utils import atomic_json_write
+from utils import atomic_json_write, base_url_identity
 
 import requests
 
@@ -836,15 +836,15 @@ def _catalog_search_order(
     if mdev_provider_id.endswith(_CODING_PLAN_CATALOG_SUFFIX):
         return (mdev_provider_id,)
 
-    requested_url = str(base_url or "").strip().lower().rstrip("/")
-    if requested_url:
+    requested_identity = base_url_identity(base_url)
+    if requested_identity is not None:
         for provider_id, provider_data in data.items():
             if not provider_id.endswith(_CODING_PLAN_CATALOG_SUFFIX):
                 continue
             if not isinstance(provider_data, dict):
                 continue
-            catalog_url = str(provider_data.get("api") or "").strip().lower().rstrip("/")
-            if catalog_url and catalog_url == requested_url:
+            catalog_identity = base_url_identity(str(provider_data.get("api") or ""))
+            if catalog_identity is not None and catalog_identity == requested_identity:
                 return (provider_id, mdev_provider_id)
 
     return (mdev_provider_id,)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1010,7 +1010,15 @@ _MODEL_OVERRIDE_METADATA_KEYS = frozenset({
 
 
 def _split_config_key_path(dotted_key: str) -> list[str]:
-    """Split a config path while preserving dotted model override IDs."""
+    """Split a config path while preserving dotted model override IDs.
+
+    ``model_overrides`` is an open mapping, so its model segment consumes every
+    remaining component except a recognized trailing metadata key. This keeps
+    arbitrary dotted IDs addressable, but the dotted CLI syntax cannot
+    distinguish a model ID ending in a metadata-key name from that metadata
+    field; such an override must be written directly in YAML. An unrecognized
+    trailing component is therefore part of the model ID, not a schema error.
+    """
     parts = dotted_key.split(".")
     if (
         len(parts) >= 3

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -999,6 +999,28 @@ def get_missing_env_vars(required_only: bool = False) -> List[Dict[str, Any]]:
     return missing
 
 
+_MODEL_OVERRIDE_METADATA_KEYS = frozenset({
+    "context_window",
+    "max_output_tokens",
+    "supports_tools",
+    "supports_vision",
+    "supports_reasoning",
+    "model_family",
+})
+
+
+def _split_config_key_path(dotted_key: str) -> list[str]:
+    """Split a config path while preserving dotted model override IDs."""
+    parts = dotted_key.split(".")
+    if (
+        len(parts) >= 5
+        and parts[0] == "model_overrides"
+        and parts[-1] in _MODEL_OVERRIDE_METADATA_KEYS
+    ):
+        return [parts[0], parts[1], ".".join(parts[2:-1]), parts[-1]]
+    return parts
+
+
 def _set_nested(config, dotted_key: str, value):
     """Set a value at an arbitrarily nested dotted key path.
 
@@ -1021,7 +1043,7 @@ def _set_nested(config, dotted_key: str, value):
     destroying list-typed config like ``custom_providers`` whenever a
     caller used an indexed path.
     """
-    parts = dotted_key.split(".")
+    parts = _split_config_key_path(dotted_key)
     current = config
     for part in parts[:-1]:
         if isinstance(current, list):
@@ -1083,7 +1105,7 @@ _MISSING = object()
 def _get_nested(config, dotted_key: str):
     """Return a dotted-path value from nested dict/list config data."""
     current = config
-    for part in dotted_key.split("."):
+    for part in _split_config_key_path(dotted_key):
         if isinstance(current, list):
             try:
                 current = current[int(part)]
@@ -1100,7 +1122,7 @@ def _get_nested(config, dotted_key: str):
 
 def _unset_nested(config, dotted_key: str) -> bool:
     """Remove a dotted-path value from nested dict/list config data."""
-    parts = dotted_key.split(".")
+    parts = _split_config_key_path(dotted_key)
     if not parts:
         return False
 
@@ -5042,7 +5064,7 @@ def _default_value_for_key(dotted_key: str):
     best-effort coercion used by ``config set``.
     """
     node = DEFAULT_CONFIG
-    for part in dotted_key.split("."):
+    for part in _split_config_key_path(dotted_key):
         if not isinstance(node, dict) or part not in node:
             return None
         node = node[part]
@@ -5063,6 +5085,7 @@ _OPEN_DICT_TOP_LEVEL_KEYS = frozenset({
     "personalities",
     "command_allowlist",
     "model_catalog",
+    "model_overrides",
     "channel_prompts",
     "server_actions",
     "secrets",
@@ -5154,7 +5177,7 @@ def _validate_config_key(key: str) -> tuple[bool, Optional[str]]:
     if not key:
         return False, None
 
-    segments = key.split(".")
+    segments = _split_config_key_path(key)
     top = segments[0]
 
     # ── Underscore-prefixed keys are internal/test markers ───────────

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1013,11 +1013,13 @@ def _split_config_key_path(dotted_key: str) -> list[str]:
     """Split a config path while preserving dotted model override IDs."""
     parts = dotted_key.split(".")
     if (
-        len(parts) >= 5
+        len(parts) >= 3
         and parts[0] == "model_overrides"
-        and parts[-1] in _MODEL_OVERRIDE_METADATA_KEYS
+        and parts[1] != "_default"
     ):
-        return [parts[0], parts[1], ".".join(parts[2:-1]), parts[-1]]
+        if len(parts) >= 4 and parts[-1] in _MODEL_OVERRIDE_METADATA_KEYS:
+            return [parts[0], parts[1], ".".join(parts[2:-1]), parts[-1]]
+        return [parts[0], parts[1], ".".join(parts[2:])]
     return parts
 
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -217,6 +217,27 @@ class TestEstimateRequestTokensRough:
 # =========================================================================
 
 class TestDefaultContextLengths:
+    def test_zai_coding_plan_context_comes_from_route_catalog(self):
+        registry = {
+            "zai": {"models": {}},
+            "zai-coding-plan": {
+                "models": {
+                    "glm-5.3": {"limit": {"context": 1_000_000}},
+                },
+            },
+        }
+        with patch(
+            "agent.models_dev.fetch_models_dev", return_value=registry
+        ), patch(
+            "agent.model_metadata.get_cached_context_length", return_value=None
+        ):
+            assert get_model_context_length(
+                "glm-5.3",
+                base_url="https://api.z.ai/api/coding/paas/v4",
+                api_key="dummy",
+                provider="zai",
+            ) == 1_000_000
+
     def test_nvidia_deepseek_v4_pro_context_is_endpoint_scoped(self):
         """NVIDIA's 262K NIM window must not lower DeepSeek V4 globally."""
         with patch("agent.model_metadata.get_cached_context_length", return_value=None), \

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -221,6 +221,7 @@ class TestDefaultContextLengths:
         registry = {
             "zai": {"models": {}},
             "zai-coding-plan": {
+                "api": "https://api.z.ai/api/coding/paas/v4",
                 "models": {
                     "glm-5.3": {"limit": {"context": 1_000_000}},
                 },

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -139,8 +139,10 @@ class TestLookupModelsDevContext:
         mock_fetch.return_value = {
             "zai": {"models": {}},
             "zai-coding-plan": {
+                "api": "https://api.z.ai/api/coding/paas/v4",
                 "models": {
                     "glm-5.3": {"limit": {"context": 1_000_000}},
+                    "glm-5.2-highspeed": {"limit": {"context": 1_000_000}},
                 },
             },
         }
@@ -152,9 +154,52 @@ class TestLookupModelsDevContext:
         ) == 1_000_000
         assert lookup_models_dev_context(
             "zai",
+            "glm-5.2-highspeed",
+            base_url="https://api.z.ai/api/coding/paas/v4/",
+        ) == 1_000_000
+        assert lookup_models_dev_context(
+            "zai",
             "glm-5.3",
             base_url="https://api.z.ai/api/paas/v4",
         ) is None
+
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_coding_route_matches_catalog_api_instead_of_provider_name(self, mock_fetch):
+        mock_fetch.return_value = {
+            "zai": {"models": {}},
+            "zhipuai-coding-plan": {
+                "api": "https://open.bigmodel.cn/api/coding/paas/v4",
+                "models": {
+                    "glm-5.3": {"limit": {"context": 1_000_000}},
+                },
+            },
+        }
+
+        assert lookup_models_dev_context(
+            "zai",
+            "glm-5.3",
+            base_url="https://open.bigmodel.cn/api/coding/paas/v4",
+        ) == 1_000_000
+
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_alibaba_coding_plan_catalog_is_route_scoped(self, mock_fetch):
+        mock_fetch.return_value = {
+            "alibaba": {"models": {}},
+            "alibaba-coding-plan": {
+                "api": "https://coding-intl.dashscope.aliyuncs.com/v1",
+                "models": {
+                    "glm-5": {"limit": {"context": 202_752}},
+                },
+            },
+        }
+
+        assert lookup_models_dev_context(
+            "alibaba",
+            "glm-5",
+            base_url="https://coding-intl.dashscope.aliyuncs.com/v1",
+        ) == 202_752
+        assert lookup_models_dev_context("alibaba", "glm-5") is None
+        assert lookup_models_dev_context("alibaba-coding-plan", "glm-5") == 202_752
 
 
 

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -134,6 +134,28 @@ class TestLookupModelsDevContext:
         mock_fetch.return_value = SAMPLE_REGISTRY
         assert lookup_models_dev_context("anthropic", "claude-opus-4-6") == 1000000
 
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_zai_coding_route_uses_coding_plan_catalog(self, mock_fetch):
+        mock_fetch.return_value = {
+            "zai": {"models": {}},
+            "zai-coding-plan": {
+                "models": {
+                    "glm-5.3": {"limit": {"context": 1_000_000}},
+                },
+            },
+        }
+
+        assert lookup_models_dev_context(
+            "zai",
+            "glm-5.3",
+            base_url="https://api.z.ai/api/coding/paas/v4",
+        ) == 1_000_000
+        assert lookup_models_dev_context(
+            "zai",
+            "glm-5.3",
+            base_url="https://api.z.ai/api/paas/v4",
+        ) is None
+
 
 
 

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -155,7 +155,7 @@ class TestLookupModelsDevContext:
         assert lookup_models_dev_context(
             "zai",
             "glm-5.2-highspeed",
-            base_url="https://api.z.ai/api/coding/paas/v4/",
+            base_url="https://API.Z.AI:443/api/coding/paas/v4/",
         ) == 1_000_000
         assert lookup_models_dev_context(
             "zai",
@@ -178,7 +178,7 @@ class TestLookupModelsDevContext:
         assert lookup_models_dev_context(
             "zai",
             "glm-5.3",
-            base_url="https://open.bigmodel.cn/api/coding/paas/v4",
+            base_url="https://OPEN.BIGMODEL.CN:443/api/coding/paas/v4/",
         ) == 1_000_000
 
     @patch("agent.models_dev.fetch_models_dev")
@@ -196,7 +196,7 @@ class TestLookupModelsDevContext:
         assert lookup_models_dev_context(
             "alibaba",
             "glm-5",
-            base_url="https://coding-intl.dashscope.aliyuncs.com/v1",
+            base_url="https://CODING-INTL.DASHSCOPE.ALIYUNCS.COM:443/v1/",
         ) == 202_752
         assert lookup_models_dev_context("alibaba", "glm-5") is None
         assert lookup_models_dev_context("alibaba-coding-plan", "glm-5") == 202_752

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -221,6 +221,25 @@ class TestConfigGetUnset:
         reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
         assert "glm-5.3" not in reloaded.get("model_overrides", {}).get("zai", {})
 
+        model_key = "model_overrides.zai.glm-5.3"
+        set_config_value(model_key, '{"context_window": 1000000}')
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["model_overrides"]["zai"]["glm-5.3"] == {
+            "context_window": 1_000_000,
+        }
+
+        capsys.readouterr()
+        config_command(
+            argparse.Namespace(config_command="get", key=model_key, json=True)
+        )
+        assert json.loads(capsys.readouterr().out) == {
+            "context_window": 1_000_000,
+        }
+
+        config_command(argparse.Namespace(config_command="unset", key=model_key))
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert "glm-5.3" not in reloaded.get("model_overrides", {}).get("zai", {})
+
 
 # ---------------------------------------------------------------------------
 # List navigation — regression tests for #17876

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -197,6 +197,30 @@ class TestConfigGetUnset:
         assert reloaded["platforms"]["teams"]["extra"]["tenant_id"] == "tenant"
         assert "Unset platforms.teams.extra.access_token" in capsys.readouterr().out
 
+    def test_model_override_dotted_model_id_round_trips(
+        self, _isolated_hermes_home, capsys
+    ):
+        key = "model_overrides.zai.glm-5.3.context_window"
+        set_config_value(key, "1000000")
+
+        import yaml
+
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["model_overrides"]["zai"]["glm-5.3"] == {
+            "context_window": 1_000_000,
+        }
+        assert "glm-5" not in reloaded["model_overrides"]["zai"]
+
+        capsys.readouterr()
+        config_command(
+            argparse.Namespace(config_command="get", key=key, json=False)
+        )
+        assert capsys.readouterr().out.strip() == "1000000"
+
+        config_command(argparse.Namespace(config_command="unset", key=key))
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert "glm-5.3" not in reloaded.get("model_overrides", {}).get("zai", {})
+
 
 # ---------------------------------------------------------------------------
 # List navigation — regression tests for #17876

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -194,6 +194,50 @@ def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ct
     )
 
 
+@patch("agent.model_metadata.get_model_context_length", return_value=1_000_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_feasibility_inherits_main_context_pin_for_same_runtime(
+    mock_get_client, mock_ctx_len
+):
+    """The default aux runtime must retain the main model's explicit pin."""
+    agent = _make_agent(main_context=1_000_000, threshold_percent=0.50)
+    agent.model = "glm-5.3"
+    agent.provider = "zai"
+    agent.base_url = "https://api.z.ai/api/coding/paas/v4"
+    agent._config_context_length = 1_000_000
+    mock_client = MagicMock()
+    mock_client.base_url = "https://api.z.ai/api/coding/paas/v4/"
+    mock_client.api_key = "zai-test"
+    mock_get_client.return_value = (mock_client, "glm-5.3")
+
+    agent._emit_status = lambda msg: None
+    agent._check_compression_model_feasibility()
+
+    assert mock_ctx_len.call_args.kwargs["config_context_length"] == 1_000_000
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=200_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_feasibility_does_not_inherit_main_pin_for_other_endpoint(
+    mock_get_client, mock_ctx_len
+):
+    """A same-named model on another endpoint needs independent metadata."""
+    agent = _make_agent(main_context=1_000_000, threshold_percent=0.10)
+    agent.model = "glm-5.3"
+    agent.provider = "zai"
+    agent.base_url = "https://api.z.ai/api/coding/paas/v4"
+    agent._config_context_length = 1_000_000
+    mock_client = MagicMock()
+    mock_client.base_url = "https://other.example/v1"
+    mock_client.api_key = "other-test"
+    mock_get_client.return_value = (mock_client, "glm-5.3")
+
+    agent._emit_status = lambda msg: None
+    agent._check_compression_model_feasibility()
+
+    assert mock_ctx_len.call_args.kwargs["config_context_length"] is None
+
+
 
 
 def test_init_feasibility_check_uses_aux_context_override_from_config():

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -206,7 +206,7 @@ def test_feasibility_inherits_main_context_pin_for_same_runtime(
     agent.base_url = "https://api.z.ai/api/coding/paas/v4"
     agent._config_context_length = 1_000_000
     mock_client = MagicMock()
-    mock_client.base_url = "https://api.z.ai/api/coding/paas/v4/"
+    mock_client.base_url = "https://API.Z.AI:443/api/coding/paas/v4/"
     mock_client.api_key = "zai-test"
     mock_get_client.return_value = (mock_client, "glm-5.3")
 

--- a/utils.py
+++ b/utils.py
@@ -865,6 +865,30 @@ def base_url_hostname(base_url: str) -> str:
     return (parsed.hostname or "").lower().rstrip(".")
 
 
+def base_url_identity(base_url: str) -> tuple[str, str, int | None, str] | None:
+    """Return a canonical endpoint identity for exact base-URL comparisons."""
+    raw = (base_url or "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = urlparse(raw if "://" in raw else f"//{raw}")
+        scheme = parsed.scheme.lower()
+        hostname = (parsed.hostname or "").lower().rstrip(".")
+        port = parsed.port
+    except ValueError:
+        return None
+    if not hostname:
+        return None
+    if port is None:
+        port = 443 if scheme == "https" else 80 if scheme == "http" else None
+    path = (parsed.path or "").rstrip("/")
+    if parsed.params:
+        path = f"{path};{parsed.params}"
+    if parsed.query:
+        path = f"{path}?{parsed.query}"
+    return scheme, hostname, port, path
+
+
 # ─── Model Capability Detection ──────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What does this PR do?

Z.AI Coding Plan users can have a 1M-context model such as GLM-5.3 misdetected as the generic 202,752-token GLM fallback. That incorrect auxiliary-model result lowers the live session compression threshold and causes compression far earlier than the configured model window requires. This change resolves the route-specific catalog, preserves an explicit main-model context pin when compression uses the same runtime, and makes dotted model override IDs round-trip through the config CLI.

### Symptom

With `provider: zai`, a Coding Plan base URL, `model: glm-5.3`, and an explicit 1,000,000-token main-model context, the default auxiliary compression path can resolve the inherited model to 202,752 tokens and lower the session threshold accordingly. In addition, `hermes config set model_overrides.zai.glm-5.3.context_window 1000000` reports success but previously wrote nested `glm-5` and `3` keys that never match the model ID.

### Impact

Affected Z.AI Coding Plan sessions compress at roughly one fifth of the intended context window despite an explicit main-model pin. Users relying on the CLI workaround for dotted model IDs receive a silently ineffective override.

### Bug Cause

**Trigger:** `agent/models_dev.py` / `lookup_models_dev_context`, `agent/conversation_compression.py` / `check_compression_model_feasibility`, and `hermes_cli/config.py` / nested config path helpers

**Causal chain:**
1. A Z.AI Coding Plan request uses the Hermes `zai` provider identity with a `/api/coding/` base URL.
2. Metadata lookup searches only the regular `zai` models.dev catalog, while the compression feasibility path omits the main runtime's explicit context pin and the config CLI splits every dot in a model ID.
3. GLM-5.3 falls through to the generic 202,752-token fallback, the session threshold is lowered, and dotted override commands create keys that cannot match the requested model.

**Why it is wrong:** Provider identity alone is insufficient when one provider fronts route-specific products, and an auxiliary runtime that inherits the same model and endpoint must also preserve that runtime's explicit context pin. Model IDs under `model_overrides` are data keys, not arbitrary nested config segments.

**Working sibling / contrast:** Hand-shaped YAML, an explicit auxiliary context pin, or a hardcoded per-model fallback avoids individual symptoms. The fix instead handles the shared route, inheritance, and dotted-key paths so future Coding Plan models do not require the same workaround.

**Ruled out:** The existing GLM-5.3 support PR adds a hardcoded model entry and picker/provider support, but it does not make models.dev lookup route-aware, propagate the same-runtime context pin, or preserve dotted model IDs in config paths.

### Fix

- Pass the active base URL into models.dev metadata lookup and prefer the `zai-coding-plan` catalog for `/api/coding/` routes while retaining the regular catalog as a fallback.
- Reuse the main model's explicit context pin only when auxiliary compression inherits the same model and endpoint.
- Centralize config-key parsing for `model_overrides` so set, get, unset, validation, default lookup, and whole-object paths preserve dotted model IDs.
- Add focused regressions for route-aware lookup, compression feasibility, and dotted override path symmetry.

## Related Issue

Closes #89500

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/models_dev.py` - select route-specific models.dev provider catalogs for Coding Plan endpoints.
- `agent/model_metadata.py` - forward the active base URL to models.dev context lookup.
- `agent/conversation_compression.py` - inherit the explicit main context pin for the same compression runtime.
- `hermes_cli/config.py` - preserve dotted model IDs across nested config operations and validation.
- `tests/agent/`, `tests/run_agent/`, and `tests/hermes_cli/` - cover all three regression paths.

## How to Test

1. Resolve `glm-5.3` for `provider="zai"` with a `/api/coding/` base URL against a cache containing `zai-coding-plan`; confirm the Coding Plan context is selected.
2. Run compression feasibility with the same inherited model and endpoint plus an explicit main context pin; confirm the session threshold is not lowered from a generic fallback.
3. Set, get, and unset `model_overrides.zai.glm-5.3.context_window`; confirm `glm-5.3` remains one mapping key.
4. Automated: 258 focused tests passed on the implementation tip. After the review adjustment to whole-object config paths, the 85-test config suite passed on the final tip.

```bash
scripts/run_tests.sh tests/agent/test_model_metadata.py tests/agent/test_models_dev.py tests/run_agent/test_compression_feasibility.py tests/hermes_cli/test_set_config_value.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A - behavior and CLI syntax are unchanged
- [x] `cli-config.yaml.example` update: N/A - no config keys were added or changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow contract changed
- [x] Cross-platform impact considered: the changes are platform-independent Python logic
- [x] Tool descriptions/schemas update: N/A - no model tool behavior changed

## Screenshots / Logs

N/A - covered by focused regression tests.
