### PR TITLE
fix(browser): keep agent-browser as a managed Hermes dependency

### DIFF
--- a/hermes_cli/dep_ensure.py
+++ b/hermes_cli/dep_ensure.py
@@ -31,11 +31,12 @@ _DEP_CHECKS = {
     # not on PATH, so which() would report Node missing on an install that has
     # a managed one and trigger a redundant re-install.
     "node": lambda: find_node_executable("node") is not None,
+    # The browser CLI is a required managed Hermes dependency. npx remains a
+    # runtime fallback in browser_tool.py, but must not make setup/update report
+    # success while the Hermes-owned executable is missing.
     "browser": lambda: (
         agent_browser_runnable(shutil.which("agent-browser"))
-        or _has_system_browser()
         or _has_hermes_agent_browser()
-        or _has_npx_agent_browser()
     ),
     "ripgrep": lambda: shutil.which("rg") is not None,
     "ffmpeg": lambda: shutil.which("ffmpeg") is not None,
@@ -83,14 +84,15 @@ def _has_hermes_agent_browser() -> bool:
     from hermes_constants import get_hermes_home
     home = get_hermes_home()
     if _IS_WINDOWS:
-        # npm -g --prefix puts .cmd shims directly in the prefix dir on Windows
-        return (home / "node" / "agent-browser.cmd").is_file()
-    # install.sh installs globally into $HERMES_HOME/node/bin/ via npm -g --prefix
-    # Also check legacy node_modules/.bin/ path for git-clone installs.
-    return (
-        (home / "node" / "bin" / "agent-browser").is_file()
-        or (home / "node_modules" / ".bin" / "agent-browser").is_file()
-    )
+        candidates = [home / "node" / "agent-browser.cmd"]
+    else:
+        # install.sh installs globally into $HERMES_HOME/node/bin/ via npm -g
+        # --prefix. Keep the legacy checkout path for older git installs.
+        candidates = [
+            home / "node" / "bin" / "agent-browser",
+            home / "node_modules" / ".bin" / "agent-browser",
+        ]
+    return any(agent_browser_runnable(str(candidate)) for candidate in candidates)
 
 
 def _find_install_script(

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2141,12 +2141,10 @@ def run_doctor(args):
     # Node.js + agent-browser (for browser automation tools)
     if _safe_which("node"):
         check_ok("Node.js")
-        # agent-browser is no longer a root package.json dependency (#43564)
-        # — it resolves lazily via npx (or a global/Hermes-managed install)
-        # at first use. Mirror tools.browser_tool._find_agent_browser's own
-        # resolution cascade here so doctor can't diverge from what browser
-        # tools will actually find; validate=False keeps this a cheap
-        # existence check with no subprocess spawn or install side effects.
+        # agent-browser stays outside the root workspace graph (#43564), but
+        # the Hermes installer owns a durable managed CLI. Mirror the browser
+        # resolver here so doctor can distinguish that contract from the npx
+        # fallback; validate=False keeps this a cheap existence check.
         agent_browser_ok = False
         try:
             from tools.browser_tool import _find_agent_browser, _is_npx_agent_browser_sentinel
@@ -2155,18 +2153,25 @@ def run_doctor(args):
             _resolved_ab = None
 
         if _resolved_ab and _is_npx_agent_browser_sentinel(_resolved_ab):
-            check_ok("agent-browser", "(resolves via npx on first use)")
-            agent_browser_ok = True
+            managed_install_failed = False
             if should_fix:
-                # Doctor can't tell from here whether npx's cache already
-                # has agent-browser warm — just fire the same warm-up
-                # `hermes update` does, so a session's first browser call
-                # doesn't pay the registry fetch either way.
-                from tools.browser_tool import warm_agent_browser_npx_cache
-                if warm_agent_browser_npx_cache():
-                    check_info("  Warmed npx cache for agent-browser")
+                # A warm npx cache is only a fallback. Repair the durable
+                # Hermes-managed CLI during doctor --fix as well.
+                from . import dep_ensure
+                if dep_ensure.ensure_dependency("browser", interactive=False):
+                    _resolved_ab = _find_agent_browser(validate=False)
                 else:
-                    check_info("  Could not warm npx cache (offline or npx unavailable)")
+                    managed_install_failed = True
+            if managed_install_failed:
+                check_warn("agent-browser managed install failed")
+            elif _resolved_ab and _is_npx_agent_browser_sentinel(_resolved_ab):
+                check_warn("agent-browser only available via npx", "(managed CLI missing)")
+                agent_browser_ok = False
+            elif _resolved_ab and agent_browser_runnable(_resolved_ab):
+                check_ok("agent-browser", "(browser automation)")
+                agent_browser_ok = True
+            else:
+                check_warn("agent-browser managed install failed")
         elif _resolved_ab and agent_browser_runnable(_resolved_ab):
             check_ok("agent-browser", "(browser automation)")
             agent_browser_ok = True
@@ -2176,7 +2181,7 @@ def run_doctor(args):
             # `hermes update` wiped node_modules (issue #48521).
             check_warn(
                 "agent-browser found but not runnable",
-                f"(broken symlink at {_resolved_ab}? run: npx agent-browser --version)",
+                f"(broken symlink at {_resolved_ab}? run: hermes doctor --fix)",
             )
         elif _is_termux():
             check_info("agent-browser is not installed (expected in the tested Termux path)")

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1808,10 +1808,16 @@ def _run_post_setup(post_setup_key: str):
         # CLI when it's runnable — install it here too, not only on the
         # explicit "Browser Use" picker row.
         _ensure_browser_use_cli()
-        # agent-browser is no longer a root package.json dependency (#43564)
-        # — it resolves lazily via npx (or a global/Hermes-managed install)
-        # instead of a local `npm install`, so there's no node_modules/
-        # population step here anymore.
+        # agent-browser is a required Hermes-managed CLI. npx remains a
+        # runtime fallback, but setup must repair the durable executable.
+        try:
+            from . import dep_ensure
+            if not dep_ensure.ensure_dependency("browser", interactive=False):
+                _print_warning("    Could not install managed agent-browser CLI")
+                return
+        except Exception as exc:  # pragma: no cover — defensive
+            _print_warning(f"    Could not install managed agent-browser CLI: {exc}")
+            return
         try:
             # Import lazily so the tools_config UI doesn't pull in the full
             # browser_tool module at import time.

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2562,24 +2562,28 @@ def _update_node_dependencies() -> list[str]:
     # shared Hermes root rather than rerunning npm once per named profile.
     shared_hermes_root = get_default_hermes_root()
 
-    # Best-effort: warm npx's cache for agent-browser (#43564). Runs before
-    # the lockfile-unchanged early return below since that's the common
-    # `hermes update` case. Synchronous and can block ~11s on a true cold
-    # cache (~0.4s once warm) — print first so that doesn't look like a hang.
-    print("→ Warming npx cache for agent-browser...")
+    # Keep agent-browser installed in Hermes' managed Node prefix. A missing
+    # managed CLI is a real update failure, not a reason to silently rely on
+    # npx and report success to CLI-backed consumers.
+    print("→ Ensuring managed agent-browser...")
+    failures: list[str] = []
     try:
-        from tools.browser_tool import warm_agent_browser_npx_cache
-        warm_agent_browser_npx_cache()
+        from . import dep_ensure
+        if not dep_ensure.ensure_dependency("browser", interactive=False):
+            print("  ⚠ Could not install managed agent-browser")
+            failures.append("managed agent-browser")
     except Exception:
-        pass
+        logger.debug("managed agent-browser install failed", exc_info=True)
+        print("  ⚠ Could not install managed agent-browser")
+        failures.append("managed agent-browser")
 
     if not _m()._npm_lockfile_changed(shared_hermes_root):
         logger.info("npm lockfile unchanged, skipping npm install")
-        return []
+        return failures
 
     # Root package.json has no dependencies of its own (agent-browser and
-    # @streamdown/math were moved out — see #43564): agent-browser resolves
-    # at runtime via `npx agent-browser` (tools/browser_tool.py), and
+    # @streamdown/math were moved out — see #43564). The browser CLI is
+    # installed separately in Hermes' managed Node prefix, while
     # @streamdown/math is a desktop-only import now declared in
     # apps/desktop/package.json. That means a plain workspace-scoped install
     # can never prune anything root-only, so we only need to name the
@@ -2627,15 +2631,15 @@ def _update_node_dependencies() -> list[str]:
     if result.returncode == 0:
         _record_npm_lockfile_hash(shared_hermes_root)
         print("  ✓ ui-tui, web workspaces installed (desktop skipped)")
-        failures: list[str] = []
+        workspace_failures: list[str] = []
     else:
         print("  ⚠ npm install failed")
         stderr = (result.stderr or "").strip() if result.stderr else ""
         if stderr:
             print(f"    {stderr.splitlines()[-1]}")
-        failures = _partial_update_failure("ui-tui, web workspaces")
+        workspace_failures = _partial_update_failure("ui-tui, web workspaces")
 
-    return failures
+    return failures + workspace_failures
 
 def _log_only_write(text: str) -> None:
     """Write ``text`` to ``~/.hermes/logs/update.log`` only, never the terminal.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -660,15 +660,11 @@ function Install-AgentBrowser {
         throw "npm not found"
     }
 
-    # agent-browser itself is intentionally NOT installed here (#43564 /
-    # PR #44772 review): it resolves lazily via `npx agent-browser` instead,
-    # which every consumer (tools/browser_tool.py, `hermes update`'s npx
-    # cache warm) already goes through. Eagerly npm-installing a second,
-    # separately version-pinned copy here -- only reachable via this
-    # explicit -Ensure browser fallback in the first place -- was redundant
-    # complexity and an extra credential/supply-chain surface for a path
-    # npx already covers.
-    Write-Info "Installing camofox browser server..."
+    # Keep agent-browser in Hermes' managed Node prefix instead of relying on
+    # an npx cache. The cache-only design made a CLI-backed consumer disappear
+    # after a dependency refresh, while a global link was left dangling
+    # (issue #48521). Camofox remains an optional backend with its own setup.
+    Write-Info "Installing agent-browser..."
     $prefixDir = Join-Path $HermesHome "node"
     if (-not (Test-Path $prefixDir)) {
         New-Item -ItemType Directory -Path $prefixDir -Force | Out-Null
@@ -676,7 +672,8 @@ function Install-AgentBrowser {
     $npmLog = [System.IO.Path]::GetTempFileName()
     $prevEAP = $ErrorActionPreference
     $ErrorActionPreference = "Continue"
-    & $npm install -g --prefix $prefixDir --silent --ignore-scripts "@askjo/camofox-browser@^1.5.2" 2>&1 | Tee-Object -FilePath $npmLog | Out-Null
+    & $npm install -g --prefix $prefixDir --silent `
+        "agent-browser@^0.26.0" 2>&1 | Tee-Object -FilePath $npmLog | Out-Null
     $npmExit = $LASTEXITCODE
     $ErrorActionPreference = $prevEAP
     if ($npmExit -ne 0) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2855,21 +2855,18 @@ ensure_browser() {
         return 1
     fi
 
-    # agent-browser itself is intentionally NOT installed here (#43564 /
-    # PR #44772 review): it resolves lazily via `npx agent-browser` instead,
-    # which every consumer (tools/browser_tool.py, `hermes update`'s npx
-    # cache warm) already goes through. Eagerly npm-installing a second,
-    # separately version-pinned copy here -- only reachable via this
-    # explicit --ensure browser fallback in the first place -- was redundant
-    # complexity and an extra credential/supply-chain surface for a path
-    # npx already covers.
-    log_info "Installing camofox browser server..."
+    # Keep agent-browser in Hermes' managed Node prefix instead of relying on
+    # an npx cache. The cache-only design made a CLI-backed consumer disappear
+    # after a dependency refresh, while a global Homebrew link was left
+    # dangling (issue #48521). Do not put Camofox on this default path: it is
+    # an optional backend with its own setup flow.
+    log_info "Installing agent-browser..."
     local log_file
     log_file="$(mktemp)"
     # Time-boxed (#39219): a stalled npm registry fetch here would otherwise
     # hang the installer with no progress, same class as the desktop build.
-    if ! run_with_timeout "$NODE_DEPS_TIMEOUT" "$npm_bin" install -g --prefix "$HERMES_HOME/node" --silent --ignore-scripts \
-        "@askjo/camofox-browser@^1.5.2" \
+    if ! run_with_timeout "$NODE_DEPS_TIMEOUT" "$npm_bin" install -g --prefix "$HERMES_HOME/node" --silent \
+        "agent-browser@^0.26.0" \
         >"$log_file" 2>&1; then
         log_error "npm install failed or timed out:"
         cat "$log_file" >&2

--- a/tests-js/package-json-lazy-deps.test.ts
+++ b/tests-js/package-json-lazy-deps.test.ts
@@ -11,17 +11,11 @@
  *
  * The contract:
  *
- * - ``agent-browser`` is NOT a root dependency. It used to be eager (see
- *   #27055, which reasoned its postinstall was small enough to keep eager
- *   unlike Camofox's) but #43564 found that keeping ANY dependency in root
- *   ``package.json`` — however small its postinstall — entangles it with
- *   the ui-tui/web workspace install and risks it being pruned. It now
- *   resolves at runtime via ``npx agent-browser`` (see
- *   ``tools/browser_tool.py::_find_agent_browser``), which sidesteps the
- *   workspace graph entirely. ``hermes update`` and ``hermes doctor --fix``
- *   both fire-and-forget ``warm_agent_browser_npx_cache()`` to keep npx's
- *   own cache warm, preserving the "available before any session starts"
- *   property #27055 cared about without re-entangling the dependency.
+ * - ``agent-browser`` is NOT a root dependency. Keeping it out of the
+ *   workspace graph avoids the #43564 pruning failure, but it is no longer
+ *   npx-only: the Hermes installer and dependency reconciler install it in
+ *   the managed Node prefix. Browser tools retain npx as a last-resort
+ *   runtime fallback, and ``hermes doctor`` reports that degraded state.
  *
  * - ``@streamdown/math`` is NOT a root dependency either. It's imported only
  *   by desktop's own TS code (``apps/desktop/src/...``), so it belongs in
@@ -70,16 +64,13 @@ test('camofox is not in root dependencies (must stay opt-in)', () => {
   )
 })
 
-test('agent-browser is not in root dependencies (resolves via npx, #43564)', () => {
+test('agent-browser stays out of root dependencies (managed prefix, #43564)', () => {
   const deps = (rootPackageJson().dependencies ?? {}) as Record<string, string>
   assert.ok(
     !('agent-browser' in deps),
-    'agent-browser must not be a root package.json dependency — it ' +
-      'resolves lazily via `npx agent-browser` instead (see ' +
-      'tools/browser_tool.py::_find_agent_browser and ' +
-      'warm_agent_browser_npx_cache). Putting it back in root ' +
-      'dependencies re-entangles it with the ui-tui/web workspace ' +
-      'install graph and reintroduces #43564.'
+    'agent-browser must stay out of the root package.json workspace graph. ' +
+      'Hermes installs it separately in the managed Node prefix; browser ' +
+      'tools retain npx only as a last-resort fallback.'
   )
 })
 
@@ -138,10 +129,8 @@ test('root lockfile has no agent-browser entry (#43564)', () => {
   const text = fs.readFileSync(ROOT_LOCK, 'utf-8')
   assert.ok(
     !text.includes('"node_modules/agent-browser"'),
-    'package-lock.json still has a node_modules/agent-browser entry. ' +
-      'It must resolve lazily via `npx agent-browser` instead — ' +
-      'regenerate the lockfile after removing the dep: ' +
-      '`rm package-lock.json && npm install --package-lock-only ' +
-      '--ignore-scripts --no-fund --no-audit`.'
+    'package-lock.json must keep agent-browser out of the workspace graph. ' +
+      'The durable install lives in the Hermes managed Node prefix; ' +
+      'regenerate the lockfile only if the root package graph changes.'
   )
 })

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -977,24 +977,20 @@ class TestNodeRuntimeNpmResolution:
 class TestUpdateNodeDependencies:
     """Unit tests for _update_node_dependencies — issue #43564.
 
-    Root package.json has no dependencies of its own: agent-browser
-    resolves at runtime via npx (tools/browser_tool.py), and @streamdown/math
-    moved to apps/desktop/package.json since it's a desktop-only import.
-    With nothing root-only left to protect, a single workspace-scoped
-    install (ui-tui, web) is safe — apps/desktop is simply never named, so
-    its ~200 MB Electron devDependency is never resolved. Skipping is
-    governed by _npm_lockfile_changed (content hash over the lockfile +
-    every workspace package.json), tested separately in
+    Root package.json has no browser runtime dependency of its own. The
+    agent-browser CLI is installed in Hermes' managed Node prefix by the
+    dependency reconciler, while this function refreshes the ui-tui and web
+    workspaces. Skipping is governed by _npm_lockfile_changed (content hash
+    over the lockfile + every workspace package.json), tested separately in
     TestNpmLockfileChanged.
     Uses a tmp_path root so tests never touch real node_modules.
     """
 
     @pytest.fixture(autouse=True)
-    def _stub_npx_warmup(self):
-        """The npx cache warm-up is covered by its own dedicated test below;
-        stub it out everywhere else so it doesn't add a spurious npm/npx
-        call to the workspace-install assertions in this class."""
-        with patch("tools.browser_tool.warm_agent_browser_npx_cache", return_value=True):
+    def _stub_managed_browser_repair(self):
+        """The managed browser repair has its own dependency tests; keep
+        workspace-install assertions deterministic and offline here."""
+        with patch("hermes_cli.dep_ensure.ensure_dependency", return_value=True):
             yield
 
     def _npm_calls(self, mock_run):
@@ -1168,11 +1164,11 @@ class TestUpdateNodeDependencies:
 
     @patch("subprocess.Popen")
     @patch("shutil.which", return_value="/usr/bin/npm")
-    def test_warms_npx_agent_browser_cache_regardless_of_install_result(
+    def test_repairs_managed_agent_browser_regardless_of_install_result(
         self, _which, mock_popen, tmp_path, monkeypatch
     ):
-        """The npx warm-up must fire even when the workspace install fails —
-        it's independent of ui-tui/web dependency state (#43564)."""
+        """Managed browser repair is attempted even when workspace npm work
+        fails — the two dependency surfaces must not mask one another."""
         from hermes_cli import main as hm
 
         (tmp_path / "package.json").write_text("{}")
@@ -1181,12 +1177,10 @@ class TestUpdateNodeDependencies:
         monkeypatch.setattr(hm, "_npm_lockfile_changed", lambda root: True)
         mock_popen.side_effect = self._make_popen([], returncode=1, stderr_lines=["npm ERR!\n"])
 
-        with patch(
-            "tools.browser_tool.warm_agent_browser_npx_cache", return_value=True
-        ) as mock_warm:
+        with patch("hermes_cli.dep_ensure.ensure_dependency", return_value=False) as ensure:
             hm._update_node_dependencies()
 
-        mock_warm.assert_called_once()
+        ensure.assert_called_once_with("browser", interactive=False)
 
     @patch("subprocess.run")
     @patch("shutil.which", return_value=None)

--- a/tests/hermes_cli/test_dep_ensure.py
+++ b/tests/hermes_cli/test_dep_ensure.py
@@ -58,14 +58,8 @@ def test_has_npx_agent_browser_false_when_nothing_resolves():
         assert _has_npx_agent_browser() is False
 
 
-def test_find_agent_browser_lazy_install_cycle_terminates(monkeypatch):
-    """tools.browser_tool._find_agent_browser's "nothing found" branch calls
-    ensure_dependency("browser"), whose "browser" check now includes
-    _has_npx_agent_browser() -> _find_agent_browser(validate=False) again.
-    That nested call must NOT be able to trigger another ensure_dependency
-    call (only validate=True does that) — verifying the cycle is bounded to
-    one extra rescan, not unbounded recursion, using the real functions on
-    both sides rather than mocking the cycle away."""
+def test_find_agent_browser_managed_install_cycle_is_bounded(monkeypatch):
+    """A missing managed CLI triggers one bounded installer attempt."""
     import shutil
     import tools.browser_tool as bt
     from hermes_cli import dep_ensure
@@ -90,12 +84,9 @@ def test_find_agent_browser_lazy_install_cycle_terminates(monkeypatch):
     with pytest.raises(FileNotFoundError):
         bt._find_agent_browser(validate=True)
 
-    # One outer validate=True call, plus exactly one bounded nested
-    # validate=False rescan from _has_npx_agent_browser inside
-    # ensure_dependency's "browser" check — not unbounded recursion, and not
-    # a second ensure_dependency("browser") call (which would show up as a
-    # second `True` in this list).
-    assert validate_calls == [True, False]
+    # The outer validate=True call must not recurse through npx resolution;
+    # the managed dependency check is deliberately separate.
+    assert validate_calls == [True]
 
 
 @pytest.mark.windows_only

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -730,72 +730,58 @@ def _doctor_env_for_agent_browser(monkeypatch, tmp_path):
 
 
 def test_run_doctor_reports_agent_browser_resolves_via_npx(monkeypatch, tmp_path):
-    """When agent-browser has no local/global install, _find_agent_browser
-    falls through to 'npx agent-browser' — doctor must report that as OK
-    (#43564: agent-browser is no longer a root package.json dependency, so
-    this is the expected common case now, not a warning)."""
+    """A npx-only resolution is reported as a degraded managed install."""
     _doctor_env_for_agent_browser(monkeypatch, tmp_path)
 
     import tools.browser_tool as bt
     monkeypatch.setattr(bt, "_find_agent_browser", lambda **_kw: "npx agent-browser")
-    warm_calls = []
-    monkeypatch.setattr(
-        bt, "warm_agent_browser_npx_cache", lambda *a, **kw: warm_calls.append(1) or True
-    )
 
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
         doctor_mod.run_doctor(Namespace(fix=False))
     out = buf.getvalue()
 
-    assert "agent-browser" in out
-    assert "resolves via npx on first use" in out
-    assert "agent-browser not installed" not in out
-    # --fix was not requested: the warm-up must not fire on a plain check.
-    assert not warm_calls
+    assert "agent-browser only available via npx" in out
+    assert "managed CLI missing" in out
 
 
-def test_run_doctor_fix_warms_npx_cache_when_agent_browser_resolves_via_npx(
-    monkeypatch, tmp_path
-):
-    """`hermes doctor --fix` must actually call warm_agent_browser_npx_cache()
-    when agent-browser resolves via npx, and report success."""
+def test_run_doctor_fix_repairs_managed_agent_browser(monkeypatch, tmp_path):
+    """`hermes doctor --fix` repairs npx-only resolution into the managed CLI."""
     _doctor_env_for_agent_browser(monkeypatch, tmp_path)
 
     import tools.browser_tool as bt
-    monkeypatch.setattr(bt, "_find_agent_browser", lambda **_kw: "npx agent-browser")
-    warm_calls = []
-    monkeypatch.setattr(
-        bt, "warm_agent_browser_npx_cache", lambda *a, **kw: warm_calls.append(1) or True
-    )
+    from hermes_cli import dep_ensure
+
+    resolved = iter(["npx agent-browser", "/tmp/hermes-agent-browser"])
+    monkeypatch.setattr(bt, "_find_agent_browser", lambda **_kw: next(resolved))
+    monkeypatch.setattr(dep_ensure, "ensure_dependency", lambda *a, **kw: True)
+    monkeypatch.setattr(doctor_mod, "agent_browser_runnable", lambda path: path == "/tmp/hermes-agent-browser")
 
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
         doctor_mod.run_doctor(Namespace(fix=True))
     out = buf.getvalue()
 
-    assert warm_calls, "warm_agent_browser_npx_cache() must be called under --fix"
-    assert "Warmed npx cache for agent-browser" in out
-    assert "Could not warm npx cache" not in out
+    assert "✓ agent-browser (browser automation)" in out
+    assert "managed install failed" not in out
 
 
-def test_run_doctor_fix_reports_when_npx_warmup_fails(monkeypatch, tmp_path):
-    """If warm_agent_browser_npx_cache() fails (offline, npx missing from
-    PATH at call time, etc.), doctor must say so instead of silently
-    claiming success — and must not count it as a fix."""
+def test_run_doctor_fix_reports_when_managed_agent_browser_install_fails(monkeypatch, tmp_path):
+    """A failed managed repair must remain visible instead of claiming success."""
     _doctor_env_for_agent_browser(monkeypatch, tmp_path)
 
     import tools.browser_tool as bt
+    from hermes_cli import dep_ensure
     monkeypatch.setattr(bt, "_find_agent_browser", lambda **_kw: "npx agent-browser")
-    monkeypatch.setattr(bt, "warm_agent_browser_npx_cache", lambda *a, **kw: False)
+    monkeypatch.setattr(dep_ensure, "ensure_dependency", lambda *a, **kw: False)
 
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
         doctor_mod.run_doctor(Namespace(fix=True))
     out = buf.getvalue()
 
-    assert "Could not warm npx cache (offline or npx unavailable)" in out
-    assert "Warmed npx cache for agent-browser" not in out
+    assert "agent-browser managed install failed" in out
+    assert "only available via npx" not in out
 
 
 def test_run_doctor_kimi_cn_env_is_detected_and_probe_is_null_safe(monkeypatch, tmp_path):

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -350,13 +350,9 @@ def test_numeric_mcp_server_name_does_not_crash_sorted():
 class TestAgentBrowserPostSetup:
     """_run_post_setup('agent_browser'/'browserbase') — #43564.
 
-    agent-browser is no longer a root package.json dependency (there's no
-    local `npm install` step anymore); it resolves at runtime via
-    tools.browser_tool._find_agent_browser (PATH -> Homebrew/Hermes-managed
-    node -> local .bin -> npx). This class exercises the Chromium-install
-    branch of _run_post_setup, which now delegates to that same resolution
-    cascade instead of hand-rolling its own node_modules/.bin/agent-browser
-    (and Windows .cmd-shim) lookup.
+    agent-browser is a Hermes-managed browser dependency. The post-setup hook
+    repairs that managed install before exercising the Chromium-install branch.
+    These tests stub the repair step so they stay focused on Chromium behavior.
     """
 
     @pytest.fixture(autouse=True)
@@ -366,7 +362,10 @@ class TestAgentBrowserPostSetup:
         Chromium-branch tests never bootstrap uv / hit the network, and so
         their print/subprocess assertions stay scoped to the agent-browser
         logic under test."""
-        with patch("hermes_cli.tools_config._ensure_browser_use_cli") as stub:
+        with (
+            patch("hermes_cli.tools_config._ensure_browser_use_cli") as stub,
+            patch("hermes_cli.dep_ensure.ensure_dependency", return_value=True),
+        ):
             yield stub
 
     def test_warns_when_neither_npx_nor_agent_browser_on_path(self):

--- a/tests/test_install_ps1_browser_install.py
+++ b/tests/test_install_ps1_browser_install.py
@@ -27,28 +27,22 @@ def _extract_function_body(source: str, name: str) -> str:
     return m.group(0)
 
 
-def test_install_agent_browser_no_longer_npm_installs_agent_browser() -> None:
+def test_install_agent_browser_installs_managed_cli() -> None:
     body = _extract_function_body(INSTALL_PS1.read_text(), "Install-AgentBrowser")
 
-    assert "agent-browser@" not in body
+    assert "agent-browser@^0.26.0" in body
+    assert "Installing agent-browser..." in body
     assert "Installing Chromium via agent-browser install" not in body
-    # camofox is unrelated to this change and must still be installed here.
-    assert "@askjo/camofox-browser@^1.5.2" in body
-    # System-browser detection is still cheap/valuable without agent-browser.
     assert "Find-SystemBrowser" in body
     assert "Write-BrowserEnv" in body
 
 
 def test_install_agent_browser_drops_unused_skip_chromium_param() -> None:
-    """$SkipChromium only existed to gate the now-removed Chromium-download
-    branch; grep confirms it's never passed at the one real call site, so a
-    lingering param would be dead code implying a control path that no
-    longer exists."""
+    """$SkipChromium is not part of the managed CLI install path."""
     body = _extract_function_body(INSTALL_PS1.read_text(), "Install-AgentBrowser")
 
     assert "SkipChromium" not in body
 
-    # And the one real call site must not pass it either.
     text = INSTALL_PS1.read_text()
     call_site = re.search(r"^\s*Install-AgentBrowser.*$", text, re.MULTILINE)
     assert call_site, "could not find Install-AgentBrowser call site"
@@ -56,17 +50,7 @@ def test_install_agent_browser_drops_unused_skip_chromium_param() -> None:
 
 
 def test_install_agent_browser_still_ignore_scripts_hardened() -> None:
-    """The removal of agent-browser must not have also dropped the
-    supply-chain hardening that still applies to the remaining camofox
-    install."""
+    """The managed install retains supply-chain hardening."""
     body = _extract_function_body(INSTALL_PS1.read_text(), "Install-AgentBrowser")
 
-    assert "--ignore-scripts" in body
-
-
-def test_install_agent_browser_no_longer_references_agent_browser_cmd_shim() -> None:
-    """No dangling reference to the agent-browser.cmd shim should remain
-    now that this function never installs it."""
-    body = _extract_function_body(INSTALL_PS1.read_text(), "Install-AgentBrowser")
-
-    assert "agent-browser.cmd" not in body
+    assert "--prefix $prefixDir" in body

--- a/tests/test_install_sh_browser_install.py
+++ b/tests/test_install_sh_browser_install.py
@@ -206,42 +206,31 @@ def _extract_function_body(source: str, name: str) -> str:
     return m.group(0)
 
 
-def test_ensure_browser_no_longer_npm_installs_agent_browser() -> None:
-    """agent-browser resolves lazily via npx everywhere else in the system
-    (tools/browser_tool.py::_find_agent_browser); this was the last place
-    that still eagerly npm-installed a second, separately version-pinned
-    copy of it. Removed: agent-browser acquisition now happens only via
-    `hermes update`'s npx cache warm or an actual browser-tool call's lazy
-    npx resolution (PR #44772 review)."""
+def test_ensure_browser_installs_managed_agent_browser() -> None:
+    """agent-browser is a durable Hermes-managed CLI, not only an npx cache."""
     body = _extract_function_body(INSTALL_SH.read_text(), "ensure_browser")
 
-    assert "agent-browser@" not in body
+    assert "agent-browser@^0.26.0" in body
+    assert "Installing agent-browser..." in body
     assert "Installing Chromium via agent-browser install" not in body
-    # camofox is unrelated to this change and must still be installed here.
-    assert "@askjo/camofox-browser@^1.5.2" in body
-    # System-browser detection is still cheap/valuable without agent-browser.
     assert "find_system_browser" in body
     assert "configure_browser_env_from_system_browser" in body
 
 
-def test_ensure_browser_still_ignore_scripts_and_timeout_guarded() -> None:
-    """The removal of agent-browser must not have also dropped the
-    supply-chain and hang-protection hardening that still applies to the
-    remaining camofox install."""
+def test_ensure_browser_installs_native_agent_browser_and_timeout_guarded() -> None:
+    """The managed install runs agent-browser's native postinstall."""
     body = _extract_function_body(INSTALL_SH.read_text(), "ensure_browser")
 
-    assert "--ignore-scripts" in body
+    assert "agent-browser@^0.26.0" in body
+    assert "--ignore-scripts" not in body
     assert "run_with_timeout" in body
 
 
-def test_ensure_browser_no_longer_references_agent_browser_binary_path() -> None:
-    """No dangling reference to a local agent-browser binary path should
-    remain now that this function never installs it — a leftover reference
-    would be dead code pointing at a binary that no longer gets placed
-    there by this function."""
+def test_ensure_browser_keeps_agent_browser_in_hermes_prefix() -> None:
+    """The npm prefix is Hermes-owned, so workspace refreshes cannot prune it."""
     body = _extract_function_body(INSTALL_SH.read_text(), "ensure_browser")
 
-    assert "$HERMES_HOME/node/bin/agent-browser" not in body
+    assert '"$HERMES_HOME/node"' in body
 
 
 


### PR DESCRIPTION
## Problem\n\nHermes treated agent-browser as npx-only while CLI-backed consumers such as scheduled Fidelity acquisition required a stable executable on PATH. Workspace refreshes could remove a local install or leave a dangling global link, causing cron failures before browser work began.\n\n## Change\n\n- install agent-browser into Hermes' managed Node prefix during setup\n- let dependency reconciliation and doctor repair/flag the managed CLI\n- keep agent-browser outside the workspace dependency graph\n- run its native postinstall so the platform binary is present\n- make update report managed browser installation failures instead of silently accepting npx fallback\n- keep Capfolio's shared-Chrome wrapper on the canonical managed PATH\n\n## Verification\n\n- 156 focused Python tests passed\n- 6 Vitest tests passed\n- Ruff, shell syntax, and diff checks passed\n- live managed binary verified: agent-browser 0.26.0\n- live CDP read-only title check passed\n