### PR TITLE
feat(reasoning): configure default persistence for reasoning changes

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -479,6 +479,7 @@ def load_cli_config() -> Dict[str, Any]:
             "system_prompt": "",
             "prefill_messages_file": "",
             "reasoning_effort": "",
+            "reasoning_command_scope": "session",
             "service_tier": "",
             # Built-in personalities live in hermes_cli.personality
             # (BUILTIN_PERSONALITIES) — the single owner. Entries here are

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9194,30 +9194,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return resolve_reasoning_config(cfg, model)
 
     @staticmethod
-    def _parse_reasoning_command_args(raw_args: str) -> tuple[str, bool]:
-        """Parse `/reasoning` args into `(value, persist_global)`.
+    def _parse_reasoning_command_args(raw_args: str) -> tuple[str, str | None]:
+        """Parse `/reasoning` args into ``(value, explicit_scope)``."""
+        from hermes_constants import parse_reasoning_command_args
 
-        `/reasoning <level>` is session-scoped by default. `--global` may be
-        supplied in any position to persist the change to config.yaml.
-        """
-        import shlex
-
-        text = str(raw_args or "").strip().replace("—", "--")
-        if not text:
-            return "", False
-        try:
-            tokens = shlex.split(text)
-        except ValueError:
-            tokens = text.split()
-
-        persist_global = False
-        value_tokens = []
-        for token in tokens:
-            if token == "--global":
-                persist_global = True
-            else:
-                value_tokens.append(token)
-        return " ".join(value_tokens).strip().lower(), persist_global
+        return parse_reasoning_command_args(raw_args)
 
     def _resolve_session_reasoning_config(
         self,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3539,7 +3539,7 @@ class GatewaySlashCommandsMixin:
         session_key: str,
         platform_key: str,
         value: str,
-        persist_global: bool = False,
+        persist_global: Optional[bool] = None,
     ) -> str:
         """Apply a /reasoning argument (typed or picked) and return the reply.
 
@@ -3566,7 +3566,7 @@ class GatewaySlashCommandsMixin:
             return t("gateway.reasoning.display_set_off", platform=platform_key)
 
         if value == "reset":
-            if persist_global:
+            if persist_global is True:
                 return t("gateway.reasoning.reset_global_unsupported")
             self._set_session_reasoning_override(session_key, None)
             self._reasoning_config = self._load_reasoning_config()
@@ -3578,6 +3578,13 @@ class GatewaySlashCommandsMixin:
             return t("gateway.reasoning.unknown_arg", arg=value)
 
         self._reasoning_config = parsed
+        if persist_global is None:
+            from gateway.run import _load_gateway_runtime_config
+            from hermes_constants import resolve_reasoning_command_scope
+
+            persist_global = (
+                resolve_reasoning_command_scope(_load_gateway_runtime_config()) == "global"
+            )
         if persist_global:
             if self._save_gateway_config_key("agent.reasoning_effort", value):
                 self._set_session_reasoning_override(session_key, None)
@@ -3671,7 +3678,7 @@ class GatewaySlashCommandsMixin:
         from gateway.run import _platform_config_key
 
         raw_args = event.get_command_args().strip()
-        args, persist_global = self._parse_reasoning_command_args(raw_args)
+        args, explicit_scope = self._parse_reasoning_command_args(raw_args)
         # Normalize the source (Telegram DM topic recovery) before deriving
         # the override key so storage matches the key the next message turn
         # reads — same fix as /model (#30479).
@@ -3706,10 +3713,15 @@ class GatewaySlashCommandsMixin:
                 if self._show_reasoning
                 else t("gateway.reasoning.display_off")
             )
-            has_session_override = session_key in (getattr(self, "_session_reasoning_overrides", {}) or {})
+            from gateway.run import _load_gateway_runtime_config
+            from hermes_constants import resolve_reasoning_command_scope
+
+            command_scope = resolve_reasoning_command_scope(
+                _load_gateway_runtime_config()
+            )
             scope = (
                 t("gateway.reasoning.scope_session")
-                if has_session_override
+                if command_scope == "session"
                 else t("gateway.reasoning.scope_global")
             )
 
@@ -3746,6 +3758,11 @@ class GatewaySlashCommandsMixin:
 
         # Typed argument path — same applier the picker uses.
         platform_key = _platform_config_key(event.source.platform)
+        persist_global = (
+            True if explicit_scope == "global"
+            else False if explicit_scope == "session"
+            else None
+        )
         return self._apply_reasoning_selection(
             session_key, platform_key, args, persist_global=persist_global
         )
@@ -3864,7 +3881,8 @@ class GatewaySlashCommandsMixin:
         raw_args = event.get_command_args().strip().lower()
         # Reuse the /reasoning arg parser: strips --global (any position),
         # normalizes unicode dashes.
-        args, persist_global = self._parse_reasoning_command_args(raw_args)
+        args, explicit_scope = self._parse_reasoning_command_args(raw_args)
+        persist_global = explicit_scope == "global"
         session_key = self._session_key_for_source(event.source)
         self._service_tier = self._resolve_session_service_tier(
             session_key=session_key

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -3432,6 +3432,7 @@ class CLICommandsMixin:
             /reasoning clamp        Collapse long thinking to the first 10 lines
         """
         from cli import CLI_CONFIG, _ACCENT, _DIM, _RST, _cprint, _parse_reasoning_config, save_config_value
