### PR TITLE
fix(state): inherit pinned flag on compression child

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5691,7 +5691,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             parent = conn.execute(
                 """SELECT ended_at, cwd, git_branch, git_repo_root,
                           user_id, session_key, chat_id, chat_type,
-                          thread_id, display_name, origin_json, profile_name
+                          thread_id, display_name, origin_json, profile_name,
+                          pinned
                    FROM sessions WHERE id = ?""",
                 (parent_session_id,),
             ).fetchone()
@@ -5709,8 +5710,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                    system_prompt_hash,
                    parent_session_id, cwd, git_branch, git_repo_root,
                    profile_name, user_id, session_key, chat_id, chat_type,
-                   thread_id, display_name, origin_json, started_at
-                ) VALUES (?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   thread_id, display_name, origin_json, started_at,
+                   pinned
+                ) VALUES (?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     child_session_id,
                     source,
@@ -5735,6 +5737,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     parent["display_name"],
                     parent["origin_json"],
                     time.time(),
+                    # Inherit the parent's pinned flag: a pinned (Desktop
+                    # "keep") session must stay pinned across compression so
+                    # the surfaced tip keeps its place in the pinned list.
+                    parent["pinned"],
                 ),
             )
             total_messages, total_tool_calls = self._insert_message_rows(


### PR DESCRIPTION
## Problem

`publish_compression_child` (the "rotation" compression path) creates a new child session when a conversation gets too long, copying the parent's `cwd`, git metadata, `profile_name`, and gateway routing/origin columns — but **not** the `pinned` flag (the Desktop "keep" flag).

`list_sessions_rich` projects compression roots forward to their live tips: the list entry for a pinned, compressed conversation shows the tip's id/title/last_active. But the tip row has `pinned=0`, so after every compaction the conversation silently drops out of the Desktop pinned list. The user sees their pinned session "disappear" with no action on their part.

## Fix

Inherit `pinned` from the parent row alongside the other copied fields, so a kept conversation stays pinned across compression rotation:

```sql
SELECT ended_at, cwd, git_branch, git_repo_root,
       user_id, session_key, chat_id, chat_type,
       thread_id, display_name, origin_json, profile_name,
       pinned        -- NEW
FROM sessions WHERE id = ?
```

and pass `parent["pinned"]` into the child INSERT.

## Tests

- Syntax + unit exercised via `SessionDB.publish_compression_child` against a temp DB: pinned parent → child inherits `pinned=1`; unpinned parent → child stays `pinned=0`.

## Risk

Low. The child inherits one more column from the parent, matching the existing inheritance contract for the other columns. No schema change, no behavior change for unpinned sessions.

## Scope

- [x] Root cause: compression rotation drops the pinned flag
- [x] Fix at the single inheritance site (`publish_compression_child`)
- [ ] Sibling sites: `archive_and_compact` (in-place compaction) does not create a new session row, so pinned is preserved there by construction — no sibling fix needed.