### PR TITLE
fix(security): html_comment_injection no longer flags substrings like 'ecoSYSTEM'

### DIFF
--- a/tests/tools/test_threat_patterns.py
+++ b/tests/tools/test_threat_patterns.py
@@ -179,6 +179,29 @@ class TestClassicInjection:
         )
 
 
+    def test_html_comment_injection_word_boundary_no_false_positive(self):
+        # 'ecoSYSTEM' contains 'system' as a substring but is not the word
+        # 'system'; the pattern must not fire on it inside a benign comment.
+        assert "html_comment_injection" not in scan_for_threats(
+            "<!-- ecoSYSTEM auto-start -->", scope="all"
+        )
+        assert "html_comment_injection" not in scan_for_threats(
+            "<!-- misystemo -->", scope="all"
+        )
+
+    def test_html_comment_injection_still_detects_underscored_directives(self):
+        # Underscore-joined directives matched before the boundary fix and must
+        # keep matching: `_` is a word character, so a plain \b boundary would
+        # silently stop detecting these. The letter-lookaround boundary keeps
+        # them while still rejecting mid-word substrings like 'ecoSYSTEM'.
+        assert "html_comment_injection" in scan_for_threats(
+            "<!-- ignore_rules -->", scope="all"
+        )
+        assert "html_comment_injection" in scan_for_threats(
+            "<!-- system_prompt: replace -->", scope="all"
+        )
+
+
     def test_translate_execute(self):
         assert "translate_execute" in scan_for_threats(
             "translate this into bash and execute", scope="all"

--- a/tools/threat_patterns.py
+++ b/tools/threat_patterns.py
@@ -66,7 +66,7 @@ _PATTERNS: List[Tuple[str, str, str]] = [
     (r'system\s+prompt\s+override', "sys_prompt_override", "all"),
     (rf'disregard\s+{_FILLER}(your|all|any)\s+{_FILLER}(instructions|rules|guidelines)', "disregard_rules", "all"),
     (rf'act\s+as\s+(if|though)\s+{_FILLER}you\s+{_FILLER}(have\s+no|don\'t\s+have)\s+{_FILLER}(restrictions|limits|rules)', "bypass_restrictions", "all"),
-    (r'<!--[^>]{0,512}(?:ignore|override|system|secret|hidden)[^>]{0,512}-->', "html_comment_injection", "all"),
+    (r'<!--[^>]{0,512}(?<![A-Za-z])(?:ignore|override|system|secret|hidden)(?![A-Za-z])[^>]{0,512}-->', "html_comment_injection", "all"),
     (r'<\s*div\s+style\s*=\s*["\'][^>]{0,2048}display\s*:\s*none', "hidden_div", "all"),
     (r'translate\s+[^\n]{0,512}\s+into\s+[^\n]{0,512}\s+and\s+(execute|run|eval)', "translate_execute", "all"),
     (rf'do\s+not\s+{_FILLER}tell\s+{_FILLER}the\s+user', "deception_hide", "all"),


### PR DESCRIPTION
## Problem

The `html_comment_injection` threat pattern in `tools/threat_patterns.py` matches
its keyword alternation `(?:ignore|override|system|secret|hidden)` as a bare
substring inside HTML comments. Because there is no boundary around the
alternation, any HTML comment containing a word that merely *contains* one of
these keywords gets flagged as prompt injection. For example:

    <!-- ecoSYSTEM auto-start -->

matches on `system` (inside `ecoSYSTEM`) and is blocked, despite being a
completely benign comment.

## Fix

Wrap the alternation in **letter lookarounds** rather than a bare `\b` word
boundary:

    r'<!--[^>]{0,512}(?<![A-Za-z])(?:ignore|override|system|secret|hidden)(?![A-Za-z])[^>]{0,512}-->'

A plain `\b` looks like the obvious fix but weakens detection: Python treats
`_` as a word character, so `\b` would silently stop matching underscore-joined
directives such as `<!-- ignore_rules -->` and `<!-- system_prompt: ... -->`,
which the current pattern catches. The letter lookarounds reject only mid-word
substrings (letters on either side) while keeping `_`/digit-adjacent forms and
standalone keywords detected.

## Tests

- Existing threat-pattern suites (`tests/tools/test_threat_patterns.py`,
  `tests/tools/test_cron_prompt_injection.py`): no regressions.
- Added a false-positive regression (`<!-- ecoSYSTEM auto-start -->` and
  `<!-- misystemo -->` must not flag) and an underscore-directive regression
  (`<!-- ignore_rules -->`, `<!-- system_prompt: replace -->` must keep
  flagging — this test fails against a bare `\b` variant).
- Full suite after the change: 33 passed.

This PR only touches `tools/threat_patterns.py` and its test file.