### PR TITLE
fix(agent): honor the HTTP-date form of Retry-After on rate limits

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -85,6 +85,7 @@ from agent.retry_utils import (
     adaptive_rate_limit_backoff,
     is_zai_coding_overload_error,
     jittered_backoff,
+    parse_retry_after_seconds,
     zai_coding_overload_retry_ceiling,
 )
 from agent.repetition_guard import is_repetition_dominated
@@ -6363,17 +6364,20 @@ def run_conversation(
                 if is_rate_limited:
                     _resp_headers = getattr(getattr(api_error, "response", None), "headers", None)
                     if _resp_headers and hasattr(_resp_headers, "get"):
-                        _ra_raw = _resp_headers.get("retry-after") or _resp_headers.get("Retry-After")
-                        if _ra_raw:
-                            try:
-                                # Cap at 10 minutes. Anthropic Tier 1 input-token
-                                # buckets reset in ~171s, so a 120s cap caused us to
-                                # retry before the actual reset window and re-trip the
-                                # limit. 600s covers all realistic provider reset
-                                # windows while still rejecting pathological values. (#26293)
-                                _retry_after = min(float(_ra_raw), 600)
-                            except (TypeError, ValueError):
-                                pass
+                        # RFC 7231 allows Retry-After to be an HTTP-date, and edge
+                        # proxies (Cloudflare, nginx) in front of a provider emit
+                        # that form on 429/503. A bare float() raised on it and the
+                        # header was silently discarded, dropping us back to a ~2s
+                        # backoff that cannot outlast the window. parse_retry_after_seconds
+                        # handles both forms and clamps negative deltas to 0.
+                        _ra_parsed = parse_retry_after_seconds(_resp_headers)
+                        if _ra_parsed:
+                            # Cap at 10 minutes. Anthropic Tier 1 input-token
+                            # buckets reset in ~171s, so a 120s cap caused us to
+                            # retry before the actual reset window and re-trip the
+                            # limit. 600s covers all realistic provider reset
+                            # windows while still rejecting pathological values. (#26293)
+                            _retry_after = min(_ra_parsed, 600)
                 wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
                 _backoff_policy = None
                 if (is_rate_limited or _is_zai_coding_overload) and not _retry_after:

--- a/tests/agent/test_retry_after_http_date.py
+++ b/tests/agent/test_retry_after_http_date.py
@@ -1,0 +1,62 @@
+"""Retry-After must be honoured in both RFC 7231 forms.
+
+`conversation_loop` parsed the header with a bare `float()`, so the HTTP-date
+form — which edge proxies (Cloudflare, nginx) in front of a provider emit on
+429/503 — raised ValueError and was discarded. The loop then fell back to a
+~2s jittered backoff that cannot outlast the rate-limit window, exhausted its
+retries and surfaced a rate-limit failure to the user.
+
+`agent.retry_utils.parse_retry_after_seconds` already handled both forms; it
+simply was not wired into this call site.
+"""
+
+import datetime
+import email.utils
+
+from agent.retry_utils import parse_retry_after_seconds
+
+
+def _http_date(seconds_from_now):
+    when = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+        seconds=seconds_from_now
+    )
+    return email.utils.format_datetime(when)
+
+
+class TestRetryAfterParsing:
+    def test_delta_seconds_form(self):
+        assert parse_retry_after_seconds({"retry-after": "42"}) == 42.0
+
+    def test_header_lookup_is_case_insensitive(self):
+        assert parse_retry_after_seconds({"Retry-After": "42"}) == 42.0
+
+    def test_http_date_form_is_honoured(self):
+        """The form a bare float() rejected."""
+        parsed = parse_retry_after_seconds({"retry-after": _http_date(300)})
+        assert parsed is not None
+        assert 290 <= parsed <= 300
+
+    def test_past_http_date_clamps_to_zero(self):
+        assert parse_retry_after_seconds({"retry-after": _http_date(-300)}) == 0.0
+
+    def test_unparseable_value_is_none(self):
+        assert parse_retry_after_seconds({"retry-after": "garbage"}) is None
+
+    def test_absent_header_is_none(self):
+        assert parse_retry_after_seconds({}) is None
+
+    def test_bare_float_rejects_the_http_date_form(self):
+        """Documents the defect this call site had."""
+        try:
+            float(_http_date(300))
+        except ValueError:
+            return
+        raise AssertionError("expected float() to reject an HTTP-date")
+
+
+class TestConversationLoopWiring:
+    def test_conversation_loop_imports_the_parser(self):
+        """Guard against the call site drifting back to a bare float()."""
+        import agent.conversation_loop as cl
+
+        assert hasattr(cl, "parse_retry_after_seconds")


### PR DESCRIPTION
## What does this PR do?

RFC 7231 defines `Retry-After` as **either** delta-seconds **or** an HTTP-date. The rate-limit branch in `conversation_loop` parsed it with a bare `float()`:

```python
_ra_raw = _resp_headers.get("retry-after") or _resp_headers.get("Retry-After")
if _ra_raw:
    try:
        _retry_after = min(float(_ra_raw), 600)
    except (TypeError, ValueError):
        pass
```

`float("Wed, 21 Oct 2026 07:28:00 GMT")` raises `ValueError`, the `except` swallows it, and the header is discarded. The loop then falls back to:

```python
wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
```

roughly 2s → 4s → 8s, which cannot outlast a real rate-limit window. Retries are exhausted and a rate-limit failure is surfaced to the user, even though the provider told us exactly how long to wait.

The date form is not hypothetical: edge proxies (Cloudflare, nginx) sitting in front of a provider emit it on 429/503, as do several corporate gateways.

The repo already ships a correct parser — `agent/retry_utils.parse_retry_after_seconds` handles both forms, looks the header up case-insensitively, and clamps a past date to `0.0`. This call site simply was not using it, while already importing four other helpers from that same module.

## Related Issue

No existing issue found for the date form specifically. #88236 (honor Retry-After on retryable 5xx) and #75177 (jitter Retry-After waits) touch adjacent behaviour but neither changes how the header value is parsed.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_loop.py` — import `parse_retry_after_seconds` alongside the other `retry_utils` helpers and use it in place of the hand-rolled `float()` parse. The 600s cap and its `#26293` rationale are unchanged.
- `tests/agent/test_retry_after_http_date.py` — covers delta-seconds, case-insensitive lookup, the HTTP-date form, a past date clamping to `0.0`, unparseable and absent headers, an explicit assertion that `float()` rejects the date form (documenting the defect), and a guard that the call site still imports the parser.

### Deliberately unchanged

`if _ra_parsed:` keeps the existing truthiness semantics, so a literal `Retry-After: 0` still falls through to jittered backoff rather than retrying instantly. Switching to `is not None` would be a behaviour change beyond this fix; happy to do it in a follow-up if you'd prefer.

## How to Test

```
pytest tests/agent/test_retry_after_http_date.py -q
```

8 passed.

Behaviour before/after for `Retry-After: <HTTP-date 300s in the future>`:

| | parsed wait |
|---|---|
| before | `None` → ~2-3s jittered backoff |
| after | ~300s |

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the new tests and they pass
- [x] I've added tests for my changes
