### PR TITLE
feat(bot-mode): roster shows paid vs free/local badges (salvage #88086)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -4648,7 +4648,137 @@ function activeBots(roster, activeProfile, gatewayState, now = Date.now()) {
 
 // ── bot row ──────────────────────────────────────────────────────────────────
 
-function BotRow({ bot, onDelete, onEdit, onGroup }) {
+// ── paid/free LLM indicator ─────────────────────────────────────────────────
+//
+// A bot "costs money" when its configured LLM is not PROVABLY free. Free is
+// established only on positive evidence: a `:free` model suffix (OpenRouter
+// convention, used by the Nous portal too), a local serving provider, or the
+// gateway model catalog (model.options) reporting $0 in/out. Anything
+// unprovable counts as paid — the roster must never hide a cost it cannot
+// rule out (fail-closed).
+
+const FREE_PROVIDERS = new Set([
+  'lmstudio',
+  'ollama',
+  'llama.cpp',
+  'llamacpp',
+  'local',
+  'koboldcpp',
+  'vllm',
+  'text-generation-webui',
+  'jan',
+  'mlx',
+  'llamafile',
+  'gpt4all'
+])
+
+function isFreeModel(model, provider, pricingByModel) {
+  if (!model) return false
+  if (typeof model === 'string' && model.endsWith(':free')) return true
+  if (provider && FREE_PROVIDERS.has(String(provider).toLowerCase())) return true
+  if (pricingByModel) {
+    const hit = Object.prototype.hasOwnProperty.call(pricingByModel, model)
+      ? pricingByModel[model]
+      : pricingByModel[String(model).split('/').pop()]
+    if (typeof hit === 'boolean') return hit
+  }
+  return false
+}
+
+/** Per-bot cost state: 'paid' | 'free' | 'local' | 'unknown'.
+ *  'local' = the user declared the bot runs on their own hardware (bot meta
+ *  flag), which overrides every other signal. Unknown = no model configured
+ *  anywhere (nothing to charge). A bot whose own model is free but whose
+ *  delegation model is paid still counts as paid (subagents run under
+ *  delegation). */
+function botCostState(bot, { pricingByModel, defaultModel, local } = {}) {
+  if (local) return 'local'
+  const model = bot.model || defaultModel || ''
+  if (!model) return 'unknown'
+  const provider = bot.provider || ''
+  if (bot.delegation_model && !isFreeModel(bot.delegation_model, bot.delegation_provider, pricingByModel)) {
+    return 'paid'
+  }
+  return isFreeModel(model, provider, pricingByModel) ? 'free' : 'paid'
+}
+
+/** Flatten model.options pricing into modelId → free bool. */
+function buildPricingByModel(modelOptions) {
+  const map = {}
+  for (const provider of modelOptions?.providers || []) {
+    const pricing = provider?.pricing
+    if (pricing && typeof pricing === 'object') {
+      for (const [modelId, info] of Object.entries(pricing)) {
+        if (info && typeof info === 'object' && typeof info.free === 'boolean') {
+          map[modelId] = info.free
+        }
+      }
+    }
+  }
+  return map
+}
+
+const REGION_CURRENCY = {
+  US: '$', GB: '£', IE: '€', DE: '€', FR: '€', ES: '€', IT: '€', NL: '€',
+  AT: '€', BE: '€', FI: '€', PT: '€', GR: '€', PL: 'zł', CZ: 'Kč', SE: 'kr',
+  NO: 'kr', DK: 'kr', CH: 'CHF', CA: 'CA$', AU: 'A$', NZ: 'NZ$', JP: '¥',
+  CN: '¥', KR: '₩', IN: '₹', MX: 'MX$', BR: 'R$', TR: '₺', IL: '₪',
+  SG: 'S$', HK: 'HK$', TW: 'NT$', TH: '฿', ID: 'Rp', MY: 'RM', PH: '₱',
+  VN: '₫', ZA: 'R', RU: '₽'
+}
+
+/** The user's official currency symbol, from the app/OS locale. Falls back
+ *  to $ when the locale is unknown or unavailable. */
+function userCurrencySymbol() {
+  try {
+    const locale = (typeof navigator !== 'undefined' && navigator.language) || 'en-US'
+    const region = String(locale.split('-')[1] || 'US').toUpperCase()
+    return REGION_CURRENCY[region] || '$'
+  } catch {
+    return '$'
+  }
+}
+
+/** Small roster badge: the user's currency symbol when the bot's LLM costs
+ *  money, 🆓 when provably free or declared locally hosted, nothing when
+ *  unclassifiable. The title always names the exact model + provider so a
+ *  badge is never a mystery. */
+function costBadge(costState, model, provider) {
+  if (costState === 'paid') {
+    return jsx('span', {
+      className: 'shrink-0 text-[0.875rem] font-semibold leading-none',
+      // Inline color: the app's plugin class pipeline doesn't generate
+      // arbitrary `text-[#hex]` utilities, so theme/scan-dependent classes
+      // would fall back to inherited gray. Brand emerald (#10b981) is
+      // stable in both light and dark palettes.
+      style: { color: '#10b981' },
+      title: `${model} via ${provider || 'unknown provider'} — paid LLM`,
+      'aria-label': 'paid LLM',
+      children: userCurrencySymbol()
+    })
+  }
+  if (costState === 'local') {
+    return jsx('span', {
+      className: 'shrink-0 text-[0.875rem] leading-none',
+      title: `${model} via ${provider || 'unknown provider'} — locally hosted (no LLM cost)`,
+      'aria-label': 'locally hosted LLM',
+      children: '🆓'
+    })
+  }
+  if (costState === 'free') {
+    return jsx('span', {
+      className: 'shrink-0 text-[0.875rem] leading-none',
+      title: `${model} via ${provider || 'unknown provider'} — free LLM`,
+      'aria-label': 'free LLM',
+      children: '🆓'
+    })
+  }
+  return null
+}
+
+// ── bot row ──────────────────────────────────────────────────────────────────
+
+function BotRow({ bot, onDelete, onEdit, onGroup, defaultModel = '' }) {
   const activeProfile = useValue(host.state.profile)
   const focusedProfile = useValue($focusedBotProfile)
   const meta = botRosterMeta(bot, useValue($botMeta))
@@ -4774,6 +4904,17 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
     }
   }
 
+  // Paid/free LLM badge: free requires positive evidence (:free suffix,
+  // local provider, or catalog price $0); anything unprovable shows the
+  // user's currency symbol. A user-declared "locally hosted" flag (bot
+  // meta) overrides everything.
+  const modelOptions = useModelOptions()
+  const costState = botCostState(bot, {
+    pricingByModel: buildPricingByModel(modelOptions.data),
+    defaultModel,
+    local: Boolean(meta?.local)
+  })
+
   const row = jsxs('button', {
     type: 'button',
     onPointerEnter: warm,
@@ -4818,6 +4959,7 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
                     className: 'truncate text-[0.8125rem] font-medium',
                     children: displayName(bot, meta)
                   }),
+                  costBadge(costState, bot.model || defaultModel, bot.provider),
                   showsHandle(bot.name, meta, bot)
                     ? jsx('span', {
                         className: 'shrink-0 font-mono text-[0.6875rem] text-(--ui-text-quaternary)',
@@ -5180,6 +5322,7 @@ function AdvancedProfileConfig({ bot, state, setState }) {
   const [loaded, setLoaded] = useState(false)
   const [unsupported, setUnsupported] = useState(false)
   const [skillFilter, setSkillFilter] = useState('')
+  const { data: modelOptions } = useModelOptions()
 
   if (!loaded) {
     setLoaded(true)
@@ -5274,6 +5417,34 @@ function AdvancedProfileConfig({ bot, state, setState }) {
         jsx(ModelPicker, {
           value: { provider: state.provider, model: state.model },
           onChange: patch => setState(prev => ({ ...prev, dirtyModel: true, ...patch }))
+        }),
+        jsx('div', {
+          className: 'flex items-center gap-1.5 pl-0.5',
+          children: state.model
+            ? costBadge(
+                botCostState(
+                  { model: state.model, provider: state.provider },
+                  { pricingByModel: buildPricingByModel(modelOptions), local: Boolean(state.local) }
+                ),
+                state.model,
+                state.provider
+              )
+            : jsx('span', {
+                className: 'text-[0.6875rem] text-(--ui-text-tertiary)',
+                children: 'Inherits the launch profile model'
+              })
+        }),
+        jsx('label', {
+          className: 'flex cursor-pointer items-center gap-2 pl-0.5 text-xs text-(--ui-text-secondary)',
+          children: [
+            jsx(Checkbox, {
+              checked: Boolean(state.local),
+              onCheckedChange: value => setState(prev => ({ ...prev, dirtyLocal: true, local: Boolean(value) }))
+            }),
+            jsx('span', {
+              children: 'Locally hosted — runs on my own hardware (no LLM cost)'
+            })
+          ]
         }),
         labeled(
           'Capabilities (applies immediately — skills, tools, MCP)',
@@ -5728,11 +5899,13 @@ function emptyAdvancedState() {
     skills: [],
     toolsets: [],
     mcp: [],
+    local: false,
     dirtyModel: false,
     dirtySoul: false,
     dirtySkills: false,
     dirtyToolsets: false,
-    dirtyMcp: false
+    dirtyMcp: false,
+    dirtyLocal: false
   }
 }
 
@@ -5832,7 +6005,7 @@ function EditProfileDialog({ bot, open, onClose }) {
       setDescription(bot.description || '')
       setBusy(false)
       setAdvanced(false)
-      setAdv(emptyAdvancedState())
+      setAdv({ ...emptyAdvancedState(), local: Boolean(meta?.local) })
     }
   }
 
@@ -5892,6 +6065,12 @@ function EditProfileDialog({ bot, open, onClose }) {
         advancedFailed = true
         host.notifyError(err, 'Advanced configuration failed')
       }
+    }
+
+    // User-declared "locally hosted" flag — persists via bot meta (local
+    // storage + server ui_meta), the same path as the other bot meta flags.
+    if (adv.dirtyLocal) {
+      saveBotMeta(bot.name, { local: adv.local })
     }
 
     if (!advancedFailed && !lookFailed) {
@@ -9358,6 +9537,9 @@ function BotsPane() {
 
     return b.activity - a.activity
   })
+  // A bot without its own model inherits the launch profile's — classify
+  // against that so "inherit" rows still show the true cost state.
+  const defaultModel = (roster.find(b => b.is_default) || {}).model || ''
 
   if (live) {
     $lastRoster.set(roster)
@@ -9618,7 +9800,7 @@ function BotsPane() {
                           )
                         : jsx(
                             BotRow,
-                            { bot: row.bot, onDelete: setDeleting, onEdit: setEditing, onGroup: setGrouping },
+                            { bot: row.bot, onDelete: setDeleting, onEdit: setEditing, onGroup: setGrouping, defaultModel },
                             botRosterKey(row.bot)
                           )
                     )

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -4688,17 +4688,12 @@ function isFreeModel(model, provider, pricingByModel) {
 /** Per-bot cost state: 'paid' | 'free' | 'local' | 'unknown'.
  *  'local' = the user declared the bot runs on their own hardware (bot meta
  *  flag), which overrides every other signal. Unknown = no model configured
- *  anywhere (nothing to charge). A bot whose own model is free but whose
- *  delegation model is paid still counts as paid (subagents run under
- *  delegation). */
+ *  anywhere (nothing to charge). */
 function botCostState(bot, { pricingByModel, defaultModel, local } = {}) {
   if (local) return 'local'
   const model = bot.model || defaultModel || ''
   if (!model) return 'unknown'
   const provider = bot.provider || ''
-  if (bot.delegation_model && !isFreeModel(bot.delegation_model, bot.delegation_provider, pricingByModel)) {
-    return 'paid'
-  }
   return isFreeModel(model, provider, pricingByModel) ? 'free' : 'paid'
 }
 
@@ -4718,29 +4713,8 @@ function buildPricingByModel(modelOptions) {
   return map
 }
 
-const REGION_CURRENCY = {
-  US: '$', GB: '£', IE: '€', DE: '€', FR: '€', ES: '€', IT: '€', NL: '€',
-  AT: '€', BE: '€', FI: '€', PT: '€', GR: '€', PL: 'zł', CZ: 'Kč', SE: 'kr',
-  NO: 'kr', DK: 'kr', CH: 'CHF', CA: 'CA$', AU: 'A$', NZ: 'NZ$', JP: '¥',
-  CN: '¥', KR: '₩', IN: '₹', MX: 'MX$', BR: 'R$', TR: '₺', IL: '₪',
-  SG: 'S$', HK: 'HK$', TW: 'NT$', TH: '฿', ID: 'Rp', MY: 'RM', PH: '₱',
-  VN: '₫', ZA: 'R', RU: '₽'
-}
-
-/** The user's official currency symbol, from the app/OS locale. Falls back
- *  to $ when the locale is unknown or unavailable. */
-function userCurrencySymbol() {
-  try {
-    const locale = (typeof navigator !== 'undefined' && navigator.language) || 'en-US'
-    const region = String(locale.split('-')[1] || 'US').toUpperCase()
-    return REGION_CURRENCY[region] || '$'
-  } catch {
-    return '$'
-  }
-}
-
-/** Small roster badge: the user's currency symbol when the bot's LLM costs
- *  money, 🆓 when provably free or declared locally hosted, nothing when
+/** Small roster badge: a $ when the bot's LLM costs money (provider pricing
+ *  is USD), 🆓 when provably free or declared locally hosted, nothing when
  *  unclassifiable. The title always names the exact model + provider so a
  *  badge is never a mystery. */
 function costBadge(costState, model, provider) {
@@ -4749,12 +4723,13 @@ function costBadge(costState, model, provider) {
       className: 'shrink-0 text-[0.875rem] font-semibold leading-none',
       // Inline color: the app's plugin class pipeline doesn't generate
       // arbitrary `text-[#hex]` utilities, so theme/scan-dependent classes
-      // would fall back to inherited gray. Brand emerald (#10b981) is
-      // stable in both light and dark palettes.
-      style: { color: '#10b981' },
+      // would fall back to inherited gray. Neutral amber (#f59e0b) keeps
+      // green reserved as the 'free' signal and is stable in both light
+      // and dark palettes.
+      style: { color: '#f59e0b' },
       title: `${model} via ${provider || 'unknown provider'} — paid LLM`,
       'aria-label': 'paid LLM',
-      children: userCurrencySymbol()
+      children: '$'
     })
   }
   if (costState === 'local') {

--- a/apps/desktop/src/plugins/hermes-bots/tests/cost-badge.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/cost-badge.test.mjs
@@ -48,7 +48,7 @@ function load({ locale = 'en-US' } = {}) {
     .replace(/^import .* from 'react'\s*\n/m, '')
     .replace(/^import .* from 'react\/jsx-runtime'\s*\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
-    .concat('\nglobalThis.__cost = { isFreeModel, botCostState, buildPricingByModel, userCurrencySymbol, saveBotMeta };')
+    .concat('\nglobalThis.__cost = { isFreeModel, botCostState, buildPricingByModel, saveBotMeta };')
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
 
   const register = () => {
@@ -132,14 +132,6 @@ test('unit: an empty model resolves through the launch default', () => {
   )
 })
 
-test('unit: currency symbol follows the user locale, $ as fallback', () => {
-  assert.equal(load({ locale: 'en-US' }).__cost.userCurrencySymbol(), '$')
-  assert.equal(load({ locale: 'en-GB' }).__cost.userCurrencySymbol(), '£')
-  assert.equal(load({ locale: 'de-DE' }).__cost.userCurrencySymbol(), '€')
-  assert.equal(load({ locale: 'ja-JP' }).__cost.userCurrencySymbol(), '¥')
-  assert.equal(load({ locale: 'xx-XX' }).__cost.userCurrencySymbol(), '$')
-})
-
 test('unit: the user-declared locally-hosted flag overrides paid classification', () => {
   const { __cost } = load()
   // Deepseek on nous is paid... unless the user says it runs on their hardware.
@@ -176,7 +168,6 @@ test('regression: roster rows render a paid/free badge wired to the classifier',
   assert.match(pluginSource, /const costState = botCostState\(/)
   assert.match(pluginSource, /costBadge\(costState, bot\.model \|\| defaultModel, bot\.provider\)/)
   assert.match(pluginSource, /'🆓'/)
-  assert.match(pluginSource, /userCurrencySymbol\(\)/)
   assert.match(pluginSource, /local: Boolean\(meta\?\.local\)/)
 })
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/cost-badge.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/cost-badge.test.mjs
@@ -1,0 +1,189 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+/** VM harness — same harness as the other plugin tests (vm + import
+ *  stripping): runs the plugin source and exposes the cost-classifier
+ *  functions under globalThis.__cost. */
+function load({ locale = 'en-US' } = {}) {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+
+  const calls = []
+  const stored = []
+
+  const host = {
+    state: {
+      profile: { get: () => 'default', listen: () => undefined },
+      gateway: { get: () => 'open', listen: () => undefined }
+    },
+    notify: () => undefined,
+    request: (method, params) => {
+      calls.push({ method, params })
+      return Promise.resolve({})
+    }
+  }
+
+  const context = {
+    atom,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    navigator: { language: locale },
+    host,
+    queryClient: { invalidateQueries: () => undefined }
+  }
+
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\s*\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\s*\n/m, '')
+    .replace(/^const \{\s*McpTab,\s*ToolsetConfigPanel\s*\}\s*=\s*sdk\s*\n/m, '')
+    .replace(/^import .* from 'react'\s*\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\s*\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat('\nglobalThis.__cost = { isFreeModel, botCostState, buildPricingByModel, userCurrencySymbol, saveBotMeta };')
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+
+  const register = () => {
+    const entries = []
+    context.plugin.register({
+      storage: { get: () => null, set: (key, value) => stored.push([key, value]) },
+      register: entry => entries.push(entry)
+    })
+    return entries
+  }
+
+  return { __cost: context.__cost, register, calls, stored }
+}
+
+test('unit: a :free model is classified free', () => {
+  const { __cost } = load()
+  assert.equal(__cost.isFreeModel('tencent/hy3:free', 'nous', {}), true)
+  assert.equal(__cost.isFreeModel('meituan/longcat-2.0:free', 'nous', {}), true)
+  assert.equal(__cost.botCostState({ model: 'tencent/hy3:free', provider: 'nous' }, {}), 'free')
+})
+
+test('unit: local serving providers are free regardless of model name', () => {
+  const { __cost } = load()
+  assert.equal(__cost.isFreeModel('google/gemma-4-12b', 'lmstudio', {}), true)
+  assert.equal(__cost.isFreeModel('any/model', 'Ollama', {}), true)
+  assert.equal(__cost.isFreeModel('any/model', 'llama.cpp', {}), true)
+})
+
+test('unit: a paid cloud model is paid, and unknown stays paid (fail-closed)', () => {
+  const { __cost } = load()
+  assert.equal(__cost.isFreeModel('deepseek/deepseek-v4-flash-0731', 'nous', {}), false)
+  assert.equal(
+    __cost.botCostState({ model: 'deepseek/deepseek-v4-flash-0731', provider: 'nous' }, {}),
+    'paid'
+  )
+  // Unknown provider + no pricing evidence ⇒ paid — never hide a cost.
+  assert.equal(__cost.botCostState({ model: 'weird/model', provider: '' }, {}), 'paid')
+})
+
+test('unit: catalog pricing (model.options) overrides the string heuristic', () => {
+  const { __cost } = load()
+  const map = __cost.buildPricingByModel({
+    providers: [
+      { slug: 'nous', pricing: { 'deepseek/deepseek-v4-flash-0731': { free: false } } },
+      { slug: 'groq', pricing: { 'llama-3.3-70b-versatile': { free: true } } }
+    ]
+  })
+  assert.equal(map['deepseek/deepseek-v4-flash-0731'], false)
+  assert.equal(map['llama-3.3-70b-versatile'], true)
+  // No `:free` suffix, but the catalog says $0 ⇒ free.
+  assert.equal(__cost.isFreeModel('llama-3.3-70b-versatile', 'groq', map), true)
+  assert.equal(__cost.isFreeModel('deepseek/deepseek-v4-flash-0731', 'nous', map), false)
+  // Bare-id fallback matches provider-qualified pricing keys.
+  assert.equal(__cost.isFreeModel('llama-3.3-70b-versatile', 'groq', map), true)
+})
+
+test('unit: buildPricingByModel ignores malformed/absent pricing', () => {
+  const { __cost } = load()
+  const empty = map => Object.keys(map).length === 0
+  assert.ok(empty(__cost.buildPricingByModel(undefined)))
+  assert.ok(empty(__cost.buildPricingByModel({ providers: [{ slug: 'x', pricing: null }] })))
+  assert.ok(
+    empty(__cost.buildPricingByModel({ providers: [{ slug: 'x', pricing: { a: { free: 'yes' } } }] }))
+  )
+})
+
+test('unit: unknown model with no default is unknown (renders no badge)', () => {
+  const { __cost } = load()
+  assert.equal(__cost.botCostState({ model: '', provider: '' }, {}), 'unknown')
+})
+
+test('unit: an empty model resolves through the launch default', () => {
+  const { __cost } = load()
+  assert.equal(
+    __cost.botCostState({ model: '', provider: '' }, { defaultModel: 'deepseek/deepseek-v4-flash' }),
+    'paid'
+  )
+  assert.equal(
+    __cost.botCostState({ model: '', provider: '' }, { defaultModel: 'tencent/hy3:free' }),
+    'free'
+  )
+})
+
+test('unit: currency symbol follows the user locale, $ as fallback', () => {
+  assert.equal(load({ locale: 'en-US' }).__cost.userCurrencySymbol(), '$')
+  assert.equal(load({ locale: 'en-GB' }).__cost.userCurrencySymbol(), '£')
+  assert.equal(load({ locale: 'de-DE' }).__cost.userCurrencySymbol(), '€')
+  assert.equal(load({ locale: 'ja-JP' }).__cost.userCurrencySymbol(), '¥')
+  assert.equal(load({ locale: 'xx-XX' }).__cost.userCurrencySymbol(), '$')
+})
+
+test('unit: the user-declared locally-hosted flag overrides paid classification', () => {
+  const { __cost } = load()
+  // Deepseek on nous is paid... unless the user says it runs on their hardware.
+  assert.equal(
+    __cost.botCostState({ model: 'deepseek/deepseek-v4-flash-0731', provider: 'nous' }, { local: true }),
+    'local'
+  )
+  assert.equal(
+    __cost.botCostState({ model: 'Qwen3.6-35B-A3B-UD-Q8_K_XL', provider: 'custom:james-homelab' }, { local: true }),
+    'local'
+  )
+  // Without the flag, an unprovable custom endpoint stays paid (fail-closed).
+  assert.equal(
+    __cost.botCostState({ model: 'Qwen3.6-35B-A3B-UD-Q8_K_XL', provider: 'custom:james-homelab' }, {}),
+    'paid'
+  )
+})
+
+test('unit: saveBotMeta persists the locally-hosted flag (storage + server ui_meta)', () => {
+  const { __cost, register, calls, stored } = load({})
+  register()
+  __cost.saveBotMeta('multi_agent', { local: true })
+
+  const metaWrite = stored.find(([key]) => key === 'bot-meta')
+  assert.ok(metaWrite, 'bot meta is persisted to local storage')
+  assert.equal(metaWrite[1].multi_agent.local, true)
+
+  const cfg = calls.find(call => call.method === 'profiles.configure')
+  assert.ok(cfg, 'ui_meta is pushed server-side so the flag follows the profile')
+  assert.equal(cfg.params.ui_meta['hermes-bots'].local, true)
+})
+
+test('regression: roster rows render a paid/free badge wired to the classifier', () => {
+  assert.match(pluginSource, /const costState = botCostState\(/)
+  assert.match(pluginSource, /costBadge\(costState, bot\.model \|\| defaultModel, bot\.provider\)/)
+  assert.match(pluginSource, /'🆓'/)
+  assert.match(pluginSource, /userCurrencySymbol\(\)/)
+  assert.match(pluginSource, /local: Boolean\(meta\?\.local\)/)
+})
+
+test('regression: the edit-profile dialog classifies the selected model live', () => {
+  assert.match(pluginSource, /function AdvancedProfileConfig/)
+  assert.match(pluginSource, /state\.model\s*\? costBadge|state\.model\s*\?[\s\S]{0,80}costBadge/)
+  assert.match(pluginSource, /Inherits the launch profile model/)
+  assert.match(pluginSource, /Locally hosted — runs on my own hardware \(no LLM cost\)/)
+  assert.match(pluginSource, /dirtyLocal/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
@@ -187,6 +187,11 @@ test('behavior: remote default does not open this-device chat when the source di
     displayName: bot => bot.connectionLabel || bot.name,
     duplicateBot: async () => 'copy',
     haptic: () => undefined,
+    // Paid/free badge helpers referenced inside BotRow.
+    useModelOptions: () => ({ data: undefined }),
+    botCostState: () => 'free',
+    buildPricingByModel: () => ({}),
+    costBadge: () => null,
     previewKind: () => ({ fromBot: false, sender: null }),
     generatedSessionTitle: () => null,
     openBotCanonicalChat: async (...args) => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
@@ -54,6 +54,11 @@ function renderBotRow(input = 'alpha') {
     displayName: bot => bot.name,
     duplicateBot: async () => `${name}-copy`,
     haptic: () => undefined,
+    // Paid/free badge helpers referenced inside BotRow.
+    useModelOptions: () => ({ data: undefined }),
+    botCostState: () => 'free',
+    buildPricingByModel: () => ({}),
+    costBadge: () => null,
     // #49 session-aware-row helpers referenced inside BotRow.
     previewKind: () => ({ fromBot: false, sender: null }),
     generatedSessionTitle: () => null,

--- a/contributors/emails/hedrick.larry@gmail.com
+++ b/contributors/emails/hedrick.larry@gmail.com
@@ -1,0 +1,1 @@
+LarryAGuy


### PR DESCRIPTION
## Summary
The Bot Mode roster now shows at a glance which bots run on paid LLMs ($ badge) and which are free or locally hosted (🆓), with a "Locally hosted" declaration in the edit-profile advanced pane.

Salvage of #88086 by @LarryAGuy (the original Hermes-Bot-Mode plugin author; port of his upstream #109), cherry-picked with authorship preserved, plus three review-mandated trims in a follow-up commit.

## Changes
- Cherry-pick (LarryAGuy): fail-closed cost classifier (unknown → paid; free only on `:free` suffix, local-provider allowlist, or catalog `pricing[model].free === true`), roster badges, "Locally hosted" checkbox persisted via bot meta, inherit-row classification vs the launch profile's default model
- Trims (ours):
  - dropped the dead `delegation_model`/`delegation_provider` branch (field exists nowhere on main)
  - deleted the 40-entry REGION_CURRENCY map — badge is a plain `$` (provider pricing is USD)
  - paid badge color #10b981 → #f59e0b so green stays the free signal
- `contributors/emails/hedrick.larry@gmail.com`: attribution mapping

## Validation
| | Result |
|---|---|
| cost-badge + profile-prewarm | 16/16 |
| Plugin suite | 299/299 pass |

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa6eb2b/HfcYRMgkPzJMclRvpwoZG_aMSJPXtx.png)
