### PR TITLE
fix(cron): re-parse the serializer's own once-at/once-in displays

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -710,7 +710,6 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
         "2026-02-03T14:00" → once at timestamp
     """
     schedule = schedule.strip()
-    original = schedule
     schedule_lower = schedule.lower()
 
     # Round-trip our own display strings (#89560): jobs list/edit surfaces
@@ -724,6 +723,10 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
     elif schedule_lower.startswith("once in "):
         schedule = schedule[len("once in "):].strip()
         schedule_lower = schedule.lower()
+    # The one-shot duration display echoes this post-strip payload; assigning
+    # it BEFORE the strip made a re-submitted "once in 30m" re-serialize as
+    # "once in once in 30m", which itself no longer round-trips.
+    original = schedule
 
     # "every X" pattern → recurring interval
     if schedule_lower.startswith("every "):

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -712,7 +712,19 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
     schedule = schedule.strip()
     original = schedule
     schedule_lower = schedule.lower()
-    
+
+    # Round-trip our own display strings (#89560): jobs list/edit surfaces
+    # re-submit the serializer's "once at <ts>" / "once in <duration>"
+    # display as the new schedule, and the parser used to reject its own
+    # output with ValueError (surfacing as HTTP 500 on one-shot edits).
+    # Strip the prefix and re-parse the payload verbatim.
+    if schedule_lower.startswith("once at "):
+        schedule = schedule[len("once at "):].strip()
+        schedule_lower = schedule.lower()
+    elif schedule_lower.startswith("once in "):
+        schedule = schedule[len("once in "):].strip()
+        schedule_lower = schedule.lower()
+
     # "every X" pattern → recurring interval
     if schedule_lower.startswith("every "):
         duration_str = schedule[6:].strip()

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -90,6 +90,18 @@ class TestParseSchedule:
         now = datetime.now().astimezone()
         assert now < run_at < now + timedelta(minutes=31)
 
+    def test_once_in_display_survives_double_round_trip(self):
+        """Review follow-up on #89560: the duration branch echoes
+        ``original`` in its display. When ``original`` was captured BEFORE
+        the prefix strip, re-submitting "once in 30m" re-serialized as
+        "once in once in 30m" — which itself no longer round-trips. The
+        display must stay stable across repeated edit cycles."""
+        display = parse_schedule("30m")["display"]
+        second = parse_schedule(display)["display"]
+        third = parse_schedule(second)["display"]
+        assert second == display
+        assert third == display
+
     def test_once_prefix_with_bad_payload_still_rejected(self):
         """Prefix stripping must not swallow validation: garbage after the
         prefix still raises the actionable Invalid schedule error."""

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -69,6 +69,33 @@ class TestParseSchedule:
         assert run_at > now
         assert run_at < now + timedelta(minutes=31)
 
+    def test_reparses_own_once_at_display(self):
+        """Round-trip the serializer's timestamp display (#89560): jobs
+        list/edit surfaces re-submit the display as the new schedule, and a
+        one-shot edit used to die with ValueError (surfaced as HTTP 500)."""
+        display = parse_schedule("2030-01-15T14:00:00")["display"]
+        assert display.startswith("once at ")
+        result = parse_schedule(display)
+        assert result["kind"] == "once"
+        assert result["run_at"].startswith("2030-01-15T14:00")
+
+    def test_reparses_own_once_in_display(self):
+        """Round-trip the duration display the same way (#89560): 'once in
+        30m' must re-parse as a one-shot ~30 minutes out, not ValueError."""
+        display = parse_schedule("30m")["display"]
+        assert display == "once in 30m"
+        result = parse_schedule(display)
+        assert result["kind"] == "once"
+        run_at = datetime.fromisoformat(result["run_at"])
+        now = datetime.now().astimezone()
+        assert now < run_at < now + timedelta(minutes=31)
+
+    def test_once_prefix_with_bad_payload_still_rejected(self):
+        """Prefix stripping must not swallow validation: garbage after the
+        prefix still raises the actionable Invalid schedule error."""
+        with pytest.raises(ValueError, match="Invalid schedule"):
+            parse_schedule("once at not a timestamp")
+
     def test_every_becomes_interval(self):
         result = parse_schedule("every 2h")
         assert result["kind"] == "interval"


### PR DESCRIPTION
## What does this PR do?

`parse_schedule` emits human-readable `display` strings — `once at <YYYY-MM-DD HH:MM>` and `once in <duration>` — that it could not itself re-parse. Feeding either display back in as a `schedule` raised `ValueError: Invalid schedule`. The function was not idempotent over its own output, so any caller that round-trips the display (read a job → show its schedule → submit an edit) broke: editing an existing **one-shot** cron job through a UI that re-submits the displayed schedule failed with an HTTP 500 that read like bad user input while the value came straight out of the API's own serializer (#89560).

This PR strips the two display prefixes at the top of the parser and re-parses the payload verbatim, making `parse_schedule` round-trip its own output:

- `once at 2026-08-19 08:00` → parsed as the timestamp one-shot (run_at `2026-08-19T08:00`).
- `once in 30m` → parsed as the duration one-shot (~30 minutes out).
- Payload validation is unchanged — garbage after either prefix (`once at not a timestamp`) still raises the actionable `Invalid schedule` error.
- Every other branch (every/duration/cron/ISO) is untouched; the prefixes are unique to the serializer's one-shot displays and stripped before any branch runs.

## Related Issue

Fixes #89560

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/jobs.py` — at the top of `parse_schedule`, `once at ` / `once in ` prefixes are stripped (both the raw and lowercased views) before any branch runs, with a comment naming the round-trip failure shape.
- `tests/cron/test_jobs.py` — three new tests: the serializer's `once at` display re-parses to the same one-shot run_at; the `once in 30m` display re-parses to a one-shot ~30 minutes out; a bad payload behind the prefix still raises the actionable error.

## How to Test

```bash
python -m pytest tests/cron/test_jobs.py -q
# Observed result: 75 passed

python -m pytest tests/cron/test_jobs.py::TestParseSchedule -q
# Observed result: 8 passed
```

Fail-on-main check: with the parser change stashed, both round-trip tests fail on main (`ValueError: Invalid schedule 'once at …'` / `'once in 30m'`); the bad-payload pin passes on both.

Direct repro from the issue: `parse_schedule(parse_schedule("2026-08-19T08:00")["display"])` raises on main and returns a `once` schedule here; same for the `30m` display.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments explain intent (why the parser must accept its own serializer's displays)
- [x] Corresponding changes documented via comments
- [x] Tests added and passing (3 new; cron jobs suite green)
- [x] Single root cause, no unrelated changes
