### PR TITLE
feat: add sticky quota-aware routing for Codex credential pools

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -507,22 +507,7 @@ def _resolve_codex_usage_credentials(
     return entry.runtime_api_key, str(entry.runtime_base_url or base_url or "").strip(), None
 
 
-def _fetch_codex_account_usage(
-    base_url: Optional[str] = None,
-    api_key: Optional[str] = None,
-) -> Optional[AccountUsageSnapshot]:
-    token, resolved_base_url, account_id = _resolve_codex_usage_credentials(base_url, api_key)
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/json",
-        "User-Agent": "codex-cli",
-    }
-    if account_id:
-        headers["ChatGPT-Account-Id"] = account_id
-    with httpx.Client(timeout=15.0) as client:
-        response = client.get(_resolve_codex_usage_url(resolved_base_url), headers=headers)
-        response.raise_for_status()
-    payload = response.json() or {}
+def _codex_usage_snapshot_from_payload(payload: dict) -> AccountUsageSnapshot:
     rate_limit = payload.get("rate_limit") or {}
     windows: list[AccountUsageWindow] = []
     for key, label in (("primary_window", "Session"), ("secondary_window", "Weekly")):
@@ -561,6 +546,53 @@ def _fetch_codex_account_usage(
         windows=tuple(windows),
         details=tuple(details),
     )
+
+
+def fetch_codex_usage_for_token(
+    access_token: str,
+    base_url: Optional[str],
+    *,
+    timeout: float = 15.0,
+) -> Optional[AccountUsageSnapshot]:
+    """Fetch Codex account-usage telemetry for a bearer token.
+
+    This read-only helper intentionally does not resolve or refresh credentials
+    and does not pass ``ChatGPT-Account-Id``.  The usage endpoint keys the
+    response off the bearer token; callers that use pooled credentials can ask
+    for per-entry telemetry without mutating auth.json.
+    """
+    token = str(access_token or "").strip()
+    if not token:
+        return None
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+        "User-Agent": "codex-cli",
+    }
+    with httpx.Client(timeout=timeout) as client:
+        response = client.get(_resolve_codex_usage_url(base_url or ""), headers=headers)
+        response.raise_for_status()
+    payload = response.json() or {}
+    return _codex_usage_snapshot_from_payload(payload)
+
+
+def _fetch_codex_account_usage(
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> Optional[AccountUsageSnapshot]:
+    token, resolved_base_url, account_id = _resolve_codex_usage_credentials(base_url, api_key)
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+        "User-Agent": "codex-cli",
+    }
+    if account_id:
+        headers["ChatGPT-Account-Id"] = account_id
+    with httpx.Client(timeout=15.0) as client:
+        response = client.get(_resolve_codex_usage_url(resolved_base_url), headers=headers)
+        response.raise_for_status()
+    payload = response.json() or {}
+    return _codex_usage_snapshot_from_payload(payload)
 
 
 @dataclass(frozen=True)

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import random
@@ -110,12 +111,20 @@ STRATEGY_FILL_FIRST = "fill_first"
 STRATEGY_ROUND_ROBIN = "round_robin"
 STRATEGY_RANDOM = "random"
 STRATEGY_LEAST_USED = "least_used"
+STRATEGY_QUOTA_AWARE = "quota_aware"
 SUPPORTED_POOL_STRATEGIES = {
     STRATEGY_FILL_FIRST,
     STRATEGY_ROUND_ROBIN,
     STRATEGY_RANDOM,
     STRATEGY_LEAST_USED,
+    STRATEGY_QUOTA_AWARE,
 }
+
+CODEX_QUOTA_USAGE_TTL_SECONDS = 300.0
+CODEX_QUOTA_USAGE_TIMEOUT_SECONDS = 4.0
+CODEX_QUOTA_AVOID_BELOW_FRACTION = 0.20
+_CODEX_QUOTA_CACHE: Dict[str, Tuple[float, Optional[Any]]] = {}
+_CODEX_QUOTA_CACHE_LOCK = threading.Lock()
 
 # Cooldown before retrying an exhausted credential.
 # Transient 401 auth failures cool down briefly so single-key setups can recover.
