### PR TITLE
fix(desktop): retry a hydration timeout once when opening a Bot chat

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -3172,12 +3172,20 @@ async function openStoredBotChat(name, storedId, summary) {
     typeof summary?.message_count === 'number' && Number.isFinite(summary.message_count)
   const expectHistory = hasAuthoritativeCount ? summary.message_count > 0 : true
 
-  await host.openSession(storedId, {
-    profile: name,
-    intent: 'main',
-    awaitHydration: true,
-    expectHistory
-  })
+  const openOptions = { profile: name, intent: 'main', awaitHydration: true, expectHistory }
+
+  try {
+    await host.openSession(storedId, openOptions)
+  } catch (error) {
+    // A profile backend that just woke up can lose the hydration-timeout race
+    // even though the session is fine (hermes-agent#89617) — clicking Retry
+    // succeeds because the backend is warm by then. Do that retry internally
+    // once so a cold-start hiccup does not surface as a session-history error.
+    if (typeof error?.message !== 'string' || !error.message.startsWith('Timed out loading ')) {
+      throw error
+    }
+    await host.openSession(storedId, openOptions)
+  }
 
   return storedId
 }

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -3172,20 +3172,19 @@ async function openStoredBotChat(name, storedId, summary) {
     typeof summary?.message_count === 'number' && Number.isFinite(summary.message_count)
   const expectHistory = hasAuthoritativeCount ? summary.message_count > 0 : true
 
-  const openOptions = { profile: name, intent: 'main', awaitHydration: true, expectHistory }
-
-  try {
-    await host.openSession(storedId, openOptions)
-  } catch (error) {
-    // A profile backend that just woke up can lose the hydration-timeout race
-    // even though the session is fine (hermes-agent#89617) — clicking Retry
-    // succeeds because the backend is warm by then. Do that retry internally
-    // once so a cold-start hiccup does not surface as a session-history error.
-    if (typeof error?.message !== 'string' || !error.message.startsWith('Timed out loading ')) {
-      throw error
-    }
-    await host.openSession(storedId, openOptions)
-  }
+  // A profile backend that just woke up can lose the hydration-timeout race
+  // even though the session is fine (hermes-agent#89617) — clicking Retry
+  // succeeds because the backend is warm by then. retryHydrationTimeoutOnce
+  // asks the SDK layer to retry that same wait internally, BEFORE it arms the
+  // core stranded-session overlay: a plugin-side retry can't do this because
+  // only host.openSession sees the resume-exhausted latch that overlay reads.
+  await host.openSession(storedId, {
+    profile: name,
+    intent: 'main',
+    awaitHydration: true,
+    expectHistory,
+    retryHydrationTimeoutOnce: true
+  })
 
   return storedId
 }

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-identity.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-identity.test.mjs
@@ -111,7 +111,8 @@ test('pin: preferred_session present opens the resolved session and keeps the pi
       profile: 'ops',
       intent: 'main',
       awaitHydration: true,
-      expectHistory: true
+      expectHistory: true,
+      retryHydrationTimeoutOnce: true
     }
   }])
   assert.equal(runtime.saved.length, 0, 'a live pin must not be rewritten')
@@ -213,13 +214,17 @@ test('pin: precise hit but failed hydration keeps the pin and surfaces the failu
     'must not fork the forever-chat on a hiccup')
 })
 
