### PR TITLE
fix(desktop): star map runs on the budgeted render loop so it sleeps when hidden

### DIFF
--- a/apps/desktop/src/app/starmap/star-map.tsx
+++ b/apps/desktop/src/app/starmap/star-map.tsx
@@ -3,6 +3,7 @@ import { atom, type WritableAtom } from 'nanostores'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { useThemeEpoch } from '@/hooks/use-theme-epoch'
+import { createBudgetedLoop } from '@/lib/budgeted-loop'
 import { createDoubleTapDetector, isSmartZoomWheel } from '@/lib/trackpad-gestures'
 import type { StarmapGraph } from '@/types/hermes'
 
@@ -496,32 +497,14 @@ export function StarMap({
   }, [invalidate, themeEpoch])
 
   // Render loop. The core scramble animates continuously, so the loop runs while
-  // the window is focused — but each frame is cheap (live scramble + a blit of the
-  // cached static layer). The expensive scene only re-renders when invalidate()
-  // marks it dirty. Capped to ~30fps; interaction (force) bypasses the cap.
+  // the map is observable — but createBudgetedLoop caps it to ~30fps and, via the
+  // observability pause controller, suspends it the moment the window is hidden,
+  // minimized, or unfocused. Each frame is cheap (live scramble + a blit of the
+  // cached static layer); the expensive scene only re-renders when invalidate()
+  // marks it dirty.
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
-    let raf = 0
-    const ANIM_MS = 1000 / 30
-    let lastAnimTs = 0
-    let force = true
-
-    // The scramble keeps the loop perpetually "animating", so a fully-built,
-    // untouched map still repaints 30×/s for as long as the panel is open. That's
-    // wasted CPU/GPU (WindowServer compositing) when the window isn't even the one
-    // you're looking at. Freeze the loop while the window is hidden or unfocused;
-    // a frozen core next to other work is fine, and it resumes instantly on focus.
-    const isPaused = () =>
-      (typeof document !== 'undefined' && document.hidden) ||
-      (typeof document.hasFocus === 'function' && !document.hasFocus())
-
-    let paused = isPaused()
-
-    const schedule = () => {
-      if (!paused && !raf) {
-        raf = requestAnimationFrame(frame)
-      }
-    }
+    const loop = createBudgetedLoop(() => paint(), { fps: 30 })
 
     // The static scene (rings, bands, links, nodes, labels) is cached in an
     // offscreen layer and only re-rendered when something actually changes —
@@ -618,63 +601,14 @@ export function StarMap({
       }
     }
 
-    const frame = (ts: number) => {
-      raf = 0
-
-      // The scramble animates every frame; throttle to ANIM_MS unless an
-      // interaction (force) needs an immediate repaint.
-      if (!force && ts - lastAnimTs < ANIM_MS) {
-        schedule()
-
-        return
-      }
-
-      force = false
-      lastAnimTs = ts
-      paint()
-      schedule()
-    }
-
+    // External invalidation (hover/focus/scrub/resize/theme) marks the static
+    // scene dirty; the running budgeted loop picks it up on its next frame.
     invalidateRef.current = () => {
       dirtyRef.current = true
-      force = true
-      schedule()
     }
-
-    // Suspend the loop when the window drops out of view/focus; wake + force a
-    // fresh frame the moment it returns so the resume is seamless.
-    const onActivity = () => {
-      const next = isPaused()
-
-      if (next === paused) {
-        return
-      }
-
-      paused = next
-
-      if (paused) {
-        if (raf) {
-          cancelAnimationFrame(raf)
-          raf = 0
-        }
-      } else {
-        dirtyRef.current = true
-        force = true
-        schedule()
-      }
-    }
-
-    document.addEventListener('visibilitychange', onActivity)
-    window.addEventListener('blur', onActivity)
-    window.addEventListener('focus', onActivity)
-
-    schedule()
 
     return () => {
-      cancelAnimationFrame(raf)
-      document.removeEventListener('visibilitychange', onActivity)
-      window.removeEventListener('blur', onActivity)
-      window.removeEventListener('focus', onActivity)
+      loop.dispose()
 
       invalidateRef.current = () => {}
     }


### PR DESCRIPTION
## What

The desktop star map (memory graph view) hand-rolled its own render loop and that loop never sleeps.

It animated the core scramble continuously via `requestAnimationFrame`, throttled by a manual `ANIM_MS` counter, with an observability pause that only checked `document.hidden` and `document.hasFocus()`. That check misses windows that are minimized, or hidden behind another app — so the renderer kept repainting every frame even when nobody was looking at the map. On the reporter's Mac this pegged a core of the renderer at ~28–50% while the app sat in the background.

This is the same "decorative animation loop that never sleeps" bug class the codebase already fixed for the bots face clock, pixel egg, diffusion placeholder, and status pulse — and it's the class `createBudgetedLoop` (`apps/desktop/src/lib/budgeted-loop.ts`) was added to standardize on. The star map is the remaining hand-rolled consumer.

## Why this is the right fix

`createBudgetedLoop(() => paint(), { fps: 30 })` owns all four behaviors the hand-rolled loop re-implemented by hand:

- **fps budget** — kept at 30 for visual parity with the previous cap.
- **observability pause** — via `createRendererLoopPauseController`, which now also listens to `window.hermesDesktop.onWindowStateChanged` (the native Electron window-state bridge). This catches minimized / hidden-behind-another-app windows that `document.hasFocus()` misses, and cancels the pending frame so the renderer goes idle when not observable.
- **teardown** — `loop.dispose()` in the effect cleanup replaces manually removing three window listeners.
- **idle dormancy** — not wired up here, since the scramble is a living background animation with no natural "nothing to animate" state; the fix is about not running when hidden, not about guessing the user isn't watching a visible map.

External invalidation (hover / focus / scrub / resize / theme repaint) still works: `invalidateRef.current` marks the scene dirty and the running budgeted loop picks it up on its next frame. The self-terminating play-sweep tween in the same file is left untouched — it's user-initiated, bounded, and not the perpetual-loop bug.

## Verification

- `tsc -p . --noEmit` (renderer) — **No errors found**
- `eslint src/app/starmap/star-map.tsx` — **0 errors, 0 warnings**
- `vitest run src/lib/budgeted-loop.test.ts` — **5/5 pass**

Diff: `apps/desktop/src/app/starmap/star-map.tsx` (+10 / −76).
