### PR TITLE
fix(search): make session titles searchable in Desktop

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -256,7 +256,7 @@ const HEADER_NAV_BTN =
 
 // FTS results cover sessions that aren't in the loaded page; synthesize a
 // minimal SessionInfo so they render in the same row component (resume works
-// by id; the snippet stands in for the preview).
+// by id; the snippet stands in for the preview when the row has no title).
 
 // The backend's FTS layer wraps matched terms in literal '>>>' / '<<<'
 // highlight markers (sqlite snippet() delimiters — see hermes_state_search.py).
@@ -267,7 +267,7 @@ export function stripFtsMarkers(snippet: string): string {
   return snippet.replaceAll('>>>', '').replaceAll('<<<', '')
 }
 
-function searchResultToSession(result: SessionSearchResult): SessionInfo {
+export function searchResultToSession(result: SessionSearchResult): SessionInfo {
   const ts = result.session_started ?? Date.now() / 1000
 
   return {
@@ -285,7 +285,9 @@ function searchResultToSession(result: SessionSearchResult): SessionInfo {
     preview: stripFtsMarkers(result.snippet ?? '').trim() || null,
     source: result.source ?? null,
     started_at: ts,
-    title: null,
+    // Surface the conversation's own title (user/LLM assigned) instead of
+    // forcing null and showing only the content snippet.
+    title: result.title ?? null,
     tool_call_count: 0
   }
 }

--- a/apps/desktop/src/app/chat/sidebar/strip-fts-markers.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/strip-fts-markers.test.ts
@@ -4,7 +4,7 @@
 // rows titled ">>>foo<<<" (Aug 2026 desktop audit).
 import { describe, expect, it } from 'vitest'
 
-import { stripFtsMarkers } from './index'
+import { searchResultToSession, stripFtsMarkers } from './index'
 
 describe('stripFtsMarkers', () => {
   it('strips highlight markers around the matched term', () => {
@@ -23,5 +23,27 @@ describe('stripFtsMarkers', () => {
 
   it('handles empty string', () => {
     expect(stripFtsMarkers('')).toBe('')
+  })
+})
+
+describe('searchResultToSession', () => {
+  const result = {
+    model: 'test-model',
+    role: null,
+    session_id: '20260811_125725_5d4fac',
+    session_started: 1_760_000_000,
+    snippet: 'run buyer discovery',
+    source: 'desktop'
+  }
+
+  it('keeps a server-result title instead of replacing it with a content snippet', () => {
+    const session = searchResultToSession({ ...result, title: "Arby's Faribault, MN" })
+
+    expect(session.title).toBe("Arby's Faribault, MN")
+    expect(session.preview).toBe('run buyer discovery')
+  })
+
+  it('stays compatible with an older backend that omits title', () => {
+    expect(searchResultToSession(result).title).toBeNull()
   })
 })

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1177,6 +1177,8 @@ export interface SessionSearchResult {
   session_started: number | null
   snippet: string
   source: string | null
+  /** User/LLM-assigned title of the matched conversation, when present. */
+  title?: string | null
 }
 
 export interface SessionSearchResponse {

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -354,6 +354,37 @@ async def search_sessions(
             # Over-fetch so lineage dedup can still surface `limit` distinct
             # conversations even when several hits collapse onto one root.
             fetch_limit = max(safe_limit * 5, 50)
+
+            # Title matches next: a user-named session (e.g. "Arby's Faribault,
+            # MN") is found by typing its title. The FTS index only covers
+            # message content, and the id matcher only matches the raw session
+            # id string — neither sees sessions.title. search_sessions_by_title
+            # is SQL-bounded (reuses list_sessions_rich's search_query filter)
+            # and runs after exact-id hits so a conversation that matches both
+            # collapses onto its lineage root exactly once.
+            for row in db.search_sessions_by_title(
+                q,
+                limit=safe_limit,
+                include_archived=True,
+                source=source_filter,
+                sources=source_list or None,
+                exclude_sources=exclude_list or None,
+            ):
+                sid = row.get("id")
+                preview = (row.get("preview") or "").strip()
+                title = (row.get("title") or "").strip()
+                snippet = preview or title or f"Session ID: {sid}"
+                add_lineage_result(
+                    sid,
+                    {
+                        "snippet": snippet,
+                        "role": None,
+                        "source": row.get("source"),
+                        "model": row.get("model"),
+                        "session_started": row.get("started_at"),
+                    },
+                )
+
             matches = db.search_messages(
                 query=prefix_query,
                 source_filter=include_sources,

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -2339,6 +2339,65 @@ class SessionSearchMixin:
         )
         return [row for _, row in ranked[:limit]]
 
+    def search_sessions_by_title(
+        self,
+        query: str,
+        limit: int = 20,
+        include_archived: bool = True,
+        source: str = None,
+        sources: List[str] = None,
+        exclude_sources: List[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Search surfaced sessions by case-insensitive title substring.
+
+        Desktop search uses this so a user-named session (e.g. "Arby's Faribault,
+        MN") can be found by typing its title — the FTS content index does not
+        cover ``sessions.title``, and the id matcher only matches the raw id
+        string. This fills that gap by reusing ``list_sessions_rich``'s
+        ``search_query`` filter, which already matches title (and id) across
+        each conversation's forward compression chain, so a titled compression
+        root still resolves to its live continuation.
+        """
+        needle = (query or "").strip().lower()
+        if not needle or limit <= 0:
+            return []
+
+        # SQL-bounded like the id matcher: list_sessions_rich pushes the title
+        # LIKE filter into the query (matching the row's title AND every title
+        # in its forward compression chain), so we only materialize matching
+        # rows instead of scanning every session.
+        candidates = self.list_sessions_rich(
+            source=source,
+            sources=sources,
+            exclude_sources=exclude_sources,
+            limit=max(limit * 4, limit),
+            offset=0,
+            include_archived=include_archived,
+            order_by_last_active=True,
+            search_query=needle,
+        )
+
+        # Prefer exact-title and prefix-title matches over loose substrings so
+        # "Faribault" ranks a session literally titled "Arby's Faribault, MN"
+        # ahead of one where the word merely appears mid-title.
+        def score(row: Dict[str, Any]) -> int:
+            title = str(row.get("title") or "").lower()
+            if not title:
+                return 3
+            if title == needle:
+                return 0
+            if title.startswith(needle):
+                return 1
+            if needle in title:
+                return 2
+            return 3
+
+        ranked = sorted(
+            enumerate(candidates),
+            key=lambda item: (score(item[1]), item[0]),
+        )
+        return [row for _, row in ranked[:limit]]
+
     def _fts_table_exists(self, name: str) -> bool:
         """True if an FTS5 virtual table is queryable in this DB."""
         try:

--- a/tests/hermes_cli/test_web_server_session_search.py
+++ b/tests/hermes_cli/test_web_server_session_search.py
@@ -39,8 +39,10 @@ class _FakeSessionDB:
         sources=None,
         exclude_sources=None,
     ):
-        assert query == "20260603"
+        assert query in ("20260603", "Arby's Faribault, MN")
         assert include_archived is True
+        if query != "20260603":
+            return []
         rows = [
             {
                 "id": "20260603_090200_exact",
@@ -58,6 +60,52 @@ class _FakeSessionDB:
             )
         ][:limit]
 
+    def search_sessions_by_title(
+        self,
+        query,
+        limit=20,
+        include_archived=True,
+        source=None,
+        sources=None,
+        exclude_sources=None,
+    ):
+        # In the id/content test this runs with "20260603" and must contribute
+        # nothing (no titled sessions); in the title test it runs with the title.
+        if query == "20260603":
+            return []
+        assert query == "Arby's Faribault, MN"
+        rows = [
+            {
+                "id": "titled_session",
+                "preview": "run buyer discovery",
+                "title": "Arby's Faribault, MN",
+                "source": "desktop",
+                "model": "gpt",
+                "started_at": 150,
+            }
+        ]
+        return [
+            row
+            for row in rows
+            if self._source_allowed(
+                row, source=source, sources=sources, exclude_sources=exclude_sources
+            )
+        ][:limit]
+
+    def get_session_rich_row(self, session_id):
+        # Lets add_lineage_result hydrate the title back into the payload.
+        if session_id == "titled_session":
+            return {
+                "id": "titled_session",
+                "source": "desktop",
+                "model": "gpt",
+                "title": "Arby's Faribault, MN",
+                "started_at": 150,
+                "last_active": 150,
+                "preview": "run buyer discovery",
+            }
+        return None
+
     def search_messages(
         self,
         query,
@@ -66,7 +114,8 @@ class _FakeSessionDB:
         limit=20,
         fields=None,
     ):
-        assert query == "20260603*"
+        # Accept the title query's prefix tokens too (Arby's* AND Faribault,* MN*).
+        assert query == "20260603*" or query.startswith("Arby")
         type(self).requested_fields = fields
         rows = [
             {
@@ -141,3 +190,24 @@ def test_desktop_session_search_merges_id_matches_before_content_matches(monkeyp
         ]
     }
     assert _FakeSessionDB.opened_read_only is True
+
+
+def test_desktop_session_search_surfaces_titled_session_by_title(monkeypatch):
+    """A user-named session is findable by typing its title. The FTS index
+    only covers message content and the id matcher only covers session ids, so
+    this is the path that makes a title-string search return the session — and
+    the result must carry the stored title through for the desktop row."""
+    _FakeSessionDB.opened_read_only = None
+    _FakeSessionDB.requested_fields = None
+    monkeypatch.setattr("hermes_state.SessionDB", _FakeSessionDB)
+
+    response = asyncio.run(web_server.search_sessions(q="Arby's Faribault, MN", limit=5))
+
+    assert _FakeSessionDB.opened_read_only is True
+    results = response["results"]
+    assert results[0]["id"] == "titled_session"
+    assert results[0]["title"] == "Arby's Faribault, MN"
+    # Content hits remain available after the title-priority result.
+    assert any(r.get("id") == "content_session" for r in results)
+    # The snippet falls back to the preview when the row carries a title.
+    assert results[0]["snippet"] == "run buyer discovery"

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3824,6 +3824,52 @@ class TestSessionIdSearch:
         assert [s["id"] for s in db.search_sessions_by_id("20260603")] == ["20260603_090200_abcd12"]
         assert [s["id"] for s in db.search_sessions_by_id("ABCD12")] == ["20260603_090200_abcd12"]
 
+    def test_search_sessions_by_title_matches_titled_sessions_case_insensitively(self, db):
+        """A user-named session is findable by its title, not just its id or
+        message content. The FTS index does not cover sessions.title, so this is
+        the path that makes "Arby's Faribault, MN" show up for that string."""
+        db.create_session(session_id="20260811_125725_5d4fac", source="desktop", model="test-model")
+        db.set_session_title("20260811_125725_5d4fac", "Arby's Faribault, MN")
+        db.append_message(session_id="20260811_125725_5d4fac", role="user", content="run buyer discovery")
+
+        db.create_session(session_id="20260811_125726_prefix", source="desktop", model="test-model")
+        db.set_session_title("20260811_125726_prefix", "Arby's Faribault, MN - diligence")
+        db.append_message(session_id="20260811_125726_prefix", role="user", content="title-only prefix match")
+
+        db.create_session(session_id="20260811_125727_substring", source="desktop", model="test-model")
+        db.set_session_title("20260811_125727_substring", "Diligence for Arby's Faribault, MN")
+        db.append_message(session_id="20260811_125727_substring", role="user", content="title-only substring match")
+
+        db.create_session(session_id="20260814_144119_a9d5d1", source="desktop", model="test-model")
+        db.set_session_title("20260814_144119_a9d5d1", "Arby's Antioch")
+        db.append_message(session_id="20260814_144119_a9d5d1", role="user", content="run buyer discovery")
+
+        # Untitled session must NOT match (no title).
+        db.create_session(session_id="20260818_100000_untitled", source="desktop", model="test-model")
+        db.append_message(session_id="20260818_100000_untitled", role="user", content="Faribault appears in content only")
+
+        # Exact title, title-prefix, then loose title-substring is the ranking
+        # contract used by Desktop before falling through to content hits.
+        exact = [s["id"] for s in db.search_sessions_by_title("Arby's Faribault, MN")]
+        assert exact == [
+            "20260811_125725_5d4fac",
+            "20260811_125726_prefix",
+            "20260811_125727_substring",
+        ]
+
+        # Case-insensitive substring matches every title containing the query.
+        all_arbys = [s["id"] for s in db.search_sessions_by_title("arby's")]
+        assert set(all_arbys) == {
+            "20260811_125725_5d4fac",
+            "20260811_125726_prefix",
+            "20260811_125727_substring",
+            "20260814_144119_a9d5d1",
+        }
+
+        # Word present only in message content, not in a title, does not match.
+        content_only = db.search_sessions_by_title("Faribault appears in content")
+        assert content_only == []
+
 
 
 


### PR DESCRIPTION
## Bug Description

Desktop session search only matched session IDs and FTS message content once a chat fell outside the locally loaded sidebar page. A manually named deal or client session could be absent from results, and any server hit discarded its title in favor of raw content.

## Root Cause

`GET /api/sessions/search` ran ID matching followed by FTS content matching, with no `sessions.title` lookup. The Desktop result mapper then hard-coded `title: null` even though the backend hydration already had the title.

## Fix

- Add SQL-bounded, case-insensitive title search across compression lineages.
- Rank exact title matches, then title-prefix matches, then title-substring matches, ahead of FTS content results.
- Carry the optional title through the search response and Desktop mapper.
- Preserve compatibility with an older backend that does not yet return a title.

## How to Verify

1. Give a session a distinctive title, then let it fall outside the loaded sidebar page.
2. Search the exact title in Desktop.
3. Confirm that session is first and its heading is the stored title, with content matches still following.

## Test Plan

- [x] `scripts/run_tests.sh tests/test_hermes_state.py -k search_sessions_by_title`
- [x] `scripts/run_tests.sh tests/hermes_cli/test_web_server_session_search.py`
- [x] `npm run typecheck`
- [x] Targeted ESLint and `npm run test:ui` (557 files, 5,335 tests)
- [x] Manual invocation of the real search handler against an existing titled session in a read-only live DB
- [!] Full `tests/test_hermes_state.py` has one unrelated baseline failure in `TestFTS5Search::test_search_projection_skips_context_enrichment_queries`, reproduced on clean `origin/main`.

## Risk Assessment

Low. The change is read-only search ordering plus an optional response field. It does not change session storage, titles, compression, updater code, or the installed Desktop bundle.