### PR TITLE
fix(tools): bind persisted results to session capabilities

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1763,6 +1763,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             tool_use_id=tc.id,
             env=get_active_env(effective_task_id),
             config=_tool_budget,
+            session_id=getattr(agent, "session_id", "") or "",
         ) if not _is_multimodal_tool_result(function_result) else function_result
 
         subdir_hints = agent._subdirectory_hints.check_tool_call(name, args)
@@ -1859,7 +1860,12 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     num_tools = len(parsed_calls)
     if finalize and num_tools > 0:
         turn_tool_msgs = messages[-num_tools:]
-        enforce_turn_budget(turn_tool_msgs, env=get_active_env(effective_task_id), config=_tool_budget)
+        enforce_turn_budget(
+            turn_tool_msgs,
+            env=get_active_env(effective_task_id),
+            config=_tool_budget,
+            session_id=getattr(agent, "session_id", "") or "",
+        )
 
     # ── /steer injection ──────────────────────────────────────────────
     # Append any pending user steer text to the last tool result so the
@@ -2579,6 +2585,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             tool_use_id=tool_call.id,
             env=get_active_env(effective_task_id),
             config=_tool_budget,
+            session_id=getattr(agent, "session_id", "") or "",
         ) if not _is_multimodal_tool_result(function_result) else function_result
 
         # Discover subdirectory context files from tool arguments
@@ -2685,7 +2692,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     # be discarded when aggregate budget enforcement replaces a tool result.
     num_tools_seq = len(assistant_message.tool_calls)
     if finalize and num_tools_seq > 0:
-        enforce_turn_budget(messages[-num_tools_seq:], env=get_active_env(effective_task_id), config=_tool_budget)
+        enforce_turn_budget(
+            messages[-num_tools_seq:],
+            env=get_active_env(effective_task_id),
+            config=_tool_budget,
+            session_id=getattr(agent, "session_id", "") or "",
+        )
 
     # ── /steer injection ──────────────────────────────────────────────
     # See _execute_tool_calls_parallel for the rationale. Same hook,
@@ -2752,6 +2764,7 @@ def execute_tool_calls_segmented(agent, assistant_message, messages: list, effec
             messages[-total_tools:],
             env=get_active_env(effective_task_id),
             config=_tool_budget,
+            session_id=getattr(agent, "session_id", "") or "",
         )
         agent._apply_pending_steer_to_tool_results(messages, total_tools)
 

--- a/agent/transports/hermes_tools_mcp_server.py
+++ b/agent/transports/hermes_tools_mcp_server.py
@@ -49,6 +49,7 @@ import json
 import logging
 import os
 import sys
+import uuid
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
@@ -151,6 +152,26 @@ EXPOSED_TOOLS: tuple[str, ...] = (
 )
 
 
