### PR TITLE
fix(desktop): route link/artifact-click preview opens through loopback reach

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/preview-row.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/preview-row.test.tsx
@@ -112,6 +112,48 @@ describe('PreviewStatusRow', () => {
     expect($previewTabs.get()).toEqual([])
   })
 
+  // A localhost URL detected in tool/terminal output (the artifact this row
+  // exists for) names the GATEWAY's loopback on a remote connection, not this
+  // machine's — ⌘/Ctrl-click into the in-app pane must get the same reach
+  // resolution the address bar and the agent's own preview.open tool call
+  // already get.
+  it('resolves a detected localhost artifact through loopback reach before opening it in-app', async () => {
+    const target = 'http://localhost:5173/'
+    const reachPreviewUrl = vi.fn(async () => 'http://127.0.0.1:45173/')
+
+    $connection.set({ mode: 'remote' } as never)
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: {
+        normalizePreviewTarget: vi.fn(async () => ({
+          kind: 'url',
+          label: 'localhost:5173',
+          source: target,
+          url: target
+        })),
+        reachPreviewUrl
+      }
+    })
+
+    render(
+      <PreviewStatusRow
+        item={{ cwd: '/home/agent', id: target, label: 'localhost:5173', target }}
+        onDismiss={() => undefined}
+      />
+    )
+
+    fireEvent.click(screen.getByText('localhost:5173'), { ctrlKey: true })
+
+    await waitFor(() => expect(reachPreviewUrl).toHaveBeenCalledWith(target))
+    await waitFor(() => {
+      expect($previewTabs.get()).toEqual([
+        expect.objectContaining({
+          target: expect.objectContaining({ kind: 'url', source: target, url: 'http://127.0.0.1:45173/' })
+        })
+      ])
+    })
+  })
+
   it('keeps remote HTML on the staged browser-open path, not the in-app pane', async () => {
     const remotePath = '/home/agent/index.html'
     const html = '<!doctype html><html><body>hi</body></html>'

--- a/apps/desktop/src/app/chat/composer/status-stack/preview-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/preview-row.tsx
@@ -8,6 +8,7 @@ import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
 import { isDesktopFsRemoteMode } from '@/lib/desktop-fs'
 import { normalizeOrLocalPreviewTarget, openPreviewTargetInBrowser } from '@/lib/local-preview'
+import { reachablePreviewUrl } from '@/lib/preview-reach'
 import { cn } from '@/lib/utils'
 import { notifyError } from '@/store/notifications'
 import { $previewTabSources, closePreviewForSource, openPreview } from '@/store/preview'
@@ -50,7 +51,15 @@ export const PreviewStatusRow = memo(function PreviewStatusRow({ item, onDismiss
     setOpening(true)
 
     try {
-      openPreview(await resolveTarget(), 'tool-result')
+      const target = await resolveTarget()
+      // Same loopback-reach resolution the address bar and the agent's own
+      // preview.open tool call already get: a localhost URL detected here
+      // from tool/terminal output (the artifact this row exists for) names
+      // the GATEWAY's loopback on a remote connection, not this machine's.
+      const reached =
+        target.kind === 'url' ? { ...target, url: await reachablePreviewUrl(target.url) } : target
+
+      openPreview(reached, 'tool-result')
     } catch (error) {
       notifyError(error, t.preview.unavailable)
     } finally {

--- a/apps/desktop/src/lib/external-link.test.tsx
+++ b/apps/desktop/src/lib/external-link.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { IS_MAC } from '@/lib/keybinds/combo'
 import { $previewTabs, closeRightRail } from '@/store/preview'
+import { $connection } from '@/store/session'
 
 import {
   __resetLinkTitleCache,
@@ -41,6 +42,7 @@ afterEach(() => {
   closeRightRail()
   vi.restoreAllMocks()
   cleanup()
+  $connection.set(null)
 
   if (initialHermesDesktop) {
     desktopWindow.hermesDesktop = initialHermesDesktop
@@ -118,6 +120,27 @@ describe('external link helpers', () => {
 
     expect(openExternal).not.toHaveBeenCalled()
     await waitFor(() => expect($previewTabs.get().at(-1)?.target.url).toBe('https://example.com/path/to/resource'))
+  })
+
+  // A localhost link an agent surfaced (chat text, a linkified terminal URL)
+  // names the GATEWAY's loopback on a remote connection, not this machine's —
+  // clicking it must get the same reach resolution the address bar and the
+  // agent's own preview.open tool call already get.
+  it('resolves a clicked localhost link through loopback reach on a remote gateway', async () => {
+    const reachPreviewUrl = vi.fn(async () => 'http://127.0.0.1:45173/')
+
+    $connection.set({ mode: 'remote' } as never)
+    installDesktopBridge({ reachPreviewUrl: reachPreviewUrl as unknown as Window['hermesDesktop']['reachPreviewUrl'] })
+
+    render(<ExternalLink href="http://localhost:5173/">Dev server</ExternalLink>)
+
+    fireEvent.click(screen.getByRole('link', { name: 'Dev server' }))
+
+    await waitFor(() => expect(reachPreviewUrl).toHaveBeenCalledWith('http://localhost:5173/'))
+    await waitFor(() => expect($previewTabs.get().at(-1)?.target.url).toBe('http://127.0.0.1:45173/'))
+    // The user still sees the address the link actually said, even though the
+    // pane loads the rewritten one.
+    expect($previewTabs.get().at(-1)?.target.source).toBe('http://localhost:5173/')
   })
 
   // Platform-specific on purpose (same rule as terminal links / middle-click):

--- a/apps/desktop/src/lib/external-link.tsx
+++ b/apps/desktop/src/lib/external-link.tsx
@@ -239,8 +239,19 @@ export function openLink(href: string, options: { native?: boolean } = {}): void
   // pulls the layout/session graph behind it. A static edge would make one
   // link helper drag that whole tree into anything that renders a link. The
   // tab lands a microtask later, which is invisible.
-  void import('@/store/preview').then(({ openPreview }) =>
-    openPreview({ kind: 'url', label: hostPathLabel(target), source: target, url: target }, 'explicit-link')
+  void Promise.all([import('@/store/preview'), import('@/lib/preview-reach')]).then(
+    async ([{ openPreview }, { reachablePreviewUrl }]) => {
+      // On a remote gateway, a localhost link the agent surfaced (chat text,
+      // a linkified terminal URL) names the GATEWAY's loopback, not this
+      // machine's — give it the same loopback-reach resolution the address
+      // bar and the agent's own preview.open tool call already get, or it
+      // silently fails to load (or loads whatever happens to be listening on
+      // that port locally instead). `source`/`label` stay the original
+      // address so the user still sees what the link actually said.
+      const url = await reachablePreviewUrl(target)
+
+      openPreview({ kind: 'url', label: hostPathLabel(target), source: target, url }, 'explicit-link')
+    }
   )
 }
 


### PR DESCRIPTION
## Summary

The in-app browser's loopback-reach resolution (`reachablePreviewUrl()`, which asks main to forward a remote gateway's loopback through the SSH transport before the pane loads it) is wired into two of the feature's entry points: the address bar (`preview-pane.tsx`'s `navigateTo`) and the agent's own `preview.open` tool call (`use-preview-routing.ts`).

Two more real, user-reachable entry points construct a `kind: 'url'` `PreviewTarget` and hand it to `openPreview()` directly, skipping reach resolution entirely:

- **`lib/external-link.tsx`'s `openLink()`** — the shared chokepoint behind `ExternalLink`/`PrettyLink`/`LinkifiedText` (any `http(s)` link auto-linkified out of assistant text), the `@url:` directive chip, and in-app terminal hyperlinks.
- **`composer/status-stack/preview-row.tsx`'s `togglePreview()`** — the Ctrl/Cmd-click handler on a detected-artifact status row (a localhost URL an agent's dev server just printed to chat or terminal output).

On a remote gateway, clicking a localhost link an agent surfaced through either path — the feature's own motivating use case — loads an address on THIS machine instead of the gateway's: it either fails to connect, or, if something else happens to be listening on that port locally, silently loads unrelated content with no error at all. Meanwhile the exact same URL, typed into the address bar or opened via the agent's tool call, is correctly loopback-forwarded and works.

## Fix

Route both through `reachablePreviewUrl()` before constructing the `PreviewTarget`, keeping `label`/`source` as the original address (matching the existing pattern in `use-preview-routing.ts`) so the user still sees what the link/artifact actually said, even though the pane loads the resolved one.

## Testing

- Regression tests added to both files' existing suites, mirroring the established `$connection`/`hermesDesktop`-bridge mocking pattern already used in `preview-reach.test.ts` and `preview-row.test.tsx`'s other remote-mode cases.
- **Mutation-verified**: reverted both production changes, confirmed both new tests fail (`reachPreviewUrl` never called), restored and confirmed green.
- 64/64 tests pass across the five related suites (`external-link`, `preview-row`, preview store, `local-preview`, `preview-reach`).
- `tsc --noEmit` clean.

## Competitor check

Fresh search right before opening: no open PR or issue touches `openLink`/`togglePreview`/`reachablePreviewUrl`.