### PR TITLE
fix(runs): emit assistant.interim.completed events over /v1/runs SSE

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2643,6 +2643,7 @@ class APIServerAdapter(BasePlatformAdapter):
         ephemeral_system_prompt: Optional[str] = None,
         session_id: Optional[str] = None,
         stream_delta_callback=None,
+        interim_assistant_callback=None,
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
@@ -2956,6 +2957,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "session_id": session_id,
             "platform": "api_server",
             "stream_delta_callback": stream_delta_callback,
+            "interim_assistant_callback": interim_assistant_callback,
             "tool_progress_callback": tool_progress_callback,
             "tool_start_callback": tool_start_callback,
             "tool_complete_callback": tool_complete_callback,
@@ -6774,6 +6776,7 @@ class APIServerAdapter(BasePlatformAdapter):
         self._run_approval_sessions[run_id] = approval_session_key
 
         event_cb = self._make_run_event_callback(run_id, loop)
+        interim_sequence = 0
 
         def _put_event_if_active(event: Optional[Dict]) -> None:
             """Enqueue only while this run still owns live transport state."""
@@ -6793,6 +6796,34 @@ class APIServerAdapter(BasePlatformAdapter):
                     "timestamp": time.time(),
                     "delta": delta,
                 })
+            except Exception:
+                pass
+
+        # Surface completed interim assistant commentary (the visible text
+        # of an assistant turn that also requested tool calls) as its own
+        # event. AIAgent._emit_interim_assistant_message() already strips
+        # reasoning blocks and drops empty turns before invoking this
+        # callback, so no extra model call is needed here — without this,
+        # SSE consumers only saw tool.started/tool.completed activity and
+        # had no way to see what the assistant said between tool calls.
+        def _interim_assistant_cb(text: str, *, already_streamed: bool = False) -> None:
+            nonlocal interim_sequence
+            if not text:
+                return
+            if run_id not in self._run_streams:
+                return
+            event_id = f"{run_id}:interim:{interim_sequence}"
+            interim_sequence += 1
+            event = {
+                "event": "assistant.interim.completed",
+                "run_id": run_id,
+                "event_id": event_id,
+                "timestamp": time.time(),
+                "content": text,
+            }
+            self._set_run_status(run_id, "running", last_event=event["event"])
+            try:
+                loop.call_soon_threadsafe(_put_event_if_active, event)
             except Exception:
                 pass
 
@@ -6828,6 +6859,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         ephemeral_system_prompt=ephemeral_system_prompt,
                         session_id=session_id,
                         stream_delta_callback=_text_cb,
+                        interim_assistant_callback=_interim_assistant_cb,
                         tool_progress_callback=event_cb,
                         gateway_session_key=gateway_session_key,
                         requested_model=agent_overrides.get("requested_model"),

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -10,6 +10,7 @@ Covers:
 """
 
 import asyncio
+import json
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -333,6 +334,51 @@ class TestRunEvents:
                 assert "run.completed" in body
                 assert "Hello!" in body
 
+    @pytest.mark.asyncio
+    async def test_events_stream_emits_completed_interim_messages(self, adapter):
+        """Visible assistant commentary between tool calls should be surfaced
+        as assistant.interim.completed events, not just tool.* activity."""
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            def create_agent(**kwargs):
+                callback = kwargs["interim_assistant_callback"]
+                agent = MagicMock()
+
+                def run_conversation(**_run_kwargs):
+                    callback("checking the docs first", already_streamed=False)
+                    callback("found it, applying the fix", already_streamed=True)
+                    return {"final_response": "Done!"}
+
+                agent.run_conversation.side_effect = run_conversation
+                agent.session_prompt_tokens = 10
+                agent.session_completion_tokens = 5
+                agent.session_total_tokens = 15
+                return agent
+
+            with patch.object(adapter, "_create_agent", side_effect=create_agent):
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await resp.json())["run_id"]
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events")
+                body = await events_resp.text()
+
+        events = [
+            json.loads(line[len("data: "):])
+            for line in body.splitlines()
+            if line.startswith("data: ")
+        ]
+        interim = [e for e in events if e.get("event") == "assistant.interim.completed"]
+        assert [e["event_id"] for e in interim] == [
+            f"{run_id}:interim:0",
+            f"{run_id}:interim:1",
+        ]
+        assert [e["content"] for e in interim] == [
+            "checking the docs first",
+            "found it, applying the fix",
+        ]
+        assert any(
+            e.get("event") == "run.completed" and e.get("output") == "Done!"
+            for e in events
+        )
 
     @pytest.mark.asyncio
     async def test_approval_resolve_all_is_scoped_to_target_run(self, auth_adapter):


### PR DESCRIPTION
## What does this PR do?

The `/v1/runs` SSE event stream never surfaces an assistant's visible
interim commentary — the text a model produces in the same turn it
also requests tool calls (e.g. "let me check the docs first" before
calling a search tool). `AIAgent` already has the machinery for this:
`agent/conversation_loop.py` calls `agent._emit_interim_assistant_message()`
whenever such a turn completes, and that method strips reasoning
blocks, drops empty/placeholder turns, and invokes
`interim_assistant_callback` with the finished visible text. The API
server platform simply never wired that callback through, so `/v1/runs`
consumers could only infer progress from `tool.started`/`tool.completed`
events and had no way to see what the assistant actually said between
tool calls.

This PR wires `interim_assistant_callback` through `_create_agent` (and
into the underlying `AIAgent(...)`) and, in `_handle_runs`, forwards
each completed interim message as its own `assistant.interim.completed`
SSE event with a per-run sequential `event_id` (`{run_id}:interim:{n}`).
It reuses the existing `loop.call_soon_threadsafe(q.put_nowait, ...)`
pattern already used for `message.delta` and `tool.*` events. No
additional model call is made — only text the agent already produced
is exposed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py`: add `interim_assistant_callback`
  parameter to `_create_agent` and thread it into `AIAgent(...)`; in
  `_handle_runs`, add an `_interim_assistant_cb` closure that emits
  `assistant.interim.completed` SSE events and pass it to
  `_create_agent`.
- `tests/gateway/test_api_server_runs.py`: add
  `test_events_stream_emits_completed_interim_messages`, verifying that
  two interim callbacks produce two `assistant.interim.completed`
  events with sequential `event_id`s and correct `content`, alongside
  the existing `run.completed` event.

## How to Test

1. `pytest tests/gateway/test_api_server_runs.py -q`
2. Start an agent run against `/v1/runs` with a prompt that triggers a
   tool call plus visible commentary in the same turn (e.g. "look this
   up, then explain") and stream `/v1/runs/{run_id}/events`.
3. Observe an `assistant.interim.completed` event with the visible
   commentary text before the eventual `run.completed`.

## Testing done

Ran the full `gateway/test_api_server*.py` + `test_sse_agent_cancel.py`
suite: 296 passed. `run_agent` interim-message tests: 5 passed. The new
regression test fails without the wiring (`KeyError:
'interim_assistant_callback'`) and passes with it.
