### PR TITLE
fix(approval): collapse redundant path separators before sensitive-path detection

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -323,6 +323,49 @@ class TestTeePattern:
             assert key is None
 
 
+class TestRedundantPathSeparators:
+    """Redundant `/` runs and `/./` segments must not slip the sensitive-path rules.
+
+    POSIX resolves `~//.hermes/config.yaml` to the same file as
+    `~/.hermes/config.yaml`, but the sensitive-path fragments anchor on a single
+    separator. Since ~/.hermes/config.yaml holds approvals.mode and the config
+    cache is mtime-keyed, an unflagged write there disables the gate mid-session.
+    """
+
+    def test_doubled_separator_still_flagged(self):
+        for command in (
+            "echo 'approvals: {mode: off}' > ~//.hermes/config.yaml",
+            "echo 'approvals: {mode: off}' > ~/.hermes//config.yaml",
+            "echo x > ~//.hermes/.env",
+            "echo k >> ~//.ssh/authorized_keys",
+            "echo x >> ~//.bashrc",
+            "cat f | tee ~//.ssh/authorized_keys",
+        ):
+            dangerous, key, _desc = detect_dangerous_command(command)
+            assert dangerous is True, command
+            assert key is not None, command
+
+    def test_dot_segment_still_flagged(self):
+        for command in (
+            "echo k >> ~/./.ssh/authorized_keys",
+            "echo k >> ~/././.ssh/authorized_keys",
+            "echo 'approvals: {mode: off}' > ~/./.hermes/config.yaml",
+        ):
+            dangerous, key, _desc = detect_dangerous_command(command)
+            assert dangerous is True, command
+            assert key is not None, command
+
+    def test_urls_and_arithmetic_not_false_flagged(self):
+        for command in (
+            "curl https://example.com//api/v1",
+            "git clone https://github.com/a/b.git",
+            "echo $((10 // 3))",
+            "ls ~/projects",
+        ):
+            dangerous, _key, _desc = detect_dangerous_command(command)
+            assert dangerous is False, command
+
+
 class TestHermesConfigWriteProtection:
     """Terminal-side pairing for the file_tools write_file/patch deny on
     ~/.hermes/config.yaml (#14639). config.yaml IS the security policy

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1172,6 +1172,24 @@ def _normalize_command_for_detection(command: str) -> str:
     # first would eat the prefix the Hermes-home fold needs.
     command = _rewrite_resolved_hermes_home(command)
     command = _rewrite_resolved_user_home(command)
+    # Collapse redundant `/` runs and no-op `/./` segments inside path tokens.
+    # POSIX resolves `~//.hermes/config.yaml` and `~/./.ssh/authorized_keys` to
+    # the same files as their single-separator spellings, but the sensitive-path
+    # fragments (_SSH_SENSITIVE_PATH, _HERMES_CONFIG_PATH, ...) anchor on exactly
+    # one `/` between components, so the redundant spellings slip every rule —
+    # including the write gate on ~/.hermes/config.yaml, which IS the approval
+    # policy (approvals.mode, yolo, the permanent allowlist) and is re-read
+    # mtime-keyed, so a write takes effect mid-session.
+    #
+    # The absolute spellings already tolerate this because _home_prefix_fold_regex
+    # joins components with `[/\\]+`; this closes the same hole for the `~` and
+    # $HOME/$HERMES_HOME forms the fold above produces.
+    #
+    # Both substitutions require a preceding path character so URL schemes
+    # (`http://`), UNC roots (`\\server`) and arithmetic (`2 // 3`) are left
+    # alone. Runs first for `/./` so `~/././x` collapses fully.
+    command = re.sub(r'(?<=[\w~.\-])(?:/\.)+/', '/', command)
+    command = re.sub(r'(?<=[\w~.\-])//+', '/', command)
     # Strip shell backslash-escapes: r\m → rm. Prevents \-injection bypass.
     command = re.sub(r'\\([^\n])', r'\1', command)
     # Strip empty-string literals that split tokens: r''m → rm, r"\"m → rm.


### PR DESCRIPTION
## What does this PR do?

`_normalize_command_for_detection` folds absolute home prefixes, strips backslash escapes, and expands `$IFS` — but it never collapses redundant `/` runs or no-op `/./` segments inside a path token. The sensitive-path fragments (`_SSH_SENSITIVE_PATH`, `_HERMES_CONFIG_PATH`, the shell-rc and dotfile targets) all anchor on exactly one `/` between components, so a spelling POSIX resolves to the very same file slips every terminal-side write rule.

```
FLAGGED    echo 'approvals: {mode: off}' > ~/.hermes/config.yaml
UNFLAGGED  echo 'approvals: {mode: off}' > ~//.hermes/config.yaml
UNFLAGGED  echo 'approvals: {mode: off}' > ~/.hermes//config.yaml
UNFLAGGED  echo k >> ~//.ssh/authorized_keys
UNFLAGGED  echo k >> ~/./.ssh/authorized_keys
UNFLAGGED  echo x >> ~//.bashrc
UNFLAGGED  echo x >  ~//.hermes/.env
```

This matters most for `~/.hermes/config.yaml`, for the reason the comment above `_HERMES_CONFIG_PATH` already states: that file *is* the security policy (`approvals.mode`, yolo, the permanent-approval allowlist), `_get_approval_mode()` re-reads it live, and `check_all_command_guards` returns unconditionally once `approval_mode == "off"`. A prompt-injected agent needs one `terminal` call to write `approvals: {mode: off}` with no prompt, after which every command in the session runs ungated.

The absolute spellings were never affected — `_home_prefix_fold_regex` joins components with `[/\\]+`, so `/Users/alice//.hermes/config.yaml` **is** caught today. That inconsistency is what surfaced the gap: this PR gives the `~` / `$HOME` / `$HERMES_HOME` forms the same tolerance.

## Related Issue

No existing issue found. I searched open and merged PRs for approval/sensitive-path/separator topics before writing this; the nearest neighbours (#78653 Windows separator normalization in file-tools, #71919 Windows path command boundaries, #10682 OS-agnostic sensitive path protection) address different layers and none collapses redundant separators in `tools/approval.py`.

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `tools/approval.py` — in `_normalize_command_for_detection`, collapse `/./` runs and repeated `/` inside path tokens, immediately after the home folds and before the backslash-escape strip.
- `tests/tools/test_approval.py` — new `TestRedundantPathSeparators` covering doubled separators, `/./` segments (including repeated ones), and a false-positive guard.

Both substitutions use a lookbehind requiring a path character (`[\w~.\-]`), so URL schemes (`https://`), UNC roots (`\\server`) and integer division (`10 // 3`) are left alone.

Placement is deliberate: it runs *after* `_rewrite_resolved_hermes_home` / `_rewrite_resolved_user_home` so it also normalizes the `~`-form those produce, and *before* the backslash strip for the same Windows reason documented there.

## How to Test

Before the fix:

```python
from tools.approval import detect_dangerous_command
detect_dangerous_command("echo 'approvals: {mode: off}' > ~//.hermes/config.yaml")
# (False, None, None)   <- no approval prompt
```

After:

```python
# (True, 'sensitive_redirect', 'overwrite system file via redirection')
```

Regression suite:

```
pytest tests/tools/test_approval.py tests/tools/test_approval_windows.py tests/tools/test_approval_deny_rules.py -q
```

165 passed on my machine. One unrelated pre-existing failure, `TestDetectDangerousRm::test_nonrecursive_verification_artifact_cleanup_is_not_dangerous`, reproduces identically on unmodified `main` here — it is a macOS artifact (`/tmp` is a symlink to `/private/tmp`, so the canonical-target check in the temp-dir exemption does not match the mocked `gettempdir`), not a consequence of this change.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant test suites and all pass (modulo the pre-existing macOS failure noted above)
- [x] I've added tests for my changes
