### PR TITLE
feat: add cost-aware model routing and one-shot override

### DIFF
--- a/agent/model_escalation_policy.py
+++ b/agent/model_escalation_policy.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+
+VALID_FILE_EXTENSIONS = (
+    ".py",
+    ".js",
+    ".ts",
+    ".json",
+    ".yaml",
+    ".yml",
+    ".toml",
+    ".md",
+    ".sql",
+    ".txt",
+    ".html",
+    ".css",
+)
+
+
+@dataclass(frozen=True)
+class SelectionDecision:
+    selected_model: str
+    reason: str
+
+
+def is_valid_file_reference(token: str) -> bool:
+    token = (token or "").strip().strip("\"'`(),:;")
+    if not token:
+        return False
+    if "/" in token or "\\" in token:
+        return True
+    lowered = token.lower()
+    return any(lowered.endswith(ext) for ext in VALID_FILE_EXTENSIONS)
+
+
+def count_valid_file_references(task_text: str) -> int:
+    tokens = re.findall(r"[A-Za-z0-9_./\\:-]+", task_text or "")
+    return sum(1 for tok in tokens if is_valid_file_reference(tok))
+
+
+def _has_fix_request(task_text: str) -> bool:
+    text = (task_text or "").lower()
+    return any(word in text for word in ("fix", "repair", "resolve", "debug"))
+
+
+def _has_traceback(task_text: str) -> bool:
+    text = (task_text or "").lower()
+    return "traceback" in text or "stack trace" in text
+
+
+def _has_high_risk_intent(task_text: str) -> bool:
+    text = (task_text or "").lower()
+    return any(word in text for word in ("production", "security", "credential", "secret", "auth", "rollback"))
+
+
+def _has_architecture_or_multifile_refactor(task_text: str) -> bool:
+    text = (task_text or "").lower()
+    return (
+        "architecture" in text
+        or "multi-file refactor" in text
+        or "multifile refactor" in text
+    )
+
+
+def _is_hard_complex(task_text: str) -> bool:
+    text = (task_text or "").lower()
+    file_reference_count = count_valid_file_references(task_text)
+    has_traceback = _has_traceback(task_text)
+    asks_to_fix_failure = _has_fix_request(task_text)
+
+    return (
+        _has_high_risk_intent(task_text)
+        or "schema" in text
+        or "database migration" in text
+        or "destructive operation" in text
+        or (has_traceback and asks_to_fix_failure)
+        or file_reference_count >= 3
+        or _has_architecture_or_multifile_refactor(task_text)
+    )
+
+
+def select_initial_model(task_text: str) -> SelectionDecision:
+    if _is_hard_complex(task_text):
+        return SelectionDecision(selected_model="gpt-5.4", reason="hard_complex")
+    return SelectionDecision(selected_model="gpt-5.4-mini", reason="default_mini")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5254,6 +5254,10 @@ class TurnRunner:
                 session_key=ctx.session_key,
                 user_config=ctx.user_config,
             )
+            pending_one_shot = getattr(self._runner, "_pending_one_shot_model_overrides", {}).get(ctx.session_key)
+            if pending_one_shot and pending_one_shot.get("model") and not runtime_kwargs.get("model"):
+                runtime_kwargs = dict(runtime_kwargs)
+                runtime_kwargs["model"] = pending_one_shot["model"]
             logger.debug(
                 "run_agent resolved: model=%s provider=%s session=%s",
                 model, runtime_kwargs.get("provider"), ctx.session_key or "",
@@ -8011,6 +8015,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         return model, runtime_kwargs
 
+    def _canonical_session_key_for_source(self, source: SessionSource) -> str:
+        """Return the canonical session/chat identity shared by commands and turns."""
+        try:
+            normalized = self._normalize_source_for_session_key(source)
+        except Exception:
+            normalized = source
+        try:
+            if getattr(self, "session_store", None) is not None:
+                return self.session_store._generate_session_key(normalized)
+        except Exception:
+            pass
+        return self._session_key_for_source(normalized)
+
+    def _pop_one_shot_model_override(self, session_key: str, *, success: bool) -> Optional[dict]:
+        """Consume a pending one-shot model override after a turn outcome.
+
+        Successful turns clear the pending override. Failed turns keep it so the
+        user can retry on the same chosen model. Returns the current pending
+        override record (pre-pop or retained) for observability in tests.
+        """
+        pending = getattr(self, "_pending_one_shot_model_overrides", None)
+        if not pending or not session_key:
+            return None
+        current = pending.get(session_key)
+        if current and success:
+            pending.pop(session_key, None)
+        return current
+
     def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict) -> dict:
         """Build the effective model/runtime config for a single turn.
 
@@ -8019,7 +8051,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         mode, attach `request_overrides` so the API call is marked
         accordingly.
         """
