### PR TITLE
fix(delegation): forward top-level output_schema through _dispatch_delegate_task

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8238,6 +8238,7 @@ class AIAgent:
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
             background=(not _is_subagent),
+            output_schema=function_args.get("output_schema"),
             action=function_args.get("action"),
             subagent_id=function_args.get("subagent_id"),
             message=function_args.get("message"),

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1350,6 +1350,30 @@ class TestDelegationReasoningEffort(unittest.TestCase):
 class TestDispatchDelegateTask(unittest.TestCase):
     """Tests for the _dispatch_delegate_task helper and full param forwarding."""
 
+    def test_model_output_schema_forwarded(self):
+        """The live model dispatch path preserves the single-task contract."""
+        import run_agent
+
+        captured = {}
+        schema = {
+            "type": "object",
+            "properties": {"verdict": {"type": "string"}},
+            "required": ["verdict"],
+        }
+
+        def fake_delegate_task(**kwargs):
+            captured.update(kwargs)
+            return "{}"
+
+        parent = _make_mock_parent(depth=0)
+        with patch("tools.delegate_tool.delegate_task", fake_delegate_task):
+            run_agent.AIAgent._dispatch_delegate_task(
+                parent,
+                {"goal": "return a structured verdict", "output_schema": schema},
+            )
+
+        self.assertEqual(captured["output_schema"], schema)
+
     def test_model_acp_args_not_forwarded(self):
         """The live model dispatch path strips hidden ACP transport args."""
         import run_agent

--- a/tests/tools/test_delegate_output_schema.py
+++ b/tests/tools/test_delegate_output_schema.py
@@ -361,3 +361,47 @@ class TestDelegateTaskDispatch:
         assert "OUTPUT CONTRACT" in (captured.get("context") or "")
         results = payload.get("results") or []
         assert results and results[0].get("schema_valid") is True
+
+    def test_model_dispatch_top_level_schema_reaches_real_delegate_path(self):
+        """Model dispatch preserves the schema through the real delegate path."""
+        import run_agent
+
+        captured = {}
+
+        def fake_build(**kwargs):
+            captured.update(kwargs)
+            return _StubChild(['{"city": "Rio"}'])
+
+        parent = _make_mock_parent()
+        parent._delegate_depth = 1  # Subagent dispatch stays synchronous.
+        with (
+            patch("tools.delegate_tool._load_config", return_value={"max_iterations": 5}),
+            patch("tools.delegate_tool._get_max_spawn_depth", return_value=2),
+            patch(
+                "tools.delegate_tool._resolve_delegation_credentials",
+                return_value={
+                    "provider": None,
+                    "model": None,
+                    "base_url": None,
+                    "api_key": None,
+                    "api_mode": None,
+                },
+            ),
+            patch(
+                "tools.delegate_tool._build_child_preserving_parent_tools",
+                side_effect=fake_build,
+            ),
+        ):
+            out = run_agent.AIAgent._dispatch_delegate_task(
+                parent,
+                {
+                    "goal": "produce the address",
+                    "context": "base context",
+                    "output_schema": ADDRESS_SCHEMA,
+                },
+            )
+
+        payload = json.loads(out)
+        assert "OUTPUT CONTRACT" in (captured.get("context") or "")
+        results = payload.get("results") or []
+        assert results and results[0].get("schema_valid") is True


### PR DESCRIPTION
## What does this PR do?

Preserves the top-level `output_schema` supplied by a model for the single-goal form of `delegate_task`.

The structured-output feature already exposes this field in `DELEGATE_TASK_SCHEMA`, and `delegate_task` already validates and applies it. However, `AIAgent._dispatch_delegate_task` omitted the field when forwarding model tool arguments, so the real model-dispatch path silently downgraded single-goal delegations to schema-less execution.

This change forwards the field at the existing central dispatch seam and adds both focused forwarding coverage and real-path integration coverage through `AIAgent._dispatch_delegate_task → delegate_task → output contract → schema validation`.

## Related Issue

No linked issue. This closes an integration gap in the structured-output feature introduced by commit `d6ee58b58`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py`: forward top-level `output_schema` through `_dispatch_delegate_task`.
- `tests/tools/test_delegate.py`: assert the central model-dispatch seam preserves the exact schema object.
- `tests/tools/test_delegate_output_schema.py`: exercise the real dispatch/delegate path while stubbing only the external child/model boundary; assert the child receives an `OUTPUT CONTRACT` and the result reports `schema_valid=true`.

## How to Test

1. Apply only the new integration test to current `main` and run:
   `scripts/run_tests.sh tests/tools/test_delegate_output_schema.py -k model_dispatch_top_level_schema_reaches_real_delegate_path -q`
   It fails because the child context remains plain `base context` and has no `OUTPUT CONTRACT`.
2. Run the same command on this branch; it passes.
3. Run the relevant canonical suite:
   `scripts/run_tests.sh -j 3 tests/tools/test_delegate.py tests/tools/test_delegate_output_schema.py tests/run_agent/test_run_agent.py -q`
   Result: **356 passed, 0 failed** (rebased onto `b359db72e`).
4. Run:
   `ruff check run_agent.py tests/tools/test_delegate.py tests/tools/test_delegate_output_schema.py`
   and `git diff --check`.
   Both pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — full repository suite not run locally; the relevant canonical suite is green (356 tests)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.1.0-49-arm64 (aarch64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; this restores behavior already documented by the existing tool schema
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture/workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-neutral Python argument forwarding
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; the schema already advertised this field

## Screenshots / Logs

Not applicable. RED/GREEN and canonical suite results are included above.
