### PR TITLE
feat(desktop): surface profile conversations in Bots

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -4579,7 +4579,7 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
           jsx(ContextMenuSeparator, {}),
           jsx(ContextMenuItem, {
             onSelect: () => openBotSessionsWorkspace(bot),
-            children: 'Sessions'
+            children: 'Conversations'
           }),
           jsx(ContextMenuItem, { onSelect: () => onEdit(bot), children: 'Edit Profile' }),
           !bot.remoteSource
@@ -7273,8 +7273,33 @@ function filterProfileSessions(sessions, query) {
   const rows = Array.isArray(sessions) ? sessions : []
   if (!needle) return rows
   return rows.filter(session =>
-    `${session?.title || ''} ${session?.preview || ''} ${session?.source || ''}`.toLowerCase().includes(needle)
+    `${session?.title || ''} ${session?.preview || ''} ${session?.source || ''} ${sessionSourceLabel(session?.source)}`
+      .toLowerCase()
+      .includes(needle)
   )
+}
+
+const SESSION_SOURCE_LABELS = Object.freeze({
+  desktop: 'Bot Chat',
+  telegram: 'Telegram',
+  whatsapp: 'WhatsApp',
+  signal: 'Signal',
+  discord: 'Discord',
+  slack: 'Slack',
+  kanban: 'Kanban',
+  tool: 'Worker',
+  cron: 'Routine',
+  cli: 'CLI',
+  tui: 'Terminal'
+})
+
+function sessionSourceLabel(source) {
+  const normalized = String(source || '').trim().toLowerCase()
+  if (!normalized) return 'Session'
+  if (SESSION_SOURCE_LABELS[normalized]) return SESSION_SOURCE_LABELS[normalized]
+  return normalized
+    .replace(/[-_]+/g, ' ')
+    .replace(/^./, character => character.toUpperCase())
 }
 
 function useProfileSessions(botName, gatewayGeneration) {
@@ -7283,7 +7308,9 @@ function useProfileSessions(botName, gatewayGeneration) {
     enabled: Boolean(botName),
     // include_hidden: this browser exists precisely to see the profile's own
     // (always-hidden) Bot Mode sessions alongside its regular ones.
-    queryFn: () => host.request('session.list', { profile: botName, limit: PROFILE_SESSION_LIST_LIMIT, include_hidden: true }),
+    // include_internal is inventory-only: it surfaces Kanban/worker transcripts
+    // without copying messages into Bot Chat or triggering another model run.
+    queryFn: () => host.request('session.list', { profile: botName, limit: PROFILE_SESSION_LIST_LIMIT, include_hidden: true, include_internal: true }),
     refetchInterval: 8000,
     staleTime: 4000,
     retry: false
@@ -7312,6 +7339,7 @@ async function openProfileSession(botName, session, gatewayGeneration) {
 }
 
 function ProfileSessionRow({ session, botName, active, gatewayGeneration }) {
+  const sourceLabel = sessionSourceLabel(session.source)
   return jsxs('button', {
     type: 'button',
     'aria-current': active ? 'page' : undefined,
@@ -7322,13 +7350,23 @@ function ProfileSessionRow({ session, botName, active, gatewayGeneration }) {
       active && 'bg-(--ui-row-active-background)'
     ),
     children: [
-      jsx('span', {
-        className: 'truncate text-[0.8125rem] font-medium',
-        children: session.title || 'Untitled session'
+      jsxs('div', {
+        className: 'flex w-full min-w-0 items-center gap-1.5',
+        children: [
+          jsx('span', {
+            className: 'min-w-0 flex-1 truncate text-[0.8125rem] font-medium',
+            children: session.title || 'Untitled session'
+          }),
+          jsx('span', {
+            className:
+              'shrink-0 rounded-sm border border-(--ui-stroke-secondary) px-1 py-px text-[0.6rem] font-medium text-(--ui-text-tertiary)',
+            children: sourceLabel
+          })
+        ]
       }),
       jsx('div', {
         className: 'truncate text-[0.7rem] text-(--ui-text-tertiary)',
-        children: session.preview || session.source || 'No messages yet'
+        children: session.preview || `${sourceLabel} conversation has no messages yet`
       })
     ]
   })
@@ -7355,7 +7393,7 @@ function ProfileSessionsWorkspace({ bot }) {
       }),
       jsx('div', {
         className: 'min-w-0 flex-1 truncate text-sm font-semibold',
-        children: `${displayName(bot, $botMeta.get()[bot.name])} sessions`
+        children: `${displayName(bot, $botMeta.get()[bot.name])} conversations`
       })
     ]
   })
@@ -8737,6 +8775,7 @@ function BotsPane() {
   const gatewayState = useValue(host.state.gateway)
   const gatewayUp = gatewayState === 'open'
   const activeProfile = (useValue(host.state.profile) || 'default').trim() || 'default'
+  const selectedBotName = useValue($selectedBot)
   const [createOpen, setCreateOpen] = useState(false)
   const [groupCreateOpen, setGroupCreateOpen] = useState(false)
   const [editing, setEditing] = useState(null)
@@ -8787,6 +8826,12 @@ function BotsPane() {
 
     return activityOf(b) - activityOf(a)
   })
+  const selectedBot =
+    roster.find(bot => bot.name === selectedBotName) ||
+    roster.find(bot => bot.name === activeProfile) ||
+    roster[0] ||
+    null
+  const selectedMeta = selectedBot ? botRosterMeta(selectedBot, allMeta) : null
   const activeSourceRoster = roster.filter(bot => !bot.remoteSource)
   // Hidden bots (right-click → Hide Bot) drop out of the roster list unless
   // the header eye toggle reveals them. Display-only: every other consumer
@@ -8861,6 +8906,19 @@ function BotsPane() {
           jsxs('div', {
             className: 'flex items-center gap-0.5',
             children: [
+              selectedBot
+                ? jsx(Tip, {
+                    label: `Browse ${displayName(selectedBot, selectedMeta)} conversations`,
+                    children: jsx('button', {
+                      type: 'button',
+                      'aria-label': `Browse ${displayName(selectedBot, selectedMeta)} conversations`,
+                      className:
+                        'flex size-6 items-center justify-center rounded-md text-(--ui-text-tertiary) transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground',
+                      onClick: () => openBotSessionsWorkspace(selectedBot),
+                      children: jsx(Codicon, { name: 'comment-discussion' })
+                    })
+                  })
+                : null,
               jsx(Tip, {
                 label: activityToasts ? 'Activity toasts on — click to silence' : 'Activity toasts off — click to enable',
                 children: jsx('button', {

--- a/apps/desktop/src/plugins/hermes-bots/tests/hide-bot-chats.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/hide-bot-chats.test.mjs
@@ -140,9 +140,9 @@ test('hideOwnedBotSessions chains the ownership sweep and survives its absence o
   assert.match(source, /return Promise\.all\(\[known, sweepBotProfileSessions\(\)\.catch\(\(\) => undefined\)\]\)/)
 })
 
-test('the Bots session browser lists with include_hidden', () => {
-  // The one session.list consumer that must see the always-hidden rows.
-  // (Canonical-chat recovery now goes through profiles.list
-  // preferred_session_ids, whose resolver already sees hidden rows.)
-  assert.match(source, /session\.list', \{ profile: botName, limit: PROFILE_SESSION_LIST_LIMIT, include_hidden: true \}/)
+test('the Bots conversation browser includes hidden and internal work transcripts', () => {
+  // This profile-scoped browser is the one session.list consumer that sees both
+  // the always-hidden canonical chat and Kanban/worker transcripts. Inventory
+  // remains read-only until the user explicitly opens a row.
+  assert.match(source, /session\.list', \{ profile: botName, limit: PROFILE_SESSION_LIST_LIMIT, include_hidden: true, include_internal: true \}/)
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/session-workspace.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/session-workspace.test.mjs
@@ -52,6 +52,7 @@ function load({ profile = 'ops', request, openSession } = {}) {
       openBotSessionsWorkspace,
       openProfileSession,
       filterProfileSessions,
+      sessionSourceLabel,
       $botSessionsWorkspace,
       $botSelectedSessions,
       $sessionsGatewayGeneration,
@@ -82,8 +83,19 @@ test('sessions workspace: filtering searches title, preview, and source without 
     { id: 'docs', title: 'Write docs', preview: 'guide', source: 'desktop' }
   ]
   assert.deepEqual(plain(filterProfileSessions(rows, '').map(row => row.id)), ['named', 'deploy', 'docs'])
+  assert.deepEqual(plain(filterProfileSessions(rows, 'deploy').map(row => row.id)), ['deploy'])
   assert.deepEqual(plain(filterProfileSessions(rows, 'ship').map(row => row.id)), ['deploy'])
   assert.deepEqual(plain(filterProfileSessions(rows, 'DESKTOP').map(row => row.id)), ['docs'])
+  assert.deepEqual(plain(filterProfileSessions(rows, 'bot chat').map(row => row.id)), ['docs'])
+})
+
+test('sessions workspace: source labels distinguish chat surfaces from background work', () => {
+  const { sessionSourceLabel } = load().__sessions
+  assert.equal(sessionSourceLabel('telegram'), 'Telegram')
+  assert.equal(sessionSourceLabel('desktop'), 'Bot Chat')
+  assert.equal(sessionSourceLabel('kanban'), 'Kanban')
+  assert.equal(sessionSourceLabel('tool'), 'Worker')
+  assert.equal(sessionSourceLabel('custom-source'), 'Custom source')
 })
 
 test('sessions workspace: opening a stored row uses profile-aware navigation and records selection', async () => {
@@ -138,13 +150,13 @@ test('source contract: bot rows and Active now activate the owner before canonic
   assert.match(pluginSource, /host\.request\('profiles\.list', \{\}\)/)
   assert.match(pluginSource, /const open = async \(\) => \{[\s\S]*await prepareBotSource\(bot, pinnedChat\)[\s\S]*openBotCanonicalChat\(bot\.name, pinnedChat, previewSession\)/)
   assert.match(pluginSource, /onOpen: bot => \{[\s\S]*await prepareBotSource\(bot, pinnedChat\)[\s\S]*bot\.preferred_session \|\| bot\.last_session/)
-  assert.match(pluginSource, /openBotSessionsWorkspace\(bot\)[\s\S]*children: 'Sessions'/)
+  assert.match(pluginSource, /openBotSessionsWorkspace\(bot\)[\s\S]*children: 'Conversations'/)
 })
 
 test('source contract: workspaces disclose the bounded recent-session inventory', () => {
   assert.match(pluginSource, /queryKey: \[ID, 'profile-sessions', botName, gatewayGeneration\]/)
   assert.match(pluginSource, /enabled: Boolean\(botName\)/)
-  assert.match(pluginSource, /host\.request\('session\.list', \{ profile: botName, limit: PROFILE_SESSION_LIST_LIMIT, include_hidden: true \}\)/)
+  assert.match(pluginSource, /host\.request\('session\.list', \{ profile: botName, limit: PROFILE_SESSION_LIST_LIMIT, include_hidden: true, include_internal: true \}\)/)
   assert.match(pluginSource, /Showing the \$\{PROFILE_SESSION_LIST_LIMIT\} most recent sessions\./)
   assert.match(pluginSource, /No matching sessions in the \$\{PROFILE_SESSION_LIST_LIMIT\} most recent\./)
   assert.doesNotMatch(pluginSource, /children: 'Activate profile'/)
@@ -154,4 +166,8 @@ test('source contract: workspaces disclose the bounded recent-session inventory'
 test('source contract: session controls expose filter and selection state to assistive technology', () => {
   assert.match(pluginSource, /'aria-label': 'Filter sessions'/)
   assert.match(pluginSource, /'aria-current': active \? 'page' : undefined/)
+  assert.match(pluginSource, /sessionSourceLabel\(session\.source\)/)
+  assert.match(pluginSource, /Browse \$\{displayName\(selectedBot, selectedMeta\)\} conversations/)
+  assert.match(pluginSource, /const selectedBotName = useValue\(\$selectedBot\)/)
+  assert.match(pluginSource, /const selectedBot =\s*\n\s*roster\.find/)
 })

--- a/tests/gateway/test_session_list_allowed_sources.py
+++ b/tests/gateway/test_session_list_allowed_sources.py
@@ -28,10 +28,12 @@ class _StubDB:
         return list(self.rows)
 
 
-def _call(limit: int | None = None):
+def _call(limit: int | None = None, *, include_internal: bool = False):
     params: dict = {}
     if limit is not None:
         params["limit"] = limit
+    if include_internal:
+        params["include_internal"] = True
     return server.handle_request({
         "id": "1",
         "method": "session.list",
@@ -67,5 +69,24 @@ def test_session_list_surfaces_all_user_facing_sources(monkeypatch):
 
     # Only internal sub-agent runs stay hidden.
     assert "tool-1" not in ids
+
+
+def test_session_list_can_include_internal_work_conversations(monkeypatch):
+    """Profile conversation browsers may opt into kanban/worker transcripts."""
+    rows = [
+        {"id": "tg-1", "source": "telegram", "started_at": 9},
+        {"id": "kanban-1", "source": "kanban", "started_at": 8},
+        {"id": "tool-1", "source": "tool", "started_at": 7},
+    ]
+    db = _StubDB(rows)
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+
+    resp = _call(limit=10, include_internal=True)
+
+    assert [s["id"] for s in resp["result"]["sessions"]] == [
+        "tg-1",
+        "kanban-1",
+        "tool-1",
+    ]
 
 

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -174,8 +174,11 @@ def _(rid, params: dict) -> dict:
             # sources (``tool`` sub-agent runs and ``kanban`` dispatcher
             # workers) rather than allow-listing a fixed set of platform names
             # that goes stale whenever a new platform is added or a user names
-            # their own source.
-            deny = frozenset({"kanban", "tool"})
+            # their own source. Profile-specific conversation browsers may
+            # explicitly opt into internal work transcripts; merely listing
+            # them is read-only and does not start an agent inference.
+            include_internal = is_truthy_value(params.get("include_internal", False))
+            deny = frozenset() if include_internal else frozenset({"kanban", "tool"})
 
             limit = int(params.get("limit", 200) or 200)
             # ``include_hidden``: surfaces that OWN hidden sessions (the Bots


### PR DESCRIPTION
## Summary
- add a visible per-bot conversation browser in the Bots pane
- include source-labelled Telegram, Bot Chat, Kanban/tool, routine, and CLI sessions without duplicating messages
- add an opt-in `include_internal` flag to `session.list` so normal session lists retain their existing filtering

## Safety
- browsing is inventory-only and does not invoke the model
- existing canonical Bot Chat behavior is unchanged

## Verification
- desktop plugin suite: 271 passed
- TypeScript typecheck: passed
- ESLint: 0 errors
- gateway session-list tests: passed
- packaged macOS app QA: Bots pane rendered; Codex profile displayed Telegram, Bot Chat, Kanban, Worker, and CLI sessions