### PR TITLE
feat(desktop): group chat activity chip — live phase + preview for the bot on turn

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -4144,6 +4144,35 @@ const GROUP_TURN_POLL_MS = 2000
 // reached the room (db's Aug 2026 report).
 const GROUP_TURN_HARD_CAP_MS = 20 * 60000
 
+/** Derive the room activity chip for the member on turn from its live
+ *  session state (session.resume payload): phase + a short preview of the
+ *  work, so the room shows what the bot is doing instead of a generic
+ *  thinking line. Returns null when the session is not visibly busy —
+ *  same check the poll loop uses (inflight || running), so a retained
+ *  failed turn (inflight + running=false) still yields a chip. */
+function roomActivityFromState(state) {
+  const inflight = state?.inflight && typeof state.inflight === 'object' ? state.inflight : null
+  if (!state?.running && !inflight) {
+    return null
+  }
+
+  const text = (inflight?.assistant || inflight?.user || '').replace(/\s+/g, ' ').trim()
+  const phase = inflight?.error
+    ? 'failed'
+    : state?.status === 'waiting'
+      ? 'awaiting approval'
+      : inflight?.streaming || text
+        ? 'writing'
+        : 'thinking'
+
+  return { phase, since: state?.turn_started_at || null, preview: text.slice(0, 80) }
+}
+
+function formatGroupActivitySeconds(total) {
+  const s = Math.max(0, Math.floor(total))
+  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`
+}
+
 /** One member turn, gateway-native: submit the room delta as a prompt into
  *  the member's per-group session, then poll the session until a NEW
  *  assistant message lands (or timeout → pass). While the session visibly
@@ -4272,9 +4301,18 @@ async function runGroupChatMemberTurn(group, member, prompt, thread, images) {
       return null
     }
 
-    // Still visibly working: extend the deadline (never past the hard cap).
+    // Still visibly working: extend the deadline (never past the hard cap)
+    // and refresh the room's activity chip for the member on turn.
     if (busy) {
       deadline = Math.min(started + GROUP_TURN_HARD_CAP_MS, Math.max(deadline, Date.now() + GROUP_TURN_TIMEOUT_MS))
+      const activity = roomActivityFromState(state)
+
+      updateGroupChat(group, r => {
+        // Keep the local turn anchor when the server sends none (older
+        // gateways), so the chip's timer never jumps backwards.
+        r.turnMeta = { ...activity, since: activity.since || r.turnMeta?.since || Date.now() / 1000 }
+        return r
+      })
     }
   }
 
@@ -4441,10 +4479,12 @@ async function runGroupChatRounds(group, members, thread) {
         const deltaImages = delta.flatMap(e => (Array.isArray(e.images) ? e.images : []))
 
         // Surface WHO is on turn (runtime-only, like running/epoch) so the
-        // room shows "Radar is thinking…" instead of a generic working line —
-        // long model turns otherwise read as the room being stuck.
+        // room can show that member's live activity instead of a generic
+        // working line — long model turns otherwise read as the room
+        // being stuck.
         updateGroupChat(group, r => {
           r.turn = member.name
+          r.turnMeta = null
           return r
         })
 
@@ -4490,6 +4530,7 @@ async function runGroupChatRounds(group, members, thread) {
       updateGroupChat(group, r => {
         r.running = false
         r.turn = null
+        r.turnMeta = null
         return r
       })
     }
@@ -9251,12 +9292,24 @@ function GroupChatWorkspace({ group, members, onBack }) {
                     children: 'Say something — every bot in this group hears the room.'
                   }, 'empty')
                 ]),
-            room.running
-              ? jsx('div', {
-                  className: 'px-2 py-1 text-[0.7rem] italic text-(--ui-text-quaternary)',
-                  children: room.turn
-                    ? `${groupSpeakerLabel(room.turn)} is thinking…`
-                    : 'The room is working…'
+            room.running && room.turn
+              ? jsxs('span', {
+                  title: room.turnMeta?.preview ? `“${room.turnMeta.preview}”` : undefined,
+                  className: 'flex max-w-full flex-wrap items-center gap-1 rounded-md border border-(--ui-stroke-secondary) px-1.5 py-0.5 text-[0.65rem] text-(--ui-text-quaternary)',
+                  children: [
+                    jsx('span', { className: 'font-medium text-(--ui-text-secondary)', children: groupSpeakerLabel(room.turn) }),
+                    jsx(
+                      'span',
+                      { className: `italic ${(room.turnMeta?.phase || 'working') === 'failed' ? 'text-(--ui-danger,#ef4444)' : ''}`, children: room.turnMeta?.phase || 'working' },
+                      `phase:${room.turn}`
+                    ),
+                    room.turnMeta?.since
+                      ? jsx('span', { children: formatGroupActivitySeconds(Date.now() / 1000 - room.turnMeta.since) }, `since:${room.turn}`)
+                      : null,
+                    room.turnMeta?.preview
+                      ? jsx('span', { className: 'max-w-44 truncate', children: room.turnMeta.preview }, `preview:${room.turn}`)
+                      : null
+                  ]
                 }, 'working')
               : null
           ]

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -104,7 +104,7 @@ function load(turnScript, { busyUntilResumeCall } = {}) {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, disbandGroupChat, updateGroupChat, openGroupChat, closeGroupChatMainTab, $groupChats, $groupNeedsYou, $groupChatWorkspace, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, disbandGroupChat, updateGroupChat, roomActivityFromState, openGroupChat, closeGroupChatMainTab, $groupChats, $groupNeedsYou, $groupChatWorkspace, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -676,10 +676,32 @@ test('source contract: long visible turns extend the deadline up to a hard cap',
   assert.match(pluginSource, /deadline = Math\.min\(started \+ GROUP_TURN_HARD_CAP_MS/)
 })
 
-test('source contract: the working line names the member on turn', () => {
-  assert.match(pluginSource, /is thinking…/)
+test('source contract: the working strip names the member on turn with phase + preview', () => {
+  assert.match(pluginSource, /function roomActivityFromState\(/)
+  assert.match(pluginSource, /r\.turnMeta = \{ \.\.\.activity, since:/)
   assert.match(pluginSource, /r\.turn = member\.name/)
   assert.match(pluginSource, /r\.turn = null/)
+})
+
+test('activity derivation: phase tracks the live session state', () => {
+  const gc = load(() => '(pass)')
+  const { roomActivityFromState } = gc
+
+  assert.equal(roomActivityFromState({ running: false, inflight: null }), null, 'idle session has no chip')
+  assert.equal(roomActivityFromState(null), null, 'missing state has no chip')
+
+  const planning = roomActivityFromState({ running: true, status: 'working', inflight: { assistant: '', streaming: false }, turn_started_at: 100 })
+  assert.equal(planning.phase, 'thinking', 'no tokens yet is thinking')
+
+  const writing = roomActivityFromState({ running: true, status: 'working', inflight: { assistant: 'fixing the adapter registry now', streaming: true } })
+  assert.equal(writing.phase, 'writing', 'streaming text is writing')
+  assert.match(writing.preview, /fixing the adapter registry/)
+
+  const waiting = roomActivityFromState({ running: true, status: 'waiting', inflight: null })
+  assert.equal(waiting.phase, 'awaiting approval', 'pending approval surfaces as waiting')
+
+  const failed = roomActivityFromState({ running: false, inflight: { assistant: 'partial', error: 'turn failed' } })
+  assert.equal(failed.phase, 'failed', 'a retained failed turn still shows a chip')
 })
 
 test('source contract: creating a group with a taken name mints a fresh room, never reopens the old log', () => {


### PR DESCRIPTION
## What

The group-chat room's working line said `X is thinking…` for the entire length of a member turn, even when the bot was clearly deep in a long generation. That reads as the room being stuck.

This replaces it with a live chip for the member on turn:

- **phase** — `thinking` / `writing` / `awaiting approval` / `failed`, derived from the session state the poll loop already reads (no new RPC).
- **elapsed timer** — anchored on `turn_started_at`; a local anchor is retained when the server sends none (older gateways), so the timer never jumps backwards.
- **80-char preview** of the streaming text, with the full line in the tooltip.
- Failed retained turns keep their chip until the round ends.

## How

- `roomActivityFromState(state)` — pure derivation of the chip from `session.resume` payload. Returns `null` when the session is not visibly busy (same `inflight || running` check the poll loop already uses), so a retained failed turn (`inflight` + `running=false`) still yields a chip.
- `formatGroupActivitySeconds(total)` — `m:ss` formatter for the timer.
- The poll loop refreshes `room.turnMeta` on each busy tick; `runGroupChatRounds` resets it at turn start and on round end.
- The `GroupChatWorkspace` working strip renders the chip (speaker, phase, timer, preview) instead of the generic italic line.

No new model tool, no new env var, no new core surface — this is a desktop-plugin-local feature riding the poll loop that already runs.

## Verification

- `node --test src/plugins/hermes-bots/tests/group-chat.test.mjs` — 36/36 pass (adds `source contract: the working strip names the member on turn with phase + preview` and `activity derivation: phase tracks the live session state`).
- `node --test src/plugins/*/tests/*.test.mjs` (full plugin suite) — 289/289 pass.

## Platforms

- **Linux** — developed and tested on a Linux desktop; the activity chip renders in the live Electron desktop renderer and the plugin test suite (36/36 + 289/289) passes on Linux.
- No file I/O, process management, terminal, or signal handling touched — purely renderer-side React + the existing 2s poll loop, so no Windows-footgun / cross-platform surface.

Rebased onto latest `origin/main` (`5dd15872a6`). Diff is a single focused change: 2 files, +87/−12.