+        from agent.model_escalation_policy import select_initial_model
         from hermes_cli.models import resolve_fast_mode_overrides
+
+        explicit_model_override = runtime_kwargs.get("model")
+        effective_model = model
+        if not explicit_model_override:
+            decision = select_initial_model(user_message)
+            if decision.selected_model:
+                effective_model = decision.selected_model
 
         runtime = {
             "api_key": runtime_kwargs.get("api_key"),
@@ -8033,10 +8073,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "max_tokens": runtime_kwargs.get("max_tokens"),
         }
         route = {
-            "model": model,
+            "model": explicit_model_override or effective_model,
             "runtime": runtime,
             "signature": (
-                model,
+                explicit_model_override or effective_model,
                 runtime["provider"],
                 runtime["requested_provider"],
                 runtime["base_url"],
@@ -20050,6 +20090,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "clear_resume_pending failed for %s: %s",
                         session_key, _e,
                     )
+
+            self._pop_one_shot_model_override(
+                session_key,
+                success=bool(response) and not bool(agent_result.get("error")),
+            )
 
             # Normalize empty responses: surface errors, partial failures, and
             # the case where agent did work but returned no text. Fix for #18765.

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1770,12 +1770,25 @@ class GatewaySlashCommandsMixin:
         from hermes_cli.providers import get_label
 
         raw_args = event.get_command_args().strip()
+        normalized_raw_args = raw_args.lower()
         source = event.source
         _command_profile_home = None
         if getattr(getattr(self, "config", None), "multiplex_profiles", False):
             _command_profile_home = getattr(
                 self, "_resolve_profile_home_for_source"
             )(source)
+
+        # One-shot helpers for Telegram/gateway model selection.
+        session_key = self._canonical_session_key_for_source(source)
+        if not hasattr(self, "_pending_one_shot_model_overrides"):
+            self._pending_one_shot_model_overrides = {}
+
+        if normalized_raw_args == "auto":
+            self._pending_one_shot_model_overrides.pop(session_key, None)
+            return "Автоматический выбор модели включён."
+        if normalized_raw_args == "strong":
+            self._pending_one_shot_model_overrides[session_key] = {"model": "gpt-5.4"}
+            return "Сильная модель gpt-5.4 выбрана для следующей задачи. После неё вернусь в auto."
 
         # Parse --provider, --global, --session, --once, and --refresh flags
         # via the shared single-owner parser (hermes_cli.model_switch).
@@ -1833,13 +1846,7 @@ class GatewaySlashCommandsMixin:
         except Exception:
             pass
 
-        # Check for session override. Normalize the source the same way a normal
-        # message turn does
-        # (Telegram DM topic recovery) before deriving the override key, so
-        # the override is stored under the key the next message turn reads
-        # (#30479).
-        source = await asyncio.to_thread(self._normalize_source_for_session_key, source)
-        session_key = self._session_key_for_source(source)
+        # Check for session override
         override = self._session_model_overrides.get(session_key, {})
         restore_snapshot = (
             self._snapshot_session_model_override(session_key) if one_turn else None
@@ -2244,6 +2251,14 @@ class GatewaySlashCommandsMixin:
             )
         except Exception as exc:
             logger.debug("preflight-compression switch warning failed: %s", exc)
+
+        if (
+            not persist_global
+            and not explicit_provider
+            and (result.new_model or "").strip().lower() == "gpt-5.4"
+        ):
+            self._pending_one_shot_model_overrides[session_key] = {"model": "gpt-5.4"}
+            return "Следующая задача будет выполнена с gpt-5.4. После неё вернусь в auto."
 
         async def _finish_switch() -> str:
             """Apply the resolved switch (agent, session, config) and build the reply."""

--- a/tests/agent/test_gateway_model_escalation_handoff.py
+++ b/tests/agent/test_gateway_model_escalation_handoff.py
@@ -1,0 +1,76 @@
+from gateway.run import GatewayRunner
+
+
+def _make_runner() -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner._service_tier = None
+    runner._pending_one_shot_model_overrides = {}
+    return runner
+
+
+def test_gateway_route_ordinary_message_stays_on_mini():
+    runner = _make_runner()
+    route = runner._resolve_turn_agent_config(
+        "Reply exactly: hello",
+        "gpt-5.4-mini",
+        {
+            "provider": "openai-api",
+            "base_url": "http://localhost:20128/v1",
+            "api_key": "redacted",
+            "api_mode": "chat_completions",
+        },
+    )
+    assert route["model"] == "gpt-5.4-mini"
+
+
+def test_gateway_route_hard_complex_message_uses_gpt54():
+    runner = _make_runner()
+    route = runner._resolve_turn_agent_config(
+        "architecture and multi-file refactor across src/app.py, src/api.py, src/db.py",
+        "gpt-5.4-mini",
+        {
+            "provider": "openai-api",
+            "base_url": "http://localhost:20128/v1",
+            "api_key": "redacted",
+            "api_mode": "chat_completions",
+        },
+    )
+    assert route["model"] == "gpt-5.4"
+
+
+def test_pending_one_shot_override_wins_for_ordinary_message():
+    runner = _make_runner()
+    runner._pending_one_shot_model_overrides["telegram:chat-1"] = {"model": "gpt-5.4"}
+    route = runner._resolve_turn_agent_config(
+        "Reply exactly: hello",
+        "gpt-5.4-mini",
+        {
+            "model": "gpt-5.4",
+            "provider": "openai-api",
+            "base_url": "http://localhost:20128/v1",
+            "api_key": "redacted",
+            "api_mode": "chat_completions",
+        },
+    )
+    assert route["model"] == "gpt-5.4"
+
+
+def test_provider_base_url_and_api_key_are_unchanged():
+    runner = _make_runner()
+    runtime_kwargs = {
+        "provider": "openai-api",
+        "base_url": "http://localhost:20128/v1",
+        "api_key": "redacted",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": [],
+    }
+    route = runner._resolve_turn_agent_config(
+        "architecture and multi-file refactor across src/app.py, src/api.py, src/db.py",
+        "gpt-5.4-mini",
+        runtime_kwargs,
+    )
+    assert route["model"] == "gpt-5.4"
+    assert route["runtime"]["provider"] == runtime_kwargs["provider"]
+    assert route["runtime"]["base_url"] == runtime_kwargs["base_url"]
+    assert route["runtime"]["api_key"] == runtime_kwargs["api_key"]

--- a/tests/agent/test_gateway_one_shot_model_override.py
+++ b/tests/agent/test_gateway_one_shot_model_override.py
@@ -1,0 +1,226 @@
+import types
+
+import pytest
+
+from gateway.platforms.base import MessageEvent, MessageType, Platform, SessionSource
+from gateway.run import GatewayRunner
+from gateway.slash_commands import GatewaySlashCommandsMixin
+
+
+class _DummySlashRunner(GatewaySlashCommandsMixin):
+    pass
+
+
+class _FakeSessionStore:
+    def _generate_session_key(self, source):
+        return f"{source.platform.value}:{source.chat_id}:{source.user_id}"
+
+
+def _make_source(chat_id: str) -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=chat_id,
+        chat_name="chat",
+        chat_type="dm",
+        user_id="user-1",
+        user_name="user",
+    )
+
+
+def _make_command_event(text: str, chat_id: str = "chat-1") -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.COMMAND,
+        source=_make_source(chat_id),
+    )
+
+
+def _make_runner() -> _DummySlashRunner:
+    runner = object.__new__(_DummySlashRunner)
+    runner.adapters = {}
+    runner.session_store = _FakeSessionStore()
+    runner._session_model_overrides = {}
+    runner._pending_model_notes = {}
+    runner._pending_one_shot_model_overrides = {}
+    runner._normalize_source_for_session_key = types.MethodType(
+        GatewayRunner._normalize_source_for_session_key, runner
+    )
+    runner._session_key_for_source = types.MethodType(
+        GatewayRunner._session_key_for_source, runner
+    )
+    runner._canonical_session_key_for_source = types.MethodType(
+        GatewayRunner._canonical_session_key_for_source, runner
+    )
+    runner._resolve_turn_agent_config = types.MethodType(
+        GatewayRunner._resolve_turn_agent_config, runner
+    )
+    runner._pop_one_shot_model_override = types.MethodType(
+        GatewayRunner._pop_one_shot_model_override, runner
+    )
+    runner._thread_metadata_for_source = lambda source, anchor: None
+    runner._reply_anchor_for_event = lambda event: None
+    runner._evict_cached_agent = lambda session_key: None
+    runner._agent_cache_lock = None
+    runner._agent_cache = None
+    runner._session_db = None
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_model_auto_clears_pending_override():
+    runner = _make_runner()
+    session_key = runner._canonical_session_key_for_source(_make_source("chat-1"))
+    runner._pending_one_shot_model_overrides[session_key] = {"model": "gpt-5.4"}
+
+    result = await runner._handle_model_command(_make_command_event("/model auto"))
+
+    assert result == "Автоматический выбор модели включён."
+    assert session_key not in runner._pending_one_shot_model_overrides
+
+
+@pytest.mark.asyncio
+async def test_model_strong_sets_pending_override_for_session_only():
+    runner = _make_runner()
+
+    result = await runner._handle_model_command(_make_command_event("/model strong", chat_id="chat-1"))
+
+    key1 = runner._canonical_session_key_for_source(_make_source("chat-1"))
+    key2 = runner._canonical_session_key_for_source(_make_source("chat-2"))
+    assert result == "Сильная модель gpt-5.4 выбрана для следующей задачи. После неё вернусь в auto."
+    assert runner._pending_one_shot_model_overrides[key1]["model"] == "gpt-5.4"
+    assert key2 not in runner._pending_one_shot_model_overrides
+
+
+@pytest.mark.asyncio
+async def test_model_gpt54_sets_pending_override(monkeypatch):
+    from gateway import run as gateway_run
+
+    runner = _make_runner()
+
+    class _Result:
+        success = True
+        new_model = "gpt-5.4"
+        target_provider = "openai-api"
+        api_key = "redacted"
+        base_url = "http://localhost:20128/v1"
+        api_mode = "chat_completions"
+        provider_label = "OpenAI"
+        model_info = None
+        warning_message = None
+
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {"model": {}})
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", lambda **kwargs: _Result())
+
+    result = await runner._handle_model_command(_make_command_event("/model gpt-5.4"))
+
+    key = runner._canonical_session_key_for_source(_make_source("chat-1"))
+    assert result == "Следующая задача будет выполнена с gpt-5.4. После неё вернусь в auto."
+    assert runner._pending_one_shot_model_overrides[key]["model"] == "gpt-5.4"
+
+
+def test_pending_override_clears_after_successful_completion():
+    runner = object.__new__(GatewayRunner)
+    runner._pending_one_shot_model_overrides = {"session-1": {"model": "gpt-5.4"}}
+
+    current = runner._pop_one_shot_model_override("session-1", success=True)
+
+    assert current == {"model": "gpt-5.4"}
+    assert "session-1" not in runner._pending_one_shot_model_overrides
+
+
+def test_pending_override_remains_after_provider_failure():
+    runner = object.__new__(GatewayRunner)
+    runner._pending_one_shot_model_overrides = {"session-1": {"model": "gpt-5.4"}}
+
+    current = runner._pop_one_shot_model_override("session-1", success=False)
+
+    assert current == {"model": "gpt-5.4"}
+    assert runner._pending_one_shot_model_overrides["session-1"]["model"] == "gpt-5.4"
+
+
+@pytest.mark.asyncio
+async def test_command_to_next_turn_handoff_uses_canonical_key_and_clears_after_success():
+    runner = _make_runner()
+
+    command_result = await runner._handle_model_command(_make_command_event("/model strong", chat_id="chat-1"))
+    assert command_result == "Сильная модель gpt-5.4 выбрана для следующей задачи. После неё вернусь в auto."
+
+    same_chat_source = _make_source("chat-1")
+    session_key = runner._canonical_session_key_for_source(same_chat_source)
+    assert runner._pending_one_shot_model_overrides[session_key]["model"] == "gpt-5.4"
+
+    def build_effective_route(source, message):
+        canonical_key = runner._canonical_session_key_for_source(source)
+        model = "gpt-5.4-mini"
+        runtime_kwargs = {
+            "provider": "openai-api",
+            "base_url": "http://localhost:20128/v1",
+            "api_key": "redacted",
+            "api_mode": "chat_completions",
+        }
+        pending = runner._pending_one_shot_model_overrides.get(canonical_key)
+        if pending and pending.get("model") and not runtime_kwargs.get("model"):
+            runtime_kwargs = dict(runtime_kwargs)
+            runtime_kwargs["model"] = pending["model"]
+        route = runner._resolve_turn_agent_config(message, model, runtime_kwargs)
+        return canonical_key, route
+
+    first_key, first_route = build_effective_route(same_chat_source, "OVERRIDE_OK")
+    assert first_key == session_key
+    assert first_route["model"] == "gpt-5.4"
+
+    runner._pop_one_shot_model_override(session_key, success=True)
+    assert session_key not in runner._pending_one_shot_model_overrides
+
+    _, second_route = build_effective_route(same_chat_source, "AUTO_MINI_OK")
+    assert second_route["model"] == "gpt-5.4-mini"
+
+
+@pytest.mark.asyncio
+async def test_different_chat_does_not_receive_override():
+    runner = _make_runner()
+
+    await runner._handle_model_command(_make_command_event("/model strong", chat_id="chat-1"))
+
+    key1 = runner._canonical_session_key_for_source(_make_source("chat-1"))
+    key2 = runner._canonical_session_key_for_source(_make_source("chat-2"))
+
+    runtime_kwargs = {
+        "provider": "openai-api",
+        "base_url": "http://localhost:20128/v1",
+        "api_key": "redacted",
+        "api_mode": "chat_completions",
+    }
+    pending = runner._pending_one_shot_model_overrides.get(key2)
+    if pending and pending.get("model") and not runtime_kwargs.get("model"):
+        runtime_kwargs = dict(runtime_kwargs)
+        runtime_kwargs["model"] = pending["model"]
+    route = runner._resolve_turn_agent_config("AUTO_MINI_OK", "gpt-5.4-mini", runtime_kwargs)
+
+    assert runner._pending_one_shot_model_overrides[key1]["model"] == "gpt-5.4"
+    assert key2 not in runner._pending_one_shot_model_overrides
+    assert route["model"] == "gpt-5.4-mini"
+
+
+@pytest.mark.asyncio
+async def test_failure_before_final_response_keeps_pending_override_for_same_chat():
+    runner = _make_runner()
+
+    await runner._handle_model_command(_make_command_event("/model strong", chat_id="chat-1"))
+    session_key = runner._canonical_session_key_for_source(_make_source("chat-1"))
+
+    runtime_kwargs = {
+        "provider": "openai-api",
+        "base_url": "http://localhost:20128/v1",
+        "api_key": "redacted",
+        "api_mode": "chat_completions",
+    }
+    pending = runner._pending_one_shot_model_overrides.get(session_key)
+    if pending and pending.get("model") and not runtime_kwargs.get("model"):
+        runtime_kwargs = dict(runtime_kwargs)
+        runtime_kwargs["model"] = pending["model"]
+    route = runner._resolve_turn_agent_config("OVERRIDE_OK", "gpt-5.4-mini", runtime_kwargs)
+
+    assert route["model"] == "gpt-5.4"
+    runner._pop_one_shot_model_override(session_key, success=False)
+    assert runner._pending_one_shot_model_overrides[session_key]["model"] == "gpt-5.4"

