### PR TITLE
feat(video_gen/xai): allow 1080p for Grok Imagine text/image-to-video

### DIFF
--- a/plugins/video_gen/xai/__init__.py
+++ b/plugins/video_gen/xai/__init__.py
@@ -54,7 +54,7 @@ DEFAULT_POLL_INTERVAL_SECONDS = 5
 DEFAULT_EXTEND_DURATION = 6
 
 VALID_ASPECT_RATIOS = {"1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3"}
-VALID_RESOLUTIONS = {"480p", "720p"}
+VALID_RESOLUTIONS = {"480p", "720p", "1080p"}
 MAX_REFERENCE_IMAGES = 7
 
 
@@ -612,6 +612,9 @@ async def _generate_xai_video_async(
         normalized_aspect_ratio = DEFAULT_ASPECT_RATIO
     if normalized_resolution not in VALID_RESOLUTIONS:
         normalized_resolution = DEFAULT_RESOLUTION
+    # xAI caps reference-to-video at 720p regardless of the requested value.
+    if refs and normalized_resolution == "1080p":
+        normalized_resolution = "720p"
 
     modality_used = "reference" if refs else ("image" if image_input else "text")
     resolved_model = _resolve_model_for_modality(

--- a/tests/plugins/video_gen/test_xai_plugin_integration.py
+++ b/tests/plugins/video_gen/test_xai_plugin_integration.py
@@ -180,3 +180,51 @@ class TestXAIClamping:
         provider, captured = xai_provider
         provider.generate("x", aspect_ratio="21:9")
         assert _last_post(captured)["json"]["aspect_ratio"] == "16:9"
+
+
+class TestXAIResolution:
+    """1080p is model-gated on xAI: 1.5 supports it, reference-to-video does not."""
+
+    def test_1080p_passes_through_for_image_to_video(self, xai_provider):
+        provider, captured = xai_provider
+        provider.generate(
+            "animate this",
+            image_url="https://example.com/cat.png",
+            resolution="1080p",
+        )
+        payload = _last_post(captured)["json"]
+        assert payload["model"] == "grok-imagine-video-1.5"
+        assert payload["resolution"] == "1080p"
+
+    def test_1080p_passes_through_for_explicit_1_5_text_to_video(self, xai_provider):
+        provider, captured = xai_provider
+        provider.generate(
+            "a sunlit meadow",
+            model="grok-imagine-video-1.5",
+            _model_override_explicit=True,
+            resolution="1080p",
+        )
+        payload = _last_post(captured)["json"]
+        assert payload["model"] == "grok-imagine-video-1.5"
+        assert payload["resolution"] == "1080p"
+
+    def test_1080p_clamped_to_720p_for_reference_to_video(self, xai_provider):
+        """xAI caps reference-to-video at 720p; asking for 1080p must not leak out."""
+        provider, captured = xai_provider
+        provider.generate(
+            "keep this character",
+            reference_image_urls=["https://example.com/a.png"],
+            resolution="1080p",
+        )
+        payload = _last_post(captured)["json"]
+        assert payload["resolution"] == "720p"
+
+    def test_unknown_resolution_still_falls_back_to_default(self, xai_provider):
+        provider, captured = xai_provider
+        provider.generate("a dog on a skateboard", resolution="4k")
+        payload = _last_post(captured)["json"]
+        assert payload["resolution"] == "720p"
+
+    def test_capabilities_advertise_1080p(self, xai_provider):
+        provider, _ = xai_provider
+        assert "1080p" in provider.capabilities()["resolutions"]


### PR DESCRIPTION
## What does this PR do?

Allows Grok Imagine to generate 1080p video through the xAI video plugin. xAI's [video generation docs](https://docs.x.ai/developers/model-capabilities/video/generation) list `1080p` for `grok-imagine-video-1.5` on text-to-video and image-to-video, but the plugin allow-lists only `480p`/`720p` and silently rewrites anything else to the `720p` default — so requests for Full HD were downgraded before ever leaving the process.

This adds `1080p` to `VALID_RESOLUTIONS` and soft-clamps reference-to-video back to `720p`, since xAI caps that mode regardless of the requested value. The clamp mirrors the file's existing soft-clamp idiom for invalid aspect ratios rather than introducing a new error path.

Scope notes:
- **edit/extend untouched** — those take no custom resolution and follow the input video, capped at 720p per xAI's docs.
- **`DEFAULT_RESOLUTION` stays `720p`** — callers that don't ask for 1080p are unaffected.
- **Tool description updates for free** — `capabilities()` reports `sorted(VALID_RESOLUTIONS)`, which is what builds the `resolution choices:` line in the `video_generate` description, so agents stop being told 720p is the ceiling (issue's item 4).
- The default text-to-video path still routes to legacy `grok-imagine-video` via `_resolve_model_for_modality`; reaching 1080p t2v today requires an explicit `model=grok-imagine-video-1.5`. The routing (and its now-stale "1.5 rejects text-only" rationale — verified no longer true on a live deployment) is a separate concern left for a follow-up so this PR stays minimal.

## Related Issue

Fixes #89549

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/video_gen/xai/__init__.py` — add `1080p` to `VALID_RESOLUTIONS`; clamp reference-to-video 1080p requests to `720p` (xAI API constraint, hence the literal rather than `DEFAULT_RESOLUTION`)
- `tests/plugins/video_gen/test_xai_plugin_integration.py` — new `TestXAIResolution` class: 1080p passes through for image-to-video and explicit-1.5 text-to-video, reference-to-video clamps to 720p, unknown values still fall back to the default, and `capabilities()` advertises 1080p

## How to Test

1. `pytest tests/plugins/video_gen/ tests/agent/test_video_gen_registry.py -q`
2. Mutation check: revert the `plugins/video_gen/xai/__init__.py` hunks and re-run — exactly the 3 tests asserting the new behavior fail; the 2 regression guards still pass.
3. Live proof: applied this same change to a running Hermes deployment (Docker, `hvps-hermes-agent` image), restarted, and a `video_generate` call with `model=grok-imagine-video-1.5`, `resolution=1080p` returned a genuine 1920×1080 file where it previously came back 1280×720.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — the touched area is fully green (`tests/plugins/video_gen/` + `tests/agent/test_video_gen_registry.py`, 22/22, and the 3 new behavior tests fail without the source change). A full local run of the 35,199-test suite was OOM-killed at ~79% on my machine before the summary, so I can't personally attest a complete green run — deferring full-suite verification to this PR's CI, which splits the suite into lanes for exactly this reason
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5 (tests) + Ubuntu 24.04 Docker deployment (live 1080p generation)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no docs reference the resolution list
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python set/string change, no platform surface
- [x] I've updated tool descriptions/schemas if I changed tool behavior — the `video_generate` description derives from `capabilities()`, which picks up the new value automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)
