### PR TITLE
fix(agent): skip malformed `data: null` SSE frames in provider streams

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -332,7 +332,15 @@ def _provider_stream_error_from_json_decode_error(
 def _iter_provider_stream_chunks(stream, *, response: Any = None):
     """Yield SDK chunks while translating SDK-level SSE decode failures."""
     try:
-        yield from stream
+        for chunk in stream:
+            # Some OpenAI-compatible relays emit a bare ``data: null`` SSE
+            # frame, which the SDK deserializes into ``None`` and yields like
+            # any other chunk. Consumers dereference ``chunk.choices``, so the
+            # frame would kill the turn with an AttributeError even though
+            # every other frame was valid. It carries no payload — drop it.
+            if chunk is None:
+                continue
+            yield chunk
     except json.JSONDecodeError as error:
         stream_response = response() if callable(response) else response
         if stream_response is None:

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -186,6 +186,38 @@ class TestStreamingAccumulator:
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_null_sse_frame_is_skipped(self, mock_close, mock_create):
+        """A ``data: null`` SSE frame (SDK yields None) is dropped, not fatal."""
+        from run_agent import AIAgent
+
+        chunks = [
+            _make_stream_chunk(content="Hello"),
+            None,  # malformed `data: null` frame from an OpenAI-compat relay
+            _make_stream_chunk(content=" world", finish_reason="stop", model="test-model"),
+        ]
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.choices[0].message.content == "Hello world"
+        assert response.choices[0].finish_reason == "stop"
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
     def test_chat_stream_closes_original_provider_resource(
         self,
         mock_close,


### PR DESCRIPTION
## What does this PR do?

Some OpenAI-compatible relays and proxies emit a bare `data: null` SSE frame mid-stream. The OpenAI SDK deserializes that frame into a Python `None` and yields it like any other chunk, so the chat-completions streaming loop reaches `if not chunk.choices:` holding a `None` and the whole turn dies with:

```
AttributeError: 'NoneType' object has no attribute 'choices'
```

Every other frame in the stream is valid — the response is lost purely because one provider-side frame is malformed, and neither the user nor the model can do anything about it. In the log it surfaces as `Streaming failed after partial delivery, not retrying: 'NoneType' object has no attribute 'choices'`.

The guard goes in `_iter_provider_stream_chunks`, which already exists to normalize SDK-level stream failures (it translates `json.JSONDecodeError` into a `ProviderStreamError`). A `None` chunk carries no payload, so drop it and keep reading. Putting it in the generator rather than in the consumer loop means every consumer of a provider stream is covered by one check, and the consumer keeps its invariant that a chunk is chunk-shaped.

`yield from stream` becomes an explicit `for` loop so the filter can sit inside the existing `try:` — the `JSONDecodeError` translation still wraps the whole iteration, which `tests/run_agent/test_jsondecodeerror_retryable.py` continues to cover.

## Related Issue

No existing issue — I searched open and closed issues and PRs for `data: null`, malformed SSE, `None` chunk, and `NoneType ... choices` and found nothing covering this.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py` — `_iter_provider_stream_chunks()` now skips `None` chunks instead of passing them through to consumers that dereference `chunk.choices`.
- `tests/run_agent/test_streaming.py` — `TestStreamingAccumulator::test_null_sse_frame_is_skipped`: a `None` interleaved between two content chunks; asserts the accumulated response is still `"Hello world"` with `finish_reason == "stop"`.

## How to Test

1. **Against a real provider** — point Hermes at any OpenAI-compatible endpoint that emits a `data: null` keepalive frame (I hit this on a third-party relay) and send one message. On `main` the turn dies with the `AttributeError` above; with this patch the stream completes normally.
2. **Deterministic repro, no relay needed** — the new test injects the same frame through the existing mock-stream harness:
   ```bash
   scripts/run_tests.sh tests/run_agent/test_streaming.py -q
   ```
   - with the patch: `35 tests passed, 0 failed, 4 skipped`
   - negative control (patch reverted, test kept): the new test fails with `WARNING agent.chat_completion_helpers: Streaming failed after partial delivery, not retrying: 'NoneType' object has no attribute 'choices'`
3. **Adjacent streaming + SSE-error regressions:**
   ```bash
   scripts/run_tests.sh tests/run_agent/test_streaming.py \
     tests/run_agent/test_partial_stream_finish_reason.py \
     tests/run_agent/test_stream_interrupt_retry.py \
     tests/run_agent/test_stream_stale_circuit_breaker.py -q     # 61 passed, 0 failed
   scripts/run_tests.sh tests/run_agent/test_jsondecodeerror_retryable.py -q   # 4 passed, 0 failed
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **ran the targeted files only** (counts above). I did not run the full suite locally; relying on CI for that, and happy to run anything specific you want.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Kali Linux (aarch64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python control flow, no OS-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
