### PR TITLE
fix(desktop): restore profile/agent switching in release builds (nanostores 1.4.2)

### DIFF
--- a/apps/bootstrap-installer/package.json
+++ b/apps/bootstrap-installer/package.json
@@ -32,7 +32,7 @@
     "clsx": "2.1.1",
     "katex": "0.16.47",
     "lucide-react": "0.577.0",
-    "nanostores": "1.4.0",
+    "nanostores": "1.4.2",
     "radix-ui": "1.6.7",
     "react": "19.2.7",
     "react-dom": "19.2.7",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -129,7 +129,7 @@
     "katex": "0.16.47",
     "mermaid": "11.16.1",
     "motion": "12.42.2",
-    "nanostores": "1.4.0",
+    "nanostores": "1.4.2",
     "node-pty": "1.1.0",
     "radix-ui": "1.6.7",
     "react": "19.2.7",

--- a/apps/desktop/src/store/nanostores-batch-guard.test.ts
+++ b/apps/desktop/src/store/nanostores-batch-guard.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Regression guard: the desktop's gateway-switch publication runs inside
+ * nanostores' batch(). nanostores 1.4.0–1.4.1 annotated batch() with
+ * `/* @__NO_SIDE_EFFECTS__ *\/`, which let production bundlers (Rollup, via
+ * `vite build`) erase result-unused batch(...) calls — callback included —
+ * deleting the entire publication from release builds and freezing
+ * profile/agent switching there. Dev builds and vitest run unminified, so
+ * only the packaged app broke. nanostores 1.4.2 removed the annotation;
+ * this test fails if the installed version ever carries it again.
+ */
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+
+describe('nanostores batch()', () => {
+  it('is not annotated @__NO_SIDE_EFFECTS__ — bundlers would erase its calls', () => {
+    const nanostoresEntry = require.resolve('nanostores')
+    const atomSource = readFileSync(path.join(path.dirname(nanostoresEntry), 'atom/index.js'), 'utf8')
+
+    // Capture any block comment immediately preceding the batch export.
+    const match = atomSource.match(/(\/\*(?:[^*]|\*(?!\/))*\*\/\s*)?export const batch\b/)
+
+    expect(match, 'nanostores atom/index.js should export const batch').toBeTruthy()
+    expect(match![1] ?? '').not.toContain('__NO_SIDE_EFFECTS')
+    expect(match![1] ?? '').not.toContain('__PURE__')
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "clsx": "2.1.1",
         "katex": "0.16.47",
         "lucide-react": "0.577.0",
-        "nanostores": "1.4.0",
+        "nanostores": "1.4.2",
         "radix-ui": "1.6.7",
         "react": "19.2.7",
         "react-dom": "19.2.7",
@@ -115,7 +115,7 @@
         "katex": "0.16.47",
         "mermaid": "11.16.1",
         "motion": "12.42.2",
-        "nanostores": "1.4.0",
+        "nanostores": "1.4.2",
         "node-pty": "1.1.0",
         "radix-ui": "1.6.7",
         "react": "19.2.7",
@@ -14520,9 +14520,9 @@
       }
     },
     "node_modules/nanostores": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.4.0.tgz",
-      "integrity": "sha512-i0tloweeudshAEuddpDxcg9Ik6pkPfVsHIgKyf143JrgG7/MOh0+q7BypdLXZPoOP7fOYt1eTcwGkyiVmhJFkA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.4.2.tgz",
+      "integrity": "sha512-Wxv8Roefr2nqtiRG0bnaFlpYqpIVtOEeJZHaH+4nGgOK1/7n6OHOuHCb/bhqrNQgZM8fyd0s1PqhdrJc9Ib44g==",
       "funding": [
         {
           "type": "github",
@@ -19120,7 +19120,7 @@
         "@hermes/shared": "file:../apps/shared",
         "@nanostores/react": "1.1.0",
         "ink-text-input": "6.0.0",
-        "nanostores": "1.4.0",
+        "nanostores": "1.4.2",
         "react": "19.2.7",
         "undici": "6.28.0",
         "unicode-animations": "1.0.3"

--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -23,7 +23,7 @@
     "@hermes/shared": "file:../apps/shared",
     "@nanostores/react": "1.1.0",
     "ink-text-input": "6.0.0",
-    "nanostores": "1.4.0",
+    "nanostores": "1.4.2",
     "react": "19.2.7",
     "undici": "6.28.0",
     "unicode-animations": "1.0.3"


### PR DESCRIPTION
## What does this PR do?

**🔴 Critical production breakage:** in packaged (minified) desktop builds, switching profiles or connection-scoped agents does **nothing at all** — clicking a profile in the rail is a silent no-op.

Root cause: nanostores 1.4.0–1.4.1 annotate `batch()` with `/* @__NO_SIDE_EFFECTS__ */`. Rollup (via `vite build`) honors that annotation and erases any result-unused `batch(...)` call as dead code — **including its callback**. Since `d57f94a33` / `053eb7aab` / `4e520f085` moved the gateway-switch publication (`activate()` + `$activeGatewayProfile.set()` + `setConnection()`) inside `batch(() => { ... })`, the entire publication is missing from release bundles:

```
// minified release bundle, before this fix:
let [e, n] = await Promise.all([la(t), Oi(t)])})().catch(...)   // <- nothing between await and catch
```

Dev builds and vitest run unminified, which is why this only shows up in the packaged app.

Fix: bump nanostores to **1.4.2**, which removes the `@__NO_SIDE_EFFECTS__` annotation from `batch()` (it remains on the creation functions like `atom`/`computed`, where it is correct). All three pinned copies are bumped (`apps/desktop`, `apps/bootstrap-installer`, `ui-tui`). No source changes to app code are needed.

A regression test (`apps/desktop/src/store/nanostores-batch-guard.test.ts`) asserts the installed nanostores never re-introduces a purity annotation on `batch`, so a future downgrade or re-annotation fails CI instead of silently shipping a dead profile switcher.

## Related Issue

Fixes # — (no existing issue found; happy to file one if preferred)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/package.json`, `apps/bootstrap-installer/package.json`, `ui-tui/package.json`: nanostores `1.4.0` → `1.4.2`
- `package-lock.json`: matching lock entries (surgical, no other churn)
- `apps/desktop/src/store/nanostores-batch-guard.test.ts` (new): regression guard against the annotation returning

## How to Test

1. `cd apps/desktop && npm ci && npm run build` — then inspect the minified bundle: the gateway-switch publication survives (`s(() => { n() && (X.set(t), e && Jt(e)) })` now present after the `Promise.all` in the profile chunk; previously the block was erased entirely).
2. `npx vitest run src/store/` — all 37 tests pass, including the atomic-publication tests from `4e520f085` and the new guard test.
3. Packaged app end-to-end (Linux, Wayland): built with `npm run pack`, launched `release/linux-unpacked/Hermes`, pressed `Ctrl+Shift+]` twice — active profile cycled `cetcworker → hermes-wsl → quantify` and the sidebar session list followed each switch. Before the fix the same steps were a no-op.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (desktop TS change only; ran the desktop vitest suite instead: 37/37 pass)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (Wayland, GNOME fractional scaling), Electron 40.10.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the bug is platform-independent (build-time treeshaking), and the fix is a patch-level dependency bump
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Verification log from the packaged Linux build (keyboard profile cycling; before the fix this produced no state change):

```
active before: cetcworker | top session: 开发体系 #29
active after next: hermes-wsl | top session: 自由空间 #7
active after next#2: quantify | top session: 量化主进程
```
