### PR TITLE
fix(skills): unstick stale skills index (#66616)

### DIFF
--- a/.github/workflows/skills-index.yml
+++ b/.github/workflows/skills-index.yml
@@ -9,6 +9,7 @@ on:
     branches: [main]
     paths:
       - "scripts/build_skills_index.py"
+      - "tools/skills_hub.py"
       - ".github/workflows/skills-index.yml"
 
 permissions:
@@ -20,7 +21,9 @@ jobs:
     # Only run on the upstream repository, not on forks
     if: github.repository == 'NousResearch/hermes-agent'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Full catalog + skills.sh path resolve regularly exceeds 15m and GitHub
+    # cancels the job (~15m19s). Freshness then nags #66616 forever.
+    timeout-minutes: 45
     environment: trusted-automation
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/tests/tools/test_skills_hub_clawhub.py
+++ b/tests/tools/test_skills_hub_clawhub.py
@@ -427,6 +427,45 @@ class TestClawHubSource(unittest.TestCase):
         mock_get.assert_called_once()
 
 
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub.httpx.get")
+    def test_catalog_walk_accepts_non_string_next_cursor(
+        self, mock_get, _mock_read_cache, mock_write_cache
+    ):
+        """Object nextCursor must not end the walk after one page (#66616)."""
+        page_calls = {"n": 0}
+
+        def side_effect(url, *args, **kwargs):
+            if url.endswith("/skills"):
+                idx = page_calls["n"]
+                page_calls["n"] += 1
+                if idx == 0:
+                    return _MockResponse(
+                        status_code=200,
+                        json_data={
+                            "items": [{"slug": "page-a", "displayName": "A"}],
+                            "nextCursor": {"v": 1, "index": idx},
+                        },
+                    )
+                return _MockResponse(
+                    status_code=200,
+                    json_data={
+                        "items": [{"slug": "page-b", "displayName": "B"}],
+                    },
+                )
+            return _MockResponse(status_code=404, json_data={})
+
+        mock_get.side_effect = side_effect
+        results = self.src._load_catalog_index(max_items=0)
+        slugs = {r.identifier for r in results}
+        self.assertEqual(page_calls["n"], 2)
+        self.assertEqual(slugs, {"page-a", "page-b"})
+        kwargs = mock_get.call_args_list[1].kwargs
+        self.assertIn("cursor", kwargs.get("params") or {})
+
+
 class TestClawHubCatalogWalkBounded(unittest.TestCase):
     """max_items bounds the walk so browse's cold-start fallback renders one
     page without walking the entire 50k+ catalog. The offline index builder
@@ -674,45 +713,6 @@ class TestFetchOwnerHandleRetry(unittest.TestCase):
         # 3 skills × 2 attempts each = 6 total HTTP calls (no abort)
         self.assertEqual(call_count["n"], 6)
         mock_sleep.assert_called()
-
-
-if __name__ == "__main__":
-    @patch("tools.skills_hub._write_index_cache")
-    @patch("tools.skills_hub._read_index_cache", return_value=None)
-    @patch("tools.skills_hub.httpx.get")
-    def test_catalog_walk_accepts_non_string_next_cursor(
-        self, mock_get, _mock_read_cache, mock_write_cache
-    ):
-        """Object nextCursor must not end the walk after one page (#66616)."""
-        page_calls = {"n": 0}
-
-        def side_effect(url, *args, **kwargs):
-            if url.endswith("/skills"):
-                idx = page_calls["n"]
-                page_calls["n"] += 1
-                if idx == 0:
-                    return _MockResponse(
-                        status_code=200,
-                        json_data={
-                            "items": [{"slug": "page-a", "displayName": "A"}],
-                            "nextCursor": {"v": 1, "index": idx},
-                        },
-                    )
-                return _MockResponse(
-                    status_code=200,
-                    json_data={
-                        "items": [{"slug": "page-b", "displayName": "B"}],
-                    },
-                )
-            return _MockResponse(status_code=404, json_data={})
-
-        mock_get.side_effect = side_effect
-        results = self.src._load_catalog_index(max_items=0)
-        slugs = {r.identifier for r in results}
-        self.assertEqual(page_calls["n"], 2)
-        self.assertEqual(slugs, {"page-a", "page-b"})
-        kwargs = mock_get.call_args_list[1].kwargs
-        self.assertIn("cursor", kwargs.get("params") or {})
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_skills_hub_clawhub.py
+++ b/tests/tools/test_skills_hub_clawhub.py
@@ -677,4 +677,43 @@ class TestFetchOwnerHandleRetry(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub.httpx.get")
+    def test_catalog_walk_accepts_non_string_next_cursor(
+        self, mock_get, _mock_read_cache, mock_write_cache
+    ):
+        """Object nextCursor must not end the walk after one page (#66616)."""
+        page_calls = {"n": 0}
+
+        def side_effect(url, *args, **kwargs):
+            if url.endswith("/skills"):
+                idx = page_calls["n"]
+                page_calls["n"] += 1
+                if idx == 0:
+                    return _MockResponse(
+                        status_code=200,
+                        json_data={
+                            "items": [{"slug": "page-a", "displayName": "A"}],
+                            "nextCursor": {"v": 1, "index": idx},
+                        },
+                    )
+                return _MockResponse(
+                    status_code=200,
+                    json_data={
+                        "items": [{"slug": "page-b", "displayName": "B"}],
+                    },
+                )
+            return _MockResponse(status_code=404, json_data={})
+
+        mock_get.side_effect = side_effect
+        results = self.src._load_catalog_index(max_items=0)
+        slugs = {r.identifier for r in results}
+        self.assertEqual(page_calls["n"], 2)
+        self.assertEqual(slugs, {"page-a", "page-b"})
+        kwargs = mock_get.call_args_list[1].kwargs
+        self.assertIn("cursor", kwargs.get("params") or {})
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2684,6 +2684,10 @@ class ClawHubSource(SkillSource):
             else:
                 # Some ClawHub payloads wrap the cursor; json.dumps keeps the walk
                 # going instead of treating a non-string as exhaustion (~1 page / 199 skills).
+                logger.debug(
+                    "ClawHub nextCursor is %s rather than str; coercing via json.dumps",
+                    type(raw_cursor).__name__,
+                )
                 cursor = json.dumps(raw_cursor, separators=(',', ':'), default=str)
             if not cursor:
                 break

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2676,8 +2676,16 @@ class ClawHubSource(SkillSource):
                     extra=extra,
                 ))
 
-            cursor = data.get("nextCursor") if isinstance(data, dict) else None
-            if not isinstance(cursor, str) or not cursor:
+            raw_cursor = data.get("nextCursor") if isinstance(data, dict) else None
+            if isinstance(raw_cursor, str) and raw_cursor:
+                cursor = raw_cursor
+            elif raw_cursor is None:
+                cursor = None
+            else:
+                # Some ClawHub payloads wrap the cursor; json.dumps keeps the walk
+                # going instead of treating a non-string as exhaustion (~1 page / 199 skills).
+                cursor = json.dumps(raw_cursor, separators=(',', ':'), default=str)
+            if not cursor:
                 break
 
             # Browse's cold-start fallback only renders one page, so stop as


### PR DESCRIPTION
## Summary
The [skills-index watchdog](https://github.com/NousResearch/hermes-agent/issues/66616) is not an OpenClaw gateway probe. Live `skills-index.json` is still `generated_at` **2026-07-20** (~700h). Scheduled `skills-index.yml` runs are **cancelled at 15m19s**; the last completed build **failed** because ClawHub returned **199** skills vs floor **20000**.

## Changes
- `timeout-minutes: 15` → **45** on `build-index` (path resolve of 20k skills.sh entries already took ~7.5m before the health check).
- Trigger the workflow when `tools/skills_hub.py` changes.
- ClawHub catalog walk: if `nextCursor` is not a string, JSON-encode it instead of treating the walk as exhausted (one listing page ≈ 199).

## Test
`python3 -m pytest tests/tools/test_skills_hub_clawhub.py -q` → 26 passed (includes new object-cursor test).

Maintainers still need a successful scheduled/manual **Build Skills Index** + deploy after merge; I cannot write the published GitHub Pages artifact from a fork.