### PR TITLE
fix(aux): translate response_format for Anthropic wires and retry when providers reject structured output

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1945,6 +1945,39 @@ class AsyncCodexAuxiliaryClient:
         self._real_client = sync_wrapper._real_client
 
 
+def _translate_anthropic_response_format(
+    anthropic_kwargs: Dict[str, Any], response_format: Any,
+) -> None:
+    """Merge an OpenAI response format into Anthropic ``output_config``."""
+    if not isinstance(response_format, dict):
+        return
+
+    format_type = response_format.get("type")
+    if format_type == "json_schema":
+        json_schema = response_format.get("json_schema")
+        if not isinstance(json_schema, dict) or "schema" not in json_schema:
+            return
+        native_format = {
+            "type": "json_schema",
+            "schema": json_schema["schema"],
+        }
+    elif format_type == "json_object":
+        # Anthropic SDK 0.87.0 exposes only JSONOutputFormatParam, whose
+        # required type is ``json_schema``; it has no schema-less JSON mode.
+        native_format = {
+            "type": "json_schema",
+            "schema": {"type": "object"},
+        }
+    else:
+        return
+
+    output_config = anthropic_kwargs.get("output_config")
+    if not isinstance(output_config, dict):
+        output_config = {}
+        anthropic_kwargs["output_config"] = output_config
+    output_config["format"] = native_format
+
+
 class _AnthropicCompletionsAdapter:
     """OpenAI-client-compatible adapter for Anthropic Messages API."""
 
@@ -2045,18 +2078,25 @@ class _AnthropicCompletionsAdapter:
         # form is the documented Anthropic SDK passthrough for non-standard
         # request body keys; merge on top of whatever build_anthropic_kwargs
         # already produced (e.g. fast-mode ``speed``) so call-time settings
-        # survive. Two exclusions:
+        # survive. Three exclusions:
         #   - ``reasoning``: the OpenAI-shaped config dict is TRANSLATED into
         #     the native ``thinking`` field above (build_anthropic_kwargs);
         #     forwarding the raw field alongside would double-specify
         #     reasoning and 400 on strict gateways.
+        #   - ``response_format``: the OpenAI structured-output shape is
+        #     TRANSLATED into top-level ``output_config.format`` below;
+        #     forwarding the raw field 400s on strict Anthropic gateways.
         #   - ``_``-prefixed keys: private Hermes plumbing (_reasoning_config
         #     et al.), never wire fields.
         caller_extra_body = kwargs.get("extra_body")
         if caller_extra_body and isinstance(caller_extra_body, dict):
+            _translate_anthropic_response_format(
+                anthropic_kwargs, caller_extra_body.get("response_format"),
+            )
             passthrough = {
                 k: v for k, v in caller_extra_body.items()
-                if k != "reasoning" and not str(k).startswith("_")
+                if k not in {"reasoning", "response_format"}
+                and not str(k).startswith("_")
             }
             if passthrough:
                 existing = anthropic_kwargs.get("extra_body") or {}

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4342,6 +4342,71 @@ def _is_unsupported_temperature_error(exc: Exception) -> bool:
     return _is_unsupported_parameter_error(exc, "temperature")
 
 
