### PR TITLE
fix(cron): re-parse own display formats for round-trip idempotency

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -712,7 +712,31 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
     schedule = schedule.strip()
     original = schedule
     schedule_lower = schedule.lower()
-    
+
+    # Re-parse own display formats so round-tripping works:
+    #   "once at 2026-08-19 08:00" → one-shot at that time
+    #   "once in 30m" / "once in 2h" → one-shot from now
+    # Without this, editing a one-shot job through a UI that
+    # re-submits the displayed schedule raises ValueError (#89560).
+    once_at_match = re.match(r'^once at (\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(?::\d{2})?)$', schedule, re.IGNORECASE)
+    if once_at_match:
+        ts = once_at_match.group(1).replace(' ', 'T', 1)
+        return parse_schedule(ts)
+
+    once_in_match = re.match(r'^once in (.+)$', schedule, re.IGNORECASE)
+    if once_in_match:
+        duration_str = once_in_match.group(1).strip()
+        try:
+            minutes = parse_duration(duration_str)
+            run_at = _hermes_now() + timedelta(minutes=minutes)
+            return {
+                "kind": "once",
+                "run_at": run_at.isoformat(),
+                "display": f"once in {duration_str}"
+            }
+        except ValueError:
+            pass
+
     # "every X" pattern → recurring interval
     if schedule_lower.startswith("every "):
         duration_str = schedule[6:].strip()


### PR DESCRIPTION
## Summary

`parse_schedule` emits human-readable `display` strings (`once at <YYYY-MM-DD HH:MM>` and `once in <duration>`) that it cannot itself re-parse. Feeding either display back as a `schedule` raises `ValueError: Invalid schedule`. This breaks one-shot cron job editing through any UI that round-trips the displayed schedule.

## Root cause

The display formats (`once at ...`, `once in ...`) are produced at `cron/jobs.py:768` and `cron/jobs.py:780` but no branch in `parse_schedule` recognizes them as input. The function only handles raw ISO timestamps, duration strings (`30m`, `2h`), cron expressions, and `every X` intervals.

## The fix

Add early-return patterns before the existing parsing logic that recognize and re-parse both display formats:

- `once at 2026-08-19 08:00` → extract timestamp, delegate to ISO parsing path
- `once in 30m` → extract duration, delegate to duration parsing path

25 lines added, 1 deleted. All existing schedule formats continue to work unchanged.

## Verification

7 tests passed on a dev instance:
1. `2026-08-19T08:00` → display → re-parse: once at correct time
2. `once at 2026-08-19 08:00` → parses as once-shot
3. `30m` → display `once in 30m` → re-parse: once-shot
4. `2h` → display `once in 2h` → re-parse: once-shot
5. `every 30m` → still works as interval
6. `0 9 * * *` → still works as cron
7. Direct ISO timestamp → still works

Closes #89560