### PR TITLE
fix(cron): respect cron.default_delivery when no explicit deliver is set

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1777,6 +1777,69 @@ def _validate_job_mode_invariants(
         )
 
 
+def _is_valid_default_delivery(value: str) -> bool:
+    """Whether *value* is an acceptable ``cron.default_delivery`` setting.
+
+    Accepts the same tokens ``cron.scheduler._resolve_delivery_targets`` does
+    at fire time: ``origin``, ``local``, ``all``, known platform names, and
+    comma-separated combinations (``platform:target`` prefixes included). A
+    value that doesn't match resolves to no delivery target at fire time —
+    validating it here catches a typo'd platform name before every unattended
+    cron job it applies to silently loses its output.
+    """
+    parts = [p.strip() for p in value.split(",") if p.strip()]
+    if not parts:
+        return False
+    try:
+        from cron.scheduler import _is_known_delivery_platform
+    except Exception:
+        return value in ("origin", "local")
+    for part in parts:
+        platform_name = part.split(":", 1)[0].lower()
+        if platform_name in ("origin", "local", "all"):
+            continue
+        if not _is_known_delivery_platform(platform_name):
+            return False
+    return True
+
+
+def _resolve_default_delivery(origin: Optional[Dict[str, Any]]) -> str:
+    """Resolve the profile-level default cron delivery target.
+
+    ``cron.default_delivery`` lets a profile opt out of the historical
+    origin-chat default. This is useful for web/UI-first profiles where a stale
+    messaging origin (for example Discord) must never receive unattended cron
+    completions. Explicit per-job ``deliver`` values still win.
+
+    An unrecognized ``cron.default_delivery`` value (typo'd platform name,
+    stray text) is rejected rather than stored — it would otherwise resolve to
+    no delivery target for every job that relies on the default, dropping
+    output silently at fire time with no signal back to the user.
+    """
+    fallback = "origin" if origin else "local"
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        cron_cfg = cfg.get("cron", {}) if isinstance(cfg, dict) else {}
+        raw_default = (
+            cron_cfg.get("default_delivery") if isinstance(cron_cfg, dict) else None
+        )
+        configured = str(raw_default).strip() if raw_default is not None else ""
+        if configured:
+            if _is_valid_default_delivery(configured):
+                return configured
+            logger.warning(
+                "Ignoring invalid cron.default_delivery=%r (not a known delivery "
+                "target); falling back to %s",
+                configured,
+                fallback,
+            )
+    except Exception as exc:
+        logger.debug("Failed to resolve cron.default_delivery: %s", exc)
+    return fallback
+
+
 def create_job(
     prompt: Optional[str],
     schedule: str,
@@ -1868,9 +1931,10 @@ def create_job(
     if parsed_schedule["kind"] == "once" and repeat is None:
         repeat = 1
 
-    # Default delivery to origin if available, otherwise local
+    # Default delivery follows the profile policy when configured, otherwise
+    # preserves the historical origin-if-available / local fallback.
     if deliver is None:
-        deliver = "origin" if origin else "local"
+        deliver = _resolve_default_delivery(origin)
 
     job_id = uuid.uuid4().hex[:12]
     now = _hermes_now().isoformat()

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -261,6 +261,83 @@ class TestJobCRUD:
         assert job["deliver"] == "origin"
 
 
+class TestDefaultDeliveryPolicy:
+    """``cron.default_delivery`` overrides the origin-if-available fallback.
+
+    Regression coverage for a routing bug: a job created without an explicit
+    ``deliver`` used to always fall back to ``origin`` (or ``local`` with no
+    origin), ignoring any profile-level delivery preference — so a profile
+    that set a default delivery target still had unattended cron output land
+    on the legacy origin platform.
+    """
+
+    def test_config_default_overrides_origin_fallback(self, tmp_cron_dir, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"cron": {"default_delivery": "telegram"}},
+        )
+        job = create_job(
+            prompt="Test", schedule="30m",
+            origin={"platform": "discord", "chat_id": "123"},
+        )
+        assert job["deliver"] == "telegram"
+
+    def test_config_default_applies_without_origin(self, tmp_cron_dir, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"cron": {"default_delivery": "local"}},
+        )
+        job = create_job(prompt="Test", schedule="30m")
+        assert job["deliver"] == "local"
+
+    def test_explicit_deliver_wins_over_config_default(self, tmp_cron_dir, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"cron": {"default_delivery": "telegram"}},
+        )
+        job = create_job(
+            prompt="Test", schedule="30m",
+            origin={"platform": "discord", "chat_id": "123"},
+            deliver="slack",
+        )
+        assert job["deliver"] == "slack"
+
+    def test_no_config_preserves_historical_fallback(self, tmp_cron_dir, monkeypatch):
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+        job = create_job(prompt="Test", schedule="30m")
+        assert job["deliver"] == "local"
+
+    def test_invalid_config_default_falls_back_and_warns(
+        self, tmp_cron_dir, monkeypatch, caplog
+    ):
+        """An unrecognized ``cron.default_delivery`` value must not be stored
+        as-is — it would resolve to no delivery target at fire time and
+        silently drop the job's output. It should be rejected with a warning
+        and the historical fallback used instead."""
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"cron": {"default_delivery": "not-a-real-platform"}},
+        )
+        with caplog.at_level("WARNING", logger="cron.jobs"):
+            job = create_job(
+                prompt="Test", schedule="30m",
+                origin={"platform": "discord", "chat_id": "123"},
+            )
+        assert job["deliver"] == "origin"
+        assert "not-a-real-platform" in caplog.text
+
+    def test_multi_target_config_default_accepted(self, tmp_cron_dir, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"cron": {"default_delivery": "origin,telegram"}},
+        )
+        job = create_job(
+            prompt="Test", schedule="30m",
+            origin={"platform": "discord", "chat_id": "123"},
+        )
+        assert job["deliver"] == "origin,telegram"
+
+
 class TestUpdateJob:
     def test_update_name(self, tmp_cron_dir):
         job = create_job(prompt="Check server status", schedule="every 1h", name="Old Name")


### PR DESCRIPTION
`create_job()` hardcoded `deliver = "origin" if origin else "local"` whenever
a job was created without an explicit `deliver`, ignoring any profile-level
delivery preference. A profile that never wants unattended cron output
landing on a stale origin platform (e.g. Discord) had no way to change this
default short of passing `deliver=` on every single job.

This adds `_resolve_default_delivery()`, which reads `cron.default_delivery`
from config and uses it when set, falling back to the historical
origin-if-available / local behavior otherwise. Explicit per-job `deliver`
still takes priority.

The configured value is validated against the same tokens
`cron.scheduler._resolve_delivery_targets()` accepts at fire time (`origin`,
`local`, `all`, known platforms, comma-separated combinations). An
unrecognized value (typo'd platform name) would otherwise resolve to no
delivery target at fire time, silently dropping output for every job that
relies on the default — so it's rejected up front with a warning instead of
being stored as-is.

Tests: `tests/cron/test_jobs.py::TestDefaultDeliveryPolicy` (6 cases,
verified to fail without the fix and pass with it). Full
`tests/cron/test_jobs.py` passes; `tests/cron/test_scheduler.py` (which owns
the imported `_is_known_delivery_platform` path) passes with no
circular-import issues.
