### PR TITLE
fix(api): prevent duplicate run/approval processing on client retries

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -988,7 +988,7 @@ class ResponseStore:
 
 _CORS_HEADERS = {
     "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
-    "Access-Control-Allow-Headers": "Authorization, Content-Type, Idempotency-Key",
+    "Access-Control-Allow-Headers": "Authorization, Content-Type, Idempotency-Key, X-Hermes-Expected-Generation",
 }
 
 
@@ -1436,6 +1436,15 @@ class APIServerAdapter(BasePlatformAdapter):
         # resolves requests by session key, while API clients address the
         # in-flight run by run_id.
         self._run_approval_sessions: Dict[str, str] = {}
+        # Process-local admission records deliberately retain only a digest and
+        # acceptance receipt, never request bodies. They are the idempotency
+        # boundary before asynchronous work is scheduled.
+        self._server_generation = str(uuid.uuid4())
+        self._run_admissions: Dict[str, Dict[str, Any]] = {}
+        # Approval decisions have their own receipt registry: a run admission
+        # receipt cannot safely stand in for a decision against a pending
+        # approval.
+        self._approval_admissions: Dict[str, Dict[str, Any]] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
         self._session_dbs: Dict[str, Any] = {}
         self._session_db_cache_lock = threading.Lock()
@@ -2092,6 +2101,12 @@ class APIServerAdapter(BasePlatformAdapter):
             ("POST", "/api/jobs/{job_id}/resume", self._handle_resume_job),
             ("POST", "/api/jobs/{job_id}/run", self._handle_run_job),
             ("POST", "/v1/runs", self._handle_runs),
+            # Must precede the dynamic /v1/runs/{run_id} entry below: routes
+            # are registered from this table in list order, and aiohttp's
+            # UrlDispatcher resolves in registration order, so a static
+            # "/v1/runs/meta" registered after the dynamic resource would be
+            # swallowed by it (run_id="meta") instead of reaching this handler.
+            ("GET", "/v1/runs/meta", self._handle_runs_meta),
             ("GET", "/v1/runs/{run_id}", self._handle_get_run),
             ("GET", "/v1/runs/{run_id}/events", self._handle_run_events),
             ("POST", "/v1/runs/{run_id}/approval", self._handle_run_approval),
@@ -6561,6 +6576,99 @@ class APIServerAdapter(BasePlatformAdapter):
 
     _RUN_STREAM_TTL = 300  # seconds before orphaned runs are swept
     _RUN_STATUS_TTL = 3600  # seconds to retain terminal run status for polling
