### PR TITLE
fix(gateway): auto-resume stops leaving an empty user row that re-trips the sanitizer every turn (#86580, salvage #86789)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1234,16 +1234,24 @@ def _prepare_resume_pending_message(
     *,
     interactive: bool = True,
 ) -> tuple[str, str]:
-    """Return the recovery message and the identical persisted user text.
+    """Return the recovery message and the user text to persist.
 
-    Resume turns replace the empty startup event with a recovery note before
-    entering the agent. Persist that note too, rather than the original empty
-    event, so the durable transcript matches what the model received.
+    Resume turns replace the startup event's text with a recovery note before
+    entering the agent. When the original message is empty (the synthesized
+    auto-resume turn), persist the note too — persisting the empty string
+    left a blank user row in state.db that the pre-call sanitizer re-healed
+    on every later call forever (#86580). When the user sent REAL text while
+    the resume was pending, keep persisting their clean words: the transcript
+    stays scaffold-free (the model still receives the wrapped note), and a
+    non-empty row never trips the sanitizer.
     """
     recovery_message = build_resume_recovery_note(
         reason, message or "", interactive=interactive,
     )
-    return recovery_message, recovery_message
+    persist_message = (
+        message if isinstance(message, str) and message.strip() else recovery_message
+    )
+    return recovery_message, persist_message
 
 
 # Assistant-message fields that must survive transcript replay so multi-turn

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1228,6 +1228,24 @@ def build_resume_recovery_note(
     )
 
 
+def _prepare_resume_pending_message(
+    reason: Optional[str],
+    message: Optional[str],
+    *,
+    interactive: bool = True,
+) -> tuple[str, str]:
+    """Return the recovery message and the identical persisted user text.
+
+    Resume turns replace the empty startup event with a recovery note before
+    entering the agent. Persist that note too, rather than the original empty
+    event, so the durable transcript matches what the model received.
+    """
+    recovery_message = build_resume_recovery_note(
+        reason, message or "", interactive=interactive,
+    )
+    return recovery_message, recovery_message
+
+
 # Assistant-message fields that must survive transcript replay so multi-turn
 # reasoning context, prefix-cache hits, and provider-specific echo
 # requirements all behave the same on the gateway as they do in the CLI.
@@ -6121,7 +6139,6 @@ class TurnRunner:
 
         if _is_resume_pending:
             _reason = getattr(_resume_entry, "resume_reason", None) or "restart_timeout"
-            _persist_user_message_override = ctx.message
             # The empty-message case is the auto-resume startup turn
             # synthesized by _schedule_resume_pending_sessions — there is
             # no NEW user message to address.  Guidance is adapter-aware:
@@ -6134,7 +6151,7 @@ class TurnRunner:
             _interactive_resume = bool(
                 getattr(_resume_adapter, "interactive_resume", True)
             )
-            ctx.message = build_resume_recovery_note(
+            ctx.message, _persist_user_message_override = _prepare_resume_pending_message(
                 _reason, ctx.message, interactive=_interactive_resume,
             )
         elif _has_fresh_tool_tail:

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -326,6 +326,30 @@ class TestResumePendingSystemNote:
         assert persisted == message
         assert persisted != ""
 
+    def test_whitespace_only_message_also_persists_the_note(self):
+        """A whitespace-only startup event is as blank as an empty one —
+        persisting it verbatim would recreate the sanitizer loop (#86580)."""
+        message, persisted = _prepare_resume_pending_message(
+            "shutdown_timeout", "   ", interactive=True
+        )
+
+        assert persisted == message
+        assert persisted.strip()
+
+    def test_real_user_text_persists_clean_not_the_scaffolded_note(self):
+        """When the user typed real text while resume was pending, the durable
+        transcript keeps their clean words; only the MODEL sees the wrapped
+        recovery note (transcript stays scaffold-free)."""
+        message, persisted = _prepare_resume_pending_message(
+            "restart_timeout", "what were we doing?", interactive=True
+        )
+
+        assert persisted == "what were we doing?"
+        assert "[System note:" not in persisted
+        assert message != persisted
+        assert "what were we doing?" in message
+        assert "[System note:" in message
+
 
     def test_resume_pending_fires_without_tool_tail(self):
         """Key improvement over PR #9934: the restart-resume note fires

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -40,6 +40,7 @@ from gateway.run import (
     _coerce_gateway_timestamp,
     _is_fresh_gateway_interruption,
     _last_transcript_timestamp,
+    _prepare_resume_pending_message,
     _should_clear_resume_pending_after_turn,
     build_resume_recovery_note,
 )
@@ -312,6 +313,18 @@ class TestResumePendingSystemNote:
         assert "skip any unfinished work" not in note
         # But still guards against re-running already-recorded tool calls.
         assert "already appear in the history" in note
+
+
+    def test_resume_note_is_persisted_instead_of_original_empty_message(self):
+        """The auto-resume note must not leave an empty row in state.db."""
+        message, persisted = _prepare_resume_pending_message(
+            "restart_timeout", "", interactive=False
+        )
+
+        assert message
+        assert "CONTINUE the interrupted task" in message
+        assert persisted == message
+        assert persisted != ""
 
 
     def test_resume_pending_fires_without_tool_tail(self):


### PR DESCRIPTION
## Summary

Gateway auto-resume no longer persists an empty user row to state.db (#86580) — the row that made the pre-call sanitizer heal-and-warn on every subsequent turn for the life of the session (26 warnings in one 2-hour QQ session). Root cause: the resume branch captured `_persist_user_message_override = ctx.message` BEFORE replacing the empty startup message with the recovery note, so the model got the note but the database got `""`.

Salvages PR #86789 by @andyst-dev (authorship preserved), plus a follow-up so real user text typed during a pending resume persists verbatim instead of the scaffolded note.

## Changes

- `gateway/run.py` (@andyst-dev): `_prepare_resume_pending_message()` builds the recovery note once and uses it for both the model input and `persist_user_message` — no more empty row.
- `gateway/run.py` (follow-up): persist the note only when the original message is blank/whitespace; a real user message typed while resume was pending keeps its clean text in the transcript (the model still receives the wrapped note) — `[System note: ...]` scaffolding never lands as the user's own words (same class as #81841 on the assistant side).
- `tests/gateway/test_restart_resume_pending.py`: contributor's regression test + 2 new tests (whitespace-only counts as blank; real text persists clean).

## Validation

| | Before | After |
|---|---|---|
| state.db user row on auto-resume | `content=''` → sanitizer warning every turn forever | recovery note text, sanitizer quiet |
| Real user text during pending resume | n/a (was empty-persist) | persisted verbatim, no scaffold leak |
| `tests/gateway/test_restart_resume_pending.py` | 31 passed | 34 passed |

ruff clean. Closes #86580. Sibling fix for the assistant-side variant of this family merged as #89544.

## Infographic

![No more blank rows](https://v3b.fal.media/files/b/0aa6e47b/Yd4jo_n1Fza87Q4BrRF48_QEfAWWmW.png)
