### PR TITLE
fix(agent): recover unattended sessions after stale providers return

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -820,33 +820,36 @@ def _touch_stale_kill_activity(agent, elapsed: float) -> None:
 def _check_stale_giveup(agent) -> None:
     """Fail fast while open, allowing one recovery probe per cooldown."""
     _giveup = env_int("HERMES_STREAM_STALE_GIVEUP", 5)
-    _streak = _stale_streak(agent)
-    if _giveup > 0 and _streak >= _giveup:
+    if _giveup <= 0:
+        return
+    with _STALE_CIRCUIT_STATE_LOCK:
+        _streak = _stale_streak(agent)
+        if _streak < _giveup:
+            return
         now = time.monotonic()
-        with _STALE_CIRCUIT_STATE_LOCK:
-            try:
-                opened_at = float(agent._stale_circuit_opened_at)
-            except (AttributeError, TypeError, ValueError):
-                opened_at = now
-                agent._stale_circuit_opened_at = now
+        try:
+            opened_at = float(agent._stale_circuit_opened_at)
+        except (AttributeError, TypeError, ValueError):
+            opened_at = now
+            agent._stale_circuit_opened_at = now
 
-            elapsed = now - opened_at
-            if elapsed >= _STALE_CIRCUIT_RECOVERY_COOLDOWN_S:
-                # Claim this window before dispatch so concurrent calls cannot
-                # all become probes. A stale probe refreshes the timestamp in
-                # _bump_stale_streak; a successful one clears it in reset.
-                agent._stale_circuit_opened_at = now
-                logger.warning(
-                    "Stale-call circuit breaker entering half-open state after "
-                    "%.0fs; probing provider recovery.",
-                    elapsed,
-                )
-                return
-
-            retry_after = max(
-                1,
-                math.ceil(_STALE_CIRCUIT_RECOVERY_COOLDOWN_S - elapsed),
+        elapsed = now - opened_at
+        if elapsed >= _STALE_CIRCUIT_RECOVERY_COOLDOWN_S:
+            # Claim this window before dispatch so concurrent calls cannot
+            # all become probes. A stale probe refreshes the timestamp in
+            # _bump_stale_streak; a successful one clears it in reset.
+            agent._stale_circuit_opened_at = now
+            logger.warning(
+                "Stale-call circuit breaker entering half-open state after "
+                "%.0fs; probing provider recovery.",
+                elapsed,
             )
+            return
+
+        retry_after = max(
+            1,
+            math.ceil(_STALE_CIRCUIT_RECOVERY_COOLDOWN_S - elapsed),
+        )
         raise RuntimeError(
             "Provider has been unresponsive (no response received) for "
             f"{_streak} consecutive stale attempts — aborting this call to "

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -709,8 +709,12 @@ def _codex_wait_notice_recovery(
 # stale kill, reset only when a call actually completes (or when the
 # provider is swapped — switch_model / try_activate_fallback /
 # restore_primary_runtime — since the streak measured the OLD provider).
-# Past the give-up threshold, calls abort immediately with an actionable
-# error instead of re-waiting out the stale timeout.
+# Past the give-up threshold, calls abort immediately instead of re-waiting
+# out the stale timeout. One half-open probe per cooldown lets a recovered
+# provider close the breaker without hammering one that remains unhealthy.
+
+_STALE_CIRCUIT_RECOVERY_COOLDOWN_S = 60.0
+_STALE_CIRCUIT_STATE_LOCK = threading.Lock()
 
 def _stale_streak(agent) -> int:
     try:
@@ -721,14 +725,21 @@ def _stale_streak(agent) -> int:
 
 def _bump_stale_streak(agent) -> None:
     try:
-        agent._consecutive_stale_streams = _stale_streak(agent) + 1
+        with _STALE_CIRCUIT_STATE_LOCK:
+            streak = _stale_streak(agent) + 1
+            agent._consecutive_stale_streams = streak
+            giveup = env_int("HERMES_STREAM_STALE_GIVEUP", 5)
+            if giveup > 0 and streak >= giveup:
+                agent._stale_circuit_opened_at = time.monotonic()
     except Exception:
         pass
 
 
 def _reset_stale_streak(agent) -> None:
     try:
-        agent._consecutive_stale_streams = 0
+        with _STALE_CIRCUIT_STATE_LOCK:
+            agent._consecutive_stale_streams = 0
+            agent._stale_circuit_opened_at = None
     except Exception:
         pass
 
@@ -807,16 +818,40 @@ def _touch_stale_kill_activity(agent, elapsed: float) -> None:
 
 
 def _check_stale_giveup(agent) -> None:
-    """Raise immediately when the consecutive-stale streak is past the
-    give-up threshold — no network attempt, no stale-timeout wait."""
+    """Fail fast while open, allowing one recovery probe per cooldown."""
     _giveup = env_int("HERMES_STREAM_STALE_GIVEUP", 5)
     _streak = _stale_streak(agent)
     if _giveup > 0 and _streak >= _giveup:
+        now = time.monotonic()
+        with _STALE_CIRCUIT_STATE_LOCK:
+            try:
+                opened_at = float(agent._stale_circuit_opened_at)
+            except (AttributeError, TypeError, ValueError):
+                opened_at = now
+                agent._stale_circuit_opened_at = now
+
+            elapsed = now - opened_at
+            if elapsed >= _STALE_CIRCUIT_RECOVERY_COOLDOWN_S:
+                # Claim this window before dispatch so concurrent calls cannot
+                # all become probes. A stale probe refreshes the timestamp in
+                # _bump_stale_streak; a successful one clears it in reset.
+                agent._stale_circuit_opened_at = now
+                logger.warning(
+                    "Stale-call circuit breaker entering half-open state after "
+                    "%.0fs; probing provider recovery.",
+                    elapsed,
+                )
+                return
+
+            retry_after = max(
+                1,
+                math.ceil(_STALE_CIRCUIT_RECOVERY_COOLDOWN_S - elapsed),
+            )
         raise RuntimeError(
             "Provider has been unresponsive (no response received) for "
             f"{_streak} consecutive stale attempts — aborting this call to "
-            "avoid an indefinite stall. Switch models or start a new "
-            "session, then retry."
+            "avoid an indefinite stall. Switch models, start a new session, "
+            f"or retry after {retry_after}s for an automatic recovery probe."
         )
 
 

--- a/tests/run_agent/test_stream_stale_circuit_breaker.py
+++ b/tests/run_agent/test_stream_stale_circuit_breaker.py
@@ -135,6 +135,43 @@ class TestStreamStaleCircuitBreaker:
         agent._anthropic_client.messages.stream.assert_called_once()
         assert agent._consecutive_stale_streams == 0
 
+    def test_guard_reads_streak_under_state_lock(self, monkeypatch):
+        """A concurrent success reset cannot land after the guard snapshots
+        the old streak but before it decides whether the breaker is open."""
+        import agent.chat_completion_helpers as helpers
+
+        monkeypatch.setenv("HERMES_STREAM_STALE_GIVEUP", "3")
+
+        class AuditedLock:
+            held = False
+
+            def __enter__(self):
+                self.held = True
+
+            def __exit__(self, exc_type, exc, tb):
+                self.held = False
+
+        lock = AuditedLock()
+
+        class AgentState:
+            _stale_circuit_opened_at = 100.0
+            unsafe_reads = 0
+
+            @property
+            def _consecutive_stale_streams(self):
+                if not lock.held:
+                    self.unsafe_reads += 1
+                return 3
+
+        agent = AgentState()
+        monkeypatch.setattr(helpers, "_STALE_CIRCUIT_STATE_LOCK", lock)
+        monkeypatch.setattr(helpers.time, "monotonic", lambda: 100.0)
+
+        with pytest.raises(RuntimeError, match="unresponsive"):
+            helpers._check_stale_giveup(agent)
+
+        assert agent.unsafe_reads == 0
+
     @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
     def test_success_resets_streak(self, monkeypatch):
         """A stream that completes successfully clears the consecutive-stale

--- a/tests/run_agent/test_stream_stale_circuit_breaker.py
+++ b/tests/run_agent/test_stream_stale_circuit_breaker.py
@@ -103,6 +103,39 @@ class TestStreamStaleCircuitBreaker:
         assert agent._consecutive_stale_streams == 3
 
     @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
+    def test_half_open_probe_recovers_after_cooldown(self, monkeypatch):
+        """A latched single-provider session eventually gets one real attempt,
+        whose success closes the breaker without a model swap or new session."""
+        monkeypatch.setenv("HERMES_STREAM_STALE_GIVEUP", "3")
+        clock = [100.0]
+        monkeypatch.setattr(
+            "agent.chat_completion_helpers.time.monotonic", lambda: clock[0]
+        )
+
+        agent = _make_anthropic_agent()
+        agent._consecutive_stale_streams = 3
+        agent._anthropic_client.messages.stream.return_value = _good_stream_cm()
+
+        # Opening the circuit still blocks immediately and starts the cooldown.
+        with pytest.raises(RuntimeError, match="unresponsive"):
+            agent._interruptible_streaming_api_call({})
+        agent._anthropic_client.messages.stream.assert_not_called()
+
+        # Calls during the cooldown remain protected from another stale wait.
+        clock[0] = 159.9
+        with pytest.raises(RuntimeError, match="unresponsive"):
+            agent._interruptible_streaming_api_call({})
+        agent._anthropic_client.messages.stream.assert_not_called()
+
+        # At the boundary, one half-open probe reaches the recovered provider.
+        clock[0] = 160.0
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response is not None
+        agent._anthropic_client.messages.stream.assert_called_once()
+        assert agent._consecutive_stale_streams == 0
+
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
     def test_success_resets_streak(self, monkeypatch):
         """A stream that completes successfully clears the consecutive-stale
         streak so a recovered provider resumes normally."""


### PR DESCRIPTION
## What does this PR do?

Long-lived unattended sessions can now recover after a stale provider becomes healthy again. Previously, reaching the cross-turn stale-call threshold permanently short-circuited every later call before network dispatch, so a single-provider gateway, cron, or board session remained unusable until a person switched models or started a new session.

### Symptom

After five consecutive stale attempts, every later turn fails immediately with a provider-unresponsive error even after the configured endpoint has recovered.

### Impact

Unattended single-provider sessions can become permanently unavailable after a temporary provider outage or load spike. This affects long-lived gateway, cron, dashboard, and board sessions that cannot perform an interactive model swap or session restart.

### Bug Cause

**Trigger:** `agent/chat_completion_helpers.py` / `_check_stale_giveup()` when `_consecutive_stale_streams` reaches `HERMES_STREAM_STALE_GIVEUP`.

**Causal chain:**
1. Repeated calls receive no provider output and increment the agent-local stale streak to the configured threshold.
2. Every later call enters `_check_stale_giveup()` and raises before dispatching a network request.
3. Because only a successful call or provider swap resets the streak, a single-provider unattended session cannot observe provider recovery and remains latched open.

**Why it is wrong:** The circuit breaker had an open state but no bounded half-open transition, making a temporary provider failure permanent for the lifetime of the agent.

**Working sibling / contrast:** A fresh worker using the same recovered endpoint succeeds because its agent-local stale streak starts below the threshold. Calls below the threshold can also succeed and use the existing reset path.

**Ruled out:** Provider fallback error classification cannot recover the session because the stale guard raises before provider dispatch, and a single-provider deployment has no swap path.

### Fix

The shared stale-call guard now allows one half-open recovery probe after a 60-second cooldown. Calls during the cooldown still fail fast, a stale probe reopens the cooldown, and a successful probe uses the existing reset path to close the breaker. Breaker state reads and updates are serialized so concurrent calls cannot claim the same probe window or race a successful reset.

## Related Issue

Closes #89587

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py` - add a bounded, serialized half-open recovery transition to the stale-call circuit breaker.
- `tests/run_agent/test_stream_stale_circuit_breaker.py` - cover cooldown fail-fast behavior, successful provider recovery, and synchronized streak reads.

## How to Test

1. Run the focused stale-breaker and direct-call watchdog suites.
2. Confirm calls at the threshold fail without provider dispatch during the cooldown.
3. Confirm exactly one call becomes eligible at the cooldown boundary and a successful response resets the stale streak.

```bash
scripts/run_tests.sh tests/run_agent/test_stream_stale_circuit_breaker.py tests/run_agent/test_stream_stale_breaker_reset.py tests/cron/test_cron_direct_api_call_watchdog.py
```

Result: 29 passed across isolated focused reruns.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run the repository test entry on the relevant tests and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A - behavior and error guidance are covered in code and tests
- [x] `cli-config.yaml.example` update: N/A - no configuration keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered - the state machine uses Python synchronization and monotonic time
- [x] Tool descriptions/schemas update: N/A - no model tool behavior changed

## Screenshots / Logs

N/A - this is an in-process circuit-breaker state transition covered by deterministic regression tests.
