### PR TITLE
fix(kanban): expose max_retries in agent-facing create tool

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -416,6 +416,85 @@ def test_create_happy_path(worker_env):
         conn.close()
 
 
+def test_create_schema_exposes_optional_max_retries():
+    from tools import kanban_tools as kt
+
+    parameters = kt.KANBAN_CREATE_SCHEMA["parameters"]
+    max_retries = parameters["properties"]["max_retries"]
+    assert max_retries["type"] == "integer"
+    assert max_retries["minimum"] == 1
+    assert "max_retries" not in parameters["required"]
+
+
+def test_create_persists_max_retries(worker_env):
+    from tools import kanban_tools as kt
+
+    out = kt._handle_create({
+        "title": "bounded child",
+        "assignee": "peer",
+        "parents": [worker_env],
+        "max_retries": 3,
+    })
+    result = json.loads(out)
+    assert result["ok"] is True
+
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        child = kb.get_task(conn, result["task_id"])
+        assert child.max_retries == 3
+    finally:
+        conn.close()
+
+
+def test_create_omitted_max_retries_preserves_fallback(worker_env):
+    from tools import kanban_tools as kt
+
+    out = kt._handle_create({
+        "title": "fallback child",
+        "assignee": "peer",
+        "parents": [worker_env],
+    })
+    result = json.loads(out)
+    assert result["ok"] is True
+
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        child = kb.get_task(conn, result["task_id"])
+        assert child.max_retries is None
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize("value", [0, -1, "3", 1.5, True])
+def test_create_rejects_invalid_max_retries_without_row(worker_env, value):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        before = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+    finally:
+        conn.close()
+
+    out = kt._handle_create({
+        "title": "invalid child",
+        "assignee": "peer",
+        "parents": [worker_env],
+        "max_retries": value,
+    })
+    result = json.loads(out)
+    assert result["error"] == "max_retries must be an integer >= 1"
+
+    conn = kb.connect()
+    try:
+        after = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+    finally:
+        conn.close()
+    assert after == before
+
+
 def test_link_happy_path(worker_env):
     from hermes_cli import kanban_db as kb
     conn = kb.connect()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1396,6 +1396,14 @@ def _handle_create(args: dict, **kw) -> str:
         return tool_error(bool_error)
     idempotency_key = args.get("idempotency_key")
     max_runtime_seconds = args.get("max_runtime_seconds")
+    max_retries = args.get("max_retries")
+    if max_retries is not None:
+        if (
+            isinstance(max_retries, bool)
+            or not isinstance(max_retries, int)
+            or max_retries < 1
+        ):
+            return tool_error("max_retries must be an integer >= 1")
     initial_status = args.get("initial_status") or "running"
     skills = args.get("skills")
     if isinstance(skills, str):
@@ -1451,6 +1459,7 @@ def _handle_create(args: dict, **kw) -> str:
                     int(max_runtime_seconds)
                     if max_runtime_seconds is not None else None
                 ),
+                max_retries=max_retries,
                 skills=skills,
                 model_override=model_override,
                 provider_override=provider_override,
@@ -2235,6 +2244,17 @@ KANBAN_CREATE_SCHEMA = {
                     "Per-task runtime cap. When exceeded, the "
                     "dispatcher SIGTERMs the worker and re-queues the "
                     "task with outcome='timed_out'."
+                ),
+            },
+            "max_retries": {
+                "type": "integer",
+                "minimum": 1,
+                "description": (
+                    "Maximum consecutive failed attempts before the task "
+                    "sticks 'blocked' instead of auto-recovering. Overrides "
+                    "the board's 'kanban.failure_limit' for this task only. "
+                    "Optional; omitting it preserves the board's existing "
+                    "fallback."
                 ),
             },
             "initial_status": {


### PR DESCRIPTION
## Problem

`hermes kanban create --max-retries` (CLI) and `kanban_db.create_task(..., max_retries=...)` already support a per-task retry-limit override — it caps `consecutive_failures` before the task sticks `blocked` instead of auto-recovering, overriding the board's `kanban.failure_limit` for that task only.

The agent-facing `kanban_create` tool in `tools/kanban_tools.py` never exposed it: `KANBAN_CREATE_SCHEMA` didn't declare a `max_retries` property, and `_handle_create` never read `args.get("max_retries")` or forwarded it to `create_task`. An orchestrator worker fanning out child tasks via `kanban_create` therefore had no way to bound a child's retries, even though the DB layer and the human-operated CLI both already support it — an interface gap between the two task-creation entry points, not a behavior difference in the DB.

## Solution

- `KANBAN_CREATE_SCHEMA`: add an optional `max_retries` integer property (`minimum: 1`), documented next to `max_runtime_seconds`.
- `_handle_create`: read `args.get("max_retries")`, validate it (must be an `int` that isn't a `bool`, and `>= 1`) before any task row is created, then forward it to `kanban_db.create_task(..., max_retries=...)`.
- Invalid values return a `tool_error` (same shape as the tool's other validation errors) without touching the database.

## Compatibility

Omitting `max_retries` passes `None` through to `create_task`, exactly as before this change — the board's existing fallback chain (`max_retries` → `kanban.failure_limit` → `DEFAULT_FAILURE_LIMIT`) is unaffected for callers that don't set it.

## Scope

Two files only:
- `tools/kanban_tools.py`
- `tests/tools/test_kanban_tools.py`

## Tests

Added to `tests/tools/test_kanban_tools.py`:
- `test_create_schema_exposes_optional_max_retries` — schema shape (`type`, `minimum`, not in `required`).
- `test_create_persists_max_retries` — `max_retries=3` round-trips through `_handle_create` into the stored task.
- `test_create_omitted_max_retries_preserves_fallback` — omitting the arg leaves `max_retries` `NULL`, preserving current behavior.
- `test_create_rejects_invalid_max_retries_without_row` (parametrized `0, -1, "3", 1.5, True`) — each invalid value returns the tool error and creates zero rows.

## Validation

- `scripts/run_tests.sh tests/tools/test_kanban_tools.py -q` → 40/40 passed (36 pre-existing + 4 new).
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_blocked_sticky.py tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_dispatch_lock.py -q` → all passed (no regressions in adjacent kanban DB/CLI coverage).
- `ruff check tools/kanban_tools.py tests/tools/test_kanban_tools.py` → all checks passed.
- `git diff --check` → clean.
- `scripts/run_tests.sh tests/tools/` surfaced unrelated pre-existing failures (video/image generation, Daytona, Modal snapshot, web tools config) — reproduced identically on unmodified `main` via `git stash`, confirming they predate and are unaffected by this change.

## Risks and rollback

Low risk: the change is additive (one new optional schema field, one new `if` branch, one new keyword argument forwarded to an already-`Optional` parameter). No existing call path's default behavior changes. Revert is a straight `git revert` of this commit.