### PR TITLE
fix(desktop): keep lazy code highlighting from shifting the transcript

### DIFF
--- a/apps/desktop/e2e/code-block-highlight-jitter.spec.ts
+++ b/apps/desktop/e2e/code-block-highlight-jitter.spec.ts
@@ -1,0 +1,258 @@
+/**
+ * Diagnostic regression for #88151: opening a persisted transcript containing
+ * fenced code blocks must not move the viewport when LazyShiki replaces its
+ * plain Suspense fallback with the highlighted DOM.
+ *
+ * This uses the real Electron renderer and a real persisted SessionDB row. The
+ * mock provider only supplies deterministic Markdown; no external model calls.
+ */
+
+import {
+  buildAppEnv,
+  createSandbox,
+  launchDesktop,
+  type MockBackendFixture,
+  waitForAppReady,
+  writeEnvFile,
+  writeMockProviderConfig,
+} from './fixtures'
+import { startMockServer } from './mock-server'
+import { RealSessionBuilder } from './real-session-builder'
+import { expect, test } from './test'
+
+const SESSION_TITLE = 'E2E Code Block Highlight Jitter'
+const SURFACE = '[data-composer-target]:not([data-pane-hidden] [data-composer-target])'
+const INLINE_BLOCK_COUNT = 6
+const LONG_BLOCK_LINES = 240
+const LINES_PER_SHORT_BLOCK = 14
+
+const shortBlocks = Array.from({ length: INLINE_BLOCK_COUNT }, (_, block) => {
+  const lines = Array.from(
+    { length: LINES_PER_SHORT_BLOCK },
+    (_, line) => `const value_${block}_${line} = ${block * 100 + line}`,
+  )
+
+  return [`Block ${block + 1}`, '```typescript', ...lines, '```'].join('\n')
+})
+
+const longBlock = [
+  'Long block (exercises the >200-line chunked fallback)',
+  '```typescript',
+  ...Array.from({ length: LONG_BLOCK_LINES }, (_, line) => `const long_value_${line} = ${line}`),
+  '```',
+].join('\n')
+
+const CODE_REPLY = [...shortBlocks, longBlock].join('\n\n')
+
+interface LayoutSample {
+  reason: string
+  at: number
+  blockCount: number
+  fallbackCount: number
+  shikiCount: number
+  heights: number[]
+  typography: Array<{
+    codeFontSize: string
+    codeHeight: number
+    codeLineHeight: string
+    codeDisplay: string
+    innerPreHeight: number | null
+    outerFontSize: string
+    outerLineHeight: string
+    outerPaddingBlock: string
+    node: string
+  }>
+  totalHeight: number
+  scrollTop: number
+  scrollHeight: number
+}
+
+interface LayoutProbe {
+  samples: LayoutSample[]
+  observer: MutationObserver
+}
+
+let fixture: MockBackendFixture | null = null
+
+test.beforeAll(async () => {
+  const mock = await startMockServer({ replyText: CODE_REPLY })
+  const sandbox = createSandbox('code-jitter')
+  writeMockProviderConfig(sandbox.hermesHome, mock.url)
+  writeEnvFile(sandbox.hermesHome)
+
+  const builder = await RealSessionBuilder.start(sandbox.hermesHome)
+
+  try {
+    await builder.createSession({
+      title: SESSION_TITLE,
+      turns: ['Render a deterministic fenced-code transcript for layout measurement.'],
+    })
+  } finally {
+    await builder.close()
+  }
+
+  const { app, page } = await launchDesktop(buildAppEnv(sandbox))
+  fixture = {
+    app,
+    page,
+    mock,
+    mockUrl: mock.url,
+    sandbox,
+    cleanup: async () => {
+      await app.close().catch(() => undefined)
+      await mock.close()
+      sandbox.cleanup()
+    },
+  }
+  await waitForAppReady(fixture, 120_000)
+})
+
+test.afterAll(async () => {
+  await fixture?.cleanup()
+  fixture = null
+})
+
+// Playwright requires the fixture argument to use object destructuring.
+// eslint-disable-next-line no-empty-pattern
+test('LazyShiki replacement keeps code block height stable', async ({}, testInfo) => {
+  const page = fixture!.page
+
+  const sessionRow = page
+    .locator('[data-slot="sidebar"] button')
+    .filter({ hasText: SESSION_TITLE })
+    .first()
+
+  await sessionRow.waitFor({ state: 'visible', timeout: 60_000 })
+
+  await page.evaluate((surfaceSelector: string) => {
+    const state: LayoutProbe = {
+      samples: [],
+      observer: null as unknown as MutationObserver,
+    }
+
+    let lastSignature = ''
+
+    const capture = (reason: string) => {
+      const surfaces = [...document.querySelectorAll<HTMLElement>(surfaceSelector)]
+      const surface = surfaces.at(-1)
+      const viewport = surface?.querySelector<HTMLElement>('[data-slot="aui_thread-viewport"]')
+      const blocks = [...(surface?.querySelectorAll<HTMLElement>('.aui-shiki') ?? [])]
+
+      if (!viewport || blocks.length === 0) {
+        return
+      }
+
+      const heights = blocks.map(block => Number(block.getBoundingClientRect().height.toFixed(2)))
+
+      const typography = blocks.map(block => {
+        const node = block.querySelector<HTMLElement>('code') ?? block
+        const innerPre = block.querySelector<HTMLElement>('pre')
+        const outerStyle = getComputedStyle(block)
+        const codeStyle = getComputedStyle(node)
+
+        return {
+          codeFontSize: codeStyle.fontSize,
+          codeHeight: Number(node.getBoundingClientRect().height.toFixed(2)),
+          codeLineHeight: codeStyle.lineHeight,
+          codeDisplay: codeStyle.display,
+          innerPreHeight: innerPre ? Number(innerPre.getBoundingClientRect().height.toFixed(2)) : null,
+          outerFontSize: outerStyle.fontSize,
+          outerLineHeight: outerStyle.lineHeight,
+          outerPaddingBlock: `${outerStyle.paddingTop} ${outerStyle.paddingBottom}`,
+          node: node.tagName.toLowerCase(),
+        }
+      })
+
+      const shikiCount = blocks.filter(block => Boolean(block.querySelector('.shiki'))).length
+      const fallbackCount = blocks.length - shikiCount
+
+      const sample: LayoutSample = {
+        reason,
+        at: performance.now(),
+        blockCount: blocks.length,
+        fallbackCount,
+        shikiCount,
+        heights,
+        typography,
+        totalHeight: Number(heights.reduce((sum, height) => sum + height, 0).toFixed(2)),
+        scrollTop: Number(viewport.scrollTop.toFixed(2)),
+        scrollHeight: viewport.scrollHeight,
+      }
+
+      const signature = JSON.stringify([
+        sample.blockCount,
+        sample.fallbackCount,
+        sample.shikiCount,
+        sample.heights,
+        sample.scrollTop,
+        sample.scrollHeight,
+      ])
+
+      if (signature !== lastSignature) {
+        state.samples.push(sample)
+        lastSignature = signature
+      }
+    }
+
+    state.observer = new MutationObserver(() => {
+      capture('mutation')
+      requestAnimationFrame(() => capture('animation-frame'))
+    })
+    state.observer.observe(document.body, { childList: true, subtree: true })
+    ;(window as unknown as { __CODE_BLOCK_LAYOUT_PROBE__?: LayoutProbe }).__CODE_BLOCK_LAYOUT_PROBE__ = state
+  }, SURFACE)
+
+  await sessionRow.click()
+  await page.waitForFunction(
+    ([surfaceSelector, expected]: [string, number]) => {
+      const surfaces = [...document.querySelectorAll<HTMLElement>(surfaceSelector)]
+      const surface = surfaces.at(-1)
+
+      return (surface?.querySelectorAll('.aui-shiki .shiki').length ?? 0) === expected
+    },
+    [SURFACE, INLINE_BLOCK_COUNT] as [string, number],
+    { timeout: 60_000 },
+  )
+  await page.waitForTimeout(1_000)
+
+  const samples = await page.evaluate(() => {
+    const probe = (window as unknown as { __CODE_BLOCK_LAYOUT_PROBE__?: LayoutProbe }).__CODE_BLOCK_LAYOUT_PROBE__
+    probe?.observer.disconnect()
+
+    return probe?.samples ?? []
+  })
+
+  await testInfo.attach('code-block-layout-samples', {
+    body: Buffer.from(JSON.stringify(samples, null, 2)),
+    contentType: 'application/json',
+  })
+
+  const completeSamples = samples.filter(sample => sample.blockCount === INLINE_BLOCK_COUNT)
+
+  const fallback = completeSamples
+    .filter(sample => sample.fallbackCount > 0)
+    .sort((a, b) => b.fallbackCount - a.fallbackCount || a.at - b.at)[0]
+
+  const highlighted = [...completeSamples].reverse().find(sample => sample.shikiCount === INLINE_BLOCK_COUNT)
+
+  expect(fallback, `Expected to capture the PlainCode fallback. Samples: ${JSON.stringify(samples)}`).toBeTruthy()
+  expect(highlighted, `Expected to capture the final Shiki DOM. Samples: ${JSON.stringify(samples)}`).toBeTruthy()
+  await expect(page.getByRole('button', { name: /typescript Code Open/ })).toBeVisible()
+
+  const perBlockHeightDeltas = highlighted!.heights.map((height, index) =>
+    Number(Math.abs(height - fallback!.heights[index]).toFixed(2)),
+  )
+
+  const heightDelta = Number(Math.abs(highlighted!.totalHeight - fallback!.totalHeight).toFixed(2))
+  const scrollDelta = Number(Math.abs(highlighted!.scrollTop - fallback!.scrollTop).toFixed(2))
+  console.log(
+    `#88151 layout evidence: height ${fallback!.totalHeight} -> ${highlighted!.totalHeight} (Δ${heightDelta}px), ` +
+      `scrollTop ${fallback!.scrollTop} -> ${highlighted!.scrollTop} (Δ${scrollDelta}px)`,
+  )
+
+  expect(
+    Math.max(...perBlockHeightDeltas),
+    `Individual code block heights changed across fallback -> Shiki: ${JSON.stringify({ perBlockHeightDeltas, fallback, highlighted })}`,
+  ).toBeLessThanOrEqual(1)
+  expect(heightDelta, `Code block height changed across fallback -> Shiki: ${JSON.stringify({ fallback, highlighted })}`).toBeLessThanOrEqual(1)
+})

