### PR TITLE
feat(desktop): session-scoped composer append + pane reveal host doors

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
@@ -15,6 +15,7 @@ import {
   type ComposerAttachment,
   type ComposerDraftSyncMode,
   onComposerDraftSyncRequest,
+  onComposerSessionAppendRequest,
   reloadPersistedDrafts,
   stashSessionDraft,
   takeSessionDraft
@@ -458,6 +459,18 @@ export function useComposerDraft({
       }),
     [target]
   )
+
+  // Session-scoped external append: the browser annotator (or any plugin)
+  // queues text + attachments into a durable draft even while the target
+  // session's ChatBar is hidden behind another pane; the matching mounted
+  // composer repaints it live instead of waiting for the next focus.
+  useLayoutEffect(() => onComposerSessionAppendRequest(detail => {
+    if (detail.handled || detail.sessionKey !== draftScopeRef.current) return
+    if (isBrowsingHistory(sessionIdRef.current) || queueEditRef.current) return
+    detail.handled = true
+    appendExternalText(detail.text, 'block')
+    detail.attachments.forEach(attachment => attachmentScope.add(attachment))
+  }), [appendExternalText, attachmentScope, queueEditRef])
 
   // pagehide is load-bearing: React skips effect cleanups on reload, so Cmd+R
   // inside the debounce/rAF window would drop trailing keystrokes without this.

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-session-append.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-session-append.test.tsx
@@ -1,0 +1,54 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { appendComposerToSessionDraft, clearSessionDraft, mainComposerScope } from '@/store/composer'
+
+import { useComposerDraft } from './use-composer-draft'
+import type { QueueEditState } from '../composer-utils'
+
+const mockComposerApi = { setText: vi.fn() }
+
+vi.mock('@assistant-ui/react', () => ({
+  useAui: () => ({ composer: () => mockComposerApi }),
+  useAuiState: (selector: (state: { composer: { text: string } }) => unknown) => selector({ composer: { text: '' } }),
+  useComposerRuntime: () => ({
+    getState: () => ({ text: '' }),
+    subscribe: () => () => undefined
+  })
+}))
+
+function Probe({ sessionKey }: { sessionKey: string }) {
+  useComposerDraft({
+    activeQueueSessionKey: sessionKey,
+    focusKey: null,
+    inputDisabled: false,
+    queueEditRef: { current: null as QueueEditState | null },
+    sessionId: sessionKey
+  })
+  return null
+}
+
+describe('useComposerDraft session-scoped external append', () => {
+  afterEach(() => {
+    cleanup()
+    mainComposerScope.clear()
+    clearSessionDraft('session-a')
+    clearSessionDraft('session-b')
+    mockComposerApi.setText.mockClear()
+  })
+
+  it('appends into the matching mounted composer without replacing existing draft', () => {
+    render(<Probe sessionKey="session-a" />)
+    act(() => appendComposerToSessionDraft('session-a', 'existing input', []))
+    mockComposerApi.setText.mockClear()
+    act(() => appendComposerToSessionDraft('session-a', 'region annotation', []))
+    expect(mockComposerApi.setText).toHaveBeenLastCalledWith('existing input\n\nregion annotation')
+  })
+
+  it('does not repaint a composer mounted for another session', () => {
+    render(<Probe sessionKey="session-b" />)
+    mockComposerApi.setText.mockClear()
+    act(() => appendComposerToSessionDraft('session-a', 'must not enter B', []))
+    expect(mockComposerApi.setText).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -42,6 +42,7 @@ import { onGatewayEvent } from '@/contrib/events'
 import { registry } from '@/contrib/registry'
 import type { WorkspaceMode } from '@/contrib/types'
 import { deleteProfile, getLogs, getStatus, hermesApi, type HermesGateway } from '@/hermes'
+import { appendComposerToSessionDraft, type ComposerAttachment } from '@/store/composer'
 import {
   $gateway,
   activeGatewayConnectionId,
@@ -566,6 +567,13 @@ async function awaitProfileActivation(
 }
 
 export const host = {
+  composer: {
+    /** Append text and attachments to a durable session draft, even when its
+     *  ChatBar is currently hidden behind another pane. */
+    appendToSession: (sessionKey: string, text: string, attachments: ComposerAttachment[] = []) => {
+      appendComposerToSessionDraft(sessionKey, text, attachments)
+    }
+  },
   state: {
     /** Runtime id of the active chat session (null on a fresh draft). */
     activeSessionId: readonlyAtom<null | string>($activeSessionId),
@@ -1131,6 +1139,12 @@ export const host = {
     ownerKey: null | string = null,
     newSessionTarget: WorkspaceNewSessionTarget | null = null
   ): boolean => publishWorkspaceScope(mode, ownerKey, newSessionTarget),
+
+  /** Reveal and front an existing contributed pane in its docked zone. */
+  revealPane: (paneId: string): void => {
+    const key = paneId.trim()
+    if (key) revealTreePane(key)
+  },
 
   /** Start a fresh chat draft, optionally pointed at another profile (its
    *  backend spins up in the background — same door the sidebar's per-profile

--- a/apps/desktop/src/sdk/pane-actions.test.ts
+++ b/apps/desktop/src/sdk/pane-actions.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import * as tree from '@/components/pane-shell/tree/store'
+
+import { host } from './index'
+
+describe('host pane actions', () => {
+  it('reveals a plugin pane by contribution-scoped id', () => {
+    const spy = vi.spyOn(tree, 'revealTreePane')
+    host.revealPane('browser-annotator:browser-annotator')
+    expect(spy).toHaveBeenCalledWith('browser-annotator:browser-annotator')
+  })
+})

--- a/apps/desktop/src/store/composer-session-append.test.ts
+++ b/apps/desktop/src/store/composer-session-append.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  appendComposerToSessionDraft,
+  clearSessionDraft,
+  onComposerSessionAppendRequest,
+  takeSessionDraft
+} from '@/store/composer'
+import { setSessions } from '@/store/session'
+
+describe('session-scoped composer append', () => {
+  afterEach(() => {
+    // Keep the test scope isolated from the module-level draft map.
+    clearSessionDraft('session-test')
+    clearSessionDraft('root-id')
+    clearSessionDraft('tip-id')
+    setSessions([])
+  })
+
+  it('appends text and attachments to the requested durable session draft', () => {
+    appendComposerToSessionDraft('session-test', 'web annotation text', [
+      {
+        id: 'browser-annotation-1',
+        kind: 'image',
+        label: 'browser-annotation-1.png',
+        path: '/tmp/browser-annotation-1.png',
+        refText: '@image:/tmp/browser-annotation-1.png',
+        attachedSessionId: 'session-test'
+      }
+    ])
+
+    expect(takeSessionDraft('session-test')).toEqual({
+      text: 'web annotation text',
+      attachments: [expect.objectContaining({ id: 'browser-annotation-1', kind: 'image' })]
+    })
+  })
+
+  it('notifies only the matching mounted composer', () => {
+    const received: string[] = []
+    const dispose = onComposerSessionAppendRequest(detail => {
+      detail.handled = true
+      received.push(detail.sessionKey)
+    })
+    appendComposerToSessionDraft('session-test', 'annotation', [])
+    dispose()
+    expect(received).toEqual(['session-test'])
+  })
+
+  it('normalizes a compressed tip id to the durable lineage root', () => {
+    setSessions([{ id: 'tip-id', _lineage_root_id: 'root-id' }] as never)
+    appendComposerToSessionDraft('tip-id', 'post-compaction annotation', [])
+    expect(takeSessionDraft('root-id').text).toBe('post-compaction annotation')
+    expect(takeSessionDraft('tip-id').text).toBe('')
+  })
+
+  it('upserts repeated attachment ids in the stashed draft', () => {
+    const first = { id: 'same', kind: 'image', label: 'old.png' } as const
+    const replacement = { id: 'same', kind: 'image', label: 'new.png' } as const
+    appendComposerToSessionDraft('session-test', 'one', [first])
+    appendComposerToSessionDraft('session-test', 'two', [replacement])
+    expect(takeSessionDraft('session-test').attachments).toEqual([replacement])
+  })
+})

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -2,6 +2,7 @@ import { atom } from 'nanostores'
 
 import { deriveDraftTitle } from '@/lib/draft-title'
 import { triggerHaptic } from '@/lib/haptics'
+import { $sessions, resolveComposerSessionKey } from '@/store/session'
 
 export interface ComposerAttachment {
   id: string
@@ -362,6 +363,22 @@ export function onComposerDraftSyncRequest(handler: (detail: ComposerDraftSyncDe
   return () => window.removeEventListener(DRAFT_SYNC_EVENT, listener)
 }
 
+export interface ComposerSessionAppendDetail {
+  sessionKey: string
+  text: string
+  attachments: ComposerAttachment[]
+  handled: boolean
+}
+
+const sessionAppendListeners = new Set<(detail: ComposerSessionAppendDetail) => void>()
+
+export function onComposerSessionAppendRequest(
+  listener: (detail: ComposerSessionAppendDetail) => void
+): () => void {
+  sessionAppendListeners.add(listener)
+  return () => sessionAppendListeners.delete(listener)
+}
+
 function persistDraftTexts() {
   try {
     const entries = [...draftsBySession]
@@ -391,6 +408,23 @@ export function stashSessionDraft(scope: string | null | undefined, text: string
 
   persistDraftTexts()
   publishDraftTitle(key, deriveDraftTitle(text))
+}
+
+export function appendComposerToSessionDraft(
+  scope: string,
+  text: string,
+  attachments: ComposerAttachment[] = []
+): void {
+  const key = draftKey(resolveComposerSessionKey(scope, $sessions.get()) || scope)
+  const current = takeSessionDraft(key)
+  const value = text.trim()
+  const separator = current.text && value && !current.text.endsWith('\n') ? '\n\n' : ''
+  const mergedAttachments = attachments.reduce(upsertAttachment, current.attachments)
+  stashSessionDraft(key, `${current.text}${separator}${value}`, mergedAttachments)
+  const detail: ComposerSessionAppendDetail = { sessionKey: key, text: value, attachments, handled: false }
+  sessionAppendListeners.forEach(listener => {
+    if (!detail.handled) listener(detail)
+  })
 }
 
 export function takeSessionDraft(scope: string | null | undefined): SessionDraft {


### PR DESCRIPTION
## What does this PR do?

Lets plugins (the Browser Annotator being the first consumer) queue text + image attachments into the **durable draft of a specific session** — even when that session's ChatBar is hidden behind another pane — and reveal a contributed pane on demand.

## Related Issue

No existing issue. Searched open PRs for `composer append` / `reveal pane` / `session draft` — no duplicates of this exact scope (the closest neighbors scope composer drafts per profile or preserve focus, which are orthogonal).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- **`apps/desktop/src/store/composer.ts`**: `appendComposerToSessionDraft(scope, text, attachments)` appends to the session's stashed draft — normalizing a compressed tip id to its durable lineage root, merging attachments via the existing occurrence upsert — then notifies matching mounted composers through the new `onComposerSessionAppendRequest` listener set.
- **`apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts`**: the mounted composer subscribes and repaints external appends live, guarded by the existing queue-edit / browsing-history checks, so a hidden session's composer picks up the appended text the moment it mounts.
- **`apps/desktop/src/sdk/index.ts`**: two new host doors —
  - `host.composer.appendToSession(sessionKey, text, attachments)` — programmatic append into a session draft;
  - `host.revealPane(paneId)` — reveal and front an existing contributed pane in its docked zone.
- **Tests** (3 new files, 7 cases): store append semantics (lineage normalization, attachment upsert, single-listener notification), session-scoped composer repaint (only the matching mounted composer is touched), and `revealPane` delegation.

## How to Test

1. `vitest run src/store/composer-session-append.test.ts src/sdk/pane-actions.test.ts src/app/chat/composer/hooks/use-composer-session-append.test.tsx` → 3 files / 7 tests passed.
2. Manual (desktop): open the Browser Annotator, annotate a page, and append to the session — the text + image chips land in the session's composer draft even when the chat pane is not focused, and the pane can be re-fronted from a plugin via `host.revealPane`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(desktop):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've added tests for my changes (7 unit cases)
- [x] I've tested on my platform: macOS (desktop + vitest)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (JSDoc on the new host doors and store functions)
- [x] I've considered cross-platform impact (Windows, macOS) — change is platform-neutral TypeScript; desktop only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no tools changed)
