### PR TITLE
fix(cli): bind logger in the resume-safety guard so it fails open

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -636,6 +636,13 @@ class CLIAgentSetupMixin:
         except SessionResumeTooLargeError as exc:
             return str(exc)
         except Exception as exc:
+            # `logger` is not a module-level name here — every other method in
+            # this mixin imports it from `cli` locally. Without this import the
+            # handler raised NameError, which propagated instead of the
+            # documented fail-OPEN behaviour: an unexpected guard failure would
+            # abort the resume rather than let it proceed.
+            from cli import logger
+
             logger.warning(
                 "Resume safety check failed for %s (proceeding without guard): %s",
                 self.session_id, exc,

--- a/tests/hermes_cli/test_resume_history_limit_guard.py
+++ b/tests/hermes_cli/test_resume_history_limit_guard.py
@@ -1,0 +1,60 @@
+"""Regression tests for the resume-safety guard's fail-open contract.
+
+`_resume_history_limit_error` documents that "Generic guard failures fail OPEN
+(resume proceeds) — only a genuine over-limit result blocks." Its
+`except Exception` handler called a bare `logger`, which is not bound at module
+level in this mixin, so an unexpected failure raised NameError out of the
+handler and the guard failed CLOSED instead.
+"""
+
+import pytest
+
+from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
+
+
+def _mixin(session_db):
+    obj = CLIAgentSetupMixin.__new__(CLIAgentSetupMixin)
+    obj._session_db = session_db
+    obj.session_id = "20260819_120000_abc123"
+    return obj
+
+
+class _RaisingDB:
+    """A SessionDB whose safety probes blow up the way a locked DB would."""
+
+    def assert_resume_safe(self, session_id):
+        raise RuntimeError("sqlite3.OperationalError: database is locked")
+
+    def assert_export_safe(self, session_id, max_messages=None):
+        raise RuntimeError("sqlite3.OperationalError: database is locked")
+
+
+class TestResumeGuardFailsOpen:
+    def test_unexpected_failure_returns_none(self):
+        """A generic probe failure must let the resume proceed, not crash."""
+        assert _mixin(_RaisingDB())._resume_history_limit_error() is None
+
+    def test_unexpected_failure_returns_none_tip_only(self):
+        assert _mixin(_RaisingDB())._resume_history_limit_error(tip_only=True) is None
+
+    def test_unexpected_failure_does_not_raise_nameerror(self):
+        """Guard against a regression that re-breaks the handler itself."""
+        try:
+            _mixin(_RaisingDB())._resume_history_limit_error()
+        except NameError as exc:  # pragma: no cover - the bug being fixed
+            pytest.fail(f"resume guard handler raised NameError: {exc}")
+
+    def test_no_session_db_is_a_noop(self):
+        assert _mixin(None)._resume_history_limit_error() is None
+
+    def test_over_limit_still_blocks(self):
+        """The fail-open path must not swallow a genuine over-limit verdict."""
+        from hermes_state import SessionResumeTooLargeError
+
+        class _TooLargeDB:
+            def assert_resume_safe(self, session_id):
+                raise SessionResumeTooLargeError(50_000, 10_000)
+
+        result = _mixin(_TooLargeDB())._resume_history_limit_error()
+        assert result is not None
+        assert isinstance(result, str)


### PR DESCRIPTION
## What does this PR do?

`_resume_history_limit_error` (`hermes_cli/cli_agent_setup_mixin.py`) states its contract in its own docstring:

> Generic guard failures fail OPEN (resume proceeds) — only a genuine over-limit result blocks.

Its `except Exception` handler calls a bare `logger`:

```python
        except SessionResumeTooLargeError as exc:
            return str(exc)
        except Exception as exc:
            logger.warning(
                "Resume safety check failed for %s (proceeding without guard): %s",
                self.session_id, exc,
            )
            return None
```

But `logger` is not bound at module level in this mixin. The module's only imports are `sys`, `rich.markup.escape` and `utils.base_url_host_matches`; every other method that logs pulls it in locally — `from cli import ChatConsole, _cprint, logger` (line 34), `from cli import _cprint, logger` (line 237), and the larger import at line 347.

So the handler raises `NameError: name 'logger' is not defined` **while already unwinding**, and that NameError propagates out of the guard. The behaviour inverts: instead of failing open, an unexpected probe failure aborts the resume.

The trigger is ordinary — `assert_resume_safe` / `assert_export_safe` hitting a locked or briefly unavailable `state.db` (`sqlite3.OperationalError: database is locked`) is exactly the "generic guard failure" the fail-open branch exists for. The user sees a NameError traceback instead of their session resuming.

## Related Issue

No existing issue or PR found for this. #82557 touches the resume-safety guard but bounds two runaway-transcript sites; it does not address this handler.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/cli_agent_setup_mixin.py` — add the same local `from cli import logger` the sibling methods already use, inside the `except Exception` branch.
- `tests/hermes_cli/test_resume_history_limit_guard.py` — new file covering:
  - generic failure returns `None` (fail open) on both the full-lineage and `tip_only=True` paths
  - an explicit assertion that the handler does not raise `NameError`
  - `_session_db is None` short-circuit
  - a genuine `SessionResumeTooLargeError` still returns a blocking message, so the fix cannot silently widen the fail-open path

## How to Test

```
pytest tests/hermes_cli/test_resume_history_limit_guard.py -q
```

5 passed with the fix. Reverting only the source change makes 3 of the 5 fail with `NameError: name 'logger' is not defined`, which is the bug.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the new tests and they pass
- [x] I've added tests for my changes
