### PR TITLE
Add eight Academica hosted MCP catalog entries

### DIFF
--- a/optional-mcps/academica-clinical-trials/manifest.yaml
+++ b/optional-mcps/academica-clinical-trials/manifest.yaml
@@ -1,0 +1,41 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: academica-clinical-trials
+description: >-
+  Clinical-trial protocol, recruitment, intervention, eligibility, and outcome retrieval.
+source: https://github.com/academica-sh/academica-mcp
+
+# Hosted Streamable HTTP. Read-only evidence retrieval. Hermes does not
+# spawn a local process. One Academica API key authenticates every server
+# in this family (https://academica.sh/mcp/keys).
+transport:
+  type: http
+  url: https://academica.sh/api/mcp/clinical-trials
+  headers:
+    Authorization: "Bearer ${ACADEMICA_API_KEY}"
+
+auth:
+  type: api_key
+  env:
+    - name: ACADEMICA_API_KEY
+      prompt: "Academica API key (https://academica.sh/mcp/keys)"
+      required: true
+      secret: true
+
+suggest:
+  keywords:
+    - clinical trials
+    - NCT
+    - study protocols
+  hosts:
+    - academica.sh
+
+post_install: |
+  Issue a key at https://academica.sh/mcp/keys. Developer keys are 100
+  calls/month. Privacy: https://academica.sh/legal/privacy. Terms:
+  https://academica.sh/legal/terms.
+
+  The eight Academica catalog entries share ACADEMICA_API_KEY. Start a
+  new Hermes session after install so the tools load.

--- a/optional-mcps/academica-hcp/manifest.yaml
+++ b/optional-mcps/academica-hcp/manifest.yaml
@@ -1,0 +1,41 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: academica-hcp
+description: >-
+  US NPI healthcare-provider identity, taxonomy, credential, and location retrieval.
+source: https://github.com/academica-sh/academica-mcp
+
+# Hosted Streamable HTTP. Read-only evidence retrieval. Hermes does not
+# spawn a local process. One Academica API key authenticates every server
+# in this family (https://academica.sh/mcp/keys).
+transport:
+  type: http
+  url: https://academica.sh/api/mcp/hcp
+  headers:
+    Authorization: "Bearer ${ACADEMICA_API_KEY}"
+
+auth:
+  type: api_key
+  env:
+    - name: ACADEMICA_API_KEY
+      prompt: "Academica API key (https://academica.sh/mcp/keys)"
+      required: true
+      secret: true
+
+suggest:
+  keywords:
+    - NPI
+    - NPPES
+    - healthcare providers
+  hosts:
+    - academica.sh
+
+post_install: |
+  Issue a key at https://academica.sh/mcp/keys. Developer keys are 100
+  calls/month. Privacy: https://academica.sh/legal/privacy. Terms:
+  https://academica.sh/legal/terms.
+
+  The eight Academica catalog entries share ACADEMICA_API_KEY. Start a
+  new Hermes session after install so the tools load.

--- a/optional-mcps/academica-open-payments/manifest.yaml
+++ b/optional-mcps/academica-open-payments/manifest.yaml
@@ -1,0 +1,41 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: academica-open-payments
+description: >-
+  CMS Open Payments transfer-of-value and ownership-disclosure retrieval.
+source: https://github.com/academica-sh/academica-mcp
+
+# Hosted Streamable HTTP. Read-only evidence retrieval. Hermes does not
+# spawn a local process. One Academica API key authenticates every server
+# in this family (https://academica.sh/mcp/keys).
+transport:
+  type: http
+  url: https://academica.sh/api/mcp/open-payments
+  headers:
+    Authorization: "Bearer ${ACADEMICA_API_KEY}"
+
+auth:
+  type: api_key
+  env:
+    - name: ACADEMICA_API_KEY
+      prompt: "Academica API key (https://academica.sh/mcp/keys)"
+      required: true
+      secret: true
+
+suggest:
+  keywords:
+    - open payments
+    - CMS
+    - financial disclosures
+  hosts:
+    - academica.sh
+
+post_install: |
+  Issue a key at https://academica.sh/mcp/keys. Developer keys are 100
+  calls/month. Privacy: https://academica.sh/legal/privacy. Terms:
+  https://academica.sh/legal/terms.
+
+  The eight Academica catalog entries share ACADEMICA_API_KEY. Start a
+  new Hermes session after install so the tools load.