+        from hermes_constants import parse_reasoning_command_args, resolve_reasoning_command_scope
         parts = cmd.strip().split(maxsplit=1)
 
         if len(parts) < 2:
@@ -3445,22 +3446,14 @@ class CLICommandsMixin:
                 level = rc.get("effort", "medium")
             display_state = "on ✓" if self.show_reasoning else "off"
             full_state = "full" if getattr(self, "reasoning_full", False) else "clamped to 10 lines"
+            command_scope = resolve_reasoning_command_scope(CLI_CONFIG)
             _cprint(f"  {_ACCENT}Reasoning effort:  {level}{_RST}")
             _cprint(f"  {_ACCENT}Reasoning display: {display_state} ({full_state}){_RST}")
-            _cprint(f"  {_DIM}Usage: /reasoning <none|minimal|low|medium|high|xhigh|max|ultra|show|hide|full|clamp> [--global]{_RST}")
+            _cprint(f"  {_ACCENT}Command default:   {command_scope}{_RST}")
+            _cprint(f"  {_DIM}Usage: /reasoning <none|minimal|low|medium|high|xhigh|max|ultra|show|hide|full|clamp> [--session|--global]{_RST}")
             return
 
-        arg = parts[1].strip().lower()
-        arg_tokens = arg.split()
-        # Session scope is the default; --global opts into persisting to
-        # config.yaml. --session is accepted as an explicit no-op for parity
-        # with /model and the gateway /reasoning handler.
-        explicit_global = "--global" in arg_tokens
-        if explicit_global or "--session" in arg_tokens:
-            arg = " ".join(
-                token for token in arg_tokens
-                if token not in ("--global", "--session")
-            )
+        arg, explicit_scope = parse_reasoning_command_args(parts[1])
 
         # Display toggle
         if arg in {"show", "on"}:
@@ -3506,14 +3499,15 @@ class CLICommandsMixin:
         self.reasoning_config = parsed
         self.agent = None  # Force agent re-init with new reasoning config
 
-        if explicit_global and save_config_value("agent.reasoning_effort", arg):
+        persist_global = resolve_reasoning_command_scope(CLI_CONFIG, explicit_scope) == "global"
+        if persist_global and save_config_value("agent.reasoning_effort", arg):
             agent_cfg = CLI_CONFIG.get("agent")
             if not isinstance(agent_cfg, dict):
                 agent_cfg = {}
                 CLI_CONFIG["agent"] = agent_cfg
             agent_cfg["reasoning_effort"] = arg
             _cprint(f"  {_ACCENT}✓ Reasoning effort set to '{arg}' (saved to config){_RST}")
