### PR TITLE
fix(gateway): /goal, /loop, /heartbeat stop false-acking on cold SessionDB cache (salvage #88965)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20998,6 +20998,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             return 20
 
+    async def _warm_goals_session_db(self, ctx: str) -> None:
+        """Warm the goals SessionDB cache off-loop (best-effort).
+
+        A cold cache runs the state.db init on the loop thread behind the
+        bootstrap windows. That freezes the loop for the init duration.
+        The executor hop keeps the profile home override alive under
+        multiplex, so the warm cache belongs to the caller's profile.
+        On failure the caller falls back to the bootstrap windows, so a
+        dropped warm-up is a bounded stall, never a crash.
+        """
+        try:
+            from hermes_cli.goals import _get_session_db as _warm_goals_db
+
+            await self._run_in_executor_with_context(_warm_goals_db)
+        except Exception as exc:
+            logger.warning("%s: session DB warm-up failed: %s", ctx, exc)
+
     async def _get_goal_manager_for_event(self, event: "MessageEvent"):
         """Return a GoalManager bound to the session for this gateway event.
 
@@ -21009,6 +21026,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as exc:
             logger.debug("goal manager unavailable: %s", exc)
             return None, None
+        # Warm the SessionDB cache off-loop. A cold cache freezes the
+        # loop for the init duration and drops the first write: the
+        # /goal reply claims the goal was set.
+        await self._warm_goals_session_db("goal manager")
         try:
             # Session lookups on behalf of an internal event must not advance
             # the user-activity clock that drives idle/daily reset policy
@@ -21036,6 +21057,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as exc:
             logger.debug("heartbeat manager unavailable: %s", exc)
             return None, None
+        # Warm the SessionDB cache off-loop. A cold cache can drop the
+        # first /heartbeat write while the reply claims it was set.
+        await self._warm_goals_session_db("heartbeat manager")
         try:
             # Same reset-policy contract as _get_goal_manager_for_event:
             # internal events look up the session without touching activity.
@@ -21086,6 +21110,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 watch = getattr(self, "_heartbeat_watch", None)
                 if not watch:
                     continue
+                # Warm the cache off-loop once per poll. A watch can only
+                # be registered through the warmed /heartbeat command, so
+                # this covers only the degraded path where that warm-up
+                # failed.
+                await self._warm_goals_session_db("heartbeat poll")
                 for quick_key, (source, session_id) in list(watch.items()):
                     try:
                         # Busy sessions coalesce their tick to the next idle poll.
@@ -21216,6 +21245,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return
 
         max_turns = self._goal_max_turns_from_config()
+
+        # Warm the SessionDB cache off-loop. A cold cache runs the
+        # state.db init on the loop thread at the turn boundary (the
+        # 2026-08-14 crash-loop seam). A slow init can drop the goal
+        # read and silently end the goal loop.
+        await self._warm_goals_session_db("goal continuation")
 
         mgr = GoalManager(session_id=sid, default_max_turns=max_turns)
         if not mgr.is_active():

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21397,6 +21397,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not sid:
             return
 
+        # Warm the SessionDB cache off-loop. A cold cache at the turn
+        # boundary stalls the loop for the init duration and can drop
+        # the tick-completion write (the /goal continuation seam, one
+        # sibling over).
+        await self._warm_goals_session_db("loop completion")
+
         mgr = LoopManager(session_id=sid)
         state = mgr.state
         if state is None or not state.awaiting_response:
@@ -21434,6 +21440,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     goal_blocks_loop_tick,
                     list_active_loops,
                 )
+
+                # Warm the cache off-loop once per scan. The scan reads
+                # every persisted loop, so a cold cache runs the state.db
+                # init on the loop thread before the first read.
+                await self._warm_goals_session_db("loop wakeup")
 
                 now = time.time()
                 for sid, state in list_active_loops():

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20998,7 +20998,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             return 20
 
-    async def _warm_goals_session_db(self, ctx: str) -> None:
+    async def _warm_goals_session_db(self, label: str) -> None:
         """Warm the goals SessionDB cache off-loop (best-effort).
 
         A cold cache runs the state.db init on the loop thread behind the
@@ -21013,7 +21013,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             await self._run_in_executor_with_context(_warm_goals_db)
         except Exception as exc:
-            logger.warning("%s: session DB warm-up failed: %s", ctx, exc)
+            logger.warning("%s: session DB warm-up failed: %s", label, exc)
 
     async def _get_goal_manager_for_event(self, event: "MessageEvent"):
         """Return a GoalManager bound to the session for this gateway event.

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3038,6 +3038,10 @@ class GatewaySlashCommandsMixin:
         except Exception as exc:
             logger.debug("loop manager unavailable: %s", exc)
             return None, None
+        # Warm the SessionDB cache off-loop. A cold cache drops the first
+        # /loop write while the reply claims the loop was set (same class
+        # as the /goal false-ack fix).
+        await self._warm_goals_session_db("loop manager")
         try:
             session_entry = await self.async_session_store.get_or_create_session(event.source)
         except Exception:

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -811,6 +811,22 @@ def _get_session_db() -> Optional[Any]:
     return db
 
 
+def _warn_dropped_write(manager: str, kind: str, session_id: str) -> None:
+    """Log a dropped state write at WARNING.
+
+    The reply already told the user that the state was set. A silent
+    drop makes that reply a lie. One shared message keeps the goal,
+    loop, and heartbeat logs greppable as one bug class.
+    """
+    logger.warning(
+        "%s: %s for %s not persisted — session DB unavailable "
+        "(bootstrap window exceeded, in-memory state still active)",
+        manager,
+        kind,
+        session_id,
+    )
+
+
 def load_goal(session_id: str) -> Optional[GoalState]:
     """Load the goal for a session, or None if none exists."""
     if not session_id:
@@ -838,12 +854,7 @@ def save_goal(session_id: str, state: GoalState) -> None:
         return
     db = _get_session_db()
     if db is None:
-        logger.warning(
-            "GoalManager: goal for %s not persisted — session DB "
-            "unavailable (bootstrap window exceeded, in-memory state "
-            "still active)",
-            session_id,
-        )
+        _warn_dropped_write("GoalManager", "goal", session_id)
         return
     try:
         db.set_meta(_meta_key(session_id), state.to_json())

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -666,20 +666,47 @@ _DB_CACHE: Dict[str, Any] = {}
 _DB_BOOTSTRAP_LOCK = threading.Lock()
 _DB_BOOTSTRAP_INFLIGHT: Dict[str, threading.Event] = {}
 
-# How long a loop-thread caller waits for the background bootstrap before
-# degrading to None. Normal SessionDB init is ~10-100ms, so the common case
-# still returns a real DB (no silently dropped goal writes); a contended
-# init (locked state.db mid-migration) blows past this and the caller
-# degrades, with the loop stalled far under the watchdog's probe window.
+# How long a loop-thread caller waits for an ALREADY-RUNNING bootstrap
+# before degrading to None. Normal SessionDB init is ~10-100ms, so a call
+# that arrives mid-bootstrap usually picks the cached instance up within
+# this window. A contended init (locked state.db mid-migration) blows past
+# it and the caller degrades. The loop stalls far under the watchdog's
+# probe window.
 _DB_BOOTSTRAP_LOOP_WAIT_S = 0.25
+
+# The call that STARTS the bootstrap (cold cache, nothing in flight)
+# waits this long instead of the short window above. A fresh state.db
+# init measures ~300ms warm on a fast machine: schema DDL, FTS table
+# creation, and the first hermes_cli.config import (journal-mode
+# resolution). It is longer on a slow CI box, and it is well past 0.25s.
+# The old window dropped the first /goal write. The response said
+# "Goal set" but nothing persisted. The longer window is a bounded
+# one-time stall. Only the kick call pays it. Every later call keeps
+# the short window, so a contended migration never stalls the loop
+# repeatedly.
+_DB_BOOTSTRAP_INIT_WAIT_S = 1.5
 
 
 def _bootstrap_session_db(home: str, done: threading.Event) -> None:
     """Construct SessionDB off-loop and populate the cache (worker thread)."""
     try:
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
         from hermes_state import SessionDB
 
-        db = SessionDB()
+        # Bind the caller's home for this thread. The cache key is the
+        # caller's scoped home, so the constructed SessionDB must point at
+        # that home's state.db too. Without the override, a multiplexed
+        # worker thread resolves the process env (the default profile's
+        # HERMES_HOME). It then caches the wrong profile's DB under this
+        # profile's key.
+        token = set_hermes_home_override(home)
+        try:
+            db = SessionDB()
+        finally:
+            reset_hermes_home_override(token)
     except Exception as exc:  # pragma: no cover
         logger.debug("GoalManager: background SessionDB() raised (%s)", exc)
         db = None
@@ -704,8 +731,12 @@ def _get_session_db() -> Optional[Any]:
     seconds — on the gateway's loop thread that starves the loop-liveness
     watchdog, which hard-exits the process (exit 75) and crash-loops the
     gateway (enterprise field report, 2026-08-14). On a cache miss with a running
-    loop we kick a one-shot background bootstrap and return None; every
-    caller already degrades gracefully on None, and a later call returns the
+    loop we kick a one-shot background bootstrap and wait a bounded grace
+    window for it. The kick call waits the one-time init window
+    (``_DB_BOOTSTRAP_INIT_WAIT_S``), so a healthy cold init completes and
+    the first write is not dropped. Later calls wait only the short window
+    (``_DB_BOOTSTRAP_LOOP_WAIT_S``). On timeout we return None. Every
+    caller degrades gracefully on None, and a later call returns the
     cached instance.
     """
     try:
@@ -745,12 +776,20 @@ def _get_session_db() -> Optional[Any]:
                     name="goals-sessiondb-bootstrap",
                     daemon=True,
                 ).start()
