### PR TITLE
fix(kanban): keep first worktree spawn on its resolved branch

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10247,7 +10247,12 @@ def _dispatch_once_locked(
         # Persist the resolved workspace path so the worker can cd there.
         set_workspace_path(conn, claimed.id, str(workspace))
         if claimed.workspace_kind == "worktree":
-            set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
+            claimed.branch_name = (
+                resolved_branch_name
+                or (claimed.branch_name or "").strip()
+                or f"wt/{claimed.id}"
+            )
+            set_branch_name(conn, claimed.id, claimed.branch_name)
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
@@ -10374,7 +10379,12 @@ def _dispatch_once_locked(
         # Persist the resolved workspace path so the worker can cd there.
         set_workspace_path(conn, claimed.id, str(workspace))
         if claimed.workspace_kind == "worktree":
-            set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
+            claimed.branch_name = (
+                resolved_branch_name
+                or (claimed.branch_name or "").strip()
+                or f"wt/{claimed.id}"
+            )
+            set_branch_name(conn, claimed.id, claimed.branch_name)
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
         # Force-load the sdlc-review skill for review agents — it carries
         # the review logic (AC verification, merge, etc.). The mandatory

--- a/tests/hermes_cli/test_kanban_worktree_isolation.py
+++ b/tests/hermes_cli/test_kanban_worktree_isolation.py
@@ -126,5 +126,96 @@ def test_resolve_worktree_falls_back_when_path_occupied(kanban_home, tmp_path):
     assert head == "wt/sibling"
 
 
+@pytest.mark.parametrize("lane", ["ready", "review"])
+def test_first_dispatch_spawn_receives_resolved_worktree_branch(
+    kanban_home, tmp_path, monkeypatch, lane
+):
+    """The first worker sees the same fallback branch persisted for its task."""
+    import hermes_cli.config as cfgmod
+    import hermes_cli.profiles as profmod
+
+    workspace = tmp_path / "worktree"
+    workspace.mkdir()
+    monkeypatch.setattr(profmod, "profile_exists", lambda _name: True)
+    monkeypatch.setattr(
+        kb,
+        "_resolve_worktree_workspace",
+        lambda task, **_kwargs: (workspace, f"wt/{task.id}"),
+    )
+    monkeypatch.setattr(
+        cfgmod,
+        "load_config",
+        lambda *args, **kwargs: {"kanban": {"review_dispatch": True}},
+    )
+    captured = {}
+
+    def spawn(task, workspace):
+        captured["branch_name"] = task.branch_name
+        captured["workspace"] = workspace
+
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title=f"{lane} worktree",
+            assignee="worker",
+            workspace_kind="worktree",
+            workspace_path=str(workspace),
+        )
+        if lane == "review":
+            conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (tid,))
+            conn.commit()
+
+        result = kb.dispatch_once(conn, spawn_fn=spawn)
+        persisted = kb.get_task(conn, tid)
+
+    expected_branch = f"wt/{tid}"
+    assert result.spawned == [(tid, "worker", captured["workspace"])]
+    assert persisted is not None
+    assert persisted.branch_name == expected_branch
+    assert captured["branch_name"] == expected_branch
+    assert Path(captured["workspace"]) == workspace
+
+
+@pytest.mark.parametrize("lane", ["ready", "review"])
+def test_dispatch_does_not_invent_branch_for_directory_workspace(
+    kanban_home, tmp_path, monkeypatch, lane
+):
+    """Only worktree tasks receive branch metadata at spawn time."""
+    import hermes_cli.config as cfgmod
+    import hermes_cli.profiles as profmod
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setattr(profmod, "profile_exists", lambda _name: True)
+    monkeypatch.setattr(
+        cfgmod,
+        "load_config",
+        lambda *args, **kwargs: {"kanban": {"review_dispatch": True}},
+    )
+    captured = {}
+
+    def spawn(task, _workspace):
+        captured["branch_name"] = task.branch_name
+
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title=f"{lane} directory",
+            assignee="worker",
+            workspace_kind="dir",
+            workspace_path=str(workspace),
+        )
+        if lane == "review":
+            conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (tid,))
+            conn.commit()
+
+        kb.dispatch_once(conn, spawn_fn=spawn)
+        persisted = kb.get_task(conn, tid)
+
+    assert persisted is not None
+    assert persisted.branch_name is None
+    assert captured["branch_name"] is None
+
+
 
 


### PR DESCRIPTION
## What does this PR do?

Kanban worktree tasks that need a derived fallback branch now pass that resolved branch to the first worker spawn. Without this fix, fail-closed branch binding can reject a valid first attempt even though the dispatcher already prepared the correct worktree and persisted its branch.

### Symptom

A ready or review task with `workspace_kind="worktree"` and no explicit `branch_name` gets a derived branch in SQLite, but its first worker process receives no `HERMES_KANBAN_BRANCH`. A retry works only because it reloads the persisted value.

### Impact

The first valid attempt can be rejected by branch-bound worker policies, consuming retry budget and delaying both implementation and review tasks.

### Bug Cause

**Trigger:** `hermes_cli/kanban_db.py:10247` and `hermes_cli/kanban_db.py:10379` in the ready and review dispatch lanes.

**Causal chain:**
1. The dispatcher claims a worktree task whose branch is not yet assigned.
2. `_resolve_worktree_workspace()` derives the fallback branch and `set_branch_name()` persists it, but the already-claimed `Task` object remains stale.
3. The same stale object reaches the spawn callback, so `_default_spawn()` cannot inject `HERMES_KANBAN_BRANCH` on the first attempt.

**Why it is wrong:** The worker receives branch metadata from the claimed task snapshot, so persisting the resolved value without updating that snapshot creates a one-attempt mismatch between the prepared worktree, the database, and the worker environment.

**Working sibling / contrast:** Later retries reload the persisted branch and receive the expected environment value. Directory workspaces correctly remain branchless.

**Ruled out:** Branch derivation and worktree materialization already return the correct branch, and the existing spawn environment mapping correctly injects any non-empty `task.branch_name`.

### Fix

Assign the resolved branch to the claimed task object before persisting and spawning it in both the ready and review lanes. Regression coverage verifies the first-spawn contract for both lanes and preserves the branchless invariant for directory workspaces.

## Related Issue

Closes #89677

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py` - synchronize the claimed task snapshot with the resolved branch before first spawn in ready and review dispatch.
- `tests/hermes_cli/test_kanban_worktree_isolation.py` - cover first-spawn branch propagation and non-worktree counterexamples for both lanes.

## How to Test

1. Create a ready or review worktree task without `branch_name`, dispatch it once, and capture the task passed to the spawn callback.
2. Confirm the first spawn sees the same fallback branch persisted for the task.
3. Confirm directory workspaces still receive no branch metadata.

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_worktree_isolation.py tests/hermes_cli/test_kanban_review_lifecycle.py
scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py -k test_dispatcher_spawn_injects_kanban_paths_without_stale_session
```

Result: 25 passed in the related suite and 1 passed in the focused environment-injection contract.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation is N/A because this fixes internal dispatcher state propagation without changing user-facing configuration or APIs
- [x] `cli-config.yaml.example` is N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no architecture or workflow contract changed
- [x] Cross-platform impact was considered; the fix is platform-independent task state propagation
- [x] Tool descriptions and schemas are N/A because no model tool behavior changed

## Screenshots / Logs

N/A - focused automated regressions directly cover the dispatcher and spawn-environment contracts.
