### PR TITLE
fix(desktop): bot clicks no longer reset the profile filter (salvage #89031)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -3186,7 +3186,8 @@ async function openStoredBotChat(name, storedId, summary) {
     profile: name,
     intent: 'main',
     awaitHydration: true,
-    expectHistory
+    expectHistory,
+    keepAllProfilesScope: false
   })
 
   return storedId
@@ -3226,7 +3227,7 @@ function createCanonicalChat(name) {
 
     if (sid && typeof host.openSession === 'function') {
       try {
-        await host.openSession(sid, { profile: name, intent: 'main' })
+        await host.openSession(sid, { profile: name, intent: 'main', keepAllProfilesScope: false })
         opened = true
       } catch {
         // The stored row may not exist until the kickoff persists it. Retry
@@ -3241,7 +3242,7 @@ function createCanonicalChat(name) {
         await host.request('prompt.submit', { session_id: runtime, text: 'Hey, tell me about yourself!' })
 
         if (!opened && sid && typeof host.openSession === 'function') {
-          await host.openSession(sid, { profile: name, intent: 'main' })
+          await host.openSession(sid, { profile: name, intent: 'main', keepAllProfilesScope: false })
         }
       } catch {
         // The chat already exists. Keep the pin so the next click
@@ -7656,7 +7657,7 @@ async function openProfileSession(botName, session, gatewayGeneration) {
     typeof session?.message_count === 'number' && Number.isFinite(session.message_count)
   const expectHistory = hasAuthoritativeCount ? session.message_count > 0 : Boolean(session?.preview)
 
-  await host.openSession(id, { profile, awaitHydration: true, expectHistory })
+  await host.openSession(id, { profile, awaitHydration: true, expectHistory, keepAllProfilesScope: false })
   if (gatewayGeneration !== $sessionsGatewayGeneration.get()) return
   $botSelectedSessions.set({ ...$botSelectedSessions.get(), [profile]: id })
 }

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-identity.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-identity.test.mjs
@@ -111,7 +111,8 @@ test('pin: preferred_session present opens the resolved session and keeps the pi
       profile: 'ops',
       intent: 'main',
       awaitHydration: true,
-      expectHistory: true
+      expectHistory: true,
+      keepAllProfilesScope: false
     }
   }])
   assert.equal(runtime.saved.length, 0, 'a live pin must not be rewritten')

--- a/apps/desktop/src/plugins/hermes-bots/tests/session-workspace.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/session-workspace.test.mjs
@@ -90,7 +90,7 @@ test('sessions workspace: opening a stored row uses profile-aware navigation and
   const runtime = load({ profile: 'default' })
   await runtime.__sessions.openProfileSession('ops', { id: 'stored-123', message_count: 4 }, 0)
   assert.deepEqual(plain(runtime.calls), [
-    ['openSession', 'stored-123', { profile: 'ops', awaitHydration: true, expectHistory: true }]
+    ['openSession', 'stored-123', { profile: 'ops', awaitHydration: true, expectHistory: true, keepAllProfilesScope: false }]
   ])
   assert.equal(runtime.__sessions.$botSelectedSessions.get().ops, 'stored-123')
 })
@@ -117,7 +117,7 @@ test('sessions workspace: an empty session with no preview does not demand histo
   const runtime = load()
   await runtime.__sessions.openProfileSession('ops', { id: 'stored-empty', message_count: 0 }, 0)
   assert.deepEqual(plain(runtime.calls), [
-    ['openSession', 'stored-empty', { profile: 'ops', awaitHydration: true, expectHistory: false }]
+    ['openSession', 'stored-empty', { profile: 'ops', awaitHydration: true, expectHistory: false, keepAllProfilesScope: false }]
   ])
 })
 

--- a/contributors/emails/marketing@cflow.co.kr
+++ b/contributors/emails/marketing@cflow.co.kr
@@ -1,0 +1,1 @@
+marketing2981


### PR DESCRIPTION
## Summary
Clicking a different bot no longer resets the Sessions sidebar to the all-profiles view — the user's per-profile filter survives bot navigation.

Salvage of #89031 by @marketing2981. The original 7 openSession call sites became 4 after the plugin refactor; the intent (keepAllProfilesScope: false, the documented SDK opt-out at sdk/index.ts:515) was re-applied surgically to all 4 current sites with the contributor's authorship.

## Changes
- `apps/desktop/src/plugins/hermes-bots/plugin.js`: keepAllProfilesScope: false at all 4 host.openSession sites (verified by grep, none remain)
- `tests/session-workspace.test.mjs`: expectation ported to current assertion shape
- `tests/canonical-chat-identity.test.mjs`: exact-options assertion updated (follow-up commit)
- `contributors/emails/marketing@cflow.co.kr`: attribution mapping

## Validation
| | Result |
|---|---|
| Plugin suite | 288/288 pass |
| session-workspace | 11/11 |

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa6eb25/t-tPwqL0b9afjmqqNC-dx_XBkePPxF.png)
