### PR TITLE
fix(desktop): Bot Mode @name-device mentions to remote connections are ignored

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -2625,6 +2625,55 @@ function preferredSessionIds(allMeta) {
   return pins
 }
 
+/** Roster snapshot for imperative readers (mention completions, the mention
+ *  middleware). useRoster keys its query on [...ROSTER_KEY, connectionId] —
+ *  one cache entry per connection the window has been on — so a bare
+ *  getQueryData(ROSTER_KEY) exact-match read misses every entry and the
+ *  readers see an empty roster: completions offer no handles and remote
+ *  @name-device mentions pass through unhandled. Scan the key family
+ *  instead: prefer the active connection's entry, then any other entry (a
+ *  stale roster beats none). Older surfaces that still write the bare key
+ *  are honored by the exact read first. Never throws. */
+function cachedRoster() {
+  try {
+    if (typeof queryClient === 'undefined' || !queryClient || typeof queryClient.getQueryData !== 'function') {
+      return null
+    }
+
+    const exact = queryClient.getQueryData(ROSTER_KEY)
+
+    if (Array.isArray(exact?.profiles)) {
+      return exact
+    }
+
+    if (typeof queryClient.getQueriesData !== 'function') {
+      return null
+    }
+
+    const entries = queryClient.getQueriesData({ queryKey: ROSTER_KEY }) || []
+    const activeConnectionId = String(host.state.connectionId?.get?.() || host.activeConnectionId?.() || 'local')
+    let fallback = null
+
+    for (const [key, value] of entries) {
+      if (!Array.isArray(value?.profiles)) {
+        continue
+      }
+
+      if (String(key?.[ROSTER_KEY.length] || '') === activeConnectionId) {
+        return value
+      }
+
+      if (!fallback) {
+        fallback = value
+      }
+    }
+
+    return fallback
+  } catch {
+    return null
+  }
+}
+
 function useRoster() {
   const activeConnectionId = useValue(host.state.connectionId)
 
@@ -9718,7 +9767,7 @@ export default {
       area: COMPOSER_AREAS.atCompletions,
       data: {
         provide: query => {
-          const roster = queryClient.getQueryData(ROSTER_KEY)
+          const roster = cachedRoster()
           const profiles = Array.isArray(roster?.profiles) ? roster.profiles : []
 
           if (!profiles.length) {
@@ -10023,9 +10072,7 @@ export default {
             name: (host.state.profile.get() || 'default').trim() || 'default',
             connectionId: String(host.state.connectionId?.get?.() || host.activeConnectionId?.() || 'local')
           }
-          const cached = typeof queryClient !== 'undefined' && queryClient && typeof queryClient.getQueryData === 'function'
-            ? queryClient.getQueryData(ROSTER_KEY)
-            : null
+          const cached = cachedRoster()
           const roster = Array.isArray(cached?.profiles) ? cached.profiles : null
           let mentionedBots = roster ? resolveRosterMentions(text, roster, live) : []
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/mention-roster-cache-key.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/mention-roster-cache-key.test.mjs
@@ -1,0 +1,210 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// useRoster() keys its query on [...ROSTER_KEY, connectionId] — one cache
+// entry per connection the window has been on. The imperative roster readers
+// (the @mention completions and the mention middleware) used to call
+// getQueryData(ROSTER_KEY) with the BARE key, which is an exact-key match in
+// TanStack Query and therefore matched NOTHING: completions offered no
+// roster handles and remote @name-device mentions passed through the
+// middleware unhandled (the local profiles.list fallback only knows bare
+// local names). Reproduced on a two-source install where the same profile
+// name exists locally and on an SSH connection ("Vera"): typing
+// `@default-vera` did nothing. These tests model the REAL cache semantics —
+// entries stored under the suffixed key, exact-key reads missing them,
+// prefix reads finding them — so the key-shape regression is pinned.
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+/** Faithful-enough TanStack Query v5 cache: getQueryData matches ONLY the
+ *  exact key, getQueriesData prefix-matches a key family. */
+function makeQueryClient() {
+  const entries = new Map()
+  const keyOf = key => JSON.stringify(key)
+
+  return {
+    setQueryData: (key, value) => {
+      entries.set(keyOf(key), { key, value })
+    },
+    getQueryData: key => entries.get(keyOf(key))?.value,
+    getQueriesData: ({ queryKey }) =>
+      [...entries.values()]
+        .filter(({ key }) => queryKey.every((part, index) => key[index] === part))
+        .map(({ key, value }) => [key, value]),
+    invalidateQueries: () => undefined
+  }
+}
+
+// One profile name on two sources: locally and on the SSH connection "vera".
+// The union roster disambiguates the remote row as @default-vera.
+const ROSTER = {
+  profiles: [
+    { name: 'default', connectionId: 'local', connectionKind: 'local', connectionLabel: 'This device' },
+    {
+      name: 'default',
+      handle: 'default-vera',
+      connectionId: 'vera',
+      connectionKind: 'ssh',
+      connectionLabel: 'Vera',
+      remoteSource: true,
+      sourceScoped: true
+    }
+  ]
+}
+
+function load({ cacheKeyConnection = 'local' } = {}) {
+  const registrations = []
+  const delivered = []
+  let submitted = false
+  const atom = value => {
+    let current = value
+
+    return { get: () => current, set: next => (current = next), listen: () => () => undefined }
+  }
+  const jsx = (type, props = {}) => ({ type, props })
+  const queryClient = makeQueryClient()
+
+  // Exactly where useRoster writes it: suffixed with the connection id.
+  queryClient.setQueryData(['hermes-bots', 'roster', cacheKeyConnection], ROSTER)
+
+  const context = {
+    atom,
+    jsx,
+    jsxs: jsx,
+    useQuery: () => ({}),
+    useValue: v => (v?.get ? v.get() : v),
+    useState: v => [v, () => undefined],
+    setTimeout,
+    clearTimeout,
+    performance,
+    window: {
+      setTimeout,
+      clearTimeout,
+      performance,
+      requestAnimationFrame: () => 0,
+      cancelAnimationFrame: () => undefined,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined
+    },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    queryClient,
+    host: {
+      state: {
+        profile: { get: () => 'default', listen: () => () => undefined },
+        connectionId: { get: () => 'local', listen: () => () => undefined },
+        gateway: { get: () => null, listen: () => () => undefined }
+      },
+      request: async () => ({}),
+      requestProfile: async (route, method, params) => {
+        delivered.push([route?.connectionId, route?.profile, method])
+
+        if (method === 'profiles.list') {
+          return {
+            profiles: [{ name: 'default', ui_meta: { 'hermes-bots': { chat: 'remote-pin' } } }]
+          }
+        }
+
+        if (method === 'session.resume') {
+          if (params?.omit_messages) {
+            return { session_id: 'remote-1', session_key: 'remote-pin' }
+          }
+
+          // Baseline read before the submit, then the reply poll after it:
+          // once the submit happened, hand back an assistant message so the
+          // bounded reply poll terminates on its first pass (~2s) instead of
+          // idling until the 180s timeout.
+          if (!submitted) {
+            return { messages: [] }
+          }
+
+          return {
+            messages: [
+              { role: 'user', content: 'ping' },
+              { role: 'assistant', content: 'first' },
+              { role: 'assistant', content: 'ok' }
+            ]
+          }
+        }
+
+        if (method === 'prompt.submit') {
+          submitted = true
+        }
+
+        return {}
+      },
+      onEvent: () => () => undefined
+    },
+    COMPOSER_AREAS: { middleware: 'composer.middleware', atCompletions: 'composer.atCompletions' },
+    PALETTE_AREA: 'palette',
+    sdk: new Proxy({}, { get: () => undefined })
+  }
+  const code = pluginSource
+    .replace(/^import \* as sdk from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat('\nglobalThis.__botMeta = $botMeta;')
+  vm.runInNewContext(code, context)
+  context.__botMeta.set({})
+
+  const ctx = {
+    register: c => registrations.push(c),
+    storage: { get: async () => undefined, set: async () => undefined }
+  }
+
+  try {
+    context.plugin.register(ctx)
+  } catch {
+    /* registration walks UI surfaces the stub doesn't fully model — the
+       contributions registered before any throw are what we assert on */
+  }
+
+  const completions = registrations.find(c => c.id === 'mention-completions')
+  const middleware = registrations.find(c => c.id === 'mention-middleware')
+  assert.ok(completions, 'mention-completions contribution registered')
+  assert.ok(middleware, 'mention middleware registered')
+
+  return { provide: completions.data.provide, handler: middleware.data.handler, delivered, queryClient }
+}
+
+test('the roster cache entry lives under the connection-suffixed key, invisible to the bare-key read', () => {
+  // Documents the regression's shape: the entry useRoster writes is NOT
+  // reachable through an exact getQueryData(ROSTER_KEY).
+  const { queryClient } = load()
+
+  assert.equal(queryClient.getQueryData(['hermes-bots', 'roster']), undefined)
+  assert.equal(queryClient.getQueriesData({ queryKey: ['hermes-bots', 'roster'] }).length, 1)
+})
+
+test('mention completions offer remote @name-device handles from the suffixed cache entry', () => {
+  const { provide } = load()
+  const inserts = provide('').map(item => item.insert)
+
+  assert.ok(inserts.includes('@default-vera'), `expected @default-vera in ${JSON.stringify(inserts)}`)
+})
+
+test('the middleware resolves a remote @name-device mention and routes delivery over Connections', async () => {
+  const { handler, delivered } = load()
+  const result = await handler({ text: '@default-vera what is the disk space on the server?' })
+
+  assert.match(result.text, /stay on this device/i)
+  assert.match(result.text, /@default-vera/)
+  // No local CLI handoff is composed for remote bots — only the note's
+  // "do not run hermes -p" instruction must mention the phrase.
+  assert.doesNotMatch(result.text, /hermes -p '?default/)
+  await new Promise(resolve => setTimeout(resolve, 0))
+  assert.ok(delivered.length > 0, 'remote delivery dispatched')
+  assert.equal(delivered[0][0], 'vera')
+  assert.equal(delivered[0][1], 'default')
+})
+
+test('a roster cached under another connection id still resolves (fallback entry)', () => {
+  // The window moved connections; the stale entry is the only one cached.
+  const { provide } = load({ cacheKeyConnection: 'vera' })
+  const inserts = provide('').map(item => item.insert)
+
+  assert.ok(inserts.includes('@default-vera'), `expected @default-vera in ${JSON.stringify(inserts)}`)
+})


### PR DESCRIPTION
## What does this PR do?

Fixes a Bot Mode regression where `@name-device` mentions to agents on **other registered connections** (e.g. an SSH host) are silently ignored — the message goes to the local agent instead of being routed over Connections.

**Root cause.** `useRoster()` keys its query on `[...ROSTER_KEY, connectionId]` (one cache entry per connection the window has been on — added in `ed20a6f01af`), but the two imperative roster readers — the `@`-mention completions and the mention middleware — still read `queryClient.getQueryData(ROSTER_KEY)`. TanStack Query's `getQueryData` is an **exact-key** match, so the bare key matches nothing and both readers see an empty roster:

- the composer offers no agent handles in the `@` popover, and
- remote `@name-device` mentions fall through to the local `profiles.list` fallback, which only knows bare **local** names — so `@default-vera` (a same-named `default` profile on an SSH connection) passes through untouched to the local agent.

The `invalidateQueries({ queryKey: ROSTER_KEY })` call sites were unaffected (prefix matching), which is why only the reads broke. The existing tests stubbed `getQueryData` to ignore the key entirely — which is exactly why the key-shape mismatch slipped through.

**Fix.** Adds a `cachedRoster()` helper used by both readers: honor a legacy bare-key entry first, then scan the key family via `getQueriesData({ queryKey: ROSTER_KEY })`, preferring the **active** connection's entry and falling back to any other entry (a stale roster beats none). Never throws, matching the readers' existing posture. No changes to the write path, `useRoster`, or the `@name-device` computation in Electron (`buildAgentRoster`).

**Reproduced on:** a two-source install where the same profile name (`default`) exists locally and on a registered SSH connection — the Bots roster renders the remote agent as `@default-vera`, but typing `@default-vera …` in the composer delivers nothing to the remote machine (the local agent answers instead).

## Related Issue

<!-- No existing issue found; happy to file one if preferred. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.js`
  - New `cachedRoster()` helper: exact bare-key read first (legacy surfaces), then a prefix scan of the `[...ROSTER_KEY, connectionId]` key family — active connection preferred, any other entry as fallback.
  - `mention-completions` (`provide`) and `mention-middleware` now read through `cachedRoster()` instead of `getQueryData(ROSTER_KEY)`.
- `apps/desktop/src/plugins/hermes-bots/tests/mention-roster-cache-key.test.mjs` (new)
  - Models the **real** cache semantics (entries stored under the suffixed key; exact-key reads miss them; prefix reads find them) and pins: completions offer `@default-vera`, the middleware resolves the remote mention and dispatches delivery via `host.requestProfile` to the right connection/profile, and a roster cached under another connection id still resolves as fallback.

## How to Test

1. `cd apps/desktop && node --test src/plugins/hermes-bots/tests/mention-roster-cache-key.test.mjs` — 4/4 pass (on `main`, tests 2–4 fail with the bare-key read).
2. Full Bot Mode suite: `node --test src/plugins/hermes-bots/tests/*.test.mjs` — 292/292 pass.
3. Manual: register an SSH connection that exposes a profile with the same name as a local one, then type `@<name>-<device> …` in any composer — the `@` popover now offers the handle, and the message is delivered to the remote agent's Bot Chat over Connections.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A for this change (desktop plugin only); `node --test src/plugins/hermes-bots/tests/*.test.mjs` runs green (292/292)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A — N/A (behavior matches the documented `@name-device` contract in `website/docs/user-guide/multi-connection-desktop.md`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A — renderer-only cache read; no platform-specific APIs used
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A — N/A

## Screenshots / Logs

```
# main (before): regression tests fail
not ok 2 - mention completions offer remote @name-device handles from the suffixed cache entry
  error: 'expected @default-vera in []'
not ok 3 - the middleware resolves a remote @name-device mention and routes delivery over Connections
not ok 4 - a roster cached under another connection id still resolves (fallback entry)

# this PR: green
ok 1 - the roster cache entry lives under the connection-suffixed key, invisible to the bare-key read
ok 2 - mention completions offer remote @name-device handles from the suffixed cache entry
ok 3 - the middleware resolves a remote @name-device mention and routes delivery over Connections
ok 4 - a roster cached under another connection id still resolves (fallback entry)
# tests 4 / pass 4 / fail 0
```
