### PR TITLE
fix: Slack DMのトップレベル見出しをdispatch前に抑止

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -67,6 +67,9 @@ except ImportError:  # pragma: no cover - plugin loaded outside package context
 
 logger = logging.getLogger(__name__)
 
+_SLACK_DM_HEADING_SEPARATOR_RE = re.compile(r"^[\s\u3000、,，:：]+")
+_DEFAULT_SLACK_DM_HEADING_ACK = "Heading received. Send details in this thread."
+
 # User-Agent prefix for outbound Slack API calls so platform partners can
 # identify HermesAgent traffic — matching other Hermes outbound surfaces
 # that already set ``HermesAgent/<version>`` for platform-partner attribution.
@@ -3542,6 +3545,69 @@ class SlackAdapter(BasePlatformAdapter):
             return True  # default: each DM thread is its own session
         return str(raw).strip().lower() in {"1", "true", "yes", "on"}
 
+    def _slack_dm_heading_prefixes(self) -> tuple[str, ...]:
+        """Return configured prefixes for top-level one-to-one DM headings."""
+        raw = self.config.extra.get("dm_heading_prefixes")
+        if raw is None:
+            return ()
+        if isinstance(raw, str):
+            raw = [raw]
+        if not isinstance(raw, (list, tuple, set)):
+            return ()
+        prefixes = tuple(str(value).strip() for value in raw if str(value).strip())
+        return prefixes
+
+    def _slack_dm_heading_ack(self) -> str:
+        """Return the direct acknowledgement sent for a DM heading."""
+        raw = self.config.extra.get("dm_heading_ack", _DEFAULT_SLACK_DM_HEADING_ACK)
+        return str(raw).strip() or _DEFAULT_SLACK_DM_HEADING_ACK
+
+    def _is_slack_dm_heading_text(self, text: str) -> bool:
+        """Return whether *text* is a configured heading, not ordinary prose."""
+        normalized = (text or "").strip()
+        for prefix in self._slack_dm_heading_prefixes():
+            if normalized == prefix:
+                return True
+            suffix = normalized[len(prefix) :] if normalized.startswith(prefix) else ""
+            if suffix and _SLACK_DM_HEADING_SEPARATOR_RE.match(suffix):
+                return True
+        return False
+
+    def _is_slack_top_level_dm_heading(self, event: dict, text: str) -> bool:
+        """Return whether a raw Slack event is a top-level 1:1 DM heading.
+
+        Deliberately checks raw ``thread_ts`` presence instead of
+        ``SessionSource.thread_id``. The latter is synthesized from the
+        message ts for top-level DMs when per-message DM sessions are enabled.
+        A present-but-equal ``thread_ts`` is also treated as a real thread
+        marker, as required by Slack payload semantics.
+        """
+        return (
+            event.get("channel_type") == "im"
+            and "thread_ts" not in event
+            and self._is_slack_dm_heading_text(text)
+        )
+
+    async def _send_slack_dm_heading_ack(
+        self, event: dict, *, team_id: str
+    ) -> None:
+        """Acknowledge a DM heading directly, without Gateway/Agent dispatch."""
+        channel_id = str(event.get("channel") or "")
+        message_ts = str(event.get("ts") or "")
+        if not channel_id or not message_ts:
+            logger.warning("[Slack] Cannot acknowledge DM heading without channel/ts")
+            return
+        result = await self.send(
+            channel_id,
+            self._slack_dm_heading_ack(),
+            reply_to=message_ts,
+            metadata={"thread_id": message_ts, "team_id": team_id},
+        )
+        if not result.success:
+            logger.warning(
+                "[Slack] DM heading acknowledgement failed: %s", result.error
+            )
+
     def _cron_continuable_surface(self) -> str:
         """Resolve the continuable-cron delivery surface for this platform.
 
@@ -6056,6 +6122,21 @@ class SlackAdapter(BasePlatformAdapter):
                     channel_id,
                 )
                 return
+
+        # Top-level one-to-one DM headings are an inbound routing control, not
+        # an Agent turn. Stop here — before session keying, thread hydration,
+        # attachment downloads, and MessageEvent dispatch — and acknowledge
+        # directly through the Slack adapter. This must use raw event
+        # ``thread_ts`` presence because top-level DM session scoping may have
+        # already synthesized ``source.thread_id = event.ts``.
+        if self._is_slack_top_level_dm_heading(event, text):
+            await self._send_slack_dm_heading_ack(event, team_id=str(team_id or ""))
+            logger.info(
+                "[Slack] Suppressed Agent dispatch for top-level DM heading: channel=%s ts=%s",
+                channel_id,
+                ts,
+            )
+            return
 
         # Build thread_ts for session keying.
         # In channels: fall back to ts so each top-level @mention starts a

--- a/tests/gateway/test_slack_dm_headings.py
+++ b/tests/gateway/test_slack_dm_headings.py
@@ -1,0 +1,164 @@
+"""Regression tests for Slack top-level DM heading suppression."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.slack.adapter import SlackAdapter
+
+
+HEADING_ACK = "見出しとして受信しました。詳細はこのスレッドに送ってください。"
+DEFAULT_HEADING_ACK = "Heading received. Send details in this thread."
+
+
+def make_adapter(extra=None):
+    adapter = SlackAdapter(PlatformConfig(enabled=True, extra=extra or {}))
+    adapter._bot_user_id = "UBOT"
+    adapter._team_bot_user_ids["T1"] = "UBOT"
+    adapter._has_active_session_for_thread = lambda **_: False
+    adapter._fetch_thread_context = AsyncMock(return_value="")
+    adapter._fetch_thread_parent_text = AsyncMock(return_value="")
+    adapter._resolve_user_name = AsyncMock(return_value="Sunahara")
+    adapter.send = AsyncMock(return_value=type("Result", (), {"success": True, "error": None})())
+    return adapter
+
+
+def slack_event(text, *, ts="100.000", thread_ts_marker=...):
+    event = {
+        "type": "message",
+        "channel": "D123",
+        "channel_type": "im",
+        "team": "T1",
+        "user": "U123",
+        "client_msg_id": "client-1",
+        "text": text,
+        "ts": ts,
+    }
+    if thread_ts_marker is not ...:
+        event["thread_ts"] = thread_ts_marker
+    return event
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("text", ["スレッド", "スレッド Hermes", "スレッド　Hermes", "スレッド、Hermes"])
+async def test_top_level_dm_heading_is_acknowledged_without_dispatch(text):
+    adapter = make_adapter(
+        {
+            "dm_heading_prefixes": "スレッド",
+            "dm_heading_ack": HEADING_ACK,
+        }
+    )
+    adapter.handle_message = AsyncMock()
+
+    await adapter._handle_slack_message(slack_event(text))
+
+    adapter.handle_message.assert_not_awaited()
+    adapter.send.assert_awaited_once_with(
+        "D123",
+        HEADING_ACK,
+        reply_to="100.000",
+        metadata={"thread_id": "100.000", "team_id": "T1"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_heading_prefix_does_not_suppress_dispatch():
+    adapter = make_adapter()
+    adapter.handle_message = AsyncMock()
+
+    await adapter._handle_slack_message(slack_event("スレッド Hermes"))
+
+    adapter.handle_message.assert_awaited_once()
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prefixes", ["", []])
+async def test_empty_heading_prefix_disables_suppression(prefixes):
+    adapter = make_adapter({"dm_heading_prefixes": prefixes})
+    adapter.handle_message = AsyncMock()
+
+    await adapter._handle_slack_message(slack_event("スレッド Hermes"))
+
+    adapter.handle_message.assert_awaited_once()
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_normal_top_level_dm_still_dispatches():
+    adapter = make_adapter()
+    adapter.handle_message = AsyncMock()
+
+    await adapter._handle_slack_message(slack_event("通常の依頼"))
+
+    adapter.handle_message.assert_awaited_once()
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_heading_like_text_without_separator_is_normal_message():
+    adapter = make_adapter({"dm_heading_prefixes": "スレッド"})
+    adapter.handle_message = AsyncMock()
+
+    await adapter._handle_slack_message(slack_event("スレッドについて調べて"))
+
+    adapter.handle_message.assert_awaited_once()
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("thread_ts", ["101.000", "999.000"])
+async def test_real_thread_reply_is_not_suppressed_even_when_text_is_heading(thread_ts):
+    adapter = make_adapter({"dm_heading_prefixes": "スレッド"})
+    adapter.handle_message = AsyncMock()
+
+    await adapter._handle_slack_message(
+        slack_event("スレッド Hermes", ts="101.000", thread_ts_marker=thread_ts)
+    )
+
+    adapter.handle_message.assert_awaited_once()
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_default_ack_is_generic_when_not_configured():
+    adapter = make_adapter({"dm_heading_prefixes": "Topic"})
+    adapter.handle_message = AsyncMock()
+
+    await adapter._handle_slack_message(slack_event("Topic Hermes"))
+
+    adapter.handle_message.assert_not_awaited()
+    adapter.send.assert_awaited_once_with(
+        "D123",
+        DEFAULT_HEADING_ACK,
+        reply_to="100.000",
+        metadata={"thread_id": "100.000", "team_id": "T1"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_heading_prefix_and_ack_are_configurable():
+    adapter = make_adapter(
+        {
+            "dm_heading_prefixes": ["話題"],
+            "dm_heading_ack": "このスレッドで受け付けました。",
+        }
+    )
+    adapter.handle_message = AsyncMock()
+
+    await adapter._handle_slack_message(slack_event("話題 Hermes", ts="200.000"))
+
+    adapter.handle_message.assert_not_awaited()
+    adapter.send.assert_awaited_once_with(
+        "D123",
+        "このスレッドで受け付けました。",
+        reply_to="200.000",
+        metadata={"thread_id": "200.000", "team_id": "T1"},
+    )
+
+    adapter.handle_message.reset_mock()
+    adapter.send.reset_mock()
+    await adapter._handle_slack_message(slack_event("スレッド Hermes", ts="201.000"))
+    adapter.handle_message.assert_awaited_once()
+    adapter.send.assert_not_awaited()

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -223,6 +223,30 @@ Or run the interactive setup:
 hermes gateway setup    # Select Slack when prompted
 ```
 
+### Slack DM thread headings
+
+Hermes can optionally reserve top-level one-to-one DM messages as thread headings. This
+feature is disabled by default. When configured, a matching message is acknowledged
+directly by the Slack adapter and is not dispatched to the Agent. Replies posted inside
+that Slack thread are still processed normally.
+
+Enable it by configuring `dm_heading_prefixes` under the Slack platform's `extra` settings:
+
+```yaml
+platforms:
+  slack:
+    extra:
+      dm_heading_prefixes:
+        - "Topic"
+      dm_heading_ack: "Heading received. Send details in this thread."
+```
+
+`dm_heading_prefixes` accepts a list of prefixes. Exact matches and matches followed
+by whitespace, full-width whitespace, or common punctuation are treated as headings;
+ordinary prose such as `スレッドについて調べて` is not. Only top-level `channel_type=im`
+messages are affected. The adapter uses raw Slack `thread_ts` presence, not the
+session source's synthesized `thread_id`, so real thread replies are never suppressed.
+
 Then start the gateway:
 
 ```bash


### PR DESCRIPTION
Closes #89652

## 概要

Slackの1:1 DMにおけるトップレベルの見出しメッセージを、Agent dispatch前に抑止します。

- 機能はデフォルト無効で、`dm_heading_prefixes` 設定時のみ有効
- raw Slack `thread_ts` の有無でトップレベルメッセージと実スレッド返信を区別
- 見出しはSlack Adapterから直接ACKし、Agent / LLMを起動しない
- 見出しprefixとACK本文は設定可能
- 実スレッド返信は従来どおり処理
- 語境界と空白・区切り表記を考慮し、通常文を誤抑止しない

## テスト

- Slack DM見出し回帰テスト: 13 passed
- Slack Adapter全体テスト: 165 passed
- Ruff: passed
- `git diff --check`: passed

既存テスト実行時にMock由来のRuntimeWarningが10件ありますが、テスト失敗はありません。