### PR TITLE
fix(cli): stop the venv-blocker preflight aborting slow Windows updates

### DIFF
--- a/apps/desktop/electron/venv-blocker-scan.test.ts
+++ b/apps/desktop/electron/venv-blocker-scan.test.ts
@@ -295,6 +295,27 @@ describe('scanVenvBlockers', () => {
     assert.equal(typeof c.timeout, 'number')
     assert.ok(c.timeout > 0)
   })
+
+  it('allows a slow scan enough headroom to finish (#89659)', async () => {
+    // The scan is a one-shot psutil enumeration that legitimately takes ~19s
+    // on a loaded Windows box. A ceiling at or below that SIGTERMs the probe
+    // mid-scan, which the caller reads as `probe-failure` and turns into a
+    // hard update abort — on every attempt, unrecoverably, because the
+    // updater's `git reset --hard` reverts any local patch.
+    const calls: any[] = []
+
+    const spy = (async (_cmd: string, _args: string[], opts: any) => {
+      calls.push(opts.timeout)
+
+      return { stdout: okJson, stderr: '' }
+    }) as any
+
+    await scanVenvBlockers('/update/root', spy, stubVenv)
+    assert.ok(
+      calls[0] >= 60_000,
+      `scan timeout ${calls[0]}ms is too tight for a slow process enumeration`
+    )
+  })
 })
 
 describe('stopSafeVenvBlockers', () => {

--- a/apps/desktop/electron/venv-blocker-scan.ts
+++ b/apps/desktop/electron/venv-blocker-scan.ts
@@ -45,7 +45,13 @@ export type ScanOutcome =
 // Constants
 // ---------------------------------------------------------------------------
 
-const SCAN_TIMEOUT_MS = 15000
+// A one-shot process enumeration, not a poll: the only thing this ceiling has
+// to catch is a genuinely wedged scan. 15s was below the honest cost on loaded
+// Windows boxes (Defender real-time scanning, large process tables), so the
+// probe was SIGTERM'd mid-scan and every update aborted with
+// `venv-probe-failed` (#89659). 60s still fails fast on a stuck scan while
+// leaving headroom for slow machines.
+const SCAN_TIMEOUT_MS = 60000
 const SCAN_MODULE = 'hermes_cli._scan_venv_blockers'
 
 // ---------------------------------------------------------------------------
@@ -204,8 +210,8 @@ export function parseVenvBlockerScanOutput(raw: string): ScanOutcome {
 
 /**
  * Run the venv-blocker scan subprocess.  Async so the Electron main-process
- * event loop is never blocked by the psutil process scan (up to 15s on a
- * loaded Windows box).  Accepts optional overrides for testing (dependency
+ * event loop is never blocked by the psutil process scan (tens of seconds on
+ * a loaded Windows box).  Accepts optional overrides for testing (dependency
  * injection).
  */
 export async function scanVenvBlockers(

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3354,6 +3354,24 @@ def _venv_core_imports_healthy() -> tuple[bool, str]:
         return False, "; ".join(missing[:4])
     return True, ""
 
+def _proc_cwd_prefix(proc: object) -> str:
+    """Return *proc*'s working directory, lowered and ``os.sep``-terminated.
+
+    Returns ``""`` when the directory cannot be read — a zombie, a process
+    owned by another user, or a system process psutil is denied access to.
+    That is not an error: an unreadable cwd simply cannot match this install's
+    root, which is the same answer the eager ``process_iter(["cwd"])`` field
+    produced for those processes.
+    """
+    try:
+        cwd = proc.cwd()  # type: ignore[attr-defined]
+    except Exception:
+        return ""
+    if not isinstance(cwd, str) or not cwd:
+        return ""
+    return cwd.lower().rstrip(os.sep) + os.sep
+
+
 def _detect_venv_python_processes(
     *, exclude_pids: set[int] | None = None
 ) -> list[tuple[int, str, str]]:
@@ -3400,7 +3418,14 @@ def _detect_venv_python_processes(
 
     matches: list[tuple[int, str, str]] = []
     try:
-        proc_iter = psutil.process_iter(["pid", "exe", "name", "cmdline", "cwd"])
+        # `cwd` is deliberately NOT requested here. On Windows psutil reads it
+        # out of the target process's PEB, which costs a handle open + remote
+        # memory read for every process on the box — the dominant cost of this
+        # scan (~19s on a loaded machine, tripping the Desktop preflight's
+        # timeout and aborting valid updates, #89659). Only the narrow
+        # `hermes_cli.main` fallback below consults it, so it is fetched lazily
+        # per candidate instead of eagerly for the whole process table.
+        proc_iter = psutil.process_iter(["pid", "exe", "name", "cmdline"])
     except Exception:
         return []
     for proc in proc_iter:
@@ -3418,7 +3443,6 @@ def _detect_venv_python_processes(
             exe_norm = str(exe).lower()
         cmdline_raw = " ".join(info.get("cmdline") or [])
         cmdline_low = cmdline_raw.lower()
-        cwd_low = str(info.get("cwd") or "").lower().rstrip(os.sep) + os.sep
 
         # Primary match: the executable itself lives under this venv
         # (venv\Scripts\python(w).exe — the desktop backend / gateway case).
@@ -3431,7 +3455,7 @@ def _detect_venv_python_processes(
         if not is_holder and venv_prefix in cmdline_low:
             is_holder = True
         if not is_holder and "hermes_cli.main" in cmdline_low:
-            if root_prefix in cmdline_low or cwd_low.startswith(root_prefix):
+            if root_prefix in cmdline_low or _proc_cwd_prefix(proc).startswith(root_prefix):
                 is_holder = True
         if not is_holder:
             continue

--- a/tests/hermes_cli/test_update_venv_health.py
+++ b/tests/hermes_cli/test_update_venv_health.py
@@ -86,6 +86,81 @@ def test_detect_venv_python_excludes_self_and_ancestors(_winp, tmp_path):
         assert cli_main._detect_venv_python_processes() == []
 
 
+# ---------------------------------------------------------------------------
+# Lazy cwd resolution (#89659)
+# ---------------------------------------------------------------------------
+
+
+def _lazy_proc(pid: int, exe: str, name: str, cmdline: list[str], cwd: str | None):
+    """A process whose cwd is readable ONLY via proc.cwd(), never via info.
+
+    Mirrors the post-#89659 contract: `cwd` is not in the process_iter attrs
+    list, so anything that still reads it out of `info` sees nothing.
+    """
+    proc = MagicMock()
+    proc.info = {"pid": pid, "exe": exe, "name": name, "cmdline": cmdline}
+    if cwd is None:
+        proc.cwd.side_effect = PermissionError("access denied")
+    else:
+        proc.cwd.return_value = cwd
+    return proc
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_detect_venv_python_does_not_request_cwd_for_every_process(_winp, tmp_path):
+    """The expensive `cwd` field must not be pulled for the whole process table.
+
+    On Windows psutil reads cwd from the target's PEB — a handle open plus a
+    remote memory read per process. Paying that for every process is what made
+    the scan exceed the Desktop preflight's timeout and abort valid updates.
+    """
+    requested: list[list[str]] = []
+
+    def _iter(attrs):
+        requested.append(list(attrs))
+        return iter([])
+
+    fake_psutil = types.SimpleNamespace(
+        process_iter=_iter, Process=lambda *a, **k: MagicMock(parents=lambda: [])
+    )
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.dict(
+        sys.modules, {"psutil": fake_psutil}
+    ):
+        cli_main._detect_venv_python_processes()
+
+    assert requested, "process_iter was never called"
+    assert "cwd" not in requested[0]
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_detect_venv_python_still_matches_by_cwd_lazily(_winp, tmp_path):
+    """Dropping the eager field must not lose the cwd-based fallback match.
+
+    A base-interpreter trampoline running `-m hermes_cli.main` from inside the
+    install root is a real venv holder even though neither its exe nor its
+    cmdline names the venv — cwd is the only signal that identifies it.
+    """
+    outside_py = str(tmp_path / "other" / "python.exe")
+    holder = _lazy_proc(
+        4242, outside_py, "python.exe", ["python.exe", "-m", "hermes_cli.main", "serve"], str(tmp_path)
+    )
+    # Same shape, but its cwd is unreadable — must not be reported as a holder.
+    denied = _lazy_proc(
+        4243, outside_py, "python.exe", ["python.exe", "-m", "hermes_cli.main", "serve"], None
+    )
+    fake_psutil = types.SimpleNamespace(
+        process_iter=lambda attrs: iter([holder, denied]),
+        Process=lambda *a, **k: MagicMock(parents=lambda: []),
+    )
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.dict(
+        sys.modules, {"psutil": fake_psutil}
+    ):
+        matches = cli_main._detect_venv_python_processes()
+
+    assert [pid for pid, _name, _cmd in matches] == [4242]
+    holder.cwd.assert_called()
+
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop update handoff aborting with **"Update aborted: Desktop could not verify the Hermes installation is free."** on Windows machines where the venv-blocker preflight scan runs long.

The causal chain reported in #89659:

1. `venv-blocker-scan.ts` runs `python -m hermes_cli._scan_venv_blockers` with `timeout: SCAN_TIMEOUT_MS` (15s).
2. On a loaded box the scan legitimately takes ~19s, so `execFile` SIGTERMs it mid-enumeration.
3. The dead subprocess surfaces as `exit code -1` → `{ kind: 'probe-failure' }`.
4. `main.ts` turns `probe-failure` into a hard abort (`venv-probe-failed`), so **no** update can complete.

It is also self-perpetuating: the updater runs `git reset --hard` before rebuilding, so a locally raised timeout is wiped by the next update that does succeed. Affected machines stay stuck forever.

The issue offered three possible directions (faster scan / bigger ceiling / don't hard-abort). This PR takes the first two, which together remove the failure without weakening the guard — deliberately **not** the third, since downgrading `probe-failure` to a soft pass would let a genuinely blocked venv get mutated mid-update, which is the half-updated-venv corruption the probe exists to prevent (#83149).

**Why the scan was slow.** `_detect_venv_python_processes()` requested `cwd` from `psutil.process_iter` for the entire process table. On Windows psutil reads that field out of each target process's PEB — a handle open plus a remote memory read, per process — while every other requested field is cheap. Only the narrow `hermes_cli.main` trampoline fallback ever consults it, and only for processes that already failed both cheaper checks. Fetching it lazily per candidate keeps the fallback's behavior and stops the common case paying for it.

Measured on Windows 11 (316 processes):

```
with cwd:    3.20s
without cwd: 1.59s   → 2.0x faster
```

The ratio grows with process count and with anything that slows handle opens (Defender real-time scanning), which is exactly the reporter's environment.

**Why also raise the ceiling.** The scan being 2x faster is not by itself a guarantee for every machine — the reporter's 19s becomes ~10s, still uncomfortably close to a 15s wall. 60s gives real headroom while still failing fast on a genuinely wedged scan (the alternative, an unbounded wait, would hang the update UI).

An unreadable `cwd` (denied, zombie, other user) is treated as "no match", which is exactly what the eager field produced for those processes — `psutil` yields `None` there and the old code normalized it to a non-matching string.

## Related Issue

Fixes #89659

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/update_cmd.py`
  - Dropped `cwd` from the `psutil.process_iter` attrs list in `_detect_venv_python_processes()`.
  - Added `_proc_cwd_prefix(proc)`, which reads the working directory on demand and returns `""` when it cannot be read.
  - The `hermes_cli.main` fallback branch now calls it instead of the pre-fetched `cwd_low`.
- `apps/desktop/electron/venv-blocker-scan.ts`
  - `SCAN_TIMEOUT_MS` 15000 → 60000, with a comment recording why a tight ceiling here is a hard update abort rather than a retry.
  - Corrected the now-stale "up to 15s" note in the `scanVenvBlockers` docstring.
- `tests/hermes_cli/test_update_venv_health.py` — two regression tests.
- `apps/desktop/electron/venv-blocker-scan.test.ts` — one regression test.

## How to Test

Each new test fails on `main` and passes with this branch.

**Python** — `pytest tests/hermes_cli/test_update_venv_health.py -q`

- `test_detect_venv_python_does_not_request_cwd_for_every_process` asserts `cwd` is absent from the `process_iter` attrs list.
- `test_detect_venv_python_still_matches_by_cwd_lazily` feeds two trampoline processes whose cwd is readable *only* via `proc.cwd()` — one inside the install root, one raising `PermissionError` — and asserts only the first is reported.

Without the fix:

```
FAILED tests/hermes_cli/test_update_venv_health.py::test_detect_venv_python_does_not_request_cwd_for_every_process
FAILED tests/hermes_cli/test_update_venv_health.py::test_detect_venv_python_still_matches_by_cwd_lazily
2 failed, 5 passed
```

With the fix: `7 passed`.

**TypeScript** — `npx vitest run electron/venv-blocker-scan.test.ts` from `apps/desktop`

`allows a slow scan enough headroom to finish (#89659)` asserts the ceiling leaves room for a slow enumeration. Without the fix:

```
AssertionError: scan timeout 15000ms is too tight for a slow process enumeration
Tests  1 failed | 24 passed (25)
```

With the fix: `25 passed`.

**Timing check** (the reason for the lazy field), on any Windows box:

```python
import psutil, time
t=time.time(); [p for p in psutil.process_iter(['pid','exe','name','cmdline','cwd'])]; print(time.time()-t)
t=time.time(); [p for p in psutil.process_iter(['pid','exe','name','cmdline'])];        print(time.time()-t)
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **left unchecked deliberately.** I have not run the entire suite green on this Windows box; it has pre-existing failures unrelated to this change. What I did run:
  - `tests/hermes_cli/test_update_venv_health.py`, `test_scan_venv_blockers.py`, `test_update_self_lock.py`, `test_update_orphan_backend_reap.py` → **73 passed**
  - full `apps/desktop` electron suite → **26 failed / 1365 passed** on this branch vs **28 failed / 1362 passed** on clean `main`. No failure is introduced by this change; the delta is flaky `ssh-*` / `git-worktree-ops` tests that vary run to run.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (build 26100), Python 3.12.10, Node 22.23.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on both touched functions; no user-facing docs describe this constant
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `_detect_venv_python_processes()` already returns early off Windows, so the lazy-cwd change is Windows-only in effect; `psutil.Process.cwd()` is supported on Linux/macOS regardless. `scripts/check-windows-footguns.py --diff main` reports clean (2 files scanned).
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Reported failure this fixes:

```
2026-08-19T02:17:15.097Z [hermes] [updates] venv-blocker probe failed: exit code -1
2026-08-19T02:17:15.097Z [hermes] [updates] error: Update aborted: Desktop could not verify the Hermes installation is free.
```
