### PR TITLE
fix(desktop): tear down backends through the retained handle, never by pid

### DIFF
--- a/apps/desktop/electron/backend-child.ts
+++ b/apps/desktop/electron/backend-child.ts
@@ -1,37 +1,37 @@
 /**
  * backend-child.ts
  *
- * Windows-aware teardown for the desktop's managed backend child process.
+ * Teardown for the desktop's managed backend child process.
  *
- * Node's `child.kill()` only signals the direct child. On Windows a backend
- * that spawned its own grandchildren (a `hermes` REPL, a pty terminal
- * session, the gateway) survives a plain SIGTERM and keeps files (e.g. the
- * venv shim) locked. So on Windows we tree-kill via `forceKillProcessTree`.
+ * ONE RULE, and it is the whole point of this module after #89614: a mutator
+ * may act only on authority it still holds. A retained `ChildProcess` handle
+ * is such authority. A bare pid is NOT -- the OS may have reaped the process
+ * and handed the number to somebody else.
  *
- * On POSIX the backend IS spawned into its own session/process-group
- * (start_new_session=True), so `child.kill('SIGTERM')` would only reach the
- * backend and orphan its MCP grandchildren (the leak in #serve-orphans). We
- * signal the whole group via `process.kill(-pid, ...)` instead, falling back
- * to the direct child if the group send fails.
+ * So `stopBackendChild` signals through the handle and nothing else. It no
+ * longer tree-kills by pid on Windows, and no longer group-signals by pid on
+ * POSIX, because both reconstruct authority from a number.
+ *
+ * The cost is real and accepted. `child.kill()` reaches only the direct child,
+ * so on Windows a backend's grandchildren (a hermes REPL, a pty terminal, the
+ * gateway, MCP servers) survive this call and can keep venv files locked.
+ * That residue is contained downstream rather than escalated: the update
+ * hand-off polls the venv shim and ABORTS if it stays locked, instead of
+ * reaching for a pid kill. Leaving residue is acceptable; mutating a recycled
+ * pid is not.
+ *
+ * Reaching a whole tree with handle-grade authority needs a kernel object that
+ * owns the tree -- a Windows Job Object, or a process group we hold a handle
+ * to -- not a pid. That is deliberately out of scope here.
+ *
+ * `stopBackendTreesForUpdate` still tree-kills, because no handle can reach a
+ * grandchild, but only for a root whose handle PROVES it is still live.
  *
  * Extracted into its own dependency-free module (no electron import) so the
- * tree-kill / group-kill branching can be asserted directly with a fake child
- * object and spy kill functions, instead of grepping main.ts source text for
- * the function body.
+ * teardown contract can be asserted directly with fake child objects and spy
+ * kill functions, instead of grepping main.ts source text for the function
+ * body.
  */
