### PR TITLE
fix(desktop): persist backend skins so the selected skin survives relaunch

### DIFF
--- a/apps/desktop/src/themes/backend-sync.test.ts
+++ b/apps/desktop/src/themes/backend-sync.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $backendThemes, $pendingSkinApply, __resetBackendSkinSync, ingestBackendSkin } from './backend-sync'
 
@@ -105,5 +105,107 @@ describe('ingestBackendSkin', () => {
     ingestBackendSkin({ name: '' }, { apply: true })
 
     expect($pendingSkinApply.get()).toBeNull()
+  })
+})
+
+describe('backend skin persistence', () => {
+  beforeEach(() => __resetBackendSkinSync())
+
+  it('persists a backend skin to localStorage so it survives reload', () => {
+    ingestBackendSkin(skin('neon'), { apply: false })
+
+    // The memory store holds it AND localStorage got it, so at boot — before
+    // any gateway event lands — `$backendThemes` rehydrates from storage and
+    // `resolveTheme('neon')` succeeds.
+    expect($backendThemes.get().neon?.name).toBe('neon')
+    expect(window.localStorage.getItem('hermes-desktop-backend-skins-v1')).toContain('"neon"')
+  })
+
+  it('rehydrates the backend store from localStorage on a fresh module load', async () => {
+    // Simulate a prior session having persisted a skin: seed the storage key
+    // directly, then reload the module so the atom is re-constructed against
+    // that storage — exactly what happens on a real cold start.
+    const seeded = {
+      neon: {
+        name: 'neon',
+        label: 'Neon',
+        description: 'Hermes skin',
+        colors: { background: '#000000', foreground: '#ffffff', primary: '#ff33aa' },
+        darkColors: { background: '#000000', foreground: '#ffffff', primary: '#ff33aa' }
+      }
+    }
+
+    window.localStorage.setItem('hermes-desktop-backend-skins-v1', JSON.stringify(seeded))
+
+    vi.resetModules()
+    const fresh = await import('./backend-sync')
+
+    expect((fresh.$backendThemes.get().neon as unknown as { name?: string })?.name).toBe('neon')
+  })
+
+  it('drops unusable entries when rehydrating (corrupted / partial writes)', async () => {
+    // A malformed seed must never shadow a live skin or a user install.
+    const seeded = {
+      broken: { name: 'broken', label: 'Broken', colors: {} }, // missing required color keys
+      good: { name: 'good', label: 'Good', colors: { background: '#000', foreground: '#fff', primary: '#888' } }
+    }
+
+    window.localStorage.setItem('hermes-desktop-backend-skins-v1', JSON.stringify(seeded))
+
+    vi.resetModules()
+    const fresh = await import('./backend-sync')
+
+    expect(fresh.$backendThemes.get().broken).toBeUndefined()
+    expect((fresh.$backendThemes.get().good as unknown as { name?: string })?.name).toBe('good')
+  })
+
+  it('never rehydrates a built-in or default name from storage', async () => {
+    // Built-ins and `default` are never persisted, so a stale/foreign entry
+    // under those names must not come back either.
+    const seeded = {
+      default: { name: 'default', label: 'Default', colors: { background: '#000', foreground: '#fff', primary: '#888' } },
+      mono: { name: 'mono', label: 'Mono', colors: { background: '#000', foreground: '#fff', primary: '#888' } }
+    }
+
+    window.localStorage.setItem('hermes-desktop-backend-skins-v1', JSON.stringify(seeded))
+
+    vi.resetModules()
+    const fresh = await import('./backend-sync')
+
+    expect(fresh.$backendThemes.get().default).toBeUndefined()
+    expect(fresh.$backendThemes.get().mono).toBeUndefined()
+  })
+
+  it('never persists default or built-ins', () => {
+    ingestBackendSkin(skin('default'), { apply: true })
+    ingestBackendSkin(skin('mono'), { apply: true })
+
+    const raw = window.localStorage.getItem('hermes-desktop-backend-skins-v1') ?? ''
+    expect(raw).not.toContain('"default"')
+    expect(raw).not.toContain('"mono"')
+  })
+
+  it('does not rewrite storage when the skin is unchanged', () => {
+    ingestBackendSkin(skin('neon'), { apply: false })
+    const first = window.localStorage.getItem('hermes-desktop-backend-skins-v1')
+
+    // Same skin, same payload → no store change → no localStorage rewrite.
+    ingestBackendSkin(skin('neon'), { apply: true })
+
+    expect(window.localStorage.getItem('hermes-desktop-backend-skins-v1')).toBe(first)
+  })
+
+  it('rewrites storage when the skin palette changes (in-place recolor)', () => {
+    ingestBackendSkin(skin('neon'), { apply: false })
+    const first = window.localStorage.getItem('hermes-desktop-backend-skins-v1')
+
+    // A recolor of the same named skin changes the converted palette.
+    ingestBackendSkin({ ...skin('neon'), colors: { background: '#202040', ui_accent: '#ff33aa', banner_text: '#eeeeee' } }, {
+      apply: true
+    })
+
+    const second = window.localStorage.getItem('hermes-desktop-backend-skins-v1')
+    expect(second).not.toBe(first)
+    expect(second).toContain('"neon"')
   })
 })

