### PR TITLE
fix(zai): stop configured API endpoints from switching to Coding Plan

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -558,11 +558,19 @@ def _resolve_runtime_from_pool_entry(
         configured_provider = str(model_cfg.get("provider") or "").strip().lower()
         # Honour model.base_url from config.yaml when the configured provider
         # matches this provider — same pattern as the Anthropic branch above.
-        # Only override when the pool entry has no explicit base_url (i.e. it
-        # fell back to the hardcoded default).  Env var overrides win (#6039).
+        # An env-seeded Z.AI entry may contain an auto-detected endpoint rather
+        # than an explicit route; config must still win in that case (#89685).
+        # Explicit base-URL env vars and manual pool routes remain authoritative.
         pconfig = PROVIDER_REGISTRY.get(provider)
         pool_url_is_default = pconfig and base_url.rstrip("/") == pconfig.inference_base_url.rstrip("/")
-        if configured_provider == provider and pool_url_is_default:
+        entry_source = str(getattr(entry, "source", "") or "")
+        explicit_env_url = ""
+        if pconfig and pconfig.base_url_env_var:
+            explicit_env_url = _getenv(pconfig.base_url_env_var, "").strip()
+        config_may_override_pool_url = pool_url_is_default or (
+            entry_source.startswith("env:") and not explicit_env_url
+        )
+        if configured_provider == provider and config_may_override_pool_url:
             cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
             if cfg_base_url:
                 base_url = cfg_base_url

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -16,6 +16,7 @@ from agent.credential_pool import (
     PooledCredential,
     credential_pool_matches_provider,
     get_custom_provider_pool_key,
+    get_env_prefer_dotenv,
     load_pool,
 )
 from agent.secret_scope import get_secret as _get_secret
@@ -566,7 +567,7 @@ def _resolve_runtime_from_pool_entry(
         entry_source = str(getattr(entry, "source", "") or "")
         explicit_env_url = ""
         if pconfig and pconfig.base_url_env_var:
-            explicit_env_url = _getenv(pconfig.base_url_env_var, "").strip()
+            explicit_env_url = get_env_prefer_dotenv(pconfig.base_url_env_var).strip()
         config_may_override_pool_url = pool_url_is_default or (
             entry_source.startswith("env:") and not explicit_env_url
         )

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -568,8 +568,8 @@ def _resolve_runtime_from_pool_entry(
         explicit_env_url = ""
         if pconfig and pconfig.base_url_env_var:
             explicit_env_url = get_env_prefer_dotenv(pconfig.base_url_env_var).strip()
-        config_may_override_pool_url = pool_url_is_default or (
-            entry_source.startswith("env:") and not explicit_env_url
+        config_may_override_pool_url = not explicit_env_url and (
+            pool_url_is_default or entry_source.startswith("env:")
         )
         if configured_provider == provider and config_may_override_pool_url:
             cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -918,6 +918,37 @@ def test_zai_explicit_pool_routes_override_model_config(
     assert resolved["base_url"] == "https://api.z.ai/api/coding/paas/v4"
 
 
+def test_zai_dotenv_base_url_keeps_explicit_pool_route(monkeypatch):
+    """The pool and precedence guard must use the same .env-first reader."""
+    entry = SimpleNamespace(
+        access_token="glm-key",
+        runtime_api_key="glm-key",
+        source="env:GLM_API_KEY",
+        base_url="https://proxy.example.com/zai/v4",
+        runtime_base_url=None,
+    )
+    monkeypatch.delenv("GLM_BASE_URL", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "get_env_prefer_dotenv",
+        lambda name: (
+            "https://proxy.example.com/zai/v4" if name == "GLM_BASE_URL" else ""
+        ),
+    )
+
+    resolved = rp._resolve_runtime_from_pool_entry(
+        provider="zai",
+        entry=entry,
+        requested_provider="zai",
+        model_cfg={
+            "provider": "zai",
+            "base_url": "https://api.z.ai/api/paas/v4",
+        },
+    )
+
+    assert resolved["base_url"] == "https://proxy.example.com/zai/v4"
+
+
 def test_opencode_go_model_derivation_beats_stale_persisted_api_mode(monkeypatch):
     """opencode-zen/go re-derive api_mode from the effective model on every
     resolve, ignoring any persisted ``api_mode`` in config. Refs #16878 /

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -949,6 +949,31 @@ def test_zai_dotenv_base_url_keeps_explicit_pool_route(monkeypatch):
     assert resolved["base_url"] == "https://proxy.example.com/zai/v4"
 
 
+def test_zai_explicit_default_env_url_overrides_model_config(monkeypatch):
+    """An explicit env route remains authoritative even when it equals the default."""
+    default_url = "https://api.z.ai/api/paas/v4"
+    entry = SimpleNamespace(
+        access_token="glm-key",
+        runtime_api_key="glm-key",
+        source="env:GLM_API_KEY",
+        base_url=default_url,
+        runtime_base_url=None,
+    )
+    monkeypatch.setenv("GLM_BASE_URL", default_url)
+
+    resolved = rp._resolve_runtime_from_pool_entry(
+        provider="zai",
+        entry=entry,
+        requested_provider="zai",
+        model_cfg={
+            "provider": "zai",
+            "base_url": "https://proxy.example.com/zai/v4",
+        },
+    )
+
+    assert resolved["base_url"] == default_url
+
+
 def test_opencode_go_model_derivation_beats_stale_persisted_api_mode(monkeypatch):
     """opencode-zen/go re-derive api_mode from the effective model on every
     resolve, ignoring any persisted ``api_mode`` in config. Refs #16878 /

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -858,6 +858,66 @@ def test_minimax_config_base_url_overrides_hardcoded_default(monkeypatch):
     assert resolved["api_mode"] == "anthropic_messages"
 
 
+def test_zai_config_base_url_overrides_auto_detected_env_pool_route(monkeypatch):
+    """An auto-detected pool route must not override explicit model config."""
+    entry = SimpleNamespace(
+        access_token="glm-key",
+        runtime_api_key="glm-key",
+        source="env:GLM_API_KEY",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        runtime_base_url=None,
+    )
+    monkeypatch.delenv("GLM_BASE_URL", raising=False)
+
+    resolved = rp._resolve_runtime_from_pool_entry(
+        provider="zai",
+        entry=entry,
+        requested_provider="zai",
+        model_cfg={
+            "provider": "zai",
+            "base_url": "https://api.z.ai/api/paas/v4",
+        },
+    )
+
+    assert resolved["base_url"] == "https://api.z.ai/api/paas/v4"
+
+
+@pytest.mark.parametrize(
+    ("source", "env_base_url"),
+    [
+        ("env:GLM_API_KEY", "https://api.z.ai/api/coding/paas/v4"),
+        ("manual:account-1", ""),
+    ],
+)
+def test_zai_explicit_pool_routes_override_model_config(
+    monkeypatch, source, env_base_url
+):
+    """Explicit env and manual-account routes retain their existing precedence."""
+    entry = SimpleNamespace(
+        access_token="glm-key",
+        runtime_api_key="glm-key",
+        source=source,
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        runtime_base_url=None,
+    )
+    if env_base_url:
+        monkeypatch.setenv("GLM_BASE_URL", env_base_url)
+    else:
+        monkeypatch.delenv("GLM_BASE_URL", raising=False)
+
+    resolved = rp._resolve_runtime_from_pool_entry(
+        provider="zai",
+        entry=entry,
+        requested_provider="zai",
+        model_cfg={
+            "provider": "zai",
+            "base_url": "https://api.z.ai/api/paas/v4",
+        },
+    )
+
+    assert resolved["base_url"] == "https://api.z.ai/api/coding/paas/v4"
+
+
 def test_opencode_go_model_derivation_beats_stale_persisted_api_mode(monkeypatch):
     """opencode-zen/go re-derive api_mode from the effective model on every
     resolve, ignoring any persisted ``api_mode`` in config. Refs #16878 /


### PR DESCRIPTION
## What does this PR do?

Z.AI users who explicitly configure the general API endpoint now keep that endpoint instead of being silently routed to the Coding Plan endpoint. This prevents requests such as GLM-5.2 calls from hitting the wrong service route and receiving route-specific overload responses, while preserving automatic Coding Plan detection when no endpoint is configured.

### Symptom

With `model.provider: zai` and `model.base_url: https://api.z.ai/api/paas/v4`, an environment-seeded credential pool entry could still send requests to `https://api.z.ai/api/coding/paas/v4`.

### Impact

Affected Z.AI users cannot reliably select the general API route through `config.yaml`; their requests may instead receive HTTP 429 responses from the Coding Plan route.

### Bug Cause

**Trigger:** `hermes_cli/runtime_provider.py:470` / `_resolve_runtime_from_pool_entry()` when a Z.AI credential comes from an environment-seeded pool entry whose endpoint was auto-detected.

**Causal chain:**
1. Z.AI endpoint probing stores the detected Coding Plan URL on the environment-seeded credential pool entry.
2. Runtime resolution treats that detected URL like an explicit pool route and only allows `model.base_url` to override a registry-default URL.
3. The configured general API endpoint is ignored, so requests are sent to the Coding Plan route.

**Why it is wrong:** The detected route is a fallback derived from the credential, not an explicit user endpoint, so it must not outrank a matching `model.base_url` configuration.

**Working sibling / contrast:** The direct non-pool provider path already honors a matching configured `model.base_url`.

**Ruled out:** The retry policy does not choose the endpoint; the wrong base URL is selected earlier during runtime provider resolution.

### Fix

Allow matching model configuration to override auto-detected environment-pool routes. Continue to prioritize explicit `GLM_BASE_URL` values, including values loaded from `.env`, and manual credential-pool routes. Behavioral tests cover each precedence case.

## Related Issue

Closes #89685

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/runtime_provider.py` - distinguish auto-detected environment-pool routes from explicit base URL overrides.
- `tests/hermes_cli/test_runtime_provider_resolution.py` - cover configured, environment, dotenv, default-value, and manual-pool precedence.

## How to Test

1. Resolve a Z.AI environment-seeded credential whose detected pool route is `/coding/paas/v4` while `model.base_url` explicitly selects `/paas/v4`; confirm the configured endpoint wins.
2. Set `GLM_BASE_URL`, load the equivalent setting from `.env`, or use a manual pool route; confirm each explicit route remains authoritative.
3. Run:

```bash
scripts/run_tests.sh tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_api_key_providers.py
```

Result: 169 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant test files and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A - no user-facing configuration shape changed
- [x] `cli-config.yaml.example` update: N/A - no configuration keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered: the precedence logic is platform-independent
- [x] Tool descriptions/schemas update: N/A - no model tool schema changed

## Screenshots / Logs

N/A - automated behavior-contract tests cover the provider-resolution path.
