### PR TITLE
feat(bot-mode): add configurable roster views

### DIFF
--- a/apps/desktop/src/components/ui/context-menu.tsx
+++ b/apps/desktop/src/components/ui/context-menu.tsx
@@ -82,6 +82,32 @@ function ContextMenuCheckboxItem({
   )
 }
 
+function ContextMenuRadioGroup({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.RadioGroup>) {
+  return <ContextMenuPrimitive.RadioGroup data-slot="context-menu-radio-group" {...props} />
+}
+
+function ContextMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.RadioItem>) {
+  return (
+    <ContextMenuPrimitive.RadioItem
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-md px-2 py-1 text-xs outline-hidden select-none focus:bg-(--ui-control-active-background) focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
+        className
+      )}
+      data-slot="context-menu-radio-item"
+      {...props}
+    >
+      {children}
+      <ContextMenuPrimitive.ItemIndicator className="ml-auto flex items-center pl-2 text-foreground">
+        <Codicon name="circle-filled" size="0.75rem" />
+      </ContextMenuPrimitive.ItemIndicator>
+    </ContextMenuPrimitive.RadioItem>
+  )
+}
+
 function ContextMenuLabel({
   className,
   inset,
@@ -172,6 +198,8 @@ export {
   ContextMenuItem,
   ContextMenuLabel,
   ContextMenuPortal,
+  ContextMenuRadioGroup,
+  ContextMenuRadioItem,
   ContextMenuSeparator,
   ContextMenuSub,
   ContextMenuSubContent,

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -26,7 +26,13 @@ import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuLabel,
+  ContextMenuRadioGroup,
+  ContextMenuRadioItem,
   ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
   ContextMenuTrigger,
   ConfirmDialog,
   CopyButton,
@@ -37,8 +43,13 @@ import {
   DialogHeader,
   DialogTitle,
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
   EmptyState,
   GlyphSpinner,
@@ -83,6 +94,79 @@ const blobatarSvg = typeof sdk === 'undefined' ? undefined : sdk.blobatarSvg
 const createBudgetedLoop = typeof sdk === 'undefined' ? undefined : sdk.createBudgetedLoop
 
 const ID = 'hermes-bots'
+
+const BOT_ROSTER_EN = {
+  view: {
+    options: 'View options', grouping: 'Grouping', none: 'None', sections: 'Sections', groups: 'Groups', sorting: 'Sorting',
+    alphabetical: 'Alphabetical A–Z', recent: 'Pinned first then recent', manual: 'Manual order', groupDisplay: 'Group display',
+    nestMembers: 'Nest group members', groupsMode: 'Groups mode', display: 'Display', showHidden: 'Show hidden bots',
+    manageSections: 'Manage Sections…', hiddenUnread: 'A hidden Bot has unread activity'
+  },
+  bot: {
+    backInRoster: name => `${name} is back in the roster`,
+    hidden: name => `${name} hidden — use View → Show hidden bots in the Bots header to see them`
+  },
+  sections: {
+    manage: 'Manage Sections',
+    description: 'Visual Sections partition the roster for display only. They never alter Bot groups or room membership.',
+    save: 'Save', cancel: 'Cancel', noSections: 'No sections yet. Create one to partition the roster.', newName: 'New section name…',
+    add: 'Add', peerAssignments: 'Peer assignments', unassigned: 'Unassigned', done: 'Done', moveTo: 'Move to section',
+    assignTo: (peer, destination) => `Move ${peer} to ${destination}`,
+    peers: count => `${count} peer${count === 1 ? '' : 's'}`, moveUp: title => `Move ${title} up`, moveDown: title => `Move ${title} down`,
+    rename: title => `Rename ${title}`, delete: title => `Delete ${title}`, collapse: title => `Collapse ${title}`, expand: title => `Expand ${title}`,
+    noMatch: query => `No bots match “${query}”`, allHidden: 'All bots are hidden — use View → Show hidden bots to show them.'
+  }
+}
+
+const BOT_LOCALES = {
+  en: BOT_ROSTER_EN,
+  ja: {
+    view: { options: '表示オプション', grouping: 'グループ化', none: 'なし', sections: 'セクション', groups: 'グループ', sorting: '並べ替え', alphabetical: 'アルファベット順 A–Z', recent: 'ピン留め優先、次に最近', manual: '手動順序', groupDisplay: 'グループ表示', nestMembers: 'グループメンバーを入れ子表示', groupsMode: 'グループモード', display: '表示', showHidden: '非表示のBotを表示', manageSections: 'セクションを管理…', hiddenUnread: '非表示のBotに未読のアクティビティがあります' },
+    bot: { backInRoster: name => `${name}を名簿に戻しました`, hidden: name => `${name}を非表示にしました — Botヘッダーの「表示」→「非表示のBotを表示」で確認できます` },
+    sections: { manage: 'セクションを管理', description: '表示用セクションは名簿の見た目だけを分けます。Botグループやルーム所属は変更しません。', save: '保存', cancel: 'キャンセル', noSections: 'セクションはまだありません。名簿を分けるセクションを作成してください。', newName: '新しいセクション名…', add: '追加', peerAssignments: '割り当て', unassigned: '未割り当て', done: '完了', moveTo: 'セクションへ移動', assignTo: (peer, destination) => `${peer}を${destination}へ移動`, peers: count => `${count}件`, moveUp: title => `${title}を上へ`, moveDown: title => `${title}を下へ`, rename: title => `${title}の名前を変更`, delete: title => `${title}を削除`, collapse: title => `${title}を折りたたむ`, expand: title => `${title}を展開`, noMatch: query => `「${query}」に一致するBotはありません`, allHidden: 'すべてのBotが非表示です。「表示」→「非表示のBotを表示」を使用してください。' }
+  },
+  zh: {
+    view: { options: '视图选项', grouping: '分组', none: '无', sections: '分区', groups: '群组', sorting: '排序', alphabetical: '按字母 A–Z', recent: '置顶优先，其次最近', manual: '手动顺序', groupDisplay: '群组显示', nestMembers: '嵌套群组成员', groupsMode: '群组模式', display: '显示', showHidden: '显示隐藏 Bot', manageSections: '管理分区…', hiddenUnread: '隐藏的 Bot 有未读活动' },
+    bot: { backInRoster: name => `${name} 已恢复到名册`, hidden: name => `${name} 已隐藏 — 可在 Bot 标题栏中使用“视图 → 显示隐藏 Bot”查看` },
+    sections: { manage: '管理分区', description: '可视分区只改变名册显示，不会修改 Bot 群组或房间成员关系。', save: '保存', cancel: '取消', noSections: '尚无分区。创建一个分区来整理名册。', newName: '新分区名称…', add: '添加', peerAssignments: '成员分配', unassigned: '未分配', done: '完成', moveTo: '移动到分区', assignTo: (peer, destination) => `将 ${peer} 移动到 ${destination}`, peers: count => `${count} 个成员`, moveUp: title => `上移 ${title}`, moveDown: title => `下移 ${title}`, rename: title => `重命名 ${title}`, delete: title => `删除 ${title}`, collapse: title => `折叠 ${title}`, expand: title => `展开 ${title}`, noMatch: query => `没有匹配“${query}”的 Bot`, allHidden: '所有 Bot 均已隐藏，请使用“视图 → 显示隐藏 Bot”。' }
+  },
+  'zh-hant': {
+    view: { options: '檢視選項', grouping: '分組', none: '無', sections: '分區', groups: '群組', sorting: '排序', alphabetical: '依字母 A–Z', recent: '釘選優先，其次最近', manual: '手動順序', groupDisplay: '群組顯示', nestMembers: '巢狀顯示群組成員', groupsMode: '群組模式', display: '顯示', showHidden: '顯示隱藏 Bot', manageSections: '管理分區…', hiddenUnread: '隱藏的 Bot 有未讀活動' },
+    bot: { backInRoster: name => `${name} 已恢復到名冊`, hidden: name => `${name} 已隱藏 — 可在 Bot 標題列中使用「檢視 → 顯示隱藏 Bot」查看` },
+    sections: { manage: '管理分區', description: '視覺分區只改變名冊顯示，不會修改 Bot 群組或房間成員關係。', save: '儲存', cancel: '取消', noSections: '尚無分區。建立一個分區來整理名冊。', newName: '新分區名稱…', add: '新增', peerAssignments: '成員分配', unassigned: '未分配', done: '完成', moveTo: '移動到分區', assignTo: (peer, destination) => `將 ${peer} 移動到 ${destination}`, peers: count => `${count} 位成員`, moveUp: title => `上移 ${title}`, moveDown: title => `下移 ${title}`, rename: title => `重新命名 ${title}`, delete: title => `刪除 ${title}`, collapse: title => `收合 ${title}`, expand: title => `展開 ${title}`, noMatch: query => `沒有符合「${query}」的 Bot`, allHidden: '所有 Bot 均已隱藏，請使用「檢視 → 顯示隱藏 Bot」。' }
+  }
+}
+
+function fallbackBotTranslate(key, ...args) {
+  let value = BOT_ROSTER_EN
+  for (const part of String(key).split('.')) value = value && value[part]
+  return typeof value === 'function' ? value(...args) : String(value || key)
+}
+
+const useBotRosterTranslate =
+  typeof sdk !== 'undefined' && typeof sdk.usePluginI18n === 'function'
+    ? sdk.usePluginI18n
+    : () => fallbackBotTranslate
+
+function bindBotText(t, template, prefix = '') {
+  const out = {}
+  for (const [key, value] of Object.entries(template)) {
+    const path = prefix ? `${prefix}.${key}` : key
+    out[key] = typeof value === 'function'
+      ? (...args) => t(path, ...args)
+      : value && typeof value === 'object'
+        ? bindBotText(t, value, path)
+        : t(path)
+  }
+  return out
+}
+
+function useBotRosterText() {
+  const reactive = useBotRosterTranslate(ID)
+  const translate = globalThis.__HERMES_BOTS_TEST__ && pluginCtx?.i18n?.t ? pluginCtx.i18n.t : reactive
+  return bindBotText(translate, BOT_ROSTER_EN)
+}
+
 const ROSTER_KEY = [ID, 'roster']
 const ROUTINES_KEY = [ID, 'routines']
 const NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
@@ -296,8 +380,137 @@ async function saveBotMeta(name, patch) {
 // that asymmetry lets mergeServerMeta resurrect a stale truthy copy. A
 // literal false round-trips identically through both stores.
 
-/** Session-only view toggle: reveal hidden bots (dimmed) in the roster. */
-const $showHiddenBots = atom(false)
+// ── View state: grouping, sorting, visual sections ────────────────────────
+// Persisted view preferences for the Bots roster. Uses race-safe hydration
+// to prevent old storage-read cycles from overwriting newer local mutations.
+
+const VIEW_GROUPING_NONE = 'none'
+const VIEW_GROUPING_SECTIONS = 'sections'
+const VIEW_GROUPING_GROUPS = 'groups'
+const VIEW_SORT_ALPHA = 'alpha'
+const VIEW_SORT_PINNED_RECENCY = 'pinned-recency'
+const VIEW_SORT_MANUAL = 'manual'
+const ROSTER_VIEW_STORAGE_KEY = 'roster-view:window'
+
+/** Current view state wrapper { state, token, localGeneration }. It must be
+ * renderable synchronously: plugin storage hydration always yields at least
+ * once, while the bundled pane may mount immediately after registration. */
+const $viewStateWrapper = atom({ state: normalizeViewState(null), token: 0, localGeneration: 0 })
+function getOrInitViewState() {
+  return $viewStateWrapper.get()
+}
+let viewHydrationToken = 0
+
+/** Persist view state to plugin storage (fire-and-forget). */
+function persistViewState() {
+  const wrapper = getOrInitViewState()
+  if (!pluginCtx?.storage?.set) {
+    return
+  }
+
+  const toStore = { ...wrapper.state }
+  Promise.resolve(pluginCtx.storage.set(ROSTER_VIEW_STORAGE_KEY, toStore)).catch(() => undefined)
+}
+
+/** Hydrate view state from storage with lifecycle and mutation race safety. */
+async function hydrateViewStateFromStorage(requestToken, ctxAtStart = pluginCtx) {
+  const startedGeneration = getOrInitViewState().localGeneration
+  let stored = null
+  try {
+    stored = await ctxAtStart?.storage?.get?.(ROSTER_VIEW_STORAGE_KEY)
+    if (stored == null) stored = await ctxAtStart?.storage?.get?.('view-state')
+  } catch {
+    /* storage unavailable */
+  }
+
+  if (pluginCtx !== ctxAtStart) {
+    return
+  }
+
+  const current = getOrInitViewState()
+  const next = hydrateViewState(current, stored, requestToken, startedGeneration)
+  $viewStateWrapper.set(next)
+}
+
+/** Write a view state patch and persist. Returns the new normalized state. */
+function updateViewState(patch) {
+  const wrapper = getOrInitViewState()
+  const nextState = normalizeViewState({ ...wrapper.state, ...patch })
+
+  $viewStateWrapper.set({
+    state: nextState,
+    token: wrapper.token,
+    localGeneration: (wrapper.localGeneration || 0) + 1
+  })
+
+  persistViewState()
+
+  return nextState
+}
+
+/** Mutation helpers that call updateViewState and return the new state. */
+function setGroupingMode(mode) { return updateViewState({ grouping: mode }) }
+function setSortMode(mode) { return updateViewState({ sort: mode }) }
+function toggleNestMembers() { return updateViewState({ nestMembers: !getOrInitViewState().state.nestMembers }) }
+function toggleShowHidden() { return updateViewState({ showHidden: !getOrInitViewState().state.showHidden }) }
+
+function addVisualSection(title) {
+  const state = getOrInitViewState().state
+  const section = createVisualSection(state.visualSections, title)
+  const nextSections = [...state.visualSections, section]
+  const nextOrder = [...state.sectionOrder, section.key]
+
+  return updateViewState({ visualSections: nextSections, sectionOrder: nextOrder })
+}
+
+function editVisualSection(key, newTitle) {
+  const state = getOrInitViewState().state
+  return updateViewState({ visualSections: renameVisualSection(state.visualSections, key, newTitle) })
+}
+
+function removeVisualSection(key) {
+  const state = getOrInitViewState().state
+  const result = deleteVisualSection(state.visualSections, state.sectionAssignments, state.sectionOrder, key)
+
+  return updateViewState({
+    visualSections: result.sections,
+    sectionAssignments: result.assignments,
+    sectionOrder: result.order
+  })
+}
+
+function changeVisualSectionOrder(key, newIndex) {
+  const state = getOrInitViewState().state
+  const result = reorderVisualSections(state.visualSections, state.sectionOrder, key, newIndex)
+
+  return updateViewState({ visualSections: result.sections, sectionOrder: result.order })
+}
+
+function movePeerToSection(peerId, sectionKey) {
+  const state = getOrInitViewState().state
+  const assignments = sectionKey
+    ? assignPeerToSection(state.sectionAssignments, peerId, sectionKey)
+    : unassignPeerFromSection(state.sectionAssignments, peerId)
+
+  return updateViewState({ sectionAssignments: assignments })
+}
+
+function toggleSectionCollapse(sectionKey) {
+  const state = getOrInitViewState().state
+  const collapsed = collapseSection(state.sectionCollapsed, sectionKey, !isSectionCollapsed(state.sectionCollapsed, sectionKey))
+
+  return updateViewState({ sectionCollapsed: collapsed })
+}
+
+/** Collapse/expand a nested group row (None/Sections Nest ON). Reuses the
+ *  generic collapse-map helpers against `nestedExpansion`, which is already
+ *  normalized and persisted by the view-state layer. */
+function toggleNestedGroupCollapse(groupKey) {
+  const state = getOrInitViewState().state
+  const expanded = collapseSection(state.nestedExpansion, groupKey, !isSectionCollapsed(state.nestedExpansion, groupKey))
+
+  return updateViewState({ nestedExpansion: expanded })
+}
 
 /** Hidden flag for a roster row. Thin remote-source rows never read local
  *  meta (botRosterMeta returns null for them), so hide is by NAME on the
@@ -3392,6 +3605,29 @@ function displayName(bot, meta) {
   return raw.replace(/\b\w/g, ch => ch.toUpperCase())
 }
 
+/** Per-descriptor search match against the four identities a row can carry:
+ *  the customizable display name, the profile name, its @handle, and the
+ *  multi-source connection label. Shared by roster filtering and section
+ *  search so a remote-only room member matches by the same semantics as a
+ *  local roster row (remote descriptors can't ride the precomputed visible
+ *  roster, so they need the filter applied directly). */
+function matchesBotDescriptor(bot, metaByName, query) {
+  const needle = String(query || '').trim().toLowerCase().replace(/^@/, '')
+
+  if (!needle) {
+    return true
+  }
+
+  const display = displayName(bot, botRosterMeta(bot, metaByName)).toLowerCase()
+  const profile = (bot.name || '').toLowerCase()
+  const handle = botHandle(bot.name, bot).toLowerCase()
+  // Multi-source rows also match on their device name ("homelab" finds
+  // every bot living on the Homelab connection).
+  const sourceLabel = (bot.connectionLabel || '').toLowerCase()
+
+  return display.includes(needle) || profile.includes(needle) || handle.includes(needle) || sourceLabel.includes(needle)
+}
+
 /** Filter by the two stable identities rendered in every roster row: the
  * customizable display name and the profile's @handle. Keep the current
  * activity order — search narrows the roster, it never re-ranks it. */
@@ -3402,17 +3638,7 @@ function filterBots(roster, metaByName, query) {
     return roster
   }
 
-  return roster.filter(bot => {
-    const display = displayName(bot, botRosterMeta(bot, metaByName)).toLowerCase()
-    const profile = (bot.name || '').toLowerCase()
-    const handle = botHandle(bot.name, bot).toLowerCase()
-    // Multi-source rows also match on their device name ("homelab" finds
-    // every bot living on the Homelab connection).
-    const sourceLabel = (bot.connectionLabel || '').toLowerCase()
-    return (
-      display.includes(needle) || profile.includes(needle) || handle.includes(needle) || sourceLabel.includes(needle)
-    )
-  })
+  return roster.filter(bot => matchesBotDescriptor(bot, metaByName, needle))
 }
 
 function slugify(value) {
@@ -3497,7 +3723,7 @@ function groupChatNames(metaByName, rooms) {
 }
 
 /** Millisecond timestamp of a room's newest log entry (0 for a silent room) —
- *  the group's recency key, competing in the same ordering as bot rows. */
+ *  the group header's relative-time label. */
 function groupLastActivity(room) {
   const log = Array.isArray(room?.log) ? room.log : []
 
@@ -3506,12 +3732,14 @@ function groupLastActivity(room) {
 
 /** Seat a group's member roster: local bots whose meta names the group, plus
  *  the room record's stored descriptors (remote members can't ride bot-meta).
- *  Prefers the LIVE roster row for a stored descriptor when present. */
-function groupChatMemberBots(group, roster, metaByName) {
+ *  Prefers the LIVE roster row for a stored descriptor when present. `rooms`
+ *  defaults to the live room map; callers that project pure sections pass it
+ *  explicitly so the helper stays free of hidden store reads. */
+function groupChatMemberBots(group, roster, metaByName, rooms = $groupChats.get()) {
   const local = (roster || []).filter(
     bot => !bot.remoteSource && botGroups(botRosterMeta(bot, metaByName)).includes(group)
   )
-  const stored = ($groupChats.get()[group] || {}).members || []
+  const stored = ((rooms || {})[group] || {}).members || []
   const seated = new Set(local.map(botRosterKey))
   const remote = []
 
@@ -3555,6 +3783,1022 @@ function knownGroups(metaByName) {
   }
 
   return [...names].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
+}
+
+// ── View model: grouping, sorting, visual sections, nesting ─────────────────
+//
+// Bot Mode groups and user-created visual Sections are DIFFERENT concepts.
+// Groups are Bot membership labels stored in bot-meta. Visual Sections are
+// manually created divider headers that partition the peer row list for
+// display only — they never alter Bot groups[], room membership, routing, or
+// canonical chats.
+//
+// View modes:
+//   None     — flat list: every visible Bot + every known group, no dividers.
+//   Sections — peers partitioned by manual visual Sections (unassigned first).
+//   Groups   — every Bot standalone, followed by alphabetical group shortcuts
+//              that duplicate every seated member beneath each membership.
+
+// ── Peer identity ─────────────────────────────────────────────────────────
+
+/** Source-qualified Bot identity — delegates to botRosterKey. */
+function botPeerIdentity(bot) {
+  return botRosterKey(bot)
+}
+
+/** Kind-qualified group identity — always 'group:<name>', never collides with
+ *  Bot ids (which are source-qualified, e.g. 'legacy::name'). */
+function groupPeerIdentity(name) {
+  return `group:${name}`
+}
+
+// ── Peer list construction ────────────────────────────────────────────────
+
+/** Build the top-level peer list: every visible Bot (respecting showHidden)
+ *  plus every durable/known group row exactly once. Groups never depend on
+ *  roster visibility — they stay visible even with zero local members. */
+function buildPeerList(roster, metaByName, rooms, showHidden) {
+  const peers = []
+  const seen = new Set()
+
+  for (const bot of (roster || [])) {
+    if (!showHidden && isBotHidden(bot, metaByName)) {
+      continue
+    }
+
+    const id = botPeerIdentity(bot)
+
+    if (seen.has(id)) {
+      continue
+    }
+
+    seen.add(id)
+    const meta = botRosterMeta(bot, metaByName)
+
+    peers.push({
+      kind: 'bot',
+      peerId: id,
+      name: bot.name,
+      remoteSource: bot.remoteSource || false,
+      sourceScoped: bot.sourceScoped || false,
+      connectionId: bot.connectionId,
+      connectionLabel: bot.connectionLabel,
+      handle: bot.handle,
+      last_session: bot.last_session,
+      groups: botGroups(meta),
+      meta,
+      botRow: bot
+    })
+  }
+
+  // Durable group rows: union bot-meta groups + room records.
+  const names = groupChatNames(metaByName, rooms || {})
+
+  for (const name of [...names].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))) {
+    const id = groupPeerIdentity(name)
+
+    if (seen.has(id)) {
+      continue
+    }
+
+    seen.add(id)
+    const room = (rooms || {})[name] || null
+
+    peers.push({
+      kind: 'group',
+      peerId: id,
+      title: name,
+      meta: null,
+      members: groupChatMemberBots(name, roster, metaByName, rooms || {}),
+      groupActivity: groupLastActivity(room),
+      groupRoom: room
+    })
+  }
+
+  return peers
+}
+
+// ── Sorting ────────────────────────────────────────────────────────────────
+
+/** Alphabetical A–Z: bots by display name, groups by group name. Case-insensitive. */
+function sortAlpha(items) {
+  return [...items].sort((a, b) => {
+    const aLabel = (a.kind === 'group' ? a.title : displayName(a.botRow, a.meta || null)).toLowerCase()
+    const bLabel = (b.kind === 'group' ? b.title : displayName(b.botRow, b.meta || null)).toLowerCase()
+
+    return aLabel.localeCompare(bLabel, undefined, { sensitivity: 'base' })
+  })
+}
+
+/** Pinned first then recency: pinned bots (newest activity first), then
+ *  unpinned bots (newest first), then groups (by room activity, newest
+ *  first). Groups are never pinned. */
+function sortPinnedRecency(items) {
+  const bots = items.filter(i => i.kind === 'bot')
+  const groups = items.filter(i => i.kind === 'group')
+
+  const pinned = bots.filter(b => b.meta?.pinned).sort((a, b) => (b.activity || 0) - (a.activity || 0))
+  const unpinned = bots.filter(b => !b.meta?.pinned).sort((a, b) => (b.activity || 0) - (a.activity || 0))
+  const sortedGroups = groups.sort((a, b) => (b.groupActivity || 0) - (a.groupActivity || 0))
+
+  return [...pinned, ...unpinned, ...sortedGroups]
+}
+
+/** Manual order: uses persisted peer-id array as the authoritative order.
+ *  New peers (not in persisted) append deterministically at the end; stale
+ *  IDs (not in current peers) are silently ignored. */
+function sortManual(items, persistedOrder) {
+  const idx = new Map()
+  const order = Array.isArray(persistedOrder) ? persistedOrder : []
+  const currentIds = new Set(items.map(i => i.peerId))
+
+  for (let i = 0; i < order.length; i++) {
+    const id = order[i]
+
+    if (currentIds.has(id)) {
+      idx.set(id, i)
+    }
+  }
+
+  const sorted = [...items].sort((a, b) => {
+    const ai = idx.has(a.peerId) ? idx.get(a.peerId) : Infinity
+    const bi = idx.has(b.peerId) ? idx.get(b.peerId) : Infinity
+
+    return ai - bi
+  })
+
+  return sorted
+}
+
+/** Dispatch to the correct sort function based on mode. */
+function resolveSortOrder(sortMode, items, manualOrder, pinnedRecencyActivity) {
+  switch (sortMode) {
+    case VIEW_SORT_ALPHA:
+      return sortAlpha(items)
+    case VIEW_SORT_MANUAL:
+      return sortManual(items, manualOrder)
+    case VIEW_SORT_PINNED_RECENCY:
+    default:
+      return sortPinnedRecency(items)
+  }
+}
+
+// ── Visual Sections ────────────────────────────────────────────────────────
+
+/** Generate a collision-safe section key. */
+function visualSectionKey(title, existingKeys) {
+  const base = title
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 32) || 'section'
+  let key = `section:${base}`
+  let n = 1
+
+  while (existingKeys && existingKeys.has(key)) {
+    key = `section:${base}-${n++}`
+  }
+
+  return key
+}
+
+/** Create a new visual section. Returns the new section object. */
+function createVisualSection(existingSections, title) {
+  const keys = new Set((existingSections || []).map(s => s.key))
+  const maxOrder = (existingSections || []).reduce((max, s) => Math.max(max, s.order || 0), -1)
+  const key = visualSectionKey(title, keys)
+
+  return { key, title: title.trim(), order: maxOrder + 1 }
+}
+
+/** Rename a visual section. Returns new sections array. */
+function renameVisualSection(sections, key, newTitle) {
+  return (sections || []).map(s => (s.key === key ? { ...s, title: newTitle.trim() } : s))
+}
+
+/** Reorder visual sections by moving one section to a new index. Returns
+ *  { sections, order } with updated order fields. */
+function reorderVisualSections(sections, currentOrder, key, newIndex) {
+  const order = (currentOrder || []).filter(k => k !== key)
+
+  order.splice(Math.min(Math.max(0, newIndex), order.length), 0, key)
+
+  const sectionMap = new Map((sections || []).map(s => [s.key, s]))
+
+  return {
+    sections: order.map((k, i) => {
+      const s = sectionMap.get(k)
+
+      return s ? { ...s, order: i } : s
+    }).filter(Boolean),
+    order
+  }
+}
+
+/** Delete a visual section. Unassigns all peers assigned to it and removes
+ *  it from sections, order, and collapsed state. Never deletes a group or Bot.
+ *  Returns { sections, assignments, order, collapsed }. */
+function deleteVisualSection(sections, assignments, sectionOrder, key) {
+  const nextAssignments = { ...(assignments || {}) }
+
+  for (const peerId of Object.keys(nextAssignments)) {
+    if (nextAssignments[peerId] === key) {
+      delete nextAssignments[peerId]
+    }
+  }
+
+  const nextCollapsed = {}
+  const nextSections = (sections || []).filter(s => s.key !== key)
+  const nextOrder = (sectionOrder || []).filter(k => k !== key)
+
+  return {
+    sections: nextSections,
+    assignments: nextAssignments,
+    order: nextOrder,
+    collapsed: nextCollapsed
+  }
+}
+
+/** Assign a peer to a visual section. Returns new assignments map. */
+function assignPeerToSection(assignments, peerId, sectionKey) {
+  return { ...(assignments || {}), [peerId]: sectionKey }
+}
+
+/** Unassign a peer from a visual section. Returns new assignments map. */
+function unassignPeerFromSection(assignments, peerId) {
+  const next = { ...(assignments || {}) }
+  delete next[peerId]
+
+  return next
+}
+
+/** Collapse/expand a section. Returns new collapsed map. */
+function collapseSection(collapsed, sectionKey, value) {
+  const next = { ...(collapsed || {}) }
+
+  if (value) {
+    next[sectionKey] = true
+  } else {
+    delete next[sectionKey]
+  }
+
+  return next
+}
+
+/** Check if a section is collapsed. */
+function isSectionCollapsed(collapsed, sectionKey) {
+  return Boolean((collapsed || {})[sectionKey])
+}
+
+// ── Grouping mode application ──────────────────────────────────────────────
+
+/** Apply the selected grouping mode to a peer list and optional view state.
+ *  Returns a flat or sectioned render array.
+ *
+ *  In None mode: every peer is a flat row (no section dividers).
+ *  In Sections mode: peers are partitioned by visual sections with unassigned
+ *    first, each section with header + peer list.
+ *  In Groups mode: every Bot remains standalone, followed by automatic group
+ *    shortcuts alphabetically with duplicated members under every membership.
+ *
+ *  `nestMembers` controls whether group shortcuts expose duplicated member
+ *  children in None and Sections modes; canonical Bot rows remain top-level.
+ *  Groups mode shortcut nesting is inherent.
+ *
+ *  `searchOpts` is optional { query, matchesBotId }. When provided, the
+ *  projection is filtered: only matching Bots and group rows (by name match
+ *  or containing a matching member) survive. Collapsed sections do not bury
+ *  search matches — active search reveals matching rows. */
+function applyGroupingMode(mode, peers, viewState, nestMembers, searchOpts) {
+  const vsSections = (viewState || {}).visualSections || []
+  const vsAssignments = (viewState || {}).sectionAssignments || {}
+  const vsCollapsed = (viewState || {}).sectionCollapsed || {}
+  const vsOrder = (viewState || {}).sectionOrder || []
+  const vsNestedExpansion = (viewState || {}).nestedExpansion || {}
+  const manualSort = (viewState || {}).sort === VIEW_SORT_MANUAL
+  const manualOrderUnassigned = (viewState || {}).manualOrderUnassigned || {}
+  const manualOrderGroups = (viewState || {}).manualOrderGroups || {}
+  const searching = searchOpts && String(searchOpts.query || '').trim().toLowerCase()
+  const matchesBotId = searchOpts ? (searchOpts.matchesBotId || new Set()) : null
+
+  /** Whether a peer matches the current search. */
+  function peerMatches(peer) {
+    if (!searching) {
+      return true
+    }
+
+    if (peer.kind === 'bot' && matchesBotId && matchesBotId.has(peer.peerId)) {
+      return true
+    }
+
+    if (peer.kind === 'group' && peer.title.toLowerCase().includes(searching)) {
+      return true
+    }
+
+    // A group matches if any nested member would match
+    if (peer.kind === 'group' && matchesBotId && peer.children) {
+      return peer.children.some(c => matchesBotId.has(c.peerId))
+    }
+
+    // A raw group peer (from buildPeerList) carries `members` descriptors, not
+    // `children`. Match against those members by source-qualified identity and
+    // by descriptor so a member-name search keeps the group row even before
+    // nesting computes children (Sections Nest ON filters peers first).
+    if (peer.kind === 'group' && Array.isArray(peer.members)) {
+      return peer.members.some(member => {
+        if (matchesBotId && matchesBotId.has(botRosterKey(member))) {
+          return true
+        }
+
+        return matchesBotDescriptor(member, null, searching)
+      })
+    }
+
+    return false
+  }
+
+  /** Compute nested shortcut children from authoritative room seating first,
+   * falling back to local `groups[]` metadata for legacy/local-only rows. */
+  function nestChildren(groupPeer, botPeers) {
+    const seated = Array.isArray(groupPeer.members) ? groupPeer.members : []
+
+    return botPeers.filter(peer => {
+      const bot = peer.botRow || peer
+      const seatedMatch = seated.some(member => {
+        if (member?.remoteSource || member?.connectionId) {
+          return botRosterKey(member) === peer.peerId
+        }
+        return !bot?.remoteSource && member?.name === bot?.name
+      })
+
+      return seatedMatch || Boolean(peer.groups && peer.groups.includes(groupPeer.title))
+    })
+  }
+
+  if (mode === VIEW_GROUPING_GROUPS) {
+    // Group shortcuts are alphabetical; every Bot also stays standalone above.
+    const botPeers = peers.filter(p => p.kind === 'bot')
+    const groupPeers = peers.filter(p => p.kind === 'group')
+
+    const result = []
+
+    // Every Bot remains standalone; groups below are shortcuts that duplicate
+    // their members without replacing the canonical Bot rows.
+    const standaloneBots = manualSort
+      ? sortManual(botPeers, manualOrderGroups[MANUAL_ORDER_UNASSIGNED_KEY])
+      : botPeers
+    const filteredStandalone = searching
+      ? standaloneBots.filter(peerMatches)
+      : standaloneBots
+
+    for (const bot of filteredStandalone) {
+      result.push({ ...bot, level: 0 })
+    }
+
+    // Group sections alphabetically
+    const sortedGroups = [...groupPeers].sort((a, b) =>
+      a.title.localeCompare(b.title, undefined, { sensitivity: 'base' })
+    )
+
+    for (const gp of sortedGroups) {
+      const children = manualSort
+        ? sortManual(nestChildren(gp, botPeers), manualOrderGroups[groupPeerIdentity(gp.title)])
+        : nestChildren(gp, botPeers)
+      const filteredChildren = searching ? children.filter(b => matchesBotId.has(b.peerId)) : children
+
+      // Skip empty group sections during search (unless group name matches)
+      if (searching && filteredChildren.length === 0 && !gp.title.toLowerCase().includes(searching)) {
+        continue
+      }
+
+      result.push({
+        ...gp,
+        level: 0,
+        children: filteredChildren.map(c => ({ ...c, level: 1, parentId: gp.peerId })),
+        isGroupHeader: true
+      })
+    }
+
+    return result
+  }
+
+  if (mode === VIEW_GROUPING_SECTIONS) {
+    // Visual Section assignment and Bot group membership are independent. When
+    // nesting is enabled, each group draws children from the complete visible
+    // Bot peer set, so a multi-group Bot appears under every group even when
+    // those group rows live in different visual Sections.
+    const allSectionBotPeers = peers.filter(p => p.kind === 'bot')
+
+    // Partition peers by visual sections, unassigned first.
+    const unassigned = []
+    const bySection = new Map()
+
+    // Build the section-key → title lookup
+    const sectionMeta = new Map(vsSections.map(s => [s.key, s]))
+
+    for (const peer of peers) {
+      const assigned = vsAssignments[peer.peerId]
+      const sectionKey = assigned && sectionMeta.has(assigned) ? assigned : null
+
+      if (sectionKey) {
+        if (!bySection.has(sectionKey)) {
+          bySection.set(sectionKey, [])
+        }
+
+        bySection.get(sectionKey).push(peer)
+      } else {
+        unassigned.push(peer)
+      }
+    }
+
+    // Manual sort: order each range (unassigned + each section) by its own
+    // collision-safe bucket. Peers not yet in a bucket append deterministically.
+    if (manualSort) {
+      const unassignedOrder = sortManual(unassigned, manualOrderUnassigned[MANUAL_ORDER_UNASSIGNED_KEY])
+
+      unassigned.splice(0, unassigned.length, ...unassignedOrder)
+
+      for (const [key, list] of bySection) {
+        bySection.set(key, sortManual(list, manualOrderUnassigned[key]))
+      }
+    }
+
+    const result = []
+
+    // For searching, filter within sections but never hide matches
+    function filterPeers(sectionPeers) {
+      if (!searching) {
+        return sectionPeers.map(p => ({ ...p, level: 0 }))
+      }
+
+      return sectionPeers.filter(peerMatches).map(p => ({ ...p, level: 0 }))
+    }
+
+    // Unassigned section (always first, no header)
+    const filteredUnassigned = searching
+      ? unassigned.filter(peerMatches)
+      : unassigned
+
+    // Apply nesting within unassigned if requested
+    if (nestMembers) {
+      const nestedResult = []
+
+      for (const peer of filteredUnassigned) {
+        if (peer.kind === 'bot') {
+          nestedResult.push({ ...peer, level: 0 })
+          continue
+        }
+
+        const children = nestChildren(peer, allSectionBotPeers)
+        const visibleChildren = searching
+          ? children.filter(b => matchesBotId.has(b.peerId))
+          : children
+
+        if (searching && visibleChildren.length === 0 && !peerMatches(peer)) {
+          continue
+        }
+
+        nestedResult.push({
+          ...peer,
+          level: 0,
+          children: visibleChildren.map(c => ({ ...c, level: 1, parentId: peer.peerId })),
+          isGroupHeader: true,
+          collapsed: searching ? false : isSectionCollapsed(vsNestedExpansion, peer.peerId)
+        })
+      }
+
+      if (nestedResult.length > 0) {
+        result.push({ sectionKey: undefined, title: null, peers: nestedResult, level: 0 })
+      }
+    } else {
+      if (filteredUnassigned.length > 0) {
+        result.push({
+          sectionKey: undefined,
+          title: null,
+          peers: filteredUnassigned.map(p => ({ ...p, level: 0 })),
+          level: 0
+        })
+      }
+    }
+
+    // Named sections in persisted order
+    const orderedKeys = vsOrder.filter(k => sectionMeta.has(k))
+
+    for (const key of orderedKeys) {
+      const meta = sectionMeta.get(key)
+      const sectionPeers = bySection.get(key) || []
+      const collapsed = isSectionCollapsed(vsCollapsed, key)
+
+      let filteredPeers = filterPeers(sectionPeers)
+
+      // Apply nesting within this section if requested
+      if (nestMembers) {
+        const nestedResult = []
+
+        for (const peer of filteredPeers) {
+          if (peer.kind === 'bot') {
+            nestedResult.push({ ...peer, level: 0 })
+            continue
+          }
+
+          const children = nestChildren(peer, allSectionBotPeers)
+          const visibleChildren = searching
+            ? children.filter(b => matchesBotId.has(b.peerId))
+            : children
+
+          if (searching && visibleChildren.length === 0 && !peerMatches(peer)) {
+            continue
+          }
+
+          nestedResult.push({
+            ...peer,
+            level: 0,
+            children: visibleChildren.map(c => ({ ...c, level: 1, parentId: peer.peerId })),
+            isGroupHeader: true,
+            collapsed: searching ? false : isSectionCollapsed(vsNestedExpansion, peer.peerId)
+          })
+        }
+
+        filteredPeers = nestedResult
+      }
+
+      // During search: skip empty sections unless group name matches
+      if (searching && filteredPeers.length === 0 && !(meta.title && meta.title.toLowerCase().includes(searching))) {
+        continue
+      }
+
+      // During search, collapsed sections still show matching peers
+      const effectivePeers = (searching || !collapsed) ? filteredPeers : []
+
+      result.push({
+        sectionKey: key,
+        title: meta ? meta.title : key,
+        peers: effectivePeers,
+        peerCount: sectionPeers.length,
+        level: 0,
+        collapsed: searching ? false : collapsed
+      })
+    }
+
+    return result
+  }
+
+  // VIEW_GROUPING_NONE — default: flat list, no dividers
+  const result = []
+
+  if (nestMembers) {
+    const botPeers = peers.filter(p => p.kind === 'bot')
+
+    for (const peer of peers) {
+      if (peer.kind === 'bot') {
+        if (peerMatches(peer)) {
+          result.push({ ...peer, level: 0 })
+        }
+        continue
+      }
+
+      const children = nestChildren(peer, botPeers)
+      const visibleChildren = searching
+        ? children.filter(b => matchesBotId && matchesBotId.has(b.peerId))
+        : children
+
+      if (!peerMatches(peer) && searching && visibleChildren.length === 0) {
+        continue
+      }
+
+      result.push({
+        ...peer,
+        level: 0,
+        children: visibleChildren.map(c => ({ ...c, level: 1, parentId: peer.peerId })),
+        isGroupHeader: true,
+        collapsed: searching ? false : isSectionCollapsed(vsNestedExpansion, peer.peerId)
+      })
+    }
+  } else {
+    // Flat mode: every peer at level 0, no nesting
+    for (const peer of peers) {
+      if (peerMatches(peer)) {
+        result.push({ ...peer, level: 0 })
+      }
+    }
+  }
+
+  return result
+}
+
+// ── Drag-and-drop (native HTML5; no dependencies) ──────────────────────────
+//
+// Dragging is layered on the pure view model. Peer identities are opaque
+// strings (`botPeerIdentity` / `groupPeerIdentity`) that are compared by
+// equality only — never parsed — so adversarial names (a Bot literally named
+// "group:x", a group named "unassigned", …) can never corrupt assignments or
+// order buckets. All of these helpers are pure and unit-tested.
+
+/** Reserved bucket key for the top-level/unassigned range in Sections and
+ *  Groups manual orders. It cannot collide with a section key (always
+ *  `section:…`) or a group key (always `group:…`), so a section or group can
+ *  never be confused with the unassigned range. */
+const MANUAL_ORDER_UNASSIGNED_KEY = 'unassigned'
+
+/** Canonical, collision-free manual-order bucket key for a range within a
+ *  grouping mode:
+ *  - None: a single flat bucket (stored in `manualOrderNone`), key unused.
+ *  - Sections: the section key itself (`section:…`), or the reserved
+ *    `unassigned` key for the unassigned range.
+ *  - Groups: `group:<name>` for a named group, or `unassigned` for the
+ *    ungrouped top-level range. */
+function manualOrderBucketKey(groupingMode, rangeKey) {
+  if (groupingMode === VIEW_GROUPING_SECTIONS) {
+    return rangeKey == null ? MANUAL_ORDER_UNASSIGNED_KEY : rangeKey
+  }
+  if (groupingMode === VIEW_GROUPING_GROUPS) {
+    return rangeKey == null ? MANUAL_ORDER_UNASSIGNED_KEY : groupPeerIdentity(rangeKey)
+  }
+  return MANUAL_ORDER_UNASSIGNED_KEY
+}
+
+/** Compute the new manual-order bucket after dragging `peerId` onto
+ *  `targetPeerId` within `rangePeerIds` (the range's current, authoritative
+ *  peer-id order). A null `targetPeerId` means "drop at the end". Handles both
+ *  an in-range move (peer already in the list) and a cross-range insert (peer
+ *  not yet in the list — it is inserted at the target's slot). Returns the new
+ *  array, or null when the drag is a no-op (peer or target absent, or already
+ *  in place). Pure — never mutates its inputs.
+ *
+ *  `position` is 'before' (default) or 'after' and controls whether the peer
+ *  lands directly before or after the target. With a null target, both
+ *  positions append to the end. */
+function reorderPeerInto(rangePeerIds, peerId, targetPeerId, position = 'before') {
+  const input = Array.isArray(rangePeerIds) ? rangePeerIds : []
+  const list = [...input]
+  const from = list.indexOf(peerId)
+
+  if (!peerId || peerId === targetPeerId) {
+    return null
+  }
+
+  let to
+
+  if (targetPeerId == null) {
+    to = list.length
+  } else {
+    to = list.indexOf(targetPeerId)
+
+    if (to < 0) {
+      return null
+    }
+  }
+
+  if (from >= 0) {
+    // In-range move: splice out, then re-insert. Adjust the target index when
+    // the removal shifts later indices down by one, and respect the position
+    // parameter so 'after' landings move past the target.
+    const [moved] = list.splice(from, 1)
+
+    let insertAt = to
+
+    if (to > from) {
+      // Removing the peer from an earlier slot shifted the target left by one.
+      insertAt = to - 1
+    }
+
+    if (position === 'after') {
+      insertAt += 1
+    }
+
+    list.splice(insertAt, 0, moved)
+  } else {
+    // Cross-range insert: drop the peer at the target's slot (before it), or
+    // after it when position is 'after'; append when dropped on empty space.
+    const insertAt = position === 'after' && targetPeerId != null ? to + 1 : to
+    list.splice(insertAt, 0, peerId)
+  }
+
+  if (list.length === input.length && list.every((id, i) => id === input[i])) {
+    return null
+  }
+
+  return list
+}
+
+/** Resolve a peer (Bot or group row) drop into a view-state patch, or null if
+ *  the drop is disallowed / a no-op. Encodes every drag semantic:
+ *
+ *  - Sections mode: dropping a peer on a section assigns it; dropping on the
+ *    Unassigned range unassigns it. In Manual sort the drop also inserts the
+ *    peer into the target range's collision-safe order bucket.
+ *  - None mode: Manual sort reorders the flat `manualOrderNone` bucket; Alpha
+ *    and Recency sort are authoritative and never reorder.
+ *  - Groups mode: Manual sort reorders Bots only WITHIN the automatic group
+ *    they were dragged from; cross-group drops are ignored and never mutate
+ *    `groups[]`, room membership, or canonical chats. Alpha/Recency are
+ *    authoritative.
+ *
+ *  `drag` = {
+ *    peerId, kind ('bot'|'group'), grouping, sort,
+ *    fromRangeKey, toRangeKey, targetPeerId, rangePeerIds, position
+ *  }
+ *  where `toRangeKey` is a section key / group name / null (unassigned).
+ *  Returns a patch for `updateViewState`, or null. */
+function applyPeerDrop(viewState, drag) {
+  if (!drag || !drag.peerId) {
+    return null
+  }
+
+  const grouping = drag.grouping
+  const sort = drag.sort
+  const peerId = drag.peerId
+
+  if (grouping === VIEW_GROUPING_SECTIONS) {
+    const assignments = { ...((viewState && viewState.sectionAssignments) || {}) }
+    const toKey = drag.toRangeKey
+
+    if (toKey) {
+      assignments[peerId] = toKey
+    } else {
+      delete assignments[peerId]
+    }
+
+    const patch = { sectionAssignments: assignments }
+
+    if (sort === VIEW_SORT_MANUAL && drag.rangePeerIds) {
+      const buckets = { ...((viewState && viewState.manualOrderUnassigned) || {}) }
+      const bucketKey = manualOrderBucketKey(grouping, toKey)
+      const persistedRange = Array.isArray(buckets[bucketKey]) ? buckets[bucketKey] : []
+      const visibleRange = Array.isArray(drag.rangePeerIds) ? drag.rangePeerIds : []
+      // A collapsed Section projects no visible peers. Preserve its persisted
+      // manual order and append the dropped peer instead of replacing the
+      // hidden bucket with a one-item list.
+      const targetRange = visibleRange.length === 0 && persistedRange.length > 0 ? persistedRange : visibleRange
+      const next = reorderPeerInto(targetRange, peerId, drag.targetPeerId, drag.position)
+
+      if (next) {
+        buckets[bucketKey] = next
+        patch.manualOrderUnassigned = buckets
+      }
+    }
+
+    return patch
+  }
+
+  if (grouping === VIEW_GROUPING_NONE) {
+    if (sort !== VIEW_SORT_MANUAL || !drag.rangePeerIds) {
+      return null
+    }
+
+    const next = reorderPeerInto(drag.rangePeerIds, peerId, drag.targetPeerId, drag.position)
+
+    return next ? { manualOrderNone: next } : null
+  }
+
+  if (grouping === VIEW_GROUPING_GROUPS) {
+    if (sort !== VIEW_SORT_MANUAL) {
+      return null
+    }
+
+    // Cross-group guard: a Bot may only reorder within the group it was
+    // dragged from. Never mutate groups[] or room membership.
+    if (drag.kind === 'bot' && drag.fromRangeKey !== drag.toRangeKey) {
+      return null
+    }
+
+    if (!drag.rangePeerIds) {
+      return null
+    }
+
+    const buckets = { ...((viewState && viewState.manualOrderGroups) || {}) }
+    const bucketKey = manualOrderBucketKey(grouping, drag.toRangeKey)
+    const next = reorderPeerInto(drag.rangePeerIds, peerId, drag.targetPeerId, drag.position)
+
+    if (next) {
+      buckets[bucketKey] = next
+      return { manualOrderGroups: buckets }
+    }
+
+    return null
+  }
+
+  return null
+}
+
+/** Keyboard-equivalent of a one-slot manual drag. */
+function applyKeyboardPeerMove(viewState, move) {
+  const rangePeerIds = Array.isArray(move?.rangePeerIds) ? move.rangePeerIds : []
+  const from = rangePeerIds.indexOf(move?.peerId)
+  const delta = move?.delta < 0 ? -1 : move?.delta > 0 ? 1 : 0
+  const to = from + delta
+
+  if (!delta || from < 0 || to < 0 || to >= rangePeerIds.length) {
+    return null
+  }
+
+  return applyPeerDrop(viewState, {
+    peerId: move.peerId,
+    kind: move.kind,
+    grouping: move.grouping,
+    sort: VIEW_SORT_MANUAL,
+    fromRangeKey: move.rangeKey,
+    toRangeKey: move.rangeKey,
+    targetPeerId: rangePeerIds[to],
+    rangePeerIds,
+    position: delta < 0 ? 'before' : 'after'
+  })
+}
+
+/** Resolve a visual-Section header drop (reorder Sections) into a view-state
+ *  patch, or null if the drop is a no-op. Only reorders — never changes a
+ *  Section's peers, assignments, or collapse state. */
+function applySectionDrop(viewState, drag) {
+  const sectionKey = drag && drag.sectionKey
+  const toSectionKey = drag && drag.toSectionKey
+
+  if (!sectionKey || !toSectionKey || sectionKey === toSectionKey) {
+    return null
+  }
+
+  const sections = (viewState && viewState.visualSections) || []
+  const order = (viewState && viewState.sectionOrder) || []
+  const nextOrder = reorderPeerInto(order, sectionKey, toSectionKey, drag.position)
+
+  if (!nextOrder) {
+    return null
+  }
+
+  const rank = new Map(nextOrder.map((key, index) => [key, index]))
+  const nextSections = sections
+    .map(section => ({ ...section, order: rank.has(section.key) ? rank.get(section.key) : section.order }))
+    .sort((a, b) => (a.order || 0) - (b.order || 0))
+
+  return { visualSections: nextSections, sectionOrder: nextOrder }
+}
+
+// ── View state normalization and hydration ─────────────────────────────────
+
+/** Rename or remove every renderer-local reference to a group shortcut. */
+function remapGroupViewState(viewState, oldName, newName) {
+  const oldId = groupPeerIdentity(oldName)
+  const nextId = newName ? groupPeerIdentity(newName) : null
+  const remapList = list => (Array.isArray(list) ? list.flatMap(id => id === oldId ? (nextId ? [nextId] : []) : [id]) : [])
+
+  const sectionAssignments = { ...((viewState && viewState.sectionAssignments) || {}) }
+  if (Object.hasOwn(sectionAssignments, oldId)) {
+    const section = sectionAssignments[oldId]
+    delete sectionAssignments[oldId]
+    if (nextId) sectionAssignments[nextId] = section
+  }
+
+  const manualOrderUnassigned = {}
+  for (const [key, list] of Object.entries((viewState && viewState.manualOrderUnassigned) || {})) {
+    manualOrderUnassigned[key] = remapList(list)
+  }
+
+  const manualOrderGroups = {}
+  for (const [key, list] of Object.entries((viewState && viewState.manualOrderGroups) || {})) {
+    const mappedKey = key === oldId ? nextId : key
+    if (mappedKey) manualOrderGroups[mappedKey] = remapList(list)
+  }
+
+  const nestedExpansion = { ...((viewState && viewState.nestedExpansion) || {}) }
+  if (Object.hasOwn(nestedExpansion, oldId)) {
+    const expanded = nestedExpansion[oldId]
+    delete nestedExpansion[oldId]
+    if (nextId) nestedExpansion[nextId] = expanded
+  }
+
+  return {
+    sectionAssignments,
+    manualOrderNone: remapList(viewState && viewState.manualOrderNone),
+    manualOrderUnassigned,
+    manualOrderGroups,
+    nestedExpansion
+  }
+}
+
+/** Normalize a stored view state: fill defaults, strip stale section
+ *  assignments, deduplicate order, remove unknown section keys. Safe to call
+ *  with null/undefined/malformed input. */
+function normalizeViewState(raw) {
+  const input = raw && typeof raw === 'object' ? raw : {}
+
+  const grouping =
+    input.grouping === VIEW_GROUPING_NONE ||
+    input.grouping === VIEW_GROUPING_SECTIONS ||
+    input.grouping === VIEW_GROUPING_GROUPS
+      ? input.grouping
+      : VIEW_GROUPING_NONE
+  const sort =
+    input.sort === VIEW_SORT_ALPHA ||
+    input.sort === VIEW_SORT_PINNED_RECENCY ||
+    input.sort === VIEW_SORT_MANUAL
+      ? input.sort
+      : VIEW_SORT_PINNED_RECENCY
+  const nestMembers = Boolean(input.nestMembers)
+  const showHidden = Boolean(input.showHidden)
+
+  const visualSections = Array.isArray(input.visualSections)
+    ? input.visualSections.filter(s => s && typeof s.key === 'string' && typeof s.title === 'string')
+    : []
+  const validKeys = new Set(visualSections.map(s => s.key))
+
+  // Strip stale assignments
+  const rawAssignments = input.sectionAssignments && typeof input.sectionAssignments === 'object'
+    ? input.sectionAssignments
+    : {}
+  const sectionAssignments = {}
+
+  for (const peerId of Object.keys(rawAssignments)) {
+    if (validKeys.has(rawAssignments[peerId])) {
+      sectionAssignments[peerId] = rawAssignments[peerId]
+    }
+  }
+
+  // Strip stale collapsed
+  const rawCollapsed = input.sectionCollapsed && typeof input.sectionCollapsed === 'object'
+    ? input.sectionCollapsed
+    : {}
+  const sectionCollapsed = {}
+
+  for (const key of Object.keys(rawCollapsed)) {
+    if (validKeys.has(key) && rawCollapsed[key]) {
+      sectionCollapsed[key] = true
+    }
+  }
+
+  // Deduplicate and filter section order
+  const rawOrder = Array.isArray(input.sectionOrder) ? input.sectionOrder : []
+  const seen = new Set()
+  const sectionOrder = []
+
+  for (const key of rawOrder) {
+    if (validKeys.has(key) && !seen.has(key)) {
+      seen.add(key)
+      sectionOrder.push(key)
+    }
+  }
+
+  // Add any valid sections not in the order
+  for (const s of visualSections) {
+    if (!seen.has(s.key)) {
+      sectionOrder.push(s.key)
+    }
+  }
+
+  const manualOrderNone = Array.isArray(input.manualOrderNone) ? input.manualOrderNone : []
+  const manualOrderUnassigned =
+    input.manualOrderUnassigned && typeof input.manualOrderUnassigned === 'object'
+      ? input.manualOrderUnassigned
+      : {}
+  const manualOrderGroups =
+    input.manualOrderGroups && typeof input.manualOrderGroups === 'object'
+      ? input.manualOrderGroups
+      : {}
+  const nestedExpansion =
+    input.nestedExpansion && typeof input.nestedExpansion === 'object'
+      ? input.nestedExpansion
+      : {}
+
+  return {
+    grouping,
+    sort,
+    nestMembers,
+    showHidden,
+    visualSections,
+    sectionAssignments,
+    sectionCollapsed,
+    sectionOrder,
+    manualOrderNone,
+    manualOrderUnassigned,
+    manualOrderGroups,
+    nestedExpansion
+  }
+}
+
+/** Apply a stored hydration only when it is newer and no local mutation landed
+ * after that read began. `startedGeneration` is captured before awaiting the
+ * storage backend. */
+function hydrateViewState(current, stored, requestToken, startedGeneration = current?.localGeneration || 0) {
+  if (requestToken === 0) {
+    return {
+      state: normalizeViewState(null),
+      token: current?.token || 0,
+      localGeneration: 0
+    }
+  }
+
+  if (!current || requestToken <= (current.token || 0)) {
+    return current
+  }
+
+  if ((current.localGeneration || 0) !== startedGeneration) {
+    return current
+  }
+
+  return {
+    state: normalizeViewState(stored),
+    token: requestToken,
+    localGeneration: current.localGeneration || 0
+  }
 }
 
 // ── group chats: bounded round-robin coordination over a shared room log ─────
@@ -3823,6 +5067,7 @@ async function disbandGroupChat(group, members) {
   }
 
   $groupChats.set(all)
+  updateViewState(remapGroupViewState(getOrInitViewState().state, group, null))
 
   if ($groupChatWorkspace.get() === group) {
     $groupChatWorkspace.set(null)
@@ -3922,6 +5167,7 @@ async function renameGroupChat(oldName, newName, members) {
   }
 
   $groupChats.set(all)
+  updateViewState(remapGroupViewState(getOrInitViewState().state, oldName, next))
 
   const needs = { ...$groupNeedsYou.get() }
 
@@ -4638,7 +5884,13 @@ function activeBots(roster, activeProfile, gatewayState, now = Date.now()) {
 
 // ── bot row ──────────────────────────────────────────────────────────────────
 
-function BotRow({ bot, onDelete, onEdit, onGroup }) {
+function BotRow({ bot, onDelete, onEdit, onGroup, peerId, viewState, draggable, onDragStart, onDragOver, onDrop, onDragEnd, onKeyDown, insertion }) {
+  const rowText = (key, name) => {
+    if (typeof pluginCtx !== 'undefined' && pluginCtx?.i18n?.t) return pluginCtx.i18n.t(key, name)
+    return key === 'bot.backInRoster'
+      ? `${name} is back in the roster`
+      : `${name} hidden — use View → Show hidden bots in the Bots header to see them`
+  }
   const activeProfile = useValue(host.state.profile)
   const meta = botRosterMeta(bot, useValue($botMeta))
   const groups = botGroups(meta)
@@ -4760,15 +6012,25 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
 
   const row = jsxs('button', {
     type: 'button',
+    draggable: Boolean(draggable),
+    'data-drop-position': insertion && insertion.targetId === peerId ? insertion.position : undefined,
+    onDragStart,
+    onDragOver,
+    onDrop,
+    onDragEnd,
+    onKeyDown,
+    'aria-keyshortcuts': onKeyDown ? 'Alt+ArrowUp Alt+ArrowDown' : undefined,
     onPointerEnter: warm,
     onClick: open,
     className: cn(
       'flex w-full min-w-0 max-w-full items-center gap-2.5 overflow-hidden rounded-md px-2 py-2 text-left transition-colors',
       'hover:bg-(--chrome-action-hover)',
       isActive && 'bg-(--chrome-action-hover)',
-      // Hidden bots only render while the header eye toggle is on — dimmed,
-      // so the temporary reveal reads as a different state from the roster.
-      meta?.hidden && 'opacity-60'
+      // Hidden bots only render while the View menu's Show hidden toggle is on
+      // — dimmed, so the temporary reveal reads as a different state from the
+      // roster.
+      meta?.hidden && 'opacity-60',
+      draggable && 'cursor-grab active:cursor-grabbing'
     ),
     children: [
       jsx('div', {
@@ -4862,11 +6124,25 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
     ]
   })
 
-  // Thin rows from another source are navigation targets only. Their profile
-  // metadata is not loaded yet, so edit/delete/pin/group actions would mutate
-  // whichever backend happens to be active. A normal click activates the
-  // owner; the refreshed rich row then exposes the full context menu.
+  // Thin rows from another source must never expose profile mutations against
+  // the active backend. Visual Section placement is renderer-local, however,
+  // so it remains safely available from the remote row's context menu.
   if (bot.remoteSource) {
+    if (viewState?.grouping === 'sections' && peerId) {
+      return jsxs(ContextMenu, {
+        children: [
+          jsx(ContextMenuTrigger, { asChild: true, children: row }),
+          jsx(ContextMenuContent, {
+            children: jsx(MoveToSectionSubmenu, {
+              peerId,
+              sectionAssignments: viewState?.sectionAssignments || {},
+              sections: viewState?.visualSections || []
+            })
+          })
+        ]
+      })
+    }
+
     return row
   }
 
@@ -4900,8 +6176,8 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
               host.notify({
                 kind: 'info',
                 message: hidden
-                  ? `${displayName(bot, meta)} is back in the roster`
-                  : `${displayName(bot, meta)} hidden — use the eye button in the Bots header to see hidden bots`
+                  ? rowText('bot.backInRoster', displayName(bot, meta))
+                  : rowText('bot.hidden', displayName(bot, meta))
               })
             },
             children: meta?.hidden ? 'Unhide Bot' : 'Hide Bot'
@@ -4916,6 +6192,13 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
             ? jsx(ContextMenuItem, {
                 onSelect: () => onGroup(bot),
                 children: groups.length ? `Groups: ${groups.join(', ')}…` : 'Manage groups…'
+              })
+            : null,
+          viewState?.grouping === 'sections' && peerId
+            ? jsx(MoveToSectionSubmenu, {
+                peerId,
+                sectionAssignments: viewState?.sectionAssignments || {},
+                sections: viewState?.visualSections || []
               })
             : null,
           jsx(ContextMenuItem, {
@@ -9141,14 +10424,707 @@ function openGroupChat(group) {
   $groupChatWorkspace.set(group)
 }
 
-/** One group chat as ONE roster row — the Discord shape: stacked member
- *  avatars, group name, member count, the newest room line as the preview
- *  (markdown flattened), relative time of the last activity, and the
- *  needs-you badge on the row itself. Sorts into the same recency ordering
- *  as bot rows; clicking opens the room in the main chat window. */
-function GroupRow({ group, members, needsYou, onOpen }) {
+// ── View Menu ──────────────────────────────────────────────────────────────
+
+/** Dropdown content for the View menu. Renders grouping (single-select),
+ *  sorting (single-select), nest toggle, show hidden toggle, and a
+ *  "Manage Sections…" action. */
+function ViewMenuContent({ viewState, onSetGrouping, onSetSort, onToggleNest, onToggleShowHidden, onManageSections }) {
+  const copy = useBotRosterText()
+  const grouping = viewState?.grouping || VIEW_GROUPING_NONE
+  const sort = viewState?.sort || VIEW_SORT_PINNED_RECENCY
+  const nestMembers = viewState?.nestMembers || false
+  const showHidden = viewState?.showHidden || false
+
+  return jsxs(DropdownMenuContent, {
+    align: 'end',
+    className: 'w-52',
+    children: [
+      jsx(DropdownMenuLabel, { children: copy.view.grouping }),
+      jsxs(DropdownMenuRadioGroup, {
+        value: grouping,
+        onValueChange: onSetGrouping,
+        children: [
+          jsx(DropdownMenuRadioItem, { value: VIEW_GROUPING_NONE, children: copy.view.none }),
+          jsx(DropdownMenuRadioItem, { value: VIEW_GROUPING_SECTIONS, children: copy.view.sections }),
+          jsx(DropdownMenuRadioItem, { value: VIEW_GROUPING_GROUPS, children: copy.view.groups })
+        ]
+      }),
+      jsx(DropdownMenuSeparator, {}),
+      jsx(DropdownMenuLabel, { children: copy.view.sorting }),
+      jsxs(DropdownMenuRadioGroup, {
+        value: sort,
+        onValueChange: onSetSort,
+        children: [
+          jsx(DropdownMenuRadioItem, { value: VIEW_SORT_ALPHA, children: copy.view.alphabetical }),
+          jsx(DropdownMenuRadioItem, { value: VIEW_SORT_PINNED_RECENCY, children: copy.view.recent }),
+          jsx(DropdownMenuRadioItem, { value: VIEW_SORT_MANUAL, children: copy.view.manual })
+        ]
+      }),
+      jsx(DropdownMenuSeparator, {}),
+      jsx(DropdownMenuLabel, { children: copy.view.groupDisplay }),
+      grouping !== VIEW_GROUPING_GROUPS
+        ? jsx(DropdownMenuCheckboxItem, {
+            checked: nestMembers,
+            onCheckedChange: onToggleNest,
+            onSelect: event => event.preventDefault(),
+            children: copy.view.nestMembers
+          })
+        : jsxs(DropdownMenuCheckboxItem, {
+            checked: true,
+            disabled: true,
+            children: [
+              copy.view.nestMembers,
+              jsx('span', { className: 'ml-auto text-[0.625rem] text-(--ui-text-quaternary)', children: copy.view.groupsMode })
+            ]
+          }),
+      jsx(DropdownMenuSeparator, {}),
+      jsx(DropdownMenuLabel, { children: copy.view.display }),
+      jsx(DropdownMenuCheckboxItem, {
+        checked: showHidden,
+        onCheckedChange: onToggleShowHidden,
+        onSelect: event => event.preventDefault(),
+        children: copy.view.showHidden
+      }),
+      jsx(DropdownMenuSeparator, {}),
+      jsxs(DropdownMenuItem, {
+        onSelect: () => onManageSections(),
+        children: [jsx(Codicon, { name: 'list-tree', className: 'mr-1.5' }), copy.view.manageSections]
+      })
+    ]
+  })
+}
+
+// ── Manage Sections dialog ─────────────────────────────────────────────────
+
+/** Dialog for creating, renaming, reordering, deleting, and assigning
+ *  peers to visual Sections. */
+function ManageSectionsDialog({ open, onClose }) {
+  const copy = useBotRosterText()
+  const viewState = useValue($viewStateWrapper).state
+  const roster = useValue($lastRoster)
+  const allMeta = useValue($botMeta)
+  const groupRooms = useValue($groupChats)
+  const showHidden = viewState.showHidden || false
+  const [newTitle, setNewTitle] = useState('')
+  const [editingSection, setEditingSection] = useState(null)
+  const [editingTitle, setEditingTitle] = useState('')
+
+  const sections = viewState.visualSections || []
+  const assignments = viewState.sectionAssignments || {}
+  const order = viewState.sectionOrder || []
+
+  // Build peer list for assignment
+  const peers = buildPeerList(roster, allMeta, groupRooms, showHidden)
+
+  function handleCreate() {
+    const title = newTitle.trim()
+    if (!title) return
+    addVisualSection(title)
+    setNewTitle('')
+  }
+
+  function handleRename(key) {
+    const title = editingTitle.trim()
+    if (!title) return
+    editVisualSection(key, title)
+    setEditingSection(null)
+    setEditingTitle('')
+  }
+
+  function handleDelete(key) {
+    removeVisualSection(key)
+  }
+
+  function handleMoveUp(key) {
+    const idx = order.indexOf(key)
+    if (idx > 0) {
+      changeVisualSectionOrder(key, idx - 1)
+    }
+  }
+
+  function handleMoveDown(key) {
+    const idx = order.indexOf(key)
+    if (idx < order.length - 1) {
+      changeVisualSectionOrder(key, idx + 1)
+    }
+  }
+
+  // Ordered sections
+  const orderedSections = order
+    .map(k => sections.find(s => s.key === k))
+    .filter(Boolean)
+
+  if (!open) return null
+
+  return jsx(Dialog, {
+    open: true,
+    onOpenChange: open => { if (!open) onClose() },
+    children: jsxs(DialogContent, {
+      className: 'max-h-[80vh] max-w-md',
+      children: [
+        jsx(DialogHeader, {
+          children: jsx(DialogTitle, { children: copy.sections.manage })
+        }),
+        jsx(DialogDescription, {
+          className: 'text-xs',
+          children: copy.sections.description
+        }),
+        jsxs('div', {
+          className: 'mt-3 space-y-3',
+          children: [
+            // Section list with reorder/rename/delete
+            orderedSections.length
+              ? jsxs('div', {
+                  className: 'space-y-1',
+                  children: orderedSections.map((section, i) => {
+                    const isEditing = editingSection === section.key
+                    const peerCount = Object.values(assignments).filter(v => v === section.key).length
+
+                    return jsxs('div', {
+                      key: section.key,
+                      className: 'flex items-center gap-1 py-1',
+                      children: [
+                        isEditing
+                          ? jsxs('div', {
+                              className: 'flex flex-1 items-center gap-1',
+                              children: [
+                                jsx(Input, {
+                                  'aria-label': copy.sections.rename(section.title),
+                                  value: editingTitle,
+                                  onChange: e => setEditingTitle(e.target.value),
+                                  onKeyDown: e => { if (e.key === 'Enter') handleRename(section.key) },
+                                  autoFocus: true
+                                }),
+                                jsx(Button, { size: 'sm', variant: 'ghost', onClick: () => handleRename(section.key), children: copy.sections.save }),
+                                jsx(Button, { size: 'sm', variant: 'ghost', onClick: () => { setEditingSection(null); setEditingTitle('') }, children: copy.sections.cancel })
+                              ]
+                            })
+                          : jsxs('div', {
+                              className: 'flex flex-1 items-center gap-1 min-w-0',
+                              children: [
+                                jsx('span', { className: 'truncate text-xs font-medium', children: section.title }),
+                                jsx('span', { className: 'shrink-0 text-[0.625rem] text-(--ui-text-quaternary)', children: copy.sections.peers(peerCount) })
+                              ]
+                            }),
+                        jsxs('div', {
+                          className: 'flex items-center gap-0.5',
+                          children: [
+                            jsx(Button, {
+                              variant: 'ghost',
+                              size: 'icon-xs',
+                              disabled: i === 0,
+                              'aria-label': copy.sections.moveUp(section.title),
+                              onClick: () => handleMoveUp(section.key),
+                              children: jsx(Codicon, { name: 'chevron-up' })
+                            }),
+                            jsx(Button, {
+                              variant: 'ghost',
+                              size: 'icon-xs',
+                              disabled: i === orderedSections.length - 1,
+                              'aria-label': copy.sections.moveDown(section.title),
+                              onClick: () => handleMoveDown(section.key),
+                              children: jsx(Codicon, { name: 'chevron-down' })
+                            }),
+                            jsx(Button, {
+                              variant: 'ghost',
+                              size: 'icon-xs',
+                              'aria-label': copy.sections.rename(section.title),
+                              onClick: () => { setEditingSection(section.key); setEditingTitle(section.title) },
+                              children: jsx(Codicon, { name: 'edit' })
+                            }),
+                            jsx(Button, {
+                              variant: 'ghost',
+                              size: 'icon-xs',
+                              'aria-label': copy.sections.delete(section.title),
+                              onClick: () => handleDelete(section.key),
+                              className: 'hover:text-destructive',
+                              children: jsx(Codicon, { name: 'trash' })
+                            })
+                          ]
+                        })
+                      ]
+                    }, section.key)
+                  })
+                })
+              : jsx('div', {
+                  className: 'py-4 text-center text-xs text-(--ui-text-tertiary)',
+                  children: copy.sections.noSections
+                }),
+
+            // Create new section
+            jsxs('div', {
+              className: 'flex gap-1',
+              children: [
+                jsx(Input, {
+                  'aria-label': copy.sections.newName,
+                  placeholder: copy.sections.newName,
+                  value: newTitle,
+                  onChange: e => setNewTitle(e.target.value),
+                  onKeyDown: e => { if (e.key === 'Enter') handleCreate() }
+                }),
+                jsx(Button, { size: 'sm', variant: 'secondary', onClick: handleCreate, disabled: !newTitle.trim(), children: copy.sections.add })
+              ]
+            }),
+
+            // Peer assignments — every Bot and group peer exactly once, with a
+            // current-assignment label and controls for Unassigned + every section.
+            peers.length
+              ? jsxs('div', {
+                  className: 'border-t border-(--ui-stroke-secondary) pt-2',
+                  children: [
+                    jsx('div', {
+                      className: 'mb-1 text-[0.625rem] font-semibold uppercase tracking-wider text-(--ui-text-quaternary)',
+                      children: copy.sections.peerAssignments
+                    }),
+                    jsxs('div', {
+                      className: 'max-h-48 space-y-1 overflow-y-auto',
+                      children: peers.map(peer => {
+                        const currentKey = assignments[peer.peerId] || null
+                        const currentTitle = currentKey
+                          ? (sections.find(s => s.key === currentKey)?.title || currentKey)
+                          : copy.sections.unassigned
+                        const peerLabel = peer.kind === 'bot' ? displayName(peer.botRow, peer.meta) : peer.title
+
+                        return jsxs('div', {
+                          key: peer.peerId,
+                          className: 'flex flex-wrap items-center gap-1 py-0.5',
+                          children: [
+                            jsx('span', {
+                              className: 'min-w-0 flex-1 truncate text-xs',
+                              children: peerLabel
+                            }),
+                            jsx('span', {
+                              className: 'shrink-0 text-[0.625rem] text-(--ui-text-quaternary)',
+                              children: currentTitle
+                            }),
+                            jsxs('div', {
+                              className: 'flex flex-wrap gap-1',
+                              children: [
+                                jsx(Button, {
+                                  variant: !currentKey ? 'default' : 'secondary',
+                                  size: 'xs',
+                                  'aria-pressed': !currentKey,
+                                  'aria-label': copy.sections.assignTo(peerLabel, copy.sections.unassigned),
+                                  onClick: () => movePeerToSection(peer.peerId, null),
+                                  children: copy.sections.unassigned
+                                }),
+                                ...orderedSections.map(s =>
+                                  jsx(Button, {
+                                    key: s.key,
+                                    variant: currentKey === s.key ? 'default' : 'secondary',
+                                    size: 'xs',
+                                    'aria-pressed': currentKey === s.key,
+                                    'aria-label': copy.sections.assignTo(peerLabel, s.title),
+                                    onClick: () => movePeerToSection(peer.peerId, s.key),
+                                    children: s.title
+                                  }, `assignto:${s.key}`)
+                                )
+                              ]
+                            })
+                          ]
+                        }, peer.peerId)
+                      })
+                    })
+                  ]
+                })
+              : null
+          ]
+        }),
+        jsx(DialogFooter, {
+          children: jsx(Button, { variant: 'secondary', onClick: onClose, children: copy.sections.done })
+        })
+      ]
+    })
+  })
+}
+
+/** Match insertion feedback to one concrete roster range. A Bot can have the
+ * same peer ID in its standalone row and several group shortcuts. */
+function insertionMatches(insertion, targetId, rangeKey, position) {
+  return Boolean(
+    insertion &&
+    insertion.type === 'peer' &&
+    insertion.targetId === targetId &&
+    insertion.rangeKey === rangeKey &&
+    insertion.position === position
+  )
+}
+
+/** Render projected roster items. Handles all three grouping modes.
+ *  In None/Groups: flat render with nesting support.
+ *  In Sections: section headers + peer rows per section, collapsible.
+ *  Drag-and-drop is wired through `ctx.drag` (native HTML5; no deps). */
+function renderProjectedRoster(projected, mode, ctx) {
+  const { setDeleting, setEditing, setGrouping, groupNeedsYou, openGroupChat, viewState, drag, toggleNestedGroup } = ctx
+
+  /** Drag affordance for a group's nested member rows. In Groups mode the
+   *  members are draggable within their automatic group; in None/Sections
+   *  nesting the members are a re-projection of the flat/section peers and are
+   *  NOT independently draggable. */
+  function dragInfoForChildren(groupItem, children) {
+    if (mode === VIEW_GROUPING_GROUPS) {
+      return {
+        draggable: drag.canDragPeer,
+        rangeKey: groupItem.title,
+        rangePeerIds: children.map(c => c.peerId)
+      }
+    }
+
+    return { draggable: false, rangeKey: null, rangePeerIds: [] }
+  }
+
+  function renderPeerRow(item, dragInfo) {
+    const insertion = drag.insertion
+    const showInsertionBefore = insertionMatches(insertion, item.peerId, dragInfo.rangeKey, 'before')
+    const showInsertionAfter = insertionMatches(insertion, item.peerId, dragInfo.rangeKey, 'after')
+    const keyboardMovable = Boolean(drag.canKeyboardMovePeer && dragInfo.draggable && dragInfo.rangePeerIds.length > 1)
+
+    let row = null
+
+    if (item.kind === 'group') {
+      // Group row with optional children
+      const children = item.isGroupHeader && Array.isArray(item.children) ? item.children : []
+      const collapsed = item.collapsed
+      const childDragInfo = children.length ? dragInfoForChildren(item, children) : null
+      // Collapse chevron only for the None/Sections nest projection; Groups mode
+      // rich headers keep their current behavior.
+      const collapsible = children.length > 0 && mode !== VIEW_GROUPING_GROUPS
+
+      const groupRow = jsx(
+        GroupRowEnhanced,
+        {
+          group: item.title,
+          members: item.members || [],
+          needsYou: Boolean((groupNeedsYou || {})[item.title]),
+          onOpen: openGroupChat,
+          collapsed,
+          peerId: item.peerId,
+          viewState,
+          collapsible,
+          onToggleCollapse: toggleNestedGroup,
+          draggable: dragInfo.draggable,
+          onDragStart: dragInfo.draggable ? event => drag.beginPeerDrag(event, item.peerId, 'group', dragInfo.rangeKey, item.title, '👥') : undefined,
+          onDragOver: dragInfo.draggable ? event => drag.allowPeerDrop(event, dragInfo.rangeKey, item.peerId) : undefined,
+          onDrop: dragInfo.draggable ? event => drag.dropPeer(event, dragInfo.rangeKey, item.peerId, dragInfo.rangePeerIds) : undefined,
+          onDragEnd: drag.endPeerDrag,
+          onKeyDown: keyboardMovable
+            ? event => drag.keyboardMovePeer(event, item.peerId, 'group', dragInfo.rangeKey, dragInfo.rangePeerIds)
+            : undefined,
+          insertion
+        },
+        `group:${item.title}`
+      )
+
+      const childrenTree = !collapsed && children.length
+        ? jsx('div', {
+            className: 'grid gap-0.5 pl-4',
+            children: children.map(child =>
+              renderPeerRow(child, childDragInfo)
+            )
+          }, `group-members:${item.title}`)
+        : null
+
+      const pieces = [
+        showInsertionBefore ? jsx(InsertionLine, { position: 'before' }, `insertion-before:${item.peerId}`) : null,
+        groupRow,
+        childrenTree,
+        showInsertionAfter ? jsx(InsertionLine, { position: 'after' }, `insertion-after:${item.peerId}`) : null
+      ].filter(Boolean)
+
+      row = pieces
+      return row.flat()
+    }
+
+    // Bot row
+    row = jsx(
+      BotRow,
+      {
+        bot: item.botRow,
+        onDelete: setDeleting,
+        onEdit: setEditing,
+        onGroup: setGrouping,
+        peerId: item.peerId,
+        viewState,
+        draggable: dragInfo.draggable,
+        onDragStart: dragInfo.draggable
+          ? event => drag.beginPeerDrag(event, item.peerId, 'bot', dragInfo.rangeKey, displayName(item.botRow, item.meta || null), '🤖')
+          : undefined,
+        onDragOver: dragInfo.draggable ? event => drag.allowPeerDrop(event, dragInfo.rangeKey, item.peerId) : undefined,
+        onDrop: dragInfo.draggable ? event => drag.dropPeer(event, dragInfo.rangeKey, item.peerId, dragInfo.rangePeerIds) : undefined,
+        onDragEnd: drag.endPeerDrag,
+        onKeyDown: keyboardMovable
+          ? event => drag.keyboardMovePeer(event, item.peerId, 'bot', dragInfo.rangeKey, dragInfo.rangePeerIds)
+          : undefined,
+        insertion
+      },
+      `bot:${item.peerId}`
+    )
+
+    const botPieces = [showInsertionBefore ? jsx(InsertionLine, { position: 'before' }, `insertion-before:${item.peerId}`) : null, row, showInsertionAfter ? jsx(InsertionLine, { position: 'after' }, `insertion-after:${item.peerId}`) : null].filter(Boolean)
+
+    return botPieces.flat()
+  }
+
+  if (mode === VIEW_GROUPING_SECTIONS) {
+    // Sections mode: an unassigned range (always first, no header unless a drag
+    // is active) followed by named sections with draggable headers + peers.
+    const namedSections = projected.filter(s => s.sectionKey)
+    const unassignedSection = projected.find(s => !s.sectionKey)
+    const unassignedPeers = unassignedSection?.peers || []
+    const unassignedPeerIds = unassignedPeers.map(p => p.peerId)
+
+    const pieces = []
+
+    // Unassigned peers (no header normally).
+    pieces.push(
+      unassignedPeers.map(p =>
+        renderPeerRow(p, { draggable: drag.canDragPeer, rangeKey: null, rangePeerIds: unassignedPeerIds })
+      )
+    )
+
+    // Permanently reserve the Unassigned target so beginning a drag never
+    // reflows assigned rows or Section headers under the pointer.
+    if (namedSections.length) {
+      pieces.push(
+        jsx(UnassignedDropZone, {
+          active: drag.isDragging,
+          onDragOver: event => drag.allowPeerDrop(event, null, null),
+          onDrop: event => drag.dropPeer(event, null, null, unassignedPeerIds)
+        }, 'unassigned-drop-zone')
+      )
+    }
+
+    for (const section of namedSections) {
+      const peers = section.peers || []
+      const peerIds = peers.map(p => p.peerId)
+      const sectionMeta = (viewState?.visualSections || []).find(s => s.key === section.sectionKey)
+      const sectionTitle = sectionMeta?.title || section.sectionKey
+      const sectionInsertion = drag.insertion
+      const showSectionBefore = sectionInsertion && sectionInsertion.targetId === section.sectionKey && sectionInsertion.position === 'before'
+      const showSectionAfter = sectionInsertion && sectionInsertion.targetId === section.sectionKey && sectionInsertion.position === 'after'
+
+      if (showSectionBefore) {
+        pieces.push(
+          jsx(InsertionLine, { position: 'before' }, `insertion-before-section:${section.sectionKey}`)
+        )
+      }
+
+      const sectionChildren = [
+        jsx(
+          SectionHeader,
+          {
+            key: section.sectionKey,
+            sectionKey: section.sectionKey,
+            title: sectionTitle,
+            collapsed: section.collapsed,
+            peerCount: section.peerCount ?? peers.length,
+            draggable: drag.canDragSection,
+            onDragStart: drag.canDragSection ? event => drag.beginSectionDrag(event, section.sectionKey, sectionTitle, section.peerCount ?? peers.length) : undefined,
+            onDragOver: drag.canDragSection ? event => drag.allowSectionTarget(event, section.sectionKey) : undefined,
+            onDrop: drag.canDragSection ? event => drag.dropOnSection(event, section.sectionKey, peerIds) : undefined,
+            onDragEnd: drag.endSectionDrag,
+            insertion: sectionInsertion
+          },
+          `section:${section.sectionKey}`
+        )
+      ]
+
+      if (!section.collapsed) {
+        sectionChildren.push(
+          jsx('div', {
+            className: 'ml-5 grid gap-0.5',
+            children: peers.map(p =>
+              renderPeerRow(p, { draggable: drag.canDragPeer, rangeKey: section.sectionKey, rangePeerIds: peerIds })
+            )
+          }, `section-peers:${section.sectionKey}`)
+        )
+      }
+
+      pieces.push(
+        jsx('div', {
+          className: 'min-w-0',
+          children: sectionChildren
+        }, `section-container:${section.sectionKey}`)
+      )
+
+      if (showSectionAfter) {
+        pieces.push(
+          jsx(InsertionLine, { position: 'after' }, `insertion-after-section:${section.sectionKey}`)
+        )
+      }
+    }
+
+    return pieces.flat()
+  }
+
+  if (mode === VIEW_GROUPING_GROUPS) {
+    // Groups mode: ungrouped bots (level 0) are draggable within the ungrouped
+    // range; automatic group headers are not draggable; members are draggable
+    // within their own group (see dragInfoForChildren).
+    const ungroupedBots = projected.filter(i => i.level === 0 && i.kind === 'bot')
+    const ungroupedPeerIds = ungroupedBots.map(i => i.peerId)
+
+    return projected
+      .flatMap(item => {
+        if (item.kind === 'bot') {
+          return renderPeerRow(item, { draggable: drag.canDragPeer, rangeKey: null, rangePeerIds: ungroupedPeerIds })
+        }
+
+        return renderPeerRow(item, { draggable: false, rangeKey: null, rangePeerIds: [] })
+      })
+      .flat()
+  }
+
+  // None mode: flat list. Nested members (nest toggle on) are a re-projection
+  // and are not independently draggable; the flat bucket reorders top-level
+  // peers only.
+  const flatPeerIds = projected.filter(i => i.level === 0).map(i => i.peerId)
+
+  return projected
+    .flatMap(item =>
+      renderPeerRow(item, {
+        draggable: item.level === 0 ? drag.canDragPeer : false,
+        rangeKey: null,
+        rangePeerIds: flatPeerIds
+      })
+    )
+    .flat()
+}
+
+/** A permanently reserved "Unassigned" target above the first named Section.
+ *  Keeping its footprint stable prevents drag-start from shifting every assigned
+ *  row and Section header under the pointer; active drag only changes styling. */
+function UnassignedDropZone({ active, onDragOver, onDrop }) {
+  const copy = useBotRosterText()
+  return jsx('div', {
+    onDragOver,
+    onDrop,
+    'data-unassigned-drop-target': 'true',
+    'aria-hidden': active ? undefined : 'true',
+    className: cn(
+      'my-0.5 flex items-center justify-center rounded-md border px-2 py-1.5 text-[0.6875rem] font-semibold uppercase tracking-wider transition-colors',
+      active
+        ? 'border-dashed border-(--ui-accent) text-(--ui-accent)'
+        : 'border-transparent text-(--ui-text-quaternary)'
+    ),
+    children: copy.sections.unassigned
+  })
+}
+
+/** Create a compact drag preview element, attach to dataTransfer, and return
+ *  a cleanup function. The element is positioned offscreen and
+ *  pointer-events: none — the browser shows it as the drag ghost instead of
+ *  the giant transparent full-row default. Pure DOM helper — no framework
+ *  deps, testable with an injected document/dataTransfer seam. */
+function createDragPreview(event, opts) {
+  const { kind, label, icon, sectionTitle, peerCount } = opts
+  try {
+    const wrapper = document.createElement('div')
+    wrapper.style.cssText = [
+      'position: fixed',
+      'top: -9999px',
+      'left: -9999px',
+      'pointer-events: none',
+      'z-index: 2147483647',
+      'display: flex',
+      'align-items: center',
+      'gap: 6px',
+      'padding: 4px 8px',
+      'border-radius: 6px',
+      'background: var(--card)',
+      'color: var(--foreground)',
+      'font-size: 12px',
+      'font-family: inherit',
+      'white-space: nowrap',
+      'border: 1px solid var(--border)'
+    ].join(';')
+
+    if (kind === 'section') {
+      wrapper.textContent = `${sectionTitle} (${peerCount})`
+    } else if (kind === 'bot' || kind === 'group') {
+      if (icon) {
+        const iconSpan = document.createElement('span')
+        iconSpan.style.cssText = 'font-size:14px;line-height:1'
+        iconSpan.textContent = icon
+        wrapper.appendChild(iconSpan)
+      }
+      const labelSpan = document.createElement('span')
+      labelSpan.textContent = label
+      wrapper.appendChild(labelSpan)
+    } else {
+      wrapper.textContent = String(label || '')
+    }
+
+    document.body.appendChild(wrapper)
+    event.dataTransfer.setDragImage(wrapper, 0, 0)
+    return () => { try { wrapper.remove() } catch { /* already removed */ } }
+  } catch {
+    return () => {}
+  }
+}
+
+/** A thin accent insertion line rendered during drag-over, indicating where the
+ *  dragged peer or section will land. Respects position='before'|'after'. */
+function InsertionLine({ position }) {
+  return jsx('div', {
+    'data-drop-position': position,
+    'aria-hidden': 'true',
+    className: 'h-[2px] rounded-full mx-1 my-0.5 bg-(--ui-accent) opacity-80',
+    style: { transition: 'opacity 0.1s ease' }
+  })
+}
+
+/** Section header with collapse toggle. The title row is the drag handle while
+ *  the dedicated left chevron mirrors nested group rows exactly. */
+function SectionHeader({ title, collapsed, peerCount, sectionKey, draggable, onDragStart, onDragOver, onDrop, onDragEnd, insertion }) {
+  const copy = useBotRosterText()
+  return jsxs('div', {
+    'data-drop-position': insertion && insertion.targetId === sectionKey ? insertion.position : undefined,
+    onDragOver,
+    onDrop,
+    className: 'flex w-full items-center gap-0.5',
+    children: [
+      jsx(Button, {
+        variant: 'ghost',
+        size: 'icon-xs',
+        onClick: () => toggleSectionCollapse(sectionKey),
+        'aria-label': collapsed ? copy.sections.expand(title) : copy.sections.collapse(title),
+        'aria-expanded': !collapsed,
+        children: jsx(Codicon, {
+          name: collapsed ? 'chevron-right' : 'chevron-down',
+          className: 'text-xs'
+        })
+      }),
+      jsxs(Button, {
+        variant: 'ghost',
+        size: 'xs',
+        draggable: Boolean(draggable),
+        onDragStart,
+        onDragEnd,
+        onClick: () => toggleSectionCollapse(sectionKey),
+        className: cn(
+          'min-w-0 flex-1 justify-start overflow-hidden text-(--ui-text-tertiary)',
+          draggable && 'cursor-grab active:cursor-grabbing'
+        ),
+        children: [
+          jsx('span', { className: 'flex-1 uppercase tracking-wide', children: title }),
+          jsx('span', {
+            className: 'text-[0.625rem] text-(--ui-text-quaternary)',
+            children: peerCount
+          })
+        ]
+      })
+    ]
+  })
+}
+
+/** Group row with optional context menu (for move-to-section in Sections mode). */
+function GroupRowEnhanced({ group, members, needsYou, onOpen, collapsed, peerId, viewState, draggable, onDragStart, onDragOver, onDrop, onDragEnd, onKeyDown, collapsible, onToggleCollapse, insertion }) {
+  const copy = useBotRosterText()
   const rooms = useValue($groupChats)
   const allMeta = useValue($botMeta)
+  const mode = viewState?.grouping || VIEW_GROUPING_NONE
   const room = rooms[group] || { log: [] }
   const log = Array.isArray(room.log) ? room.log : []
   const last = log.length ? log[log.length - 1] : null
@@ -9158,20 +11134,27 @@ function GroupRow({ group, members, needsYou, onOpen }) {
     : 'No messages yet — say hi to the room'
   const faces = members.slice(0, 3)
 
-  return jsxs('button', {
+  const row = jsxs('button', {
     type: 'button',
+    draggable: Boolean(draggable),
+    'data-drop-position': insertion && insertion.targetId === peerId ? insertion.position : undefined,
+    onDragStart,
+    onDragOver,
+    onDrop,
+    onDragEnd,
+    onKeyDown,
+    'aria-keyshortcuts': onKeyDown ? 'Alt+ArrowUp Alt+ArrowDown' : undefined,
     onClick: () => {
       haptic('tap')
       onOpen(group)
     },
     className: cn(
-      'flex w-full min-w-0 max-w-full items-center gap-2.5 overflow-hidden rounded-md px-2 py-2 text-left transition-colors',
-      'hover:bg-(--chrome-action-hover)'
+      'flex min-w-0 max-w-full items-center gap-2.5 overflow-hidden rounded-md px-2 py-2 text-left transition-colors',
+      collapsible ? 'flex-1' : 'w-full',
+      'hover:bg-(--chrome-action-hover)',
+      draggable && 'cursor-grab active:cursor-grabbing'
     ),
     children: [
-      // Room picture when the user set one; else a composite avatar of up to
-      // three member faces fanned like Discord's group-DM icon; a bare glyph
-      // when the room has no seated members.
       jsx('div', {
         className: 'flex w-[34px] shrink-0 items-center justify-center',
         children: room.image
@@ -9225,8 +11208,8 @@ function GroupRow({ group, members, needsYou, onOpen }) {
               needsYou
                 ? jsx('span', {
                     className:
-                      'shrink-0 rounded-full bg-(--ui-accent,#4f9cf9) px-1.5 text-[0.6rem] font-semibold text-white',
-                    title: 'A bot in this room needs your input',
+                      'shrink-0 rounded-full bg-primary px-1.5 text-[0.6rem] font-semibold text-primary-foreground',
+                    'aria-label': 'A bot in this room needs your input',
                     children: 'needs you'
                   })
                 : null,
@@ -9246,9 +11229,111 @@ function GroupRow({ group, members, needsYou, onOpen }) {
       })
     ]
   })
+
+  // Nested group rows (None/Sections Nest ON) expose a sibling collapse chevron
+  // — a separate button next to the room-open action, never nested inside it
+  // (a nested button would be invalid HTML). Groups mode headers keep their
+  // current behavior (no chevron) because `collapsible` is only set for the
+  // None/Sections nest projection.
+  const rowWithToggle = collapsible
+    ? jsxs('div', {
+        className: 'flex w-full items-center gap-0.5',
+        children: [
+          jsx(Button, {
+            variant: 'ghost',
+            size: 'icon-xs',
+            onClick: () => onToggleCollapse(peerId),
+            'aria-label': collapsed ? copy.sections.expand(group) : copy.sections.collapse(group),
+            'aria-expanded': !collapsed,
+            children: jsx(Codicon, { name: collapsed ? 'chevron-right' : 'chevron-down', className: 'text-xs' })
+          }),
+          row
+        ]
+      })
+    : row
+
+  // In Sections mode, add right-click context menu for move-to-section
+  if (mode === VIEW_GROUPING_SECTIONS && peerId) {
+    return jsxs(ContextMenu, {
+      children: [
+        jsx(ContextMenuTrigger, { asChild: true, children: rowWithToggle }),
+        jsx(MoveToSectionMenu, {
+          peerId,
+          viewState,
+          sectionAssignments: viewState?.sectionAssignments || {},
+          sections: viewState?.visualSections || []
+        })
+      ]
+    })
+  }
+
+  return rowWithToggle
+}
+
+/** "Move to section" submenu for the Bot context menu: a proper
+ *  `ContextMenuSub` whose trigger is a normal hover/click target (a context
+ *  menu gesture is NOT a submenu trigger). The content lists Unassigned +
+ *  every visual Section. The SubTrigger renders its own chevron. */
+function MoveToSectionSubmenu({ peerId, sectionAssignments, sections }) {
+  const copy = useBotRosterText()
+  const currentSection = sectionAssignments[peerId] || null
+
+  return jsxs(ContextMenuSub, {
+    children: [
+      jsx(ContextMenuSubTrigger, { children: copy.sections.moveTo }),
+      jsx(ContextMenuSubContent, {
+        children: jsxs(ContextMenuRadioGroup, {
+          value: currentSection || MANUAL_ORDER_UNASSIGNED_KEY,
+          onValueChange: value => movePeerToSection(peerId, value === MANUAL_ORDER_UNASSIGNED_KEY ? null : value),
+          children: [
+            jsx(ContextMenuRadioItem, {
+              value: MANUAL_ORDER_UNASSIGNED_KEY,
+              children: copy.sections.unassigned
+            }),
+            ...(sections || []).map(s =>
+              jsx(ContextMenuRadioItem, {
+                value: s.key,
+                children: s.title
+              }, `move-to:${s.key}`)
+            )
+          ]
+        })
+      })
+    ]
+  })
+}
+
+/** "Move to section" submenu for Bot and Group context menus.
+ *  Shows "Unassigned" + every visual Section. */
+function MoveToSectionMenu({ peerId, viewState, sectionAssignments, sections }) {
+  const copy = useBotRosterText()
+  const currentSection = sectionAssignments[peerId] || null
+
+  return jsxs(ContextMenuContent, {
+    children: [
+      jsx(ContextMenuLabel, { children: copy.sections.moveTo }),
+      jsxs(ContextMenuRadioGroup, {
+        value: currentSection || MANUAL_ORDER_UNASSIGNED_KEY,
+        onValueChange: value => movePeerToSection(peerId, value === MANUAL_ORDER_UNASSIGNED_KEY ? null : value),
+        children: [
+          jsx(ContextMenuRadioItem, {
+            value: MANUAL_ORDER_UNASSIGNED_KEY,
+            children: copy.sections.unassigned
+          }),
+          ...(sections || []).map(s =>
+            jsx(ContextMenuRadioItem, {
+              value: s.key,
+              children: s.title
+            }, `move-to:${s.key}`)
+          )
+        ]
+      })
+    ]
+  })
 }
 
 function BotsPane() {
+  const copy = useBotRosterText()
   const { data, error, isLoading, refetch } = useRoster()
   const gatewayState = useValue(host.state.gateway)
   const gatewayUp = gatewayState === 'open'
@@ -9258,12 +11343,21 @@ function BotsPane() {
   const [editing, setEditing] = useState(null)
   const [deleting, setDeleting] = useState(null)
   const [grouping, setGrouping] = useState(null)
+  const [managingSections, setManagingSections] = useState(false)
   const [query, setQuery] = useState('')
   const activityToasts = useValue($activityToasts)
   const sessionsWorkspaceName = useValue($botSessionsWorkspace)
   const groupChatName = useValue($groupChatWorkspace)
   const groupNeedsYou = useValue($groupNeedsYou)
   const groupRooms = useValue($groupChats)
+
+  // View state from the persisted atom
+  const viewWrapper = useValue($viewStateWrapper)
+  const viewState = viewWrapper.state
+  const groupingMode = viewState.grouping || VIEW_GROUPING_NONE
+  const sortMode = viewState.sort || VIEW_SORT_PINNED_RECENCY
+  const nestMembers = groupingMode === VIEW_GROUPING_GROUPS ? true : (viewState.nestMembers || false)
+  const showHidden = viewState.showHidden || false
 
   // The socket opening (boot, SSH reconnect, sleep/wake) is the signal to
   // retry immediately instead of waiting out the poll interval.
@@ -9305,41 +11399,305 @@ function BotsPane() {
   })
   const activeSourceRoster = roster.filter(bot => !bot.remoteSource)
   // Hidden bots (right-click → Hide Bot) drop out of the roster list unless
-  // the header eye toggle reveals them. Display-only: every other consumer
-  // (mentions, group chats, name-collision checks, merge/avatar/activity
+  // the View menu's Show hidden toggle reveals them. Display-only: every other
+  // consumer (mentions, group chats, name-collision checks, merge/avatar/activity
   // sweeps) keeps the FULL roster.
-  const showHidden = useValue($showHiddenBots)
   const unreadByName = useValue($botUnread)
   const hiddenBots = roster.filter(bot => isBotHidden(bot, allMeta))
   const hiddenUnread = hiddenBots.some(bot => !bot.remoteSource && unreadByName[bot.name])
   const visibleRoster = showHidden ? roster : roster.filter(bot => !isBotHidden(bot, allMeta))
   const filteredRoster = filterBots(visibleRoster, allMeta, query)
-  // Group chats are first-class roster rows (Discord-style): one standalone
-  // row per room, competing in the SAME recency ordering as bot rows — a
-  // group's activity is its newest room-log line. Pinned bots still lead;
-  // groups and unpinned bots interleave by recency below them.
-  const needle = query.trim().toLowerCase()
-  const groupRows = groupChatNames(allMeta, groupRooms)
-    .filter(name => !needle || name.toLowerCase().includes(needle))
-    .map(name => ({
-      kind: 'group',
-      name,
-      members: groupChatMemberBots(name, roster, allMeta),
-      activity: groupLastActivity(groupRooms[name])
-    }))
-  const rosterRows = [
-    ...filteredRoster.map(bot => ({ kind: 'bot', bot, pinned: isPinned(bot), activity: activityOf(bot) })),
-    ...groupRows
-  ].sort((a, b) => {
-    const pa = a.pinned ? 1 : 0
-    const pb = b.pinned ? 1 : 0
 
-    if (pa !== pb) {
-      return pb - pa
+  // ── New view pipeline ─────────────────────────────────────────────────┐
+  // Build peers, sort, then project through the selected grouping mode.
+
+  // 1. Build the peer list (Bots + Groups)
+  const allPeers = buildPeerList(roster, allMeta, groupRooms, showHidden)
+
+  // 2. Annotate with activity for recency sort
+  const peersWithActivity = allPeers.map(p => ({
+    ...p,
+    activity: p.kind === 'bot' ? activityOf(p.botRow) : (p.groupActivity || 0)
+  }))
+
+  // 3. Sort peers according to selected sort mode. In Sections and Groups the
+  // manual order is per-range and applied inside applyGroupingMode; the flat
+  // manual bucket applies only to None mode here.
+  const manualOrder = sortMode === VIEW_SORT_MANUAL && groupingMode === VIEW_GROUPING_NONE
+    ? viewState.manualOrderNone || []
+    : null
+  const sortedPeers = resolveSortOrder(sortMode, peersWithActivity, manualOrder, null)
+
+  // 4. Project through grouping mode
+  const needle = query.trim().toLowerCase()
+  const matchingBots = new Set(filteredRoster.map(botRosterKey))
+
+  const searchOpts = needle ? { query, matchesBotId: matchingBots } : undefined
+
+  const projected = applyGroupingMode(groupingMode, sortedPeers, viewState, nestMembers, searchOpts)
+
+  // 5. For search in Sections mode: filter section peers by search
+  // (applyGroupingMode handles this internally via searchOpts)
+
+  // Map projected items to peer renders for flat None/Groups modes,
+  // or section groups for Sections mode.
+
+  // ── drag-and-drop (native HTML5; no dependencies) ─────────────────────────
+  // Drag payload lives in a ref (ephemeral interaction, no re-render churn);
+  // `isDragging` is a lightweight state flag that reveals drop zones while a
+  // drag is in flight. Peer drops resolve through applyPeerDrop (assignment in
+  // Sections mode, manual reorder in Manual sort); section-header drops reorder
+  // Sections through applySectionDrop.
+  const dragRef = useRef(null)
+  const [isDragging, setIsDragging] = useState(false)
+  const [insertion, setInsertion] = useState(null) // {type,targetId,position,rangeKey}|null
+  const canDragPeer = groupingMode === VIEW_GROUPING_SECTIONS || sortMode === VIEW_SORT_MANUAL
+  const canKeyboardMovePeer = sortMode === VIEW_SORT_MANUAL
+  const canDragSection = groupingMode === VIEW_GROUPING_SECTIONS
+
+  const clearDragState = () => {
+    const drag = dragRef.current
+    if (drag && drag.cleanupPreview) {
+      try { drag.cleanupPreview() } catch { /* noop */ }
+    }
+    dragRef.current = null
+    setIsDragging(false)
+    setInsertion(null)
+  }
+
+  // A mode/sort change invalidates the active drag contract. Clean up the
+  // preview and insertion feedback immediately instead of leaving stale UI.
+  useEffect(() => {
+    const drag = dragRef.current
+    if (!drag) return
+    if (drag.cleanupPreview) {
+      try { drag.cleanupPreview() } catch { /* noop */ }
+    }
+    dragRef.current = null
+    setIsDragging(false)
+    setInsertion(null)
+  }, [groupingMode, sortMode])
+
+  // Unmount can happen mid-drag (workspace navigation/plugin disposal). Remove
+  // the temporary preview node without scheduling state on an unmounted tree.
+  useEffect(() => () => {
+    const drag = dragRef.current
+    if (drag?.cleanupPreview) {
+      try { drag.cleanupPreview() } catch { /* noop */ }
+    }
+    dragRef.current = null
+  }, [])
+
+  const beginPeerDrag = (event, peerId, kind, rangeKey, label, icon) => {
+    if (!canDragPeer) return
+    const previewLabel = String(label || peerId)
+    const previewIcon = kind === 'group' ? (icon || '\uD83D\uDC65') : (icon || '\uD83E\uDD16')
+    const cleanupPreview = createDragPreview(event, { kind, label: previewLabel, icon: previewIcon })
+    dragRef.current = { type: 'peer', peerId, kind, fromRangeKey: rangeKey, cleanupPreview }
+    setIsDragging(true)
+    try {
+      event.dataTransfer.effectAllowed = 'move'
+      event.dataTransfer.setData('text/plain', peerId)
+    } catch {
+      /* dataTransfer may be absent in tests */
+    }
+  }
+
+  const allowPeerDrop = (event, rangeKey, targetPeerId) => {
+    const drag = dragRef.current
+    if (!drag || drag.type !== 'peer') return
+    if (targetPeerId === drag.peerId) {
+      drag.dropPosition = null
+      setInsertion(null)
+      return
+    }
+    // In Groups mode a cross-group drop is disallowed — never advertise a
+    // valid target outside the peer's own automatic group.
+    if (groupingMode === VIEW_GROUPING_GROUPS && drag.kind === 'bot' && drag.fromRangeKey !== rangeKey) {
+      drag.dropPosition = null
+      setInsertion(null)
+      return
+    }
+    event.preventDefault()
+    try {
+      event.dataTransfer.dropEffect = 'move'
+    } catch {
+      /* noop */
     }
 
-    return b.activity - a.activity
-  })
+    // Compute insertion position from pointer Y relative to target midpoint.
+    try {
+      const rect = event.currentTarget.getBoundingClientRect()
+      const midY = rect.top + rect.height / 2
+      const position = event.clientY < midY ? 'before' : 'after'
+      drag.dropPosition = position
+      const next = { type: 'peer', targetId: targetPeerId, position, rangeKey }
+      setInsertion(prev =>
+        prev && prev.targetId === next.targetId && prev.position === next.position && prev.rangeKey === next.rangeKey
+          ? prev
+          : next
+      )
+    } catch {
+      /* no bounding rect available — skip insertion line */
+    }
+  }
+
+  const endPeerDrag = () => {
+    clearDragState()
+  }
+
+  const dropPeer = (event, rangeKey, targetPeerId, rangePeerIds) => {
+    const drag = dragRef.current
+    if (!drag || drag.type !== 'peer') return
+    event.preventDefault()
+    const patch = applyPeerDrop(viewState, {
+      peerId: drag.peerId,
+      kind: drag.kind,
+      grouping: groupingMode,
+      sort: sortMode,
+      fromRangeKey: drag.fromRangeKey,
+      toRangeKey: rangeKey,
+      targetPeerId,
+      rangePeerIds,
+      position: drag.dropPosition || (insertion ? insertion.position : undefined)
+    })
+    if (patch) updateViewState(patch)
+    clearDragState()
+  }
+
+  const keyboardMovePeer = (event, peerId, kind, rangeKey, rangePeerIds) => {
+    if (sortMode !== VIEW_SORT_MANUAL || !event.altKey) return
+    const delta = event.key === 'ArrowUp' ? -1 : event.key === 'ArrowDown' ? 1 : 0
+    if (!delta) return
+
+    const patch = applyKeyboardPeerMove(viewState, {
+      peerId,
+      kind,
+      grouping: groupingMode,
+      rangeKey,
+      rangePeerIds,
+      delta
+    })
+    if (!patch) return
+
+    event.preventDefault()
+    event.stopPropagation()
+    updateViewState(patch)
+  }
+
+  const beginSectionDrag = (event, sectionKey, title, peerCount) => {
+    if (!canDragSection) return
+    const cleanupPreview = createDragPreview(event, { kind: 'section', sectionTitle: String(title || sectionKey), peerCount: peerCount || 0 })
+    dragRef.current = { type: 'section', sectionKey, cleanupPreview }
+    setIsDragging(true)
+    try {
+      event.dataTransfer.effectAllowed = 'move'
+      event.dataTransfer.setData('text/plain', sectionKey)
+    } catch {
+      /* dataTransfer may be absent in tests */
+    }
+  }
+
+  const allowSectionTarget = (event, sectionKey) => {
+    const drag = dragRef.current
+    if (!drag) {
+      setInsertion(null)
+      return
+    }
+    // A section header accepts both a section-reorder drop and a peer drop
+    // (assign to that section, including when the section is empty).
+    if (drag.type === 'section' || drag.type === 'peer') {
+      event.preventDefault()
+      try {
+        event.dataTransfer.dropEffect = 'move'
+      } catch {
+        /* noop */
+      }
+      // Compute section insertion position from pointer Y.
+      try {
+        const rect = event.currentTarget.getBoundingClientRect()
+        const midY = rect.top + rect.height / 2
+        // A peer dropped on a Section header is appended to that Section, so
+        // its feedback belongs after the complete Section container. Section
+        // reorders still use the pointer midpoint for before/after placement.
+        const position = drag.type === 'peer' ? 'after' : (event.clientY < midY ? 'before' : 'after')
+        drag.dropPosition = position
+        const next = { type: 'section', targetId: sectionKey, position, rangeKey: sectionKey }
+        setInsertion(prev =>
+          prev && prev.targetId === next.targetId && prev.position === next.position && prev.rangeKey === next.rangeKey
+            ? prev
+            : next
+        )
+      } catch {
+        /* no bounding rect */
+      }
+    } else {
+      drag.dropPosition = null
+      setInsertion(null)
+    }
+  }
+
+  const endSectionDrag = () => {
+    clearDragState()
+  }
+
+  const dropOnSection = (event, toSectionKey, sectionPeerIds) => {
+    const drag = dragRef.current
+    if (!drag) return
+    event.preventDefault()
+
+    if (drag.type === 'section') {
+      const patch = applySectionDrop(viewState, {
+        sectionKey: drag.sectionKey,
+        toSectionKey,
+        position: drag.dropPosition || (insertion ? insertion.position : undefined)
+      })
+      if (patch) updateViewState(patch)
+    } else if (drag.type === 'peer') {
+      // Dropping a peer on a section header assigns it to that section (at the
+      // end of its manual-order bucket when sort is Manual).
+      const patch = applyPeerDrop(viewState, {
+        peerId: drag.peerId,
+        kind: drag.kind,
+        grouping: groupingMode,
+        sort: sortMode,
+        fromRangeKey: drag.fromRangeKey,
+        toRangeKey: toSectionKey,
+        targetPeerId: null,
+        rangePeerIds: sectionPeerIds,
+        position: drag.dropPosition || (insertion ? insertion.position : undefined)
+      })
+      if (patch) updateViewState(patch)
+    }
+
+    clearDragState()
+  }
+
+  const drag = {
+    canDragPeer,
+    canKeyboardMovePeer,
+    canDragSection,
+    isDragging,
+    insertion,
+    beginPeerDrag,
+    allowPeerDrop,
+    dropPeer,
+    keyboardMovePeer,
+    endPeerDrag,
+    beginSectionDrag,
+    allowSectionTarget,
+    dropOnSection,
+    endSectionDrag
+  }
+
+  // Active styling on the View trigger whenever any non-default view setting is
+  // live (the old standalone eye button carried this signal; it now rides the
+  // single View trigger alongside the hidden-unread dot).
+  const viewActive =
+    groupingMode !== VIEW_GROUPING_NONE ||
+    sortMode !== VIEW_SORT_PINNED_RECENCY ||
+    showHidden ||
+    (groupingMode !== VIEW_GROUPING_GROUPS && nestMembers)
 
   if (live) {
     $lastRoster.set(roster)
@@ -9387,35 +11745,41 @@ function BotsPane() {
                   children: jsx(Codicon, { name: activityToasts ? 'bell' : 'bell-slash' })
                 })
               }),
-              // Eye toggle appears only once something is hidden — zero
-              // hidden bots means zero extra chrome. It stays visible while
-              // hidden rows are revealed, so Unhide is always reachable.
-              hiddenBots.length
-                ? jsx(Tip, {
-                    label: showHidden
-                      ? 'Hide hidden bots again'
-                      : `Show ${hiddenBots.length} hidden bot${hiddenBots.length === 1 ? '' : 's'}`,
-                    children: jsxs('button', {
-                      type: 'button',
-                      'aria-label': showHidden ? 'Hide hidden bots' : 'Show hidden bots',
-                      className: cn(
-                        'relative flex size-6 items-center justify-center rounded-md transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground',
-                        showHidden ? 'text-foreground' : 'text-(--ui-text-tertiary)'
-                      ),
-                      onClick: () => $showHiddenBots.set(!showHidden),
+              // The single View menu carries grouping, sorting, nest toggle,
+              // Show hidden, and Manage Sections. The old standalone eye button
+              // is gone — its hidden-unread dot now rides the View trigger
+              // (below), and Show hidden lives in the menu.
+              jsxs(DropdownMenu, {
+                children: [
+                  jsx(DropdownMenuTrigger, {
+                    asChild: true,
+                    children: jsx(Button, {
+                      variant: 'ghost',
+                      size: 'icon-xs',
+                      'aria-label': copy.view.options,
+                      className: cn('relative', viewActive ? 'text-(--ui-accent)' : 'text-(--ui-text-tertiary)'),
                       children: [
-                        jsx(Codicon, { name: showHidden ? 'eye' : 'eye-closed' }),
+                        jsx(Codicon, { name: 'list-filter' }),
                         hiddenUnread && !showHidden
                           ? jsx('span', {
                               className:
-                                'absolute right-0.5 top-0.5 size-1.5 rounded-full bg-(--ui-accent,#4f9cf9)',
-                              'aria-label': 'a hidden bot has unread activity'
+                                'absolute right-0.5 top-0.5 size-1.5 rounded-full bg-(--ui-accent)',
+                              'aria-label': copy.view.hiddenUnread
                             })
                           : null
                       ]
                     })
+                  }),
+                  jsx(ViewMenuContent, {
+                    viewState,
+                    onSetGrouping: setGroupingMode,
+                    onSetSort: setSortMode,
+                    onToggleNest: toggleNestMembers,
+                    onToggleShowHidden: toggleShowHidden,
+                    onManageSections: () => setManagingSections(true)
                   })
-                : null,
+                ]
+              }),
               jsxs(DropdownMenu, {
                 children: [
                   jsx(Tip, {
@@ -9570,40 +11934,36 @@ function BotsPane() {
                 title: 'No agents yet',
                 description: 'Create your first teammate.'
               })
-            : filteredRoster.length === 0 && rosterRows.length === 0
+            : projected.length === 0
               ? jsx('div', {
                   'aria-live': 'polite',
                   className:
                     'flex flex-1 items-center justify-center px-4 text-center text-xs text-(--ui-text-tertiary)',
                   role: 'status',
                   children: query.trim()
-                    ? `No bots match “${query.trim()}”`
-                    : 'All bots are hidden — use the eye button above to show them.'
+                    ? copy.sections.noMatch(query.trim())
+                    : copy.sections.allHidden
                 })
               : jsx(ScrollArea, {
                   className: 'hermes-bots-roster min-h-0 flex-1',
                   children: jsx('div', {
                     className: 'grid w-full min-w-0 gap-0.5 px-1.5 pb-2',
-                    // Flat, Discord-style list: bot rows and group rows
-                    // interleaved by recency — no section headers.
-                    children: rosterRows.map(row =>
-                      row.kind === 'group'
-                        ? jsx(
-                            GroupRow,
-                            {
-                              group: row.name,
-                              members: row.members,
-                              needsYou: Boolean(groupNeedsYou[row.name]),
-                              onOpen: openGroupChat
-                            },
-                            `group:${row.name}`
-                          )
-                        : jsx(
-                            BotRow,
-                            { bot: row.bot, onDelete: setDeleting, onEdit: setEditing, onGroup: setGrouping },
-                            botRosterKey(row.bot)
-                          )
-                    )
+                    onDragLeave: event => {
+                      if (!event.currentTarget.contains(event.relatedTarget)) {
+                        if (dragRef.current) dragRef.current.dropPosition = null
+                        setInsertion(null)
+                      }
+                    },
+                    children: renderProjectedRoster(projected, groupingMode, {
+                      setDeleting,
+                      setEditing,
+                      setGrouping,
+                      groupNeedsYou,
+                      openGroupChat,
+                      viewState,
+                      drag,
+                      toggleNestedGroup: toggleNestedGroupCollapse
+                    })
                   })
                 }),
       jsx('div', {
@@ -9640,6 +12000,7 @@ function BotsPane() {
         }
       }),
       grouping ? jsx(GroupDialog, { bot: grouping, onClose: () => setGrouping(null) }) : null,
+      jsx(ManageSectionsDialog, { open: managingSections, onClose: () => setManagingSections(false) }),
       jsx(ConfirmDialog, {
         open: Boolean(deleting),
         title: 'Delete bot and profile?',
@@ -9682,11 +12043,32 @@ export default {
   description: 'Bot Mode — a one-chat-per-agent roster with avatars, routines, group chats, and bot-to-bot messaging. Ships with the app; disable here if unwanted.',
   register(ctx) {
     pluginCtx = ctx
+    ctx.i18n?.register?.(BOT_LOCALES)
     startFaceClock()
     // Disabling the plugin (or a hot reload) must actually stop the clock —
     // before this, the rAF loop + 1Hz document scan ran until app restart.
     if (typeof ctx.onDispose === 'function') {
       ctx.onDispose(stopFaceClock)
+    }
+
+    // Hydrate view state from plugin-scoped storage. The atom already contains
+    // a normalized default, so the pane can render before this async read lands.
+    const requestToken = ++viewHydrationToken
+    void hydrateViewStateFromStorage(requestToken, ctx)
+    if (typeof ctx.onDispose === 'function') {
+      ctx.onDispose(() => {
+        // Advance rather than reset the lifecycle token so every in-flight read
+        // from this registration is permanently stale.
+        const disposeToken = ++viewHydrationToken
+        $viewStateWrapper.set({
+          state: normalizeViewState(null),
+          token: disposeToken,
+          localGeneration: 0
+        })
+        if (pluginCtx === ctx) {
+          pluginCtx = null
+        }
+      })
     }
 
     // @-mention autocomplete: typing "@rese…" in ANY composer offers the
@@ -10072,4 +12454,63 @@ export default {
         }      }
     })
   }
+}
+
+// Runtime-import tests opt into this non-enumerable seam before evaluating the
+// real bundled module. Production and legacy source harnesses never set it.
+if (globalThis.__HERMES_BOTS_TEST__) {
+  Object.defineProperty(globalThis, '__HERMES_BOTS_TEST_API__', {
+    configurable: true,
+    value: {
+      $botMeta,
+      $groupChats,
+      $lastRoster,
+      $viewStateWrapper,
+      BOT_LOCALES,
+      BotRow,
+      GroupRowEnhanced,
+      ManageSectionsDialog,
+      MoveToSectionMenu,
+      SectionHeader,
+      UnassignedDropZone,
+      ViewMenuContent,
+      setPluginCtxForTest: value => { pluginCtx = value },
+      applyGroupingMode,
+      applyKeyboardPeerMove,
+      applyPeerDrop,
+      applySectionDrop,
+      assignPeerToSection,
+      botPeerIdentity,
+      botRosterKey,
+      buildPeerList,
+      collapseSection,
+      createDragPreview,
+      createVisualSection,
+      deleteVisualSection,
+      groupPeerIdentity,
+      hydrateViewState,
+      insertionMatches,
+      isSectionCollapsed,
+      MANUAL_ORDER_UNASSIGNED_KEY,
+      manualOrderBucketKey,
+      normalizeViewState,
+      remapGroupViewState,
+      renameVisualSection,
+      renderProjectedRoster,
+      reorderPeerInto,
+      reorderVisualSections,
+      resolveSortOrder,
+      sortAlpha,
+      sortManual,
+      sortPinnedRecency,
+      unassignPeerFromSection,
+      visualSectionKey,
+      VIEW_GROUPING_GROUPS,
+      VIEW_GROUPING_NONE,
+      VIEW_GROUPING_SECTIONS,
+      VIEW_SORT_ALPHA,
+      VIEW_SORT_MANUAL,
+      VIEW_SORT_PINNED_RECENCY
+    }
+  })
 }

--- a/apps/desktop/src/plugins/hermes-bots/roster-view-model.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-view-model.test.ts
@@ -1,0 +1,1760 @@
+// @ts-nocheck -- migrated legacy JS behavior matrix; production is exercised through real imports.
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+// Exercise the real ESM module; production never exposes this seam.
+globalThis.__HERMES_BOTS_TEST__ = true
+await import('./plugin.js')
+const viewModel = globalThis.__HERMES_BOTS_TEST_API__
+
+function load() {
+  return viewModel
+}
+
+// ── Constants ───────────────────────────────────────────────────────────────
+
+const VIEW_GROUPING_NONE = 'none'
+const VIEW_GROUPING_SECTIONS = 'sections'
+const VIEW_GROUPING_GROUPS = 'groups'
+const VIEW_SORT_ALPHA = 'alpha'
+const VIEW_SORT_PINNED_RECENCY = 'pinned-recency'
+const VIEW_SORT_MANUAL = 'manual'
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const bot = (name, opts = {}) => ({
+  name,
+  remoteSource: opts.remoteSource || false,
+  sourceScoped: opts.sourceScoped || opts.remoteSource || false,
+  connectionId: opts.connectionId || undefined,
+  connectionLabel: opts.connectionLabel || undefined,
+  last_session: opts.last_session || null,
+  ...opts.extra
+})
+
+const meta = (opts = {}) => ({
+  title: opts.title,
+  groups: opts.groups || [],
+  pinned: opts.pinned || false,
+  hidden: opts.hidden || false,
+  ...opts.extra
+})
+
+// ── Peer identity tests ─────────────────────────────────────────────────────
+
+test('botPeerIdentity: source-qualified key as botRosterKey', () => {
+  const { botPeerIdentity, botRosterKey: keyFor } = load()
+  // Must match botRosterKey for backwards compat
+  const local = { name: 'hermes', sourceScoped: true }
+  const remote = { name: 'spark', remoteSource: true, sourceScoped: true, connectionId: 'mini' }
+
+  assert.equal(botPeerIdentity(local), keyFor(local))
+  assert.equal(botPeerIdentity(remote), keyFor(remote))
+  assert.equal(botPeerIdentity({ name: 'default' }), 'legacy::default')
+})
+
+test('groupPeerIdentity: kind-qualified, never collides with bot identity', () => {
+  const { groupPeerIdentity, botPeerIdentity } = load()
+
+  const gId = groupPeerIdentity('Engineering')
+  assert.ok(gId.startsWith('group:'))
+  assert.equal(gId, 'group:Engineering')
+
+  // No collision with a similarly-named bot
+  const bId = botPeerIdentity({ name: 'Engineering', sourceScoped: true })
+  assert.notEqual(gId, bId)
+})
+
+test('groupPeerIdentity: collision-safe even for adversarial names', () => {
+  const { groupPeerIdentity, botPeerIdentity } = load()
+
+  // A bot named "group:x" must not collide with group "x"
+  const gId = groupPeerIdentity('flat')
+  const bId = botPeerIdentity({ name: 'flat', sourceScoped: true })
+  assert.notEqual(gId, bId)
+
+  // Unicode group names
+  const uId = groupPeerIdentity('ÜberGroup')
+  assert.ok(uId.startsWith('group:'))
+  assert.ok(uId.includes('ÜberGroup'))
+})
+
+// ── buildPeerList tests ─────────────────────────────────────────────────────
+
+test('buildPeerList: every visible bot + every known group, no duplicates', () => {
+  const { buildPeerList } = load()
+  const roster = [bot('hermes'), bot('atlas'), bot('echo')]
+
+  const metaByName = {
+    atlas: meta({ groups: ['Engineering'] }),
+    echo: meta({ groups: ['Engineering', 'Research'] })
+  }
+
+  const rooms = {}
+
+  const peers = buildPeerList(roster, metaByName, rooms, false)
+
+  // 3 bots + 2 groups = 5 peers
+  assert.equal(peers.length, 5)
+  assert.equal(peers.filter(p => p.kind === 'bot').length, 3)
+  assert.equal(peers.filter(p => p.kind === 'group').length, 2)
+
+  const groupNames = peers.filter(p => p.kind === 'group').map(p => p.title)
+  assert.equal(JSON.stringify(groupNames.sort()), JSON.stringify(['Engineering', 'Research']))
+  assert.equal(peers.find(p => p.kind === 'group' && p.title === 'Engineering').members.length, 2)
+  assert.equal(peers.find(p => p.kind === 'group' && p.title === 'Research').members.length, 1)
+})
+
+test('buildPeerList: group rows stay visible even with no members in roster', () => {
+  const { buildPeerList } = load()
+  const roster = [bot('hermes')]
+
+  const metaByName = {
+    ghost: meta({ groups: ['Empty'] }) // bot not in roster
+  }
+
+  const rooms = {}
+
+  const peers = buildPeerList(roster, metaByName, rooms, false)
+  assert.ok(peers.some(p => p.kind === 'group' && p.title === 'Empty'))
+})
+
+test('buildPeerList: hidden bots excluded when showHidden=false', () => {
+  const { buildPeerList } = load()
+  const roster = [bot('hermes'), bot('atlas')]
+  const metaByName = { atlas: meta({ hidden: true }) }
+
+  const peers = buildPeerList(roster, metaByName, {}, false)
+  assert.equal(peers.filter(p => p.kind === 'bot').length, 1)
+  assert.equal(peers.filter(p => p.kind === 'bot')[0].name, 'hermes')
+})
+
+test('buildPeerList: hidden bots included when showHidden=true', () => {
+  const { buildPeerList } = load()
+  const roster = [bot('hermes'), bot('atlas')]
+  const metaByName = { atlas: meta({ hidden: true }) }
+
+  const peers = buildPeerList(roster, metaByName, {}, true)
+  assert.equal(peers.filter(p => p.kind === 'bot').length, 2)
+})
+
+// ── Sorting tests ───────────────────────────────────────────────────────────
+
+test('sortAlpha: bots by display name, groups by group name, case-insensitive', () => {
+  const { sortAlpha } = load()
+
+  const items = [
+    { kind: 'bot', name: 'Zeta', meta: meta(), botRow: { name: 'Zeta' } },
+    { kind: 'bot', name: 'alpha', meta: meta(), botRow: { name: 'alpha' } },
+    { kind: 'group', title: 'Research', meta: null },
+    { kind: 'group', title: 'engineering', meta: null },
+    { kind: 'bot', name: 'Beta', meta: meta(), botRow: { name: 'Beta' } }
+  ]
+
+  const sorted = sortAlpha(items)
+  const names = sorted.map(i => (i.kind === 'bot' ? i.name : i.title))
+  // All sorted together alphabetically, case-insensitive: alpha, Beta, engineering, Research, Zeta
+  assert.equal(JSON.stringify(names), JSON.stringify(['alpha', 'Beta', 'engineering', 'Research', 'Zeta']))
+})
+
+test('sortPinnedRecency: pinned bots first (by recency), then unpinned by recency, groups by room activity', () => {
+  const { sortPinnedRecency } = load()
+
+  const items = [
+    { kind: 'bot', name: 'echo', meta: meta(), activity: 100, peerId: 'legacy::echo' },
+    { kind: 'bot', name: 'atlas', meta: meta({ pinned: true }), activity: 50, peerId: 'legacy::atlas' },
+    { kind: 'bot', name: 'hermes', meta: meta({ pinned: true }), activity: 200, peerId: 'legacy::hermes' },
+    { kind: 'group', title: 'Eng', meta: null, groupActivity: 30, peerId: 'group:Eng' },
+    { kind: 'group', title: 'Research', meta: null, groupActivity: 80, peerId: 'group:Research' },
+    { kind: 'bot', name: 'scout', meta: meta(), activity: 150, peerId: 'legacy::scout' }
+  ]
+
+  const sorted = sortPinnedRecency(items)
+  const names = sorted.map(i => (i.kind === 'bot' ? i.name : i.title))
+  // Pinned: hermes(200), atlas(50). Unpinned: scout(150), echo(100). Groups: Research(80), Eng(30)
+  assert.equal(JSON.stringify(names), JSON.stringify(['hermes', 'atlas', 'scout', 'echo', 'Research', 'Eng']))
+})
+
+test('sortManual: preserves persisted order, new items appended', () => {
+  const { sortManual } = load()
+
+  const items = [
+    { peerId: 'legacy::echo', kind: 'bot', name: 'echo' },
+    { peerId: 'legacy::atlas', kind: 'bot', name: 'atlas' },
+    { peerId: 'legacy::hermes', kind: 'bot', name: 'hermes' }
+  ]
+
+  const persisted = ['legacy::atlas', 'legacy::echo'] // hermes is new
+
+  const sorted = sortManual(items, persisted)
+  assert.equal(
+    JSON.stringify(sorted.map(i => i.peerId)),
+    JSON.stringify(['legacy::atlas', 'legacy::echo', 'legacy::hermes'])
+  )
+})
+
+test('sortManual: stale IDs in persistence are ignored', () => {
+  const { sortManual } = load()
+
+  const items = [
+    { peerId: 'legacy::echo', kind: 'bot', name: 'echo' },
+    { peerId: 'legacy::atlas', kind: 'bot', name: 'atlas' }
+  ]
+
+  const persisted = ['legacy::atlas', 'legacy::ghost', 'legacy::echo']
+
+  const sorted = sortManual(items, persisted)
+  assert.equal(JSON.stringify(sorted.map(i => i.peerId)), JSON.stringify(['legacy::atlas', 'legacy::echo']))
+})
+
+// ── Grouping mode tests ─────────────────────────────────────────────────────
+
+test('applyGroupingMode None: every peer as flat list, no section dividers', () => {
+  const { applyGroupingMode, VIEW_GROUPING_NONE } = load()
+
+  const peers = [
+    { kind: 'bot', peerId: 'legacy::hermes', name: 'hermes', groups: [], meta: meta() },
+    { kind: 'bot', peerId: 'legacy::atlas', name: 'atlas', groups: ['Engineering'], meta: meta() },
+    { kind: 'group', peerId: 'group:Engineering', title: 'Engineering', meta: null }
+  ]
+
+  const result = applyGroupingMode(VIEW_GROUPING_NONE, peers, {}, false)
+
+  // All peers rendered flat, no section dividers
+  assert.ok(Array.isArray(result))
+  assert.equal(result.length, 3)
+  assert.equal(result[0].kind, 'bot')
+  assert.equal(result[1].kind, 'bot')
+  assert.equal(result[2].kind, 'group')
+})
+
+test('applyGroupingMode None + Nest ON: group members are duplicated under shortcuts and remain standalone', () => {
+  const { applyGroupingMode, VIEW_GROUPING_NONE } = load()
+
+  const peers = [
+    { kind: 'bot', peerId: 'legacy::hermes', name: 'hermes', groups: [], meta: meta(), botRow: { name: 'hermes' } },
+    {
+      kind: 'bot',
+      peerId: 'legacy::atlas',
+      name: 'atlas',
+      groups: ['Engineering'],
+      meta: meta(),
+      botRow: { name: 'atlas' }
+    },
+    {
+      kind: 'bot',
+      peerId: 'legacy::kiln',
+      name: 'kiln',
+      groups: ['Engineering', 'Research'],
+      meta: meta(),
+      botRow: { name: 'kiln' }
+    },
+    { kind: 'group', peerId: 'group:Engineering', title: 'Engineering', meta: null },
+    { kind: 'group', peerId: 'group:Research', title: 'Research', meta: null }
+  ]
+
+  const result = applyGroupingMode(VIEW_GROUPING_NONE, peers, {}, true)
+
+  // Every Bot remains a standalone peer; groups add shortcut copies.
+  const topLevel = result.filter(r => r.level === 0)
+  assert.equal(topLevel.length, 5)
+  assert.equal(topLevel.filter(r => r.kind === 'bot').length, 3)
+
+  const engGroup = result.find(r => r.peerId === 'group:Engineering')
+  assert.ok(engGroup)
+  assert.ok(Array.isArray(engGroup.children))
+  assert.equal(engGroup.children.length, 2) // atlas, kiln
+  assert.equal(
+    JSON.stringify(engGroup.children.map(c => c.peerId).sort()),
+    JSON.stringify(['legacy::atlas', 'legacy::kiln'])
+  )
+
+  // kiln appears under BOTH groups
+  const researchGroup = result.find(r => r.peerId === 'group:Research')
+  assert.equal(researchGroup.children.length, 1)
+  assert.equal(researchGroup.children[0].peerId, 'legacy::kiln')
+})
+
+test('applyGroupingMode None + Nest OFF: every bot as top-level peer, groups also visible', () => {
+  const { applyGroupingMode, VIEW_GROUPING_NONE } = load()
+
+  const peers = [
+    { kind: 'bot', peerId: 'legacy::hermes', name: 'hermes', groups: [], meta: meta(), botRow: { name: 'hermes' } },
+    {
+      kind: 'bot',
+      peerId: 'legacy::atlas',
+      name: 'atlas',
+      groups: ['Engineering'],
+      meta: meta(),
+      botRow: { name: 'atlas' }
+    },
+    { kind: 'group', peerId: 'group:Engineering', title: 'Engineering', meta: null }
+  ]
+
+  const result = applyGroupingMode(VIEW_GROUPING_NONE, peers, {}, false)
+
+  // All 3 as top-level peers
+  assert.equal(result.length, 3)
+  assert.equal(result.filter(r => r.kind === 'bot').length, 2)
+  assert.equal(result.filter(r => r.kind === 'group').length, 1)
+  // No children on the group
+  const eng = result.find(r => r.peerId === 'group:Engineering')
+  assert.ok(!eng.children || eng.children.length === 0)
+})
+
+test('applyGroupingMode Groups: retains current behavior from 21fb9f779', () => {
+  const { applyGroupingMode, VIEW_GROUPING_GROUPS } = load()
+
+  const peers = [
+    { kind: 'bot', peerId: 'legacy::hermes', name: 'hermes', groups: [], meta: meta(), botRow: { name: 'hermes' } },
+    {
+      kind: 'bot',
+      peerId: 'legacy::atlas',
+      name: 'atlas',
+      groups: ['Engineering'],
+      meta: meta(),
+      botRow: { name: 'atlas' }
+    },
+    {
+      kind: 'bot',
+      peerId: 'legacy::kiln',
+      name: 'kiln',
+      groups: ['Engineering', 'Research'],
+      meta: meta(),
+      botRow: { name: 'kiln' }
+    },
+    { kind: 'group', peerId: 'group:Engineering', title: 'Engineering', meta: null },
+    { kind: 'group', peerId: 'group:Research', title: 'Research', meta: null }
+  ]
+
+  const result = applyGroupingMode(VIEW_GROUPING_GROUPS, peers, {}, false)
+
+  // All Bots remain standalone before the group shortcuts.
+  const standaloneBots = result.filter(r => r.kind === 'bot' && r.level === 0)
+  assert.equal(
+    JSON.stringify(standaloneBots.map(r => r.peerId)),
+    JSON.stringify(['legacy::hermes', 'legacy::atlas', 'legacy::kiln'])
+  )
+
+  // Then group sections alphabetically with nested shortcut copies.
+  const eng = result.find(r => r.peerId === 'group:Engineering')
+  assert.ok(eng)
+  assert.ok(eng.children)
+  assert.equal(eng.children.length, 2)
+})
+
+test('applyGroupingMode Sections: peers partitioned by visual sections, unassigned first', () => {
+  const { applyGroupingMode, VIEW_GROUPING_SECTIONS } = load()
+
+  const peers = [
+    { kind: 'bot', peerId: 'legacy::hermes', name: 'hermes', groups: [], meta: meta(), botRow: { name: 'hermes' } },
+    {
+      kind: 'bot',
+      peerId: 'legacy::atlas',
+      name: 'atlas',
+      groups: ['Engineering'],
+      meta: meta(),
+      botRow: { name: 'atlas' }
+    },
+    {
+      kind: 'bot',
+      peerId: 'legacy::scout',
+      name: 'scout',
+      groups: ['Research'],
+      meta: meta(),
+      botRow: { name: 'scout' }
+    },
+    { kind: 'group', peerId: 'group:Engineering', title: 'Engineering', meta: null }
+  ]
+
+  const viewState = {
+    visualSections: [
+      { key: 'section:A', title: 'Core Team', order: 0 },
+      { key: 'section:B', title: 'External', order: 1 }
+    ],
+    sectionAssignments: {
+      'legacy::atlas': 'section:A',
+      'legacy::scout': 'section:A',
+      'group:Engineering': 'section:B'
+    },
+    sectionCollapsed: {},
+    sectionOrder: ['section:A', 'section:B']
+  }
+
+  const result = applyGroupingMode(VIEW_GROUPING_SECTIONS, peers, viewState, false)
+
+  // Should produce: unassigned section + section:A + section:B
+  assert.equal(result.length, 3)
+
+  // Unassigned first
+  assert.equal(result[0].sectionKey, undefined)
+  assert.ok(Array.isArray(result[0].peers))
+  assert.equal(result[0].peers.length, 1)
+  assert.equal(result[0].peers[0].peerId, 'legacy::hermes')
+
+  // Section A
+  assert.equal(result[1].sectionKey, 'section:A')
+  assert.equal(result[1].title, 'Core Team')
+  assert.equal(result[1].peers.length, 2)
+
+  // Section B
+  assert.equal(result[2].sectionKey, 'section:B')
+  assert.equal(result[2].title, 'External')
+  assert.equal(result[2].peers.length, 1)
+  assert.equal(result[2].peers[0].peerId, 'group:Engineering')
+})
+
+test('applyGroupingMode Sections: empty sections render their header', () => {
+  const { applyGroupingMode, VIEW_GROUPING_SECTIONS } = load()
+
+  const peers = [
+    { kind: 'bot', peerId: 'legacy::hermes', name: 'hermes', groups: [], meta: meta(), botRow: { name: 'hermes' } }
+  ]
+
+  const viewState = {
+    visualSections: [{ key: 'section:A', title: 'Empty Team', order: 0 }],
+    sectionAssignments: {},
+    sectionCollapsed: {},
+    sectionOrder: ['section:A']
+  }
+
+  const result = applyGroupingMode(VIEW_GROUPING_SECTIONS, peers, viewState, false)
+  assert.equal(result.length, 2)
+  assert.equal(result[1].sectionKey, 'section:A')
+  assert.equal(result[1].peers.length, 0) // empty but still rendered
+})
+
+test('applyGroupingMode Sections: sections respect persisted order', () => {
+  const { applyGroupingMode, VIEW_GROUPING_SECTIONS } = load()
+
+  const peers = [
+    { kind: 'bot', peerId: 'legacy::hermes', name: 'hermes', groups: [], meta: meta(), botRow: { name: 'hermes' } },
+    {
+      kind: 'bot',
+      peerId: 'legacy::atlas',
+      name: 'atlas',
+      groups: ['Engineering'],
+      meta: meta(),
+      botRow: { name: 'atlas' }
+    }
+  ]
+
+  const viewState = {
+    visualSections: [
+      { key: 'section:B', title: 'Second', order: 1 },
+      { key: 'section:A', title: 'First', order: 0 }
+    ],
+    sectionAssignments: {
+      'legacy::atlas': 'section:A',
+      'legacy::hermes': 'section:B'
+    },
+    sectionCollapsed: {},
+    sectionOrder: ['section:B', 'section:A'] // B first, then A
+  }
+
+  const result = applyGroupingMode(VIEW_GROUPING_SECTIONS, peers, viewState, false)
+  // Unassigned is empty (both peers assigned), so first section is B, then A
+  assert.equal(result[0].sectionKey, 'section:B') // B before A per viewState.sectionOrder
+  assert.equal(result[1].sectionKey, 'section:A')
+})
+
+test('applyGroupingMode Sections: group rows can be assigned to sections', () => {
+  const { applyGroupingMode, VIEW_GROUPING_SECTIONS } = load()
+
+  const peers = [
+    { kind: 'bot', peerId: 'legacy::hermes', name: 'hermes', groups: [], meta: meta(), botRow: { name: 'hermes' } },
+    { kind: 'group', peerId: 'group:Engineering', title: 'Engineering', meta: null },
+    { kind: 'group', peerId: 'group:Research', title: 'Research', meta: null }
+  ]
+
+  const viewState = {
+    visualSections: [{ key: 'section:A', title: 'Active', order: 0 }],
+    sectionAssignments: {
+      'group:Engineering': 'section:A'
+    },
+    sectionCollapsed: {},
+    sectionOrder: ['section:A']
+  }
+
+  const result = applyGroupingMode(VIEW_GROUPING_SECTIONS, peers, viewState, false)
+  assert.equal(result[0].peers[0].peerId, 'legacy::hermes')
+  assert.equal(result[0].peers[1].peerId, 'group:Research')
+  assert.equal(result[1].peers[0].peerId, 'group:Engineering')
+})
+
+// ── Visual Section CRUD tests ───────────────────────────────────────────────
+
+test('createVisualSection: generates collision-safe key', () => {
+  const { createVisualSection } = load()
+  const sections = []
+
+  const s = createVisualSection(sections, 'My Section')
+  assert.equal(s.title, 'My Section')
+  assert.ok(s.key.startsWith('section:'))
+  assert.equal(typeof s.order, 'number')
+})
+
+test('createVisualSection: deduplicates title suffixes for keys', () => {
+  const { createVisualSection } = load()
+  const sections = []
+  const a = createVisualSection(sections, 'Same')
+  const b = createVisualSection([a], 'Same')
+
+  assert.notEqual(a.key, b.key)
+  assert.equal(a.title, 'Same')
+  assert.equal(b.title, 'Same')
+})
+
+test('renameVisualSection: changes title, returns updated', () => {
+  const { renameVisualSection } = load()
+  const sections = [{ key: 'section:A', title: 'Old', order: 0 }]
+  const updated = renameVisualSection(sections, 'section:A', 'New Name')
+
+  assert.equal(updated[0].title, 'New Name')
+  assert.equal(updated[0].key, 'section:A')
+})
+
+test('deleteVisualSection: unassigns all peers, removes section', () => {
+  const { deleteVisualSection } = load()
+  const sections = [{ key: 'section:A', title: 'To Delete', order: 0 }]
+  const assignments = { 'legacy::atlas': 'section:A', 'group:Eng': 'section:A' }
+  const order = ['section:A']
+
+  const result = deleteVisualSection(sections, assignments, order, 'section:A')
+  assert.equal(result.sections.length, 0)
+  assert.equal(Object.keys(result.assignments).length, 0)
+  // original assignments unchanged (pure)
+  assert.equal(assignments['legacy::atlas'], 'section:A')
+})
+
+test('deleteVisualSection: never deletes a group or bot', () => {
+  const { deleteVisualSection } = load()
+  // Just verifies the function signature — it doesn't receive the roster
+  const sections = [{ key: 'section:A', title: 'Section', order: 0 }]
+  const assignments = {}
+  const order = ['section:A']
+
+  const result = deleteVisualSection(sections, assignments, order, 'section:A')
+  assert.equal(result.sections.length, 0)
+  // The caller handles what happens to unassigned peers
+})
+
+test('assignPeerToSection: sets assignment, returns new map', () => {
+  const { assignPeerToSection } = load()
+  const assignments = {}
+  const updated = assignPeerToSection(assignments, 'legacy::atlas', 'section:A')
+
+  assert.equal(updated['legacy::atlas'], 'section:A')
+  // Original not mutated
+  assert.equal(Object.keys(assignments).length, 0)
+})
+
+test('unassignPeerFromSection: removes assignment', () => {
+  const { unassignPeerFromSection } = load()
+  const assignments = { 'legacy::atlas': 'section:A', 'legacy::hermes': 'section:B' }
+  const updated = unassignPeerFromSection(assignments, 'legacy::atlas')
+
+  assert.equal(updated['legacy::atlas'], undefined)
+  assert.equal(updated['legacy::hermes'], 'section:B')
+  assert.equal(Object.keys(updated).length, 1)
+})
+
+test('collapseSection: toggles collapsed state', () => {
+  const { collapseSection, isSectionCollapsed } = load()
+  const collapsed = {}
+
+  const c1 = collapseSection(collapsed, 'section:A', true)
+  assert.equal(isSectionCollapsed(c1, 'section:A'), true)
+
+  const c2 = collapseSection(c1, 'section:A', false)
+  assert.equal(isSectionCollapsed(c2, 'section:A'), false)
+})
+
+// ── resolveSortOrder tests ──────────────────────────────────────────────────
+
+test('resolveSortOrder: uses mode-appropriate sort function', () => {
+  const { resolveSortOrder, VIEW_SORT_ALPHA, VIEW_SORT_PINNED_RECENCY, VIEW_SORT_MANUAL } = load()
+
+  const items = [
+    { kind: 'bot', peerId: 'legacy::z', name: 'z', meta: meta(), activity: 10, botRow: { name: 'z' } },
+    { kind: 'bot', peerId: 'legacy::a', name: 'a', meta: meta(), activity: 100, botRow: { name: 'a' } }
+  ]
+
+  const alphaSorted = resolveSortOrder(VIEW_SORT_ALPHA, items, null, null)
+  assert.equal(alphaSorted[0].name, 'a')
+
+  const recencySorted = resolveSortOrder(VIEW_SORT_PINNED_RECENCY, items, null, null)
+  assert.equal(recencySorted[0].name, 'a') // most recent
+
+  const manualSorted = resolveSortOrder(VIEW_SORT_MANUAL, items, ['legacy::z', 'legacy::a'], null)
+  assert.equal(manualSorted[0].name, 'z')
+})
+
+// ── Malformed persistence normalization tests ───────────────────────────────
+
+test('normalizeViewState: fills in defaults for empty/missing', () => {
+  const { normalizeViewState } = load()
+
+  const result = normalizeViewState(null)
+  assert.equal(result.grouping, VIEW_GROUPING_NONE)
+  assert.equal(result.sort, VIEW_SORT_PINNED_RECENCY)
+  assert.equal(result.nestMembers, false)
+  assert.equal(result.showHidden, false)
+  assert.ok(Array.isArray(result.visualSections))
+  assert.equal(typeof result.sectionAssignments, 'object')
+  assert.ok(Array.isArray(result.sectionOrder))
+  assert.ok(Array.isArray(result.manualOrderNone))
+  assert.equal(typeof result.manualOrderUnassigned, 'object')
+})
+
+test('normalizeViewState: strips stale section assignments', () => {
+  const { normalizeViewState } = load()
+
+  const input = {
+    visualSections: [{ key: 'section:A', title: 'Real', order: 0 }],
+    sectionAssignments: {
+      'legacy::atlas': 'section:A',
+      'legacy::hermes': 'section:GONE' // stale
+    },
+    sectionOrder: ['section:A'],
+    sectionCollapsed: { 'section:GONE': true }
+  }
+
+  const result = normalizeViewState(input)
+  assert.equal(result.sectionAssignments['legacy::atlas'], 'section:A')
+  assert.equal(result.sectionAssignments['legacy::hermes'], undefined)
+  assert.equal(result.sectionCollapsed['section:GONE'], undefined)
+})
+
+test('normalizeViewState: deduplicates section order', () => {
+  const { normalizeViewState } = load()
+
+  const input = {
+    visualSections: [{ key: 'section:A', title: 'A', order: 0 }],
+    sectionOrder: ['section:A', 'section:A', 'section:A'],
+    sectionAssignments: {},
+    sectionCollapsed: {}
+  }
+
+  const result = normalizeViewState(input)
+  assert.equal(result.sectionOrder.length, 1)
+  assert.equal(result.sectionOrder[0], 'section:A')
+})
+
+test('normalizeViewState: unknown section keys in order are removed', () => {
+  const { normalizeViewState } = load()
+
+  const input = {
+    visualSections: [{ key: 'section:A', title: 'A', order: 0 }],
+    sectionOrder: ['section:GHOST', 'section:A'],
+    sectionAssignments: {},
+    sectionCollapsed: {}
+  }
+
+  const result = normalizeViewState(input)
+  assert.equal(result.sectionOrder.length, 1)
+  assert.equal(result.sectionOrder[0], 'section:A')
+})
+
+// ── Race-safe hydration tests ───────────────────────────────────────────────
+
+test('hydrateViewState: first load sets token and applies normalized state', () => {
+  const { hydrateViewState, normalizeViewState } = load()
+  const stored = { grouping: 'groups', sort: 'alpha', nestMembers: true, showHidden: true }
+  const current = { state: normalizeViewState(null), token: 0, localGeneration: 0 }
+
+  const result = hydrateViewState(current, stored, 1, 0)
+  assert.equal(result.state.grouping, 'groups')
+  assert.equal(result.state.sort, 'alpha')
+  assert.equal(result.state.nestMembers, true)
+  assert.equal(result.token, 1)
+})
+
+test('hydrateViewState: stale request token is rejected', () => {
+  const { hydrateViewState } = load()
+
+  const current = {
+    state: { grouping: 'none', sort: 'pinned-recency' },
+    token: 5,
+    localGeneration: 0
+  }
+
+  const stored = { grouping: 'groups', sort: 'alpha' }
+
+  // Request token 3 < current token 5 → rejected
+  const result = hydrateViewState(current, stored, 3)
+  assert.equal(result, current)
+})
+
+test('hydrateViewState: later request token with no local mutations overwrites', () => {
+  const { hydrateViewState } = load()
+
+  const current = {
+    state: { grouping: 'none', sort: 'pinned-recency', nestMembers: false, showHidden: false },
+    token: 3,
+    localGeneration: 0
+  }
+
+  const stored = { grouping: 'groups', sort: 'alpha', nestMembers: true, showHidden: true }
+
+  const result = hydrateViewState(current, stored, 5)
+  assert.equal(result.state.grouping, 'groups')
+  assert.equal(result.state.sort, 'alpha')
+  assert.equal(result.token, 5)
+})
+
+test('hydrateViewState: later request with active local mutations is rejected', () => {
+  const { hydrateViewState } = load()
+
+  const current = {
+    state: { grouping: 'none', sort: 'pinned-recency', nestMembers: false, showHidden: false },
+    token: 3,
+    localGeneration: 2 // local mutation pending
+  }
+
+  const stored = { grouping: 'groups', sort: 'alpha' }
+
+  const result = hydrateViewState(current, stored, 5, 0)
+  // A mutation after the read began wins; stored state is NOT applied
+  assert.equal(result, current)
+})
+
+test('hydrateViewState: reset keeps the lifecycle token monotonic', () => {
+  const { hydrateViewState } = load()
+
+  const current = {
+    state: { grouping: 'groups', sort: 'manual' },
+    token: 5,
+    localGeneration: 1
+  }
+
+  // token=0 means reset (dispose)
+  const result = hydrateViewState(current, null, 0)
+  assert.equal(result.state.grouping, VIEW_GROUPING_NONE)
+  assert.equal(result.token, 5)
+  assert.equal(result.localGeneration, 0)
+})
+
+// ── Nesting + Section interaction tests ─────────────────────────────────────
+
+test('applyGroupingMode Sections + Nest ON: bot members nest under group rows within sections', () => {
+  const { applyGroupingMode, VIEW_GROUPING_SECTIONS } = load()
+
+  const peers = [
+    { kind: 'bot', peerId: 'legacy::hermes', name: 'hermes', groups: [], meta: meta(), botRow: { name: 'hermes' } },
+    {
+      kind: 'bot',
+      peerId: 'legacy::atlas',
+      name: 'atlas',
+      groups: ['Engineering'],
+      meta: meta(),
+      botRow: { name: 'atlas' }
+    },
+    { kind: 'group', peerId: 'group:Engineering', title: 'Engineering', meta: null }
+  ]
+
+  const viewState = {
+    visualSections: [{ key: 'section:A', title: 'Core', order: 0 }],
+    sectionAssignments: {
+      'legacy::hermes': 'section:A',
+      'legacy::atlas': 'section:A',
+      'group:Engineering': 'section:A'
+    },
+    sectionCollapsed: {},
+    sectionOrder: ['section:A']
+  }
+
+  const result = applyGroupingMode(VIEW_GROUPING_SECTIONS, peers, viewState, true)
+  // Section A keeps both standalone Bots and the Engineering shortcut.
+  const sectionA = result.find(r => r.sectionKey === 'section:A')
+  assert.ok(sectionA)
+  assert.equal(sectionA.peers.length, 3) // hermes + atlas + group:Engineering
+  const engGroup = sectionA.peers.find(p => p.peerId === 'group:Engineering')
+  assert.ok(engGroup.children)
+  assert.equal(engGroup.children.length, 1)
+  assert.equal(engGroup.children[0].peerId, 'legacy::atlas')
+})
+
+test('Sections + Nest ON: a multi-group Bot appears under every group across Section assignments', () => {
+  const { applyGroupingMode, VIEW_GROUPING_SECTIONS } = load()
+
+  const peers = [
+    {
+      kind: 'bot',
+      peerId: 'legacy::atlas',
+      name: 'atlas',
+      groups: ['Engineering', 'Research'],
+      meta: meta(),
+      botRow: { name: 'atlas' }
+    },
+    { kind: 'group', peerId: 'group:Engineering', title: 'Engineering', meta: null },
+    { kind: 'group', peerId: 'group:Research', title: 'Research', meta: null }
+  ]
+
+  const viewState = {
+    visualSections: [
+      { key: 'section:A', title: 'Core', order: 0 },
+      { key: 'section:B', title: 'Labs', order: 1 }
+    ],
+    sectionAssignments: {
+      'legacy::atlas': 'section:A',
+      'group:Engineering': 'section:A',
+      'group:Research': 'section:B'
+    },
+    sectionCollapsed: {},
+    sectionOrder: ['section:A', 'section:B']
+  }
+
+  const result = applyGroupingMode(VIEW_GROUPING_SECTIONS, peers, viewState, true)
+  const core = result.find(r => r.sectionKey === 'section:A')
+  const labs = result.find(r => r.sectionKey === 'section:B')
+  const engineering = core.peers.find(p => p.peerId === 'group:Engineering')
+  const research = labs.peers.find(p => p.peerId === 'group:Research')
+
+  assert.deepEqual(
+    engineering.children.map(c => c.peerId),
+    ['legacy::atlas']
+  )
+  assert.deepEqual(
+    research.children.map(c => c.peerId),
+    ['legacy::atlas']
+  )
+  assert.ok(
+    core.peers.some(p => p.kind === 'bot' && p.peerId === 'legacy::atlas' && p.level === 0),
+    'member Bot remains standalone and draggable'
+  )
+})
+
+// ── Search composition tests ────────────────────────────────────────────────
+
+test('applyGroupingMode None + search: bot query retains matching bot rows; group query retains group row', () => {
+  const { applyGroupingMode, VIEW_GROUPING_NONE } = load()
+
+  const peers = [
+    { kind: 'bot', peerId: 'legacy::hermes', name: 'hermes', groups: [], meta: meta(), botRow: { name: 'hermes' } },
+    {
+      kind: 'bot',
+      peerId: 'legacy::atlas',
+      name: 'atlas',
+      groups: ['Engineering'],
+      meta: meta(),
+      botRow: { name: 'atlas' }
+    },
+    { kind: 'group', peerId: 'group:Engineering', title: 'Engineering', meta: null }
+  ]
+
+  const searchOpts = { query: 'atlas', matchesBotId: new Set(['legacy::atlas']) }
+
+  const result = applyGroupingMode(VIEW_GROUPING_NONE, peers, {}, false, searchOpts)
+  assert.equal(result.length, 1)
+  assert.equal(result[0].peerId, 'legacy::atlas')
+})
+
+test('applyGroupingMode None + search: group name match retains group row', () => {
+  const { applyGroupingMode, VIEW_GROUPING_NONE } = load()
+
+  const peers = [
+    { kind: 'bot', peerId: 'legacy::hermes', name: 'hermes', groups: [], meta: meta(), botRow: { name: 'hermes' } },
+    { kind: 'group', peerId: 'group:Engineering', title: 'Engineering', meta: null }
+  ]
+
+  const searchOpts = { query: 'engin', matchesBotId: new Set() }
+
+  const result = applyGroupingMode(VIEW_GROUPING_NONE, peers, {}, false, searchOpts)
+  assert.equal(result.length, 1)
+  assert.equal(result[0].peerId, 'group:Engineering')
+})
+
+// ── Member-name search retains group rows ───────────────────────────────────
+
+// buildPeerList seats group peers with `members` descriptors (not `children`).
+// A member-name search must keep the group row even before nesting computes
+// children, in both None and Sections and with Nest OFF and ON.
+
+test('search None + Nest OFF: member-name match keeps the group row alongside the bot', () => {
+  const { applyGroupingMode, VIEW_GROUPING_NONE } = load()
+
+  const peers = [
+    {
+      kind: 'bot',
+      peerId: 'legacy::atlas',
+      name: 'atlas',
+      groups: ['Engineering'],
+      meta: meta(),
+      botRow: { name: 'atlas' }
+    },
+    { kind: 'bot', peerId: 'legacy::hermes', name: 'hermes', groups: [], meta: meta(), botRow: { name: 'hermes' } },
+    { kind: 'group', peerId: 'group:Engineering', title: 'Engineering', meta: null, members: [{ name: 'atlas' }] }
+  ]
+
+  const searchOpts = { query: 'atlas', matchesBotId: new Set(['legacy::atlas']) }
+
+  const result = applyGroupingMode(VIEW_GROUPING_NONE, peers, {}, false, searchOpts)
+
+  const ids = result.map(p => p.peerId)
+  assert.ok(ids.includes('legacy::atlas'), 'matching bot retained')
+  assert.ok(ids.includes('group:Engineering'), 'group row retained by member match')
+  assert.equal(result.length, 2)
+})
+
+test('search None + Nest ON: group row keeps its matching child nested', () => {
+  const { applyGroupingMode, VIEW_GROUPING_NONE } = load()
+
+  const peers = [
+    {
+      kind: 'bot',
+      peerId: 'legacy::atlas',
+      name: 'atlas',
+      groups: ['Engineering'],
+      meta: meta(),
+      botRow: { name: 'atlas' }
+    },
+    { kind: 'bot', peerId: 'legacy::hermes', name: 'hermes', groups: [], meta: meta(), botRow: { name: 'hermes' } },
+    { kind: 'group', peerId: 'group:Engineering', title: 'Engineering', meta: null, members: [{ name: 'atlas' }] }
+  ]
+
+  const searchOpts = { query: 'atlas', matchesBotId: new Set(['legacy::atlas']) }
+
+  const result = applyGroupingMode(VIEW_GROUPING_NONE, peers, {}, true, searchOpts)
+
+  const eng = result.find(r => r.peerId === 'group:Engineering')
+  assert.ok(eng, 'Engineering group row retained')
+  assert.equal(eng.children.length, 1)
+  assert.equal(eng.children[0].peerId, 'legacy::atlas')
+  // atlas remains standalone while also appearing in the group shortcut
+  assert.ok(result.some(r => r.kind === 'bot' && r.peerId === 'legacy::atlas' && r.level === 0))
+})
+
+test('search Sections + Nest OFF: member-name match keeps the group row', () => {
+  const { applyGroupingMode, VIEW_GROUPING_SECTIONS } = load()
+
+  const peers = [
+    {
+      kind: 'bot',
+      peerId: 'legacy::atlas',
+      name: 'atlas',
+      groups: ['Engineering'],
+      meta: meta(),
+      botRow: { name: 'atlas' }
+    },
+    { kind: 'group', peerId: 'group:Engineering', title: 'Engineering', meta: null, members: [{ name: 'atlas' }] }
+  ]
+
+  const viewState = { visualSections: [], sectionAssignments: {}, sectionCollapsed: {}, sectionOrder: [] }
+  const searchOpts = { query: 'atlas', matchesBotId: new Set(['legacy::atlas']) }
+
+  const result = applyGroupingMode(VIEW_GROUPING_SECTIONS, peers, viewState, false, searchOpts)
+
+  const unassigned = result.find(r => !r.sectionKey)
+  assert.ok(unassigned, 'unassigned range present')
+  const ids = unassigned.peers.map(p => p.peerId)
+  assert.ok(ids.includes('legacy::atlas'))
+  assert.ok(ids.includes('group:Engineering'))
+})
+
+test('search Sections + Nest ON: group row keeps its matching child nested', () => {
+  const { applyGroupingMode, VIEW_GROUPING_SECTIONS } = load()
+
+  const peers = [
+    {
+      kind: 'bot',
+      peerId: 'legacy::atlas',
+      name: 'atlas',
+      groups: ['Engineering'],
+      meta: meta(),
+      botRow: { name: 'atlas' }
+    },
+    { kind: 'group', peerId: 'group:Engineering', title: 'Engineering', meta: null, members: [{ name: 'atlas' }] }
+  ]
+
+  const viewState = { visualSections: [], sectionAssignments: {}, sectionCollapsed: {}, sectionOrder: [] }
+  const searchOpts = { query: 'atlas', matchesBotId: new Set(['legacy::atlas']) }
+
+  const result = applyGroupingMode(VIEW_GROUPING_SECTIONS, peers, viewState, true, searchOpts)
+
+  const unassigned = result.find(r => !r.sectionKey)
+  assert.ok(unassigned)
+  const eng = unassigned.peers.find(p => p.peerId === 'group:Engineering')
+  assert.ok(eng, 'Engineering group row retained')
+  assert.equal(eng.children.length, 1)
+  assert.equal(eng.children[0].peerId, 'legacy::atlas')
+  assert.ok(unassigned.peers.some(p => p.kind === 'bot' && p.peerId === 'legacy::atlas' && p.level === 0))
+})
+
+test('search Sections + Nest ON: separated matching member still retains its assigned group row', () => {
+  const { applyGroupingMode, VIEW_GROUPING_SECTIONS } = load()
+
+  const peers = [
+    {
+      kind: 'bot',
+      peerId: 'legacy::atlas',
+      name: 'atlas',
+      groups: ['Engineering'],
+      meta: meta(),
+      botRow: { name: 'atlas' }
+    },
+    { kind: 'group', peerId: 'group:Engineering', title: 'Engineering', meta: null, members: [{ name: 'atlas' }] }
+  ]
+
+  const viewState = {
+    visualSections: [{ key: 'section:Core', title: 'Core', order: 0 }],
+    sectionAssignments: { 'group:Engineering': 'section:Core' },
+    sectionCollapsed: {},
+    sectionOrder: ['section:Core']
+  }
+
+  const searchOpts = { query: 'atlas', matchesBotId: new Set(['legacy::atlas']) }
+
+  const result = applyGroupingMode(VIEW_GROUPING_SECTIONS, peers, viewState, true, searchOpts)
+  const unassigned = result.find(r => !r.sectionKey)
+  const core = result.find(r => r.sectionKey === 'section:Core')
+
+  const engineering = core.peers.find(p => p.peerId === 'group:Engineering')
+  assert.ok(engineering, 'assigned group row retained across section boundary')
+  assert.deepEqual(
+    engineering.children.map(c => c.peerId),
+    ['legacy::atlas'],
+    'matching member nests under its group across the Section boundary'
+  )
+  assert.ok(
+    unassigned.peers.some(p => p.peerId === 'legacy::atlas'),
+    'matching member remains standalone across the Section boundary'
+  )
+})
+
+test('search None + Nest OFF: a multi-group match retains every matching group row', () => {
+  const { applyGroupingMode, VIEW_GROUPING_NONE } = load()
+
+  const peers = [
+    {
+      kind: 'bot',
+      peerId: 'legacy::atlas',
+      name: 'atlas',
+      groups: ['Engineering', 'Research'],
+      meta: meta(),
+      botRow: { name: 'atlas' }
+    },
+    { kind: 'group', peerId: 'group:Engineering', title: 'Engineering', meta: null, members: [{ name: 'atlas' }] },
+    { kind: 'group', peerId: 'group:Research', title: 'Research', meta: null, members: [{ name: 'atlas' }] }
+  ]
+
+  const searchOpts = { query: 'atlas', matchesBotId: new Set(['legacy::atlas']) }
+
+  const result = applyGroupingMode(VIEW_GROUPING_NONE, peers, {}, false, searchOpts)
+
+  const ids = result.map(r => r.peerId)
+  assert.ok(ids.includes('legacy::atlas'), 'matching bot retained')
+  assert.ok(ids.includes('group:Engineering'), 'first group retained')
+  assert.ok(ids.includes('group:Research'), 'second group retained')
+  assert.equal(result.length, 3)
+})
+
+test('search: source-qualified remote member descriptor keeps its group even when absent from the roster', () => {
+  const { applyGroupingMode, VIEW_GROUPING_NONE } = load()
+  const descriptor = { name: 'spark', handle: 'spark', remoteSource: true, sourceScoped: true, connectionId: 'mini' }
+
+  const peers = [{ kind: 'group', peerId: 'group:Remote', title: 'Remote', meta: null, members: [descriptor] }]
+
+  // spark is NOT a live roster row, so matchesBotId does not carry `mini::spark`.
+  const searchOpts = { query: 'spark', matchesBotId: new Set() }
+
+  const result = applyGroupingMode(VIEW_GROUPING_NONE, peers, {}, false, searchOpts)
+  assert.equal(result.length, 1)
+  assert.equal(result[0].peerId, 'group:Remote')
+})
+
+// ── Nested group collapse ───────────────────────────────────────────────────
+
+test('normalizeViewState: preserves nestedExpansion for persistence', () => {
+  const { normalizeViewState } = load()
+  const result = normalizeViewState({ nestedExpansion: { 'group:Engineering': true } })
+  assert.equal(result.nestedExpansion['group:Engineering'], true)
+})
+
+test('applyGroupingMode None + Nest ON: nested group rows honor nestedExpansion collapse', () => {
+  const { applyGroupingMode, VIEW_GROUPING_NONE } = load()
+
+  const peers = [
+    {
+      kind: 'bot',
+      peerId: 'legacy::atlas',
+      name: 'atlas',
+      groups: ['Engineering'],
+      meta: meta(),
+      botRow: { name: 'atlas' }
+    },
+    { kind: 'group', peerId: 'group:Engineering', title: 'Engineering', meta: null, members: [{ name: 'atlas' }] }
+  ]
+
+  const viewState = { nestedExpansion: { 'group:Engineering': true } }
+
+  const result = applyGroupingMode(VIEW_GROUPING_NONE, peers, viewState, true)
+
+  const eng = result.find(r => r.peerId === 'group:Engineering')
+  assert.equal(eng.collapsed, true)
+})
+
+test('applyGroupingMode: search bypasses nested group collapse to reveal matches', () => {
+  const { applyGroupingMode, VIEW_GROUPING_NONE } = load()
+
+  const peers = [
+    {
+      kind: 'bot',
+      peerId: 'legacy::atlas',
+      name: 'atlas',
+      groups: ['Engineering'],
+      meta: meta(),
+      botRow: { name: 'atlas' }
+    },
+    { kind: 'group', peerId: 'group:Engineering', title: 'Engineering', meta: null, members: [{ name: 'atlas' }] }
+  ]
+
+  const viewState = { nestedExpansion: { 'group:Engineering': true } }
+  const searchOpts = { query: 'atlas', matchesBotId: new Set(['legacy::atlas']) }
+
+  const result = applyGroupingMode(VIEW_GROUPING_NONE, peers, viewState, true, searchOpts)
+
+  const eng = result.find(r => r.peerId === 'group:Engineering')
+  assert.equal(eng.collapsed, false)
+  assert.equal(eng.children.length, 1)
+})
+
+// ── reorderVisualSections test ──────────────────────────────────────────────
+
+test('reorderVisualSections: updates order keys and sorts correctly', () => {
+  const { reorderVisualSections } = load()
+
+  const sections = [
+    { key: 'section:A', title: 'A', order: 0 },
+    { key: 'section:B', title: 'B', order: 1 },
+    { key: 'section:C', title: 'C', order: 2 }
+  ]
+
+  const order = ['section:A', 'section:B', 'section:C']
+
+  // Move C to first
+  const result = reorderVisualSections(sections, order, 'section:C', 0)
+  assert.equal(JSON.stringify(result.order), JSON.stringify(['section:C', 'section:A', 'section:B']))
+  assert.equal(result.sections[0].key, 'section:C')
+  assert.equal(result.sections[0].order, 0)
+  assert.equal(result.sections[1].key, 'section:A')
+  assert.equal(result.sections[1].order, 1)
+})
+
+// ── Section collapse + search interaction test ──────────────────────────────
+
+test('collapsed section does not bury search match', () => {
+  const { applyGroupingMode, VIEW_GROUPING_SECTIONS, collapseSection } = load()
+
+  const peers = [
+    { kind: 'bot', peerId: 'legacy::scout', name: 'scout', groups: [], meta: meta(), botRow: { name: 'scout' } },
+    { kind: 'bot', peerId: 'legacy::hermes', name: 'hermes', groups: [], meta: meta(), botRow: { name: 'hermes' } }
+  ]
+
+  let vsCollapsed = collapseSection({}, 'section:A', true)
+
+  const viewState = {
+    visualSections: [{ key: 'section:A', title: 'Hidden Section', order: 0 }],
+    sectionAssignments: {
+      'legacy::scout': 'section:A',
+      'legacy::hermes': 'section:A'
+    },
+    sectionCollapsed: vsCollapsed,
+    sectionOrder: ['section:A']
+  }
+
+  const searchOpts = { query: 'scout', matchesBotId: new Set(['legacy::scout']) }
+  const result = applyGroupingMode(VIEW_GROUPING_SECTIONS, peers, viewState, false, searchOpts)
+
+  // Scout must be visible despite collapsed section
+  const sectionA = result.find(r => r.sectionKey === 'section:A')
+  assert.ok(sectionA)
+  assert.equal(sectionA.peers.length, 1) // only scout visible
+  assert.equal(sectionA.peerCount, 2) // header count remains the full assigned range
+  assert.equal(sectionA.peers[0].peerId, 'legacy::scout')
+})
+
+// ── Drag-and-drop helpers ───────────────────────────────────────────────────
+
+test('manualOrderBucketKey: collision-safe across modes and adversarial names', () => {
+  const { manualOrderBucketKey, MANUAL_ORDER_UNASSIGNED_KEY } = load()
+
+  assert.equal(manualOrderBucketKey(VIEW_GROUPING_SECTIONS, null), MANUAL_ORDER_UNASSIGNED_KEY)
+  assert.equal(manualOrderBucketKey(VIEW_GROUPING_SECTIONS, 'section:A'), 'section:A')
+  // A section literally named "unassigned" still lives under its `section:` key,
+  // never the reserved unassigned bucket.
+  assert.equal(manualOrderBucketKey(VIEW_GROUPING_SECTIONS, 'section:unassigned'), 'section:unassigned')
+  assert.notEqual(manualOrderBucketKey(VIEW_GROUPING_SECTIONS, 'section:unassigned'), MANUAL_ORDER_UNASSIGNED_KEY)
+
+  assert.equal(manualOrderBucketKey(VIEW_GROUPING_GROUPS, null), MANUAL_ORDER_UNASSIGNED_KEY)
+  assert.equal(manualOrderBucketKey(VIEW_GROUPING_GROUPS, 'Engineering'), 'group:Engineering')
+  // A group literally named "unassigned" is namespaced under `group:`.
+  assert.equal(manualOrderBucketKey(VIEW_GROUPING_GROUPS, 'unassigned'), 'group:unassigned')
+  assert.notEqual(manualOrderBucketKey(VIEW_GROUPING_GROUPS, 'unassigned'), MANUAL_ORDER_UNASSIGNED_KEY)
+})
+
+test('reorderPeerInto: moves a peer onto a target, returns a new array, never mutates input', () => {
+  const { reorderPeerInto } = load()
+  const order = ['a', 'b', 'c', 'd']
+  // Move 'a' before 'c' → ['b','a','c','d'] (index adjust: to > from, shifts left)
+  const next = reorderPeerInto(order, 'a', 'c')
+  assert.equal(JSON.stringify(next), JSON.stringify(['b', 'a', 'c', 'd']))
+  // Input untouched
+  assert.equal(JSON.stringify(order), JSON.stringify(['a', 'b', 'c', 'd']))
+})
+
+test('reorderPeerInto: null target appends to the end', () => {
+  const { reorderPeerInto } = load()
+  assert.equal(JSON.stringify(reorderPeerInto(['a', 'b', 'c'], 'a', null)), JSON.stringify(['b', 'c', 'a']))
+})
+
+test('reorderPeerInto: no-op returns null when target absent or already in place', () => {
+  const { reorderPeerInto } = load()
+  assert.equal(reorderPeerInto(['a', 'b'], 'a', 'ghost'), null)
+  assert.equal(reorderPeerInto(['a', 'b'], 'a', 'a'), null)
+  assert.equal(reorderPeerInto(['a', 'b'], 'b', null), null) // already last
+})
+
+test('reorderPeerInto: a peer absent from the range is a cross-range insert at the target slot', () => {
+  const { reorderPeerInto } = load()
+  // Dropping a peer that is not yet in the range onto a target inserts it at
+  // the target's slot (before it); dropping onto empty space appends.
+  assert.equal(JSON.stringify(reorderPeerInto(['hermes'], 'atlas', 'hermes')), JSON.stringify(['atlas', 'hermes']))
+  assert.equal(JSON.stringify(reorderPeerInto(['hermes'], 'atlas', null)), JSON.stringify(['hermes', 'atlas']))
+})
+
+test('reorderPeerInto: dropping on itself is always a no-op', () => {
+  const { reorderPeerInto } = load()
+  const ids = ['a', 'b', 'c']
+
+  assert.equal(reorderPeerInto(ids, 'a', 'a', 'before'), null)
+  assert.equal(reorderPeerInto(ids, 'a', 'a', 'after'), null)
+  assert.equal(reorderPeerInto(ids, 'b', 'b', 'after'), null)
+  assert.equal(JSON.stringify(ids), JSON.stringify(['a', 'b', 'c']))
+})
+
+test('reorderPeerInto position=before: inserts before the target (default)', () => {
+  const { reorderPeerInto } = load()
+  // Explicit 'before' is the default — insert at target's index, adjusted when
+  // the peer was ahead of the target (to > from shifts left).
+  assert.equal(JSON.stringify(reorderPeerInto(['a', 'b', 'c'], 'a', 'c', 'before')), JSON.stringify(['b', 'a', 'c']))
+  // Move 'c' before 'a' — 'c' is after 'a', so no index shift needed.
+  assert.equal(JSON.stringify(reorderPeerInto(['a', 'b', 'c'], 'c', 'a', 'before')), JSON.stringify(['c', 'a', 'b']))
+})
+
+test('reorderPeerInto position=after: inserts after the target', () => {
+  const { reorderPeerInto } = load()
+  // In-range move: 'a' after 'c' → [b, c, a]
+  assert.equal(JSON.stringify(reorderPeerInto(['a', 'b', 'c'], 'a', 'c', 'after')), JSON.stringify(['b', 'c', 'a']))
+  // Cross-range insert after target: 'x' after 'c' → [a, b, c, x]
+  assert.equal(
+    JSON.stringify(reorderPeerInto(['a', 'b', 'c'], 'x', 'c', 'after')),
+    JSON.stringify(['a', 'b', 'c', 'x'])
+  )
+  // Cross-range insert after FIRST item: 'x' after 'a' → [a, x, b, c]
+  assert.equal(
+    JSON.stringify(reorderPeerInto(['a', 'b', 'c'], 'x', 'a', 'after')),
+    JSON.stringify(['a', 'x', 'b', 'c'])
+  )
+})
+
+test('reorderPeerInto position=after with null target appends (same as before)', () => {
+  const { reorderPeerInto } = load()
+  assert.equal(JSON.stringify(reorderPeerInto(['a', 'b'], 'a', null, 'after')), JSON.stringify(['b', 'a']))
+})
+
+test('reorderPeerInto position=after: no-op when already after target', () => {
+  const { reorderPeerInto } = load()
+  // 'b' is already directly after 'a' — no change
+  assert.equal(reorderPeerInto(['a', 'b'], 'b', 'a', 'after'), null)
+  // 'a' after last is no-op (same as null append for last)
+  assert.equal(reorderPeerInto(['x', 'a'], 'a', null, 'after'), null)
+})
+
+test('reorderPeerInto position=before: no-op boundaries', () => {
+  const { reorderPeerInto } = load()
+  // Already before target
+  assert.equal(reorderPeerInto(['a', 'b', 'c'], 'a', 'b', 'before'), null)
+  // Unknown target
+  assert.equal(reorderPeerInto(['a', 'b'], 'a', 'ghost', 'before'), null)
+  // Same peer
+  assert.equal(reorderPeerInto(['a', 'b'], 'a', 'a', 'before'), null)
+})
+
+// ── applyPeerDrop ───────────────────────────────────────────────────────────
+
+test('applyPeerDrop Sections + alpha: assigns a peer to a section, no reorder', () => {
+  const { applyPeerDrop } = load()
+
+  const viewState = {
+    visualSections: [{ key: 'section:A', title: 'Core', order: 0 }],
+    sectionAssignments: {},
+    sectionOrder: ['section:A']
+  }
+
+  const patch = applyPeerDrop(viewState, {
+    peerId: 'legacy::atlas',
+    kind: 'bot',
+    grouping: VIEW_GROUPING_SECTIONS,
+    sort: VIEW_SORT_ALPHA,
+    fromRangeKey: null,
+    toRangeKey: 'section:A',
+    targetPeerId: null,
+    rangePeerIds: ['legacy::atlas']
+  })
+
+  assert.equal(patch.sectionAssignments['legacy::atlas'], 'section:A')
+  assert.equal(patch.manualOrderUnassigned, undefined, 'alpha sort never reorders')
+})
+
+test('applyPeerDrop Sections: dropping on the Unassigned range unassigns', () => {
+  const { applyPeerDrop } = load()
+
+  const viewState = {
+    visualSections: [{ key: 'section:A', title: 'Core', order: 0 }],
+    sectionAssignments: { 'legacy::atlas': 'section:A' },
+    sectionOrder: ['section:A']
+  }
+
+  const patch = applyPeerDrop(viewState, {
+    peerId: 'legacy::atlas',
+    kind: 'bot',
+    grouping: VIEW_GROUPING_SECTIONS,
+    sort: VIEW_SORT_PINNED_RECENCY,
+    fromRangeKey: 'section:A',
+    toRangeKey: null,
+    targetPeerId: null,
+    rangePeerIds: ['legacy::atlas']
+  })
+
+  assert.equal(patch.sectionAssignments['legacy::atlas'], undefined)
+  assert.equal(Object.keys(patch.sectionAssignments).length, 0)
+})
+
+test('applyPeerDrop Sections + manual: assigns AND inserts into the target range bucket', () => {
+  const { applyPeerDrop } = load()
+
+  const viewState = {
+    visualSections: [{ key: 'section:A', title: 'Core', order: 0 }],
+    sectionAssignments: {},
+    sectionOrder: ['section:A'],
+    manualOrderUnassigned: {}
+  }
+
+  const patch = applyPeerDrop(viewState, {
+    peerId: 'legacy::atlas',
+    kind: 'bot',
+    grouping: VIEW_GROUPING_SECTIONS,
+    sort: VIEW_SORT_MANUAL,
+    fromRangeKey: null,
+    toRangeKey: 'section:A',
+    targetPeerId: null,
+    rangePeerIds: ['legacy::hermes']
+  })
+
+  assert.equal(patch.sectionAssignments['legacy::atlas'], 'section:A')
+  // atlas is appended into section:A's bucket (rangePeerIds [hermes] + atlas at end)
+  assert.equal(
+    JSON.stringify(patch.manualOrderUnassigned['section:A']),
+    JSON.stringify(['legacy::hermes', 'legacy::atlas'])
+  )
+})
+
+test('applyPeerDrop Sections + manual: collapsed Section header appends without discarding hidden order', () => {
+  const { applyPeerDrop } = load()
+
+  const viewState = {
+    visualSections: [{ key: 'section:A', title: 'Core', order: 0 }],
+    sectionAssignments: { 'legacy::a': 'section:A', 'legacy::b': 'section:A' },
+    sectionOrder: ['section:A'],
+    manualOrderUnassigned: { 'section:A': ['legacy::a', 'legacy::b'] }
+  }
+
+  const patch = applyPeerDrop(viewState, {
+    peerId: 'legacy::c',
+    kind: 'bot',
+    grouping: VIEW_GROUPING_SECTIONS,
+    sort: VIEW_SORT_MANUAL,
+    fromRangeKey: null,
+    toRangeKey: 'section:A',
+    targetPeerId: null,
+    rangePeerIds: []
+  })
+
+  assert.deepEqual(patch.manualOrderUnassigned['section:A'], ['legacy::a', 'legacy::b', 'legacy::c'])
+})
+
+test('applyPeerDrop Sections + manual: reorder within the same section', () => {
+  const { applyPeerDrop } = load()
+
+  const viewState = {
+    visualSections: [{ key: 'section:A', title: 'Core', order: 0 }],
+    sectionAssignments: { 'legacy::atlas': 'section:A', 'legacy::hermes': 'section:A' },
+    sectionOrder: ['section:A'],
+    manualOrderUnassigned: { 'section:A': ['legacy::atlas', 'legacy::hermes'] }
+  }
+
+  // Move hermes before atlas (was [atlas, hermes] → [hermes, atlas])
+  const patch = applyPeerDrop(viewState, {
+    peerId: 'legacy::hermes',
+    kind: 'bot',
+    grouping: VIEW_GROUPING_SECTIONS,
+    sort: VIEW_SORT_MANUAL,
+    fromRangeKey: 'section:A',
+    toRangeKey: 'section:A',
+    targetPeerId: 'legacy::atlas',
+    rangePeerIds: ['legacy::atlas', 'legacy::hermes']
+  })
+
+  assert.equal(
+    JSON.stringify(patch.manualOrderUnassigned['section:A']),
+    JSON.stringify(['legacy::hermes', 'legacy::atlas'])
+  )
+})
+
+test('applyPeerDrop None + manual: reorders the flat bucket', () => {
+  const { applyPeerDrop } = load()
+  const viewState = { manualOrderNone: ['legacy::atlas', 'legacy::hermes', 'legacy::scout'] }
+
+  const patch = applyPeerDrop(viewState, {
+    peerId: 'legacy::scout',
+    kind: 'bot',
+    grouping: VIEW_GROUPING_NONE,
+    sort: VIEW_SORT_MANUAL,
+    fromRangeKey: null,
+    toRangeKey: null,
+    targetPeerId: 'legacy::atlas',
+    rangePeerIds: ['legacy::atlas', 'legacy::hermes', 'legacy::scout']
+  })
+
+  assert.equal(
+    JSON.stringify(patch.manualOrderNone),
+    JSON.stringify(['legacy::scout', 'legacy::atlas', 'legacy::hermes'])
+  )
+})
+
+test('applyPeerDrop None + alpha/recency: sort is authoritative, no reorder', () => {
+  const { applyPeerDrop } = load()
+  const viewState = { manualOrderNone: ['legacy::atlas'] }
+
+  const patch = applyPeerDrop(viewState, {
+    peerId: 'legacy::atlas',
+    kind: 'bot',
+    grouping: VIEW_GROUPING_NONE,
+    sort: VIEW_SORT_ALPHA,
+    fromRangeKey: null,
+    toRangeKey: null,
+    targetPeerId: null,
+    rangePeerIds: ['legacy::atlas']
+  })
+
+  assert.equal(patch, null)
+})
+
+test('applyPeerDrop Groups + manual: reorders within the same automatic group', () => {
+  const { applyPeerDrop } = load()
+  const viewState = { manualOrderGroups: { 'group:Engineering': ['legacy::atlas', 'legacy::kiln'] } }
+
+  // Move kiln before atlas (was [atlas, kiln] → [kiln, atlas])
+  const patch = applyPeerDrop(viewState, {
+    peerId: 'legacy::kiln',
+    kind: 'bot',
+    grouping: VIEW_GROUPING_GROUPS,
+    sort: VIEW_SORT_MANUAL,
+    fromRangeKey: 'Engineering',
+    toRangeKey: 'Engineering',
+    targetPeerId: 'legacy::atlas',
+    rangePeerIds: ['legacy::atlas', 'legacy::kiln']
+  })
+
+  assert.equal(
+    JSON.stringify(patch.manualOrderGroups['group:Engineering']),
+    JSON.stringify(['legacy::kiln', 'legacy::atlas'])
+  )
+})
+
+test('applyPeerDrop Groups + manual: cross-group drop is ignored and never mutates groups[]', () => {
+  const { applyPeerDrop } = load()
+  const viewState = { manualOrderGroups: { 'group:Engineering': ['legacy::atlas'] } }
+
+  const patch = applyPeerDrop(viewState, {
+    peerId: 'legacy::atlas',
+    kind: 'bot',
+    grouping: VIEW_GROUPING_GROUPS,
+    sort: VIEW_SORT_MANUAL,
+    fromRangeKey: 'Engineering',
+    toRangeKey: 'Research',
+    targetPeerId: 'legacy::scout',
+    rangePeerIds: ['legacy::scout']
+  })
+
+  assert.equal(patch, null, 'cross-group drop must be ignored')
+  // viewState.manualOrderGroups untouched (no mutation of groups[]/rooms)
+  assert.equal(JSON.stringify(viewState.manualOrderGroups), JSON.stringify({ 'group:Engineering': ['legacy::atlas'] }))
+})
+
+test('applyPeerDrop Groups + alpha/recency: authoritative, no reorder', () => {
+  const { applyPeerDrop } = load()
+
+  const patch = applyPeerDrop(
+    { manualOrderGroups: {} },
+    {
+      peerId: 'legacy::atlas',
+      kind: 'bot',
+      grouping: VIEW_GROUPING_GROUPS,
+      sort: VIEW_SORT_ALPHA,
+      fromRangeKey: 'Engineering',
+      toRangeKey: 'Engineering',
+      targetPeerId: null,
+      rangePeerIds: ['legacy::atlas']
+    }
+  )
+
+  assert.equal(patch, null)
+})
+
+test('applyPeerDrop Sections + manual + position=after: cross-range insert after target', () => {
+  const { applyPeerDrop } = load()
+
+  const viewState = {
+    visualSections: [{ key: 'section:A', title: 'Core', order: 0 }],
+    sectionAssignments: {},
+    sectionOrder: ['section:A'],
+    manualOrderUnassigned: { 'section:A': ['legacy::hermes'] }
+  }
+
+  // Insert atlas AFTER hermes into section:A's manual bucket
+  const patch = applyPeerDrop(viewState, {
+    peerId: 'legacy::atlas',
+    kind: 'bot',
+    grouping: VIEW_GROUPING_SECTIONS,
+    sort: VIEW_SORT_MANUAL,
+    fromRangeKey: null,
+    toRangeKey: 'section:A',
+    targetPeerId: 'legacy::hermes',
+    position: 'after',
+    rangePeerIds: ['legacy::hermes']
+  })
+
+  assert.equal(patch.sectionAssignments['legacy::atlas'], 'section:A')
+  assert.equal(
+    JSON.stringify(patch.manualOrderUnassigned['section:A']),
+    JSON.stringify(['legacy::hermes', 'legacy::atlas'])
+  )
+})
+
+test('applyPeerDrop Sections + manual + position=after: reorder after target within same section', () => {
+  const { applyPeerDrop } = load()
+
+  const viewState = {
+    visualSections: [{ key: 'section:A', title: 'Core', order: 0 }],
+    sectionAssignments: { 'legacy::atlas': 'section:A', 'legacy::hermes': 'section:A' },
+    sectionOrder: ['section:A'],
+    manualOrderUnassigned: { 'section:A': ['legacy::atlas', 'legacy::hermes'] }
+  }
+
+  // Move atlas after hermes (was [atlas, hermes] → [hermes, atlas])
+  const patch = applyPeerDrop(viewState, {
+    peerId: 'legacy::atlas',
+    kind: 'bot',
+    grouping: VIEW_GROUPING_SECTIONS,
+    sort: VIEW_SORT_MANUAL,
+    fromRangeKey: 'section:A',
+    toRangeKey: 'section:A',
+    targetPeerId: 'legacy::hermes',
+    position: 'after',
+    rangePeerIds: ['legacy::atlas', 'legacy::hermes']
+  })
+
+  assert.equal(
+    JSON.stringify(patch.manualOrderUnassigned['section:A']),
+    JSON.stringify(['legacy::hermes', 'legacy::atlas'])
+  )
+})
+
+test('applyPeerDrop adversarial: a Bot named "group:x" and the group "x" key independently', () => {
+  const { applyPeerDrop, groupPeerIdentity } = load()
+
+  // The group's peerId is `group:Engineering`; a bot's peerId is `legacy::group:Engineering`
+  // (botRosterKey namespaces the bot, so they cannot collide). Both are opaque to
+  // the drop resolver — assignment keys by exact identity only.
+  const viewState = {
+    visualSections: [{ key: 'section:A', title: 'Core', order: 0 }],
+    sectionAssignments: { [groupPeerIdentity('Engineering')]: 'section:A' },
+    sectionOrder: ['section:A']
+  }
+
+  const botPeerId = 'legacy::group:Engineering'
+
+  const patch = applyPeerDrop(viewState, {
+    peerId: botPeerId,
+    kind: 'bot',
+    grouping: VIEW_GROUPING_SECTIONS,
+    sort: VIEW_SORT_ALPHA,
+    fromRangeKey: null,
+    toRangeKey: 'section:A',
+    targetPeerId: null,
+    rangePeerIds: [botPeerId]
+  })
+
+  // The BOT gets its own assignment; the group's assignment is untouched.
+  assert.equal(patch.sectionAssignments[botPeerId], 'section:A')
+  assert.equal(patch.sectionAssignments[groupPeerIdentity('Engineering')], 'section:A')
+})
+
+test('applyPeerDrop adversarial: a group named "unassigned" cannot collide with the reserved bucket', () => {
+  const { applyPeerDrop, manualOrderBucketKey } = load()
+  assert.notEqual(manualOrderBucketKey(VIEW_GROUPING_GROUPS, 'unassigned'), 'unassigned')
+
+  // Dragging a bot within a group named "unassigned" lands in `group:unassigned`,
+  // never the reserved `unassigned` key.
+  const patch = applyPeerDrop(
+    { manualOrderGroups: {} },
+    {
+      peerId: 'legacy::atlas',
+      kind: 'bot',
+      grouping: VIEW_GROUPING_GROUPS,
+      sort: VIEW_SORT_MANUAL,
+      fromRangeKey: 'unassigned',
+      toRangeKey: 'unassigned',
+      targetPeerId: 'legacy::hermes',
+      rangePeerIds: ['legacy::hermes', 'legacy::atlas']
+    }
+  )
+
+  assert.equal(
+    JSON.stringify(patch.manualOrderGroups['group:unassigned']),
+    JSON.stringify(['legacy::atlas', 'legacy::hermes'])
+  )
+  assert.equal(patch.manualOrderGroups['unassigned'], undefined)
+})
+
+// ── applySectionDrop ────────────────────────────────────────────────────────
+
+test('applySectionDrop: reorders two visual sections', () => {
+  const { applySectionDrop } = load()
+
+  const viewState = {
+    visualSections: [
+      { key: 'section:A', title: 'A', order: 0 },
+      { key: 'section:B', title: 'B', order: 1 }
+    ],
+    sectionOrder: ['section:A', 'section:B']
+  }
+
+  const patch = applySectionDrop(viewState, { sectionKey: 'section:B', toSectionKey: 'section:A' })
+  assert.equal(JSON.stringify(patch.sectionOrder), JSON.stringify(['section:B', 'section:A']))
+  assert.equal(patch.sectionAssignments, undefined, 'section reorder never touches assignments')
+})
+
+test('applySectionDrop: honors before and after insertion positions', () => {
+  const { applySectionDrop } = load()
+
+  const viewState = {
+    visualSections: [
+      { key: 'section:A', title: 'A', order: 0 },
+      { key: 'section:B', title: 'B', order: 1 },
+      { key: 'section:C', title: 'C', order: 2 }
+    ],
+    sectionOrder: ['section:A', 'section:B', 'section:C']
+  }
+
+  const after = applySectionDrop(viewState, {
+    sectionKey: 'section:A',
+    toSectionKey: 'section:B',
+    position: 'after'
+  })
+
+  assert.equal(JSON.stringify(after.sectionOrder), JSON.stringify(['section:B', 'section:A', 'section:C']))
+
+  const before = applySectionDrop(viewState, {
+    sectionKey: 'section:C',
+    toSectionKey: 'section:B',
+    position: 'before'
+  })
+
+  assert.equal(JSON.stringify(before.sectionOrder), JSON.stringify(['section:A', 'section:C', 'section:B']))
+})
+
+test('applySectionDrop: same section or unknown target is a no-op', () => {
+  const { applySectionDrop } = load()
+
+  const viewState = {
+    visualSections: [{ key: 'section:A', title: 'A', order: 0 }],
+    sectionOrder: ['section:A']
+  }
+
+  assert.equal(applySectionDrop(viewState, { sectionKey: 'section:A', toSectionKey: 'section:A' }), null)
+  assert.equal(applySectionDrop(viewState, { sectionKey: 'section:A', toSectionKey: 'section:GHOST' }), null)
+  assert.equal(applySectionDrop(viewState, {}), null)
+})
+
+// ── Per-range manual order in applyGroupingMode ─────────────────────────────
+
+test('applyGroupingMode Sections + manual: each range obeys its own order bucket', () => {
+  const { applyGroupingMode, VIEW_GROUPING_SECTIONS, VIEW_SORT_MANUAL } = load()
+
+  const peers = [
+    { kind: 'bot', peerId: 'legacy::a', name: 'a', groups: [], meta: meta(), botRow: { name: 'a' } },
+    { kind: 'bot', peerId: 'legacy::b', name: 'b', groups: [], meta: meta(), botRow: { name: 'b' } },
+    { kind: 'bot', peerId: 'legacy::c', name: 'c', groups: [], meta: meta(), botRow: { name: 'c' } },
+    { kind: 'bot', peerId: 'legacy::d', name: 'd', groups: [], meta: meta(), botRow: { name: 'd' } }
+  ]
+
+  const viewState = {
+    sort: VIEW_SORT_MANUAL,
+    visualSections: [
+      { key: 'section:A', title: 'A', order: 0 },
+      { key: 'section:B', title: 'B', order: 1 }
+    ],
+    sectionAssignments: {
+      'legacy::a': 'section:A',
+      'legacy::b': 'section:A',
+      'legacy::c': 'section:B',
+      'legacy::d': 'section:B'
+    },
+    sectionCollapsed: {},
+    sectionOrder: ['section:A', 'section:B'],
+    manualOrderUnassigned: {
+      'section:A': ['legacy::b', 'legacy::a'], // b before a (reverse of input)
+      'section:B': ['legacy::d', 'legacy::c']
+    }
+  }
+
+  const result = applyGroupingMode(VIEW_GROUPING_SECTIONS, peers, viewState, false)
+  const sectionA = result.find(r => r.sectionKey === 'section:A')
+  const sectionB = result.find(r => r.sectionKey === 'section:B')
+  assert.equal(JSON.stringify(sectionA.peers.map(p => p.peerId)), JSON.stringify(['legacy::b', 'legacy::a']))
+  assert.equal(JSON.stringify(sectionB.peers.map(p => p.peerId)), JSON.stringify(['legacy::d', 'legacy::c']))
+})
+
+test('applyGroupingMode Groups + manual: ungrouped and per-group buckets are authoritative', () => {
+  const { applyGroupingMode, VIEW_GROUPING_GROUPS, VIEW_SORT_MANUAL } = load()
+
+  const peers = [
+    { kind: 'bot', peerId: 'legacy::u1', name: 'u1', groups: [], meta: meta(), botRow: { name: 'u1' } },
+    { kind: 'bot', peerId: 'legacy::u2', name: 'u2', groups: [], meta: meta(), botRow: { name: 'u2' } },
+    { kind: 'bot', peerId: 'legacy::a', name: 'a', groups: ['Eng'], meta: meta(), botRow: { name: 'a' } },
+    { kind: 'bot', peerId: 'legacy::b', name: 'b', groups: ['Eng'], meta: meta(), botRow: { name: 'b' } },
+    { kind: 'group', peerId: 'group:Eng', title: 'Eng', meta: null }
+  ]
+
+  const viewState = {
+    sort: VIEW_SORT_MANUAL,
+    manualOrderGroups: {
+      unassigned: ['legacy::u2', 'legacy::u1'],
+      'group:Eng': ['legacy::b', 'legacy::a']
+    }
+  }
+
+  const result = applyGroupingMode(VIEW_GROUPING_GROUPS, peers, viewState, false)
+  const standalone = result.filter(r => r.level === 0 && r.kind === 'bot')
+  assert.equal(
+    JSON.stringify(standalone.map(p => p.peerId)),
+    JSON.stringify(['legacy::u2', 'legacy::u1', 'legacy::a', 'legacy::b'])
+  )
+
+  const eng = result.find(r => r.peerId === 'group:Eng')
+  assert.equal(JSON.stringify(eng.children.map(c => c.peerId)), JSON.stringify(['legacy::b', 'legacy::a']))
+})

--- a/apps/desktop/src/plugins/hermes-bots/roster-view.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-view.test.ts
@@ -1,0 +1,445 @@
+import { ContextMenu, ContextMenuTrigger, DropdownMenu, DropdownMenuTrigger } from '@hermes/plugin-sdk'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { createElement } from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+// Exercise the real ESM module; production never exposes this seam.
+;(globalThis as any).__HERMES_BOTS_TEST__ = true
+// @ts-expect-error Bot Mode is an intentionally plain-JavaScript bundled plugin.
+await import('./plugin.js')
+const plugin = (globalThis as any).__HERMES_BOTS_TEST_API__
+
+const {
+  $groupChats,
+  $lastRoster,
+  $botMeta,
+  $viewStateWrapper,
+  applyGroupingMode,
+  applyKeyboardPeerMove,
+  BOT_LOCALES,
+  BotRow,
+  GroupRowEnhanced,
+  hydrateViewState,
+  insertionMatches,
+  ManageSectionsDialog,
+  MoveToSectionMenu,
+  normalizeViewState,
+  remapGroupViewState,
+  renderProjectedRoster,
+  SectionHeader,
+  setPluginCtxForTest,
+  ViewMenuContent
+} = plugin
+
+const translate = (key: string, ...args: unknown[]) => {
+  let value: any = BOT_LOCALES.en
+
+  for (const part of key.split('.')) {
+    value = value?.[part]
+  }
+
+  return typeof value === 'function' ? value(...args) : String(value ?? key)
+}
+
+setPluginCtxForTest({ i18n: { t: translate } })
+
+afterEach(() => cleanup())
+
+describe('Bot roster localized copy', () => {
+  it('ships the same message contract for every supported locale', () => {
+    const flatten = (value: any, prefix = ''): string[] =>
+      Object.entries(value)
+        .flatMap(([key, child]) => {
+          const path = prefix ? `${prefix}.${key}` : key
+
+          return child && typeof child === 'object' ? flatten(child, path) : [path]
+        })
+        .sort()
+
+    const enKeys = flatten(BOT_LOCALES.en)
+
+    expect(Object.keys(BOT_LOCALES).sort()).toEqual(['en', 'ja', 'zh', 'zh-hant'])
+
+    for (const bundle of Object.values(BOT_LOCALES)) {
+      expect(flatten(bundle)).toEqual(enKeys)
+    }
+
+    expect(BOT_LOCALES.ja.view.grouping).not.toBe(BOT_LOCALES.en.view.grouping)
+  })
+})
+
+describe('Bot roster view state lifecycle', () => {
+  it('starts with a renderable normalized state before async storage hydration', () => {
+    expect($viewStateWrapper.get().state).toEqual(normalizeViewState(null))
+  })
+
+  it('rejects hydration when a local mutation lands after the read starts', () => {
+    const initial = {
+      state: normalizeViewState(null),
+      token: 0,
+      localGeneration: 0
+    }
+
+    const locallyMutated = {
+      state: normalizeViewState({ grouping: 'sections' }),
+      token: 0,
+      localGeneration: 1
+    }
+
+    expect(hydrateViewState(locallyMutated, { grouping: 'groups' }, 1, initial.localGeneration)).toBe(locallyMutated)
+  })
+
+  it('accepts a newer hydration when the generation is unchanged since read start', () => {
+    const current = {
+      state: normalizeViewState({ grouping: 'none' }),
+      token: 1,
+      localGeneration: 3
+    }
+
+    const hydrated = hydrateViewState(current, { grouping: 'sections' }, 2, current.localGeneration)
+
+    expect(hydrated.state.grouping).toBe('sections')
+    expect(hydrated.token).toBe(2)
+    expect(hydrated.localGeneration).toBe(3)
+  })
+})
+
+describe('Bot roster projection contracts', () => {
+  const botPeer = (peerId: string, name: string, groups: string[] = []) => ({
+    kind: 'bot',
+    peerId,
+    name,
+    groups,
+    botRow: { name },
+    meta: { groups }
+  })
+
+  const groupPeer = (
+    title: string,
+    members: Array<{ name: string; connectionId?: string; remoteSource?: boolean }> = []
+  ) => ({
+    kind: 'group',
+    peerId: `group:${title}`,
+    title,
+    members
+  })
+
+  it('preserves the selected top-level order when shortcut nesting is enabled', () => {
+    const alpha = botPeer('legacy::alpha', 'Alpha', ['Bravo'])
+    const bravo = groupPeer('Bravo', [{ name: 'Alpha' }])
+    const charlie = botPeer('legacy::charlie', 'Charlie')
+
+    const projected = applyGroupingMode('none', [alpha, bravo, charlie], { nestedExpansion: {} }, true)
+
+    expect(projected.map((item: { peerId: string }) => item.peerId)).toEqual([
+      'legacy::alpha',
+      'group:Bravo',
+      'legacy::charlie'
+    ])
+  })
+
+  it('uses source-qualified seated group members for shortcut children', () => {
+    const remote = {
+      ...botPeer('mini::spark', 'spark'),
+      botRow: { name: 'spark', remoteSource: true, connectionId: 'mini', sourceScoped: true }
+    }
+
+    const group = groupPeer('Remote', [{ name: 'spark', remoteSource: true, connectionId: 'mini' }])
+
+    const projected = applyGroupingMode('groups', [remote, group], {}, true)
+    const shortcut = projected.find((item: { peerId: string }) => item.peerId === 'group:Remote')
+
+    expect(shortcut.children.map((item: { peerId: string }) => item.peerId)).toEqual(['mini::spark'])
+  })
+
+  it('returns no projection for a Sections search with no matches', () => {
+    const projected = applyGroupingMode(
+      'sections',
+      [botPeer('legacy::atlas', 'Atlas')],
+      {
+        visualSections: [{ key: 'section:core', title: 'Core' }],
+        sectionAssignments: { 'legacy::atlas': 'section:core' },
+        sectionOrder: ['section:core'],
+        sectionCollapsed: {},
+        nestedExpansion: {}
+      },
+      false,
+      { query: 'missing', matchesBotId: new Set() }
+    )
+
+    expect(projected).toEqual([])
+  })
+
+  it('temporarily expands a collapsed Section to reveal a search match', () => {
+    const projected = applyGroupingMode(
+      'sections',
+      [botPeer('legacy::atlas', 'Atlas')],
+      {
+        visualSections: [{ key: 'section:core', title: 'Core' }],
+        sectionAssignments: { 'legacy::atlas': 'section:core' },
+        sectionOrder: ['section:core'],
+        sectionCollapsed: { 'section:core': true },
+        nestedExpansion: {}
+      },
+      false,
+      { query: 'atlas', matchesBotId: new Set(['legacy::atlas']) }
+    )
+
+    expect(projected).toHaveLength(1)
+    expect(projected[0].collapsed).toBe(false)
+    expect(projected[0].peers.map((item: { peerId: string }) => item.peerId)).toEqual(['legacy::atlas'])
+  })
+
+  it('migrates or clears group-keyed view state when a room identity changes', () => {
+    const state = normalizeViewState({
+      visualSections: [{ key: 'section:core', title: 'Core' }],
+      sectionOrder: ['section:core'],
+      sectionAssignments: { 'group:Old': 'section:core' },
+      manualOrderNone: ['legacy::atlas', 'group:Old'],
+      manualOrderUnassigned: { 'section:core': ['group:Old'] },
+      manualOrderGroups: { 'group:Old': ['legacy::atlas'] },
+      nestedExpansion: { 'group:Old': true }
+    })
+
+    const renamed = normalizeViewState({ ...state, ...remapGroupViewState(state, 'Old', 'New') })
+    expect(renamed.sectionAssignments['group:New']).toBe('section:core')
+    expect(renamed.manualOrderNone).toContain('group:New')
+    expect(renamed.manualOrderGroups['group:New']).toEqual(['legacy::atlas'])
+    expect(renamed.nestedExpansion['group:New']).toBe(true)
+
+    const removed = normalizeViewState({ ...renamed, ...remapGroupViewState(renamed, 'New', null) })
+    expect(removed.sectionAssignments['group:New']).toBeUndefined()
+    expect(removed.manualOrderNone).not.toContain('group:New')
+    expect(removed.manualOrderGroups['group:New']).toBeUndefined()
+    expect(removed.nestedExpansion['group:New']).toBeUndefined()
+  })
+
+  it('reorders a manual peer range from the keyboard without drag state', () => {
+    const patch = applyKeyboardPeerMove(
+      normalizeViewState({ sort: 'manual', manualOrderNone: ['legacy::atlas', 'legacy::forge', 'legacy::scout'] }),
+      {
+        peerId: 'legacy::forge',
+        kind: 'bot',
+        grouping: 'none',
+        rangeKey: null,
+        rangePeerIds: ['legacy::atlas', 'legacy::forge', 'legacy::scout'],
+        delta: -1
+      }
+    )
+
+    expect(patch.manualOrderNone).toEqual(['legacy::forge', 'legacy::atlas', 'legacy::scout'])
+  })
+
+  it('scopes insertion feedback to one shortcut range', () => {
+    const insertion = {
+      type: 'peer',
+      targetId: 'legacy::kiln',
+      position: 'before',
+      rangeKey: 'Engineering'
+    }
+
+    expect(insertionMatches(insertion, 'legacy::kiln', 'Engineering', 'before')).toBe(true)
+    expect(insertionMatches(insertion, 'legacy::kiln', 'Research', 'before')).toBe(false)
+    expect(insertionMatches(insertion, 'legacy::kiln', null, 'before')).toBe(false)
+  })
+})
+
+describe('Bot roster current-main integrations', () => {
+  it('exposes grouping/sorting and toggles as semantic menu controls', () => {
+    render(
+      createElement(DropdownMenu, {
+        open: true,
+        children: [
+          createElement(DropdownMenuTrigger, { key: 'trigger' }, 'Open'),
+          createElement(ViewMenuContent, {
+            key: 'content',
+            viewState: { grouping: 'sections', sort: 'manual', nestMembers: true, showHidden: true },
+            onSetGrouping: () => undefined,
+            onSetSort: () => undefined,
+            onToggleNest: () => undefined,
+            onToggleShowHidden: () => undefined,
+            onManageSections: () => undefined
+          })
+        ]
+      })
+    )
+
+    expect(screen.getAllByRole('menuitemradio')).toHaveLength(6)
+    expect(screen.getAllByRole('menuitemcheckbox')).toHaveLength(2)
+    expect(
+      screen.getAllByRole('menuitemradio').filter(item => item.getAttribute('data-state') === 'checked')
+    ).toHaveLength(2)
+  })
+
+  it('gives collapse and Section-management icon buttons accessible names without native titles', () => {
+    const { rerender } = render(
+      createElement(SectionHeader, {
+        title: 'Core',
+        collapsed: false,
+        peerCount: 2,
+        sectionKey: 'section:core'
+      })
+    )
+
+    const collapseSection = screen.getByRole('button', { name: 'Collapse Core' })
+    expect(collapseSection.getAttribute('title')).toBeNull()
+
+    rerender(
+      createElement(GroupRowEnhanced, {
+        group: 'Engineering',
+        members: [{ name: 'atlas' }],
+        needsYou: false,
+        onOpen: () => undefined,
+        collapsed: false,
+        peerId: 'group:Engineering',
+        viewState: { grouping: 'sections' },
+        collapsible: true,
+        onToggleCollapse: () => undefined
+      })
+    )
+    const collapseGroup = screen.getByRole('button', { name: 'Collapse Engineering' })
+    expect(collapseGroup.getAttribute('title')).toBeNull()
+
+    cleanup()
+    $lastRoster.set([{ name: 'atlas' }])
+    $botMeta.set({ atlas: { groups: [] } })
+    $groupChats.set({})
+    $viewStateWrapper.set({
+      state: normalizeViewState({
+        grouping: 'sections',
+        visualSections: [{ key: 'section:core', title: 'Core' }],
+        sectionOrder: ['section:core']
+      }),
+      token: 1,
+      localGeneration: 0
+    })
+    render(createElement(ManageSectionsDialog, { open: true, onClose: () => undefined }))
+
+    expect(screen.getByRole('button', { name: 'Move Core up' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Move Core down' })).toBeTruthy()
+    const renameButton = screen.getByRole('button', { name: 'Rename Core' })
+    expect(renameButton).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Delete Core' })).toBeTruthy()
+    expect(screen.getByRole('textbox', { name: 'New section name…' })).toBeTruthy()
+
+    const unassigned = screen.getByRole('button', { name: 'Move Atlas to Unassigned' })
+    const core = screen.getByRole('button', { name: 'Move Atlas to Core' })
+    expect(unassigned.getAttribute('aria-pressed')).toBe('true')
+    expect(core.getAttribute('aria-pressed')).toBe('false')
+
+    fireEvent.click(renameButton)
+    expect(screen.getByRole('textbox', { name: 'Rename Core' })).toBeTruthy()
+  })
+
+  it('does not advertise manual keyboard movement on automatic group headers', () => {
+    const tree = renderProjectedRoster(
+      [
+        {
+          kind: 'group',
+          peerId: 'group:Engineering',
+          title: 'Engineering',
+          members: [],
+          level: 0,
+          children: [],
+          isGroupHeader: true
+        }
+      ],
+      'groups',
+      {
+        setDeleting: () => undefined,
+        setEditing: () => undefined,
+        setGrouping: () => undefined,
+        groupNeedsYou: {},
+        openGroupChat: () => undefined,
+        viewState: { grouping: 'groups', sort: 'manual' },
+        toggleNestedGroup: () => undefined,
+        drag: {
+          canDragPeer: true,
+          canKeyboardMovePeer: true,
+          insertion: null,
+          endPeerDrag: () => undefined,
+          keyboardMovePeer: () => undefined
+        }
+      }
+    )
+
+    const { container } = render(createElement('div', null, tree))
+    const group = [...container.querySelectorAll('button')].find(button => button.textContent?.includes('Engineering'))
+
+    expect(group).toBeTruthy()
+    expect(group?.getAttribute('aria-keyshortcuts')).toBeNull()
+  })
+
+  it('renders a configured room picture in the active group-row component', () => {
+    $groupChats.set({
+      Engineering: { image: 'data:image/png;base64,room-picture', log: [] }
+    })
+
+    const { container } = render(
+      createElement(GroupRowEnhanced, {
+        group: 'Engineering',
+        members: [],
+        needsYou: false,
+        onOpen: () => undefined,
+        peerId: 'group:Engineering',
+        viewState: { grouping: 'none' }
+      })
+    )
+
+    expect(container.querySelector('img')?.getAttribute('src')).toBe('data:image/png;base64,room-picture')
+  })
+
+  it('exposes the current visual Section as a semantic context-menu radio choice', () => {
+    render(
+      createElement(ContextMenu, {
+        open: true,
+        children: [
+          createElement(ContextMenuTrigger, { key: 'trigger', children: 'Open' }),
+          createElement(MoveToSectionMenu, {
+            key: 'content',
+            peerId: 'mini::spark',
+            viewState: { grouping: 'sections' },
+            sectionAssignments: {},
+            sections: [{ key: 'section:core', title: 'Core' }]
+          })
+        ]
+      })
+    )
+
+    const choices = screen.getAllByRole('menuitemradio')
+    const unassigned = screen.getByRole('menuitemradio', { name: 'Unassigned' })
+    expect(choices).toHaveLength(2)
+    expect(unassigned.getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('offers Move to section for a source-qualified remote Bot without unsafe profile actions', async () => {
+    const { container } = render(
+      createElement(BotRow, {
+        bot: {
+          name: 'spark',
+          remoteSource: true,
+          sourceScoped: true,
+          connectionId: 'mini',
+          connectionLabel: 'Mini'
+        },
+        peerId: 'mini::spark',
+        viewState: {
+          grouping: 'sections',
+          sectionAssignments: {},
+          visualSections: [{ key: 'section:core', title: 'Core' }]
+        },
+        onDelete: () => undefined,
+        onEdit: () => undefined,
+        onGroup: () => undefined
+      })
+    )
+
+    const row = container.querySelector('button')
+    expect(row).not.toBeNull()
+    fireEvent.contextMenu(row!)
+
+    const moveToSection = await screen.findByText('Move to section')
+    expect(moveToSection).toBeTruthy()
+    expect(screen.queryByText('Edit Profile')).toBeNull()
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/hide-bots.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/hide-bots.test.mjs
@@ -57,7 +57,6 @@ globalThis.__hide = {
   $botUnread,
   $selectedBot,
   $lastRoster,
-  $showHiddenBots,
   $activityToasts,
   setPluginCtx: value => { pluginCtx = value }
 };
@@ -192,11 +191,6 @@ test('shape: roster list filters through isBotHidden unless the show-hidden togg
     /const visibleRoster = showHidden \? roster : roster\.filter\(bot => !isBotHidden\(bot, allMeta\)\)/
   )
   assert.match(pluginSource, /const filteredRoster = filterBots\(visibleRoster, allMeta, query\)/)
-})
-
-test('shape: header eye toggle renders only when at least one bot is hidden', () => {
-  assert.match(pluginSource, /hiddenBots\.length\s*\n?\s*\? jsx\(Tip, \{/)
-  assert.match(pluginSource, /onClick: \(\) => \$showHiddenBots\.set\(!showHidden\)/)
 })
 
 test('shape: revealed hidden rows are dimmed and flagged with the eye-closed glyph', () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/roster-groups.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/roster-groups.test.mjs
@@ -188,16 +188,3 @@ test('stripPreviewMarkdown: flattens bold, quotes, code, and links out of previe
   assert.equal(stripPreviewMarkdown('## Heading\nbody'), 'Heading body')
   assert.equal(stripPreviewMarkdown(''), '')
 })
-
-test('source contract: the roster stays a flat list of bot and group rows', () => {
-  // Ordering is deliberately unchanged in this PR; sectioned ordering follows separately.
-  assert.doesNotMatch(pluginSource, /function groupRoster\(/)
-  assert.match(pluginSource, /rosterRows\.map\(row =>/)
-  assert.match(pluginSource, /function GroupRow\(/)
-  assert.match(pluginSource, /onGroup: setGrouping/)
-})
-
-test('source contract: group rows carry the needs-you badge and open via openGroupChat', () => {
-  assert.match(pluginSource, /needsYou: Boolean\(groupNeedsYou\[row\.name\]\)/)
-  assert.match(pluginSource, /onOpen: openGroupChat/)
-})

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -776,7 +776,13 @@ export {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuLabel,
+  ContextMenuRadioGroup,
+  ContextMenuRadioItem,
   ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
   ContextMenuTrigger
 } from '@/components/ui/context-menu'
 export { CopyButton } from '@/components/ui/copy-button'
@@ -792,8 +798,12 @@ export {
 } from '@/components/ui/dialog'
 export {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'

--- a/website/docs/user-guide/bot-mode.md
+++ b/website/docs/user-guide/bot-mode.md
@@ -21,7 +21,7 @@ The roster shows one row per agent profile: avatar, latest-message preview, and 
 - **Sessions** (from a Bot's context menu) browses and filters that profile's 200 most recent stored conversations, without changing the primary click-to-chat flow.
 - **Active now** — a presence strip above the roster shows every Bot currently working: the gateway-busy profile plus any Bot that wrote within the last 90 seconds. Each chip opens that Bot's chat. The strip never reorders the roster and disappears when the fleet is idle.
 - **Search** filters the roster as you type.
-- **Hide a Bot** — right-click a row → **Hide Bot** to take a Bot you don't use out of the roster and the Active-now strip. Hiding is display-only: @mentions still resolve, group-chat memberships are untouched, and routines keep running. Once at least one Bot is hidden, an **eye toggle** appears in the pane header — click it to reveal hidden Bots dimmed in place, then right-click → **Unhide Bot** to bring one back. Hidden Bots never toast, but they accumulate unread activity silently and the eye badges a dot so you know something happened. Hidden state is saved in the Bot's profile metadata, so it follows the Bot to every desktop connected to that backend.
+- **Hide a Bot** — right-click a row → **Hide Bot** to take a Bot you don't use out of the roster and the Active-now strip. Hiding is display-only: @mentions still resolve, group-chat memberships are untouched, and routines keep running. Reveal hidden Bots (dimmed in place) with the **View → Show hidden bots** toggle, then right-click → **Unhide Bot** to bring one back. Hidden Bots never toast, but they accumulate unread activity silently and the View menu button badges a dot so you know something happened. Hidden state is saved in the Bot's profile metadata, so it follows the Bot to every desktop connected to that backend.
 
 :::note The canonical Bot Chat is a forever-chat
 Typing `/new` (or `/reset`) inside a Bot's canonical chat would fork the relationship into a scratch session — the one thing Bot Mode promises never happens. The composer reroutes it to `/compact` instead: fresh working context, same conversation. Regular sessions on the same profile keep full `/new` freedom.
@@ -78,7 +78,7 @@ Routines are plain [Hermes cron jobs](./features/cron.md) namespaced `[bot:<name
 
 Right-click a local Bot → **Manage groups** to add or remove it from any number of group chats. Pick existing groups independently or create one inline. Local membership is stored in the Bot's backend-synced profile metadata, so it follows that profile across desktops; older profiles with one legacy group continue to work. Connections Bots join through the New Group Chat picker and remain source-qualified in that room's local Desktop state.
 
-Groups are standalone rows in the same activity-ordered roster as Bot DMs. A Bot keeps one DM row even when it belongs to several groups, while every group gets its own room row with member count, latest-message preview, timestamp, and needs-you state.
+**Important: Bot Mode groups and user-created visual Sections are different concepts.** Groups are membership labels stored in Bot metadata — they determine which Bots belong to which group chat rooms and appear in the group-chat member roster. Visual Sections (see below) are manual divider headers for display only; they never alter Bot groups, room membership, routing, or canonical chats.
 
 **Open chat** on any group row (2–6 Bots) opens a shared room where the whole group coordinates:
 
@@ -88,6 +88,38 @@ Groups are standalone rows in the same activity-ordered roster as Bot DMs. A Bot
 - Each member keeps its own persistent `Group: <name>` session, so room context survives like any other conversation.
 - **Not every Bot replies to every message.** Speaking is each member's own choice — a Bot replies only when it has something new to add and passes otherwise, and @-mentioning specific members scopes the round to them. Expect the members you addressed (or whoever has something to say) to speak, and the rest to stay quiet.
 - **Rooms can span machines.** The New Group Chat picker seats Bots from any registered connection; each member's turns run on its own machine, in its own `Group: <name>` session there. Cross-machine members carry a device badge (`dixie · Mac Mini`) in the room and in other members' transcripts, and the disambiguated `@name-device` handle works in room mentions — so same-named agents on two machines never blur together.
+
+## View controls
+
+The **View** menu (list-filter icon in the Bots header) controls how the roster is displayed. All preferences persist across app restarts via local plugin storage:
+
+### Grouping (single select)
+
+- **None** — every Bot and group row is a flat list. No automatic section dividers. Group rows remain visible.
+- **Sections** — peers are partitioned by manually created visual Section dividers (see below). Unassigned peer rows appear above the first section. Section headers are individually collapsible.
+- **Groups** — every Bot remains as a standalone row, followed by automatic named group shortcuts in alphabetical order. Each shortcut duplicates its members beneath it, and multi-group Bots appear under every group they belong to.
+
+### Sorting (single select)
+
+- **Alphabetical A–Z** — peers sorted by display name (case-insensitive). Bots and groups intermix alphabetically.
+- **Pinned first then recent** — pinned Bots at the top (newest activity first), then unpinned Bots by recency, then group rows by room activity. Groups are never pinned. This is the default.
+- **Manual order** — drag-and-drop reorder the roster, or focus a row and press **Alt+↑ / Alt+↓** to move it one slot; new peers append deterministically at the bottom. Order is persisted per grouping mode and per range: the flat list in None mode, each visual Section (and the Unassigned range) in Sections mode, and each automatic group in Groups mode.
+
+### Group display
+
+- **Nest group members** — in None and Sections modes: ON expands group rows into shortcuts that duplicate their member Bots beneath them; every Bot still keeps its standalone draggable row. Multi-group Bots appear under EVERY group they belong to. OFF hides the shortcut copies while group rows and standalone Bots remain visible. In Groups mode, shortcut nesting is inherent and the toggle is ignored.
+
+### Display
+
+- **Show hidden bots** — reveal Bots hidden via right-click → Hide Bot. This is the single place to reveal hidden Bots; there is no separate eye button.
+
+### Manage Sections…
+
+Opens a dialog for creating, renaming, reordering, and deleting visual Sections, and assigning Bot peers and group peers to sections. Deleting a visual Section makes its assigned rows unassigned; it never deletes a group or Bot.
+
+In Sections grouping mode, right-click any Bot row or group row → **Move to section** to assign it to a visual Section or return it to Unassigned. You can also **drag-and-drop**: drag a Section header to reorder Sections, and drag a Bot or group row into a Section or onto the always-reserved **Unassigned** target above the first Section. The target highlights during an active drag without shifting the roster under the pointer. In Manual order, dropping a peer inside its own range also reorders that range; in Alphabetical and Pinned-then-recent sorts, a cross-range drop changes assignment only and the sort stays authoritative. In Groups mode + Manual order, Bots reorder only within their own automatic group — cross-group drops are ignored and never alter group membership. Visual Section headers are individually collapsible — collapse hides only rows assigned to that section (rows hidden by similar group-collapse state stay visible).
+
+**Search composes after the selected grouping and sort projection.** In None and Sections modes: a Bot query retains matching Bot rows; a group name or member query retains the group row. In Groups mode, the current group search behavior is preserved. A collapsed visual Section never buries a search match — active search reveals matching rows.
 
 ## Bot-to-bot messaging
 


### PR DESCRIPTION
## What does this PR do?

Adds configurable Bot Mode roster **Views** without changing Bot group membership, room routing, or canonical chats.

The Bots header now has one **View** menu for grouping, sorting, nested group shortcuts, hidden Bots, and visual Section management. Every Bot remains a standalone canonical row; group rows are shortcuts that can duplicate members beneath them, including source-qualified Connections Bots and Bots in multiple groups.

## Related work and dependency

No linked issue. I searched open/closed issues and PRs plus current source before submission.

- The earlier multi-group contribution, #88864, is closed; equivalent multi-group and cross-machine routing support is already on `main` (`9bea43918`, `4bb7e4913`). This PR therefore has **no open-PR dependency** and is based directly on current `main`.
- Related open work is complementary, not duplicate: #88912 (durable managed Groups), #89216 (model/token data in roster rows), #89020 (selected group highlighting), and #89301 (Routines docking). Those PRs touch the same bundled plugin and may require a straightforward rebase depending on merge order.

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes made

### One View menu

- grouping: **None**, **Sections**, or **Groups**
- sorting: **Alphabetical A–Z**, **Pinned first then recent**, or **Manual order**
- **Nest group members** shortcut copies
- **Show hidden bots** (replaces the standalone eye button)
- **Manage Sections…**

### Visual Sections

- create, rename, delete, reorder, collapse, and persist Sections
- assign/unassign Bot and group peers through Manage Sections, right-click **Move to section**, or drag-and-drop
- keep Unassigned peers above named Sections
- use indentation only for hierarchy—no Section color container
- preserve Section/group independence: assignments never mutate `groups[]`, room membership, routing, or canonical chats

### Roster projection and interaction

- keep every Bot as one standalone row in all modes
- render each group as a shortcut; duplicate multi-group and source-qualified members under every applicable group
- independently collapse group shortcuts and visual Sections
- preserve the selected sort/manual order when nesting is enabled
- native compact drag preview and exact before/after insertion feedback
- stable, always-reserved Unassigned target so drag start never reflows assigned rows or Section headers
- preserve hidden manual order when a peer is appended through a collapsed Section header
- keyboard manual reordering with **Alt+↑ / Alt+↓**
- search temporarily reveals matches hidden by collapse
- preserve room pictures, hidden/unread state, pin/recency semantics, same-name local/remote identity, and Connections routing

### Persistence, accessibility, and localization

- lifecycle-safe async hydration with monotonic request tokens and mutation-generation snapshots
- window-scoped plugin storage key with migration from the pre-release key
- semantic radio/checkbox menu primitives, labelled icon controls, and keyboard ordering
- plugin-scoped locale bundles for English, Japanese, Simplified Chinese, and Traditional Chinese
- runtime behavior tests import the real ESM plugin; obsolete source-shape assertions were removed

## How to test

1. Open Bot Mode and choose **View → Grouping → Sections**.
2. Create two Sections in **Manage Sections…** and assign Bots/groups.
3. Drag an assigned Bot between both Sections, then to Unassigned, then back; repeat immediately without waiting.
4. Drag Section headers to change their order.
5. Set **Manual order** and reorder peers with drag-and-drop and **Alt+↑ / Alt+↓**.
6. Enable **Nest group members** and verify every Bot remains standalone while each group shows shortcut copies; a multi-group Bot appears under every group.
7. Collapse Sections and groups independently; search for a hidden match and verify it becomes visible.
8. Reveal hidden Bots through View and verify same-named local/Connections rows remain distinct.

## Validation

Final candidate validation on Arch Linux / Electron:

- `npm run check:test:plugins` — **280 passed**
- real-module roster View tests — **100 passed**
- full UI suite — **5,000 passed**
- `umask 022; npm run test:desktop:platforms -- --maxWorkers=4` — **1,449 passed, 2 skipped**
- `npm run check:lint` — typecheck passed, **0 errors** (repository baseline warnings only)
- `npm run build` — passed
- `npm run test:desktop:all` — Linux unpacked package produced
- `git diff --check origin/main...HEAD` — clean
- real Playwright mouse sequences against the packaged app — assigned Bot Section A → B → A, Section reorder both directions, assigned → Unassigned → assigned, and drop onto a collapsed Section header while preserving `[A, B]` as `[A, B, C]`; all passed without reload delays
- real keyboard sequence against the packaged app — focused manual row + Alt+Arrow persisted the new order
- packaged accessibility smoke — keyboard-opened View and Manage Sections, found the labelled create field, and verified one selected `aria-pressed` assignment choice per peer
- independent blocker-only standards and runtime reviews — no blocking findings

The canonical root Python wrapper was also attempted. It reported unrelated failures in untouched Python/LSP/lazy-dependency/environment paths; representative failures reproduced in a clean `origin/main` worktree. This PR changes only Desktop renderer/plugin code, SDK component exports, tests, and Bot Mode documentation.

## Checklist

### Code

- [x] I read `CONTRIBUTING.md`, root `AGENTS.md`, Desktop `AGENTS.md`, and `DESIGN.md`
- [x] Commit message follows Conventional Commits
- [x] I searched existing issues and PRs for duplicates
- [x] PR contains one focused logical feature
- [x] Tests cover new behavior through real imports/runtime rendering
- [x] Tested on Arch Linux in the packaged Electron app

### Documentation and housekeeping

- [x] Updated Bot Mode user documentation
- [x] No config keys or environment variables added
- [x] No tool schemas or model tools changed
- [x] Cross-platform impact considered; implementation is renderer/plugin logic with no OS/process/path assumptions
- [x] No credentials, tokens, or production infrastructure changes

## Reviewer notes

- Group shortcuts deliberately duplicate members; they do not replace standalone Bot rows.
- Nested shortcut copies are not canonical Section-placement controls; drag the standalone Bot row to move its visual Section.
- Visual Section state is renderer-local and source-qualified. It never writes Bot membership metadata.
- The permanent Unassigned target is intentional: changing only its styling during drag avoids Chromium cancelling native drags when assigned rows shift beneath the pointer.
