### PR TITLE
fix(managed-node): treat dangling npm/npx symlinks as broken, not absent

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -815,8 +815,15 @@ def find_hermes_node_executable(command: str) -> str | None:
         for directory in iter_hermes_node_dirs():
             for name in names:
                 candidate = directory / name
-                if candidate.is_file() and (
-                    sys.platform == "win32" or os.access(candidate, os.X_OK)
+                # A dangling symlink (target removed, e.g. bin/npm ->
+                # lib/node_modules/npm/... after a partial update) is a BROKEN
+                # shim, not an absent one: is_file() follows the link and
+                # reports False, which would silently skip the heal below and
+                # leave the desktop/web rebuild gated on a missing npm. Detect
+                # the link itself so node_tool_runnable() can mark it broken.
+                if candidate.is_symlink() or (
+                    candidate.is_file()
+                    and (sys.platform == "win32" or os.access(candidate, os.X_OK))
                 ):
                     resolved = str(candidate)
                     if node_tool_runnable(resolved):

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -271,6 +271,43 @@ class TestNodeToolRunnable:
 
         assert find_node_executable("npm") is None
 
+    def test_dangling_npm_symlink_triggers_heal(self, tmp_path, monkeypatch):
+        """A dangling bin/npm symlink (target dir removed) is broken, not absent:
+        is_file() follows the link and lies, so the heal must still fire."""
+        profile_home = tmp_path / "profiles" / "assistant"
+        managed_bin = profile_home / "node" / "bin"
+        managed_bin.mkdir(parents=True)
+        self._stub(managed_bin, "node", "#!/bin/sh\necho '22.0.0'\nexit 0\n")
+        # Dangling: points at a node_modules/npm that no longer exists.
+        (managed_bin / "npm").symlink_to(profile_home / "node" / "lib" / "node_modules" / "npm" / "bin" / "npm-cli.js")
+
+        system_bin = tmp_path / "system-bin"
+        system_bin.mkdir()
+        self._stub(system_bin, "npm", "#!/bin/sh\necho '11.10.0'\nexit 0\n")
+
+        heal_called = {"value": False}
+
+        def _heal():
+            heal_called["value"] = True
+            # Heal restores the real npm tree; re-create the target so the
+            # resolved npm becomes runnable.
+            (profile_home / "node" / "lib" / "node_modules" / "npm" / "bin").mkdir(parents=True)
+            (profile_home / "node" / "lib" / "node_modules" / "npm" / "bin" / "npm-cli.js").write_text("#!/bin/sh\necho '22.0.0'\nexit 0\n")
+            (profile_home / "node" / "lib" / "node_modules" / "npm" / "bin" / "npm-cli.js").chmod(0o755)
+            return True
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        monkeypatch.setenv("PATH", str(system_bin))
+        monkeypatch.setattr(hermes_constants, "_managed_node_heal_attempted", False)
+        monkeypatch.setattr(hermes_constants, "heal_hermes_managed_node", _heal)
+
+        resolved = find_node_executable("npm")
+        assert heal_called["value"] is True
+        # After the heal the managed bin/npm shim resolves and runs — that is
+        # the path returned, not the system npm on PATH.
+        assert resolved == str(profile_home / "node" / "bin" / "npm")
+        assert resolved != str(system_bin / "npm")
+
     def test_outdated_managed_node_heals_to_target_major(self, tmp_path, monkeypatch):
         """A healthy managed tree below the target major upgrades on next resolve."""
         target = hermes_constants._HERMES_NODE_TARGET_MAJOR


### PR DESCRIPTION
## Problem

A partial update can leave `$HERMES_HOME/node/bin/npm` pointing at a `lib/node_modules/npm` that no longer exists. `Path.is_file()` follows the symlink and reports `False` for a dangling link, so `_first_runnable()` in `find_hermes_node_executable()` treated the shim as **absent** rather than **broken** — the managed-node heal never fired, and `find_node_executable("npm")` returned `None` (the tree still counts as "present" via `node`).

`_resolve_node_runtime_npm()` then returned `None`, which made `_rebuild_desktop_after_update()` silently skip **every** desktop rebuild on subsequent `hermes update` runs. The desktop app keeps running an old renderer bundle while the source tree advances — new sidebar/session features never appear.

## Fix

Detect the symlink itself (`candidate.is_symlink()`) so `node_tool_runnable()` probes it, marks the tree broken, and triggers `heal_hermes_managed_node()` — the same heal path the existing "npm exits 1" tests already cover.

## Test

`tests/test_hermes_constants.py::test_dangling_npm_symlink_triggers_heal` — creates a dangling `bin/npm` symlink, asserts the heal fires and the managed npm is returned (not the system PATH npm).

All tests in `tests/test_hermes_constants.py` pass (62 passed, 5 skipped).