### PR TITLE
fix(api_server): client_platform hint for /v1/runs callers

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1073,6 +1073,19 @@ PLATFORM_HINTS = {
         "![alt](/path) for local files; local paths are not served that way. "
         "Use MEDIA:/absolute/path instead."
     ),
+    "openwebui": (
+        "You are in an Open WebUI-based chat interface, reached through a "
+        "custom Function that talks to Hermes via /v1/runs (not "
+        "/v1/chat/completions). Full Markdown rendering is supported — "
+        "headings, bold, italic, code blocks, tables, and math all render "
+        "natively. "
+        "To deliver a file to the user, include MEDIA:/absolute/path/to/file "
+        "in your response. Unlike the generic api_server platform, this "
+        "integration DOES intercept and import MEDIA: tags for any file type "
+        "(not just images) via /v1/runs — the Function turns them into a "
+        "real downloadable or inline attachment in the chat, scoped to this "
+        "profile's configured media roots. Local file paths must be absolute."
+    ),
 }
 
 # Telegram rich-messages extension — only injected when the user has opted in

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2653,6 +2653,7 @@ class APIServerAdapter(BasePlatformAdapter):
         route: Optional[Dict[str, Any]] = None,
         session_model: Optional[str] = None,
         confirmed_runtime_lock: bool = False,
+        client_platform: Optional[str] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -2686,6 +2687,14 @@ class APIServerAdapter(BasePlatformAdapter):
         session ``/model`` override, disables the global fallback model
         chain, and fails closed if the locked provider's credentials cannot
         be resolved.
