### PR TITLE
fix(desktop): hide hover close buttons on Sessions and Bots tabs

### DIFF
--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -154,6 +154,7 @@ registry.registerMany([
       collapsible: true,
       dock: { pane: 'workspace', pos: 'left' },
       revealAliases: ['chat-sidebar'],
+      showCloseButton: false,
       width: `${SIDEBAR_DEFAULT_WIDTH}px`,
       minWidth: `${SIDEBAR_DEFAULT_WIDTH}px`,
       maxWidth: `${SIDEBAR_MAX_WIDTH}px`

--- a/apps/desktop/src/components/pane-shell/tree/renderer/track-model.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/track-model.ts
@@ -65,6 +65,8 @@ interface PaneChrome extends PaneSizing {
   /** No Close in the tab menu — the one surface the app can't lose (the
    *  main workspace). Session tiles share `placement: 'main'` but close. */
   uncloseable?: boolean
+  /** Hide the hover ✕ while retaining explicit close behavior for this pane. */
+  showCloseButton?: boolean
   /** Wrap this pane's TAB (e.g. in a domain context menu — a session tile's
    *  pin/branch/rename/archive/delete). The wrapper must render `tab` as its
    *  interactive child; the zone's own strip menu still owns non-tab space. */

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -539,6 +539,7 @@ export function TreeGroup({
                   }}
                   role="tab"
                   selected={isSelected}
+                  showCloseButton={chrome.showCloseButton !== false}
                   style={{ cursor: 'grab' }}
                 >
                   {chrome.tabLead ? (

--- a/apps/desktop/src/components/ui/pane-tab.test.tsx
+++ b/apps/desktop/src/components/ui/pane-tab.test.tsx
@@ -124,6 +124,21 @@ describe('PaneTab hover close button', () => {
     expect(screen.queryByRole('button', { name: 'Close' })).toBeNull()
   })
 
+  it('can hide the hover ✕ while retaining the close handler', () => {
+    const onClose = vi.fn()
+    render(
+      <PaneTab onClose={onClose} showCloseButton={false}>
+        <PaneTabLabel>tab</PaneTabLabel>
+      </PaneTab>
+    )
+
+    expect(screen.queryByRole('button', { name: 'Close' })).toBeNull()
+    const tab = screen.getByText('tab')
+    fireEvent.pointerDown(tab, { button: 1 })
+    fireEvent.pointerUp(tab, { button: 1 })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
   it('renders no ✕ on a vertical rail tab (middle/⌘-click only there)', () => {
     const onClose = vi.fn()
     render(

--- a/apps/desktop/src/components/ui/pane-tab.tsx
+++ b/apps/desktop/src/components/ui/pane-tab.tsx
@@ -58,6 +58,8 @@ interface PaneTabProps extends React.ComponentProps<'div'> {
   /** Part of a multi-tab selection (⌥/Ctrl-click, Shift-click) — an accent
    *  wash marks every tab that a drag would carry, Chrome-style. */
   selected?: boolean
+  /** Whether a closeable horizontal tab reveals the hover ✕. */
+  showCloseButton?: boolean
   /** Vertical rail form (collapsed sidebar zones). */
   vertical?: boolean
   /** Content-facing edge of a vertical rail — the strip line the active tab cuts. */
@@ -81,6 +83,7 @@ export const PaneTab = React.forwardRef<HTMLDivElement, PaneTabProps>(function P
     onPointerUp,
     onClickCapture,
     selected = false,
+    showCloseButton = true,
     vertical = false,
     side = 'left',
     children,
@@ -159,7 +162,7 @@ export const PaneTab = React.forwardRef<HTMLDivElement, PaneTabProps>(function P
           <span className="size-2 rounded-full bg-amber-500 shadow-[0_0_0_2px_var(--tab-bg),0_1px_2px_rgba(0,0,0,0.45)] dark:bg-amber-400" />
         </span>
       )}
-      {onClose && !vertical && (
+      {onClose && showCloseButton && !vertical && (
         // Hover ✕, painted OVER the label's right edge as an overlay (no
         // layout shift, tab width never jumps on hover). The runway is a tiny
         // transparent→`--tab-face` gradient, so the button melts into the

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -9777,7 +9777,7 @@ export default {
       // sessions pane collapses alone without this flag. The zone then keeps
       // a stranded BOTS tab on screen. The narrow edge overlay mirrors the
       // zone's tab strip, so the pane stays reachable while collapsed.
-      data: { placement: 'left', width: '260px', collapsible: true, dock: { pane: 'sessions', pos: 'center', enforce: true } },
+      data: { placement: 'left', width: '260px', collapsible: true, showCloseButton: false, dock: { pane: 'sessions', pos: 'center', enforce: true } },
       render: () => jsx(BotsPane, {})
     })
 


### PR DESCRIPTION
## Summary

- Hide the hover `×` close affordance on the persistent `SESSIONS | BOTS` navigation tabs.
- Keep the generic hover close button enabled for ordinary closeable pane tabs.
- Preserve the existing close handlers, middle/Cmd-click gestures, context-menu behavior, tab switching, and dragging.

Fixes #89546.

## Root cause

PR #89428 introduced the hover close button in the shared `PaneTab` primitive for every closeable horizontal pane tab:

- https://github.com/NousResearch/hermes-agent/pull/89428
- https://github.com/NousResearch/hermes-agent/commit/542e146b055f0d43767ac43cdb9e78054b240263

Sessions and Bots were already modeled as closeable horizontal panes, so they inherited the button. The original PR changed only the shared primitive and did not define a distinction between disposable content tabs and persistent navigation panes.

Related earlier implementations are #69392 and #89243.

## Approach

Add an explicit `showCloseButton` pane policy:

- `PaneTab.showCloseButton` defaults to `true`.
- The tree renderer forwards the pane contribution's policy to `PaneTab`.
- The core Sessions pane and bundled Bots pane set `showCloseButton: false`.
- The existing `onClose` handler remains attached, so this PR changes only the visible hover affordance rather than silently changing close routing.

This avoids hard-coding pane IDs in the shared renderer and preserves the generic behavior for ordinary content tabs.

## Tests

- `NODE_ENV=test npx vitest run src/components/ui/pane-tab.test.tsx` — 10 passed.
- `NODE_ENV=test npm run test:ui` — 526 files / 4,879 tests passed.
- `npm run check:lint` — typecheck passed; lint passed with existing warnings only.
- `npx prettier --check` on affected TypeScript files — passed.
- `node --check apps/desktop/src/plugins/hermes-bots/plugin.js` — passed.

## Scope and risk

Low-risk UI-only change. No layout persistence, pane-close routing, or session state behavior is changed. The unrelated explicit close/recovery paths remain available.