--- a/apps/desktop/src/themes/backend-sync.ts
+++ b/apps/desktop/src/themes/backend-sync.ts
@@ -23,8 +23,82 @@ import { BUILTIN_THEMES } from './presets'
 import { skinToDesktopTheme } from './skin'
 import type { DesktopTheme } from './types'
 
+// Backend skins persist to localStorage so they resolve at boot, when the
+// in-memory backend store is still empty. Keyed by skin name → converted
+// DesktopTheme. This is a BOOT SEED only: at runtime `$backendThemes` is the
+// live source of truth and wins over the seed (same key, same object).
+const BACKEND_SKINS_KEY = 'hermes-desktop-backend-skins-v1'
+
+function readPersistedBackendSkins(): Record<string, DesktopTheme> {
+  try {
+    const raw = window.localStorage.getItem(BACKEND_SKINS_KEY)
+
+    if (!raw) {
+      return {}
+    }
+
+    const parsed: unknown = JSON.parse(raw)
+
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {}
+    }
+
+    const out: Record<string, DesktopTheme> = {}
+
+    for (const [name, value] of Object.entries(parsed)) {
+      // Built-ins and `default` are never persisted, so a stale/foreign entry
+      // under those names must not be rehydrated either — the built-in
+      // palette (or the desktop's own default) always wins.
+      if (name === 'default' || BUILTIN_THEMES[name]) {
+        continue
+      }
+
+      if (isUsableBackendTheme(value)) {
+        out[name] = value
+      }
+    }
+
+    return out
+  } catch {
+    return {}
+  }
+}
+
+function persistBackendSkins(record: Record<string, DesktopTheme>): void {
+  try {
+    window.localStorage.setItem(BACKEND_SKINS_KEY, JSON.stringify(record))
+  } catch {
+    // Best-effort: a restricted storage context shouldn't break theming.
+  }
+}
+
+/**
+ * A persisted entry is only worth rehydrating if it can actually paint:
+ * the same minimal bar `applyTheme` tolerates — name/label present plus the
+ * three load-bearing color slots. Anything else (corrupted read, partial
+ * write, stored from an incompatible future shape) is dropped so a stale
+ * seed can never shadow a live skin or a user install.
+ */
+function isUsableBackendTheme(value: unknown): value is DesktopTheme {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const theme = value as Partial<DesktopTheme>
+  const colors = theme.colors as unknown as Record<string, unknown> | undefined
+
+  return (
+    typeof theme.name === 'string' &&
+    typeof theme.label === 'string' &&
+    !!colors &&
+    ['background', 'foreground', 'primary'].every(key => typeof colors[key] === 'string')
+  )
+}
+
 /** Skins pushed by the backend, keyed by name. Merged by `listAllThemes`. */