--- a/apps/desktop/e2e/mock-server.ts
+++ b/apps/desktop/e2e/mock-server.ts
@@ -26,6 +26,8 @@ export const MOCK_REPLY = 'Hello from the mock inference server! The full boot c
 export interface MockServerOptions {
   /** Pause the matching stream after its first token for session-switch E2E coverage. */
   holdFirstStreamForPrompt?: string
+  /** Override the normal canned assistant reply for focused renderer tests. */
+  replyText?: string
 /** Pause the first completion whose request JSON contains this text. */
 holdFirstCompletionContaining?: string
 /** Absolute sandbox path written by the verify-on-stop scripted tool call. */
@@ -465,6 +467,7 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
 
           const stream = parsed.stream === true
           const model = parsed.model || 'mock-model'
+          const replyText = options.replyText ?? MOCK_REPLY
           const holdThisCompletion = Boolean(
             options.holdFirstCompletionContaining &&
             heldCompletionCount === 0 &&
@@ -620,7 +623,7 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
               options.holdFirstStreamForPrompt && typeof lastUserMessage?.content === 'string' &&
                 lastUserMessage.content.includes(options.holdFirstStreamForPrompt),
             )
-            streamTextResponse(res, model, MOCK_REPLY, holdThisStream || holdThisCompletion ? () => {
+            streamTextResponse(res, model, replyText, holdThisStream || holdThisCompletion ? () => {
               if (holdThisCompletion) {
                 heldCompletionCount++
               }
@@ -631,9 +634,9 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
             if (holdThisCompletion) {
               heldCompletionCount++
               resolveHeldStreamStarted?.()
-              void heldStreamReleased.then(() => nonStreamingTextResponse(res, model, MOCK_REPLY))
+              void heldStreamReleased.then(() => nonStreamingTextResponse(res, model, replyText))
             } else {
-              nonStreamingTextResponse(res, model, MOCK_REPLY)
+              nonStreamingTextResponse(res, model, replyText)
             }
           }
         })

--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -105,7 +105,7 @@ const PlainCode: FC<{ code: string }> = ({ code }) => {
   const chunks = useMemo(() => chunkByLines(code, CHUNK_LINES), [code])
 
   if (chunks.length === 1) {
-    return <code className="block whitespace-pre">{code}</code>
+    return <code className="whitespace-pre">{code}</code>
   }
 
   return (

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1807,6 +1807,15 @@ body.guest-pointer-lock :is(webview, iframe) {
   margin: 0 !important;
 }
 
+/* The LazyShiki Suspense fallback is a direct <code> child. Streamdown's
+   prose reset otherwise shrinks it to 0.9em, then the highlighted Shiki DOM
+   restores the code-card typography and makes every fence grow on load. Keep
+   both render paths on the same inherited font metrics (#88151). */
+[data-slot='aui_assistant-message-content'] .aui-md .aui-shiki > code {
+  font-size: inherit;
+  line-height: inherit;
+}
+
 /* react-shiki nests its own `pre.shiki` inside our `.aui-shiki` Pre, so the
    code card's `[&_pre]` padding lands on both and doubles the inset. The outer
    Pre already carries the card's padding — zero the inner one. */


### PR DESCRIPTION
## Summary

Prevent fenced code blocks from changing height when the lazy Shiki highlighter replaces its plain Suspense fallback.

## Why

The plain fallback and the final Shiki DOM used different font metrics and line-box structures:

- fallback: 10.08px font / 16.38px line height
- highlighted: 11.2px font / 18.2px line height

In a real Electron reproduction with six 14-line code blocks, the combined code-block height changed from 1507.50px to 1649.04px while the Shiki chunk resolved. That repeated growth is what makes the conversation viewport visibly jump.

## What changed

- Keep the single-chunk `PlainCode` fallback inline, matching Shiki's code line-box structure.
- Make the direct LazyShiki fallback inherit the code card's font size and line height.
- Add a real Electron E2E regression that:
  - creates a persisted session through the real gateway/AIAgent path;
  - captures the PlainCode and Shiki layouts in Chromium;
  - verifies every inline code block and the combined layout stay within 1px;
  - confirms a 240-line fence follows the existing externalized `Code Open` path rather than LazyShiki.
- Allow the E2E mock provider to return scenario-specific reply text without changing the default reply used by existing tests.

## Test plan

- Before the fix (real Electron): six inline blocks 1507.50px → 1649.04px (Δ141.54px)
- After the fix (real Electron): six inline blocks 1649.04px → 1649.04px (Δ0px)
- `npm run build` (apps/desktop)
- `npx playwright test e2e/code-block-highlight-jitter.spec.ts --workers=1` — 1 passed
- `npx vitest run --project ui` — 527 files / 4900 tests passed
- `npx tsc -p . --noEmit` — passed
- ESLint on changed TS/TSX files — 0 errors

## Tested platforms

- macOS 26, Apple Silicon
- Real Electron/Chromium renderer with an isolated `HERMES_HOME`

Closes #88151
