### PR TITLE
fix(mcp): reuse live HTTP session in _probe_single_server

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -253,22 +253,144 @@ def _resolve_mcp_server_config(config: dict) -> dict:
     return _interpolate_env_vars(config)
 
 
+def _truncate_mcp_tool_desc(desc: str) -> str:
+    desc = desc or ""
+    return desc[:77] + "..." if len(desc) > 80 else desc
+
+
+def _tool_rows_from_mcp_server(server) -> List[Tuple[str, str]]:
+    return [
+        (t.name, _truncate_mcp_tool_desc(getattr(t, "description", "") or ""))
+        for t in (getattr(server, "_tools", None) or [])
+    ]
+
+
+def _fill_probe_schema_chars(name: str, server, details: dict) -> None:
+    """Per-tool registry-schema sizes (the SAME converted schema the agent registers)."""
+    try:
+        import json as _json
+        from tools.mcp_tool_schema import _convert_mcp_schema
+
+        details["schema_chars"] = {
+            t.name: len(_json.dumps(_convert_mcp_schema(name, t), separators=(",", ":"), default=str))
+            for t in (getattr(server, "_tools", None) or [])
+        }
+    except Exception:  # pragma: no cover — display-only extra
+        pass
+
+
+async def _fill_probe_capability_counts(server, config: dict, details: dict) -> None:
+    """Best-effort prompts/resources counts on an existing session. Never opens a new one."""
+    from tools.mcp_tool_common import _parse_boolish
+
+    tools_filter = config.get("tools") or {}
+    advertised_caps = getattr(getattr(server, "initialize_result", None), "capabilities", None)
+
+    def _wanted(cap: str) -> bool:
+        # No capability info captured (legacy fixtures / older servers) => always try.
+        if not _parse_boolish(tools_filter.get(cap), default=True):
+            return False
+        return advertised_caps is None or getattr(advertised_caps, cap, None) is not None
+
+    session = getattr(server, "session", None)
+    if session is None:
+        return
+    if _wanted("prompts"):
+        try:
+            details["prompts"] = len((await session.list_prompts()).prompts)
+        except Exception:
+            pass
+    if _wanted("resources"):
+        try:
+            details["resources"] = len((await session.list_resources()).resources)
+        except Exception:
+            pass
+
+
+def _apply_probe_details(name: str, server, config: dict, details: Optional[dict], *, capability_rpcs: bool) -> None:
+    if details is None:
+        return
+    _fill_probe_schema_chars(name, server, details)
+    if not capability_rpcs:
+        return
+    from tools.mcp_tool_loop import _run_on_mcp_loop
+
+    try:
+        _run_on_mcp_loop(lambda: _fill_probe_capability_counts(server, config, details), timeout=15)
+    except Exception:
+        pass  # display-only; a live tools list is still a successful probe
+
+
+def _wait_for_live_mcp_server(name: str, timeout: float, *, wait_for_claim: bool = False):
+    """Poll for a live session owned by this process. Never opens a new one.
+
+    Synchronous: may ``time.sleep`` on a worker/CLI thread. Must not run on
+    the dedicated MCP event-loop thread — if it does, we snapshot once and
+    return instead of blocking the loop.
+
+    ``wait_for_claim`` keeps waiting even before discovery has inserted the
+    name into the process-owned table — desktop's health sweep races that
+    by a few hundred milliseconds on gateway-open.
+    """
+    from tools.mcp_tool_discovery import (
+        mcp_event_loop_is_current,
+        mcp_server_owned_or_connecting,
+        snapshot_live_mcp_server,
+    )
+
+    if mcp_event_loop_is_current():
+        return snapshot_live_mcp_server(name)
+
+    deadline = time.monotonic() + max(0.0, timeout)
+    saw_claim = False
+    while True:
+        server = snapshot_live_mcp_server(name)
+        if server is not None:
+            return server
+        owned = mcp_server_owned_or_connecting(name)
+        if owned:
+            saw_claim = True
+        elif saw_claim or not wait_for_claim:
+            return None
+        if time.monotonic() >= deadline:
+            return None
+        time.sleep(0.1)
+
+
 def _probe_single_server(
     name: str, config: dict, connect_timeout: Optional[float] = None, *, details: Optional[dict] = None
 ) -> List[Tuple[str, str]]:
-    """Temporarily connect to one MCP server, list its tools, disconnect.
+    """List tools from one MCP server without evicting a live process-owned session.
 