-
-export interface StopBackendChildDeps {
-  /** Defaults to the real platform check; injectable for tests. */
-  isWindows?: boolean
-  /** Windows tree-kill implementation (real: taskkill /T /F via execFileSync). */
-  forceKillProcessTree: (pid: number) => void
-  /**
-   * POSIX group-signal implementation. Real: process.kill(-pgid, signal).
-   * Injectable so the negative-pid group send is asserted in tests without a
-   * live process group. Defaults to process.kill.
-   */
-  killGroup?: (pgid: number, signal: string) => void
-}
 
 export interface StopBackendTreesForUpdateDeps {
   /** Synchronous Windows taskkill /T /F implementation. */
@@ -42,6 +42,81 @@ export interface StopBackendTreesForUpdateDeps {
 
 export interface BackendProcessRoot {
   pid?: number | null
+  /**
+   * Node sets these the moment the child is reaped, and leaves `pid` in place
+   * forever. They are therefore the ONLY reliable liveness signal on a
+   * `ChildProcess` handle -- see `isLiveProcessRoot`.
+   */
+  exitCode?: null | number
+  signalCode?: null | string
+}
+
+/**
+ * True when this handle still refers to a RUNNING process.
+ *
+ * `child.pid` is not a liveness check. Node keeps the number after the child
+ * is reaped -- `Number.isInteger(child.pid)` stays true, and `child.killed`
+ * stays *false* for a child that exited on its own rather than being
+ * signalled. So every `Number.isInteger(pid)` guard in this file used to pass
+ * for a dead child, and the caller then force-killed that number.
+ *
+ * On Windows that is not a harmless no-op. PIDs are recycled aggressively, so
+ * `taskkill /PID <recycled> /T /F` kills whatever process inherited the
+ * number. When the winner is a protected system process the kernel raises
+ * bugcheck 0xEF (CRITICAL_PROCESS_DIED) -- a blue screen, attributed by WER to
+ * `taskkill.exe` (#89614).
+ *
+ * Fail-closed by design: liveness must be WITNESSED, never assumed. The
+ * witness is the pair of lifecycle fields Node maintains on a `ChildProcess`.
+ * A record carrying neither -- a bare `{ pid }` -- is a number with no
+ * evidence of authority behind it, so it reads as NOT live. The strict
+ * `=== null` on BOTH fields is what enforces that: `undefined` (field absent)
+ * is not `null`, so an evidence-free record cannot be mistaken for a live one.
+ * Node sets whichever field applies before emitting 'exit', so a handle we
+ * still own answers truthfully.
+ *
+ * This NARROWS the stale-pid window; it does not close it, and no in-process
+ * predicate can. Between this check and the moment `taskkill` resolves the
+ * number inside the kernel, the process can exit and the pid be reassigned.
+ * That residual race is why pid-based mutation is confined to the one caller
+ * that cannot avoid it, and why the handle path below does not use this
+ * function at all.
+ */
+export function isLiveProcessRoot(root: BackendProcessRoot | null | undefined): boolean {
+  if (!root || !Number.isInteger(root.pid) || (root.pid as number) <= 0) {
+    return false
+  }
+
+  return root.exitCode === null && root.signalCode === null
+}
+
+/**
+ * The PIDs of every backend root that is still running, for a Windows
+ * tree-kill sweep.
+ *
+ * The update hand-off re-collects and re-kills on every pass of its wait loop,
+ * which is what made the stale-PID window so easy to hit: pass 1 kills the
+ * children, and passes 2..N re-issue `taskkill` against the same numbers,
+ * which by then may belong to unrelated processes. Filtering here means a
+ * reaped root drops out of the sweep instead of being re-killed forever.
+ */
+export function collectLiveStragglerPids(
+  primary: BackendProcessRoot | null | undefined,
+  poolRoots: Iterable<BackendProcessRoot | null | undefined>
+): number[] {
+  const pids: number[] = []
+
+  if (isLiveProcessRoot(primary)) {
+    pids.push((primary as BackendProcessRoot).pid as number)
+  }
+
+  for (const root of poolRoots) {
+    if (isLiveProcessRoot(root)) {
+      pids.push(root!.pid as number)
+    }
+  }
+
+  return pids
 }
 
 export interface KillableChild extends BackendProcessRoot {
@@ -50,33 +125,32 @@ export interface KillableChild extends BackendProcessRoot {
 }
 
 /**
- * Stop a managed child process, choosing the right strategy for the platform.
- * No-ops silently if `child` is falsy, already killed, or the kill attempt
- * throws (the process may already be gone) -- mirrors the original inline
- * best-effort semantics in main.ts.
+ * Stop a managed child process, using ONLY the authority we still hold.
+ *
+ * `child.kill()` acts through Node's retained handle, so it is safe by
+ * construction: once the child is reaped Node has already dropped the
+ * underlying handle, and the call issues no syscall against the number at all.
+ * It therefore cannot reach a process that merely inherited the pid.
+ *
+ * No liveness precondition is applied here, deliberately. `isLiveProcessRoot`
+ * guards pid-based mutators and this is not one; gating the handle path on it
+ * would only stop us signalling a child whose pid never materialised (a failed
+ * spawn), which is both harmless and worth attempting.
+ *
+ * What is gone, on purpose (#89614):
+ *   - the Windows `forceKillProcessTree(child.pid)` branch, and
+ *   - the POSIX `process.kill(-child.pid, ...)` process-group branch.
+ *
+ * Both mutated by number. See the module header for what removing them costs
+ * and where the resulting residue is contained.
  */
-export function stopBackendChild(child: KillableChild | null | undefined, deps: StopBackendChildDeps) {
+export function stopBackendChild(child: KillableChild | null | undefined) {
   if (!child || child.killed) {
     return
   }
 
-  const isWindows = deps.isWindows ?? process.platform === 'win32'
-  const killGroup = deps.killGroup ?? ((pgid: number, signal: string) => process.kill(pgid, signal))
-
   try {
-    if (isWindows && Number.isInteger(child.pid)) {
-      deps.forceKillProcessTree(child.pid as number)
-    } else if (Number.isInteger(child.pid)) {
-      // POSIX: pgid == pid (start_new_session). Signal the whole group so MCP
-      // grandchildren die too; fall back to the direct child on failure.
-      try {
-        killGroup(-(child.pid as number), 'SIGTERM')
-      } catch {
-        child.kill('SIGTERM')
-      }
-    } else {
-      child.kill('SIGTERM')
-    }
+    child.kill('SIGTERM')
   } catch {
     // Already gone.
   }
@@ -95,8 +169,10 @@ export function stopBackendTreesForUpdate(
   primary: BackendProcessRoot | null | undefined,
   deps: StopBackendTreesForUpdateDeps
 ): void {
-  if (primary && Number.isInteger(primary.pid)) {
-    deps.forceKillProcessTree(primary.pid as number)
+  // Live-only: a reaped primary still carries its pid, and tree-killing that
+  // number after Windows recycled it is how this path blue-screened (#89614).
+  if (isLiveProcessRoot(primary)) {
+    deps.forceKillProcessTree(primary!.pid as number)
   }
 
   deps.stopAllPoolBackends()

--- a/apps/desktop/electron/backend-stale-pid.test.ts
+++ b/apps/desktop/electron/backend-stale-pid.test.ts
@@ -1,0 +1,221 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { collectLiveStragglerPids, isLiveProcessRoot, stopBackendChild, stopBackendTreesForUpdate } from './backend-child'
+
+// A reaped child must never be tree-killed by PID (#89614).
+//
+// `child.pid` is not a liveness check: Node keeps the number after the child
+// is reaped, and `child.killed` stays FALSE for a child that exited on its own
+// rather than being signalled. Every guard here used to be
+// `Number.isInteger(child.pid)`, which passes for a dead child.
+//
+// On Windows that is not a harmless no-op. PIDs are recycled aggressively, so
+// `taskkill /PID <recycled> /T /F` kills whoever inherited the number; when
+// that is a protected system process the kernel bugchecks 0xEF
+// (CRITICAL_PROCESS_DIED) and the machine blue-screens, which WER attributes
+// to taskkill.exe.
+//
+// These tests pin the liveness contract rather than any one call site.
+
+const live = (pid: number) => ({ exitCode: null, pid, signalCode: null })
+const exited = (pid: number, code = 0) => ({ exitCode: code, pid, signalCode: null })
+const signalled = (pid: number, sig = 'SIGTERM') => ({ exitCode: null, pid, signalCode: sig })
+
+test('isLiveProcessRoot rejects a reaped child that still carries its pid', () => {
+  assert.equal(isLiveProcessRoot(live(4242)), true)
+  // THE regression: exitCode 0 with a populated pid is the shape Node leaves
+  // behind, and it used to pass every `Number.isInteger(pid)` guard.
+  assert.equal(isLiveProcessRoot(exited(4242)), false)
+  assert.equal(isLiveProcessRoot(signalled(4242)), false)
+})
+
+test('isLiveProcessRoot rejects absent and nonsensical pids', () => {
+  assert.equal(isLiveProcessRoot(null), false)
+  assert.equal(isLiveProcessRoot(undefined), false)
+  assert.equal(isLiveProcessRoot({ exitCode: null, pid: null, signalCode: null }), false)
+  assert.equal(isLiveProcessRoot({ exitCode: null, pid: 0, signalCode: null }), false)
+  // A negative pid would be a POSIX process-GROUP id. taskkill has no such
+  // notion, so letting one through would pass a nonsense argument to it.
+  assert.equal(isLiveProcessRoot({ exitCode: null, pid: -991, signalCode: null }), false)
+})
+
+// ---------------------------------------------------------------------------
+// Stale-record witness: a bare `{ pid }` carries no evidence of authority, so
+// it must not reach any pid-based mutator. Liveness is witnessed, not assumed.
+// ---------------------------------------------------------------------------
+
+test('a pid-only record is not live and cannot enter the force path', () => {
+  const stale = { pid: 77 }
+
+  assert.equal(isLiveProcessRoot(stale), false, 'no lifecycle fields means no proof of liveness')
+
+  // The predicate is only useful if the callers that mutate by pid honour it.
+  assert.deepEqual(collectLiveStragglerPids(stale, [{ pid: 78 }, { pid: 79 }]), [], 'no stale pid may be swept')
+
+  const treeKilled: number[] = []
+
+  stopBackendTreesForUpdate(stale, {
+    forceKillProcessTree: pid => treeKilled.push(pid),
+    stopAllPoolBackends: () => {}
+  })
+
+  assert.deepEqual(treeKilled, [], 'a record with no lifecycle evidence must never be tree-killed')
+})
+
+test('a half-populated record is not live either', () => {
+  // Exactly one field present is still not a witness -- an object that carries
+  // exitCode but no signalCode cannot rule out having been signalled.
+  assert.equal(isLiveProcessRoot({ exitCode: null, pid: 77 }), false)
+  assert.equal(isLiveProcessRoot({ pid: 77, signalCode: null }), false)
+})
+
+test('collectLiveStragglerPids drops reaped roots and keeps live ones', () => {
+  const pids = collectLiveStragglerPids(exited(100), [live(200), exited(300), signalled(400), live(500)])
+
+  assert.deepEqual(pids, [200, 500])
+})
+
+test('collectLiveStragglerPids tolerates an empty or absent pool', () => {
+  assert.deepEqual(collectLiveStragglerPids(live(11), []), [11])
+  assert.deepEqual(collectLiveStragglerPids(null, [null, undefined]), [])
+})
+
+test('collectLiveStragglerPids stops re-killing a root once it is reaped', () => {
+  // The update hand-off re-collects on EVERY pass of its wait loop. Pass 1
+  // kills the child; by pass 2 the handle is reaped and its number may already
+  // belong to something else, so it must drop out of the sweep.
+  const root = { exitCode: null as null | number, pid: 6060, signalCode: null }
+
+  assert.deepEqual(collectLiveStragglerPids(root, []), [6060], 'pass 1 kills the live root')
+
+  root.exitCode = 0
+
+  assert.deepEqual(collectLiveStragglerPids(root, []), [], 'pass 2 must not re-kill the recycled number')
+})
+
+// ---------------------------------------------------------------------------
+// stopBackendChild mutates ONLY through the retained handle. There is no
+// dependency injection left to spy on, because there is no pid-based mutator
+// left to inject -- so these watch process.kill itself, which is the only way
+// one could come back.
+// ---------------------------------------------------------------------------
+
+function withKillSpy(body: () => void): Array<[number, unknown]> {
+  const pidKills: Array<[number, unknown]> = []
+  const realKill = process.kill
+
+  process.kill = ((pid: number, signal?: unknown) => {
+    pidKills.push([pid, signal])
+  }) as typeof process.kill
+
+  try {
+    body()
+  } finally {
+    process.kill = realKill
+  }
+
+  return pidKills
+}
+
+test('stopBackendChild issues no pid-based kill for a child that exited on its own', () => {
+  let handleKills = 0
+  const child = { ...exited(1234), kill: () => (handleKills += 1), killed: false }
+
+  const pidKills = withKillSpy(() => stopBackendChild(child))
+
+  // `killed: false` is the crux: this child was never signalled by us, so the
+  // pre-existing `child.killed` guard does not catch it. Before #89614 it took
+  // a taskkill against a number Windows may already have reassigned.
+  assert.deepEqual(pidKills, [])
+  // The HANDLE kill still runs, and is safe: on a reaped child Node has already
+  // dropped the internal handle, so `child.kill()` returns false without
+  // issuing any syscall against the number.
+  assert.equal(handleKills, 1)
+})
+
+test('stopBackendChild issues no pid-based kill for a LIVE child either', () => {
+  // The contract is not "be careful with dead children", it is "never mutate
+  // by number". A live child is the case where the old code was most confident
+  // it was allowed to tree-kill, and it is still not allowed to.
+  const calls: string[] = []
+  const child = { ...live(1234), kill: (s: string) => calls.push(s), killed: false }
+
+  const pidKills = withKillSpy(() => stopBackendChild(child))
+
+  assert.deepEqual(pidKills, [])
+  assert.deepEqual(calls, ['SIGTERM'])
+})
+
+// ---------------------------------------------------------------------------
+// PID-reuse witness: once the owned child exits, its number may belong to an
+// unrelated process. Nothing we do afterwards may touch that number.
+// ---------------------------------------------------------------------------
+
+test('a recycled pid belonging to an unrelated process is never mutated', () => {
+  const RECYCLED = 4242
+
+  // The child we owned. It exited on its own, so `killed` is false and `pid`
+  // is still populated -- the exact shape that used to pass every guard.
+  let ownedHandleKills = 0
+  const owned = { ...exited(RECYCLED), kill: () => (ownedHandleKills += 1), killed: false }
+
+  // Somebody else now holds that number. Its only mutator is its own handle,
+  // which we do not have, so any kill that reaches it must come through the pid.
+  let strangerKills = 0
+  const stranger = { ...live(RECYCLED), kill: () => (strangerKills += 1), killed: false }
+
+  assert.equal(stranger.pid, owned.pid, 'the premise: both refer to the same number')
+
+  const treeKilled: number[] = []
+
+  const pidKills = withKillSpy(() => {
+    stopBackendChild(owned)
+
+    // Every pid-based path in this module, given the reaped owner.
+    assert.deepEqual(collectLiveStragglerPids(owned, [owned]), [], 'sweep must not surface the recycled number')
+
+    stopBackendTreesForUpdate(owned, {
+      forceKillProcessTree: pid => treeKilled.push(pid),
+      stopAllPoolBackends: () => {}
+    })
+  })
+
+  assert.deepEqual(treeKilled, [], `taskkill must never be issued against ${RECYCLED}`)
+  assert.deepEqual(pidKills, [], `no process.kill may be issued against ${RECYCLED}`)
+  assert.equal(strangerKills, 0, 'the unrelated process holding the recycled pid must be untouched')
+  // The owner's own handle is still signalled -- that is the safe path, and it
+  // cannot reach the stranger because the handle, not the number, is the target.
+  assert.equal(ownedHandleKills, 1)
+})
+
+test('stopBackendTreesForUpdate skips a reaped primary but still drains the pool', () => {
+  const killed: number[] = []
+  let pooled = 0
+
+  stopBackendTreesForUpdate(exited(555), {
+    forceKillProcessTree: pid => killed.push(pid),
+    stopAllPoolBackends: () => {
+      pooled += 1
+    }
+  })
+
+  assert.deepEqual(killed, [], 'the reaped primary must not be tree-killed')
+  // Pool teardown is unconditional: skipping the dead primary must not skip
+  // the live grandchildren the hand-off is actually trying to clear.
+  assert.equal(pooled, 1)
+})
+
+test('stopBackendTreesForUpdate still tree-kills a live primary first', () => {
+  const order: string[] = []
+
+  stopBackendTreesForUpdate(live(555), {
+    forceKillProcessTree: pid => order.push(`kill:${pid}`),
+    stopAllPoolBackends: () => order.push('pool')
+  })
+
+  // Ordering matters: if the primary root exits before taskkill /T enumerates
+  // it, Windows can no longer reach its grandchildren.
+  assert.deepEqual(order, ['kill:555', 'pool'])
+})

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -31,7 +31,11 @@ import {
 } from 'electron'
 
 import { classifyActiveRuntime } from './active-runtime-state'
-import { stopBackendChild as stopBackendChildImpl, stopBackendTreesForUpdate } from './backend-child'
+import {
+  collectLiveStragglerPids,
+  stopBackendChild as stopBackendChildImpl,
+  stopBackendTreesForUpdate
+} from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { buildDesktopBackendEnv, hermesManagedNodePathEntries, normalizeHermesHomeRoot } from './backend-env'
@@ -3386,19 +3390,15 @@ async function releaseBackendLock(updateRoot, tag) {
     // A supervised backend can respawn between kill and check (grandchildren,
     // pool entries registered mid-teardown). Re-collect and re-kill each pass
     // instead of trusting the initial sweep.
-    const stragglers = []
-
-    const currentHermesProcess = backendConnectionState.getProcess()
-
-    if (currentHermesProcess && Number.isInteger(currentHermesProcess.pid)) {
-      stragglers.push(currentHermesProcess.pid)
-    }
-
-    for (const entry of backendPool.values()) {
-      if (entry.process && Number.isInteger(entry.process.pid)) {
-        stragglers.push(entry.process.pid)
-      }
-    }
+    // LIVE roots only. This loop re-collects every pass, so once pass 1 has
+    // killed a child, a pid-only filter would keep re-issuing taskkill against
+    // its number on every later pass -- and Windows recycles pids fast enough
+    // that the number can already belong to a system process, which bugchecks
+    // the machine rather than failing quietly (#89614).
+    const stragglers = collectLiveStragglerPids(
+      backendConnectionState.getProcess(),
+      Array.from(backendPool.values(), entry => entry.process)
+    )
 
     for (const pid of stragglers) {
       forceKillProcessTree(pid)
@@ -9511,8 +9511,10 @@ function resetBootProgressForReconnect() {
   )
 }
 
+// No deps: teardown signals through the retained handle only. It deliberately
+// no longer receives forceKillProcessTree -- a pid is not authority (#89614).
 function stopBackendChild(child) {
-  stopBackendChildImpl(child, { forceKillProcessTree, isWindows: IS_WINDOWS })
+  stopBackendChildImpl(child)
 }
 
 // Soft gateway-mode apply: tear down the primary without resetting boot UI or

--- a/apps/desktop/electron/windows-child-options.test.ts
+++ b/apps/desktop/electron/windows-child-options.test.ts
@@ -37,114 +37,106 @@ test('hiddenWindowsChildOptions defaults isWindows from process.platform when om
   assert.equal(Boolean(result.windowsHide), expectedHide)
 })
 
-function makeChild(overrides: Partial<{ pid: number | null; killed: boolean }> = {}) {
+function makeChild(
+  overrides: Partial<{
+    exitCode: number | null
+    killed: boolean
+    pid: number | null
+    signalCode: string | null
+  }> = {}
+) {
   const calls: string[] = []
 
   return {
     calls,
     child: {
+      // A LIVE handle carries both lifecycle fields as null. `isLiveProcessRoot`
+      // is fail-closed (#89614), so a fixture that omits them is a stale record
+      // rather than a live one -- that case is pinned in
+      // backend-stale-pid.test.ts, deliberately not here.
+      exitCode: 'exitCode' in overrides ? (overrides.exitCode as number | null) : null,
       kill: (signal: string) => {
         calls.push(signal)
       },
       killed: overrides.killed ?? false,
-      pid: 'pid' in overrides ? overrides.pid : 1234
+      pid: 'pid' in overrides ? overrides.pid : 1234,
+      signalCode: 'signalCode' in overrides ? (overrides.signalCode as string | null) : null
     }
   }
 }
 
-test('stopBackendChild tree-kills on Windows when the child has a pid', () => {
-  const { child, calls } = makeChild({ pid: 4242 })
-  const treeKillCalls: number[] = []
-
-  stopBackendChild(child, {
-    forceKillProcessTree: (pid: number) => treeKillCalls.push(pid),
-    isWindows: true
-  })
-
-  assert.deepEqual(treeKillCalls, [4242])
-  assert.deepEqual(calls, [], 'SIGTERM must not be sent when the Windows tree-kill path is taken')
-})
-
-test('stopBackendChild group-SIGTERMs on POSIX (negative pgid) when the child has a pid', () => {
-  const { child, calls } = makeChild({ pid: 4242 })
-  const treeKillCalls: number[] = []
-  const groupKills: Array<[number, string]> = []
-
-  stopBackendChild(child, {
-    forceKillProcessTree: (pid: number) => treeKillCalls.push(pid),
-    isWindows: false,
-    killGroup: (pgid, signal) => groupKills.push([pgid, signal])
-  })
-
-  assert.deepEqual(groupKills, [[-4242, 'SIGTERM']], 'must signal the whole process group')
-  assert.deepEqual(calls, [], 'direct child.kill must not run when the group send succeeds')
-  assert.deepEqual(treeKillCalls, [], 'tree-kill must not run off Windows')
-})
-
-test('stopBackendChild falls back to direct SIGTERM on POSIX when the group send throws', () => {
+test('stopBackendChild signals through the retained handle and never tree-kills by pid', () => {
+  // INVERTED on purpose (#89614). This used to assert taskkill /T /F against
+  // child.pid. A pid is not authority: the OS can reap the child and reassign
+  // the number, and taskkill would then kill whoever inherited it.
   const { child, calls } = makeChild({ pid: 4242 })
 
-  stopBackendChild(child, {
-    forceKillProcessTree: () => {},
-    isWindows: false,
-    killGroup: () => {
-      throw new Error('ESRCH: no such process group')
-    }
-  })
+  stopBackendChild(child)
 
-  assert.deepEqual(calls, ['SIGTERM'], 'must fall back to signalling the direct child')
+  assert.deepEqual(calls, ['SIGTERM'], 'the retained handle must be the only mutator')
 })
 
-test('stopBackendChild falls back to SIGTERM on Windows when the pid is not an integer', () => {
-  const { child, calls } = makeChild({ pid: null })
-  const treeKillCalls: number[] = []
+test('stopBackendChild issues no pid-based syscall of any kind', () => {
+  // Also inverted. The POSIX branch used process.kill(-pid, ...), which is
+  // pid-based too -- a recycled number means signalling an unrelated process
+  // GROUP. Quieter than a Windows bugcheck, same defect.
+  //
+  // With dependency injection gone, process.kill is the only remaining way to
+  // smuggle a pid mutator back into this path, so watch it directly.
+  const { child, calls } = makeChild({ pid: 4242 })
+  const pidKills: Array<[number, unknown]> = []
+  const realKill = process.kill
 
-  stopBackendChild(child, {
-    forceKillProcessTree: (pid: number) => treeKillCalls.push(pid),
-    isWindows: true
-  })
+  process.kill = ((pid: number, signal?: unknown) => {
+    pidKills.push([pid, signal])
+  }) as typeof process.kill
 
+  try {
+    stopBackendChild(child)
+  } finally {
+    process.kill = realKill
+  }
+
+  assert.deepEqual(pidKills, [], 'no process.kill by pid or pgid may be issued')
   assert.deepEqual(calls, ['SIGTERM'])
-  assert.deepEqual(treeKillCalls, [])
+})
+
+test('stopBackendChild still signals a child whose pid never materialised', () => {
+  const { child, calls } = makeChild({ pid: null })
+
+  stopBackendChild(child)
+
+  assert.deepEqual(calls, ['SIGTERM'], 'a failed spawn is still worth signalling through the handle')
 })
 
 test('stopBackendChild is a no-op for an already-killed child', () => {
   const { child, calls } = makeChild({ killed: true })
-  const treeKillCalls: number[] = []
 
-  stopBackendChild(child, {
-    forceKillProcessTree: (pid: number) => treeKillCalls.push(pid),
-    isWindows: true
-  })
+  stopBackendChild(child)
 
   assert.deepEqual(calls, [])
-  assert.deepEqual(treeKillCalls, [])
 })
 
 test('stopBackendChild is a no-op for a null/undefined child', () => {
-  const treeKillCalls: number[] = []
-
   assert.doesNotThrow(() => {
-    stopBackendChild(null, { forceKillProcessTree: (pid: number) => treeKillCalls.push(pid), isWindows: true })
-    stopBackendChild(undefined, { forceKillProcessTree: (pid: number) => treeKillCalls.push(pid), isWindows: true })
+    stopBackendChild(null)
+    stopBackendChild(undefined)
   })
-  assert.deepEqual(treeKillCalls, [])
 })
 
 test('stopBackendChild swallows errors thrown by the kill strategy', () => {
   const child = {
+    exitCode: null,
     kill: () => {
       throw new Error('ESRCH: no such process')
     },
     killed: false,
-    pid: 99
+    pid: 99,
+    signalCode: null
   }
 
   assert.doesNotThrow(() => {
-    stopBackendChild(child, {
-      forceKillProcessTree: () => {},
-      isWindows: false
-    })
+    stopBackendChild(child)
   })
 })
 


### PR DESCRIPTION
## Read this first: `Refs`, not `Fixes`

This does not close #89614. It removes the pid-based mutators from the desktop's backend teardown, which eliminates the mechanism that was firing in the field, but a residual race remains and no in-process check can remove it. The closure contract is @andrexibiza's two-stage one on #89614; this is stage 1.

**Second revision.** The first version kept tree-kill and guarded it with a liveness predicate. That was the wrong shape and I have replaced it - see [What changed in this revision](#what-changed-in-this-revision).

## The rule

A mutator may act only on authority it still holds.

A retained `ChildProcess` handle is authority. A pid is not: the OS may have reaped the process and handed the number to somebody else. `child.pid` is not a liveness check either - Node keeps the number after the child is reaped, and `child.killed` stays **false** for a child that exited on its own rather than being signalled. Verified rather than assumed:

```js
const c = spawn(process.execPath, ['-e', 'process.exit(0)'])
c.on('exit', () => setTimeout(() => {
  console.log(c.pid, c.exitCode, c.killed, Number.isInteger(c.pid))
}, 50))
// 7964  0  false  true
```

Every guard on this path was `Number.isInteger(child.pid)`, which passes for that dead child. On Windows PIDs are recycled aggressively, so `taskkill /PID <recycled> /T /F` then kills whatever process inherited the number - and when the winner is a protected system process the kernel raises bugcheck **0xEF (CRITICAL_PROCESS_DIED)**. #89614 reports 8 blue screens in 48 hours, every one bucketed `BUGCHECK_CRITICAL_PROCESS_TERMINATED_BY_taskkill.exe`.

## Which path actually fires - not the one the report names

The report points at the persisted ownership record. That path is **already guarded**: `stopOwnedBackend` calls `processIdentityMatches`, which compares `processStartMarker(pid)` (Windows start ticks, or `ps -o lstart=`) and returns early unless it matches, so a stale ownership pid does not reach `taskkill`. I could not get it to misfire.

The unguarded path is the update hand-off. `releaseBackendLock` re-collects and re-kills stragglers on **every pass** of its wait loop:

```js
const stragglers = []
const currentHermesProcess = backendConnectionState.getProcess()
if (currentHermesProcess && Number.isInteger(currentHermesProcess.pid)) { … }
for (const entry of backendPool.values()) {
  if (entry.process && Number.isInteger(entry.process.pid)) { … }
}
for (const pid of stragglers) forceKillProcessTree(pid)
```

These are live `ChildProcess` handles, so they look safe - but pass 1 kills the children, and from pass 2 onward the same handles are reaped while still reporting an integer `pid`. **The loop poisons itself**: it re-issues `taskkill` against numbers it just freed, once per 300ms pass until the 15s deadline - roughly 50 shots at a recycled number per hand-off. That matches the reporter's timing evidence (app rebuilt 17:16, blue screens 17:19 and 17:23) better than the ownership-file theory does, because this loop runs precisely during update teardown.

## Changes Made

- **`apps/desktop/electron/backend-child.ts`**
  - `stopBackendChild` now signals **only** through the retained handle. The Windows `forceKillProcessTree(child.pid)` branch and the POSIX `process.kill(-child.pid, 'SIGTERM')` group branch are both removed, along with the `deps` parameter that injected them - so there is no injection point left through which a pid mutator could return.
  - `isLiveProcessRoot(root)` is **fail-closed**: live only when the pid is a positive integer **and both** `exitCode` and `signalCode` are exactly `null`. A record carrying neither - a bare `{ pid }` - has no evidence of authority behind it and reads as not live. `undefined !== null` is what enforces that.
  - `collectLiveStragglerPids` filters the update sweep through that predicate, so a reaped root drops out instead of being re-killed on every pass.
  - `stopBackendTreesForUpdate` still tree-kills, because no handle can reach a grandchild, but only for a primary whose handle proves it is live.
- **`apps/desktop/electron/main.ts`** - the `stopBackendChild` wrapper no longer passes `forceKillProcessTree`.
- **`apps/desktop/electron/backend-stale-pid.test.ts`** - new; the liveness contract, the PID-reuse witness and the stale-record witness.
- **`apps/desktop/electron/windows-child-options.test.ts`** - two existing assertions inverted, see below.

### The handle call is deliberately not liveness-gated

`child.kill()` cannot reach a recycled pid: once the child is reaped Node has already dropped the internal handle, so the call issues no syscall against the number at all. Gating it would only stop us signalling a child whose pid never materialised (a failed spawn), which is harmless and worth attempting. The rule is "never reconstruct authority from a number", and the handle is not a number.

### Two existing tests are inverted, on purpose

`windows-child-options.test.ts` asserted `stopBackendChild tree-kills on Windows when the child has a pid` and the POSIX group-signal equivalent. Those are the behaviour being removed, so they now assert the opposite, with a comment saying why - not deleted, so that nobody restores them believing they are repairing a regression.

Its `makeChild` fixture was itself the stale shape (`{ kill, killed, pid }`, no lifecycle fields), so the old suite was inadvertently asserting that an evidence-free record may be tree-killed. The fixture now carries `exitCode: null` / `signalCode: null` to mean "live", and the evidence-free case is pinned deliberately in the new file instead.

## What this costs, priced rather than discovered

**Handle-only cannot reach a grandchild.** That is what a `ChildProcess` handle is, not a limitation of this patch, and it is the whole trade:

- `stopBackendChild` is the ordinary path - 8 call sites: quit, restart, pool eviction, failed-start cleanup.
- On Windows `child.kill()` reaches only the direct child, so a backend's grandchildren (a hermes REPL, a pty terminal, the gateway, MCP servers) now survive it. This module was extracted to fix exactly that leak, and the POSIX group-signal was added for the same reason (orphaned MCP children).
- Concretely: expect orphaned backend trees to accumulate across restarts, and update hand-offs to hit the 15s abort more often than before.

That abort already exists and is already the right shape - `releaseBackendLock` never kills a locker, it polls the venv shim and gives up:

```js
rememberLog(`[${tag}] venv shim still locked after 15s; aborting hand-off (something outside this app holds the venv)`)

return { unlocked: false }
```

So the residue lands somewhere that fails closed rather than escalating. Leaving residue is recoverable; a 0xEF is not. I think that is the right trade, but it is a real behaviour change and should be chosen knowingly.

**Reaching a tree with handle-grade authority needs a kernel object that owns the tree** - a Windows Job Object, or a process group we hold open - not a pid. Deliberately out of scope here; happy to take it as a follow-up.

Worth knowing before anyone proposes a cheaper shortcut: `processStartMarker` already exists in `main.ts` and is a genuine start-tick authority check (a recycled number has a different start time). It does not drop into this path, because it is `async` while these teardowns are synchronous, and because on Windows it spawns `powershell.exe -Command Get-Process -Id <pid>` per pid - hundreds of milliseconds, inside a 300ms poll over every pool entry.

## Related Issue

Refs #89614

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## How to Test

```
cd apps/desktop
npx vitest run --project electron electron/backend-stale-pid.test.ts electron/windows-child-options.test.ts
```

## Verification

**The PID-reuse witness constructs the scenario literally.** The owned child exits carrying pid 4242; an unrelated live stub also holds 4242. The test asserts `taskkill` is never issued against that number, that `process.kill` is never called at all (spied directly - with dependency injection gone, it is the only remaining way a pid mutator could come back), and that the stranger's own kill counter stays 0 - while the owner's handle is still signalled exactly once.

**The stale-record witness** drives `{ pid: 77 }` through all three pid-based entry points (`isLiveProcessRoot`, `collectLiveStragglerPids`, `stopBackendTreesForUpdate`) and asserts none of them mutate. A second case covers the half-populated shapes, where only one of the two lifecycle fields is present.

**Mutation proof - 7 mutations, 7 caught.** Each was applied to `backend-child.ts` and the two suites re-run:

| # | Mutation | Caught by |
|---|---|---|
| 1 | `stopBackendChild` mutates by pid again (`process.kill(child.pid, 'SIGTERM')`) | the `process.kill` spies in both suites |
| 2 | `isLiveProcessRoot` tolerates a missing witness, so a bare `{ pid }` reads live again (the previous revision's behaviour) | the stale-record witness |
| 3 | it stops consulting `signalCode` | the signalled-root cases |
| 4 | it stops consulting `exitCode` | the reaped-root cases, including the PID-reuse witness |
| 5 | it drops the positive-pid guard | the absent/nonsensical-pid case |
| 6 | `stopBackendTreesForUpdate` tree-kills any record carrying a pid | the reaped-primary case and both witnesses |
| 7 | `collectLiveStragglerPids` sweeps every pid regardless of liveness | the re-kill-across-passes case |

Mutation 2 is the one that matters most here: it is exactly what this revision changed, so it proves the new tests bind the new contract rather than merely coexisting with it.

**Suite delta, measured rather than assumed.** `vitest run --project electron`, Windows 11:

```
pristine upstream/main   44 failed | 1428 passed | 3 skipped   (10 files)
this branch              42 failed | 1441 passed | 3 skipped   (10 files)
```

Same ten pre-existing failing files, all environmental on Windows (POSIX file-mode assertions in `hardening.test.ts`, WSL path bridging, ssh config). No failure is introduced by this branch. `tsc -p tsconfig.electron.json --noEmit` and `eslint` on the changed files are both clean.

**Platform:** Windows 11.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the tests and all pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation or N/A: the module header states the authority rule and what it costs
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A: no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility): the change is deliberately not Windows-only. POSIX recycles pids too, and `process.kill(-pid)` against a recycled number signals an unrelated process group - quieter than a bugcheck, same defect.
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## What changed in this revision

Responding to @andrexibiza's containment contract on #89614:

| Ask | Status |
|---|---|
| `Refs`, not `Fixes` | done |
| `stopBackendChild` mutates only through the retained owner | done - both pid branches and the `deps` parameter removed |
| Once exit is observed, authority is spent | done - fail-closed predicate; the handle path never uses a number |
| PID-reuse witness | added |
| Stale-record witness (`{ pid }` cannot enter the force path) | added - this **inverts** the previous revision's explicit choice, which I withdraw: it was justified by a legacy caller that does not exist. Every caller in tree passes a real `ChildProcess`. |
| Updater aborts on remaining locks rather than killing a locker | already the behaviour; `releaseBackendLock` polls and returns `{ unlocked: false }` |

One deviation, flagged rather than smuggled: the handle call is not liveness-gated, for the reason above. Say the word and I will gate it.
