### PR TITLE
fix(codex): surface reasoning summary for content-empty tool-call turns

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -1233,8 +1233,8 @@ def _extract_responses_message_text(item: Any) -> str:
     return "".join(chunks).strip()
 
 
-def _extract_responses_reasoning_text(item: Any) -> str:
-    """Extract a compact reasoning text from a Responses reasoning item."""
+def _extract_responses_reasoning_summary(item: Any) -> str:
+    """Extract only explicit, provider-authored reasoning summary text."""
     summary = getattr(item, "summary", None)
     if isinstance(summary, list):
         chunks: List[str] = []
@@ -1244,6 +1244,14 @@ def _extract_responses_reasoning_text(item: Any) -> str:
                 chunks.append(text)
         if chunks:
             return "\n".join(chunks).strip()
+    return ""
+
+
+def _extract_responses_reasoning_text(item: Any) -> str:
+    """Extract a compact reasoning text from a Responses reasoning item."""
+    summary_text = _extract_responses_reasoning_summary(item)
+    if summary_text:
+        return summary_text
     text = getattr(item, "text", None)
     if isinstance(text, str) and text:
         return text.strip()
@@ -1359,6 +1367,7 @@ def _normalize_codex_response(
 
     content_parts: List[str] = []
     reasoning_parts: List[str] = []
+    reasoning_summary_parts: List[str] = []
     reasoning_items_raw: List[Dict[str, Any]] = []
     message_items_raw: List[Dict[str, Any]] = []
     tool_calls: List[Any] = []
@@ -1449,6 +1458,9 @@ def _normalize_codex_response(
                 message_items_raw.append(raw_message_item)
         elif item_type == "reasoning":
             saw_reasoning_item = True
+            reasoning_summary = _extract_responses_reasoning_summary(item)
+            if reasoning_summary:
+                reasoning_summary_parts.append(reasoning_summary)
             reasoning_text = _extract_responses_reasoning_text(item)
             if reasoning_text:
                 reasoning_parts.append(reasoning_text)
@@ -1631,6 +1643,11 @@ def _normalize_codex_response(
         reasoning="\n\n".join(reasoning_parts).strip() if reasoning_parts else None,
         reasoning_content=None,
         reasoning_details=None,
+        codex_reasoning_summary=(
+            "\n\n".join(reasoning_summary_parts).strip()
+            if reasoning_summary_parts
+            else None
+        ),
         codex_reasoning_items=reasoning_items_raw or None,
         codex_message_items=message_items_raw or None,
     )

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -198,6 +198,42 @@ def test_codex_api_preflight_defangs_every_outbound_text_carrier():
     assert "<|im_start|>" in serialized
 
 
+def test_normalize_codex_response_surfaces_reasoning_summary_on_tool_call_turn():
+    """Regression: a tool-call turn with no assistant content but an explicit
+    Responses ``reasoning.summary`` used to discard that summary entirely, so
+    callers had nothing but generic tool activity to show as interim
+    progress. The explicit summary text should be preserved separately so it
+    can be surfaced as commentary."""
+    response = SimpleNamespace(
+        status="completed",
+        output=[
+            SimpleNamespace(
+                type="reasoning",
+                id="rs_789",
+                encrypted_content="opaque-stable",
+                summary=[SimpleNamespace(text="Checking the config file next")],
+            ),
+            SimpleNamespace(
+                type="function_call",
+                id="fc_1",
+                call_id="call_1",
+                name="read_file",
+                arguments="{}",
+                status="completed",
+            ),
+        ],
+    )
+
+    assistant_message, finish_reason = _normalize_codex_response(response)
+
+    assert finish_reason == "tool_calls"
+    assert assistant_message.content == ""
+    assert (
+        assistant_message.codex_reasoning_summary
+        == "Checking the config file next"
+    )
+
+
 def test_normalize_codex_response_treats_summary_only_reasoning_as_incomplete():
     """Summary-only reasoning keeps the continuation path for Codex backends.
 


### PR DESCRIPTION
## Problem

When a Codex Responses API turn produces a tool call with no assistant
content, but the reasoning item carries an explicit provider-authored
`summary`, that summary text is discarded. `_extract_responses_reasoning_text`
folds the explicit summary and the private encrypted-reasoning fallback
into a single value, and `_normalize_codex_response` never exposes it
separately on the normalized assistant message. Callers rendering interim
progress for a content-empty tool-call turn are left with nothing but
generic tool activity, even though the model already produced a
human-readable summary of what it was doing.

## Fix

Split summary extraction into its own helper,
`_extract_responses_reasoning_summary`, and thread its output through
`_normalize_codex_response` as a new `codex_reasoning_summary` field,
kept distinct from the existing `reasoning` field (which still falls
back to raw reasoning text when no summary is present). This preserves
the summary's provenance as an explicit, provider-authored value rather
than conflating it with private reasoning state, so consumers can use
it as interim commentary without guessing.

## Testing

Added a regression test verifying that a tool-call turn with an
explicit reasoning summary populates `codex_reasoning_summary` on the
normalized assistant message. Confirmed it fails with `AttributeError`
before this change and passes after.

`python3 -m pytest -q tests/agent/test_codex_responses_adapter.py`
→ 13 passed (up from 12).
