### PR TITLE
fix(config): stop dropping per-provider max_output_tokens during normalization

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3803,6 +3803,12 @@ def _normalize_custom_provider_entry(
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body",
+        # Per-provider output cap. runtime_provider._lift_max_output_tokens
+        # reads these off a custom_providers entry, but they were missing
+        # here, so the normalizer dropped them before the lifter ran: the
+        # setting silently did nothing and every startup logged
+        # "unknown config keys ignored: max_output_tokens".
+        "max_output_tokens", "max_tokens",
     }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:
@@ -3900,6 +3906,15 @@ def _normalize_custom_provider_entry(
     extra_body = entry.get("extra_body")
     if isinstance(extra_body, dict):
         normalized["extra_body"] = dict(extra_body)
+
+    # Per-provider output cap. runtime_provider._lift_max_output_tokens reads
+    # these off the entry, but normalization rebuilds entries field-by-field
+    # and dropped them, so the setting silently did nothing.
+    for _cap_key in ("max_output_tokens", "max_tokens"):
+        _cap = entry.get(_cap_key)
+        if isinstance(_cap, int) and _cap > 0:
+            normalized["max_output_tokens"] = _cap
+            break
 
     return normalized
 


### PR DESCRIPTION
## Problem

A `custom_providers` entry that sets `max_output_tokens` has no effect, and every startup logs:

```
providers.?: unknown config keys ignored: max_output_tokens
```

`runtime_provider._lift_max_output_tokens()` is written to read `max_output_tokens` / `max_tokens` off a `custom_providers` entry, but the value never reaches it.

## Two defects

1. `_KNOWN_KEYS` in `_normalize_custom_provider_entry` omits both spellings → the warning.
2. More importantly, that function **rebuilds** the entry field-by-field (`name`, `base_url`, `model`, `models`, `context_length`, `rate_limit_delay`, `discover_models`, `extra_body`) and never copies the cap through — so it is dropped before the lifter runs.

Fixing only (1) silences the warning while the setting stays broken, which is the trap here.

## Verification

Against a provider entry with `max_output_tokens: 8192`:

```
before:  max_output_tokens = None        # + startup warning
after:   max_output_tokens = 8192        # warning gone
```

Both spellings are accepted and normalized onto `max_output_tokens`, matching what `_lift_max_output_tokens` already expects. The documented global `model.max_tokens` still wins — this only restores the documented per-provider fallback.