-    Returns ``(tool_name, description)`` tuples; raises on connection failure. ``details`` is an
-    out-param filled with ``schema_chars``/``prompts``/``resources`` so the return shape stays stable.
+    Reuses the process-owned session when one exists (including a live session
+    with zero tools). Raises on connection failure, including ``TimeoutError``
+    when this process already owns the server (parked or still connecting) and
+    a second Streamable HTTP connect would evict it. All current callers wrap
+    the probe in ``except Exception`` (CLI print, dashboard/desktop ``ok:
+    false`` / red row, ``hermes doctor --live`` fail).
+
+    ``details`` is an out-param filled with ``schema_chars``/``prompts``/
+    ``resources`` so the return shape stays stable. Live reuse fills the same
+    contract via the existing session — it does not open a second connect.
+
+    Synchronous. May poll with a short sleep on a worker/CLI thread.
+    Must not be called on the dedicated MCP event-loop thread (dashboard
+    uses ``asyncio.to_thread``; ``mcp.servers.test`` is in
+    ``_LONG_HANDLERS``). If it ever is, the wait snapshots once and
+    returns instead of blocking the loop.
     """
     issues = validate_mcp_server_entry(name, config)
     if issues:
         raise ValueError("; ".join(issues))
 
     from tools.mcp_tool_loop import _ensure_mcp_loop, _run_on_mcp_loop
-    from tools.mcp_tool_discovery import _connect_server
+    from tools.mcp_tool_discovery import (
+        _connect_server,
+        mcp_event_loop_is_current,
+        mcp_event_loop_is_running,
+        mcp_server_owned_or_connecting,
+    )
     from tools.mcp_tool_lifecycle import _stop_mcp_loop_if_idle
-    from tools.mcp_tool_common import _parse_boolish
 
     config = _resolve_mcp_server_config(config)
     if connect_timeout is None:
@@ -277,53 +399,59 @@ def _probe_single_server(
         except (TypeError, ValueError):
             connect_timeout = 30.0
 
+    # Reuse (or wait for) the process-global session. A second Streamable HTTP
+    # connect to Slack MCP expires the live desktop session and is exactly
+    # what paints the Capabilities row red on every launch.
+    live = _wait_for_live_mcp_server(name, connect_timeout)
+    if live is not None:
+        logger.info(
+            "MCP probe '%s': reusing live session (%d tool(s)); skip standalone connect",
+            name,
+            len(getattr(live, "_tools", None) or []),
+        )
+        _apply_probe_details(
+            name, live, config, details, capability_rpcs=not mcp_event_loop_is_current()
+        )
+        return _tool_rows_from_mcp_server(live)
+
+    if mcp_server_owned_or_connecting(name):
+        raise TimeoutError(
+            f"MCP server '{name}' is already claimed by this process; not opening a second session"
+        )
+    # Desktop/gateway: the MCP loop is already up, and the health sweep can
+    # beat discover_mcp_tools by a few hundred milliseconds. Wait briefly for
+    # this process to claim the server before opening a second Streamable HTTP
+    # session that would evict Slack's live one. Gated on the loop so a cold
+    # `hermes mcp test` (no loop, no discovery) does not stall 5s waiting for a
+    # claim that will never come.
+    if config.get("url") and mcp_event_loop_is_running():
+        grace = min(5.0, float(connect_timeout))
+        live = _wait_for_live_mcp_server(name, grace, wait_for_claim=True)
+        if live is not None:
+            logger.info(
+                "MCP probe '%s': reusing live session after claim grace (%d tool(s))",
+                name,
+                len(getattr(live, "_tools", None) or []),
+            )
+            _apply_probe_details(
+                name, live, config, details, capability_rpcs=not mcp_event_loop_is_current()
+            )
+            return _tool_rows_from_mcp_server(live)
+        if mcp_server_owned_or_connecting(name):
+            raise TimeoutError(
+                f"MCP server '{name}' is already claimed by this process; not opening a second session"
+            )
+
     _ensure_mcp_loop()
     tools_found: List[Tuple[str, str]] = []
 
     async def _probe():
         server = await asyncio.wait_for(_connect_server(name, config), timeout=connect_timeout)
         try:
-            for t in server._tools:
-                desc = getattr(t, "description", "") or ""
-                if len(desc) > 80:
-                    desc = desc[:77] + "..."
-                tools_found.append((t.name, desc))
+            tools_found.extend(_tool_rows_from_mcp_server(server))
             if details is not None:
-                # Per-tool registry-schema sizes (the SAME converted schema the agent registers) so
-                # the desktop can estimate per-call token cost. Best-effort, absent on failure.
-                try:
-                    import json as _json
-                    from tools.mcp_tool_schema import _convert_mcp_schema
-
-                    details["schema_chars"] = {
-                        t.name: len(_json.dumps(_convert_mcp_schema(name, t), separators=(",", ":"), default=str))
-                        for t in server._tools
-                    }
-                except Exception:  # pragma: no cover — display-only extra
-                    pass
-                # Gate capability probes like runtime registration (_select_utility_schemas):
-                # honour tools.prompts / tools.resources config AND only call a family the server
-                # advertises — some servers hard-error on unknown prompts/list.
-                tools_filter = config.get("tools") or {}
-                advertised_caps = getattr(getattr(server, "initialize_result", None), "capabilities", None)
-
-                def _wanted(cap: str) -> bool:
-                    # No capability info captured (legacy fixtures / older servers) => always try.
-                    if not _parse_boolish(tools_filter.get(cap), default=True):
-                        return False
-                    return advertised_caps is None or getattr(advertised_caps, cap, None) is not None
-
-                # Best-effort: servers without the capability raise, which just means "0".
-                if _wanted("prompts"):
-                    try:
-                        details["prompts"] = len((await server.session.list_prompts()).prompts)
-                    except Exception:
-                        pass
-                if _wanted("resources"):
-                    try:
-                        details["resources"] = len((await server.session.list_resources()).resources)
-                    except Exception:
-                        pass
+                _fill_probe_schema_chars(name, server, details)
+                await _fill_probe_capability_counts(server, config, details)
         finally:
             await server.shutdown()
 

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -534,6 +534,205 @@ class TestProbeEnvResolution:
         assert seen["config"]["headers"]["Authorization"] == "Bearer jwt-token-xyz"
 
 
+class TestProbeLiveSessionReuse:
+    """Desktop health checks must not open a second Slack-like HTTP session."""
+
+    def test_probe_reuses_live_session_without_second_connect(self, monkeypatch):
+        import hermes_cli.mcp_config as mc
+        import tools.mcp_tool as mt
+
+        class _FakeTool:
+            name = "slack_search_users"
+            description = "find people"
+
+        class _Live:
+            session = object()
+            _tools = [_FakeTool()]
+
+        called = {"connect": 0}
+
+        async def _fake_connect(name, config):
+            called["connect"] += 1
+            raise AssertionError("standalone probe must not run when live")
+
+        monkeypatch.setattr("tools.mcp_tool_discovery._connect_server", _fake_connect)
+        mt._servers["slack"] = _Live()  # type: ignore[assignment]
+        try:
+            tools = mc._probe_single_server(
+                "slack",
+                {"url": "https://mcp.slack.com/mcp", "auth": "oauth"},
+            )
+        finally:
+            mt._servers.pop("slack", None)
+
+        assert tools == [("slack_search_users", "find people")]
+        assert called["connect"] == 0
+
+    def test_probe_does_not_second_connect_while_owned_session_is_down(self, monkeypatch):
+        import hermes_cli.mcp_config as mc
+        import tools.mcp_tool as mt
+
+        class _Parked:
+            session = None
+            _tools = []
+
+        async def _fake_connect(name, config):
+            raise AssertionError("must not second-connect a parked server")
+
+        monkeypatch.setattr("tools.mcp_tool_discovery._connect_server", _fake_connect)
+        mt._servers["slack"] = _Parked()  # type: ignore[assignment]
+        try:
+            with pytest.raises(TimeoutError, match="already claimed"):
+                mc._probe_single_server(
+                    "slack",
+                    {"url": "https://mcp.slack.com/mcp", "auth": "oauth"},
+                    connect_timeout=0.2,
+                )
+        finally:
+            mt._servers.pop("slack", None)
+
+    def test_wait_on_mcp_loop_does_not_sleep(self, monkeypatch):
+        """Probe wait must not block-sleep if invoked on the MCP event loop."""
+        import hermes_cli.mcp_config as mc
+
+        slept: list[float] = []
+        monkeypatch.setattr(
+            "tools.mcp_tool_discovery.mcp_event_loop_is_current", lambda: True
+        )
+        monkeypatch.setattr(
+            "tools.mcp_tool_discovery.snapshot_live_mcp_server", lambda name: None
+        )
+        monkeypatch.setattr(mc.time, "sleep", lambda seconds: slept.append(seconds))
+        assert mc._wait_for_live_mcp_server("slack", 30.0, wait_for_claim=True) is None
+        assert slept == []
+
+    def test_live_zero_tools_is_healthy_not_timeout(self, monkeypatch):
+        """Prompt/resource-only servers have a live session with empty _tools."""
+        import hermes_cli.mcp_config as mc
+        import tools.mcp_tool as mt
+
+        class _LiveNoTools:
+            session = object()
+            _tools = []
+
+        async def _fake_connect(name, config):
+            raise AssertionError("must not second-connect a live zero-tool server")
+
+        monkeypatch.setattr("tools.mcp_tool_discovery._connect_server", _fake_connect)
+        mt._servers["prompts-only"] = _LiveNoTools()  # type: ignore[assignment]
+        try:
+            tools = mc._probe_single_server(
+                "prompts-only",
+                {"url": "https://example.com/mcp"},
+            )
+        finally:
+            mt._servers.pop("prompts-only", None)
+
+        assert tools == []
+
+    def test_url_claim_grace_reuses_session_that_appears_while_loop_running(self, monkeypatch):
+        """When the MCP loop is up, wait_for_claim covers the health-sweep vs discovery race."""
+        import hermes_cli.mcp_config as mc
+
+        class _FakeTool:
+            name = "slack_search_users"
+            description = "find people"
+
+        class _Live:
+            session = object()
+            _tools = [_FakeTool()]
+
+        live = _Live()
+        snapshots = {"n": 0}
+
+        def snapshot(name):
+            snapshots["n"] += 1
+            return live if snapshots["n"] >= 3 else None
+
+        def owned(name):
+            return snapshots["n"] >= 2
+
+        async def _fake_connect(name, config):
+            raise AssertionError("must not second-connect during claim grace")
+
+        monkeypatch.setattr("tools.mcp_tool_discovery.snapshot_live_mcp_server", snapshot)
+        monkeypatch.setattr("tools.mcp_tool_discovery.mcp_server_owned_or_connecting", owned)
+        monkeypatch.setattr("tools.mcp_tool_discovery.mcp_event_loop_is_running", lambda: True)
+        monkeypatch.setattr("tools.mcp_tool_discovery.mcp_event_loop_is_current", lambda: False)
+        monkeypatch.setattr("tools.mcp_tool_discovery._connect_server", _fake_connect)
+        monkeypatch.setattr(mc.time, "sleep", lambda seconds: None)
+
+        tools = mc._probe_single_server(
+            "slack",
+            {"url": "https://mcp.slack.com/mcp", "auth": "oauth"},
+        )
+        assert tools == [("slack_search_users", "find people")]
+        assert snapshots["n"] >= 3
+
+    def test_live_reuse_fills_details_contract(self, monkeypatch):
+        """Reuse must still populate schema_chars / prompts / resources."""
+        import asyncio
+        import hermes_cli.mcp_config as mc
+        import tools.mcp_tool as mt
+
+        class _FakeTool:
+            name = "do_thing"
+            description = "a tool"
+
+        class _Result(list):
+            @property
+            def prompts(self):
+                return self
+
+            @property
+            def resources(self):
+                return self
+
+        class _Session:
+            async def list_prompts(self):
+                return _Result([object(), object()])
+
+            async def list_resources(self):
+                return _Result([object()])
+
+        class _Caps:
+            prompts = object()
+            resources = object()
+
+        class _InitResult:
+            capabilities = _Caps()
+
+        class _Live:
+            session = _Session()
+            _tools = [_FakeTool()]
+            initialize_result = _InitResult()
+
+        async def _fake_connect(name, config):
+            raise AssertionError("standalone probe must not run when live")
+
+        def _run(coro_or_factory, timeout=30):
+            coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+            return asyncio.run(coro)
+
+        monkeypatch.setattr("tools.mcp_tool_discovery._connect_server", _fake_connect)
+        monkeypatch.setattr("tools.mcp_tool_loop._run_on_mcp_loop", _run)
+        mt._servers["slack"] = _Live()  # type: ignore[assignment]
+        details: dict = {}
+        try:
+            tools = mc._probe_single_server(
+                "slack",
+                {"url": "https://mcp.slack.com/mcp", "auth": "oauth"},
+                details=details,
+            )
+        finally:
+            mt._servers.pop("slack", None)
+
+        assert tools == [("do_thing", "a tool")]
+        assert "do_thing" in details.get("schema_chars", {})
+        assert details.get("prompts") == 2
+        assert details.get("resources") == 1
+
+
 class TestProbeCapabilityGating:
     """The ``details`` probe must not fire prompts/list or resources/list at
     servers that either disabled them in config or never advertised them.

