### PR TITLE
fix(vision): let URL-only providers analyze public images

### DIFF
--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -294,6 +294,132 @@ class TestVisionConfig:
         assert kwargs["timeout"] == 120.0
 
 
+class TestPublicImageUrlPassthrough:
+    @staticmethod
+    def _response(text="Public URL image"):
+        response = MagicMock()
+        response.choices[0].message.content = text
+        return response
+
+    @pytest.mark.asyncio
+    async def test_public_http_url_is_sent_to_auxiliary_provider(self):
+        public_url = "https://images.example.com/cat.png"
+        resolved = MagicMock(
+            data=b"\x89PNG\r\n\x1a\n" + b"\x00" * 8,
+            mime="image/png",
+        )
+
+        with (
+            patch(
+                "tools.image_source.resolve_image_source",
+                new_callable=AsyncMock,
+                return_value=resolved,
+            ),
+            patch(
+                "tools.vision_tools._image_to_base64_data_url",
+                return_value="data:image/png;base64,abc",
+            ),
+            patch(
+                "tools.vision_tools.async_call_llm",
+                new_callable=AsyncMock,
+                return_value=self._response(),
+            ) as mock_llm,
+        ):
+            result = json.loads(
+                await vision_analyze_tool(public_url, "describe this", "test/model")
+            )
+
+        assert result["success"] is True
+        sent_url = mock_llm.await_args.kwargs["messages"][0]["content"][1][
+            "image_url"
+        ]["url"]
+        assert sent_url == public_url
+        mock_llm.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_public_url_rejection_retries_with_inline_image(self):
+        public_url = "https://images.example.com/cat.png"
+        inline_url = "data:image/png;base64,abc"
+        resolved = MagicMock(
+            data=b"\x89PNG\r\n\x1a\n" + b"\x00" * 8,
+            mime="image/png",
+        )
+        sent_urls = []
+
+        async def fake_llm(**kwargs):
+            sent_urls.append(
+                kwargs["messages"][0]["content"][1]["image_url"]["url"]
+            )
+            if len(sent_urls) == 1:
+                raise RuntimeError("provider could not fetch image URL")
+            return self._response("Inline fallback image")
+
+        with (
+            patch(
+                "tools.image_source.resolve_image_source",
+                new_callable=AsyncMock,
+                return_value=resolved,
+            ),
+            patch(
+                "tools.vision_tools._image_to_base64_data_url",
+                return_value=inline_url,
+            ),
+            patch("tools.vision_tools.async_call_llm", side_effect=fake_llm),
+        ):
+            result = json.loads(
+                await vision_analyze_tool(public_url, "describe this", "test/model")
+            )
+
+        assert result["success"] is True
+        assert sent_urls == [public_url, inline_url]
+
+    @pytest.mark.asyncio
+    async def test_public_url_region_uses_cropped_inline_image(self, tmp_path):
+        public_url = "https://images.example.com/cat.png"
+        inline_url = "data:image/png;base64,cropped"
+        resolved = MagicMock(
+            data=b"\x89PNG\r\n\x1a\n" + b"\x00" * 8,
+            mime="image/png",
+        )
+        cropped = tmp_path / "crop.png"
+        cropped.write_bytes(resolved.data)
+
+        with (
+            patch(
+                "tools.image_source.resolve_image_source",
+                new_callable=AsyncMock,
+                return_value=resolved,
+            ),
+            patch(
+                "tools.vision_tools._crop_image_region",
+                return_value=(cropped, "image/png", None),
+            ),
+            patch(
+                "tools.vision_tools._image_to_base64_data_url",
+                return_value=inline_url,
+            ),
+            patch(
+                "tools.vision_tools.async_call_llm",
+                new_callable=AsyncMock,
+                return_value=self._response("Cropped image"),
+            ) as mock_llm,
+        ):
+            result = json.loads(
+                await vision_analyze_tool(
+                    public_url,
+                    "read this area",
+                    "test/model",
+                    region=[0, 0, 4, 4],
+                )
+            )
+
+        assert result["success"] is True
+        sent_url = mock_llm.await_args.kwargs["messages"][0]["content"][1][
+            "image_url"
+        ]["url"]
+        assert sent_url == inline_url
+
+
 class TestVisionSafetyGuards:
     @pytest.mark.asyncio
     async def test_local_non_image_file_rejected_before_llm_call(self, tmp_path):

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -374,6 +374,81 @@ class TestPublicImageUrlPassthrough:
         assert sent_urls == [public_url, inline_url]
 
     @pytest.mark.asyncio
