### PR TITLE
fix(vision): support public-image (URL) mode for auxiliary vision providers

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -725,6 +725,12 @@ prompt_caching:
 #     timeout: 30            # LLM API call timeout (seconds)
 #     download_timeout: 30   # Image HTTP download timeout (seconds)
 #                            # Increase for slow connections or self-hosted image servers
+#     public_url_only: false # Forward http(s) image URLs as-is instead of
+#                            # downloading + base64-encoding them. Enable for
+#                            # providers (e.g. SenseNova) that only accept a
+#                            # publicly reachable image URL and reject inline
+#                            # base64 images. Local file paths still download
+#                            # normally.
 #     reasoning_effort: ""   # Per-task thinking level: none, minimal, low, medium,
 #                            # high, xhigh, max, ultra. Empty = provider default.
 #                            # Works on every auxiliary task block (vision,

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -986,6 +986,7 @@ DEFAULT_CONFIG = {
             "extra_body": {},      # OpenAI-compatible provider-specific request fields
             "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
             "download_timeout": 30,  # seconds — image HTTP download timeout; increase for slow connections
+            "public_url_only": False,  # forward http(s) image URLs as-is instead of base64 — for providers (e.g. SenseNova) that reject inline images
         },
         "web_extract": {
             "provider": "auto",

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -368,6 +368,40 @@ class TestPublicUrlOnlyMode:
         sent_url = mock_llm.await_args.kwargs["messages"][0]["content"][1]["image_url"]["url"]
         assert sent_url.startswith("data:image/png;base64,")
 
+    @pytest.mark.asyncio
+    async def test_public_url_only_still_enforces_website_policy(self):
+        blocked = {
+            "host": "blocked.test",
+            "rule": "blocked.test",
+            "source": "config",
+            "message": "Blocked by website policy",
+        }
+
+        with (
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"auxiliary": {"vision": {"public_url_only": True}}},
+            ),
+            patch(
+                "tools.vision_tools._validate_image_url_async",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch("tools.vision_tools.check_website_access", return_value=blocked),
+            patch(
+                "tools.vision_tools.async_call_llm", new_callable=AsyncMock
+            ) as mock_llm,
+        ):
+            result = json.loads(
+                await vision_analyze_tool(
+                    "https://blocked.test/photo.png", "describe this"
+                )
+            )
+
+        assert result["success"] is False
+        assert "Blocked by website policy" in result["error"]
+        mock_llm.assert_not_awaited()
+
 
 class TestVisionSafetyGuards:
     @pytest.mark.asyncio

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -294,6 +294,81 @@ class TestVisionConfig:
         assert kwargs["timeout"] == 120.0
 
 
