### PR TITLE
fix(hooks): mirror delivered interim commentary onto agent:commentary

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5348,6 +5348,26 @@ class TurnRunner:
                 if ctx._run_still_current():
                     _stts_consumer_ref.on_delta(text)
 
+        async def _emit_commentary_delivery_hook(
+            delivered_text: str,
+            platform_message_id: Optional[str],
+        ) -> None:
+            await ctx._hooks_ref.emit("agent:commentary", {
+                "platform": ctx.source.platform.value if ctx.source.platform else "",
+                "user_id": ctx.source.user_id,
+                "chat_id": ctx.source.chat_id or "",
+                "thread_id": (
+                    str(getattr(ctx.source, "thread_id", None))
+                    if getattr(ctx.source, "thread_id", None) else ""
+                ),
+                "chat_type": getattr(ctx.source, "chat_type", "") or "",
+                "session_id": ctx.session_id,
+                "response": delivered_text,
+                "event_message_id": (
+                    str(platform_message_id) if platform_message_id is not None else ""
+                ),
+            })
+
         def _interim_assistant_cb(text: str, *, already_streamed: bool = False) -> None:
             if not ctx._run_still_current():
                 return
@@ -5360,7 +5380,7 @@ class TurnRunner:
                 return
             if already_streamed or not ctx._status_adapter or not str(display_text or "").strip():
                 return
-            safe_schedule_threadsafe(
+            _commentary_fut = safe_schedule_threadsafe(
                 ctx._status_adapter.send(
                     ctx._status_chat_id,
                     display_text,
@@ -5370,6 +5390,29 @@ class TurnRunner:
                 logger=logger,
                 log_message="interim_assistant_callback scheduling error",
             )
+            if _commentary_fut is None:
+                return
+
+            # Only emit the agent:commentary hook once the platform has
+            # confirmed delivery — hook consumers (logging/audit mirrors)
+            # need the exact text the user actually saw, not every
+            # attempted send.
+            def _emit_commentary_hook_on_delivery(fut, _text=display_text) -> None:
+                try:
+                    res = fut.result()
+                except Exception:
+                    return
+                if not getattr(res, "success", False):
+                    return
+                safe_schedule_threadsafe(
+                    _emit_commentary_delivery_hook(
+                        _text, getattr(res, "message_id", None)
+                    ),
+                    ctx._loop_for_step,
+                    logger=logger,
+                    log_message="agent:commentary hook scheduling error",
+                )
+            _commentary_fut.add_done_callback(_emit_commentary_hook_on_delivery)
 
         turn_route = self._runner._resolve_turn_agent_config(ctx.message, model, runtime_kwargs)
 

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -6,6 +6,7 @@ import sys
 import time
 import types
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -471,7 +472,7 @@ def _make_runner(adapter):
     runner._running_agents = {}
     runner._session_run_generation = {}
     runner.session_store = SimpleNamespace(_entries={}, _save=lambda: None)
-    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.hooks = SimpleNamespace(loaded_hooks=False, emit=AsyncMock())
     runner.config = SimpleNamespace(
         thread_sessions_per_user=False,
         group_sessions_per_user=False,
@@ -1006,6 +1007,8 @@ async def _run_with_agent(
     adapter_cls=ProgressCaptureAdapter,
     user_id=None,
     scope_id=None,
+    event_message_id=None,
+    return_runner=False,
 ):
     if config_data:
         import yaml
@@ -1053,7 +1056,10 @@ async def _run_with_agent(
         source=source,
         session_id=session_id,
         session_key=session_key,
+        event_message_id=event_message_id,
     )
+    if return_runner:
+        return adapter, result, runner
     return adapter, result
 
 
@@ -1181,6 +1187,48 @@ async def test_display_streaming_does_not_enable_gateway_streaming(monkeypatch, 
     assert result.get("already_sent") is not True
     assert adapter.edits == []
     assert [call["content"] for call in adapter.sent] == ["I'll inspect the repo first."]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_emits_hook_after_commentary_delivery(monkeypatch, tmp_path):
+    """Interim commentary that a platform actually delivers must be mirrored
+    onto the agent:commentary hook so logging/audit consumers see the same
+    text the user saw, instead of only learning about it via agent:end's
+    final-response-only payload.
+    """
+    adapter, result, runner = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        CommentaryAgent,
+        session_id="sess-commentary-hook",
+        config_data={"display": {"interim_assistant_messages": True}},
+        platform=Platform.BLUEBUBBLES,
+        chat_id="iMessage;-;user@example.com",
+        chat_type="dm",
+        thread_id=None,
+        user_id="user-7",
+        event_message_id="inbound-user-message",
+        adapter_cls=NonEditingProgressCaptureAdapter,
+        return_runner=True,
+    )
+
+    assert result.get("already_sent") is not True
+    commentary_calls = [
+        call
+        for call in runner.hooks.emit.await_args_list
+        if call.args and call.args[0] == "agent:commentary"
+    ]
+    assert len(commentary_calls) == 1
+    assert commentary_calls[0].args[1] == {
+        "platform": "bluebubbles",
+        "user_id": "user-7",
+        "chat_id": "iMessage;-;user@example.com",
+        "thread_id": "",
+        "chat_type": "dm",
+        "session_id": "sess-commentary-hook",
+        "response": "I'll inspect the repo first.",
+        "event_message_id": "progress-1",
+    }
 
 
 class TransformedStreamAgent:


### PR DESCRIPTION
## Problem

The `agent:end` hook only carries the final response text. A hook consumer
that mirrors what the user actually saw during a turn (logging, audit,
timeline sync, etc.) has no way to see interim assistant commentary that
was delivered to the platform along the way — it simply never appears in
any hook payload.

## Fix

When interim commentary is delivered through the direct adapter-send path
(the path used whenever no per-message stream consumer is active — e.g.
adapters that don't support in-place message editing, such as BlueBubbles,
QQ, WeChat), emit a new `agent:commentary` hook once the adapter confirms
the send succeeded. The hook payload mirrors the existing `agent:start` /
`agent:end` context shape:

    {
      "platform": ...,
      "user_id": ...,
      "chat_id": ...,
      "thread_id": ...,
      "chat_type": ...,
      "session_id": ...,
      "response": <exact delivered text>,
      "event_message_id": <platform message id from the successful send>,
    }

The hook is wired through the existing scheduled-future callback pattern
already used elsewhere in this function for status-message tracking, so it
only fires after a confirmed successful send — a failed or dropped send
never produces a false "delivered" record.

## Scope

This covers the direct-send delivery path. Interim commentary delivered
through the streaming `GatewayStreamConsumer` (the common case when
streaming/editable adapters are active) is queued and confirmed inside
`gateway/stream_consumer.py`'s own send loop, which isn't touched here —
covering that path needs a follow-up that adds a delivery-confirmation
callback to `GatewayStreamConsumer` itself. This PR is self-contained and
doesn't depend on that follow-up.

## Testing

Added `test_run_agent_emits_hook_after_commentary_delivery` in
`tests/gateway/test_run_progress_topics.py`, which reproduces the gap
(fails on main: the hook never fires) and asserts it fires exactly once
with the correct payload after this change.

- `tests/gateway/test_run_progress_topics.py` + `test_stream_consumer.py`:
  127 passed (126 pre-existing + 1 new)
- Full `tests/gateway/` suite: no new failures vs. main (both runs show the
  same 9 pre-existing, order-dependent failures unrelated to this change)
