### PR TITLE
feat(proxy): add OpenAI Codex OAuth broker

### DIFF
--- a/hermes_cli/proxy/adapters/__init__.py
+++ b/hermes_cli/proxy/adapters/__init__.py
@@ -9,12 +9,14 @@ from typing import Dict, Type
 
 from hermes_cli.proxy.adapters.base import UpstreamAdapter
 from hermes_cli.proxy.adapters.nous_portal import NousPortalAdapter
+from hermes_cli.proxy.adapters.openai_codex import OpenAICodexAdapter
 from hermes_cli.proxy.adapters.xai import XAIGrokAdapter
 
 # Registry of available adapter classes keyed by provider name as used on
 # the ``hermes proxy start --provider <name>`` CLI flag.
 ADAPTERS: Dict[str, Type[UpstreamAdapter]] = {
     "nous": NousPortalAdapter,
+    "openai-codex": OpenAICodexAdapter,
     "xai": XAIGrokAdapter,
 }
 

--- a/hermes_cli/proxy/adapters/openai_codex.py
+++ b/hermes_cli/proxy/adapters/openai_codex.py
@@ -1,0 +1,129 @@
+"""OpenAI Codex adapter for the Hermes local OAuth proxy.
+
+The adapter resolves Hermes-managed Codex OAuth state only inside the Hermes
+process. Callers receive an ordinary OpenAI-compatible proxy response and
+never read, persist, or receive the upstream OAuth credential.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, FrozenSet, Optional
+
+from agent.credential_pool import load_pool
+from hermes_cli.auth import (
+    get_provider_auth_state,
+    resolve_codex_runtime_credentials,
+)
+from hermes_cli.proxy.adapters.base import UpstreamAdapter, UpstreamCredential
+
+logger = logging.getLogger(__name__)
+
+# The local broker intentionally forwards only the Responses endpoint. This is
+# the narrow contract used by the Codex adapter and avoids becoming a generic
+# bearer relay for unrelated upstream paths.
+_ALLOWED_PATHS: FrozenSet[str] = frozenset({"/responses"})
+_ALLOWED_METHODS: FrozenSet[str] = frozenset({"POST"})
+
+
+class OpenAICodexAdapter(UpstreamAdapter):
+    """Proxy upstream for Hermes-managed OpenAI Codex OAuth."""
+
+    auth_hint = "hermes auth add openai-codex"
+
+    def __init__(self) -> None:
+        # The auth resolver serializes cross-process refresh/persistence. This
+        # lock prevents concurrent proxy requests in this process from making
+        # duplicate resolver calls around the same credential rotation.
+        self._lock = threading.Lock()
+
+    @property
+    def name(self) -> str:
+        return "openai-codex"
+
+    @property
+    def display_name(self) -> str:
+        return "OpenAI Codex OAuth"
+
+    @property
+    def allowed_paths(self) -> FrozenSet[str]:
+        return _ALLOWED_PATHS
+
+    @property
+    def allowed_methods(self) -> FrozenSet[str]:
+        return _ALLOWED_METHODS
+
+    def is_authenticated(self) -> bool:
+        """Check local Hermes state without resolving or refreshing a token."""
+        try:
+            pool = load_pool("openai-codex")
+            if pool is not None and pool.has_credentials():
+                return True
+        except Exception:
+            pass
+        try:
+            state = get_provider_auth_state("openai-codex")
+        except Exception:
+            return False
+        if not isinstance(state, dict):
+            return False
+        tokens = state.get("tokens")
+        if not isinstance(tokens, dict):
+            return False
+        return self._has_nonempty_string(tokens.get("access_token")) and self._has_nonempty_string(
+            tokens.get("refresh_token")
+        )
+
+    def get_credential(self) -> UpstreamCredential:
+        return self._get_credential()
+
+    def get_retry_credential(
+        self,
+        *,
+        failed_credential: UpstreamCredential,
+        status_code: int,
+    ) -> Optional[UpstreamCredential]:
+        if status_code != 401:
+            return None
+        refreshed = self._get_credential(force_refresh=True)
+        if refreshed.bearer == failed_credential.bearer:
+            return None
+        logger.info("proxy: OpenAI Codex upstream rejected bearer; retried after Hermes refresh")
+        return refreshed
+
+    def _get_credential(self, *, force_refresh: bool = False) -> UpstreamCredential:
+        with self._lock:
+            try:
+                resolved = resolve_codex_runtime_credentials(force_refresh=force_refresh)
+            except Exception as exc:
+                # Upstream/provider failures can carry arbitrary response text;
+                # neither the proxy client nor its logs should expose it.
+                logger.info(
+                    "proxy: OpenAI Codex credential resolution failed (%s)",
+                    type(exc).__name__,
+                )
+                raise RuntimeError(
+                    "OpenAI Codex authentication is unavailable. "
+                    "Run `hermes auth add openai-codex` to sign in."
+                ) from None
+
+            bearer = resolved.get("api_key") if isinstance(resolved, dict) else None
+            base_url = resolved.get("base_url") if isinstance(resolved, dict) else None
+            if not self._has_nonempty_string(bearer) or not self._has_nonempty_string(base_url):
+                raise RuntimeError(
+                    "OpenAI Codex authentication is unavailable. "
+                    "Run `hermes auth add openai-codex` to sign in."
+                )
+            assert isinstance(bearer, str) and isinstance(base_url, str)
+            return UpstreamCredential(
+                bearer=bearer.strip(),
+                base_url=base_url.strip().rstrip("/"),
+            )
+
+    @staticmethod
+    def _has_nonempty_string(value: Any) -> bool:
+        return isinstance(value, str) and bool(value.strip())
+
+
+__all__ = ["OpenAICodexAdapter"]

--- a/hermes_cli/proxy/cli.py
+++ b/hermes_cli/proxy/cli.py
@@ -116,12 +116,13 @@ def cmd_proxy(args: Any) -> int:
     if sub in {"providers", "list"}:
         return cmd_proxy_list_providers(args)
     # No subcommand → print short help.
+    available = "|".join(sorted(ADAPTERS)) or "provider"
     print(
         "hermes proxy — local OpenAI-compatible proxy that attaches your\n"
         "OAuth-authenticated provider credentials to outbound requests.\n"
         "\n"
         "Subcommands:\n"
-        "  hermes proxy start [--provider nous|xai] [--host 127.0.0.1] [--port 8645]\n"
+        f"  hermes proxy start [--provider {available}] [--host 127.0.0.1] [--port 8645]\n"
         "      Run the proxy in the foreground.\n"
         "  hermes proxy status\n"
         "      Show which upstream adapters are ready.\n"

--- a/hermes_cli/proxy/server.py
+++ b/hermes_cli/proxy/server.py
@@ -121,6 +121,14 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
                 code="path_not_allowed",
             )
 
+        allowed_methods = getattr(adapter, "allowed_methods", None)
+        if allowed_methods is not None and request.method not in allowed_methods:
+            return _json_error(
+                405,
+                "This proxy does not forward that HTTP method for the requested path.",
+                code="method_not_allowed",
+            )
+
         try:
             cred = adapter.get_credential()
         except Exception as exc:

--- a/hermes_cli/subcommands/gateway.py
+++ b/hermes_cli/subcommands/gateway.py
@@ -331,7 +331,7 @@ def build_gateway_parser(
     proxy_start.add_argument(
         "--provider",
         default="nous",
-        help="Upstream provider: nous or xai (default: nous). See `hermes proxy providers`.",
+        help="Upstream provider (default: nous). See `hermes proxy providers`.",
     )
     proxy_start.add_argument(
         "--host",

--- a/scripts/run_codex_broker_tests.sh
+++ b/scripts/run_codex_broker_tests.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Targeted, serial validation for the Hermes-managed OpenAI Codex broker.
+#
+# This is intentionally not the full Hermes suite: it exercises the changed
+# proxy adapter, private-auth boundary, local HTTP forwarding, refresh retry,
+# and method/path restrictions without starting unrelated optional providers.
+# Keep it serial on a shared host so validation cannot starve a live gateway.
+set -euo pipefail
+
+if (($# != 0)); then
+  echo "usage: scripts/run_codex_broker_tests.sh" >&2
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/run_tests.sh" -j 1 tests/hermes_cli/test_proxy.py

--- a/tests/hermes_cli/test_proxy.py
+++ b/tests/hermes_cli/test_proxy.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import threading
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Dict
 from unittest.mock import MagicMock, patch
 
@@ -14,7 +15,9 @@ import pytest
 from hermes_cli.proxy.adapters import ADAPTERS, get_adapter
 from hermes_cli.proxy.adapters.base import UpstreamAdapter, UpstreamCredential
 from hermes_cli.proxy.adapters.nous_portal import NousPortalAdapter
+from hermes_cli.proxy.adapters.openai_codex import OpenAICodexAdapter
 from hermes_cli.proxy.adapters.xai import XAIGrokAdapter
+from hermes_cli.proxy.cli import cmd_proxy
 
 
 # ---------------------------------------------------------------------------
@@ -26,6 +29,102 @@ from hermes_cli.proxy.adapters.xai import XAIGrokAdapter
 
 
 
+
+
+# ---------------------------------------------------------------------------
+# OpenAI Codex adapter
+# ---------------------------------------------------------------------------
+
+
+def test_codex_adapter_is_registered_for_proxy_use():
+    assert ADAPTERS["openai-codex"] is OpenAICodexAdapter
+    adapter = get_adapter("openai-codex")
+    assert isinstance(adapter, OpenAICodexAdapter)
+    assert adapter.allowed_paths == frozenset({"/responses"})
+    assert adapter.allowed_methods == frozenset({"POST"})
+
+
+def test_codex_proxy_is_discoverable_from_cli_help(capsys):
+    assert cmd_proxy(SimpleNamespace(proxy_command=None)) == 0
+    assert "openai-codex" in capsys.readouterr().err
+
+
+def test_codex_adapter_forwards_responses_via_hermes_runtime_auth(monkeypatch):
+    """The proxy may resolve Hermes auth, but returns only a live upstream bearer."""
+    adapter = OpenAICodexAdapter()
+    monkeypatch.setattr(
+        "hermes_cli.proxy.adapters.openai_codex.get_provider_auth_state",
+        lambda provider: {
+            "tokens": {"access_token": "placeholder-access", "refresh_token": "placeholder-refresh"}
+        }
+        if provider == "openai-codex" else None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.proxy.adapters.openai_codex.resolve_codex_runtime_credentials",
+        lambda **kwargs: {
+            "api_key": "opaque-test-bearer",
+            "base_url": "https://example.invalid/codex",
+        },
+    )
+
+    assert adapter.is_authenticated()
+    assert adapter.allowed_paths == frozenset({"/responses"})
+    credential = adapter.get_credential()
+    assert credential.base_url == "https://example.invalid/codex"
+    assert credential.bearer == "opaque-test-bearer"
+
+
+def test_codex_adapter_detects_pool_only_hermes_credentials(monkeypatch):
+    class Pool:
+        def has_credentials(self):
+            return True
+
+    monkeypatch.setattr(
+        "hermes_cli.proxy.adapters.openai_codex.load_pool",
+        lambda provider: Pool() if provider == "openai-codex" else None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.proxy.adapters.openai_codex.get_provider_auth_state",
+        lambda provider: None,
+    )
+
+    assert OpenAICodexAdapter().is_authenticated()
+
+
+def test_codex_adapter_forces_a_hermes_refresh_after_upstream_401(monkeypatch):
+    adapter = OpenAICodexAdapter()
+    calls: list[bool] = []
+
+    def resolve(**kwargs):
+        calls.append(bool(kwargs.get("force_refresh")))
+        return {
+            "api_key": "after-refresh" if kwargs.get("force_refresh") else "before-refresh",
+            "base_url": "https://example.invalid/codex",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.proxy.adapters.openai_codex.resolve_codex_runtime_credentials",
+        resolve,
+    )
+
+    failed = adapter.get_credential()
+    retried = adapter.get_retry_credential(failed_credential=failed, status_code=401)
+    assert retried is not None
+    assert retried.bearer == "after-refresh"
+    assert calls == [False, True]
+
+
+def test_codex_adapter_returns_value_free_auth_errors(monkeypatch):
+    """Broker clients must never receive an upstream-auth failure body."""
+    adapter = OpenAICodexAdapter()
+    monkeypatch.setattr(
+        "hermes_cli.proxy.adapters.openai_codex.resolve_codex_runtime_credentials",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("untrusted upstream detail")),
+    )
+
+    with pytest.raises(RuntimeError, match="OpenAI Codex authentication is unavailable") as raised:
+        adapter.get_credential()
+    assert "untrusted upstream detail" not in str(raised.value)
 
 
 # ---------------------------------------------------------------------------
@@ -313,6 +412,7 @@ def _build_fake_upstream(captured: Dict[str, Any]) -> "web.Application":
 
     app = web.Application()
     app.router.add_route("*", "/v1/chat/completions", echo)
+    app.router.add_route("*", "/v1/responses", echo)
     app.router.add_route("*", "/v1/embeddings", echo)
     app.router.add_route("*", "/v1/sse", sse)
     return app
@@ -358,6 +458,44 @@ def test_server_strips_client_auth_header():
                     await resp.read()
             assert captured["requests"][0]["auth"] == "Bearer ours"
             assert "SHOULD_NOT_LEAK" not in captured["requests"][0]["auth"]
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_codex_proxy_forwards_responses_without_exposing_hermes_auth(monkeypatch):
+    """A local client gets a response while only the proxy sees the upstream bearer."""
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        monkeypatch.setattr(
+            "hermes_cli.proxy.adapters.openai_codex.resolve_codex_runtime_credentials",
+            lambda **kwargs: {
+                "api_key": "opaque-hermes-bearer",
+                "base_url": f"{upstream_base}/v1",
+            },
+        )
+        proxy_runner, proxy_base = await _start_runner(create_app(OpenAICodexAdapter()))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/responses",
+                    json={"model": "test", "input": "hello"},
+                    headers={"Authorization": "Bearer local-client-placeholder"},
+                ) as response:
+                    assert response.status == 200
+                    await response.read()
+                async with session.get(f"{proxy_base}/v1/responses") as response:
+                    assert response.status == 405
+                    await response.read()
+            assert captured["requests"] == [{
+                "method": "POST",
+                "path": "/v1/responses",
+                "auth": "Bearer opaque-hermes-bearer",
+                "body": '{"model": "test", "input": "hello"}',
+            }]
         finally:
             await proxy_runner.cleanup()
             await upstream_runner.cleanup()

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -524,11 +524,11 @@ Common flags for migration subcommands:
 hermes proxy <subcommand>
 ```
 
-Run a local OpenAI-compatible HTTP server that forwards requests to an OAuth-authenticated upstream provider (e.g. Nous Portal, xAI). External apps can point at the proxy with any bearer token; the proxy attaches your real OAuth credentials on the way out. See [Subscription Proxy](../user-guide/features/subscription-proxy.md) for the full guide.
+Run a local OpenAI-compatible HTTP server that forwards requests to an OAuth-authenticated upstream provider (e.g. Nous Portal, OpenAI Codex, xAI). External apps can point at the proxy with any bearer token; the proxy attaches your real OAuth credentials on the way out. See [Subscription Proxy](../user-guide/features/subscription-proxy.md) for the full guide.
 
 | Subcommand | Description |
 |------------|-------------|
-| `start` | Run the proxy in the foreground. Flags: `--provider <nous\|xai>` (default `nous`), `--host <addr>` (default `127.0.0.1`; use `0.0.0.0` to expose on LAN), `--port <int>` (default `8645`). |
+| `start` | Run the proxy in the foreground. Flags: `--provider <nous\|openai-codex\|xai>` (default `nous`), `--host <addr>` (default `127.0.0.1`; use `0.0.0.0` to expose on LAN), `--port <int>` (default `8645`). |
 | `status` | Show which proxy upstreams are ready (credentials present, OAuth valid). |
 | `providers` | List available proxy upstream providers. |
 

--- a/website/docs/user-guide/features/subscription-proxy.md
+++ b/website/docs/user-guide/features/subscription-proxy.md
@@ -72,8 +72,7 @@ automatically when the bearer approaches expiry.
 hermes proxy providers
 ```
 
-Currently shipped: `nous` (Nous Portal) and `xai` (xAI / Grok). More
-OAuth providers can be added by implementing the `UpstreamAdapter`
+Currently shipped: `nous` (Nous Portal), `openai-codex` (OpenAI Codex), and `xai` (xAI / Grok). More OAuth providers can be added by implementing the `UpstreamAdapter`
 interface in `hermes_cli/proxy/adapters/`.
 
 ## Check status
@@ -93,6 +92,26 @@ If you see `not logged in`, run `hermes portal`. If you see
 happens if you signed out from the Portal web UI) — just re-run
 `hermes portal`.
 
+## OpenAI Codex broker
+
+Authenticate Hermes once, then start the Codex upstream explicitly:
+
+```bash
+hermes auth add openai-codex
+hermes proxy start --provider openai-codex
+```
+
+The Codex adapter permits only `POST /v1/responses`. It resolves and refreshes
+Hermes-managed OAuth credentials only inside the Hermes process, then forwards
+the Responses request upstream. A client receives the response stream but never
+receives a Hermes access token, refresh token, or credential-store value.
+
+For a local DeepSeek Harness client, use the default proxy endpoint:
+
+```text
+http://127.0.0.1:8645/v1/responses
+```
+
 ## Allowed paths
 
 The proxy only forwards paths the upstream actually serves. For Nous
@@ -108,6 +127,12 @@ Portal:
 Other paths (`/v1/images/generations`, `/v1/audio/speech`, etc.) return
 404 with a clear error pointing at the allowed paths. This keeps stray
 clients from leaking weird requests to the upstream.
+
+For the OpenAI Codex adapter, the only permitted path is:
+
+| Path | Purpose |
+|------|---------|
+| `/v1/responses` | Codex Responses API (streaming + non-streaming) |
 
 ## Configuring OpenViking to use Portal
 


### PR DESCRIPTION
## What does this PR do?

Adds a narrow local `openai-codex` OAuth-proxy adapter. Hermes remains the sole owner of the Codex OAuth session and upstream bearer; local clients receive ordinary Responses API results and cannot read Hermes credential storage.

## Related Issue

No issue.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Registers `openai-codex` with the existing proxy adapter registry.
- Restricts the adapter to `POST /v1/responses` and rejects unsupported paths/methods before credential resolution.
- Resolves and refreshes Codex credentials only through Hermes’s existing runtime resolver; retries once after an upstream 401 only when the credential changes.
- Returns generic, value-free authentication failures to local callers.
- Adds serial focused validation at `scripts/run_codex_broker_tests.sh`.
- Documents the provider and loopback Responses endpoint.

## How to Test

1. Run `scripts/run_codex_broker_tests.sh`.
2. Verify the suite reports one worker and all 11 proxy tests pass.
3. With an already authenticated Codex account, start `hermes proxy start --provider openai-codex` and use only `POST /v1/responses` through the loopback proxy.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs before opening this PR.
- [x] My PR contains only changes related to this feature.
- [ ] I've run `pytest tests/ -q` and all tests pass. The clean WSL managed environment lacks several optional integrations; the scoped serial proxy gate passed. CI remains the authoritative full-matrix gate.
- [x] I've added tests for my changes.
- [x] I've tested on Linux/WSL.

### Documentation & Housekeeping

- [x] I've updated relevant documentation and docstrings.
- [x] No config keys were added.
- [x] No contributor workflow architecture was changed.
- [x] Cross-platform impact is limited to the existing Python/aiohttp proxy implementation.
- [x] No model-tool schema changed.
