### PR TITLE
fix(dashboard): one models-analytics row per model/provider pair

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15404,23 +15404,63 @@ def _get_models_analytics(days: int = 30, profile: Optional[str] = None):
         # (dedicated vision/compression models) appear on the Models page
         # instead of being invisible (issue #23270). Keyed by
         # model+billing_provider to match the GROUP BY above.
+        #
+        # _aux_usage_rows groups by (model, task, billing_provider), so one
+        # model used for several aux tasks yields several rows for the SAME
+        # (model, billing_provider) pair. Appending them unconditionally
+        # emitted one card per aux task next to the sessions-derived card
+        # (#89631), and their session counts summed past totals.total_sessions
+        # because aux usage happens inside sessions the main row already
+        # counted. Fold into the existing pair when there is one; only a pair
+        # with no sessions-derived row becomes a new row.
+        aux_index: Dict[tuple, Dict[str, Any]] = {
+            (row.get("model") or "", row.get("billing_provider") or ""): row
+            for row in raw_rows
+        }
         for aux in _aux_usage_rows(db, cutoff):
-            raw_rows.append({
-                "model": aux.get("model") or "unknown",
-                "billing_provider": aux.get("billing_provider") or "",
-                "input_tokens": aux.get("input_tokens") or 0,
-                "output_tokens": aux.get("output_tokens") or 0,
-                "cache_read_tokens": aux.get("cache_read_tokens") or 0,
-                "reasoning_tokens": aux.get("reasoning_tokens") or 0,
-                "estimated_cost": aux.get("estimated_cost") or 0,
-                "actual_cost": 0,
-                "sessions": aux.get("sessions") or 0,
-                "api_calls": aux.get("api_calls") or 0,
-                "tool_calls": 0,
-                "last_used_at": aux.get("last_used_at"),
-                "avg_tokens_per_session": 0,
-                "aux_task": aux.get("task") or "",
-            })
+            model = aux.get("model") or "unknown"
+            provider = aux.get("billing_provider") or ""
+            target = aux_index.get((model, provider))
+            if target is None:
+                target = {
+                    "model": model,
+                    "billing_provider": provider,
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "cache_read_tokens": 0,
+                    "reasoning_tokens": 0,
+                    "estimated_cost": 0,
+                    "actual_cost": 0,
+                    # Only an aux-only pair carries its own session count; a
+                    # folded row must not re-count sessions it already has.
+                    "sessions": aux.get("sessions") or 0,
+                    "api_calls": 0,
+                    "tool_calls": 0,
+                    "last_used_at": None,
+                    "avg_tokens_per_session": 0,
+                    "aux_task": aux.get("task") or "",
+                }
+                aux_index[(model, provider)] = target
+                raw_rows.append(target)
+            for key in (
+                "input_tokens",
+                "output_tokens",
+                "cache_read_tokens",
+                "reasoning_tokens",
+                "estimated_cost",
+                "api_calls",
+            ):
+                target[key] = (target.get(key) or 0) + (aux.get(key) or 0)
+            if aux.get("last_used_at") is not None:
+                target["last_used_at"] = max(
+                    target.get("last_used_at") or 0, aux.get("last_used_at") or 0
+                )
+            sessions = target.get("sessions") or 0
+            if sessions:
+                target["avg_tokens_per_session"] = (
+                    (target.get("input_tokens") or 0)
+                    + (target.get("output_tokens") or 0)
+                ) / sessions
 
         # Session rows can be created before the first billable provider call
         # finishes. If that early row records only the model name, and a later

--- a/tests/hermes_cli/test_models_analytics_dedup.py
+++ b/tests/hermes_cli/test_models_analytics_dedup.py
@@ -1,0 +1,79 @@
+"""Models analytics must emit one row per (model, provider) pair (#89631).
+
+``_aux_usage_rows`` groups by (model, task, billing_provider), so a model
+used for several auxiliary tasks returns several rows for the SAME (model,
+billing_provider) pair. Appending them unconditionally rendered one
+duplicate card per aux task, and their session counts summed past
+``totals.total_sessions`` because aux usage happens inside sessions the
+sessions-derived row already counted.
+"""
+
+import time
+
+import pytest
+
+from hermes_cli import web_server
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SessionDB(tmp_path / "state.db")
+
+
+@pytest.fixture
+def analytics(monkeypatch, db):
+    """Run _get_models_analytics against the test DB."""
+    monkeypatch.setattr(
+        web_server,
+        "_open_session_db_for_profile",
+        lambda profile, read_only=True: db,
+    )
+    # The helper closes the DB it is handed; keep it open for assertions.
+    monkeypatch.setattr(db, "close", lambda: None)
+    return lambda: web_server._get_models_analytics(days=30)
+
+
+def _session(db, session_id, model, provider):
+    db.create_session(session_id, source="cli", model=model)
+    with db._lock:
+        db._conn.execute(
+            "UPDATE sessions SET billing_provider = ?, started_at = ? WHERE id = ?",
+            (provider, time.time(), session_id),
+        )
+        db._conn.commit()
+
+
+def test_aux_tasks_do_not_duplicate_the_model_card(db, analytics):
+    """Several aux tasks on one pair fold into that pair's single row."""
+    _session(db, "s1", "gpt-5.6-terra", "openai-codex")
+    for task in ("vision", "compression", "title_generation"):
+        db.record_auxiliary_usage(
+            "s1", task, model="gpt-5.6-terra",
+            billing_provider="openai-codex",
+            input_tokens=100, output_tokens=10,
+        )
+
+    result = analytics()
+    pairs = [(m["model"], m["provider"]) for m in result["models"]]
+
+    assert pairs == [("gpt-5.6-terra", "openai-codex")]
+    # Session counts must stay reconcilable with the totals block.
+    assert sum(m["sessions"] for m in result["models"]) == result["totals"]["total_sessions"]
+    # Aux tokens are still accounted for, just on the one row.
+    assert result["models"][0]["input_tokens"] == 300
+
+
+def test_aux_only_model_still_gets_its_own_row(db, analytics):
+    """Regression guard for #23270 — a dedicated aux model stays visible."""
+    _session(db, "s1", "gpt-5.6-terra", "openai-codex")
+    db.record_auxiliary_usage(
+        "s1", "vision", model="gemini-3-flash", billing_provider="gemini",
+        input_tokens=500, output_tokens=50,
+    )
+
+    result = analytics()
+    pairs = {(m["model"], m["provider"]) for m in result["models"]}
+
+    assert ("gemini-3-flash", "gemini") in pairs
+    assert ("gpt-5.6-terra", "openai-codex") in pairs


