### PR TITLE
fix(desktop): notify when a profile switch fails instead of silently reverting

### DIFF
--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2201,6 +2201,7 @@ export const en: Translations = {
   composer: {
     message: 'Message',
     wakingProfile: profile => `Waking up ${profile}…`,
+    profileSwitchFailed: profile => `Could not switch to ${profile}`,
     placeholderStarting: 'Starting Hermes...',
     placeholderReconnecting: 'Reconnecting to Hermes…',
     placeholderFollowUp: 'Send follow-up',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1875,6 +1875,7 @@ export interface Translations {
   composer: {
     message: string
     wakingProfile: (profile: string) => string
+    profileSwitchFailed: (profile: string) => string
     placeholderStarting: string
     placeholderReconnecting: string
     placeholderFollowUp: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2384,6 +2384,7 @@ export const zh: Translations = {
   composer: {
     message: '消息',
     wakingProfile: profile => `正在唤醒 ${profile}…`,
+    profileSwitchFailed: profile => `无法切换到 ${profile}`,
     placeholderStarting: '正在启动 Hermes…',
     placeholderReconnecting: '正在重新连接 Hermes…',
     placeholderFollowUp: '发送后续消息',

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -17,6 +17,7 @@ const prepareGatewayForProfile = vi.fn(async (_profile: string) => activateGatew
 const openGatewayForProfile = vi.fn(async (_profile: string) => undefined)
 const $gateway = atom<unknown>({ id: 'live-socket' })
 const resetStarmapGraph = vi.fn()
+const notifyError = vi.fn()
 
 vi.mock('@/store/gateway', () => ({
   $gateway,
@@ -31,6 +32,7 @@ vi.mock('@/hermes', () => ({
 }))
 vi.mock('@/lib/query-client', () => ({ invalidateProfileScopedQueries: vi.fn() }))
 vi.mock('@/store/starmap', () => ({ resetStarmapGraph }))
+vi.mock('@/store/notifications', () => ({ notifyError }))
 
 const {
   $activeGatewayProfile,
@@ -76,6 +78,7 @@ beforeEach(() => {
   vi.stubGlobal('window', { hermesDesktop: { getConnection } })
   vi.mocked(invalidateProfileScopedQueries).mockClear()
   resetStarmapGraph.mockClear()
+  notifyError.mockClear()
 })
 
 afterEach(() => {
@@ -124,6 +127,20 @@ describe('ensureGatewayProfile → $connection sync (#46651)', () => {
     expect(activateGateway).not.toHaveBeenCalled()
     expect($activeGatewayProfile.get()).toBe('default')
     expect($connection.get()?.mode).toBe('local')
+  })
+
+  it('notifies the user when a fire-and-forget switch fails (#89622)', async () => {
+    // selectProfile/newSessionInProfile call ensureGatewayProfile without
+    // awaiting it, and a failed switch publishes nothing. Without a
+    // notification here, the rail's "waking up" overlay just disappears with
+    // no explanation — the switch silently no-ops instead of visibly failing.
+    const error = new Error('backend unreachable')
+
+    getConnection.mockRejectedValue(error)
+
+    await ensureGatewayProfile('vps-remote')
+
+    expect(notifyError).toHaveBeenCalledWith(error, expect.stringContaining('vps-remote'))
   })
 
   it('never publishes the new gateway before its connection descriptor', async () => {

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -2,6 +2,7 @@ import { atom, batch, computed } from 'nanostores'
 
 import type { HermesConnection } from '@/global'
 import { getProfiles, setApiRequestProfile, STARTUP_REQUEST_TIMEOUT_MS } from '@/hermes'
+import { translateNow } from '@/i18n'
 import { invalidateProfileScopedQueries } from '@/lib/query-client'
 import {
   arraysEqual,
@@ -14,6 +15,7 @@ import {
 } from '@/lib/storage'
 import { invalidateCronModelImpactScopeState } from '@/store/cron-model-impact-scope'
 import { $gateway, openGatewayForProfile, prepareGatewayForAgent, prepareGatewayForProfile } from '@/store/gateway'
+import { notifyError } from '@/store/notifications'
 import { setConnection } from '@/store/session'
 import { resetStarmapGraph } from '@/store/starmap'
 import type { ProfileInfo } from '@/types/hermes'
@@ -361,10 +363,14 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
         setConnection(connection)
       }
     })
-  })().catch(() => {
+  })().catch(error => {
     // Descriptor lookup failed: the switch fails as a unit. Nothing was
     // published, so every atom still consistently describes the previous
-    // profile; the user can retry the switch.
+    // profile; the user can retry the switch. selectProfile/newSessionInProfile
+    // call this fire-and-forget, so without a notification here the "waking
+    // up" overlay just vanishes with no explanation — the rail looks broken
+    // rather than having declined an unreachable switch.
+    notifyError(error, translateNow('composer.profileSwitchFailed', target))
   })
 
   try {


### PR DESCRIPTION
## What does this PR do?

Fixes the desktop profile switcher silently failing: clicking a profile shows the "Waking up …" overlay, then it just disappears and nothing switches, with no error and no way to tell what happened.

## Related Issue

Fixes #89622

## Root Cause

`selectProfile()` / `newSessionInProfile()` (`apps/desktop/src/store/profile.ts`) call `ensureGatewayProfile(target)` fire-and-forget (`void ensureGatewayProfile(target)`), and `ensureGatewayProfile` itself swallows a failed descriptor lookup:

```ts
})().catch(() => {
  // Descriptor lookup failed: the switch fails as a unit. Nothing was
  // published, so every atom still consistently describes the previous
  // profile; the user can retry the switch.
})
```

That "publish nothing on failure" behavior is correct (it's what `#46651`'s regression test in `profile.test.ts` already locks in) — but it is also completely silent. When `resolveConnectionForProfile`/`prepareGatewayForProfile` reject (backend unreachable, profile deleted mid-dial, etc.), the `ChatSwapOverlay` "waking up" indicator (driven by `$gatewaySwapTarget`, cleared in the `finally` regardless of outcome) just fades out, `$activeGatewayProfile` never moves, and the caller never learns the switch was declined. From the user's side that reads exactly like #89622: "it says waking up... but it didn't actually switch."

## Changes Made

- `apps/desktop/src/store/profile.ts` — `ensureGatewayProfile`'s failure path now calls `notifyError()` (the app's existing top-center toast) with a new translated message, so a failed switch is visibly reported instead of silently reverting.
- `apps/desktop/src/i18n/types.ts`, `apps/desktop/src/i18n/en.ts`, `apps/desktop/src/i18n/zh.ts` — add the `composer.profileSwitchFailed` string (the two locales that declare the full `Translations` type directly; the other locales fall back to English via `defineLocale`).
- `apps/desktop/src/store/profile.test.ts` — new regression test asserting `notifyError` fires with the failing error when the descriptor fetch rejects.

## How to Test

Commands run from `apps/desktop`:

```bash
npx vitest run --project ui src/store/profile.test.ts
npm run typecheck
npm run lint
```

Results:

- `src/store/profile.test.ts`: 16 passed (15 pre-existing + 1 new).
- A/B guard: with only the `profile.ts` hunk reverted (`git checkout HEAD~1 -- apps/desktop/src/store/profile.ts apps/desktop/src/i18n/en.ts apps/desktop/src/i18n/types.ts`), the new test `notifies the user when a fire-and-forget switch fails (#89622)` FAILS (`expected "vi.fn()" to be called ... Number of calls: 0`); all other tests in the file still pass.
- `npm run typecheck`: passed (`tsc -p . --noEmit && tsc -p tsconfig.electron.json --noEmit && tsc -p tsconfig.e2e.json --noEmit`).
- `npm run lint`: 0 errors, 129 pre-existing warnings (none in touched files).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (checked #77957, #88153, #86092, #84024 — none address this silent-failure path)
- [x] My PR contains **only** changes related to this fix (no unrelated commits, no dependency/lockfile changes)
- [x] I've added a test for the change
- [x] I've tested on my platform: Linux (CI-equivalent); this is UI-store logic exercised entirely through vitest, not platform-specific

### Documentation & Housekeeping

- [x] No config keys changed — N/A
- [x] No architecture/workflow change — N/A
- [x] Cross-platform: no OS-specific code — N/A

## Disclosure

This change was prepared with AI assistance (Claude Code), including root-cause analysis of the swallowed rejection path, the fix, and the regression test. All commands above were run and their real output is reported here.