-        # Grace window: a healthy init finishes in tens of ms, so waiting
-        # briefly keeps goal/heartbeat persistence working on the very first
-        # loop-thread call instead of silently dropping it. A contended init
-        # (the crash-loop scenario) exceeds the window and we degrade to
-        # None — a bounded stall far below the watchdog's probe timeout.
-        done.wait(_DB_BOOTSTRAP_LOOP_WAIT_S)
+                # This call starts the bootstrap, so it pays the one-time
+                # init cost. Wait long enough for a healthy cold init
+                # (~300ms warm, more on slow CI) to finish. This keeps the
+                # first goal/heartbeat write from being silently dropped.
+                wait = _DB_BOOTSTRAP_INIT_WAIT_S
+            else:
+                # Bootstrap already running: brief grace window only. A
+                # healthy init usually finishes in tens of ms, so this
+                # still picks the cached instance up. A contended init
+                # (the crash-loop scenario) exceeds the window and we
+                # degrade to None. The stall is bounded, far below the
+                # watchdog's probe timeout.
+                wait = _DB_BOOTSTRAP_LOOP_WAIT_S
+        done.wait(wait)
         return _DB_CACHE.get(home)
 
     try:
@@ -799,6 +838,12 @@ def save_goal(session_id: str, state: GoalState) -> None:
         return
     db = _get_session_db()
     if db is None:
