### PR TITLE
fix(bedrock): read reasoningText on non-streaming Converse responses

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -765,7 +765,19 @@ def normalize_converse_response(response: Dict) -> SimpleNamespace:
         elif "reasoningContent" in block:
             reasoning = block["reasoningContent"]
             if isinstance(reasoning, dict):
-                thinking_text = reasoning.get("text", "")
+                # Converse has two different shapes for this field. The
+                # NON-streaming ReasoningContentBlock is a union whose text
+                # member is {"reasoningText": {"text", "signature"}}; only the
+                # streaming ReasoningContentBlockDelta puts "text" at the top
+                # level (see the contentBlockDelta handler below). Reading the
+                # streaming shape here made reasoning_content always empty.
+                reasoning_text = reasoning.get("reasoningText")
+                if isinstance(reasoning_text, dict):
+                    thinking_text = reasoning_text.get("text", "")
+                else:
+                    # Delta shape, tolerated so a caller that hands us an
+                    # already-flattened block still works.
+                    thinking_text = reasoning.get("text", "")
                 if thinking_text:
                     reasoning_parts.append(str(thinking_text))
         elif "toolUse" in block:

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1212,3 +1212,70 @@ class TestBearerTokenRoutesToConverse:
         runtime = self._resolve(monkeypatch, bearer=False)
         assert runtime["api_mode"] == "anthropic_messages"
         assert runtime.get("bedrock_anthropic") is True
+
+
+class TestNonStreamingReasoningContent:
+    """Non-streaming Converse responses use a different reasoningContent shape.
+
+    The AWS `ReasoningContentBlock` (non-streaming) is a union whose text member
+    is `{"reasoningText": {"text", "signature"}}`. Only the streaming
+    `ReasoningContentBlockDelta` puts `"text"` at the top level.
+    `normalize_converse_response` read the streaming shape, so
+    `reasoning_content` was always None on non-streaming calls and the model's
+    chain of thought was dropped from display, accounting and replay.
+    """
+
+    @staticmethod
+    def _normalize(reasoning_block):
+        from agent.bedrock_adapter import normalize_converse_response
+
+        return normalize_converse_response(
+            {
+                "output": {
+                    "message": {
+                        "role": "assistant",
+                        "content": [reasoning_block, {"text": "done"}],
+                    }
+                },
+                "stopReason": "end_turn",
+                "usage": {"inputTokens": 10, "outputTokens": 5},
+            }
+        )
+
+    def test_reasoning_text_union_member_is_preserved(self):
+        resp = self._normalize(
+            {
+                "reasoningContent": {
+                    "reasoningText": {
+                        "text": "The user wants the file. I should call read_file.",
+                        "signature": "sig-abc",
+                    }
+                }
+            }
+        )
+        assert (
+            resp.choices[0].message.reasoning_content
+            == "The user wants the file. I should call read_file."
+        )
+        assert resp.choices[0].message.content == "done"
+
+    def test_flat_delta_shape_still_accepted(self):
+        """A caller handing us an already-flattened block keeps working."""
+        resp = self._normalize({"reasoningContent": {"text": "flattened"}})
+        assert resp.choices[0].message.reasoning_content == "flattened"
+
+    def test_redacted_only_block_yields_no_text(self):
+        resp = self._normalize({"reasoningContent": {"redactedContent": b"\x00\x01"}})
+        assert resp.choices[0].message.reasoning_content is None
+
+    def test_absent_reasoning_is_none(self):
+        from agent.bedrock_adapter import normalize_converse_response
+
+        resp = normalize_converse_response(
+            {
+                "output": {"message": {"role": "assistant", "content": [{"text": "hi"}]}},
+                "stopReason": "end_turn",
+                "usage": {"inputTokens": 1, "outputTokens": 1},
+            }
+        )
+        assert resp.choices[0].message.reasoning_content is None


### PR DESCRIPTION
## What does this PR do?

AWS Converse has **two different shapes** for reasoning content:

- non-streaming `ReasoningContentBlock` — a union whose text member is `{"reasoningText": {"text", "signature"}}`
- streaming `ReasoningContentBlockDelta` — puts `"text"` at the top level

`normalize_converse_response` used the **streaming** shape on the **non-streaming** response:

```python
elif "reasoningContent" in block:
    reasoning = block["reasoningContent"]
    if isinstance(reasoning, dict):
        thinking_text = reasoning.get("text", "")     # always "" here
        if thinking_text:
            reasoning_parts.append(str(thinking_text))
```

So `reasoning.get("text")` was always empty and `reasoning_content` always `None` on non-streaming calls. The reasoning box never rendered, reasoning-token accounting saw nothing, and nothing was stored for replay. `reasoningText` appears nowhere in the tree (`grep -rn reasoningText` → 0 hits before this PR).

The streaming handler in `stream_converse_response` is correct for *its* shape, so this is a mismatch between the two functions rather than a systematic omission.

### Reproduction

```python
from agent.bedrock_adapter import normalize_converse_response

resp = normalize_converse_response({
    "output": {"message": {"role": "assistant", "content": [
        {"reasoningContent": {"reasoningText": {"text": "MY REASONING", "signature": "sig"}}},
        {"text": "done"},
    ]}},
    "stopReason": "end_turn",
    "usage": {"inputTokens": 10, "outputTokens": 5},
})

resp.choices[0].message.reasoning_content
# before: None
# after:  'MY REASONING'
```

Hit by any model that emits `reasoningContent` on a non-streaming `converse()` call — `us.deepseek.r1-v1:0` emits it unconditionally, and Claude models do with extended thinking enabled via `additionalModelRequestFields`.

## Related Issue

No open issue found. #21202 (merged) added `reasoningContent` handling to normalized responses but used the delta shape; #36261 is about preserving the reasoning *signature* on interleaved-thinking replay, which is a separate concern and unaffected by this change.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/bedrock_adapter.py` — `normalize_converse_response` reads the `reasoningText.text` union member, falling back to the flat `text` form so a caller passing an already-flattened block keeps working. A block carrying only `redactedContent` correctly yields no text.
- `tests/agent/test_bedrock_adapter.py` — new `TestNonStreamingReasoningContent`: union member preserved, flat form still accepted, redacted-only yields `None`, absent reasoning yields `None`.

## How to Test

```
pytest tests/agent/test_bedrock_adapter.py -q
```

70 passed (66 existing + 4 new). Reverting only the source change makes `test_reasoning_text_union_member_is_preserved` fail with `None != 'The user wants the file. I should call read_file.'`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/agent/test_bedrock_adapter.py -q` and all tests pass
- [x] I've added tests for my changes
