### PR TITLE
fix(tools): keep blank context lines in V4A hunks

### DIFF
--- a/tests/tools/test_patch_parser.py
+++ b/tests/tools/test_patch_parser.py
@@ -56,6 +56,101 @@ class TestParseUpdateFile:
         assert ops[0].hunks[1].context_hint == "second"
 
 
+
+class TestBlankContextLines:
+    """A blank line inside a hunk body is context, not a line to drop.
+
+    Producers that strip trailing whitespace emit a blank CONTEXT line as ""
+    rather than " ". The parser's `elif current_op and line:` guard treated the
+    empty string as falsy and skipped it, shortening the hunk's search pattern.
+    A shortened pattern can match a *different* block, so the edit lands in the
+    wrong place while reporting success.
+    """
+
+    def test_interior_blank_line_kept_as_context(self):
+        patch = """\
+*** Begin Patch
+*** Update File: conf.py
+@@ PRIMARY = { @@
+     "a": 1,
+
+-    "b": 2,
++    "b": 99,
+*** End Patch"""
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+        lines = [(l.prefix, l.content) for l in ops[0].hunks[0].lines]
+        assert lines == [
+            (" ", '    "a": 1,'),
+            (" ", ""),
+            ("-", '    "b": 2,'),
+            ("+", '    "b": 99,'),
+        ]
+
+    def test_blank_context_anchors_to_the_right_block(self):
+        """Without the blank line the pattern also matches BACKUP."""
+        content = (
+            'PRIMARY = {\n'
+            '    "a": 1,\n'
+            '\n'
+            '    "b": 2,\n'
+            '}\n'
+            'BACKUP = {\n'
+            '    "a": 1,\n'
+            '    "b": 2,\n'
+            '}\n'
+        )
+        patch = """\
+*** Begin Patch
+*** Update File: conf.py
+@@ PRIMARY = { @@
+     "a": 1,
+
+-    "b": 2,
++    "b": 99,
+*** End Patch"""
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+        search = "\n".join(
+            l.content for l in ops[0].hunks[0].lines if l.prefix in (" ", "-")
+        )
+        # The search text must include the blank line, so it occurs once
+        # (inside PRIMARY) rather than also matching BACKUP.
+        assert content.count(search) == 1
+        assert search.startswith('    "a": 1,\n\n')
+
+    def test_trailing_blank_lines_are_not_context(self):
+        """Blank runs at the end of a hunk are separators, not pattern text."""
+        patch = """\
+*** Begin Patch
+*** Update File: c.py
+@@
+-old
+
++new
+
+
+*** End Patch"""
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+        lines = [(l.prefix, l.content) for l in ops[0].hunks[0].lines]
+        assert lines == [("-", "old"), (" ", ""), ("+", "new")]
+
+    def test_patch_without_blank_lines_unchanged(self):
+        patch = """\
+*** Begin Patch
+*** Update File: c.py
+@@
+ ctx
+-old
++new
+*** End Patch"""
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+        lines = [(l.prefix, l.content) for l in ops[0].hunks[0].lines]
+        assert lines == [(" ", "ctx"), ("-", "old"), ("+", "new")]
+
+
 class TestParseAddFile:
     def test_add_file(self):
         patch = """\

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -113,6 +113,9 @@ def parse_v4a_patch(patch_content: str) -> Tuple[List[PatchOperation], Optional[
     i = start_idx + 1
     current_op: Optional[PatchOperation] = None
     current_hunk: Optional[Hunk] = None
+    # Blank lines seen inside the current hunk body, held until a real hunk
+    # line proves they are interior context rather than trailing separator.
+    pending_blank_context = 0
     
     while i < end_idx:
         line = lines[i]
@@ -135,6 +138,7 @@ def parse_v4a_patch(patch_content: str) -> Tuple[List[PatchOperation], Optional[
                 file_path=update_match.group(1).strip()
             )
             current_hunk = None
+            pending_blank_context = 0
             
         elif add_match:
             if current_op:
@@ -187,11 +191,33 @@ def parse_v4a_patch(patch_content: str) -> Tuple[List[PatchOperation], Optional[
                 hint_match = re.match(r'@@\s*(.+?)\s*@@', line)
                 hint = hint_match.group(1) if hint_match else None
                 current_hunk = Hunk(context_hint=hint)
+                pending_blank_context = 0
                 
+        elif current_op and not line:
+            # A blank line inside a hunk body. Producers that strip trailing
+            # whitespace turn a blank CONTEXT line (" ") into "", and an empty
+            # string is falsy — so the old `elif current_op and line:` dropped
+            # it. That shortens the hunk's search pattern and can re-anchor the
+            # edit onto a different block that happens to match the shortened
+            # form.
+            #
+            # Buffer instead of appending directly: a blank run at the END of a
+            # hunk is separator whitespace, not context, and must not extend the
+            # pattern. Buffered blanks are only committed when a real hunk line
+            # follows, and are discarded at every hunk/op boundary.
+            if current_hunk is not None and current_hunk.lines:
+                pending_blank_context += 1
+        
         elif current_op and line:
             # Parse hunk line
             if current_hunk is None:
                 current_hunk = Hunk()
+            
+            if pending_blank_context:
+                current_hunk.lines.extend(
+                    HunkLine(' ', '') for _ in range(pending_blank_context)
+                )
+                pending_blank_context = 0
             
             if line.startswith('+'):
                 current_hunk.lines.append(HunkLine('+', line[1:]))


### PR DESCRIPTION
## What does this PR do?

`parse_v4a_patch` gates hunk-line parsing on:

```python
elif current_op and line:
```

An empty string is falsy, so a **blank context line inside a hunk body** is skipped entirely instead of becoming `HunkLine(' ', '')`.

Blank context lines arrive as `""` rather than `" "` from any producer that strips trailing whitespace — a very common case. Dropping one shortens the hunk's search pattern, and a shortened pattern can match a *different* block that happens to be identical once the blank line is gone. The patch then applies cleanly to the wrong location and returns `success=True`. The `@@` context hint is never consulted, because a unique match was already found.

### Reproduction

`conf.py`:

```python
PRIMARY = {
    "a": 1,

    "b": 2,
}
BACKUP = {
    "a": 1,
    "b": 2,
}
```

Patch:

```
*** Begin Patch
*** Update File: conf.py
@@ PRIMARY = { @@
     "a": 1,

-    "b": 2,
+    "b": 99,
*** End Patch
```

Before — the blank line is gone from the parsed hunk:

```python
[(' ', '    "a": 1,'), ('-', '    "b": 2,'), ('+', '    "b": 99,')]
```

The resulting pattern `    "a": 1,\n    "b": 2,` matches `BACKUP` exactly once, so **`BACKUP` is edited and `PRIMARY` is left untouched**, reported as success.

After:

```python
[(' ', '    "a": 1,'), (' ', ''), ('-', '    "b": 2,'), ('+', '    "b": 99,')]
```

The pattern now contains the blank line and occurs once, inside `PRIMARY`.

## Related Issue

No open issue or PR found for this defect. The nearest V4A parser PRs (#50376 non-overlapping context-hint counting, #41393 Add-File onto existing path, #87546 duplicate paths) address unrelated parts of the same file.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/patch_parser.py` — a blank line inside a hunk body is recorded as a blank context line.

  Blank lines are **buffered**, not appended directly. A blank run at the *end* of a hunk is separator whitespace, not context, and extending the pattern with it would break patches that work today. Buffered blanks are committed only when a real hunk line follows, and are discarded at every hunk (`@@`) and file-operation boundary.

- `tests/tools/test_patch_parser.py` — new `TestBlankContextLines` with four cases: interior blank preserved, the PRIMARY/BACKUP anchoring case above, trailing blanks correctly discarded, and a no-blank-lines control proving existing patches are unaffected.

## How to Test

```
pytest tests/tools/test_patch_parser.py -q
```

37 passed (33 existing + 4 new).

Manual check of the three shapes:

| input | parsed hunk |
|---|---|
| interior blank | `[(' ', '    "a": 1,'), (' ', ''), ('-', ...), ('+', ...)]` |
| trailing blanks | `[('-', 'old'), (' ', ''), ('+', 'new')]` — trailing run dropped |
| no blanks | unchanged |

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/tools/test_patch_parser.py -q` and all tests pass
- [x] I've added tests for my changes
