### PR TITLE
fix(provider): expose DeepInfra env vars

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3648,6 +3648,22 @@ OPTIONAL_ENV_VARS = {
         "category": "provider",
         "advanced": True,
     },
+    "DEEPINFRA_API_KEY": {
+        "description": "DeepInfra API key",
+        "prompt": "DeepInfra API key",
+        "url": "https://deepinfra.com/dash/api_keys",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "DEEPINFRA_BASE_URL": {
+        "description": "DeepInfra OpenAI-compatible base URL override",
+        "prompt": "DeepInfra base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
     "LM_API_KEY": {
         "description": "LM Studio bearer token for auth-enabled local servers",
         "prompt": "LM Studio API key / bearer token",


### PR DESCRIPTION
## Summary
- update the scratch checkout to current upstream main
- add DeepInfra API key/base URL entries to OPTIONAL_ENV_VARS so the provider setup surfaces recognize the latest DeepInfra provider profile
- fixes the provider test regression introduced by the latest main branch

## Test Plan
- python -m pytest tests/providers tests/hermes_cli/test_provider_catalog.py tests/hermes_cli/test_provider_parity.py tests/hermes_cli/test_api_key_providers.py tests/hermes_cli/test_runtime_provider_resolution.py -q -o 'addopts='