### PR TITLE
docs: hermes://plugin/install one-click install links are now documented

### DIFF
--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -688,6 +688,21 @@ only locally installed packages contribute a desktop half (same rule as the
 standalone door).
 :::
 
+### Distributing with an install link {#install-link}
+
+Ship your plugin repo (agent half, desktop half, or both) and link to it with
+the `hermes://` scheme — a plain anchor on your website or README:
+
+```html
+<a href="hermes://plugin/install?repo=owner/repo&enable=1">Install in Hermes</a>
+```
+
+The user gets a confirmation dialog (repo id, source links, a probe of what
+the repo ships) and picks components before anything is installed — deep links
+never auto-install. `force=1` replaces an existing install; dev builds use
+`hermes-dev://`. Full link reference:
+[One-click install links](/user-guide/features/plugins#one-click-install-links-desktop).
+
 ### The Python side
 
 Desktop plugins reuse the dashboard plugin backend mount. Put the backend in a

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -344,6 +344,41 @@ hermes plugins disable my-plugin             # remove from allow-list + add to d
 hermes plugins capabilities [my-plugin]      # declared vs granted capabilities
 ```
 
+### One-click install links (Desktop)
+
+Hermes Desktop registers the `hermes://` URL scheme, so a website, README, or
+chat message can link straight to a plugin install:
+
+```
+hermes://plugin/install?repo=owner/repo            # main install link
+hermes://plugin/install?repo=owner/repo&enable=1   # enable the agent plugin after install
+hermes://plugin/install?repo=owner/repo&force=1    # replace an existing install
+```
+
+Clicking one opens Hermes and shows a **confirmation dialog** — the repo id,
+a "Before you install" note, and GitHub browse + clone links — then
+shallow-clones the repo to detect what it ships (an **agent plugin** —
+backend Python, a **desktop plugin** — app UI, or both). You pick the
+components with checkboxes and confirm. Nothing is installed until you do;
+deep links never auto-install, and agent-plugin installs go through the same
+[install-time security scanning](#install-time-security-scanning) as
+`hermes plugins install`.
+
+Hybrid repos (agent + desktop halves in one repo) use one link and one
+dialog. The same modal is reachable without a link via **Settings → Plugins →
+Install from Git**. Legacy `hermes://plugin-agent/…` and
+`hermes://plugin-desktop/…` URLs route into the same dialog. In dev builds
+(`npm run dev`) the scheme is `hermes-dev://`.
+
+Websites need no SDK — a normal anchor works:
+
+```html
+<a href="hermes://plugin/install?repo=owner/repo&enable=1">Install in Hermes</a>
+```
+
+MCP servers have the equivalent link form — see
+[Add to Hermes link](/reference/mcp-config-reference#add-to-hermes-link).
+
 ### Plugin capabilities and consent
 
 Plugins can declare the privileged host surfaces they want in their


### PR DESCRIPTION
## Summary
The one-click plugin install flow that shipped in #89464 (`hermes://plugin/install` deeplinks + the Settings → Plugins → Install from Git modal) is now documented — it landed with zero docs.

## Changes
- `website/docs/user-guide/features/plugins.md`: new "One-click install links (Desktop)" section under Managing plugins — the three link forms (`repo`, `enable=1`, `force=1`), the confirm-first dialog contract (never auto-installs; agent-half installs go through the same install-time security scanning as the CLI), hybrid-repo behavior, legacy `plugin-agent`/`plugin-desktop` routing, `hermes-dev://` in dev builds, and the no-SDK anchor example; cross-links the MCP "Add to Hermes link" equivalent
- `website/docs/developer-guide/desktop-plugin-sdk.md`: "Distributing with an install link" section next to the packaging docs, pointing back to the full reference

## Validation
| Check | Result |
|---|---|
| `npx docusaurus build` | SUCCESS (en + zh-Hans) |
| Anchor cross-links (`#add-to-hermes-link`, `#one-click-install-links-desktop`, `#install-time-security-scanning`) | verified against generated headings |

## Infographic

![Docs: install links](https://v3b.fal.media/files/b/0aa6e465/rKD7bYFISEV8KeRUzKvJC_ywNXl5G5.png)
