### PR TITLE
fix(kanban): isolate linked worktree anchors

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7808,10 +7808,12 @@ def _resolve_worktree_workspace(
             if fallback.resolve(strict=False) != requested_resolved:
                 _ensure_git_worktree(fallback_root, fallback, branch_name)
                 return fallback.resolve(strict=False), branch_name
-        # No repo to anchor a fallback on (or the occupied path IS this
-        # task's own canonical worktree): keep the legacy reuse rather
-        # than failing dispatch.
-        return requested_resolved, actual_branch or branch_name
+        # The linked checkout is not owned by a surrounding checkout, so it is
+        # itself the requested repo-root anchor. Materialize the task worktree
+        # below that exact linked root instead of silently reusing its branch.
+        target = requested_resolved / ".worktrees" / task.id
+        _ensure_git_worktree(requested_resolved, target, branch_name)
+        return target, branch_name
 
     repo_root = _git_toplevel(requested)
     if repo_root is not None and requested_resolved == repo_root:

--- a/tests/hermes_cli/test_kanban_worktree_isolation.py
+++ b/tests/hermes_cli/test_kanban_worktree_isolation.py
@@ -66,6 +66,37 @@ def _add_worktree(repo: Path, target: Path, branch: str) -> Path:
     return target
 
 
+def test_resolve_linked_repo_root_anchor_materializes_task_worktree(
+    kanban_home, tmp_path
+):
+    repo = _make_repo(tmp_path)
+    linked_root = _add_worktree(repo, tmp_path / "linked-root", "anchor/main")
+    branch = "wt/linked-anchor-task"
+
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="linked anchor",
+            workspace_kind="worktree",
+            workspace_path=str(linked_root),
+            branch_name=branch,
+        )
+        task = kb.get_task(conn, tid)
+
+    assert task is not None
+    workspace, resolved_branch = kb._resolve_worktree_workspace(task)
+    expected = linked_root / ".worktrees" / tid
+    assert workspace == expected
+    assert resolved_branch == branch
+    head = subprocess.run(
+        ["git", "-C", str(workspace), "branch", "--show-current"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert head == branch
+
+
 def test_decompose_worktree_children_get_own_workspace(kanban_home):
     with kb.connect() as conn:
         root = kb.create_task(conn, title="build the feature", triage=True)


### PR DESCRIPTION
## Summary
- treat an existing linked checkout on another branch as a repository anchor instead of silently reusing it
- materialize the task at `<linked-root>/.worktrees/<task-id>` on the requested branch
- add a real-git regression test matching the linked canonical-checkout topology

## Root cause
`_resolve_worktree_workspace` could not discover a surrounding checkout when the requested anchor was itself a linked worktree. It then reused the anchor on its current branch and returned that branch as the task branch. Completion cleanup subsequently treated the canonical linked checkout as task-owned and could remove it.

This was reproduced against current `main`: the resolver returned the linked anchor rather than an isolated nested task worktree.

## Validation
- regression test failed before the implementation and passed afterward
- `python -m pytest tests/hermes_cli/test_kanban_worktree_isolation.py tests/hermes_cli/test_kanban_worktree_teardown.py tests/hermes_cli/test_worktree_command.py -o 'addopts=' -q` (23 passed)
- `python -m py_compile hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_worktree_isolation.py`
- `git diff --check`

## Risk / rollback
The change is limited to the linked-anchor mismatch path. Normal repo-root anchors and already-correct task worktrees keep their existing behavior. Revert this commit to restore the previous resolver behavior.

Supersedes the same core fix from closed/conflicted PR #70585 on current `main`.