### PR TITLE
fix(desktop): scope active session lookup

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
@@ -67,8 +67,8 @@ describe('resolveStoredSession profile ownership', () => {
     const resolved = await resolveStoredSession('s1')
 
     expect(resolved?.profile).toBe('default')
-    // rung 2 (bare) then rung 3 (stamped cross-profile probe)
-    expect(mockGetSession).toHaveBeenNthCalledWith(1, 's1')
+    // rung 2 (active profile) then rung 3 (stamped cross-profile probe)
+    expect(mockGetSession).toHaveBeenNthCalledWith(1, 's1', 'meta')
     expect(mockGetSession).toHaveBeenNthCalledWith(2, 's1', 'default')
   })
 
@@ -82,7 +82,23 @@ describe('resolveStoredSession profile ownership', () => {
     expect(mockGetSession).not.toHaveBeenCalled()
   })
 
-  it('stamps the active profile on a bare by-id hit from an older backend', async () => {
+  it('scopes the first by-id lookup to the active profile', async () => {
+    mockGetSession.mockImplementation(async (_storedSessionId, profile) => {
+      if (profile === 'meta') {
+        return session({ id: 's1' })
+      }
+
+      throw new Error('404: Session not found')
+    })
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved?.profile).toBe('meta')
+    expect(mockGetSession).toHaveBeenCalledTimes(1)
+    expect(mockGetSession).toHaveBeenCalledWith('s1', 'meta')
+  })
+
+  it('stamps the active profile on a scoped by-id hit from an older backend', async () => {
     mockGetSession.mockResolvedValueOnce(session({ id: 's1' }))
 
     const resolved = await resolveStoredSession('s1')
@@ -90,6 +106,7 @@ describe('resolveStoredSession profile ownership', () => {
     expect(resolved?.profile).toBe('meta')
     // the upserted cache row is owned too, so the next hit short-circuits
     expect($sessions.get().find(s => s.id === 's1')?.profile).toBe('meta')
+    expect(mockGetSession).toHaveBeenCalledWith('s1', 'meta')
   })
 
   it('probed desktop profile overrides a remote backend answering as its own "default"', async () => {
@@ -104,6 +121,8 @@ describe('resolveStoredSession profile ownership', () => {
 
     expect(resolved?.profile).toBe('meta')
     expect($sessions.get().find(s => s.id === 's1')?.profile).toBe('meta')
+    expect(mockGetSession).toHaveBeenNthCalledWith(1, 's1', 'default')
+    expect(mockGetSession).toHaveBeenNthCalledWith(2, 's1', 'meta')
   })
 
   it('stamps the probed profile on a scoped hit from an older backend that omits it', async () => {
@@ -115,6 +134,8 @@ describe('resolveStoredSession profile ownership', () => {
     expect(resolved?.profile).toBe('default')
     // the cached row is owned too — no unowned row is ever re-cached
     expect($sessions.get().find(s => s.id === 's1')?.profile).toBe('default')
+    expect(mockGetSession).toHaveBeenNthCalledWith(1, 's1', 'meta')
+    expect(mockGetSession).toHaveBeenNthCalledWith(2, 's1', 'default')
   })
 
   it('resolveSessionProfile routes a default-profile session from a non-default gateway', async () => {
@@ -122,5 +143,7 @@ describe('resolveStoredSession profile ownership', () => {
     mockGetSession.mockResolvedValueOnce(session({ id: 's1', profile: 'default' }))
 
     await expect(resolveSessionProfile('s1')).resolves.toBe('default')
+    expect(mockGetSession).toHaveBeenNthCalledWith(1, 's1', 'meta')
+    expect(mockGetSession).toHaveBeenNthCalledWith(2, 's1', 'default')
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
@@ -109,6 +109,26 @@ describe('resolveStoredSession profile ownership', () => {
     expect(mockGetSession).toHaveBeenCalledWith('s1', 'meta')
   })
 
+  it('preserves explicit non-default ownership returned by the scoped backend', async () => {
+    mockGetSession.mockResolvedValueOnce(session({ id: 's1', profile: 'work' }))
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved?.profile).toBe('work')
+    expect(mockGetSession).toHaveBeenCalledWith('s1', 'meta')
+  })
+
+  it('preserves the legacy unowned row on the default-profile lookup', async () => {
+    $activeGatewayProfile.set('default')
+    $profiles.set(profiles('default'))
+    mockGetSession.mockResolvedValueOnce(session({ id: 's1' }))
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved?.profile).toBeUndefined()
+    expect(mockGetSession).toHaveBeenCalledWith('s1', 'default')
+  })
+
   it('probed desktop profile overrides a remote backend answering as its own "default"', async () => {
     // Per-profile remote override: Electron strips the desktop alias before
     // forwarding, so the standalone backend stamps its backend-local root.

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1307,17 +1307,19 @@ export async function resolveStoredSession(storedSessionId: string): Promise<Ses
     return cached
   }
 
-  // Direct by-id on the live backend — one row lookup, no list scan. Covers
-  // single-profile users and any id on the active profile (e.g. an old session
-  // past the sidebar's recent window). 404 just means it's not on this profile.
-  try {
-    const session = await getSession(storedSessionId)
+  const activeKey = normalizeProfileKey($activeGatewayProfile.get())
 
-    // Older backends omit `profile` on unscoped GETs; the serving backend is
-    // the active gateway's, so back-fill that rather than caching an unowned
-    // row. A present stamp is preserved: in app-global remote mode a bare hit
-    // can legitimately carry another profile's row (see the branch tests).
-    session.profile ||= normalizeProfileKey($activeGatewayProfile.get())
+  // Direct by-id on the active profile — one row lookup, no list scan. REST
+  // routing is independent from the renderer's active gateway, so the profile
+  // must be explicit: an unscoped request still lands on Desktop's primary
+  // backend and can 404 before the fallback excludes the real active owner.
+  try {
+    const session = await getSession(storedSessionId, activeKey)
+
+    // The Desktop profile we explicitly queried is authoritative. A pooled
+    // remote backend can answer with its own local alias (usually "default"),
+    // which is not the profile identity the renderer must route with.
+    session.profile = activeKey
 
     upsertResolvedSession(session, storedSessionId)
 
@@ -1329,8 +1331,6 @@ export async function resolveStoredSession(storedSessionId: string): Promise<Ses
   // Multi-profile only: probe each other profile by id (still one cheap lookup
   // each) rather than pulling every profile's recent sessions. The first hit
   // carries its owning `profile`, which routes the resume to the right backend.
-  const activeKey = normalizeProfileKey($activeGatewayProfile.get())
-
   const otherProfiles = $profiles
     .get()
     .map(profile => normalizeProfileKey(profile.name))

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1316,10 +1316,15 @@ export async function resolveStoredSession(storedSessionId: string): Promise<Ses
   try {
     const session = await getSession(storedSessionId, activeKey)
 
-    // The Desktop profile we explicitly queried is authoritative. A pooled
-    // remote backend can answer with its own local alias (usually "default"),
-    // which is not the profile identity the renderer must route with.
-    session.profile = activeKey
+    // A non-default Desktop profile can point at a standalone backend that
+    // answers with its own local alias (usually "default") or omits ownership.
+    // Stamp the Desktop routing key in those compatibility cases, but preserve
+    // explicit non-default ownership and the legacy unowned default-profile row.
+    const reportedProfile = session.profile?.trim()
+
+    if (activeKey !== 'default' && (!reportedProfile || normalizeProfileKey(reportedProfile) === 'default')) {
+      session.profile = activeKey
+    }
 
     upsertResolvedSession(session, storedSessionId)
 


### PR DESCRIPTION
## What does this PR do?

Scopes `resolveStoredSession()`'s first by-ID lookup to the renderer's active Desktop profile.

Desktop's gateway socket and Electron REST routing are separate. Activating a non-default Bot profile updates the gateway, but an unscoped REST request still goes to the primary backend. The resolver then excluded the active profile from its fallback probes because it assumed that unscoped request had already checked it. A stored Bot Chat owned by the active non-default profile could therefore 404 on the primary backend and time out without ever querying its actual owner.

The active profile is now explicit on the first lookup and remains authoritative even when a pooled or remote backend reports its own local alias.

## Related Issue

Discord support report: https://discord.com/channels/1053877538025386074/1539430577185497138

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-session-actions/utils.ts`: route the initial stored-session lookup through the active profile instead of the primary REST backend.
- `apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts`: cover a session that exists only on the active non-default profile and update the resolver ladder assertions.

## How to Test

1. Configure a local non-default Desktop profile with an existing stored Bot Chat.
2. Open that bot from the Bots pane while the primary backend belongs to another profile.
3. Verify Desktop queries the bot's active profile, resolves the session owner, and hydrates the transcript without a primary-backend `Session not found` timeout.

Focused verification on Windows 11:

- `vitest run --project ui src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts` (10 passed)
- focused ESLint (passed)
- focused Prettier check (passed)
- `git diff --check` (passed)

The full Desktop typecheck was attempted, but this workstation's shared dependency cache does not yet contain the `blobatar` package already declared by current `main`; TypeScript stops in `src/sdk/index.ts` before reaching this patch. GitHub CI will install the current lockfile dependencies.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

The regression is covered at the resolver boundary: current `main` sends the first lookup without a profile, while the fixed path sends `getSession(storedSessionId, activeProfile)` and succeeds without probing unrelated profiles.
