### PR TITLE
fix(skills): bound skill usage lock contention with a timeout

### DIFF
--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -1,5 +1,6 @@
 """Tests for tools/skill_usage.py — sidecar telemetry + provenance filtering."""
 
+import errno
 import json
 import multiprocessing as mp
 import os
@@ -14,6 +15,17 @@ def _bump_view_many(hermes_home: str, skill_name: str, iterations: int) -> None:
 
     for _ in range(iterations):
         bump_view(skill_name)
+
+
+def _hold_usage_lock(hermes_home: str, ready, release) -> None:
+    os.environ["HERMES_HOME"] = hermes_home
+    import importlib
+    import tools.skill_usage as mod
+
+    importlib.reload(mod)
+    with mod._usage_file_lock():
+        ready.set()
+        release.wait(timeout=10)
 
 
 @pytest.fixture
@@ -327,6 +339,87 @@ def test_concurrent_bump_view_preserves_all_updates(skills_home):
     for process in processes:
         assert process.exitcode == 0
     assert get_record("shared-skill")["view_count"] == process_count * iterations
+
+
+def test_usage_lock_times_out_when_held(skills_home, monkeypatch):
+    import tools.skill_usage as mod
+
+    ctx = mp.get_context("spawn")
+    ready = ctx.Event()
+    release = ctx.Event()
+    holder = ctx.Process(
+        target=_hold_usage_lock,
+        args=(str(skills_home), ready, release),
+    )
+    holder.start()
+    assert ready.wait(timeout=5), "holder did not acquire the usage lock"
+
+    monkeypatch.setattr(mod, "LOCK_TIMEOUT_SECONDS", 0.2)
+    try:
+        with pytest.raises(TimeoutError, match="Timed out acquiring skill usage lock"):
+            with mod._usage_file_lock():
+                pass
+    finally:
+        release.set()
+        holder.join(timeout=5)
+
+    assert holder.exitcode == 0
+
+
+class _FakeMsvcrt:
+    """Minimal stand-in for the Windows ``msvcrt`` locking API.
+
+    ``msvcrt`` cannot be imported on POSIX CI, so the Windows branch of
+    ``_usage_file_lock`` is otherwise unreachable from the test suite.
+    """
+
+    LK_NBLCK = 1
+    LK_UNLCK = 0
+
+    def __init__(self, exc):
+        self._exc = exc
+        self.attempts = 0
+
+    def locking(self, _fd, mode, _nbytes):
+        if mode == self.LK_UNLCK:
+            return
+        self.attempts += 1
+        raise self._exc
+
+
+def test_usage_lock_propagates_real_oserror_on_windows_path(skills_home, monkeypatch):
+    """A non-contention OSError must propagate, not spin out as a TimeoutError."""
+    import tools.skill_usage as mod
+
+    fake = _FakeMsvcrt(OSError(errno.EBADF, "Bad file descriptor"))
+    monkeypatch.setattr(mod, "fcntl", None)
+    monkeypatch.setattr(mod, "msvcrt", fake)
+
+    with pytest.raises(OSError) as excinfo:
+        with mod._usage_file_lock():
+            pass
+
+    # TimeoutError subclasses OSError, so assert on the concrete failure.
+    assert not isinstance(excinfo.value, TimeoutError)
+    assert excinfo.value.errno == errno.EBADF
+    assert fake.attempts == 1, "a real error must not be retried"
+
+
+def test_usage_lock_retries_windows_contention_errno(skills_home, monkeypatch):
+    """EACCES -- how msvcrt reports a held lock -- still retries to the deadline."""
+    import tools.skill_usage as mod
+
+    fake = _FakeMsvcrt(OSError(errno.EACCES, "Permission denied"))
+    monkeypatch.setattr(mod, "fcntl", None)
+    monkeypatch.setattr(mod, "msvcrt", fake)
+    monkeypatch.setattr(mod, "LOCK_TIMEOUT_SECONDS", 0.2)
+    monkeypatch.setattr(mod, "LOCK_RETRY_SECONDS", 0.01)
+
+    with pytest.raises(TimeoutError, match="Timed out acquiring skill usage lock"):
+        with mod._usage_file_lock():
+            pass
+
+    assert fake.attempts > 1
 
 
 # ---------------------------------------------------------------------------

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -24,10 +24,12 @@ Lifecycle states:
 
 from __future__ import annotations
 