+    async def test_non_fetch_error_does_not_retry_inline(self):
+        public_url = "https://images.example.com/cat.png"
+        resolved = MagicMock(
+            data=b"\x89PNG\r\n\x1a\n" + b"\x00" * 8,
+            mime="image/png",
+        )
+
+        with (
+            patch(
+                "tools.image_source.resolve_image_source",
+                new_callable=AsyncMock,
+                return_value=resolved,
+            ),
+            patch(
+                "tools.vision_tools._image_to_base64_data_url",
+                return_value="data:image/png;base64,abc",
+            ),
+            patch(
+                "tools.vision_tools.async_call_llm",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("rate limit exceeded"),
+            ) as mock_llm,
+        ):
+            result = json.loads(
+                await vision_analyze_tool(public_url, "describe this", "test/model")
+            )
+
+        assert result["success"] is False
+        assert "rate limit exceeded" in result["error"]
+        mock_llm.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_public_url_success_omits_inline_resize_note(self):
+        public_url = "https://images.example.com/large.png"
+        resolved = MagicMock(
+            data=b"\x89PNG\r\n\x1a\n" + b"\x00" * 8,
+            mime="image/png",
+        )
+
+        def fake_resize(*args, scale_out=None, **kwargs):
+            scale_out.update(
+                orig_width=4000,
+                orig_height=2000,
+                new_width=1000,
+                new_height=500,
+            )
+            return "data:small"
+
+        with (
+            patch(
+                "tools.image_source.resolve_image_source",
+                new_callable=AsyncMock,
+                return_value=resolved,
+            ),
+            patch(
+                "tools.vision_tools._image_to_base64_data_url",
+                return_value="data:image/png;base64,oversized",
+            ),
+            patch("tools.vision_tools._MAX_BASE64_BYTES", 10),
+            patch("tools.vision_tools._resize_image_for_vision", side_effect=fake_resize),
+            patch(
+                "tools.vision_tools.async_call_llm",
+                new_callable=AsyncMock,
+                return_value=self._response(),
+            ),
+        ):
+            result = json.loads(
+                await vision_analyze_tool(public_url, "describe this", "test/model")
+            )
+
+        assert result["success"] is True
+        assert result["analysis"] == "Public URL image"
+        assert "scale_note" not in result
+
+    @pytest.mark.asyncio
     async def test_public_url_region_uses_cropped_inline_image(self, tmp_path):
         public_url = "https://images.example.com/cat.png"
         inline_url = "data:image/png;base64,cropped"

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -660,6 +660,28 @@ def _is_image_size_error(error: Exception) -> bool:
     ))
 
 
+def _is_public_image_fetch_error(error: Exception) -> bool:
+    """Return whether a provider rejected or could not fetch an image URL."""
+    err_str = str(error).lower()
+    if any(hint in err_str for hint in (
+        "could not fetch image",
+        "couldn't fetch image",
+        "failed to fetch image",
+        "unable to fetch image",
+        "image download failed",
+        "failed to download image",
+        "unable to download image",
+        "could not download image",
+        "failed to load image",
+    )):
+        return True
+    return (
+        "image_url" in err_str or "image url" in err_str
+    ) and any(hint in err_str for hint in (
+        "invalid", "unsupported", "not support", "reject",
+    ))
+
+
 def _image_exceeds_dimension(image_path: Path, max_dimension: int) -> bool:
     """True if the image's longest side exceeds ``max_dimension`` px.
 
@@ -1470,6 +1492,7 @@ async def vision_analyze_tool(
             if region is None and _image_url_shape_ok(image_url)
             else None
         )
+        used_inline_image = public_image_url is None
 
         # Prepare the message. The inline payload remains available as a
         # fallback for providers that cannot fetch the public URL themselves.
@@ -1548,16 +1571,19 @@ async def vision_analyze_tool(
         try:
             response = await async_call_llm(**call_kwargs)
         except Exception as _api_err:
-            if public_image_url:
+            if public_image_url and _is_public_image_fetch_error(_api_err):
                 logger.info(
                     "Vision provider could not use the public image URL; "
                     "retrying with inline image bytes"
                 )
+                used_inline_image = True
                 messages[0]["content"][1]["image_url"]["url"] = image_data_url
                 try:
                     response = await async_call_llm(**call_kwargs)
                 except Exception as _inline_err:
                     response = await _retry_with_resized_inline(_inline_err)
+            elif public_image_url:
+                raise
             else:
                 response = await _retry_with_resized_inline(_api_err)
         
@@ -1577,7 +1603,8 @@ async def vision_analyze_tool(
         # Prepare successful response
         analysis = analysis or "There was a problem with the request and the image could not be analyzed."
         scale_note = _build_scale_note(
-            _scale_info or None, _crop_offset or None,
+            (_scale_info or None) if used_inline_image else None,
+            _crop_offset or None,
         )
         result = {
             "success": True,

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -10,7 +10,7 @@ Available tools:
 - vision_analyze_tool: Analyze images from URLs with custom prompts
 
 Features:
-- Downloads images from URLs and converts to base64 for API compatibility
+- Preserves public image URLs, with an inline-base64 compatibility fallback
 - Comprehensive image description
 - Context-aware analysis based on user queries
 - Automatic temporary file cleanup
@@ -1306,9 +1306,10 @@ async def vision_analyze_tool(
     """
     Analyze an image from a URL or local file path using vision AI.
     
