### PR TITLE
fix(retry): match all GLM-5.x chat IDs for Z.AI coding-plan overload backoff

### DIFF
--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -18,12 +18,13 @@ from typing import Any, Optional
 _jitter_counter = 0
 _jitter_lock = threading.Lock()
 
-# Z.AI Coding Plan's GLM-5.2 endpoint often returns HTTP 429 code 1305
+# Z.AI Coding Plan's GLM-5.x chat endpoints often return HTTP 429 code 1305
 # ("The service may be temporarily overloaded...") for otherwise valid
 # Hermes requests. Short retries tend to hammer the same overloaded window;
 # after a few normal retries, progressively widen the wait window. Keep the
 # cap interactive-friendly: a simple TUI message should fail visibly in minutes,
-# not sit silent for 20+ minutes.
+# not sit silent for 20+ minutes. Do not match glm-5v* here — those IDs are a
+# different entitlement and a 429 on them can lock the shared Z.AI key.
 _ZAI_CODING_OVERLOAD_LONG_BACKOFF = (30.0, 60.0, 90.0, 120.0)
 
 # Number of initial short retries before the adaptive long-backoff tier kicks
@@ -145,7 +146,8 @@ def is_zai_coding_overload_error(*, base_url: str | None, model: str | None, err
     The coding-plan endpoint reports overload as HTTP 429 with body code 1305
     and message "The service may be temporarily overloaded...". Treat only
     that narrow shape specially so ordinary quota/billing 429s still fail fast
-    through the existing classifier.
+    through the existing classifier. Match GLM-5.x chat IDs (5.2, 5.3, …);
+    do not treat glm-5v* vision IDs as this retry class.
     """
     base = (base_url or "").lower()
     model_name = (model or "").lower()
@@ -154,7 +156,8 @@ def is_zai_coding_overload_error(*, base_url: str | None, model: str | None, err
     return (
         status == 429
         and "api.z.ai/api/coding/paas/v4" in base
-        and "glm-5.2" in model_name
+        and "glm-5." in model_name
+        and "glm-5v" not in model_name
         and ("1305" in text or "temporarily overloaded" in text)
     )
 
@@ -171,7 +174,7 @@ def adaptive_rate_limit_backoff(
     """Provider-aware rate-limit backoff.
 
     For most providers this returns ``default_wait`` unchanged. For Z.AI
-    Coding Plan GLM-5.2 overloads, keep the first ``short_attempts`` retries on
+    Coding Plan GLM-5.x overloads, keep the first ``short_attempts`` retries on
     the normal short exponential schedule, then switch to progressively longer
     waits (30s → 60s → 90s → 120s, capped) plus light jitter.
 

--- a/tests/test_retry_utils.py
+++ b/tests/test_retry_utils.py
@@ -142,6 +142,19 @@ def test_zai_overload_retry_ceiling_exceeds_short_attempts():
     assert last_attempt_with_backoff - short_attempts >= len(_ZAI_CODING_OVERLOAD_LONG_BACKOFF)
 
 
+def test_zai_overload_detects_glm53_not_glm5v():
+    """Deployments pinned to glm-5.3 showed the old glm-5.2 substring
+    left 1305 overload on that ID as a 3-retry tombstone."""
+    err = _zai_overload_error()
+    coding = "https://api.z.ai/api/coding/paas/v4"
+    assert is_zai_coding_overload_error(base_url=coding, model="glm-5.3", error=err)
+    assert is_zai_coding_overload_error(base_url=coding, model="z-ai/glm-5.3", error=err)
+    assert is_zai_coding_overload_error(base_url=coding, model="glm-5.2", error=err)
+    assert not is_zai_coding_overload_error(
+        base_url=coding, model="glm-5v-turbo", error=err
+    )
+
+
 def test_zai_overload_ceiling_makes_long_tier_reachable(monkeypatch):
     """End-to-end over the attempt range the retry loop actually walks: with the
     extended ceiling, at least one attempt reaches the long-backoff tier and the


### PR DESCRIPTION
## What does this PR do?

`is_zai_coding_overload_error` matched the literal substring `glm-5.2`, so deployments pinned to `glm-5.3` (or any later GLM-5.x chat ID) never entered the adaptive long-backoff tier on HTTP 429 code 1305 — requests failed after the short retries while the coding-plan endpoint was merely overloaded, leaving the agent silent instead of recovering.

This matches `glm-5.` generically while explicitly excluding `glm-5v*` vision IDs, which are a separate entitlement where hammering a 429 can lock a shared Z.AI key.

Related: #77771 classifies localized code-1305 bodies as overloaded in `error_classifier`; this PR is the complementary retry-policy side in `retry_utils` for the coding-plan chat endpoint (different file, no overlap). #87656 covers vision-ID retries in the auxiliary client — this PR deliberately keeps vision IDs out of the chat overload class.

## Related Issue

No existing issue found (searched issues/PRs for glm 429 / 1305 / z.ai retry; #77771 and #87656 are adjacent but different layers).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/retry_utils.py` — `is_zai_coding_overload_error` matches `glm-5.` chat IDs and excludes `glm-5v`; comments/docstrings updated.
- `tests/test_retry_utils.py` — regression test `test_zai_overload_detects_glm53_not_glm5v` (glm-5.3 and z-ai/glm-5.3 match; glm-5v-turbo does not).

## How to Test

1. `scripts/run_tests.sh tests/test_retry_utils.py` — 12 passed with the fix.
2. Red→green verified: the new test fails on origin/main (glm-5.3 not matched) and passes with the change.
3. Live: pin a coding-plan profile to glm-5.3 and induce a 1305 overload — retries now progress into the 30/60/90/120s long-backoff tier instead of failing after the short schedule.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (#77771/#87656 reviewed — complementary, not overlapping)
- [x] My PR contains **only** changes related to this fix (single commit, two files)
- [x] I've run the canonical `scripts/run_tests.sh` full suite — the affected suites pass; residual failures on my host are identical on a clean origin/main worktree (missing optional provider extras) and unrelated to this change
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Apple Silicon)

### Documentation & Housekeeping

- [x] Documentation — N/A (docstrings updated in-place)
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform impact considered — pure string matching, no platform APIs
- [x] Tool descriptions/schemas — N/A