### PR TITLE
fix(desktop): keep active cron run transcripts up to date

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -3,7 +3,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { $changeEventsAvailable, notifySessionsChanged, resetLiveSync } from '@/store/live-sync'
-import { $activeSessionId, $selectedStoredSessionId, setBusy, setMessagingSessions, setSessions } from '@/store/session'
+import {
+  $activeSessionId,
+  $selectedStoredSessionId,
+  setBusy,
+  setCronSessions,
+  setMessagingSessions,
+  setSessions
+} from '@/store/session'
 import {
   $attentionSessionIds,
   $stalledSessionIds,
@@ -127,6 +134,7 @@ afterEach(() => {
   $activeSessionId.set(null)
   $selectedStoredSessionId.set(null)
   setSessions([])
+  setCronSessions([])
   setMessagingSessions([])
   setBusy(false)
   vi.clearAllMocks()
@@ -237,6 +245,19 @@ describe('active transcript refresh', () => {
 })
 
 describe('reconcileActiveTranscript', () => {
+  it('resolves and hydrates a cron session from the cron sessions store', async () => {
+    setCronSessions([{ id: ACTIVE_STORED_ID, profile: 'cron-profile', source: 'cron' } as never])
+    const fixture = makeRefresh(resolveActiveTranscriptSession)
+    vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('cron progress') as never)
+
+    await fixture.refresh()
+
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(ACTIVE_STORED_ID, 'cron-profile')
+    expect(fixture.states.get(ACTIVE_RUNTIME_ID)?.messages.at(-1)?.parts[0]).toMatchObject({
+      text: 'cron progress'
+    })
+  })
+
   it('resolves and hydrates a messaging session from the messaging sessions store', async () => {
     setMessagingSessions([{ id: ACTIVE_STORED_ID, profile: 'messaging-profile', source: 'telegram' } as never])
     const fixture = makeRefresh(resolveActiveTranscriptSession)

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -12,6 +12,7 @@ import { refreshActiveProfile } from '@/store/profile'
 import {
   $activeSessionId,
   $busy,
+  $cronSessions,
   $currentCwd,
   $messagingSessions,
   $selectedStoredSessionId,
@@ -33,10 +34,11 @@ interface ActiveTranscriptSession {
   profile?: string | null
 }
 
-/** Resolve an active transcript from either local recents or messaging slices. */
+/** Resolve an active transcript from any independently paged sidebar slice. */
 export function resolveActiveTranscriptSession(storedSessionId: string): ActiveTranscriptSession | undefined {
   return (
     $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId)) ??
+    $cronSessions.get().find(session => sessionMatchesStoredId(session, storedSessionId)) ??
     $messagingSessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
   )
 }


### PR DESCRIPTION
## What does this PR do?

Desktop now keeps an opened cron run transcript synchronized as the background scheduler persists new messages. Previously, the run history could refresh while the active transcript remained frozen until the user switched away and back.

### Symptom

When a user opens an active cron run in Desktop, later assistant messages, tool calls, and completion output do not appear in the transcript even though the run history continues to update. Re-selecting the run catches the transcript up to the latest persisted state.

### Impact

Users monitoring active cron work from Desktop see stale progress and cannot reliably tell what the run is doing without repeatedly switching sessions. This is especially visible when Desktop connects to a remote backend whose scheduler writes the session from another process.

### Bug Cause

**Trigger:** `apps/desktop/src/app/contrib/hooks/use-background-sync.ts:38` / `resolveActiveTranscriptSession`

**Causal chain:**
1. The scheduler persists additional messages and the backend emits `sessions.changed`.
2. Active transcript reconciliation tries to resolve the selected durable session, but searches only recent and messaging session slices. Cron runs are intentionally stored in the separate cron slice, so resolution returns no row and skips `getLatestSessionMessages`.
3. The open transcript stays at its initial resume snapshot until re-selection performs another resume.

**Why it is wrong:** Persisted transcript reconciliation must resolve every independently paged sidebar session source that can become the active transcript. Omitting the cron slice prevents the existing change-event refresh path from hydrating cron sessions.

**Working sibling / contrast:** Local/Desktop sessions resolve from the recent sessions slice, and messaging sessions resolve from the messaging slice, so both already reach the persisted-message fetch.

**Ruled out:** A missing per-session live subscription is not the cause. The intended cross-process path already uses `sessions.changed` followed by persisted transcript reconciliation; the resolver stopped that path before the fetch.

### Fix

Include the cron sessions slice in the shared active transcript resolver. The resolver returns the cron row unchanged, preserving its profile when `getLatestSessionMessages` fetches the latest persisted tail. A focused behavior test seeds only the cron slice and verifies both profile routing and transcript hydration.

## Related Issue

Closes #89705

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/contrib/hooks/use-background-sync.ts` - resolve active cron runs from the cron session slice before persisted transcript hydration.
- `apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts` - cover cron transcript refresh and profile propagation through the production resolver and reconciler.

## How to Test

1. Start a cron job whose run emits multiple messages or tool calls.
2. Open that active run in Desktop and keep its transcript selected.
3. Confirm later persisted messages appear without switching to another run and back.
4. Run the focused automated suite:

```bash
cd apps/desktop
npx vitest run src/app/contrib/hooks/use-background-sync.test.ts
```

Result: 2 files passed, 16 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant project test entry and all focused tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)

### Documentation & Housekeeping

- [x] Relevant documentation: N/A - no user-facing configuration or workflow changed
- [x] `cli-config.yaml.example`: N/A - no configuration keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered - the change is renderer state reconciliation with no platform-specific branch
- [x] Tool descriptions/schemas: N/A - no tool behavior changed
