### PR TITLE
fix(slack): don't re-answer threads on bot metadata-only edits

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -5775,6 +5775,34 @@ class SlackAdapter(BasePlatformAdapter):
             if not isinstance(updated_message, dict):
                 return
 
+            # A bot/app-authored root whose EDIT did not change the visible text
+            # must never wake the agent. Some integrations (e.g. an escalation
+            # poster syncing ticket status/fields) periodically edit their own
+            # root messages; each edit arrives as message_changed and, when
+            # unwrapped below into a normal inbound, is fed to the model as a
+            # fresh message that re-answers an already-handled thread. Drop the
+            # event when (a) the edited message is bot/app-authored AND (b) the
+            # body text is byte-identical to previous_message. Human edits that
+            # add an @mention change the text, so they still wake the agent.
+            prev_message = event.get("previous_message")
+            updated_is_bot = bool(
+                updated_message.get("bot_id")
+                or updated_message.get("app_id")
+                or updated_message.get("subtype") == "bot_message"
+            )
+            if updated_is_bot and isinstance(prev_message, dict):
+                if (updated_message.get("text") or "") == (
+                    prev_message.get("text") or ""
+                ):
+                    logger.info(
+                        "[Slack] Dropping bot metadata-only edit "
+                        "(message_changed, bot-authored, text-unchanged): "
+                        "webchat=%s ts=%s",
+                        event.get("channel", ""),
+                        str(updated_message.get("ts") or ""),
+                    )
+                    return
+
             original_message_ts = str(updated_message.get("ts") or "")
             if (
                 original_message_ts


### PR DESCRIPTION
## Problem

A bot/app-authored root message that is **edited without changing its visible text** causes the agent to re-answer an already-handled thread.

Observed in production: an escalation integration periodically edits its own root messages to sync ticket status/fields. Each edit fires a Slack `message_changed` event. In `_process_event` the handler unwraps `event.message` (the root text) into a normal inbound, assigns a fresh `_slack_changed_event_ts` (the edit ts), and processes it as a brand-new message. The agent then posts an unsolicited reply into an old resolved thread.

The existing dedup does **not** suppress this because its key is the fresh edit event ts, not the original message ts.

## Fix

In the `message_changed` branch, drop the event when:
1. the edited message is bot/app-authored (`bot_id` / `app_id` / `subtype == "bot_message"`), **and**
2. the body text is byte-identical to `previous_message`.

Human edits that add an `@mention` change the text, so they still wake the agent. Only content-free metadata edits by bots are filtered.

## Scope

- Single branch, `plugins/platforms/slack/adapter.py`, +28 lines, no behavior change for human edits or text-changing bot edits.
- Verified against production: the three affected escalation roots each carried an `edited` marker by the integration bot with timestamps matching the phantom inbounds exactly; channel history showed zero real messages at those times.
