### PR TITLE
fix(desktop): unpinning a session no longer bounces back into Pinned

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -125,6 +125,7 @@ import {
   setCurrentCwd
 } from '@/store/session'
 import { $sessionDotStateById, sessionStatusBucket } from '@/store/session-dot-state'
+import { isPinUnpinPending } from '@/store/session-pin-sync'
 import { $focusedStoredSessionId, $workingSessionIds, type SplitDir } from '@/store/session-states'
 import { ackAllSessionsRead } from '@/store/session-unread'
 import { markSessionUnread } from '@/store/session-unread-remote'
@@ -547,13 +548,17 @@ export function ChatSidebar({
   // Local pin ids first (hand-picked order), then server-flagged pins the
   // local set doesn't know about — a backend `pinned=1` row must never be
   // invisible just because localStorage is cold or was clobbered (#85969).
+  // A row just unpinned locally is excluded from that fallback too, via
+  // isPinUnpinPending — its cached `pinned` flag is stale until the PATCH is
+  // confirmed, and the fallback must not use it to re-add the row (#89700).
   const pinnedSessions = useMemo(
     () =>
-      resolvePinnedSessions(pinnedSessionIds, sessionByAnyId, [
-        ...visibleSessions,
-        ...cronSessions,
-        ...messagingSessions
-      ]),
+      resolvePinnedSessions(
+        pinnedSessionIds,
+        sessionByAnyId,
+        [...visibleSessions, ...cronSessions, ...messagingSessions],
+        isPinUnpinPending
+      ),
     [pinnedSessionIds, sessionByAnyId, visibleSessions, cronSessions, messagingSessions]
   )
 

--- a/apps/desktop/src/app/chat/sidebar/session-index.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-index.test.ts
@@ -94,4 +94,14 @@ describe('resolvePinnedSessions', () => {
 
     expect(resolvePinnedSessions([], index, sessions)).toEqual([])
   })
+
+  it('does not re-add a row via the server fallback while its local unpin is unconfirmed (#89700)', () => {
+    // Unpinning removes 'a' from the local set, but the cached row still
+    // carries pinned: true until a fresh page confirms the PATCH. Without
+    // the pending-unpin guard, the fallback below would re-add it instantly.
+    const sessions = [row('a', { pinned: true })]
+    const index = buildSessionByAnyId(sessions, [], [])
+
+    expect(resolvePinnedSessions([], index, sessions, () => true)).toEqual([])
+  })
 })

