### PR TITLE
fix(install): install Debian build tools as root

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1552,7 +1552,9 @@ install_deps() {
     # Check and offer to install them if missing.
     if [ "$DISTRO" = "ubuntu" ] || [ "$DISTRO" = "debian" ]; then
         local need_build_tools=false
-        for pkg in gcc python3-dev libffi-dev; do
+        # npm may compile native modules with node-gyp after Python dependencies
+        # finish, so check its C/C++ toolchain as well as Python build headers.
+        for pkg in gcc g++ make python3-dev libffi-dev; do
             if ! dpkg -s "$pkg" &>/dev/null; then
                 need_build_tools=true
                 break
@@ -1560,18 +1562,39 @@ install_deps() {
         done
         if [ "$need_build_tools" = true ]; then
             log_info "Some build tools may be needed for Python packages..."
-            if command -v sudo &> /dev/null; then
-                if sudo -n true 2>/dev/null; then
-                    sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update -qq && sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -qq build-essential python3-dev libffi-dev >/dev/null 2>&1 || true
+            if [ "$(id -u)" -eq 0 ]; then
+                if DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update -qq \
+                    && DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -qq build-essential python3-dev libffi-dev >/dev/null 2>&1; then
                     log_success "Build tools installed"
+                else
+                    log_warn "Could not install build tools automatically"
+                    log_info "Install manually: apt-get install build-essential python3-dev libffi-dev"
+                fi
+            elif command -v sudo &> /dev/null; then
+                if sudo -n true 2>/dev/null; then
+                    if sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update -qq \
+                        && sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -qq build-essential python3-dev libffi-dev >/dev/null 2>&1; then
+                        log_success "Build tools installed"
+                    else
+                        log_warn "Could not install build tools automatically"
+                        log_info "Install manually: sudo apt-get install build-essential python3-dev libffi-dev"
+                    fi
                 else
                     log_info "sudo is needed ONLY to install build tools (build-essential, python3-dev, libffi-dev) via apt."
                     log_info "Hermes Agent itself does not require or retain root access."
                     if prompt_yes_no "Install build tools?" "yes"; then
-                        sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update -qq && sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -qq build-essential python3-dev libffi-dev >/dev/null 2>&1 || true
-                        log_success "Build tools installed"
+                        if sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update -qq \
+                            && sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -qq build-essential python3-dev libffi-dev >/dev/null 2>&1; then
+                            log_success "Build tools installed"
+                        else
+                            log_warn "Could not install build tools automatically"
+                            log_info "Install manually: sudo apt-get install build-essential python3-dev libffi-dev"
+                        fi
                     fi
                 fi
+            else
+                log_warn "Build tools are missing but sudo is unavailable"
+                log_info "Install manually: apt-get install build-essential python3-dev libffi-dev"
             fi
         fi
     fi

--- a/tests/test_install_sh_build_tools.py
+++ b/tests/test_install_sh_build_tools.py
@@ -1,0 +1,95 @@
+"""Regression coverage for Debian build-tool installation in install.sh."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _install_deps_function() -> str:
+    source = INSTALL_SH.read_text(encoding="utf-8")
+    start = source.index("install_deps() {\n")
+    end = source.index("\n}\n\n", start) + len("\n}\n")
+    return source[start:end]
+
+
+def _run_root_build_tool_install(
+    tmp_path: Path, missing_package: str
+) -> tuple[subprocess.CompletedProcess[str], list[str], list[str]]:
+    apt_log = tmp_path / "apt.log"
+    dpkg_log = tmp_path / "dpkg.log"
+    install_dir = tmp_path / "install"
+    install_dir.mkdir()
+
+    harness = f"""
+set -eu
+APT_LOG={shlex.quote(str(apt_log))}
+DPKG_LOG={shlex.quote(str(dpkg_log))}
+MISSING_PACKAGE={shlex.quote(missing_package)}
+: > "$APT_LOG"
+: > "$DPKG_LOG"
+
+log_info() {{ :; }}
+log_success() {{ :; }}
+log_warn() {{ :; }}
+id() {{ echo 0; }}
+dpkg() {{
+    printf '%s\\n' "$2" >> "$DPKG_LOG"
+    [ "$2" = "$MISSING_PACKAGE" ] && return 1
+    return 0
+}}
+apt-get() {{ printf '%s\\n' "$*" >> "$APT_LOG"; }}
+sudo() {{ return 1; }}
+uv() {{ [ "$1" = "sync" ]; }}
+
+DISTRO=debian
+USE_VENV=false
+INSTALL_DIR={shlex.quote(str(install_dir))}
+UV_CMD=uv
+
+{_install_deps_function()}
+
+install_deps
+"""
+    harness_path = tmp_path / "run-install-deps.sh"
+    harness_path.write_text(harness, encoding="utf-8")
+    proc = subprocess.run(
+        ["bash", str(harness_path)],
+        cwd=REPO_ROOT,
+        env=os.environ.copy(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return (
+        proc,
+        apt_log.read_text(encoding="utf-8").splitlines(),
+        dpkg_log.read_text(encoding="utf-8").splitlines(),
+    )
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="requires bash")
+@pytest.mark.parametrize("missing_package", ["g++", "make"])
+def test_root_debian_installs_complete_node_gyp_toolchain(
+    tmp_path: Path, missing_package: str
+) -> None:
+    """Root installs must not depend on sudo to repair node-gyp prerequisites."""
+    proc, apt_calls, dpkg_calls = _run_root_build_tool_install(
+        tmp_path, missing_package
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert missing_package in dpkg_calls
+    assert apt_calls == [
+        "update -qq",
+        "install -y -qq build-essential python3-dev libffi-dev",
+    ]


### PR DESCRIPTION
## What does this PR do?

Fixes root Debian and Ubuntu installs that detect missing build tooling but skip `apt-get` because root FHS installs commonly have no `sudo`. The prerequisite check now includes the C++ compiler and `make`, so node-gyp can build native npm dependencies. The existing `uv.lock` fallback remains unchanged because it is non-fatal.

## Related Issue

Refs #87093

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `scripts/install.sh`: install Debian build prerequisites directly as root, retain the non-root sudo flow, and detect the `g++`/`make` requirements used by node-gyp.
- `tests/test_install_sh_build_tools.py`: cover root installation when either C++ or `make` is missing, without requiring a real package manager.

## How to Test

1. With the Python 3.11 environment active, run `/opt/homebrew/bin/timeout -k 30 480 pytest -q --timeout=60 tests/test_install_sh_build_tools.py tests/test_install_sh_node_deps_failure.py tests/test_install_sh_node_npm_check.py`.
2. Run `bash -n scripts/install.sh`.
3. Run `python scripts/check-windows-footguns.py scripts/install.sh tests/test_install_sh_build_tools.py`.

The full `pytest tests/ -q -x --timeout=60` suite was attempted under the shared Python 3.11 environment. It stopped before installer coverage at `tests/gateway/test_teams.py`; rerunning with that file excluded stopped at `tests/agent/lsp/test_client_e2e.py::test_client_lifecycle_clean`. The covering installer suite above passed (7 tests).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin-arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

<!-- autocontrib:worker-id=issue-new-7620e5d6 kind=pr-open -->