### PR TITLE
fix(desktop): ellipsize long options in searchable selects

### DIFF
--- a/apps/desktop/src/app/settings/searchable-select.test.tsx
+++ b/apps/desktop/src/app/settings/searchable-select.test.tsx
@@ -95,6 +95,24 @@ describe('SearchableSelect', () => {
 
     expect(screen.getByRole('combobox').textContent).toContain('Search…')
   })
+
+  it('wraps option text in a truncating span so narrow popovers stay readable', () => {
+    render(
+      <SearchableSelect
+        clearLabel="System default"
+        onChange={vi.fn()}
+        options={['Africa/Abidjan', 'America/Argentina/Buenos_Aires']}
+        value=""
+      />
+    )
+
+    fireEvent.click(screen.getByRole('combobox'))
+
+    // Long IANA identifiers must ellipsize (truncate) instead of wrapping and
+    // clipping mid-word when the popover is narrower than the option text.
+    expect(screen.getByText('Africa/Abidjan').className).toContain('truncate')
+    expect(screen.getByText('System default').className).toContain('truncate')
+  })
 })
 
 describe('ConfigField searchable routing', () => {

--- a/apps/desktop/src/app/settings/searchable-select.tsx
+++ b/apps/desktop/src/app/settings/searchable-select.tsx
@@ -88,7 +88,7 @@ export function SearchableSelect({
           <Codicon className="shrink-0 opacity-60" name={open ? 'chevron-up' : 'chevron-down'} size="1rem" />
         </button>
       </PopoverTrigger>
-      <PopoverContent align="start" className="w-[var(--radix-popover-trigger-width)] p-0">
+      <PopoverContent align="start" className="w-[var(--radix-popover-trigger-width)] min-w-60 p-0">
         <Command filter={rankSearchOption}>
           <CommandInput autoFocus placeholder={placeholder} />
           <CommandList>
@@ -97,13 +97,13 @@ export function SearchableSelect({
               {clearLabel && (
                 <CommandItem onSelect={() => handleSelect('')} value={clearLabel}>
                   <Codicon className={cn('mr-2 size-4', value === '' ? 'opacity-100' : 'opacity-0')} name="check" />
-                  {clearLabel}
+                  <span className="min-w-0 flex-1 truncate">{clearLabel}</span>
                 </CommandItem>
               )}
               {options.map(option => (
                 <CommandItem key={option} onSelect={() => handleSelect(option)} value={option}>
                   <Codicon className={cn('mr-2 size-4', option === value ? 'opacity-100' : 'opacity-0')} name="check" />
-                  {option}
+                  <span className="min-w-0 flex-1 truncate">{option}</span>
                 </CommandItem>
               ))}
             </CommandGroup>


### PR DESCRIPTION
Bug: The timezone dropdown in Settings renders unreadable when the sidebar is narrow — every IANA option clips mid-word (Africa/Abidjan shows as "Afric", repeated down the list) and the "System default" clear item wraps onto two lines. Reproduced on Windows 10, Hermes Desktop, Settings → Chat → Timezone.

Cause: SearchableSelect's popover inherits the trigger width (w-[var(--radix-popover-trigger-width)]) and CommandItem doesn't constrain its text, so long identifiers wrap and the list clips the overflow.

Fix: popover gets a min-w-60 floor; option/clear text wraps in a min-w-0 flex-1 truncate span — one line, clean ellipsis.

Tests: added a regression test asserting option and clear-label text render inside a truncate span. 13/13 tests in the file pass, eslint clean.