@@ -587,6 +596,28 @@ def credential_pool_matches_provider(
     except Exception:
         return False
     return str(matched_pool or "").strip().lower() == pool_provider
+
+
+def _coerce_quota_fraction(value: Any, default: float) -> float:
+    try:
+        fraction = float(value)
+    except (TypeError, ValueError):
+        return default
+    if 0.0 <= fraction <= 1.0:
+        return fraction
+    return default
+
+
+def get_quota_aware_avoid_below_fraction() -> float:
+    """Return the low-watermark threshold for quota-aware pools."""
+    config = _load_config_safe()
+    quota_config = config.get("credential_pool_quota_aware") if config else None
+    if not isinstance(quota_config, dict):
+        return CODEX_QUOTA_AVOID_BELOW_FRACTION
+    return _coerce_quota_fraction(
+        quota_config.get("avoid_below_fraction"),
+        CODEX_QUOTA_AVOID_BELOW_FRACTION,
+    )
 
 
 DEFAULT_MAX_CONCURRENT_PER_CREDENTIAL = 1
@@ -1992,6 +2023,108 @@ class CredentialPool:
         self._last_no_entries_log_at = now
         logger.info("credential pool: no available entries (all exhausted or empty)")
 
+    def _increment_request_count_unlocked(self, entry: PooledCredential) -> PooledCredential:
+        updated = replace(entry, request_count=entry.request_count + 1)
+        self._replace_entry(entry, updated)
+        self._current_id = entry.id
+        return updated
+
+    def _select_least_used_unlocked(self, available: List[PooledCredential]) -> PooledCredential:
+        entry = min(available, key=lambda e: (e.request_count, e.priority, e.id))
+        # Increment usage counter so subsequent selections distribute load
+        return self._increment_request_count_unlocked(entry)
+
+    def _select_quota_aware_unlocked(self, available: List[PooledCredential]) -> Optional[PooledCredential]:
+        if self.provider != "openai-codex":
+            return self._select_least_used_unlocked(available)
+
+        scored: List[Tuple[float, int, int, str, PooledCredential]] = []
+        for entry in available:
+            snapshot = self._codex_usage_snapshot_for_entry(entry)
+            remaining = self._remaining_fraction_from_usage(snapshot)
+            if remaining is None:
+                continue
+            scored.append((remaining, entry.request_count, entry.priority, entry.id, entry))
+
+        if not scored:
+            return self._select_least_used_unlocked(available)
+
+        avoid_below = get_quota_aware_avoid_below_fraction()
+        current = self.current()
+        if current is not None:
+            current_score = next((item for item in scored if item[4].id == current.id), None)
+            if current_score is not None and current_score[0] >= avoid_below:
+                return self._increment_request_count_unlocked(current_score[4])
+
+        def choose_highest_remaining(
+            candidates: List[Tuple[float, int, int, str, PooledCredential]]
+        ) -> PooledCredential:
+            # Highest remaining quota wins; ties go to lower request_count,
+            # then lower priority and stable id for deterministic routing.
+            return min(candidates, key=lambda item: (-item[0], item[1], item[2], item[3]))[4]
+
+        valid_candidates = [
+            item for item in scored if item[0] >= avoid_below
+        ]
+        if current is not None:
+            valid_candidates = [item for item in valid_candidates if item[4].id != current.id]
+        if valid_candidates:
+            return self._increment_request_count_unlocked(
+                choose_highest_remaining(valid_candidates)
+            )
+
+        # If every known credential is below the avoid threshold, fail open to
+        # the least-bad option instead of pretending the whole pool is unusable.
+        return self._increment_request_count_unlocked(choose_highest_remaining(scored))
+
+    def _codex_usage_snapshot_for_entry(self, entry: PooledCredential) -> Optional[Any]:
+        token = str(entry.runtime_api_key or "").strip()
+        if not token:
+            return None
+        fingerprint = hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
+        cache_key = f"{self.provider}:{entry.id}:{fingerprint}"
+        now = time.time()
+        with _CODEX_QUOTA_CACHE_LOCK:
+            cached = _CODEX_QUOTA_CACHE.get(cache_key)
+            if cached is not None:
+                fetched_at, snapshot = cached
+                if now - fetched_at < CODEX_QUOTA_USAGE_TTL_SECONDS:
+                    return snapshot
+
+        snapshot = None
+        try:
+            from agent.account_usage import fetch_codex_usage_for_token
+
+            snapshot = fetch_codex_usage_for_token(
+                token,
+                entry.runtime_base_url,
+                timeout=CODEX_QUOTA_USAGE_TIMEOUT_SECONDS,
+            )
+        except Exception as exc:
+            logger.debug(
+                "credential pool: Codex quota telemetry unavailable for %s/%s: %s",
+                self.provider,
+                entry.id,
+                exc,
+            )
+        with _CODEX_QUOTA_CACHE_LOCK:
+            _CODEX_QUOTA_CACHE[cache_key] = (now, snapshot)
+        return snapshot
+
+    @staticmethod
+    def _remaining_fraction_from_usage(snapshot: Optional[Any]) -> Optional[float]:
+        if snapshot is None or getattr(snapshot, "unavailable_reason", None):
+            return None
+        windows = getattr(snapshot, "windows", ()) or ()
+        used_values: List[float] = []
+        for window in windows:
+            used = getattr(window, "used_percent", None)
+            if isinstance(used, (int, float)):
+                used_values.append(max(0.0, min(100.0, float(used))))
+        if not used_values:
+            return None
+        return max(0.0, min(1.0, 1.0 - (max(used_values) / 100.0)))
+
     def _select_unlocked(self, *, refresh: bool = True) -> Tuple[Optional[PooledCredential], List[tuple]]:
         """Select the best available credential entry.
 
@@ -2014,13 +2147,13 @@ class CredentialPool:
             self._current_id = entry.id
             return entry, pending_refresh
 
+        if self._strategy == STRATEGY_QUOTA_AWARE and len(available) > 1:
+            entry = self._select_quota_aware_unlocked(available)
+            if entry is not None:
+                return entry, pending_refresh
+
         if self._strategy == STRATEGY_LEAST_USED and len(available) > 1:
-            entry = min(available, key=lambda e: e.request_count)
-            # Increment usage counter so subsequent selections distribute load
-            updated = replace(entry, request_count=entry.request_count + 1)
-            self._replace_entry(entry, updated)
-            self._current_id = entry.id
-            return updated, pending_refresh
+            return self._select_least_used_unlocked(available), pending_refresh
 
         if self._strategy == STRATEGY_ROUND_ROBIN and len(available) > 1:
             entry = available[0]

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -19,6 +19,7 @@ from agent.credential_pool import (
     STRATEGY_ROUND_ROBIN,
     STRATEGY_RANDOM,
     STRATEGY_LEAST_USED,
+    STRATEGY_QUOTA_AWARE,
     PooledCredential,
     _exhausted_until,
     _normalize_custom_pool_name,
@@ -736,7 +737,13 @@ def _interactive_reset() -> None:
 def _interactive_strategy() -> None:
     provider = _pick_provider("Provider to set strategy for")
     current = get_pool_strategy(provider)
-    strategies = [STRATEGY_FILL_FIRST, STRATEGY_ROUND_ROBIN, STRATEGY_LEAST_USED, STRATEGY_RANDOM]
+    strategies = [
+        STRATEGY_FILL_FIRST,
+        STRATEGY_ROUND_ROBIN,
+        STRATEGY_LEAST_USED,
+        STRATEGY_RANDOM,
+        STRATEGY_QUOTA_AWARE,
+    ]
 
     print(f"\nCurrent strategy for {provider}: {current}")
     print()
@@ -745,13 +752,14 @@ def _interactive_strategy() -> None:
         STRATEGY_ROUND_ROBIN: "Cycle through keys evenly",
         STRATEGY_LEAST_USED: "Always pick the least-used key",
         STRATEGY_RANDOM: "Random selection",
+        STRATEGY_QUOTA_AWARE: "Codex: prefer healthiest usage windows",
     }
     for i, s in enumerate(strategies, 1):
         marker = " ←" if s == current else ""
         print(f"  {i}. {s:15s} — {descriptions.get(s, '')}{marker}")
 
     try:
-        raw = input("\nStrategy [1-4]: ").strip()
+        raw = input("\nStrategy [1-5]: ").strip()
     except (EOFError, KeyboardInterrupt):
         return
     if not raw:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -9,6 +9,9 @@ DEFAULT_CONFIG = {
     "providers": {},
     "fallback_providers": [],
     "credential_pool_strategies": {},
+    "credential_pool_quota_aware": {
+        "avoid_below_fraction": 0.20,
+    },
     "toolsets": ["hermes-cli"],
     # SQLite journal mode used by every Hermes database opener. WAL is the
     # normal default; set DELETE for weak-fsync/shared filesystems where WAL is

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -262,7 +262,7 @@ TIPS = [
     "hermes acp runs Hermes as an ACP server for VS Code, Zed, and JetBrains integration.",
     "Custom providers: save named endpoints in config.yaml under custom_providers.",
     "HERMES_EPHEMERAL_SYSTEM_PROMPT injects a system prompt that's never persisted to history.",
-    "credential_pool_strategies supports fill_first, round_robin, least_used, and random rotation.",
+    "credential_pool_strategies supports fill_first, round_robin, least_used, random, and Codex quota_aware rotation.",
     "hermes auth add nous or hermes auth add openai-codex sets up OAuth-based providers.",
     "The API server supports both Chat Completions and Responses API with server-side state.",
     "tool_preview_length: 0 in config shows full file paths in the spinner's activity feed.",
@@ -371,6 +371,7 @@ TIPS = [
     # --- Credential Pools & Routing ---
     'hermes auth reset <provider> clears all cooldowns and exhaustion flags on a credential pool.',
     'credential_pool_strategies.<provider>: round_robin cycles keys evenly instead of the fill_first default.',
+    "credential_pool_strategies.openai-codex: quota_aware sticks to the current Codex credential until remaining quota drops below the configured low watermark.",
     'use_gateway: true per-tool routes web, image, tts, or browser through your Nous subscription — no extra keys.',
     'provider_routing.data_collection: deny excludes data-storing providers on OpenRouter.',
     'provider_routing.require_parameters: true only routes to providers that support every param in your request.',

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2079,3 +2079,625 @@ class TestCredentialPoolQueryLocking:
             inner.release()
 
         assert done.wait(timeout=2.0), f"{method}() did not complete after lock release"
+
+
+def _codex_usage_snapshot(used_values):
+    from datetime import datetime, timezone
+    from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
+
+    return AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=datetime.now(timezone.utc),
+        windows=tuple(
+            AccountUsageWindow(label=label, used_percent=used, reset_at=None)
+            for label, used in used_values
+        ),
+    )
+
+
+def _write_quota_aware_pool(tmp_path, monkeypatch, *, provider="openai-codex", entries=None):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(
+        "agent.credential_pool._seed_from_singletons",
+        lambda provider, entries: (False, set()),
+    )
+    monkeypatch.setattr(
+        "agent.credential_pool._seed_from_env",
+        lambda provider, entries: (False, set()),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._codex_access_token_is_expiring",
+        lambda *_args, **_kwargs: False,
+    )
+    default_entries = [
+        {
+            "id": "low",
+            "label": "low",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "manual:device_code",
+            "access_token": "tok-low",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "request_count": 0,
+        },
+        {
+            "id": "healthy",
+            "label": "healthy",
+            "auth_type": "oauth",
+            "priority": 1,
+            "source": "manual:device_code",
+            "access_token": "tok-healthy",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "request_count": 0,
+        },
+    ]
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {provider: entries or default_entries},
+        },
+    )
+    (tmp_path / "hermes" / "config.yaml").write_text(
+        f"credential_pool_strategies:\n  {provider}: quota_aware\n"
+    )
+
+
+def test_quota_aware_strategy_selects_higher_remaining_codex_entry(tmp_path, monkeypatch):
+    _write_quota_aware_pool(tmp_path, monkeypatch)
+
+    from agent import credential_pool as cp
+    from agent.credential_pool import load_pool
+
+    cp._CODEX_QUOTA_CACHE.clear()
+    snapshots = {
+        "tok-low": _codex_usage_snapshot((("Session", 80), ("Weekly", 60))),
+        "tok-healthy": _codex_usage_snapshot((("Session", 30), ("Weekly", 40))),
+    }
+    seen_tokens = []
+
+    def fake_fetch(token, base_url, *, timeout):
+        seen_tokens.append(token)
+        assert timeout == cp.CODEX_QUOTA_USAGE_TIMEOUT_SECONDS
+        return snapshots[token]
+
+    monkeypatch.setattr("agent.account_usage.fetch_codex_usage_for_token", fake_fetch)
+
+    pool = load_pool("openai-codex")
+    selected = pool.select()
+
+    assert selected is not None
+    assert selected.id == "healthy"
+    assert selected.request_count == 1
+    assert seen_tokens == ["tok-low", "tok-healthy"]
+
+
+def test_quota_aware_sticks_with_current_above_avoid_threshold(tmp_path, monkeypatch):
+    entries = [
+        {
+            "id": "current",
+            "label": "current",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "manual:device_code",
+            "access_token": "tok-current",
+            "request_count": 0,
+        },
+        {
+            "id": "healthier",
+            "label": "healthier",
+            "auth_type": "oauth",
+            "priority": 1,
+            "source": "manual:device_code",
+            "access_token": "tok-healthier",
+            "request_count": 0,
+        },
+    ]
+    _write_quota_aware_pool(tmp_path, monkeypatch, entries=entries)
+
+    from agent import credential_pool as cp
+    from agent.credential_pool import load_pool
+
+    snapshots = {
+        "tok-current": _codex_usage_snapshot((("Session", 20),)),
+        "tok-healthier": _codex_usage_snapshot((("Session", 40),)),
+    }
+    cp._CODEX_QUOTA_CACHE.clear()
+    monkeypatch.setattr(
+        "agent.account_usage.fetch_codex_usage_for_token",
+        lambda token, _base_url, *, timeout: snapshots[token],
+    )
+
+    pool = load_pool("openai-codex")
+    first = pool.select()
+    assert first is not None and first.id == "current"
+
+    snapshots.update(
+        {
+            "tok-current": _codex_usage_snapshot((("Session", 45),)),  # 55% left
+            "tok-healthier": _codex_usage_snapshot((("Session", 5),)),  # 95% left
+        }
+    )
+    cp._CODEX_QUOTA_CACHE.clear()
+    second = pool.select()
+
+    assert second is not None
+    assert second.id == "current"
+
+
+def test_quota_aware_sticks_in_working_band_without_ping_pong(tmp_path, monkeypatch):
+    entries = [
+        {
+            "id": "a",
+            "label": "a",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "manual:device_code",
+            "access_token": "tok-a",
+            "request_count": 0,
+        },
+        {
+            "id": "b",
+            "label": "b",
+            "auth_type": "oauth",
+            "priority": 1,
+            "source": "manual:device_code",
+            "access_token": "tok-b",
+            "request_count": 0,
+        },
+    ]
+    _write_quota_aware_pool(tmp_path, monkeypatch, entries=entries)
+
+    from agent import credential_pool as cp
+    from agent.credential_pool import load_pool
+
+    snapshots = {
+        "tok-a": _codex_usage_snapshot((("Session", 55),)),  # 45% remaining
+        "tok-b": _codex_usage_snapshot((("Session", 56),)),  # 44% remaining
+    }
+    cp._CODEX_QUOTA_CACHE.clear()
+    monkeypatch.setattr(
+        "agent.account_usage.fetch_codex_usage_for_token",
+        lambda token, _base_url, *, timeout: snapshots[token],
+    )
+
+    pool = load_pool("openai-codex")
+    selected_ids = []
+    for _ in range(8):
+        selected = pool.select()
+        assert selected is not None
+        selected_ids.append(selected.id)
+
+    assert selected_ids == ["a"] * 8
+
+
+def test_quota_aware_switches_current_below_avoid_threshold(tmp_path, monkeypatch):
+    entries = [
+        {
+            "id": "current",
+            "label": "current",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "manual:device_code",
+            "access_token": "tok-current",
+        },
+        {
+            "id": "candidate",
+            "label": "candidate",
+            "auth_type": "oauth",
+            "priority": 1,
+            "source": "manual:device_code",
+            "access_token": "tok-candidate",
+        },
+    ]
+    _write_quota_aware_pool(tmp_path, monkeypatch, entries=entries)
+
+    from agent import credential_pool as cp
+    from agent.credential_pool import load_pool
+
+    snapshots = {
+        "tok-current": _codex_usage_snapshot((("Session", 20),)),
+        "tok-candidate": _codex_usage_snapshot((("Session", 30),)),
+    }
+    cp._CODEX_QUOTA_CACHE.clear()
+    monkeypatch.setattr(
+        "agent.account_usage.fetch_codex_usage_for_token",
+        lambda token, _base_url, *, timeout: snapshots[token],
+    )
+
+    pool = load_pool("openai-codex")
+    first = pool.select()
+    assert first is not None and first.id == "current"
+
+    snapshots.update(
+        {
+            "tok-current": _codex_usage_snapshot((("Session", 85),)),  # 15% left
+            "tok-candidate": _codex_usage_snapshot((("Session", 30),)),
+        }
+    )
+    cp._CODEX_QUOTA_CACHE.clear()
+    second = pool.select()
+
+    assert second is not None
+    assert second.id == "candidate"
+
+
+def test_quota_aware_switch_avoids_candidates_below_avoid_threshold(tmp_path, monkeypatch):
+    entries = [
+        {
+            "id": "current",
+            "label": "current",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "manual:device_code",
+            "access_token": "tok-current",
+        },
+        {
+            "id": "too-low",
+            "label": "too-low",
+            "auth_type": "oauth",
+            "priority": 1,
+            "source": "manual:device_code",
+            "access_token": "tok-too-low",
+        },
+        {
+            "id": "acceptable",
+            "label": "acceptable",
+            "auth_type": "oauth",
+            "priority": 2,
+            "source": "manual:device_code",
+            "access_token": "tok-acceptable",
+        },
+    ]
+    _write_quota_aware_pool(tmp_path, monkeypatch, entries=entries)
+
+    from agent import credential_pool as cp
+    from agent.credential_pool import load_pool
+
+    snapshots = {
+        "tok-current": _codex_usage_snapshot((("Session", 85),)),  # 15% left, switch away
+        "tok-too-low": _codex_usage_snapshot((("Session", 90),)),  # 10% left, avoid
+        "tok-acceptable": _codex_usage_snapshot((("Session", 75),)),  # 25% left
+    }
+    cp._CODEX_QUOTA_CACHE.clear()
+    monkeypatch.setattr(
+        "agent.account_usage.fetch_codex_usage_for_token",
+        lambda token, _base_url, *, timeout: snapshots[token],
+    )
+
+    pool = load_pool("openai-codex")
+    pool._current_id = "current"
+    selected = pool.select()
+
+    assert selected is not None
+    assert selected.id == "acceptable"
+
+
+def test_quota_aware_all_low_falls_back_to_highest_remaining(tmp_path, monkeypatch):
+    entries = [
+        {
+            "id": "lowest",
+            "label": "lowest",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "manual:device_code",
+            "access_token": "tok-lowest",
+        },
+        {
+            "id": "highest-low",
+            "label": "highest-low",
+            "auth_type": "oauth",
+            "priority": 1,
+            "source": "manual:device_code",
+            "access_token": "tok-highest-low",
+        },
+    ]
+    _write_quota_aware_pool(tmp_path, monkeypatch, entries=entries)
+
+    from agent import credential_pool as cp
+    from agent.credential_pool import load_pool
+
+    snapshots = {
+        "tok-lowest": _codex_usage_snapshot((("Session", 95),)),  # 5% left
+        "tok-highest-low": _codex_usage_snapshot((("Session", 85),)),  # 15% left
+    }
+    cp._CODEX_QUOTA_CACHE.clear()
+    monkeypatch.setattr(
+        "agent.account_usage.fetch_codex_usage_for_token",
+        lambda token, _base_url, *, timeout: snapshots[token],
+    )
+
+    selected = load_pool("openai-codex").select()
+
+    assert selected is not None
+    assert selected.id == "highest-low"
+
+
+def test_quota_aware_ties_break_by_request_count_priority_then_id(tmp_path, monkeypatch):
+    entries = [
+        {
+            "id": "z-id",
+            "label": "z-id",
+            "auth_type": "oauth",
+            "priority": 1,
+            "source": "manual:device_code",
+            "access_token": "tok-z",
+            "request_count": 3,
+        },
+        {
+            "id": "a-id",
+            "label": "a-id",
+            "auth_type": "oauth",
+            "priority": 1,
+            "source": "manual:device_code",
+            "access_token": "tok-a",
+            "request_count": 3,
+        },
+        {
+            "id": "lower-request-count",
+            "label": "lower-request-count",
+            "auth_type": "oauth",
+            "priority": 2,
+            "source": "manual:device_code",
+            "access_token": "tok-low-count",
+            "request_count": 2,
+        },
+    ]
+    _write_quota_aware_pool(tmp_path, monkeypatch, entries=entries)
+
+    from agent import credential_pool as cp
+    from agent.credential_pool import load_pool
+
+    snapshots = {
+        "tok-z": _codex_usage_snapshot((("Session", 30),)),
+        "tok-a": _codex_usage_snapshot((("Session", 30),)),
+        "tok-low-count": _codex_usage_snapshot((("Session", 30),)),
+    }
+    cp._CODEX_QUOTA_CACHE.clear()
+    monkeypatch.setattr(
+        "agent.account_usage.fetch_codex_usage_for_token",
+        lambda token, _base_url, *, timeout: snapshots[token],
+    )
+
+    selected = load_pool("openai-codex").select()
+
+    assert selected is not None
+    assert selected.id == "lower-request-count"
+
+
+def test_quota_aware_strategy_avoids_near_threshold_entry(tmp_path, monkeypatch):
+    _write_quota_aware_pool(tmp_path, monkeypatch)
+
+    from agent import credential_pool as cp
+    from agent.credential_pool import load_pool
+
+    cp._CODEX_QUOTA_CACHE.clear()
+    snapshots = {
+        "tok-low": _codex_usage_snapshot((("Session", 85), ("Weekly", 95))),
+        "tok-healthy": _codex_usage_snapshot((("Session", 40), ("Weekly", 50))),
+    }
+    monkeypatch.setattr(
+        "agent.account_usage.fetch_codex_usage_for_token",
+        lambda token, _base_url, *, timeout: snapshots[token],
+    )
+
+    selected = load_pool("openai-codex").select()
+
+    assert selected is not None
+    assert selected.id == "healthy"
+
+
+def test_quota_aware_unknown_telemetry_falls_back_to_least_used(tmp_path, monkeypatch):
+    entries = [
+        {
+            "id": "heavy",
+            "label": "heavy",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "manual:device_code",
+            "access_token": "tok-heavy",
+            "request_count": 50,
+        },
+        {
+            "id": "light",
+            "label": "light",
+            "auth_type": "oauth",
+            "priority": 1,
+            "source": "manual:device_code",
+            "access_token": "tok-light",
+            "request_count": 3,
+        },
+    ]
+    _write_quota_aware_pool(tmp_path, monkeypatch, entries=entries)
+
+    from agent import credential_pool as cp
+    from agent.credential_pool import load_pool
+
+    cp._CODEX_QUOTA_CACHE.clear()
+    monkeypatch.setattr(
+        "agent.account_usage.fetch_codex_usage_for_token",
+        lambda *_args, **_kwargs: None,
+    )
+
+    selected = load_pool("openai-codex").select()
+
+    assert selected is not None
+    assert selected.id == "light"
+    assert selected.request_count == 4
+
+
+def test_quota_aware_excludes_exhausted_and_dead_entries_before_scoring(tmp_path, monkeypatch):
+    now = time.time()
+    entries = [
+        {
+            "id": "exhausted",
+            "label": "exhausted",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "manual:device_code",
+            "access_token": "tok-exhausted",
+            "last_status": "exhausted",
+            "last_status_at": now,
+            "last_error_code": 429,
+            "last_error_reset_at": now + 3600,
+        },
+        {
+            "id": "dead",
+            "label": "dead",
+            "auth_type": "oauth",
+            "priority": 1,
+            "source": "manual:device_code",
+            "access_token": "tok-dead",
+            "last_status": "dead",
+            "last_status_at": now,
+            "last_error_code": 401,
+        },
+        {
+            "id": "healthy",
+            "label": "healthy",
+            "auth_type": "oauth",
+            "priority": 2,
+            "source": "manual:device_code",
+            "access_token": "tok-healthy",
+        },
+        {
+            "id": "other",
+            "label": "other",
+            "auth_type": "oauth",
+            "priority": 3,
+            "source": "manual:device_code",
+            "access_token": "tok-other",
+        },
+    ]
+    _write_quota_aware_pool(tmp_path, monkeypatch, entries=entries)
+
+    from agent import credential_pool as cp
+    from agent.credential_pool import load_pool
+
+    cp._CODEX_QUOTA_CACHE.clear()
+    called = []
+
+    def fake_fetch(token, _base_url, *, timeout):
+        called.append(token)
+        return _codex_usage_snapshot((("Session", 10), ("Weekly", 10)))
+
+    monkeypatch.setattr("agent.account_usage.fetch_codex_usage_for_token", fake_fetch)
+
+    selected = load_pool("openai-codex").select()
+
+    assert selected is not None
+    assert selected.id == "healthy"
+    assert called == ["tok-healthy", "tok-other"]
+
+
+def test_quota_aware_non_codex_provider_degrades_to_least_used(tmp_path, monkeypatch):
+    entries = [
+        {
+            "id": "heavy",
+            "label": "heavy",
+            "auth_type": "api_key",
+            "priority": 0,
+            "source": "manual",
+            "access_token": "sk-heavy",
+            "request_count": 12,
+        },
+        {
+            "id": "light",
+            "label": "light",
+            "auth_type": "api_key",
+            "priority": 1,
+            "source": "manual",
+            "access_token": "sk-light",
+            "request_count": 1,
+        },
+    ]
+    _write_quota_aware_pool(tmp_path, monkeypatch, provider="openrouter", entries=entries)
+
+    from agent import credential_pool as cp
+    from agent.credential_pool import load_pool
+
+    cp._CODEX_QUOTA_CACHE.clear()
+    selected = load_pool("openrouter").select()
+
+    assert selected is not None
+    assert selected.id == "light"
+    assert selected.request_count == 2
+
+
+def test_quota_aware_cache_key_uses_fingerprint_not_raw_token(tmp_path, monkeypatch):
+    secret_token = "tok-secret-never-cache"
+    entries = [
+        {
+            "id": "only",
+            "label": "only",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "manual:device_code",
+            "access_token": secret_token,
+            "request_count": 0,
+        },
+        {
+            "id": "other",
+            "label": "other",
+            "auth_type": "oauth",
+            "priority": 1,
+            "source": "manual:device_code",
+            "access_token": "tok-other",
+            "request_count": 1,
+        },
+    ]
+    _write_quota_aware_pool(tmp_path, monkeypatch, entries=entries)
+
+    from agent import credential_pool as cp
+    from agent.credential_pool import load_pool
+
+    cp._CODEX_QUOTA_CACHE.clear()
+    monkeypatch.setattr(
+        "agent.account_usage.fetch_codex_usage_for_token",
+        lambda token, _base_url, *, timeout: _codex_usage_snapshot((("Session", 10),)),
+    )
+
+    pool = load_pool("openai-codex")
+    pool.select()
+
+    cache_dump = repr(cp._CODEX_QUOTA_CACHE)
+    assert secret_token not in cache_dump
+    persisted = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert secret_token in json.dumps(persisted)  # credential itself is unchanged
+    assert "usage_api" not in json.dumps(persisted)
+
+
+def test_quota_aware_is_supported_pool_strategy():
+    from agent.credential_pool import STRATEGY_QUOTA_AWARE, SUPPORTED_POOL_STRATEGIES
+
+    assert STRATEGY_QUOTA_AWARE == "quota_aware"
+    assert STRATEGY_QUOTA_AWARE in SUPPORTED_POOL_STRATEGIES
+
+
+def test_quota_aware_uses_ttl_cache_for_repeated_selects(tmp_path, monkeypatch):
+    _write_quota_aware_pool(tmp_path, monkeypatch)
+
+    from agent import credential_pool as cp
+    from agent.credential_pool import load_pool
+
+    cp._CODEX_QUOTA_CACHE.clear()
+    calls = []
+    snapshots = {
+        "tok-low": _codex_usage_snapshot((("Session", 70), ("Weekly", 70))),
+        "tok-healthy": _codex_usage_snapshot((("Session", 20), ("Weekly", 20))),
+    }
+
+    def fake_fetch(token, _base_url, *, timeout):
+        calls.append(token)
+        return snapshots[token]
+
+    monkeypatch.setattr("agent.account_usage.fetch_codex_usage_for_token", fake_fetch)
+
+    pool = load_pool("openai-codex")
+    first = pool.select()
+    second = pool.select()
+
+    assert first is not None and first.id == "healthy"
+    assert second is not None and second.id == "healthy"
+    assert calls == ["tok-low", "tok-healthy"]

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -563,3 +563,97 @@ class TestFailureAttribution:
         failed = {e.id: e for e in pool.entries()}["cred-1"]
         assert failed.failure_reason != "billing"
 
+
+
+def test_quota_aware_codex_selects_healthy_then_429_rotates(tmp_path, monkeypatch):
+    """Quota-aware selection still preserves existing exhausted+rotate recovery."""
+    import json
+    from datetime import datetime, timezone
+
+    from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(
+        "agent.credential_pool._seed_from_singletons",
+        lambda provider, entries: (False, set()),
+    )
+    monkeypatch.setattr(
+        "agent.credential_pool._seed_from_env",
+        lambda provider, entries: (False, set()),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._codex_access_token_is_expiring",
+        lambda *_args, **_kwargs: False,
+    )
+    (hermes_home / "auth.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "credential_pool": {
+                    "openai-codex": [
+                        {
+                            "id": "low",
+                            "label": "low",
+                            "auth_type": "oauth",
+                            "priority": 0,
+                            "source": "manual:device_code",
+                            "access_token": "tok-low",
+                            "base_url": "https://chatgpt.com/backend-api/codex",
+                        },
+                        {
+                            "id": "healthy",
+                            "label": "healthy",
+                            "auth_type": "oauth",
+                            "priority": 1,
+                            "source": "manual:device_code",
+                            "access_token": "tok-healthy",
+                            "base_url": "https://chatgpt.com/backend-api/codex",
+                        },
+                    ]
+                },
+            }
+        )
+    )
+    (hermes_home / "config.yaml").write_text(
+        "credential_pool_strategies:\n  openai-codex: quota_aware\n"
+    )
+
+    from agent import credential_pool as cp
+    from agent.credential_pool import load_pool
+
+    cp._CODEX_QUOTA_CACHE.clear()
+
+    def snapshot(used):
+        return AccountUsageSnapshot(
+            provider="openai-codex",
+            source="usage_api",
+            fetched_at=datetime.now(timezone.utc),
+            windows=(
+                AccountUsageWindow(label="Session", used_percent=used, reset_at=None),
+                AccountUsageWindow(label="Weekly", used_percent=used, reset_at=None),
+            ),
+        )
+
+    monkeypatch.setattr(
+        "agent.account_usage.fetch_codex_usage_for_token",
+        lambda token, _base_url, *, timeout: {
+            "tok-low": snapshot(92),
+            "tok-healthy": snapshot(25),
+        }[token],
+    )
+
+    pool = load_pool("openai-codex")
+    first = pool.select()
+    assert first is not None
+    assert first.id == "healthy"
+
+    rotated = pool.mark_exhausted_and_rotate(status_code=429)
+    assert rotated is not None
+    assert rotated.id == "low"
+
+    persisted = json.loads((hermes_home / "auth.json").read_text())
+    by_id = {entry["id"]: entry for entry in persisted["credential_pool"]["openai-codex"]}
+    assert by_id["healthy"]["last_status"] == "exhausted"
+    assert by_id["healthy"]["last_error_code"] == 429

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -58,31 +58,40 @@ def test_fetch_account_usage_codex(monkeypatch):
             "api_key": "access-token",
         },
     )
-    monkeypatch.setattr(
-        "agent.account_usage._read_codex_tokens",
-        lambda: {"tokens": {"account_id": "acct_123"}},
-    )
-    monkeypatch.setattr(
-        "agent.account_usage.httpx.Client",
-        lambda timeout=15.0: _Client(
-            {
-                "plan_type": "pro",
-                "rate_limit": {
-                    "primary_window": {
-                        "used_percent": 15,
-                        "reset_at": 1_900_000_000,
-                        "limit_window_seconds": 18000,
+    requests = []
+
+    class _CodexClient:
+        def __init__(self, timeout=15.0):
+            self.timeout = timeout
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, url, headers=None):
+            requests.append((url, headers or {}, self.timeout))
+            return _Response(
+                {
+                    "plan_type": "pro",
+                    "rate_limit": {
+                        "primary_window": {
+                            "used_percent": 15,
+                            "reset_at": 1_900_000_000,
+                            "limit_window_seconds": 18000,
+                        },
+                        "secondary_window": {
+                            "used_percent": 40,
+                            "reset_at": 1_900_500_000,
+                            "limit_window_seconds": 604800,
+                        },
                     },
-                    "secondary_window": {
-                        "used_percent": 40,
-                        "reset_at": 1_900_500_000,
-                        "limit_window_seconds": 604800,
-                    },
-                },
-                "credits": {"has_credits": True, "balance": 12.5},
-            }
-        ),
-    )
+                    "credits": {"has_credits": True, "balance": 12.5},
+                }
+            )
+
+    monkeypatch.setattr("agent.account_usage.httpx.Client", _CodexClient)
 
     snapshot = fetch_account_usage("openai-codex")
 
@@ -93,6 +102,9 @@ def test_fetch_account_usage_codex(monkeypatch):
     assert snapshot.windows[0].used_percent == 15.0
     assert snapshot.windows[0].reset_at == datetime.fromtimestamp(1_900_000_000, tz=timezone.utc)
     assert "Credits balance: $12.50" in snapshot.details
+    assert requests
+    assert requests[0][1]["Authorization"] == "Bearer access-token"
+    assert "ChatGPT-Account-Id" not in requests[0][1]
 
 
 def test_render_account_usage_lines_includes_reset_and_provider():

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1097,7 +1097,21 @@ credential_pool_strategies:
   anthropic: least_used      # always pick the least-used key
 ```
 
-Options: `fill_first` (default), `round_robin`, `least_used`, `random`. See [Credential Pools](/user-guide/features/credential-pools) for full documentation.
+Options: `fill_first` (default), `round_robin`, `least_used`, `random`, and `quota_aware`. See [Credential Pools](/user-guide/features/credential-pools) for full documentation.
+
+`quota_aware` is currently Codex-specific and opt-in:
+
+```yaml
+credential_pool_strategies:
+  openai-codex: quota_aware
+```
+
+For pooled Codex OAuth credentials, Hermes reads the Codex usage endpoint with each entry's bearer token and uses sticky low-watermark routing: keep the current credential while remaining quota is at or above `credential_pool_quota_aware.avoid_below_fraction` (default `0.20`), switch to the highest-remaining candidate above that threshold only once current drops below it, and fall back to the highest remaining credential if every account is low. Ties go to lower `request_count`, then priority/id. If usage telemetry is unavailable, stale, or rate-limited, Hermes falls back gracefully to `least_used` instead of failing closed. Non-Codex providers configured with `quota_aware` degrade to least-used selection.
+
+```yaml
+credential_pool_quota_aware:
+  avoid_below_fraction: 0.20
+```
 
 ## Prompt caching
 

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -23,7 +23,7 @@ Credential pools are mainly for API-key providers (OpenRouter, Anthropic). A sin
 
 ```
 Your request
-  → Pick key from pool (round_robin / least_used / fill_first / random)
+  → Pick key from pool (round_robin / least_used / fill_first / random / quota_aware)
   → Send to provider
   → 429 rate limit?
       → Plan/usage limit reached (e.g. ChatGPT/Codex "usage limit reached")?
@@ -125,6 +125,7 @@ Configure via `hermes auth` → "Set rotation strategy" or in `config.yaml`:
 credential_pool_strategies:
   openrouter: round_robin
   anthropic: least_used
+  openai-codex: quota_aware
 ```
 
 | Strategy | Behavior |
@@ -133,6 +134,14 @@ credential_pool_strategies:
 | `round_robin` | Cycle through keys evenly, rotating after each selection |
 | `least_used` | Always pick the key with the lowest request count |
 | `random` | Random selection among healthy keys |
+| `quota_aware` | Codex-specific: uses Codex session/weekly usage telemetry with sticky low-watermark routing. Hermes keeps the current `openai-codex` OAuth credential while remaining quota is at or above `avoid_below_fraction` (default `0.20`), then switches to the valid credential with the most remaining quota above that same threshold. Ties go to lower `request_count`, then priority/id. If all known credentials are below `avoid_below_fraction`, Hermes picks the highest remaining quota instead of failing; if telemetry is unavailable, it falls back to `least_used`. |
+
+Optional low-watermark threshold:
+
+```yaml
+credential_pool_quota_aware:
+  avoid_below_fraction: 0.20   # keep current credential until it drops below this; avoid switching to candidates below it unless all are low
+```
 
 ## Error Recovery
 


### PR DESCRIPTION
## What

Adds a `quota_aware` credential-pool strategy for pooled `openai-codex` OAuth credentials.

Hermes reads Codex usage telemetry per credential (bearer-only; no `ChatGPT-Account-Id` header) and **keeps using the current credential while its remaining quota stays at or above a low watermark**, switching only once it drops below. This stops the pool ping-ponging between accounts on every message while still moving off accounts that are close to exhaustion.

Opt-in; nothing changes unless you configure it:

```yaml
credential_pool_strategies:
  openai-codex: quota_aware
credential_pool_quota_aware:
  avoid_below_fraction: 0.20   # default
```

## Behaviour

- Keep the current credential while `remaining >= avoid_below_fraction` (default `0.20`); switch only once it drops below.
- When switching, pick the highest-remaining candidate above the threshold; ties break by `request_count`, then `priority`, then `id` (deterministic).
- All credentials below the threshold → pick the highest remaining (fail open rather than declaring the pool dead).
- Telemetry unavailable → fall back to `least_used`.
- A non-Codex provider configured with `quota_aware` degrades to `least_used`.
- Per-credential usage is cached fingerprint-keyed (SHA-256 prefix, never the raw token) with a 300s TTL and a 4s fetch timeout.

## Why

On a two-account Codex pool, a burst of requests can 429 the healthy account seconds after the exhausted one, because rotation is blind to how much quota each account actually has left. A 429 then benches that credential for the full cooldown and the whole pool falls through to the configured fallback provider — while an account with most of its week still unspent sits idle. Sticky, quota-informed selection is the smallest fix that keeps rotation stable rather than reactive.

## Implementation notes

- `agent/account_usage.py`: extracts the payload→snapshot parsing into `_codex_usage_snapshot_from_payload()` and adds `fetch_codex_usage_for_token()` — a read-only per-bearer-token telemetry fetch that deliberately does **not** resolve or refresh credentials and does not send `ChatGPT-Account-Id`, so pooled callers can ask for per-entry telemetry without mutating `auth.json`. The existing tiered `_resolve_codex_usage_credentials()` path is untouched.
- `agent/credential_pool.py`: adds `STRATEGY_QUOTA_AWARE` plus the selection helpers. `least_used` selection is factored into `_select_least_used_unlocked()` so the quota-aware path can reuse it as its fallback; behaviour is unchanged.
- Docs, config reference, and the `hermes auth` strategy picker are updated.

## Verification

Run against `main` at 210cdb0ed3:

- `pytest tests/agent/test_credential_pool.py tests/agent/test_credential_pool_routing.py` → **91 passed** (15 of them new: sticky selection, threshold switching, low-quota avoidance, all-low fail-open, telemetry-unavailable fallback, non-Codex degrade, fingerprint cache key, TTL cache reuse, tie-breaking, and a working-band no-ping-pong regression).
- `pytest tests/test_account_usage.py` → 4 passed.
- `pytest tests/agent/` → failure set is **byte-identical** to `main` on the same machine (311 pre-existing env-related failures/errors both sides); this branch adds 15 passing tests and introduces no new failures.
- `ruff check` (repo's `PLW1514`) → clean on every changed file.

## History

This restores #56954, which was auto-closed on 2026-08-16 when the `banozz0` fork was deleted and recreated as a real fork — not for any review reason. Rebased onto current `main`; the branch's second commit (`fix: target credential exhaustion by active key`) is **dropped** because `main` has since landed the same fix independently and more completely, via `api_key_hint`/`credential_id` on `mark_exhausted_and_rotate()` and `entry_id_for_api_key()`.
