### PR TITLE
fix(agent): interrupted-turn hidden placeholder no longer re-heals every call (#88955, salvage #89525)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2136,8 +2136,28 @@ def run_conversation(
             # from every outgoing copy so strict OpenAI-compatible backends
             # don't reject the request after a model switch or resumed typed
             # event row enters the live history.
-            api_msg.pop("display_kind", None)
+            _display_kind = api_msg.pop("display_kind", None)
             api_msg.pop("display_metadata", None)
+
+            # Legacy hidden redirect placeholders (#88955): rows persisted
+            # BEFORE the writer-side api_content stamp in
+            # _apply_active_turn_redirect are content="" with no sidecar.
+            # Once display_kind is stripped the pre-call sanitizer
+            # (repair_empty_non_final_messages) would re-heal such a row on
+            # every call forever, since the durable transcript is never
+            # mutated. Give the wire copy the same neutral payload here so
+            # old sessions converge too. Never the interrupt scaffold —
+            # replaying scaffold bytes as assistant text is #81841.
+            if (
+                _display_kind == "hidden"
+                and api_msg.get("role") == "assistant"
+                and not _api_content
+                and not (api_msg.get("content") or "").strip()
+                and not api_msg.get("tool_calls")
+            ):
+                from agent.agent_runtime_helpers import _INTERRUPTED_PLACEHOLDER
+
+                api_msg["content"] = _INTERRUPTED_PLACEHOLDER
 
             # Durable row identity stamped by _rows_to_conversation so the
             # desktop can address a specific persisted message (reactions).

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -331,6 +331,19 @@ def _apply_active_turn_redirect(agent: Any, messages: List[Dict[str, Any]], text
         }
         if not visible:
             placeholder["display_kind"] = "hidden"
+            # Keep the transcript hidden and empty, but give the historical
+            # API projection a non-empty neutral assistant turn so the
+            # pre-call sanitizer (repair_empty_non_final_messages) does not
+            # re-heal this row on every later call (#88955). display_kind is
+            # stripped before sanitization, while api_content is projected
+            # back into content for historical assistant rows. Use the
+            # canonical neutral interruption placeholder, never
+            # _INTERRUPT_SCAFFOLD_MARKER: replaying the scaffold as assistant
+            # text made the model echo it and self-replicate ghost rows
+            # (#81841).
+            from agent.agent_runtime_helpers import _INTERRUPTED_PLACEHOLDER
+
+            placeholder["api_content"] = _INTERRUPTED_PLACEHOLDER
         append_message(messages, placeholder)
         append_message(
             messages,

--- a/contributors/emails/agent@Agents-Mac-mini.local
+++ b/contributors/emails/agent@Agents-Mac-mini.local
@@ -1,1 +1,0 @@
-skip-agent

--- a/contributors/emails/agent@agents-Mac-mini.local
+++ b/contributors/emails/agent@agents-Mac-mini.local
@@ -1,1 +1,0 @@
-momomojo

--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -327,7 +327,9 @@ class TestActiveTurnRedirectCheckpoint:
         assert placeholder["role"] == "assistant"
         assert placeholder["display_kind"] == "hidden"
         assert placeholder.get("content") == ""
-        assert not placeholder.get("api_content")
+        # Neutral provider-replay payload (#88955): keeps the row out of the
+        # re-heal sanitizer loop; the interrupt scaffold is still never here.
+        assert placeholder.get("api_content") == "[response interrupted]"
         assert correction["content"] == "New direction."
         assert (
             "[This response was interrupted by a user correction.]"
@@ -353,13 +355,134 @@ class TestActiveTurnRedirectCheckpoint:
         assert placeholder["role"] == "assistant"
         assert placeholder.get("display_kind") == "hidden"
         assert placeholder.get("content") == ""
-        assert not placeholder.get("api_content")
+        # Neutral provider-replay payload (#88955), NOT the interrupt scaffold.
+        assert placeholder.get("api_content") == "[response interrupted]"
         assert correction["role"] == "user"
         assert correction["content"] == "Stop and do X instead."
         assert correction["api_content"].startswith(
             "[Context from the interrupted assistant response]\n"
             "[This response was interrupted by a user correction.]"
         )
+
+
+class TestEmptyHiddenAssistantRehealRegression:
+    """#88955: a no-visible-text redirect persisted an empty
+    ``display_kind="hidden"`` assistant placeholder that the pre-call sanitizer
+    re-healed on every later call (wire copy only, so the loop never converged).
+    The placeholder must carry a neutral provider-replay ``api_content`` so the
+    historical API projection fills ``content`` and the sanitizer stops
+    touching the row — while the durable transcript stays hidden and empty."""
+
+    def test_active_turn_redirect_hidden_placeholder_has_provider_replay_payload(self):
+        from agent.conversation_loop import _apply_active_turn_redirect
+
+        agent = _bare_agent()
+        agent._current_streamed_assistant_text = ""
+        messages = [{"role": "user", "content": "start"}]
+
+        _apply_active_turn_redirect(agent, messages, "Use Postgres instead.")
+
+        placeholder = messages[-2]
+        correction = messages[-1]
+        assert placeholder["role"] == "assistant"
+        assert placeholder["content"] == ""
+        assert placeholder["display_kind"] == "hidden"
+        assert placeholder["api_content"] == "[response interrupted]"
+        # The user correction keeps clean text in content and the interruption
+        # context only in its own api_content sidecar.
+        assert correction["role"] == "user"
+        assert correction["content"] == "Use Postgres instead."
+        assert (
+            "[This response was interrupted by a user correction.]"
+            in correction["api_content"]
+        )
+        # #81841: the interrupt scaffold must never reach assistant content or
+        # api_content (API replay substitutes api_content back into content).
+        assert (
+            "[This response was interrupted by a user correction.]"
+            not in str(placeholder.get("content") or "")
+            + str(placeholder.get("api_content") or "")
+        )
+
+    def test_hidden_redirect_placeholder_does_not_reheal_on_repeated_projection(self):
+        from agent.agent_runtime_helpers import (
+            _msg_has_payload,
+            repair_empty_non_final_messages,
+        )
+        from agent.conversation_loop import _apply_active_turn_redirect
+
+        agent = _bare_agent()
+        agent._current_streamed_assistant_text = ""
+        messages = [{"role": "user", "content": "start"}]
+        _apply_active_turn_redirect(agent, messages, "Do X instead.")
+        durable = list(messages)
+
+        def project(rows):
+            """Mirror the real send-time projection (conversation_loop.py):
+            api_content -> content for historical user/assistant rows, and the
+            display/row bookkeeping stripped from every outgoing copy."""
+            out = []
+            for msg in rows:
+                api_msg = dict(msg)
+                _api_content = api_msg.pop("api_content", None)
+                api_msg.pop("display_kind", None)
+                api_msg.pop("display_metadata", None)
+                api_msg.pop("_row_id", None)
+                if (
+                    isinstance(_api_content, str)
+                    and _api_content
+                    and msg.get("role") in ("user", "assistant")
+                ):
+                    api_msg["content"] = _api_content
+                out.append(api_msg)
+            return out
+
+        for _pass in range(2):
+            projected = project(durable)
+            hidden_assistant = next(
+                m for m in projected if m.get("role") == "assistant"
+            )
+            # The provider replay sidecar was projected into content, so the
+            # row already carries payload and the sanitizer has nothing to heal.
+            assert _msg_has_payload(hidden_assistant) is True
+            assert hidden_assistant["content"] == "[response interrupted]"
+            assert "display_kind" not in hidden_assistant
+            assert "api_content" not in hidden_assistant
+
+            healed = repair_empty_non_final_messages(projected)
+            healed_assistant = next(
+                m for m in healed if m.get("role") == "assistant"
+            )
+            assert healed_assistant["content"] == "[response interrupted]"
+            assert "display_kind" not in healed_assistant
+            assert "api_content" not in healed_assistant
+            # Durable transcript is never mutated by projection or sanitizer.
+            assert durable == messages
+            assert durable[1]["content"] == ""
+            assert durable[1]["display_kind"] == "hidden"
+            assert durable[1]["api_content"] == "[response interrupted]"
+
+        # #81841 scaffold never appears on the assistant wire.
+        assert (
+            "[This response was interrupted by a user correction.]"
+            not in healed_assistant["content"]
+        )
+
+    def test_empty_non_final_sanitizer_still_repairs_unmarked_empty_assistant(self):
+        """Control: a genuinely empty non-final assistant with no provider-replay
+        sidecar is still healed — the fix must not disable the generic net."""
+        from agent.agent_runtime_helpers import repair_empty_non_final_messages
+
+        rows = [
+            {"role": "user", "content": "start"},
+            {"role": "assistant", "content": "", "display_kind": "hidden"},
+            {"role": "user", "content": "correction"},
+        ]
+        healed = repair_empty_non_final_messages(rows)
+        assistant = next(m for m in healed if m.get("role") == "assistant")
+        assert assistant["content"] == "[response interrupted]"
+        # The durable list is not mutated (wire-copy-only design).
+        assert rows[1]["content"] == ""
 
 
 class TestSteerInjection:

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -711,3 +711,139 @@ class TestSteerCommandRegistry:
 
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])
+
+
+class TestLegacyHiddenPlaceholderWireSubstitution:
+    """Projection-side half of #88955: rows persisted BEFORE the writer-side
+    ``api_content`` stamp are ``content=""`` + ``display_kind="hidden"`` with
+    no sidecar. The send-time projection must give the WIRE copy the neutral
+    ``[response interrupted]`` payload so legacy sessions converge instead of
+    re-healing forever — while the durable row stays hidden and empty."""
+
+    def _loop_agent(self):
+        from unittest.mock import MagicMock, patch
+
+        from run_agent import AIAgent
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        agent.client = MagicMock()
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+        return agent
+
+    def test_legacy_empty_hidden_assistant_row_gets_neutral_wire_payload(self):
+        """The projection itself must fill the row — the sanitizer must have
+        NOTHING left to heal (its per-turn warning spam IS the bug)."""
+        from unittest.mock import patch
+
+        import agent.agent_runtime_helpers as _arh
+
+        from tests.run_agent.test_run_agent import _mock_response
+
+        agent = self._loop_agent()
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(content="ok", finish_reason="stop"),
+        ]
+        sanitizer_inputs = []
+        _real_repair = _arh.repair_empty_non_final_messages
+
+        def _spy_repair(messages, *a, **k):
+            sanitizer_inputs.append(
+                [
+                    (m.get("role"), m.get("content"))
+                    for m in messages
+                    if isinstance(m, dict)
+                ]
+            )
+            return _real_repair(messages, *a, **k)
+        # Legacy pre-fix row: no api_content sidecar.
+        history = [
+            {"role": "user", "content": "start"},
+            {"role": "assistant", "content": "", "display_kind": "hidden"},
+            {"role": "user", "content": "correction", "finish_reason": "stop"},
+            {"role": "assistant", "content": "earlier reply", "finish_reason": "stop"},
+        ]
+
+        with (
+            patch.object(agent, "_flush_messages_to_session_db"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(
+                _arh, "repair_empty_non_final_messages", side_effect=_spy_repair
+            ),
+        ):
+            agent.run_conversation("next question", conversation_history=history)
+
+        # Precondition: the sanitizer actually ran on this call path.
+        assert sanitizer_inputs, "sanitizer was never invoked — test is vacuous"
+        # The projection already filled the legacy row BEFORE sanitization:
+        # every assistant row the sanitizer saw carried payload, so it healed 0.
+        for snapshot in sanitizer_inputs:
+            for role, content in snapshot:
+                if role == "assistant":
+                    assert (content or "").strip(), (
+                        "sanitizer still received an empty assistant row — "
+                        "the re-heal loop is back (#88955)"
+                    )
+
+        wire = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        wire_assistants = [m for m in wire if m.get("role") == "assistant"]
+        legacy = wire_assistants[0]
+        # Substituted on the wire by the projection (not the sanitizer):
+        assert legacy["content"] == "[response interrupted]"
+        assert "display_kind" not in legacy
+        # #81841: never the interrupt scaffold.
+        assert "[This response was interrupted" not in legacy["content"]
+        # Durable history untouched.
+        assert history[1]["content"] == ""
+        assert history[1]["display_kind"] == "hidden"
+        assert "api_content" not in history[1]
+
+    def test_hidden_row_with_tool_calls_or_text_is_not_touched(self):
+        from agent.conversation_loop import _clone_message_for_send  # noqa: F401
+        from unittest.mock import patch
+
+        from tests.run_agent.test_run_agent import _mock_response
+
+        agent = self._loop_agent()
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(content="ok", finish_reason="stop"),
+        ]
+        history = [
+            {"role": "user", "content": "start"},
+            {
+                "role": "assistant",
+                "content": "visible text",
+                "display_kind": "hidden",
+                "finish_reason": "stop",
+            },
+            {"role": "user", "content": "more"},
+            {"role": "assistant", "content": "reply", "finish_reason": "stop"},
+        ]
+
+        with (
+            patch.object(agent, "_flush_messages_to_session_db"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            agent.run_conversation("next", conversation_history=history)
+
+        wire = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        wire_assistants = [m for m in wire if m.get("role") == "assistant"]
+        assert wire_assistants[0]["content"] == "visible text"


### PR DESCRIPTION
## Summary

The interrupted-turn hidden assistant placeholder no longer re-triggers the pre-call sanitizer on every subsequent turn (#88955). Root cause: `_apply_active_turn_redirect()` persisted `content=""` + `display_kind="hidden"` rows that `repair_empty_non_final_messages()` saw as wire-empty forever, since heals only touch the per-call copy while the durable transcript is never mutated.

Salvages PR #89525 by @andrexibiza (writer-side fix + regression tests, authorship preserved), plus a follow-up covering the projection side so already-poisoned sessions converge too — approach credit @JoaoMarcos44 (PR #88996, first submitter on this issue).

## Changes

- `agent/conversation_loop.py` (@andrexibiza): hidden redirect placeholders now stamp `api_content="[response interrupted]"` — the existing historical projection fills the wire content, the sanitizer sees payload, transcript stays hidden/empty. Never the interrupt scaffold (#81841).
- `agent/conversation_loop.py` (follow-up): legacy rows persisted before the stamp (no sidecar) get the same neutral payload substituted on the wire copy at the `display_kind` projection stage, so old sessions stop looping.
- `tests/run_agent/test_steer.py`: 3 regression tests from the salvaged PR + 2 end-to-end tests driving `run_conversation` with a spied sanitizer asserting it has nothing left to heal (verified failing without the projection fix via sabotage run).
- `contributors/emails/`: removes the case-colliding `agent@*Mac-mini.local` pair that breaks checkouts on case-insensitive filesystems (@andrexibiza).

## Validation

| | Before | After |
|---|---|---|
| Sanitizer warning on turns after a no-text interruption | every call, forever | none (new + legacy rows) |
| `tests/run_agent/test_steer.py` | 29 passed | 34 passed |
| Sanitizer suites (streaming, thinking-only, partial-stream, sanitization policy, incremental persistence) | — | 123 passed |

Closes #88955. Supersedes #88996 (credited).

## Infographic

![The re-heal loop, ended](https://v3b.fal.media/files/b/0aa6e3e0/5CWwwwcrCOJDhMtjw8DUx_Tc9KDwjj.png)