--- a/optional-mcps/academica-provider-market/manifest.yaml
+++ b/optional-mcps/academica-provider-market/manifest.yaml
@@ -1,0 +1,42 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: academica-provider-market
+description: >-
+  NPPES provider identity, declared organization relationships, observed procedure utilization, and account comparisons.
+source: https://github.com/academica-sh/academica-mcp
+
+# Hosted Streamable HTTP. Read-only evidence retrieval. Hermes does not
+# spawn a local process. One Academica API key authenticates every server
+# in this family (https://academica.sh/mcp/keys).
+transport:
+  type: http
+  url: https://academica.sh/api/mcp/provider-market
+  headers:
+    Authorization: "Bearer ${ACADEMICA_API_KEY}"
+
+auth:
+  type: api_key
+  env:
+    - name: ACADEMICA_API_KEY
+      prompt: "Academica API key (https://academica.sh/mcp/keys)"
+      required: true
+      secret: true
+
+suggest:
+  keywords:
+    - NPI
+    - utilization
+    - provider market
+    - accounts
+  hosts:
+    - academica.sh
+
+post_install: |
+  Issue a key at https://academica.sh/mcp/keys. Developer keys are 100
+  calls/month. Privacy: https://academica.sh/legal/privacy. Terms:
+  https://academica.sh/legal/terms.
+
+  The eight Academica catalog entries share ACADEMICA_API_KEY. Start a
+  new Hermes session after install so the tools load.

--- a/optional-mcps/academica-pubmed/manifest.yaml
+++ b/optional-mcps/academica-pubmed/manifest.yaml
@@ -1,0 +1,42 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: academica-pubmed
+description: >-
+  Ranked PubMed literature retrieval with retained source identifiers (PMID, journal, authorship).
+source: https://github.com/academica-sh/academica-mcp
+
+# Hosted Streamable HTTP. Read-only evidence retrieval. Hermes does not
+# spawn a local process. One Academica API key authenticates every server
+# in this family (https://academica.sh/mcp/keys).
+transport:
+  type: http
+  url: https://academica.sh/api/mcp/pubmed
+  headers:
+    Authorization: "Bearer ${ACADEMICA_API_KEY}"
+
+auth:
+  type: api_key
+  env:
+    - name: ACADEMICA_API_KEY
+      prompt: "Academica API key (https://academica.sh/mcp/keys)"
+      required: true
+      secret: true
+
+suggest:
+  keywords:
+    - pubmed
+    - medline
+    - biomedical literature
+    - PMID
+  hosts:
+    - academica.sh
+
+post_install: |
+  Issue a key at https://academica.sh/mcp/keys. Developer keys are 100
+  calls/month. Privacy: https://academica.sh/legal/privacy. Terms:
+  https://academica.sh/legal/terms.
+
+  The eight Academica catalog entries share ACADEMICA_API_KEY. Start a
+  new Hermes session after install so the tools load.

--- a/optional-mcps/academica-reimbursement/manifest.yaml
+++ b/optional-mcps/academica-reimbursement/manifest.yaml
@@ -1,0 +1,43 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: academica-reimbursement
+description: >-
+  Native reimbursement schedules, code evidence, provider economics, jurisdiction coverage, and observed procedure volume.
+source: https://github.com/academica-sh/academica-mcp
+
+# Hosted Streamable HTTP. Read-only evidence retrieval. Hermes does not
+# spawn a local process. One Academica API key authenticates every server
+# in this family (https://academica.sh/mcp/keys).
+transport:
+  type: http
+  url: https://academica.sh/api/mcp/reimbursement
+  headers:
+    Authorization: "Bearer ${ACADEMICA_API_KEY}"
+
+auth:
+  type: api_key
+  env:
+    - name: ACADEMICA_API_KEY
+      prompt: "Academica API key (https://academica.sh/mcp/keys)"
+      required: true
+      secret: true
+
+suggest:
+  keywords:
+    - reimbursement
+    - market access
+    - CMS
+    - HCRIS
+    - MBS
+  hosts:
+    - academica.sh
+
+post_install: |
+  Issue a key at https://academica.sh/mcp/keys. Developer keys are 100
+  calls/month. Privacy: https://academica.sh/legal/privacy. Terms:
+  https://academica.sh/legal/terms.
+
+  The eight Academica catalog entries share ACADEMICA_API_KEY. Start a
+  new Hermes session after install so the tools load.

