### PR TITLE
feat(mcp): add Pin Seeker to the MCP catalog

### DIFF
--- a/optional-mcps/pin-seeker/manifest.yaml
+++ b/optional-mcps/pin-seeker/manifest.yaml
@@ -3,7 +3,7 @@
 manifest_version: 1
 
 name: pin-seeker
-description: Search golf tee times. Returns GolfNow links; does not book or hold.
+description: Search golf tee times. Returns GolfNow links; does not book or hold. Search queries (location and schedule) are sent to pinseeker.xyz.
 source: https://pinseeker.xyz/agents.html
 
 # Official hosted Streamable HTTP server. URL-only — Hermes never spawns a
@@ -36,3 +36,4 @@ post_install: |
   link so they can complete checkout themselves.
 
   Try: "Find me a Saturday morning tee time near Pleasanton for 2."
+  Search queries (location and schedule) are sent to pinseeker.xyz.

--- a/optional-mcps/pin-seeker/manifest.yaml
+++ b/optional-mcps/pin-seeker/manifest.yaml
@@ -1,0 +1,38 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: pin-seeker
+description: Search golf tee times. Returns GolfNow links; does not book or hold.
+source: https://pinseeker.xyz/agents.html
+
+# Official hosted Streamable HTTP server. URL-only — Hermes never spawns a
+# local process for this entry. Public search; no credentials required.
+transport:
+  type: http
+  url: https://pinseeker.xyz/mcp
+
+auth:
+  type: none
+
+tools:
+  default_enabled:
+    - search_tee_times
+
+suggest:
+  keywords:
+    - golf
+    - tee time
+    - tee times
+    - golfnow
+    - pin seeker
+  hosts:
+    - pinseeker.xyz
+    - golfnow.com
+
+post_install: |
+  Pin Seeker searches public tee times and returns GolfNow URLs.
+  It cannot book, hold, reserve, or pay. Give the golfer the GolfNow
+  link so they can complete checkout themselves.
+
+  Try: "Find me a Saturday morning tee time near Pleasanton for 2."


### PR DESCRIPTION
## What does this PR do?

Adds Pin Seeker as a Nous catalog MCP: hosted Streamable HTTP at `https://pinseeker.xyz/mcp`.

It searches public GolfNow tee times from natural language and returns booking URLs. It does **not** book, hold, reserve, or pay — the golfer finishes checkout on GolfNow. Auth is `none`. Hermes never spawns a local process.

Live today:
- MCP: https://pinseeker.xyz/mcp
- Health: https://pinseeker.xyz/mcp-health
- Install page: https://pinseeker.xyz/agents.html
- Official MCP Registry: `xyz.pinseeker/tee-times` (https://registry.modelcontextprotocol.io/?q=xyz.pinseeker%2Ftee-times)

The only tool is `search_tee_times`. `tools.default_enabled` lists that single tool so install-time selection stays read-only.

## Related Issue

No existing issue. Catalog entries are merged via PR review.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- Added `optional-mcps/pin-seeker/manifest.yaml` (HTTP transport, `auth: none`)

## How to Test

1. `hermes mcp add pin-seeker --url https://pinseeker.xyz/mcp` (works today; catalog install after merge is `hermes mcp install official/pin-seeker`)
2. Ask: `Find me a Saturday morning tee time near Pleasanton for 2`
3. Confirm the reply includes GolfNow URLs and does **not** claim a time is booked or held
4. Confirm `GET https://pinseeker.xyz/mcp-health` returns `Pin Seeker MCP server is running`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (live server at pinseeker.xyz)

N/A: catalog YAML only; no Hermes runtime code. Pytest not applicable.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


Made with [Cursor](https://cursor.com)