--- a/tools/mcp_tool_discovery.py
+++ b/tools/mcp_tool_discovery.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 from tools.mcp_tool_common import _core, _parse_boolish
 from tools import mcp_tool_config as _config
 from tools import mcp_tool_errors as _errors
@@ -454,6 +454,50 @@ def is_mcp_tool_parallel_safe(tool_name: str) -> bool:
     with _core._lock:
         server_name = _core._mcp_tool_server_names.get(tool_name)
         return bool(server_name and server_name in _core._parallel_safe_servers)
+
+
+def snapshot_live_mcp_server(name: str) -> Optional[Any]:
+    """Return the process-owned live session for ``name``, or ``None``.
+
+    Used by health / ``hermes mcp test`` so they do not open a second Streamable
+    HTTP session against hosts that evict the first (Slack MCP). A live session
+    with zero tools is still returned — empty ``_tools`` is not "no session".
+    Parked servers (``session is None``) and servers owned by another multiplex
+    profile return ``None``.
+    """
+    current_scope = _core._mcp_registry_scope()
+    with _core._lock:
+        if not _core._server_visible_in_scope(name, current_scope):
+            return None
+        server = _core._servers.get(name)
+        if server is None or getattr(server, "session", None) is None:
+            return None
+        return server
+
+
+def mcp_server_owned_or_connecting(name: str) -> bool:
+    """True if this process has claimed ``name`` (live, parked, or connecting) in the current profile scope."""
+    current_scope = _core._mcp_registry_scope()
+    with _core._lock:
+        if not _core._server_visible_in_scope(name, current_scope):
+            return False
+        return name in _core._servers or name in _core._server_connecting
+
+
+def mcp_event_loop_is_current() -> bool:
+    """True when the caller is running on the dedicated MCP event-loop thread."""
+    try:
+        running = asyncio.get_running_loop()
+    except RuntimeError:
+        return False
+    with _core._lock:
+        loop = _core._mcp_loop
+    return loop is not None and running is loop
+
+
+def mcp_event_loop_is_running() -> bool:
+    """True when the dedicated MCP loop exists and is running (any thread)."""
+    return _loop._running_loop() is not None
 
 
 def get_mcp_status(configured: Optional[Dict[str, dict]] = None, *, include_runtime: bool = True) -> List[dict]:


