### PR TITLE
fix(desktop): surface an actionable hint when Smart App Control blocks a backend DLL

### DIFF
--- a/apps/desktop/electron/backend-exit-diagnosis.test.ts
+++ b/apps/desktop/electron/backend-exit-diagnosis.test.ts
@@ -1,0 +1,41 @@
+'use strict'
+
+/**
+ * Tests for apps/desktop/electron/backend-exit-diagnosis.ts
+ *
+ * Run with: npx vitest run electron/backend-exit-diagnosis.test.ts
+ * (from apps/desktop; wired into npm test:desktop:platforms)
+ */
+
+import assert from 'node:assert/strict'
+
+import { describe, it } from 'vitest'
+
+import { describeBackendExitHint } from './backend-exit-diagnosis'
+
+describe('describeBackendExitHint', () => {
+  it('recognizes a blocked native DLL import and points at the Windows guide', () => {
+    const logTail =
+      'ImportError: DLL load failed while importing _sqlite3: ' +
+      '应用程序控制策略已阻止此文件。'
+
+    const hint = describeBackendExitHint(logTail)
+
+    assert.ok(hint)
+    assert.match(hint, /Smart App Control/)
+    assert.match(hint, /windows-native/)
+  })
+
+  it('matches regardless of case', () => {
+    const hint = describeBackendExitHint('dll load failed while importing _ssl')
+    assert.ok(hint)
+  })
+
+  it('returns null for an unrelated exit log', () => {
+    assert.equal(describeBackendExitHint('Traceback (most recent call last):\nOSError: address already in use'), null)
+  })
+
+  it('returns null for an empty log tail', () => {
+    assert.equal(describeBackendExitHint(''), null)
+  })
+})

