### PR TITLE
fix(cron): stop warning when a fan-out target never had the origin thread

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2629,7 +2629,17 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         origin = _resolve_origin(job) or {}
         origin_thread = origin.get("thread_id")
         if origin_thread and not thread_id:
-            logger.warning(
+            # Only the origin conversation itself losing its thread lane is a
+            # routing fault. A target pointing at some OTHER chat (deliver=all
+            # fan-out, explicit platform:chat_id, home-channel fallback) never
+            # had the origin's thread to lose — that is a deliberate, valid
+            # configuration, so keep it at debug (#89650).
+            same_chat = (
+                str(origin.get("platform", "")).lower() == str(platform_name).lower()
+                and str(origin.get("chat_id", "")) == str(chat_id)
+            )
+            log_fn = logger.warning if same_chat else logger.debug
+            log_fn(
                 "Job '%s': origin has thread_id=%s but delivery target lost it "
                 "(deliver=%s, target=%s)",
                 job["id"], origin_thread, job.get("deliver", "local"), target,

--- a/tests/cron/test_deliver_thread_diagnostic.py
+++ b/tests/cron/test_deliver_thread_diagnostic.py
@@ -1,0 +1,75 @@
+"""Thread-loss delivery diagnostic must not warn on deliberate fan-out.
+
+A job created inside a thread stamps ``origin.thread_id``. Pointing
+``deliver`` at a DIFFERENT channel is an ordinary fan-out configuration —
+that target never had the origin's thread lane, so nothing was "lost" and
+the diagnostic must stay at debug. Only the origin conversation itself
+arriving without its thread lane is a routing fault worth a WARNING
+(#89650: the old unconditional warning fired 10-24x/day on correct setups,
+burying real thread-routing problems).
+"""
+
+import logging
+
+import pytest
+
+from cron import scheduler
+
+
+@pytest.fixture
+def _stub_delivery(monkeypatch):
+    """Stub everything past the diagnostic so _deliver_result exits early."""
+
+    class _StubConfig:
+        platforms = {}
+
+    monkeypatch.setattr(
+        "gateway.config.load_gateway_config", lambda: _StubConfig()
+    )
+    monkeypatch.setattr(
+        "gateway.delivery.resolve_delivery_transport",
+        lambda platform, config, adapters: None,
+    )
+    monkeypatch.setattr(scheduler, "load_config", lambda: {})
+
+
+def _job(origin_thread="t9", deliver="discord:456"):
+    return {
+        "id": "job-1",
+        "name": "job-1",
+        "deliver": deliver,
+        "origin": {
+            "platform": "discord",
+            "chat_id": "123",
+            "thread_id": origin_thread,
+        },
+    }
+
+
+def _run(monkeypatch, caplog, target):
+    monkeypatch.setattr(
+        scheduler, "_resolve_delivery_targets", lambda job: [target]
+    )
+    with caplog.at_level(logging.DEBUG, logger=scheduler.logger.name):
+        scheduler._deliver_result(_job(), "content")
+    return [
+        r for r in caplog.records if "delivery target lost it" in r.getMessage()
+    ]
+
+
+def test_fanout_target_losing_thread_is_debug(monkeypatch, caplog, _stub_delivery):
+    """A target for another chat never had the origin thread: debug, not warning."""
+    records = _run(
+        monkeypatch, caplog,
+        {"platform": "discord", "chat_id": "456", "thread_id": None},
+    )
+    assert [r.levelno for r in records] == [logging.DEBUG]
+
+
+def test_origin_chat_losing_thread_still_warns(monkeypatch, caplog, _stub_delivery):
+    """The origin conversation arriving without its thread lane is a real fault."""
+    records = _run(
+        monkeypatch, caplog,
+        {"platform": "discord", "chat_id": "123", "thread_id": None},
+    )
+    assert [r.levelno for r in records] == [logging.WARNING]


### PR DESCRIPTION
## What does this PR do?

Stops `cron.scheduler`'s thread_id delivery diagnostic from logging a `WARNING` on a valid, ordinary configuration.

A job created inside a thread stamps `origin.thread_id`. Pointing that job's `deliver` at a plain channel is a deliberate fan-out — but the diagnostic warned on every such delivery, reportedly 10–24 times a day across 20 distinct jobs on a correct setup. The wording compounds it: "delivery target lost it" reads as data loss when the target simply never was the origin lane.

The warning gates nothing (delivery proceeds; `last_delivery_error` is `None` on every affected job), so the real cost is that a **genuine** thread-routing problem is indistinguishable from expected noise.

**Why this approach:** the condition only asked "did the origin have a thread and this target doesn't" — it never checked whether the target is the origin conversation at all. A fan-out target pointing at another chat never had the origin's thread to lose. Scoping the warning to the origin conversation mirrors what `_target_matches_origin()` already does for mirroring a few lines below, where a fan-out target is likewise treated as "not the same conversation". No new concept is introduced.

## Related Issue

Fixes #89650

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/scheduler.py` — in `_deliver_result`'s per-target delivery loop, the thread-loss diagnostic now resolves whether the target *is* the origin conversation (same platform and `chat_id`). Warns only in that case; every other target logs at `debug`. Message text is unchanged.
- `tests/cron/test_deliver_thread_diagnostic.py` — new; covers both directions.

## How to Test

1. `pytest tests/cron/test_deliver_thread_diagnostic.py -v`
2. `test_fanout_target_losing_thread_is_debug` — a job whose origin carries a `thread_id` delivering to a *different* chat now logs at DEBUG. Verified this fails on the parent commit (it asserted WARNING before the fix).
3. `test_origin_chat_losing_thread_still_warns` — the origin chat arriving without its thread lane still logs at WARNING, so the real routing fault is not silenced.

Full `tests/cron/` on this branch: **764 passed, 10 failed**. Those same 10 failures reproduce on a clean checkout of the parent commit (I re-ran with my changes stashed), so they are pre-existing and unrelated — Windows-environment issues in `test_scheduler_provider.py`, `test_script_claim_heartbeat.py` and friends. `tests/cron/test_codex_execution_paths.py` cannot be collected here at all: it needs the optional `concurrent_log_handler` module. I have **not** run the entire `tests/` suite green on Windows, so I have not ticked that checklist box.

`scripts/check-windows-footguns.py --diff main`: clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — see **How to Test**: relevant suites pass, but this Windows environment has pre-existing unrelated failures, so I can't honestly tick this
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (Python 3.13)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (comment at the callsite explains the scoping; no user-facing docs describe this diagnostic)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure logging-level logic, no OS-specific behavior; footgun checker clean
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before — one of these per fire, on a correct fan-out config:

```
WARNING cron.scheduler: Job 'daily-brief': origin has thread_id=42 but delivery target lost it (deliver=discord:998, target={'platform': 'discord', 'chat_id': '998', 'thread_id': None})
```

After: the same line is emitted at DEBUG for a fan-out target, and stays at WARNING when the target *is* the origin chat.
