### PR TITLE
fix(desktop): keep routine timing metadata visible

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -7072,15 +7072,15 @@ function RoutineRow({ job, profile }) {
         ]
       }),
       jsxs('div', {
-        className: 'flex items-center justify-between gap-2 pl-3.5',
+        className: 'flex flex-wrap items-center gap-x-2 gap-y-1 pl-3.5',
         children: [
           jsxs('span', {
             className:
-              'inline-flex items-center gap-1 rounded-full border border-(--ui-stroke-secondary) px-1.5 py-0.5 text-[0.65rem] text-(--ui-text-tertiary)',
+              'inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-full border border-(--ui-stroke-secondary) px-1.5 py-0.5 text-[0.65rem] text-(--ui-text-tertiary)',
             children: [jsx(Codicon, { name: 'calendar', className: 'text-[0.7rem]' }), scheduleLabel(job.schedule)]
           }),
           jsx('span', {
-            className: 'truncate text-[0.65rem] text-(--ui-text-quaternary)',
+            className: 'ml-auto shrink-0 whitespace-nowrap text-[0.65rem] text-(--ui-text-quaternary)',
             children: active && job.next_run_at ? `next ${relativeTime(new Date(job.next_run_at).getTime())}` : 'paused'
           })
         ]

--- a/apps/desktop/src/plugins/hermes-bots/tests/routine-row-layout.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routine-row-layout.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+const start = source.indexOf('function RoutineRow(')
+const end = source.indexOf('// Structured schedule picker:', start)
+
+assert.ok(start >= 0 && end > start, 'RoutineRow must remain extractable')
+
+function renderRoutineRow() {
+  const context = {
+    Codicon: 'Codicon',
+    Switch: 'Switch',
+    Tip: 'Tip',
+    cn: (...values) => values.filter(Boolean).join(' '),
+    host: { request: async () => undefined, notifyError: () => undefined },
+    invalidateRoutineOwner: async () => undefined,
+    isLegacyDelegatedRoutine: () => false,
+    jsx: (type, props) => ({ type, props }),
+    jsxs: (type, props) => ({ type, props }),
+    relativeTime: () => 'in 4 days',
+    routineTitle: () => 'Daily digest',
+    scheduleLabel: () => 'Every day',
+    useState: initial => [initial, () => undefined]
+  }
+
+  vm.createContext(context)
+  vm.runInContext(`${source.slice(start, end)}\nglobalThis.__RoutineRow = RoutineRow`, context)
+
+  return context.__RoutineRow({
+    job: {
+      enabled: true,
+      job_id: 'daily-digest',
+      next_run_at: '2026-08-23T09:00:00Z',
+      schedule: '0 9 * * *'
+    },
+    profile: 'default'
+  })
+}
+
+test('routine metadata wraps without truncating the schedule or next-run time', () => {
+  const row = renderRoutineRow()
+  const metadata = row.props.children[1]
+  const [schedule, nextRun] = metadata.props.children
+
+  assert.match(metadata.props.className, /\bflex-wrap\b/)
+  assert.match(schedule.props.className, /\bshrink-0\b/)
+  assert.match(schedule.props.className, /\bwhitespace-nowrap\b/)
+  assert.match(nextRun.props.className, /\bshrink-0\b/)
+  assert.match(nextRun.props.className, /\bwhitespace-nowrap\b/)
+  assert.doesNotMatch(nextRun.props.className, /\btruncate\b/)
+  assert.equal(nextRun.props.children, 'next in 4 days')
+})


### PR DESCRIPTION
Fixes #89534.

Bot Mode routine rows forced the schedule pill and next-run label onto one shrinking flex line. In a narrow Routines pane, the next-run text was truncated and the schedule pill could be squeezed as well.

The metadata row now wraps when necessary while keeping each label intact. The next-run value stays right-aligned on wide rows and moves to a second line only when the pane cannot fit both values.

Validation:
- `npm --prefix apps/desktop run check:test:plugins` — 284 passed
- The new `RoutineRow` render regression fails on `main` and passes with this change
- `git diff --check`
