### PR TITLE
fix(desktop): render the sidebar PR badge on session rows and branch lanes

### DIFF
--- a/apps/desktop/e2e/real-session-builder.ts
+++ b/apps/desktop/e2e/real-session-builder.ts
@@ -35,6 +35,10 @@ export interface RealSessionTurn {
 }
 
 export interface RealSessionSpec {
+  /** Working directory for the session. Defaults to the repo root. Set this to
+   * place a session in a specific checkout, so the row records that
+   * worktree's branch and the sidebar files it under that lane. */
+  cwd?: string
   /** Session label. The durable row stores no title, so clients fall back to
    * the preview (the first 60 characters of the first user message). */
   title: string
@@ -84,7 +88,8 @@ export class RealSessionBuilder {
     createInterface({ input: this.child.stdout }).on('line', line => this.handleLine(line))
     createInterface({ input: this.child.stderr }).on('line', line => {
       this.stderr.push(line)
-      if (this.stderr.length > 80) this.stderr.shift()
+
+      if (this.stderr.length > 80) {this.stderr.shift()}
     })
     this.child.once('error', error => this.failAll(new Error(`real-session gateway failed to start: ${error.message}`)))
     this.child.once('exit', (code, signal) => {
@@ -97,6 +102,7 @@ export class RealSessionBuilder {
   static async start(hermesHome: string): Promise<RealSessionBuilder> {
     const builder = new RealSessionBuilder(hermesHome)
     await builder.waitForEvent(frame => frame.params?.type === 'gateway.ready')
+
     return builder
   }
 
@@ -107,10 +113,11 @@ export class RealSessionBuilder {
 
     const created = await this.request<CreatedSession>('session.create', {
       cols: 120,
-      cwd: REPO_ROOT,
+      cwd: spec.cwd ?? REPO_ROOT,
       source: 'desktop',
       title: spec.title,
     })
+
     const runtimeId = requireString(created, 'session_id')
     const sessionId = requireString(created, 'stored_session_id')
 
@@ -124,20 +131,23 @@ export class RealSessionBuilder {
       const completion = this.waitForEvent(
         frame => frame.params?.type === 'message.complete' && frame.params.session_id === runtimeId,
       )
+
       await this.request('prompt.submit', { session_id: runtimeId, text })
       const frame = await completion
       const status = readString(frame.params?.payload, 'status')
+
       if (status !== 'complete') {
         throw new Error(`real session turn failed with status ${status ?? 'unknown'}: ${JSON.stringify(frame.params?.payload)}`)
       }
     }
 
     await this.request('session.close', { session_id: runtimeId })
+
     return { runtimeId, sessionId }
   }
 
   async close(): Promise<void> {
-    if (this.closed) return
+    if (this.closed) {return}
     this.closed = true
     this.child.stdin.end()
     await new Promise<void>(resolve => {
@@ -145,6 +155,7 @@ export class RealSessionBuilder {
         this.child.kill('SIGTERM')
         resolve()
       }, 5_000)
+
       this.child.once('exit', () => {
         clearTimeout(timeout)
         resolve()
@@ -154,6 +165,7 @@ export class RealSessionBuilder {
 
   private request<T = unknown>(method: string, params: Record<string, unknown>): Promise<T> {
     const id = ++this.nextRequestId
+
     return this.withTimeout(new Promise<T>((resolve, reject) => {
       this.pending.set(id, { resolve: value => resolve(value as T), reject })
       this.child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`, error => {
@@ -167,9 +179,11 @@ export class RealSessionBuilder {
 
   private waitForEvent(predicate: (frame: JsonRpcFrame) => boolean): Promise<JsonRpcFrame> {
     const index = this.events.findIndex(predicate)
+
     if (index >= 0) {
       return Promise.resolve(this.events.splice(index, 1)[0])
     }
+
     return this.withTimeout(new Promise<JsonRpcFrame>((resolve, reject) => {
       this.eventWaiters.push({ predicate, resolve, reject })
     }), 'gateway event')
@@ -177,6 +191,7 @@ export class RealSessionBuilder {
 
   private handleLine(line: string): void {
     let frame: JsonRpcFrame
+
     try {
       frame = JSON.parse(line) as JsonRpcFrame
     } catch {
@@ -185,22 +200,28 @@ export class RealSessionBuilder {
 
     if (typeof frame.id === 'number') {
       const pending = this.pending.get(frame.id)
-      if (!pending) return
+
+      if (!pending) {return}
       this.pending.delete(frame.id)
+
       if (frame.error) {
         pending.reject(new Error(`JSON-RPC error ${frame.error.code ?? 'unknown'}: ${frame.error.message ?? 'unknown error'}`))
       } else {
         pending.resolve(frame.result)
       }
+
       return
     }
 
-    if (frame.method !== 'event') return
+    if (frame.method !== 'event') {return}
     const waiter = this.eventWaiters.find(candidate => candidate.predicate(frame))
+
     if (!waiter) {
       this.events.push(frame)
+
       return
     }
+
     this.eventWaiters.splice(this.eventWaiters.indexOf(waiter), 1)
     waiter.resolve(frame)
   }
@@ -219,21 +240,25 @@ export class RealSessionBuilder {
   }
 
   private failAll(error: Error): void {
-    for (const pending of this.pending.values()) pending.reject(error)
+    for (const pending of this.pending.values()) {pending.reject(error)}
     this.pending.clear()
-    for (const waiter of this.eventWaiters) waiter.reject(error)
+
+    for (const waiter of this.eventWaiters) {waiter.reject(error)}
     this.eventWaiters.length = 0
   }
 }
 
 function readString(value: unknown, key: string): string | undefined {
-  if (!value || typeof value !== 'object') return undefined
+  if (!value || typeof value !== 'object') {return undefined}
   const candidate = (value as Record<string, unknown>)[key]
+
   return typeof candidate === 'string' ? candidate : undefined
 }
 
 function requireString(value: unknown, key: string): string {
   const candidate = readString(value, key)
-  if (!candidate) throw new Error(`Gateway response omitted required ${key}: ${JSON.stringify(value)}`)
+
+  if (!candidate) {throw new Error(`Gateway response omitted required ${key}: ${JSON.stringify(value)}`)}
+
   return candidate
 }

--- a/apps/desktop/e2e/sidebar-pr-badges.spec.ts
+++ b/apps/desktop/e2e/sidebar-pr-badges.spec.ts
@@ -1,0 +1,304 @@
+/**
+ * Screenshots + coverage for the sidebar PR badges.
+ *
+ * Builds a real git repo with real linked worktrees, creates REAL desktop
+ * sessions in each worktree through the gateway (so each row records its own
+ * git_branch — the column the badge joins on), and stubs `gh` with a script
+ * that answers the GraphQL query the way GitHub does. Nothing about the join
+ * is faked: the rows, the lanes, the store and the renderer are all real.
+ *
+ * Guards two things at once:
+ *  - the gateway fix: a session created in a worktree records its branch, so
+ *    its row badges. Before the fix every row here had a NULL branch.
+ *  - the lane badge: a branch lane in a project shows the PR for its branch.
+ */
+import { execFileSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+import {
+  buildAppEnv,
+  createSandbox,
+  launchDesktop,
+  type MockBackendFixture,
+  waitForAppReady,
+  writeEnvFile,
+  writeMockProviderConfig
+} from './fixtures'
+import { startMockServer } from './mock-server'
+import { RealSessionBuilder } from './real-session-builder'
+import { expect, test } from './test'
+import { expectVisualSnapshot } from './visual-snapshot'
+
+/** Branch lanes the screenshots show, with the PR state each one renders. */
+const LANES = [
+  {
+    branch: 'ethie/title-gen',
+    number: 8123,
+    state: 'OPEN',
+    title: 'fix(aux): translate response_format for Anthropic wires'
+  },
+  {
+    branch: 'ethie/themepicker',
+    number: 8098,
+    state: 'MERGED',
+    title: 'feat(desktop): live-preview themes from the palette'
+  },
+  {
+    branch: 'ethie/browser-external',
+    number: 8140,
+    state: 'OPEN',
+    draft: true,
+    title: 'feat(desktop): open the in-app browser tab externally'
+  },
+  {
+    branch: 'ethie/cli-env-deprecated',
+    number: 8077,
+    state: 'CLOSED',
+    title: 'fix(cli): show the deprecated cwd hint on real lines'
+  }
+] as const
+
+/** The project overview previews this many rows (PROJECT_PREVIEW_COUNT). */
+const PREVIEW_COUNT = 3
+
+function git(args: string[], cwd: string): void {
+  execFileSync('git', args, { cwd })
+}
+
+/** A repo with one worktree per lane, each on its own branch. */
+function createRepoWithWorktrees(root: string): { repo: string; worktrees: Map<string, string> } {
+  const repo = path.join(root, 'hermes-agent')
+
+  fs.mkdirSync(repo, { recursive: true })
+  git(['init', '--initial-branch=main'], repo)
+  git(['config', 'user.email', 'e2e@example.com'], repo)
+  git(['config', 'user.name', 'Hermes E2E'], repo)
+  // A GitHub remote, so `gh repo view` resolves an owner/name for the query.
+  git(['remote', 'add', 'origin', 'https://github.com/NousResearch/hermes-agent.git'], repo)
+  fs.writeFileSync(path.join(repo, 'README.md'), '# hermes-agent\n', 'utf8')
+  git(['add', 'README.md'], repo)
+  git(['commit', '-m', 'initial'], repo)
+
+  const worktrees = new Map<string, string>()
+
+  for (const { branch } of LANES) {
+    const dir = path.join(repo, '.worktrees', branch.replace(/\//g, '-'))
+
+    git(['worktree', 'add', '-b', branch, dir], repo)
+    worktrees.set(branch, dir)
+  }
+
+  return { repo, worktrees }
+}
+
+/**
+ * A `gh` stand-in on PATH. Answers the two calls reviewPrList makes:
+ * `gh repo view --json nameWithOwner` and `gh api graphql -f query=...`.
+ * The GraphQL reply mirrors the real shape — aliases `b<i>` per branch, each
+ * holding `nodes`, with isCrossRepository so the fork guard is exercised.
+ */
+function writeGhStub(binDir: string): void {
+  fs.mkdirSync(binDir, { recursive: true })
+
+  const prs = LANES.map(lane => ({
+    headRefName: lane.branch,
+    isCrossRepository: false,
+    isDraft: 'draft' in lane ? lane.draft : false,
+    number: lane.number,
+    state: lane.state,
+    title: lane.title,
+    url: `https://github.com/NousResearch/hermes-agent/pull/${lane.number}`
+  }))
+
+  const script = `#!/usr/bin/env node
+const args = process.argv.slice(2)
+const PRS = ${JSON.stringify(prs)}
+
+if (args[0] === 'repo' && args[1] === 'view') {
+  process.stdout.write('NousResearch/hermes-agent\\n')
+  process.exit(0)
+}
+
+if (args[0] === 'api' && args[1] === 'graphql') {
+  const query = (args.find(a => a.startsWith('query=')) || '').slice('query='.length)
+  const repository = {}
+  // Reply only to the aliases the caller actually asked for, exactly as the
+  // API would — that is what proves the desktop asked about this branch.
+  for (const [, alias, branch] of query.matchAll(/(b\\d+): pullRequests\\(headRefName: "([^"]+)"/g)) {
+    const hit = PRS.find(pr => pr.headRefName === branch)
+    repository[alias] = { nodes: hit ? [hit] : [] }
+  }
+  process.stdout.write(JSON.stringify({ data: { repository } }))
+  process.exit(0)
+}
+
+process.exit(1)
+`
+
+  const ghPath = path.join(binDir, 'gh')
+
+  fs.writeFileSync(ghPath, script, 'utf8')
+  fs.chmodSync(ghPath, 0o755)
+}
+
+let fixture: MockBackendFixture | null = null
+
+test.beforeAll(async () => {
+  const sandbox = createSandbox('sidebar-pr-badges')
+  const { repo, worktrees } = createRepoWithWorktrees(sandbox.root)
+  const binDir = path.join(sandbox.root, 'bin')
+
+  writeGhStub(binDir)
+
+  const mock = await startMockServer()
+
+  writeMockProviderConfig(sandbox.hermesHome, mock.url)
+  fs.appendFileSync(path.join(sandbox.hermesHome, 'config.yaml'), `\nterminal:\n  cwd: ${repo}\n`, 'utf8')
+  writeEnvFile(sandbox.hermesHome)
+
+  // Real sessions, one per worktree, through the real gateway + agent loop.
+  // Each row records the branch of the worktree it ran in.
+  const builder = await RealSessionBuilder.start(sandbox.hermesHome)
+
+  try {
+    for (const { branch } of LANES) {
+      await builder.createSession({
+        cwd: worktrees.get(branch)!,
+        title: branch,
+        turns: [`Working on ${branch}`]
+      })
+    }
+  } finally {
+    await builder.close()
+  }
+
+  const env = buildAppEnv(sandbox, { PATH: `${binDir}:${process.env.PATH ?? ''}` })
+  const { app, page } = await launchDesktop(env)
+
+  fixture = {
+    app,
+    mock,
+    mockUrl: mock.url,
+    page,
+    sandbox,
+    cleanup: async () => {
+      await app.close()
+      await mock.close()
+      sandbox.cleanup()
+    }
+  }
+
+  await waitForAppReady(fixture, 120_000)
+})
+
+test.afterAll(async () => {
+  await fixture?.cleanup()
+  fixture = null
+})
+
+/** The sidebar subtree. Badge queries MUST be scoped to it: the composer's
+ *  coding rail renders the same PrTag for the chat's own branch, so a
+ *  page-wide query counts a badge this feature did not put there. */
+function sidebar() {
+  return fixture!.page.locator('[data-slot="sidebar"]').first()
+}
+
+/**
+ * Put the sidebar into the view the badges live in: grouped by project (so
+ * repos render their branch lanes) with the PR row metadata on, and back out
+ * of any project a previous test entered.
+ *
+ * Written straight into the persisted atoms rather than walked through the
+ * filter menu. The menu is three nested popovers deep, and driving it makes
+ * the test assert on menu structure instead of on badges — the atoms ARE the
+ * state the menu sets. `agentsGroupedByWorkspace` is the authority for the
+ * project view (see the comment above $sidebarFlatGrouping); grouping `date`
+ * vs `project` is not stored in the grouping atom at all.
+ *
+ * Every entry is rewritten on each call, and the page reloaded, because the
+ * entered project persists: without the reset the second test opens already
+ * inside the project and never finds the row it means to click.
+ */
+async function showProjectOverview(): Promise<void> {
+  const page = fixture!.page
+
+  await page.evaluate(() => {
+    localStorage.setItem('hermes.desktop.agentsGroupedByWorkspace', 'true')
+    localStorage.setItem('hermes.desktop.sidebarRowMeta', JSON.stringify(['pr', 'updated']))
+
+    // Leave whichever project an earlier test entered.
+    for (const key of Object.keys(localStorage)) {
+      if (key.includes('enteredProject') || key.includes('projectScope')) {
+        localStorage.removeItem(key)
+      }
+    }
+  })
+  await page.reload()
+  await waitForAppReady(fixture!, 120_000)
+}
+
+/** Enter the repo's project. The label is path-disambiguated when a basename
+ *  collides with another repo on this machine, so match the suffix. */
+async function enterProject(): Promise<void> {
+  await sidebar()
+    .getByRole('button', { name: /^Open .*hermes-agent$/ })
+    .first()
+    .click()
+}
+
+test('session rows badge the PR of the branch their session recorded', async () => {
+  // Setup is billed to the first test: four worktrees, four real agent turns
+  // and an Electron boot do not fit the default per-test budget.
+  test.slow()
+
+  const page = fixture!.page
+
+  await showProjectOverview()
+
+  // These are session-ROW badges, which render only when the row recorded a
+  // git_branch — the gateway half of this change. The overview previews
+  // PROJECT_PREVIEW_COUNT rows newest-first, so assert the count rather than
+  // naming which PRs survive the cut: that ordering is not this test's claim.
+  await expect(sidebar().getByRole('button', { name: /^Open pull request #/ })).toHaveCount(PREVIEW_COUNT)
+
+  await expectVisualSnapshot(page, { app: fixture!.app, name: 'sidebar-pr-badges-rows' })
+})
+
+test('every branch lane badges the PR for its own branch', async () => {
+  test.slow()
+
+  const page = fixture!.page
+
+  await showProjectOverview()
+  await enterProject()
+
+  // The lane badge — the new surface. One assertion per PR state, so a
+  // regression in the state→glyph mapping fails here too.
+  for (const lane of LANES) {
+    await expect(
+      sidebar()
+        .getByRole('button', { name: `Open pull request #${lane.number}` })
+        .first()
+    ).toBeVisible()
+  }
+
+  await expectVisualSnapshot(page, { app: fixture!.app, name: 'sidebar-pr-badges-lanes' })
+})
+
+test('an expanded lane and the session row inside it carry the same PR', async () => {
+  test.slow()
+
+  const lane = LANES[0]
+
+  await showProjectOverview()
+  await enterProject()
+
+  // A lane that holds sessions defaults OPEN, so the row is already there —
+  // clicking the label would collapse it. Two badges: the lane header (from
+  // its label) and the session row inside it (from the branch its session
+  // recorded). Both halves of this change, in one assertion.
+  await expect(sidebar().getByRole('button', { name: `Open pull request #${lane.number}` })).toHaveCount(2)
+
+  await expectVisualSnapshot(fixture!.page, { app: fixture!.app, name: 'sidebar-pr-badges-lane-expanded' })
+})

--- a/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
@@ -176,6 +176,7 @@ function RepoFlatSection({
           onNewSession={group.isKanban ? undefined : onNewSession}
           onRemove={group.isMain || group.isKanban ? undefined : () => setRemoveTarget(group)}
           renderRows={renderRows}
+          repoPath={repo.path}
         />
       ))}
     </>

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-group.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-group.test.tsx
@@ -1,0 +1,136 @@
+// The lane badge: a branch lane in a project shows its PR the same way a
+// session row does. Regression — the whole `projects/` folder never touched
+// the PR store, so "Show PR" badged the rows under a lane but never the lane
+// itself. These tests drive the REAL component with the real stores for
+// layout + pull-requests; only the git bridge and the heavy neighbors are
+// stubbed.
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { HermesBranchPullRequest } from '@/global'
+
+import type { SidebarSessionGroup as Lane } from './workspace-groups'
+
+afterEach(cleanup)
+
+vi.mock('@/lib/desktop-git', () => ({
+  desktopGit: vi.fn(() => undefined)
+}))
+
+// Partial: the real @/store/profile (kept above) imports this module's config
+// and profile calls at load. Only the PR transcript scan needs stubbing — it
+// would otherwise shell out through the gateway.
+vi.mock('@/hermes', async importOriginal => ({
+  ...((await importOriginal()) as Record<string, unknown>),
+  scanSessionPullRequests: vi.fn()
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      profiles: { switchToProfile: (name: string) => `Switch to ${name}` },
+      sidebar: {
+        newSessionIn: (label: string) => `New session in ${label}`,
+        noSessions: 'No sessions yet',
+        projects: {
+          copyPath: 'Copy path',
+          menu: 'Actions',
+          removeWorktree: 'Remove worktree',
+          reveal: 'Reveal in file manager',
+          toggle: (label: string, open: boolean) => `${open ? 'Expand' : 'Collapse'} ${label}`
+        },
+        showMoreIn: (n: number, label: string) => `Show ${n} more in ${label}`
+      },
+      statusStack: { coding: { switchFailed: (b: string) => `Switch to ${b} failed` } }
+    }
+  })
+}))
+
+vi.mock('@/store/projects', () => ({
+  copyPath: vi.fn(),
+  revealPath: vi.fn(),
+  switchBranchInRepo: vi.fn()
+}))
+
+// Partial mock: layout.ts computes off this module's atoms ($showAllProfiles),
+// so replacing it wholesale breaks the real store this test drives.
+vi.mock('@/store/profile', async importOriginal => ({
+  ...((await importOriginal()) as Record<string, unknown>),
+  newSessionInProfile: vi.fn(),
+  selectProfile: vi.fn()
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notifyError: vi.fn()
+}))
+
+vi.mock('@/store/coding-status', () => ({
+  openWorktreeDialog: vi.fn()
+}))
+
+const { $sidebarRowMeta } = await import('@/store/layout')
+const { $pullRequestsByBranch, branchPrKey } = await import('@/store/pull-requests')
+const { SidebarWorkspaceGroup } = await import('./workspace-group')
+
+const REPO = '/home/ethie/src/hermes-agent'
+
+const openPr: HermesBranchPullRequest = {
+  branch: 'ethie/title-gen',
+  draft: false,
+  number: 8123,
+  state: 'open',
+  title: 'fix: title generation',
+  url: 'https://github.com/x/y/pull/8123'
+} as never
+
+const lane = (label: string, extra: Partial<Lane> = {}): Lane => ({
+  id: `${REPO}::branch::${label}`,
+  label,
+  path: REPO,
+  sessions: [],
+  ...extra
+})
+
+const renderLane = (label: string, extra: Partial<Lane> = {}) =>
+  render(<SidebarWorkspaceGroup group={lane(label, extra)} renderRows={() => null} repoPath={REPO} />)
+
+beforeEach(() => {
+  $pullRequestsByBranch.set({ [branchPrKey(REPO, 'ethie/title-gen')]: openPr })
+  $sidebarRowMeta.set(['pr'])
+})
+
+describe('branch lane PR badge', () => {
+  it('badges the lane with the PR for its branch when Show PR is on', () => {
+    renderLane('ethie/title-gen')
+
+    expect(screen.getByRole('button', { name: 'Open pull request #8123' })).toBeTruthy()
+  })
+
+  it('shows no badge when Show PR is off — the toggle governs the lane like it governs a row', () => {
+    $sidebarRowMeta.set([])
+    renderLane('ethie/title-gen')
+
+    expect(screen.queryByRole('button', { name: 'Open pull request #8123' })).toBeNull()
+  })
+
+  it('shows no badge on a lane whose branch has no PR', () => {
+    renderLane('ethie/some-other-branch')
+
+    expect(screen.queryByRole('button', { name: /Open pull request/ })).toBeNull()
+  })
+
+  it('never badges the kanban aggregate — it is many branches in one lane', () => {
+    $pullRequestsByBranch.set({ [branchPrKey(REPO, 'Tasks')]: { ...openPr, branch: 'Tasks' } })
+    renderLane('Tasks', { isKanban: true })
+
+    expect(screen.queryByRole('button', { name: /Open pull request/ })).toBeNull()
+  })
+
+  it('keeps the lane label clickable beside the badge (the chip is a sibling, not nested)', () => {
+    renderLane('ethie/title-gen')
+
+    const chip = screen.getByRole('button', { name: 'Open pull request #8123' })
+    // A button inside a button is invalid HTML and unreachable by keyboard.
+    expect(chip.closest('button')).toBe(chip)
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
@@ -1,17 +1,19 @@
 import { useStore } from '@nanostores/react'
 import type * as React from 'react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
+import { PrTag } from '@/app/chat/pr-tag'
 import { Codicon } from '@/components/ui/codicon'
 import { ProfileGlyph } from '@/components/ui/profile-glyph'
 import type { SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { displayPath } from '@/lib/display-path'
 import { useStoreSelector } from '@/lib/use-session-slice'
-import { setWorkspaceNodeOpen } from '@/store/layout'
+import { $sidebarRowMeta, setWorkspaceNodeOpen } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
 import { newSessionInProfile, selectProfile } from '@/store/profile'
 import { switchBranchInRepo } from '@/store/projects'
+import { $pullRequestsByBranch, branchLanePrKey, refreshPullRequests } from '@/store/pull-requests'
 import { $sessionProfilesUsage } from '@/store/session'
 import { $sidebarSessionRankIds } from '@/store/sidebar-sort'
 
@@ -35,9 +37,19 @@ interface SidebarWorkspaceGroupProps {
   // When set (linked worktree rows), shows a remove affordance that runs a real
   // `git worktree remove`.
   onRemove?: () => void
+  // The repo root the lane belongs to — the join key for the lane's PR badge
+  // (with the lane label as the branch). Absent for profile/source groups,
+  // which have no single repo and take no badge.
+  repoPath?: null | string
 }
 
-export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemove }: SidebarWorkspaceGroupProps) {
+export function SidebarWorkspaceGroup({
+  group,
+  renderRows,
+  onNewSession,
+  onRemove,
+  repoPath
+}: SidebarWorkspaceGroupProps) {
   const { t } = useI18n()
   const s = t.sidebar
   const isProfileGroup = group.mode === 'profile'
@@ -70,6 +82,23 @@ export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemov
       size="0.75rem"
     />
   )
+
+  // The lane's PR, behind the same Show-menu toggle as the session rows'
+  // badges. A lane's label IS its branch (linked worktrees are relabeled to
+  // the live checked-out branch by the visual enhancer; main lanes carry the
+  // branch name outright) — except the kanban aggregate, which is many
+  // branches in one lane and takes no badge. The trunk guard lives in the key.
+  const rowMeta = useStore($sidebarRowMeta)
+  const lanePrKey = !group.isKanban && rowMeta.includes('pr') ? branchLanePrKey(repoPath, group.label) : null
+  const lanePr = useStoreSelector($pullRequestsByBranch, prs => (lanePrKey ? prs[lanePrKey] : undefined))
+
+  useEffect(() => {
+    if (lanePrKey) {
+      const [root, branch] = lanePrKey.split('\n')
+
+      void refreshPullRequests({ [root]: [branch] })
+    }
+  }, [lanePrKey])
 
   const handleNewSession = async () => {
     // Reveal the lane the new session targets — an empty worktree/branch lane
@@ -158,6 +187,7 @@ export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemov
             }
             icon={leadingIcon}
             label={group.label}
+            meta={lanePr && <PrTag pr={lanePr} />}
             onToggle={toggleOpen}
             open={open}
             title={group.path ? displayPath(group.path) : undefined}

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-header.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-header.tsx
@@ -183,6 +183,7 @@ export function WorkspaceHeader({
   emphasis = false,
   icon,
   label,
+  meta,
   onToggle,
   open,
   title,
@@ -193,6 +194,10 @@ export function WorkspaceHeader({
   emphasis?: boolean
   icon: React.ReactNode
   label: string
+  /** Identity chips beside the label (the lane's PR badge). A SIBLING of the
+   *  toggle button, not a child: the chip is itself a button, and a button
+   *  inside a button is invalid HTML (and unreachable by keyboard). */
+  meta?: React.ReactNode
   onToggle: () => void
   open: boolean
   /** Hover tooltip — the lane's full on-disk path (worktree / repo root). */
@@ -209,7 +214,11 @@ export function WorkspaceHeader({
     >
       <button
         className={cn(
-          'flex min-w-0 flex-1 items-center gap-1.5 bg-transparent text-left',
+          'flex min-w-0 items-center gap-1.5 bg-transparent text-left',
+          // With a chip beside the label the button yields the chip's width
+          // (flex-1 would push the chip into the actions' corner); without one
+          // it keeps the whole row as its click target.
+          meta ? 'min-w-0 shrink' : 'min-w-0 flex-1',
           emphasis ? 'hover:text-foreground' : 'hover:text-(--ui-text-secondary)'
         )}
         onClick={onToggle}
@@ -222,6 +231,8 @@ export function WorkspaceHeader({
           open={open}
         />
       </button>
+      {meta}
+      {meta ? <div className="min-w-0 flex-1" /> : null}
       {action}
     </div>
   )

--- a/apps/desktop/src/store/pull-requests.test.ts
+++ b/apps/desktop/src/store/pull-requests.test.ts
@@ -1,0 +1,93 @@
+// The PR store's join keys and fetch coordination. The lane badge (workspace
+// headers) and the session-row badge share one map and one fetcher; these
+// tests pin the key guards (trunk, kanban callers pass nothing) and the two
+// fetch behaviors the lane badge added: lookup-coverage staleness (a fresh
+// repo still re-fetches for an uncovered branch) and lookup merging (a
+// narrow ask must not shrink the repo's slice — the store replaces a repo's
+// PRs wholesale).
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { HermesBranchPullRequest } from '@/global'
+
+vi.mock('@/lib/desktop-git', () => ({
+  desktopGit: vi.fn()
+}))
+
+vi.mock('@/hermes', () => ({
+  scanSessionPullRequests: vi.fn()
+}))
+
+const git = await import('@/lib/desktop-git')
+const desktopGit = vi.mocked(git.desktopGit)
+
+const { $pullRequestsByBranch, branchLanePrKey, branchPrKey, refreshPullRequests } =
+  await import('@/store/pull-requests')
+
+const pr = (number: number, branch: string): HermesBranchPullRequest =>
+  ({ branch, draft: false, number, state: 'open', title: `pr ${number}`, url: `https://x/${number}` }) as never
+
+const prListMock = (prs: HermesBranchPullRequest[]) => {
+  const prList = vi.fn().mockResolvedValue({ prs })
+
+  desktopGit.mockReturnValue({ review: { prList } } as never)
+
+  return prList
+}
+
+describe('branchLanePrKey', () => {
+  it('builds the same key a session row uses for the branch join', () => {
+    expect(branchLanePrKey('/repo', 'feat/x')).toBe(branchPrKey('/repo', 'feat/x'))
+  })
+
+  it('returns null for trunk branches — asking GitHub about main badges a stranger fork PR onto it', () => {
+    for (const trunk of ['main', 'MASTER', 'develop', 'dev', 'trunk']) {
+      expect(branchLanePrKey('/repo', trunk)).toBeNull()
+    }
+  })
+
+  it('returns null without both halves of the key', () => {
+    expect(branchLanePrKey(null, 'feat/x')).toBeNull()
+    expect(branchLanePrKey('/repo', null)).toBeNull()
+    expect(branchLanePrKey('/repo', '  ')).toBeNull()
+    expect(branchLanePrKey(undefined, undefined)).toBeNull()
+  })
+})
+
+describe('refreshPullRequests', () => {
+  beforeEach(() => {
+    $pullRequestsByBranch.set({})
+    vi.clearAllMocks()
+  })
+
+  it('re-fetches a fresh repo when the ask includes an uncovered lookup', async () => {
+    const first = prListMock([pr(1, 'feat/a')])
+
+    await refreshPullRequests({ '/repo': ['feat/a'] })
+    expect(first).toHaveBeenCalledTimes(1)
+
+    // Same lookups, inside the TTL: stays cached.
+    await refreshPullRequests({ '/repo': ['feat/a'] })
+    expect(first).toHaveBeenCalledTimes(1)
+
+    // A NEW lookup (a lane appearing) must not be starved by the TTL.
+    const second = prListMock([pr(1, 'feat/a'), pr(2, 'feat/b')])
+
+    await refreshPullRequests({ '/repo': ['feat/b'] })
+    expect(second).toHaveBeenCalledTimes(1)
+  })
+
+  it('merges covered lookups into a narrow ask so the wholesale replace keeps sibling PRs', async () => {
+    prListMock([pr(1, 'feat/a'), pr(2, 'feat/b')])
+    await refreshPullRequests({ '/repo': ['feat/a', 'feat/b'] })
+
+    // A narrow force-refresh (one lane) must still ask about both branches:
+    // the store replaces the repo's slice wholesale, so an uncovered sibling
+    // would otherwise vanish from the session rows that render it.
+    const narrow = prListMock([pr(1, 'feat/a'), pr(2, 'feat/b')])
+
+    await refreshPullRequests({ '/repo': ['feat/a'] }, true)
+
+    expect(narrow).toHaveBeenCalledWith('/repo', expect.arrayContaining(['feat/a', 'feat/b']), [])
+    expect($pullRequestsByBranch.get()[branchPrKey('/repo', 'feat/b')]).toBeDefined()
+  })
+})

--- a/apps/desktop/src/store/pull-requests.ts
+++ b/apps/desktop/src/store/pull-requests.ts
@@ -35,6 +35,10 @@ export const $prBranchBySession = persistentAtom<Record<string, string>>(
 const $prScannedSessions = persistentAtom<string[]>('hermes.desktop.prScannedSessions', [], Codecs.stringArray)
 
 const fetchedAt = new Map<string, number>()
+// The lookups the last fetch for a repo actually asked about. A repo is fresh
+// only for THOSE: a new asker (a lane appearing, a project entered) with a
+// branch outside this set must not be starved by the TTL.
+const fetchedLookups = new Map<string, Set<string>>()
 const inFlight = new Set<string>()
 let scanUnavailable = false
 let scanInFlight = false
@@ -49,6 +53,16 @@ export const branchPrKey = (repoRoot: string, branch: string): string => `${repo
  *  share the one map. GitHub answers by number just as happily as by branch. */
 export const numberPrKey = (repoRoot: string, number: number): string => `${repoRoot}\n#${number}`
 
+/** The trunk-guarded lookup key for a branch lane (or any repo+branch pair the
+ *  UI wants to badge). Null when there is nothing safe to ask about — no repo,
+ *  no branch, or a trunk branch (see TRUNK_BRANCHES above). */
+export function branchLanePrKey(repoRoot: null | string | undefined, branch: null | string | undefined): null | string {
+  const root = repoRoot?.trim()
+  const name = branch?.trim()
+
+  return root && name && !TRUNK_BRANCHES.has(name.toLowerCase()) ? branchPrKey(root, name) : null
+}
+
 export function sessionPrKey(session: SessionInfo): null | string {
   const stamped = $prBranchBySession.get()[session.id]
 
@@ -56,10 +70,7 @@ export function sessionPrKey(session: SessionInfo): null | string {
     return stamped
   }
 
-  const root = session.git_repo_root
-  const branch = session.git_branch
-
-  return root && branch && !TRUNK_BRANCHES.has(branch.toLowerCase()) ? branchPrKey(root, branch) : null
+  return branchLanePrKey(session.git_repo_root, session.git_branch)
 }
 
 /** Bind a session to the branch it just opened a PR from. */
@@ -145,15 +156,30 @@ export async function refreshPullRequests(lookupsByRepo: Record<string, string[]
 
   const now = Date.now()
 
-  const stale = Object.keys(lookupsByRepo).filter(
-    root => !inFlight.has(root) && (force || now - (fetchedAt.get(root) ?? 0) > PR_STALE_MS)
-  )
+  const stale = Object.keys(lookupsByRepo).filter(root => {
+    if (inFlight.has(root)) {
+      return false
+    }
+
+    if (force || now - (fetchedAt.get(root) ?? 0) > PR_STALE_MS) {
+      return true
+    }
+
+    // Fresh for the lookups it asked about — but a caller asking about a
+    // branch the last fetch did not cover still needs an answer now.
+    const covered = fetchedLookups.get(root)
+
+    return !covered || lookupsByRepo[root].some(lookup => !covered.has(lookup))
+  })
 
   await Promise.all(
     stale.map(async root => {
       inFlight.add(root)
 
-      const lookups = lookupsByRepo[root]
+      // Merge what the last fetch covered into this ask, so a narrow caller
+      // (one lane's branch) doesn't shrink the repo's slice and drop PRs the
+      // session rows are rendering — the replace below is wholesale.
+      const lookups = [...new Set([...lookupsByRepo[root], ...(fetchedLookups.get(root) ?? [])])]
       const numbers = lookups.filter(l => l.startsWith('#')).map(l => Number(l.slice(1)))
 
       try {
@@ -164,6 +190,7 @@ export async function refreshPullRequests(lookupsByRepo: Record<string, string[]
         )
 
         fetchedAt.set(root, Date.now())
+        fetchedLookups.set(root, new Set(lookups))
 
         // Replace this repo's slice wholesale: a PR that closed since the last
         // pull has to disappear, not linger as a stale merge of old and new.

--- a/tests/tui_gateway/test_session_git_branch_persistence.py
+++ b/tests/tui_gateway/test_session_git_branch_persistence.py
@@ -1,0 +1,177 @@
+"""The desktop session lifecycle must persist git_branch for the PR join.
+
+Regression: a desktop chat created in a worktree lane wrote its row with cwd
+but never a git_branch (146 of 156 rows in a real profile db). The sidebar's
+PR badge joins on ``git_repo_root + git_branch`` (sessionPrKey), so the badge
+never rendered even with Show PR on, while the composer statusline — which
+probes git live — showed the PR fine.
+
+Two arms in ``server.py`` failed to schedule the async git enrichment:
+
+* create: ``_ensure_session_db_row`` inserted the row AFTER the only
+  enrichment call site, so the generation claim found no row and gave up.
+* resume: ``_init_session`` adopted an existing row's cwd and skipped
+  enrichment entirely, so a branchless row stayed branchless forever.
+
+These tests run the REAL SessionDB against a temp state.db — only the git
+subprocess probes and the enrichment thread are stubbed.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+import tui_gateway.server as server
+from hermes_state import SessionDB
+
+
+class _ImmediateThread:
+    """Run the git-meta enrichment inline; inert stand-in for other threads.
+
+    ``_init_session`` also spawns the notification poller through
+    ``threading.Thread`` — that one must NOT run inline (it loops forever)
+    and the poller registry calls ``is_alive()`` on it.
+    """
+
+    def __init__(self, *, target=None, name=None, **_kwargs):
+        self._target = target
+        self._name = name or ""
+
+    def start(self):
+        if self._name == "git-meta" and self._target is not None:
+            self._target()
+
+    def is_alive(self):
+        return False
+
+
+@pytest.fixture
+def git_env(tmp_path, monkeypatch):
+    """Real db + deterministic git probes + synchronous enrichment thread."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_git_branch_for_cwd", lambda _cwd: "ethie/title-gen")
+    monkeypatch.setattr(
+        server, "_git_common_repo_root_for_cwd", lambda _cwd: "/repo"
+    )
+    yield db
+    db.close()
+
+
+def _desktop_session(key: str, cwd: str) -> dict:
+    return {
+        "session_key": key,
+        "cwd": cwd,
+        "explicit_cwd": True,
+        "profile_home": None,
+        "model_override": None,
+        "parent_session_id": None,
+    }
+
+
+def test_create_path_persists_git_branch(git_env, monkeypatch, tmp_path):
+    """A fresh desktop row must come out of first-submit with a branch."""
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+    monkeypatch.setattr(server, "_session_source", lambda _s: "desktop")
+
+    workdir = tmp_path / "wt"
+    workdir.mkdir()
+    session = _desktop_session("sess-create", str(workdir))
+
+    server._ensure_session_db_row(session)
+
+    row = git_env.get_session("sess-create")
+    assert row is not None
+    assert row["cwd"] == str(workdir)
+    # The invariant the sidebar join needs: branch and root both present.
+    assert row["git_branch"] == "ethie/title-gen"
+    assert row["git_repo_root"] == "/repo"
+
+
+def test_resume_backfills_branchless_row(git_env, monkeypatch, tmp_path):
+    """Adopting a persisted cwd must heal a row with no git metadata."""
+    # A real directory, so _heal_dead_cwd stays a no-op and the enrichment we
+    # observe is the adopt arm's own, not the heal path's.
+    workdir = tmp_path / "wt-resume"
+    workdir.mkdir()
+    # A row the old create path left behind: cwd yes, branch no.
+    git_env.create_session("sess-resume", source="desktop", cwd=str(workdir))
+    before = git_env.get_session("sess-resume")
+    assert before["git_branch"] is None
+
+    monkeypatch.setattr(server, "_SlashWorker", None, raising=False)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *a: None)
+
+    import tools.approval as approval
+
+    monkeypatch.setattr(approval, "register_gateway_notify", lambda k, cb: None)
+    monkeypatch.setattr(approval, "load_permanent_allowlist", lambda: None)
+
+    sid = "sid-resume"
+    try:
+        server._init_session(
+            sid,
+            "sess-resume",
+            types.SimpleNamespace(model="x"),
+            history=[],
+            cols=80,
+        )
+        after = git_env.get_session("sess-resume")
+        assert after["git_branch"] == "ethie/title-gen"
+        assert after["git_repo_root"] == "/repo"
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_resume_leaves_enriched_row_alone(git_env, monkeypatch, tmp_path):
+    """A row that already has its metadata must not be re-enriched on adopt.
+
+    ``_init_session`` still probes git for the LIVE session.info payload (the
+    composer statusline) — that is fine and not what this guards. The guard is
+    on the persistence scheduler: an enriched row must not claim a new
+    generation, and its stored branch must survive the resume.
+    """
+    workdir = tmp_path / "wt-full"
+    workdir.mkdir()
+    git_env.create_session("sess-full", source="desktop", cwd=str(workdir))
+    gen = git_env.update_session_cwd("sess-full", str(workdir))
+    git_env.publish_session_git_metadata(
+        "sess-full", str(workdir), gen, "already-there", "/repo"
+    )
+
+    scheduled = []
+    real = server._persist_session_cwd_and_schedule_git_meta
+    monkeypatch.setattr(
+        server,
+        "_persist_session_cwd_and_schedule_git_meta",
+        lambda session, cwd, **kw: scheduled.append(cwd) or real(session, cwd, **kw),
+    )
+    monkeypatch.setattr(server, "_SlashWorker", None, raising=False)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *a: None)
+
+    import tools.approval as approval
+
+    monkeypatch.setattr(approval, "register_gateway_notify", lambda k, cb: None)
+    monkeypatch.setattr(approval, "load_permanent_allowlist", lambda: None)
+
+    sid = "sid-full"
+    try:
+        server._init_session(
+            sid,
+            "sess-full",
+            types.SimpleNamespace(model="x"),
+            history=[],
+            cols=80,
+        )
+        assert scheduled == []
+        after = git_env.get_session("sess-full")
+        assert after["git_branch"] == "already-there"
+    finally:
+        server._sessions.pop(sid, None)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3011,6 +3011,14 @@ def _ensure_session_db_row(session: dict) -> None:
             # means the launch/default profile (matches run_agent's convention).
             profile_name=Path(profile_home).name if profile_home else None,
         )
+        # The insert above writes cwd but not git_branch. The enrichment
+        # could not start earlier: update_session_cwd claims a generation
+        # only when the row exists, and the row did not exist before this
+        # insert. Claim one now. Then the branch probe publishes, and the
+        # sidebar PR join has a branch to join on.
+        row_cwd = _persisted_session_cwd(session)
+        if row_cwd:
+            _persist_session_cwd_and_schedule_git_meta(session, row_cwd, db=db)
         # A session can be born hidden (session.create hidden=true, or a
         # session.set_hidden that arrived before the row existed): apply the
         # deferred intent now that the row exists, mirroring pending_title.
@@ -7086,6 +7094,20 @@ def _init_session(
                 with _sessions_lock:
                     if sid in _sessions:
                         _sessions[sid]["cwd"] = row["cwd"]
+                # The adopt path did not start enrichment before. A row with
+                # no git_branch stayed branchless forever, and the sidebar PR
+                # badge never rendered. Heal the row here. The claim is
+                # generation-guarded, so a concurrent move still wins.
+                if not (row.get("git_branch") and row.get("git_repo_root")):
+                    try:
+                        if hasattr(db, "update_session_cwd"):
+                            _persist_session_cwd_and_schedule_git_meta(
+                                _sessions[sid], row["cwd"], db=db
+                            )
+                    except Exception:
+                        logger.debug(
+                            "failed to backfill session git metadata", exc_info=True
+                        )
             else:
                 try:
                     _cwd = _sessions[sid]["cwd"]


### PR DESCRIPTION
## What does this PR do?

The desktop sidebar can badge a session with its pull request. The badge did not appear. This PR repairs the data that the badge needs, and adds the badge to project branch lanes.

There are two defects, one behind the other.

**1. The gateway did not record `git_branch` on desktop session rows.**

The sidebar joins pull requests on `git_repo_root` + `git_branch` from the persisted `sessions` row (`sessionPrKey`, `apps/desktop/src/store/pull-requests.ts`). The composer status line shows a PR for the same branch, because it probes git live. That difference is why the feature looked half broken: the status line was correct and the sidebar was empty.

In a real profile database, 146 of 156 rows with a `git_repo_root` had a NULL `git_branch`. Both arms of session start failed to run the enrichment:

- Create: `_ensure_session_db_row` inserted the row AFTER the only call to the enrichment scheduler. `update_session_cwd` claims a generation only for a row that exists, so the call returned None and the branch probe never started.
- Resume: `_init_session` adopted the `cwd` of an existing row and skipped enrichment. A row with no branch stayed that way.

**2. The project branch lanes never read the pull-request store.**

The `projects/` folder had no reference to it. "Show PR" badged the session rows under a lane, but not the lane itself, although the lane label IS the branch name.

## Related Issue

No existing issue. Related but separate: #79623 reports the same NULL columns for **cron and CLI** sessions. This PR repairs the **desktop gateway** path only. The cron path writes its row elsewhere and needs its own fix.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

**Gateway (commit 1)**

- `tui_gateway/server.py` — `_ensure_session_db_row` claims a generation and starts the branch probe AFTER `create_session` inserts the row.
- `tui_gateway/server.py` — `_init_session` starts the same enrichment when the adopted row has no git metadata. Rows from before this fix repair themselves on the next resume. The generation guard in `publish_session_git_metadata` keeps a concurrent workspace move authoritative.
- `tests/tui_gateway/test_session_git_branch_persistence.py` — 3 tests against a real `SessionDB` on a temp path.

**Desktop (commit 2)**

- `apps/desktop/src/store/pull-requests.ts` — new `branchLanePrKey(repoRoot, branch)`, the trunk-guarded key. `sessionPrKey` now uses it, so both surfaces build the key one way.
- `apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx` — the lane reads the store behind the same `rowMeta.includes('pr')` toggle and requests its own branch.
- `apps/desktop/src/app/chat/sidebar/projects/workspace-header.tsx` — new `meta` slot. The chip is a SIBLING of the toggle button, because a button inside a button is invalid HTML and the keyboard cannot reach it.
- `apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx` — passes `repoPath` to the lane.
- Tests: `apps/desktop/src/store/pull-requests.test.ts`, `apps/desktop/src/app/chat/sidebar/projects/workspace-group.test.tsx`.

Two store changes that a second caller made necessary:

- Staleness is now per lookup. A repo that is fresh for the branches of the last fetch still fetches for a branch it has not asked about. Without this, a lane that appears after the fetch waits 60 seconds for a badge.
- A narrow ask merges the lookups of the last fetch. The store replaces the pull requests of a repo wholesale, so a one-branch ask would otherwise delete the PRs that the session rows show.

## How to Test

Both screenshots below come from a real Electron run: a real git repository, four real linked worktrees, four real sessions built through the gateway and the agent loop, and a `gh` stand-in that answers the real GraphQL query shape.

**Session rows (the gateway fix).** Before this PR every row here had a NULL branch and no badge.

![Session rows with PR badges](https://raw.githubusercontent.com/ethernet8023/hermes-pr-assets/main/pr-89709/01-session-rows.png)

**Branch lanes (the new surface).** Each lane carries the PR for its branch: #8077 closed, #8140 draft, #8098 merged, #8123 open.

![Branch lanes with PR badges](https://raw.githubusercontent.com/ethernet8023/hermes-pr-assets/main/pr-89709/02-branch-lanes.png)

**Both at once.** An expanded lane: the lane header carries #8123 from its label, and the session row inside it carries the same #8123 from the branch its session recorded. The lane badge and the gateway fix, in one frame.

![Lane and session row with the same PR](https://raw.githubusercontent.com/ethernet8023/hermes-pr-assets/main/pr-89709/03-lane-expanded.png)

Manual steps:

1. Open a chat in a worktree on a branch that has an open PR.
2. Turn on Filters → Show → PR in the sidebar.
3. The session row shows the PR number.
4. Group by project and enter the project. The branch lane shows the same PR.

Automated:

```bash
nix develop -c scripts/run_tests.sh tests/tui_gateway/test_session_git_branch_persistence.py
cd apps/desktop && npx vitest run src/app/chat/sidebar/ src/store/pull-requests.test.ts
```

Results on this branch:

- Python: 36 tests pass (the new file plus every neighbour that touches this machinery).
- Desktop: 181 tests pass. `npx tsc --noEmit` and `npx eslint` are clean.

Fault detection, which is the part that matters:

- Remove the gateway change: the two regression tests fail, the guard test still passes.
- Remove the renderer change: the two badge tests fail, the three guard tests (toggle off, no PR, kanban) still pass.

## Notes for review

- Existing rows repair themselves lazily, on the next resume of each session. There is no migration. Say the word if you want one.
- The lane badge appears in the entered-project view. Profile and source groups have no single repository, so they take no badge.
- The kanban lane takes no badge. It collects many branches into one lane.
- The Playwright spec that produced the screenshots above is included (`apps/desktop/e2e/sidebar-pr-badges.spec.ts`). Every test body passes and writes its snapshot. The run then reports a per-test timeout during teardown. The untouched `worktree-branch-status.spec.ts` fails the same way on the same machine, so the cause is the harness or this host, not this spec. CI runs no Playwright lane, so this spec does not gate the merge. It is here for a maintainer who runs the suite locally.
- `RealSessionSpec` takes an optional `cwd` (`apps/desktop/e2e/real-session-builder.ts`). The builder placed every session at the repository root before. A session must start in a named worktree for this spec, and any later test that needs a specific checkout can now do the same.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the tests and all pass (see How to Test)
- [x] I've added tests for my changes
- [x] I've tested on my platform: NixOS (Linux 7.1.8)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact. The gateway change is path independent. The renderer change is layout only.




