### PR TITLE
fix(buzz): acknowledge trusted agent tags without dispatch

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -25,11 +25,12 @@ Configuration in config.yaml::
             cli_path: ""               # path to the buzz binary (default: PATH, then ~/bin/buzz)
             credentials_file: ""       # JSON file holding the nsec (fallback for BUZZ_PRIVATE_KEY)
             allowed_users: []          # empty = allow all; entries are hex pubkeys or npubs
+            reaction_only_users: []    # acknowledge explicit tags without dispatching; allowed_users wins on overlap
 
 Or via environment variables (overrides config.yaml):
     BUZZ_RELAY_URL, BUZZ_CHANNELS, BUZZ_HOME_CHANNEL, BUZZ_POLL_INTERVAL,
     BUZZ_CLI_PATH, BUZZ_CREDENTIALS_FILE, BUZZ_ALLOWED_USERS,
-    BUZZ_ALLOW_ALL_USERS
+    BUZZ_REACTION_ONLY_USERS, BUZZ_ALLOW_ALL_USERS
 
 The only secret is BUZZ_PRIVATE_KEY (nsec or hex) — it belongs in
 ``~/.hermes/.env``.  It is passed to the CLI via the subprocess

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -414,6 +414,8 @@ class BuzzAdapter(BasePlatformAdapter):
         # Verified local-agent identities may acknowledge explicit tags without
         # gaining prompt/dispatch authority. This keeps the human allow-list
         # intact while providing receipt visibility for agent-authored notes.
+        # If a pubkey appears in both sets, allowed_users takes precedence: the
+        # normal authorized dispatch path runs and this reaction-only path does not.
         raw_reaction_only = (
             os.getenv("BUZZ_REACTION_ONLY_USERS")
             or extra.get("reaction_only_users", [])

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -411,6 +411,21 @@ class BuzzAdapter(BasePlatformAdapter):
             if isinstance(entry, str) and (normalized := _normalize_user_ref(entry))
         }
 
+        # Verified local-agent identities may acknowledge explicit tags without
+        # gaining prompt/dispatch authority. This keeps the human allow-list
+        # intact while providing receipt visibility for agent-authored notes.
+        raw_reaction_only = (
+            os.getenv("BUZZ_REACTION_ONLY_USERS")
+            or extra.get("reaction_only_users", [])
+        )
+        if isinstance(raw_reaction_only, str):
+            raw_reaction_only = raw_reaction_only.split(",")
+        self._reaction_only_pubkeys: set = {
+            normalized
+            for entry in raw_reaction_only
+            if isinstance(entry, str) and (normalized := _normalize_user_ref(entry))
+        }
+
         # Secret — resolved lazily (never at import/registration time and
         # never logged).  connect() re-resolves it to fail fast with a clear
         # error when it is missing.
@@ -1039,6 +1054,19 @@ class BuzzAdapter(BasePlatformAdapter):
         # Adapter-level allow-list (the gateway applies BUZZ_ALLOWED_USERS /
         # BUZZ_ALLOW_ALL_USERS centrally as well; empty list = no filter here).
         if self._allowed_pubkeys and pubkey not in self._allowed_pubkeys:
+            explicitly_tagged = any(
+                isinstance(tag, (list, tuple))
+                and len(tag) > 1
+                and tag[0] == "p"
+                and str(tag[1]).lower() == self._self_pubkey
+                for tag in event.get("tags") or []
+            )
+            if (
+                pubkey in self._reaction_only_pubkeys
+                and explicitly_tagged
+                and self._is_mentioned(content)
+            ):
+                await self.send_reaction(channel_id, event_id, "👀")
             logger.debug("Buzz: ignoring message from unauthorized pubkey %s…", pubkey[:8])
             return
 
@@ -1312,6 +1340,11 @@ def _apply_yaml_config(yaml_cfg: dict, buzz_cfg: dict) -> Optional[dict]:
         if isinstance(allowed, (list, tuple)):
             allowed = ",".join(str(a) for a in allowed)
         os.environ["BUZZ_ALLOWED_USERS"] = str(allowed)
+    reaction_only = extra.get("reaction_only_users")
+    if reaction_only is not None and not os.getenv("BUZZ_REACTION_ONLY_USERS"):
+        if isinstance(reaction_only, (list, tuple)):
+            reaction_only = ",".join(str(v) for v in reaction_only)
+        os.environ["BUZZ_REACTION_ONLY_USERS"] = str(reaction_only)
     if "allow_all_users" in extra and not os.getenv("BUZZ_ALLOW_ALL_USERS"):
         os.environ["BUZZ_ALLOW_ALL_USERS"] = str(extra["allow_all_users"]).lower()
     if "require_mention" in extra and not os.getenv("BUZZ_REQUIRE_MENTION"):

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -266,6 +266,19 @@ class TestMentionGating:
         assert adapter._dispatched == []
 
     @pytest.mark.asyncio