+def _is_structured_output_rejection(exc: Exception) -> bool:
+    """Detect provider 400s that reject the structured-output request field.
+
+    One predicate covers the field on both wires, because both come from the
+    same caller-supplied ``response_format``:
+
+    - OpenAI wire: the provider rejects ``response_format`` itself. vLLM
+      gateways translate the field into ``guided_grammar`` and fail when the
+      grammar backend is absent (``compile_grammar_error: No module named
+      'xgrammar'``, #82816). Other endpoints answer ``This response_format
+      type is unavailable now``.
+    - Anthropic wire: the adapter translates ``response_format`` into
+      ``output_config.format``. Gateways that predate structured outputs
+      (the documented case is the ``bedrock-mantle`` Messages endpoint)
+      reject that field: ``output_config: Extra inputs are not permitted``.
+
+    Callers tolerate an unconstrained reply — the title prompt demands bare
+    JSON and ``_extract_title_text`` has a loose-JSON fallback — so the right
+    reaction is one retry without the field, not a hard failure.
+    """
+    status = getattr(exc, "status_code", None)
+    if status is not None and status not in {400, 422}:
+        return False
+    err_lower = str(exc).lower()
+    # vLLM grammar-backend failures name the translated parameter, not ours.
+    if "guided_grammar" in err_lower or "xgrammar" in err_lower or (
+        "compile_grammar_error" in err_lower
+    ):
+        return True
+    if "extra inputs are not permitted" in err_lower and (
+        "response_format" in err_lower or "output_config" in err_lower
+    ):
+        return True
+    if "response_format" in err_lower and "unavailable" in err_lower:
+        return True
+    return (
+        _is_unsupported_parameter_error(exc, "response_format")
+        or _is_unsupported_parameter_error(exc, "output_config")
+    )
+
+
+def _without_structured_output_format(kwargs: dict) -> Optional[dict]:
+    """Copy *kwargs* without any ``response_format`` request field.
+
+    Removes the top-level kwarg and the ``extra_body`` entry. Returns None
+    when the kwargs carry no such field, so call sites do not retry a
+    request that the removal did not change.
+    """
+    changed = False
+    retry_kwargs = dict(kwargs)
+    if retry_kwargs.pop("response_format", None) is not None:
+        changed = True
+    extra_body = retry_kwargs.get("extra_body")
+    if isinstance(extra_body, dict) and "response_format" in extra_body:
+        remaining = {
+            k: v for k, v in extra_body.items() if k != "response_format"
+        }
+        if remaining:
+            retry_kwargs["extra_body"] = remaining
+        else:
+            retry_kwargs.pop("extra_body", None)
+        changed = True
+    return retry_kwargs if changed else None
+
+
 def _is_model_not_found_error(exc: Exception) -> bool:
     """Detect "the requested model doesn't exist" errors (404 / invalid model).
 
@@ -9422,6 +9487,39 @@ def _call_llm_impl(
                 first_err = retry_err
                 kwargs = retry_kwargs
 
+        if _is_structured_output_rejection(first_err):
+            retry_kwargs = _without_structured_output_format(kwargs)
+            if retry_kwargs is not None:
+                logger.info(
+                    "Auxiliary %s: provider rejected the structured-output "
+                    "format field; retrying once without it (schema "
+                    "enforcement degrades to prompt compliance): %s",
+                    task or "call", first_err,
+                )
+                try:
+                    return _validate_llm_response(
+                        _relay_sync_completion(
+                            client,
+                            retry_kwargs,
+                            provider=resolved_provider,
+                            api_mode=resolved_api_mode,
+                        ), task)
+                except Exception as retry_err:
+                    # Same contract as the temperature rung: fall through to
+                    # the max_tokens / payment / auth chains below with the
+                    # stripped kwargs; re-raise anything those chains do not
+                    # handle.
+                    if not (
+                        _is_payment_error(retry_err)
+                        or _is_connection_error(retry_err)
+                        or _is_auth_error(retry_err)
+                        or "max_tokens" in str(retry_err)
+                        or "unsupported_parameter" in str(retry_err)
+                    ):
+                        raise
+                    first_err = retry_err
+                    kwargs = retry_kwargs
+
         err_str = str(first_err)
         # ZAI vision models (glm-4v-flash etc.) return error code 1210
         # ("API 调用参数有误") when max_tokens is passed on multimodal
@@ -10133,6 +10231,40 @@ async def _async_call_llm_impl(
                     raise
                 first_err = retry_err
                 kwargs = retry_kwargs
+
+        if _is_structured_output_rejection(first_err):
+            retry_kwargs = _without_structured_output_format(kwargs)
+            if retry_kwargs is not None:
+                logger.info(
+                    "Auxiliary %s (async): provider rejected the "
+                    "structured-output format field; retrying once without "
+                    "it (schema enforcement degrades to prompt "
+                    "compliance): %s",
+                    task or "call", first_err,
+                )
+                try:
+                    return _validate_llm_response(
+                        await _relay_async_completion(
+                            client,
+                            retry_kwargs,
+                            provider=resolved_provider,
+                            api_mode=resolved_api_mode,
+                        ), task)
+                except Exception as retry_err:
+                    # Same contract as the temperature rung: fall through to
+                    # the max_tokens / payment / auth chains below with the
+                    # stripped kwargs; re-raise anything those chains do not
+                    # handle.
+                    if not (
+                        _is_payment_error(retry_err)
+                        or _is_connection_error(retry_err)
+                        or _is_auth_error(retry_err)
+                        or "max_tokens" in str(retry_err)
+                        or "unsupported_parameter" in str(retry_err)
+                    ):
+                        raise
+                    first_err = retry_err
+                    kwargs = retry_kwargs
 
         err_str = str(first_err)
         # ZAI vision models (glm-4v-flash etc.) return error code 1210

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2089,6 +2089,19 @@ class _AnthropicCompletionsAdapter:
         #   - ``_``-prefixed keys: private Hermes plumbing (_reasoning_config
         #     et al.), never wire fields.
         caller_extra_body = kwargs.get("extra_body")
+        # A top-level ``response_format`` kwarg (the OpenAI SDK's documented
+        # call shape) must get the same translation as the extra_body form.
+        # The adapter builds the Messages body from a fixed allow-list of
+        # kwargs, so before this an unrecognized top-level kwarg was dropped
+        # on the floor: the request succeeded but the schema contract
+        # silently became prompt compliance (#85626 review, point 2). When
+        # both shapes are present, the extra_body form wins — it is the shape
+        # every in-tree caller uses.
+        top_level_response_format = kwargs.get("response_format")
+        if top_level_response_format is not None:
+            _translate_anthropic_response_format(
+                anthropic_kwargs, top_level_response_format,
+            )
         if caller_extra_body and isinstance(caller_extra_body, dict):
             _translate_anthropic_response_format(
                 anthropic_kwargs, caller_extra_body.get("response_format"),

--- a/tests/agent/test_anthropic_structured_output.py
+++ b/tests/agent/test_anthropic_structured_output.py
@@ -8,7 +8,8 @@ from unittest.mock import MagicMock, patch
 
 
 def _capture_anthropic_kwargs(
-    extra_body: dict, *, model: str = "claude-sonnet-4-6", async_call: bool = False,
+    extra_body: dict | None, *, model: str = "claude-sonnet-4-6",
+    async_call: bool = False, top_level_kwargs: dict | None = None,
 ) -> dict:
     from agent.auxiliary_client import (
         _AnthropicCompletionsAdapter,
@@ -35,6 +36,9 @@ def _capture_anthropic_kwargs(
         reasoning=None,
         finish_reason="stop",
     )
+    call_kwargs = dict(top_level_kwargs or {})
+    if extra_body is not None:
+        call_kwargs["extra_body"] = extra_body
     with patch(
         "agent.anthropic_adapter.create_anthropic_message",
         side_effect=_fake_create,
@@ -44,7 +48,7 @@ def _capture_anthropic_kwargs(
             model=model,
             messages=[{"role": "user", "content": "hi"}],
             max_tokens=64,
-            extra_body=extra_body,
+            **call_kwargs,
         )
         if async_call:
             asyncio.run(call)
@@ -143,5 +147,68 @@ def test_async_anthropic_adapter_uses_the_same_translation():
     assert api_kwargs["output_config"]["format"] == {
         "type": "json_schema",
         "schema": schema,
+    }
+    _assert_no_raw_response_format(api_kwargs)
+
+
+def test_top_level_response_format_kwarg_is_translated_not_dropped():
+    """#85626 review, point 2: the top-level kwarg shape must also translate.
+
+    ``client.chat.completions.create(..., response_format=...)`` is the
+    OpenAI SDK's documented call shape. The adapter builds the Messages body
+    from a fixed allow-list of kwargs, so before this an unrecognized
+    top-level kwarg was dropped on the floor: the request succeeded, but the
+    schema contract silently became prompt compliance. Pin-test pattern from
+    PR #85626 (Matt McClean), adapted from strip to translate semantics.
+    """
+    schema = {
+        "type": "object",
+        "properties": {"title": {"type": "string"}},
+        "required": ["title"],
+    }
+    api_kwargs = _capture_anthropic_kwargs(
+        None,
+        top_level_kwargs={
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {"name": "session_title", "schema": schema},
+            },
+        },
+    )
+
+    assert api_kwargs["output_config"]["format"] == {
+        "type": "json_schema",
+        "schema": schema,
+    }
+    _assert_no_raw_response_format(api_kwargs)
+
+
+def test_extra_body_response_format_wins_over_top_level_kwarg():
+    """When both shapes are present, extra_body wins.
+
+    Every in-tree caller uses the extra_body shape. The top-level kwarg is
+    the compatibility path, so it must not override an explicit extra_body
+    value when a caller somehow sends both.
+    """
+    eb_schema = {"type": "object", "properties": {"a": {"type": "string"}}}
+    top_schema = {"type": "object", "properties": {"b": {"type": "string"}}}
+    api_kwargs = _capture_anthropic_kwargs(
+        {
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {"schema": eb_schema},
+            },
+        },
+        top_level_kwargs={
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {"schema": top_schema},
+            },
+        },
+    )
+
+    assert api_kwargs["output_config"]["format"] == {
+        "type": "json_schema",
+        "schema": eb_schema,
     }
     _assert_no_raw_response_format(api_kwargs)

--- a/tests/agent/test_anthropic_structured_output.py
+++ b/tests/agent/test_anthropic_structured_output.py
@@ -1,0 +1,147 @@
+"""Structured-output translation for Anthropic auxiliary calls."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _capture_anthropic_kwargs(
+    extra_body: dict, *, model: str = "claude-sonnet-4-6", async_call: bool = False,
+) -> dict:
+    from agent.auxiliary_client import (
+        _AnthropicCompletionsAdapter,
+        _AsyncAnthropicCompletionsAdapter,
+    )
+
+    captured = {}
+    sync_adapter = _AnthropicCompletionsAdapter(
+        MagicMock(name="anthropic_client"), model, is_oauth=False,
+    )
+    adapter = (
+        _AsyncAnthropicCompletionsAdapter(sync_adapter)
+        if async_call
+        else sync_adapter
+    )
+
+    def _fake_create(_client, api_kwargs, **_kwargs):
+        captured.update(api_kwargs)
+        return SimpleNamespace()
+
+    normalized = SimpleNamespace(
+        content="ok",
+        tool_calls=None,
+        reasoning=None,
+        finish_reason="stop",
+    )
+    with patch(
+        "agent.anthropic_adapter.create_anthropic_message",
+        side_effect=_fake_create,
+    ), patch("agent.transports.get_transport") as mock_get_transport:
+        mock_get_transport.return_value.normalize_response.return_value = normalized
+        call = adapter.create(
+            model=model,
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=64,
+            extra_body=extra_body,
+        )
+        if async_call:
+            asyncio.run(call)
+
+    return captured
+
+
+def _assert_no_raw_response_format(api_kwargs: dict) -> None:
+    assert "response_format" not in api_kwargs
+    assert "response_format" not in api_kwargs.get("extra_body", {})
+
+
+def test_json_schema_response_format_uses_native_output_config():
+    schema = {
+        "type": "object",
+        "properties": {"title": {"type": "string"}},
+        "required": ["title"],
+    }
+    api_kwargs = _capture_anthropic_kwargs({
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "thread_title",
+                "schema": schema,
+                "strict": False,
+            },
+        },
+    })
+
+    assert api_kwargs["output_config"]["format"] == {
+        "type": "json_schema",
+        "schema": schema,
+    }
+    _assert_no_raw_response_format(api_kwargs)
+
+
+def test_json_object_response_format_uses_permissive_object_schema():
+    api_kwargs = _capture_anthropic_kwargs({
+        "response_format": {"type": "json_object"},
+    })
+
+    assert api_kwargs["output_config"]["format"] == {
+        "type": "json_schema",
+        "schema": {"type": "object"},
+    }
+    _assert_no_raw_response_format(api_kwargs)
+
+
+def test_response_format_merges_with_adaptive_thinking_effort():
+    schema = {"type": "object", "properties": {"ok": {"type": "boolean"}}}
+    api_kwargs = _capture_anthropic_kwargs({
+        "reasoning": {"enabled": True, "effort": "high"},
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {"schema": schema},
+        },
+    })
+
+    assert api_kwargs["output_config"] == {
+        "effort": "high",
+        "format": {"type": "json_schema", "schema": schema},
+    }
+    assert api_kwargs["thinking"] == {
+        "type": "adaptive",
+        "display": "summarized",
+    }
+    _assert_no_raw_response_format(api_kwargs)
+
+
+def test_unrelated_extra_body_keys_still_pass_through():
+    api_kwargs = _capture_anthropic_kwargs({
+        "response_format": {"type": "json_object"},
+        "metadata": {"user_id": "thread-autotitle"},
+        "vendor_option": True,
+    })
+
+    assert api_kwargs["extra_body"] == {
+        "metadata": {"user_id": "thread-autotitle"},
+        "vendor_option": True,
+    }
+    _assert_no_raw_response_format(api_kwargs)
+
+
+def test_async_anthropic_adapter_uses_the_same_translation():
+    schema = {"type": "object"}
+    api_kwargs = _capture_anthropic_kwargs(
+        {
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {"schema": schema},
+            },
+        },
+        async_call=True,
+    )
+
+    assert api_kwargs["output_config"]["format"] == {
+        "type": "json_schema",
+        "schema": schema,
+    }
+    _assert_no_raw_response_format(api_kwargs)

