### PR TITLE
feat(video-gen): enable 1080p xAI text and image generation

### DIFF
--- a/plugins/video_gen/xai/__init__.py
+++ b/plugins/video_gen/xai/__init__.py
@@ -54,7 +54,8 @@ DEFAULT_POLL_INTERVAL_SECONDS = 5
 DEFAULT_EXTEND_DURATION = 6
 
 VALID_ASPECT_RATIOS = {"1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3"}
-VALID_RESOLUTIONS = {"480p", "720p"}
+STANDARD_RESOLUTIONS = ("480p", "720p")
+FULL_HD_RESOLUTIONS = (*STANDARD_RESOLUTIONS, "1080p")
 MAX_REFERENCE_IMAGES = 7
 
 
@@ -65,13 +66,15 @@ _MODELS: Dict[str, Dict[str, Any]] = {
         "strengths": "Text-to-video; legacy image-to-video fallback.",
         "price": "see https://docs.x.ai/developers/models/grok-imagine-video",
         "modalities": ["text", "image"],
+        "resolutions": list(STANDARD_RESOLUTIONS),
     },
     "grok-imagine-video-1.5": {
         "display": "Grok Imagine Video 1.5",
         "speed": "~60-240s",
-        "strengths": "Latest xAI image-to-video model.",
+        "strengths": "Latest xAI text-to-video and image-to-video model.",
         "price": "see https://docs.x.ai/developers/pricing",
-        "modalities": ["image"],
+        "modalities": ["text", "image"],
+        "resolutions": list(FULL_HD_RESOLUTIONS),
     },
 }
 
@@ -289,18 +292,33 @@ def _resolve_model_for_modality(
 ) -> str:
     """Select xAI's text/video model without treating config as a prompt override.
 
-    ``grok-imagine-video-1.5`` currently rejects text-only video
-    generation, but it is the desired image-to-video backend. Explicit tool
-    ``model=`` still wins for users who intentionally request another model.
+    Preview/date-stamped 1.5 aliases reject text-only video generation, but
+    the canonical 1.5 model supports both text-to-video and image-to-video.
+    Explicit tool ``model=`` still wins for intentional overrides.
     """
     requested = (model or "").strip()
     if explicit_model and requested:
         return requested
     if modality == "image":
         return DEFAULT_IMAGE_TO_VIDEO_MODEL
-    if requested == DEFAULT_IMAGE_TO_VIDEO_MODEL or requested in _IMAGE_TO_VIDEO_COMPAT_MODEL_IDS:
+    if requested in _IMAGE_TO_VIDEO_COMPAT_MODEL_IDS:
         return DEFAULT_TEXT_TO_VIDEO_MODEL
     return requested or DEFAULT_TEXT_TO_VIDEO_MODEL
