### PR TITLE
fix(gateway): background off setting can't be overridden by notify_on_complete

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25578,9 +25578,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         logger.debug("Process watcher started: %s (every %ss, notify=%s, agent_notify=%s)",
                       session_id, interval, notify_mode, agent_notify)
 
-        if notify_mode == "off" and not agent_notify:
-            # Still wait for the process to exit so we can log it, but don't
-            # push any messages to the user.
+        if notify_mode == "off":
+            # The profile-level operator setting is authoritative, including
+            # over per-call notify_on_complete requests. Still wait for exit
+            # so lifecycle logging and watcher cleanup remain intact.
             while True:
                 await asyncio.sleep(interval)
                 session = process_registry.get(session_id)

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -180,6 +180,41 @@ async def test_consumed_completion_skips_raw_notification_without_agent_notify(
 
 
 @pytest.mark.asyncio
+async def test_run_process_watcher_off_mode_overrides_notify_on_complete(monkeypatch, tmp_path):
+    """Operator-level ``off`` must win over a per-call ``notify_on_complete=True``.
+
+    ``display.background_process_notifications: off`` is meant to be an
+    operator kill switch, but the silent/wait-only branch only triggered when
+    ``notify_mode == "off" and not agent_notify`` — so a call-site
+    ``notify_on_complete=True`` request (agent_notify) fell through to the
+    normal delivery path and re-enabled the completion message the operator
+    had turned off. The watcher must still wait for exit (lifecycle logging /
+    cleanup stay intact), it just must not push anything to the user.
+    """
+    import tools.process_registry as pr_module
+
+    sessions = [SimpleNamespace(
+        output_buffer="done\n", exited=True, exit_code=0, command="sleep 1; echo done",
+    )]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "off")
+    adapter = runner.adapters[Platform.TELEGRAM]
+
+    watcher = _watcher_dict()
+    watcher["chat_type"] = "dm"  # routable evt so a real delivery attempt is observable
+    watcher["notify_on_complete"] = True
+    await runner._run_process_watcher(watcher)
+
+    adapter.send.assert_not_awaited()
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_inject_watch_notification_routes_from_session_store_origin(monkeypatch, tmp_path):
     from gateway.session import SessionSource
 


### PR DESCRIPTION
`display.background_process_notifications: off` is meant to be an
operator-level kill switch, but `_run_process_watcher` only takes the
silent/wait-only branch when `notify_mode == "off"` AND the watcher's own
`notify_on_complete` is falsy — so a call-site `notify_on_complete=True`
request re-enables the completion message the operator had turned off.

Make the operator setting authoritative: when mode is off,
`_run_process_watcher` always takes the silent branch (still waiting for
exit so lifecycle logging and watcher cleanup still run).

Note: an earlier revision of this PR also gated `watch_match` /
`watch_disabled` events in `_inject_watch_notification`; that bypass has
since been fixed upstream (9b554758bd, "honor notification-off watch
reinjection" — the drain step returns early when mode is off), so this PR
now contains only the remaining `notify_on_complete` precedence fix.

## Testing

Added `test_run_process_watcher_off_mode_overrides_notify_on_complete` in
`test_background_process_notifications.py` — verified it fails against the
pre-fix code (the completion message is actually delivered) and passes
after the fix. Full file: 22 passed, no regressions.