+
+        ``client_platform`` lets a known, trusted /v1/runs caller identify
+        itself so PLATFORM_HINTS reflects what it actually supports, instead
+        of the generic "api_server" hint's file-delivery caveats (which are
+        wrong for e.g. the Open WebUI Function -- it does intercept MEDIA:
+        tags for any file type). Deliberately allowlisted rather than passed
+        through verbatim: an unrecognized value falls back to "api_server"
+        unchanged, so this can never widen what a caller can claim.
         """
         from run_agent import AIAgent
         from gateway.run import (
@@ -2954,7 +2963,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "ephemeral_system_prompt": ephemeral_system_prompt or None,
             "enabled_toolsets": enabled_toolsets,
             "session_id": session_id,
-            "platform": "api_server",
+            "platform": "openwebui" if client_platform == "openwebui" else "api_server",
             "stream_delta_callback": stream_delta_callback,
             "tool_progress_callback": tool_progress_callback,
             "tool_start_callback": tool_start_callback,
@@ -6697,6 +6706,14 @@ class APIServerAdapter(BasePlatformAdapter):
         if not user_message:
             return web.json_response(_openai_error("No user message found in input"), status=400)
 
+        # Optional: a known /v1/runs caller identifying itself so the system
+        # prompt's platform hint reflects what it actually supports (see
+        # _create_agent's client_platform docstring). Allowlisted there, not
+        # here -- an unrecognized value is inert, never an error.
+        client_platform = body.get("client_platform")
+        if client_platform is not None and not isinstance(client_platform, str):
+            return web.json_response(_openai_error("'client_platform' must be a string"), status=400)
+
         instructions = body.get("instructions")
         previous_response_id = body.get("previous_response_id")
 
@@ -6834,6 +6851,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         requested_provider=agent_overrides.get("requested_provider"),
                         model_options=agent_overrides.get("model_options"),
                         route=route,
+                        client_platform=client_platform,
                     )
                 self._active_run_agents[run_id] = agent
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -724,6 +724,23 @@ class TestPromptBuilderConstants:
         # Fallback guidance: plain file path in the response text.
         assert "plain" in hint.lower()
 
+    def test_openwebui_hint_does_not_inherit_api_server_non_image_caveat(self):
+        """The openwebui platform hint must NOT carry the api_server hint's
+        "non-image files aren't intercepted, state a plain path" caveat --
+        that's accurate for a generic /v1/runs API caller (Hermes's own
+        server-side _resolve_media_to_data_urls never runs for /v1/runs at
+        all, see test_api_server_hint_scopes_media_tag_guidance), but wrong
+        for the Open WebUI Function: it fully imports MEDIA: tags for any
+        file type client-side, from the raw SSE stream, independent of
+        Hermes's own resolver. Found live 2026-08-18: a Kim-generated PPTX
+        leaked as a raw host path in chat because the model, correctly
+        following the api_server hint it was actually given (there was no
+        openwebui-specific one), stated a plain path instead of a MEDIA: tag."""
+        hint = PLATFORM_HINTS["openwebui"]
+        assert "include MEDIA:" in hint
+        assert "non-image" not in hint.lower()
+        assert "state the plain file path" not in hint.lower()
+
     def test_markdown_converting_platform_hints_do_not_forbid_markdown(self):
         """#12224 — WhatsApp (Baileys) and Signal adapters actively convert
         markdown to native formatting (gateway/platforms/whatsapp_common.py

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -260,6 +260,64 @@ class TestStartRun:
         assert kwargs["requested_provider"] == "minimax"
         assert kwargs["model_options"] == model_options
 
+    @pytest.mark.asyncio
+    async def test_start_passes_client_platform_to_create_agent(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "client_platform": "openwebui"},
+                )
+                assert resp.status == 202
+                for _ in range(20):
+                    if mock_create.call_args is not None:
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert mock_create.call_args.kwargs["client_platform"] == "openwebui"
+
+    @pytest.mark.asyncio
+    async def test_start_rejects_non_string_client_platform(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/runs",
+                json={"input": "hello", "client_platform": 123},
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_start_without_client_platform_passes_none(self, adapter):
+        """Existing callers that never send client_platform must be
+        unaffected -- _create_agent receives None, same as before this field
+        existed, and internally falls back to the 'api_server' platform."""
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                assert resp.status == 202
+                for _ in range(20):
+                    if mock_create.call_args is not None:
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert mock_create.call_args.kwargs["client_platform"] is None
+
 
 # ---------------------------------------------------------------------------
 # GET /v1/runs/{run_id} — poll run status

--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -80,3 +80,58 @@ class TestApiServerAdapterToolset:
             assert len(toolsets) > 0
             assert call_kwargs.kwargs.get("platform") == "api_server"
 
+    @patch("gateway.platforms.api_server.AIOHTTP_AVAILABLE", True)
+    def test_create_agent_client_platform_openwebui_sets_platform_hint(self):
+        """A /v1/runs caller identifying itself as client_platform='openwebui'
+        gets the accurate openwebui PLATFORM_HINTS entry instead of the
+        generic api_server one (whose file-delivery caveats are wrong for
+        this integration -- it does intercept MEDIA: tags for any file
+        type). Found live 2026-08-18 diagnosing a generated file that leaked
+        as a raw host path instead of a chat attachment."""
+        from gateway.platforms.api_server import APIServerAdapter
+        from gateway.config import PlatformConfig
+
+        adapter = APIServerAdapter(PlatformConfig())
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs") as mock_kwargs, \
+             patch("gateway.run._resolve_gateway_model") as mock_model, \
+             patch("gateway.run._load_gateway_config") as mock_config, \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+
+            mock_kwargs.return_value = {"api_key": "test-key", "base_url": None,
+                                        "provider": None, "api_mode": None,
+                                        "command": None, "args": []}
+            mock_model.return_value = "test/model"
+            mock_config.return_value = {}
+            mock_agent_cls.return_value = MagicMock()
+
+            adapter._create_agent(client_platform="openwebui")
+
+            assert mock_agent_cls.call_args.kwargs.get("platform") == "openwebui"
+
+    @patch("gateway.platforms.api_server.AIOHTTP_AVAILABLE", True)
+    def test_create_agent_unrecognized_client_platform_falls_back_to_api_server(self):
+        """An unrecognized client_platform value is inert, never an error and
+        never a way to claim an arbitrary platform hint -- it must fall back
+        to the same 'api_server' behavior as not sending the field at all."""
+        from gateway.platforms.api_server import APIServerAdapter
+        from gateway.config import PlatformConfig
+
+        adapter = APIServerAdapter(PlatformConfig())
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs") as mock_kwargs, \
+             patch("gateway.run._resolve_gateway_model") as mock_model, \
+             patch("gateway.run._load_gateway_config") as mock_config, \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+
+            mock_kwargs.return_value = {"api_key": "test-key", "base_url": None,
+                                        "provider": None, "api_mode": None,
+                                        "command": None, "args": []}
+            mock_model.return_value = "test/model"
+            mock_config.return_value = {}
+            mock_agent_cls.return_value = MagicMock()
+
+            adapter._create_agent(client_platform="totally-made-up-platform")
+
+            assert mock_agent_cls.call_args.kwargs.get("platform") == "api_server"
+


### PR DESCRIPTION
## What does this PR do?

`PLATFORM_HINTS` (`agent/prompt_builder.py`) gives the model per-platform guidance on
how to hand back a generated file. Every `/v1/runs` request resolves to the generic
`"api_server"` hint, which correctly tells a bare API caller:

> "Non-image files are NOT intercepted anywhere, and the runs endpoint intercepts
> nothing — a MEDIA: tag there renders as literal text exposing a raw host filesystem
> path. For those cases, state the plain file path in your response text instead of a
> MEDIA: tag."

That's accurate for Hermes's own server-side handling (`_resolve_media_to_data_urls`
never runs for `/v1/runs`, only `/v1/chat/completions`/`/v1/responses`, and only for
images — see the existing `test_api_server_hint_scopes_media_tag_guidance`). But it's
wrong for a client that does its own full `MEDIA:` interception after receiving the raw
SSE stream — which is exactly what our Open WebUI integration does (an Open WebUI
Function that talks to `/v1/runs` and imports `MEDIA:` tags for any file type,
independent of Hermes's own resolver). Models were correctly following the only
instruction they were given, and stating bare host filesystem paths for every
non-image generated file reached through that integration — which show up unclickable
in the client instead of as a real attachment.

This adds a small, additive way for a trusted `/v1/runs` caller to identify itself so
the system prompt reflects what it actually supports, without touching the default
behavior for every other caller (CLI tools, curl, other integrations hitting `/v1/runs`
directly).

## Related Issue

No existing issue — happy to open one first if preferred, this felt small enough to
lead with the PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/prompt_builder.py`: new `PLATFORM_HINTS["openwebui"]` entry, describing the
  real capability (MEDIA: tags for any file type, via /v1/runs, independent of the
  server-side image-only resolver).
- `gateway/platforms/api_server.py`:
  - `_create_agent()` gains an optional `client_platform: Optional[str] = None`
    parameter. Deliberately allowlisted, not passed through verbatim: only
    `client_platform == "openwebui"` changes the resolved `platform` kwarg (to
    `"openwebui"`); any other value — including unrecognized strings — falls back to
    today's `"api_server"` unchanged. A caller can never claim an arbitrary platform
    hint this way.
  - `_handle_runs` (`POST /v1/runs`) reads an optional `client_platform` string field
    from the request body and threads it through. 400s only if the field is present
    and non-string; an absent field is identical to pre-PR behavior for every existing
    caller.

## How to Test

1. `POST /v1/runs` with `{"input": "...", "client_platform": "openwebui"}` and a
   prompt asking the model to produce a small non-image file (e.g. a `.txt`) — the
   response should contain a `MEDIA:/absolute/path` tag.
2. The same request without `client_platform` — response should state a plain path
   instead (unchanged existing behavior).
3. `pytest tests/agent/test_prompt_builder.py tests/gateway/test_api_server_toolset.py tests/gateway/test_api_server_runs.py -q`

Verified live against both steps 1 and 2 on a real gateway (not just the unit tests
below) before opening this PR.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — specifically the 3 files this PR
      touches (98 passed, 0 failed, run against current `main`). I did not run the
      full unrelated suite as part of this PR prep.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Debian, Raspberry Pi)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — the new
      parameter is documented in `_create_agent`'s docstring; didn't see an existing
      doc page enumerating `PLATFORM_HINTS` keys to update, happy to add one if there
      is a better spot for it.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no
      config keys changed, this is a request-body field.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or
      workflows — N/A.
- [x] I've considered cross-platform impact — N/A, no platform-specific code.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool
      schema changed.

## Screenshots / Logs

Live verification against a real gateway, `client_platform: "openwebui"`:

```
completed_output: 'File ready: MEDIA:/tmp/platform_hint_test.txt'
```

Same prompt, same gateway, without `client_platform` (pre-existing, unchanged
behavior):

```
completed_output: 'Deck:\n/home/.../some_generated_file.pptx'
```
