### PR TITLE
fix(model): honor named-provider context metadata

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2470,9 +2470,30 @@ def init_agent(
     # Store for reuse by _check_compression_model_feasibility (auxiliary
     # compression model context-length detection needs the same list).
     agent._custom_providers = _custom_providers
+    agent._user_providers = (
+        _agent_cfg.get("providers")
+        if isinstance(_agent_cfg.get("providers"), dict)
+        else {}
+    )
     _merge_custom_provider_extra_body(agent, _custom_providers)
 
-    # Check custom_providers per-model context_length
+    # Prefer exact metadata from the selected named provider. Provider identity
+    # keeps shared endpoints from borrowing another route's model metadata.
+    if _config_context_length is None and agent._user_providers:
+        try:
+            from hermes_cli.config import get_named_provider_context_length
+
+            _named_ctx_resolved = get_named_provider_context_length(
+                model=agent.model,
+                provider=agent.requested_provider,
+                user_providers=agent._user_providers,
+            )
+            if _named_ctx_resolved:
+                _config_context_length = int(_named_ctx_resolved)
+        except Exception:
+            pass
+
+    # Check legacy custom_providers per-model context_length.
     if _config_context_length is None and _custom_providers:
         try:
             from hermes_cli.config import get_custom_provider_context_length

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2493,13 +2493,19 @@ def init_agent(
         except Exception:
             pass
 
-    # Check legacy custom_providers per-model context_length.
+    # Endpoint-scoped custom_providers fallback. Identity-aware: once the
+    # selected provider is a named ``providers:`` entry, a shared-endpoint
+    # sibling must not lend its per-model window through the converted
+    # compatible view — genuine legacy ``custom_providers`` still apply.
     if _config_context_length is None and _custom_providers:
         try:
-            from hermes_cli.config import get_custom_provider_context_length
-            _cp_ctx_resolved = get_custom_provider_context_length(
+            from hermes_cli.config import get_endpoint_fallback_context_length
+            _cp_ctx_resolved = get_endpoint_fallback_context_length(
                 model=agent.model,
                 base_url=agent.base_url,
+                provider=agent.requested_provider,
+                config=_agent_cfg if isinstance(_agent_cfg, dict) else None,
+                user_providers=agent._user_providers,
                 custom_providers=_custom_providers,
             )
             if _cp_ctx_resolved:

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2848,20 +2848,29 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
 
     # ── LM Studio: preload before probing context length ──
     _sm_custom_providers = None
+    _sm_user_providers = None
     try:
         from hermes_cli.config import (
             get_compatible_custom_providers,
             get_custom_provider_context_length,
+            get_named_provider_context_length,
             load_config,
         )
 
         _sm_cfg = load_config()
+        _sm_user_providers = _sm_cfg.get("providers")
         _sm_custom_providers = get_compatible_custom_providers(_sm_cfg)
-        _destination_context_intent = get_custom_provider_context_length(
+        _destination_context_intent = get_named_provider_context_length(
             model=agent.model,
-            base_url=agent.base_url,
-            custom_providers=_sm_custom_providers,
+            provider=agent.requested_provider,
+            user_providers=_sm_user_providers,
         )
+        if _destination_context_intent is None:
+            _destination_context_intent = get_custom_provider_context_length(
+                model=agent.model,
+                base_url=agent.base_url,
+                custom_providers=_sm_custom_providers,
+            )
     except Exception:
         _destination_context_intent = None
     agent._config_context_length = _destination_context_intent
@@ -2887,6 +2896,8 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     # switch (the policy would read the stale init-time snapshot).
     if _sm_custom_providers is not None:
         agent._custom_providers = _sm_custom_providers
+    if isinstance(_sm_user_providers, dict):
+        agent._user_providers = _sm_user_providers
     agent._use_prompt_caching, agent._use_native_cache_layout = (
         agent._anthropic_prompt_cache_policy(
             provider=new_provider,

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2852,7 +2852,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     try:
         from hermes_cli.config import (
             get_compatible_custom_providers,
-            get_custom_provider_context_length,
+            get_endpoint_fallback_context_length,
             get_named_provider_context_length,
             load_config,
         )
@@ -2866,9 +2866,15 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             user_providers=_sm_user_providers,
         )
         if _destination_context_intent is None:
-            _destination_context_intent = get_custom_provider_context_length(
+            # Endpoint fallback stays identity-aware: once the selected provider
+            # is a named ``providers:`` entry, a shared-endpoint sibling must not
+            # lend its per-model window through the converted compatible view.
+            _destination_context_intent = get_endpoint_fallback_context_length(
                 model=agent.model,
                 base_url=agent.base_url,
+                provider=agent.requested_provider,
+                config=_sm_cfg,
+                user_providers=_sm_user_providers,
                 custom_providers=_sm_custom_providers,
             )
     except Exception:

--- a/cli.py
+++ b/cli.py
@@ -10641,6 +10641,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 api_key=result.api_key or self.api_key or "",
                 model_info=mi,
                 config_context_length=getattr(self.agent, "_config_context_length", None) if self.agent else None,
+                user_providers=getattr(self.agent, "_user_providers", None) if self.agent else None,
                 custom_providers=getattr(self.agent, "_custom_providers", None) if self.agent else None,
             )
             if ctx:
@@ -11025,6 +11026,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             api_key=result.api_key or self.api_key or "",
             model_info=mi,
             config_context_length=getattr(self.agent, "_config_context_length", None) if self.agent else None,
+            user_providers=getattr(self.agent, "_user_providers", None) if self.agent else None,
             custom_providers=getattr(self.agent, "_custom_providers", None) if self.agent else None,
         )
         if ctx:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2775,6 +2775,8 @@ def _resolve_gateway_model_context(model: Optional[str] = None) -> _GatewayModel
     provider = None
     base_url = None
     api_key = None
+    requested_provider = None
+    user_providers = None
     custom_providers = None
     configured_model = None
     configured_provider = None
@@ -2799,8 +2801,10 @@ def _resolve_gateway_model_context(model: Optional[str] = None) -> _GatewayModel
             try:
                 from hermes_cli.config import get_compatible_custom_providers
 
+                user_providers = data.get("providers")
                 custom_providers = get_compatible_custom_providers(data)
             except Exception:
+                user_providers = data.get("providers")
                 custom_providers = data.get("custom_providers")
     except Exception:
         pass
@@ -2808,6 +2812,7 @@ def _resolve_gateway_model_context(model: Optional[str] = None) -> _GatewayModel
     try:
         runtime = _resolve_runtime_agent_kwargs()
         provider = runtime.get("provider") or provider
+        requested_provider = runtime.get("requested_provider") or configured_provider
         base_url = runtime.get("base_url") or base_url
         api_key = runtime.get("api_key")
     except Exception:
@@ -2828,6 +2833,18 @@ def _resolve_gateway_model_context(model: Optional[str] = None) -> _GatewayModel
                 config_context_length = None
         except Exception:
             config_context_length = None
+
+    if config_context_length is None and user_providers:
+        try:
+            from hermes_cli.config import get_named_provider_context_length
+
+            config_context_length = get_named_provider_context_length(
+                model=resolved_model,
+                provider=requested_provider or configured_provider or provider or "",
+                user_providers=user_providers,
+            )
+        except Exception:
+            pass
 
     if config_context_length is None and custom_providers and base_url:
         try:
@@ -18222,7 +18239,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             _msg_config_ctx = None
                     except Exception:
                         _msg_config_ctx = None
-                if _msg_custom_providers and _msg_base_url:
+                if _msg_config_ctx is None and isinstance(_msg_cfg, dict):
+                    try:
+                        from hermes_cli.config import get_named_provider_context_length
+
+                        _msg_config_ctx = get_named_provider_context_length(
+                            model=_msg_model,
+                            provider=(
+                                _msg_runtime.get("requested_provider")
+                                or _msg_model_cfg.get("provider")
+                                or _msg_runtime.get("provider")
+                                or ""
+                            ),
+                            user_providers=_msg_cfg.get("providers"),
+                        )
+                    except Exception:
+                        pass
+                if (
+                    _msg_config_ctx is None
+                    and _msg_custom_providers
+                    and _msg_base_url
+                ):
                     try:
                         from hermes_cli.config import get_custom_provider_context_length
 
@@ -19002,6 +19039,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _hyg_configured_provider = None
             _hyg_configured_base_url = None
             _hyg_data = {}
+            _hyg_runtime = {}
             try:
                 _hyg_data = _load_gateway_config()
                 if _hyg_data:
@@ -19101,9 +19139,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     except Exception:
                         _hyg_config_context_length = None
 
-                # Check custom_providers per-model context_length
+                # Check selected named-provider metadata before the legacy
+                # endpoint-scoped custom_providers fallback.
                 # (same fallback as run_agent.py lines 1171-1189).
                 # Must run after runtime resolution so _hyg_base_url is set.
+                if _hyg_config_context_length is None:
+                    try:
+                        from hermes_cli.config import (
+                            get_named_provider_context_length as _gw_gnpcl,
+                        )
+
+                        _hyg_config_context_length = _gw_gnpcl(
+                            model=_hyg_model,
+                            provider=(
+                                _hyg_runtime.get("requested_provider")
+                                or _hyg_configured_provider
+                                or _hyg_provider
+                                or ""
+                            ),
+                            user_providers=_hyg_data.get("providers"),
+                        )
+                    except Exception:
+                        pass
                 if _hyg_config_context_length is None and _hyg_base_url:
                     try:
                         try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2781,6 +2781,7 @@ def _resolve_gateway_model_context(model: Optional[str] = None) -> _GatewayModel
     configured_model = None
     configured_provider = None
     configured_base_url = None
+    data = None
 
     try:
         data = _load_gateway_config()
@@ -2834,26 +2835,35 @@ def _resolve_gateway_model_context(model: Optional[str] = None) -> _GatewayModel
         except Exception:
             config_context_length = None
 
+    _gw_provider_identity = (
+        # The effective runtime provider (session/override-aware) wins over the
+        # globally-configured provider so a shared-endpoint sibling can't lend
+        # its per-model metadata.
+        requested_provider or provider or configured_provider or ""
+    )
     if config_context_length is None and user_providers:
         try:
             from hermes_cli.config import get_named_provider_context_length
 
             config_context_length = get_named_provider_context_length(
                 model=resolved_model,
-                provider=requested_provider or configured_provider or provider or "",
+                provider=_gw_provider_identity,
                 user_providers=user_providers,
             )
         except Exception:
             pass
 
-    if config_context_length is None and custom_providers and base_url:
+    if config_context_length is None and base_url:
         try:
-            from hermes_cli.config import get_custom_provider_context_length
+            from hermes_cli.config import get_endpoint_fallback_context_length
 
-            custom_ctx = get_custom_provider_context_length(
+            custom_ctx = get_endpoint_fallback_context_length(
                 model=resolved_model,
                 base_url=base_url,
-                custom_providers=custom_providers,
+                provider=_gw_provider_identity,
+                config=data if isinstance(data, dict) else None,
+                user_providers=user_providers,
+                custom_providers=custom_providers if custom_providers else None,
             )
             if custom_ctx:
                 config_context_length = custom_ctx
@@ -7895,6 +7905,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             override_model = override.get("model", model)
             override_runtime = {
                 "provider": override.get("provider"),
+                # Carry the named provider identity so per-model context
+                # metadata resolves against the session's provider, not the
+                # globally-configured one on a shared endpoint.
+                "requested_provider": (
+                    override.get("requested_provider") or override.get("provider")
+                ),
                 "api_key": override.get("api_key"),
                 "base_url": override.get("base_url"),
                 "api_mode": override.get("api_mode"),
@@ -18239,34 +18255,48 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             _msg_config_ctx = None
                     except Exception:
                         _msg_config_ctx = None
+                _msg_provider_identity = (
+                    _msg_runtime.get("requested_provider")
+                    # The effective session-override provider must win over the
+                    # globally-configured provider so a session /model switch to
+                    # a shared-endpoint sibling doesn't borrow the default
+                    # route's per-model metadata.
+                    or _msg_runtime.get("provider")
+                    or (
+                        _msg_model_cfg.get("provider")
+                        if isinstance(_msg_model_cfg, dict)
+                        else None
+                    )
+                    or ""
+                )
                 if _msg_config_ctx is None and isinstance(_msg_cfg, dict):
                     try:
                         from hermes_cli.config import get_named_provider_context_length
 
                         _msg_config_ctx = get_named_provider_context_length(
                             model=_msg_model,
-                            provider=(
-                                _msg_runtime.get("requested_provider")
-                                or _msg_model_cfg.get("provider")
-                                or _msg_runtime.get("provider")
-                                or ""
-                            ),
+                            provider=_msg_provider_identity,
                             user_providers=_msg_cfg.get("providers"),
                         )
                     except Exception:
                         pass
-                if (
-                    _msg_config_ctx is None
-                    and _msg_custom_providers
-                    and _msg_base_url
-                ):
+                if _msg_config_ctx is None and _msg_base_url:
                     try:
-                        from hermes_cli.config import get_custom_provider_context_length
+                        from hermes_cli.config import (
+                            get_endpoint_fallback_context_length,
+                        )
 
-                        _msg_custom_ctx = get_custom_provider_context_length(
+                        _msg_custom_ctx = get_endpoint_fallback_context_length(
                             model=_msg_model,
                             base_url=_msg_base_url,
-                            custom_providers=_msg_custom_providers,
+                            provider=_msg_provider_identity,
+                            config=_msg_cfg if isinstance(_msg_cfg, dict) else None,
+                            user_providers=(
+                                _msg_cfg.get("providers")
+                                if isinstance(_msg_cfg, dict)
+                                else None
+                            ),
+                            custom_providers=_msg_custom_providers or None,
                         )
                         if _msg_custom_ctx:
                             _msg_config_ctx = _msg_custom_ctx
@@ -19143,6 +19173,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # endpoint-scoped custom_providers fallback.
                 # (same fallback as run_agent.py lines 1171-1189).
                 # Must run after runtime resolution so _hyg_base_url is set.
+                _hyg_provider_identity = (
+                    _hyg_runtime.get("requested_provider")
+                    # Prefer the effective session-override provider over the
+                    # globally-configured one so a shared-endpoint sibling
+                    # can't lend its per-model metadata to this session.
+                    or _hyg_provider
+                    or _hyg_configured_provider
+                    or ""
+                )
                 if _hyg_config_context_length is None:
                     try:
                         from hermes_cli.config import (
@@ -19151,36 +19190,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                         _hyg_config_context_length = _gw_gnpcl(
                             model=_hyg_model,
-                            provider=(
-                                _hyg_runtime.get("requested_provider")
-                                or _hyg_configured_provider
-                                or _hyg_provider
-                                or ""
-                            ),
+                            provider=_hyg_provider_identity,
                             user_providers=_hyg_data.get("providers"),
                         )
                     except Exception:
                         pass
                 if _hyg_config_context_length is None and _hyg_base_url:
                     try:
-                        try:
-                            from hermes_cli.config import (
-                                get_compatible_custom_providers as _gw_gcp,
-                                get_custom_provider_context_length as _gw_gccl,
-                            )
-                            _hyg_custom_providers = _gw_gcp(_hyg_data)
-                        except Exception:
-                            _hyg_custom_providers = _hyg_data.get("custom_providers")
-                            if not isinstance(_hyg_custom_providers, list):
-                                _hyg_custom_providers = []
-                        _hyg_custom_ctx = _gw_gccl(
+                        from hermes_cli.config import (
+                            get_endpoint_fallback_context_length as _gw_gefcl,
+                        )
+                        _hyg_custom_ctx = _gw_gefcl(
                             model=_hyg_model,
                             base_url=_hyg_base_url,
-                            custom_providers=_hyg_custom_providers,
+                            provider=_hyg_provider_identity,
+                            config=_hyg_data if isinstance(_hyg_data, dict) else None,
+                            user_providers=(
+                                _hyg_data.get("providers")
+                                if isinstance(_hyg_data, dict)
+                                else None
+                            ),
                         )
                         if _hyg_custom_ctx:
                             _hyg_config_context_length = int(_hyg_custom_ctx)
                     except (TypeError, ValueError):
+                        pass
+                    except Exception:
                         pass
             except Exception:
                 pass
@@ -26056,6 +26091,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         override: Dict[str, Any] = {
             "model": persisted.get("model"),
             "provider": persisted.get("provider"),
+            # Restore the named provider identity (non-secret) so a rehydrated
+            # session keeps resolving its own per-model context metadata after
+            # a restart, not a shared-endpoint sibling's.
+            "requested_provider": (
+                persisted.get("requested_provider") or persisted.get("provider")
+            ),
             "base_url": persisted.get("base_url"),
         }
         provider = persisted.get("provider")
@@ -26099,10 +26140,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not override:
             return model, runtime_kwargs
         model = override.get("model", model)
-        for key in ("provider", "api_key", "base_url", "api_mode", "credential_pool"):
+        for key in (
+            "provider",
+            "requested_provider",
+            "api_key",
+            "base_url",
+            "api_mode",
+            "credential_pool",
+        ):
             val = override.get(key)
             if val is not None:
                 runtime_kwargs[key] = val
+        # A named-provider override that predates requested_provider
+        # write-through (or a built-in switch that only set provider) still
+        # needs the named identity so per-model metadata resolves against this
+        # session. When the override changes provider without carrying its own
+        # requested_provider, the override's provider is authoritative — never
+        # leave a stale global requested_provider paired with the new provider.
+        if override.get("provider") and not override.get("requested_provider"):
+            runtime_kwargs["requested_provider"] = override.get("provider")
         if (
             runtime_kwargs.get("api_key")
             and runtime_kwargs.get("credential_pool") is None

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -753,7 +753,7 @@ def build_session_context_prompt(
 # provider resolution) is intentionally excluded: credentials must NEVER be
 # written to sessions.json.  On rehydration after a gateway restart the
 # runner re-resolves credentials via the normal runtime provider resolution.
-PERSISTABLE_MODEL_OVERRIDE_KEYS = ("model", "provider", "base_url")
+PERSISTABLE_MODEL_OVERRIDE_KEYS = ("model", "provider", "requested_provider", "base_url")
 
 
 def sanitize_model_override(override: Optional[Dict[str, Any]]) -> Optional[Dict[str, str]]:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1929,6 +1929,7 @@ class GatewaySlashCommandsMixin:
                                 _self,
                                 session_key=_session_key,
                                 source=event.source,
+                                user_providers=user_provs,
                                 custom_providers=custom_provs,
                                 load_gateway_config=_load_gateway_config,
                             )
@@ -2116,6 +2117,7 @@ class GatewaySlashCommandsMixin:
                             base_url=result.base_url or current_base_url or "",
                             api_key=result.api_key or current_api_key or "",
                             model_info=mi,
+                            user_providers=user_provs,
                             custom_providers=custom_provs,
                             config_context_length=_sw_config_ctx,
                             configured_model=(
@@ -2239,6 +2241,7 @@ class GatewaySlashCommandsMixin:
                 self,
                 session_key=session_key,
                 source=source,
+                user_providers=user_provs,
                 custom_providers=custom_provs,
                 load_gateway_config=_load_gateway_config,
             )
@@ -2443,6 +2446,7 @@ class GatewaySlashCommandsMixin:
                 base_url=result.base_url or current_base_url or "",
                 api_key=result.api_key or current_api_key or "",
                 model_info=mi,
+                user_providers=user_provs,
                 custom_providers=custom_provs,
                 config_context_length=_sw2_config_ctx,
                 configured_model=(

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2007,6 +2007,10 @@ class GatewaySlashCommandsMixin:
                         _self._session_model_overrides[_session_key] = {
                             "model": result.new_model,
                             "provider": result.target_provider,
+                            # Preserve the *named* provider identity so a
+                            # shared-endpoint sibling can't lend its exact
+                            # per-model context metadata to this session.
+                            "requested_provider": result.target_provider,
                             "api_key": result.api_key,
                             "base_url": result.base_url,
                             "api_mode": result.api_mode,
@@ -2321,6 +2325,10 @@ class GatewaySlashCommandsMixin:
             self._session_model_overrides[session_key] = {
                 "model": result.new_model,
                 "provider": result.target_provider,
+                # Preserve the *named* provider identity so a shared-endpoint
+                # sibling can't lend its exact per-model context metadata to
+                # this session.
+                "requested_provider": result.target_provider,
                 "api_key": result.api_key,
                 "base_url": result.base_url,
                 "api_mode": result.api_mode,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1863,6 +1863,61 @@ def get_custom_provider_context_length(
     return None
 
 
+def get_named_provider_context_length(
+    model: str,
+    provider: str,
+    user_providers: Optional[Dict[str, Any]] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> Optional[int]:
+    """Return exact per-model metadata for the selected ``providers:`` entry.
+
+    Provider and model keys match case-insensitively but otherwise exactly.
+    The provider identity is required so entries sharing an endpoint cannot
+    borrow each other's metadata.
+    """
+    model_id = str(model or "").strip()
+    provider_id = str(provider or "").strip()
+    if not model_id or not provider_id:
+        return None
+    if user_providers is None:
+        if config is None:
+            try:
+                config = load_config_readonly()
+            except Exception:
+                return None
+        user_providers = config.get("providers") if isinstance(config, dict) else None
+    if not isinstance(user_providers, dict):
+        return None
+
+    provider_cfg = None
+    provider_key = provider_id.casefold()
+    for key, candidate in user_providers.items():
+        if str(key).strip().casefold() == provider_key and isinstance(candidate, dict):
+            provider_cfg = candidate
+            break
+    if provider_cfg is None or not is_provider_enabled(provider_cfg):
+        return None
+
+    models = provider_cfg.get("models")
+    if not isinstance(models, dict):
+        return None
+    model_key = model_id.casefold()
+    for configured_model, metadata in models.items():
+        if str(configured_model).strip().casefold() != model_key:
+            continue
+        if not isinstance(metadata, dict):
+            return None
+        raw_ctx = metadata.get("context_length")
+        if raw_ctx is None:
+            return None
+        try:
+            context_length = int(raw_ctx)
+        except (TypeError, ValueError):
+            return None
+        return context_length if context_length > 0 else None
+    return None
+
+
 def get_custom_provider_model_capability(
     model: str,
     base_url: str,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1918,6 +1918,102 @@ def get_named_provider_context_length(
     return None
 
 
+def is_named_provider(
+    provider: str,
+    config: Optional[Dict[str, Any]] = None,
+    user_providers: Optional[Dict[str, Any]] = None,
+) -> bool:
+    """Return ``True`` when ``provider`` names an entry under config ``providers:``.
+
+    Matching is case-insensitive, mirroring
+    :func:`get_named_provider_context_length`. Used to decide whether an
+    endpoint-scoped context fallback may reach through the compatible view
+    (which merges converted ``providers:`` entries) or must stay restricted to
+    genuine legacy ``custom_providers`` so a shared-endpoint sibling can't lend
+    its per-model metadata.
+    """
+    provider_id = str(provider or "").strip()
+    if not provider_id:
+        return False
+    if user_providers is None:
+        if config is None:
+            try:
+                config = load_config_readonly()
+            except Exception:
+                return False
+        user_providers = config.get("providers") if isinstance(config, dict) else None
+    if not isinstance(user_providers, dict):
+        return False
+    provider_key = provider_id.casefold()
+    return any(str(key).strip().casefold() == provider_key for key in user_providers)
+
+
+def get_legacy_custom_providers(
+    config: Optional[Dict[str, Any]] = None,
+) -> List[Dict[str, Any]]:
+    """Return a normalized view of *genuine* on-disk ``custom_providers`` only.
+
+    Unlike :func:`get_compatible_custom_providers`, this excludes the converted
+    new-style ``providers:`` entries. Endpoint-scoped context fallbacks use it
+    when the selected provider is a named ``providers:`` entry, so a sibling
+    named provider sharing the same ``base_url`` cannot lend its
+    ``context_length`` through the compatibility layer while genuine legacy
+    behavior is preserved.
+    """
+    if config is None:
+        config = load_config()
+    custom_providers = config.get("custom_providers")
+    if not isinstance(custom_providers, list):
+        return []
+    out: List[Dict[str, Any]] = []
+    for entry in custom_providers:
+        normalized = _normalize_custom_provider_entry(entry)
+        if normalized is not None:
+            out.append(normalized)
+    return out
+
+
+def get_endpoint_fallback_context_length(
+    model: str,
+    base_url: str,
+    provider: str = "",
+    *,
+    config: Optional[Dict[str, Any]] = None,
+    user_providers: Optional[Dict[str, Any]] = None,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
+) -> Optional[int]:
+    """Endpoint-scoped context fallback that never borrows a sibling's metadata.
+
+    Exact per-model metadata for a configured ``providers:`` entry is resolved
+    by :func:`get_named_provider_context_length` (identity-aware). This is the
+    *endpoint* fallback used only after that exact lookup misses.
+
+    When ``provider`` names a ``providers:`` entry, the endpoint match is
+    restricted to genuine legacy ``custom_providers`` (via
+    :func:`get_legacy_custom_providers`) so a sibling named provider sharing the
+    same ``base_url`` cannot lend its ``context_length`` through the converted
+    entries in the compatible view. Otherwise the caller-supplied
+    ``custom_providers`` (or the full compatible view) is used unchanged, which
+    preserves real legacy ``custom_providers`` behavior.
+    """
+    if not model or not base_url:
+        return None
+    if is_named_provider(provider, config=config, user_providers=user_providers):
+        providers_for_match = get_legacy_custom_providers(config)
+    elif custom_providers is not None:
+        providers_for_match = custom_providers
+    else:
+        try:
+            providers_for_match = get_compatible_custom_providers(config)
+        except Exception:
+            providers_for_match = []
+    return get_custom_provider_context_length(
+        model=model,
+        base_url=base_url,
+        custom_providers=providers_for_match,
+    )
+
+
 def get_custom_provider_model_capability(
     model: str,
     base_url: str,

--- a/hermes_cli/context_switch_guard.py
+++ b/hermes_cli/context_switch_guard.py
@@ -67,6 +67,7 @@ def merge_preflight_compression_warning(
     *,
     agent: Any = None,
     messages: Optional[List[dict]] = None,
+    user_providers: dict | None = None,
     custom_providers: list | None = None,
     config_context_length: int | None = None,
     configured_model: str | None = None,
@@ -89,6 +90,8 @@ def merge_preflight_compression_warning(
     # even when custom_providers[].models.<id>.context_length was 1M.
     if custom_providers is None:
         custom_providers = getattr(agent, "_custom_providers", None)
+    if user_providers is None:
+        user_providers = getattr(agent, "_user_providers", None)
 
     old_ctx = int(getattr(cc, "context_length", 0) or 0)
     new_ctx = resolve_display_context_length(
@@ -97,6 +100,7 @@ def merge_preflight_compression_warning(
         base_url=result.base_url or getattr(agent, "base_url", "") or "",
         api_key=result.api_key or getattr(agent, "api_key", "") or "",
         model_info=result.model_info,
+        user_providers=user_providers,
         custom_providers=custom_providers,
         config_context_length=config_context_length,
         configured_model=(
@@ -150,6 +154,7 @@ def enrich_model_switch_warnings_for_gateway(
     *,
     session_key: str,
     source: Any,
+    user_providers: dict | None = None,
     custom_providers: list | None = None,
     load_gateway_config: Callable[[], dict] | None = None,
 ) -> None:
@@ -195,6 +200,7 @@ def enrich_model_switch_warnings_for_gateway(
         result,
         agent=agent,
         messages=messages,
+        user_providers=user_providers,
         custom_providers=custom_providers,
         config_context_length=cfg_ctx,
         configured_model=configured_model,

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1235,6 +1235,7 @@ def resolve_display_context_length(
     configured_model: str | None = None,
     configured_provider: str | None = None,
     configured_base_url: str | None = None,
+    user_providers: dict | None = None,
 ) -> Optional[int]:
     """Resolve the context length to show in /model output.
 
@@ -1245,10 +1246,9 @@ def resolve_display_context_length(
     about Codex OAuth, Copilot, Nous, and falls back to models.dev for the
     rest.
 
-    When ``custom_providers`` is provided, per-model ``context_length``
-    overrides from ``custom_providers[].models.<id>.context_length`` are
-    honored — this closes #15779 where ``/model`` switch ignored user-set
-    overrides.
+    Exact per-model ``context_length`` metadata from the selected
+    ``providers.<name>`` entry takes precedence over endpoint probes and
+    catalogs. Legacy ``custom_providers`` metadata remains supported.
 
     Prefer the provider-aware value; fall back to ``model_info.context_window``
     only if the resolver returns nothing.
@@ -1270,6 +1270,20 @@ def resolve_display_context_length(
                 config_context_length = None
         except Exception:
             config_context_length = None
+
+    if config_context_length is None and user_providers:
+        try:
+            from hermes_cli.config import get_named_provider_context_length
+
+            named_context_length = get_named_provider_context_length(
+                model=model,
+                provider=provider,
+                user_providers=user_providers,
+            )
+            if named_context_length is not None:
+                return named_context_length
+        except Exception:
+            pass
 
     try:
         from agent.model_metadata import get_model_context_length
@@ -1301,6 +1315,7 @@ async def resolve_display_context_length_async(
     configured_model: str | None = None,
     configured_provider: str | None = None,
     configured_base_url: str | None = None,
+    user_providers: dict | None = None,
 ) -> Optional[int]:
     """Async variant of :func:`resolve_display_context_length`.
 
@@ -1324,6 +1339,7 @@ async def resolve_display_context_length_async(
         base_url=base_url,
         api_key=api_key,
         model_info=model_info,
+        user_providers=user_providers,
         custom_providers=custom_providers,
         config_context_length=config_context_length,
         configured_model=configured_model,

--- a/tests/gateway/test_model_command_context_offload.py
+++ b/tests/gateway/test_model_command_context_offload.py
@@ -23,6 +23,15 @@ from gateway.platforms.base import MessageEvent, MessageType
 from gateway.session import SessionSource
 
 
+class _PickerAdapter:
+    def __init__(self):
+        self.callback = None
+
+    async def send_model_picker(self, *, on_model_selected, **_kwargs):
+        self.callback = on_model_selected
+        return type("_PickerResult", (), {"success": True})()
+
+
 def _make_source() -> SessionSource:
     return SessionSource(
         platform=Platform.TELEGRAM,
@@ -41,7 +50,13 @@ def _event(text: str) -> MessageEvent:
     )
 
 
-def _runner_with_store(tmp_path, monkeypatch):
+def _runner_with_store(
+    tmp_path,
+    monkeypatch,
+    *,
+    config=None,
+    switch_result=None,
+):
     """Minimal GatewayRunner harness driving the real /model handler."""
     import yaml as _yaml
 
@@ -51,15 +66,13 @@ def _runner_with_store(tmp_path, monkeypatch):
 
     hermes_home = tmp_path / ".hermes"
     hermes_home.mkdir()
-    (hermes_home / "config.yaml").write_text(
-        _yaml.safe_dump({"model": {"default": "old-model", "provider": "openrouter"}}),
-        encoding="utf-8",
-    )
+    if config is None:
+        config = {"model": {"default": "old-model", "provider": "openrouter"}}
+    (hermes_home / "config.yaml").write_text(_yaml.safe_dump(config), encoding="utf-8")
     monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
-    monkeypatch.setattr(
-        "hermes_cli.model_switch.switch_model",
-        lambda **kw: ModelSwitchResult(
+    if switch_result is None:
+        switch_result = ModelSwitchResult(
             success=True,
             new_model="gpt-5.5",
             target_provider="openrouter",
@@ -68,7 +81,10 @@ def _runner_with_store(tmp_path, monkeypatch):
             base_url="https://openrouter.ai/api/v1",
             api_mode="chat_completions",
             provider_label="OpenRouter",
-        ),
+        )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model",
+        lambda **kw: switch_result,
     )
     monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: hermes_home)
     monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: hermes_home)
@@ -145,3 +161,171 @@ async def test_warning_enrichment_is_offloaded(tmp_path, monkeypatch):
         "enrich_model_switch_warnings_for_gateway must be dispatched via "
         "asyncio.to_thread (it was called inline on the event loop instead)"
     )
+
+
+@pytest.mark.asyncio
+async def test_typed_model_uses_named_provider_model_context(tmp_path, monkeypatch):
+    from hermes_cli import model_switch
+    from hermes_cli.model_switch import ModelSwitchResult
+
+    model = "vllm/DeepSeek-V4-Flash-0731"
+    provider = "bifrost"
+    base_url = "http://da-aihost01:4000/v1"
+    providers = {
+        provider: {
+            "base_url": base_url,
+            "models": {model: {"context_length": 1_048_576}},
+        }
+    }
+    switch_result = ModelSwitchResult(
+        success=True,
+        new_model=model,
+        target_provider=provider,
+        provider_changed=True,
+        api_key="sk-test",
+        base_url=base_url,
+        api_mode="chat_completions",
+        provider_label="Bifrost",
+    )
+
+    def _resolver(selected_model, selected_provider, **kwargs):
+        metadata = (
+            kwargs.get("user_providers", {})
+            .get(selected_provider, {})
+            .get("models", {})
+            .get(selected_model, {})
+        )
+        return metadata.get("context_length", 1_000_000)
+
+    monkeypatch.setattr(model_switch, "resolve_display_context_length", _resolver)
+    runner = _runner_with_store(
+        tmp_path,
+        monkeypatch,
+        config={
+            "model": {"default": "old-model", "provider": "openrouter"},
+            "providers": providers,
+        },
+        switch_result=switch_result,
+    )
+
+    result = await runner._handle_model_command(
+        _event(f"/model {model} --provider {provider} --session")
+    )
+
+    assert result is not None
+    assert "Context: 1,048,576" in result
+    assert "Context: 1,000,000" not in result
+
+
+@pytest.mark.asyncio
+async def test_picker_model_uses_named_provider_model_context(tmp_path, monkeypatch):
+    from hermes_cli import model_switch
+    from hermes_cli.model_switch import ModelSwitchResult
+
+    model = "vllm/DeepSeek-V4-Flash-0731"
+    provider = "bifrost"
+    base_url = "http://da-aihost01:4000/v1"
+    providers = {
+        provider: {
+            "base_url": base_url,
+            "models": {model: {"context_length": 1_048_576}},
+        }
+    }
+    switch_result = ModelSwitchResult(
+        success=True,
+        new_model=model,
+        target_provider=provider,
+        provider_changed=True,
+        api_key="sk-test",
+        base_url=base_url,
+        api_mode="chat_completions",
+        provider_label="Bifrost",
+    )
+
+    def _resolver(selected_model, selected_provider, **kwargs):
+        metadata = (
+            kwargs.get("user_providers", {})
+            .get(selected_provider, {})
+            .get("models", {})
+            .get(selected_model, {})
+        )
+        return metadata.get("context_length", 1_000_000)
+
+    monkeypatch.setattr(model_switch, "resolve_display_context_length", _resolver)
+    monkeypatch.setattr(
+        model_switch,
+        "list_picker_providers",
+        lambda **_kwargs: [
+            {
+                "slug": provider,
+                "name": "Bifrost",
+                "models": [model],
+                "total_models": 1,
+            }
+        ],
+    )
+    runner = _runner_with_store(
+        tmp_path,
+        monkeypatch,
+        config={
+            "model": {"default": "old-model", "provider": "openrouter"},
+            "providers": providers,
+        },
+        switch_result=switch_result,
+    )
+    adapter = _PickerAdapter()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+
+    sent = await runner._handle_model_command(_event("/model --session"))
+    assert sent is None
+    assert adapter.callback is not None
+
+    result = await adapter.callback("c1", model, provider)
+    assert "Context: 1,048,576" in result
+    assert "Context: 1,000,000" not in result
+
+
+def test_gateway_context_authority_uses_named_provider_identity(monkeypatch):
+    import gateway.run as gateway_run
+
+    model = "vllm/DeepSeek-V4-Flash-0731"
+    base_url = "http://da-aihost01:4000/v1"
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "model": {"default": model, "provider": "bifrost"},
+            "providers": {
+                "other": {
+                    "base_url": base_url,
+                    "models": {model: {"context_length": 1_000_000}},
+                },
+                "bifrost": {
+                    "base_url": base_url,
+                    "models": {model: {"context_length": 1_048_576}},
+                },
+            },
+        },
+    )
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda: model)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "custom",
+            "requested_provider": "bifrost",
+            "base_url": base_url,
+            "api_key": "sk-test",
+        },
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, config_context_length=None, **_kwargs: (
+            config_context_length or 1_000_000
+        ),
+    )
+
+    context = gateway_run._resolve_gateway_model_context()
+
+    assert context.context_length == 1_048_576
+    assert context.context_source == "config"

--- a/tests/gateway/test_model_command_context_offload.py
+++ b/tests/gateway/test_model_command_context_offload.py
@@ -329,3 +329,56 @@ def test_gateway_context_authority_uses_named_provider_identity(monkeypatch):
 
     assert context.context_length == 1_048_576
     assert context.context_source == "config"
+
+
+def test_gateway_context_endpoint_fallback_no_sibling_leak(monkeypatch):
+    """After an exact named-provider miss, the endpoint fallback must NOT reach
+    through a converted sibling ``providers:`` entry that shares the base_url.
+
+    ``beta`` is the selected provider and declares the model but no
+    ``context_length``; ``alpha`` shares the endpoint and declares 1,048,576.
+    ``beta`` must not borrow ``alpha``'s window via the compatible endpoint
+    match (Medium review finding on #89714)."""
+    import gateway.run as gateway_run
+
+    model = "vllm/DeepSeek-V4-Flash-0731"
+    base_url = "http://da-aihost01:4000/v1"
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "model": {"default": model, "provider": "beta"},
+            "providers": {
+                "alpha": {
+                    "base_url": base_url,
+                    "models": {model: {"context_length": 1_048_576}},
+                },
+                "beta": {
+                    "base_url": base_url,
+                    "models": {model: {}},
+                },
+            },
+        },
+    )
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda: model)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "custom",
+            "requested_provider": "beta",
+            "base_url": base_url,
+            "api_key": "sk-test",
+        },
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, config_context_length=None, **_kwargs: (
+            config_context_length or 512_000
+        ),
+    )
+
+    context = gateway_run._resolve_gateway_model_context()
+
+    assert context.context_length != 1_048_576
+    assert context.context_length == 512_000

--- a/tests/gateway/test_session_model_override_persistence.py
+++ b/tests/gateway/test_session_model_override_persistence.py
@@ -133,3 +133,60 @@ def test_sanitize_model_override():
         "provider": "openai",
         "base_url": "https://api.openai.example/v1",
     }
+
+
+# --- named-provider identity must survive session overrides + restart -------
+# Two named providers (A configured globally, B chosen per-session) can share a
+# single model id AND base_url yet declare different exact context windows. The
+# session override must carry B's *named* identity (``requested_provider``) so a
+# later metadata lookup resolves B's window, not the globally-configured A's.
+
+_NAMED_SHARED_URL = "http://da-aihost01:4000/v1"
+_NAMED_MODEL = "vllm/DeepSeek-V4-Flash-0731"
+_NAMED_OVERRIDE_B = {
+    "model": _NAMED_MODEL,
+    "provider": "beta",
+    "requested_provider": "beta",
+    "api_key": "sk-SECRET-do-not-persist",
+    "base_url": _NAMED_SHARED_URL,
+    "api_mode": "chat_completions",
+}
+
+
+def test_named_requested_provider_persists_and_survives_restart(store_factory):
+    store = store_factory()
+    entry = store.get_or_create_session(_make_source())
+    session_key = entry.session_key
+
+    store.set_model_override(session_key, _NAMED_OVERRIDE_B)
+
+    store2 = store_factory()
+    persisted = store2.get_model_override(session_key)
+    assert persisted is not None
+    # The named identity must round-trip so a shared-endpoint sibling cannot
+    # borrow it after a restart.
+    assert persisted.get("requested_provider") == "beta"
+    # Secrets are still never written.
+    assert "api_key" not in persisted
+
+
+def test_runner_rehydrate_restores_named_requested_provider(store_factory):
+    store = store_factory()
+    entry = store.get_or_create_session(_make_source())
+    session_key = entry.session_key
+    store.set_model_override(session_key, _NAMED_OVERRIDE_B)
+
+    runner = _make_runner(store_factory())
+    with patch(
+        "gateway.run._resolve_runtime_agent_kwargs_for_provider",
+        return_value={
+            "api_key": "sk-fresh",
+            "api_mode": "chat_completions",
+            "base_url": _NAMED_SHARED_URL,
+            "provider": "beta",
+        },
+    ):
+        runner._rehydrate_session_model_override(session_key)
+
+    override = runner._session_model_overrides[session_key]
+    assert override["requested_provider"] == "beta"

--- a/tests/gateway/test_session_model_override_routing.py
+++ b/tests/gateway/test_session_model_override_routing.py
@@ -137,3 +137,72 @@ fallback_providers:
     assert runtime_kwargs["api_key"] == "sk-openrouter"
 
 
+def test_session_override_threads_named_requested_provider(monkeypatch):
+    """A per-session /model override to a named provider must expose that
+    provider's *named* identity via ``requested_provider`` in the resolved
+    runtime, so a shared-endpoint sibling declared globally cannot lend its
+    exact context metadata to this session (High review finding on #89714)."""
+    runner = _make_runner()
+    session_key = "agent:main:telegram:dm:c1"
+    runner._session_model_overrides[session_key] = {
+        "model": "vllm/DeepSeek-V4-Flash-0731",
+        "provider": "beta",
+        "requested_provider": "beta",
+        "api_key": "sk-live",
+        "base_url": "http://da-aihost01:4000/v1",
+        "api_mode": "chat_completions",
+    }
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda cfg=None: "global-model")
+    monkeypatch.setattr(gateway_run, "_credential_pool_for_provider", lambda _p: None)
+
+    model, runtime_kwargs = runner._resolve_session_agent_runtime(
+        session_key=session_key,
+        user_config={"model": {"default": "global-model", "provider": "alpha"}},
+    )
+
+    assert model == "vllm/DeepSeek-V4-Flash-0731"
+    assert runtime_kwargs.get("provider") == "beta"
+    assert runtime_kwargs.get("requested_provider") == "beta"
+
+
+def test_apply_session_model_override_threads_requested_provider():
+    """The credential-less override merge path must also carry the named
+    identity onto the runtime kwargs it patches."""
+    runner = _make_runner()
+    session_key = "agent:main:telegram:dm:c2"
+    runner._session_model_overrides[session_key] = {
+        "model": "vllm/DeepSeek-V4-Flash-0731",
+        "provider": "beta",
+        "requested_provider": "beta",
+        "base_url": "http://da-aihost01:4000/v1",
+    }
+
+    model, runtime_kwargs = runner._apply_session_model_override(
+        session_key, "old-model", {"provider": "alpha", "requested_provider": "alpha"}
+    )
+
+    assert model == "vllm/DeepSeek-V4-Flash-0731"
+    assert runtime_kwargs.get("provider") == "beta"
+    assert runtime_kwargs.get("requested_provider") == "beta"
+
+
+def test_apply_session_model_override_replaces_stale_requested_provider():
+    """A legacy override (provider only, no requested_provider) must not leave a
+    stale global requested_provider paired with the new provider — the
+    override's provider is authoritative for identity."""
+    runner = _make_runner()
+    session_key = "agent:main:telegram:dm:c3"
+    runner._session_model_overrides[session_key] = {
+        "model": "vllm/DeepSeek-V4-Flash-0731",
+        "provider": "beta",
+        "base_url": "http://da-aihost01:4000/v1",
+    }
+
+    model, runtime_kwargs = runner._apply_session_model_override(
+        session_key, "old-model", {"provider": "alpha", "requested_provider": "alpha"}
+    )
+
+    assert runtime_kwargs.get("provider") == "beta"
+    assert runtime_kwargs.get("requested_provider") == "beta"
+
+

--- a/tests/hermes_cli/test_model_switch_context_display.py
+++ b/tests/hermes_cli/test_model_switch_context_display.py
@@ -91,5 +91,99 @@ class TestResolveDisplayContextLength:
             "over probe-down fallback"
         )
 
+    def test_named_provider_exact_model_metadata_wins(self):
+        user_providers = {
+            "bifrost": {
+                "base_url": "http://da-aihost01:4000/v1",
+                "models": {
+                    "vllm/DeepSeek-V4-Flash-0731": {
+                        "context_length": 1_048_576,
+                    }
+                },
+            }
+        }
+        with patch(
+            "agent.model_metadata.get_model_context_length",
+            return_value=1_000_000,
+        ):
+            ctx = resolve_display_context_length(
+                "vllm/DeepSeek-V4-Flash-0731",
+                "bifrost",
+                base_url="http://da-aihost01:4000/v1",
+                user_providers=user_providers,
+            )
+
+        assert ctx == 1_048_576
+
+    def test_named_provider_metadata_matches_model_case_insensitively(self):
+        user_providers = {
+            "bifrost": {
+                "base_url": "http://da-aihost01:4000/v1",
+                "models": {
+                    "VLLM/DEEPSEEK-V4-FLASH-0731": {
+                        "context_length": 1_048_576,
+                    }
+                },
+            }
+        }
+        with patch(
+            "agent.model_metadata.get_model_context_length",
+            return_value=1_000_000,
+        ):
+            ctx = resolve_display_context_length(
+                "vllm/deepseek-v4-flash-0731",
+                "BIFROST",
+                base_url="http://da-aihost01:4000/v1",
+                user_providers=user_providers,
+            )
+
+        assert ctx == 1_048_576
+
+    def test_named_provider_metadata_does_not_leak_across_provider_identity(self):
+        user_providers = {
+            "other": {
+                "base_url": "http://da-aihost01:4000/v1",
+                "models": {
+                    "vllm/DeepSeek-V4-Flash-0731": {
+                        "context_length": 1_048_576,
+                    }
+                },
+            }
+        }
+        with patch(
+            "agent.model_metadata.get_model_context_length",
+            return_value=1_000_000,
+        ):
+            ctx = resolve_display_context_length(
+                "vllm/DeepSeek-V4-Flash-0731",
+                "bifrost",
+                base_url="http://da-aihost01:4000/v1",
+                user_providers=user_providers,
+            )
+
+        assert ctx == 1_000_000
+
+    def test_named_provider_metadata_does_not_substring_match_model_alias(self):
+        user_providers = {
+            "bifrost": {
+                "models": {
+                    "DeepSeek-V4-Flash-0731": {
+                        "context_length": 1_048_576,
+                    }
+                },
+            }
+        }
+        with patch(
+            "agent.model_metadata.get_model_context_length",
+            return_value=1_000_000,
+        ):
+            ctx = resolve_display_context_length(
+                "vllm/DeepSeek-V4-Flash-0731",
+                "bifrost",
+                user_providers=user_providers,
+            )
+
+        assert ctx == 1_000_000
+
 
 

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -177,6 +177,44 @@ def test_switch_model_uses_selected_named_provider_model_metadata(monkeypatch):
     assert agent.context_compressor.context_length == 1_048_576
 
 
+def test_switch_model_endpoint_fallback_no_sibling_named_provider_leak(monkeypatch):
+    """After an exact named-provider miss, ``switch_model`` must NOT borrow a
+    sibling named provider's per-model window via the shared endpoint.
+
+    ``beta`` (selected) declares the model but no ``context_length``; ``alpha``
+    shares the endpoint and declares 1,048,576. Selecting ``beta`` must fall
+    through to the live probe, not inherit ``alpha``'s window through the
+    converted-new-style compatible list (Medium review finding on #89714)."""
+    agent = _make_agent_with_compressor(config_context_length=None)
+    shared_url = "http://da-aihost01:4000/v1"
+    model = "vllm/DeepSeek-V4-Flash-0731"
+    cfg = {
+        "providers": {
+            "alpha": {
+                "base_url": shared_url,
+                "models": {model: {"context_length": 1_048_576}},
+            },
+            "beta": {
+                "base_url": shared_url,
+                "models": {model: {}},
+            },
+        }
+    }
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+    monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: cfg)
+
+    with patch(
+        "agent.model_metadata.get_model_context_length",
+        return_value=200_000,
+    ) as mock_ctx:
+        agent.switch_model(model, "beta", api_key="sk-test", base_url=shared_url)
+
+    assert agent.requested_provider == "beta"
+    assert agent._config_context_length != 1_048_576
+    assert mock_ctx.call_args.kwargs.get("config_context_length") != 1_048_576
+    assert agent.context_compressor.context_length == 200_000
+
+
 def test_direct_start_model_override_does_not_inherit_profile_context_length():
     """A CLI ``--model`` startup override must not inherit another model's window."""
     cfg = {

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -44,7 +44,12 @@ def test_route_url_normalization_preserves_path_slash_before_query():
 
 
 def _make_direct_start_agent(
-    cfg: dict, *, model: str, provider: str, base_url: str
+    cfg: dict,
+    *,
+    model: str,
+    provider: str,
+    base_url: str,
+    requested_provider: str | None = None,
 ) -> AIAgent:
     with (
         patch("hermes_cli.config.load_config", return_value=cfg), patch("hermes_cli.config.load_config_readonly", return_value=cfg),
@@ -56,6 +61,7 @@ def _make_direct_start_agent(
         return AIAgent(
             model=model,
             provider=provider,
+            requested_provider=requested_provider,
             api_key="fake-test-token",
             base_url=base_url,
             quiet_mode=True,
@@ -133,6 +139,44 @@ def test_switch_model_without_config_context_length():
         assert call_kwargs.get("config_context_length") is None
 
 
+def test_switch_model_uses_selected_named_provider_model_metadata(monkeypatch):
+    agent = _make_agent_with_compressor(config_context_length=32_768)
+    shared_url = "http://da-aihost01:4000/v1"
+    model = "vllm/DeepSeek-V4-Flash-0731"
+    cfg = {
+        "providers": {
+            "other": {
+                "base_url": shared_url,
+                "models": {model: {"context_length": 1_000_000}},
+            },
+            "bifrost": {
+                "base_url": shared_url,
+                "models": {model: {"context_length": 1_048_576}},
+            },
+        }
+    }
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+    monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: cfg)
+
+    def _resolve_context(*_args, config_context_length=None, **_kwargs):
+        return config_context_length or 1_000_000
+
+    with patch(
+        "agent.model_metadata.get_model_context_length",
+        side_effect=_resolve_context,
+    ):
+        agent.switch_model(
+            model,
+            "bifrost",
+            api_key="sk-test",
+            base_url=shared_url,
+        )
+
+    assert agent.requested_provider == "bifrost"
+    assert agent._config_context_length == 1_048_576
+    assert agent.context_compressor.context_length == 1_048_576
+
+
 def test_direct_start_model_override_does_not_inherit_profile_context_length():
     """A CLI ``--model`` startup override must not inherit another model's window."""
     cfg = {
@@ -181,6 +225,38 @@ def test_direct_start_preserves_context_for_normalized_default_model_alias():
 
     assert agent.context_compressor.config_context_length == 272_000
     assert agent.context_compressor.context_length == 272_000
+
+
+def test_direct_start_uses_selected_named_provider_model_metadata():
+    shared_url = "http://da-aihost01:4000/v1"
+    model = "vllm/DeepSeek-V4-Flash-0731"
+    cfg = {
+        "model": {
+            "default": model,
+            "provider": "bifrost",
+        },
+        "providers": {
+            "other": {
+                "base_url": shared_url,
+                "models": {model: {"context_length": 1_000_000}},
+            },
+            "bifrost": {
+                "base_url": shared_url,
+                "models": {model: {"context_length": 1_048_576}},
+            },
+        },
+    }
+
+    agent = _make_direct_start_agent(
+        cfg,
+        model=model,
+        provider="custom",
+        requested_provider="bifrost",
+        base_url=shared_url,
+    )
+
+    assert agent.context_compressor.config_context_length == 1_048_576
+    assert agent.context_compressor.context_length == 1_048_576
 
 
 


### PR DESCRIPTION
## Summary
- resolve exact, case-insensitive per-model context metadata from the selected named `providers:` entry before endpoint probes and built-in catalogs
- thread named-provider identity through typed/picker model switches, gateway context consumers, session startup, and runtime compressor updates
- preserve exact provider/model scoping, stale route-pin clearing, provider-aware fallback behavior, and legacy `custom_providers` support

## Test plan
- [x] Proved RED first: 6 focused failures on typed `/model`, picker confirmation, resolver input, and runtime initialization
- [x] `scripts/run_tests.sh tests/hermes_cli/test_model_switch_context_display.py tests/gateway/test_model_command_context_offload.py tests/run_agent/test_switch_model_context.py -q` (20 passed)
- [x] Related model-switch/context/session suites (107 passed)
- [x] Ruff lint on all changed Python files
- [x] Python bytecode compilation and `git diff --check`
- [ ] Full optional-dependency suite was attempted; this minimal `dev` environment reports 162 unrelated failures across 45 files plus 40 collection errors, primarily because messaging/provider extras such as Anthropic, Slack, Matrix, and media backends are not installed

Made with [Cursor](https://cursor.com)