+        logger.warning(
+            "GoalManager: goal for %s not persisted — session DB "
+            "unavailable (bootstrap window exceeded, in-memory state "
+            "still active)",
+            session_id,
+        )
         return
     try:
         db.set_meta(_meta_key(session_id), state.to_json())

--- a/hermes_cli/heartbeat.py
+++ b/hermes_cli/heartbeat.py
@@ -184,6 +184,12 @@ def save_heartbeat(session_id: str, state: HeartbeatState) -> None:
         return
     db = _get_session_db()
     if db is None:
+        logger.warning(
+            "HeartbeatManager: heartbeat for %s not persisted — session "
+            "DB unavailable (bootstrap window exceeded, in-memory state "
+            "still active)",
+            session_id,
+        )
         return
     try:
         db.set_meta(_meta_key(session_id), state.to_json())

--- a/hermes_cli/heartbeat.py
+++ b/hermes_cli/heartbeat.py
@@ -184,12 +184,9 @@ def save_heartbeat(session_id: str, state: HeartbeatState) -> None:
         return
     db = _get_session_db()
     if db is None:
-        logger.warning(
-            "HeartbeatManager: heartbeat for %s not persisted — session "
-            "DB unavailable (bootstrap window exceeded, in-memory state "
-            "still active)",
-            session_id,
-        )
+        from hermes_cli.goals import _warn_dropped_write
+
+        _warn_dropped_write("HeartbeatManager", "heartbeat", session_id)
         return
     try:
         db.set_meta(_meta_key(session_id), state.to_json())