+
+
+def _normalize_resolution(
+    resolution: Optional[str],
+    *,
+    model: str,
+    modality: str,
+) -> str:
+    requested = (resolution or DEFAULT_RESOLUTION).strip().lower()
+    allowed = (
+        FULL_HD_RESOLUTIONS
+        if model == DEFAULT_IMAGE_TO_VIDEO_MODEL and modality in {"text", "image"}
+        else STANDARD_RESOLUTIONS
+    )
+    return requested if requested in allowed else DEFAULT_RESOLUTION
 
 
 async def _submit(
@@ -418,7 +436,7 @@ class XAIVideoGenProvider(VideoGenProvider):
         return {
             "modalities": ["text", "image"],
             "aspect_ratios": sorted(VALID_ASPECT_RATIOS),
-            "resolutions": sorted(VALID_RESOLUTIONS),
+            "resolutions": list(FULL_HD_RESOLUTIONS),
             "max_duration": 15,
             "min_duration": 1,
             "supports_audio": False,
@@ -579,7 +597,6 @@ async def _generate_xai_video_async(
                 prompt=prompt,
             )
     normalized_aspect_ratio = (aspect_ratio or DEFAULT_ASPECT_RATIO).strip()
-    normalized_resolution = (resolution or DEFAULT_RESOLUTION).strip().lower()
     refs, refs_error = _normalize_reference_images(reference_image_urls)
     if refs_error:
         return error_response(
@@ -610,9 +627,6 @@ async def _generate_xai_video_async(
 
     if normalized_aspect_ratio not in VALID_ASPECT_RATIOS:
         normalized_aspect_ratio = DEFAULT_ASPECT_RATIO
-    if normalized_resolution not in VALID_RESOLUTIONS:
-        normalized_resolution = DEFAULT_RESOLUTION
-
     modality_used = "reference" if refs else ("image" if image_input else "text")
     resolved_model = _resolve_model_for_modality(
         model,
@@ -632,6 +646,12 @@ async def _generate_xai_video_async(
                 prompt=prompt,
             )
         resolved_model = DEFAULT_TEXT_TO_VIDEO_MODEL
+
+    normalized_resolution = _normalize_resolution(
+        resolution,
+        model=resolved_model,
+        modality=modality_used,
+    )
 
     clamped_duration = _clamp_duration(duration, has_reference_images=bool(refs))
     payload = {

--- a/plugins/video_gen/xai/__init__.py
+++ b/plugins/video_gen/xai/__init__.py
@@ -416,8 +416,8 @@ class XAIVideoGenProvider(VideoGenProvider):
         except Exception:
             storage_notice = ""
         tag = (
-            "grok-imagine-video for text/reference; "
-            "grok-imagine-video-1.5 for image-to-video; "
+            "grok-imagine-video for legacy text/reference; "
+            "grok-imagine-video-1.5 for 1080p text/image; "
             "edit/extend: pass the stored public HTTPS MP4 (`video` / "
             "`public_url` from a prior Imagine result); uses xAI Grok OAuth "
             "or XAI_API_KEY"

--- a/tests/plugins/video_gen/test_xai_plugin.py
+++ b/tests/plugins/video_gen/test_xai_plugin.py
@@ -23,6 +23,7 @@ def test_xai_provider_registers():
     assert video_gen_registry.get_provider("xai") is provider
     assert provider.display_name == "xAI"
     assert provider.default_model() == "grok-imagine-video"
+    assert "grok-imagine-video-1.5 for 1080p text/image" in provider.get_setup_schema()["tag"]
 
 
 def test_xai_resolved_credentials_threaded_through_request(monkeypatch):

--- a/tests/plugins/video_gen/test_xai_plugin_integration.py
+++ b/tests/plugins/video_gen/test_xai_plugin_integration.py
@@ -133,6 +133,46 @@ class TestXAIPayload:
         payload = _last_post(captured)["json"]
         assert payload["model"] == "grok-imagine-video"
 
+    def test_1080p_is_forwarded_for_image_to_video_1_5(self, xai_provider):
+        provider, captured = xai_provider
+
+        provider.generate(
+            "animate this",
+            image_url="https://example.com/cat.png",
+            resolution="1080p",
+        )
+
+        payload = _last_post(captured)["json"]
+        assert payload["model"] == "grok-imagine-video-1.5"
+        assert payload["resolution"] == "1080p"
+
+    def test_1080p_is_forwarded_for_text_to_video_1_5(self, xai_provider):
+        provider, captured = xai_provider
+
+        provider.generate(
+            "a dog on a skateboard",
+            model="grok-imagine-video-1.5",
+            resolution="1080p",
+            _model_override_explicit=True,
+        )
+
+        payload = _last_post(captured)["json"]
+        assert payload["model"] == "grok-imagine-video-1.5"
+        assert payload["resolution"] == "1080p"
+
+    def test_configured_1_5_is_used_for_text_to_video(self, xai_provider):
+        provider, captured = xai_provider
+
+        provider.generate(
+            "a dog on a skateboard",
+            model="grok-imagine-video-1.5",
+            resolution="1080p",
+        )
+
+        payload = _last_post(captured)["json"]
+        assert payload["model"] == "grok-imagine-video-1.5"
+        assert payload["resolution"] == "1080p"
+
     def test_reference_images_payload(self, xai_provider):
         provider, captured = xai_provider
         provider.generate(
@@ -180,3 +220,21 @@ class TestXAIClamping:
         provider, captured = xai_provider
         provider.generate("x", aspect_ratio="21:9")
         assert _last_post(captured)["json"]["aspect_ratio"] == "16:9"
+
+    def test_1080p_soft_clamps_for_legacy_model(self, xai_provider):
+        provider, captured = xai_provider
+
+        provider.generate("x", resolution="1080p")
+
+        assert _last_post(captured)["json"]["resolution"] == "720p"
+
+    def test_1080p_soft_clamps_for_reference_to_video(self, xai_provider):
+        provider, captured = xai_provider
+
+        provider.generate(
+            "keep this character",
+            reference_image_urls=["https://example.com/a.png"],
+            resolution="1080p",
+        )
+
+        assert _last_post(captured)["json"]["resolution"] == "720p"

--- a/tests/tools/test_video_generation_dynamic_schema.py
+++ b/tests/tools/test_video_generation_dynamic_schema.py
@@ -114,6 +114,30 @@ class TestDynamicSchemaBuilder:
         assert "supports both text-to-video" in desc
         assert "duration range: 1-15s" in desc
 
+    def test_resolution_choices_follow_active_model(self, cfg_home, monkeypatch):
+        from plugins.video_gen.xai import XAIVideoGenProvider
+        from tools.video_generation_tool import _build_dynamic_video_schema
+
+        monkeypatch.setenv("XAI_API_KEY", "test-key")
+        video_gen_registry.register_provider(XAIVideoGenProvider())
+
+        _write_cfg(
+            cfg_home,
+            {"video_gen": {"provider": "xai", "model": "grok-imagine-video-1.5"}},
+        )
+        latest_desc = _build_dynamic_video_schema()["description"]
+
+        _write_cfg(
+            cfg_home,
+            {"video_gen": {"provider": "xai", "model": "grok-imagine-video"}},
+        )
+        legacy_desc = _build_dynamic_video_schema()["description"]
+
+        assert "resolution choices: 480p, 720p, 1080p" in latest_desc
+        assert "supports both text-to-video" in latest_desc
+        assert "image-to-video only" not in latest_desc
+        assert "resolution choices: 480p, 720p, 1080p" not in legacy_desc
+
     def test_i2v_only_model_does_not_claim_text_to_video(self, cfg_home):
         """A dual-modality backend with an i2v-only active model must not
         contradict the model caveat with a 'supports both' line."""

--- a/tools/video_generation_tool.py
+++ b/tools/video_generation_tool.py
@@ -553,8 +553,9 @@ def _build_dynamic_video_schema() -> Dict[str, Any]:
 
     if caps.get("aspect_ratios"):
         parts.append(f"- aspect_ratio choices: {', '.join(caps['aspect_ratios'])}")
-    if caps.get("resolutions"):
-        parts.append(f"- resolution choices: {', '.join(caps['resolutions'])}")
+    resolutions = model_meta.get("resolutions") or caps.get("resolutions")
+    if resolutions:
+        parts.append(f"- resolution choices: {', '.join(resolutions)}")
     min_duration = model_meta.get("min_duration", caps.get("min_duration"))
     max_duration = model_meta.get("max_duration", caps.get("max_duration"))
     if min_duration and max_duration:


### PR DESCRIPTION
## What does this PR do?

Adds native 1080p generation for xAI Grok Imagine Video 1.5 text-to-video and image-to-video requests. Hermes previously advertised only 480p and 720p and silently normalized every 1080p request to 720p, preventing users from selecting a resolution the provider supports. The change keeps legacy generation and reference-to-video limited to 720p, while edit and extend remain unchanged.

### Motivation

xAI documents native 1080p output for Grok Imagine Video 1.5 text-to-video and image-to-video. Hermes could not request or advertise that capability because the xAI plugin used one provider-wide resolution allowlist.

### Behavior

- Grok Imagine Video 1.5 text-to-video and image-to-video requests can use 1080p.
- The active model's resolution choices appear in the dynamic `video_generate` description.
- Legacy `grok-imagine-video` and reference-to-video continue to normalize 1080p to 720p.
- Edit and extend payloads remain resolution-free.

### Implementation

Resolution metadata now lives with each xAI model, and normalization runs after model and modality resolution. Dynamic video tool descriptions prefer active-model resolution metadata over provider-wide capabilities. Integration tests cover 1.5 text and image forwarding, configured-model routing, legacy and reference clamping, setup guidance, and dynamic schema output.

## Related Issue

Closes #89549

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/video_gen/xai/__init__.py` - add model and modality-aware resolution support and update xAI capability metadata.
- `tools/video_generation_tool.py` - advertise resolution choices from the active model when available.
- `tests/plugins/video_gen/test_xai_plugin.py` - cover the xAI setup capability hint.
- `tests/plugins/video_gen/test_xai_plugin_integration.py` - cover 1080p forwarding and unsupported-path clamping.
- `tests/tools/test_video_generation_dynamic_schema.py` - cover active-model resolution descriptions.

## How to Test

1. Configure xAI video generation with `grok-imagine-video-1.5`.
2. Request text-to-video or image-to-video generation with `resolution="1080p"` and verify the submitted payload preserves 1080p.
3. Request 1080p with the legacy model or reference images and verify the submitted payload remains capped at 720p.
4. Run the focused automated tests:

```bash
scripts/run_tests.sh tests/plugins/video_gen/test_xai_plugin.py tests/plugins/video_gen/test_xai_plugin_integration.py tests/tools/test_video_generation_dynamic_schema.py tests/tools/test_video_generation_dispatch.py
scripts/run_tests.sh tests/plugins/video_gen/test_video_provider_surface_matrix.py -k xai
```

Focused result: 27 tests passed, plus 1 xAI provider surface-matrix test passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all focused tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A, no standalone documentation changes are required
- [x] I've updated `cli-config.yaml.example` if I added or changed config keys - N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A, no architecture or workflow changed
- [x] I've considered cross-platform impact per the compatibility guide - the change is provider payload and metadata logic with platform-independent tests
- [x] I've updated tool descriptions or schemas if I changed tool behavior - the dynamic tool description now reflects active-model resolution support