--- a/apps/desktop/src/app/chat/sidebar/session-index.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-index.ts
@@ -47,11 +47,18 @@ export function buildSessionByAnyId(
  * a session the backend says is pinned is always reachable from the Pinned
  * section, whatever the local cache holds. session-pin-sync then adopts the
  * pin into the local set on its next reconcile, restoring ordering control.
+ *
+ * A session just unpinned locally is the mirror-image case: its cached row
+ * still carries `pinned: true` (session-pin-sync's PATCH ack never rewrites
+ * it) until a fresh list page confirms the flip. Without `isPendingUnpin`,
+ * that stale flag would fall through to the fallback below and re-add the
+ * row immediately after the user cleared it (#89700).
  */
 export function resolvePinnedSessions(
   pinnedSessionIds: readonly string[],
   sessionByAnyId: Map<string, SessionInfo>,
-  allSessions: readonly SessionInfo[]
+  allSessions: readonly SessionInfo[],
+  isPendingUnpin: (pinId: string) => boolean = () => false
 ): SessionInfo[] {
   const seen = new Set<string>()
   const out: SessionInfo[] = []
@@ -66,7 +73,9 @@ export function resolvePinnedSessions(
   }
 
   for (const session of allSessions) {
-    if (session.pinned === true && !seen.has(session.id)) {
+    const pinId = session._lineage_root_id ?? session.id
+
+    if (session.pinned === true && !seen.has(session.id) && !isPendingUnpin(pinId) && !isPendingUnpin(session.id)) {
       seen.add(session.id)
       out.push(session)
     }

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -46,6 +46,17 @@ function profileFor(pinId: string): null | string | undefined {
   return $sessions.get().find(row => sessionMatchesStoredId(row, pinId))?.profile
 }
 
+/**
+ * True while a local unpin's PATCH(false) hasn't been confirmed by a page yet.
+ * The cached `$sessions` row for this id can still read `pinned: true` (the
+ * PATCH ack doesn't rewrite it), so the sidebar's server-flagged fallback
+ * (session-index.ts) must not use that stale flag to re-add the row while
+ * this is true, or the unpin never sticks (#89700).
+ */
+export function isPinUnpinPending(pinId: string): boolean {
+  return unconfirmed.get(pinId)?.value === false
+}
+
 /** PATCH the flag, guarding reads against pages that predate the write. */
 function writePin(id: string, pinned: boolean, profile?: null | string): Promise<void> {
   unconfirmed.set(id, { at: Date.now(), value: pinned })


### PR DESCRIPTION
## What does this PR do?

Fixes the sidebar Pinned section immediately re-adding a session right after
the user unpins it. The session would stay at the bottom of Pinned until a
repeat click or an app restart forced a fresh session list.

## Related Issue

Fixes #89700

## Root cause

`resolvePinnedSessions` (`apps/desktop/src/app/chat/sidebar/session-index.ts`)
builds the Pinned section from the local `$pinnedSessionIds` order first, then
falls back to any cached `$sessions` row still flagged `pinned: true` that the
local set doesn't (yet) know about — a fallback added for #85969 so a
server-flagged pin stays reachable when localStorage is cold.

That fallback has no way to distinguish a genuine server pin from a *just
unpinned* row: `unpinSession()` removes the id from `$pinnedSessionIds`
immediately, but the cached `$sessions` row for that session still carries
`pinned: true` — `session-pin-sync.ts`'s PATCH ack never rewrites the cached
row, only a fresh list page does. So the fallback loop re-added the row from
the stale flag on the very next render, landing it at the bottom (no longer in
the local ordering list) — exactly the reported symptom.

`session-pin-sync.ts` already tracks in-flight writes via its `unconfirmed`
map (used to fence `pullRemotePins` against stale pages, #74570). This PR
exposes that as `isPinUnpinPending(pinId)` and threads it into
`resolvePinnedSessions` as an optional predicate, so the fallback skips a row
while its local unpin's PATCH(false) hasn't been confirmed by a page yet.

## Changes Made

- `apps/desktop/src/store/session-pin-sync.ts`: export `isPinUnpinPending(pinId)`,
  reading the existing `unconfirmed` map for a not-yet-confirmed local unpin.
- `apps/desktop/src/app/chat/sidebar/session-index.ts`: `resolvePinnedSessions`
  takes an optional `isPendingUnpin` predicate (default no-op, so existing
  callers/tests are unaffected) and skips a row in the server-flagged fallback
  when its pin id (or lineage root) is pending unpin.
- `apps/desktop/src/app/chat/sidebar/index.tsx`: wires `isPinUnpinPending` into
  the `resolvePinnedSessions` call that builds the sidebar's Pinned section.
- `apps/desktop/src/app/chat/sidebar/session-index.test.ts`: new regression
  test.

## How to Test

1. `cd apps/desktop && npx vitest run src/app/chat/sidebar/session-index.test.ts`
2. Manually: pin a session, click unpin — it should leave the Pinned section
   immediately instead of sinking to the bottom and staying there.

### Test output (after fix)

```
 Test Files  2 passed (2)
      Tests  29 passed (29)
```

### Proof the new test fails without the fix

Reverted `session-index.ts` to `HEAD` (pre-fix) while keeping the new test:

```
❯ |ui| src/app/chat/sidebar/session-index.test.ts (11 tests | 1 failed)
 × does not re-add a row via the server fallback while its local unpin is unconfirmed (#89700)
AssertionError: expected [ { id: 'a', ... } ] to deeply equal []
```

Restored the fix and the suite is green again (see above).

### Full suite / lint / typecheck

- `npx vitest run` (whole `apps/desktop` workspace): `Test Files 636 passed | 1 skipped (637)`, `Tests 6355 passed | 2 skipped (6357)`
- `npx eslint` on the changed files: clean
- `npx tsc -p . --noEmit`: clean

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added a regression test and confirmed it fails without the fix
- [ ] I've tested on my platform (no macOS desktop environment available in this sandbox — verified via unit tests and code reading only)

### Documentation & Housekeeping

- [x] N/A — no docs/config/tool-schema changes needed

## Disclosure

This fix was prepared with AI assistance (an autonomous coding agent), with the
diff, tests, and test output reviewed before submission.
