### PR TITLE
fix(tools): never drop todo items that lack an id (#83389)

### DIFF
--- a/tests/tools/test_todo_tool.py
+++ b/tests/tools/test_todo_tool.py
@@ -44,6 +44,48 @@ class TestWriteAndRead:
             {"id": "2", "content": "Verify freed space", "status": "pending"},
         ]
 
+    def test_write_keeps_items_without_explicit_ids(self):
+        """Regression (#83389): items lacking an 'id' key were silently
+        dropped by deduplication because they all collapsed onto the '?'
+        placeholder key. Every no-id item must survive in position."""
+        store = TodoStore()
+        result = store.write([
+            {"content": "Task 1", "status": "pending"},
+            {"content": "Task 2", "status": "pending"},
+        ])
+        assert len(result) == 2
+        assert [item["content"] for item in result] == ["Task 1", "Task 2"]
+
+    def test_write_keeps_whitespace_only_ids(self):
+        """Regression (#83389): empty or whitespace-only 'id' values are the
+        same as missing ids — none of them may be dropped."""
+        store = TodoStore()
+        result = store.write([
+            {"id": "", "content": "Alpha", "status": "pending"},
+            {"id": "   ", "content": "Beta", "status": "pending"},
+            {"id": "1", "content": "Has real id", "status": "pending"},
+        ])
+        assert len(result) == 3
+        assert [item["content"] for item in result] == ["Alpha", "Beta", "Has real id"]
+        assert result[0]["id"] == "?"
+        assert result[1]["id"] == "?"
+
+    def test_write_mixed_ids_preserve_dedupe_of_real_ids(self):
+        """Regression guard (#83389): real duplicate ids still collapse to the
+        last occurrence while every no-id item is kept."""
+        store = TodoStore()
+        result = store.write([
+            {"id": "1", "content": "First", "status": "pending"},
+            {"content": "No id A", "status": "pending"},
+            {"id": "1", "content": "Updated", "status": "in_progress"},
+            {"content": "No id B", "status": "pending"},
+        ])
+        assert result == [
+            {"id": "1", "content": "Updated", "status": "in_progress"},
+            {"id": "?", "content": "No id A", "status": "pending"},
+            {"id": "?", "content": "No id B", "status": "pending"},
+        ]
+
 
 class TestHasItems:
     def test_empty_store(self):

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -191,14 +191,23 @@ class TodoStore:
 
     @staticmethod
     def _dedupe_by_id(todos: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """Collapse duplicate ids, keeping the last occurrence in its position."""
-        last_index: Dict[str, int] = {}
+        """Collapse duplicate ids, keeping the last occurrence in its position.
+
+        Items without an id (or with a whitespace-only id) cannot collide, so
+        they must never be collapsed away — each is kept by a unique
+        index-scoped key (a tuple, so it cannot clash with any real id string).
+        """
+        last_index: Dict[Any, int] = {}
         for i, item in enumerate(todos):
             if not isinstance(item, dict):
                 # Non-dict items get a synthetic key so _validate can handle them
                 last_index[f"__invalid_{i}"] = i
                 continue
-            item_id = str(item.get("id", "")).strip() or "?"
+            item_id = str(item.get("id", "")).strip()
+            if not item_id:
+                # Missing id => cannot be a duplicate; keep in position
+                last_index[("__no_id__", i)] = i
+                continue
             last_index[item_id] = i
         return [todos[i] for i in sorted(last_index.values())]
 


### PR DESCRIPTION
## What does this PR do?

Fixes silent data loss in the `todo` tool: `TodoStore.write` dropped every todo item that lacked an explicit `id` key — all but one. Because `_dedupe_by_id` collapsed such items onto the shared `"?"` placeholder key, each no-id item overwrote the previous one's index, so everything but the final no-id item was discarded with no warning.

This is a common case in practice: the agent often calls the todo tool with bare `{content, status}` items and lets the store assign ids.

## Related Issue

Fixes #83389

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/todo_tool.py` (`_dedupe_by_id`): items with a missing or whitespace-only `id` now get a unique, index-scoped tuple key (`("__no_id__", i)`) instead of the shared `"?"` key, so they are never collapsed into each other. Real duplicate ids still deduplicate as before; the tuple key cannot collide with any real id string.

## How to Test

1. Reproduce before the fix:
   ```python
   from tools.todo_tool import TodoStore
   TodoStore().write([
       {"content": "Task 1", "status": "pending"},
       {"content": "Task 2", "status": "pending"},
   ])
   # before: only "Task 2" survived
   # after:  both tasks preserved
   ```
2. `uv run pytest tests/tools/test_todo_tool.py -q` — 19 passed (includes three new regression tests that fail on the old code).

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass (affected suites pass: `tests/tools/test_todo_tool.py`, plus the agent-side todo consumers; a few `tests/tools` modules fail at collection on Windows due to missing optional deps — pre-existing, unrelated)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

- [x] Updated relevant documentation — N/A
- [x] Updated `cli-config.yaml.example` — N/A
- [x] Updated `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Considered cross-platform impact — platform-neutral
- [x] Updated tool descriptions/schemas — N/A