### PR TITLE
fix(browser): harden sealed local Browser Use resolution

### DIFF
--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -26,6 +26,7 @@ def _clean_env(monkeypatch):
     monkeypatch.delenv("BU_NAME", raising=False)
     monkeypatch.delenv("BU_AUTOSPAWN", raising=False)
     monkeypatch.delenv("BROWSER_USE_API_KEY", raising=False)
+    monkeypatch.delenv("HERMES_DISABLE_LAZY_INSTALLS", raising=False)
     yield
 
 
@@ -196,6 +197,26 @@ class TestFindCli:
         )
         assert bu_cli._find_cli_unpatched() == ["/usr/local/bin/uvx", "browser-use"]
 
+    def test_sealed_runtime_does_not_treat_uvx_as_installed_cli(self, monkeypatch):
+        monkeypatch.setenv("HERMES_DISABLE_LAZY_INSTALLS", "1")
+        monkeypatch.setattr(
+            bu_cli.shutil,
+            "which",
+            lambda name, path=None: "/usr/local/bin/uvx" if name == "uvx" else None,
+        )
+        assert bu_cli._find_cli_unpatched() is None
+
+    def test_sealed_runtime_still_uses_direct_cli(self, monkeypatch):
+        monkeypatch.setenv("HERMES_DISABLE_LAZY_INSTALLS", "1")
+        monkeypatch.setattr(
+            bu_cli.shutil,
+            "which",
+            lambda name, path=None: "/opt/hermes/bin/browser-use"
+            if name == "browser-use"
+            else None,
+        )
+        assert bu_cli._find_cli_unpatched() == ["/opt/hermes/bin/browser-use"]
+
     def test_none_when_neither_available(self, monkeypatch):
         monkeypatch.setattr(bu_cli.shutil, "which", lambda name, path=None: None)
         assert bu_cli._find_cli_unpatched() is None
@@ -301,6 +322,23 @@ class TestLegacyCloudMigration:
         monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
         result = json.loads(bu_cli.browser_exec("print(1)"))
         assert "autospawn:1" in result["output"]
+
+    def test_resolved_cdp_suppresses_legacy_cloud_autospawn(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", lambda: self._LEGACY)
+        monkeypatch.setenv("BROWSER_USE_API_KEY", "bu-key")
+        cli = _fake_cli(
+            tmp_path,
+            'cat > /dev/null\necho "autospawn:[$BU_AUTOSPAWN] cdp:$BU_CDP_URL"\n',
+        )
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
+
+        def resolve_local_cdp(env, task_id, session_name=""):
+            env["BU_CDP_URL"] = "http://127.0.0.1:9222"
+
+        monkeypatch.setattr(bu_cli, "_resolve_backend_cdp", resolve_local_cdp)
+        result = json.loads(bu_cli.browser_exec("print(1)"))
+        assert "autospawn:[]" in result["output"]
+        assert "cdp:http://127.0.0.1:9222" in result["output"]
 
     def test_explicit_backend_does_not_set_bu_autospawn(self, tmp_path, monkeypatch):
         monkeypatch.setattr(

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -296,6 +296,14 @@ def _find_cli() -> Optional[List[str]]:
             direct = shutil.which("browser-use", path=probe_path)
             if direct:
                 return [direct]
+    # Sealed images must never turn a missing image dependency into an
+    # implicit uvx resolve/download at request time. A direct image-owned or
+    # user-installed binary remains valid; only the zero-install fallback is
+    # disabled. This keeps immutable runtimes deterministic and avoids
+    # misleading "available" detection when uvx itself exists but the tool
+    # is absent from its cache.
+    if is_truthy_value(os.getenv("HERMES_DISABLE_LAZY_INSTALLS"), default=False):
+        return None
     for probe_path in probe_paths:
         if probe_path is None or probe_path:
             uvx = shutil.which("uvx", path=probe_path)
@@ -606,7 +614,11 @@ def browser_exec(
 
     # BU_AUTOSPAWN makes the CLI start a Browser Use cloud browser when no
     # local Chrome/CDP endpoint is reachable (their API key authenticates it)
-    if "BU_AUTOSPAWN" not in env and is_legacy_browser_use_cloud_config(_read_browser_cfg()):
+    if (
+        "BU_AUTOSPAWN" not in env
+        and not (env.get("BU_CDP_URL") or env.get("BU_CDP_WS"))
+        and is_legacy_browser_use_cloud_config(_read_browser_cfg())
+    ):
         env["BU_AUTOSPAWN"] = "1"
 
     try:


### PR DESCRIPTION
## Summary
- do not report Browser Use as available via `uvx` when runtime lazy installs are disabled
- continue to prefer an image-owned or user-installed direct CLI
- suppress legacy Browser Use cloud autospawn when a local/explicit CDP endpoint has already resolved

## Why
Immutable Hermes images may bundle `uvx` without caching `browser-use`. Discovery then selects Browser Use mode, performs a runtime resolve/download, and may fall through to paid cloud autospawn even when an image-bundled local Chromium endpoint exists.

## Tests
- `tests/tools/test_browser_use_cli.py`: 95 passed
- adds sealed-runtime direct/uvx resolution coverage and resolved-CDP autospawn coverage