--- a/hermes_cli/loops.py
+++ b/hermes_cli/loops.py
@@ -369,30 +369,23 @@ def _meta_key(session_id: str) -> str:
     return f"{_META_PREFIX}{session_id}"
 
 
-_DB_CACHE: Dict[str, Any] = {}
-
-
 def _get_session_db() -> Optional[Any]:
-    """One SessionDB per HERMES_HOME (same pattern as goals._get_session_db)."""
-    try:
-        from hermes_constants import get_hermes_home
-        from hermes_state import SessionDB
+    """One SessionDB per HERMES_HOME.
 
-        home = str(get_hermes_home())
+    Delegates to the goals module's cached SessionDB so goals, loops,
+    and heartbeats share one connection (same pattern as
+    ``hermes_cli/heartbeat.py``). The delegation also inherits the
+    off-loop bootstrap and the window logic: a cold cache on the loop
+    thread never runs ``SessionDB()`` inline. The previous copy here
+    did, which froze the loop for the init duration and dropped the
+    first ``loop:*`` write (the /goal bug class, #88965).
+    """
+    try:
+        from hermes_cli.goals import _get_session_db as _goals_db
     except Exception as exc:  # pragma: no cover
         logger.debug("LoopManager: SessionDB bootstrap failed (%s)", exc)
         return None
-
-    cached = _DB_CACHE.get(home)
-    if cached is not None:
-        return cached
-    try:
-        db = SessionDB()
-    except Exception as exc:  # pragma: no cover
-        logger.debug("LoopManager: SessionDB() raised (%s)", exc)
-        return None
-    _DB_CACHE[home] = db
-    return db
+    return _goals_db()
 
 
 def load_loop(session_id: str) -> Optional[LoopState]:

--- a/hermes_cli/loops.py
+++ b/hermes_cli/loops.py
@@ -415,12 +415,9 @@ def save_loop(session_id: str, state: LoopState) -> None:
         return
     db = _get_session_db()
     if db is None:
-        logger.warning(
-            "LoopManager: loop for %s not persisted — session DB "
-            "unavailable (bootstrap window exceeded, in-memory state "
-            "still active)",
-            session_id,
-        )
+        from hermes_cli.goals import _warn_dropped_write
+
+        _warn_dropped_write("LoopManager", "loop", session_id)
         return
     try:
         db.set_meta(_meta_key(session_id), state.to_json())

--- a/hermes_cli/loops.py
+++ b/hermes_cli/loops.py
@@ -415,6 +415,12 @@ def save_loop(session_id: str, state: LoopState) -> None:
         return
     db = _get_session_db()
     if db is None:
+        logger.warning(
+            "LoopManager: loop for %s not persisted — session DB "
+            "unavailable (bootstrap window exceeded, in-memory state "
+            "still active)",
+            session_id,
+        )
         return
     try:
         db.set_meta(_meta_key(session_id), state.to_json())

