### PR TITLE
fix(desktop): preserve project session profiles

### DIFF
--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -205,6 +205,48 @@ def test_tree_build_warms_every_path_it_will_resolve(monkeypatch, tmp_path):
     assert str(repo) in warmed
 
 
+@pytest.mark.parametrize(
+    ("profile_name", "expected_profile"),
+    [("builder", "builder"), (None, "default")],
+)
+def test_project_session_rows_carry_profile_identity(tmp_path, profile_name, expected_profile):
+    """Project overview and drill-in rows preserve their owning profile."""
+    workspace = tmp_path / expected_profile
+    workspace.mkdir()
+    project = _call(
+        "projects.create",
+        {"name": f"Project {expected_profile}", "folders": [str(workspace)]},
+    )["project"]
+
+    session_id = f"project-profile-{expected_profile}"
+    db = server._get_db()
+    assert db is not None
+    db.create_session(
+        session_id,
+        "desktop",
+        cwd=str(workspace),
+        profile_name=profile_name,
+    )
+    db.append_message(session_id, "user", "show my owning profile")
+
+    overview = _call("projects.tree", {"preview_limit": 3})
+    overview_project = next(item for item in overview["projects"] if item["id"] == project["id"])
+    overview_row = next(item for item in overview_project["previewSessions"] if item["id"] == session_id)
+
+    assert overview_row["profile"] == expected_profile
+
+    detail = _call("projects.project_sessions", {"project_id": project["id"]})["project"]
+    detail_row = next(
+        item
+        for repo in detail["repos"]
+        for group in repo["groups"]
+        for item in group["sessions"]
+        if item["id"] == session_id
+    )
+
+    assert detail_row["profile"] == expected_profile
+
+
 def test_create_list_roundtrip(tmp_path):
     created = _call("projects.create", {"name": "Demo", "folders": [str(tmp_path)], "use": True})
     assert created["project"]["slug"] == "demo"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12908,6 +12908,7 @@ def _project_tree_row(r: dict) -> dict:
         "ended_at": r.get("ended_at"),
         "last_active": r.get("last_active") or r.get("started_at") or 0,
         "source": r.get("source"),
+        "profile": r.get("profile_name") or "default",
         "archived": bool(r.get("archived")),
         "message_count": r.get("message_count") or 0,
         "tool_call_count": r.get("tool_call_count") or 0,


### PR DESCRIPTION
## What does this PR do?

Fixes Hermes Desktop's **Filters → Show → Profile** option for session rows rendered inside **Project** grouping.

Project overview and drill-in rows come from the shared `projects.tree` projection. That projection dropped the persisted `profile_name`, so the renderer received no `session.profile`, normalized the row to `default`, and intentionally suppressed the profile glyph. The session itself was still correctly owned by the named profile; only its display metadata was missing.

This PR projects the existing profile identity into the response once, at the shared backend boundary. Named-profile project rows can therefore use the existing `ProfileTag` rendering path, while rows whose persisted profile is `NULL` retain the canonical `default` identity and existing default-profile UI behavior.

This is distinct from #86258 / #86259, which covers ordinary flat **All Profiles** recents and explicitly leaves scoped/project views unchanged.

## Related Issue

Fixes #89731

Related: #72767, #86258

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py`
  - preserve the session row's owning profile in the shared project-tree projection
  - normalize a missing persisted profile to the canonical `default` identity
  - cover both `projects.tree` overview rows and `projects.project_sessions` drill-in rows through their shared projection
- `tests/tui_gateway/test_projects_rpc.py`
  - exercise the real temporary `state.db` → project RPC response path
  - verify named-profile and default-profile identities in both overview and drill-in payloads

## How to Test

1. Select a named Desktop profile and create a session inside a project/worktree.
2. Set the session sidebar to **Grouping → Project**.
3. Enable **Show → Profile**.
4. Confirm the project session row shows the existing named-profile glyph and `Profile: <name>` accessible label.
5. Confirm default-profile rows retain their existing default-profile behavior.

Automated verification:

```text
RED (before production change):
  scripts/run_tests.sh tests/tui_gateway/test_projects_rpc.py \
    -k project_session_rows_carry_profile_identity -q
  2 failed with KeyError: 'profile'

GREEN (after production change):
  same focused command
  2 passed

Related project RPC/tree suite:
  scripts/run_tests.sh tests/tui_gateway/test_projects_rpc.py \
    tests/tui_gateway/test_project_tree.py -q
  58 passed

Static checks:
  ruff check tui_gateway/server.py tests/tui_gateway/test_projects_rpc.py
  All checks passed

  python scripts/check-windows-footguns.py \
    tui_gateway/server.py tests/tui_gateway/test_projects_rpc.py
  No Windows footguns found

  git diff --check
  passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — the focused and neighboring project RPC/tree suites passed; the full repository suite was not run locally
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2, Python 3.11.15, Hermes 0.20.4

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no documented command or configuration changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; existing response contract only
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility); the change is data projection only and the Windows footgun scan passed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model tool changes

## Screenshots / Logs

The original UI symptom is captured in #89731. The regression test records the exact response-shape failure (`profile` absent) and proves the repaired named/default profile contract through both project RPCs.
