### PR TITLE
fix(state): project the tip's usage/cost totals in session-list rows

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -9005,6 +9005,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     "id", "ended_at", "end_reason", "message_count",
                     "tool_call_count", "title", "last_active", "preview",
                     "model", "system_prompt", "cwd", "git_branch", "git_repo_root",
+                    # Usage/cost rollups are per-session-row counters. Without
+                    # these keys the projected row kept the ROOT's totals
+                    # under the tip's title/id — the sidebar showed the
+                    # oldest segment's spend for the newest segment (#89519).
+                    "input_tokens", "output_tokens", "cache_read_tokens",
+                    "cache_write_tokens", "reasoning_tokens",
+                    "estimated_cost_usd", "actual_cost_usd",
                 ):
                     if key in tip_row:
                         merged[key] = tip_row[key]

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2129,6 +2129,35 @@ class TestListSessionsRich:
         assert [session["id"] for session in sessions] == ["lane_tip"]
         assert sessions[0]["_lineage_root_id"] == "lane_root"
 
+    def test_projection_carries_tip_usage_and_cost_totals(self, db):
+        """A projected row must carry the TIP's usage/cost rollups, not the
+        root's (#89519): the sidebar renders the tip's title/id, and showing
+        the oldest segment's spend for the newest segment misattributes
+        cost. The root's started_at (sort order) is still preserved."""
+        db.create_session("root", "cli")
+        db.set_session_title("root", "Old conversation")
+        db.end_session("root", "compression")
+        db.create_session("tip", "cli", parent_session_id="root")
+        db.set_session_title("tip", "Newest segment")
+        # Distinct per-segment usage: root spent big early, tip spent less.
+        db._conn.execute(
+            "UPDATE sessions SET input_tokens=339123, output_tokens=1000,"
+            " estimated_cost_usd=0.1652 WHERE id='root'"
+        )
+        db._conn.execute(
+            "UPDATE sessions SET input_tokens=514280, output_tokens=9000,"
+            " estimated_cost_usd=0.3025 WHERE id='tip'"
+        )
+        db._conn.commit()
+
+        sessions = db.list_sessions_rich()
+
+        assert sessions[0]["id"] == "tip"
+        assert sessions[0]["_lineage_root_id"] == "root"
+        assert sessions[0]["input_tokens"] == 514280
+        assert sessions[0]["output_tokens"] == 9000
+        assert sessions[0]["estimated_cost_usd"] == pytest.approx(0.3025)
+
     @pytest.mark.parametrize(
         "end_reason",
         [


### PR DESCRIPTION
## What does this PR do?

`list_sessions_rich`'s compression-tip projection replaces a root row's identity and activity fields (id, title, message_count, last_active, preview, …) with its live tip's values — one logical conversation, one list entry. But the usage and cost rollups were left untouched, so the projected row rendered the **newest segment's title and id with the oldest segment's token counts and spend**. On the issue's five-link chain the sidebar attributed the root's $0.165 / 339k input tokens to the tip row titled after the newest conversation (#89519).

This PR adds the per-session-row usage/cost columns (`input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_write_tokens`, `reasoning_tokens`, `estimated_cost_usd`, `actual_cost_usd`) to the projection merge, next to the other surfaced fields. The batch SELECT already selects every `sessions` column, so this is purely naming the keys that were previously left stale.

Unchanged by design:
- The root's `started_at` is still preserved (chronological ordering by original conversation start).
- `compact_rows` fetches still omit the prompt blob — usage columns are plain `sessions` columns present in both shapes.
- Segments' totals remain per-row counters; the projection shows the tip's own totals, matching the identity it already shows.

## Related Issue

Fixes #89519

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state.py` — the compression-tip projection merge carries the tip's usage/cost columns, with a comment stating the misattribution this prevents; the projection-block docstring above already enumerates the surfaced-field contract.
- `tests/test_hermes_state.py` — `test_projection_carries_tip_usage_and_cost_totals`: a root/tip pair with distinct per-segment usage (the issue's numbers); the projected row carries the tip's token counts and cost while `_lineage_root_id` still names the root (fails on main: the root's totals render under the tip's row).

## How to Test

```bash
python -m pytest tests/test_hermes_state.py -q
# Observed result: 239 passed, 1 failed
# (the failure is TestFTS5Search::test_search_projection_skips_context_enrichment_queries,
#  which fails identically on unmodified main — an FTS context-enrichment test
#  unrelated to this change; verified by stashing the source diff)

python -m pytest tests/hermes_cli/test_session_listing.py tests/hermes_cli/test_session_browse.py -q
# Observed result: 14 passed
```

Fail-on-main check: with the source change stashed, the new usage-projection test fails (the root's `input_tokens`/`estimated_cost_usd` appear under the tip's row).

Manual repro from the issue: compress a long conversation several times, check the Desktop sidebar's cost/token columns for the projected row — on main they show the root's totals; with this change they show the tip's.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments explain intent (why usage rollups must follow the identity they render under)
- [x] Corresponding changes documented via comments
- [x] Tests added and passing (1 new; state + listing suites green except the pre-existing unrelated failure)
- [x] Single root cause, no unrelated changes