### PR DESCRIPTION
## What does this PR do?

Desktop's MCP health sweep (`POST /api/mcp/servers/<name>/test`) always opened a **new** Streamable HTTP session, listed tools, then disconnected. Hosts that allow one live session per user token (official Slack MCP) treat that as a replacement and expire the process's discover session.

That is why Desktop paints Slack **Error** on launch and new chats have no `mcp_slack_*` tools, while `hermes mcp test slack` in a fresh process is green.

This PR makes `_probe_single_server` reuse (or wait for) the process-owned session and refuse a second connect when the server is already claimed.

## Related Issue

Fixes #89576

Adjacent, not addressed here: #77765 (keepalive → park), #18165 (HTTP recovery umbrella).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/mcp_config.py`: snapshot tools from `_servers[name]` when a live session exists; wait if the name is owned/connecting; 5s claim-grace for URL servers only when the MCP loop is already running (Desktop). Standalone connect remains for a cold `hermes mcp test`.
- `tests/hermes_cli/test_mcp_config.py`: reuse live session; refuse second connect while parked.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_mcp_config.py`
2. With Slack MCP already connected in Desktop, refresh the Capabilities row — it should not evict the live session (row stays or becomes green; new chat still has Slack tools).
3. `hermes mcp test slack` in a **separate** process still connects (standalone path unchanged).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Searched existing PRs — no duplicate for probe evicting the live session
- [x] PR contains only this fix
- [x] Targeted tests: 40/40 in `tests/hermes_cli/test_mcp_config.py`
- [x] Added regression tests (sabotage run: reuse test fails without the early return)
- [x] Tested on macOS 26.6 / Hermes v0.20.4

### Documentation & Housekeeping

- [x] Docs N/A (internal probe behavior)
- [x] `cli-config.yaml.example` N/A
- [x] CONTRIBUTING/AGENTS N/A
- [x] Cross-platform: no I/O/process/terminal changes
- [x] Tool schemas N/A
