### PR TITLE
fix(cli): show the deprecated cwd hint on real lines

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2243,10 +2243,9 @@ def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> Non
 
         hint_path = display_hermes_home()
         lines.insert(0, "\033[33m⚠ Deprecated .env settings detected:\033[0m")
-        lines.append(
-            "  \033[2mMove to config.yaml instead:  "
-            "terminal:\\n    cwd: /your/project/path\033[0m"
-        )
+        lines.append("  \033[2mMove to config.yaml instead:\033[0m")
+        lines.append("  \033[2m  terminal:\033[0m")
+        lines.append("  \033[2m    cwd: /your/project/path\033[0m")
         lines.append(
             f"  \033[2mThen remove the old entries from {hint_path}/.env\033[0m"
         )

--- a/tests/hermes_cli/test_deprecated_cwd_warning.py
+++ b/tests/hermes_cli/test_deprecated_cwd_warning.py
@@ -27,3 +27,25 @@ class TestDeprecatedCwdWarning:
         captured = capsys.readouterr()
         assert "MESSAGING_CWD" in captured.err
         assert "TERMINAL_CWD" in captured.err
+
+    def test_migration_hint_has_no_literal_escape_text(self, monkeypatch, capsys):
+        """The config.yaml hint must be real lines, not literal '\\n' text.
+
+        Regression: the hint was built with '\\\\n' inside an f-string, which
+        printed the two characters backslash-n into the terminal instead of a
+        newline.
+        """
+        monkeypatch.setenv("TERMINAL_CWD", "/term/path")
+        monkeypatch.delenv("MESSAGING_CWD", raising=False)
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+        warn_deprecated_cwd_env_vars(config={})
+
+        captured = capsys.readouterr()
+        assert "\\n" not in captured.err
+        # The yaml snippet is on its own lines and cwd is nested under terminal:
+        plain_lines = captured.err.splitlines()
+        terminal_idx = next(
+            i for i, ln in enumerate(plain_lines) if ln.strip("\x1b[02m ").startswith("terminal:")
+        )
+        assert "cwd:" in plain_lines[terminal_idx + 1]


### PR DESCRIPTION
## What does this PR do?

The deprecated-cwd warning shows a broken migration hint. The hint string contains a double backslash. The terminal shows the two characters `\n` instead of a line break:

```
  Move to config.yaml instead:  terminal:\n    cwd: /your/project/path
```

This PR splits the hint into three real lines. The warning now shows a correct YAML snippet:

```
  Move to config.yaml instead:
    terminal:
      cwd: /your/project/path
```

The bad string is in `warn_deprecated_cwd_env_vars()` and came in with #11029.

Related work: #87919 reports two problems in the startup warnings. Problem one is the mangled ANSI escape bytes. Problem two is the literal `\n` text. PR #87613 corrects problem one, but its color branch keeps the literal `\n` string. This PR corrects problem two at the source. The two PRs do not conflict in intent, and one line overlaps.

## Related Issue

Part of #87919

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py` — the migration hint is now three list entries with real line breaks and YAML indentation.
- `tests/hermes_cli/test_deprecated_cwd_warning.py` — a new regression test makes sure that the output contains no literal `\n` text and that `cwd:` is on its own line below `terminal:`.

## How to Test

1. Run `TERMINAL_CWD=/tmp/x python -c "from hermes_cli.config import warn_deprecated_cwd_env_vars; warn_deprecated_cwd_env_vars(config={})"`.
2. Make sure that the hint shows the YAML snippet on three lines.
3. Run `scripts/run_tests.sh tests/hermes_cli/test_deprecated_cwd_warning.py -q`. All 3 tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the test suite and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before:

```
⚠ Deprecated .env settings detected:
  ⚠ TERMINAL_CWD=/tmp/bar found in .env — this is deprecated.
  Move to config.yaml instead:  terminal:\n    cwd: /your/project/path
  Then remove the old entries from ~/.hermes/.env
```

After:

```
⚠ Deprecated .env settings detected:
  ⚠ TERMINAL_CWD=/tmp/bar found in .env — this is deprecated.
  Move to config.yaml instead:
    terminal:
      cwd: /your/project/path
  Then remove the old entries from ~/.hermes/.env
```
