### PR TITLE
fix(profiles): reject non-string profile names instead of coercing

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -314,9 +314,17 @@ def normalize_profile_name(name: str) -> str:
     alias ``default`` is matched case-insensitively (``Default`` → ``default``).
     Dashboards and tools may pass title-cased display labels; normalize before
     validation, assignment, and subprocess spawn (see issue #18498).
+
+    Raises ``ValueError`` for non-string input: a numeric profile id (e.g. a
+    DB row id or a falsy sentinel) silently coerced via ``str()`` becomes a
+    real on-disk profile directory (``profiles/0/``, #88842). Callers that
+    hold a numeric id must resolve it to an actual profile name first.
     """
     if not isinstance(name, str):
-        name = str(name)
+        raise ValueError(
+            "profile name must be a string, got "
+            f"{type(name).__name__}: {name!r}"
+        )
     stripped = name.strip()
     if not stripped:
         raise ValueError("profile name cannot be empty")

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -78,6 +78,21 @@ class TestNormalizeProfileName:
         assert normalize_profile_name("Jules") == "jules"
         assert normalize_profile_name("  Librarian ") == "librarian"
 
+    def test_non_string_name_rejected(self):
+        # A numeric profile id (DB row id / falsy sentinel) must not be
+        # silently coerced into a real on-disk profile directory (#88842).
+        with pytest.raises(ValueError):
+            normalize_profile_name(0)
+        with pytest.raises(ValueError):
+            normalize_profile_name(None)
+        with pytest.raises(ValueError):
+            normalize_profile_name(42)
+
+    def test_literal_zero_string_is_a_valid_explicit_name(self):
+        # A literal "0" typed by the user is a legal profile id; only the
+        # non-string coercion created the phantom profile.
+        assert normalize_profile_name("0") == "0"
+
 
 class TestValidateProfileName:
     """Tests for validate_profile_name()."""


### PR DESCRIPTION
## Summary

Fixes #88842: a numeric profile id (DB row id or falsy sentinel) handed to `normalize_profile_name()` was silently `str()`'d into a real profile name — `0` became `"0"`, passed validation, and bootstrapped `profiles/0/` (a phantom profile with `state.db`/skills but no `config.yaml` on desktop first launch).

## Approach

`normalize_profile_name` now raises `ValueError` for non-string input instead of coercing via `str()`. Audited all call sites: every caller passes strings (CLI args, DB fields) and `None` is already handled before the call (e.g. kanban `_canonical_assignee`). A literal `"0"` typed by a user remains a legal explicit name.

## Test Plan

- 2 new tests in `TestNormalizeProfileName`: non-string input (0 / None / 42) rejected; literal `"0"` string still accepted.
- `test_profiles.py` NormalizeProfileName: 3/3 pass. Full file: 4 pre-existing failures are Windows-specific environment noise (`.bat` wrapper names / line counts, confirmed identical with the change stashed) — unrelated to this change.
- `ruff check` clean.

## Risk / Exclusions

- Behavior change only for non-string input (previously silently coerced, now raises). String callers unaffected.
- No changes to validation rules, CLI parsing, or profile bootstrap.

References #88842