### PR TITLE
fix(desktop): stop Settings autosave from clobbering out-of-band config edits

### DIFF
--- a/apps/desktop/src/app/settings/config-settings.test.tsx
+++ b/apps/desktop/src/app/settings/config-settings.test.tsx
@@ -1,0 +1,97 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { atom } from 'nanostores'
+import { createRef } from 'react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getHermesConfigRecord = vi.fn()
+const getHermesConfigSchema = vi.fn()
+const saveHermesConfig = vi.fn()
+const getElevenLabsVoices = vi.fn()
+
+vi.mock('@/hermes', () => ({
+  getHermesConfigRecord: () => getHermesConfigRecord(),
+  getHermesConfigSchema: () => getHermesConfigSchema(),
+  saveHermesConfig: (config: unknown, profile?: string) => saveHermesConfig(config, profile),
+  getElevenLabsVoices: () => getElevenLabsVoices(),
+  setApiRequestProfile: () => {}
+}))
+
+vi.mock('../hooks/use-on-profile-switch', () => ({
+  useOnProfileSwitch: () => {}
+}))
+
+// The real stores pull in the gateway/profile stack, which needs a live
+// backend connection. This page only reads the "applies to" scope override
+// and the repo-discovery signature, neither of which this test touches.
+vi.mock('@/store/settings-scope', () => ({
+  $settingsScopeOverride: atom<null | string>(null)
+}))
+
+vi.mock('@/store/projects', () => ({
+  repoDiscoveryPolicyFromConfig: () => ({ enabled: true, roots: [], exclude_paths: [] }),
+  repoDiscoveryPolicySignature: (policy: unknown) => JSON.stringify(policy),
+  scanAndRecordRepos: vi.fn().mockResolvedValue(undefined)
+}))
+
+beforeEach(() => {
+  getElevenLabsVoices.mockResolvedValue({ available: false })
+  getHermesConfigSchema.mockResolvedValue({ fields: {} })
+  saveHermesConfig.mockResolvedValue({ ok: true })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+async function renderConfigSettings() {
+  const { ConfigSettings } = await import('./config-settings')
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const importInputRef = createRef<HTMLInputElement>()
+
+  render(
+    <MemoryRouter>
+      <QueryClientProvider client={client}>
+        <ConfigSettings activeSectionId="safety" importInputRef={importInputRef} />
+      </QueryClientProvider>
+    </MemoryRouter>
+  )
+
+  return { importInputRef }
+}
+
+describe('ConfigSettings autosave', () => {
+  it('sends a later revert instead of diffing it away against the stale page-load baseline', async () => {
+    getHermesConfigRecord.mockResolvedValue({ checkpoints: { enabled: false }, other: 'untouched' })
+
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    try {
+      await renderConfigSettings()
+
+      const toggle = await screen.findByRole('switch')
+
+      // Edit: flip checkpoints.enabled on, let the debounced autosave fire.
+      toggle.click()
+      await vi.advanceTimersByTimeAsync(700)
+
+      await waitFor(() => expect(saveHermesConfig).toHaveBeenCalledTimes(1))
+      expect(saveHermesConfig.mock.calls[0][0]).toEqual({ checkpoints: { enabled: true } })
+
+      // Revert: flip it back to its original value and let autosave fire again.
+      toggle.click()
+      await vi.advanceTimersByTimeAsync(700)
+
+      await waitFor(() => expect(saveHermesConfig).toHaveBeenCalledTimes(2))
+      // Must still explicitly send the reverted value — diffing against the
+      // never-advanced page-load baseline would produce an empty patch here
+      // (the field is back to its original value) and leave disk stuck at
+      // `enabled: true` from the first save.
+      expect(saveHermesConfig.mock.calls[1][0]).toEqual({ checkpoints: { enabled: false } })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -127,6 +127,10 @@ function ConfigSettingsInner({
   // never touched — possibly changed out-of-band by `hermes config set`
   // while this page sat open — is never resent with its stale value.
   const configBaselineRef = useRef<HermesConfigRecord | null>(null)
+  // Serializes autosave requests so an older save that's still in flight can't
+  // resolve after a newer one and re-advance the baseline / cache with stale
+  // data — each save's diff+request only starts once the previous one lands.
+  const saveQueueRef = useRef<Promise<void>>(Promise.resolve())
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
@@ -149,6 +153,7 @@ function ConfigSettingsInner({
     setConfig(null)
     saveVersionRef.current = 0
     setSaveVersion(0)
+    saveQueueRef.current = Promise.resolve()
   })
 
   useEffect(() => {
@@ -181,26 +186,37 @@ function ConfigSettingsInner({
     }
 
     const v = saveVersion
+    const snapshot = config
 
     const t = window.setTimeout(() => {
-      void (async () => {
+      // Chained onto the queue (not fired directly) so an older save that's
+      // still awaiting its response can't land after this one and undo its
+      // baseline advance — each save's diff is computed once its predecessor
+      // has fully resolved.
+      saveQueueRef.current = saveQueueRef.current.then(async () => {
         try {
-          const patch = diffConfig(configBaselineRef.current ?? {}, config)
+          const patch = diffConfig(configBaselineRef.current ?? {}, snapshot)
           const result = await saveHermesConfig(patch, scopeProfile ?? undefined)
 
           if (!result.ok) {
             throw new Error(c.autosaveFailed)
           }
 
+          // The saved snapshot becomes the new baseline, so the next autosave
+          // diffs against what's actually on disk instead of the page-load
+          // (or last-baseline) copy — otherwise reverting a field to its
+          // pre-save value diffs to nothing and the revert never reaches disk.
+          configBaselineRef.current = snapshot
+
           // Mirror the saved record into the shared cache so MCP/model surfaces
           // reflect the edit without their own refetch.
-          writeConfigCache(config)
+          writeConfigCache(snapshot)
 
           if (saveVersionRef.current === v) {
             // The repo-discovery scan reads the ACTIVE profile's workspace
             // policy; skip it when this page is editing another profile.
             if (scopeProfile == null) {
-              const discoverySignature = repoDiscoveryPolicySignature(repoDiscoveryPolicyFromConfig(config))
+              const discoverySignature = repoDiscoveryPolicySignature(repoDiscoveryPolicyFromConfig(snapshot))
 
               if (savedDiscoverySignatureRef.current !== discoverySignature) {
                 savedDiscoverySignatureRef.current = discoverySignature
@@ -215,7 +231,7 @@ function ConfigSettingsInner({
             notifyError(err, c.autosaveFailed)
           }
         }
-      })()
+      })
     }, 550)
 
     return () => window.clearTimeout(t)

--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -33,6 +33,7 @@ import { PanelEmpty } from '../overlays/panel'
 import { ConfigField } from './config-field'
 import {
   clearsEnabledToolsets,
+  diffConfig,
   enumOptionsFor,
   getNested,
   isExternalMemoryProvider,
@@ -121,11 +122,17 @@ function ConfigSettingsInner({
   // Seed the local draft once, the first time the shared record lands.
   // Background refetches thereafter must not clobber in-progress edits.
   const configSeeded = useRef(false)
+  // Snapshot of the record as it was when the draft was seeded. Autosave
+  // diffs the draft against this (not against disk) so a field the user
+  // never touched — possibly changed out-of-band by `hermes config set`
+  // while this page sat open — is never resent with its stale value.
+  const configBaselineRef = useRef<HermesConfigRecord | null>(null)
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
     if (loadedConfig && !configSeeded.current) {
       configSeeded.current = true
+      configBaselineRef.current = loadedConfig
       savedDiscoverySignatureRef.current = repoDiscoveryPolicySignature(repoDiscoveryPolicyFromConfig(loadedConfig))
       setConfig(loadedConfig)
     }
@@ -137,6 +144,7 @@ function ConfigSettingsInner({
   // the pending debounced autosave is cancelled by its effect cleanup.
   useOnProfileSwitch(() => {
     configSeeded.current = false
+    configBaselineRef.current = null
     savedDiscoverySignatureRef.current = undefined
     setConfig(null)
     saveVersionRef.current = 0
@@ -177,7 +185,8 @@ function ConfigSettingsInner({
     const t = window.setTimeout(() => {
       void (async () => {
         try {
-          const result = await saveHermesConfig(config, scopeProfile ?? undefined)
+          const patch = diffConfig(configBaselineRef.current ?? {}, config)
+          const result = await saveHermesConfig(patch, scopeProfile ?? undefined)
 
           if (!result.ok) {
             throw new Error(c.autosaveFailed)

--- a/apps/desktop/src/app/settings/helpers.test.ts
+++ b/apps/desktop/src/app/settings/helpers.test.ts
@@ -6,6 +6,7 @@ import { FIELD_DESCRIPTIONS, FIELD_LABELS, SECTIONS } from './constants'
 import { defineFieldCopy, fieldCopyForSchemaKey, schemaKeyToFieldCopyKey } from './field-copy'
 import {
   clearsEnabledToolsets,
+  diffConfig,
   enumOptionsFor,
   getNested,
   isExternalMemoryProvider,
@@ -402,6 +403,46 @@ describe('settings helpers', () => {
       const next: HermesConfigRecord = { model: 'b', toolsets: ['memory'] }
 
       expect(clearsEnabledToolsets(prev, next)).toBe(false)
+    })
+  })
+
+  describe('diffConfig', () => {
+    it('omits a top-level key the draft never touched', () => {
+      // The autosave baseline is a snapshot taken when Settings opened. A key
+      // an agent set via `hermes config set` while the page sat open must not
+      // come back in the patch just because it's still present in the draft.
+      const baseline: HermesConfigRecord = { fallback_providers: ['nara1'], timezone: 'UTC' }
+      const draft: HermesConfigRecord = { fallback_providers: ['nara1'], timezone: 'America/New_York' }
+
+      expect(diffConfig(baseline, draft)).toEqual({ timezone: 'America/New_York' })
+    })
+
+    it('includes a nested key only when it actually changed, leaving siblings out', () => {
+      const baseline: HermesConfigRecord = { display: { personality: 'default', show_reasoning: true } }
+      const draft: HermesConfigRecord = { display: { personality: 'default', show_reasoning: false } }
+
+      expect(diffConfig(baseline, draft)).toEqual({ display: { show_reasoning: false } })
+    })
+
+    it('sends a new key that was absent from the baseline', () => {
+      const baseline: HermesConfigRecord = {}
+      const draft: HermesConfigRecord = { timezone: 'UTC' }
+
+      expect(diffConfig(baseline, draft)).toEqual({ timezone: 'UTC' })
+    })
+
+    it('returns an empty object when the draft matches the baseline exactly', () => {
+      const baseline: HermesConfigRecord = { toolsets: ['memory'], display: { personality: 'default' } }
+      const draft: HermesConfigRecord = { toolsets: ['memory'], display: { personality: 'default' } }
+
+      expect(diffConfig(baseline, draft)).toEqual({})
+    })
+
+    it('treats an array as a whole value, not diffed element by element', () => {
+      const baseline: HermesConfigRecord = { toolsets: ['memory', 'terminal'] }
+      const draft: HermesConfigRecord = { toolsets: ['memory'] }
+
+      expect(diffConfig(baseline, draft)).toEqual({ toolsets: ['memory'] })
     })
   })
 })

--- a/apps/desktop/src/app/settings/helpers.ts
+++ b/apps/desktop/src/app/settings/helpers.ts
@@ -97,6 +97,43 @@ export function getNested(obj: HermesConfigRecord, path: string): unknown {
   return cur
 }
 
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+/**
+ * Structural diff between two config snapshots: an object holding only the
+ * branches of `next` that changed relative to `base`. Plain-object values are
+ * compared key by key so editing one field doesn't drag its untouched
+ * siblings back into the result; arrays and scalars are compared as whole
+ * values.
+ *
+ * The autosave path sends this instead of the full draft so a field the user
+ * never touched — one an agent may have changed via `hermes config set`
+ * while Settings was open with a stale snapshot — is never resent with its
+ * now-stale value. `PUT /api/config` deep-merges onto disk, so an omitted
+ * key keeps whatever is currently there.
+ */
+export function diffConfig(base: HermesConfigRecord, next: HermesConfigRecord): HermesConfigRecord {
+  const patch: HermesConfigRecord = {}
+
+  for (const key of Object.keys(next)) {
+    const baseValue = base[key]
+    const nextValue = next[key]
+
+    if (isPlainObject(baseValue) && isPlainObject(nextValue)) {
+      const nested = diffConfig(baseValue, nextValue)
+
+      if (Object.keys(nested).length > 0) {
+        patch[key] = nested
+      }
+    } else if (JSON.stringify(baseValue) !== JSON.stringify(nextValue)) {
+      patch[key] = nextValue
+    }
+  }
+
+  return patch
+}
+
 /**
  * True when an edit clears the entire "Enabled Toolsets" list — i.e. the
  * previous config had a non-empty toolsets array and the next one is an

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7524,15 +7524,22 @@ def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:
     string; the rest is preserved transparently.
 
     Also handles ``model_context_length`` — writes it back into the model dict
-    as ``context_length``.  A value of 0 or absent means "auto-detect" (omitted
-    from the dict so get_model_context_length() uses its normal resolution).
+    as ``context_length``.  A value of 0 means "auto-detect" (omitted from the
+    dict so get_model_context_length() uses its normal resolution). ``config``
+    may be a partial update (e.g. the Settings autosave diff) that omits
+    ``model_context_length`` entirely when the user didn't touch it — that
+    must leave the on-disk override untouched, not get treated the same as an
+    explicit 0 and cleared.
     """
     config = dict(config)
     # Remove any _model_meta that might have leaked in (shouldn't happen
     # with the stripped GET response, but be defensive)
     config.pop("_model_meta", None)
 
-    # Extract and remove model_context_length before processing model
+    # Extract and remove model_context_length before processing model, but
+    # remember whether it was actually present: a partial update omitting the
+    # key means "unchanged", which is different from an explicit 0.
+    ctx_sent = "model_context_length" in config
     ctx_override = config.pop("model_context_length", 0)
     if not isinstance(ctx_override, int):
         try:
@@ -7541,50 +7548,59 @@ def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:
             ctx_override = 0
 
     model_val = config.get("model")
-    if isinstance(model_val, str) and model_val:
+    if (isinstance(model_val, str) and model_val) or ctx_sent:
         # Read the current disk config to recover model subkeys
         try:
             disk_config = load_config()
             disk_model = disk_config.get("model")
             if isinstance(disk_model, dict):
-                prev_default = str(disk_model.get("default") or "").strip()
-                prev_provider = str(disk_model.get("provider") or "").strip()
-                # When the model name actually changed, re-detect which
-                # provider serves it. The Config-page Model field is a flat
-                # string with no provider info, so without this a user who
-                # picks an OpenRouter model while their default provider is
-                # ollama-local keeps the stale provider and 404s. Only fires
-                # on a real model change so saving unrelated config fields
-                # never overwrites an explicit provider.
-                if model_val != prev_default and prev_provider:
-                    new_provider, resolved_model = _infer_provider_on_model_change(
-                        model_val, prev_provider
-                    )
-                    if new_provider and new_provider.strip().lower() != prev_provider.lower():
-                        # Route through the canonical assignment chokepoints so
-                        # the model is normalized for the new provider and stale
-                        # base_url/api_mode/api_key are cleared on the switch
-                        # (and preserved on a same-provider re-pick).
-                        norm_provider, norm_model = _normalize_main_model_assignment(
-                            new_provider, resolved_model
+                if isinstance(model_val, str) and model_val:
+                    prev_default = str(disk_model.get("default") or "").strip()
+                    prev_provider = str(disk_model.get("provider") or "").strip()
+                    # When the model name actually changed, re-detect which
+                    # provider serves it. The Config-page Model field is a flat
+                    # string with no provider info, so without this a user who
+                    # picks an OpenRouter model while their default provider is
+                    # ollama-local keeps the stale provider and 404s. Only fires
+                    # on a real model change so saving unrelated config fields
+                    # never overwrites an explicit provider.
+                    if model_val != prev_default and prev_provider:
+                        new_provider, resolved_model = _infer_provider_on_model_change(
+                            model_val, prev_provider
                         )
-                        disk_model = _apply_main_model_assignment(
-                            disk_model, norm_provider, norm_model
-                        )
-                        model_val = norm_model
-                # Preserve all subkeys, update default with the new value
-                disk_model["default"] = model_val
-                # Write context_length into the model dict (0 = remove/auto)
-                if ctx_override > 0:
-                    disk_model["context_length"] = ctx_override
-                else:
-                    disk_model.pop("context_length", None)
+                        if new_provider and new_provider.strip().lower() != prev_provider.lower():
+                            # Route through the canonical assignment chokepoints so
+                            # the model is normalized for the new provider and stale
+                            # base_url/api_mode/api_key are cleared on the switch
+                            # (and preserved on a same-provider re-pick).
+                            norm_provider, norm_model = _normalize_main_model_assignment(
+                                new_provider, resolved_model
+                            )
+                            disk_model = _apply_main_model_assignment(
+                                disk_model, norm_provider, norm_model
+                            )
+                            model_val = norm_model
+                    # Preserve all subkeys, update default with the new value
+                    disk_model["default"] = model_val
+                # Write context_length into the model dict (0 = remove/auto),
+                # but only when the payload actually carried the key.
+                if ctx_sent:
+                    if ctx_override > 0:
+                        disk_model["context_length"] = ctx_override
+                    else:
+                        disk_model.pop("context_length", None)
                 config["model"] = disk_model
-            # Model was previously a bare string — upgrade to dict if
-            # user is setting a context_length override
-            elif ctx_override > 0:
+            # Model was previously a bare string (or absent) — upgrade to a
+            # dict if the user is setting a context_length override.
+            elif ctx_sent and ctx_override > 0:
+                if isinstance(model_val, str) and model_val:
+                    default = model_val
+                elif isinstance(disk_model, str) and disk_model:
+                    default = disk_model
+                else:
+                    default = ""
                 config["model"] = {
-                    "default": model_val,
+                    "default": default,
                     "context_length": ctx_override,
                 }
         except Exception:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2891,6 +2891,43 @@ class TestModelContextLength:
         assert result["model"]["context_length"] == 100000
         assert "model_context_length" not in result  # virtual field removed
 
+    def test_denormalize_context_length_alone_is_applied(self):
+        """The Settings autosave now sends a diff, not the full draft: editing
+        only the Context Window control must not omit ``model`` and thereby
+        drop the context_length edit on the floor (#89597 review)."""
+        from hermes_cli.web_server import _denormalize_config_from_web
+        from hermes_cli.config import save_config
+
+        save_config({
+            "model": {"default": "anthropic/claude-sonnet-4", "provider": "anthropic",
+                      "context_length": 100000}
+        })
+
+        result = _denormalize_config_from_web({"model_context_length": 200000})
+        assert isinstance(result["model"], dict)
+        assert result["model"]["context_length"] == 200000
+        assert result["model"]["default"] == "anthropic/claude-sonnet-4"
+
+    def test_denormalize_model_alone_preserves_context_length(self):
+        """The mirror case: editing only the Model field must not silently
+        wipe an existing context_length override just because the diff omits
+        the unrelated model_context_length key (#89597 review).
+
+        No ``provider`` on disk here on purpose: that keeps this test isolated
+        to the diff-omission bug rather than the separate, pre-existing (and
+        intentional, see ``_apply_main_model_assignment``) behavior where a
+        real provider switch drops the context_length override."""
+        from hermes_cli.web_server import _denormalize_config_from_web
+        from hermes_cli.config import save_config
+
+        save_config({
+            "model": {"default": "anthropic/claude-sonnet-4", "context_length": 150000}
+        })
+
+        result = _denormalize_config_from_web({"model": "anthropic/claude-opus-4.6"})
+        assert result["model"]["context_length"] == 150000
+        assert result["model"]["default"] == "anthropic/claude-opus-4.6"
+
 
 class TestDenormalizeProviderSwitch:
     """The flat Config-page Model field carries no provider info. When the


### PR DESCRIPTION
Fixes #89597.

## Problem

The issue reports that on Windows, the desktop Settings UI has priority over
`config.yaml`: an edit an agent makes via `hermes config set` gets silently
reverted the next time Settings is touched, leaving no reliable
programmatic config path.

Two of the issue's three sub-problems are already resolved on `main`:
- `hermes config set` parsing composite (list/mapping) values was fixed by
  #88163 (tracked separately in #89561, closed as a duplicate of that merge).
- Agents are deliberately blocked from writing `config.yaml` directly
  (`tools/file_tools.py::_check_sensitive_path`) for a real security reason
  (it guards `approvals.mode` and other exec-approval settings from
  prompt-injected writes) — `hermes config set` is the documented guarded
  path, and it already works.

What's left, and what this PR fixes, is the actual clobbering mechanism —
and it isn't Windows-specific; the code path is shared across every
platform, so the issue title just reflects the reporter's environment.

## Root cause

`ConfigSettingsInner` (`apps/desktop/src/app/settings/config-settings.tsx`)
seeds its local editable draft **once** from the config record when Settings
opens, and deliberately does not re-seed it from background refetches while
the page stays open (`configSeeded` ref — this is intentional, so in-progress
edits aren't clobbered by a stale refetch).

The debounced autosave, however, always sent the **entire** draft object on
every save:

```ts
const result = await saveHermesConfig(config, scopeProfile ?? undefined)
```

The backend (`hermes_cli/web_server.py::update_config`) deep-merges the
incoming body onto a fresh read of disk specifically so a field the frontend
doesn't know about (e.g. `custom_providers`) survives an untouched round
trip. But every *schema-known* field — including `fallback_providers`, the
exact field the issue names — is always present in the draft, so it's always
"explicitly sent," and the deep-merge degenerates into a full overwrite for
it.

Concretely: open Settings, have an agent run
`hermes config set fallback_providers '[...]'` in the meantime, then edit any
unrelated field in the still-open Settings page (e.g. toggle a switch on
another section). The debounced autosave fires 550ms later and writes the
*seed-time* value of `fallback_providers` back to disk, discarding the
agent's change — with no error, no conflict, nothing to signal it happened.

## Fix

Snapshot the record at seed time (`configBaselineRef`) and, on autosave,
diff the current draft against that baseline (`diffConfig`, new pure helper
in `helpers.ts`). Only the branches that actually changed are sent. Plain
objects are diffed recursively (so a sibling under the same top-level key
that the user never touched stays out of the patch too); arrays and scalars
are compared as whole values. A field nobody edited locally is now never
resent, so the backend's existing deep-merge genuinely protects it instead
of being handed a full copy of its own stale value.

`configBaselineRef` resets alongside `configSeeded` on a profile switch, so
it always tracks "the record as of this page's most recent seed."

## Follow-up: a hidden `model` / `model_context_length` coupling

Review caught a real regression in the initial version of this fix.
`model` and `model_context_length` are two *virtual* top-level fields that
`_normalize_config_for_web` synthesizes from a single on-disk `model` dict
(`model.default` and `model.context_length`). `_denormalize_config_from_web`
reverses that, but it only ever wrote `model_context_length` back into the
model dict inside the branch gated on `model` also being present in the
payload:

```python
model_val = config.get("model")
if isinstance(model_val, str) and model_val:
    ...
    if ctx_override > 0:
        disk_model["context_length"] = ctx_override
    ...
```

Under the old full-draft autosave this was never a problem — `model` was
always present, so the branch always ran. Under `diffConfig`, editing the
Context Window control alone (a real field, one of only two in the Model
section) produces a patch containing only `model_context_length`; `model`
is absent, the branch is skipped, and the edit is silently discarded before
it ever reaches disk.

The mirror case regressed too, more subtly: editing `model` alone now
omits `model_context_length` from the diff. The old code treated a missing
key the same as an explicit `0` and popped any existing `context_length`
off the disk model — so saving an unrelated model change would silently
wipe a context-length override the user never touched.

Fixed by tracking whether `model_context_length` was actually present in
the payload (`ctx_sent`) and only mutating `context_length` when it was,
independent of whether `model` also changed in the same payload. Added two
regression tests in `tests/hermes_cli/test_web_server.py`
(`TestModelContextLength`) exercising the real (mocked-disk)
`_denormalize_config_from_web` path directly — one for each direction —
and confirmed both fail on the pre-fix code (`KeyError`) and pass after.

## Test plan

Added `describe('diffConfig', ...)` to
`apps/desktop/src/app/settings/helpers.test.ts` (5 cases): omits an untouched
top-level key, includes a nested key only when it changed while leaving
siblings out, includes a brand-new key, returns `{}` for an unchanged draft,
and treats arrays as whole values.

Verified the tests fail without the fix:

```
$ git checkout HEAD~1 -- apps/desktop/src/app/settings/helpers.ts
$ npx vitest run src/app/settings/helpers.test.ts
 Test Files  1 failed (1)
      Tests  5 failed | 36 passed (41)
 TypeError: diffConfig is not a function
$ git checkout HEAD -- apps/desktop/src/app/settings/helpers.ts
```

Full suite green with the fix applied:

```
$ npx vitest run src/app/settings/
 Test Files  31 passed (31)
      Tests  297 passed (297)

$ npx tsc -p . --noEmit          # clean, no output
$ npx eslint src/app/settings/config-settings.tsx src/app/settings/helpers.ts src/app/settings/helpers.test.ts   # clean
$ npx prettier --check src/app/settings/config-settings.tsx src/app/settings/helpers.ts src/app/settings/helpers.test.ts
All matched files use Prettier code style!
```

Backend regression tests (`scripts/run_tests.sh tests/hermes_cli/test_web_server.py`):

```
166 passed, 1 skipped
```

Confirmed the two new tests fail on the pre-fix code:

```
$ git stash push -- hermes_cli/web_server.py   # keep only the new tests
$ scripts/run_tests.sh tests/hermes_cli/test_web_server.py -k \
    "test_denormalize_context_length_alone_is_applied or test_denormalize_model_alone_preserves_context_length"
2 failed  (KeyError: 'model', KeyError: 'context_length')
$ git stash pop                                # restore the fix
```

`ruff check` clean on both changed files; `ty check hermes_cli/web_server.py`
shows only pre-existing, unrelated diagnostics (Windows-only stubs and an
optional `uvicorn` import), none near the changed lines.

Manual testing on Windows itself wasn't possible from this environment; the
affected code path (`config-settings.tsx`, `use-config-record.ts`,
`hermes.ts`, `web_server.py`) has no OS branching, so the fix and its test
coverage apply identically on macOS/Linux/Windows.

## Disclosure

This PR was prepared with AI assistance (Claude Code), with the root cause,
fix, and tests verified by running the actual test suite, typecheck, and
lint locally as shown above.
