### PR TITLE
fix(kanban): let the dispatch lock degrade to a no-op when fcntl is missing

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1727,6 +1727,11 @@ def _dispatch_tick_lock(db_path: Path):
                 nb_lock = getattr(msvcrt, "LK_NBLCK")
                 locking(handle.fileno(), nb_lock, 1)
                 acquired = True
+            except ImportError:
+                # No locking primitive on this build: degrade to a no-op, per
+                # the contract in the docstring. See the POSIX branch below for
+                # why this is deliberately NOT the same answer as a failed lock.
+                acquired = True
             except (OSError, AttributeError):
                 acquired = False
         else:
@@ -1734,6 +1739,21 @@ def _dispatch_tick_lock(db_path: Path):
                 import fcntl
 
                 fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                acquired = True
+            except ImportError:
+                # A platform with no fcntl cannot enforce single-writer at all,
+                # so the docstring's contract is that it still dispatches. That
+                # is the OPPOSITE call from every other failure here, and the
+                # difference is permanence: a missing module never resolves, so
+                # failing closed would disable dispatch on this platform
+                # forever, whereas a busy or unopenable lock is re-evaluated
+                # next tick and costs one deferred interval.
+                #
+                # Caught separately rather than folded into the tuple below
+                # because ImportError is not an OSError (nor is it caught by
+                # the enclosing `except OSError`), so before this the
+                # documented degradation was unreachable and the tick raised
+                # instead (#89653).
                 acquired = True
             except (BlockingIOError, OSError):
                 acquired = False
@@ -1759,7 +1779,14 @@ def _dispatch_tick_lock(db_path: Path):
                         import fcntl
 
                         fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
-            except (OSError, AttributeError):
+            # ImportError belongs here for the same reason it does on the
+            # acquire path: on a platform with no locking primitive `acquired`
+            # is now True by design, so this block runs and re-imports the
+            # module that was never there. Without it the degradation would
+            # only move the crash from acquire to release, which is why the
+            # regression test exits the context manager rather than asserting
+            # inside it (#89653).
+            except (AttributeError, ImportError, OSError):
                 pass
             finally:
                 handle.close()

--- a/tests/hermes_cli/test_kanban_dispatch_lock.py
+++ b/tests/hermes_cli/test_kanban_dispatch_lock.py
@@ -12,6 +12,8 @@ empty ``DispatchResult`` with ``skipped_locked=True`` and does no DB writes.
 
 from __future__ import annotations
 
+import builtins
+
 from pathlib import Path
 
 import pytest
@@ -77,3 +79,98 @@ def test_lock_is_board_scoped(conn):
             assert held_b is True, "a lock on a different board must be independent"
 
 
