### PR TITLE
fix(desktop): let get-windows staging degrade on all win32 arches when binding is missing

### DIFF
--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -515,11 +515,12 @@ export function stageGetWindowsInto(
       bindingDirs = scanBindingDirs()
     }
     if (bindingDirs.length === 0 && arch !== 'arm64') {
-      throw new Error(
-        `[stage-native-deps] get-windows has no win32-${arch} prebuilt binding under lib/binding. ` +
-          'Recover from the checkout root with:\n' +
-          '  npm install-scripts approve get-windows\n' +
-          '  npm rebuild get-windows'
+      // The staged windows.js fails soft (returns no-op stubs) when no
+      // binding is present, and window-below.ts catches the import on
+      // every platform. Degrade instead of failing the Desktop build.
+      console.warn(
+        `[stage-native-deps] get-windows has no win32-${arch} prebuilt binding under lib/binding; ` +
+          'staging the fail-soft JS surface without native window enumeration.'
       )
     }
     for (const dir of bindingDirs) {
@@ -569,9 +570,11 @@ export function stageGetWindows(
     // expected on Linux and win32-arm64 because get-windows 9.3.0 publishes no
     // native prebuilt for either target. The runtime import already fails soft,
     // so disable only window enumeration instead of failing the Desktop build.
-    // Other Windows architectures and macOS have supported native payloads and
-    // remain fail-closed so a broken package cannot ship silently.
-    const canDegrade = platform === 'linux' || (platform === 'win32' && arch === 'arm64')
+    // All win32 arches and Linux can degrade: the STAGED_WINDOWS_JS stub returns
+    // no-op objects when no binding is present, and window-below.ts catches the
+    // import on every platform. macOS has a mandatory Swift helper binary and
+    // remains fail-closed so a broken package cannot ship silently.
+    const canDegrade = platform === 'linux' || platform === 'win32'
     if (canDegrade) {
       console.warn(
         `[stage-native-deps] get-windows not installed (optional dep skipped for ${platform}-${arch}); ` +


### PR DESCRIPTION
## Problem

`stage-native-deps.mjs` has two throw points for `get-windows` on win32-x64 that contradict the runtime layer's fail-soft design:

1. **`stageGetWindows()` line 574**: `canDegrade` only allows `linux` and `win32-arm64`. A missing package on `win32-x64` throws instead of degrading.
2. **`stageGetWindowsInto()` line 517**: A missing binding on non-arm64 throws.

Both contradict:
- **`window-below.ts:133`**: `import('get-windows').catch(() => null)` — fail-soft on **every** platform
- **`STAGED_WINDOWS_JS` (line 366-407)**: `getAddon()` returns no-op stubs (`getActiveWindow() {}` / `getOpenWindows() {}`) when no binding is present
- **`readWindowBelow()`**: returns `enumerationFailureNote()` when enumeration returns null

The runtime is designed to degrade gracefully. The staging throws are inconsistent with this design and force `npm ci` to successfully install `get-windows` — but its `node-pre-gyp` install script can fail on any Windows host (no prebuilt for the exact Electron ABI, `allowScripts` blocking, etc.), making the Desktop GUI build fail on a clean install.

## Fix

1. Widen `canDegrade` from `platform === 'linux' || (platform === 'win32' && arch === 'arm64')` to `platform === 'linux' || platform === 'win32'` — all win32 arches can degrade when the package is missing.
2. Change the binding-missing throw (line 517-523) to a `console.warn` + degrade — same fail-soft behavior as arm64 already has.

macOS stays fail-closed (Swift helper binary is mandatory and cannot be stubbed).

## Verification

On a Windows x64 host where `npm ci` skips `get-windows` (e.g. `allowScripts` blocking):

```bash
cd apps/desktop
npm ci
node scripts/stage-native-deps.mjs win32 x64
# Before: throws "[stage-native-deps] get-windows has no win32-x64 prebuilt binding..."
# After:  warns  "[stage-native-deps] get-windows has no win32-x64 prebuilt binding; staging the fail-soft JS surface..."
# dist/node_modules/get-windows/lib/windows.js exists, getAddon() returns no-op stubs
npm run pack  # succeeds
```