-test('pin: hydration timeout on a waking backend retries internally and succeeds', async () => {
-  const opened = []
+test('pin: a waking-backend hydration timeout asks the SDK to retry internally', async () => {
+  // The internal retry-and-succeed behavior lives in host.openSession itself
+  // (apps/desktop/src/sdk/index.ts) now, because only that layer sees the
+  // $resumeExhaustedSessionId latch that the core stranded-session overlay
+  // reads — a plugin-side retry can silently resolve while that overlay stays
+  // latched (hermes-agent#89617). This harness stubs host.openSession with a
+  // bare mock, so it can only prove the plugin ASKS for the retry, not that
+  // the overlay never appears; see profile-routing.test.ts for that.
+  const opts = []
   const runtime = loadOpenPath({
-    openSession: async id => {
-      opened.push(id)
-      if (opened.length === 1) throw new Error("Timed out loading ops's session history.")
-    },
+    openSession: async (id, options) => { opts.push(options) },
     request: async method => {
       if (method === 'profiles.list') {
         return {
@@ -239,11 +244,11 @@ test('pin: hydration timeout on a waking backend retries internally and succeeds
   const result = await runtime.openBotCanonicalChat('ops', 'pin-1', HISTORY)
 
   assert.equal(result, 'pin-1')
-  assert.deepEqual(opened, ['pin-1', 'pin-1'], 'a hydration timeout is retried once before surfacing')
-  assert.equal(runtime.saved.length, 0, 'a confirmed-live pin must survive a retried hydration timeout')
+  assert.equal(opts.length, 1)
+  assert.equal(opts[0].retryHydrationTimeoutOnce, true, 'the SDK must own the hydration-timeout retry')
 })
 
-test('pin: hydration timeout that fails twice still surfaces the failure', async () => {
+test('pin: a persistent hydration timeout still surfaces the failure', async () => {
   const runtime = loadOpenPath({
     openSession: async () => { throw new Error("Timed out loading ops's session history.") },
     request: async method => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-identity.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-identity.test.mjs
@@ -213,6 +213,59 @@ test('pin: precise hit but failed hydration keeps the pin and surfaces the failu
     'must not fork the forever-chat on a hiccup')
 })
 
+test('pin: hydration timeout on a waking backend retries internally and succeeds', async () => {
+  const opened = []
+  const runtime = loadOpenPath({
+    openSession: async id => {
+      opened.push(id)
+      if (opened.length === 1) throw new Error("Timed out loading ops's session history.")
+    },
+    request: async method => {
+      if (method === 'profiles.list') {
+        return {
+          profiles: [{
+            name: 'ops',
+            preferred_session: {
+              id: 'pin-1', resolved_id: 'pin-1', title: 'Bot Chat',
+              preview: 'latest', started_at: 1, last_active: 2, message_count: 3
+            }
+          }]
+        }
+      }
+      return {}
+    }
+  })
+
+  const result = await runtime.openBotCanonicalChat('ops', 'pin-1', HISTORY)
+
+  assert.equal(result, 'pin-1')
+  assert.deepEqual(opened, ['pin-1', 'pin-1'], 'a hydration timeout is retried once before surfacing')
+  assert.equal(runtime.saved.length, 0, 'a confirmed-live pin must survive a retried hydration timeout')
+})
+
+test('pin: hydration timeout that fails twice still surfaces the failure', async () => {
+  const runtime = loadOpenPath({
+    openSession: async () => { throw new Error("Timed out loading ops's session history.") },
+    request: async method => {
+      if (method === 'profiles.list') {
+        return {
+          profiles: [{
+            name: 'ops',
+            preferred_session: {
+              id: 'pin-1', resolved_id: 'pin-1', title: 'Bot Chat',
+              preview: 'latest', started_at: 1, last_active: 2, message_count: 3
+            }
+          }]
+        }
+      }
+      return {}
+    }
+  })
+
+  await assert.rejects(runtime.openBotCanonicalChat('ops', 'pin-1', HISTORY), /Timed out loading/)
+  assert.equal(runtime.saved.length, 0, 'a confirmed-live pin must survive a persistent hydration timeout')
+})
+
 // ── transient failures must never destroy the pin ──────────────────────────
 
 test('transient: profiles.list failure keeps the pin when the direct open works', async () => {

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -208,6 +208,12 @@ interface PluginOpenSessionOptions {
   intent?: OpenSessionIntent
   keepAllProfilesScope?: boolean
   profile?: null | string
+  /** A cold profile backend can lose the hydration-timeout race once and still
+   *  be fine on a second try. When set, a hydration timeout is retried
+   *  internally before it reaches the caller or arms the core stranded-session
+   *  overlay ($resumeExhaustedSessionId) — a caller-side retry can't do this
+   *  itself because only this SDK layer sees $resumeExhaustedSessionId. */
+  retryHydrationTimeoutOnce?: boolean
 }
 
 function waitForFocusedSessionHydration({
@@ -504,71 +510,85 @@ export const host = {
       $gatewaySwapTarget.set(targetProfile)
     }
 
+    // Bounded to 2 attempts (never more): a cold profile backend can lose the
+    // hydration-timeout race once and still be fine moments later, but this is
+    // a caller-opt-in retry of the SAME wait, not a backoff loop.
+    const maxAttempts = options.awaitHydration && options.retryHydrationTimeoutOnce ? 2 : 1
+
     try {
-      openSession(
-        storedSessionId,
-        (to: string, opts?: { replace?: boolean }) => {
-          const target = to.startsWith('#') ? to : `#${to}`
+      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+          openSession(
+            storedSessionId,
+            (to: string, opts?: { replace?: boolean }) => {
+              const target = to.startsWith('#') ? to : `#${to}`
 
-          if (opts?.replace) {
-            window.location.replace(target)
-          } else {
-            window.location.hash = target
+              if (opts?.replace) {
+                window.location.replace(target)
+              } else {
+                window.location.hash = target
+              }
+            },
+            options.intent ?? 'in-place'
+          )
+
+          // Judge the main surface AFTER the open: on a cold start the persisted
+          // route can already point at this session while selection has not
+          // settled, so a pre-open "already selected" precondition skips the
+          // resume exactly when it is needed (#89206 — blank Bot Chat with the
+          // roster preview intact). The surface is healthy only when this stored
+          // session is selected, a runtime is bound, and the expected transcript
+          // is present; anything less gets an explicit sequenced resume request.
+          // The route-resume effect only honors the request while the route
+          // points at this session, and consumes it alongside any resume the
+          // navigation itself triggers, so a redundant request is a no-op.
+          const surfaceHealthy =
+            $selectedStoredSessionId.get() === storedSessionId &&
+            Boolean($activeSessionId.get()) &&
+            (!expectHistory || $messages.get().length > 0)
+
+          if (options.awaitHydration && !surfaceHealthy) {
+            requestSessionResume(storedSessionId)
           }
-        },
-        options.intent ?? 'in-place'
-      )
 
-      // Judge the main surface AFTER the open: on a cold start the persisted
-      // route can already point at this session while selection has not
-      // settled, so a pre-open "already selected" precondition skips the
-      // resume exactly when it is needed (#89206 — blank Bot Chat with the
-      // roster preview intact). The surface is healthy only when this stored
-      // session is selected, a runtime is bound, and the expected transcript
-      // is present; anything less gets an explicit sequenced resume request.
-      // The route-resume effect only honors the request while the route
-      // points at this session, and consumes it alongside any resume the
-      // navigation itself triggers, so a redundant request is a no-op.
-      const surfaceHealthy =
-        $selectedStoredSessionId.get() === storedSessionId &&
-        Boolean($activeSessionId.get()) &&
-        (!expectHistory || $messages.get().length > 0)
+          if (options.awaitHydration) {
+            await waitForFocusedSessionHydration({
+              expectHistory,
+              generation,
+              profile: targetProfile,
+              storedSessionId,
+              timeoutMs: Math.max(1, options.hydrationTimeoutMs ?? DEFAULT_SESSION_HYDRATION_TIMEOUT_MS)
+            })
+          }
 
-      if (options.awaitHydration && !surfaceHealthy) {
-        requestSessionResume(storedSessionId)
+          break
+        } catch (error) {
+          const isHydrationTimeout = error instanceof Error && error.message.startsWith('Timed out loading ')
+
+          if (options.awaitHydration && generation === openSessionGeneration && isHydrationTimeout) {
+            console.warn('[bot-wake] hydration timed out', {
+              attempt,
+              hydrationWaitMs: Date.now() - profileActiveAt,
+              profile: targetProfile,
+              profileActivationMs: profileActiveAt - wakeStartedAt,
+              runtimeBound: Boolean($activeSessionId.get()),
+              selectionSettled: $selectedStoredSessionId.get() === storedSessionId,
+              storedSessionId,
+              transcriptPainted: $messages.get().length > 0
+            })
+
+            if (attempt < maxAttempts) {
+              continue
+            }
+
+            // Reuse the core stranded-session surface: it renders the explicit
+            // error and Retry button, and the normal resume path clears the latch.
+            setResumeExhaustedSessionId(storedSessionId)
+          }
+
+          throw error
+        }
       }
-
-      if (options.awaitHydration) {
-        await waitForFocusedSessionHydration({
-          expectHistory,
-          generation,
-          profile: targetProfile,
-          storedSessionId,
-          timeoutMs: Math.max(1, options.hydrationTimeoutMs ?? DEFAULT_SESSION_HYDRATION_TIMEOUT_MS)
-        })
-      }
-    } catch (error) {
-      if (
-        options.awaitHydration &&
-        generation === openSessionGeneration &&
-        error instanceof Error &&
-        error.message.startsWith('Timed out loading ')
-      ) {
-        console.warn('[bot-wake] hydration timed out', {
-          hydrationWaitMs: Date.now() - profileActiveAt,
-          profile: targetProfile,
-          profileActivationMs: profileActiveAt - wakeStartedAt,
-          runtimeBound: Boolean($activeSessionId.get()),
-          selectionSettled: $selectedStoredSessionId.get() === storedSessionId,
-          storedSessionId,
-          transcriptPainted: $messages.get().length > 0
-        })
-        // Reuse the core stranded-session surface: it renders the explicit
-        // error and Retry button, and the normal resume path clears the latch.
-        setResumeExhaustedSessionId(storedSessionId)
-      }
-
-      throw error
     } finally {
       if (options.awaitHydration && generation === openSessionGeneration) {
         $gatewaySwapTarget.set(null)

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -465,6 +465,57 @@ describe('profile-aware plugin session opens', () => {
     expect($gatewaySwapTarget.get()).toBeNull()
   })
 
+  it('retries a Bot Chat hydration timeout once without ever arming the Retry surface (#89617)', async () => {
+    $activeGatewayProfile.set('hyoseob')
+
+    // First attempt: leave the surface unhealthy so the hydration wait below
+    // times out, exactly like a profile backend still waking up. Second
+    // attempt: the backend is warm now — hydrate immediately. Queued as two
+    // one-shots (not a standing mockImplementation) so this doesn't leak into
+    // later tests via the shared afterEach's vi.clearAllMocks(), which clears
+    // call history but not a standing implementation.
+    vi.mocked(openSessionCore).mockImplementationOnce(() => undefined).mockImplementationOnce(() => {
+      setMockAtom($selectedStoredSessionId, 'waking-bot-chat')
+      setMockAtom($activeSessionId, 'runtime-waking')
+      setMockAtom($messages, [{ id: 'history-waking', parts: [], role: 'assistant' }] as never)
+    })
+
+    await host.openSession('waking-bot-chat', {
+      profile: 'hyoseob',
+      awaitHydration: true,
+      expectHistory: true,
+      hydrationTimeoutMs: 1,
+      retryHydrationTimeoutOnce: true
+    })
+
+    expect(openSessionCore).toHaveBeenCalledTimes(2)
+    // The overlay in apps/desktop/src/app/chat/index.tsx is gated purely on
+    // this atom equalling the routed session id — if it were ever set here,
+    // the user would land on "Couldn't load this session" even though the
+    // retry above succeeded underneath, since only a manual resumeSession()
+    // call clears it for the currently-routed session.
+    expect(setResumeExhaustedSessionId).not.toHaveBeenCalled()
+    expect($gatewaySwapTarget.get()).toBeNull()
+  })
+
+  it('still arms the Retry surface when a retried Bot Chat hydration times out twice', async () => {
+    $activeGatewayProfile.set('hyoseob')
+
+    await expect(
+      host.openSession('stranded-bot-chat', {
+        profile: 'hyoseob',
+        awaitHydration: true,
+        expectHistory: true,
+        hydrationTimeoutMs: 1,
+        retryHydrationTimeoutOnce: true
+      })
+    ).rejects.toThrow(/timed out loading/i)
+
+    expect(openSessionCore).toHaveBeenCalledTimes(2)
+    expect(setResumeExhaustedSessionId).toHaveBeenCalledWith('stranded-bot-chat')
+    expect($gatewaySwapTarget.get()).toBeNull()
+  })
+
   it('lets the latest rapid bot selection win and cancels the older hydration wait', async () => {
     vi.mocked(ensureGatewayProfile).mockImplementation(async (target: null | string | undefined) => {
       $activeGatewayProfile.set(target || 'default')


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop Bot Mode "session-history timeout" reported in #89617. Opening
a Bot right after Hermes Desktop starts can hit a profile backend that is still
waking up. `openStoredBotChat` calls `host.openSession(..., { awaitHydration: true })`,
which races the transcript hydration against a fixed 20s budget
(`DEFAULT_SESSION_HYDRATION_TIMEOUT_MS` in `apps/desktop/src/sdk/index.ts`) and
rejects with `Timed out loading <profile>'s session history.` if it loses.

**Revision note:** an earlier version of this PR retried at the plugin layer
(`openStoredBotChat` catching the rejection and calling `host.openSession` a
second time). A review caught that this doesn't fix the reported bug: on a
hydration timeout, `host.openSession`'s own catch block
(`apps/desktop/src/sdk/index.ts`) unconditionally calls
`setResumeExhaustedSessionId(storedSessionId)` *before* rethrowing. That atom
drives a hard, full-screen "Couldn't load this session" overlay
(`apps/desktop/src/app/chat/index.tsx`) that only clears for the
currently-routed session via an explicit `resumeSession()` call (the manual
Retry button) — never automatically. A plugin-side retry calling
`host.openSession()` again is a different code path that can succeed and
hydrate the transcript underneath, but nothing clears the latch, so the user
still lands on the exact stranded-session screen the issue asked to
eliminate. The fix has to live in the SDK layer, since only it sees
`$resumeExhaustedSessionId`.

## Changes Made

- `apps/desktop/src/sdk/index.ts` — `host.openSession` gains a
  `retryHydrationTimeoutOnce` option. When set, a hydration timeout is retried
  internally (re-navigate, re-check surface health, re-wait) once *before*
  `setResumeExhaustedSessionId` is ever called. If the retry succeeds, the
  latch is never armed, so the stranded-session overlay never appears. If the
  retry also times out, the existing behavior (arm the latch, rethrow) applies
  unchanged.
- `apps/desktop/src/plugins/hermes-bots/plugin.js` — `openStoredBotChat` now
  passes `retryHydrationTimeoutOnce: true` instead of doing its own
  catch-and-retry. This is the only behavioral change at the plugin layer.
- `apps/desktop/src/sdk/profile-routing.test.ts` — two new tests against the
  *real* `host.openSession` implementation (not a bare mock): one where a
  first-attempt timeout is followed by a successful retry and asserts
  `setResumeExhaustedSessionId` is **never called**, and one where both
  attempts time out and asserts the latch **is** armed. These are the tests
  that actually exercise the overlay-latch mechanics the bug is about.
- `apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-identity.test.mjs`
  — updated the two hydration-timeout tests to assert the plugin now asks for
  `retryHydrationTimeoutOnce: true` rather than asserting it retries
  `host.openSession` itself (that mock can't see the SDK-level latch, so it
  only proves the plugin delegates correctly — the real proof is in
  `profile-routing.test.ts`).

## How to Test

1. `cd apps/desktop && npm run check:test:plugins` (`node --test src/plugins/*/tests/*.test.mjs`)

   ```
   1..285
   # tests 285
   # pass 285
   # fail 0
   ```

2. `cd apps/desktop && npx vitest run src/sdk/` (real SDK-layer tests, including the new overlay-latch coverage)

   ```
   Test Files  3 passed (3)
        Tests  27 passed (27)
   ```

3. Proved the new SDK tests fail without the `apps/desktop/src/sdk/index.ts` fix:
   ```
   git checkout HEAD~1 -- apps/desktop/src/sdk/index.ts
   npx vitest run src/sdk/profile-routing.test.ts
   # 2 failed | 15 passed (17)
   #   × retries a Bot Chat hydration timeout once without ever arming the Retry surface (#89617)
   #   × still arms the Retry surface when a retried Bot Chat hydration times out twice
   git checkout HEAD -- apps/desktop/src/sdk/index.ts
   npx vitest run src/sdk/profile-routing.test.ts
   # 17 passed (17)
   ```

## Notes

`apps/desktop/src/plugins/hermes-bots/plugin.js` is a plain `.js` plugin file
excluded from `tsc` (`allowJs: false`); `apps/desktop/src/sdk/index.ts` is a
regular `.ts` module and type-checks cleanly (`npx tsc --noEmit` shows no new
errors). `eslint` itself isn't resolvable as an installed dependency in this
sandbox (`ERR_MODULE_NOT_FOUND` for `globals`, pre-existing/unrelated to this
change), so I could not run `npm run lint`.

This PR was prepared by an AI coding agent (Claude) and reviewed before
submission.

Fixes #89617