-        elif explicit_global:
+        elif persist_global:
             _cprint(f"  {_ACCENT}✓ Reasoning effort set to '{arg}' (session only; config save failed){_RST}")
         else:
             _cprint(f"  {_ACCENT}✓ Reasoning effort set to '{arg}' (this session — use --global to persist){_RST}")

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -328,6 +328,9 @@ DEFAULT_CONFIG = {
         # matches a key in this dict.
         # Edit directly in config.yaml (no CLI support due to dots in keys).
         "reasoning_overrides": {},
+        # Persistence scope for bare `/reasoning <level>` changes. Explicit
+        # --session / --global flags always override this default.
+        "reasoning_command_scope": "session",
     },
 
     "terminal": {

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1156,6 +1156,49 @@ VALID_REASONING_EFFORTS = (
     "minimal", "low", "medium", "high", "xhigh", "max", "ultra",
 )
 
+REASONING_COMMAND_SCOPES = ("session", "global")
+
+
+def parse_reasoning_command_args(raw_args: str) -> tuple[str, str | None]:
+    """Parse a reasoning value and optional explicit persistence scope."""
+    import shlex
+
+    text = str(raw_args or "").strip().replace("—", "--").replace("–", "--")
+    if not text:
+        return "", None
+    try:
+        tokens = shlex.split(text)
+    except ValueError:
+        tokens = text.split()
+
+    explicit_scope = None
+    value_tokens = []
+    for token in tokens:
+        normalized = token.lower()
+        if normalized in {"--session", "--global"}:
+            # Repeated scope flags follow normal CLI convention: last wins.
+            explicit_scope = normalized[2:]
+        else:
+            value_tokens.append(token)
+    return " ".join(value_tokens).strip().lower(), explicit_scope
+
+
+def resolve_reasoning_command_scope(
+    cfg: dict | None,
+    explicit_scope: str | None = None,
+) -> str:
+    """Resolve effort-change persistence, defaulting safely to session scope."""
+    normalized_explicit = str(explicit_scope or "").strip().lower()
+    if normalized_explicit in REASONING_COMMAND_SCOPES:
+        return normalized_explicit
+
+    cfg = cfg if isinstance(cfg, dict) else {}
+    agent_cfg = cfg.get("agent")
+    if not isinstance(agent_cfg, dict):
+        return "session"
+    configured = str(agent_cfg.get("reasoning_command_scope") or "session").strip().lower()
+    return configured if configured in REASONING_COMMAND_SCOPES else "session"
+
 
 def parse_reasoning_effort(effort) -> dict | None:
     """Parse a reasoning effort level into a config dict.

--- a/tests/cli/test_reasoning_command.py
+++ b/tests/cli/test_reasoning_command.py
@@ -103,6 +103,46 @@ class TestHandleReasoningCommand(unittest.TestCase):
         self.assertEqual(stub.reasoning_config, {"enabled": True, "effort": "high"})
         self.assertIsNone(stub.agent)
 
+    def test_configured_global_default_persists_effort(self):
+        from cli import CLI_CONFIG
+        from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+        stub = self._make_cli(reasoning_config={"enabled": True, "effort": "medium"})
+        with patch.dict(
+            CLI_CONFIG.setdefault("agent", {}),
+            {"reasoning_command_scope": "global"},
+        ), patch("cli.save_config_value", return_value=True) as save_config, patch("cli._cprint"):
+            CLICommandsMixin._handle_reasoning_command(stub, "/reasoning high")
+
+        save_config.assert_called_once_with("agent.reasoning_effort", "high")
+
+    def test_explicit_session_overrides_configured_global_default(self):
+        from cli import CLI_CONFIG
+        from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+        stub = self._make_cli(reasoning_config={"enabled": True, "effort": "medium"})
+        with patch.dict(
+            CLI_CONFIG.setdefault("agent", {}),
+            {"reasoning_command_scope": "global"},
+        ), patch("cli.save_config_value") as save_config, patch("cli._cprint"):
+            CLICommandsMixin._handle_reasoning_command(stub, "/reasoning high --session")
+
+        save_config.assert_not_called()
+        self.assertEqual(stub.reasoning_config, {"enabled": True, "effort": "high"})
+
+    def test_status_reports_configured_command_default(self):
+        from cli import CLI_CONFIG
+        from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+        stub = self._make_cli(reasoning_config={"enabled": True, "effort": "medium"})
+        with patch.dict(
+            CLI_CONFIG.setdefault("agent", {}),
+            {"reasoning_command_scope": "global"},
+        ), patch("cli._cprint") as cprint:
+            CLICommandsMixin._handle_reasoning_command(stub, "/reasoning")
+
+        assert any("Command default:   global" in call.args[0] for call in cprint.call_args_list)
+
 
 
     def test_new_session_clears_session_reasoning_override(self):

--- a/tests/gateway/test_reasoning_command.py
+++ b/tests/gateway/test_reasoning_command.py
@@ -67,8 +67,57 @@ class TestReasoningCommand:
 
 
     def test_parse_reasoning_command_args_accepts_ascii_and_smart_global_flags(self):
-        assert gateway_run.GatewayRunner._parse_reasoning_command_args("high --global") == ("high", True)
-        assert gateway_run.GatewayRunner._parse_reasoning_command_args("—global xhigh") == ("xhigh", True)
+        assert gateway_run.GatewayRunner._parse_reasoning_command_args("high --global") == ("high", "global")
+        assert gateway_run.GatewayRunner._parse_reasoning_command_args("—global xhigh") == ("xhigh", "global")
+
+    @pytest.mark.asyncio
+    async def test_configured_global_default_persists_plain_effort(self, monkeypatch):
+        runner = _make_runner()
+        runner._save_gateway_config_key = MagicMock(return_value=True)
+        monkeypatch.setattr(
+            gateway_run,
+            "_load_gateway_runtime_config",
+            lambda: {"agent": {"reasoning_command_scope": "global"}},
+        )
+
+        await runner._handle_reasoning_command(_make_event("/reasoning high"))
+
+        runner._save_gateway_config_key.assert_called_once_with(
+            "agent.reasoning_effort", "high"
+        )
+
+    @pytest.mark.asyncio
+    async def test_explicit_session_overrides_configured_global_default(self, monkeypatch):
+        runner = _make_runner()
+        runner._save_gateway_config_key = MagicMock(return_value=True)
+        monkeypatch.setattr(
+            gateway_run,
+            "_load_gateway_runtime_config",
+            lambda: {"agent": {"reasoning_command_scope": "global"}},
+        )
+        event = _make_event("/reasoning high --session")
+        session_key = runner._session_key_for_source(event.source)
+
+        await runner._handle_reasoning_command(event)
+
+        runner._save_gateway_config_key.assert_not_called()
+        assert runner._session_reasoning_overrides[session_key] == {
+            "enabled": True,
+            "effort": "high",
+        }
+
+    @pytest.mark.asyncio
+    async def test_status_reports_configured_command_default(self, monkeypatch):
+        runner = _make_runner()
+        monkeypatch.setattr(
+            gateway_run,
+            "_load_gateway_runtime_config",
+            lambda: {"agent": {"reasoning_command_scope": "global"}},
+        )
+
+        result = await runner._handle_reasoning_command(_make_event("/reasoning"))
+
+        assert "**Scope:** global config" in result
 
     @pytest.mark.asyncio
     async def test_reasoning_command_reloads_current_state_from_config(self, tmp_path, monkeypatch):

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -404,6 +404,32 @@ class TestParseReasoningEffort:
         assert documented.issubset(set(VALID_REASONING_EFFORTS))
 
 
+class TestReasoningCommandScope:
+    def test_parser_returns_value_and_explicit_scope(self):
+        from hermes_constants import parse_reasoning_command_args
+
+        assert parse_reasoning_command_args("high") == ("high", None)
+        assert parse_reasoning_command_args("—session xhigh") == ("xhigh", "session")
+        assert parse_reasoning_command_args("low --session --global") == ("low", "global")
+
+    def test_config_default_and_explicit_flags_resolve_in_order(self):
+        from hermes_constants import resolve_reasoning_command_scope
+
+        cfg = {"agent": {"reasoning_command_scope": "global"}}
+        assert resolve_reasoning_command_scope(cfg) == "global"
+        assert resolve_reasoning_command_scope(cfg, "session") == "session"
+        assert resolve_reasoning_command_scope({}, "global") == "global"
+
+    def test_invalid_config_fails_back_to_session(self):
+        from hermes_constants import resolve_reasoning_command_scope
+
+        assert resolve_reasoning_command_scope(None) == "session"
+        assert resolve_reasoning_command_scope({"agent": "bad"}) == "session"
+        assert resolve_reasoning_command_scope(
+            {"agent": {"reasoning_command_scope": "forever"}}
+        ) == "session"
+
+
 class TestResolvePerModelReasoningEffort:
     """Tests for resolve_per_model_reasoning_effort() — spelling-tolerant
     per-model override lookup from agent.reasoning_overrides dict.
@@ -514,6 +540,11 @@ class TestReasoningOverridesDefaultConfig:
         from hermes_cli.config import DEFAULT_CONFIG
         assert "reasoning_overrides" in DEFAULT_CONFIG["agent"]
         assert DEFAULT_CONFIG["agent"]["reasoning_overrides"] == {}
+
+    def test_default_reasoning_command_scope_is_session(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        assert DEFAULT_CONFIG["agent"]["reasoning_command_scope"] == "session"
 
 
     def test_spelling_tolerant_lookup_works_with_user_config(self):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8155,6 +8155,55 @@ def test_config_set_reasoning_global_scope_clears_session_override(tmp_path, mon
     assert status["result"]["value"] == "high"
 
 
+def test_config_set_reasoning_honors_configured_default_and_explicit_session(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text(
+        "agent:\n"
+        "  reasoning_effort: medium\n"
+        "  reasoning_command_scope: global\n",
+        encoding="utf-8",
+    )
+    agent = types.SimpleNamespace(reasoning_config=None)
+    server._sessions["sid"] = _session(agent=agent)
+
+    plain = server.handle_request(
+        {
+            "id": "1",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "reasoning", "value": "high"},
+        }
+    )
+    assert plain["result"]["value"] == "high"
+    assert server._load_cfg()["agent"]["reasoning_effort"] == "high"
+    assert "create_reasoning_override" not in server._sessions["sid"]
+
+    session_only = server.handle_request(
+        {
+            "id": "2",
+            "method": "config.set",
+            "params": {
+                "session_id": "sid",
+                "key": "reasoning",
+                "value": "low",
+                "scope": "session",
+            },
+        }
+    )
+    assert session_only["result"]["value"] == "low"
+    assert server._load_cfg()["agent"]["reasoning_effort"] == "high"
+    assert server._sessions["sid"]["create_reasoning_override"] == {
+        "enabled": True,
+        "effort": "low",
+    }
+
+    status = server.handle_request(
+        {"id": "3", "method": "config.get", "params": {"key": "reasoning"}}
+    )
+    assert status["result"]["command_scope"] == "global"
+
+
 def test_config_set_verbose_updates_session_mode_and_agent(tmp_path, monkeypatch):
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
     agent = types.SimpleNamespace(verbose_logging=False)

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -219,6 +219,8 @@ def _(rid, params: dict) -> dict:
         )
     if key == "reasoning":
         cfg = _load_cfg()
+        from hermes_constants import resolve_reasoning_command_scope
+
         session = _sessions.get(params.get("session_id", ""))
         reasoning_config = None
         if session is not None:
@@ -248,7 +250,14 @@ def _(rid, params: dict) -> dict:
             if bool((cfg.get("display") or {}).get("show_reasoning", True))
             else "hide"
         )
-        return _ok(rid, {"value": effort, "display": display})
+        return _ok(
+            rid,
+            {
+                "value": effort,
+                "display": display,
+                "command_scope": resolve_reasoning_command_scope(cfg),
+            },
+        )
     if key == "fast":
         # Prefer the session's live/pinned value — `config.set fast` is
         # session-scoped, so the global key may not reflect this chat. A

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12110,7 +12110,6 @@ def _(rid, params: dict) -> dict:
 
             arg = str(value or "").strip().lower()
             scope = str(params.get("scope") or "").strip().lower()
-            global_scope = scope == "global"
             if arg in {"show", "on"}:
                 cfg = _load_cfg_raw()  # write-back round-trip
                 display = (
@@ -12190,6 +12189,14 @@ def _(rid, params: dict) -> dict:
             parsed = parse_reasoning_effort(arg)
             if parsed is None:
                 return _err(rid, 4002, f"unknown reasoning value: {value}")
+            from hermes_constants import resolve_reasoning_command_scope
+
+            global_scope = (
+                resolve_reasoning_command_scope(
+                    _load_cfg(), scope if scope in {"session", "global"} else None
+                )
+                == "global"
+            )
             if global_scope or session is None:
                 _write_config_key("agent.reasoning_effort", arg)
                 if session is not None:

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -333,14 +333,22 @@ describe('createSlashHandler', () => {
     })
   })
 