+    async def test_allowlist_takes_precedence_over_reaction_only(self, adapter):
+        adapter._allowed_pubkeys = {AGENT_PUBKEY}
+        adapter._reaction_only_pubkeys = {AGENT_PUBKEY}
+        adapter.send_reaction = AsyncMock(return_value=True)
+        event = _event("e1", pubkey=AGENT_PUBKEY, content="@Chip coordinate", created_at=10)
+        event["tags"].append(["p", SELF_PUBKEY])
+
+        await self._poll_with(adapter, event)
+
+        adapter.send_reaction.assert_not_awaited()
+        assert len(adapter._dispatched) == 1
+
+    @pytest.mark.asyncio
     async def test_agent_message_without_explicit_recipient_gets_no_reaction(self, adapter):
         adapter._allowed_pubkeys = {OTHER_PUBKEY}
         adapter._reaction_only_pubkeys = {AGENT_PUBKEY}

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -29,6 +29,7 @@ _standalone_send = _buzz_mod._standalone_send
 SELF_PUBKEY = "9fd5c7ba6d3ef224da78f541e0fcb9c50f72cc63edb19aae76ac6a0474dfa860"
 SELF_NPUB = "npub1nl2u0wnd8mezfknc74q7pl9ec58h9nrrakce4tnk434qgaxl4psqe5twr6"
 OTHER_PUBKEY = "a" * 64
+AGENT_PUBKEY = "b" * 64
 CHANNEL = "ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd"
 # Real DM conversation as materialized by a hosted relay: `dms list` returns
 # [] for it (#68871) while `channels list` shows it as name "DM", empty
@@ -41,6 +42,7 @@ _ENV_VARS = (
     "BUZZ_CHANNELS",
     "BUZZ_HOME_CHANNEL",
     "BUZZ_ALLOWED_USERS",
+    "BUZZ_REACTION_ONLY_USERS",
     "BUZZ_ALLOW_ALL_USERS",
     "BUZZ_POLL_INTERVAL",
     "BUZZ_CLI_PATH",
@@ -248,6 +250,46 @@ class TestMentionGating:
     async def test_allowlist_blocks_unauthorized(self, adapter):
         adapter._allowed_pubkeys = {"b" * 64}
         await self._poll_with(adapter, _event("e1", content="@Chip hello", created_at=10))
+        assert adapter._dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_explicit_agent_tag_reacts_without_dispatch(self, adapter):
+        adapter._allowed_pubkeys = {OTHER_PUBKEY}
+        adapter._reaction_only_pubkeys = {AGENT_PUBKEY}
+        adapter.send_reaction = AsyncMock(return_value=True)
+        event = _event("e1", pubkey=AGENT_PUBKEY, content="@Chip coordinate", created_at=10)
+        event["tags"].append(["p", SELF_PUBKEY])
+
+        await self._poll_with(adapter, event)
+
+        adapter.send_reaction.assert_awaited_once_with(CHANNEL, "e1", "👀")
+        assert adapter._dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_agent_message_without_explicit_recipient_gets_no_reaction(self, adapter):
+        adapter._allowed_pubkeys = {OTHER_PUBKEY}
+        adapter._reaction_only_pubkeys = {AGENT_PUBKEY}
+        adapter.send_reaction = AsyncMock(return_value=True)
+
+        await self._poll_with(
+            adapter,
+            _event("e1", pubkey=AGENT_PUBKEY, content="@Chip coordinate", created_at=10),
+        )
+
+        adapter.send_reaction.assert_not_awaited()
+        assert adapter._dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_unknown_sender_tag_gets_no_reaction(self, adapter):
+        adapter._allowed_pubkeys = {OTHER_PUBKEY}
+        adapter._reaction_only_pubkeys = {AGENT_PUBKEY}
+        adapter.send_reaction = AsyncMock(return_value=True)
+        event = _event("e1", pubkey="c" * 64, content="@Chip coordinate", created_at=10)
+        event["tags"].append(["p", SELF_PUBKEY])
+
+        await self._poll_with(adapter, event)
+
+        adapter.send_reaction.assert_not_awaited()
         assert adapter._dispatched == []
 
 


### PR DESCRIPTION
## Summary
- add `reaction_only_users` Buzz configuration
- emit 👀 only for verified reaction-only sender with explicit recipient p-tag and visible mention
- preserve human allowlist and prevent model dispatch/thread ownership
- add regressions for trusted tagged, untagged, and unknown senders

## Verification
- `uv run --with pytest --with pytest-asyncio pytest -q tests/gateway/test_buzz_adapter.py` (26 passed)