### PR TITLE
fix(cron): refuse terminal one-shot resurrection and add re-arm

### DIFF
--- a/cron/__init__.py
+++ b/cron/__init__.py
@@ -24,6 +24,7 @@ from cron.jobs import (
     pause_job,
     resume_job,
     trigger_job,
+    rearm_oneshot,
     JOBS_FILE,
 )
 from cron.scheduler import tick
@@ -37,6 +38,7 @@ __all__ = [
     "pause_job",
     "resume_job",
     "trigger_job",
+    "rearm_oneshot",
     "tick",
     "JOBS_FILE",
 ]

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2284,6 +2284,70 @@ def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
     )
 
 
+def _claim_is_live(claim: Any, now: datetime, ttl_seconds: float) -> bool:
+    if not isinstance(claim, dict) or not claim.get("at"):
+        return False
+    try:
+        age = (now - _ensure_aware(datetime.fromisoformat(claim["at"]))).total_seconds()
+    except (TypeError, ValueError):
+        return False
+    return 0 <= age < ttl_seconds
+
+
+def rearm_oneshot(job_id: str, run_at: Any) -> Optional[Dict[str, Any]]:
+    """Re-arm a completed one-shot as an explicit new occurrence."""
+    job_ref = resolve_job_ref(job_id)
+    if not job_ref:
+        return None
+    if isinstance(run_at, datetime):
+        run_at = run_at.isoformat()
+    parsed_schedule = parse_schedule(str(run_at))
+    if parsed_schedule.get("kind") != "once":
+        raise ValueError(
+            "Cannot re-arm recurring jobs: re-arm is one-shot-only; "
+            "use plain resume or cron run."
+        )
+    next_run_at = compute_next_run(parsed_schedule)
+    if next_run_at is None:
+        requested = parsed_schedule.get("run_at") or run_at
+        raise ValueError(
+            f"Requested one-shot time {requested} is more than "
+            f"{ONESHOT_GRACE_SECONDS}s in the past and cannot be scheduled."
+        )
+
+    with _jobs_lock():
+        jobs = load_jobs()
+        for index, job in enumerate(jobs):
+            if job.get("id") != job_ref["id"]:
+                continue
+            now = _hermes_now()
+            if _claim_is_live(job.get("run_claim"), now, _oneshot_run_claim_ttl_seconds()):
+                raise ValueError("Cannot re-arm one-shot over a live run claim.")
+            if _claim_is_live(job.get("fire_claim"), now, 300):
+                raise ValueError("Cannot re-arm one-shot over a live fire claim.")
+            if job.get("schedule", {}).get("kind") != "once":
+                raise ValueError(
+                    "Cannot re-arm recurring jobs: re-arm is one-shot-only; "
+                    "use plain resume or cron run."
+                )
+            repeat = job.get("repeat") or {}
+            repeat["completed"] = 0
+            job["schedule"] = parsed_schedule
+            job["schedule_display"] = parsed_schedule.get("display", str(run_at))
+            job["repeat"] = repeat
+            job["run_claim"] = None
+            job["fire_claim"] = None
+            job["enabled"] = True
+            job["state"] = "scheduled"
+            job["paused_at"] = None
+            job["paused_reason"] = None
+            job["next_run_at"] = next_run_at
+            jobs[index] = job
+            save_jobs(jobs)
+            return _normalize_job_record(job)
+    return None
+
+
 def remove_job(job_id: str) -> bool:
     """Remove a job by ID or name."""
     job = resolve_job_ref(job_id)

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -602,6 +602,11 @@ def effective_job_state(job: Dict[str, Any]) -> str:
     return stored or "scheduled"
 
 
+def is_terminal_job(job: Dict[str, Any]) -> bool:
+    """Return whether a job record is in a terminal scheduler state."""
+    return job.get("state") in {"completed", "error"}
+
+
 def _secure_dir(path: Path):
     """Set directory to owner-only access (0700). No-op on Windows."""
     try:
@@ -2104,6 +2109,16 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})
 
+            if is_terminal_job(job) and (
+                updated.get("state") not in {"completed", "error"}
+                or updated.get("enabled") is True
+                or updated.get("next_run_at") is not None
+            ):
+                raise ValueError(
+                    f"Cannot activate terminal cron job '{job.get('name', job_id)}' "
+                    "through update_job; use cron resume --run-now or --at."
+                )
+
             # Re-check execution-mode invariants on the MERGED record when
             # any participating field changes, so create-time invariants
             # can't be violated through the update door (e.g. flipping
