### PR TITLE
fix(desktop): surface profile-switch failures instead of swallowing them

### DIFF
--- a/apps/desktop/src/app/chat/chat-swap-overlay.tsx
+++ b/apps/desktop/src/app/chat/chat-swap-overlay.tsx
@@ -6,10 +6,23 @@ import { cn } from '@/lib/utils'
 // Braille spinner frames — reads as a tiny ASCII loader in monospace.
 const FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
 
+export interface ChatSwapError {
+  profile: string
+  message: string
+}
+
 // Shown over the conversation while the live gateway swaps to another profile's
 // backend (lazily spawned). Keeps the last profile name through the fade-out so
-// the label doesn't blank. Purely visual — pointer-events-none.
-export function ChatSwapOverlay({ profile }: { profile: string | null }) {
+// the label doesn't blank. Purely visual — pointer-events-none. When a switch
+// FAILS (descriptor lookup or dial), the overlay renders the surfaced error in
+// place of the spinner so a dead click is never silent.
+export function ChatSwapOverlay({
+  error,
+  profile
+}: {
+  error: ChatSwapError | null
+  profile: string | null
+}) {
   const { t } = useI18n()
   const [frame, setFrame] = useState(0)
   const [label, setLabel] = useState<null | string>(profile)
@@ -29,6 +42,31 @@ export function ChatSwapOverlay({ profile }: { profile: string | null }) {
 
     return () => window.clearInterval(id)
   }, [profile])
+
+  if (error) {
+    return (
+      <div
+        aria-hidden
+        className={cn(
+          'pointer-events-none absolute inset-0 z-50 flex items-center justify-center transition-opacity duration-150 ease-out',
+          'opacity-100'
+        )}
+      >
+        <div
+          className="flex max-w-md items-start gap-2 bg-[color-mix(in_srgb,var(--dt-card)_92%,transparent)] px-4 py-2 font-mono text-[0.8125rem] text-destructive shadow-composer"
+          role="alert"
+        >
+          <span aria-hidden className="mt-0.5 shrink-0 text-(--ui-accent)">
+            ⚠
+          </span>
+          <span className="min-w-0 break-words">
+            {t.composer.switchFailed(error.profile)}
+            <span className="opacity-80"> — {error.message}</span>
+          </span>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -29,7 +29,7 @@ import { migrateQueuedPrompts, parkQueuedPrompts } from '@/store/composer-queue'
 import { $pinnedSessionIds } from '@/store/layout'
 import { $petActive } from '@/store/pet'
 import { $petOverlayActive } from '@/store/pet-overlay'
-import { $activeGatewayProfile, $gatewaySwapTarget, $profiles } from '@/store/profile'
+import { $activeGatewayProfile, $gatewaySwapTarget, $gatewaySwitchError, $profiles } from '@/store/profile'
 import {
   $contextSuggestions,
   $freshDraftReady,
@@ -377,6 +377,7 @@ export const ChatView = memo(function ChatView({
   const freshDraftReady = useStore($freshDraftReady)
   const gatewayState = useStore($gatewayState)
   const gatewaySwapTarget = useStore($gatewaySwapTarget)
+  const gatewaySwitchError = useStore($gatewaySwitchError)
   const gatewayOpen = gatewayState === 'open'
   const introPersonality = useStore($introPersonality)
   const introSeed = useStore($introSeed)
@@ -636,7 +637,7 @@ export const ChatView = memo(function ChatView({
           {/* A session drag hovering an EDGE hands the visual to the zone
               target; the link overlay shows only for the center region. */}
           <ChatDropOverlay kind={overlayKind} />
-          <ChatSwapOverlay profile={gatewaySwapTarget} />
+          <ChatSwapOverlay error={gatewaySwitchError} profile={gatewaySwapTarget} />
         </div>
         {/* Composer renders OUTSIDE the contain:[layout paint] wrapper above:
             that wrapper is a containing block for — and clips — position:fixed

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1737,6 +1737,7 @@ export const ar = defineLocale({
   composer: {
     message: 'الرسالة',
     wakingProfile: profile => `جار إيقاظ ${profile}`,
+    switchFailed: profile => `تعذّر التبديل إلى ${profile}`,
     placeholderStarting: 'جار بدء Hermes...',
     placeholderReconnecting: 'جار إعادة الاتصال...',
     placeholderFollowUp: 'اكتب متابعة...',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2210,6 +2210,7 @@ export const en: Translations = {
   composer: {
     message: 'Message',
     wakingProfile: profile => `Waking up ${profile}…`,
+    switchFailed: profile => `Couldn't switch to ${profile}`,
     placeholderStarting: 'Starting Hermes...',
     placeholderReconnecting: 'Reconnecting to Hermes…',
     placeholderFollowUp: 'Send follow-up',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1911,6 +1911,7 @@ export const ja = defineLocale({
   composer: {
     message: 'メッセージ',
     wakingProfile: profile => `${profile} を起動中…`,
+    switchFailed: profile => `${profile} に切り替えられません`,
     placeholderStarting: 'Hermes を起動中...',
     placeholderReconnecting: 'Hermes に再接続中…',
     placeholderFollowUp: 'フォローアップを送信',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1885,6 +1885,7 @@ export interface Translations {
   composer: {
     message: string
     wakingProfile: (profile: string) => string
+    switchFailed: (profile: string) => string
     placeholderStarting: string
     placeholderReconnecting: string
     placeholderFollowUp: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1849,6 +1849,7 @@ export const zhHant = defineLocale({
   composer: {
     message: '訊息',
     wakingProfile: profile => `正在喚醒 ${profile}…`,
+    switchFailed: profile => `無法切換到 ${profile}`,
     placeholderStarting: '正在啟動 Hermes...',
     placeholderReconnecting: '正在重新連線至 Hermes…',
     placeholderFollowUp: '傳送後續訊息',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2395,6 +2395,7 @@ export const zh: Translations = {
   composer: {
     message: '消息',
     wakingProfile: profile => `正在唤醒 ${profile}…`,
+    switchFailed: profile => `无法切换到 ${profile}`,
     placeholderStarting: '正在启动 Hermes…',
     placeholderReconnecting: '正在重新连接 Hermes…',
     placeholderFollowUp: '发送后续消息',

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -22,11 +22,13 @@ vi.mock('@/store/starmap', () => ({ resetStarmapGraph }))
 
 const {
   $activeGatewayProfile,
+  $gatewaySwitchError,
   $profiles,
   ensureGatewayProfile,
   invalidateProfileListFetches,
   prewarmProfileBackend,
-  refreshProfiles
+  refreshProfiles,
+  GATEWAY_SWITCH_MUTEX_TIMEOUT_MS
 } = await import('./profile')
 
 const { $connection } = await import('./session')
@@ -96,13 +98,60 @@ describe('ensureGatewayProfile → $connection sync (#46651)', () => {
     expect($connection.get()?.mode).toBe('local')
   })
 
-  it('leaves the prior connection intact when the descriptor fetch fails', async () => {
-    getConnection.mockRejectedValue(new Error('backend unreachable'))
+  it('leaves the prior connection intact when the switch fails', async () => {
+    // The gateway activation rejected (socket dial / descriptor lookup inside
+    // ensureGatewayForProfile). That failure is surfaced ($gatewaySwitchError
+    // + console.error) instead of swallowed, so a dead click with no log and
+    // no UI state never happens again. Nothing else was published: the
+    // connection descriptor and active profile stay on the previous one.
+    ensureGatewayForProfile.mockRejectedValueOnce(new Error('backend unreachable'))
 
     await ensureGatewayProfile('vps-remote')
 
     // Best-effort: boot/reconnect resyncs later; we must not null it out here.
     expect($connection.get()?.mode).toBe('local')
+    expect($activeGatewayProfile.get()).toBe('default')
+    expect($gatewaySwitchError.get()).toEqual({ profile: 'vps-remote', message: 'backend unreachable' })
+  })
+
+  it('clears a previous switch error once a fresh switch attempt starts', async () => {
+    // The error atom holds the LAST failed switch. A new attempt must clear it
+    // first so a retry that succeeds does not leave a stale failure banner.
+    ensureGatewayForProfile.mockRejectedValueOnce(new Error('first attempt failed'))
+    await ensureGatewayProfile('vps-remote')
+    expect($gatewaySwitchError.get()).toEqual({ profile: 'vps-remote', message: 'first attempt failed' })
+
+    ensureGatewayForProfile.mockResolvedValueOnce(undefined)
+    await ensureGatewayProfile('vps-remote')
+
+    expect($gatewaySwitchError.get()).toBeNull()
+    expect($activeGatewayProfile.get()).toBe('vps-remote')
+  })
+
+  it('a wedged in-flight switch cannot block later clicks forever (bounded mutex)', async () => {
+    // A hung descriptor IPC (never resolves, never rejects) used to wedge the
+    // gatewaySwitch mutex: every later click awaited the stuck promise and
+    // the rail went permanently dead. The mutex wait is now bounded, so a
+    // wedged switch degrades to a visible no-op instead of a silent one.
+    vi.useFakeTimers()
+
+    try {
+      getConnection.mockReturnValueOnce(new Promise(() => undefined)) // wedged switch
+      const wedged = ensureGatewayProfile('vps-remote')
+      await vi.advanceTimersByTimeAsync(0) // let the wedged call arm its mutex
+
+      // Second click while the first is stuck: must not await it forever.
+      getConnection.mockResolvedValue(localConn({ profile: 'coder' }))
+      const retry = ensureGatewayProfile('coder')
+
+      await vi.advanceTimersByTimeAsync(GATEWAY_SWITCH_MUTEX_TIMEOUT_MS + 1)
+      await retry
+
+      expect($activeGatewayProfile.get()).toBe('coder')
+      expect(wedged).not.toBeUndefined()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('does not churn $connection when the target is already the active profile', async () => {

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -235,6 +235,14 @@ $activeGatewayProfile.subscribe(value => {
 // so a lazy spawn doesn't read as a hang. Single-profile users never swap.
 export const $gatewaySwapTarget = atom<string | null>(null)
 
+// Last gateway-switch failure, published instead of being swallowed by the
+// switch's internal catch. The rail used to die SILENTLY on a failed
+// descriptor lookup or dial — a dead click with no log and no UI state read
+// as a broken rail, and the user had no way to know the switch even ran.
+// Surfacing it lets the swap overlay show why the switch didn't happen, and
+// makes the failure diagnosable in the console on the first click.
+export const $gatewaySwitchError = atom<{ profile: string; message: string } | null>(null)
+
 // ── Hover-intent backend pre-warm ───────────────────────────────────────────
 // A cold switch to a profile whose pool backend isn't running pays the full
 // spawn (Python boot + port announce + readiness probe — measured ~2.5-3s)
@@ -269,6 +277,14 @@ export function prewarmProfileBackend(name: string): void {
 }
 
 let gatewaySwitch: Promise<void> | null = null
+
+// A switch that never settles (a hung descriptor IPC, a wedged dial) must not
+// brick the rail: every later click awaits the previous switch's promise, so
+// one stuck switch would make ALL subsequent profile clicks silently dead.
+// Bound the wait so a wedged switch degrades to a visible error instead of a
+// permanent no-op. Longer than the gateway connect timeout (15s) plus a cold
+// spawn, so healthy switches never hit it.
+export const GATEWAY_SWITCH_MUTEX_TIMEOUT_MS = 30_000
 
 // The target profile's connection descriptor (mode / baseUrl / …), resolved
 // CONCURRENTLY with the socket work so the switch can publish the profile
@@ -328,13 +344,25 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
   // Serialize concurrent activations so two rapid session switches don't race
   // the active pointer.
   if (gatewaySwitch) {
-    await gatewaySwitch.catch(() => undefined)
+    // Bound the mutex wait: a wedged in-flight switch (hung descriptor IPC or
+    // stuck dial) must not block every later click forever. The previous
+    // switch failing-open here is safe — the activation epoch guard (see
+    // applyActive) means a stale switch can no longer publish once THIS one
+    // begins; and any real failure it would have surfaced gets surfaced by
+    // the new attempt (or its own catch, whichever lands first).
+    await Promise.race([
+      gatewaySwitch.catch(() => undefined),
+      new Promise(resolve => setTimeout(resolve, GATEWAY_SWITCH_MUTEX_TIMEOUT_MS))
+    ])
 
     if (normalizeProfileKey($activeGatewayProfile.get()) === target && $gateway.get()) {
       return
     }
   }
 
+  // A fresh switch attempt clears the previous failure: the error atom shows
+  // the LAST failed switch, and an in-flight retry hasn't failed yet.
+  $gatewaySwitchError.set(null)
   $gatewaySwapTarget.set(target)
   gatewaySwitch = (async () => {
     // ensureGatewayForProfile opens (or reuses) the target's socket and points
@@ -357,13 +385,28 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
         setConnection(connection)
       }
     })
-  })()
+  })().catch(error => {
+    // The switch failed as a unit (socket dial or activation). Surfaced here
+    // instead of swallowed: a dead click with no log and no UI state read as
+    // a broken rail, and hid the real reason (e.g. a failing dial) from both
+    // the console and the swap overlay.
+    const message = error instanceof Error ? error.message : String(error ?? 'unknown error')
+    console.error(`[profile] gateway switch to "${target}" failed: ${message}`)
+    $gatewaySwitchError.set({ profile: target, message })
+  })
+
+  const currentSwitch = gatewaySwitch
 
   try {
-    await gatewaySwitch
+    await currentSwitch
   } finally {
-    gatewaySwitch = null
-    $gatewaySwapTarget.set(null)
+    // Only the OWNER of the mutex clears it. If the bounded mutex wait above
+    // let a newer switch start while this one was still wedged, this stale
+    // finally must not null out the NEWER switch's promise or its swap target.
+    if (gatewaySwitch === currentSwitch) {
+      gatewaySwitch = null
+      $gatewaySwapTarget.set(null)
+    }
   }
 }
 
@@ -415,7 +458,13 @@ export async function ensureGatewayAgent(connectionId: null | string, profile: s
 
   // Serialize against any in-flight profile/agent switch (shared mutex).
   if (gatewaySwitch) {
-    await gatewaySwitch.catch(() => undefined)
+    // Bounded like the profile path: a wedged in-flight switch must not block
+    // every later activation forever. The epoch guard makes a stale switch's
+    // late activation a no-op, so failing open here is safe.
+    await Promise.race([
+      gatewaySwitch.catch(() => undefined),
+      new Promise(resolve => setTimeout(resolve, GATEWAY_SWITCH_MUTEX_TIMEOUT_MS))
+    ])
   }
 
   $gatewaySwapTarget.set(target)
@@ -449,11 +498,18 @@ export async function ensureGatewayAgent(connectionId: null | string, profile: s
     })
   })()
 
+  const currentSwitch = gatewaySwitch
+
   try {
-    await gatewaySwitch
+    await currentSwitch
   } finally {
-    gatewaySwitch = null
-    $gatewaySwapTarget.set(null)
+    // Only the OWNER of the mutex clears it. If the bounded mutex wait above
+    // let a newer switch start while this one was still wedged, this stale
+    // finally must not null out the NEWER switch's promise or its swap target.
+    if (gatewaySwitch === currentSwitch) {
+      gatewaySwitch = null
+      $gatewaySwapTarget.set(null)
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

The desktop profile rail's gateway switch used to fail **silently**. Every rejection inside `ensureGatewayProfile` (descriptor lookup, gateway preparation, socket dial) was caught by an empty `.catch()`, so a failed switch to another profile published nothing — no log, no UI state, no error. A dead click read as a broken rail, and the real reason (e.g. a failing descriptor IPC) was invisible in both the console and the swap overlay. This became visible in the field as "clicking Kuro/Vesper does nothing; only the All view still opens sessions."

## Changes

- **Publish failures to a new `$gatewaySwitchError` atom + log to console** — the `ChatSwapOverlay` now renders "Couldn't switch to `<profile>` — `<message>`" in place of the spinner when a switch fails, instead of a silent no-op. i18n keys added for en/ar/ja/zh/zh-hant + the shared `types.ts` contract.
- **Bound the `gatewaySwitch` mutex wait (30s)** — a wedged in-flight switch (hung descriptor IPC or stuck dial) previously blocked *every later click forever*: each new switch awaited the previous promise with no timeout, so one stuck switch bricked the whole rail for the session. The activation epoch guard makes a stale switch's late publish a no-op, so failing open is safe. Applied to both the profile and agent paths.
- **Guard the mutex-release `finally` with identity** — when the bounded wait lets a newer switch start while the old one is still wedged, the stale `finally` no longer nulls out the newer switch's promise or swap target.

## Test Plan

- `apps/desktop`: 44 tests pass across `profile.test.ts`, `gateway-switch`, `gateway-profile-request`, `profile-agent-activation`, `chat/index`, `i18n/languages`
- `tsc --noEmit` clean
- New tests: failed switch publishes the error and clears on retry; a wedged in-flight switch no longer blocks a later click; identity-guarded finally.
- Pre-existing failures in `electron/*` (ssh, hardening, darwin staging) are Windows-host environment issues unrelated to this change — verified they reproduce on the base tree.

## Notes

- Fixes the class where a failed profile switch is indistinguishable from a broken install: the first click after this change surfaces the real error message in both console and UI.