--- a/tests/agent/test_structured_output_rejection_retry.py
+++ b/tests/agent/test_structured_output_rejection_retry.py
@@ -1,0 +1,307 @@
+"""Regression tests for the structured-output rejection retry in
+``agent.auxiliary_client``.
+
+Auxiliary callers (title generation, plugin structured completions) send an
+OpenAI ``response_format`` request field. Some providers reject the field, or
+its Anthropic translation, with a hard 400:
+
+  * vLLM gateways translate ``response_format: json_schema`` into
+    ``guided_grammar`` and fail when the grammar backend is absent
+    (``compile_grammar_error: No module named 'xgrammar'``, #82816).
+  * Some OpenAI-compatible endpoints answer
+    ``This response_format type is unavailable now`` (#82816).
+  * Anthropic-compatible gateways that predate structured outputs reject the
+    translated ``output_config`` field with
+    ``output_config: Extra inputs are not permitted`` (the documented case is
+    the ``bedrock-mantle`` Messages endpoint).
+
+Callers tolerate an unconstrained reply: the title prompt demands bare JSON
+and ``_extract_title_text`` has a loose-JSON fallback. The fix is reactive,
+like the temperature retry: when the provider rejects the structured-output
+field, retry once without it. These tests lock in that behaviour for both
+sync and async paths.
+"""
+
+from unittest.mock import patch, MagicMock, AsyncMock
+
+import pytest
+
+from agent.auxiliary_client import (
+    call_llm,
+    async_call_llm,
+    _is_structured_output_rejection,
+    _without_structured_output_format,
+)
+
+
+_TITLE_RESPONSE_FORMAT = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "session_title",
+        "strict": True,
+        "schema": {
+            "type": "object",
+            "properties": {"title": {"type": "string"}},
+            "required": ["title"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+
+class TestIsStructuredOutputRejection:
+    """The detector must match the phrasings providers actually return."""
+
+    @pytest.mark.parametrize("message", [
+        # vLLM guided_grammar / xgrammar (#82816, verbatim from the report)
+        (
+            "Error code: 400 - {'error': {'message': 'guided_grammar "
+            '\'{"additionalProperties":false}\' has compile_grammar_error: '
+            "No module named 'xgrammar'', 'type': 'invalid_request_error'}}"
+        ),
+        # Second endpoint from the same report
+        "HTTP 400: This response_format type is unavailable now",
+        # Strict Anthropic-wire gateways rejecting the raw OpenAI field
+        "HTTP 400: response_format: Extra inputs are not permitted",
+        # Gateways that predate output_config (bedrock-mantle documented case)
+        "HTTP 400: output_config: Extra inputs are not permitted",
+        # Generic unsupported-parameter phrasings for both field names
+        "Unsupported parameter: response_format",
+        "output_config is not supported",
+    ])
+    def test_matches_real_provider_messages(self, message):
+        assert _is_structured_output_rejection(RuntimeError(message)) is True
+
+    @pytest.mark.parametrize("message", [
+        # Unrelated 400s must NOT trigger a silent schema downgrade
+        "HTTP 400: Invalid value: 'tool'. Supported values are: 'assistant'",
+        "HTTP 400: Unsupported parameter: temperature",
+        "max_tokens is too large for this model",
+        "Rate limit exceeded",
+        "Connection reset by peer",
+        # Alternation errors that happen to mention messages
+        "messages: Extra inputs are not permitted",
+    ])
+    def test_does_not_match_unrelated_errors(self, message):
+        assert _is_structured_output_rejection(RuntimeError(message)) is False
+
+    def test_does_not_match_non_400_statuses(self):
+        exc = RuntimeError("output_config: Extra inputs are not permitted")
+        exc.status_code = 500
+        assert _is_structured_output_rejection(exc) is False
+
+
+class TestWithoutStructuredOutputFormat:
+    """The kwargs scrubber removes the field on both call shapes."""
+
+    def test_removes_extra_body_entry_and_keeps_siblings(self):
+        kwargs = {
+            "model": "m",
+            "extra_body": {
+                "response_format": dict(_TITLE_RESPONSE_FORMAT),
+                "metadata": {"user_id": "u1"},
+            },
+        }
+        result = _without_structured_output_format(kwargs)
+        assert result is not None
+        assert result["extra_body"] == {"metadata": {"user_id": "u1"}}
+        # The input dict is not mutated.
+        assert "response_format" in kwargs["extra_body"]
+
+    def test_drops_extra_body_entirely_when_it_becomes_empty(self):
+        kwargs = {
+            "model": "m",
+            "extra_body": {"response_format": dict(_TITLE_RESPONSE_FORMAT)},
+        }
+        result = _without_structured_output_format(kwargs)
+        assert result is not None
+        assert "extra_body" not in result
+
+    def test_removes_top_level_kwarg(self):
+        kwargs = {"model": "m", "response_format": dict(_TITLE_RESPONSE_FORMAT)}
+        result = _without_structured_output_format(kwargs)
+        assert result is not None
+        assert "response_format" not in result
+
+    def test_returns_none_when_nothing_to_remove(self):
+        assert _without_structured_output_format({"model": "m"}) is None
+        assert _without_structured_output_format(
+            {"model": "m", "extra_body": {"metadata": {}}}
+        ) is None
+
+
+def _dummy_response():
+    return {"ok": True}
+
+
+class TestCallLlmStructuredOutputRetry:
+    """``call_llm`` retries once without the field and returns on success."""
+
+    def _setup(self, first_exc):
+        client = MagicMock()
+        client.base_url = "https://api.openai.com/v1"
+        client.chat.completions.create.side_effect = [
+            first_exc, _dummy_response(),
+        ]
+        return client
+
+    @pytest.mark.parametrize("error_message", [
+        # vLLM guided_grammar (#82816)
+        "Error code: 400 - guided_grammar has compile_grammar_error: "
+        "No module named 'xgrammar'",
+        # Second endpoint flavor from the same report
+        "HTTP 400: This response_format type is unavailable now",
+        # Strict gateway that rejects the translated Anthropic field
+        "HTTP 400: output_config: Extra inputs are not permitted",
+    ])
+    def test_retries_once_without_response_format(self, error_message):
+        client = self._setup(RuntimeError(error_message))
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model",
+                  return_value=("openai-codex", "gpt-5.5", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client",
+                  return_value=(client, "gpt-5.5")),
+            patch("agent.auxiliary_client._validate_llm_response",
+                  side_effect=lambda resp, _task, **_kw: resp),
+        ):
+            result = call_llm(
+                task="title_generation",
+                messages=[{"role": "user", "content": "hi"}],
+                max_tokens=64,
+                extra_body={"response_format": dict(_TITLE_RESPONSE_FORMAT)},
+            )
+
+        assert result == {"ok": True}
+        assert client.chat.completions.create.call_count == 2
+        first_kwargs = client.chat.completions.create.call_args_list[0].kwargs
+        retry_kwargs = client.chat.completions.create.call_args_list[1].kwargs
+        first_eb = first_kwargs.get("extra_body") or {}
+        retry_eb = retry_kwargs.get("extra_body") or {}
+        assert "response_format" in first_eb
+        assert "response_format" not in retry_eb
+        assert "response_format" not in retry_kwargs
+        assert retry_kwargs["model"] == first_kwargs["model"]
+
+    def test_unrelated_400_does_not_strip_response_format(self):
+        """Unrelated 400s must not silently downgrade the schema contract."""
+        client = MagicMock()
+        client.base_url = "https://api.openai.com/v1"
+        client.chat.completions.create.side_effect = RuntimeError(
+            "HTTP 400: Invalid value: 'tool'. Supported values are: 'assistant'"
+        )
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model",
+                  return_value=("openai-codex", "gpt-5.5", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client",
+                  return_value=(client, "gpt-5.5")),
+            patch("agent.auxiliary_client._validate_llm_response",
+                  side_effect=lambda resp, _task, **_kw: resp),
+            patch("agent.auxiliary_client._try_payment_fallback",
+                  return_value=None),
+        ):
+            with pytest.raises(RuntimeError, match="Invalid value"):
+                call_llm(
+                    task="title_generation",
+                    messages=[{"role": "user", "content": "x"}],
+                    max_tokens=64,
+                    extra_body={
+                        "response_format": dict(_TITLE_RESPONSE_FORMAT),
+                    },
+                )
+        assert client.chat.completions.create.call_count == 1
+
+    def test_no_retry_when_no_response_format_was_sent(self):
+        """A rejection with no field in the request must not loop a retry."""
+        client = MagicMock()
+        client.base_url = "https://api.openai.com/v1"
+        client.chat.completions.create.side_effect = RuntimeError(
+            "HTTP 400: output_config: Extra inputs are not permitted"
+        )
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model",
+                  return_value=("openai-codex", "gpt-5.5", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client",
+                  return_value=(client, "gpt-5.5")),
+            patch("agent.auxiliary_client._validate_llm_response",
+                  side_effect=lambda resp, _task, **_kw: resp),
+            patch("agent.auxiliary_client._try_payment_fallback",
+                  return_value=None),
+        ):
+            with pytest.raises(RuntimeError):
+                call_llm(
+                    task="title_generation",
+                    messages=[{"role": "user", "content": "x"}],
+                    max_tokens=64,
+                )
+        assert client.chat.completions.create.call_count == 1
+
+
+class TestAsyncCallLlmStructuredOutputRetry:
+    """``async_call_llm`` mirror of the sync retry semantics."""
+
+    @pytest.mark.asyncio
+    async def test_async_retries_once_without_response_format(self):
+        client = MagicMock()
+        client.base_url = "https://api.openai.com/v1"
+        client.chat.completions.create = AsyncMock(side_effect=[
+            RuntimeError(
+                "Error code: 400 - guided_grammar has compile_grammar_error: "
+                "No module named 'xgrammar'"
+            ),
+            _dummy_response(),
+        ])
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model",
+                  return_value=("openai-codex", "gpt-5.5", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client",
+                  return_value=(client, "gpt-5.5")),
+            patch("agent.auxiliary_client._validate_llm_response",
+                  side_effect=lambda resp, _task, **_kw: resp),
+        ):
+            result = await async_call_llm(
+                task="title_generation",
+                messages=[{"role": "user", "content": "hi"}],
+                max_tokens=64,
+                extra_body={"response_format": dict(_TITLE_RESPONSE_FORMAT)},
+            )
+
+        assert result == {"ok": True}
+        assert client.chat.completions.create.await_count == 2
+        first_kwargs = client.chat.completions.create.call_args_list[0].kwargs
+        retry_kwargs = client.chat.completions.create.call_args_list[1].kwargs
+        assert "response_format" in (first_kwargs.get("extra_body") or {})
+        assert "response_format" not in (retry_kwargs.get("extra_body") or {})
+        assert "response_format" not in retry_kwargs
+
+    @pytest.mark.asyncio
+    async def test_async_unrelated_400_does_not_retry(self):
+        client = MagicMock()
+        client.base_url = "https://api.openai.com/v1"
+        client.chat.completions.create = AsyncMock(
+            side_effect=RuntimeError("HTTP 400: Invalid value: 'tool'"),
+        )
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model",
+                  return_value=("openai-codex", "gpt-5.5", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client",
+                  return_value=(client, "gpt-5.5")),
+            patch("agent.auxiliary_client._validate_llm_response",
+                  side_effect=lambda resp, _task, **_kw: resp),
+            patch("agent.auxiliary_client._try_payment_fallback",
+                  return_value=None),
+        ):
+            with pytest.raises(RuntimeError, match="Invalid value"):
+                await async_call_llm(
+                    task="title_generation",
+                    messages=[{"role": "user", "content": "x"}],
+                    max_tokens=64,
+                    extra_body={
+                        "response_format": dict(_TITLE_RESPONSE_FORMAT),
+                    },
+                )
+        assert client.chat.completions.create.await_count == 1


