### PR TITLE
fix(anthropic): point PKCE login at platform.claude.com (console endpoint 404s)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1251,8 +1251,8 @@ def run_oauth_setup_token() -> Optional[str]:
 # Stores credentials in ~/.hermes/.anthropic_oauth.json (our own file).
 
 _OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
-_OAUTH_TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
-_OAUTH_REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
+_OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
+_OAUTH_REDIRECT_URI = "https://platform.claude.com/oauth/code/callback"
 _OAUTH_SCOPES = "org:create_api_key user:profile user:inference"
 _HERMES_OAUTH_FILE = get_hermes_home() / ".anthropic_oauth.json"
 


### PR DESCRIPTION
## Problem

Subscription login via `hermes auth add anthropic --type oauth` fails at the token exchange:

```
Token exchange failed: HTTP Error 404: Not Found
```

`_OAUTH_TOKEN_URL` / `_OAUTH_REDIRECT_URI` still point at `console.anthropic.com`, which no longer serves the `authorization_code` exchange.

## Evidence

Identical request body posted to both hosts:

| endpoint | result |
|---|---|
| `console.anthropic.com/v1/oauth/token` | **404** `not_found_error` |
| `platform.claude.com/v1/oauth/token` | **400** `invalid_grant` — endpoint live, correctly rejecting a test code |

## Scope

Login only. `refresh_anthropic_oauth_pure` (~line 995) already tries `platform.claude.com` first, so existing sessions keep refreshing — which is why this goes unnoticed until someone re-authenticates.

## Verification

Applied locally; `hermes auth add anthropic --type oauth` then completes and the credential lands in the pool (`anthropic-oauth-1`, source `hermes_pkce`).