--- a/apps/desktop/electron/backend-exit-diagnosis.ts
+++ b/apps/desktop/electron/backend-exit-diagnosis.ts
@@ -1,0 +1,30 @@
+'use strict'
+
+/**
+ * backend-exit-diagnosis.ts
+ *
+ * Recognizes known-cause signatures in the backend's stdout/stderr tail when
+ * it exits before becoming ready, and returns an actionable hint to append to
+ * the boot-failure message. Dependency-free pure function so it is testable
+ * without booting Electron.
+ */
+
+// Windows-only CPython error string for a blocked/unloadable native extension
+// (.pyd). Seen when Smart App Control, antivirus, or a corrupted venv blocks
+// one of Hermes's bundled Python DLLs (e.g. `_sqlite3.pyd`) — the backend
+// aborts on import before it can announce its port, so the generic "exited
+// before it became ready" message otherwise gives the user no lead at all.
+const DLL_LOAD_BLOCKED_PATTERN = /DLL load failed while importing/i
+
+export function describeBackendExitHint(logTail: string): string | null {
+  if (DLL_LOAD_BLOCKED_PATTERN.test(logTail)) {
+    return (
+      'This looks like Windows blocking one of the bundled Python DLLs ' +
+      '(Smart App Control, antivirus, or a corrupted install can all do this). ' +
+      'See "Common pitfalls" in the Windows guide: ' +
+      'https://hermes-agent.nousresearch.com/docs/user-guide/windows-native#common-pitfalls'
+    )
+  }
+
+  return null
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -36,6 +36,7 @@ import { stopBackendChild as stopBackendChildImpl, stopBackendTreesForUpdate } f
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { buildDesktopBackendEnv, hermesManagedNodePathEntries, normalizeHermesHomeRoot } from './backend-env'
+import { describeBackendExitHint } from './backend-exit-diagnosis'
 import { isReauthRequiredError, waitForHermesReady } from './backend-health'
 import { backendCommandMatches, createBackendOwnership, createBackendShutdownCoordinator } from './backend-ownership'
 import {
@@ -10609,7 +10610,9 @@ async function startHermes() {
       sendBackendExit({ code, signal })
 
       if (!backendReady) {
-        const message = `Hermes backend exited before it became ready (${signal || code}).`
+        const logTail = recentHermesLog()
+        const hint = describeBackendExitHint(logTail)
+        const message = `Hermes backend exited before it became ready (${signal || code}).${hint ? ` ${hint}` : ''}`
         updateBootProgress(
           {
             error: message,
@@ -10619,11 +10622,7 @@ async function startHermes() {
           },
           { allowDecrease: true }
         )
-        rejectBackendStart?.(
-          new Error(
-            `Hermes backend exited before it became ready (${signal || code}). Log: ${DESKTOP_LOG_PATH}\n${recentHermesLog()}`
-          )
-        )
+        rejectBackendStart?.(new Error(`${message} Log: ${DESKTOP_LOG_PATH}\n${logTail}`))
       }
     })
 

--- a/website/docs/user-guide/windows-native.md
+++ b/website/docs/user-guide/windows-native.md
@@ -311,6 +311,9 @@ The installer provisions Node 26 at `%LOCALAPPDATA%\hermes\node` but your PATH m
 **Chinese / Japanese / Arabic characters show as `?` in the CLI.**
 The UTF-8 stdio shim didn't activate. Check that `HERMES_DISABLE_WINDOWS_UTF8` is NOT set (`Get-ChildItem env:HERMES_DISABLE_WINDOWS_UTF8`). If it's empty and you still see `?`, the console host (very old `cmd.exe`) may not support UTF-8 at all — switch to Windows Terminal.
 
+**"Hermes couldn't start" with `DLL load failed while importing _sqlite3` in the log, only when Smart App Control is on.**
+Windows Smart App Control blocks unsigned binaries with no cloud reputation, and Hermes's bundled Python interpreter's `.pyd` extension DLLs (e.g. `_sqlite3.pyd`) aren't code-signed. Unlike Defender, SAC has no exclusion list, and once enabled it can't be turned back off without resetting Windows — so this isn't something Hermes can work around at runtime. Until the bundled Python is signed, SAC and Hermes Desktop are incompatible: turn Smart App Control off before installing, or use [WSL2](./windows-wsl-quickstart.md) instead, which isn't subject to SAC's native-binary checks.
+
 **Gateway can't send Telegram photos — "`BadRequest: payload contains invalid characters`".**
 This is unrelated to Windows but sometimes surfaces first there. Usually it means your file path contains unescaped backslashes in a JSON body. Telegram should be receiving paths Hermes normalizes, not raw Windows paths — if you're seeing this inside a custom plugin, make sure you're passing the Hermes-provided path, not `str(Path(...))` from user input.
 


### PR DESCRIPTION
## What does this PR do?

With Windows Smart App Control (SAC) enabled, Hermes Desktop's bundled Python interpreter can't load its own C-extension DLLs (e.g. `_sqlite3.pyd`) — they aren't code-signed, and SAC blocks unsigned binaries with no cloud reputation and offers no exclusion list. The backend process aborts on import before it announces its port, so the desktop app only ever showed the generic:

```
Hermes couldn't start
The background gateway didn't come up.
Error: Hermes backend exited before it became ready (1).
```

with the real cause (`ImportError: DLL load failed while importing _sqlite3: ...`) buried in `desktop.log`. Full code-signing the bundled Python (the proper long-term fix) is out of scope for this PR — it needs an actual code-signing certificate and release-pipeline change that only maintainers can set up. This PR does what's achievable from the app/docs side: make the failure recognizable and point at a documented workaround.

## Related Issue

Fixes #89627

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/electron/backend-exit-diagnosis.ts` (new) — `describeBackendExitHint()`, a pure function that recognizes the Windows `DLL load failed while importing` signature in the backend's recent log tail and returns an actionable hint (mentions Smart App Control/antivirus/corrupted install as known causes, links the new docs entry).
- `apps/desktop/electron/main.ts` — the backend `exit` handler (when the backend dies before becoming ready) now appends this hint to the boot-progress error message and the rejected error, instead of only the generic "exited before it became ready" text. No change for any other exit cause (hint is `null`, message is byte-for-byte the same as before).
- `apps/desktop/electron/backend-exit-diagnosis.test.ts` (new) — unit tests for the detector (matches, case-insensitivity, no false positive on an unrelated exit log, empty input).
- `website/docs/user-guide/windows-native.md` — new "Common pitfalls" entry documenting the SAC incompatibility and the WSL2 workaround, per the issue's suggestion #2 ("If signing is not feasible short-term, document the incompatibility").

## How to Test

1. `cd apps/desktop && npx vitest run electron/backend-exit-diagnosis.test.ts` — passes (4/4).
2. Confirmed the test fails without the fix: temporarily removed `backend-exit-diagnosis.ts` (the file this PR adds) and re-ran the same test — `Cannot find module './backend-exit-diagnosis'`, 1 failed suite.
3. Full electron test project: `npx vitest run --project electron` — 110 passed | 1 skipped (unrelated, pre-existing), 1453 passed | 2 skipped.
4. `npx tsc -p tsconfig.electron.json --noEmit` — clean.
5. `npx eslint electron/backend-exit-diagnosis.ts electron/backend-exit-diagnosis.test.ts electron/main.ts` — clean.
6. `npx vitest run src/app/gateway/hooks/use-gateway-boot.test.tsx --project ui` — 13/13 passed (confirms the boot-progress message consumer is unaffected for the non-hint case).

### Test output

```
 RUN  v4.1.10 apps/desktop
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

```
 RUN  v4.1.10 apps/desktop
 Test Files  110 passed | 1 skipped (111)
      Tests  1453 passed | 2 skipped (1455)
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've added tests for my changes
- [x] Windows-specific change, reasoned about via code + doc reading (no Windows machine available in this environment to reproduce SAC itself)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/windows-native.md`)
- [ ] N/A — no config keys changed
- [ ] N/A — no architecture/workflow change
- [x] Cross-platform impact considered: the detector only fires on the Windows-only CPython "DLL load failed while importing" string; non-Windows exits are unaffected (hint stays `null`, message unchanged byte-for-byte)

## AI assistance disclosure

This PR was authored with AI assistance (an autonomous Claude-based coding agent), with the change scoped, implemented, and verified (tests run, lint/typecheck run, pre-fix-vs-post-fix test behavior confirmed) before opening.