+def _make_spill_reader(dispatcher, session_id: str):
+    """Build the capability-only read_file exception for Codex MCP."""
+    # Keep ordinary paths on Codex's own filesystem/approval path. Only the
+    # opaque scheme requires a callback into the Hermes host process.
+    def _read_spill_capability(*, path: str) -> str:
+        if not isinstance(path, str) or not path.startswith("hermes-spill://v1/"):
+            return json.dumps(
+                {"error": "read_file accepts only hermes-spill capabilities"}
+            )
+        try:
+            return dispatcher(
+                "read_file", {"path": path}, session_id=session_id,
+            )
+        except Exception:
+            logger.exception("capability-only read_file raised")
+            return json.dumps({"error": "result-spill capability read failed"})
+
+    return _read_spill_capability
+
+
 def _build_server() -> Any:
     """Create the MCP server with Hermes tools attached. Lazy imports
     so the module can be imported without the mcp package installed
@@ -179,6 +200,10 @@ def _build_server() -> Any:
             "subagent delegation, vision, image generation, persistent "
             "memory, skills, and cross-session search."
         ),
+    )
+    mcp_session_id = (
+        os.environ.get("HERMES_SESSION_ID", "").strip()
+        or f"mcp-{uuid.uuid4().hex}"
     )
 
     # Pull authoritative Hermes tool schemas for the ones we expose, so
@@ -216,7 +241,11 @@ def _build_server() -> Any:
                     # Filter out None values before dispatch so unset optionals
                     # aren't forwarded to the handler.
                     args = {k: v for k, v in kwargs.items() if v is not None}
-                    return handle_function_call(tool_name, args or {})
+                    return handle_function_call(
+                        tool_name,
+                        args or {},
+                        session_id=mcp_session_id,
+                    )
                 except Exception as exc:
                     logger.exception("tool %s raised", tool_name)
                     return json.dumps({"error": str(exc), "tool": tool_name})
@@ -242,10 +271,28 @@ def _build_server() -> Any:
 
         exposed_count += 1
 
+    spill_reader = _make_spill_reader(handle_function_call, mcp_session_id)
+    spill_description = (
+        "Read a hermes-spill:// capability from the current Hermes session. "
+        "Ordinary filesystem paths are rejected."
+    )
+    try:
+        mcp.add_tool(
+            spill_reader,
+            name="read_file",
+            description=spill_description,
+        )
+    except TypeError:
+        mcp.tool(
+            name="read_file",
+            description=spill_description,
+        )(spill_reader)
+    exposed_count += 1
+
     logger.info(
         "hermes-tools MCP server registered %d/%d tools",
         exposed_count,
-        len(EXPOSED_TOOLS),
+        len(EXPOSED_TOOLS) + 1,
     )
     return mcp
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -29,6 +29,7 @@ from contextvars import ContextVar
 import logging
 import threading
 import time
+import uuid
 from typing import Dict, Any, List, Optional, Tuple
 
 from tools.registry import (
@@ -1582,6 +1583,22 @@ def handle_function_call(
                         break
         except Exception as _hook_err:
             logger.debug("transform_tool_result hook error: %s", _hook_err)
+
+        # Central model-facing persistence seam. Agent-loop callers apply a
+        # context-scaled budget again in agent.tool_executor; direct transports
+        # such as Codex MCP otherwise bypass that executor entirely.
+        if isinstance(result, str):
+            try:
+                from tools.tool_result_storage import maybe_persist_tool_result
+
+                result = maybe_persist_tool_result(
+                    content=result,
+                    tool_name=function_name,
+                    tool_use_id=tool_call_id or uuid.uuid4().hex,
+                    session_id=session_id or "",
+                )
+            except Exception as _spill_err:
+                logger.debug("tool-result persistence fail-open: %s", _spill_err)
 
         return result
 

--- a/tests/agent/transports/test_hermes_tools_mcp_server.py
+++ b/tests/agent/transports/test_hermes_tools_mcp_server.py
@@ -9,9 +9,13 @@ build helper assembles a server when the SDK is present.
 from __future__ import annotations
 
 import inspect
+import json
+import sys
+import types
 from typing import get_args
 
 from agent.transports.hermes_tools_mcp_server import (
+    _make_spill_reader,
     _signature_from_schema,
 )
 
@@ -108,8 +112,98 @@ class TestModuleSurface:
         )
 
 
+class TestSpillReader:
+    def test_mcp_callback_spills_and_recovers_oversized_result(self, monkeypatch, tmp_path):
+        class FakeMCPServer:
+            def __init__(self, *_args, **_kwargs):
+                self.handlers = {}
 
+            def add_tool(self, handler, *, name, description):
+                self.handlers[name] = handler
 
+        fake_server_module = types.ModuleType("mcp.server")
+        setattr(fake_server_module, "MCPServer", FakeMCPServer)
+        monkeypatch.setitem(sys.modules, "mcp.server", fake_server_module)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.setenv("HERMES_SESSION_ID", "mcp-producer-session")
+        monkeypatch.setattr(
+            "model_tools.get_tool_definitions",
+            lambda **_kwargs: [{
+                "type": "function",
+                "function": {
+                    "name": "web_search",
+                    "description": "search",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }],
+        )
+        payload = "mcp-result\n" + ("z" * 120_000)
+        monkeypatch.setattr("model_tools.registry.dispatch", lambda *_a, **_k: payload)
+
+        from agent.transports.hermes_tools_mcp_server import _build_server
+        from tools.tool_result_storage import resolve_spill_capability
+
+        server = _build_server()
+        notice = server.handlers["web_search"]()
+        uri = next(part for part in notice.split() if part.startswith("hermes-spill://"))
+        assert resolve_spill_capability(uri, "mcp-producer-session") == payload
+
+    def test_forwards_capability_with_captured_session(self):
+        calls = []
+
+        def dispatch(name, args, **kwargs):
+            calls.append((name, args, kwargs))
+            return json.dumps({"ok": True})
+
+        uri = f"hermes-spill://v1/{'a' * 64}/{'b' * 64}/{'c' * 32}"
+        reader = _make_spill_reader(dispatch, "session-123")
+
+        assert json.loads(reader(path=uri)) == {"ok": True}
+        assert calls == [
+            ("read_file", {"path": uri}, {"session_id": "session-123"})
+        ]
+
+    def test_rejects_ordinary_paths_without_dispatch(self):
+        def dispatch(*_args, **_kwargs):
+            raise AssertionError("ordinary path was dispatched")
+
+        result = json.loads(
+            _make_spill_reader(dispatch, "session-123")(path="/etc/passwd")
+        )
+        assert "error" in result
+
+    def test_build_server_registers_capability_reader_with_mcp2(self, monkeypatch):
+        class FakeMCPServer:
+            def __init__(self, *_args, **_kwargs):
+                self.handlers = {}
+
+            def add_tool(self, handler, *, name, description):
+                self.handlers[name] = handler
+
+        fake_server_module = types.ModuleType("mcp.server")
+        setattr(fake_server_module, "MCPServer", FakeMCPServer)
+        monkeypatch.setitem(sys.modules, "mcp.server", fake_server_module)
+        monkeypatch.setenv("HERMES_SESSION_ID", "mcp-session")
+        monkeypatch.setattr(
+            "model_tools.get_tool_definitions",
+            lambda **_kwargs: [],
+        )
+        calls = []
+
+        def dispatch(name, args, **kwargs):
+            calls.append((name, args, kwargs))
+            return json.dumps({"ok": True})
+
+        monkeypatch.setattr("model_tools.handle_function_call", dispatch)
+        from agent.transports.hermes_tools_mcp_server import _build_server
+
+        server = _build_server()
+        assert set(server.handlers) == {"read_file"}
+        uri = f"hermes-spill://v1/{'a' * 64}/{'b' * 64}/{'c' * 32}"
+        assert json.loads(server.handlers["read_file"](path=uri)) == {"ok": True}
+        assert calls == [
+            ("read_file", {"path": uri}, {"session_id": "mcp-session"})
+        ]
 
 
 class TestMain:

--- a/tests/run_agent/test_tool_call_incremental_persistence.py
+++ b/tests/run_agent/test_tool_call_incremental_persistence.py
@@ -332,6 +332,7 @@ def test_persistence_cause_resets_between_turns():
 # ---------------------------------------------------------------------------
 def test_execute_tool_calls_sequential_flushes_each_tool_result_before_next_dispatch():
     agent = _make_agent()
+    agent.session_id = "spill-scope-session"
     tool_calls = [
         _mock_tool_call(name="web_search", call_id="c1"),
         _mock_tool_call(name="web_search", call_id="c2"),
@@ -341,6 +342,7 @@ def test_execute_tool_calls_sequential_flushes_each_tool_result_before_next_disp
 
     # Ordered event log interleaving real dispatches and DB flushes.
     events: list = []
+    persist_calls: list[dict] = []
 
     def _fake_dispatch(function_name, function_args, effective_task_id, **kwargs):
         # The result for call N must have been flushed before call N+1 fires.
@@ -352,13 +354,17 @@ def test_execute_tool_calls_sequential_flushes_each_tool_result_before_next_disp
         tail = flush_messages[-1]
         events.append(("flush", tail.get("role"), tail.get("tool_call_id")))
 
+    def _capture_persist(**kwargs):
+        persist_calls.append(kwargs)
+        return kwargs["content"]
+
     agent._flush_messages_to_session_db = MagicMock(side_effect=_record_flush)
 
     with (
         patch("run_agent.handle_function_call", side_effect=_fake_dispatch) as disp,
         patch(
             "agent.tool_executor.maybe_persist_tool_result",
-            side_effect=lambda **kwargs: kwargs["content"],
+            side_effect=_capture_persist,
         ),
     ):
         agent._execute_tool_calls_sequential(assistant_message, messages, "task-1")
@@ -369,6 +375,10 @@ def test_execute_tool_calls_sequential_flushes_each_tool_result_before_next_disp
     # Both tool results landed, in order.
     assert [m["role"] for m in messages] == ["tool", "tool"]
     assert [m["tool_call_id"] for m in messages] == ["c1", "c2"]
+    assert [call["session_id"] for call in persist_calls] == [
+        "spill-scope-session",
+        "spill-scope-session",
+    ]
 
     # Ordering contract: each tool result is flushed AFTER its own dispatch
     # and BEFORE the next dispatch. Expected interleaving:

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -50,7 +50,9 @@ from tools.code_execution_tool import (
 from tools.registry import registry
 
 
-def _mock_handle_function_call(function_name, function_args, task_id=None, user_task=None):
+def _mock_handle_function_call(
+    function_name, function_args, task_id=None, user_task=None, **_kwargs,
+):
     """Mock dispatcher that returns canned responses for each tool."""
     if function_name == "terminal":
         cmd = function_args.get("command", "")
@@ -286,7 +288,9 @@ else:
     print(f"OK {N}/{N}")
 '''
 
-        def slow_mock(function_name, function_args, task_id=None, user_task=None):
+        def slow_mock(
+            function_name, function_args, task_id=None, user_task=None, **_kwargs,
+        ):
             import time as _t
             if function_name == "terminal":
                 _t.sleep(0.05)  # ensure requests overlap on the socket
@@ -861,6 +865,52 @@ class TestRpcTokenAuthorization(unittest.TestCase):
         src = generate_hermes_tools_module(["terminal"], transport="uds")
         self.assertIn("HERMES_RPC_TOKEN", src)
         self.assertIn('"token"', src)
+
+    def test_rpc_server_forwards_parent_session_id(self):
+        from tools.code_execution_tool import _rpc_server_loop
+
+        srv, cli = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+
+        class _OneShotListener:
+            def settimeout(self, _timeout):
+                pass
+
+            def accept(self):
+                return srv, ("peer", 0)
+
+        seen = []
+        stop_event = threading.Event()
+
+        def dispatch(name, args, **kwargs):
+            seen.append((name, args, kwargs))
+            return json.dumps({"ok": True})
+
+        with patch("model_tools.handle_function_call", side_effect=dispatch):
+            thread = threading.Thread(
+                target=_rpc_server_loop,
+                args=(
+                    _OneShotListener(), "task", [], [0], 1,
+                    frozenset({"terminal"}), stop_event, "token",
+                ),
+                kwargs={"session_id": "parent-session"},
+                daemon=True,
+            )
+            thread.start()
+            cli.sendall((json.dumps({
+                "token": "token",
+                "tool": "terminal",
+                "args": {"command": "true"},
+            }) + "\n").encode())
+            cli.settimeout(5)
+            self.assertEqual(json.loads(cli.recv(65536).decode()), {"ok": True})
+            cli.close()
+            thread.join(timeout=5)
+
+        self.assertEqual(seen, [(
+            "terminal",
+            {"command": "true"},
+            {"task_id": "task", "session_id": "parent-session"},
+        )])
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_code_execution_modes.py
+++ b/tests/tools/test_code_execution_modes.py
@@ -57,7 +57,9 @@ def _mock_mode(mode):
         yield
 
 
-def _mock_handle_function_call(function_name, function_args, task_id=None, user_task=None):
+def _mock_handle_function_call(
+    function_name, function_args, task_id=None, user_task=None, **_kwargs,
+):
     """Minimal mock dispatcher reused across tests."""
     if function_name == "terminal":
         return json.dumps({"output": "mock", "exit_code": 0})

--- a/tests/tools/test_tool_result_capability.py
+++ b/tests/tools/test_tool_result_capability.py
@@ -1,0 +1,270 @@
+"""Opaque, same-session recovery for persisted tool results."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from tools.file_tools import _handle_read_file, read_file_tool
+from tools.tool_result_storage import (
+    PERSISTED_OUTPUT_TAG,
+    SpillCapabilityError,
+    maybe_persist_tool_result,
+    get_spillover_dir,
+    resolve_spill_capability,
+)
+
+_URI_RE = re.compile(
+    r"hermes-spill://v1/[0-9a-f]{64}/[0-9a-f]{64}/[0-9a-f]{32}"
+)
+
+
+@pytest.fixture(autouse=True)
+def isolated_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+
+def _spill(content: str, session_id: str) -> tuple[str, str]:
+    notice = maybe_persist_tool_result(
+        content=content,
+        tool_name="terminal",
+        tool_use_id="call/reused-across-sessions",
+        env=None,
+        threshold=1,
+        session_id=session_id,
+    )
+    match = _URI_RE.search(notice)
+    assert PERSISTED_OUTPUT_TAG in notice
+    assert match is not None
+    return notice, match.group(0)
+
+
+def test_capability_round_trip_is_exact_and_host_path_is_hidden():
+    payload = "head\n" + ("middle\n" * 200) + "tail"
+    notice, uri = _spill(payload, "owner-session")
+
+    assert resolve_spill_capability(uri, session_id="owner-session") == payload
+    assert "cache/spillover" not in notice
+    assert "/Users/" not in notice
+
+
+def test_capability_payload_is_not_plaintext_at_rest_or_named_with_bearer_token():
+    payload = "private-secret-payload\n" + ("x" * 2_000)
+    _notice, uri = _spill(payload, "owner-session")
+    capability = uri.rsplit("/", 1)[-1]
+    path = next(get_spillover_dir().glob("spill_*"))
+
+    assert payload.encode("utf-8") not in path.read_bytes()
+    assert capability not in path.name
+
+
+def test_cross_session_and_tampered_capabilities_fail_closed():
+    payload = "private\n" + ("x" * 2_000)
+    _notice, uri = _spill(payload, "owner-session")
+
+    with pytest.raises(SpillCapabilityError):
+        resolve_spill_capability(uri, session_id="other-session")
+
+    tampered = uri[:-1] + ("0" if uri[-1] != "0" else "1")
+    with pytest.raises(SpillCapabilityError):
+        resolve_spill_capability(tampered, session_id="owner-session")
+
+
+def test_reused_tool_call_id_cannot_collide_across_sessions():
+    _notice_a, uri_a = _spill("payload-a", "session-a")
+    _notice_b, uri_b = _spill("payload-b", "session-b")
+
+    assert uri_a != uri_b
+    assert resolve_spill_capability(uri_a, session_id="session-a") == "payload-a"
+    assert resolve_spill_capability(uri_b, session_id="session-b") == "payload-b"
+
+
+def test_scoped_write_failure_never_downgrades_to_host_path(monkeypatch):
+    from tools import tool_result_storage
+
+    monkeypatch.setattr(
+        tool_result_storage,
+        "_write_capability_spillover",
+        lambda *_args, **_kwargs: None,
+    )
+    content = "private\n" + ("x" * 5_000)
+
+    result = maybe_persist_tool_result(
+        content=content,
+        tool_name="terminal",
+        tool_use_id="predictable-id",
+        threshold=1,
+        session_id="scoped-session",
+    )
+
+    assert "hermes-spill://" not in result
+    assert "cache/spillover" not in result
+    assert "predictable-id" not in result
+    assert "no recovery path was emitted" in result
+    assert len(result) < len(content)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+def test_symlink_swap_and_payload_tampering_fail_closed():
+    _notice, uri = _spill("original-payload", "tamper-session")
+    path = next(get_spillover_dir().glob("spill_*"))
+    backup = path.with_suffix(".backup")
+    path.rename(backup)
+    path.symlink_to(backup)
+
+    with pytest.raises(SpillCapabilityError):
+        resolve_spill_capability(uri, session_id="tamper-session")
+
+    path.unlink()
+    backup.rename(path)
+    path.write_text("changed-payload")
+    os.chmod(path, 0o600)
+    with pytest.raises(SpillCapabilityError):
+        resolve_spill_capability(uri, session_id="tamper-session")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX FIFO semantics")
+def test_fifo_replacement_fails_closed_without_blocking():
+    _notice, uri = _spill("original-payload", "fifo-session")
+    path = next(get_spillover_dir().glob("spill_*"))
+    path.unlink()
+    os.mkfifo(path, mode=0o600)
+
+    with pytest.raises(SpillCapabilityError):
+        resolve_spill_capability(uri, session_id="fifo-session")
+
+
+def test_reparse_metadata_is_rejected_before_open(monkeypatch):
+    from tools import tool_result_storage
+
+    _notice, uri = _spill("original-payload", "reparse-session")
+    real = next(get_spillover_dir().glob("spill_*")).lstat()
+    fake = SimpleNamespace(
+        st_mode=real.st_mode,
+        st_dev=real.st_dev,
+        st_ino=real.st_ino,
+        st_file_attributes=getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400),
+    )
+    monkeypatch.setattr(tool_result_storage.os, "lstat", lambda _path: fake)
+    monkeypatch.setattr(
+        tool_result_storage.os,
+        "open",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("reparse point was opened")
+        ),
+    )
+
+    with pytest.raises(SpillCapabilityError):
+        resolve_spill_capability(uri, session_id="reparse-session")
+
+
+def test_read_file_paginates_capability_before_backend_routing():
+    payload = "\n".join(f"row-{index}" for index in range(20))
+    _notice, uri = _spill(payload, "page-session")
+
+    with (
+        patch("tools.file_tools._get_file_ops", side_effect=AssertionError("backend called")),
+        patch("tools.file_tools._resolve_path_for_task", side_effect=AssertionError("path resolver called")),
+        patch("tools.file_tools._is_blocked_device", side_effect=AssertionError("device guard called")),
+    ):
+        raw = read_file_tool(
+            uri,
+            offset=3,
+            limit=4,
+            session_id="page-session",
+        )
+
+    result = json.loads(raw)
+    assert result["content"].splitlines() == [
+        "3|row-2",
+        "4|row-3",
+        "5|row-4",
+        "6|row-5",
+    ]
+    assert result["total_lines"] == 20
+    assert result["truncated"] is True
+
+
+def test_handler_forwards_hidden_session_scope():
+    _notice, uri = _spill("line-1\nline-2\nline-3", "handler-session")
+
+    result = json.loads(
+        _handle_read_file(
+            {"path": uri, "offset": 2, "limit": 1},
+            task_id="task",
+            session_id="handler-session",
+        )
+    )
+
+    assert result["content"] == "2|line-2"
+    assert "error" not in result
+
+
+def test_capability_read_obeys_existing_char_budget(monkeypatch):
+    from tools import file_tools
+
+    _notice, uri = _spill("x" * 5_000, "budget-session")
+    monkeypatch.setattr(file_tools, "_max_read_chars_cached", 120)
+
+    result = json.loads(
+        read_file_tool(uri, session_id="budget-session")
+    )
+
+    assert len(result["content"]) <= 120
+    assert result["truncated"] is True
+    assert result["truncated_by"] == "bytes"
+
+
+def test_central_dispatch_spills_direct_transport_result(monkeypatch):
+    import model_tools
+
+    payload = "direct-transport\n" + ("z" * 120_000)
+    monkeypatch.setattr(model_tools.registry, "dispatch", lambda *_a, **_k: payload)
+
+    notice = model_tools.handle_function_call(
+        "web_search",
+        {"query": "test"},
+        task_id="direct-task",
+        tool_call_id="direct-call",
+        session_id="direct-session",
+        skip_pre_tool_call_hook=True,
+        skip_tool_request_middleware=True,
+        skip_tool_execution_middleware=True,
+    )
+
+    match = _URI_RE.search(notice)
+    assert match is not None
+    assert resolve_spill_capability(
+        match.group(0), session_id="direct-session",
+    ) == payload
+
+
+def test_central_dispatch_fails_open_when_persistence_raises(monkeypatch):
+    import model_tools
+    from tools import tool_result_storage
+
+    monkeypatch.setattr(model_tools.registry, "dispatch", lambda *_a, **_k: "result")
+
+    def fail_persistence(**_kwargs):
+        raise OSError("disk unavailable")
+
+    monkeypatch.setattr(
+        tool_result_storage,
+        "maybe_persist_tool_result",
+        fail_persistence,
+    )
+
+    assert model_tools.handle_function_call(
+        "web_search",
+        {"query": "test"},
+        session_id="direct-session",
+        skip_pre_tool_call_hook=True,
+        skip_tool_request_middleware=True,
+        skip_tool_execution_middleware=True,
+    ) == "result"

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -658,6 +658,7 @@ def _rpc_server_loop(
     allowed_tools: frozenset,
     stop_event: threading.Event,
     rpc_token: str,
+    session_id: str = "",
 ):
     """
     Accept one client connection and dispatch tool-call requests until
@@ -746,7 +747,10 @@ def _rpc_server_loop(
                 try:
                     with thread_scoped_silence():
                         result = handle_function_call(
-                            tool_name, tool_args, task_id=task_id
+                            tool_name,
+                            tool_args,
+                            task_id=task_id,
+                            session_id=session_id,
                         )
                 except Exception as exc:
                     logger.error("Tool call failed in sandbox: %s", exc, exc_info=True)
@@ -928,6 +932,7 @@ def _rpc_poll_loop(
     allowed_tools: frozenset,
     stop_event: threading.Event,
     rpc_token: str,
+    session_id: str = "",
 ):
     """Poll the remote filesystem for tool call requests and dispatch them.
 