+def _hide_module(monkeypatch, missing: str) -> None:
+    """Make ``import <missing>`` raise, as it does on a platform without it.
+
+    Patches ``builtins.__import__`` rather than poking ``sys.modules``: the
+    locking primitives are imported *inside* ``_dispatch_tick_lock``, so the
+    import statement runs on every call and a ``sys.modules[missing] = None``
+    would raise ``ImportError`` only on some Python versions. Intercepting the
+    import hook reproduces ``ModuleNotFoundError`` exactly, on every version.
+    """
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == missing:
+            raise ModuleNotFoundError(f"No module named {missing!r}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+def test_missing_locking_primitive_degrades_to_a_no_op(conn, monkeypatch):
+    """A platform with no fcntl/msvcrt must still dispatch (#89653).
+
+    Regression: the handler around the import caught ``(BlockingIOError,
+    OSError)`` and the enclosing block caught ``OSError``, but a missing module
+    raises ``ModuleNotFoundError`` -> ``ImportError`` -> ``Exception``, which is
+    neither. The documented degradation to a no-op was therefore unreachable and
+    the tick raised instead, so a platform that merely *cannot enforce*
+    single-writer could not dispatch at all.
+
+    The lock's own docstring makes this the intended contract: single-writer
+    enforcement is best-effort, and the orphan-dispatcher scenario it defends
+    against (#35240) is specific to POSIX service managers.
+    """
+    db_path = kb.kanban_db_path(board="default")
+    _hide_module(monkeypatch, "msvcrt" if kb._IS_WINDOWS else "fcntl")
+
+    with kb._dispatch_tick_lock(db_path) as held:
+        assert held is True, (
+            "a platform with no locking primitive cannot enforce single-writer, "
+            "so the guard must degrade to a no-op and let the tick proceed "
+            "rather than raising"
+        )
+
+
+def test_missing_locking_primitive_also_survives_release(conn, monkeypatch):
+    """The no-op must survive *exiting* the context manager, not just entering.
+
+    The release path re-imports the same module under a handler that also
+    excluded ``ImportError``, so fixing only the acquire path moves the crash
+    from ``__enter__`` to ``__exit__`` instead of removing it.
+
+    The test above does also exercise the exit (leaving its ``with`` block runs
+    the same ``finally``), but it surfaces a release crash as a teardown error
+    on a test named for the acquire contract. This one names the release path
+    directly and asserts after the block has closed, so the failure says which
+    half regressed.
+    """
+    db_path = kb.kanban_db_path(board="default")
+    _hide_module(monkeypatch, "msvcrt" if kb._IS_WINDOWS else "fcntl")
+
+    seen = None
+
+    with kb._dispatch_tick_lock(db_path) as held:
+        seen = held
+
+    assert seen is True, "the degraded tick must report that it may proceed"
+
+
+def test_missing_primitive_is_not_confused_with_a_busy_lock(conn, monkeypatch):
+    """The two failure modes resolve OPPOSITE ways, so pin them together.
+
+    A *busy* lock (another dispatcher owns it) must yield ``False`` - that is
+    the whole point of the guard. A *missing primitive* must yield ``True``.
+    Collapsing ImportError into the busy tuple would silently disable dispatch
+    forever on such a platform, which is the failure this pairing guards
+    against.
+    """
+    db_path = kb.kanban_db_path(board="default")
+
+    with kb._dispatch_tick_lock(db_path) as first:
+        assert first is True, "an uncontended lock must be acquired"
+
+        with kb._dispatch_tick_lock(db_path) as second:
+            assert second is False, (
+                "a lock already held by this process must NOT be reported as "
+                "acquired - a busy lock skips the tick"
+            )
+
+    _hide_module(monkeypatch, "msvcrt" if kb._IS_WINDOWS else "fcntl")
+
+    with kb._dispatch_tick_lock(db_path) as degraded:
+        assert degraded is True, (
+            "a missing primitive is permanent, so it must resolve the opposite "
+            "way from a busy lock"
+        )


### PR DESCRIPTION
## What does this PR do?

Makes `_dispatch_tick_lock` actually honour the degradation its own docstring promises:

> On platforms without `fcntl`/`msvcrt` the guard degrades to a no-op (yields `True`) - single-writer enforcement is best-effort and the orphan-dispatcher scenario is specific to POSIX service managers.

It could not. A missing module raises `ModuleNotFoundError`, whose MRO is `ModuleNotFoundError -> ImportError -> Exception -> BaseException`. It is **not** an `OSError`, so it was caught neither by the handler around the import:

```python
try:
    import fcntl

    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
    acquired = True
except (BlockingIOError, OSError):   # <- cannot catch a missing module
    acquired = False
```

nor by the enclosing `except OSError:` a few lines further down. It propagated straight out of the context manager, so a platform that merely could not *enforce* single-writer could not dispatch **at all** - the exact inversion of the documented contract.

### Why `ImportError` gets its own handler instead of joining the tuple

Because it resolves the **opposite** way from every other failure in this function, and the difference is permanence:

| Failure | Lifetime | Correct answer | Cost of being wrong |
|---|---|---|---|
| Lock held by another dispatcher | transient | `False` - skip the tick | one deferred interval |
| Lock file unopenable (perms, AV, sync client) | transient | `False` - skip the tick (#87609) | one deferred interval |
| **No locking primitive on the platform** | **permanent** | **`True` - proceed** | **dispatch disabled forever** |

Folding `ImportError` into `except (BlockingIOError, OSError)` would compile and read naturally and would silently disable dispatch on such a platform for good. The separate handler exists so that the next person who tidies these tuples has to read why.

### The half that is easy to miss

The **release** path re-imports the same module under a handler that also excluded `ImportError`:

```python
else:
    import fcntl

    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
except (OSError, AttributeError):
    pass
```

Since the fix makes `acquired` **true** on such a platform, that block now runs - and re-imports the module that was never there. Fixing only the acquire path moves the crash from `__enter__` to `__exit__` instead of removing it. Both sites are fixed here, and one of the tests exists specifically to pin the release half.

## Related Issue

Fixes #89653

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`hermes_cli/kanban_db.py`** — `_dispatch_tick_lock` catches `ImportError` at all three import sites: the `msvcrt` acquire branch, the `fcntl` acquire branch, and the shared release branch. The acquire branches get a dedicated `except ImportError:` yielding `acquired = True`; the release branch widens its existing tuple to `(AttributeError, ImportError, OSError)` since its answer there is `pass` either way.
- **`tests/hermes_cli/test_kanban_dispatch_lock.py`** — 3 regression tests plus a `_hide_module` helper that patches `builtins.__import__`. It patches the import hook rather than poking `sys.modules`, because the primitives are imported *inside* the function (so the statement re-runs every call) and a `sys.modules[name] = None` raises `ImportError` only on some Python versions, whereas intercepting the hook reproduces `ModuleNotFoundError` exactly on all of them.

## How to Test

The trigger is "a non-Windows platform where `import fcntl` fails", which cannot be produced on a normal POSIX host, so the tests simulate the missing module rather than the platform. `_hide_module` picks `msvcrt` on Windows and `fcntl` elsewhere, so **each CI platform exercises its own live branch**.

```bash
pytest tests/hermes_cli/test_kanban_dispatch_lock.py -q      # 5 passed (2 existing + 3 new)
ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_dispatch_lock.py
```

To see the bug directly, the handler shape reproduces it standalone:

```python
try:
    try:
        import definitely_not_fcntl
    except (BlockingIOError, OSError):
        pass
except OSError:
    print("degradation works")     # never printed
# ModuleNotFoundError: No module named 'definitely_not_fcntl'
```

### Sabotage proof

Each row reverts one piece and re-runs the suite. Nothing survives:

| Reverted | Tests that fail |
|---|---|
| the acquire path stops catching `ImportError` | 3 |
| the acquire path treats a missing primitive as a busy lock (`acquired = False`) | 3 |
| the release path stops catching `ImportError` | 3 |

The third row is the one worth noting: reverting *only* the release fix still fails all three tests, which is the evidence that the acquire-only fix would not have been a fix.

### Test scope - correcting an earlier version of this PR body

The checklist originally said I had run `tests/hermes_cli/`. That was overstated: my first attempt at the full directory was killed by my own tooling partway through, and I wrote the line before noticing. What I have actually run, with a clean-`main` baseline to compare against, is the kanban subset - every test that can reach `kanban_db.py`:

```bash
python -m pytest tests/hermes_cli -q -k kanban \
  --ignore=tests/hermes_cli/test_doctor_journal_modes.py
```

| | Passed | Failed |
|---|---|---|
| clean `upstream/main` | 279 | 25 |
| this branch | **282** | 25 |

**+3 (exactly the three new tests), and the two failure sets are byte-identical** - diffed, not eyeballed. None of the 25 are in `test_kanban_dispatch_lock.py`.

Two exclusions, both pre-existing and both reproducing on clean `main`:

- `test_doctor_journal_modes.py` fails **collection** on Windows (`AttributeError: module 'os' has no attribute 'geteuid'`), and a collection error aborts the entire run, which is why it is ignored rather than just tolerated.
- The 25 failures are Windows-environment failures in unrelated kanban modules (`test_kanban_write_guard`, `test_kanban_boards`, `test_backup`, …), unchanged by this PR in either direction.

I have not run the full `tests/` tree on this box and am not claiming to have. If CI's Linux run surfaces anything here I will fix it.

### Scope note on platform coverage

I developed this on Windows, so my local runs exercised the `msvcrt` branch; the `fcntl` branch is exercised by the Linux/macOS CI jobs via the same tests. Both branches are symmetrical and both are covered by the sabotage table above on the branch that was live locally. Flagging it rather than implying I ran both.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — nothing open touches `_dispatch_tick_lock` except my own #87620, which changes a different branch (see below)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits) — one commit, applies cleanly to a fresh `main`
- [x] I've run `pytest tests/ -q` and all tests pass — **corrected, see "Test scope" below.** I ran the kanban subset of `tests/hermes_cli/` (`-k kanban`) against a clean-`main` baseline, not the whole tree; an earlier version of this line overstated that.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the docstring already described this behaviour; this makes the code match it, and the new inline comments explain the asymmetry
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — this change is *entirely* about cross-platform behaviour; both the `msvcrt` and `fcntl` branches are fixed symmetrically and the tests select the branch live on the running platform
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Relationship to #87620

Both touch `_dispatch_tick_lock`, in **different branches**, and they want **opposite** resolutions - which is exactly why they are separate PRs:

- **#87620** (issue #87609): the lock file cannot be *opened* — transient, so it now fails **closed** (`acquired = False`, skip the tick) instead of proceeding as though it held the lock.
- **This PR** (issue #89653): the locking *primitive* does not exist — permanent, so it degrades to a **no-op** (`acquired = True`, proceed).

They do not conflict textually and can land in either order. Found this one while answering @monerostar's review on #87620; that PR now carries a comment pointing here so the asymmetry is documented at the site.

## Screenshots / Logs

```
$ python -m pytest tests/hermes_cli/test_kanban_dispatch_lock.py -q
.....                                                            [100%]
5 passed
```

