### PR TITLE
fix(desktop): pass --no-ui to posix update script to skip shim browser window

### DIFF
--- a/apps/desktop/electron/updater-process.test.ts
+++ b/apps/desktop/electron/updater-process.test.ts
@@ -262,7 +262,7 @@ test('resolvePosixScriptHandoff returns the bash recipe when the script exists',
 
   assert.ok(handoff)
   assert.equal(handoff.command, '/bin/bash')
-  assert.deepEqual(handoff.args, [expected])
+  assert.deepEqual(handoff.args, [expected, '--no-ui'])
 })
 
 test('resolvePosixScriptHandoff is null when the checkout predates the script', () => {

--- a/apps/desktop/electron/updater-process.ts
+++ b/apps/desktop/electron/updater-process.ts
@@ -99,7 +99,10 @@ export function resolvePosixScriptHandoff(
 
   return {
     command: '/bin/bash',
-    args: [scriptPath],
+    // --no-ui: skip the shim progress window (opens a throwaway Chrome
+    // window during updates; some users find the popup intrusive, and a
+    // stale window can linger after the update finishes).
+    args: [scriptPath, '--no-ui'],
     scriptPath
   }
 }


### PR DESCRIPTION
## What

The desktop updater spawns `scripts/desktop-update/posix.sh` without any args, so the shim progress UI opens a **throwaway Chrome window during every update** and can leave a stale window behind after the update finishes.

`posix.sh` already supports `--no-ui` (skips `start_ui` entirely); this PR passes it through so updates run silently in the background.

## Why it matters

Users on macOS see a browser popup on every update — intrusive, and the window sometimes doesn't close itself. The flag already exists upstream in the script; the desktop side just never passes it.

## Test

`updater-process.test.ts` updated to assert `args` includes `--no-ui` — 26/26 pass.