### PR TITLE
fix(bot-mode): Routines pane scopes to the clicked bot, not the stale gateway profile

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -7446,13 +7446,19 @@ function CreateRoutineDialog({ bot, open, onClose }) {
   })
 }
 
+/** Which bot the Routines tile should scope to. $selectedBot already tracks
+ *  the live gateway profile (see the host.state.profile listener that keeps
+ *  it in sync) plus roster clicks, so it is current the instant a bot is
+ *  clicked; the raw gateway profile is only a fallback before any selection
+ *  has landed. */
+function resolveRoutinesBot(selected, gatewayProfile) {
+  return (selected || gatewayProfile || 'default').trim() || 'default'
+}
+
 function RoutinesPane() {
   const selected = useValue($selectedBot)
   const gatewayProfile = useValue(host.state.profile)
-  // The tile maps to the bot you're chatting with: the live gateway profile
-  // is the truth once a chat opens; $selectedBot covers the gap between a
-  // roster click and the profile swap landing.
-  const bot = (gatewayProfile || selected || 'default').trim() || 'default'
+  const bot = resolveRoutinesBot(selected, gatewayProfile)
   const meta = useValue($botMeta)[bot]
   const { shape, color, image } = botAppearance(bot, meta)
   const { data, error, isLoading, refetch } = useRoutines(bot)

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -7446,13 +7446,32 @@ function CreateRoutineDialog({ bot, open, onClose }) {
   })
 }
 
