### PR TITLE
fix(bot-mode): Routines pane no longer keeps a stale bot after re-enable (#89625, salvage #89637)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -7462,6 +7462,24 @@ function CreateRoutineDialog({ bot, open, onClose }) {
   })
 }
 
+/** Keeps $selectedBot in sync with the focused chat's owner profile.
+ *  nanostores' `.listen()` never replays the current value the way
+ *  `.subscribe()` does, so a disable → profile switch → re-enable sequence
+ *  would otherwise leave $selectedBot pointed at whichever bot was active
+ *  before the plugin was disabled — reseeding here on every register() call
+ *  closes that gap. Returns the unbind function for ctx.onDispose. */
+function bindProfileSync(profileStore) {
+  const current = profileStore.get?.()
+  if (current && typeof current === 'string') {
+    $selectedBot.set(current)
+  }
+  return profileStore.listen(profile => {
+    if (profile && typeof profile === 'string') {
+      $selectedBot.set(profile)
+    }
+  })
+}
+
 function RoutinesPane() {
   const selected = useValue($selectedBot)
   const focusedProfile = useValue($focusedBotProfile)
@@ -9846,11 +9864,7 @@ export default {
     // Capture the unbinds: without them a disable → re-enable cycle stacks a
     // duplicate listener per cycle (same survives-disable class as the face
     // clock before its onDispose hook — these kept firing until app restart).
-    const unbindProfileListener = $focusedBotProfile.listen(profile => {
-      if (profile && typeof profile === 'string') {
-        $selectedBot.set(profile)
-      }
-    })
+    const unbindProfileListener = bindProfileSync($focusedBotProfile)
     const unbindGatewayListener = host.state.gateway.listen(handleSessionsGatewayTransition)
 
     if (typeof ctx.onDispose === 'function') {

--- a/apps/desktop/src/plugins/hermes-bots/tests/focused-bot-highlight.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/focused-bot-highlight.test.mjs
@@ -48,6 +48,6 @@ test('RoutinesPane scopes the Cronjobs tile to the focused chat owner', () => {
   assert.ok(!/useValue\(host\.state\.profile\)/.test(pane), 'the tile must not read the socket-home atom directly')
 })
 
-test('the $selectedBot tracker listens on the focused profile ladder (unbind captured)', () => {
-  assert.match(source, /const unbindProfileListener = \$focusedBotProfile\.listen\(profile => \{/)
+test('the $selectedBot tracker binds the focused profile ladder (reseed + unbind captured)', () => {
+  assert.match(source, /const unbindProfileListener = bindProfileSync\(\$focusedBotProfile\)/)
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/routines-selected-bot.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routines-selected-bot.test.mjs
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// #89625 follow-up (PR #89637 residual): nanostores' `.listen()` never replays
+// the current value the way `.subscribe()` does, so the $focusedBotProfile
+// listener in register() only kept $selectedBot current from the moment it was
+// attached. A disable -> profile switch -> re-enable cycle (Settings > Plugins)
+// left $selectedBot pointed at whichever bot was active before the plugin was
+// disabled. bindProfileSync() reseeds $selectedBot from the store's CURRENT
+// value before attaching the listener, so every register() starts in sync.
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function load() {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+  const context = {
+    atom,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: { state: { profile: { listen: () => undefined } } }
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat('\nglobalThis.__api = { bindProfileSync, $selectedBot };\n')
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  return context
+}
+
+// Mimic real nanostores atom semantics (get + non-replaying listen) — not a
+// mock that assumes the fix — so this fails honestly if bindProfileSync
+// regresses to a plain, non-reseeding listen().
+function fakeProfileStore(initial) {
+  let value = initial
+  const listeners = new Set()
+  return {
+    get: () => value,
+    set: next => {
+      value = next
+      for (const listener of listeners) listener(value)
+    },
+    listen: listener => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    }
+  }
+}
+
+test('regression: re-enabling after a profile switch while disabled resyncs, not stays stale', () => {
+  const { bindProfileSync, $selectedBot } = load().__api
+  const profile = fakeProfileStore('blog-writer')
+
+  const unbind1 = bindProfileSync(profile)
+  assert.equal($selectedBot.get(), 'blog-writer', 'reseeded to the live profile on first bind')
+
+  unbind1() // plugin disabled: listener torn down
+  profile.set('researcher') // profile changes while nothing is listening
+
+  bindProfileSync(profile) // plugin re-enabled: register() runs again
+  assert.equal($selectedBot.get(), 'researcher', 'reseeded to the live profile on re-bind, not left stale')
+})
+
+test('unit: bindProfileSync keeps forwarding live profile changes after (re)binding', () => {
+  const { bindProfileSync, $selectedBot } = load().__api
+  const profile = fakeProfileStore('default')
+
+  bindProfileSync(profile)
+  profile.set('researcher')
+  assert.equal($selectedBot.get(), 'researcher', 'live changes still flow through the listener')
+})
+
+test('unit: an empty/non-string current value is not seeded into $selectedBot', () => {
+  const { bindProfileSync, $selectedBot } = load().__api
+  const before = $selectedBot.get()
+  bindProfileSync(fakeProfileStore(''))
+  assert.equal($selectedBot.get(), before, 'falsy current value leaves $selectedBot untouched')
+})
+
+test('unit: register() wires the focused-profile ladder through bindProfileSync', () => {
+  assert.match(
+    pluginSource,
+    /const unbindProfileListener = bindProfileSync\(\$focusedBotProfile\)/,
+    'the reseeding helper must own the $focusedBotProfile subscription'
+  )
+})


### PR DESCRIPTION
## Summary
Bot Mode's Routines pane no longer goes stale after a disable → profile switch → re-enable cycle: `$selectedBot` is now reseeded from the store's current value before the listener attaches.

Salvage of #89637 by @chelsealong. The PR's headline precedence flip was superseded on main by 23c1c9815 ($focusedBotProfile design); this carries the residual real bug she diagnosed — `register()` attached `$focusedBotProfile.listen()` with no get()-before-listen reseed, so nanostores never replayed the current value across a disable/re-enable cycle.

## Changes
- `apps/desktop/src/plugins/hermes-bots/plugin.js`: `bindProfileSync()` helper — reseed from store current value, then listen; wired into `register()`
- `tests/routines-selected-bot.test.mjs`: 4 regression tests (reseed, live forwarding, falsy-seed guard, wiring)
- `tests/focused-bot-highlight.test.mjs`: updated one assertion pinning the old inline `.listen()` form

## Validation
| | Result |
|---|---|
| Plugin suite | 292 pass / 0 fail |
| Sabotage check | reseed removed → regression test fails (1) |

Fixes #89625 (residual half). Authorship preserved: chelsealong.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa6eb16/0d1Py7Ikg4M6W-zhtVhxR_gs2tHah9.png)
