### PR TITLE
fix(kanban): make active_pr guard role-aware

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7902,8 +7902,12 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
 
     ``"active_pr"``
         A GitHub PR URL appears in a recent task comment (within
-        ``_RESPAWN_GUARD_PR_WINDOW`` seconds).  A prior worker already
-        opened a PR; re-spawning risks a duplicate PR on the same task.
+        ``_RESPAWN_GUARD_PR_WINDOW`` seconds) authored by the card's own
+        assignee — that role already opened a PR, so re-spawning risks a
+        duplicate. A PR URL left by a *different* role (comment ``author``
+        != card ``assignee``, e.g. an implementer's PR on a card since
+        reassigned to a reviewer/tester) is a handoff artifact and does
+        NOT block the successor's respawn.
 
     Stale / dead claim locks are NOT a guard reason — they are handled
     by ``release_stale_claims`` and ``detect_crashed_workers`` which
@@ -7911,7 +7915,7 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
     genuinely dead (no live PID on this host).
     """
     row = conn.execute(
-        "SELECT last_failure_error FROM tasks WHERE id = ?",
+        "SELECT last_failure_error, assignee FROM tasks WHERE id = ?",
         (task_id,),
     ).fetchone()
     if row is None:
@@ -7986,13 +7990,26 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
             return "recent_success"
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
-    pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
-    for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
-        (task_id, pr_cutoff),
-    ).fetchall():
-        if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
-            return "active_pr"
+    #    Only a comment authored by THIS card's assignee counts: the comment
+    #    ``author`` is the posting worker's ``HERMES_PROFILE``, which the
+    #    dispatcher sets to the card's ``assignee``. A PR URL left by a
+    #    different role (e.g. an implementer's PR on a card since reassigned
+    #    to a reviewer/tester) is a handoff artifact, not this role's own PR,
+    #    so it must not block the successor's respawn.
+    assignee = row["assignee"]
+    if assignee:
+        pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
+        for c in conn.execute(
+            "SELECT author, body FROM task_comments "
+            "WHERE task_id = ? AND created_at >= ?",
+            (task_id, pr_cutoff),
+        ).fetchall():
+            if (
+                c["author"] == assignee
+                and c["body"]
+                and _RESPAWN_GUARD_PR_URL_RE.search(c["body"])
+            ):
+                return "active_pr"
 
     return None
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -502,6 +502,34 @@ def test_delete_task_removes_task_and_cascades(kanban_home):
 # ---------------------------------------------------------------------------
 
 
+def test_respawn_guard_active_pr_blocks_same_assignee(kanban_home):
+    """A PR URL comment authored by the card's own assignee still blocks:
+    that role already opened a PR, so re-spawning risks a duplicate."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="pr-same-role", assignee="reviewer")
+        kb.add_comment(
+            conn, tid, "reviewer",
+            "Opened https://github.com/foo/bar/pull/123 for review.",
+        )
+        conn.commit()
+        assert kb.check_respawn_guard(conn, tid) == "active_pr"
+
+
+def test_respawn_guard_active_pr_allows_cross_role(kanban_home):
+    """A PR URL left by a *different* role (author != assignee) is a handoff
+    artifact — an implementer's PR on a card now assigned to a reviewer —
+    and must NOT block the successor role's respawn."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="pr-cross-role", assignee="reviewer")
+        # PR opened by the implementer ("coder"), not the current assignee.
+        kb.add_comment(
+            conn, tid, "coder",
+            "Opened https://github.com/foo/bar/pull/123 for review.",
+        )
+        conn.commit()
+        assert kb.check_respawn_guard(conn, tid) is None
+
+
 
 
 


### PR DESCRIPTION
## Summary
- filter recent PR URL comments by the card assignee
- allow cross-role PR handoff comments without blocking successor respawns
- retain duplicate-PR protection for comments authored by the current assignee

## Test plan
- [x] 32/32 focused `tests/hermes_cli/test_kanban_db.py` tests pass (pre-commit verification)
- [x] independent reviewer PASS with 5 scratch-DB probes

## Scope
Two files only: `hermes_cli/kanban_db.py` and `tests/hermes_cli/test_kanban_db.py`.