### PR TITLE
feat(agent): configure intent-ack vocabulary for multilingual models

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1905,6 +1905,11 @@ def init_agent(
     # model-name substrings.  Resolved against the active api_mode/model in the
     # conversation loop's intent-ack block.
     agent._intent_ack_continuation = _agent_section.get("intent_ack_continuation", "auto")
+    # Additive literal phrases for models that announce actions in vocabulary
+    # the built-in English detector does not know (including other languages).
+    # Validation stays at the detector boundary so malformed user config safely
+    # contributes no markers instead of breaking agent initialization.
+    agent._intent_ack_vocabulary = _agent_section.get("intent_ack_vocabulary", {})
 
     # Universal task-completion guidance toggle.  Default True.  Surfaced
     # as a separate flag from tool_use_enforcement because the guidance

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3737,6 +3737,21 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
 
 
 
+def _intent_ack_custom_markers(agent, key: str) -> Tuple[str, ...]:
+    """Return normalized additive markers from ``agent.intent_ack_vocabulary``."""
+    vocabulary = getattr(agent, "_intent_ack_vocabulary", {})
+    if not isinstance(vocabulary, dict):
+        return ()
+    markers = vocabulary.get(key, ())
+    if not isinstance(markers, list):
+        return ()
+    return tuple(
+        marker.strip().casefold()
+        for marker in markers
+        if isinstance(marker, str) and marker.strip()
+    )
+
+
 def looks_like_codex_intermediate_ack(
     agent,
     user_message: Any,
@@ -3760,15 +3775,16 @@ def looks_like_codex_intermediate_ack(
     if any(isinstance(msg, dict) and msg.get("role") == "tool" for msg in messages):
         return False
 
-    assistant_text = agent._strip_think_blocks(assistant_content or "").strip().lower()
+    assistant_text = agent._strip_think_blocks(assistant_content or "").strip().casefold()
     if not assistant_text:
         return False
     if len(assistant_text) > 1200:
         return False
 
+    custom_future_ack_markers = _intent_ack_custom_markers(agent, "future_ack_markers")
     has_future_ack = bool(
         re.search(r"\b(i['’]ll|i will|let me|i can do that|i can help with that)\b", assistant_text)
-    )
+    ) or any(marker in assistant_text for marker in custom_future_ack_markers)
     if not has_future_ack:
         return False
 
@@ -3792,7 +3808,7 @@ def looks_like_codex_intermediate_ack(
         "walkthrough",
         "report back",
         "summarize",
-    )
+    ) + _intent_ack_custom_markers(agent, "action_markers")
     workspace_markers = (
         "directory",
         "current directory",
@@ -3807,7 +3823,7 @@ def looks_like_codex_intermediate_ack(
         "file tree",
         "files",
         "path",
-    )
+    ) + _intent_ack_custom_markers(agent, "workspace_markers")
 
     assistant_mentions_action = any(marker in assistant_text for marker in action_markers)
     if not assistant_mentions_action:
@@ -3826,7 +3842,7 @@ def looks_like_codex_intermediate_ack(
     # raises ``AttributeError`` — flatten to text first.
     from agent.codex_responses_adapter import _summarize_user_message_for_log
 
-    user_text = _summarize_user_message_for_log(user_message).strip().lower()
+    user_text = _summarize_user_message_for_log(user_message).strip().casefold()
     user_targets_workspace = (
         any(marker in user_text for marker in workspace_markers)
         or "~/" in user_text

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -156,6 +156,14 @@ DEFAULT_CONFIG = {
         # api_modes — fixes the Gemini/Claude "stops after stating intent" case),
         # false (never), or a list of model-name substrings to match.
         "intent_ack_continuation": "auto",
+        # Optional additive literal phrases for intent-ack detection. These let
+        # users teach the runtime model- or language-specific wording without
+        # replacing the built-in English vocabulary.
+        "intent_ack_vocabulary": {
+            "future_ack_markers": [],
+            "action_markers": [],
+            "workspace_markers": [],
+        },
         # Universal "finish the job" guidance — short prompt block applied to
         # all models that targets two cross-family failure modes: (1) stopping
         # after a stub instead of finishing the artifact, (2) fabricating

--- a/tests/agent/test_intent_ack_continuation.py
+++ b/tests/agent/test_intent_ack_continuation.py
@@ -25,12 +25,14 @@ def _agent(
     mode: Union[str, bool, list] = "auto",
     api_mode="chat_completions",
     model="anthropic/claude-sonnet-4",
+    vocabulary=None,
 ):
     # _strip_think_blocks is a no-op for these plain-text fixtures.
     return SimpleNamespace(
         _intent_ack_continuation=mode,
         api_mode=api_mode,
         model=model,
+        _intent_ack_vocabulary=vocabulary or {},
         _strip_think_blocks=lambda c: c,
     )
 
@@ -113,6 +115,48 @@ def test_all_path_drops_workspace_requirement():
     msgs = [{"role": "user", "content": REPRO_USER}]
     assert looks_like_codex_intermediate_ack(
         a, REPRO_USER, REPRO_ACK, msgs, require_workspace=False
+    )
+
+
+def test_custom_multilingual_vocabulary_extends_detector():
+    vocabulary = {
+        "future_ack_markers": ["我来", "让我"],
+        "action_markers": ["查一下", "看看"],
+    }
+    a = _agent(True, "chat_completions", vocabulary=vocabulary)
+    user = "数据库现在是什么状态？"
+    msgs = [{"role": "user", "content": user}]
+
+    assert looks_like_codex_intermediate_ack(
+        a, user, "我来查一下数据库。", msgs, require_workspace=False
+    )
+    assert looks_like_codex_intermediate_ack(
+        a, user, "让我看看配置。", msgs, require_workspace=False
+    )
+
+
+def test_custom_workspace_marker_respects_codex_scope():
+    vocabulary = {
+        "future_ack_markers": ["我来"],
+        "action_markers": ["检查"],
+        "workspace_markers": ["代码库"],
+    }
+    a = _agent("auto", "codex_responses", vocabulary=vocabulary)
+    user = "检查代码库"
+    msgs = [{"role": "user", "content": user}]
+
+    assert looks_like_codex_intermediate_ack(
+        a, user, "我来检查。", msgs, require_workspace=True
+    )
+
+
+def test_malformed_custom_vocabulary_is_ignored():
+    a = _agent(True, "chat_completions", vocabulary={"future_ack_markers": "我来"})
+    user = "检查数据库"
+    msgs = [{"role": "user", "content": user}]
+
+    assert not looks_like_codex_intermediate_ack(
+        a, user, "我来检查数据库。", msgs, require_workspace=False
     )
 
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1648,6 +1648,21 @@ agent:
   tool_use_enforcement: ["gpt", "codex", "gemini", "grok", "my-custom-model"]
 ```
 
+## Intent-Ack Continuation Vocabulary
+
+`agent.intent_ack_continuation` is the runtime counterpart to prompt-side tool-use enforcement. When an enabled model ends a turn by only announcing an action, Hermes nudges it to continue and make the tool call. The detector keeps its built-in English vocabulary by default. Add literal phrases when your model uses different wording or another language:
+
+```yaml
+agent:
+  intent_ack_continuation: true
+  intent_ack_vocabulary:
+    future_ack_markers: ["我来", "让我", "接下来我"]
+    action_markers: ["查一下", "看看", "编译", "部署"]
+    workspace_markers: ["代码库", "项目", "文件"]
+```
+
+The lists are additive and use case-insensitive literal substring matching; they do not replace the built-in markers and are not regular expressions. `future_ack_markers` and `action_markers` apply to every enabled mode. `workspace_markers` matters only in the default `"auto"` Codex scope, where the acknowledgement must also refer to a filesystem or repository. The existing two-continuation-per-turn limit is unchanged.
+
 ## Tool-Loop Guardrails
 
 Hermes detects when the agent is stuck in an unproductive tool-calling loop — the same tool call failing repeatedly, the same tool failing over and over, or an idempotent call returning the same result with no progress. By default it injects a **warning** into the tool result so the model self-corrects; it does not hard-stop, since a person watching the CLI/TUI can intervene.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -1166,6 +1166,21 @@ agent:
   tool_use_enforcement: ["gpt", "codex", "gemini", "grok", "my-custom-model"]
 ```
 
+## 意图确认继续执行词汇
+
+`agent.intent_ack_continuation` 是提示词侧工具使用强制的运行时补充。当已启用的模型仅声明下一步操作便结束轮次时，Hermes 会提示它继续并实际调用工具。检测器默认保留内置英文词汇；当模型使用其他表达或语言时，可以添加字面短语：
+
+```yaml
+agent:
+  intent_ack_continuation: true
+  intent_ack_vocabulary:
+    future_ack_markers: ["我来", "让我", "接下来我"]
+    action_markers: ["查一下", "看看", "编译", "部署"]
+    workspace_markers: ["代码库", "项目", "文件"]
+```
+
+这些列表是增量配置，使用不区分大小写的字面子字符串匹配；它们不会替换内置标记，也不是正则表达式。`future_ack_markers` 和 `action_markers` 适用于所有已启用模式。`workspace_markers` 仅影响默认 `"auto"` 的 Codex 范围，该范围还要求意图确认提及文件系统或代码仓库。每轮最多继续两次的现有限制保持不变。
+
 ## TTS 配置
 
 ```yaml


### PR DESCRIPTION
## What does this PR do?

This PR lets users extend the intent-ack continuation detector with literal future-ack, action, and workspace markers. Models that announce an action in another language or with model-specific wording can now trigger the existing bounded continuation path instead of ending the turn without a tool call.

### Motivation

The detector currently relies on a fixed English vocabulary. Users cannot teach it phrases used by multilingual or custom models, so valid promise-and-action responses can bypass continuation even when `agent.intent_ack_continuation` is enabled.

### Behavior

Users can add markers under `agent.intent_ack_vocabulary`. Custom markers extend the built-in defaults rather than replacing them, malformed values are ignored safely, and the existing mode gates and two-continuation-per-turn limit remain unchanged.

### Implementation

The merged agent configuration is captured during initialization and normalized at the detector boundary. The detector performs case-insensitive literal substring matching for configured future acknowledgements, actions, and workspace references. Focused tests cover multilingual phrases, custom Codex workspace markers, preserved built-ins, and malformed configuration.

## Related Issue

Closes #89577

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/agent_init.py` - retain the merged custom vocabulary for runtime detection.
- `agent/agent_runtime_helpers.py` - extend built-in markers with validated literal custom markers.
- `hermes_cli/config_defaults.py` - add empty additive vocabulary lists to the default agent configuration.
- `tests/agent/test_intent_ack_continuation.py` - cover multilingual, workspace, compatibility, and malformed-config behavior.
- `website/docs/user-guide/configuration.md` and the current-version copy - document configuration and matching semantics.

## How to Test

1. Configure custom future-ack and action markers under `agent.intent_ack_vocabulary`.
2. Submit a task to an enabled model that responds using those markers without calling a tool, and verify Hermes uses the existing continuation path.
3. Run the focused automated tests:

```bash
scripts/run_tests.sh tests/agent/test_intent_ack_continuation.py tests/run_agent/test_verification_continuation_budget.py -q
```

Result: 15 passed, 0 failed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant test suite and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` is N/A because defaults and user documentation cover this nested optional configuration
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no architecture or workflow contract changed
- [x] I've considered cross-platform impact; matching and config parsing are platform-independent
- [x] Tool descriptions and schemas are N/A because no model tool surface changed

## Screenshots / Logs

N/A. The focused automated test result is included above.