-    This tool accepts either an HTTP/HTTPS URL or a local file path. For URLs,
-    it downloads the image first. In both cases, the image is converted to base64
-    and processed using Gemini 3 Flash Preview via OpenRouter API.
+    This tool accepts either an HTTP/HTTPS URL or a local file path. HTTP(S)
+    inputs are validated and passed to the provider as public URLs, with the
+    resolved bytes retained as an inline-base64 compatibility fallback. Local
+    inputs and cropped regions are sent inline.
     
     The user_prompt parameter is expected to be pre-formatted by the calling
     function (typically model_tools.py) to include both full description
@@ -1459,7 +1460,19 @@ async def vision_analyze_tool(
         # Use the prompt as provided (model_tools.py now handles full description formatting)
         comprehensive_prompt = user_prompt
         
-        # Prepare the message with base64-encoded image
+        # Preserve validated public URLs for providers that reject inline
+        # base64 images. resolve_image_source() above still downloads and
+        # validates the bytes first, retaining the existing SSRF, website
+        # policy, MIME, normalization, and size guards. Keep cropped regions
+        # inline because the original URL does not represent the crop.
+        public_image_url = (
+            image_url
+            if region is None and _image_url_shape_ok(image_url)
+            else None
+        )
+
+        # Prepare the message. The inline payload remains available as a
+        # fallback for providers that cannot fetch the public URL themselves.
         messages = [
             {
                 "role": "user",
@@ -1471,7 +1484,7 @@ async def vision_analyze_tool(
                     {
                         "type": "image_url",
                         "image_url": {
-                            "url": image_data_url
+                            "url": public_image_url or image_data_url
                         }
                     }
                 ]
@@ -1506,26 +1519,47 @@ async def vision_analyze_tool(
         if model:
             call_kwargs["model"] = model
         _load_auxiliary_client()
-        # Try full-size image first; on size-related rejection, downscale and retry.
+        async def _retry_with_resized_inline(api_error):
+            """Downscale and retry an inline image after a size rejection."""
+            nonlocal image_data_url
+            if not (
+                _is_image_size_error(api_error)
+                and len(image_data_url) > _RESIZE_TARGET_BYTES
+            ):
+                raise api_error
+            logger.info(
+                "API rejected image (%.1f MB, likely too large); "
+                "auto-resizing to ~%.0f MB and retrying...",
+                len(image_data_url) / (1024 * 1024),
+                _RESIZE_TARGET_BYTES / (1024 * 1024),
+            )
+            image_data_url = await _run_encode_on_cpu_executor(
+                _resize_image_for_vision,
+                temp_image_path,
+                mime_type=detected_mime_type,
+                scale_out=_scale_info,
+            )
+            messages[0]["content"][1]["image_url"]["url"] = image_data_url
+            return await async_call_llm(**call_kwargs)
+
+        # Try a validated public URL first. If the provider cannot fetch URLs,
+        # retry with the already-resolved inline image to preserve compatibility.
+        # Inline size rejections retain the existing downscale-and-retry path.
         try:
             response = await async_call_llm(**call_kwargs)
         except Exception as _api_err:
-            if (_is_image_size_error(_api_err)
-                    and len(image_data_url) > _RESIZE_TARGET_BYTES):
+            if public_image_url:
                 logger.info(
-                    "API rejected image (%.1f MB, likely too large); "
-                    "auto-resizing to ~%.0f MB and retrying...",
-                    len(image_data_url) / (1024 * 1024),
-                    _RESIZE_TARGET_BYTES / (1024 * 1024),
+                    "Vision provider could not use the public image URL; "
+                    "retrying with inline image bytes"
                 )
-                image_data_url = await _run_encode_on_cpu_executor(
-                    _resize_image_for_vision,
-                    temp_image_path, mime_type=detected_mime_type,
-                    scale_out=_scale_info)
                 messages[0]["content"][1]["image_url"]["url"] = image_data_url
-                response = await async_call_llm(**call_kwargs)
+                try:
+                    response = await async_call_llm(**call_kwargs)
+                except Exception as _inline_err:
+                    response = await _retry_with_resized_inline(_inline_err)
             else:
-                raise
+                response = await _retry_with_resized_inline(_api_err)
         
         # Extract the analysis — fall back to reasoning if content is empty
         analysis = extract_content_or_reasoning(response)


### PR DESCRIPTION
## What does this PR do?

`vision_analyze` now preserves validated public HTTP(S) image URLs when calling the auxiliary vision provider. Providers that reject inline base64 images can analyze those images instead of returning an image download failure, while providers that cannot fetch public URLs retain a narrowly scoped inline-image fallback.

### Symptom

A public image URL works when sent directly to a URL-capable vision provider, but the same URL fails through `vision_analyze` because the auxiliary path replaces it with a `data:image/...;base64` payload. SenseNova reports HTTP 400 with `image download failed` for that payload form.

### Impact

Users of URL-only vision providers cannot analyze otherwise reachable public images through `vision_analyze`. Local files, data URLs, cropped regions, and providers that accept inline images remain supported.

### Bug Cause

**Trigger:** `tools/vision_tools.py` in `vision_analyze_tool` when handling an HTTP(S) image without a requested crop.

**Causal chain:**
1. The resolver safely downloads and validates the public image URL.
2. The auxiliary path unconditionally converts the resolved bytes to an inline base64 data URL and discards the original URL identity.
3. A provider that only accepts fetchable public URLs rejects the inline payload, so analysis fails despite the original image being reachable.

**Why it is wrong:** The auxiliary path forced one transport representation even though the provider-facing image content supports public URLs and some providers reject inline data URLs.

**Working sibling / contrast:** The main-agent native image path preserves image URLs, so URL-capable providers can fetch the same public image there.

**Ruled out:** Image resolution and validation are not the failure. Those steps successfully obtain the bytes and continue to enforce SSRF, website-policy, MIME, normalization, and size checks before any URL is passed to the provider.

### Fix

Preserve a validated public HTTP(S) URL for the first auxiliary request when no crop is requested. Keep the resolved inline bytes for compatibility, but retry with them only when the provider error specifically indicates that it could not fetch or accept the image URL. Retain existing inline processing for local sources and crops, retain resize retry behavior for inline size errors, and report resize coordinates only when inline bytes were actually sent.

## Related Issue

Closes #89628

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/vision_tools.py` - preserve validated public URLs, classify URL-fetch failures, and narrowly fall back to inline bytes.
- `tests/tools/test_vision_tools.py` - cover URL-first delivery, fallback classification, resize behavior, crop behavior, and scale-note accuracy.

## How to Test

1. Submit a reachable public HTTP(S) image URL through `vision_analyze` with no crop and verify that the first provider payload contains the public URL.
2. Simulate an image-fetch rejection and verify that the retry uses the validated inline bytes; verify that unrelated provider errors do not trigger the fallback.
3. Run the focused test suite:

```bash
scripts/run_tests.sh tests/tools/test_vision_tools.py tests/agent/test_auxiliary_config_bridge.py
```

Result: 50 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A; the behavior is internal provider compatibility
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact; the transport selection is platform-independent
- [x] Tool schema update is N/A; accepted inputs and the user-facing tool contract are unchanged

## Screenshots / Logs

N/A; focused automated tests exercise the provider payload and fallback behavior directly.
