### PR TITLE
fix(tts): keep repaired explicit .ogg outputs voice-compatible

### DIFF
--- a/tests/tools/test_tts_opus_routing.py
+++ b/tests/tools/test_tts_opus_routing.py
@@ -70,6 +70,24 @@ def test_edge_telegram_converts_to_opus_voice(tmp_path, monkeypatch):
     convert.assert_called_once_with(str(out))
 
 
+def test_edge_explicit_telegram_ogg_repair_is_voice_compatible(tmp_path, monkeypatch):
+    """A repaired explicit .ogg output must retain the voice-message marker."""
+    out = tmp_path / "speech.ogg"
+
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "edge"})
+    monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
+    monkeypatch.setattr(tts_tool, "_generate_edge_tts", _write_edge_output)
+    monkeypatch.setattr(tts_tool, "_repair_ogg_container", lambda path: path)
+
+    result = json.loads(tts_tool.text_to_speech_tool("hello", output_path=str(out)))
+
+    assert result["success"] is True
+    assert result["file_path"] == str(out)
+    assert result["voice_compatible"] is True
+    assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{out}"
+
+
 def test_edge_matrix_converts_to_opus_voice(tmp_path, monkeypatch):
     """Matrix voice bubbles need Ogg/Opus too (MSC3245, issue #14841)."""
     out = tmp_path / "speech.mp3"

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -3442,12 +3442,16 @@ def _text_to_speech_single(
         elif (
             want_opus
             and provider in {"edge", "neutts", "minimax", "xai", "kittentts", "piper"}
-            and not file_str.endswith(".ogg")
         ):
-            opus_path = _convert_to_opus(file_str)
-            if opus_path:
-                file_str = opus_path
-                voice_compatible = True
+            # ``_repair_ogg_container`` above may already have converted an
+            # MP3/WAV payload written into an explicit Telegram ``.ogg`` path.
+            # Treat that repaired Ogg file as voice-compatible instead of only
+            # setting the flag when this branch performs a second conversion.
+            if not file_str.endswith(".ogg"):
+                opus_path = _convert_to_opus(file_str)
+                if opus_path:
+                    file_str = opus_path
+            voice_compatible = file_str.endswith(".ogg")
         elif provider in {"elevenlabs", "openai", "mistral", "gemini"}:
             voice_compatible = want_opus and file_str.endswith(".ogg")
 


### PR DESCRIPTION
## What does this PR do?

When `want_opus` is set and a provider (edge/neutts/minimax/xai/kittentts/piper) writes an MP3/WAV payload into an **explicit Telegram `.ogg` output path**, `_repair_ogg_container` already fixes the container — but `voice_compatible` was only set when the `.ogg`-suffix branch performed a second conversion. The repaired Ogg was therefore delivered as a plain audio attachment instead of a voice bubble.

This sets `voice_compatible` from the final file suffix, so a repaired Ogg keeps its voice-message marker without a redundant second conversion. Found in production running Telegram voice replies through the edge provider.

## Related Issue

No existing issue found (searched open/merged PRs and issues for voice_compatible / repaired ogg — nearest are #76570 and #73482, which cover different providers/paths).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/tts_tool.py` — in `_text_to_speech_single`, drop the `not file_str.endswith('.ogg')` condition from the branch guard, convert only when the suffix isn't `.ogg`, and derive `voice_compatible` from the final suffix.
- `tests/tools/test_tts_opus_routing.py` — regression test `test_edge_explicit_telegram_ogg_repair_is_voice_compatible`.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_tts_opus_routing.py` — 4 passed with the fix.
2. Red→green verified: the new test fails on origin/main without the `tools/tts_tool.py` change (voice_compatible=False for the repaired file) and passes with it.
3. Live: with provider=edge on Telegram, request TTS with an explicit `.ogg` output — the result arrives as a voice bubble.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (single commit, two files)
- [x] I've run the canonical `scripts/run_tests.sh` full suite — the affected suites pass; residual failures on my host are identical on a clean origin/main worktree (missing optional provider extras, e.g. video/wake-word backends) and unrelated to this change
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Apple Silicon)

### Documentation & Housekeeping

- [x] Documentation — N/A (behavioral bug fix, docstrings updated in-place)
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform impact considered — pure path-suffix logic, no platform APIs
- [x] Tool descriptions/schemas — N/A (no schema change)