+import errno
 import json
 import logging
 import os
 import tempfile
+import time
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
@@ -54,6 +56,26 @@ STATE_ACTIVE = "active"
 STATE_STALE = "stale"
 STATE_ARCHIVED = "archived"
 _VALID_STATES = {STATE_ACTIVE, STATE_STALE, STATE_ARCHIVED}
+LOCK_TIMEOUT_SECONDS = 5.0
+LOCK_RETRY_SECONDS = 0.05
+# Errnos that mean "another holder has the lock" and are therefore worth
+# retrying until the deadline. ``fcntl.flock(LOCK_NB)`` reports contention as
+# BlockingIOError (EAGAIN/EWOULDBLOCK), but ``msvcrt.locking`` has no dedicated
+# exception type and signals it through errno instead: EACCES for LK_NBLCK,
+# EDEADLOCK for the retrying LK_LOCK/LK_RLCK variants. Anything else -- EBADF,
+# EINVAL, ENOSPC -- is a genuine failure that must propagate immediately rather
+# than spin in the retry loop and resurface as a misleading TimeoutError.
+_LOCK_UNAVAILABLE_ERRNOS = frozenset(
+    code
+    for code in (
+        getattr(errno, "EACCES", None),
+        getattr(errno, "EAGAIN", None),
+        getattr(errno, "EWOULDBLOCK", None),
+        getattr(errno, "EDEADLK", None),
+        getattr(errno, "EDEADLOCK", None),
+    )
+    if code is not None
+)
 
 # Load-bearing bundled built-ins the curator must NEVER archive or consolidate,
 # regardless of ``curator.prune_builtins``, pin state, or LLM judgment. These
@@ -86,6 +108,11 @@ def _usage_file() -> Path:
     return _skills_dir() / ".usage.json"
 
 
+def _lock_unavailable(exc: OSError) -> bool:
+    """Whether *exc* means the lock is held elsewhere rather than a real error."""
+    return isinstance(exc, BlockingIOError) or exc.errno in _LOCK_UNAVAILABLE_ERRNOS
+
+
 @contextmanager
 def _usage_file_lock():
     """Serialize .usage.json read-modify-write cycles across processes."""
@@ -100,20 +127,33 @@ def _usage_file_lock():
         lock_path.write_text(" ", encoding="utf-8")
 
     fd = open(lock_path, "r+" if msvcrt else "a+", encoding="utf-8")
+    locked = False
+    deadline = time.monotonic() + LOCK_TIMEOUT_SECONDS
     try:
-        if fcntl:
-            fcntl.flock(fd, fcntl.LOCK_EX)
-        else:
-            fd.seek(0)
-            msvcrt.locking(fd.fileno(), msvcrt.LK_LOCK, 1)
+        while not locked:
+            try:
+                if fcntl:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                else:
+                    fd.seek(0)
+                    msvcrt.locking(fd.fileno(), msvcrt.LK_NBLCK, 1)
+                locked = True
+            except OSError as exc:
+                if not _lock_unavailable(exc):
+                    raise
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        f"Timed out acquiring skill usage lock: {lock_path}"
+                    )
+                time.sleep(LOCK_RETRY_SECONDS)
         yield
     finally:
-        if fcntl:
+        if locked and fcntl:
             try:
                 fcntl.flock(fd, fcntl.LOCK_UN)
             except (OSError, IOError):
                 pass
-        elif msvcrt:
+        elif locked and msvcrt:
             try:
                 fd.seek(0)
                 msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)


### PR DESCRIPTION
## What does this PR do?

`_usage_file_lock()` took the `.usage.json` advisory lock with a **blocking** acquire —
`fcntl.flock(fd, LOCK_EX)` on POSIX, `msvcrt.locking(..., LK_LOCK, 1)` on Windows — with
no deadline. Any holder that wedges (crashed mid-write, SIGSTOPped process, a stalled
NFS/SMB `HERMES_HOME`) parks **every** other caller of `bump_view` / `bump_use` /
`_mutate` indefinitely. Because usage telemetry is written on the tool-dispatch path,
that hang does not stay inside the curator: it propagates up into the agent turn, which
stops producing output with no error and no timeout.

