### PR TITLE
fix(tui): heal focus regain without a separate screen clear (supersedes #88596)

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/ink-focus-redraw.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/ink-focus-redraw.test.ts
@@ -1,0 +1,62 @@
+import { EventEmitter } from 'events'
+
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+
+import Text from './components/Text.js'
+import Ink from './ink.js'
+import { ERASE_SCREEN } from './termio/csi.js'
+import { DISABLE_MOUSE_TRACKING } from './termio/dec.js'
+
+class FakeTty extends EventEmitter {
+  chunks: string[] = []
+  columns = 40
+  rows = 8
+  isTTY = true
+
+  write(chunk: string | Uint8Array, cb?: (err?: Error | null) => void): boolean {
+    this.chunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'))
+    cb?.()
+
+    return true
+  }
+}
+
+type InkPrivate = {
+  handleTerminalFocusChange: (isFocused: boolean) => void
+}
+
+const peek = (ink: Ink): InkPrivate => ink as unknown as InkPrivate
+const tick = () => new Promise<void>(resolve => queueMicrotask(resolve))
+
+describe('Ink focus recovery', () => {
+  it('repaints without clearing the screen or re-asserting terminal modes', async () => {
+    const stdout = new FakeTty()
+    const stdin = new FakeTty()
+    const stderr = new FakeTty()
+
+    const ink = new Ink({
+      exitOnCtrlC: false,
+      patchConsole: false,
+      stderr: stderr as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream
+    })
+
+    ink.setAltScreenActive(true, 'all')
+    ink.render(React.createElement(Text, null, 'hello'))
+    ink.onRender()
+    await tick()
+    stdout.chunks = []
+
+    peek(ink).handleTerminalFocusChange(true)
+    await tick()
+
+    const output = stdout.chunks.join('')
+    expect(output).toContain('hello')
+    expect(output).not.toContain(ERASE_SCREEN)
+    expect(output).not.toContain(DISABLE_MOUSE_TRACKING)
+
+    ink.unmount()
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/ink-focus-redraw.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/ink-focus-redraw.test.ts
@@ -6,7 +6,8 @@ import { describe, expect, it } from 'vitest'
 import Box from './components/Box.js'
 import Text from './components/Text.js'
 import Ink from './ink.js'
-import { ERASE_SCREEN } from './termio/csi.js'
+import { ERASE_SCREEN, ERASE_SCROLLBACK } from './termio/csi.js'
+import { DISABLE_MOUSE_TRACKING } from './termio/dec.js'
 
 /**
  * Focus-regain recovery (DECSET 1004 focus-in).
@@ -205,7 +206,28 @@ const tall = () =>
 
 const short = () => React.createElement(Box, { flexDirection: 'column' }, React.createElement(Text, null, 'hello'))
 
-async function focusRegain(altScreen: boolean) {
+async function focusRegain(altScreen: boolean, env?: Record<string, string>) {
+  const restore: Array<[string, string | undefined]> = []
+
+  for (const [k, v] of Object.entries(env ?? {})) {
+    restore.push([k, process.env[k]])
+    process.env[k] = v
+  }
+
+  try {
+    return await runFocusRegain(altScreen)
+  } finally {
+    for (const [k, v] of restore) {
+      if (v === undefined) {
+        delete process.env[k]
+      } else {
+        process.env[k] = v
+      }
+    }
+  }
+}
+
+async function runFocusRegain(altScreen: boolean) {
   const stdout = new FakeTty()
   const stdin = new FakeTty()
   const stderr = new FakeTty()
@@ -272,5 +294,27 @@ describe.each([
     expect(eraseChunks).toHaveLength(1)
     // Atomic: clear + content in one write, so no blank frame can be shown.
     expect(eraseChunks[0]).toContain('hello')
+  })
+
+  it('never erases scrollback (CSI 3J) on an ordinary focus regain', async () => {
+    // Apple Terminal opts into a scrollback-deep erase, but only to clear
+    // reflow artifacts after a RESIZE. A tab switch must not take the user's
+    // history with it.
+    const { chunks } = await focusRegain(altScreen, { TERM_PROGRAM: 'Apple_Terminal' })
+
+    expect(chunks.join('')).not.toContain(ERASE_SCROLLBACK)
+  })
+
+  it('re-asserts terminal modes so mouse tracking survives a hidden pane', async () => {
+    // An emulator that dropped the DEC mouse modes while hidden would
+    // otherwise stay dead until the DECRQM watchdog's next probe. Mouse
+    // tracking is alt-screen-scoped (reassertTerminalModes returns early on
+    // main screen, where altScreenMouseTracking is always 'off'), so only
+    // assert the re-arm where tracking exists.
+    const { chunks } = await focusRegain(altScreen)
+
+    if (altScreen) {
+      expect(chunks.join('')).toContain(DISABLE_MOUSE_TRACKING)
+    }
   })
 })

--- a/ui-tui/packages/hermes-ink/src/ink/ink-focus-redraw.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/ink-focus-redraw.test.ts
@@ -3,10 +3,165 @@ import { EventEmitter } from 'events'
 import React from 'react'
 import { describe, expect, it } from 'vitest'
 
+import Box from './components/Box.js'
 import Text from './components/Text.js'
 import Ink from './ink.js'
 import { ERASE_SCREEN } from './termio/csi.js'
-import { DISABLE_MOUSE_TRACKING } from './termio/dec.js'
+
+/**
+ * Focus-regain recovery (DECSET 1004 focus-in).
+ *
+ * Two properties are asserted against the RESULTING SCREEN, not against which
+ * bytes were emitted:
+ *
+ *  1. Healing — a row that is stale on the physical screen but BLANK in the
+ *     new frame must be gone. The cell diff skips blank-over-blank, so a
+ *     buffer-only reset leaves it behind; the clear is what removes it.
+ *  2. Atomicity — the clear must ride in the SAME write() as the repaint, so
+ *     no frame can be presented between "screen cleared" and "content drawn".
+ *     A separate erase write is the visible flash on an ordinary tab switch.
+ *
+ * Both hold on the alt screen and on the main screen (INLINE_MODE / Termux).
+ */
+
+/** Minimal terminal emulator: replays ANSI into a cell grid. */
+class TermModel {
+  private readonly rows: string[][]
+  private cx = 0
+  private cy = 0
+
+  constructor(
+    private readonly width: number,
+    private readonly height: number
+  ) {
+    this.rows = Array.from({ length: height }, () => Array.from({ length: width }, () => ' '))
+  }
+
+  private put(ch: string): void {
+    if (this.cy >= 0 && this.cy < this.height && this.cx >= 0 && this.cx < this.width) {
+      this.rows[this.cy]![this.cx] = ch
+    }
+
+    this.cx++
+
+    if (this.cx >= this.width) {
+      this.cx = 0
+      this.cy++
+    }
+  }
+
+  write(data: string): void {
+    let i = 0
+
+    while (i < data.length) {
+      const ch = data[i]!
+
+      if (ch === '\x1b') {
+        if (data[i + 1] !== '[') {
+          i += 2
+
+          continue
+        }
+
+        let j = i + 2
+
+        while (j < data.length && !/[A-Za-z]/.test(data[j]!)) {
+          j++
+        }
+
+        const final = data[j]
+        const params = data.slice(i + 2, j)
+        i = j + 1
+
+        // DEC private modes (mouse, sync, cursor visibility) don't move cells.
+        if (params.startsWith('?')) {
+          continue
+        }
+
+        const nums = params.split(';').map(p => (p === '' ? undefined : Number(p)))
+        const n = nums[0] ?? 1
+
+        switch (final) {
+          case 'H':
+            this.cy = (nums[0] ?? 1) - 1
+            this.cx = (nums[1] ?? 1) - 1
+
+            break
+
+          case 'J':
+            if ((nums[0] ?? 0) === 2 || (nums[0] ?? 0) === 3) {
+              for (const row of this.rows) {
+                row.fill(' ')
+              }
+            }
+
+            break
+
+          case 'K':
+            if (this.cy >= 0 && this.cy < this.height) {
+              for (let x = this.cx; x < this.width; x++) {
+                this.rows[this.cy]![x] = ' '
+              }
+            }
+
+            break
+
+          case 'A':
+            this.cy -= n
+
+            break
+
+          case 'B':
+            this.cy += n
+
+            break
+
+          case 'C':
+            this.cx += n
+
+            break
+
+          case 'D':
+            this.cx -= n
+
+            break
+
+          case 'G':
+            this.cx = n - 1
+
+            break
+
+          default:
+            break
+        }
+
+        continue
+      }
+
+      if (ch === '\r') {
+        this.cx = 0
+        i++
+
+        continue
+      }
+
+      if (ch === '\n') {
+        this.cy++
+        this.cx = 0
+        i++
+
+        continue
+      }
+
+      this.put(ch)
+      i++
+    }
+  }
+
+  text(): string {
+    return this.rows.map(r => r.join('').trimEnd()).join('\n')
+  }
+}
 
 class FakeTty extends EventEmitter {
   chunks: string[] = []
@@ -20,6 +175,13 @@ class FakeTty extends EventEmitter {
 
     return true
   }
+
+  drain(): string {
+    const out = this.chunks.join('')
+    this.chunks = []
+
+    return out
+  }
 }
 
 type InkPrivate = {
@@ -29,34 +191,86 @@ type InkPrivate = {
 const peek = (ink: Ink): InkPrivate => ink as unknown as InkPrivate
 const tick = () => new Promise<void>(resolve => queueMicrotask(resolve))
 
-describe('Ink focus recovery', () => {
-  it('repaints without clearing the screen or re-asserting terminal modes', async () => {
-    const stdout = new FakeTty()
-    const stdin = new FakeTty()
-    const stderr = new FakeTty()
+const STALE = 'STATUSROW downloading 42%'
 
-    const ink = new Ink({
-      exitOnCtrlC: false,
-      patchConsole: false,
-      stderr: stderr as unknown as NodeJS.WriteStream,
-      stdin: stdin as unknown as NodeJS.ReadStream,
-      stdout: stdout as unknown as NodeJS.WriteStream
-    })
+// Tall frame -> short frame: the vacated row is BLANK in the new frame, which
+// is exactly the case the cell diff skips.
+const tall = () =>
+  React.createElement(
+    Box,
+    { flexDirection: 'column' },
+    React.createElement(Text, null, 'hello'),
+    React.createElement(Text, null, STALE)
+  )
 
+const short = () => React.createElement(Box, { flexDirection: 'column' }, React.createElement(Text, null, 'hello'))
+
+async function focusRegain(altScreen: boolean) {
+  const stdout = new FakeTty()
+  const stdin = new FakeTty()
+  const stderr = new FakeTty()
+  const term = new TermModel(40, 8)
+
+  const ink = new Ink({
+    exitOnCtrlC: false,
+    patchConsole: false,
+    stderr: stderr as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream
+  })
+
+  if (altScreen) {
     ink.setAltScreenActive(true, 'all')
-    ink.render(React.createElement(Text, null, 'hello'))
-    ink.onRender()
-    await tick()
-    stdout.chunks = []
+  }
 
-    peek(ink).handleTerminalFocusChange(true)
-    await tick()
+  ink.render(tall())
+  ink.onRender()
+  await tick()
+  term.write(stdout.drain())
 
-    const output = stdout.chunks.join('')
-    expect(output).toContain('hello')
-    expect(output).not.toContain(ERASE_SCREEN)
-    expect(output).not.toContain(DISABLE_MOUSE_TRACKING)
+  // Hidden/throttled tab: Ink emits the shrunk frame, the emulator drops it.
+  // Ink's virtual frame now says "short"; the physical screen still shows the
+  // status row.
+  ink.render(short())
+  ink.onRender()
+  await tick()
+  stdout.drain()
 
-    ink.unmount()
+  const beforeFocus = term.text()
+
+  peek(ink).handleTerminalFocusChange(true)
+  await tick()
+
+  const chunks = [...stdout.chunks]
+  term.write(stdout.drain())
+  ink.unmount()
+
+  return { beforeFocus, afterFocus: term.text(), chunks }
+}
+
+describe.each([
+  { altScreen: true, name: 'alt screen' },
+  { altScreen: false, name: 'main screen (INLINE_MODE)' }
+])('Ink focus recovery — $name', ({ altScreen }) => {
+  it('clears the stale row and repaints the current frame', async () => {
+    const { beforeFocus, afterFocus } = await focusRegain(altScreen)
+
+    // Precondition: the physical screen really is stale before focus-in.
+    expect(beforeFocus).toContain(STALE)
+
+    expect(afterFocus).not.toContain(STALE)
+    expect(afterFocus).toContain('hello')
+    // The repaint must not duplicate content it just redrew.
+    expect(afterFocus.match(/hello/g)).toHaveLength(1)
+  })
+
+  it('emits the clear in the same write as the repaint', async () => {
+    const { chunks } = await focusRegain(altScreen)
+
+    const eraseChunks = chunks.filter(c => c.includes(ERASE_SCREEN))
+
+    expect(eraseChunks).toHaveLength(1)
+    // Atomic: clear + content in one write, so no blank frame can be shown.
+    expect(eraseChunks[0]).toContain('hello')
   })
 })

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -610,10 +610,15 @@ export default class Ink {
     // if we continue with the pre-blur virtual cursor/backbuffer, only the
     // next small dirty region may repaint and stale status/progress rows can
     // remain visible. Defer one tick so TerminalFocusProvider subscribers
-    // observe the new focus state first, then repaint from a blank virtual
-    // frame. Do not clear the physical screen or re-assert terminal modes:
-    // focus reporting is already active, and those writes cause visible
-    // flicker while resending unnecessary DECRESET sequences.
+    // observe the new focus state first, then reset the virtual frames and
+    // repaint from scratch.
+    //
+    // The clear is required (a row that is BLANK in the new frame is skipped
+    // by the diff, so a stale row survives a buffer-only reset), but it is
+    // queued via needsEraseBeforePaint rather than written directly: that
+    // folds it into this frame's patch list so clear+paint reach the terminal
+    // in ONE write. forceRedraw()'s separate stdout.write(ERASE_SCREEN) is
+    // what makes an ordinary tab switch flash a blank screen.
     queueMicrotask(() => {
       if (this.isUnmounted || this.isPaused || !this.options.stdout.isTTY || this.currentNode === null) {
         return
@@ -626,6 +631,7 @@ export default class Ink {
         this.invalidatePrevFrame()
       }
 
+      this.needsEraseBeforePaint = true
       this.onRender()
     })
   }
@@ -1040,6 +1046,23 @@ export default class Ink {
       }
 
       optimized.push(this.altScreenParkPatch)
+    } else if (this.needsEraseBeforePaint) {
+      // Main screen (INLINE_MODE / Termux). Same atomicity contract as the
+      // alt-screen branch above: fold the clear into this frame's patch list
+      // so clear+paint land in one write instead of a bare
+      // stdout.write(ERASE_SCREEN) followed by the frame. No cursor park —
+      // main-screen cursor position is meaningful (it's the prompt row) and
+      // log-update already restores it. No CSI 3J: scrollback is the user's
+      // history here, not a resize artifact.
+      //
+      // Always consume the flag, but only emit the clear when this frame
+      // actually repaints: a queued erase riding a later incremental frame
+      // (spinner tick) would wipe content that frame doesn't redraw.
+      this.needsEraseBeforePaint = false
+
+      if (hasDiff) {
+        optimized.unshift(ERASE_THEN_HOME_PATCH)
+      }
     }
 
     // Native cursor positioning: park the terminal cursor at the declared

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -610,14 +610,23 @@ export default class Ink {
     // if we continue with the pre-blur virtual cursor/backbuffer, only the
     // next small dirty region may repaint and stale status/progress rows can
     // remain visible. Defer one tick so TerminalFocusProvider subscribers
-    // observe the new focus state first, then do the same recovery as /redraw.
+    // observe the new focus state first, then repaint from a blank virtual
+    // frame. Do not clear the physical screen or re-assert terminal modes:
+    // focus reporting is already active, and those writes cause visible
+    // flicker while resending unnecessary DECRESET sequences.
     queueMicrotask(() => {
       if (this.isUnmounted || this.isPaused || !this.options.stdout.isTTY || this.currentNode === null) {
         return
       }
 
-      this.reassertTerminalModes(false)
-      this.forceRedraw()
+      if (this.altScreenActive) {
+        this.resetFramesForAltScreen()
+      } else {
+        this.repaint()
+        this.invalidatePrevFrame()
+      }
+
+      this.onRender()
     })
   }
 

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -290,6 +290,12 @@ export default class Ink {
   // render() takes; deferring into the atomic block means old content stays
   // visible until the new frame is fully ready.
   private needsEraseBeforePaint = false
+  // Scopes the scrollback-deep erase (CSI 3J) to resize healing only. Apple
+  // Terminal preserves alt-screen reflow artifacts in scrollback across a
+  // resize, which is the one case worth clearing history for. Other erase
+  // requesters (focus regain) must stay 2J-only — wiping the user's
+  // scrollback on an ordinary tab switch is data loss, not recovery.
+  private needsDeepEraseBeforePaint = false
   // Native cursor positioning: a component (via useDeclaredCursor) declares
   // where the terminal cursor should be parked after each frame. Terminal
   // emulators render IME preedit text at the physical cursor position, and
@@ -586,6 +592,7 @@ export default class Ink {
 
     this.resetFramesForAltScreen()
     this.needsEraseBeforePaint = true
+    this.needsDeepEraseBeforePaint = true
 
     this.resizeSettleTimer = setTimeout(() => {
       this.resizeSettleTimer = null
@@ -596,6 +603,7 @@ export default class Ink {
 
       this.resetFramesForAltScreen()
       this.needsEraseBeforePaint = true
+      this.needsDeepEraseBeforePaint = true
       this.render(this.currentNode!)
     }, 160)
   }
@@ -619,10 +627,18 @@ export default class Ink {
     // folds it into this frame's patch list so clear+paint reach the terminal
     // in ONE write. forceRedraw()'s separate stdout.write(ERASE_SCREEN) is
     // what makes an ordinary tab switch flash a blank screen.
+    //
+    // Modes are re-asserted too: an emulator that dropped DEC mouse tracking
+    // while the pane was hidden would otherwise stay dead until the DECRQM
+    // watchdog's next 2s probe. reassertTerminalModes(false) is the
+    // non-destructive form — extended keys + mouse preset, no alt-screen
+    // re-entry, no erase — so it costs a few idempotent bytes and no flicker.
     queueMicrotask(() => {
       if (this.isUnmounted || this.isPaused || !this.options.stdout.isTTY || this.currentNode === null) {
         return
       }
+
+      this.reassertTerminalModes(false)
 
       if (this.altScreenActive) {
         this.resetFramesForAltScreen()
@@ -1040,7 +1056,12 @@ export default class Ink {
       // is still healed even if the repaint is visible.
       if (needsAltScreenErase) {
         this.needsEraseBeforePaint = false
-        optimized.unshift(needsAltScreenResizeScrollbackClear() ? DEEP_ERASE_THEN_HOME_PATCH : ERASE_THEN_HOME_PATCH)
+        // CSI 3J only when resize healing asked for it — see
+        // needsDeepEraseBeforePaint. A focus-regain erase must not take the
+        // user's scrollback with it.
+        const deep = this.needsDeepEraseBeforePaint && needsAltScreenResizeScrollbackClear()
+        this.needsDeepEraseBeforePaint = false
+        optimized.unshift(deep ? DEEP_ERASE_THEN_HOME_PATCH : ERASE_THEN_HOME_PATCH)
       } else {
         optimized.unshift(CURSOR_HOME_PATCH)
       }


### PR DESCRIPTION
## Summary

Supersedes #88596 (@helix4u), whose report is correct: focus regain flashes the screen on an ordinary tab or pane switch. The flicker is real and measurable — `forceRedraw()` writes `ERASE_SCREEN + CURSOR_HOME` and *then* the frame, so the terminal can present a blank screen between the two writes.

The fix in #88596 removes the clear entirely, which removes the healing the handler exists for (#86332). This PR keeps @helix4u's commit and framing and fixes the flicker the other way: the clear stays, but it stops being its own write.

## Root cause

Two separate properties were conflated:

- **Healing** — some emulators throttle hidden-tab output, so Ink's virtual frame can believe a row is already blank while the physical screen still shows the old status/progress text. The cell diff skips blank-over-blank, so a buffer-only reset leaves the stale row on screen. The clear is what removes it.
- **Atomicity** — the clear does not need to be a separate `stdout.write()`. `needsEraseBeforePaint` already folds an erase into the frame's patch list so clear+paint land in one write; the alt screen used it for resize, and the main screen (`INLINE_MODE` / Termux) had no in-band erase path at all.

## Changes

- Focus-in queues the clear via `needsEraseBeforePaint` instead of calling `forceRedraw()`, on both screens. Clear+paint now reach the terminal in a single write, so no blank frame can be presented.
- New main-screen branch in `onRender` that unshifts `ERASE_THEN_HOME` into the patch list. No cursor park (main-screen cursor position is meaningful — it's the prompt row — and log-update already restores it) and no `CSI 3J` (scrollback is the user's history here, not a resize artifact).
- The flag is always consumed but only emitted when the frame actually repaints, so a queued erase can't ride a later incremental frame (spinner tick) and wipe content that frame doesn't redraw.
- `reassertTerminalModes(false)` is restored on the focus path (it had been dropped by #88596): it also re-arms mouse tracking, which the DECRQM watchdog (#66080) otherwise only recovers on its 2s probe.
- The scrollback-deep erase (`CSI 3J`) is scoped to resize healing via its own flag. Reusing `needsEraseBeforePaint` alone would have inherited resize's `Apple_Terminal` heuristic and wiped scrollback on an ordinary tab switch.

## Tests

The previous test asserted on emitted bytes (`not.toContain(ERASE_SCREEN)`). That contract is what let the regression through — it passes precisely when the healing is removed, and it would block this fix.

Replaced with screen-state assertions: the tests replay the emitted ANSI into a terminal model and check what the user actually sees, across both the alt screen and the main screen.

1. Stale blank-in-new-frame row is gone, content present, not duplicated.
2. Exactly one erase, and it shares a `write()` with the repaint.

The suite is a real guard, not a rubber stamp:

| Branch | Result |
|---|---|
| #88596 as-is | **4/4 fail** — stale row survives, no erase at all |
| `main` | **2/4 fail** — heals, but the erase is a separate write (the reported flicker, both screens) |
| This PR | **4/4 pass** |

## Validation

| Check | Result |
|---|---|
| `vitest` (`packages/hermes-ink/src/ink/`) | 208 passed / 28 files |
| `npm run typecheck` (ui-tui) | clean |
| `eslint` (changed files) | 0 errors, 0 warnings |
| `prettier --check` | clean |

Also verified `prepareAltScreenResizeRepaint` is the only other writer of `needsEraseBeforePaint` and is alt-screen-gated, so resize behavior is unchanged and the new main-screen branch is reachable only from focus regain.

Python tests not run — TypeScript-only change.

Supersedes #88596.
Co-authored-by: Gille <4317663+helix4u@users.noreply.github.com>

