### PR TITLE
fix(kanban): recover malformed decomposition policy

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -913,6 +913,33 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     )
     p_ctx.add_argument("task_id")
 
+    # --- constraint --- (authenticated non-delegated operator policy)
+    p_constraint = sub.add_parser(
+        "constraint",
+        help="Set/supersede SAME-LINEAGE / NO-DECOMPOSITION, or recover a stale decomposition reservation",
+    )
+    constraint_sub = p_constraint.add_subparsers(
+        dest="constraint_action", required=True
+    )
+    for constraint_action in ("set", "supersede"):
+        parser = constraint_sub.add_parser(
+            constraint_action,
+            help=f"{constraint_action.title()} the SAME-LINEAGE / NO-DECOMPOSITION constraint",
+        )
+        parser.add_argument("task_id")
+        parser.add_argument("constraint", choices=("same-lineage",))
+        parser.add_argument("--reason", required=True, help="Required durable operator audit reason")
+    p_recover = constraint_sub.add_parser(
+        "recover",
+        help="Audit and clear a crash-stale decomposition reservation",
+    )
+    p_recover.add_argument("task_id")
+    p_recover.add_argument(
+        "--older-than-seconds", type=int, required=True,
+        help="Required staleness threshold (60..86400 seconds)",
+    )
+    p_recover.add_argument("--reason", required=True, help="Required durable operator audit reason")
+
     # --- specify --- (triage → todo via auxiliary LLM)
     p_specify = sub.add_parser(
         "specify",
@@ -1148,6 +1175,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "notify-list":        _cmd_notify_list,
             "notify-unsubscribe": _cmd_notify_unsubscribe,
             "context":  _cmd_context,
+            "constraint": _cmd_constraint,
             "specify":  _cmd_specify,
             "decompose":  _cmd_decompose,
             "gc":       _cmd_gc,
@@ -1208,6 +1236,7 @@ _DELEGATED_CHILD_DENIED_ACTIONS: frozenset[str] = frozenset({
     "notify-unsubscribe",
     "specify",
     "decompose",
+    "constraint",
     "gc",
 })
 
@@ -3126,6 +3155,44 @@ def _cmd_specify(args: argparse.Namespace) -> int:
     # --all: succeed if at least one promotion landed; exit 1 only when
     # every candidate failed (honest signal for scripts).
     return 0 if (ok_count > 0 or not ids) else 1
+
+
+def _cmd_constraint(args: argparse.Namespace) -> int:
+    """Non-delegated operator surface for durable decomposition policy."""
+    action = args.constraint_action
+    with kb.connect_closing() as conn:
+        if action == "set":
+            kb.set_decomposition_constraint(
+                conn,
+                args.task_id,
+                constraint=kb.DECOMPOSITION_CONSTRAINT_SAME_LINEAGE,
+                reason=args.reason,
+            )
+            print(
+                f"Set SAME-LINEAGE / NO-DECOMPOSITION on {args.task_id}."
+            )
+            return 0
+        if action == "supersede":
+            kb.supersede_decomposition_constraint(
+                conn, args.task_id, reason=args.reason
+            )
+            print(
+                f"Superseded SAME-LINEAGE / NO-DECOMPOSITION on {args.task_id}."
+            )
+            return 0
+        if action == "recover":
+            recovered = kb.recover_stale_decomposition_reservation(
+                conn,
+                args.task_id,
+                older_than_seconds=args.older_than_seconds,
+                reason=args.reason,
+            )
+            if not recovered:
+                print(f"kanban: no decomposition reservation for {args.task_id}", file=sys.stderr)
+                return 1
+            print(f"Recovered stale decomposition reservation for {args.task_id}.")
+            return 0
+    raise ValueError(f"unknown constraint action {action!r}")
 
 
 def _cmd_decompose(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -939,6 +939,14 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="Required staleness threshold (60..86400 seconds)",
     )
     p_recover.add_argument("--reason", required=True, help="Required durable operator audit reason")
+    p_repair_policy = constraint_sub.add_parser(
+        "repair-policy",
+        help="Append a cursor-bound recovery for malformed/ambiguous decomposition policy history",
+    )
+    p_repair_policy.add_argument("task_id")
+    p_repair_policy.add_argument(
+        "--reason", required=True, help="Required durable operator audit reason"
+    )
 
     # --- specify --- (triage → todo via auxiliary LLM)
     p_specify = sub.add_parser(
@@ -3191,6 +3199,12 @@ def _cmd_constraint(args: argparse.Namespace) -> int:
                 print(f"kanban: no decomposition reservation for {args.task_id}", file=sys.stderr)
                 return 1
             print(f"Recovered stale decomposition reservation for {args.task_id}.")
+            return 0
+        if action == "repair-policy":
+            kb.recover_decomposition_policy(
+                conn, args.task_id, reason=args.reason
+            )
+            print(f"Repaired decomposition policy for {args.task_id}.")
             return 0
     raise ValueError(f"unknown constraint action {action!r}")
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -137,9 +137,11 @@ DECOMPOSITION_CONSTRAINT_SAME_LINEAGE = "same-lineage/no-decomposition"
 _DECOMPOSITION_EVENT_VERSION = 1
 _DECOMPOSITION_CONSTRAINT_EVENT = "decomposition_constraint_set"
 _DECOMPOSITION_SUPERSEDED_EVENT = "decomposition_constraint_superseded"
+_DECOMPOSITION_POLICY_RECOVERED_EVENT = "decomposition_policy_recovered"
 _DECOMPOSITION_RELEVANT_KINDS = (
     _DECOMPOSITION_CONSTRAINT_EVENT,
     _DECOMPOSITION_SUPERSEDED_EVENT,
+    _DECOMPOSITION_POLICY_RECOVERED_EVENT,
 )
 
 
@@ -7137,13 +7139,14 @@ def _decomposition_policy_state(
     """Return (denied, relevant cursor, reason), failing closed on bad events."""
     rows = conn.execute(
         "SELECT id, kind, payload FROM task_events "
-        "WHERE task_id = ? AND kind IN (?, ?) ORDER BY id",
+        "WHERE task_id = ? AND kind IN (?, ?, ?) ORDER BY id",
         (task_id, *_DECOMPOSITION_RELEVANT_KINDS),
     ).fetchall()
     active: dict[int, dict] = {}
     cursor = 0
     malformed = False
     for row in rows:
+        prior_cursor = cursor
         cursor = int(row["id"])
         try:
             payload = json.loads(row["payload"])
@@ -7153,7 +7156,22 @@ def _decomposition_policy_state(
         if not isinstance(payload, dict) or payload.get("version") != _DECOMPOSITION_EVENT_VERSION:
             malformed = True
             continue
-        if row["kind"] == _DECOMPOSITION_CONSTRAINT_EVENT:
+        if row["kind"] == _DECOMPOSITION_POLICY_RECOVERED_EVENT:
+            provenance = payload.get("provenance")
+            reason = payload.get("reason")
+            if (
+                prior_cursor <= 0
+                or payload.get("recovered_through_event_id") != prior_cursor
+                or not isinstance(reason, str)
+                or not reason.strip()
+                or not isinstance(provenance, dict)
+                or provenance.get("prior_state") != "malformed_or_ambiguous"
+            ):
+                malformed = True
+                continue
+            active.clear()
+            malformed = False
+        elif row["kind"] == _DECOMPOSITION_CONSTRAINT_EVENT:
             if payload.get("constraint") != DECOMPOSITION_CONSTRAINT_SAME_LINEAGE:
                 malformed = True
                 continue
@@ -7254,6 +7272,49 @@ def supersede_decomposition_constraint(
                 "version": _DECOMPOSITION_EVENT_VERSION,
                 "constraint_event_id": int(row["id"]),
                 "reason": reason.strip(),
+            },
+        )
+        return int(conn.execute("SELECT last_insert_rowid()").fetchone()[0])
+
+
+def recover_decomposition_policy(
+    conn: sqlite3.Connection, task_id: str, *, reason: str
+) -> int:
+    """Append a cursor-bound recovery for malformed/ambiguous policy history."""
+    if not str(reason or "").strip():
+        raise ValueError("policy recovery reason is required")
+    with write_txn(conn):
+        if conn.execute(
+            "SELECT 1 FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone() is None:
+            raise ValueError("unknown task id")
+        if conn.execute(
+            "SELECT 1 FROM task_decomposition_reservations WHERE task_id = ?",
+            (task_id,),
+        ).fetchone():
+            raise RuntimeError(
+                "decomposition is already reserved; policy was not recovered"
+            )
+        denied, cursor, policy_reason = _decomposition_policy_state(conn, task_id)
+        if not denied or not policy_reason.startswith("malformed or ambiguous"):
+            if policy_reason.startswith("SAME-LINEAGE"):
+                raise RuntimeError(
+                    "valid active SAME-LINEAGE constraint cannot be force-cleared; "
+                    "use constraint supersede"
+                )
+            raise RuntimeError("no malformed or ambiguous policy lock to recover")
+        _append_event(
+            conn,
+            task_id,
+            _DECOMPOSITION_POLICY_RECOVERED_EVENT,
+            {
+                "version": _DECOMPOSITION_EVENT_VERSION,
+                "recovered_through_event_id": cursor,
+                "reason": reason.strip(),
+                "provenance": {
+                    "prior_state": "malformed_or_ambiguous",
+                    "authority_boundary": "non_delegated_operator_process",
+                },
             },
         )
         return int(conn.execute("SELECT last_insert_rowid()").fetchone()[0])

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -133,6 +133,14 @@ VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 # not dispatcher spawn/crash/timeout failures.
 BLOCK_RECURRENCE_LIMIT = 2
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
+DECOMPOSITION_CONSTRAINT_SAME_LINEAGE = "same-lineage/no-decomposition"
+_DECOMPOSITION_EVENT_VERSION = 1
+_DECOMPOSITION_CONSTRAINT_EVENT = "decomposition_constraint_set"
+_DECOMPOSITION_SUPERSEDED_EVENT = "decomposition_constraint_superseded"
+_DECOMPOSITION_RELEVANT_KINDS = (
+    _DECOMPOSITION_CONSTRAINT_EVENT,
+    _DECOMPOSITION_SUPERSEDED_EVENT,
+)
 
 
 def normalize_reasoning_effort(effort: Optional[str]) -> Optional[str]:
@@ -1446,6 +1454,16 @@ CREATE TABLE IF NOT EXISTS task_events (
     kind       TEXT NOT NULL,
     payload    TEXT,
     created_at INTEGER NOT NULL
+);
+
+-- Ephemeral-but-durable decomposition lease. A crash intentionally leaves the
+-- row behind (fail closed); only the bounded operator recovery command may
+-- clear it. Constraint/supersession/recovery provenance remains in task_events.
+CREATE TABLE IF NOT EXISTS task_decomposition_reservations (
+    task_id       TEXT PRIMARY KEY,
+    token         TEXT NOT NULL UNIQUE,
+    event_cursor  INTEGER NOT NULL,
+    reserved_at   INTEGER NOT NULL
 );
 
 -- Historical attempt record. Each time the dispatcher claims a task, a
@@ -7105,6 +7123,241 @@ def invalidate_descendants_for_parent_reopen(
     return {"invalidated": invalidated, "terminations": terminations}
 
 
+@dataclass(frozen=True)
+class DecompositionReservation:
+    ok: bool
+    reason: str
+    token: Optional[str] = None
+    event_cursor: Optional[int] = None
+
+
+def _decomposition_policy_state(
+    conn: sqlite3.Connection, task_id: str
+) -> tuple[bool, int, str]:
+    """Return (denied, relevant cursor, reason), failing closed on bad events."""
+    rows = conn.execute(
+        "SELECT id, kind, payload FROM task_events "
+        "WHERE task_id = ? AND kind IN (?, ?) ORDER BY id",
+        (task_id, *_DECOMPOSITION_RELEVANT_KINDS),
+    ).fetchall()
+    active: dict[int, dict] = {}
+    cursor = 0
+    malformed = False
+    for row in rows:
+        cursor = int(row["id"])
+        try:
+            payload = json.loads(row["payload"])
+        except (TypeError, json.JSONDecodeError):
+            malformed = True
+            continue
+        if not isinstance(payload, dict) or payload.get("version") != _DECOMPOSITION_EVENT_VERSION:
+            malformed = True
+            continue
+        if row["kind"] == _DECOMPOSITION_CONSTRAINT_EVENT:
+            if payload.get("constraint") != DECOMPOSITION_CONSTRAINT_SAME_LINEAGE:
+                malformed = True
+                continue
+            active[int(row["id"])] = payload
+        else:
+            target = payload.get("constraint_event_id")
+            if not isinstance(target, int) or target not in active:
+                malformed = True
+                continue
+            active.pop(target)
+    if malformed:
+        return True, cursor, "malformed or ambiguous decomposition policy events (fail closed)"
+    if len(active) > 1:
+        return True, cursor, "malformed or ambiguous decomposition policy events (fail closed)"
+    if active:
+        return True, cursor, "SAME-LINEAGE / NO-DECOMPOSITION constraint is active"
+    return False, cursor, ""
+
+
+def _append_decomposition_refusal_once(
+    conn: sqlite3.Connection, task_id: str, *, cursor: int, reason: str
+) -> None:
+    rows = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id = ? "
+        "AND kind = 'decomposition_refused' ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchall()
+    expected = {"version": 1, "policy_cursor": cursor, "reason": reason}
+    if rows:
+        try:
+            if json.loads(rows[0]["payload"]) == expected:
+                return
+        except (TypeError, json.JSONDecodeError):
+            pass
+    _append_event(conn, task_id, "decomposition_refused", expected)
+
+
+def set_decomposition_constraint(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    constraint: str,
+    reason: str,
+) -> int:
+    """Durably set the canonical operator constraint, linearized vs reserve."""
+    if constraint != DECOMPOSITION_CONSTRAINT_SAME_LINEAGE:
+        raise ValueError("unsupported decomposition constraint")
+    if not str(reason or "").strip():
+        raise ValueError("constraint reason is required")
+    with write_txn(conn):
+        if conn.execute("SELECT 1 FROM tasks WHERE id = ?", (task_id,)).fetchone() is None:
+            raise ValueError("unknown task id")
+        if conn.execute(
+            "SELECT 1 FROM task_decomposition_reservations WHERE task_id = ?",
+            (task_id,),
+        ).fetchone():
+            raise RuntimeError("decomposition is already reserved; constraint was not set")
+        denied, _, policy_reason = _decomposition_policy_state(conn, task_id)
+        if denied:
+            raise RuntimeError(policy_reason)
+        _append_event(
+            conn,
+            task_id,
+            _DECOMPOSITION_CONSTRAINT_EVENT,
+            {
+                "version": _DECOMPOSITION_EVENT_VERSION,
+                "constraint": constraint,
+                "reason": reason.strip(),
+            },
+        )
+        return int(conn.execute("SELECT last_insert_rowid()").fetchone()[0])
+
+
+def supersede_decomposition_constraint(
+    conn: sqlite3.Connection, task_id: str, *, reason: str
+) -> int:
+    """Remove one canonical constraint via a separate durable operator event."""
+    if not str(reason or "").strip():
+        raise ValueError("supersession reason is required")
+    with write_txn(conn):
+        if conn.execute(
+            "SELECT 1 FROM task_decomposition_reservations WHERE task_id = ?",
+            (task_id,),
+        ).fetchone():
+            raise RuntimeError("decomposition is already reserved; constraint was not superseded")
+        denied, _, policy_reason = _decomposition_policy_state(conn, task_id)
+        if not denied or not policy_reason.startswith("SAME-LINEAGE"):
+            raise RuntimeError(policy_reason or "no active SAME-LINEAGE constraint")
+        row = conn.execute(
+            "SELECT id FROM task_events WHERE task_id = ? AND kind = ? ORDER BY id DESC LIMIT 1",
+            (task_id, _DECOMPOSITION_CONSTRAINT_EVENT),
+        ).fetchone()
+        _append_event(
+            conn,
+            task_id,
+            _DECOMPOSITION_SUPERSEDED_EVENT,
+            {
+                "version": _DECOMPOSITION_EVENT_VERSION,
+                "constraint_event_id": int(row["id"]),
+                "reason": reason.strip(),
+            },
+        )
+        return int(conn.execute("SELECT last_insert_rowid()").fetchone()[0])
+
+
+def reserve_decomposition(conn: sqlite3.Connection, task_id: str) -> DecompositionReservation:
+    """Atomically check policy and uniquely reserve one decomposition attempt."""
+    with write_txn(conn):
+        task = conn.execute("SELECT status FROM tasks WHERE id = ?", (task_id,)).fetchone()
+        if task is None:
+            return DecompositionReservation(False, "unknown task id")
+        if task["status"] != "triage":
+            return DecompositionReservation(False, f"task is not in triage (status={task['status']!r})")
+        denied, cursor, reason = _decomposition_policy_state(conn, task_id)
+        if denied:
+            _append_decomposition_refusal_once(conn, task_id, cursor=cursor, reason=reason)
+            return DecompositionReservation(False, reason, event_cursor=cursor)
+        token = secrets.token_urlsafe(24)
+        try:
+            conn.execute(
+                "INSERT INTO task_decomposition_reservations "
+                "(task_id, token, event_cursor, reserved_at) VALUES (?, ?, ?, ?)",
+                (task_id, token, cursor, int(time.time())),
+            )
+        except sqlite3.IntegrityError:
+            return DecompositionReservation(False, "decomposition is already reserved")
+        return DecompositionReservation(True, "reserved", token, cursor)
+
+
+def _validate_decomposition_reservation(
+    conn: sqlite3.Connection,
+    task_id: str,
+    token: str,
+    expected_cursor: Optional[int],
+) -> None:
+    row = conn.execute(
+        "SELECT token, event_cursor FROM task_decomposition_reservations WHERE task_id = ?",
+        (task_id,),
+    ).fetchone()
+    denied, cursor, reason = _decomposition_policy_state(conn, task_id)
+    if (
+        row is None
+        or not secrets.compare_digest(str(row["token"]), str(token))
+        or expected_cursor is None
+        or int(row["event_cursor"]) != int(expected_cursor)
+        or cursor != int(expected_cursor)
+        or denied
+    ):
+        raise RuntimeError(reason or "decomposition reservation/cursor is no longer valid")
+
+
+def release_decomposition_reservation(
+    conn: sqlite3.Connection, task_id: str, token: str
+) -> bool:
+    """Release only the caller's reservation token."""
+    with write_txn(conn):
+        cur = conn.execute(
+            "DELETE FROM task_decomposition_reservations WHERE task_id = ? AND token = ?",
+            (task_id, token),
+        )
+        return cur.rowcount == 1
+
+
+def recover_stale_decomposition_reservation(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    older_than_seconds: int,
+    reason: str,
+) -> bool:
+    """Operator-only bounded crash recovery with durable audit provenance."""
+    age = int(older_than_seconds)
+    if age < 60 or age > 86400:
+        raise ValueError("older_than_seconds must be between 60 and 86400")
+    if not str(reason or "").strip():
+        raise ValueError("recovery reason is required")
+    now = int(time.time())
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT token, reserved_at FROM task_decomposition_reservations "
+            "WHERE task_id = ?", (task_id,),
+        ).fetchone()
+        if row is None:
+            return False
+        if int(row["reserved_at"]) > now - age:
+            raise RuntimeError("decomposition reservation is not stale enough")
+        conn.execute(
+            "DELETE FROM task_decomposition_reservations WHERE task_id = ?",
+            (task_id,),
+        )
+        _append_event(
+            conn,
+            task_id,
+            "decomposition_reservation_recovered",
+            {
+                "version": 1,
+                "reason": reason.strip(),
+                "older_than_seconds": age,
+                "reserved_at": int(row["reserved_at"]),
+            },
+        )
+        return True
+
+
 def specify_triage_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -7113,6 +7366,8 @@ def specify_triage_task(
     body: Optional[str] = None,
     assignee: Optional[str] = None,
     author: Optional[str] = None,
+    decomposition_token: Optional[str] = None,
+    decomposition_event_cursor: Optional[int] = None,
 ) -> bool:
     """Flesh out a triage task and promote it to ``todo``.
 
@@ -7134,6 +7389,10 @@ def specify_triage_task(
         raise ValueError("title cannot be blank")
     assignee = _canonical_assignee(assignee)
     with write_txn(conn):
+        if decomposition_token is not None:
+            _validate_decomposition_reservation(
+                conn, task_id, decomposition_token, decomposition_event_cursor
+            )
         existing = conn.execute(
             "SELECT title, body, assignee FROM tasks WHERE id = ? AND status = 'triage'",
             (task_id,),
@@ -7204,6 +7463,8 @@ def decompose_triage_task(
     children: list[dict],
     author: Optional[str] = None,
     auto_promote: bool = True,
+    decomposition_token: Optional[str] = None,
+    decomposition_event_cursor: Optional[int] = None,
 ) -> Optional[list[str]]:
     """Fan a triage task out into child tasks and promote the root to ``todo``.
 
@@ -7288,6 +7549,14 @@ def decompose_triage_task(
     now = int(time.time())
     child_ids: list[str] = []
     with write_txn(conn):
+        if decomposition_token is not None:
+            _validate_decomposition_reservation(
+                conn, task_id, decomposition_token, decomposition_event_cursor
+            )
+        else:
+            denied, _, reason = _decomposition_policy_state(conn, task_id)
+            if denied:
+                raise RuntimeError(reason)
         root_row = conn.execute(
             "SELECT id, status, tenant, workspace_kind, workspace_path "
             "FROM tasks WHERE id = ?",

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -274,6 +274,38 @@ def decompose_task(
     author: Optional[str] = None,
     timeout: Optional[int] = None,
 ) -> DecomposeOutcome:
+    """Reserve and enforce durable policy before any decomposer LLM call."""
+    with kb.connect_closing() as conn:
+        reservation = kb.reserve_decomposition(conn, task_id)
+    if not reservation.ok:
+        return DecomposeOutcome(task_id, False, reservation.reason)
+    assert reservation.token is not None
+    try:
+        return _decompose_reserved_task(
+            task_id,
+            author=author,
+            timeout=timeout,
+            reservation_token=reservation.token,
+            reservation_cursor=reservation.event_cursor,
+        )
+    finally:
+        try:
+            with kb.connect_closing() as conn:
+                kb.release_decomposition_reservation(
+                    conn, task_id, reservation.token
+                )
+        except Exception:
+            logger.exception("decompose: failed to release reservation for %s", task_id)
+
+
+def _decompose_reserved_task(
+    task_id: str,
+    *,
+    author: Optional[str] = None,
+    timeout: Optional[int] = None,
+    reservation_token: str,
+    reservation_cursor: Optional[int],
+) -> DecomposeOutcome:
     """Decompose a triage task into a graph of child tasks.
 
     Returns an outcome describing what happened. Never raises for
@@ -361,15 +393,20 @@ def decompose_task(
             return DecomposeOutcome(
                 task_id, False, "decomposer returned fanout=false with no title/body",
             )
-        with kb.connect_closing() as conn:
-            ok = kb.specify_triage_task(
-                conn,
-                task_id,
-                title=title_val,
-                body=body_val,
-                assignee=assignee_val,
-                author=audit_author,
-            )
+        try:
+            with kb.connect_closing() as conn:
+                ok = kb.specify_triage_task(
+                    conn,
+                    task_id,
+                    title=title_val,
+                    body=body_val,
+                    assignee=assignee_val,
+                    author=audit_author,
+                    decomposition_token=reservation_token,
+                    decomposition_event_cursor=reservation_cursor,
+                )
+        except RuntimeError as exc:
+            return DecomposeOutcome(task_id, False, f"DB rejected respecification: {exc}")
         if not ok:
             return DecomposeOutcome(
                 task_id, False, "task moved out of triage before promotion",
@@ -438,6 +475,8 @@ def decompose_task(
                 children=children,
                 author=audit_author,
                 auto_promote=auto_promote,
+                decomposition_token=reservation_token,
+                decomposition_event_cursor=reservation_cursor,
             )
     except ValueError as exc:
         return DecomposeOutcome(task_id, False, f"DB rejected graph: {exc}")

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -100,6 +100,31 @@ def test_constraint_cli_sets_supersedes_and_rejects_delegated_producers(
     assert "superseded" in removed.lower()
 
 
+def test_constraint_repair_policy_cli_is_explicit_and_rejects_delegated_child(
+    kanban_home, monkeypatch
+):
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="malformed policy", triage=True)
+        with kb.write_txn(conn):
+            conn.execute(
+                "INSERT INTO task_events(task_id, kind, payload, created_at) "
+                "VALUES (?, 'decomposition_constraint_set', 'not-json', 1)",
+                (tid,),
+            )
+
+    monkeypatch.setenv("HERMES_DELEGATED_CHILD_CONTEXT", "1")
+    denied = kc.run_slash(
+        f"constraint repair-policy {tid} --reason 'delegated spoof'"
+    )
+    assert "delegate_task child contexts cannot mutate" in denied
+
+    monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT")
+    repaired = kc.run_slash(
+        f"constraint repair-policy {tid} --reason 'operator inspected history'"
+    )
+    assert "repaired decomposition policy" in repaired.lower()
+
+
 def test_board_override_is_isolated_per_concurrent_call(kanban_home, monkeypatch):
     kb.create_board("alpha")
     kb.create_board("beta")

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -12,6 +12,7 @@ import pytest
 
 from hermes_cli import kanban as kc
 from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_decompose as decomp
 
 
 @pytest.fixture
@@ -68,6 +69,35 @@ def test_kanban_show_text_renders_graph_with_open_connection(kanban_home):
     assert f"Task {child_id}: child task" in output
     assert f"parents:   {parent_id}" in output
     assert "Cannot operate on a closed database" not in output
+
+
+def test_constraint_cli_sets_supersedes_and_rejects_delegated_producers(
+    kanban_home, monkeypatch
+):
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="operator guarded", triage=True)
+
+    set_output = kc.run_slash(
+        f"constraint set {tid} same-lineage --reason 'approved guard'"
+    )
+    assert "SAME-LINEAGE" in set_output
+    assert not decomp.decompose_task(tid, author="operator").ok
+
+    monkeypatch.setenv("HERMES_DELEGATED_CHILD_CONTEXT", "1")
+    delegated_set = kc.run_slash(
+        f"constraint set {tid} same-lineage --reason spoof"
+    )
+    delegated_remove = kc.run_slash(
+        f"constraint supersede {tid} same-lineage --reason spoof"
+    )
+    assert "delegate_task child contexts cannot mutate" in delegated_set
+    assert "delegate_task child contexts cannot mutate" in delegated_remove
+
+    monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT")
+    removed = kc.run_slash(
+        f"constraint supersede {tid} same-lineage --reason 'operator release'"
+    )
+    assert "superseded" in removed.lower()
 
 
 def test_board_override_is_isolated_per_concurrent_call(kanban_home, monkeypatch):
@@ -177,5 +207,3 @@ def test_run_slash_reclaim_running_task(kanban_home):
 # ---------------------------------------------------------------------------
 # /kanban help / no-args / unknown-action UX (issue #21794)
 # ---------------------------------------------------------------------------
-
-

--- a/tests/hermes_cli/test_kanban_db_init.py
+++ b/tests/hermes_cli/test_kanban_db_init.py
@@ -123,6 +123,23 @@ def test_migration_is_idempotent(tmp_path, monkeypatch):
         assert len(conn.execute("SELECT * FROM task_events").fetchall()) == 2
 
 
+def test_legacy_board_migration_adds_decomposition_reservations_table(
+    tmp_path, monkeypatch
+):
+    db_path = _setup_home(tmp_path, monkeypatch)
+    _make_legacy_db(db_path)
+
+    with kb.connect(db_path) as conn:
+        columns = {
+            row["name"]
+            for row in conn.execute(
+                "PRAGMA table_info(task_decomposition_reservations)"
+            )
+        }
+
+    assert columns == {"task_id", "token", "event_cursor", "reserved_at"}
+
+
 def test_unseen_events_for_sub_survives_migrated_db(tmp_path, monkeypatch):
     """The crash that motivated #35096 — ``int(None)`` on a NULL cursor — is
     gone after migration; the notifier query returns an integer cursor."""

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -8,6 +8,7 @@ and the assignee-fallback logic.
 from __future__ import annotations
 
 import json as jsonlib
+import threading
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -161,3 +162,202 @@ def test_decompose_returns_false_when_task_not_triage(kanban_home):
     assert "not in triage" in outcome.reason
 
 
+def test_same_lineage_constraint_refuses_before_llm(kanban_home):
+    """A durable operator constraint gates the real entrypoint before inference."""
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="keep this task whole", triage=True)
+        kb.set_decomposition_constraint(
+            conn,
+            tid,
+            constraint=kb.DECOMPOSITION_CONSTRAINT_SAME_LINEAGE,
+            reason="operator approved no decomposition",
+        )
+
+    with patch("agent.auxiliary_client.call_llm") as call_llm:
+        outcome = decomp.decompose_task(tid, author="auto-decomposer")
+
+    assert outcome.ok is False
+    assert "SAME-LINEAGE" in outcome.reason
+    call_llm.assert_not_called()
+
+
+def test_manual_author_spoof_cannot_bypass_and_refusal_audit_is_idempotent(kanban_home):
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="whole", triage=True)
+        kb.set_decomposition_constraint(
+            conn, tid, constraint=kb.DECOMPOSITION_CONSTRAINT_SAME_LINEAGE,
+            reason="keep lineage",
+        )
+
+    for author in ("operator", "root", "auto-decomposer"):
+        assert not decomp.decompose_task(tid, author=author).ok
+
+    with kb.connect_closing() as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM task_events "
+            "WHERE task_id = ? AND kind = 'decomposition_refused'", (tid,),
+        ).fetchone()[0]
+    assert count == 1
+
+
+def test_direct_manual_graph_write_cannot_bypass_constraint(kanban_home):
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="whole", triage=True)
+        kb.set_decomposition_constraint(
+            conn, tid, constraint=kb.DECOMPOSITION_CONSTRAINT_SAME_LINEAGE,
+            reason="keep lineage",
+        )
+        with pytest.raises(RuntimeError, match="SAME-LINEAGE"):
+            kb.decompose_triage_task(
+                conn,
+                tid,
+                root_assignee="operator",
+                children=[{"title": "bypass", "parents": []}],
+                author="operator",
+            )
+        assert kb.get_task(conn, tid).status == "triage"
+
+
+@pytest.mark.parametrize("payload", [None, "not-json", '{"version":1}'])
+def test_malformed_typed_constraint_events_fail_closed_before_llm(kanban_home, payload):
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="whole", triage=True)
+        with kb.write_txn(conn):
+            conn.execute(
+                "INSERT INTO task_events(task_id, kind, payload, created_at) "
+                "VALUES (?, 'decomposition_constraint_set', ?, 1)", (tid, payload),
+            )
+    with patch("agent.auxiliary_client.call_llm") as call_llm:
+        outcome = decomp.decompose_task(tid)
+    assert not outcome.ok
+    assert "malformed or ambiguous" in outcome.reason
+    call_llm.assert_not_called()
+
+
+def test_ambiguous_typed_constraints_fail_closed(kanban_home):
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="whole", triage=True)
+        payload = jsonlib.dumps({
+            "version": 1,
+            "constraint": kb.DECOMPOSITION_CONSTRAINT_SAME_LINEAGE,
+            "reason": "duplicate",
+        })
+        with kb.write_txn(conn):
+            conn.execute(
+                "INSERT INTO task_events(task_id, kind, payload, created_at) "
+                "VALUES (?, 'decomposition_constraint_set', ?, 1)", (tid, payload),
+            )
+            conn.execute(
+                "INSERT INTO task_events(task_id, kind, payload, created_at) "
+                "VALUES (?, 'decomposition_constraint_set', ?, 2)", (tid, payload),
+            )
+    assert not decomp.decompose_task(tid).ok
+
+
+@pytest.mark.parametrize("fanout", [False, True])
+def test_policy_cursor_change_invalidates_respec_and_fanout_writes(
+    kanban_home, fanout
+):
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="race", triage=True)
+    payload = ({
+        "fanout": True,
+        "tasks": [{"title": "child", "body": "x", "assignee": "orchestrator", "parents": []}],
+    } if fanout else {"fanout": False, "title": "changed", "body": "changed"})
+
+    def race_policy(*args, **kwargs):
+        with kb.connect_closing() as conn:
+            with kb.write_txn(conn):
+                conn.execute(
+                    "INSERT INTO task_events(task_id, kind, payload, created_at) "
+                    "VALUES (?, 'decomposition_constraint_set', ?, 1)",
+                    (tid, jsonlib.dumps({
+                        "version": 1,
+                        "constraint": kb.DECOMPOSITION_CONSTRAINT_SAME_LINEAGE,
+                        "reason": "arrived during inference",
+                    })),
+                )
+        return _fake_aux_response(jsonlib.dumps(payload))
+
+    patches = _patch_list_profiles(["orchestrator"])
+    for p in patches:
+        p.start()
+    try:
+        with patch("agent.auxiliary_client.call_llm", side_effect=race_policy):
+            outcome = decomp.decompose_task(tid)
+    finally:
+        for p in patches:
+            p.stop()
+    assert not outcome.ok
+    with kb.connect_closing() as conn:
+        assert kb.get_task(conn, tid).status == "triage"
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_decomposition_reservations WHERE task_id = ?",
+            (tid,),
+        ).fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM task_links").fetchone()[0] == 0
+
+
+def test_reserve_vs_constraint_set_has_exactly_one_winner(kanban_home):
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="linearize", triage=True)
+    barrier = threading.Barrier(2)
+    outcomes = []
+
+    def reserve():
+        with kb.connect_closing() as conn:
+            barrier.wait()
+            outcomes.append(("reserve", kb.reserve_decomposition(conn, tid)))
+
+    def constrain():
+        with kb.connect_closing() as conn:
+            barrier.wait()
+            try:
+                kb.set_decomposition_constraint(
+                    conn, tid,
+                    constraint=kb.DECOMPOSITION_CONSTRAINT_SAME_LINEAGE,
+                    reason="race",
+                )
+            except RuntimeError:
+                outcomes.append(("constraint", False))
+            else:
+                outcomes.append(("constraint", True))
+
+    threads = [threading.Thread(target=reserve), threading.Thread(target=constrain)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    reserve_result = next(value for kind, value in outcomes if kind == "reserve")
+    constraint_result = next(value for kind, value in outcomes if kind == "constraint")
+    assert int(reserve_result.ok) + int(constraint_result) == 1
+
+
+def test_crash_reservation_fails_closed_until_bounded_audited_recovery(kanban_home):
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="crashed decomposer", triage=True)
+        reservation = kb.reserve_decomposition(conn, tid)
+        assert reservation.ok
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE task_decomposition_reservations SET reserved_at = 1 "
+                "WHERE task_id = ?", (tid,),
+            )
+
+    blocked = decomp.decompose_task(tid)
+    assert not blocked.ok
+    assert "already reserved" in blocked.reason
+
+    with kb.connect_closing() as conn:
+        with pytest.raises(ValueError, match="between"):
+            kb.recover_stale_decomposition_reservation(
+                conn, tid, older_than_seconds=0, reason="unsafe",
+            )
+        assert kb.recover_stale_decomposition_reservation(
+            conn, tid, older_than_seconds=60, reason="operator verified crash",
+        )
+        event = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id = ? "
+            "AND kind = 'decomposition_reservation_recovered'", (tid,),
+        ).fetchone()
+        assert jsonlib.loads(event["payload"])["reason"] == "operator verified crash"

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -361,3 +361,179 @@ def test_crash_reservation_fails_closed_until_bounded_audited_recovery(kanban_ho
             "AND kind = 'decomposition_reservation_recovered'", (tid,),
         ).fetchone()
         assert jsonlib.loads(event["payload"])["reason"] == "operator verified crash"
+
+
+@pytest.mark.parametrize("history_kind", ["malformed", "ambiguous"])
+def test_operator_can_append_cursor_bound_policy_recovery_without_rewriting_history(
+    kanban_home, history_kind
+):
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="repair policy", triage=True)
+        with kb.write_txn(conn):
+            if history_kind == "malformed":
+                conn.execute(
+                    "INSERT INTO task_events(task_id, kind, payload, created_at) "
+                    "VALUES (?, 'decomposition_constraint_set', 'not-json', 1)",
+                    (tid,),
+                )
+            else:
+                payload = jsonlib.dumps({
+                    "version": 1,
+                    "constraint": kb.DECOMPOSITION_CONSTRAINT_SAME_LINEAGE,
+                    "reason": "duplicate",
+                })
+                conn.execute(
+                    "INSERT INTO task_events(task_id, kind, payload, created_at) "
+                    "VALUES (?, 'decomposition_constraint_set', ?, 1)",
+                    (tid, payload),
+                )
+                conn.execute(
+                    "INSERT INTO task_events(task_id, kind, payload, created_at) "
+                    "VALUES (?, 'decomposition_constraint_set', ?, 2)",
+                    (tid, payload),
+                )
+        original = conn.execute(
+            "SELECT id, kind, payload FROM task_events WHERE task_id = ? ORDER BY id",
+            (tid,),
+        ).fetchall()
+
+        denied = kb.reserve_decomposition(conn, tid)
+        assert not denied.ok
+        assert "malformed or ambiguous" in denied.reason
+        with pytest.raises(RuntimeError, match="malformed or ambiguous"):
+            kb.supersede_decomposition_constraint(conn, tid, reason="normal removal")
+
+        recovery_id = kb.recover_decomposition_policy(
+            conn, tid, reason="operator inspected corrupt policy history"
+        )
+        after = conn.execute(
+            "SELECT id, kind, payload FROM task_events WHERE task_id = ? ORDER BY id",
+            (tid,),
+        ).fetchall()
+
+        assert [(row["id"], row["kind"], row["payload"]) for row in after[:len(original)]] == [
+            (row["id"], row["kind"], row["payload"]) for row in original
+        ]
+        recovery = after[-1]
+        assert recovery["id"] == recovery_id
+        assert recovery["kind"] == "decomposition_policy_recovered"
+        recovery_payload = jsonlib.loads(recovery["payload"])
+        assert recovery_payload["recovered_through_event_id"] == original[-1]["id"]
+        assert recovery_payload["reason"] == "operator inspected corrupt policy history"
+        assert recovery_payload["provenance"]["prior_state"] == "malformed_or_ambiguous"
+
+        available = kb.reserve_decomposition(conn, tid)
+        assert available.ok
+        kb.release_decomposition_reservation(conn, tid, available.token)
+
+
+@pytest.mark.parametrize(
+    "recovery_payload",
+    [
+        "not-json",
+        jsonlib.dumps({
+            "version": 1,
+            "recovered_through_event_id": 0,
+            "reason": "wrong cursor",
+            "provenance": {"prior_state": "malformed_or_ambiguous"},
+        }),
+    ],
+)
+def test_invalid_policy_recovery_event_is_itself_fail_closed(
+    kanban_home, recovery_payload
+):
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="bad recovery", triage=True)
+        with kb.write_txn(conn):
+            conn.execute(
+                "INSERT INTO task_events(task_id, kind, payload, created_at) "
+                "VALUES (?, 'decomposition_constraint_set', 'not-json', 1)",
+                (tid,),
+            )
+            conn.execute(
+                "INSERT INTO task_events(task_id, kind, payload, created_at) "
+                "VALUES (?, 'decomposition_policy_recovered', ?, 2)",
+                (tid, recovery_payload),
+            )
+
+    with patch("agent.auxiliary_client.call_llm") as call_llm:
+        outcome = decomp.decompose_task(tid)
+    assert not outcome.ok
+    assert "malformed or ambiguous" in outcome.reason
+    call_llm.assert_not_called()
+
+
+def test_policy_recovery_refuses_valid_constraint_and_live_reservation(kanban_home):
+    with kb.connect_closing() as conn:
+        with pytest.raises(ValueError, match="unknown task id"):
+            kb.recover_decomposition_policy(
+                conn, "missing-task", reason="cannot repair missing task"
+            )
+
+        valid_tid = kb.create_task(conn, title="valid guard", triage=True)
+        kb.set_decomposition_constraint(
+            conn, valid_tid,
+            constraint=kb.DECOMPOSITION_CONSTRAINT_SAME_LINEAGE,
+            reason="valid operator policy",
+        )
+        with pytest.raises(RuntimeError, match="valid active SAME-LINEAGE"):
+            kb.recover_decomposition_policy(conn, valid_tid, reason="must not force clear")
+
+        reserved_tid = kb.create_task(conn, title="reserved corrupt policy", triage=True)
+        reservation = kb.reserve_decomposition(conn, reserved_tid)
+        assert reservation.ok
+        with kb.write_txn(conn):
+            conn.execute(
+                "INSERT INTO task_events(task_id, kind, payload, created_at) "
+                "VALUES (?, 'decomposition_constraint_set', 'not-json', 1)",
+                (reserved_tid,),
+            )
+        with pytest.raises(RuntimeError, match="already reserved"):
+            kb.recover_decomposition_policy(
+                conn, reserved_tid, reason="wait for reservation owner"
+            )
+
+
+def test_fresh_constraint_after_policy_recovery_still_blocks_before_llm(kanban_home):
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="repaired then guarded", triage=True)
+        with kb.write_txn(conn):
+            conn.execute(
+                "INSERT INTO task_events(task_id, kind, payload, created_at) "
+                "VALUES (?, 'decomposition_constraint_set', 'not-json', 1)",
+                (tid,),
+            )
+        kb.recover_decomposition_policy(conn, tid, reason="repair corrupt history")
+        kb.set_decomposition_constraint(
+            conn, tid,
+            constraint=kb.DECOMPOSITION_CONSTRAINT_SAME_LINEAGE,
+            reason="fresh valid guard",
+        )
+
+    with patch("agent.auxiliary_client.call_llm") as call_llm:
+        outcome = decomp.decompose_task(tid)
+    assert not outcome.ok
+    assert "SAME-LINEAGE" in outcome.reason
+    call_llm.assert_not_called()
+
+
+def test_new_malformed_event_after_policy_recovery_fails_closed_again(kanban_home):
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="re-corrupted policy", triage=True)
+        with kb.write_txn(conn):
+            conn.execute(
+                "INSERT INTO task_events(task_id, kind, payload, created_at) "
+                "VALUES (?, 'decomposition_constraint_set', 'not-json', 1)",
+                (tid,),
+            )
+        kb.recover_decomposition_policy(conn, tid, reason="first repair")
+        with kb.write_txn(conn):
+            conn.execute(
+                "INSERT INTO task_events(task_id, kind, payload, created_at) "
+                "VALUES (?, 'decomposition_constraint_set', 'still-not-json', 2)",
+                (tid,),
+            )
+
+    outcome = decomp.decompose_task(tid)
+    assert not outcome.ok
+    assert "malformed or ambiguous" in outcome.reason


### PR DESCRIPTION
This PR publishes the reviewed same-lineage auto-decomposer/Kanban guard repair from an exact reviewed commit.

Exact head: `21a820eff7de784321d6df09740d061aa76802a9`

Summary:
- add an explicit `constraint repair-policy` recovery path for malformed/ambiguous decomposition policy history
- preserve append-only history with a cursor-bound recovery event
- keep valid SAME-LINEAGE constraints and live reservations fail-closed
- prevent delegated child contexts from invoking the recovery mutation
- add regression coverage for malformed, ambiguous, stale, delegated, reservation, and re-corruption cases

Reported local review status before publication: independent review PASS for the auto-decomposer prevention fix.