### PR TITLE
feat: Bot Mode blob avatars gain 4 new silhouettes (blobatar 2.0.0)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -113,7 +113,7 @@
     "@xterm/addon-web-links": "0.12.0",
     "@xterm/addon-webgl": "0.19.0",
     "@xterm/xterm": "6.0.0",
-    "blobatar": "0.2.0",
+    "blobatar": "2.0.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "cmdk": "1.1.1",

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -852,17 +852,21 @@ function defaultShapeFor(name) {
 //   'blobatar'                — the face follows the bot's NAME (renaming the
 //                               bot re-rolls the face, live in the dialog)
 //   'blobatar:<seed>'         — seed locked (the 🔒 lock / 🎲 randomize picks)
-//   'blobatar:<seed>:<kind>'  — plus one of the six silhouettes pinned
+//   'blobatar:<seed>:<kind>'  — plus one of the ten silhouettes pinned
 //   'blobatar::<kind>'        — silhouette pinned, seed still follows the name
 // Bot names are slugs (NAME_RE) and generated seeds are base36, so ':' never
 // appears inside a segment. Colors come from the library's own name-derived
 // palette (contrast-guaranteed) — the classic color swatches don't apply.
 
-const BLOB_KINDS = ['round', 'organic', 'boxy', 'nub', 'cloud', 'sun']
+const BLOB_KINDS = ['round', 'organic', 'boxy', 'capsule', 'nub', 'cloud', 'droplet', 'hexagon', 'sun', 'triangle']
 
 // Trait positions at the center of each silhouette band. Band thresholds are
-// frozen per blobatar major (0.28 / 0.58 / 0.72 / 0.84 / 0.93).
-const BLOB_KIND_TRAIT = { round: 0.14, organic: 0.43, boxy: 0.65, nub: 0.78, cloud: 0.885, sun: 0.965 }
+// frozen per blobatar major (gen2: 0.22 / 0.48 / 0.60 / 0.70 / 0.79 / 0.86 /
+// 0.915 / 0.95 / 0.98).
+const BLOB_KIND_TRAIT = {
+  round: 0.11, organic: 0.35, boxy: 0.54, capsule: 0.65, nub: 0.745,
+  cloud: 0.825, droplet: 0.8875, hexagon: 0.9325, sun: 0.965, triangle: 0.99
+}
 
 function isBlobShape(shape) {
   return shape === 'blobatar' || (typeof shape === 'string' && shape.startsWith('blobatar:'))

--- a/apps/desktop/src/plugins/hermes-bots/tests/blobatar-shapes.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/blobatar-shapes.test.mjs
@@ -64,7 +64,11 @@ test('blob shape strings round-trip through parse/build', () => {
 
 test('every silhouette has a trait position inside its frozen band', () => {
   const b = load()
-  const bands = { round: [0, 0.28], organic: [0.28, 0.58], boxy: [0.58, 0.72], nub: [0.72, 0.84], cloud: [0.84, 0.93], sun: [0.93, 1] }
+  const bands = {
+    round: [0, 0.22], organic: [0.22, 0.48], boxy: [0.48, 0.60], capsule: [0.60, 0.70],
+    nub: [0.70, 0.79], cloud: [0.79, 0.86], droplet: [0.86, 0.915], hexagon: [0.915, 0.95],
+    sun: [0.95, 0.98], triangle: [0.98, 1]
+  }
 
   for (const kind of b.BLOB_KINDS) {
     const v = b.BLOB_KIND_TRAIT[kind]

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
         "@xterm/addon-web-links": "0.12.0",
         "@xterm/addon-webgl": "0.19.0",
         "@xterm/xterm": "6.0.0",
-        "blobatar": "0.2.0",
+        "blobatar": "2.0.0",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "cmdk": "1.1.1",
@@ -192,6 +192,20 @@
       },
       "optionalDependencies": {
         "global-agent": "^3.0.0"
+      }
+    },
+    "apps/desktop/node_modules/blobatar": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/blobatar/-/blobatar-2.0.0.tgz",
+      "integrity": "sha512-46STsjELfKv5hnnRYsWKgN1vlWFkaewSkwnqRRnptCD+LwxejfyXs1lYwek4fkwAtGrXabmJHP4fpzDxjnqAEg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "apps/desktop/node_modules/electron": {
@@ -7689,20 +7703,6 @@
       "license": "MIT",
       "peerDependencies": {
         "react": ">=17.0.1"
-      }
-    },
-    "node_modules/blobatar": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/blobatar/-/blobatar-0.2.0.tgz",
-      "integrity": "sha512-TL4blQf9fu+EzsFEKMjh7PVORnf42G9HdpaXzdLR9dTHcMSYJWEj5fPeLhsXTN5YFCNstZaRAQRAWyhW8lRAdw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        }
       }
     },
     "node_modules/bluebird": {


### PR DESCRIPTION
## Summary
Bot Mode blob avatars gain four new silhouettes — capsule, triangle, hexagon and droplet — by upgrading `blobatar` 0.2.0 → 2.0.0 (gen2, ten silhouettes total).

Context: the avatar feature shipped Aug 18 pinned to 0.2.0, which was `latest` at the time; blobatar released 1.0.0 and 2.0.0 within the following 26 hours.

## Changes
- `apps/desktop/package.json` + `package-lock.json`: blobatar 0.2.0 → 2.0.0
- `plugins/hermes-bots/plugin.js`: `BLOB_KINDS` grows 6 → 10; `BLOB_KIND_TRAIT` repinned to gen2 band centers. The avatar picker maps over `BLOB_KINDS`, so the new shapes appear there with zero further wiring
- `tests/blobatar-shapes.test.mjs`: frozen-band test updated to the gen2 band table

## Validation
| Check | Result |
|---|---|
| `node --test blobatar-shapes.test.mjs` | 4/4 pass |
| E2E vs published 2.0.0: each of the 10 pinned trait values resolves to its named silhouette (`layout(traits(seed, true, {shape: v}))`) across 4 seeds | all pin correctly |
| `blobatar/blob` + `blobatar/react` subpath exports still present with same signatures | confirmed |
| SVG renders for every pinned kind | confirmed |

Behavior note (upstream, by design): gen2 remaps the seed→face mapping for roughly two-thirds of names, so most existing unpinned bot faces will change appearance once. Pinned `blobatar:<seed>:<kind>` picks keep their silhouette; stored PNG backfills are unaffected until re-rendered.

## Infographic

![blobatar 2.0.0 upgrade infographic](https://v3b.fal.media/files/b/0aa6ea56/BT6fseQOqP6MsujUyl-d6_T1DozIYQ.png)