+class TestPublicUrlOnlyMode:
+    """auxiliary.vision.public_url_only forwards http(s) URLs unmodified.
+
+    Providers such as SenseNova reject inline base64 images and only accept
+    a publicly reachable HTTP(S) URL (issue #89628). When the flag is set,
+    vision_analyze_tool must send the URL through as-is instead of
+    downloading + base64-encoding it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_public_url_only_forwards_url_without_base64(self):
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "A public image"
+        mock_response.choices = [mock_choice]
+
+        with (
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"auxiliary": {"vision": {"public_url_only": True}}},
+            ),
+            patch(
+                "tools.vision_tools._validate_image_url_async",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "tools.vision_tools.async_call_llm",
+                new_callable=AsyncMock,
+                return_value=mock_response,
+            ) as mock_llm,
+        ):
+            result = json.loads(
+                await vision_analyze_tool(
+                    "https://example.com/photo.png", "describe this"
+                )
+            )
+
+        assert result["success"] is True
+        sent_url = mock_llm.await_args.kwargs["messages"][0]["content"][1]["image_url"]["url"]
+        assert sent_url == "https://example.com/photo.png"
+
+    @pytest.mark.asyncio
+    async def test_public_url_only_off_by_default_still_base64_encodes(self):
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "A public image"
+        mock_response.choices = [mock_choice]
+
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 8
+
+        with (
+            patch("hermes_cli.config.load_config", return_value={}),
+            patch(
+                "tools.image_source.resolve_image_source",
+                new_callable=AsyncMock,
+                return_value=MagicMock(data=png_bytes, mime="image/png"),
+            ),
+            patch(
+                "tools.vision_tools.async_call_llm",
+                new_callable=AsyncMock,
+                return_value=mock_response,
+            ) as mock_llm,
+        ):
+            result = json.loads(
+                await vision_analyze_tool(
+                    "https://example.com/photo.png", "describe this"
+                )
+            )
+
+        assert result["success"] is True
+        sent_url = mock_llm.await_args.kwargs["messages"][0]["content"][1]["image_url"]["url"]
+        assert sent_url.startswith("data:image/png;base64,")
+
+
 class TestVisionSafetyGuards:
     @pytest.mark.asyncio
     async def test_local_non_image_file_rejected_before_llm_call(self, tmp_path):

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1364,95 +1364,116 @@ async def vision_analyze_tool(
         logger.info("Analyzing image: %s", image_url[:60])
         logger.info("User prompt: %s", user_prompt[:100])
 
-        # Resolve the source to raw bytes through the single resolver (unifies
-        # data:/http/file/local/container and enforces terminal-backend
-        # confinement). Materialize to a temp file so the existing path-based
-        # encode/resize pipeline below is reused verbatim.
-        from tools.image_source import (
-            ImageResolutionError,
-            ResolveContext,
-            resolve_image_source,
-        )
-
+        # Public-image mode: some auxiliary vision providers (e.g. SenseNova)
+        # only accept a publicly reachable HTTP(S) URL and reject inline
+        # base64 images outright. When auxiliary.vision.public_url_only is
+        # set and the input is already such a URL, skip the
+        # download/normalize/base64 pipeline below and forward the URL
+        # through unchanged — the provider fetches it server-side, same as
+        # the native image-attachment path already does.
+        public_url_only = False
         try:
-            resolved = await resolve_image_source(image_url, ResolveContext(task_id=task_id))
-        except ImageResolutionError as exc:
-            raise ValueError(str(exc))
+            from hermes_cli.config import cfg_get, load_config
+            public_url_only = bool(
+                cfg_get(load_config(), "auxiliary", "vision", "public_url_only", default=False)
+            )
+        except Exception:
+            pass
 
-        detected_mime_type = resolved.mime
-        temp_dir = get_hermes_dir("cache/vision", "temp_vision_images")
-        temp_dir.mkdir(parents=True, exist_ok=True)
-        temp_image_path = temp_dir / f"temp_image_{uuid.uuid4()}.img"
-        await asyncio.to_thread(temp_image_path.write_bytes, resolved.data)
-        should_cleanup = True
-
-        # Get image file size for logging
-        image_size_bytes = len(resolved.data)
-        image_size_kb = image_size_bytes / 1024
-        logger.info("Image ready (%.1f KB)", image_size_kb)
-        # Normalize unsupported formats (SVG, BMP, ...) to PNG. Vision providers
-        # reject these media types; convert before encoding. Offloaded — the
-        # rasterizers/Pillow are blocking.
-        normalized_path, detected_mime_type, _norm_err = await asyncio.to_thread(
-            _normalize_to_supported_image, temp_image_path, detected_mime_type,
-        )
-        if _norm_err or normalized_path is None:
-            raise ValueError(_norm_err or "Image normalization failed.")
-        if normalized_path != temp_image_path:
-            if should_cleanup and temp_image_path.exists():
-                try:
-                    temp_image_path.unlink()
-                except Exception:
-                    pass
-            temp_image_path = normalized_path
-            should_cleanup = True
-
-        # Optional region zoom: crop BEFORE the encode/downscale pipeline so
-        # the cropped area gets the full resolution budget.
         _crop_offset: dict = {}
         _scale_info: dict = {}
-        if region is not None:
-            cropped_path, cropped_mime, crop_err = await asyncio.to_thread(
-                _crop_image_region, temp_image_path, region,
-                offset_out=_crop_offset,
+        if public_url_only and region is None and await _validate_image_url_async(image_url):
+            image_data_url = image_url.strip()
+            image_size_bytes = 0
+            logger.info("Public-image mode: forwarding URL without base64 encoding")
+        else:
+            # Resolve the source to raw bytes through the single resolver (unifies
+            # data:/http/file/local/container and enforces terminal-backend
+            # confinement). Materialize to a temp file so the existing path-based
+            # encode/resize pipeline below is reused verbatim.
+            from tools.image_source import (
+                ImageResolutionError,
+                ResolveContext,
+                resolve_image_source,
             )
-            if crop_err or cropped_path is None:
-                raise ValueError(crop_err or "Region crop failed.")
-            if should_cleanup and temp_image_path.exists():
-                try:
-                    temp_image_path.unlink()
-                except Exception:
-                    pass
-            temp_image_path = cropped_path
-            detected_mime_type = cropped_mime
+
+            try:
+                resolved = await resolve_image_source(image_url, ResolveContext(task_id=task_id))
+            except ImageResolutionError as exc:
+                raise ValueError(str(exc))
+
+            detected_mime_type = resolved.mime
+            temp_dir = get_hermes_dir("cache/vision", "temp_vision_images")
+            temp_dir.mkdir(parents=True, exist_ok=True)
+            temp_image_path = temp_dir / f"temp_image_{uuid.uuid4()}.img"
+            await asyncio.to_thread(temp_image_path.write_bytes, resolved.data)
             should_cleanup = True
 
-        # Convert image to base64 — send at full resolution first.
-        # If the provider rejects it as too large, we auto-resize and retry.
-        # Offloaded to the bounded vision CPU executor so a fan-out of encodes
-        # can't saturate every core and starve the event loop.
-        logger.info("Converting image to base64...")
-        image_data_url = await _run_encode_on_cpu_executor(
-            _image_to_base64_data_url, temp_image_path, mime_type=detected_mime_type)
-        data_size_kb = len(image_data_url) / 1024
-        logger.info("Image converted to base64 (%.1f KB)", data_size_kb)
+            # Get image file size for logging
+            image_size_bytes = len(resolved.data)
+            image_size_kb = image_size_bytes / 1024
+            logger.info("Image ready (%.1f KB)", image_size_kb)
+            # Normalize unsupported formats (SVG, BMP, ...) to PNG. Vision providers
+            # reject these media types; convert before encoding. Offloaded — the
+            # rasterizers/Pillow are blocking.
+            normalized_path, detected_mime_type, _norm_err = await asyncio.to_thread(
+                _normalize_to_supported_image, temp_image_path, detected_mime_type,
+            )
+            if _norm_err or normalized_path is None:
+                raise ValueError(_norm_err or "Image normalization failed.")
+            if normalized_path != temp_image_path:
+                if should_cleanup and temp_image_path.exists():
+                    try:
+                        temp_image_path.unlink()
+                    except Exception:
+                        pass
+                temp_image_path = normalized_path
+                should_cleanup = True
 
-        # Hard limit (20 MB) — no provider accepts payloads this large.
-        if len(image_data_url) > _MAX_BASE64_BYTES:
-            # Try to resize down to 5 MB before giving up.
-            image_data_url = await _run_encode_on_cpu_executor(
-                _resize_image_for_vision,
-                temp_image_path, mime_type=detected_mime_type,
-                scale_out=_scale_info)
-            if len(image_data_url) > _MAX_BASE64_BYTES:
-                raise ValueError(
-                    f"Image too large for vision API: base64 payload is "
-                    f"{len(image_data_url) / (1024 * 1024):.1f} MB "
-                    f"(limit {_MAX_BASE64_BYTES / (1024 * 1024):.0f} MB) "
-                    f"even after resizing. "
-                    f"Install Pillow (`pip install Pillow`) for better auto-resize, "
-                    f"or compress the image manually."
+            # Optional region zoom: crop BEFORE the encode/downscale pipeline so
+            # the cropped area gets the full resolution budget.
+            if region is not None:
+                cropped_path, cropped_mime, crop_err = await asyncio.to_thread(
+                    _crop_image_region, temp_image_path, region,
+                    offset_out=_crop_offset,
                 )
+                if crop_err or cropped_path is None:
+                    raise ValueError(crop_err or "Region crop failed.")
+                if should_cleanup and temp_image_path.exists():
+                    try:
+                        temp_image_path.unlink()
+                    except Exception:
+                        pass
+                temp_image_path = cropped_path
+                detected_mime_type = cropped_mime
+                should_cleanup = True
+
+            # Convert image to base64 — send at full resolution first.
+            # If the provider rejects it as too large, we auto-resize and retry.
+            # Offloaded to the bounded vision CPU executor so a fan-out of encodes
+            # can't saturate every core and starve the event loop.
+            logger.info("Converting image to base64...")
+            image_data_url = await _run_encode_on_cpu_executor(
+                _image_to_base64_data_url, temp_image_path, mime_type=detected_mime_type)
+            data_size_kb = len(image_data_url) / 1024
+            logger.info("Image converted to base64 (%.1f KB)", data_size_kb)
+
+            # Hard limit (20 MB) — no provider accepts payloads this large.
+            if len(image_data_url) > _MAX_BASE64_BYTES:
+                # Try to resize down to 5 MB before giving up.
+                image_data_url = await _run_encode_on_cpu_executor(
+                    _resize_image_for_vision,
+                    temp_image_path, mime_type=detected_mime_type,
+                    scale_out=_scale_info)
+                if len(image_data_url) > _MAX_BASE64_BYTES:
+                    raise ValueError(
+                        f"Image too large for vision API: base64 payload is "
+                        f"{len(image_data_url) / (1024 * 1024):.1f} MB "
+                        f"(limit {_MAX_BASE64_BYTES / (1024 * 1024):.0f} MB) "
+                        f"even after resizing. "
+                        f"Install Pillow (`pip install Pillow`) for better auto-resize, "
+                        f"or compress the image manually."
+                    )
 
         debug_call_data["image_size_bytes"] = image_size_bytes
         
@@ -1511,6 +1532,7 @@ async def vision_analyze_tool(
             response = await async_call_llm(**call_kwargs)
         except Exception as _api_err:
             if (_is_image_size_error(_api_err)
+                    and temp_image_path is not None
                     and len(image_data_url) > _RESIZE_TARGET_BYTES):
                 logger.info(
                     "API rejected image (%.1f MB, likely too large); "

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1383,6 +1383,9 @@ async def vision_analyze_tool(
         _crop_offset: dict = {}
         _scale_info: dict = {}
         if public_url_only and region is None and await _validate_image_url_async(image_url):
+            blocked = check_website_access(image_url)
+            if blocked:
+                raise PermissionError(blocked["message"])
             image_data_url = image_url.strip()
             image_size_bytes = 0
             logger.info("Public-image mode: forwarding URL without base64 encoding")


### PR DESCRIPTION
## What does this PR do?

Adds a "public-image" mode to the auxiliary vision path so `vision_analyze` can be used with providers (e.g. SenseNova 6.8 / U1 Fast) that only accept a publicly reachable `http(s)://` image URL and reject inline base64 images outright.

`vision_analyze_tool` (`tools/vision_tools.py`) always downloaded the image and re-encoded it as a `data:image/...;base64,...` URL before sending, regardless of whether the input was already a public URL. SenseNova rejects that inline form with `400 image download failed`. The main-agent native-attachment path (`agent/image_routing.build_native_content_parts`) already passes public URLs through unchanged — this brings the same behavior to the auxiliary vision tool path, opt-in via config.

## Related Issue

Fixes #89628

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/vision_tools.py` — `vision_analyze_tool`: when `auxiliary.vision.public_url_only` is set and the input is already a safe `http(s)://` URL (validated via the existing SSRF-safe `_validate_image_url_async`) and no region-crop was requested, skip the download/normalize/base64 pipeline and forward the URL unchanged. Also guards the size-triggered resize-retry path so it only fires when a local temp file actually exists.
- `hermes_cli/config_defaults.py` — new `auxiliary.vision.public_url_only` default (`False`), so behavior is unchanged unless explicitly enabled.
- `cli-config.yaml.example` — documents the new key next to the existing `auxiliary.vision` block.
- `tests/tools/test_vision_tools.py` — new `TestPublicUrlOnlyMode`:
  - `test_public_url_only_forwards_url_without_base64` — with the flag on, asserts the URL sent to the LLM is the original URL, not a base64 data URL.
  - `test_public_url_only_off_by_default_still_base64_encodes` — asserts default behavior (flag unset) is unchanged.

## How to Test

1. Set `auxiliary.vision.public_url_only: true` in `config.yaml` (or per the SenseNova provider block).
2. Call `vision_analyze` with an already-public `http(s)://` image URL.
3. Confirm the request sent to the vision provider carries the original URL in `image_url.url`, not a `data:` URL — verified in the new unit tests below.

### Test output

```
$ scripts/run_tests.sh tests/tools/test_vision_tools.py -q
Discovered 1 test files (~36 tests) under ['tests/tools/test_vision_tools.py']; running with -j 8
[100.0% |    36/~36 | ✓36 | ✗ 0] ✓ tests/tools/test_vision_tools.py (36✓, 3.0s)
=== Summary: 1 files, 36 tests passed, 0 failed (100% complete) in 3.0s (8 workers) ===
```

Proved the new test fails without the fix (reverted only the fix files to `HEAD~2`, the pre-fix commit — `HEAD~1` is this branch's own docs-only follow-up commit and doesn't touch these files, so it's identical to `HEAD` for this purpose):

```
$ git checkout HEAD~2 -- tools/vision_tools.py hermes_cli/config_defaults.py
$ scripts/run_tests.sh tests/tools/test_vision_tools.py -q -k TestPublicUrlOnlyMode
FAILED tests/tools/test_vision_tools.py::TestPublicUrlOnlyMode::test_public_url_only_forwards_url_without_base64
httpx.HTTPStatusError: Client error '404 Not Found' for url 'https://example.com/photo.png'
1 failed, 1 passed, 34 deselected in 0.81s
$ git checkout HEAD -- tools/vision_tools.py hermes_cli/config_defaults.py   # restore the fix
```

Also ran the broader related suites clean: `tests/agent/test_image_routing.py`, `tests/hermes_cli/test_aux_config.py`, `tests/agent/test_auxiliary_client.py` (227 tests passed).

`ruff check tools/vision_tools.py tests/tools/test_vision_tools.py hermes_cli/config_defaults.py` — all checks passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `pytest tests/ -q` and all tests pass (ran targeted files above via `scripts/run_tests.sh`)
- [x] I've added tests for my changes
- [ ] I've tested on my platform — untested against a real SenseNova endpoint; verified via unit tests only (no live API credentials in this environment)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (config-only addition, documented in the example file below)
- [x] I've updated `cli-config.yaml.example` since I added a config key
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A, no architecture/workflow change
- [ ] Cross-platform impact — N/A, pure config/routing logic, no OS-specific code
- [ ] Tool descriptions/schemas — N/A, `vision_analyze`'s public schema/behavior contract is unchanged; this only changes an internal auxiliary-config-gated code path

## AI assistance disclosure

This PR was prepared with AI assistance (Claude, Anthropic) under human supervision: the diff, tests, and this description were generated by an autonomous coding agent, then reviewed before opening.
