### PR TITLE
feat(desktop): surface cron-fleet model defaults and routing in the UI

### DIFF
--- a/apps/desktop/src/app/cron/cron-job-model.test.ts
+++ b/apps/desktop/src/app/cron/cron-job-model.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest'
 
 import {
   cronEditorUpdates,
+  cronModelChoiceLabel,
   jobIsScriptOnly,
+  jobModelRouting,
+  MODEL_FLEET_VALUE,
   parseCronDeliveryTargets,
   toggleCronDeliveryTarget,
   validateCronEditor
@@ -56,6 +59,43 @@ describe('cron delivery targets', () => {
 
   it('does not allow the final delivery target to be unchecked', () => {
     expect(toggleCronDeliveryTarget('origin', 'origin', false)).toBe('origin')
+  })
+})
+
+describe('jobModelRouting', () => {
+  it('reports pinned jobs with provider and model', () => {
+    expect(jobModelRouting({ model: 'hermes-4', provider: 'nous' }, null)).toEqual({
+      kind: 'pinned',
+      label: 'nous · hermes-4'
+    })
+    expect(jobModelRouting({ model: 'hermes-4', provider: '' }, null)).toEqual({ kind: 'pinned', label: 'hermes-4' })
+  })
+
+  it('reports the cron-fleet default when the job is unpinned and a fleet model is configured', () => {
+    expect(jobModelRouting({ model: '', provider: '' }, { model: 'deepseek-v4-flash', provider: 'opencode-go' })).toEqual(
+      { kind: 'fleet', label: 'opencode-go · deepseek-v4-flash' }
+    )
+  })
+
+  it('reports global default when unpinned and no fleet model is configured', () => {
+    expect(jobModelRouting({ model: '', provider: '' }, null)).toEqual({ kind: 'global', label: 'Global default' })
+    expect(jobModelRouting({ model: '', provider: '' }, { model: '', provider: '' })).toEqual({
+      kind: 'global',
+      label: 'Global default'
+    })
+  })
+})
+
+describe('cronModelChoiceLabel', () => {
+  it('labels the fleet sentinel with the configured cron.model', () => {
+    expect(cronModelChoiceLabel(MODEL_FLEET_VALUE, { model: 'deepseek-v4-flash', provider: 'opencode-go' })).toBe(
+      'Fleet default (cron.model): opencode-go · deepseek-v4-flash'
+    )
+  })
+
+  it('falls back to the plain global default label for the empty slot', () => {
+    expect(cronModelChoiceLabel(MODEL_FLEET_VALUE, null)).toBe('Fleet default (cron.model)')
+    expect(cronModelChoiceLabel('anything-else', null)).toBe('Default (global model)')
   })
 })
 

--- a/apps/desktop/src/app/cron/cron-job-model.ts
+++ b/apps/desktop/src/app/cron/cron-job-model.ts
@@ -36,13 +36,63 @@ export function validateCronEditor(input: CronEditorValidationInput): CronEditor
 
 export interface CronEditorSaveValues {
   deliver: string
-  /** Per-job model override ('' = follow the global default at fire time). */
+  /** Per-job model override ('' = follow the cron/global default at fire time). */
   model: string
   name: string
   prompt: string
   /** Provider for the model override ('' = none). Always paired with model. */
   provider: string
   schedule: string
+}
+
+/**
+ * Routing status for an agent job's inference model, mirroring the backend's
+ * fire-time resolution (per-job pin > cron.model > global model.default).
+ * Drift-guard visibility (#89513): a job with no explicit pin may resolve to
+ * the cron-fleet default (cron.model) rather than the global chat model.
+ */
+export type CronModelRoutingKind = 'pinned' | 'fleet' | 'global'
+
+export interface CronFleetConfig {
+  model: string
+  provider: string
+}
+
+export function jobModelRouting(
+  job: Pick<CronJob, 'model' | 'provider'>,
+  fleet: CronFleetConfig | null
+): { kind: CronModelRoutingKind; label: string } {
+  const model = String(job.model ?? '').trim()
+  const provider = String(job.provider ?? '').trim()
+
+  if (model) {
+    return { kind: 'pinned', label: provider ? `${provider} · ${model}` : model }
+  }
+
+  const fleetModel = fleet?.model?.trim()
+
+  if (fleetModel) {
+    const fleetProvider = fleet?.provider?.trim()
+
+    return { kind: 'fleet', label: fleetProvider ? `${fleetProvider} · ${fleetModel}` : fleetModel }
+  }
+
+  return { kind: 'global', label: 'Global default' }
+}
+
+/** Sentinel for the cron-fleet default (cron.model) in the model picker. */
+export const MODEL_FLEET_VALUE = '__fleet__'
+
+export function cronModelChoiceLabel(choice: string, fleet: CronFleetConfig | null): string {
+  if (choice === MODEL_FLEET_VALUE) {
+    const fleetLabel = fleet?.model?.trim() || ''
+    const fleetProvider = fleet?.provider?.trim()
+    const rendered = fleetProvider && fleetLabel ? `${fleetProvider} · ${fleetLabel}` : fleetLabel
+
+    return rendered ? `Fleet default (cron.model): ${rendered}` : 'Fleet default (cron.model)'
+  }
+
+  return 'Default (global model)'
 }
 
 export function parseCronDeliveryTargets(value: string): string[] {

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -52,6 +52,7 @@ import { $changeEventsAvailable, $cronChangeTick } from '@/store/live-sync'
 import { notify, notifyError } from '@/store/notifications'
 import { $profileScope, ALL_PROFILES } from '@/store/profile'
 
+import { useHermesConfigRecord } from '../hooks/use-config-record'
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import {
   Panel,
@@ -76,7 +77,11 @@ import { BlueprintSlotControl, blueprintSlotHelp, cleanBlueprintFieldError, init
 import { mutateAndRefreshCronJobs, refreshCronJobs, triggerAndRefreshCronJobs } from './cron-actions'
 import {
   cronEditorUpdates,
+  type CronFleetConfig,
+  cronModelChoiceLabel,
   jobIsScriptOnly,
+  jobModelRouting,
+  MODEL_FLEET_VALUE,
   parseCronDeliveryTargets,
   toggleCronDeliveryTarget,
   validateCronEditor
@@ -799,7 +804,20 @@ function CronJobDetail({
   const isPaused = state === 'paused'
   const deliver = jobDeliver(job)
   const prompt = jobPrompt(job)
-  const modelOverride = jobModel(job)
+
+  // Routing badge: show whether a job's inference model follows its own pin,
+  // the cron-fleet default (cron.model), or the global default (#89513).
+  const { data: cronConfig } = useHermesConfigRecord()
+
+  const fleetConfig = useMemo<CronFleetConfig | null>(() => {
+    const cronBlock = (cronConfig ?? {}) as { cron?: { model?: unknown; model_provider?: unknown } }
+    const model = String(cronBlock.cron?.model ?? '').trim()
+    const provider = String(cronBlock.cron?.model_provider ?? '').trim()
+
+    return model ? { model, provider } : null
+  }, [cronConfig])
+
+  const routing = jobModelRouting(job, fleetConfig)
 
   return (
     <PanelDetail>
@@ -808,6 +826,9 @@ function CronJobDetail({
           <div className="flex min-w-0 flex-wrap items-center gap-2">
             <h3 className="text-[0.95rem] font-semibold tracking-tight text-foreground">{jobTitle(job)}</h3>
             <PanelPill tone={STATE_TONE[state] ?? 'muted'}>{c.states[state] ?? state}</PanelPill>
+            <PanelPill tone={routing.kind === 'pinned' ? 'good' : routing.kind === 'fleet' ? 'warn' : 'muted'}>
+              {routing.kind === 'pinned' ? 'Pinned' : routing.kind === 'fleet' ? 'Fleet default' : 'Global default'}
+            </PanelPill>
           </div>
           <div className="flex shrink-0 items-center gap-0.5">
             <PanelAction disabled={busy} icon={isPaused ? 'play' : 'debug-pause'} onClick={onPauseResume}>
@@ -825,7 +846,7 @@ function CronJobDetail({
             { label: c.last.replace(/:$/, ''), value: formatTime(job.last_run_at) },
             { label: c.next.replace(/:$/, ''), value: formatTime(job.next_run_at) },
             { label: c.deliverLabel, value: c.deliveryLabels[deliver] ?? deliver },
-            ...(modelOverride ? [{ label: c.modelLabel, value: modelOverride }] : [])
+            { label: c.modelLabel, value: routing.label }
           ]}
         />
 
@@ -1035,6 +1056,19 @@ function CronEditorDialog({
   const initial = isEdit ? editor.job : null
   const scriptOnlyJob = initial ? jobIsScriptOnly(initial) : false
 
+  // The cron-fleet default (cron.model / cron.model_provider) routes unpinned
+  // jobs at fire time (#89513). Read it so the model picker can surface it as
+  // a selectable routing choice instead of hiding it behind "Default".
+  const { data: cronConfig } = useHermesConfigRecord()
+
+  const fleetConfig = useMemo<CronFleetConfig | null>(() => {
+    const cronBlock = (cronConfig ?? {}) as { cron?: { model?: unknown; model_provider?: unknown } }
+    const model = String(cronBlock.cron?.model ?? '').trim()
+    const provider = String(cronBlock.cron?.model_provider ?? '').trim()
+
+    return model ? { model, provider } : null
+  }, [cronConfig])
+
   const [name, setName] = useState('')
   const [prompt, setPrompt] = useState('')
   const [schedule, setSchedule] = useState('')
@@ -1096,12 +1130,21 @@ function CronEditorDialog({
     setSchedule(initial ? jobScheduleExpr(initial) : (SCHEDULE_OPTIONS[0].expr ?? ''))
     setSchedulePreset(initial ? scheduleOptionForExpr(jobScheduleExpr(initial)).value : 'daily')
     setDeliver(initial ? jobDeliver(initial) : DEFAULT_DELIVER)
-    setModelChoice(initial && jobModel(initial) ? `${jobProvider(initial)}:${jobModel(initial)}` : MODEL_DEFAULT_VALUE)
+    // A pinned job shows its pin. Unpinned jobs surface the cron-fleet default
+    // as the routing choice when one is configured (#89513); otherwise the
+    // plain global-default sentinel.
+    setModelChoice(
+      initial && jobModel(initial)
+        ? `${jobProvider(initial)}:${jobModel(initial)}`
+        : fleetConfig
+          ? MODEL_FLEET_VALUE
+          : MODEL_DEFAULT_VALUE
+    )
     setSlotValues({})
     setTemplateChoice(editor.mode === 'create' ? (editor.blueprintKey ?? CUSTOM_TEMPLATE) : CUSTOM_TEMPLATE)
     setError(null)
     setSaving(false)
-  }, [editor, initial, open])
+  }, [editor, fleetConfig, initial, open])
 
   // Seed the typed slots with the blueprint's defaults whenever a blueprint is
   // picked from "Start from" (and reset them when switching back to Custom).
@@ -1139,6 +1182,7 @@ function CronEditorDialog({
   // stored pin visible and re-selectable rather than silently dropping it.
   const modelChoiceKnown =
     modelChoice === MODEL_DEFAULT_VALUE ||
+    modelChoice === MODEL_FLEET_VALUE ||
     modelProviders.some(provider => (provider.models ?? []).some(model => `${provider.slug}:${model}` === modelChoice))
 
   async function handleSubmit(event: React.FormEvent) {
@@ -1164,7 +1208,11 @@ function CronEditorDialog({
 
     // Decode `${providerSlug}:${model}` — the model half may itself contain
     // ':' (e.g. openrouter 'anthropic/claude-sonnet-4:beta'), so split once.
-    const overrideIndex = modelChoice === MODEL_DEFAULT_VALUE ? -1 : modelChoice.indexOf(':')
+    // MODEL_DEFAULT_VALUE / MODEL_FLEET_VALUE both mean "no per-job override";
+    // the fleet sentinel just labels the routing, it does not persist a pin.
+    const overrideIndex =
+      modelChoice === MODEL_DEFAULT_VALUE || modelChoice === MODEL_FLEET_VALUE ? -1 : modelChoice.indexOf(':')
+
     const overrideProvider = overrideIndex >= 0 ? modelChoice.slice(0, overrideIndex) : ''
     const overrideModel = overrideIndex >= 0 ? modelChoice.slice(overrideIndex + 1) : ''
 
@@ -1344,6 +1392,15 @@ function CronEditorDialog({
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
+                    {/* The no-per-job-override rows. Both "no override" — the
+                        job simply isn't pinned — but labeled by which default
+                        actually routes it at fire time: cron.model (fleet) if
+                        configured, otherwise the global model. */}
+                    {fleetConfig && (
+                      <SelectItem value={MODEL_FLEET_VALUE}>
+                        {cronModelChoiceLabel(MODEL_FLEET_VALUE, fleetConfig)}
+                      </SelectItem>
+                    )}
                     <SelectItem value={MODEL_DEFAULT_VALUE}>{c.modelDefault}</SelectItem>
                     {!modelChoiceKnown && (
                       <SelectItem className="font-mono" value={modelChoice}>

--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -265,7 +265,7 @@ describe('ModelSettings', () => {
     await renderModelSettings()
     await waitFor(() => expect(getHermesConfigRecord).toHaveBeenCalled())
 
-    const fastSwitch = await screen.findByRole('switch')
+    const fastSwitch = await screen.findByRole('switch', { name: 'Fast' })
     fireEvent.click(fastSwitch)
 
     await waitFor(() =>
@@ -291,7 +291,9 @@ describe('ModelSettings', () => {
     await renderModelSettings()
     await waitFor(() => expect(getHermesConfigRecord).toHaveBeenCalled())
 
-    expect(screen.queryByRole('switch')).toBeNull()
+    // Fast/speed defaults hidden when the model reports no capabilities; the
+    // always-present cron drift-guard switch must not be mistaken for it.
+    expect(screen.queryByRole('switch', { name: 'Fast' })).toBeNull()
   })
 
   it('renders the auxiliary task rows', async () => {
@@ -383,6 +385,88 @@ describe('ModelSettings', () => {
 
     // Banner present on load, no switch required.
     expect(await screen.findByText(/still run on/)).toBeTruthy()
+  })
+})
+
+describe('ModelSettings cron defaults', () => {
+  it('renders the cron section with the drift guard on by default and saves a toggle', async () => {
+    getHermesConfigRecord.mockResolvedValue({ agent: { reasoning_effort: 'medium', service_tier: 'normal' } })
+    await renderModelSettings()
+
+    expect(await screen.findByText('Cron jobs')).toBeTruthy()
+
+    const drift = screen.getByRole('switch', { name: 'Cron drift guard' })
+    expect(drift).toBeTruthy()
+
+    fireEvent.click(drift)
+
+    await waitFor(() => expect(saveHermesConfig).toHaveBeenCalled())
+    const saved = saveHermesConfig.mock.calls[0][0] as Record<string, unknown>
+    expect(saved).toMatchObject({ cron: { model_drift_guard: false } })
+  })
+
+  it('shows the fleet provider/model dropdowns and saves them via the Save button', async () => {
+    getGlobalModelOptions.mockResolvedValue({
+      providers: [
+        {
+          name: 'Nous',
+          slug: 'nous',
+          models: ['hermes-4', 'hermes-4-mini'],
+          authenticated: true,
+          capabilities: { 'hermes-4': { reasoning: true, fast: true } }
+        },
+        {
+          name: 'OpenRouter',
+          slug: 'openrouter',
+          models: ['anthropic/claude-opus-4.8'],
+          authenticated: true
+        }
+      ]
+    })
+    getHermesConfigRecord.mockResolvedValue({
+      agent: { reasoning_effort: 'medium', service_tier: 'normal' },
+      cron: { model: 'hermes-4', model_provider: 'nous', model_drift_guard: false }
+    })
+    await renderModelSettings()
+
+    expect(await screen.findByText('Cron jobs')).toBeTruthy()
+
+    // Provider dropdown shows the saved provider's model pre-populated.
+    const providerSelect = screen.getByRole('combobox', { name: 'Cron fleet provider' })
+    expect(providerSelect).toBeTruthy()
+
+    fireEvent.click(providerSelect)
+    const openRouterOption = await screen.findByRole('option', { name: 'OpenRouter' })
+    fireEvent.click(openRouterOption)
+
+    const modelSelect = screen.getByRole('combobox', { name: 'Cron fleet model' })
+    fireEvent.click(modelSelect)
+    const claudeOption = await screen.findByRole('option', { name: 'anthropic/claude-opus-4.8' })
+    fireEvent.click(claudeOption)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(saveHermesConfig).toHaveBeenCalled())
+    const saved = saveHermesConfig.mock.calls.at(-1)![0] as Record<string, unknown>
+    expect(saved).toMatchObject({
+      cron: { model: 'anthropic/claude-opus-4.8', model_provider: 'openrouter' }
+    })
+  })
+
+  it('clears the fleet model/provider via the Clear button', async () => {
+    getHermesConfigRecord.mockResolvedValue({
+      agent: { reasoning_effort: 'medium', service_tier: 'normal' },
+      cron: { model: 'hermes-4', model_provider: 'nous', model_drift_guard: false }
+    })
+    await renderModelSettings()
+
+    expect(await screen.findByText('Cron jobs')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear' }))
+
+    await waitFor(() => expect(saveHermesConfig).toHaveBeenCalled())
+    const saved = saveHermesConfig.mock.calls.at(-1)![0] as Record<string, unknown>
+    expect(saved).toMatchObject({ cron: { model: '', model_provider: '' } })
   })
 })
 

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -548,6 +548,86 @@ export function ModelSettings({ onMainModelChanged, scopeProfile = null }: Model
     [config, m.defaultsFailed, scopeProfile, setConfig]
   )
 
+  // Same round-trip for the cron-fleet defaults (cron.model / cron.model_provider)
+  // and the drift guard (#89513). Values may be strings or booleans.
+  const writeCronConfig = useCallback(
+    async (key: string, value: string | boolean) => {
+      if (!config) {
+        return
+      }
+
+      const prev = config
+      const next = setNested(config, key, value)
+      setConfig(next)
+
+      try {
+        await saveHermesConfig(next, scopeProfile ?? undefined)
+      } catch (err) {
+        setConfig(prev)
+        notifyError(err, m.defaultsFailed)
+      }
+    },
+    [config, m.defaultsFailed, scopeProfile, setConfig]
+  )
+
+  // Drafts for the cron-fleet model/provider text fields — committed by the
+  // Save button so we don't PUT the whole config on every keystroke. Resync
+  // whenever the config record changes (initial load, save, profile switch).
+  const [fleetModelDraft, setFleetModelDraft] = useState('')
+  const [fleetProviderDraft, setFleetProviderDraft] = useState('')
+  const [fleetDraftDirty, setFleetDraftDirty] = useState(false)
+
+  useEffect(() => {
+    setFleetModelDraft(String(getNested(config ?? {}, 'cron.model') ?? ''))
+    setFleetProviderDraft(String(getNested(config ?? {}, 'cron.model_provider') ?? ''))
+    setFleetDraftDirty(false)
+  }, [config])
+
+  const fleetDriftGuardOn = getNested(config ?? {}, 'cron.model_drift_guard') !== false
+
+  // Save both fleet fields in ONE config round-trip (PUT replaces the record),
+  // so the provider write can't clobber the model write with a stale snapshot.
+  const saveCronFleet = useCallback(async () => {
+    if (!fleetDraftDirty || !config) {
+      return
+    }
+
+    const prev = config
+    let next = setNested(config, 'cron.model', fleetModelDraft.trim())
+    next = setNested(next, 'cron.model_provider', fleetProviderDraft.trim())
+    setConfig(next)
+    setFleetDraftDirty(false)
+
+    try {
+      await saveHermesConfig(next, scopeProfile ?? undefined)
+    } catch (err) {
+      setConfig(prev)
+      notifyError(err, m.defaultsFailed)
+    }
+  }, [config, fleetDraftDirty, fleetModelDraft, fleetProviderDraft, m.defaultsFailed, scopeProfile, setConfig])
+
+  // Clear the fleet default: write empty values so unpinned jobs fall back to
+  // the global model. Off by default; always button-visible (not dirty-gated)
+  // because a set-but-unchanged fleet is the state you'd want to clear.
+  const clearCronFleet = useCallback(async () => {
+    if (!config) {
+      return
+    }
+
+    const prev = config
+    let next = setNested(config, 'cron.model', '')
+    next = setNested(next, 'cron.model_provider', '')
+    setConfig(next)
+    setFleetDraftDirty(false)
+
+    try {
+      await saveHermesConfig(next, scopeProfile ?? undefined)
+    } catch (err) {
+      setConfig(prev)
+      notifyError(err, m.defaultsFailed)
+    }
+  }, [config, m.defaultsFailed, scopeProfile, setConfig])
+
   // Paste an API key for the selected `api_key` provider, persist it, then
   // refresh so the now-authenticated provider's models populate. Auto-selects
   // the recommended default model so the user can Apply in one more click.
@@ -890,6 +970,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile = null }: Model
               <label className="flex items-center gap-2 text-xs">
                 {t.shell.modelOptions.fast}
                 <Switch
+                  aria-label={String(t.shell.modelOptions.fast)}
                   checked={fastOn}
                   onCheckedChange={checked => void writeAgentDefault('agent.service_tier', checked ? 'fast' : 'normal')}
                   size="xs"
@@ -1027,6 +1108,91 @@ export function ModelSettings({ onMainModelChanged, scopeProfile = null }: Model
               </div>
             )
           })}
+        </div>
+      </section>
+      <section>
+        <SectionHeading icon={Cpu} title="Cron jobs" />
+        <p className="mb-2 text-xs text-muted-foreground">
+          Model routing for scheduled jobs, resolved in this order: a job's own pinned model, then this fleet default
+          (<code>cron.model</code>), then the global model. Unpinned jobs follow the fleet default before the global
+          model.
+        </p>
+        <ListRow
+          action={
+            <Switch
+              aria-label="Cron drift guard"
+              checked={fleetDriftGuardOn}
+              disabled={!config || applying}
+              onCheckedChange={checked => void writeCronConfig('cron.model_drift_guard', checked)}
+              size="xs"
+            />
+          }
+          description="When drift guard is on and a cron is set to the global model and the global model changes, the cron will not execute to prevent unintended spending. Disable only if you want cron jobs to always track the current global default."
+          title="Drift guard"
+        />
+        <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+            Fleet provider
+            <Select
+              onValueChange={value => {
+                setFleetProviderDraft(value)
+                setFleetModelDraft('')
+                setFleetDraftDirty(true)
+              }}
+              value={fleetProviderDraft}
+            >
+              <SelectTrigger aria-label="Cron fleet provider" className={cn('h-8', CONTROL_TEXT)}>
+                <SelectValue placeholder="Select provider" />
+              </SelectTrigger>
+              <SelectContent>
+                {providerOptions.map(provider => (
+                  <SelectItem key={provider.slug || 'none'} value={provider.slug || 'none'}>
+                    {provider.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </label>
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+            Fleet model
+            <Select
+              disabled={!fleetProviderDraft}
+              onValueChange={value => {
+                setFleetModelDraft(value)
+                setFleetDraftDirty(true)
+              }}
+              value={fleetModelDraft}
+            >
+              <SelectTrigger aria-label="Cron fleet model" className={cn('h-8', CONTROL_TEXT)}>
+                <SelectValue placeholder={fleetProviderDraft ? 'Select model' : 'Select provider first'} />
+              </SelectTrigger>
+              <SelectContent>
+                {withActive(modelsForProvider(fleetProviderDraft), fleetModelDraft).map(model => (
+                  <SelectItem key={model} value={model}>
+                    {model}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </label>
+        </div>
+        <div className="mt-2 flex items-center gap-2">
+          <Button
+            disabled={!fleetDraftDirty || !config || applying}
+            onClick={() => void saveCronFleet()}
+            size="sm"
+            variant="outline"
+          >
+            {applying ? m.applying : t.common.save}
+          </Button>
+          <Button
+            disabled={!config || applying}
+            onClick={() => void clearCronFleet()}
+            size="sm"
+            variant="ghost"
+          >
+            Clear
+          </Button>
         </div>
       </section>
       {moa && currentMoaPreset && (


### PR DESCRIPTION
## What does this PR do?

Makes cron inference-model configuration visible and configurable in the desktop app, where it previously only lived in `config.yaml` — and fixes a misleading routing label.

The Models settings page gains a **"Cron jobs"** section exposing the fleet default (`cron.model` / `cron.model_provider`) as cascading provider/model dropdowns, a **drift-guard toggle** (`cron.model_drift_guard`), and Save/Clear actions. The drift guard's fail-closed protection against unintended spending from a changed global model is now configurable from the UI rather than only `config.yaml`.

Separately, the cron editor and job detail now surface the **resolved model routing** (Pinned / Fleet default / Global default) instead of labeling every unpinned job "Default (global model)" — which was wrong once `cron.model` routes an unpinned job to a non-global model (fire-time resolution is per-job pin → `cron.model` → global).

## Related Issue

Issue describing the desktop-UI gap (Models pane missing cron config + scheduled jobs can't route to `cron.model`): **#89513**. This PR implements that surface.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `apps/desktop/src/app/settings/model-settings.tsx` — new "Cron jobs" section: drift-guard toggle (`cron.model_drift_guard`), cascading fleet provider/model dropdowns, Save + Clear
- `apps/desktop/src/app/cron/cron-job-model.ts` — `jobModelRouting()`, `cronModelChoiceLabel()`, `MODEL_FLEET_VALUE` routing helpers
- `apps/desktop/src/app/cron/index.tsx` — routing pill on job detail + truthful fleet/global options in the editor model picker
- `apps/desktop/src/app/settings/model-settings.test.tsx` — tests for the new section (toggle save, dropdown save, clear)
- `apps/desktop/src/app/cron/cron-job-model.test.ts` — tests for the routing helpers

## How to Test

1. `cd apps/desktop && npx vitest run src/app/settings/model-settings.test.tsx src/app/cron/cron-job-model.test.ts` — 43 pass
2. Settings → Models → "Cron jobs": toggle the drift guard; set a fleet provider/model, Save; Clear removes it
3. Scheduled Jobs → open a job: routing pill shows Pinned / Fleet default / Global default; the model picker shows fleet + global as distinct options when `cron.model` is set

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(desktop): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run the relevant tests and they pass (43/43)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] N/A — no config keys added by this PR (they already exist; this surfaces existing ones in the UI)
- [x] N/A — no cross-platform code change (renderer-only)

## Screenshots / Logs

<img width="717" height="223" alt="Hermes_20260818173653_1434x446" src="https://github.com/user-attachments/assets/e9225d7d-ffd2-4af9-9d0f-ab5714f77f47" />