@@ -2187,6 +2202,16 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     )
                 updated["next_run_at"] = next_run
 
+            if is_terminal_job(job) and (
+                updated.get("state") not in {"completed", "error"}
+                or updated.get("enabled") is True
+                or updated.get("next_run_at") is not None
+            ):
+                raise ValueError(
+                    f"Cannot activate terminal cron job '{job.get('name', job_id)}' "
+                    "through update_job; use cron resume --run-now or --at."
+                )
+
             jobs[i] = updated
             save_jobs(jobs)
             return _normalize_job_record(jobs[i])
@@ -2239,6 +2264,14 @@ def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
     job = resolve_job_ref(job_id)
     if not job:
         return None
+    if is_terminal_job(job):
+        state = job.get("state")
+        name = job.get("name", job_id)
+        raise ValueError(
+            f"Cannot run: job '{name}' is {state} (terminal). "
+            f"Create a new occurrence with 'hermes cron resume {name} "
+            "--run-now' or '--at <ISO-8601>'."
+        )
     return update_job(
         job["id"],
         {
@@ -2756,6 +2789,8 @@ def advance_next_runs(job_ids) -> int:
         for job in jobs:
             if job["id"] not in ids:
                 continue
+            if is_terminal_job(job):
+                continue
             kind = job.get("schedule", {}).get("kind")
             if kind not in {"cron", "interval"}:
                 continue
@@ -2855,6 +2890,8 @@ def _claim_job_for_fire_locked(
         for job in jobs:
             if job["id"] != job_id:
                 continue
+            if is_terminal_job(job):
+                return False
             # enabled + pause markers must both clear — a half-paused record
             # (enabled=true, state=paused/paused_at set) must not claim. An
             # explicit ``force`` (Trigger-now on a paused job) bypasses the
@@ -3153,6 +3190,8 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
         # job this tick" so healthy siblings still run and their recovered
         # state still reaches save_jobs() below.
         try:
+            if is_terminal_job(job):
+                continue
             if not job.get("enabled", True):
                 continue
 

--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -1599,16 +1599,26 @@ def _cron_pause(_engine: HermesConsoleEngine, args: list[str]) -> str:
 
 
 def _cron_resume(_engine: HermesConsoleEngine, args: list[str]) -> str:
-    if len(args) != 1:
-        raise ConsoleCommandError("Usage: cron resume <job>")
-    from cron.jobs import AmbiguousJobReference, resume_job
+    parser = _ArgumentParser(prog="cron resume", add_help=False)
+    parser.add_argument("job")
+    parser.add_argument("--at")
+    parser.add_argument("--run-now", action="store_true")
+    ns = parser.parse_args(args)
+    if ns.at and ns.run_now:
+        raise ConsoleCommandError("Use exactly one of --at or --run-now.")
+    from cron.jobs import AmbiguousJobReference, _hermes_now, rearm_oneshot, resume_job
 
     try:
-        job = resume_job(args[0])
+        if ns.at or ns.run_now:
+            job = rearm_oneshot(ns.job, _hermes_now().isoformat() if ns.run_now else ns.at)
+        else:
+            job = resume_job(ns.job)
     except AmbiguousJobReference as exc:
         raise ConsoleCommandError(str(exc)) from exc
+    except ValueError as exc:
+        raise ConsoleCommandError(str(exc)) from exc
     if not job:
-        raise ConsoleCommandError(f"Job not found: {args[0]}")
+        raise ConsoleCommandError(f"Job not found: {ns.job}")
     return _format_job(job, "Resumed")
 
 

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -558,6 +558,29 @@ def _job_action(action: str, job_id: str, success_verb: str) -> int:
     return 0
 
 
+def cron_resume(args) -> int:
+    """Resume a paused job or explicitly re-arm a completed one-shot."""
+    if bool(getattr(args, "run_at", None)) == bool(getattr(args, "run_now", False)):
+        if getattr(args, "run_at", None) or getattr(args, "run_now", False):
+            print(color("Use exactly one of --at or --run-now.", Colors.RED))
+            return 1
+        return _job_action("resume", args.job_id, "Resumed")
+    from cron.jobs import AmbiguousJobReference, _hermes_now, rearm_oneshot
+
+    run_at = _hermes_now().isoformat() if args.run_now else args.run_at
+    try:
+        job = rearm_oneshot(args.job_id, run_at)
+    except (AmbiguousJobReference, ValueError) as exc:
+        print(color(f"Failed to re-arm job: {exc}", Colors.RED))
+        return 1
+    if not job:
+        print(color(f"Job not found: {args.job_id}", Colors.RED))
+        return 1
+    print(color(f"Re-armed job: {job.get('name', args.job_id)} ({args.job_id})", Colors.GREEN))
+    print(f"  Next run: {job.get('next_run_at')}")
+    return 0
+
+
 def cron_notepad(args) -> int:
     """Handle ``hermes cron notepad <job_id> [get|set|delete|list]``.
 
@@ -654,7 +677,7 @@ def cron_command(args):
         return _job_action("pause", args.job_id, "Paused")
 
     if subcmd == "resume":
-        return _job_action("resume", args.job_id, "Resumed")
+        return cron_resume(args)
 
     if subcmd == "run":
         return _job_action("run", args.job_id, "Triggered")

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -238,6 +238,8 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
 
     cron_resume = cron_subparsers.add_parser("resume", help="Resume a paused job")
     cron_resume.add_argument("job_id", help="Job ID to resume")
+    cron_resume.add_argument("--at", dest="run_at", help="Re-arm at an ISO-8601 time")
+    cron_resume.add_argument("--run-now", action="store_true", help="Re-arm to run now")
 
     cron_run = cron_subparsers.add_parser(
         "run", help="Run a job on the next scheduler tick"

--- a/tests/cron/test_terminal_job_rearm.py
+++ b/tests/cron/test_terminal_job_rearm.py
@@ -1,0 +1,138 @@
+"""Behavioral coverage for terminal cron jobs and explicit one-shot re-arm."""
+
+from datetime import datetime, timedelta, timezone
+import copy
+
+import pytest
+
+from cron.jobs import (
+    advance_next_run,
+    create_job,
+    get_due_jobs,
+    get_job,
+    load_jobs,
+    mark_job_run,
+    save_jobs,
+    trigger_job,
+    update_job,
+)
+
+
+@pytest.fixture()
+def tmp_cron_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+    return tmp_path
+
+
+def test_completed_oneshot_trigger_is_refused_and_disk_record_is_unchanged(tmp_cron_dir):
+    job = create_job("done", "30m", name="done", repeat=1)
+    mark_job_run(job["id"], success=True)
+    before = copy.deepcopy(load_jobs())
+
+    with pytest.raises(ValueError, match="terminal"):
+        trigger_job(job["id"])
+
+    assert load_jobs() == before
+    assert get_job(job["id"]) == before[0]
+
+
+def test_exhausted_recurring_job_trigger_is_refused(tmp_cron_dir):
+    job = create_job("done", "every 1h", repeat=1)
+    mark_job_run(job["id"], success=True)
+
+    with pytest.raises(ValueError, match="terminal"):
+        trigger_job(job["id"])
+
+
+def test_wedged_claimed_oneshot_remains_triggerable(tmp_cron_dir):
+    now = datetime.now(timezone.utc)
+    job = create_job("wedged", "30m", repeat=2)
+    record = get_job(job["id"])
+    record.update({
+        "run_claim": {"at": now.isoformat(), "by": "dead-worker"},
+        "state": "scheduled",
+        "enabled": True,
+        "next_run_at": (now - timedelta(minutes=1)).isoformat(),
+    })
+    save_jobs([record])
+
+    triggered = trigger_job(job["id"])
+    assert triggered["state"] == "scheduled"
+    assert triggered["enabled"] is True
+
+
+def test_paused_job_run_override_remains_allowed(tmp_cron_dir):
+    job = create_job("paused", "every 1h")
+    from cron.jobs import pause_job
+
+    pause_job(job["id"])
+    triggered = trigger_job(job["id"])
+    assert triggered["state"] == "scheduled"
+    assert triggered["enabled"] is True
+
+
+def test_terminal_jobs_are_not_due_or_advanced(tmp_cron_dir):
+    job = create_job("done", "every 1h", repeat=1)
+    mark_job_run(job["id"], success=True)
+    before = copy.deepcopy(load_jobs())
+
+    assert get_due_jobs() == []
+    assert advance_next_run(job["id"]) is False
+    assert load_jobs() == before
+
+
+def test_terminal_refusal_survives_reload(tmp_cron_dir):
+    job = create_job("done", "30m", repeat=1)
+    mark_job_run(job["id"], success=True)
+    before = copy.deepcopy(load_jobs())
+    assert get_job(job["id"])["state"] == "completed"
+
+    with pytest.raises(ValueError):
+        trigger_job(job["id"])
+    assert load_jobs() == before
+
+
+def test_update_cannot_reactivate_terminal_record(tmp_cron_dir):
+    job = create_job("done", "30m", repeat=1)
+    mark_job_run(job["id"], success=True)
+    with pytest.raises(ValueError, match="terminal"):
+        update_job(job["id"], {"enabled": True})
+    with pytest.raises(ValueError, match="terminal"):
+        update_job(job["id"], {"schedule": "every 1h"})
+
+
+def test_rearm_completed_oneshot_restores_schedule_and_preserves_history(tmp_cron_dir):
+    from cron.jobs import rearm_oneshot
+
+    job = create_job("done", "30m", repeat=3)
+    mark_job_run(job["id"], success=True)
+    finished = get_job(job["id"])
+    run_at = (datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat()
+
+    rearmed = rearm_oneshot(job["id"], run_at)
+    assert rearmed["schedule"]["kind"] == "once"
+    assert rearmed["repeat"]["times"] == 3
+    assert rearmed["repeat"]["completed"] == 0
+    assert rearmed["state"] == "scheduled"
+    assert rearmed["enabled"] is True
+    assert rearmed["next_run_at"] == rearmed["schedule"]["run_at"]
+    assert rearmed["last_run_at"] == finished["last_run_at"]
+    assert rearmed["last_status"] == finished["last_status"]
+
+
+def test_rearm_refuses_recurring_and_live_claim(tmp_cron_dir):
+    from cron.jobs import rearm_oneshot
+
+    recurring = create_job("recurring", "every 1h")
+    future = (datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat()
+    with pytest.raises(ValueError, match="one-shot"):
+        rearm_oneshot(recurring["id"], future)
+
+    oneshot = create_job("claimed", "30m")
+    record = get_job(oneshot["id"])
+    record["run_claim"] = {"at": datetime.now(timezone.utc).isoformat(), "by": "live"}
+    save_jobs([record])
+    with pytest.raises(ValueError, match="claim"):
+        rearm_oneshot(oneshot["id"], future)


### PR DESCRIPTION
fix(cron): refuse to run terminal jobs and add 'cron resume --at/--run-now' re-arm

## Summary

Fixes the bug class where `hermes cron run` silently resurrects completed jobs as a NEW occurrence (filed as this-week work; relates to #38758 and wedged-recovery #59229). Part A makes terminal-state refusal a hard invariant at the job layer; Part B adds the explicit re-arm operation the refusal message points to, so operators have a safe, audited path to re-run a finished one-shot.

## Part A: terminal guard

trigger_job had no terminal-state guard: it unconditionally set enabled=True / state=scheduled / next_run_at=now, so a completed one-shot (terminal shape: enabled=False / state=completed / next_run_at=None, retained for COMPLETED_ONESHOT_RETENTION_DAYS) was silently recreated as a new occurrence. The same mark_job_run branch is hit by a recurring job that exhausted repeat.times, so the guard applies to all jobs, not just one-shots.

Changes:
- is_terminal_job(job): state in {completed, error}, beside effective_job_state. Never keyed on claim presence.
- trigger_job raises ValueError on terminal jobs; translated to ConsoleCommandError (nonzero exit) at the console boundary. jobs.py stays CLI-agnostic.
- Narrow update_job check: refuses patches that leave a terminal record active (state non-terminal, or enabled=True/next_run_at set).
- Message: Cannot run: job '<name>' is <state> (terminal). Create a new occurrence with 'hermes cron resume <job> --run-now' or '--at <ISO-8601>'.

## Step 0 tree verification

1. State writers: all job-record `state` writes are in `cron/jobs.py`; `completed` is normal finite-repeat/one-shot exhaustion, and `error` is recurring next-run computation failure. The latter remains terminal. `last_status="error"` is the distinct retry/recovery signal.
2. Claim fields: `run_claim` is the one-shot dispatch lease; `fire_claim` is the external/manual fire lease. No `dispatch_lease`, retry-eligibility, or additional job claim field exists in the repository sweep.
3. `update_job` refuses a past one-shot when `compute_next_run` returns `None`; `resume_job` has the corresponding past-window refusal. The new terminal invariant runs after merged/derived updates.
4. `advance_next_runs`, `get_due_jobs`, and `claim_job_for_fire` were the sibling fire paths. They now skip/refuse terminal records; stale recurring recovery remains keyed to `last_status`, not terminal `state`.
5. Console `_cron_run` and `_cron_resume` already catch `ValueError` and raise `ConsoleCommandError`; the console engine returns a nonzero command failure. The standard CLI reports the same exception as a failed command.
6. `hermes cron create` has a positional `schedule` flag, not `--at`; ISO timestamps are parsed by `parse_schedule`, normalized with `datetime.fromisoformat` and stored via `dt.isoformat()`. Part B intentionally adds `resume --at` and `resume --run-now` while reusing that parser and grace constant.
7. Desktop Run is backend-routed through `_trigger_cron_job_sync` and the shared `claim_job_for_fire` path, not a direct JSON writer. The shared guard therefore covers the dashboard path.

Error-state grep evidence: Whole-repo source sweep found the only job-record writers in `cron/jobs.py`: `mark_job_run` writes `state="error"` only when a recurring cron/interval schedule cannot compute `next_run_at` (missing or unavailable croniter), and writes `state="completed"` for exhausted finite repeats and one-shot no-next-run completion. No desktop/backend job writer was found. The error writer is an operational/configuration terminal state, not a last-run retry marker, so it remains guarded. The separate stale recovery path keys on `last_status="error"` and remains retryable.

Sibling-path sweep (no resurrection):

| Path | Tree finding | Result |
| --- | --- | --- |
| `advance_next_run(s)` | Advances only cron/interval records under the jobs lock | Added terminal skip |
| `get_due_jobs` | Due scan can claim one-shots and recover stale recurring errors | Added terminal skip before recovery/claim logic |
| scheduler fire path | External/manual fire uses `claim_job_for_fire` | Added terminal refusal in the shared claim path |
| `trigger_job` | Previously called `update_job` with active fields unconditionally | Added terminal refusal |
| `update_job` | Generic merged-record writer could reactivate terminal records | Added final active-terminal invariant check |

## Part B: rearm_oneshot

rearm_oneshot(job_id, run_at) is a dedicated, locked re-arm operation (not a public allow_rearm flag):
- one-shot-only, validated under the job lock.
- Reuses create_job's ISO parser and ONESHOT_GRACE_SECONDS rule.
- Sets schedule.run_at, resets repeat.completed=0 (times preserved), clears run_claim/fire_claim/dispatch-lease/retry-eligibility state, enabled=True, state=scheduled, paused_at/reason=None, next_run_at=run_at.
- Preserves last_run_at and history. Single save.
- --run-now uses the injected clock (_hermes_now); --at and --run-now are mutually exclusive; refuses recurring jobs (points at plain resume / cron run); refuses re-arm over a live unexpired claim.

Note: resetting repeat.completed changes the budget counter, not the at-least-once / at-most-times invariant (times is preserved).

Desktop: The dashboard routes Run through the backend `_trigger_cron_job_sync`, which resolves the profile and calls the shared fire/claim path; it does not write job JSON directly. The shared claim guard now refuses terminal rows and returns the existing HTTP conflict/error surface. The CLI and console resume surfaces provide `--at` and `--run-now` for explicit re-arm.

## Tests

Red proof on pristine upstream: `pytest -q tests/cron/test_terminal_job_rearm.py` reported 6 failed, 2 passed. Key failures were `Failed: DID NOT RAISE ValueError` for completed one-shot, exhausted recurring, and reload/advance invariants, plus `ImportError: cannot import name 'rearm_oneshot'` for Part B. After implementation: focused behavioral suite 9 passed; `tests/cron/test_jobs.py` 72 passed; full `tests/cron` 814 passed, 1 skipped, with one pre-existing runtime warning. Python compilation passed. Ruff/Black/Flake8 were unavailable in the environment.

The behavioral tests use the real temp cron store and reload persisted records. They cover completed one-shot refusal with full-record equality, exhausted recurring refusal, wedged #59229 claim preservation, paused manual override, due/advance non-resurrection, update-door protection, re-arm history preservation, recurring rejection, and live-claim rejection.

## Non-goals

- No change to at-most-once scheduling semantics outside the terminal guard.
- No new config/CLI/env knobs beyond the resume flags above.
- Part C (local asap tooling: heartbeat fields, lint-one-shot binding, journal compaction) is tracked separately and ships in the vault repo, not here.
- covers=cron-jobs-trigger-resume,asap-tooling