### PR DESCRIPTION
## What does this PR do?

Makes `/api/analytics/models` return at most one aggregate row per `(model, provider)` pair, so the Models dashboard stops rendering duplicate cards.

Reported symptom: five cards for two distinct models — `gpt-5.6-terra / openai-codex` three times, `gpt-5.4 / openai-codex` twice — each with different `sessions` and `last_used_at`. The card session counts summed to 13 while `totals.total_sessions` was 6. The duplication is in the API response, not the frontend.

**Root cause.** The sessions query is already correct: it groups by `model, billing_provider`, producing exactly one row per pair. The duplication comes from the aux-usage merge directly below it, which appends unconditionally:

```python
for aux in _aux_usage_rows(db, cutoff):
    raw_rows.append({...})
```

`_aux_usage_rows` groups by `(model, task, billing_provider)` — **one row per aux task**. A model used for vision *and* compression *and* title generation returns three rows carrying the same `(model, billing_provider)` pair, each appended as its own row beside the sessions-derived one. The existing comment ("Keyed by model+billing_provider to match the GROUP BY above") states the intent, but nothing actually keyed on that pair. That also explains the 13-vs-6 mismatch: each appended row carries its own `COUNT(DISTINCT session_id)`, re-counting sessions the sessions-derived row already counted.

**Why this approach.** Indexing by the pair and folding is the smallest change that restores the invariant the comment already claimed, and it keeps the aux-only path (#23270) intact rather than filtering duplicates out downstream, which would have silently dropped dedicated aux models.

## Related Issue

Fixes #89631

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_server.py` — `_get_models_analytics` now indexes the sessions-derived rows by `(model, billing_provider)` and folds aux usage into the matching row. A new row is created only for a pair with **no** sessions-derived row, so dedicated aux-only models stay visible (the behavior #23270 added). Sessions are deliberately **not** accumulated on a fold — aux usage happens inside sessions the main row already counts, which is what inflated the totals; an aux-only row still carries its own session count, as before. `last_used_at` takes the max and `avg_tokens_per_session` is recomputed after folding.
- `tests/hermes_cli/test_models_analytics_dedup.py` — new; covers the fold and guards the aux-only path.

## How to Test

1. `pytest tests/hermes_cli/test_models_analytics_dedup.py -v`
2. `test_aux_tasks_do_not_duplicate_the_model_card` — three aux tasks on one pair produce **one** card, aux tokens are still counted on it, and the card session counts reconcile with `totals.total_sessions`. Verified this fails on the parent commit (three cards, sessions over-counted).
3. `test_aux_only_model_still_gets_its_own_row` — regression guard for #23270: a dedicated aux model keeps its own card. This one passes both before and after by design, so the fix cannot silently drop aux-only models.

Related suites on this branch: `tests/hermes_state/test_aux_usage_accounting.py` all green, and the `dashboard or analytics or usage` selection in `tests/hermes_cli/` gives **320 passed, 11 failed**. The same 11 failures reproduce on a clean checkout of the parent commit (re-run with my changes stashed) — pre-existing Windows-environment issues such as `test_web_server_oauth_write.py`. I have **not** run the entire `tests/` suite green on Windows, so I have not ticked that checklist box.

`scripts/check-windows-footguns.py --diff main`: clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — see **How to Test**: relevant suites pass, but this Windows environment has pre-existing unrelated failures, so I can't honestly tick this
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (Python 3.12 / 3.13)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (the callsite comment now states the pairing invariant and why sessions are not re-counted)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure Python dict aggregation, no OS-specific behavior; footgun checker clean
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Response shape before (redacted, from the issue) — `distinct_models: 2` but five rows:

```json
{"totals": {"distinct_models": 2, "total_sessions": 6},
 "models": [
   {"model":"gpt-5.6-terra","provider":"openai-codex","sessions":4},
   {"model":"gpt-5.4","provider":"openai-codex","sessions":2},
   {"model":"gpt-5.6-terra","provider":"openai-codex","sessions":2},
   {"model":"gpt-5.6-terra","provider":"openai-codex","sessions":3},
   {"model":"gpt-5.4","provider":"openai-codex","sessions":2}]}
```

After: one row per pair, with aux tokens folded onto it and the session counts reconciling with `totals`.