--- a/tests/agent/test_model_escalation_policy.py
+++ b/tests/agent/test_model_escalation_policy.py
@@ -1,0 +1,55 @@
+"""Policy tests for automatic initial model routing.
+
+These tests exercise the pure selector logic only; they do not make live LLM
+calls.
+"""
+
+from __future__ import annotations
+
+from agent.model_escalation_policy import (
+    SelectionDecision,
+    count_valid_file_references,
+    select_initial_model,
+)
+
+
+def test_default_routine_task_stays_on_mini():
+    d = select_initial_model("Write a short summary of this paragraph.")
+    assert isinstance(d, SelectionDecision)
+    assert d.selected_model == "gpt-5.4-mini"
+    assert d.reason == "default_mini"
+
+
+def test_high_risk_intent_goes_to_gpt54():
+    d = select_initial_model("This is a production security rollback for credentials.")
+    assert d.selected_model == "gpt-5.4"
+    assert d.reason == "hard_complex"
+
+
+def test_three_file_references_go_to_gpt54():
+    d = select_initial_model("Fix these files: src/app.py, src/api.py, src/db.py.")
+    assert d.selected_model == "gpt-5.4"
+    assert d.reason == "hard_complex"
+
+
+def test_single_words_do_not_force_gpt54():
+    for text in ["API", "SQL", "error", "test", "refactor", "integration"]:
+        d = select_initial_model(text)
+        assert d.selected_model == "gpt-5.4-mini", text
+        assert d.reason == "default_mini", text
+
+
+def test_invalid_pseudo_file_tokens_do_not_increase_file_count():
+    text = "Pseudo files: version.1 release.2 build.3 just.words here"
+    assert count_valid_file_references(text) == 0
+    d = select_initial_model(text)
+    assert d.selected_model == "gpt-5.4-mini"
+    assert d.reason == "default_mini"
+
+
+def test_reason_matches_selected_model_for_architecture_trigger():
+    d = select_initial_model(
+        "Need architecture guidance and multi-file refactor across src/app.py, src/api.py, src/db.py"
+    )
+    assert d.selected_model == "gpt-5.4"
+    assert d.reason == "hard_complex"


### PR DESCRIPTION
## Summary
- Adds automatic initial model selection that defaults to `gpt-5.4-mini`
  and can escalate hard/complex technical requests to `gpt-5.4`.
- Adds session-local, in-memory one-shot overrides:
  `/model strong`, `/model gpt-5.4`, and `/model auto`.
- Preserves explicit runtime model override precedence and clears a pending
  one-shot override only after a successful final response.

## Validation
- `python -m py_compile gateway/run.py gateway/slash_commands.py agent/model_escalation_policy.py`
- `pytest -q tests/agent/test_gateway_one_shot_model_override.py` — 8 passed
- `pytest -q tests/agent/test_gateway_model_escalation_handoff.py` — 4 passed
- `pytest -q tests/agent/test_model_escalation_policy.py` — 6 passed