-  it('reads /reasoning status for the active session', () => {
+  it('reads /reasoning status and reports the command default scope', async () => {
     patchUiState({ sid: 'sid-abc' })
-    const ctx = buildCtx()
+    const rpc = vi.fn(() =>
+      Promise.resolve({ command_scope: 'global', display: 'show', value: 'high' })
+    )
+    const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })
 
     expect(createSlashHandler(ctx)('/reasoning')).toBe(true)
-    expect(ctx.gateway.rpc).toHaveBeenCalledWith('config.get', {
+    expect(rpc).toHaveBeenCalledWith('config.get', {
       key: 'reasoning',
       session_id: 'sid-abc'
+    })
+    await vi.waitFor(() => {
+      expect(ctx.transcript.sys).toHaveBeenCalledWith(
+        'reasoning: high · display show · command default global'
+      )
     })
   })
 

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -55,10 +55,8 @@ const reasoningConfigPayload = (arg: string, sid: string) => {
     }
 
     if (REASONING_SESSION_FLAGS.has(flag)) {
-      // Session scope is the default; accept the flag for parity with /model.
-      if (!scope) {
-        scope = 'session'
-      }
+      // Explicit session scope overrides the configured command default.
+      scope = 'session'
 
       continue
     }
@@ -522,7 +520,11 @@ export const sessionCommands: SlashCommand[] = [
           .rpc<ConfigGetValueResponse>('config.get', { key: 'reasoning', session_id: ctx.sid })
           .then(
             ctx.guarded<ConfigGetValueResponse>(
-              r => r.value && ctx.transcript.sys(`reasoning: ${r.value} · display ${r.display || 'hide'}`)
+              r =>
+                r.value &&
+                ctx.transcript.sys(
+                  `reasoning: ${r.value} · display ${r.display || 'hide'} · command default ${r.command_scope || 'session'}`
+                )
             )
           )
       }

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -145,6 +145,7 @@ export interface ConfigMtimeResponse {
 }
 
 export interface ConfigGetValueResponse {
+  command_scope?: string
   display?: string
   home?: string
   value?: string


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in `agent.reasoning_command_scope` setting so users can make interactive reasoning-level changes persist by default. The setting remains `session` by default for backward compatibility, while explicit `--session` and `--global` flags always override it across the classic CLI, messaging gateway, Ink TUI, and Desktop gateway RPC paths.

### Motivation

Users who frequently change reasoning levels currently need to append `--global` every time they want the new level to apply to future sessions. This configuration closes that workflow gap without changing behavior for existing users.

### Behavior

- `agent.reasoning_command_scope: session` preserves the existing session-only default.
- `agent.reasoning_command_scope: global` persists bare `/reasoning <level>` changes.
- Explicit `--session` and `--global` flags take precedence over the configured default.
- Bare `/reasoning` reports the configured command default.
- Display and reset operations retain their existing persistence semantics.

### Implementation

A shared parser and scope resolver centralize flag precedence, validation, and fail-safe fallback to session scope. The classic CLI, messaging command and picker paths, and TUI/Desktop config RPC use the shared policy, with focused behavior tests for each surface.

## Related Issue

Closes #89648

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_constants.py` and `hermes_cli/config_defaults.py` - define the validated command-scope policy and backward-compatible default.
- `hermes_cli/cli_commands_mixin.py` and `gateway/slash_commands.py` - apply configured defaults and explicit flag precedence to CLI and messaging commands.
- `tui_gateway/` and `ui-tui/` - propagate scope through config RPCs and report it in status output.
- `tests/` and `ui-tui/src/__tests__/` - cover shared resolution and each command surface.

## How to Test

1. Set `agent.reasoning_command_scope: global`, run `/reasoning high`, and confirm `agent.reasoning_effort` is persisted.
2. Run `/reasoning low --session` and confirm the change remains session-only; run `/reasoning high --global` with either configured default and confirm it persists.
3. Run the focused automated suites:

```bash
scripts/run_tests.sh tests/cli/test_reasoning_command.py tests/gateway/test_reasoning_command.py tests/test_tui_gateway_server.py
scripts/run_tests.sh tests/test_hermes_constants.py -k 'ReasoningCommandScope or default_reasoning_command_scope'
cd ui-tui && npm test -- --run src/__tests__/createSlashHandler.test.ts
```

The focused runs passed 633 command/RPC tests, 4 resolver tests, and 81 Ink tests.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run the repository test entry on the relevant tests and all focused tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant behavior is discoverable through bare `/reasoning` status output; no separate documentation update is required
- [x] `cli-config.yaml.example` does not enumerate this agent setting; no example update is required
- [x] No contributor architecture or workflow documentation changes are required
- [x] Cross-platform impact was considered; the policy is platform-neutral and covered across command surfaces
- [x] No model tool descriptions or schemas changed
