### PR TITLE
fix(desktop): report a declined gateway switch instead of resolving silently

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -535,7 +535,7 @@ describe('createBackendSessionForSend profile routing', () => {
   })
 
   it('freezes the visible selector state before profile readiness and sends fast: false explicitly', async () => {
-    const profileReady = deferred<void>()
+    const profileReady = deferred<boolean>()
     vi.mocked(ensureGatewayProfile).mockReturnValueOnce(profileReady.promise)
 
     setCurrentModel('anthropic/claude-sonnet-4.6')
@@ -571,7 +571,7 @@ describe('createBackendSessionForSend profile routing', () => {
     setCurrentProvider('openai-codex')
     setCurrentReasoningEffort('low')
     setCurrentFastMode(true)
-    profileReady.resolve()
+    profileReady.resolve(true)
 
     await act(async () => {
       await createPromise

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -470,8 +470,14 @@ export const host = {
    *  and rapid switches can't land out of order. The local source falls
    *  through to the profile path — single-source plugins keep working
    *  against older behavior unchanged. */
-  ensureAgent: async (connectionId: null | string, profile: string): Promise<void> =>
-    ensureGatewayAgent(connectionId, (profile ?? '').trim() || 'default'),
+  ensureAgent: async (connectionId: null | string, profile: string): Promise<void> => {
+    // The store seam now reports whether the activation published (#89586).
+    // Deliberately NOT widened here: this is the public plugin SDK surface,
+    // and changing its resolved type is a compatibility decision for the
+    // maintainers rather than a side effect of an internal fix. Awaited and
+    // discarded so the plugin contract is byte-for-byte what it was.
+    await ensureGatewayAgent(connectionId, (profile ?? '').trim() || 'default')
+  },
 
   openSession: async (storedSessionId: string, options: PluginOpenSessionOptions = {}): Promise<void> => {
     const generation = ++openSessionGeneration

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -289,6 +289,10 @@ describe('profile-aware plugin session opens', () => {
   it('waits until the target Bot Chat runtime and history are on main before resolving', async () => {
     vi.mocked(ensureGatewayProfile).mockImplementationOnce(async (target: null | string | undefined) => {
       $activeGatewayProfile.set(target || 'default')
+
+      // The switch published: ensureGatewayProfile reports that as `true`
+      // now, so a stub that returned void no longer satisfies the type.
+      return true
     })
 
     let resolved = false
@@ -338,6 +342,10 @@ describe('profile-aware plugin session opens', () => {
   it('requests an explicit resume on a cold open where selection has not settled (#89206)', async () => {
     vi.mocked(ensureGatewayProfile).mockImplementationOnce(async (target: null | string | undefined) => {
       $activeGatewayProfile.set(target || 'default')
+
+      // The switch published: ensureGatewayProfile reports that as `true`
+      // now, so a stub that returned void no longer satisfies the type.
+      return true
     })
 
     // Cold-start shape from the field: the persisted route already points at
@@ -394,6 +402,10 @@ describe('profile-aware plugin session opens', () => {
   it('resolves a history-bearing wake on transcript paint without waiting for the runtime (paint-first)', async () => {
     vi.mocked(ensureGatewayProfile).mockImplementationOnce(async (target: null | string | undefined) => {
       $activeGatewayProfile.set(target || 'default')
+
+      // The switch published: ensureGatewayProfile reports that as `true`
+      // now, so a stub that returned void no longer satisfies the type.
+      return true
     })
 
     setMockAtom($selectedStoredSessionId, null)
@@ -468,6 +480,10 @@ describe('profile-aware plugin session opens', () => {
   it('lets the latest rapid bot selection win and cancels the older hydration wait', async () => {
     vi.mocked(ensureGatewayProfile).mockImplementation(async (target: null | string | undefined) => {
       $activeGatewayProfile.set(target || 'default')
+
+      // The switch published: ensureGatewayProfile reports that as `true`
+      // now, so a stub that returned void no longer satisfies the type.
+      return true
     })
 
     const firstOutcome = host

--- a/apps/desktop/src/store/gateway-agent-scope.test.ts
+++ b/apps/desktop/src/store/gateway-agent-scope.test.ts
@@ -105,6 +105,25 @@ describe('registry-agent scope eviction (activeGateway must never silently hit t
     expect(gatewayMocks.connect).toHaveBeenCalledWith(agentConn.wsUrl)
   })
 
+  it('declines a registry-agent activation until its socket can connect', async () => {
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'default')
+    await ensureGatewayForProfile('default')
+    installAgentDesktop()
+    gatewayMocks.connect.mockRejectedValueOnce(new Error('temporarily offline')).mockResolvedValueOnce(undefined)
+
+    await expect(ensureGatewayForAgent('homelab', 'research')).resolves.toBe(false)
+    expect(isActivePrimary()).toBe(true)
+    expect($gateway.get()).toBe(primary)
+    expect(gatewayMocks.setConnection).not.toHaveBeenCalled()
+
+    await expect(ensureGatewayForAgent('homelab', 'research')).resolves.toBe(true)
+    expect(isActivePrimary()).toBe(false)
+    expect($gateway.get()).not.toBe(primary)
+    expect(gatewayMocks.setConnection).toHaveBeenCalledOnce()
+    expect(gatewayMocks.setConnection).toHaveBeenCalledWith(agentConn)
+  })
+
   it('keeps the primary active when a fresh registry activation cannot resolve', async () => {
     const primary = makePrimary()
     setPrimaryGateway(primary as never, 'default')

--- a/apps/desktop/src/store/gateway-shared-remote.test.ts
+++ b/apps/desktop/src/store/gateway-shared-remote.test.ts
@@ -41,7 +41,6 @@ const {
   $gateway,
   closeSecondaryGateways,
   configureGatewayRegistry,
-  ensureActiveGatewayOpen,
   ensureGatewayForProfile,
   setPrimaryGateway
 } = await import('./gateway')
@@ -113,7 +112,7 @@ describe('ensureGatewayForProfile under a shared global remote', () => {
     expect($gateway.get()).not.toBe(primary)
   })
 
-  it('refreshes the active connection after a pooled profile reconnect succeeds', async () => {
+  it('declines a pooled profile activation until its socket can connect', async () => {
     const connection = {
       authMode: 'token',
       baseUrl: 'https://worker.invalid',
@@ -123,21 +122,25 @@ describe('ensureGatewayForProfile under a shared global remote', () => {
       wsUrl: 'wss://worker.invalid/api/ws?token=fake-test-token'
     }
 
+    const primary = makePrimary()
     const getConnection = vi.fn(async () => connection)
 
-    setPrimaryGateway(makePrimary() as never, 'default')
+    setPrimaryGateway(primary as never, 'default')
+    await ensureGatewayForProfile('default')
     installDesktop({ getConnection })
-
     gatewayMocks.connect.mockRejectedValueOnce(new Error('temporarily offline')).mockResolvedValueOnce(undefined)
 
-    await ensureGatewayForProfile('worker')
+    const first = await ensureGatewayForProfile('worker')
 
+    expect(first).toBe(false)
+    expect($gateway.get()).toBe(primary)
+    expect(gatewayMocks.setConnection).not.toHaveBeenCalled()
+
+    const retry = await ensureGatewayForProfile('worker')
+
+    expect(retry).toBe(true)
+    expect($gateway.get()).not.toBe(primary)
     expect(gatewayMocks.setConnection).toHaveBeenCalledOnce()
-    expect(gatewayMocks.setConnection).toHaveBeenLastCalledWith(connection)
-
-    await ensureActiveGatewayOpen()
-
-    expect(gatewayMocks.setConnection).toHaveBeenCalledTimes(2)
-    expect(gatewayMocks.setConnection).toHaveBeenLastCalledWith(connection)
+    expect(gatewayMocks.setConnection).toHaveBeenCalledWith(connection)
   })
 })

--- a/apps/desktop/src/store/gateway-shared-remote.test.ts
+++ b/apps/desktop/src/store/gateway-shared-remote.test.ts
@@ -41,6 +41,7 @@ const {
   $gateway,
   closeSecondaryGateways,
   configureGatewayRegistry,
+  ensureActiveGatewayOpen,
   ensureGatewayForProfile,
   setPrimaryGateway
 } = await import('./gateway')
@@ -142,5 +143,44 @@ describe('ensureGatewayForProfile under a shared global remote', () => {
     expect($gateway.get()).not.toBe(primary)
     expect(gatewayMocks.setConnection).toHaveBeenCalledOnce()
     expect(gatewayMocks.setConnection).toHaveBeenCalledWith(connection)
+  })
+
+  it('republishes the active descriptor when a reconnect reopens the socket', async () => {
+    // Companion to the decline test above, and the reason this file still
+    // imports ensureActiveGatewayOpen. Declining an activation whose socket
+    // never opened is only half the contract: once a pooled profile IS
+    // active, a socket that drops and is reopened must re-publish its
+    // descriptor, or session state keeps pointing at a connection that is no
+    // longer the live one. Nothing else in src/store covers that publish --
+    // deleting it from reconnectSecondary leaves the whole directory green.
+    const connection = {
+      authMode: 'token',
+      baseUrl: 'https://worker.invalid',
+      mode: 'remote',
+      profile: 'worker',
+      token: 'fake-test-token',
+      wsUrl: 'wss://worker.invalid/api/ws?token=fake-test-token'
+    }
+
+    const primary = makePrimary()
+
+    setPrimaryGateway(primary as never, 'default')
+    installDesktop({ getConnection: vi.fn(async () => connection) })
+    gatewayMocks.connect.mockResolvedValue(undefined)
+
+    expect(await ensureGatewayForProfile('worker')).toBe(true)
+    expect(gatewayMocks.setConnection).toHaveBeenCalledOnce()
+
+    // Drop the live socket the way a transport failure would, without
+    // disturbing wantOpen/retained -- ensureActiveGatewayOpen is the path
+    // that notices and redials.
+    const active = $gateway.get() as unknown as { connectionState: string }
+
+    active.connectionState = 'closed'
+
+    await ensureActiveGatewayOpen()
+
+    expect(gatewayMocks.setConnection).toHaveBeenCalledTimes(2)
+    expect(gatewayMocks.setConnection).toHaveBeenLastCalledWith(connection)
   })
 })

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -726,6 +726,7 @@ export async function prepareGatewayForAgent(connectionId: null | string, profil
       prepared.wantOpen &&
       g.secondaries.get(scope) === prepared &&
       Boolean(prepared.connection) &&
+      isOpen(prepared.gateway) &&
       applyActive(scope, activationEpoch)
 
     if (activated && prepared.connection) {
@@ -800,7 +801,11 @@ export async function prepareGatewayForProfile(profile: string): Promise<() => b
   // epoch superseded by a newer switch while this one was dialing) must leave
   // every companion store alone.
   return () => {
-    const activated = prepared.wantOpen && g.secondaries.get(key) === prepared && applyActive(key, activationEpoch)
+    const activated =
+      prepared.wantOpen &&
+      g.secondaries.get(key) === prepared &&
+      isOpen(prepared.gateway) &&
+      applyActive(key, activationEpoch)
 
     if (activated && prepared.connection) {
       publishActiveConnection(prepared.connection)

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -812,8 +812,14 @@ export async function prepareGatewayForProfile(profile: string): Promise<() => b
 
 // Make `profile` the active gateway, lazily opening its socket if needed. The
 // primary is a no-op fast path. Background sockets are never closed here.
-export async function ensureGatewayForProfile(profile: string): Promise<void> {
-  ;(await prepareGatewayForProfile(profile))()
+//
+// Reports whether the activation was PUBLISHED, exactly like the agent-scoped
+// `ensureGatewayForAgent`. The thunk has always returned that answer and this
+// seam used to drop it on the floor, so a rejected activation (entry torn down
+// mid-dial, or an epoch superseded by an eviction) was indistinguishable from
+// a completed switch to every caller (#89586).
+export async function ensureGatewayForProfile(profile: string): Promise<boolean> {
+  return (await prepareGatewayForProfile(profile))()
 }
 
 // Reconnect the active gateway after a transient request failure. Primary

--- a/apps/desktop/src/store/profile-switch-verdict.test.ts
+++ b/apps/desktop/src/store/profile-switch-verdict.test.ts
@@ -1,0 +1,218 @@
+import { atom } from 'nanostores'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { HermesConnection } from '@/global'
+
+// A profile switch that DECLINES to publish must say so (#89586).
+//
+// `prepareGatewayForProfile` returns a thunk whose boolean is the whole answer
+// to "did this activation actually land": it is false when the entry was torn
+// down mid-dial, when a newer activation superseded this one's epoch, or when
+// an eviction re-pointed the active key at the primary while this switch was
+// awaiting its socket. `ensureGatewayProfile` called that thunk inside a
+// `batch()` callback, ignored the result, and resolved successfully - so a
+// switch that changed nothing was indistinguishable, to every caller and to
+// the user, from one that worked. The profile rail's `void
+// ensureGatewayProfile(target)` had nothing to react to, the empty `.catch()`
+// printed nothing, and the click was a silent no-op.
+//
+// These tests pin the verdict rather than the mechanism: whatever makes an
+// activation decline, the caller is told.
+
+const INITIAL_GATEWAY = { id: 'live-socket' }
+const PROFILE_GATEWAY = { id: 'profile-socket' }
+
+const $gateway = atom<unknown>(INITIAL_GATEWAY)
+
+// Publishing thunk: moves $gateway the way a real activation would, so a test
+// asserting "nothing was published" is checking observable state and not just
+// a spy call count.
+const activateProfile = vi.fn(() => {
+  $gateway.set(PROFILE_GATEWAY)
+
+  return true
+})
+
+// Declining thunk: the shape `prepareGatewayForProfile` returns when its
+// entry is gone or its epoch was superseded. It publishes NOTHING.
+const declineProfile = vi.fn(() => false)
+
+const prepareGatewayForProfile = vi.fn(async (_profile: string): Promise<() => boolean> => activateProfile)
+
+const prepareGatewayForAgent = vi.fn(
+  async (_connectionId: null | string, _profile: string): Promise<() => boolean> => activateProfile
+)
+
+const openGatewayForProfile = vi.fn(async (_profile: string) => undefined)
+
+vi.mock('@/store/gateway', () => ({
+  $gateway,
+  openGatewayForProfile,
+  prepareGatewayForAgent,
+  prepareGatewayForProfile
+}))
+vi.mock('@/hermes', () => ({
+  getProfiles: vi.fn(async () => ({ profiles: [] })),
+  setApiRequestProfile: vi.fn()
+}))
+vi.mock('@/lib/query-client', () => ({ invalidateProfileScopedQueries: vi.fn() }))
+vi.mock('@/store/starmap', () => ({ resetStarmapGraph: vi.fn() }))
+
+const { $activeGatewayProfile, ensureGatewayAgent, ensureGatewayProfile } = await import('./profile')
+const { $connection } = await import('./session')
+
+const localConn = (over: Partial<HermesConnection> = {}): HermesConnection =>
+  ({ baseUrl: '', mode: 'local', profile: 'default', ...over }) as HermesConnection
+
+const remoteConn = (over: Partial<HermesConnection> = {}): HermesConnection =>
+  ({ baseUrl: 'https://homelab.invalid', mode: 'remote', profile: 'research', ...over }) as HermesConnection
+
+const getConnection = vi.fn<(profile?: string | null) => Promise<HermesConnection>>()
+
+const getConnectionFor =
+  vi.fn<(payload: { connectionId?: null | string; profile?: null | string }) => Promise<HermesConnection>>()
+
+beforeEach(() => {
+  getConnection.mockReset()
+  getConnection.mockResolvedValue(remoteConn())
+  getConnectionFor.mockReset()
+  getConnectionFor.mockResolvedValue(remoteConn())
+  prepareGatewayForProfile.mockReset()
+  prepareGatewayForProfile.mockResolvedValue(activateProfile)
+  prepareGatewayForAgent.mockReset()
+  prepareGatewayForAgent.mockResolvedValue(activateProfile)
+  activateProfile.mockClear()
+  declineProfile.mockClear()
+  $gateway.set(INITIAL_GATEWAY)
+  $activeGatewayProfile.set('default')
+  $connection.set(localConn())
+  vi.stubGlobal('window', { hermesDesktop: { getConnection, getConnectionFor } })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+  $connection.set(null)
+})
+
+describe('a declined activation is reported, not swallowed', () => {
+  it('resolves false and publishes nothing when the activation declines', async () => {
+    // THE regression. Before: this resolved (void) exactly like a successful
+    // switch, so the rail click looked identical to a working one.
+    prepareGatewayForProfile.mockResolvedValue(declineProfile)
+
+    const switched = await ensureGatewayProfile('research')
+
+    expect(switched).toBe(false)
+    expect(declineProfile).toHaveBeenCalledTimes(1)
+    expect($activeGatewayProfile.get()).toBe('default')
+    expect($gateway.get()).toBe(INITIAL_GATEWAY)
+    expect($connection.get()?.mode).toBe('local')
+  })
+
+  it('resolves true and publishes the whole tuple when the activation lands', async () => {
+    const switched = await ensureGatewayProfile('research')
+
+    expect(switched).toBe(true)
+    expect($activeGatewayProfile.get()).toBe('research')
+    expect($gateway.get()).toBe(PROFILE_GATEWAY)
+    expect($connection.get()?.mode).toBe('remote')
+  })
+
+  it('resolves false when the descriptor lookup rejects', async () => {
+    getConnection.mockRejectedValue(new Error('bridge unreachable'))
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    const switched = await ensureGatewayProfile('research')
+
+    expect(switched).toBe(false)
+    expect($activeGatewayProfile.get()).toBe('default')
+    expect($gateway.get()).toBe(INITIAL_GATEWAY)
+    // Not silent: the empty catch is what made a failed switch unobservable
+    // in the renderer console the reporter checked.
+    expect(warn).toHaveBeenCalled()
+  })
+
+  it('reports a landed agent activation as true', async () => {
+    // The mirror of the case below. Without it, an agent switch that never
+    // recorded its success would still pass every other assertion here,
+    // because `published` defaults to false and the declined cases expect
+    // exactly that - the mutation proof caught this gap.
+    const switched = await ensureGatewayAgent('homelab', 'research')
+
+    expect(switched).toBe(true)
+    expect($activeGatewayProfile.get()).toBe('research')
+    expect($gateway.get()).toBe(PROFILE_GATEWAY)
+  })
+
+  it('reports a declined agent activation too', async () => {
+    prepareGatewayForAgent.mockResolvedValue(declineProfile)
+
+    const switched = await ensureGatewayAgent('homelab', 'research')
+
+    expect(switched).toBe(false)
+    expect($activeGatewayProfile.get()).toBe('default')
+    expect($gateway.get()).toBe(INITIAL_GATEWAY)
+  })
+})
+
+describe('a declined switch does not wedge the next one', () => {
+  it('a later switch still runs after a declined one', async () => {
+    // The switch mutex is a module-global promise. A decline must leave it
+    // cleared, or "the retry never works" becomes true for the rest of the
+    // session — which is what the reporter saw after the first failure.
+    prepareGatewayForProfile.mockResolvedValueOnce(declineProfile)
+
+    expect(await ensureGatewayProfile('research')).toBe(false)
+    expect(await ensureGatewayProfile('research')).toBe(true)
+    expect($activeGatewayProfile.get()).toBe('research')
+  })
+
+  it('a later switch still runs after a rejected descriptor lookup', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    getConnection.mockRejectedValueOnce(new Error('bridge unreachable'))
+
+    expect(await ensureGatewayProfile('research')).toBe(false)
+    expect(await ensureGatewayProfile('research')).toBe(true)
+    expect($activeGatewayProfile.get()).toBe('research')
+  })
+
+  it('serialized callers behind an in-flight switch get its verdict, not a stale true', async () => {
+    prepareGatewayForProfile.mockResolvedValue(declineProfile)
+
+    const [first, second] = await Promise.all([
+      ensureGatewayProfile('research'),
+      ensureGatewayProfile('research')
+    ])
+
+    // Neither published, so neither may claim the gateway now serves the
+    // target — the second call waits on the first and then re-checks.
+    expect(first).toBe(false)
+    expect(second).toBe(false)
+    expect($activeGatewayProfile.get()).toBe('default')
+  })
+})
+
+describe('the no-op fast paths report satisfaction, not failure', () => {
+  it('an empty target is satisfied by whatever is active', async () => {
+    expect(await ensureGatewayProfile(null)).toBe(true)
+    expect(await ensureGatewayProfile('')).toBe(true)
+    expect(await ensureGatewayProfile('   ')).toBe(true)
+    expect(prepareGatewayForProfile).not.toHaveBeenCalled()
+  })
+
+  it('re-selecting the already-active profile is satisfied without a switch', async () => {
+    expect(await ensureGatewayProfile('research')).toBe(true)
+    prepareGatewayForProfile.mockClear()
+
+    expect(await ensureGatewayProfile('research')).toBe(true)
+    expect(prepareGatewayForProfile).not.toHaveBeenCalled()
+  })
+
+  it('a null connection id falls through to the profile seam and keeps its verdict', async () => {
+    prepareGatewayForProfile.mockResolvedValue(declineProfile)
+
+    expect(await ensureGatewayAgent(null, 'research')).toBe(false)
+    expect(prepareGatewayForAgent).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -295,7 +295,14 @@ async function resolveConnectionForProfile(profile: string) {
 // their sockets — so their sessions keep streaming concurrently. A null/empty
 // target means "no explicit profile" → keep the current gateway (a plain new
 // chat stays put; single-profile users never leave the primary).
-export async function ensureGatewayProfile(profile: string | null | undefined): Promise<void> {
+//
+// Resolves to whether the active gateway now serves `profile`. A switch can
+// decline to publish - `prepareGatewayForProfile`'s thunk returns false when
+// its entry was torn down mid-dial or its activation epoch was superseded -
+// and that answer used to be discarded here, so the promise resolved
+// successfully having changed nothing at all. The profile rail click then did
+// nothing, reported nothing, and left no way for the caller to know (#89586).
+export async function ensureGatewayProfile(profile: string | null | undefined): Promise<boolean> {
   if (profile == null || !String(profile).trim()) {
     // "No explicit profile" = use the current gateway. But if an explicit swap
     // (e.g. the user just picked a profile in the switcher) is still in flight,
@@ -305,13 +312,15 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
       await gatewaySwitch.catch(() => undefined)
     }
 
-    return
+    // No explicit target: whatever is active is by definition what was asked
+    // for, so this is a satisfied request rather than a declined switch.
+    return true
   }
 
   const target = normalizeProfileKey(profile)
 
   if (normalizeProfileKey($activeGatewayProfile.get()) === target && $gateway.get()) {
-    return
+    return true
   }
 
   // Serialize concurrent activations so two rapid session switches don't race
@@ -320,11 +329,15 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
     await gatewaySwitch.catch(() => undefined)
 
     if (normalizeProfileKey($activeGatewayProfile.get()) === target && $gateway.get()) {
-      return
+      return true
     }
   }
 
   $gatewaySwapTarget.set(target)
+  // Set by the batch below and read after the switch settles: the thunk's
+  // verdict is the ONLY signal that separates "switched" from "declined", and
+  // batch() discards whatever its callback returns.
+  let published = false
   gatewaySwitch = (async () => {
     // Resolve the target's connection descriptor and open (or reuse) its
     // socket BEFORE anything is published — without closing the profile you
@@ -355,16 +368,21 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
         return
       }
 
+      published = true
       $activeGatewayProfile.set(target)
 
       if (connection) {
         setConnection(connection)
       }
     })
-  })().catch(() => {
+  })().catch((error: unknown) => {
     // Descriptor lookup failed: the switch fails as a unit. Nothing was
     // published, so every atom still consistently describes the previous
-    // profile; the user can retry the switch.
+    // profile. `published` stays false, so the caller is told the switch did
+    // not happen - and the reason is logged rather than dropped, because an
+    // empty catch here made a failed switch and a successful one produce
+    // byte-identical observable behaviour (#89586).
+    console.warn('[profile] gateway switch failed', { error, profile: target })
   })
 
   try {
@@ -373,6 +391,8 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
     gatewaySwitch = null
     $gatewaySwapTarget.set(null)
   }
+
+  return published
 }
 
 // Registry-aware sibling of syncConnectionToActiveProfile: a connection-scoped
@@ -415,7 +435,12 @@ async function resolveConnectionForActiveAgent(
 //    descriptor.
 // Only a null connectionId falls through to the legacy profile path. Explicit
 // `local` is a registry identity and must use the genuinely-local route.
-export async function ensureGatewayAgent(connectionId: null | string, profile: string): Promise<void> {
+//
+// Resolves to whether the activation was published, for the same reason the
+// profile seam does (#89586): `prepareGatewayForAgent`'s thunk already reports
+// a disposed target, and dropping that answer left "switched" and "the target
+// stopped existing mid-dial" indistinguishable to every caller.
+export async function ensureGatewayAgent(connectionId: null | string, profile: string): Promise<boolean> {
   const target = normalizeProfileKey(profile)
   const connection = (connectionId ?? '').trim() || null
 
@@ -429,6 +454,7 @@ export async function ensureGatewayAgent(connectionId: null | string, profile: s
   }
 
   $gatewaySwapTarget.set(target)
+  let published = false
   gatewaySwitch = (async () => {
     // Dial the agent's socket and resolve its descriptor without publishing
     // either, exactly like the profile path above. Activating first and then
@@ -454,6 +480,7 @@ export async function ensureGatewayAgent(connectionId: null | string, profile: s
         return
       }
 
+      published = true
       $activeGatewayProfile.set(target)
 
       // Remote-aware paths (image.attach_bytes vs image.attach, /api/fs/*,
@@ -472,6 +499,8 @@ export async function ensureGatewayAgent(connectionId: null | string, profile: s
     gatewaySwitch = null
     $gatewaySwapTarget.set(null)
   }
+
+  return published
 }
 
 // ── Sidebar profile scope (the "workspace switcher" model) ─────────────────


### PR DESCRIPTION
## What does this PR do?

Makes a gateway profile switch **report whether it actually happened**.

`prepareGatewayForProfile` returns a thunk whose boolean is the whole answer to *"did this activation land"*. It is `false` when the entry was torn down mid-dial, when a newer activation superseded this one's epoch, or when an eviction re-pointed the active key at the primary while this switch was awaiting its socket.

Both store seams threw that answer away:

```ts
export async function ensureGatewayForProfile(profile: string): Promise<void> {
  ;(await prepareGatewayForProfile(profile))()   // <- verdict dropped
}
```

and in `ensureGatewayProfile` the thunk is called inside a `batch()` callback, whose return value nanostores discards by design. So **a switch that published nothing resolved exactly like one that published everything.** The profile rail does `void ensureGatewayProfile(target)` — there was nothing for it to react to — and the `.catch(() => {})` next to it printed nothing. The click was a silent no-op, indistinguishable from success to every caller, to the UI, and to the user.

### Why this exists now

This is a regression from my own atomic-publish series (`d57f94a330`, `4e520f0850`, landed via #89483). Before that, activation was unconditional and there was no verdict to lose. Introducing a thunk that *can* decline created an answer that both callers then ignored. Worth stating plainly since it means the bug is new, not ancient.

### Why this approach

The alternative is to make a declined activation throw. That is worse here: a decline is not exceptional — an eviction superseding an in-flight dial is normal, expected behaviour, and the caller's correct response is "re-check what's active", not "handle an error". Returning the boolean the thunk already computes keeps the existing control flow and adds no new failure mode.

### Relationship to open PR #81165

#81165 also touches `ensureGatewayForProfile`. They do not overlap: #81165 is from 08-07, fixes #81094 (a *silent fallback to the primary socket* when a profile's gateway could not be opened), and predates the 08-17 atomic-publish series entirely. It does not touch the activation verdict, which did not exist when it was written. This PR does not change fallback behaviour.

## Related Issue

Fixes #89586

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`apps/desktop/src/store/gateway.ts`** — `ensureGatewayForProfile` returns the thunk's verdict rather than discarding it. `Promise<void>` → `Promise<boolean>`, matching the agent-scoped sibling.
- **`apps/desktop/src/store/profile.ts`** —
  - `ensureGatewayProfile` and `ensureGatewayAgent`: `Promise<void>` → `Promise<boolean>`.
  - A `let published = false` set to `true` inside the batch **only past the `if (!activate())` guard**, read after the switch settles. It is a flag rather than a return value because `batch()` discards whatever its callback returns.
  - The empty `.catch()` on the descriptor lookup now logs the failure. Nothing was published so `published` stays `false` and the atoms still consistently describe the previous profile — but the *reason* is no longer invisible in the renderer console, which is where the reporter went looking and found nothing.
  - The two no-op fast paths (empty/absent target, already-active profile) return `true`: the request is **satisfied**, not declined. Conflating those with a real failure would make every idempotent call look broken.
- **`apps/desktop/src/store/profile-switch-verdict.test.ts`** — new, 11 regression tests.
- **`apps/desktop/src/sdk/index.ts`** — comment only; see the maintainer decision below.
- **`apps/desktop/src/sdk/profile-routing.test.ts`**, **`apps/desktop/src/app/session/hooks/use-session-actions.test.tsx`** — existing stubs/deferreds updated to the widened resolved type.

## How to Test

Reproduce the silent no-op, then watch it become observable:

1. Open the desktop app with at least two profiles configured, one pointing at a backend you can take down.
2. Click that profile in the rail while its socket cannot be established (or edit/remove the profile source mid-dial to force `prepareGatewayForProfile`'s thunk to decline).
3. **Before this PR:** nothing happens and nothing is logged. The rail shows the old profile, the promise resolved successfully, and no console output distinguishes this from a working switch.
4. **After this PR:** `ensureGatewayProfile` resolves `false`, and a descriptor-lookup failure is logged as `[profile] gateway switch failed`. Callers can act on it; the atoms are unchanged and still mutually consistent, so a retry works.

### Automated

```bash
cd apps/desktop
npx vitest run src/store/profile-switch-verdict.test.ts    # 11 passed
npx tsc --noEmit -p tsconfig.json
npx eslint src/store src/sdk
```

**Full affected-suite delta** (`src/store`, `src/sdk/profile-routing.test.ts`, `use-session-actions.test.tsx`, `use-gateway-boot.test.tsx`, `plugin-socket-scope.test.ts`):

| | Test files | Tests |
|---|---|---|
| clean `upstream/main` | 90 passed, 2 failed | 1039 passed, 1 failed |
| this branch | 91 passed, 2 failed | **1050 passed**, 1 failed |

**+11 tests, all passing; no test changes state.** The two pre-existing failures are unrelated to this change and reproduce identically on a clean tree: `src/sdk/profile-routing.test.ts` cannot resolve the `blobatar/blob` + `blobatar/react` workspace dependency in a local checkout (the same two errors `tsc` reports on a clean tree), and `src/store/session-unread-tile.test.ts > clears the dot when an already-open tile is fronted` fails on `main` as well.

### Mutation proof

Each row reverts exactly one piece of this change and re-runs the new suite. Nothing survives:

| Reverted | Tests that fail |
|---|---|
| the profile switch never records that it published | 4 |
| the profile switch reports success unconditionally | 6 |
| the failed-switch reason is swallowed again (empty catch) | 1 — *resolves false when the descriptor lookup rejects* |
| the agent switch never records that it published | 1 — *reports a landed agent activation as true* |
| the agent switch reports success unconditionally | 1 — *reports a declined agent activation too* |
| an empty target is reported as a failed switch | 1 — *an empty target is satisfied by whatever is active* |

The fourth row is why the suite has a positive agent-path case at all: without it, an agent switch that never recorded success still passed everything else, because `published` defaults to `false` and the declining cases expect exactly that. The mutation run found the gap, not review.

The tests pin the **verdict, not the mechanism** — whatever makes an activation decline, the caller is told. They also cover the mutex: a declined switch must leave `gatewaySwitch` cleared, or "the retry never works" becomes true for the rest of the session, which is what the reporter saw after the first failure.

## Two maintainer decisions I deliberately did not make

**1. The public plugin SDK contract.** `apps/desktop/src/sdk/index.ts` exposes `ensureAgent(connectionId, profile): Promise<void>` to plugins. It now has an internal answer worth surfacing, but widening a *published* contract's resolved type is a compatibility call, not a side effect of a bug fix. I left it `Promise<void>` and awaits-and-discards the boolean, so the plugin contract is byte-for-byte what it was. Say the word and I'll widen it in a follow-up.

**2. A timeout on the descriptor/gateway IPC.** The reporter suspects the module-global `gatewaySwitch` promise can never settle, wedging every later switch. That is plausible — the `Promise.all([resolveConnectionForProfile, prepareGatewayForProfile])` has no timeout, and a bridge call that never returns would hang the mutex forever. I did not add one, because *how long* is a policy choice with real UX consequences on slow remote gateways, and picking a number unilaterally inside a bug fix is the wrong place for it. Note this PR does not depend on that question: the `finally` already clears the mutex on rejection, and two of the new tests prove a failed switch does not wedge the next one. A never-settling promise is a separate (real) issue and I'm happy to file it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — see the #81165 paragraph above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits) — one commit, applies cleanly to a fresh `main`
- [x] I've run `pytest tests/ -q` and all tests pass — N/A, desktop-only change; ran the vitest/tsc/eslint equivalents above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the changed behaviour is documented in the doc comments on all three seams
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific code; renderer TypeScript only, no paths, no shell, no line endings
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable — the entire symptom is the *absence* of output. That is the point of the fix: a declined switch previously produced no log line, no state change, and no rejected promise. It now produces a `false` and, on a lookup failure, `[profile] gateway switch failed { error, profile }`.