The module's own docstring already states the intended contract — *"All counter bumps
are best-effort: failures log at DEBUG and return silently. A broken sidecar never
breaks the underlying tool call."* An unbounded blocking lock is the one path that
violates it.

**Fix:** acquire non-blocking in a retry loop with a deadline
(`LOCK_TIMEOUT_SECONDS = 5.0`, `LOCK_RETRY_SECONDS = 0.05`) and raise a `TimeoutError`
naming the lock path instead of blocking forever. The release path now unlocks only
when the lock was actually taken, so a caller that timed out cannot drop somebody
else's lock on the way out.

**Only genuine "lock unavailable" conditions retry.** This is the subtle half of the
change and worth a reviewer's eye. `fcntl.flock(LOCK_NB)` signals contention with
`BlockingIOError`, which is easy to match on. `msvcrt.locking(LK_NBLCK)` has no
dedicated exception type — it reports contention through `errno` on a plain `OSError`
(`EACCES` for `LK_NBLCK`, `EDEADLOCK` for the retrying `LK_LOCK`/`LK_RLCK` variants).
A naive `except OSError: retry` on the Windows branch would swallow real failures —
`EBADF`, `EINVAL`, `ENOSPC` — spin on them for the full 5s, and then resurface them as
a misleading `TimeoutError` that names the wrong cause. `_lock_unavailable()` matches
exactly the contention errnos, so real errors propagate immediately and unretried.

This mirrors a pattern the project has already adopted elsewhere: the bounded
`<db>.repair.lock` flock added around `repair_state_db_schema()` (#69603). Same
reasoning, different sidecar.

### Duplicate search

I searched the issue and PR lists for existing work on `_usage_file_lock` /
`.usage.json` locking and found none. The nearest neighbors are #36701 (the PR that
introduced the `.usage.json` sidecar and this lock) and #69603 (bounded flock for the
state-db repair path, cited above as precedent) — neither changes this code path. If a
maintainer knows of an in-flight change here, I'm happy to close or rebase.

## Related Issue

No open issue tracks this; happy to file one first if you'd prefer that order.