-/** Which bot the Routines tile should scope to. $selectedBot already tracks
- *  the live gateway profile (see the host.state.profile listener that keeps
- *  it in sync) plus roster clicks, so it is current the instant a bot is
- *  clicked; the raw gateway profile is only a fallback before any selection
- *  has landed. */
+/** Which bot the Routines tile should scope to. $selectedBot is reseeded from
+ *  the live gateway profile on every register() and kept in sync afterward by
+ *  the host.state.profile listener, plus updated on roster clicks — so it is
+ *  current both the instant a bot is clicked and across disable/re-enable
+ *  cycles. The raw gateway profile is only a fallback before any value has
+ *  landed in $selectedBot. */
 function resolveRoutinesBot(selected, gatewayProfile) {
   return (selected || gatewayProfile || 'default').trim() || 'default'
+}
+
+/** Keeps $selectedBot in sync with the live gateway profile. nanostores'
+ *  `.listen()` never replays the current value the way `.subscribe()` does,
+ *  so a disable → profile switch → re-enable sequence would otherwise leave
+ *  $selectedBot pointed at whichever bot was active before the plugin was
+ *  disabled — reseeding here on every register() call closes that gap.
+ *  Returns the unbind function for ctx.onDispose. */
+function bindProfileSync(profileStore) {
+  const current = profileStore.get?.()
+  if (current && typeof current === 'string') {
+    $selectedBot.set(current)
+  }
+  return profileStore.listen(profile => {
+    if (profile && typeof profile === 'string') {
+      $selectedBot.set(profile)
+    }
+  })
 }
 
 function RoutinesPane() {
@@ -9830,11 +9849,7 @@ export default {
     // Capture the unbinds: without them a disable → re-enable cycle stacks a
     // duplicate listener per cycle (same survives-disable class as the face
     // clock before its onDispose hook — these kept firing until app restart).
-    const unbindProfileListener = host.state.profile.listen(profile => {
-      if (profile && typeof profile === 'string') {
-        $selectedBot.set(profile)
-      }
-    })
+    const unbindProfileListener = bindProfileSync(host.state.profile)
     const unbindGatewayListener = host.state.gateway.listen(handleSessionsGatewayTransition)
 
     if (typeof ctx.onDispose === 'function') {

--- a/apps/desktop/src/plugins/hermes-bots/tests/routines-selected-bot.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routines-selected-bot.test.mjs
@@ -32,7 +32,7 @@ function load() {
     .replace(/^import .* from 'react'\r?\n/m, '')
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
-    .concat('\nglobalThis.__api = { resolveRoutinesBot };\n')
+    .concat('\nglobalThis.__api = { resolveRoutinesBot, bindProfileSync, $selectedBot };\n')
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   return context
 }
@@ -51,4 +51,56 @@ test('unit: falls back to default when nothing is known yet', () => {
   const { resolveRoutinesBot } = load().__api
   assert.equal(resolveRoutinesBot('', ''), 'default')
   assert.equal(resolveRoutinesBot('   ', '   '), 'default')
+})
+
+// #89625 follow-up: nanostores' `.listen()` never replays the current value
+// the way `.subscribe()` does. Before bindProfileSync reseeded on every call,
+// a disable -> profile switch -> re-enable sequence left $selectedBot pointed
+// at whichever bot was active before the plugin was disabled, so the
+// click-wins fix above would have just relocated the original staleness bug
+// rather than closing it. Mimic real nanostores atom semantics here (not a
+// mock that assumes the fix) so this fails honestly if bindProfileSync
+// regresses to a plain, non-reseeding listen().
+function fakeProfileStore(initial) {
+  let value = initial
+  const listeners = new Set()
+  return {
+    get: () => value,
+    set: next => {
+      value = next
+      for (const listener of listeners) listener(value)
+    },
+    listen: listener => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    }
+  }
+}
+
+test('regression: re-enabling after a profile switch while disabled resyncs, not stays stale', () => {
+  const { bindProfileSync, resolveRoutinesBot, $selectedBot } = load().__api
+  const profile = fakeProfileStore('blog-writer')
+
+  const unbind1 = bindProfileSync(profile)
+  assert.equal($selectedBot.get(), 'blog-writer', 'reseeded to the live profile on first bind')
+
+  unbind1() // plugin disabled: listener torn down
+  profile.set('researcher') // profile changes while nothing is listening
+
+  bindProfileSync(profile) // plugin re-enabled: register() runs again
+  assert.equal($selectedBot.get(), 'researcher', 'reseeded to the live profile on re-bind, not left stale')
+  assert.equal(
+    resolveRoutinesBot($selectedBot.get(), profile.get()),
+    'researcher',
+    'RoutinesPane scopes to the live profile after re-enable'
+  )
+})
+
+test('unit: bindProfileSync keeps forwarding live profile changes after (re)binding', () => {
+  const { bindProfileSync, $selectedBot } = load().__api
+  const profile = fakeProfileStore('default')
+
+  bindProfileSync(profile)
+  profile.set('researcher')
+  assert.equal($selectedBot.get(), 'researcher', 'live changes still flow through the listener')
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/routines-selected-bot.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routines-selected-bot.test.mjs
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// #89625: clicking a bot in the roster updates $selectedBot immediately, but
+// the chat connection takes a moment to actually swap to that bot's gateway,
+// so host.state.profile still reports the previous bot for a beat. The
+// Routines pane must scope to the bot the user clicked during that gap, not
+// the stale gateway profile.
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function load() {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+  const context = {
+    atom,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: { state: { profile: { listen: () => undefined } } }
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat('\nglobalThis.__api = { resolveRoutinesBot };\n')
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  return context
+}
+
+test('regression: a fresh roster click wins over a not-yet-switched gateway profile', () => {
+  const { resolveRoutinesBot } = load().__api
+  assert.equal(resolveRoutinesBot('blog-writer', 'default'), 'blog-writer')
+})
+
+test('unit: the gateway profile is used before any bot has been selected', () => {
+  const { resolveRoutinesBot } = load().__api
+  assert.equal(resolveRoutinesBot('', 'blog-writer'), 'blog-writer')
+})
+
+test('unit: falls back to default when nothing is known yet', () => {
+  const { resolveRoutinesBot } = load().__api
+  assert.equal(resolveRoutinesBot('', ''), 'default')
+  assert.equal(resolveRoutinesBot('   ', '   '), 'default')
+})


### PR DESCRIPTION
Fixes #89625

## Bug

In Bot Mode, clicking a different bot in the roster doesn't change which
bot's cron jobs the Routines pane shows — it keeps showing the previously
active bot's jobs (e.g. the default profile's 14 jobs instead of Blog
Writer's 1) until a chat message is sent, and sometimes not even then.

## Root cause

`RoutinesPane` (`apps/desktop/src/plugins/hermes-bots/plugin.js`) picked
`gatewayProfile` (`host.state.profile`, the profile the chat connection is
currently routed through) ahead of `$selectedBot` (the bot the user just
clicked):

```js
const bot = (gatewayProfile || selected || 'default').trim() || 'default'
```

Clicking a bot in the roster sets `$selectedBot` synchronously, but the
gateway connection takes a moment to actually swap over — `host.state.profile`
still reports the *previous* bot during that window. Since the old code
preferred `gatewayProfile`, the pane queried `cron.manage` with the wrong
`profile` scope until the connection caught up (and could stay wrong if the
routing never fully switched, per the report).

## Fix

Flip the precedence and extract the decision into a small pure helper:

```js
function resolveRoutinesBot(selected, gatewayProfile) {
  return (selected || gatewayProfile || 'default').trim() || 'default'
}
```

`RoutinesPane` now calls `resolveRoutinesBot(selected, gatewayProfile)`.

Making `$selectedBot` win unconditionally is only safe if `$selectedBot` is
actually always current — and a first version of this fix (reviewed here)
wasn't: the `host.state.profile.listen(...)` subscriber that keeps
`$selectedBot` synced to the live gateway profile is attached in `register()`
and torn down in `onDispose()`. nanostores' `.listen()` never replays the
current value the way `.subscribe()` does, so if a user disables Bot Mode,
switches the active gateway profile while it's disabled, then re-enables it,
`$selectedBot` stayed pointed at the pre-disable bot until the *next* profile
change happened to fire the listener — which, combined with the precedence
flip, would have made RoutinesPane show the wrong bot's jobs indefinitely
(the same failure class as the original bug, just moved to a longer-lived
trigger).

Fixed by extracting the sync into `bindProfileSync()`, which reseeds
`$selectedBot` from the profile store's current value *before* attaching the
listener:

```js
function bindProfileSync(profileStore) {
  const current = profileStore.get?.()
  if (current && typeof current === 'string') {
    $selectedBot.set(current)
  }
  return profileStore.listen(profile => {
    if (profile && typeof profile === 'string') {
      $selectedBot.set(profile)
    }
  })
}
```

`register()` now calls `bindProfileSync(host.state.profile)`, so every
register — including a disable → re-enable cycle — starts back in sync with
the live profile before anything can rely on `$selectedBot`.

## Test

`apps/desktop/src/plugins/hermes-bots/tests/routines-selected-bot.test.mjs`
(following this suite's existing `vm`-harness pattern, see
`routines-error.test.mjs`) covers both the pure `resolveRoutinesBot` helper
and, separately, `bindProfileSync`'s reseed behavior — using a fake profile
store that mirrors real nanostores `get`/`listen` semantics (`listen` does
not replay the current value) rather than a mock that assumes the fix works.
The new regression test drives: bind (reseed to "blog-writer") → unbind
(disable) → profile changes to "researcher" while unbound → bind again
(re-enable) → asserts `$selectedBot` and `resolveRoutinesBot` both resolve to
the live "researcher" profile, not the stale "blog-writer".

Verified the new regression tests fail without the `bindProfileSync` reseed
(reverting just the reseed lines, keeping the plain `.listen()`):

```
not ok - regression: re-enabling after a profile switch while disabled resyncs, not stays stale
  expected: 'blog-writer'
  actual: 'default'
```

And that all tests in the file fail against the pre-fix commit, where
`bindProfileSync` doesn't exist at all:

```
$ git checkout HEAD~1 -- apps/desktop/src/plugins/hermes-bots/plugin.js
$ node --test apps/desktop/src/plugins/hermes-bots/tests/routines-selected-bot.test.mjs
error: 'bindProfileSync is not defined'
# pass 0
# fail 5
```

All pass with the fix in place:

```
$ node --test apps/desktop/src/plugins/hermes-bots/tests/routines-selected-bot.test.mjs
# tests 5
# pass 5
# fail 0
```

Full plugin test suite (from `apps/desktop`):

```
$ npm run check:test:plugins
# tests 288
# pass 288
# fail 0
```

## AI assistance disclosure

This change was authored with AI assistance (Claude).