+    _RUN_ADMISSION_TTL = _RUN_STATUS_TTL
+    _MAX_RUN_ADMISSIONS = 1024
+    _MAX_APPROVAL_ADMISSIONS = 1024
+    _MAX_IDEMPOTENCY_KEY_LENGTH = 256
+    _MAX_EXPECTED_GENERATION_LENGTH = 64
+    _TERMINAL_RUN_STATUSES = frozenset({"completed", "failed", "cancelled"})
+
+    @staticmethod
+    def _run_admission_fingerprint(body: Dict[str, Any], gateway_session_key: Optional[str]) -> str:
+        """Digest every input that can change /v1/runs admission semantics."""
+        semantic = {
+            "input": body.get("input"),
+            "instructions": body.get("instructions"),
+            "previous_response_id": body.get("previous_response_id"),
+            "conversation_history": body.get("conversation_history"),
+            "session_id": body.get("session_id"),
+            "model": body.get("model"),
+            "gateway_session_key": gateway_session_key,
+        }
+        encoded = json.dumps(semantic, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+    def _sweep_run_admissions(self) -> None:
+        """Expire terminal receipts without ever dropping a live admission."""
+        now = time.time()
+        expired = [
+            key for key, entry in self._run_admissions.items()
+            if entry.get("terminal") and now - float(entry.get("updated_at", now)) > self._RUN_ADMISSION_TTL
+        ]
+        for key in expired:
+            self._run_admissions.pop(key, None)
+
+    def _reserve_run_admission(self, key: str, fingerprint: str, run_id: str) -> bool:
+        """Reserve bounded keyed admission before any async-visible run state.
+
+        Active and unexpired terminal records are never evicted; a full registry
+        fails closed until a terminal receipt has reached its advertised TTL.
+        This method runs synchronously on the aiohttp loop, so the reservation
+        precedes both status publication and task creation.
+        """
+        self._sweep_run_admissions()
+        if len(self._run_admissions) >= self._MAX_RUN_ADMISSIONS:
+            return False
+        now = time.time()
+        self._run_admissions[key] = {
+            "key": key,
+            "fingerprint": fingerprint,
+            "run_id": run_id,
+            "response_status": "started",
+            "terminal": False,
+            "created_at": now,
+            "updated_at": now,
+        }
+        return True
+
+    def _update_run_admission_status(self, run_id: str, status: str) -> None:
+        for entry in self._run_admissions.values():
+            if entry.get("run_id") == run_id:
+                entry["terminal"] = status in self._TERMINAL_RUN_STATUSES
+                entry["updated_at"] = time.time()
+                return
+
+    @staticmethod
+    def _approval_admission_fingerprint(run_id: str, choice: str, resolve_all: bool) -> str:
+        """Digest every input that can change approval-decision admission semantics."""
+        semantic = {
+            "run_id": run_id,
+            "choice": choice,
+            "resolve_all": bool(resolve_all),
+        }
+        encoded = json.dumps(semantic, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+    def _sweep_approval_admissions(self) -> None:
+        """Drop only expired approval receipts; active receipts are never evicted."""
+        now = time.time()
+        expired = [
+            key for key, entry in self._approval_admissions.items()
+            if now - float(entry.get("created_at", now)) > self._RUN_ADMISSION_TTL
+        ]
+        for key in expired:
+            self._approval_admissions.pop(key, None)
+
+    def _reserve_approval_admission(self, key: str, fingerprint: str) -> bool:
+        """Reserve a bounded approval receipt immediately before resolution."""
+        self._sweep_approval_admissions()
+        if len(self._approval_admissions) >= self._MAX_APPROVAL_ADMISSIONS:
+            return False
+        self._approval_admissions[key] = {
+            "fingerprint": fingerprint,
+            "created_at": time.time(),
+        }
+        return True
 
     def _set_run_status(self, run_id: str, status: str, **fields: Any) -> Dict[str, Any]:
         """Update pollable run status without exposing private agent objects."""
@@ -6575,6 +6683,7 @@ class APIServerAdapter(BasePlatformAdapter):
         current.setdefault("created_at", fields.pop("created_at", now))
         current.update(fields)
         self._run_statuses[run_id] = current
+        self._update_run_admission_status(run_id, status)
         return current
 
     def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
@@ -6678,12 +6787,6 @@ class APIServerAdapter(BasePlatformAdapter):
         if key_err is not None:
             return key_err
 
-        # Enforce concurrency limit (shared across all agent-serving
-        # endpoints; configurable via gateway.api_server.max_concurrent_runs).
-        limited = self._concurrency_limited_response()
-        if limited is not None:
-            return limited
-
         try:
             body = await request.json()
         except Exception:
@@ -6757,7 +6860,75 @@ class APIServerAdapter(BasePlatformAdapter):
         if selection_error:
             return web.json_response(_openai_error(selection_error), status=400)
 
+        # Idempotency-Key lets a client safely retry a POST /v1/runs whose
+        # response was lost in transit without risking a duplicate run.
+        # X-Hermes-Expected-Generation lets a client detect a server restart
+        # (which invalidates its view of in-flight run state) before
+        # admitting a new run under stale assumptions.
+        idempotency_key = request.headers.get("Idempotency-Key", "").strip()
+        expected_generation = request.headers.get("X-Hermes-Expected-Generation")
+        if expected_generation is not None:
+            expected_generation = expected_generation.strip()
+            if (
+                not expected_generation
+                or len(expected_generation) > self._MAX_EXPECTED_GENERATION_LENGTH
+            ):
+                return web.json_response(
+                    _openai_error("X-Hermes-Expected-Generation is invalid"), status=400,
+                )
+            try:
+                uuid.UUID(expected_generation)
+            except (TypeError, ValueError, AttributeError):
+                return web.json_response(
+                    _openai_error("X-Hermes-Expected-Generation is invalid"), status=400,
+                )
+            # This comparison shares the request's admission critical section
+            # with lookup/reservation below: no run state exists before it.
+            if not hmac.compare_digest(expected_generation, self._server_generation):
+                return web.json_response(
+                    _openai_error("Hermes server generation mismatch", code="server_generation_mismatch"),
+                    status=409,
+                )
+        if "Idempotency-Key" in request.headers and not idempotency_key:
+            return web.json_response(
+                _openai_error("Idempotency-Key must be nonempty"), status=400,
+            )
+        if len(idempotency_key) > self._MAX_IDEMPOTENCY_KEY_LENGTH:
+            return web.json_response(
+                _openai_error("Idempotency-Key exceeds maximum length"), status=400,
+            )
+        fingerprint = None
+        if idempotency_key:
+            fingerprint = self._run_admission_fingerprint(body, gateway_session_key)
+            self._sweep_run_admissions()
+            admission = self._run_admissions.get(idempotency_key)
+            if admission is not None:
+                if not hmac.compare_digest(str(admission["fingerprint"]), fingerprint):
+                    return web.json_response(
+                        _openai_error("Idempotency-Key was already used with different admission inputs"),
+                        status=409,
+                    )
+                return web.json_response(
+                    {"run_id": admission["run_id"], "status": admission["response_status"]},
+                    status=202,
+                )
+
+        # A replay is accepted above even if capacity has since filled. New
+        # admissions remain subject to the shared concurrency limit (shared
+        # across all agent-serving endpoints; configurable via
+        # gateway.api_server.max_concurrent_runs).
+        limited = self._concurrency_limited_response()
+        if limited is not None:
+            return limited
+
         run_id = f"run_{uuid.uuid4().hex}"
+        if idempotency_key and not self._reserve_run_admission(
+            idempotency_key, fingerprint, run_id,
+        ):
+            return web.json_response(
+                _openai_error("Run admission registry is full", code="run_admission_capacity"),
+                status=503,
+            )
         session_id = session_id or run_id
         # Approval queues gate host-side tool execution and must be isolated
         # per API run.  Client-provided session IDs and memory session keys are
@@ -7086,6 +7257,17 @@ class APIServerAdapter(BasePlatformAdapter):
             headers=response_headers,
         )
 
+    async def _handle_runs_meta(self, request: "web.Request") -> "web.Response":
+        """GET /v1/runs/meta — process generation for safe admission recovery."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        return web.json_response({
+            "server_generation": self._server_generation,
+            "idempotency": "v1",
+            "idempotency_ttl_seconds": self._RUN_ADMISSION_TTL,
+        })
+
     async def _handle_get_run(self, request: "web.Request") -> "web.Response":
         """GET /v1/runs/{run_id} — return pollable run status for external UIs."""
         auth_err = self._check_auth(request)
@@ -7160,6 +7342,38 @@ class APIServerAdapter(BasePlatformAdapter):
             return auth_err
 
         run_id = request.match_info["run_id"]
+
+        # Mirrors the /v1/runs validation order: generation check, then
+        # Idempotency-Key shape, before anything touches run/approval state.
+        idempotency_key = request.headers.get("Idempotency-Key", "").strip()
+        expected_generation = request.headers.get("X-Hermes-Expected-Generation")
+        if expected_generation is not None:
+            expected_generation = expected_generation.strip()
+            if (
+                not expected_generation
+                or len(expected_generation) > self._MAX_EXPECTED_GENERATION_LENGTH
+            ):
+                return web.json_response(
+                    _openai_error("X-Hermes-Expected-Generation is invalid"), status=400,
+                )
+            try:
+                uuid.UUID(expected_generation)
+            except (TypeError, ValueError, AttributeError):
+                return web.json_response(
+                    _openai_error("X-Hermes-Expected-Generation is invalid"), status=400,
+                )
+            if not hmac.compare_digest(expected_generation, self._server_generation):
+                return web.json_response(
+                    _openai_error("Hermes server generation mismatch", code="server_generation_mismatch"),
+                    status=409,
+                )
+        if "Idempotency-Key" in request.headers and not idempotency_key:
+            return web.json_response(_openai_error("Idempotency-Key must be nonempty"), status=400)
+        if len(idempotency_key) > self._MAX_IDEMPOTENCY_KEY_LENGTH:
+            return web.json_response(
+                _openai_error("Idempotency-Key exceeds maximum length"), status=400,
+            )
+
         status = self._run_statuses.get(run_id)
         if status is None:
             return web.json_response(
@@ -7185,6 +7399,27 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=400,
             )
 
+        resolve_all = (
+            _coerce_request_bool(body.get("all"), default=False)
+            or _coerce_request_bool(body.get("resolve_all"), default=False)
+        )
+
+        # Idempotency-Key lets a client safely retry a resolve whose response
+        # was lost in transit without risking a second, possibly different,
+        # pending approval being resolved by mistake.
+        fingerprint = None
+        if idempotency_key:
+            fingerprint = self._approval_admission_fingerprint(run_id, choice, resolve_all)
+            self._sweep_approval_admissions()
+            admission = self._approval_admissions.get(idempotency_key)
+            if admission is not None:
+                if not hmac.compare_digest(str(admission["fingerprint"]), fingerprint):
+                    return web.json_response(
+                        _openai_error("Idempotency-Key was already used with different approval inputs"),
+                        status=409,
+                    )
+                return web.json_response(admission["response"], status=admission["status"])
+
         approval_session_key = self._run_approval_sessions.get(run_id)
         if not approval_session_key:
             return web.json_response(
@@ -7195,10 +7430,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=409,
             )
 
-        resolve_all = (
-            _coerce_request_bool(body.get("all"), default=False)
-            or _coerce_request_bool(body.get("resolve_all"), default=False)
-        )
+        if idempotency_key and not self._reserve_approval_admission(
+            idempotency_key, fingerprint,
+        ):
+            return web.json_response(
+                _openai_error("Approval admission registry is full", code="approval_admission_capacity"),
+                status=503,
+            )
         try:
             from tools.approval import resolve_gateway_approval
 
@@ -7208,10 +7446,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 resolve_all=resolve_all,
             )
         except Exception as exc:
+            if idempotency_key:
+                self._approval_admissions.pop(idempotency_key, None)
             logger.exception("[api_server] approval resolution failed for run %s", run_id)
             return web.json_response(_openai_error(str(exc)), status=500)
 
         if resolved <= 0:
+            if idempotency_key:
+                self._approval_admissions.pop(idempotency_key, None)
             return web.json_response(
                 _openai_error(
                     f"Run has no pending approval: {run_id}",
@@ -7234,12 +7476,18 @@ class APIServerAdapter(BasePlatformAdapter):
             except Exception:
                 pass
 
-        return web.json_response({
+        response_body = {
             "object": "hermes.run.approval_response",
             "run_id": run_id,
             "choice": choice,
             "resolved": resolved,
-        })
+        }
+        if idempotency_key:
+            # Store the receipt after resolution succeeds so a retry replays
+            # this exact response instead of resolving the queue again.
+            self._approval_admissions[idempotency_key]["response"] = response_body
+            self._approval_admissions[idempotency_key]["status"] = 200
+        return web.json_response(response_body)
 
     async def _handle_steer_run(self, request: "web.Request") -> "web.Response":
         """POST /v1/runs/{run_id}/steer — inject guidance into a running agent."""

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -12,6 +12,7 @@ Covers:
 import asyncio
 import threading
 import time
+import uuid
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -262,6 +263,101 @@ class TestStartRun:
 
 
 # ---------------------------------------------------------------------------
+# POST /v1/runs — Idempotency-Key admission (retry safety)
+# ---------------------------------------------------------------------------
+
+
+class TestStartRunIdempotency:
+    @pytest.mark.asyncio
+    async def test_retry_with_same_idempotency_key_does_not_start_second_run(self, adapter):
+        """A client retrying a timed-out POST /v1/runs with the same
+        Idempotency-Key must get back the original run_id, not a second run.
+        Without admission dedup this doubles the underlying agent (LLM) work.
+        """
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                headers = {"Idempotency-Key": "client-retry-1"}
+                resp1 = await cli.post("/v1/runs", json={"input": "hello"}, headers=headers)
+                assert resp1.status == 202
+                data1 = await resp1.json()
+
+                resp2 = await cli.post("/v1/runs", json={"input": "hello"}, headers=headers)
+                assert resp2.status == 202
+                data2 = await resp2.json()
+
+                assert data1["run_id"] == data2["run_id"]
+                mock_create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_same_idempotency_key_different_body_returns_409(self, adapter):
+        """Reusing a key with materially different admission inputs must be
+        rejected rather than silently returning the wrong cached run."""
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                headers = {"Idempotency-Key": "client-retry-2"}
+                resp1 = await cli.post("/v1/runs", json={"input": "hello"}, headers=headers)
+                assert resp1.status == 202
+
+                resp2 = await cli.post("/v1/runs", json={"input": "different"}, headers=headers)
+                assert resp2.status == 409
+
+    @pytest.mark.asyncio
+    async def test_empty_idempotency_key_header_returns_400(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/runs", json={"input": "hello"}, headers={"Idempotency-Key": "   "},
+            )
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_runs_meta_returns_server_generation(self, adapter):
+        # Register in the same order api_server does: the static "meta"
+        # route must precede the dynamic "/v1/runs/{run_id}" resource or
+        # aiohttp's UrlDispatcher swallows it as run_id="meta".
+        app = web.Application()
+        app["api_server_adapter"] = adapter
+        app.router.add_post("/v1/runs", adapter._handle_runs)
+        app.router.add_get("/v1/runs/meta", adapter._handle_runs_meta)
+        app.router.add_get("/v1/runs/{run_id}", adapter._handle_get_run)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/runs/meta")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["server_generation"] == adapter._server_generation
+            assert data["idempotency_ttl_seconds"] == adapter._RUN_ADMISSION_TTL
+
+    @pytest.mark.asyncio
+    async def test_expected_generation_mismatch_returns_409(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/runs",
+                json={"input": "hello"},
+                headers={"X-Hermes-Expected-Generation": str(uuid.uuid4())},
+            )
+            assert resp.status == 409
+            data = await resp.json()
+            assert data["error"]["code"] == "server_generation_mismatch"
+
+
+# ---------------------------------------------------------------------------
 # GET /v1/runs/{run_id} — poll run status
 # ---------------------------------------------------------------------------
 
@@ -403,6 +499,62 @@ class TestRunEvents:
                     approval_mod._gateway_queues.pop(victim_run, None)
                 victim_interrupted.set()
                 attacker_interrupted.set()
+
+    @pytest.mark.asyncio
+    async def test_retry_approval_with_same_idempotency_key_resolves_once(self, adapter):
+        """A retried POST .../approval with the same Idempotency-Key must
+        replay the original response instead of resolving the approval
+        queue a second time (which, without dedup, resolves whatever is
+        now at the head of the queue — silently mis-authorizing it, or
+        404s a retry that actually already succeeded).
+        """
+        app = _create_runs_app(adapter)
+        run_id = "run_idem_approval"
+        adapter._run_statuses[run_id] = {"run_id": run_id, "status": "waiting_for_approval"}
+        adapter._run_approval_sessions[run_id] = "session-idem"
+
+        async with TestClient(TestServer(app)) as cli:
+            # First call resolves 1 pending approval; if the retry reaches
+            # resolve_gateway_approval a second time it finds nothing left
+            # pending (0) — the smoking gun for missing idempotency.
+            with patch(
+                "tools.approval.resolve_gateway_approval", side_effect=[1, 0],
+            ) as mock_resolve:
+                headers = {"Idempotency-Key": "approve-retry-1"}
+                resp1 = await cli.post(
+                    f"/v1/runs/{run_id}/approval", json={"choice": "once"}, headers=headers,
+                )
+                assert resp1.status == 200
+                data1 = await resp1.json()
+
+                resp2 = await cli.post(
+                    f"/v1/runs/{run_id}/approval", json={"choice": "once"}, headers=headers,
+                )
+                assert resp2.status == 200
+                data2 = await resp2.json()
+
+        mock_resolve.assert_called_once()
+        assert data1 == data2
+
+    @pytest.mark.asyncio
+    async def test_approval_idempotency_key_different_choice_returns_409(self, adapter):
+        app = _create_runs_app(adapter)
+        run_id = "run_idem_approval_conflict"
+        adapter._run_statuses[run_id] = {"run_id": run_id, "status": "waiting_for_approval"}
+        adapter._run_approval_sessions[run_id] = "session-idem-2"
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch("tools.approval.resolve_gateway_approval", return_value=1):
+                headers = {"Idempotency-Key": "approve-retry-2"}
+                resp1 = await cli.post(
+                    f"/v1/runs/{run_id}/approval", json={"choice": "once"}, headers=headers,
+                )
+                assert resp1.status == 200
+
+                resp2 = await cli.post(
+                    f"/v1/runs/{run_id}/approval", json={"choice": "deny"}, headers=headers,
+                )
+        assert resp2.status == 409
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
POST /v1/runs has a window before any run state exists where a client
retry (e.g. after a timeout) can be admitted twice, starting the same
agent run concurrently. This isn't just a duplicate HTTP response: it
means the LLM call and any side effects it triggers (tool calls,
external actions) execute twice for a single logical request. Approval
resolution over the run's event stream has the same class of bug on
retry — a retried resolve call can process the same approval decision
twice.

This adds bounded, TTL-capped keyed admission on both endpoints:

- Clients may send an `Idempotency-Key` header. The first request with
  a given key reserves an admission record before any async-visible
  state is created; a fingerprint of the semantically relevant inputs
  is stored alongside it.
- A retry with the same key and matching fingerprint replays the
  cached outcome instead of reprocessing. A retry with the same key
  but a different fingerprint is rejected with 409, since reusing that
  key for a different request is unsafe.
- A new `GET /v1/runs/meta` endpoint exposes a per-process server
  generation UUID, so clients can detect a server restart (which
  invalidates prior admission bookkeeping) via an optional
  `X-Hermes-Expected-Generation` header instead of assuming stale
  state is still valid.
- Both admission tables are capped and swept on TTL, so retrying
  clients add bounded memory, not unbounded growth.

`/v1/runs/meta` is registered before the existing `/v1/runs/{run_id}`
route. aiohttp's `UrlDispatcher` resolves routes in registration
order, so the dynamic route would otherwise swallow the literal
`meta` path segment.

## Testing

Added `TestStartRunIdempotency` and two new cases in `TestRunEvents`
covering: duplicate-run prevention on retry, 409 on key reuse with a
changed body, 400 on an empty `Idempotency-Key` header, the new
`/v1/runs/meta` endpoint, generation-mismatch handling, and the
equivalent retry/409 behavior for approval resolution.

- `tests/gateway/test_api_server_runs.py`: 29/29 passing (22
  pre-existing + 7 new).
- Full `tests/gateway/` suite: no new failures relative to baseline.
- All 7 new tests verified to fail against pre-fix code and pass
  against the fix.
