### PR TITLE
feat(desktop): show aggregate status dots on branch, repo, and project rows

### DIFF
--- a/apps/desktop/src/app/chat/group-status-dot.test.tsx
+++ b/apps/desktop/src/app/chat/group-status-dot.test.tsx
@@ -1,0 +1,71 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
+
+import { GroupStatusDot } from './session-status-dot'
+
+afterEach(() => {
+  cleanup()
+  clearAllSessionStates()
+})
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      sidebar: {
+        row: {
+          backgroundRunning: 'Running in background',
+          draftSession: 'Draft',
+          finishedUnread: 'Finished',
+          needsInput: 'Needs input',
+          sessionRunning: 'Running',
+          waitingForAnswer: 'Waiting for answer'
+        }
+      }
+    }
+  })
+}))
+
+describe('GroupStatusDot', () => {
+  it('renders the idle fallback when every member is idle', () => {
+    render(<GroupStatusDot idle={<span data-testid="lane-glyph" />} sessionIds={['a', 'b']} />)
+
+    expect(screen.getByTestId('lane-glyph')).toBeTruthy()
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+
+  it('renders nothing at idle when no fallback is given (project row slot)', () => {
+    const { container } = render(<GroupStatusDot sessionIds={['a']} />)
+
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('replaces the fallback with the loudest member state', () => {
+    publishSessionState('rt-work', { ...createClientSessionState('stored-work'), busy: true })
+    publishSessionState('rt-ask', { ...createClientSessionState('stored-ask'), needsInput: true })
+
+    render(<GroupStatusDot idle={<span data-testid="lane-glyph" />} sessionIds={['stored-work', 'stored-ask']} />)
+
+    // needs-input outranks working. The glyph yields to the dot.
+    expect(screen.getByRole('status', { name: 'Needs input' })).toBeTruthy()
+    expect(screen.queryByTestId('lane-glyph')).toBeNull()
+  })
+
+  it('paints the member state through the same variant table as the session dot', () => {
+    publishSessionState('rt-work', { ...createClientSessionState('stored-work'), busy: true })
+
+    render(<GroupStatusDot sessionIds={['stored-work']} />)
+
+    expect(screen.getByRole('status', { name: 'Running' })).toBeTruthy()
+  })
+
+  it('ignores ids outside the group', () => {
+    publishSessionState('rt-other', { ...createClientSessionState('stored-other'), busy: true })
+
+    render(<GroupStatusDot idle={<span data-testid="lane-glyph" />} sessionIds={['stored-quiet']} />)
+
+    expect(screen.getByTestId('lane-glyph')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/chat/session-status-dot.tsx
+++ b/apps/desktop/src/app/chat/session-status-dot.tsx
@@ -1,10 +1,11 @@
 import { useStore } from '@nanostores/react'
+import type * as React from 'react'
 
 import { type Translations, useI18n } from '@/i18n'
 import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
 import { $sessionColorById, sessionColorFor } from '@/store/session-color'
-import { $sessionDotStateById, type SessionDotState } from '@/store/session-dot-state'
+import { $sessionDotStateById, maxSessionDotState, type SessionDotState } from '@/store/session-dot-state'
 import type { SessionInfo } from '@/types/hermes'
 
 // A pure lookup table: each state maps to its className, aria-label, and title.
@@ -157,5 +158,46 @@ export function SessionStatusDot({ storedSessionId, session, branchStem, classNa
         />
       )}
     </span>
+  )
+}
+
+export interface GroupStatusDotProps {
+  /** Stored session ids of every session under the group, unfiltered. The
+   *  aggregate must see work that the status filter or a pin hid. */
+  sessionIds: readonly string[]
+  /** What the slot shows when the aggregate is idle or the group is empty.
+   *  A lane passes its glyph. A project row passes nothing, so the slot
+   *  stays reserved but empty. */
+  idle?: React.ReactNode
+}
+
+/**
+ * GROUP STATUS DOT — the aggregate that a collapsible row (branch lane, repo
+ * header, project row) paints for the work under it: the loudest status
+ * bucket across its sessions, in the same visual language as the session
+ * dot. It renders through the same variant table, so a branch can never
+ * disagree with the rows inside it. It resolves through a scalar selector,
+ * so the row repaints only when its own aggregate flips, never on each
+ * member edge.
+ */
+export function GroupStatusDot({ sessionIds, idle }: GroupStatusDotProps): React.ReactNode {
+  const { t } = useI18n()
+  const r = t.sidebar.row
+
+  const state = useStoreSelector($sessionDotStateById, states => maxSessionDotState(sessionIds, states))
+
+  if (state === 'idle') {
+    return <>{idle ?? null}</>
+  }
+
+  const variant = DOT_VARIANTS[state]
+
+  return (
+    <span
+      aria-label={variant.ariaLabel?.(r)}
+      className={variant.className}
+      role={variant.role}
+      title={variant.title?.(r)}
+    />
   )
 }

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -158,6 +158,7 @@ import {
   PROJECT_PREVIEW_COUNT,
   ProjectBackRow,
   ProjectMenu,
+  projectStatusSessionIds,
   projectTreeCwd,
   sessionRecency as sessionTime,
   type SidebarProjectTree,
@@ -978,7 +979,9 @@ export function ChatSidebar({
     // RepoFlatSection, AFTER the visual git-worktree lanes are merged in (so
     // out-of-tree worktrees can be placed). Here we just order the snapshot and
     // drop pinned rows — the hydrated lanes come straight from the backend, so
-    // they haven't been through projectModel's filter.
+    // they have not been through projectModel's filter. The exclusion records
+    // the hidden ids on each lane's `statusSessionIds`. As a result, the lane
+    // and repo status aggregates continue to see that work.
     // The label comes from the overview node either way — that's the model's
     // presentation copy (Home is translated there), not the raw payload's.
     return excludeProjectSessions(
@@ -1104,6 +1107,15 @@ export function ChatSidebar({
         rankIds: sortOrderIds
       }),
     [projectOverview, agentSessions, projects, removedSessionIds, sortOrderIds]
+  )
+
+  // Per-project unfiltered status membership for the overview rows' aggregate
+  // dots. This reads `scopedSessions`, which only the profile scope narrows,
+  // not the narrowed `agentSessions`. A pinned or filtered-out session that
+  // works must still light its project row.
+  const overviewStatusSessionIds = useMemo<Record<string, string[]>>(
+    () => projectStatusSessionIds(projectOverview ?? [], scopedSessions, projects),
+    [projectOverview, scopedSessions, projects]
   )
 
   const onEnterProject = useCallback(
@@ -1792,6 +1804,7 @@ export function ChatSidebar({
                 projectOverviewPreviews={overviewPreviews}
                 projectRepoWorktrees={inProject ? scopedRepoWorktrees : undefined}
                 projectsLoading={worktreeGroupingActive ? projectTreeLoading : false}
+                projectStatusSessionIds={overviewStatusSessionIds}
                 removedSessionIds={inProject ? removedSessionIds : undefined}
                 rootClassName={cn(
                   'min-h-32 flex-1 overflow-hidden p-0',

--- a/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
@@ -2,6 +2,7 @@ import { useStore } from '@nanostores/react'
 import type * as React from 'react'
 import { useMemo, useState } from 'react'
 
+import { GroupStatusDot } from '@/app/chat/session-status-dot'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import {
@@ -25,6 +26,7 @@ import { SidebarRowStack } from '../chrome'
 import { useWorkspaceNodeOpen } from './model'
 import { SidebarWorkspaceGroup } from './workspace-group'
 import {
+  laneStatusSessionIds,
   mergeRepoWorktreeGroups,
   overlayRepoLanes,
   type SidebarProjectTree,
@@ -257,6 +259,10 @@ function RepoFlatSection({
     )
   }
 
+  // The repo header's aggregate covers every lane under it, the visible rows
+  // and the exclusion-hidden rows. A collapsed repo still reports its work.
+  const repoStatusSessionIds = [...new Set(ordered.flatMap(laneStatusSessionIds))]
+
   return (
     <SidebarRowStack>
       <WorkspaceHeader
@@ -274,7 +280,12 @@ function RepoFlatSection({
           )
         }
         emphasis
-        icon={<Codicon className="shrink-0 text-(--ui-text-tertiary)" name="repo" size="0.75rem" />}
+        icon={
+          <GroupStatusDot
+            idle={<Codicon className="shrink-0 text-(--ui-text-tertiary)" name="repo" size="0.75rem" />}
+            sessionIds={repoStatusSessionIds}
+          />
+        }
         label={repo.label}
         onToggle={toggleOpen}
         open={open}

--- a/apps/desktop/src/app/chat/sidebar/projects/index.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/index.ts
@@ -15,6 +15,7 @@ export {
   liveSessionProjectId,
   overlayLiveLanes,
   overlayLivePreviews,
+  projectStatusSessionIds,
   sessionRecency,
   type SidebarProjectTree,
   type SidebarSessionGroup,

--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
@@ -1,6 +1,7 @@
 import type * as React from 'react'
 import { useRef } from 'react'
 
+import { GroupStatusDot } from '@/app/chat/session-status-dot'
 import { Codicon } from '@/components/ui/codicon'
 import type { SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
@@ -67,6 +68,11 @@ interface ProjectOverviewRowProps {
   renderRows?: (sessions: SessionInfo[]) => React.ReactNode
   activeProjectId?: null | string
   previewSessions?: SessionInfo[]
+  // Every session id under this project, unfiltered. Pins and status filters
+  // are included, for the row's aggregate status dot. The overview node's own
+  // lanes arrive empty, so the sidebar computes this from the tree and the
+  // live cache (`projectStatusSessionIds`).
+  statusSessionIds?: readonly string[]
   reorderable?: boolean
   dragging?: boolean
   dragHandleProps?: React.HTMLAttributes<HTMLElement>
@@ -81,6 +87,7 @@ export function ProjectOverviewRow({
   renderRows,
   activeProjectId,
   previewSessions,
+  statusSessionIds,
   reorderable = false,
   dragging = false,
   dragHandleProps,
@@ -127,13 +134,24 @@ export function ProjectOverviewRow({
       className={cn(dragging && 'cursor-grabbing bg-(--ui-sidebar-surface-background)')}
       data-glass-opaque={dragging ? '' : undefined}
       label={
-        <SidebarRowLink
-          aria-label={s.projects.enter(project.label)}
-          labelClassName={cn('hover:text-foreground hover:underline', isActive && 'text-foreground')}
-          onClick={() => onEnter?.(project.id)}
-        >
-          {project.label}
-        </SidebarRowLink>
+        <>
+          <SidebarRowLink
+            aria-label={s.projects.enter(project.label)}
+            labelClassName={cn('hover:text-foreground hover:underline', isActive && 'text-foreground')}
+            onClick={() => onEnter?.(project.id)}
+          >
+            {project.label}
+          </SidebarRowLink>
+          {/* The aggregate status slot. The identity icon stays in the lead.
+              The dot sits beside the label in a fixed-size cell. The cell is
+              reserved at idle, so a project that starts work does not shift
+              the row. */}
+          {statusSessionIds ? (
+            <span className="grid size-3.5 shrink-0 place-items-center">
+              <GroupStatusDot sessionIds={statusSessionIds} />
+            </span>
+          ) : null}
+        </>
       }
       lead={lead}
       // The label is grab surface too, not just the lead's grabber — same

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
@@ -2,6 +2,7 @@ import { useStore } from '@nanostores/react'
 import type * as React from 'react'
 import { useState } from 'react'
 
+import { GroupStatusDot } from '@/app/chat/session-status-dot'
 import { Codicon } from '@/components/ui/codicon'
 import { ProfileGlyph } from '@/components/ui/profile-glyph'
 import type { SessionInfo } from '@/hermes'
@@ -19,7 +20,7 @@ import { SidebarGroupRow, SidebarRowLead, SidebarRowLink, SidebarRowStack } from
 import { rankSessions } from '../order'
 
 import { PROJECT_PREVIEW_COUNT, SIDEBAR_GROUP_PAGE, useWorkspaceNodeOpen } from './model'
-import type { SidebarSessionGroup } from './workspace-groups'
+import { laneStatusSessionIds, type SidebarSessionGroup } from './workspace-groups'
 import {
   WorkspaceAddButton,
   WorkspaceContextMenu,
@@ -61,13 +62,25 @@ export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemov
   const hiddenCount = isProfileGroup ? 0 : sessions.length - visibleSessions.length
   const nextCount = Math.min(SIDEBAR_GROUP_PAGE, hiddenCount)
 
-  // Leading glyph: a home mark for the repo's primary checkout (labeled by its
-  // live branch), a branch/kanban mark otherwise.
+  // Leading glyph: a home mark for the repo's primary checkout (labeled by
+  // its live branch), a branch/kanban mark otherwise. When a session under
+  // the lane is not idle, the lane's aggregate status dot takes the glyph's
+  // slot. The slot is the same fixed lead cell, so nothing shifts. At idle
+  // the glyph returns. The aggregate reads the unfiltered membership
+  // (`laneStatusSessionIds`) and all rows, not the visible page. Collapsed
+  // or truncated work must still show.
+  const statusSessionIds = laneStatusSessionIds(group)
+
   const leadingIcon = (
-    <Codicon
-      className="shrink-0 text-(--ui-text-tertiary)"
-      name={group.isKanban ? 'checklist' : group.isHome ? 'home' : 'git-branch'}
-      size="0.75rem"
+    <GroupStatusDot
+      idle={
+        <Codicon
+          className="shrink-0 text-(--ui-text-tertiary)"
+          name={group.isKanban ? 'checklist' : group.isHome ? 'home' : 'git-branch'}
+          size="0.75rem"
+        />
+      }
+      sessionIds={statusSessionIds}
     />
   )
 

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -12,6 +12,7 @@ import {
   NO_PROJECT_ID,
   overlayLiveLanes,
   overlayLivePreviews,
+  projectStatusSessionIds,
   sessionProjectColor,
   type SidebarProjectTree,
   type SidebarSessionGroup,
@@ -937,6 +938,18 @@ describe('overlayLiveLanes', () => {
     expect(overlaid.sessionCount).toBe(2)
   })
 
+  it('keeps the Home lane statusSessionIds marker through the overlay rebuild', () => {
+    // The exclusion recorded a pinned working session on the Home lane. A
+    // detached live session then triggers the lane rebuild. The marker must
+    // survive, or the pinned work goes dark on the Home row.
+    const home = homeNode([makeSession(null, { id: 'kept' })])
+    home.repos[0].groups[0].statusSessionIds = ['pinned-worker', 'kept']
+
+    const overlaid = overlayLiveLanes(home, [makeSession(null, { id: 'fresh' })], new Set())
+
+    expect(overlaid.repos[0].groups[0].statusSessionIds).toEqual(['pinned-worker', 'kept'])
+  })
+
   it('leaves Home alone for a session that has a cwd', () => {
     // A cwd-carrying row the backend hasn't placed yet (junk root, deleted
     // workspace) needs its probes — guessing here would flicker it into Home
@@ -1131,5 +1144,121 @@ describe('excludeProjectSessions', () => {
     const overlaid = overlayLiveLanes(filtered, [], new Set(['someone-else']))
 
     expect(overlaid.repos[0].groups.map(g => g.id)).toEqual(['wt'])
+  })
+})
+
+describe('status membership (statusSessionIds)', () => {
+  const repoWithLane = (sessions: SessionInfo[]): SidebarProjectTree =>
+    projectNode({
+      id: '/www/app',
+      repos: [
+        {
+          id: '/www/app',
+          label: 'app',
+          path: '/www/app',
+          groups: [{ id: '/www/app::branch::main', isMain: true, label: 'main', path: '/www/app', sessions }],
+          sessionCount: sessions.length
+        }
+      ],
+      sessionCount: sessions.length
+    })
+
+  it('excludeProjectSessions records what it hid so aggregates keep seeing it', () => {
+    const pinned = makeSession('/www/app', { id: 'pinned' })
+    const kept = makeSession('/www/app', { id: 'kept' })
+
+    const filtered = excludeProjectSessions(repoWithLane([pinned, kept]), s => s.id === 'pinned')
+    const lane = filtered.repos[0].groups[0]
+
+    expect(lane.sessions.map(s => s.id)).toEqual(['kept'])
+    // Both ids stay visible to the status aggregate. The exclusion only
+    // moved the row. The work under the branch is unchanged.
+    expect(lane.statusSessionIds).toContain('pinned')
+    expect(lane.statusSessionIds).toContain('kept')
+  })
+
+  it('leaves untouched lanes without the marker (sessions already carry the set)', () => {
+    const kept = makeSession('/www/app', { id: 'kept' })
+
+    const filtered = excludeProjectSessions(repoWithLane([kept]), () => false)
+
+    expect(filtered.repos[0].groups[0].statusSessionIds).toBeUndefined()
+  })
+
+  it('mergeRepoWorktreeGroups carries the marker through the home-lane fold', () => {
+    const repo = {
+      id: '/www/app',
+      path: '/www/app',
+      groups: [
+        {
+          id: '/www/app::branch::main',
+          isMain: true,
+          label: 'main',
+          path: '/www/app',
+          sessions: [makeSession('/www/app', { id: 'kept' })],
+          statusSessionIds: ['pinned', 'kept']
+        }
+      ]
+    }
+
+    const worktrees: HermesGitWorktree[] = [
+      { branch: 'main', detached: false, isMain: true, locked: false, path: '/www/app' }
+    ]
+
+    const merged = mergeRepoWorktreeGroups(repo, worktrees)
+    const home = merged.find(g => g.isHome)
+
+    expect(home?.statusSessionIds).toEqual(expect.arrayContaining(['pinned', 'kept']))
+  })
+})
+
+describe('projectStatusSessionIds', () => {
+  it('unions lane rows, exclusion-hidden ids, previews, and live rows per project', () => {
+    const laneRow = makeSession('/www/app', { id: 'lane-row' })
+    const preview = makeSession('/www/app', { id: 'preview-row' })
+
+    const node = projectNode({
+      id: '/www/app',
+      previewSessions: [preview],
+      repos: [
+        {
+          id: '/www/app',
+          label: 'app',
+          path: '/www/app',
+          groups: [
+            {
+              id: '/www/app::branch::main',
+              isMain: true,
+              label: 'main',
+              path: '/www/app',
+              sessions: [laneRow],
+              statusSessionIds: ['hidden-pin']
+            }
+          ],
+          sessionCount: 1
+        }
+      ],
+      sessionCount: 1
+    })
+
+    const live = makeSession('/www/app/src', { id: 'live-row', git_repo_root: '/www/app' })
+    const ids = projectStatusSessionIds([node], [live], [])
+
+    expect(ids['/www/app']).toEqual(expect.arrayContaining(['lane-row', 'hidden-pin', 'preview-row', 'live-row']))
+  })
+
+  it('files detached live rows under the Home bucket', () => {
+    const ids = projectStatusSessionIds([homeNode([])], [makeSession(null, { id: 'detached' })], [])
+
+    expect(ids[NO_PROJECT_ID]).toEqual(['detached'])
+  })
+
+  it('maps a live row to its explicit project by folder, like the lanes do', () => {
+    const node = projectNode({ id: 'p_app', path: '/www/app' })
+    const live = makeSession('/www/app/src', { id: 'live-row', git_repo_root: '/www/app' })
+
+    const ids = projectStatusSessionIds([node], [live], [makeProject('p_app', ['/www/app'])])
+
+    expect(ids['p_app']).toEqual(['live-row'])
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -30,6 +30,11 @@ export interface SidebarSessionGroup {
   isKanban?: boolean
   mode?: 'profile' | 'source' | 'workspace'
   sourceId?: string
+  // Every session under this lane before display exclusions (pins, the status
+  // filter). `excludeProjectSessions` sets this when it drops rows, so the
+  // lane's status aggregate continues to see work whose row is hidden. Absent
+  // when the lane was never filtered. Then `sessions` is the full set.
+  statusSessionIds?: string[]
 }
 
 /** A repo node: holds its branch/worktree lanes (`repo -> lane -> sessions`). */
@@ -114,6 +119,16 @@ export function kanbanWorktreeDir(path: string): null | string {
 
 /** Label for a main-checkout lane whose session recorded no branch. */
 export const DEFAULT_BRANCH_LABEL = 'main'
+
+/**
+ * The ids a lane's status aggregate covers: the lane's rows unioned with the
+ * ids that display exclusions (pins, the status filter) recorded on
+ * `statusSessionIds`. One helper, so the lane row and the repo header can
+ * never drift apart on what counts.
+ */
+export const laneStatusSessionIds = (group: SidebarSessionGroup): string[] => [
+  ...new Set([...group.sessions.map(session => session.id), ...(group.statusSessionIds ?? [])])
+]
 
 /** Id of the Home bucket (must match the backend tree's `NO_PROJECT_ID`). */
 export const NO_PROJECT_ID = '__no_project__'
@@ -257,13 +272,19 @@ export function mergeRepoWorktreeGroups(
   const reconciled = repo.groups.filter(group => !group.isMain).map(reconcile)
 
   if (homeBranch) {
+    // The fold rebuilds the lane. The pre-exclusion status membership of each
+    // folded main lane must ride along. If it does not, the home lane's
+    // aggregate goes blind to hidden (pinned or filtered) work.
+    const statusIds = new Set(mainGroups.flatMap(group => group.statusSessionIds ?? []))
+
     reconciled.push({
       id: branchLaneId(repo.id, homeBranch),
       label: homeBranch,
       path: repo.path,
       isMain: true,
       isHome: true,
-      sessions: dedupeById(mainGroups.flatMap(group => group.sessions))
+      sessions: dedupeById(mainGroups.flatMap(group => group.sessions)),
+      ...(statusIds.size ? { statusSessionIds: [...statusIds] } : {})
     })
   } else {
     reconciled.push(...mainGroups)
@@ -633,7 +654,17 @@ function overlayHomeLane(
   }
 
   const sessions = detached.reduce(upsertSession, kept)
-  const nextLane = { id: NO_PROJECT_ID, label: project.label, path: null, sessions }
+
+  // The rebuild replaces the lane object. The recorded pre-exclusion status
+  // membership must ride along, or pinned work under Home goes dark the
+  // moment a detached live session triggers this overlay.
+  const nextLane: SidebarSessionGroup = {
+    id: NO_PROJECT_ID,
+    label: project.label,
+    path: null,
+    sessions,
+    ...(lane?.statusSessionIds?.length ? { statusSessionIds: lane.statusSessionIds } : {})
+  }
 
   return {
     ...project,
@@ -673,7 +704,16 @@ export function excludeProjectSessions(
 
       repoChanged = true
 
-      return { ...group, sessions }
+      // Record the pre-exclusion membership. The rows leave the lane, but
+      // the lane's status aggregate must continue to count them. A pinned
+      // session still runs its turn under this branch.
+      const statusIds = new Set(group.statusSessionIds ?? [])
+
+      for (const session of group.sessions) {
+        statusIds.add(session.id)
+      }
+
+      return { ...group, sessions, statusSessionIds: [...statusIds] }
     })
 
     if (!repoChanged) {
@@ -732,6 +772,59 @@ interface PreviewOverlayOptions {
   removed?: ReadonlySet<string>
   /** The active sort key as an id order; recency when empty. */
   rankIds?: string[]
+}
+
+/**
+ * Per-project status membership for the overview rows: every session id known
+ * to belong to each project. The tree node's lanes and previews (which reach
+ * past the loaded page) are unioned with the live cache. The live cache maps
+ * by the same membership rule the lanes group by. The set is unfiltered on
+ * purpose: the overview aggregate must also see pinned and filtered-out work.
+ * Keyed by project id. Detached live rows land under the Home bucket.
+ */
+export function projectStatusSessionIds(
+  projects: SidebarProjectTree[],
+  live: SessionInfo[],
+  explicitProjects: ProjectInfo[]
+): Record<string, string[]> {
+  const byProject = new Map<string, Set<string>>()
+
+  const claim = (projectId: string, sessionId: string): void => {
+    const ids = byProject.get(projectId) ?? new Set<string>()
+    ids.add(sessionId)
+    byProject.set(projectId, ids)
+  }
+
+  for (const node of projects) {
+    for (const repo of node.repos) {
+      for (const group of repo.groups) {
+        for (const id of laneStatusSessionIds(group)) {
+          claim(node.id, id)
+        }
+      }
+    }
+
+    for (const session of node.previewSessions ?? []) {
+      claim(node.id, session.id)
+    }
+  }
+
+  for (const session of live) {
+    const projectId =
+      liveSessionProjectId(session, explicitProjects) ?? (isDetachedSession(session) ? NO_PROJECT_ID : null)
+
+    if (projectId) {
+      claim(projectId, session.id)
+    }
+  }
+
+  const out: Record<string, string[]> = {}
+
+  for (const [projectId, ids] of byProject) {
+    out[projectId] = [...ids]
+  }
+
+  return out
 }
 
 /** Merge live sessions into per-project overview previews, keyed by project id. */

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -122,6 +122,9 @@ interface SidebarSessionsSectionProps {
   projectOverview?: SidebarProjectTree[]
   // Per-project preview rows (from the backend tree), keyed by project id.
   projectOverviewPreviews?: Record<string, SessionInfo[]>
+  // Per-project unfiltered session-id sets (tree and live cache), keyed by
+  // project id. This feeds each overview row's aggregate status dot.
+  projectStatusSessionIds?: Record<string, string[]>
   // True while the backend project tree is loading (overview skeleton).
   projectsLoading?: boolean
   onEnterProject?: (id: string) => void
@@ -194,6 +197,7 @@ export function SidebarSessionsSection({
   groups,
   projectOverview,
   projectOverviewPreviews,
+  projectStatusSessionIds,
   projectsLoading = false,
   onEnterProject,
   projectContent,
@@ -422,6 +426,7 @@ export function SidebarSessionsSection({
         previewSessions={projectOverviewPreviews?.[project.id]}
         project={project}
         renderRows={renderRows}
+        statusSessionIds={projectStatusSessionIds?.[project.id] ?? []}
       />
     )
 

--- a/apps/desktop/src/store/session-dot-state.test.ts
+++ b/apps/desktop/src/store/session-dot-state.test.ts
@@ -4,7 +4,15 @@ import { createClientSessionState } from '@/lib/chat-runtime'
 import type { SessionInfo } from '@/types/hermes'
 
 import { $sessions, $unreadFinishedSessionIds, setSessions } from './session'
-import { $delegatingSessionIds, $sessionDotStateById, hasLiveTurn, showsRunningArc } from './session-dot-state'
+import {
+  $delegatingSessionIds,
+  $sessionDotStateById,
+  hasLiveTurn,
+  maxSessionDotState,
+  type SessionDotState,
+  sessionStatusBucket,
+  showsRunningArc
+} from './session-dot-state'
 import { clearAllSessionStates, publishSessionState } from './session-states'
 import { $unreadWriteGuard } from './session-unread-remote'
 import { $subagentsBySession, type SubagentProgress } from './subagents'
@@ -146,5 +154,37 @@ describe('persisted unread (backend watermark)', () => {
     setSessions([storedRow('s1')])
 
     expect($sessionDotStateById.get()['s1'] ?? 'idle').not.toBe('unread')
+  })
+})
+
+describe('maxSessionDotState', () => {
+  const ALL_STATES: SessionDotState[] = ['background', 'draft', 'idle', 'needs-input', 'stalled', 'unread', 'working']
+
+  const states = (entries: Record<string, SessionDotState>): Record<string, SessionDotState> => entries
+
+  it('is idle for an empty group and for ids with no recorded state', () => {
+    expect(maxSessionDotState([], {})).toBe('idle')
+    expect(maxSessionDotState(['a', 'b'], {})).toBe('idle')
+  })
+
+  it('folds a single member into its bucket, the same fold the sidebar filter uses', () => {
+    for (const state of ALL_STATES) {
+      expect(maxSessionDotState(['a', 'b'], states({ a: state }))).toBe(sessionStatusBucket(state))
+    }
+  })
+
+  it('ranks the buckets: needs-input > working > unread > draft > idle', () => {
+    expect(maxSessionDotState(['a', 'b'], states({ a: 'working', b: 'needs-input' }))).toBe('needs-input')
+    expect(maxSessionDotState(['a', 'b'], states({ a: 'unread', b: 'background' }))).toBe('working')
+    expect(maxSessionDotState(['a', 'b'], states({ a: 'draft', b: 'unread' }))).toBe('unread')
+    expect(maxSessionDotState(['a', 'b'], states({ a: 'draft', b: 'idle' }))).toBe('draft')
+  })
+
+  it('is order-independent', () => {
+    for (const a of ALL_STATES) {
+      for (const b of ALL_STATES) {
+        expect(maxSessionDotState(['a', 'b'], states({ a, b }))).toBe(maxSessionDotState(['b', 'a'], states({ a, b })))
+      }
+    }
   })
 })

--- a/apps/desktop/src/store/session-dot-state.ts
+++ b/apps/desktop/src/store/session-dot-state.ts
@@ -97,6 +97,32 @@ const STATUS_RANK: Record<SessionStatusBucket, number> = {
 /** Loudest first — what ordering by status sorts on. */
 export const sessionStatusRank = (state?: SessionDotState): number => STATUS_RANK[sessionStatusBucket(state)]
 
+/**
+ * The loudest status bucket across a group of sessions. This is what a
+ * collapsed branch, repo, or project row paints for the work under it. Each
+ * state folds into its filter bucket first, so `stalled` and `background`
+ * read as working, the same fold the sidebar filter uses. A session that is
+ * absent from the map is idle. An empty group is idle. The function is pure,
+ * so a caller can feed it through a scalar selector and repaint only on a
+ * real change.
+ */
+export function maxSessionDotState(
+  sessionIds: readonly string[],
+  states: Readonly<Record<string, SessionDotState>>
+): SessionStatusBucket {
+  let max: SessionStatusBucket = 'idle'
+
+  for (const id of sessionIds) {
+    const bucket = sessionStatusBucket(states[id])
+
+    if (STATUS_RANK[bucket] < STATUS_RANK[max]) {
+      max = bucket
+    }
+  }
+
+  return max
+}
+
 let dotStates: Readonly<Record<string, SessionDotState>> = {}
 
 export const $sessionDotStateById = computed(


### PR DESCRIPTION
## What does this PR do?

A collapsed branch lane hid the status of the sessions under it. The user could not see that a collapsed branch still did work.

This PR adds one aggregate status dot to branch lanes, repo headers, and project overview rows (Home included) in the desktop sidebar. The dot shows the loudest status bucket across the sessions under the row. The priority order is: needs-input, working, unread, draft, idle. When the aggregate is idle, or the row has no sessions, the row shows no dot. The dot is visual only. The row click keeps its toggle behavior.

Placement keeps the rows stable:

- Branch lanes and repo headers put the dot in the glyph slot. The slot is the same fixed lead cell, so the swap does not move the label. At idle, the glyph returns.
- Project overview rows keep the identity icon. Their dot sits in a reserved fixed-size cell beside the label, so a project that starts work does not shift the row.

The aggregate reads the unfiltered membership. It sees all rows of a lane, not the visible page. One helper, `laneStatusSessionIds()`, defines what a lane's aggregate covers. `excludeProjectSessions` records the ids of the rows it hides on `statusSessionIds`. The home-lane fold in `mergeRepoWorktreeGroups` and the Home overlay rebuild in `overlayHomeLane` carry these ids forward. A pinned or filtered-out session that does work still lights its branch.

The dot renders through the existing `DOT_VARIANTS` table, so a branch row can never disagree with the session rows inside it. No new state is computed. The aggregate folds each session state through the existing `sessionStatusBucket()` and ranks with the existing `STATUS_RANK` over `$sessionDotStateById`. `stalled` and `background` read as working, the same fold the sidebar's status filter uses. No new rank table exists.

## Related Issue

None. Ethie requested the feature directly.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/session-dot-state.ts` — `maxSessionDotState()`: a pure max that folds each state through `sessionStatusBucket()` and ranks with the existing `STATUS_RANK`. Absent and empty resolve to idle.
- `apps/desktop/src/app/chat/session-status-dot.tsx` — `GroupStatusDot`, the aggregate renderer. It uses the same `DOT_VARIANTS` table as `SessionStatusDot` and takes an `idle` fallback node. It resolves through a scalar selector, so a row repaints only when its own aggregate flips.
- `apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx` — the branch lane swaps its glyph for the dot when the aggregate is not idle.
- `apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx` — the repo header (multi-repo projects) gets the same swap, aggregated over its lanes.
- `apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx` — the project row gets a reserved status cell beside the label.
- `apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts` — `statusSessionIds` on `SidebarSessionGroup`, recorded by `excludeProjectSessions` and carried through the home-lane fold and `overlayHomeLane`; `laneStatusSessionIds()` as the one definition of a lane's covered ids; `projectStatusSessionIds()` builds the per-project id sets for the overview.
- `apps/desktop/src/app/chat/sidebar/sessions-section.tsx`, `apps/desktop/src/app/chat/sidebar/index.tsx` — thread the per-project sets from `scopedSessions` (only the profile scope narrows this list) to the overview rows.
- `apps/desktop/src/app/chat/sidebar/projects/index.ts` — export `projectStatusSessionIds`.
- Tests: `apps/desktop/src/store/session-dot-state.test.ts`, `apps/desktop/src/app/chat/group-status-dot.test.tsx` (new), `apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts`.

## How to Test

1. From `apps/desktop`, run `npx vitest run src/store/session-dot-state.test.ts src/app/chat/group-status-dot.test.tsx src/app/chat/sidebar/projects/workspace-groups.test.ts`. All pass (this branch: 9 sidebar-related test files, 125 tests, all green).
2. From `apps/desktop`, run `npx tsc -p . --noEmit`. No errors.
3. In the app: enter a project, start a turn in a session under a worktree lane, and collapse the lane. The lane's git-branch glyph becomes the working dot. Collapse the project: the overview row shows the same dot beside the label. When the turn needs input, the dot turns amber on both rows. When everything settles and is read, the dots disappear and the glyph returns.
4. Pin a working session: its branch lane still shows the working dot, because the aggregate reads the pre-exclusion membership.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the tests and all tests pass (vitest; no Python paths are touched)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Notes for review

- The running arc stays on session rows only. The aggregate rows show the dot without the arc. This follows the agreed design.
- The dot is not a click target. The design considered a jump-to-session click and rejected it, because the dot lives inside the row's toggle button.
- The repo-header wiring in `entered-content.tsx` has no direct render test. The merge and exclusion seams that feed it are covered in `workspace-groups.test.ts`, and the dot component is covered in `group-status-dot.test.tsx`.
- A two-axis self-review (standards and spec, parallel subagents) ran before the final push. It found one real defect: `overlayHomeLane` rebuilt the Home lane and dropped `statusSessionIds`, so pinned work under Home went dark when a detached live session triggered the overlay. The fix carries the field through the rebuild, and a test pins the flow. The review also drove the `laneStatusSessionIds()` extraction and explicit return types on the new functions.
- Known narrow edge: the overview row's covering set unions the tree lanes, the previews, and the loaded session page. A working session older than the loaded page and outside the preview set is invisible to the project row. Such a session also has no entry in `$sessionDotStateById`, so no aggregate over that map can see it. The lane and repo rows inside an entered project do not share this edge.