@@ -1021,7 +1026,10 @@ def _rpc_poll_loop(
                     try:
                         with thread_scoped_silence():
                             tool_result = handle_function_call(
-                                tool_name, tool_args, task_id=task_id
+                                tool_name,
+                                tool_args,
+                                task_id=task_id,
+                                session_id=session_id,
                             )
                     except Exception as exc:
                         logger.error("Tool call failed in remote sandbox: %s",
@@ -1064,6 +1072,7 @@ def _execute_remote(
     code: str,
     task_id: Optional[str],
     enabled_tools: Optional[List[str]],
+    session_id: str = "",
 ) -> str:
     """Run a script on the remote terminal backend via file-based RPC.
 
@@ -1136,7 +1145,7 @@ def _execute_remote(
             args=(
                 env, f"{sandbox_dir}/rpc", effective_task_id,
                 tool_call_log, tool_call_counter, max_tool_calls,
-                sandbox_tools, stop_event, rpc_token,
+                sandbox_tools, stop_event, rpc_token, session_id,
             ),
             daemon=True,
         )
@@ -1256,6 +1265,7 @@ def execute_code(
     code: str,
     task_id: Optional[str] = None,
     enabled_tools: Optional[List[str]] = None,
+    session_id: str = "",
 ) -> str:
     """
     Run a Python script in a sandboxed child process with RPC access
@@ -1269,6 +1279,7 @@ def execute_code(
         task_id:       Session task ID for tool isolation (terminal env, etc.).
         enabled_tools: Tool names enabled in the current session. The sandbox
                        gets the intersection with SANDBOX_ALLOWED_TOOLS.
+        session_id:    Parent session scope forwarded to nested tool calls.
 
     Returns:
         JSON string with execution results.
@@ -1321,7 +1332,7 @@ def execute_code(
         clear_current_thread_interrupt()
 
     if env_type != "local":
-        return _execute_remote(code, task_id, enabled_tools)
+        return _execute_remote(code, task_id, enabled_tools, session_id)
 
     # --- Local execution path (UDS) --- below this line is unchanged ---
 
@@ -1415,7 +1426,8 @@ def execute_code(
             target=propagate_context_to_thread(_rpc_server_loop),
             args=(
                 server_sock, task_id, tool_call_log,
-                tool_call_counter, max_tool_calls, sandbox_tools, stop_event, rpc_token,
+                tool_call_counter, max_tool_calls, sandbox_tools, stop_event,
+                rpc_token, session_id,
             ),
             daemon=True,
         )
@@ -2200,6 +2212,7 @@ def _execute_code_handler(args: dict, **kwargs) -> str:
         code=code or "",
         task_id=kwargs.get("task_id"),
         enabled_tools=kwargs.get("enabled_tools"),
+        session_id=kwargs.get("session_id") or "",
     )
 
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1621,10 +1621,80 @@ def _special_file_kind(path) -> str | None:
     return "a special (non-regular) file"
 
 
-def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str = "default") -> str:
+def _read_spill_capability(
+    uri: str,
+    *,
+    offset: int,
+    limit: int,
+    session_id: str,
+) -> str:
+    """Resolve a host-owned capability before any backend/path routing."""
+    from tools.tool_result_storage import resolve_spill_capability
+
+    try:
+        text = resolve_spill_capability(uri, session_id=session_id)
+        lines = text.splitlines()
+        total_lines = len(lines)
+        end_line = offset + limit - 1
+        page_text = "\n".join(lines[offset - 1:end_line])
+        numbered = (
+            "\n".join(
+                f"{line_number}|{line}"
+                for line_number, line in enumerate(
+                    page_text.splitlines(), start=offset,
+                )
+            )
+            if page_text
+            else ""
+        )
+        result = {
+            "content": numbered,
+            "total_lines": total_lines,
+            "file_size": len(text.encode("utf-8")),
+            "truncated": total_lines > end_line,
+        }
+        if result["truncated"]:
+            result["hint"] = (
+                f"Use offset={end_line + 1} to continue reading "
+                f"(showing {offset}-{min(end_line, total_lines)} of {total_lines} lines)"
+            )
+        max_chars = _get_max_read_chars()
+        if len(result["content"]) > max_chars:
+            trimmed, lines_kept, _ = _truncate_to_char_budget(
+                result["content"], max_chars,
+            )
+            next_offset = offset + lines_kept
+            result["content"] = trimmed
+            result["truncated"] = True
+            result["truncated_by"] = "bytes"
+            result["next_offset"] = next_offset
+            result["hint"] = (
+                f"Output truncated at the {max_chars:,}-char read budget. "
+                f"Use offset={next_offset} to continue."
+            )
+        return json.dumps(result, ensure_ascii=False)
+    except Exception:
+        return tool_error("Cannot read result-spill capability.")
+
+
+def read_file_tool(
+    path: str,
+    offset: int = 1,
+    limit: int = 2000,
+    task_id: str = "default",
+    session_id: str = "",
+) -> str:
     """Read a file with pagination and line numbers."""
     try:
         offset, limit = normalize_read_pagination(offset, limit)
+
+        if isinstance(path, str) and path.startswith("hermes-spill://v1/"):
+            return _read_spill_capability(
+                path,
+                offset=offset,
+                limit=limit,
+                session_id=session_id,
+            )
 
         # ── Device path guard ─────────────────────────────────────────
         # Block paths that would hang the process (infinite output,
@@ -2754,7 +2824,13 @@ SEARCH_FILES_SCHEMA = {
 
 def _handle_read_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid)
+    return read_file_tool(
+        path=args.get("path", ""),
+        offset=args.get("offset", 1),
+        limit=args.get("limit", 500),
+        task_id=tid,
+        session_id=kw.get("session_id") or "",
+    )
 
 
 def _handle_write_file(args, **kw):

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -11,19 +11,19 @@ Defense against context-window overflow operates at three levels:
    (registry.get_max_result_size), the full output is persisted and the
    in-context content is replaced with a preview + file path reference.
 
-   The canonical home is ALWAYS host-side:
-   ``$HERMES_HOME/cache/spillover/{tool_use_id}.txt`` — alongside the other
-   Hermes-owned caches (images, audio, documents, ...) instead of littering
-   the OS temp dir. This needs no sandbox environment, so it also works for
-   sessions that never ran a terminal command (MCP-only, cron, gateway) —
-   previously those hit the inline-truncate fallback because
-   ``get_active_env()`` returned None until the first terminal call created
-   an environment.
+   The canonical home is ALWAYS host-side under
+   ``$HERMES_HOME/cache/spillover`` — alongside the other Hermes-owned caches
+   (images, audio, documents, ...) instead of littering the OS temp dir. Real
+   sessions receive an opaque ``hermes-spill://`` capability bound to their
+   session scope; legacy/direct callers without session context retain the
+   path-based behavior. This needs no sandbox environment, so it also works
+   for sessions that never ran a terminal command (MCP-only, cron, gateway).
 
    What the model sees depends on the backend:
 
-   - **Local backend (or no active env):** the host path itself.
-   - **Remote backends (docker/ssh/modal/daytona):** ``cache/spillover`` is
+   - **Session-scoped calls:** an opaque URI resolved host-side by read_file.
+   - **Legacy local calls (or no active env):** the host path itself.
+   - **Legacy remote calls (docker/ssh/modal/daytona):** ``cache/spillover`` is
      in the auto-mounted/synced cache-dir list (tools/credential_files.py),
      so the reference is the translated in-sandbox path (probed for
      readability first). When the sandbox can't see it (e.g. a persistent
@@ -43,14 +43,19 @@ Defense against context-window overflow operates at three levels:
 """
 
 import hashlib
+import hmac
 import logging
 import os
 import re
+import secrets
 import shlex
+import stat
 import threading
 import time
 import uuid
 
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from tools.budget_config import (
     DEFAULT_PREVIEW_SIZE_CHARS,
     BudgetConfig,
@@ -67,9 +72,47 @@ HEREDOC_MARKER = "HERMES_PERSIST_EOF"
 _BUDGET_TOOL_NAME = "__budget_enforcement__"
 _UNSAFE_RESULT_FILENAME_CHARS = re.compile(r"[^A-Za-z0-9_.-]+")
 _MAX_RESULT_FILENAME_STEM = 120
+_CAPABILITY_URI_RE = re.compile(
+    r"^hermes-spill://v1/"
+    r"(?P<scope>[0-9a-f]{64})/"
+    r"(?P<digest>[0-9a-f]{64})/"
+    r"(?P<capability>[0-9a-f]{32})$"
+)
+_CAPABILITY_FILENAME = "spill_{scope}_{digest}_{locator}.bin"
+_SAFE_CAPABILITY_ERROR = "invalid or inaccessible result-spill capability"
+_O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 
 _spillover_prune_lock = threading.Lock()
 _spillover_pruned_once = False
+
+
+class SpillCapabilityError(Exception):
+    """Fail-closed capability read whose message never reveals a host path."""
+
+
+def _scope_hash(session_id: str) -> str:
+    return hashlib.sha256(session_id.encode("utf-8")).hexdigest()
+
+
+def _capability_uri(scope: str, digest: str, capability: str) -> str:
+    return f"hermes-spill://v1/{scope}/{digest}/{capability}"
+
+
+def _capability_filename(scope: str, digest: str, capability: str) -> str:
+    locator = hashlib.sha256(capability.encode("ascii")).hexdigest()
+    return _CAPABILITY_FILENAME.format(
+        scope=scope,
+        digest=digest,
+        locator=locator,
+    )
+
+
+def _capability_aad(scope: str, digest: str) -> bytes:
+    return f"hermes-spill-v1:{scope}:{digest}".encode("ascii")
+
+
+def _capability_key(capability: str) -> bytes:
+    return hashlib.sha256(capability.encode("ascii")).digest()
 
 
 def get_spillover_dir():
@@ -157,6 +200,129 @@ def _write_to_spillover(content: str, filename: str):
         return None
     _prune_spillover_once()
     return str(path)
+
+
+def _write_capability_spillover(content: str, session_id: str) -> str | None:
+    """Persist authenticated ciphertext and return an opaque same-session URI."""
+    scope = str(session_id or "").strip()
+    if not scope:
+        return None
+    data = content.encode("utf-8")
+    digest = hashlib.sha256(data).hexdigest()
+    spill_dir = get_spillover_dir()
+    try:
+        spill_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        if os.name != "nt":
+            os.chmod(spill_dir, 0o700)
+        scope_hash = _scope_hash(scope)
+        for _attempt in range(3):
+            capability = secrets.token_hex(16)
+            path = spill_dir / _capability_filename(
+                scope_hash, digest, capability,
+            )
+            try:
+                fd = os.open(
+                    path,
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL | _O_NOFOLLOW,
+                    0o600,
+                )
+            except FileExistsError:
+                continue
+            nonce = secrets.token_bytes(12)
+            encrypted = nonce + AESGCM(_capability_key(capability)).encrypt(
+                nonce,
+                data,
+                _capability_aad(scope_hash, digest),
+            )
+            try:
+                with os.fdopen(fd, "wb") as handle:
+                    handle.write(encrypted)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+            except Exception:
+                try:
+                    path.unlink()
+                except OSError:
+                    pass
+                raise
+            _prune_spillover_once()
+            return _capability_uri(scope_hash, digest, capability)
+    except OSError as exc:
+        logger.warning("Capability spillover write failed: %s", exc)
+    return None
+
+
+def resolve_spill_capability(uri: str, session_id: str = "") -> str:
+    """Resolve an opaque spill URI only for the session that minted it."""
+    scope = str(session_id or "").strip()
+    parsed = _CAPABILITY_URI_RE.fullmatch(str(uri or "").strip())
+    if not scope or parsed is None:
+        raise SpillCapabilityError(_SAFE_CAPABILITY_ERROR)
+    expected_scope = _scope_hash(scope)
+    if not hmac.compare_digest(expected_scope, parsed.group("scope")):
+        raise SpillCapabilityError(_SAFE_CAPABILITY_ERROR)
+    path = get_spillover_dir() / _capability_filename(
+        expected_scope,
+        parsed.group("digest"),
+        parsed.group("capability"),
+    )
+    fd = -1
+    try:
+        link_metadata = os.lstat(path)
+        reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+        if (
+            stat.S_ISLNK(link_metadata.st_mode)
+            or getattr(link_metadata, "st_file_attributes", 0) & reparse_flag
+        ):
+            raise SpillCapabilityError(_SAFE_CAPABILITY_ERROR)
+        fd = os.open(
+            path,
+            os.O_RDONLY | _O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0),
+        )
+        metadata = os.fstat(fd)
+        if (
+            getattr(link_metadata, "st_dev", None),
+            getattr(link_metadata, "st_ino", None),
+        ) != (
+            getattr(metadata, "st_dev", None),
+            getattr(metadata, "st_ino", None),
+        ):
+            raise SpillCapabilityError(_SAFE_CAPABILITY_ERROR)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise SpillCapabilityError(_SAFE_CAPABILITY_ERROR)
+        if os.name != "nt" and stat.S_IMODE(metadata.st_mode) != 0o600:
+            raise SpillCapabilityError(_SAFE_CAPABILITY_ERROR)
+        if hasattr(os, "getuid") and metadata.st_uid != os.getuid():
+            raise SpillCapabilityError(_SAFE_CAPABILITY_ERROR)
+        chunks = []
+        while True:
+            chunk = os.read(fd, 1024 * 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        encrypted = b"".join(chunks)
+        if len(encrypted) < 13:
+            raise SpillCapabilityError(_SAFE_CAPABILITY_ERROR)
+        nonce, ciphertext = encrypted[:12], encrypted[12:]
+        data = AESGCM(_capability_key(parsed.group("capability"))).decrypt(
+            nonce,
+            ciphertext,
+            _capability_aad(expected_scope, parsed.group("digest")),
+        )
+        digest = hashlib.sha256(data).hexdigest()
+        if not hmac.compare_digest(digest, parsed.group("digest")):
+            raise SpillCapabilityError(_SAFE_CAPABILITY_ERROR)
+        return data.decode("utf-8")
+    except SpillCapabilityError:
+        raise
+    except (OSError, UnicodeDecodeError, InvalidTag):
+        raise SpillCapabilityError(_SAFE_CAPABILITY_ERROR) from None
+    finally:
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
 
 
 def _sandbox_visible_spillover_path(host_path: str, env) -> str | None:
@@ -297,6 +463,7 @@ def maybe_persist_tool_result(
     env=None,
     config: BudgetConfig = DEFAULT_BUDGET,
     threshold: int | float | None = None,
+    session_id: str = "",
 ) -> str:
     """Layer 2: persist oversized result into the sandbox, return preview + path.
 
@@ -311,6 +478,7 @@ def maybe_persist_tool_result(
         env: The active BaseEnvironment instance, or None.
         config: BudgetConfig controlling thresholds and preview size.
         threshold: Explicit override; takes precedence over config resolution.
+        session_id: Session scope used to mint an opaque recovery capability.
 
     Returns:
         Original content if small, or <persisted-output> replacement.
@@ -326,9 +494,34 @@ def maybe_persist_tool_result(
     filename = _safe_result_filename(tool_use_id)
     preview, has_more = generate_preview(content, max_chars=config.preview_size)
 
-    # Always persist host-side first: $HERMES_HOME/cache/spillover is the
-    # single canonical home for spilled results (with the other Hermes-owned
-    # caches, pruned by gateway housekeeping) regardless of backend.
+    # Real sessions get host-resolved capabilities instead of predictable
+    # filesystem paths. This also prevents reused tool-call IDs in different
+    # sessions from overwriting each other's payloads.
+    capability_uri = _write_capability_spillover(content, session_id)
+    if capability_uri is not None:
+        logger.info(
+            "Persisted large tool result behind session capability: %s (%s, %d chars)",
+            tool_name, tool_use_id, len(content),
+        )
+        return _build_persisted_message(
+            preview, has_more, len(content), capability_uri,
+        )
+    if str(session_id or "").strip():
+        # Never downgrade a scoped session to a predictable host/sandbox path.
+        # If secure capability creation fails, preserve bounded context and fail
+        # closed on recovery rather than leaking a path or crossing sessions.
+        logger.warning(
+            "Secure result-spill capability unavailable for %s; returning bounded preview",
+            tool_use_id,
+        )
+        return (
+            f"{preview}\n\n"
+            f"[Truncated: tool response was {len(content):,} chars. "
+            "Secure result storage was unavailable; no recovery path was emitted.]"
+        )
+
+    # Calls without session context retain the legacy path-based behavior:
+    # write the single canonical host copy under the spillover cache.
     host_path = _write_to_spillover(content, filename)
 
     if _is_host_side_env(env):
@@ -379,6 +572,7 @@ def enforce_turn_budget(
     tool_messages: list[dict],
     env=None,
     config: BudgetConfig = DEFAULT_BUDGET,
+    session_id: str = "",
 ) -> list[dict]:
     """Layer 3: enforce aggregate budget across all tool results in a turn.
 
@@ -416,6 +610,7 @@ def enforce_turn_budget(
             env=env,
             config=config,
             threshold=0,
+            session_id=session_id,
         )
         if replacement != content:
             total_size -= size


### PR DESCRIPTION
## What does this PR do?

Extends Hermes Agent's existing persisted tool-result system with opaque, same-session recovery capabilities.

Oversized model-facing tool results receive a `hermes-spill://v1/...` capability instead of exposing a host cache path. The complete payload is AES-GCM encrypted at rest and can be recovered through Hermes `read_file` only by the session that minted the capability. Direct transports, Codex MCP, concurrent/sequential tool execution, and nested `execute_code` RPC preserve the same session scope.

This is the recoverable capability layer developed as part of **HERMES HARNESS**, a Hermes-native context and tool-result economy project. DeepSeek Harness was research provenance; this PR does not add its runtime, Cordis, web application, SurfaceOp, or AST Code Mode.

The implementation extends `tools/tool_result_storage.py`; it does not introduce a second spill engine or a new model tool.

## Related Issue

Related to #23200, #70949, and #415. Also compared against the overlapping path-oriented draft #85480 and storage-hardening PR #80760; this PR's distinct scope is encrypted, opaque, session-bound recovery.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add session-bound capability minting and resolution in `tools/tool_result_storage.py`.
- Encrypt scoped spill payloads with AES-GCM and authenticate session scope plus plaintext digest.
- Hide bearer tokens from filenames and validate scope, digest, symlink/reparse metadata, file identity, type, ownership, mode, AEAD tag, and plaintext digest.
- Intercept capabilities in `tools/file_tools.py` before ordinary backend/path routing.
- Propagate session IDs through `agent/tool_executor.py`, `model_tools.py`, and nested local/remote `execute_code` RPC.
- Add a capability-only `read_file` handler to the Hermes MCP transport; ordinary filesystem paths remain rejected there.
- Add focused regression tests for exact recovery, cross-session denial, encrypted storage, filesystem attacks, scoped write failure, MCP transport, central dispatch, and RPC propagation.

## How to Test

```bash
python -m pytest -q \
  tests/tools/test_tool_result_capability.py \
  tests/run_agent/test_tool_call_incremental_persistence.py \
  tests/tools/test_code_execution.py \
  tests/tools/test_code_execution_modes.py

uv run --extra mcp python -m pytest -q \
  tests/agent/transports/test_hermes_tools_mcp_server.py

python -m pytest -q \
  tests/agent/transports/test_codex_app_server_runtime.py \
  tests/run_agent/test_codex_app_server_integration.py \
  tests/cli/test_cli_codex_context_reference.py \
  tests/agent/transports/test_codex_transport.py

python -m pytest -q \
  tests/test_transform_tool_result_hook.py \
  tests/run_agent/test_run_agent.py \
  -k 'session_id or transform_tool_result'

python -m ruff check \
  tools/tool_result_storage.py tools/file_tools.py tools/code_execution_tool.py \
  model_tools.py agent/tool_executor.py agent/transports/hermes_tools_mcp_server.py \
  tests/tools/test_tool_result_capability.py \
  tests/agent/transports/test_hermes_tools_mcp_server.py \
  tests/run_agent/test_tool_call_incremental_persistence.py \
  tests/tools/test_code_execution.py tests/tools/test_code_execution_modes.py

git diff --check origin/main...HEAD
scripts/run_tests.sh
```

Verification after the final rebase onto current `origin/main` (`5dd15872a6`):

- 106 passed + 7 subtests — capability/storage, incremental persistence, execute-code local/mode coverage.
- 12 passed — Hermes MCP transport under the pinned MCP extra.
- 147 passed — Codex app-server runtime/integration, context reference, and transport.
- 6 passed, 260 deselected — dispatch session-ID and transform-hook focus.
- Ruff passed on all changed Python files.
- `py_compile` passed on changed production modules and the capability test.
- `git diff --check` passed.
- Stable patch ID is unchanged from the independently reviewed pre-rebase commit: `629678ef5cc8f0c2b7a7bcad56040c096ac62df3`.
- Full `scripts/run_tests.sh` differential was run immediately before the final five-commit upstream advance: the feature and a clean sparse checkout of exact base `74f99af470` both reported the same 81 failures across the same 23 files. None of those files is changed by this PR. After the final rebase to `5dd15872a6`, every affected suite above was rerun green and the stable patch ID remained unchanged.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit follows Conventional Commits.
- [x] I searched existing PRs and issues and documented the overlapping work above.
- [x] My PR contains only changes related to this capability/security layer.
- [ ] I've run the preferred full wrapper, but this macOS environment is not baseline-green: feature and exact-base runs both report the same 81 failures in the same 23 unrelated files. The differential is clean and the affected suites pass; GitHub CI remains the platform-matrix arbiter.
- [x] I've added tests for my changes.
- [x] I've tested on macOS 26.4, Apple Silicon.

### Documentation & Housekeeping

- [x] Documentation update: N/A — no public config or user-facing command is added.
- [x] `cli-config.yaml.example`: N/A — no config keys are added or changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A — no workflow or architecture policy is changed.
- [x] Cross-platform impact considered; Windows reparse metadata and POSIX filesystem boundaries have focused coverage.
- [x] Tool descriptions/schemas updated where behavior changed: the MCP reader is explicitly capability-only and rejects ordinary paths.

## Screenshots / Logs

Not applicable. The behavior and security boundaries are exercised by automated tests and exact recovery probes.