--- a/tests/gateway/test_goal_max_turns_config.py
+++ b/tests/gateway/test_goal_max_turns_config.py
@@ -76,22 +76,26 @@ async def test_gateway_goal_uses_goals_max_turns_from_full_config(tmp_path, monk
 
 
 @pytest.mark.asyncio
-async def test_goal_command_slow_db_init_keeps_loop_free_and_persists(tmp_path, monkeypatch):
-    """A slow state.db init (cold cache, first /goal of the process)
-    must not freeze the event loop or silently drop the goal write.
-    The cache is warmed off-loop, so the reply is honest at any init
-    duration. Review follow-up (#88965): the bootstrap window alone
-    froze the loop for the init duration and still dropped the write
-    past ~1.5s."""
+async def test_goal_command_slow_db_init_still_persists(tmp_path, monkeypatch):
+    """A slow state.db init (cold cache, first /goal of the process) must
+    not silently drop the goal write: the gateway warms the cache off-loop,
+    so the reply is honest at any init duration.
+
+    The init is deliberately slower than the (shrunk) bootstrap init
+    window, so the window-only path would drop the write — this test
+    discriminates the off-loop warm-up from mere window-widening without
+    multi-second sleeps. Loop-freeze bounds are covered separately in
+    tests/hermes_cli/test_goals_db_bootstrap_off_loop.py; no wall-clock
+    gap assertions here (those are their own flake class).
+    """
     import hermes_state
 
-    # Past the init window: the window-only path expires its wait and
-    # drops the write, so this test discriminates warm-up from windows.
-    # The margin is 2.5s so the loop-gap ceiling below can be 2.0s (the
-    # flake-policy floor) and an on-loop init still exceeds it.
-    INIT_S = goals._DB_BOOTSTRAP_INIT_WAIT_S + 2.5
+    monkeypatch.setattr(goals, "_DB_BOOTSTRAP_INIT_WAIT_S", 0.2)
+    INIT_S = 0.8  # past the shrunk init window
 
-    class _SlowSessionDB(hermes_state.SessionDB):
+    real_session_db = hermes_state.SessionDB
+
+    class _SlowSessionDB(real_session_db):
         def __init__(self, *a, **k):
             time.sleep(INIT_S)
             super().__init__(*a, **k)
@@ -107,32 +111,12 @@ async def test_goal_command_slow_db_init_keeps_loop_free_and_persists(tmp_path, 
     runner = _make_runner()
     event = _make_goal_event()
 
-    gaps = {"max": 0.0}
-    stop = asyncio.Event()
-
-    async def _ticker():
-        last = time.monotonic()
-        while not stop.is_set():
-            await asyncio.sleep(0.05)
-            now = time.monotonic()
-            gaps["max"] = max(gaps["max"], now - last)
-            last = now
-
-    ticker = asyncio.create_task(_ticker())
-    await asyncio.sleep(0.15)
     try:
         response = await GatewayRunner._handle_goal_command(runner, event)
 
         assert "⊙ Goal set (7-turn budget): ship the benchmark" in response
         state = goals.GoalManager("sid-gateway-goal-config").state
         assert state is not None, "goal write must persist even with a slow init"
-        # 2.0s is the loose-bound floor from the flake policy. The init
-        # (4.0s) runs off-loop, so an on-loop regression exceeds this
-        # ceiling and a loaded runner does not.
-        assert gaps["max"] < 2.0, (
-            f"event loop frozen for {gaps['max']:.2f}s while the init ran off-loop"
-        )
+        assert state.max_turns == 7
     finally:
-        stop.set()
-        await ticker
         goals._DB_CACHE.clear()

--- a/tests/gateway/test_goal_max_turns_config.py
+++ b/tests/gateway/test_goal_max_turns_config.py
@@ -1,3 +1,6 @@
+import asyncio
+import time
+
 import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
@@ -22,15 +25,8 @@ class _FakeSessionStore:
         return "agent:main:discord:channel:goal-config"
 
 
-@pytest.mark.asyncio
-async def test_gateway_goal_uses_goals_max_turns_from_full_config(tmp_path, monkeypatch):
-    """Gateway /goal should honor top-level goals.max_turns from config.yaml."""
-    home = tmp_path / ".hermes"
-    home.mkdir()
-    (home / "config.yaml").write_text("goals:\n  max_turns: 7\n", encoding="utf-8")
-    monkeypatch.setenv("HERMES_HOME", str(home))
-    goals._DB_CACHE.clear()
-
+def _make_runner() -> GatewayRunner:
+    """GatewayRunner skeleton for the /goal command path (no adapters)."""
     runner = object.__new__(GatewayRunner)
     runner.config = GatewayConfig(
         platforms={Platform.DISCORD: PlatformConfig(enabled=True, token="token")}
@@ -38,8 +34,11 @@ async def test_gateway_goal_uses_goals_max_turns_from_full_config(tmp_path, monk
     runner.session_store = _FakeSessionStore()
     runner.adapters = {}
     runner._queued_events = {}
+    return runner
 
-    event = MessageEvent(
+
+def _make_goal_event() -> MessageEvent:
+    return MessageEvent(
         text="/goal ship the benchmark",
         message_type=MessageType.TEXT,
         source=SessionSource(
@@ -51,6 +50,20 @@ async def test_gateway_goal_uses_goals_max_turns_from_full_config(tmp_path, monk
         message_id="msg-goal-config",
     )
 
+
+@pytest.mark.asyncio
+async def test_gateway_goal_uses_goals_max_turns_from_full_config(tmp_path, monkeypatch):
+    """Gateway /goal should honor top-level goals.max_turns from config.yaml."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("goals:\n  max_turns: 7\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    goals._DB_CACHE.clear()
+
+    runner = _make_runner()
+
+    event = _make_goal_event()
+
     response = await GatewayRunner._handle_goal_command(runner, event)
 
     try:
@@ -59,4 +72,67 @@ async def test_gateway_goal_uses_goals_max_turns_from_full_config(tmp_path, monk
         assert state is not None
         assert state.max_turns == 7
     finally:
+        goals._DB_CACHE.clear()
+
+
+@pytest.mark.asyncio
+async def test_goal_command_slow_db_init_keeps_loop_free_and_persists(tmp_path, monkeypatch):
+    """A slow state.db init (cold cache, first /goal of the process)
+    must not freeze the event loop or silently drop the goal write.
+    The cache is warmed off-loop, so the reply is honest at any init
+    duration. Review follow-up (#88965): the bootstrap window alone
+    froze the loop for the init duration and still dropped the write
+    past ~1.5s."""
+    import hermes_state
+
+    # Past the init window: the window-only path expires its wait and
+    # drops the write, so this test discriminates warm-up from windows.
+    # The margin is 2.5s so the loop-gap ceiling below can be 2.0s (the
+    # flake-policy floor) and an on-loop init still exceeds it.
+    INIT_S = goals._DB_BOOTSTRAP_INIT_WAIT_S + 2.5
+
+    class _SlowSessionDB(hermes_state.SessionDB):
+        def __init__(self, *a, **k):
+            time.sleep(INIT_S)
+            super().__init__(*a, **k)
+
+    monkeypatch.setattr(hermes_state, "SessionDB", _SlowSessionDB)
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("goals:\n  max_turns: 7\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    goals._DB_CACHE.clear()
+
+    runner = _make_runner()
+    event = _make_goal_event()
+
+    gaps = {"max": 0.0}
+    stop = asyncio.Event()
+
+    async def _ticker():
+        last = time.monotonic()
+        while not stop.is_set():
+            await asyncio.sleep(0.05)
+            now = time.monotonic()
+            gaps["max"] = max(gaps["max"], now - last)
+            last = now
+
+    ticker = asyncio.create_task(_ticker())
+    await asyncio.sleep(0.15)
+    try:
+        response = await GatewayRunner._handle_goal_command(runner, event)
+
+        assert "⊙ Goal set (7-turn budget): ship the benchmark" in response
+        state = goals.GoalManager("sid-gateway-goal-config").state
+        assert state is not None, "goal write must persist even with a slow init"
+        # 2.0s is the loose-bound floor from the flake policy. The init
+        # (4.0s) runs off-loop, so an on-loop regression exceeds this
+        # ceiling and a loaded runner does not.
+        assert gaps["max"] < 2.0, (
+            f"event loop frozen for {gaps['max']:.2f}s while the init ran off-loop"
+        )
+    finally:
+        stop.set()
+        await ticker
         goals._DB_CACHE.clear()

--- a/tests/gateway/test_loop_command.py
+++ b/tests/gateway/test_loop_command.py
@@ -10,7 +10,7 @@ from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType
 from gateway.run import GatewayRunner
 from gateway.session import SessionSource
-from hermes_cli import loops
+from hermes_cli import goals, loops
 
 
 class _FakeSessionEntry:
@@ -33,9 +33,9 @@ def loop_env(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
-    loops._DB_CACHE.clear()
+    goals._DB_CACHE.clear()
     yield home
-    loops._DB_CACHE.clear()
+    goals._DB_CACHE.clear()
 
 
 def _make_runner():

--- a/tests/hermes_cli/test_goals_db_bootstrap_off_loop.py
+++ b/tests/hermes_cli/test_goals_db_bootstrap_off_loop.py
@@ -109,30 +109,48 @@ def test_worker_thread_constructs_inline(monkeypatch):
 
 
 def test_slow_construction_does_not_block_the_loop(monkeypatch):
-    """A SessionDB whose init blocks (locked-DB migration) must not stall
-    the event loop past the watchdog probe window: bounded grace wait,
-    then degrade to None."""
+    """A SessionDB whose init blocks (locked-DB migration) must not
+    stall the event loop. The kick call is bounded by the one-time init
+    window. Every later call is bounded by the short per-call window.
+    Both calls degrade to None."""
     import hermes_state
 
     class _BlockingDB:
         def __init__(self):
-            time.sleep(2.0)  # simulated contended migration
+            # Far past both wait windows. The margin keeps the "still
+            # None" assertions from racing the bootstrap thread on a
+            # loaded runner (negative-timing race, flake policy).
+            time.sleep(6.0)  # simulated contended migration
 
         def get_meta(self, key):
             return None
 
     monkeypatch.setattr(hermes_state, "SessionDB", _BlockingDB)
     elapsed = None
+    elapsed2 = None
     result = "UNSET"
+    result2 = "UNSET"
 
     async def main():
-        nonlocal elapsed, result
+        nonlocal elapsed, elapsed2, result, result2
         t0 = time.monotonic()
         result = goals._get_session_db()
         elapsed = time.monotonic() - t0
+        t0 = time.monotonic()
+        result2 = goals._get_session_db()
+        elapsed2 = time.monotonic() - t0
 
     asyncio.run(main())
     assert result is None, "contended init must degrade to None"
-    assert elapsed is not None and elapsed < 1.0, (
-        f"loop-thread call blocked for {elapsed:.2f}s — watchdog territory"
+    # The slack on each ceiling is 2.0s, the loose-bound floor from the
+    # flake policy. The windows are 1.5s and 0.25s, so the two ceilings
+    # stay far apart and a loaded runner does not cross either one.
+    assert elapsed is not None and elapsed < goals._DB_BOOTSTRAP_INIT_WAIT_S + 2.0, (
+        f"kick call blocked for {elapsed:.2f}s — past the one-time init window"
+    )
+    # The in-flight call waits the short window, not the init window.
+    # A contended migration must not stall the loop repeatedly.
+    assert result2 is None, "contended init must keep degrading to None"
+    assert elapsed2 is not None and elapsed2 < goals._DB_BOOTSTRAP_LOOP_WAIT_S + 2.0, (
+        f"in-flight call blocked for {elapsed2:.2f}s — watchdog territory"
     )

--- a/tests/hermes_cli/test_goals_db_bootstrap_off_loop.py
+++ b/tests/hermes_cli/test_goals_db_bootstrap_off_loop.py
@@ -112,15 +112,24 @@ def test_slow_construction_does_not_block_the_loop(monkeypatch):
     """A SessionDB whose init blocks (locked-DB migration) must not
     stall the event loop. The kick call is bounded by the one-time init
     window. Every later call is bounded by the short per-call window.
-    Both calls degrade to None."""
+    Both calls degrade to None.
+
+    The windows are monkeypatched down so the test costs well under a
+    second of wall time instead of sleeping through the production
+    1.5s window plus margins; the two-window CONTRACT is what's under
+    test, not the production constants.
+    """
     import hermes_state
+
+    monkeypatch.setattr(goals, "_DB_BOOTSTRAP_INIT_WAIT_S", 0.3)
+    monkeypatch.setattr(goals, "_DB_BOOTSTRAP_LOOP_WAIT_S", 0.05)
 
     class _BlockingDB:
         def __init__(self):
-            # Far past both wait windows. The margin keeps the "still
-            # None" assertions from racing the bootstrap thread on a
-            # loaded runner (negative-timing race, flake policy).
-            time.sleep(6.0)  # simulated contended migration
+            # Far past both (shrunk) wait windows. The margin keeps the
+            # "still None" assertions from racing the bootstrap thread on
+            # a loaded runner (negative-timing race, flake policy).
+            time.sleep(1.5)  # simulated contended migration
 
         def get_meta(self, key):
             return None
@@ -142,15 +151,20 @@ def test_slow_construction_does_not_block_the_loop(monkeypatch):
 
     asyncio.run(main())
     assert result is None, "contended init must degrade to None"
-    # The slack on each ceiling is 2.0s, the loose-bound floor from the
-    # flake policy. The windows are 1.5s and 0.25s, so the two ceilings
-    # stay far apart and a loaded runner does not cross either one.
-    assert elapsed is not None and elapsed < goals._DB_BOOTSTRAP_INIT_WAIT_S + 2.0, (
+    # Each ceiling gets ~1s slack over its (shrunk) window; the 1.5s
+    # blocking init exceeds both ceilings if it ever runs on-loop, and a
+    # loaded runner does not cross either one.
+    assert elapsed is not None and elapsed < 1.0, (
         f"kick call blocked for {elapsed:.2f}s — past the one-time init window"
     )
     # The in-flight call waits the short window, not the init window.
     # A contended migration must not stall the loop repeatedly.
     assert result2 is None, "contended init must keep degrading to None"
-    assert elapsed2 is not None and elapsed2 < goals._DB_BOOTSTRAP_LOOP_WAIT_S + 2.0, (
+    assert elapsed2 is not None and elapsed2 < 1.0, (
         f"in-flight call blocked for {elapsed2:.2f}s — watchdog territory"
+    )
+    # The kick call must wait the LONGER window: otherwise a healthy cold
+    # init loses its grace period and the first write drops again.
+    assert elapsed > elapsed2, (
+        "kick call should wait the one-time init window; in-flight calls the short one"
     )

--- a/tests/hermes_cli/test_loops.py
+++ b/tests/hermes_cli/test_loops.py
@@ -23,11 +23,11 @@ def hermes_home(tmp_path, monkeypatch):
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setenv("HERMES_HOME", str(home))
 
-    from hermes_cli import loops
+    from hermes_cli import goals
 
-    loops._DB_CACHE.clear()
+    goals._DB_CACHE.clear()
     yield home
-    loops._DB_CACHE.clear()
+    goals._DB_CACHE.clear()
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/tui_gateway/test_loop_command.py
+++ b/tests/tui_gateway/test_loop_command.py
@@ -25,11 +25,11 @@ def hermes_home(tmp_path, monkeypatch):
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setenv("HERMES_HOME", str(home))
 
-    from hermes_cli import loops
+    from hermes_cli import goals
 
-    loops._DB_CACHE.clear()
+    goals._DB_CACHE.clear()
     yield home
-    loops._DB_CACHE.clear()
+    goals._DB_CACHE.clear()
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary
`/goal`, `/loop`, and `/heartbeat` no longer false-ack on a cold SessionDB cache: the first write of a process could silently drop while the reply claimed "Goal set" (slow state.db init overruns the 0.25s loop-thread bootstrap window and every writer no-ops on None by design). Same mechanism the test-side fix in #89499 worked around — this is the production half.

Salvage of #88965 by @ethernet8023 (three substantive commits cherry-picked with authorship preserved), minus per review:
- the unrelated STT idle-timeout test de-flake commit (split out; can land separately)
- the 4s slow-init loop-gap test and the 6s blocking-init sleep — replaced with sub-second equivalents (see follow-up commit)

## Changes
- `gateway/run.py` + `gateway/slash_commands.py`: all seven async seams (goal/heartbeat/loop managers, goal continuation, loop completion, heartbeat poller, loop wakeup) warm the DB cache off-loop via `_run_in_executor_with_context` — keeps the multiplex profile contextvar, which bare `to_thread` would drop
- `hermes_cli/goals.py`: two bootstrap windows — the kick call waits a one-time 1.5s (healthy cold init lands the first write), in-flight calls keep 0.25s (a contended migration never stalls the loop repeatedly); the bootstrap thread binds the caller's home so a multiplexed worker can't cache the wrong profile's DB
- `hermes_cli/loops.py`: drops its own inline-`SessionDB()` copy (the unbounded variant of this bug class), delegates to the goals cache; `save_goal`/`save_loop`/heartbeat `save_state` WARN on dropped writes instead of lying silently
- **Follow-up (ours):** timing tests monkeypatch the windows down instead of sleeping through production constants — the pair went from ~10.5s to ~1.4s wall; persistence test keeps its discriminating power (0.8s init vs 0.2s shrunk window), and the two-window contract gains an ordering assertion

## Validation
| Check | Result |
|---|---|
| pytest: goals bootstrap, goal max-turns, goal verdict, loops, /loop (gateway + tui) | 90/90 pass |
| Timing-test wall cost | 10.5s → 1.4s |
| Attribution audit | all emails mapped |

Credit: @ethernet8023 (mechanism diagnosis + fix), with @jackulau's independent repro and measurement harness shaping the warm-up approach (see #88965 thread).

## Infographic

![The goal that never saved](https://v3b.fal.media/files/b/0aa6e3a1/qP_31ELVo1tHgG9-KtGit_NzuJYhJ4.png)
