### PR TITLE
fix(config): recognize agent.reasoning_effort in config key validation (#85741)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -322,6 +322,11 @@ DEFAULT_CONFIG = {
         "image_input_mode": "auto",
         "disabled_toolsets": [],
 
+        # Global reasoning effort for the primary agent (spelling-tolerant
+        # parse). Values: none|minimal|low|medium|high|xhigh|max|ultra.
+        # Empty string = provider default. Takes lower priority than the
+        # per-model reasoning_overrides dict below.
+        "reasoning_effort": "",
         # Per-model reasoning effort overrides (spelling-tolerant).
         # Dict mapping model names (any reasonable spelling) to effort levels.
         # Takes precedence over agent.reasoning_effort when the current model

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -111,6 +111,17 @@ class TestConfigYamlRouting:
         assert "not a recognized config key" not in capsys.readouterr().out
         assert "script_timeout_seconds: 600" in _read_config(_isolated_hermes_home)
 
+    def test_agent_reasoning_effort_is_recognized(self, _isolated_hermes_home, capsys):
+        """The documented global reasoning key must not emit the #85741
+        unrecognized-key warning."""
+        set_config_value("agent.reasoning_effort", "high")
+
+        out = capsys.readouterr().out
+        assert "not a recognized config key" not in out
+        assert "Did you mean" not in out
+        config = _read_config(_isolated_hermes_home)
+        assert "reasoning_effort: high" in config
+
     def test_terminal_docker_cwd_mount_flag_goes_to_config_and_env(self, _isolated_hermes_home):
         set_config_value("terminal.docker_mount_cwd_to_workspace", "true")
         config = _read_config(_isolated_hermes_home)
@@ -515,6 +526,7 @@ class TestValidateConfigKey:
         "model",
         "terminal.backend",
         "agent.max_turns",
+        "agent.reasoning_effort",
         "discord.gateway_restart_notification",
         "telegram.bot_token",
         "mcp_servers.foo.command",

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -516,6 +516,16 @@ class TestReasoningOverridesDefaultConfig:
         assert DEFAULT_CONFIG["agent"]["reasoning_overrides"] == {}
 
 
+    def test_default_config_has_reasoning_effort_key(self):
+        """DEFAULT_CONFIG['agent'] must expose the documented global
+        ``agent.reasoning_effort`` key so ``hermes config set`` recognizes it
+        (#85741). Empty string = provider default, matching runtime behavior.
+        """
+        from hermes_cli.config import DEFAULT_CONFIG
+        assert "reasoning_effort" in DEFAULT_CONFIG["agent"]
+        assert DEFAULT_CONFIG["agent"]["reasoning_effort"] == ""
+
+
     def test_spelling_tolerant_lookup_works_with_user_config(self):
         """resolve_per_model_reasoning_effort works with user-added overrides."""
         from hermes_constants import resolve_per_model_reasoning_effort


### PR DESCRIPTION
## What does this PR do?

`hermes config set agent.reasoning_effort <effort>` correctly saves the value but emits a false warning:

```
Warning: 'agent.reasoning_effort' is not a recognized config key (did you mean 'agents.reasoning_overrides'?)
```

The runtime has consumed `agent.reasoning_effort` as the documented global reasoning-effort setting, but `_validate_config_key` walks `DEFAULT_CONFIG["agent"]` (config.py), and that block only exposes `reasoning_overrides`, so the key is reported as unrecognized. This PR adds the key to `DEFAULT_CONFIG["agent"]` with an empty-string default that matches the runtime's "provider default" semantics, so validation and the actual behavior are consistent.

## Related Issue

Fixes #85741

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config_defaults.py`: add `agent.reasoning_effort: ""` to `DEFAULT_CONFIG` (empty = provider default, lower priority than per-model `reasoning_overrides`)
- `tests/hermes_cli/test_set_config_value.py`: `agent.reasoning_effort` added to the recognized-key parameterization; new `test_agent_reasoning_effort_is_recognized` asserts no warning is emitted and the value is persisted
- `tests/test_hermes_constants.py`: new test asserting `DEFAULT_CONFIG["agent"]["reasoning_effort"] == ""`

## How to Test

1. `uv run pytest tests/hermes_cli/test_set_config_value.py tests/test_hermes_constants.py -q` — passes (local Windows run: 140 passed; only pre-existing Windows-only symlink-privilege tests fail)
2. `hermes config set agent.reasoning_effort high` — no unrecognized-key warning

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass (full suite not run; the two affected files pass, see above)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

- [x] Updated relevant documentation — N/A (`agent.reasoning_effort` is already documented; no `cli-config.yaml.example` exists in the repo)
- [x] Updated `cli-config.yaml.example` — no such file in the repo
- [x] Updated `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Considered cross-platform impact — fix is platform-neutral
- [x] Updated tool descriptions/schemas — N/A