-export const $backendThemes = atom<Record<string, DesktopTheme>>({})
+export const $backendThemes = atom<Record<string, DesktopTheme>>(
+  typeof window === 'undefined' ? {} : readPersistedBackendSkins()
+)
 
 /** One-shot skin name the ThemeProvider should switch to (it clears this). */
 export const $pendingSkinApply = atom<string | null>(null)
@@ -42,6 +116,12 @@ export function __resetBackendSkinSync(): void {
   lastSynced = null
   $backendThemes.set({})
   $pendingSkinApply.set(null)
+
+  try {
+    window.localStorage.removeItem(BACKEND_SKINS_KEY)
+  } catch {
+    // best-effort
+  }
 }
 
 /**
@@ -74,6 +154,11 @@ export function ingestBackendSkin(skin: HermesSkin | undefined | null, { apply }
 
     if (JSON.stringify(current[name]) !== JSON.stringify(theme)) {
       $backendThemes.set({ ...current, [name]: theme })
+
+      // Persist only on an actual change so the skin resolves at boot, when
+      // the in-memory backend store is still empty. The live store stays the
+      // runtime source of truth; the seed is just the pre-warm for cold start.
+      persistBackendSkins($backendThemes.get())
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes a persistence bug in the desktop app where a **backend-authored skin** (a
`$HERMES_HOME/skins/*.yaml` file resolved and pushed by the backend) reverts to
the default theme on every app relaunch.

Backend skins were registered only in the in-memory `$backendThemes` store via
`ingestBackendSkin`, and that store is empty until the first `gateway.ready` /
`skin.changed` event arrives. So a user who selected such a skin had its name
written to `hermes-desktop-theme-v2`, but on the next launch `resolveTheme(name)`
found nothing (memory store empty, no user-installed copy) and the pick silently
reset to the default `nous` theme.

## Motivation

`display.skin: <name>` in `config.yaml` + a matching `skins/<name>.yaml` is the
supported way to theme every surface from one file. On the CLI/TUI it repaints
live; on the desktop it only repainted for the current session and then fell
back to the default on every relaunch — the selection could never stick, whether
made via `/skin` or the Appearance picker, because the palette itself was never
available at boot.

## What changed

`apps/desktop/src/themes/backend-sync.ts`:

- Persist each converted backend skin to a dedicated localStorage key
  (`hermes-desktop-backend-skins-v1`) as a **boot seed**, beside the atom that
  owns the store. The in-memory `$backendThemes` remains the runtime source of
  truth; the seed only pre-warms cold start.
- Rehydrate `$backendThemes` synchronously at module load (SSR-safe:
  `typeof window === 'undefined' ? {} : readPersistedBackendSkins()`), so a
  selected backend skin resolves at boot before any gateway event lands.
- Validate rehydrated entries (`name`/`label` plus `background`/`foreground`/
  `primary`) and drop anything that cannot paint — plus skip `default` and any
  built-in name — so a corrupted, partial, or stale foreign write can never
  shadow a live skin, a user-installed theme, or the built-in palette.
- Only write storage on an actual name/palette change — no rewrite on repeat
  events, no snap-back after a manual desktop switch (the existing
  `lastSynced` apply guard is untouched).

## Validation

- `npx vitest run src/themes/` → **73 tests pass** (8 files), including new
  coverage for: real rehydration via `vi.resetModules()`, corrupted-entry drop,
  built-in/default rehydration rejection, write-on-change vs. recolor-write,
  and no persistence for `default`/built-ins.
- `tsc -p tsconfig.json --noEmit` → clean.
- `eslint src/themes/backend-sync.ts src/themes/backend-sync.test.ts` → clean
  (0 errors, 0 warnings).

## Checklist

- [x] Persistence lives beside the atom that owns the store (TypeScript style)
- [x] Boot rehydration is SSR-safe and validated (corrupted / built-in /
      default entries dropped)
- [x] Runtime store remains the single source of truth — seed never shadows
      a live skin or a user install (user store > backend store precedence)
- [x] Existing apply-guard semantics (`lastSynced`, connect-time seed without
      painting) unchanged
- [x] Tests cover the new persistence and rehydration paths, not just the
      pre-existing apply logic
- [x] English PR body; conventional `fix(desktop):` commit
