### PR TITLE
fix(tools): stop line-based match strategies emitting overlapping spans

### DIFF
--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -191,6 +191,51 @@ class TestReplaceAll:
         assert "2 matches" in err
 
 
+    def test_self_overlapping_pattern_via_line_strategies(self):
+        """The line-based strategies must be non-overlapping too.
+
+        Regression: #56211 fixed _strategy_exact but left the identical
+        one-line-at-a-time advance in _find_normalized_matches (shared by
+        line_trimmed / indentation_flexible / whitespace_normalized) and in
+        _strategy_trimmed_boundary. Those fire whenever old_string's
+        indentation does not match the file's — the common case when a model
+        quotes a snippet without its leading whitespace.
+
+        _apply_replacements splices in reverse order using offsets computed
+        against the original string, so overlapping spans made every splice
+        after the first index into shifted text and deleted surrounding
+        content while still reporting success.
+        """
+        # Indentation mismatch forces a line-based strategy, not exact.
+        content = "    x = 1\n    x = 1\n    x = 1\n"
+        new, count, _, err = fuzzy_find_and_replace(
+            content, "x = 1\nx = 1", "y = 2", replace_all=True
+        )
+        assert err is None
+        # 3 identical lines hold exactly one non-overlapping 2-line match.
+        assert count == 1
+        # The untouched third line and the trailing newline must survive.
+        assert new.count("x = 1") == 1
+        assert new.endswith("\n")
+
+        # 4 lines -> two non-overlapping matches, nothing left over.
+        content4 = "    x = 1\n    x = 1\n    x = 1\n    x = 1\n"
+        new4, count4, _, err4 = fuzzy_find_and_replace(
+            content4, "x = 1\nx = 1", "y = 2", replace_all=True
+        )
+        assert err4 is None
+        assert count4 == 2
+        assert "x = 1" not in new4
+
+        # Non-overlapping content is unaffected by the change.
+        content_distinct = "    a = 1\n    b = 2\n    a = 1\n    b = 2\n"
+        new_d, count_d, _, err_d = fuzzy_find_and_replace(
+            content_distinct, "a = 1\nb = 2", "c = 3", replace_all=True
+        )
+        assert err_d is None
+        assert count_d == 2
+
+
 class TestUnicodeNormalized:
     """Tests for the unicode_normalized strategy (Bug 5)."""
 

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -713,7 +713,10 @@ def _strategy_trimmed_boundary(content: str, pattern: str) -> List[Tuple[int, in
     matches = []
     pattern_line_count = len(pattern_lines)
     
-    for i in range(len(content_lines) - pattern_line_count + 1):
+    # Same non-overlapping advance as _find_normalized_matches / _strategy_exact.
+    i = 0
+    limit = len(content_lines) - pattern_line_count
+    while i <= limit:
         block_lines = content_lines[i:i + pattern_line_count]
         
         # Trim first and last of this block
@@ -728,6 +731,9 @@ def _strategy_trimmed_boundary(content: str, pattern: str) -> List[Tuple[int, in
                 content_lines, i, i + pattern_line_count, len(content)
             )
             matches.append((start_pos, end_pos))
+            i += pattern_line_count
+        else:
+            i += 1
     
     return matches
 
@@ -979,7 +985,15 @@ def _find_normalized_matches(content: str, content_lines: List[str],
     
     matches = []
     
-    for i in range(len(content_normalized_lines) - num_pattern_lines + 1):
+    # Advance past a whole match rather than one line at a time, so a
+    # self-overlapping pattern yields non-overlapping spans. _apply_replacements
+    # splices in reverse order on offsets computed against the ORIGINAL string;
+    # overlapping spans make every splice after the first index into shifted
+    # text and silently destroy file content under replace_all=True. This
+    # mirrors the same fix already applied to _strategy_exact.
+    i = 0
+    limit = len(content_normalized_lines) - num_pattern_lines
+    while i <= limit:
         # Check if this block matches
         block = '\n'.join(content_normalized_lines[i:i + num_pattern_lines])
         
@@ -989,6 +1003,9 @@ def _find_normalized_matches(content: str, content_lines: List[str],
                 content_lines, i, i + num_pattern_lines, len(content)
             )
             matches.append((start_pos, end_pos))
+            i += num_pattern_lines
+        else:
+            i += 1
     
     return matches
 


### PR DESCRIPTION
## What does this PR do?

`_strategy_exact` was fixed in #56211 to advance its scan cursor by `len(pattern)` so self-overlapping patterns produce non-overlapping spans. The same one-step advance was left in place in two other match loops:

- `_find_normalized_matches` (`tools/fuzzy_match.py`) — shared by the `line_trimmed`, `indentation_flexible` and `whitespace_normalized` strategies
- `_strategy_trimmed_boundary`

These strategies are not exotic — they are exactly what fires when `old_string`'s indentation does not match the file's, i.e. whenever a model quotes a snippet without its leading whitespace.

`_apply_replacements` splices in reverse order using offsets computed against the *original* string:

```python
sorted_matches = sorted(matches, key=lambda x: x[0], reverse=True)
...
result = result[:start] + adjusted + result[end:]
```

Once two spans overlap, every splice after the first indexes into text whose length has already changed, and surrounding content is deleted. `PatchResult.success` stays `True` and no error reaches the model or the user.

The `replace_all` guard in `_apply_replacements` only refuses the similarity strategies (`block_anchor`, `context_aware`), so all four affected strategies were unprotected.

### Reproduction

File `f1.py`:

```
    x = 1
    x = 1
    x = 1
```

Call `patch(mode="replace", path="f1.py", old_string="x = 1\nx = 1", new_string="y", replace_all=True)` — `old_string` without the file's indentation is what routes this to `line_trimmed` rather than `exact`.

Before:

```python
>>> _strategy_line_trimmed("    x = 1\n    x = 1\n    x = 1\n", "x = 1\nx = 1")
[(0, 19), (10, 29)]      # spans overlap by 9 chars
```

The file on disk becomes `'    y'` — two of the three lines and the trailing newline are gone, reported as success.

After:

```python
[(0, 19)]                # one non-overlapping match, str.replace() semantics
```

## Related Issue

No open issue found. #56211 (merged) fixed the exact-strategy half of this; #41256 and #50314 were closed. I found no open PR covering the line-based strategies.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/fuzzy_match.py` — `_find_normalized_matches` and `_strategy_trimmed_boundary` advance by the pattern's line count on a hit instead of always by one line.
- `tests/tools/test_fuzzy_match.py` — `TestReplaceAll::test_self_overlapping_pattern_via_line_strategies`, covering the 3-line (one match, remainder preserved) and 4-line (two matches) cases plus a non-overlapping control so the change cannot regress ordinary `replace_all`.

## How to Test

```
pytest tests/tools/test_fuzzy_match.py -q
```

56 passed. I also ran `tests/tools/test_file_tools.py tests/tools/test_patch_parser.py tests/tools/test_file_operations.py`: 142 passed, 4 skipped, and 2 failures (`TestWriteFileHandler::test_writes_content`, `TestPatchHandler::test_replace_mode_calls_patch_replace`) that reproduce identically on unmodified `main` on this macOS machine, so they are unrelated to this change.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant test suites
- [x] I've added tests for my changes
