### PR TITLE
feat(desktop): move a session back to Home from its row menu

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -31,7 +31,7 @@ import { PROFILE_SWATCHES } from '@/lib/profile-color'
 import { exportSession } from '@/lib/session-export'
 import { activeGateway } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
-import { $projectTree, moveSessionToProject, projectIdForCwd, projectRootCwd } from '@/store/projects'
+import { $projectTree, detachSessionFromProject, moveSessionToProject, projectIdForCwd, projectRootCwd } from '@/store/projects'
 import {
   $activeSessionId,
   $connection,
@@ -148,7 +148,9 @@ function SessionColorSwatches({ sessionId }: { sessionId: string }) {
 // SessionColorSwatches). Re-homes the session's workspace at the target
 // project's root — the fix for a chat created in the wrong folder. The current
 // owner and folderless projects (the Home bucket) are excluded: there is
-// nothing to move into.
+// nothing to move into. A session that DOES have an owner also gets the way
+// back out: "Home" clears its workspace so the longest-prefix matcher drops it
+// into the "(no project)" bucket (#75539's other half).
 function MoveToProjectItems({ kit, sessionId, profile }: { kit: MenuKit; sessionId: string; profile?: string }) {
   const { t } = useI18n()
   const p = t.sidebar.projects
@@ -157,13 +159,29 @@ function MoveToProjectItems({ kit, sessionId, profile }: { kit: MenuKit; session
   const cwd = session?.cwd?.trim() || ''
   const currentProjectId = cwd ? projectIdForCwd(cwd) : null
   const targets = tree.filter(node => node.id !== currentProjectId && !node.isNoProject && projectRootCwd(node))
+  const canDetach = Boolean(currentProjectId)
 
-  if (targets.length === 0) {
+  if (targets.length === 0 && !canDetach) {
     return <kit.Item disabled>{p.moveNoProjects}</kit.Item>
   }
 
   return (
     <>
+      {canDetach && (
+        <>
+          <kit.Item
+            onSelect={() => {
+              triggerHaptic('selection')
+              detachSessionFromProject(sessionId, profile)
+                .then(() => notify({ durationMs: 2_000, kind: 'success', message: p.movedTo(p.home) }))
+                .catch(err => notifyError(err, p.moveFailed))
+            }}
+          >
+            {p.home}
+          </kit.Item>
+          {targets.length > 0 && <kit.Separator />}
+        </>
+      )}
       {targets.map(node => (
         <kit.Item
           key={node.id}

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -18,6 +18,7 @@ import {
   ALL_PROJECTS,
   beginSessionMutation,
   createProject,
+  detachSessionFromProject,
   endSessionMutation,
   enterProject,
   exitProjectScope,
@@ -171,6 +172,79 @@ describe('projects RPC profile forwarding', () => {
 
     expect(request).not.toHaveBeenCalled()
     setShowAllProfiles(false)
+  })
+})
+
+describe('detachSessionFromProject (Move to Home)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    $sessions.set([])
+  })
+
+  afterEach(() => {
+    $sessions.set([])
+  })
+
+  it('clears the workspace on the backend and mirrors it into the session cache', async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === 'session.workspace.move') {
+        return { branch: null, cwd: null, git_repo_root: null }
+      }
+
+      // The post-move tree refresh re-reads the grouping; echo an empty tree.
+      return { active_id: null, projects: [], scoped_session_ids: [] }
+    })
+
+    activeGateway.mockReturnValue({ connectionState: 'open', request } as never)
+
+    $sessions.set([
+      {
+        cwd: '/work/demo',
+        ended_at: null,
+        git_branch: 'main',
+        git_repo_root: '/work/demo',
+        id: 's1',
+        input_tokens: 0
+      } as never
+    ])
+
+    await detachSessionFromProject('s1')
+
+    expect(request).toHaveBeenCalledWith(
+      'session.workspace.move',
+      expect.objectContaining({ detach: true, session_key: 's1' })
+    )
+    const row = $sessions.get().find(s => s.id === 's1')
+    expect(row?.cwd).toBeNull()
+    expect(row?.git_branch).toBeNull()
+    expect(row?.git_repo_root).toBeNull()
+  })
+
+  it('leaves the cache untouched when the backend refuses (e.g. a running session)', async () => {
+    const request = vi.fn(async () => {
+      throw new Error('cannot detach a running session')
+    })
+
+    activeGateway.mockReturnValue({ connectionState: 'open', request } as never)
+
+    $sessions.set([
+      { cwd: '/work/demo', ended_at: null, git_branch: 'main', git_repo_root: '/work/demo', id: 's1', input_tokens: 0 } as never
+    ])
+
+    await expect(detachSessionFromProject('s1')).rejects.toThrow('cannot detach a running session')
+    expect($sessions.get()[0]?.cwd).toBe('/work/demo')
+  })
+
+  it('routes the clear to the owning profile when one is given', async () => {
+    const request = vi.fn(async () => ({ branch: null, cwd: null, git_repo_root: null }))
+    activeGateway.mockReturnValue({ connectionState: 'open', request } as never)
+
+    await detachSessionFromProject('s1', 'tabby')
+
+    expect(request).toHaveBeenCalledWith(
+      'session.workspace.move',
+      expect.objectContaining({ detach: true, profile: 'tabby', session_key: 's1' })
+    )
   })
 })
 

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -579,7 +579,7 @@ export async function fetchProjectSessions(projectId: string): Promise<SidebarPr
 
 interface WorkspaceMovePayload {
   branch?: null | string
-  cwd?: string
+  cwd?: null | string
   git_repo_root?: null | string
 }
 
@@ -611,6 +611,27 @@ export async function moveSessionToProject(
       sessionMatchesStoredId(s, sessionId)
         ? { ...s, cwd: moved, git_branch: res.branch ?? null, git_repo_root: res.git_repo_root ?? null }
         : s
+    )
+  )
+  void refreshProjectTree()
+}
+
+// The inverse of moveSessionToProject: send a stored session back to the
+// "(no project)" / Home bucket ("Move to Home", the other half of #75539's
+// ask). The backend clears the row's cwd + git identity — the longest-prefix
+// matcher then claims nothing — and refuses a LIVE session, since a running
+// agent needs a directory anchor and "Home" is none. The error surfaces
+// verbatim; the cache mirror happens only after a successful clear.
+export async function detachSessionFromProject(sessionId: string, profile?: null | string): Promise<void> {
+  await gatewayRequest<WorkspaceMovePayload>('session.workspace.move', {
+    detach: true,
+    session_key: sessionId,
+    ...(profile ? { profile } : {})
+  })
+
+  setSessions(prev =>
+    prev.map(s =>
+      sessionMatchesStoredId(s, sessionId) ? { ...s, cwd: null, git_branch: null, git_repo_root: null } : s
     )
   )
   void refreshProjectTree()

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5966,6 +5966,33 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         return self._execute_write(_do)
 
+    def clear_session_workspace(self, session_id: str) -> bool:
+        """Detach a stored session from any workspace (Move to Home).
+
+        Nulls ``cwd`` together with the recorded Git identity so the sidebar's
+        longest-prefix matcher drops the row into the "(no project)" / Home
+        bucket instead of keeping it grouped under the project it left (the
+        stale ``git_repo_root`` would survive a cwd-only clear). Also bumps
+        ``git_metadata_generation`` so an async probe launched for the OLD cwd
+        can never republish its branch/root after the detach — the same
+        ordering guard :meth:`update_session_cwd` claims for moves.
+
+        Returns True when a row was actually cleared.
+        """
+        if not session_id:
+            return False
+
+        def _do(conn):
+            cursor = conn.execute(
+                "UPDATE sessions SET cwd = NULL, git_branch = NULL, git_repo_root = NULL, "
+                "git_metadata_generation = COALESCE(git_metadata_generation, 0) + 1 "
+                "WHERE id = ?",
+                (session_id,),
+            )
+            return cursor.rowcount == 1
+
+        return bool(self._execute_write(_do))
+
     def publish_session_git_metadata(
         self,
         session_id: str,

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -346,6 +346,40 @@ class TestSessionLifecycle:
         assert session["cwd"] == "/work/repo"
         assert session["git_branch"] == "pets-feature"
 
+    def test_clear_session_workspace_detaches_to_home(self, db):
+        """Move-to-Home clears cwd AND git identity so the sidebar's matcher
+        claims nothing — and bumps the git generation so an async probe from
+        the OLD cwd cannot republish its branch/root after the detach."""
+        db.create_session(session_id="s1", source="desktop")
+        db.update_session_cwd(
+            "s1", "/work/repo", git_branch="main", git_repo_root="/work/repo"
+        )
+        generation_before = db._conn.execute(
+            "SELECT git_metadata_generation FROM sessions WHERE id = ?", ("s1",)
+        ).fetchone()[0]
+
+        assert db.clear_session_workspace("s1") is True
+
+        session = db.get_session("s1")
+        assert session["cwd"] is None
+        assert session["git_branch"] is None
+        assert session["git_repo_root"] is None
+        generation_after = db._conn.execute(
+            "SELECT git_metadata_generation FROM sessions WHERE id = ?", ("s1",)
+        ).fetchone()[0]
+        assert generation_after == generation_before + 1
+
+        # A stale probe from the old cwd loses its race against the detach.
+        assert (
+            db.publish_session_git_metadata(
+                "s1", "/work/repo", generation_before, git_branch="main", git_repo_root="/work/repo"
+            )
+            is False
+        )
+
+        # Unknown session: nothing cleared, honest False.
+        assert db.clear_session_workspace("nope") is False
+
 
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -19830,3 +19830,60 @@ def test_workspace_move_rehomes_running_session(monkeypatch, tmp_path):
     assert captured["row_update"] == (target, str(new_cwd))
     assert live["cwd"] == str(new_cwd)
     assert live.get("explicit_cwd") is True
+
+
+def test_workspace_move_detach_clears_stored_row(monkeypatch):
+    """``detach: true`` sends a stored session back to Home: the row's cwd and
+    git identity are CLEARED (NULL), so the sidebar's longest-prefix matcher
+    drops it into the "(no project)" bucket — the other half of #75539. A
+    detach is a stored-row operation only: no live re-home happens."""
+    target = "stored-detach-session"
+    cleared = {}
+
+    class FakeDB:
+        def get_session(self, session_id):
+            return {"id": session_id}
+
+        def clear_session_workspace(self, session_id):
+            cleared["session_id"] = session_id
+            return True
+
+        def close(self):
+            pass
+
+    import contextlib
+
+    @contextlib.contextmanager
+    def _fake_db(_params):
+        yield FakeDB()
+
+    monkeypatch.setattr(server, "_profile_db", _fake_db)
+
+    res = server._methods["session.workspace.move"]("rid", {"session_key": target, "detach": True})
+
+    assert "error" not in res, res
+    assert cleared["session_id"] == target
+    assert res["result"]["cwd"] is None
+    assert res["result"]["branch"] is None
+    assert res["result"]["git_repo_root"] is None
+
+
+def test_workspace_move_detach_refuses_live_session(monkeypatch):
+    """A RUNNING session has no "Home" to land in — it needs a real directory
+    anchor for its next tool call. Clearing only the stored row would recreate
+    the db-vs-runtime disagreement #86626 fixed, so the detach is refused."""
+    target = "stored-running-session"
+
+    def _fail_db(_params):
+        raise AssertionError("detach of a live session must not touch the database")
+
+    monkeypatch.setattr(server, "_profile_db", _fail_db)
+
+    server._sessions["live-sid"] = {"session_key": target, "running": True, "cwd": "/tmp/project"}
+    try:
+        res = server._methods["session.workspace.move"]("rid", {"session_key": target, "detach": True})
+    finally:
+        server._sessions.clear()
+
+    assert res["error"]["code"] == 4009
+    assert "running" in res["error"]["message"]

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -974,18 +974,18 @@ def _(rid, params: dict) -> dict:
     claim success in the UI while ``state.db`` kept the old cwd — two sources
     of truth disagreeing (#86626). In-flight tool calls keep the cwd they were
     launched with; the NEXT tool call uses the new workspace.
+
+    With ``detach: true`` ("Move to Home", the counterpart the desktop's
+    submenu was missing from #75539) the stored row's workspace is CLEARED
+    instead — cwd and git identity go NULL so the sidebar's longest-prefix
+    matcher drops the session into the "(no project)" / Home bucket. A live
+    session is refused: it needs a real directory anchor for its next tool
+    call, and there is no anchor for "Home" — clearing only the row would
+    recreate the exact db-vs-runtime disagreement #86626 fixed.
     """
     target = str(params.get("session_key") or "").strip()
     if not target:
         return _err(rid, 4007, "session_key required")
-    raw = str(params.get("cwd", "") or "").strip()
-    if not raw:
-        return _err(rid, 4016, "cwd required")
-    from hermes_constants import translate_cwd_for_wsl_backend
-
-    resolved = os.path.abspath(os.path.expanduser(translate_cwd_for_wsl_backend(raw)))
-    if not os.path.isdir(resolved):
-        return _err(rid, 4017, f"working directory does not exist: {raw}")
 
     # Snapshot under the lock — concurrent RPCs mutate _sessions (same pattern
     # as _cwd_for_session_key).
@@ -996,6 +996,29 @@ def _(rid, params: dict) -> dict:
             if sess.get("session_key") == target:
                 live, live_sid = sess, sid
                 break
+
+    if params.get("detach"):
+        if live is not None:
+            return _err(rid, 4009, "cannot detach a running session")
+        with _profile_db(params) as db:
+            if db is None:
+                return _db_unavailable_error(rid, code=5007)
+            if not db.get_session(target):
+                return _err(rid, 4007, "session not found")
+            try:
+                db.clear_session_workspace(target)
+            except Exception as e:
+                return _err(rid, 5007, f"detach failed: {e}")
+        return _ok(rid, {"cwd": None, "branch": None, "git_repo_root": None})
+
+    raw = str(params.get("cwd", "") or "").strip()
+    if not raw:
+        return _err(rid, 4016, "cwd required")
+    from hermes_constants import translate_cwd_for_wsl_backend
+
+    resolved = os.path.abspath(os.path.expanduser(translate_cwd_for_wsl_backend(raw)))
+    if not os.path.isdir(resolved):
+        return _err(rid, 4017, f"working directory does not exist: {raw}")
 
     branch = _git_branch_for_cwd(resolved)
     root = _git_common_repo_root_for_cwd(resolved)


### PR DESCRIPTION
## Summary

Add a Home action to the session row menu for detaching a session from its project.

The existing workspace-move RPC now supports `detach: true`. The backend clears the stored cwd and Git identity together, advances the metadata generation to reject stale probes, and refuses live sessions with `4009 session busy`. Desktop mirrors the cleared workspace and refreshes the project tree so the session returns to Home immediately.

This closes the path back from an incorrectly assigned project without editing `state.db`, while keeping runtime and persisted state consistent.

Verification:
- Targeted backend tests: 4/4 passed
- Full gateway test file: 587/587 passed
- Affected desktop suites: 48/48 passed
- Typecheck/ESLint, Ruff, and `git diff --check`: clean
