### PR TITLE
fix(plugins): fail closed on non-interactive tool-override consent

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1666,6 +1666,21 @@ def _resolve_tool_override_grant(
             "everything the agent routes through that tool.\n"
             "  Grant it? [y/N] "
         )
+        if not (sys.stdin.isatty() and sys.stdout.isatty()):
+            # Redirected stdout swallows the prompt while stdin still waits
+            # on an answer the operator never saw — an indistinguishable
+            # deadlock for wrapper scripts / CI steps. Fail closed with the
+            # docstring's promised deny-on-non-interactive (never
+            # implemented) instead, same guard as the capability-consent
+            # prompt above (#89600).
+            console.print(
+                "[yellow]Non-interactive session: tool-override grant "
+                "denied (fail closed).[/yellow] Re-run "
+                f"`hermes plugins enable {key} --allow-tool-override` "
+                "to grant this later."
+            )
+            _set_plugin_entry_flag(key, "allow_tool_override", False)
+            return
         try:
             answer = console.input(prompt).strip().lower()
         except (EOFError, KeyboardInterrupt):

--- a/tests/hermes_cli/test_plugin_capabilities.py
+++ b/tests/hermes_cli/test_plugin_capabilities.py
@@ -432,3 +432,63 @@ class TestConsentFlow:
         )
         assert granted is True
         console.input.assert_not_called()
+
+
+class TestToolOverrideGrantNonInteractive:
+    """The tool-override consent prompt must fail closed on non-interactive
+    stdio (#89600): with stdout redirected (pipe/CI/wrapper script) the
+    prompt text is swallowed while stdin still blocks on an answer the
+    operator never saw — an indistinguishable deadlock. The docstring
+    always promised deny-on-non-interactive; the body never implemented
+    it."""
+
+    def _console(self):
+        console = MagicMock()
+        console.input.side_effect = AssertionError(
+            "must not prompt on non-interactive stdio"
+        )
+        return console
+
+    def test_non_interactive_denies_without_prompting(self, hermes_home):
+        from hermes_cli.plugins_cmd import _resolve_tool_override_grant
+
+        console = self._console()
+        with patch("sys.stdin") as stdin, patch("sys.stdout") as stdout:
+            stdin.isatty.return_value = False
+            stdout.isatty.return_value = True
+            _resolve_tool_override_grant(console, "ovplug", None)
+
+        console.input.assert_not_called()
+        from hermes_cli.config import load_config
+
+        entry = (load_config().get("plugins") or {}).get("entries", {}).get("ovplug", {})
+        assert entry.get("allow_tool_override") is False
+
+    def test_redirected_stdout_alone_denies(self, hermes_home):
+        """stdin is a tty (PowerShell wrapper case) but stdout is piped —
+        the prompt was invisible, so prompting can never be answered."""
+        from hermes_cli.plugins_cmd import _resolve_tool_override_grant
+
+        console = self._console()
+        with patch("sys.stdin") as stdin, patch("sys.stdout") as stdout:
+            stdin.isatty.return_value = True
+            stdout.isatty.return_value = False
+            _resolve_tool_override_grant(console, "ovplug", None)
+
+        console.input.assert_not_called()
+
+    def test_explicit_flag_never_prompts(self, hermes_home):
+        """--allow-tool-override / --no-tool-override bypass consent."""
+        from hermes_cli.plugins_cmd import _resolve_tool_override_grant
+
+        console = self._console()
+        with patch("sys.stdin") as stdin, patch("sys.stdout") as stdout:
+            stdin.isatty.return_value = False
+            stdout.isatty.return_value = False
+            _resolve_tool_override_grant(console, "ovplug", True)
+
+        console.input.assert_not_called()
+        from hermes_cli.config import load_config
+
+        entry = (load_config().get("plugins") or {}).get("entries", {}).get("ovplug", {})
+        assert entry.get("allow_tool_override") is True


### PR DESCRIPTION
## What does this PR do?

`hermes plugins enable <name>` blocked **forever** when its stdout was redirected (a pipe, a file, `| Out-Null`, a CI step, any wrapper script). `_resolve_tool_override_grant()` called `console.input()` with no interactivity guard: redirected stdout swallowed the prompt text while stdin stayed attached to the console, so the process waited on a question the operator never saw — no output, 0% CPU, indistinguishable from a deadlock, with no timeout. The narrow-but-common trigger is a **capability-less non-bundled plugin** (one that declares no `capabilities:` in its `plugin.yaml`), because `cmd_enable()` returns early after the capability-consent flow for plugins that do declare them — and by that point the plugin was already added to `plugins.enabled`, so the enable "worked" while the command never returned (#89600; the reporter lost ~25 minutes of a silently wedged update script).

The function's own docstring always promised the correct behavior — *"None prompts interactively (defaulting to deny on a non-interactive stdin)"* — but nothing in the body implemented the deny. This PR adds the same `sys.stdin.isatty() and sys.stdout.isatty()` guard the sibling capability-consent prompt already use:

- Non-interactive stdin **or** redirected stdout → deny the grant, **persist the explicit decline** (`allow_tool_override: false`), and print how to grant it later via `--allow-tool-override`.
- Interactive stdio → the prompt works exactly as before (default-deny on a blind Enter preserved).
- Explicit `--allow-tool-override` / `--no-tool-override` bypass consent exactly as before.

## Related Issue

Fixes #89600

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/plugins_cmd.py` — `_resolve_tool_override_grant` guards its prompt with the isatty check used by the sibling capability-consent prompt; on the non-interactive path it persists the decline and prints the later-grant instruction, with a comment naming the swallowed-prompt deadlock shape.
- `tests/hermes_cli/test_plugin_capabilities.py` — new `TestToolOverrideGrantNonInteractive`: non-interactive stdin denies without prompting (console.input asserted not called + persisted `allow_tool_override: false`); redirected stdout alone (tty stdin, piped stdout — the PowerShell wrapper case) denies without prompting; the explicit flag bypasses consent on fully non-interactive stdio and persists `true`.

## How to Test

```bash
python -m pytest tests/hermes_cli/test_plugin_capabilities.py -q
# Observed result: 42 passed

python -m pytest tests/hermes_cli/test_plugins_cmd.py tests/hermes_cli/test_plugins.py tests/hermes_cli/test_plugin_packs.py -q
# Observed result: 146 passed
```

Fail-on-main check: with the source change stashed, the two non-interactive tests fail on main (the unguarded prompt path is taken; the console mock's AssertionError fires or the decline is never persisted).

Manual repro from the issue: with a capability-less non-bundled plugin, `hermes plugins enable <plugin> | cat` hangs indefinitely on main; with this change it returns promptly, prints the fail-closed notice, and records the decline.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments explain intent (why the swallowed prompt deadlocks and why the sibling guard is the right shape)
- [x] Corresponding changes documented via comments
- [x] Tests added and passing (3 new; plugins suites green)
- [x] Single root cause, no unrelated changes
