### PR TITLE
feat(desktop): group-chat attachment chips open in the file manager

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -2039,6 +2039,145 @@ function normalizeGroupAttachment(dataUrl, maxEdge = 1568) {
   })
 }
 
+/** Materialize a staged group attachment (data URL) into a temp file and
+ *  reveal it in the OS file manager. The merged attachment pipeline keeps
+ *  only data URLs in the room log, so the chip's click-to-open rehydrates
+ *  the bytes through the desktop bridge (saveImageBuffer) and hands the
+ *  resulting path to the plugin OS door (revealPath). Resolves false when
+ *  the shell can't (older desktop build, missing bridge). */
+async function revealGroupAttachment(img) {
+  const bridge = typeof window !== 'undefined' ? window.hermesDesktop : null
+
+  if (!bridge?.saveImageBuffer) {
+    return false
+  }
+
+  const dataUrl = String(img?.data || '')
+  const comma = dataUrl.indexOf(',')
+
+  if (comma < 0) {
+    return false
+  }
+
+  const mime = /^data:([^;,]+)/.exec(dataUrl.slice(0, comma))?.[1] || ''
+  const name = String(img?.name || '')
+  const dot = name.lastIndexOf('.')
+  const ext =
+    dot >= 0
+      ? name.slice(dot)
+      : mime === 'application/pdf'
+        ? '.pdf'
+        : mime === 'image/png'
+          ? '.png'
+          : mime === 'image/jpeg'
+            ? '.jpg'
+            : mime === 'image/gif'
+              ? '.gif'
+              : mime === 'image/webp'
+                ? '.webp'
+                : '.bin'
+
+  let bytes
+
+  try {
+    bytes = Uint8Array.from(atob(dataUrl.slice(comma + 1)), c => c.charCodeAt(0))
+  } catch {
+    return false
+  }
+
+  const path = await bridge.saveImageBuffer(bytes, ext)
+
+  if (!path) {
+    return false
+  }
+
+  const os = pluginCtx?.os
+
+  if (os?.revealPath) {
+    return os.revealPath(path)
+  }
+
+  if (os?.openExternal) {
+    return os.openExternal(`file://${path}`)
+  }
+
+  return false
+}
+
+/** One staged attachment in the room log: images render an inline preview,
+ *  PDFs/files render a named chip. The whole chip is a button — click
+ *  materializes the staged bytes into a temp file and reveals it in the OS
+ *  file manager, with a busy label while the async handoff runs. */
+function GroupAttachmentChip({ img, entryKey, imgIndex }) {
+  const [busy, setBusy] = useState(false)
+  const isFile = img.kind === 'pdf' || img.kind === 'file'
+  const label = img.name || (isFile ? 'attached file' : 'attached image')
+
+  const open = async () => {
+    if (busy) {
+      return
+    }
+
+    setBusy(true)
+
+    try {
+      const ok = await revealGroupAttachment(img)
+
+      if (!ok) {
+        host.notify({ kind: 'error', message: 'Could not open this attachment in this build.' })
+      }
+    } catch {
+      host.notify({ kind: 'error', message: 'Could not open this attachment.' })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return jsxs(
+    'button',
+    {
+      type: 'button',
+      className: cn(
+        'group/chip relative cursor-pointer rounded-md border border-(--ui-stroke-secondary) text-left transition-colors hover:bg-(--chrome-action-hover)',
+        isFile ? 'flex items-center gap-1 px-1.5 py-1 text-[0.65rem] text-(--ui-text-tertiary)' : 'p-0'
+      ),
+      title: `Open ${label} in file manager`,
+      'aria-label': `Open ${label} in file manager`,
+      'aria-busy': busy || undefined,
+      onClick: () => void open(),
+      children: isFile
+        ? [
+            jsx(Codicon, { name: img.kind === 'pdf' ? 'file-pdf' : 'file', className: 'text-[0.8rem]' }, 'icon'),
+            jsx('span', { className: 'max-w-48 truncate', children: label }, 'name'),
+            jsx('span', { className: 'text-(--ui-text-quaternary)', children: busy ? '준비 중…' : '열기 ↗' }, 'action')
+          ]
+        : [
+            jsx(
+              'img',
+              {
+                src: img.data,
+                alt: label,
+                className: 'max-h-40 max-w-60 rounded-md object-contain'
+              },
+              'preview'
+            ),
+            busy
+              ? jsx(
+                  'span',
+                  {
+                    className:
+                      'absolute inset-0 grid place-items-center rounded-md bg-(--ui-bg-primary)/60 text-[0.65rem] text-(--ui-text-secondary)',
+                    children: '준비 중…'
+                  },
+                  'busy'
+                )
+              : null
+          ]
+    },
+    `${entryKey}:img:${imgIndex}`
+  )
+}
+
 /** Cached probe: does the gateway have an image backend? A `false` answer
  *  is re-checked on every dialog open — the gateway may have been restarted
  *  (picking up image.generate) or a backend enabled since the last probe.
@@ -8833,23 +8972,7 @@ function GroupChatWorkspace({ group, members, onBack }) {
                             ? jsx('div', {
                                 className: 'mt-1 flex flex-wrap items-center gap-1.5',
                                 children: entry.images.map((img, imgIndex) =>
-                                  img.kind === 'pdf' || img.kind === 'file'
-                                    ? jsxs('div', {
-                                        className:
-                                          'flex items-center gap-1 rounded-md border border-(--ui-stroke-secondary) px-1.5 py-1 text-[0.65rem] text-(--ui-text-tertiary)',
-                                        title: img.name || 'attached file',
-                                        children: [
-                                          jsx(Codicon, { name: img.kind === 'pdf' ? 'file-pdf' : 'file', className: 'text-[0.8rem]' }),
-                                          jsx('span', { className: 'max-w-48 truncate', children: img.name || 'attached file' })
-                                        ]
-                                      }, `${entryKey}:img:${imgIndex}`)
-                                    : jsx('img', {
-                                        src: img.data,
-                                        alt: img.name || 'attached image',
-                                        title: img.name || 'attached image',
-                                        className:
-                                          'max-h-40 max-w-60 rounded-md border border-(--ui-stroke-secondary) object-contain'
-                                      }, `${entryKey}:img:${imgIndex}`)
+                                  jsx(GroupAttachmentChip, { img, entryKey, imgIndex })
                                 )
                               })
                             : null
@@ -9054,7 +9177,7 @@ function GroupChatWorkspace({ group, members, onBack }) {
               children: [
                 jsx(GroupMentionInput, {
                   'aria-label': `Message ${group}`,
-                  placeholder: `New thread in ${group}… (@name to direct, @everyone for all)`,
+                  placeholder: `New thread in ${group}… (@name to direct, @everyone for all — Ctrl+V pastes images)`,
                   members,
                   value: draft,
                   onChange: setDraft,

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat-attachments.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat-attachments.test.mjs
@@ -16,6 +16,8 @@ function load(turnScript) {
   }
   const calls = []
   const attaches = []
+  const savedBuffers = []
+  const revealedPaths = []
   const sessions = new Map()
   const runtimeToStored = new Map()
   const titleToStored = new Map()
@@ -34,7 +36,19 @@ function load(turnScript) {
     clearTimeout: () => undefined,
     PALETTE_AREA: 'palette',
     COMPOSER_AREAS: { middleware: 'middleware' },
+    performance: { now: () => Date.now() },
+    atob: s => Buffer.from(s, 'base64').toString('binary'),
     document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    window: {
+      requestAnimationFrame: fn => setTimeout(() => fn(Date.now()), 0),
+      cancelAnimationFrame: id => clearTimeout(id),
+      hermesDesktop: {
+        saveImageBuffer: async (data, ext) => {
+          savedBuffers.push({ bytes: data.length, ext })
+          return `C:/temp/attachment${ext}`
+        }
+      }
+    },
     host: {
       request: async (method, params) => {
         if (method === 'session.create') {
@@ -102,14 +116,20 @@ function load(turnScript) {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gca = { sendToGroupChat, formatGroupChatLine, $groupChats };\n'
+      '\nglobalThis.__gca = { sendToGroupChat, formatGroupChatLine, $groupChats, revealGroupAttachment };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   context.plugin.register({
     storage: { get: () => null, set: () => undefined },
+    os: {
+      revealPath: async path => {
+        revealedPaths.push(path)
+        return true
+      }
+    },
     register: () => undefined
   })
-  return { ...context.__gca, calls, attaches, sessions }
+  return { ...context.__gca, calls, attaches, savedBuffers, revealedPaths, sessions, window: context.window }
 }
 
 const MEMBERS = [{ name: 'research', title: '' }, { name: 'builder', title: '' }]
@@ -257,4 +277,35 @@ test('formatGroupChatLine labels PDFs and files distinctly', () => {
     line,
     'You (user): here [attached PDF: spec.pdf] [attached file: notes.txt] [attached image: screenshot.png]'
   )
+})
+
+test('revealGroupAttachment materializes the data URL and reveals the saved path', async () => {
+  const gc = load(() => '(pass)')
+
+  const ok = await gc.revealGroupAttachment(IMG)
+  assert.equal(ok, true)
+  assert.equal(gc.savedBuffers.length, 1)
+  assert.equal(gc.savedBuffers[0].ext, '.png')
+  assert.ok(gc.savedBuffers[0].bytes > 0, 'decoded bytes are non-empty')
+  assert.deepEqual(gc.revealedPaths, ['C:/temp/attachment.png'])
+})
+
+test('revealGroupAttachment keeps the original extension for PDFs and files', async () => {
+  const gc = load(() => '(pass)')
+
+  await gc.revealGroupAttachment(PDF)
+  await gc.revealGroupAttachment(DOC)
+  assert.deepEqual(
+    gc.savedBuffers.map(b => b.ext),
+    ['.pdf', '.txt']
+  )
+})
+
+test('revealGroupAttachment resolves false when the bridge is missing', async () => {
+  const gc = load(() => '(pass)')
+  delete gc.window?.hermesDesktop
+
+  const ok = await gc.revealGroupAttachment(IMG)
+  assert.equal(ok, false)
+  assert.equal(gc.savedBuffers.length, 0)
 })


### PR DESCRIPTION
## Summary

Follow-up to the merged group-chat attachment pipeline (#89486 images, #89540 PDFs/files + drag & drop). Those PRs stage attachments into member sessions but keep only **data URLs** in the room log, so the rendered chips have no click affordance. This PR makes every attachment chip a button that **opens the file in the OS file manager**.

Also adds a one-line composer placeholder hint so the existing Ctrl+V paste path is discoverable.

## Changes

- `apps/desktop/src/plugins/hermes-bots/plugin.js`:
  - `revealGroupAttachment(img)` — materializes a staged data URL into a temp file via the desktop bridge (`saveImageBuffer`) and reveals it via the plugin OS door (`revealPath`, falling back to `openExternal`). Resolves `false` on older builds without the bridge.
  - `GroupAttachmentChip` — the whole chip (image preview or PDF/file row) is now a `<button>`: full click target, `aria-label`/`aria-busy`, busy label ("준비 중…") while the async handoff runs, double-click guard, error toast on failure.
  - `renderEntry` uses `GroupAttachmentChip` instead of the static div/img.
  - Main composer placeholder now reads `… (@name to direct, @everyone for all — Ctrl+V pastes images)`.
- `tests/group-chat-attachments.test.mjs`:
  - 3 new tests: data URL → bytes → `saveImageBuffer` → `revealPath` round trip; extension preservation for PDF/file; graceful `false` when the bridge is missing.
  - Harness gains `saveImageBuffer`/`revealPath` mocks plus `performance`/`atob`/`requestAnimationFrame` shims.

## Why this shape

- **No new IPC** — reuses the existing `saveImageBuffer` bridge (already used for HTML previews) and the plugin `os.revealPath` door.
- **Degrades cleanly** — older desktop builds without the bridge get a toast instead of a crash.
- **Accessible** — native button semantics, keyboard activation for free, `aria-busy` during the async handoff.

## Validation

- `node --test tests/group-chat-attachments.test.mjs` — 12/12 pass (9 existing + 3 new).
- Full plugin test suite (`tests/*.mjs`) — all pass.
- `npm run build` — succeeds; the bundle contains `revealGroupAttachment`, `GroupAttachmentChip`, the busy label, and the new placeholder text.
- `npm run pack` — succeeds; the packed `app.asar` was extracted and verified to contain the new placeholder, busy label, and open affordance strings.
- **Live click verification (packed app)** — the packed app was launched against a scratch profile; a test image was attached in a group chat, the rendered chip exposed `Button "Open chip-open-test.png in file manager"` (full-chip click target with aria-label), and clicking it opened the OS file manager window (`explorer.exe` "composer-images - 파일 탐색기") — confirmed via the live window list.