Fixes # <!-- n/a — no existing issue -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skill_usage.py`
  - `import errno`.
  - New `LOCK_TIMEOUT_SECONDS = 5.0` / `LOCK_RETRY_SECONDS = 0.05` module constants
    (monkeypatchable, so tests don't have to sleep for five seconds).
  - New `_LOCK_UNAVAILABLE_ERRNOS` frozenset — `EACCES`, `EAGAIN`, `EWOULDBLOCK`,
    `EDEADLK`, `EDEADLOCK`, each resolved through `getattr(errno, ..., None)` because
    the set of defined errnos differs by platform.
  - New `_lock_unavailable(exc)` predicate: `BlockingIOError`, or an errno in that set.
  - `_usage_file_lock()` now acquires with `LOCK_NB` / `LK_NBLCK` in a loop bounded by
    the deadline, raises `TimeoutError` with the lock path on expiry, and guards both
    unlock branches on a `locked` flag so a failed acquirer never calls `LOCK_UN`.
- `tests/tools/test_skill_usage.py`
  - `test_usage_lock_times_out_when_held` — spawns a real holder process, shrinks the
    timeout, asserts the second acquirer raises instead of hanging.
  - `test_usage_lock_propagates_real_oserror_on_windows_path` — drives the `msvcrt`
    branch through a `_FakeMsvcrt` stub (real `msvcrt` is unimportable on POSIX CI) and
    asserts an `EBADF` `OSError` propagates **unretried**, not as a `TimeoutError`.
    Note `TimeoutError` subclasses `OSError`, so the assertion is on the concrete
    errno, not on the exception class alone.
  - `test_usage_lock_retries_windows_contention_errno` — the mirror image: `EACCES` on
    the same stubbed branch must still retry to the deadline. This is the guard against
    over-narrowing the predicate.

## How to Test

All runs against `origin/main` @ `5dd15872a`, Debian 13 (trixie) container,
Python 3.13.5, `pytest 9.1.1`.

**1. Baseline — unpatched main, unmodified test file:**

```
$ pytest tests/tools/test_skill_usage.py -q
.........................                                                [100%]
25 passed in 4.14s
```

**2. Unpatched main + this PR's test file only — all three new tests fail:**

```
$ pytest tests/tools/test_skill_usage.py -q
E       AttributeError: <module 'tools.skill_usage' from '.../tools/skill_usage.py'> has no attribute 'LOCK_TIMEOUT_SECONDS'

tests/tools/test_skill_usage.py:415: AttributeError
=========================== short test summary info ============================
FAILED tests/tools/test_skill_usage.py::test_usage_lock_times_out_when_held
FAILED tests/tools/test_skill_usage.py::test_usage_lock_propagates_real_oserror_on_windows_path
FAILED tests/tools/test_skill_usage.py::test_usage_lock_retries_windows_contention_errno
3 failed, 25 passed in 4.51s
```

**3. With this patch applied:**

```
$ pytest tests/tools/test_skill_usage.py -q
............................                                             [100%]
28 passed in 5.01s
```

**4. The errno-narrowing specifically.** With the timeout loop in place but a broad
`except (BlockingIOError, OSError)` on the Windows branch, an `EBADF` is swallowed into
the retry loop and comes back out as the wrong exception five seconds later:

```
$ pytest tests/tools/test_skill_usage.py -q
>       assert not isinstance(excinfo.value, TimeoutError)
E       AssertionError: assert not True
E        +  where True = isinstance(TimeoutError('Timed out acquiring skill usage lock: .../skills/.usage.json.lock'), TimeoutError)
=========================== short test summary info ============================
FAILED tests/tools/test_skill_usage.py::test_usage_lock_propagates_real_oserror_on_windows_path
1 failed, 27 passed in 9.64s
```

`ruff check tools/skill_usage.py tests/tools/test_skill_usage.py` → `All checks passed!`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(skills):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate — see the
      "Duplicate search" section above
- [x] My PR contains **only** changes related to this fix (2 files, +140 / -7)
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran the touched file
      (28 passed). I could **not** run the full `tests/` tree: my sandbox hangs partway
      through `tests/tools/` at the same point on both patched and unpatched
      checkouts, so it is an environment problem on my side, not a regression from this
      change. Happy to have CI be the arbiter.
- [x] I've added tests for my changes (three, described above)
- [x] I've tested on my platform: **Linux only** — Debian 13 (trixie) container,
      Python 3.13.5, on Linux 6.18 x86_64. **Not tested on macOS and not tested on
      native Windows.** See the cross-platform note below — this matters more than
      usual for this PR.

### Documentation & Housekeeping

- [x] Documentation — N/A (internal locking behavior; `TimeoutError` is caught by the
      existing best-effort wrappers, so no user-facing surface changes)
- [x] `cli-config.yaml.example` — N/A (no new config keys; the timeout is a module
      constant, and I deliberately did not add a knob for it — say the word if you'd
      rather it were configurable)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — **and this is the honest caveat on this PR.**
      The POSIX path (`fcntl`) is exercised for real by the test suite on Linux,
      including a genuine two-process contention test. The Windows path (`msvcrt`) is
      exercised only through a stub: `msvcrt` cannot be imported on POSIX CI, so
      `_FakeMsvcrt` substitutes for it and the tests assert the *error-classification*
      logic, not the real `_locking` syscall. The errno mapping I coded to
      (`EACCES` for `LK_NBLCK`, `EDEADLOCK` for `LK_LOCK`/`LK_RLCK`) comes from the
      MSVC `_locking` documentation, not from an observed run. I do not have a Windows
      box, and macOS is likewise untested. If a maintainer or CI runner can confirm the
      Windows behavior — or if CI already covers `windows-latest` — that would close
      the one real gap in this change. The predicate is deliberately permissive on the
      contention side (`EAGAIN`/`EWOULDBLOCK`/`EDEADLK` are included even though POSIX
      `flock` surfaces those as `BlockingIOError`) so an errno I have mis-mapped fails
      toward "retry", which is the previous behavior, rather than toward a spurious
      hard error.
- [x] Tool descriptions/schemas — N/A (no tool behavior change)
