### PR TITLE
fix(desktop): /goal clear removes the Goal paused card immediately

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -9,6 +9,7 @@ import { textPart } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { $composerAttachments, $composerDraft, type ComposerAttachment, setComposerDraft } from '@/store/composer'
 import { $queuedPromptsBySession, getQueuedPrompts } from '@/store/composer-queue'
+import { $goalsBySession, setSessionGoal } from '@/store/goals'
 import { $hudMode } from '@/store/hud'
 import { $notifications, clearNotifications } from '@/store/notifications'
 import {
@@ -1201,6 +1202,69 @@ describe('usePromptActions slash.exec dispatch payloads', () => {
 
     expect(renderedText).toContain('⊙ Goal set. Starting now.')
     expect(renderedText).not.toContain('/goal: no output')
+  })
+
+  it('clears the goal card when /goal clear returns a typed exec dispatch (#80348)', async () => {
+    // The gateway can answer `/goal clear` with a TYPED `{ type: "exec" }`
+    // dispatch instead of the plain `{ output }` shape. The typed branch used
+    // to render and return without touching the goal store, so the stale
+    // "Goal paused" card kept showing until the chat was reopened.
+    setSessionGoal(RUNTIME_SESSION_ID, {
+      status: 'paused',
+      title: 'ship the release notes',
+      updatedAt: Date.now()
+    })
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'slash.exec') {
+        return { type: 'exec', output: '✓ Goal cleared.' } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+
+    await handle!.submitText('/goal clear')
+
+    expect($goalsBySession.get()[RUNTIME_SESSION_ID]).toBeUndefined()
+
+    $goalsBySession.set({})
+  })
+
+  it('updates the goal card live when /goal resume returns a typed exec dispatch', async () => {
+    // Sibling of the clear path: a typed exec `▶ Goal resumed: …` must flip
+    // the paused card back to active without a chat reopen.
+    setSessionGoal(RUNTIME_SESSION_ID, {
+      status: 'paused',
+      title: 'ship the release notes',
+      updatedAt: Date.now()
+    })
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'slash.exec') {
+        return { type: 'exec', output: '▶ Goal resumed: ship the release notes' } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+
+    await handle!.submitText('/goal resume')
+
+    expect($goalsBySession.get()[RUNTIME_SESSION_ID]).toMatchObject({
+      status: 'active',
+      title: 'ship the release notes'
+    })
+
+    $goalsBySession.set({})
   })
 
   it('queues the /goal kickoff instead of dropping it when the session is busy (#63352)', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -265,6 +265,17 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           dispatch: NonNullable<ReturnType<typeof parseCommandDispatch>>
         ): Promise<void> => {
           if (dispatch.type === 'exec' || dispatch.type === 'plugin') {
+            // `/goal clear|pause|resume|status` can come back as a TYPED exec
+            // dispatch (command.dispatch routing) instead of the plain-output
+            // shape handled below. This branch used to render and return
+            // without touching the goal store, so "✓ Goal cleared." printed
+            // while the stale "Goal paused" card kept showing until the chat
+            // was reopened (#80348). Mirror the output into the store exactly
+            // like the plain-output path does.
+            if (name === 'goal' && dispatch.output) {
+              applyGoalStatusText(sessionId, dispatch.output)
+            }
+
             renderSlashOutput(dispatch.output ?? '(no output)')
 
             return

--- a/apps/desktop/src/store/goals.test.ts
+++ b/apps/desktop/src/store/goals.test.ts
@@ -57,6 +57,14 @@ describe('goal store', () => {
     expect($goalsBySession.get().s1).toBeUndefined()
   })
 
+  it('clears immediately on /goal clear output', () => {
+    applyGoalStatusText('s1', '⊙ Goal set (20-turn budget): ship another feature')
+    applyGoalStatusText('s1', '⏸ Goal paused — 20/20 turns used. Use /goal resume to keep going.')
+    applyGoalStatusText('s1', '✓ Goal cleared.')
+
+    expect($goalsBySession.get().s1).toBeUndefined()
+  })
+
   it('cancels pending done clears when replacing a goal', () => {
     vi.useFakeTimers()
 


### PR DESCRIPTION
## Infographic

![Stale card, cleared](https://v3b.fal.media/files/b/0aa6e4af/U-VhjU0sEZerYFt6dDkFo_08ia0QPB.png)

## Outcome

`/goal clear` now removes the **Goal paused** card from the Desktop composer status stack immediately, instead of leaving it stale until the chat is reopened. The same fix covers the whole sibling class: `/goal pause`, `/goal resume`, and `/goal status` returned as typed dispatches now update the card live too.

Fixes #80348.

## Root cause

The gateway can answer `/goal <subcommand>` with a **typed** `{ type: "exec" }` command dispatch instead of the plain `{ output }` slash.exec shape. In `apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts`, the typed exec/plugin branch rendered the output (`✓ Goal cleared.`) and returned immediately — it never reached the goal-store sync (`applyGoalStatusText`) that the plain-output path runs. The backend goal was cleared, but the renderer's `$goalsBySession` cache kept the paused entry until `refreshSessionGoal` ran on chat reopen.

## Changes

- **`slash.ts`** — in the typed `exec`/`plugin` dispatch branch, when the command is `goal`, mirror the dispatch output into the goal store via `applyGoalStatusText(sessionId, output)` before rendering, matching the plain-output path. The store's parser already understands every `/goal` output shape (cleared / paused / resumed / active / done), so one sync point fixes the class; `/goal set` (a `send` dispatch notice) was already handled.
- **`use-prompt-actions/index.test.tsx`** — two regression tests at the integration level (same response shape as production): typed exec `✓ Goal cleared.` removes the session's goal entry (#80348); typed exec `▶ Goal resumed: …` flips a paused card back to active.
- **`store/goals.test.ts`** — unit test: `✓ Goal cleared.` output clears a paused goal.

## Validation

| Check | Result |
| --- | --- |
| `npx vitest run src/store/goals.test.ts src/app/session/hooks/use-prompt-actions/index.test.tsx` (apps/desktop) | ✅ 2 files, 128 tests passed |
| `npm run check:lint` (apps/desktop — tsc ×3 + eslint, CI parity) | ✅ 0 errors (126 pre-existing warnings) |
| Conflict markers / diff scope vs origin/main | ✅ 3 files, +83 only |