### PR DESCRIPTION
## What does this PR do?

Session auto-title generation fails on every call when the `title_generation` task resolves to an Anthropic-wire provider. `generate_title()` sends the OpenAI-only `response_format` field in `extra_body`. The Anthropic adapter forwarded the field verbatim into the Messages API body. Strict endpoints reject unknown body keys:

```
⚠ Auxiliary title generation failed: HTTP 400: response_format: Extra inputs are not permitted
```

The 400 is not retryable, so no fallback fires. Sessions keep their truncated derived titles forever. The failure is confirmed on Bedrock, native Anthropic, Anthropic OAuth, and Nous Portal routing (#85624). Plugin structured completions through `ctx.llm.complete_structured` fail the same way (#84948 report: 1,600+ logged errors).

This PR translates the field instead of stripping it, and adds a reactive retry for providers that reject structured output on any wire. Translation keeps the schema contract: `complete_structured()` callers still get schema-enforced JSON on Anthropic-wire providers. A strip would make those calls succeed while it silently breaks their guarantee.

Three commits:

1. **Translate `response_format` to `output_config.format`** (cherry-picked from #84948, author @Soju06). The OpenAI `json_schema` shape becomes the native Anthropic structured-output field. The `json_object` shape becomes a permissive object schema, because SDK 0.87.0 has no schema-less JSON mode. The translation merges into an existing `output_config`, so adaptive-thinking `effort` survives.
2. **Translate the top-level `response_format` kwarg too.** The adapter builds the Messages body from a fixed allow-list of kwargs. A caller that passes `response_format` as a top-level kwarg (the OpenAI SDK call shape) got it dropped on the floor: the request succeeded, but the schema contract silently became prompt compliance. The pin-test comes from the #85626 review follow-up (co-authored with @mmcclean-aws).
3. **Retry once without the field when a provider rejects it.** Gateways that predate structured outputs reject the translated field the same way they rejected the raw one. The documented case is the `bedrock-mantle` Messages endpoint ([AWS structured-output docs](https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html#structured-output-supported-apis)). On the OpenAI wire, vLLM gateways translate `response_format` into `guided_grammar` and fail when the grammar backend is absent (#82816). The new rung follows the existing `temperature` and `max_tokens` retry pattern: detect the rejection, retry once without the field, degrade to prompt compliance. Title generation tolerates this because `_extract_title_text` has a loose-JSON fallback scan.

### Verified against the live API

- The Nous Portal Anthropic route accepts `output_config.format` and returns schema-conforming JSON (`200 OK`, `{"title": "Fix Login Button on Mobile"}`).
- The shipped `generate_title()` on that route now returns real titles with no warning: `'Fix infinite recursion in Nix overlays'`.
- The pinned `anthropic` SDK (0.87.0) exposes `JSONOutputFormatParam` with required fields `type` and `schema` only. The shape has no `name` field, so the translation drops `name` correctly.

### Why translate, not strip

The competing PRs (#82307, #83963, #85626, #87987, #88271) strip the field on the Anthropic path. A strip fixes titles but downgrades every structured-output caller to prompt compliance, including `plugin_llm.complete_structured()`, whose contract is schema-conforming JSON. Translation preserves the contract where the endpoint supports it. The retry rung covers the endpoints that do not. Credit to @mmcclean-aws for the live parameter-isolation evidence on Bedrock in #85624, and to @Soju06 for the translation design and its tests.

## Related Issue

Closes #85624
Closes #82816
Closes #84948

Supersedes #82307, #83963, #85626, #87987 (Anthropic-path strip variants). #88271 targets the main-agent path in `anthropic_adapter.py` and stays independent.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`
  - `_translate_anthropic_response_format()`: converts the OpenAI `response_format` shape into Anthropic `output_config.format` (from #84948).
  - `_AnthropicCompletionsAdapter.create()`: translates both the `extra_body` form and the top-level kwarg form. When both are present, the `extra_body` form wins, because every in-tree caller uses it.
  - `_is_structured_output_rejection()`: detects provider 400s that reject `response_format`, `output_config`, or the vLLM `guided_grammar` translation.
  - `_without_structured_output_format()`: copies kwargs without the field, on both call shapes.
  - `call_llm()` / `async_call_llm()`: new retry rung after the temperature rung. If the provider rejects the structured-output field, retry once without it.
- `tests/agent/test_anthropic_structured_output.py`: translation tests (from #84948) plus the top-level kwarg pin-test and the precedence test.
- `tests/agent/test_structured_output_rejection_retry.py`: detector, scrubber, and retry tests for the sync and async paths, with the real 400 strings from #82816 and the Bedrock docs.

## How to Test

1. Configure `model.provider` to an Anthropic-wire provider (native `anthropic`, Bedrock, or `nous` with an `anthropic/` model). Leave `auxiliary.title_generation.provider` at the default `auto`.
2. Start a new session and send one message.
3. Before this PR: `agent.log` shows `Title generation failed: ... response_format: Extra inputs are not permitted` and the session title stays derived. After this PR: the session gets an LLM title and the log shows no warning.
4. Run the test suite: `scripts/run_tests.sh tests/agent/test_auxiliary_client.py tests/agent/test_anthropic_structured_output.py tests/agent/test_structured_output_rejection_retry.py tests/agent/test_unsupported_temperature_retry.py tests/agent/test_unsupported_parameter_retry.py tests/agent/test_plugin_llm.py tests/agent/test_auxiliary_client_anthropic_custom.py tests/agent/test_auxiliary_relay.py` → 278 passed, 0 failed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the test suite and all tests pass (via `scripts/run_tests.sh`, the CI-parity runner)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS (Linux), Python 3.12.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new helpers carry full docstrings; no user-facing docs change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure request-shaping logic, host-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before (every new session on an Anthropic-wire provider):

```
⚠ Auxiliary title generation failed: HTTP 400: response_format: Extra inputs are not permitted
WARNING agent.title_generator: Title generation failed: Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', 'message': 'response_format: Extra inputs are not permitted'}}
```

After (same config, live Nous Portal Anthropic route):

```
>>> generate_title("my nix build keeps failing with infinite recursion in overlays")
'Fix infinite recursion in Nix overlays'
```

Retry rung in action (provider without structured-output support, from the new tests):

```
INFO Auxiliary title_generation: provider rejected the structured-output format field; retrying once without it (schema enforcement degrades to prompt compliance): HTTP 400: output_config: Extra inputs are not permitted
```