--- a/optional-mcps/academica-sec-filings/manifest.yaml
+++ b/optional-mcps/academica-sec-filings/manifest.yaml
@@ -1,0 +1,42 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: academica-sec-filings
+description: >-
+  SEC filing sections, filing chronology, XBRL facts, metric traces, and disclosure comparisons.
+source: https://github.com/academica-sh/academica-mcp
+
+# Hosted Streamable HTTP. Read-only evidence retrieval. Hermes does not
+# spawn a local process. One Academica API key authenticates every server
+# in this family (https://academica.sh/mcp/keys).
+transport:
+  type: http
+  url: https://academica.sh/api/mcp/sec-filings
+  headers:
+    Authorization: "Bearer ${ACADEMICA_API_KEY}"
+
+auth:
+  type: api_key
+  env:
+    - name: ACADEMICA_API_KEY
+      prompt: "Academica API key (https://academica.sh/mcp/keys)"
+      required: true
+      secret: true
+
+suggest:
+  keywords:
+    - SEC filings
+    - 10-K
+    - 10-Q
+    - XBRL
+  hosts:
+    - academica.sh
+
+post_install: |
+  Issue a key at https://academica.sh/mcp/keys. Developer keys are 100
+  calls/month. Privacy: https://academica.sh/legal/privacy. Terms:
+  https://academica.sh/legal/terms.
+
+  The eight Academica catalog entries share ACADEMICA_API_KEY. Start a
+  new Hermes session after install so the tools load.

--- a/optional-mcps/academica-sec-ownership/manifest.yaml
+++ b/optional-mcps/academica-sec-ownership/manifest.yaml
@@ -1,0 +1,42 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: academica-sec-ownership
+description: >-
+  Filing-derived institutional positions, manager portfolios, security resolution, and ownership events.
+source: https://github.com/academica-sh/academica-mcp
+
+# Hosted Streamable HTTP. Read-only evidence retrieval. Hermes does not
+# spawn a local process. One Academica API key authenticates every server
+# in this family (https://academica.sh/mcp/keys).
+transport:
+  type: http
+  url: https://academica.sh/api/mcp/sec-ownership
+  headers:
+    Authorization: "Bearer ${ACADEMICA_API_KEY}"
+
+auth:
+  type: api_key
+  env:
+    - name: ACADEMICA_API_KEY
+      prompt: "Academica API key (https://academica.sh/mcp/keys)"
+      required: true
+      secret: true
+
+suggest:
+  keywords:
+    - SEC ownership
+    - 13F
+    - N-PORT
+    - Form 4
+  hosts:
+    - academica.sh
+
+post_install: |
+  Issue a key at https://academica.sh/mcp/keys. Developer keys are 100
+  calls/month. Privacy: https://academica.sh/legal/privacy. Terms:
+  https://academica.sh/legal/terms.
+
+  The eight Academica catalog entries share ACADEMICA_API_KEY. Start a
+  new Hermes session after install so the tools load.


### PR DESCRIPTION
## What

Adds eight Nous-catalog entries under `optional-mcps/` for Academica's hosted, read-only Streamable HTTP MCP servers:

- `academica-pubmed`
- `academica-clinical-trials`
- `academica-open-payments`
- `academica-hcp`
- `academica-sec-ownership`
- `academica-sec-filings`
- `academica-provider-market`
- `academica-reimbursement`

## Why

Hermes users can `hermes mcp install academica-pubmed` (and the rest) instead of hand-writing HTTP config. The public distribution repo is https://github.com/academica-sh/academica-mcp (`v1.4.0`).

## Auth

`auth.type: api_key` with a shared `ACADEMICA_API_KEY`. Hermes writes the key to `~/.hermes/.env`. Transport sends `Authorization: Bearer ${ACADEMICA_API_KEY}`. Keys: https://academica.sh/mcp/keys. Privacy: https://academica.sh/legal/privacy.

## Trust

- Hosted HTTPS only. No `install`, no `command`, no local bootstrap.
- Read-only evidence retrieval. No writes to the source corpora.
- `source:` is the public `academica-sh/academica-mcp` repository.

## Test plan

- [ ] Manifests parse (`hermes mcp catalog` lists all eight).
- [ ] `hermes mcp install academica-pubmed` prompts for `ACADEMICA_API_KEY` and writes the HTTP transport + header.
- [ ] A representative `search` / `lookup` tool returns a non-error content block against `https://academica.sh/api/mcp/pubmed`.