### PR TITLE
feat(swarm): per-swarm verifier + synthesizer body and skills overrides (#34273)

### DIFF
--- a/hermes_cli/kanban_swarm.py
+++ b/hermes_cli/kanban_swarm.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 import json
 import sqlite3
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable, Optional, Tuple
 
 from hermes_cli import kanban_db as kb
 
@@ -125,6 +125,21 @@ def _activate_root_inline(
     return True
 
 
+
+_DEFAULT_VERIFIER_BODY = (
+    "Review every worker handoff and blackboard update. Gate the swarm: "
+    "complete only with metadata {\"gate\": \"pass\"} when evidence is "
+    "sufficient; otherwise block with exact missing work."
+)
+_DEFAULT_VERIFIER_SKILLS: Tuple[str, ...] = ("requesting-code-review",)
+
+_DEFAULT_SYNTHESIZER_BODY = (
+    "Synthesize the verified worker outputs into the final deliverable. "
+    "Do not start until the verifier has passed the gate."
+)
+_DEFAULT_SYNTHESIZER_SKILLS: Tuple[str, ...] = ("humanizer",)
+
+
 def create_swarm(
     conn: sqlite3.Connection,
     *,
@@ -141,8 +156,20 @@ def create_swarm(
     workspace_path: Optional[str] = None,
     priority: int = 0,
     idempotency_key: Optional[str] = None,
+    # #34273: per-swarm overrides for verifier + synthesizer body/skills.
+    # None preserves historical defaults (code-review verifier, humanizer).
+    verifier_body: Optional[str] = None,
+    verifier_skills: Optional[Iterable[str]] = None,
+    synthesizer_body: Optional[str] = None,
+    synthesizer_skills: Optional[Iterable[str]] = None,
 ) -> SwarmCreated:
-    """Atomically create a durable, immediately dispatchable Kanban swarm."""
+    """Atomically create a durable, immediately dispatchable Kanban swarm.
+
+    Verifier/synthesizer bodies default to a code-review-style flow. Callers
+    with different semantics can override verifier_body/skills and
+    synthesizer_body/skills (#34273). Custom bodies still receive the swarm
+    context_suffix so workers see protocol metadata.
+    """
     activation_summary = (
         "Swarm topology planned; root remains the shared blackboard."
     )
@@ -163,6 +190,10 @@ def create_swarm(
             workspace_path=workspace_path,
             priority=priority,
             idempotency_key=idempotency_key,
+            verifier_body=verifier_body,
+            verifier_skills=verifier_skills,
+            synthesizer_body=synthesizer_body,
+            synthesizer_skills=synthesizer_skills,
         )
         root = kb.get_task(conn, created.root_id)
         if root is not None and root.status == "blocked":
@@ -212,6 +243,10 @@ def _create_swarm_uncommitted(
     workspace_path: Optional[str] = None,
     priority: int = 0,
     idempotency_key: Optional[str] = None,
+    verifier_body: Optional[str] = None,
+    verifier_skills: Optional[Iterable[str]] = None,
+    synthesizer_body: Optional[str] = None,
+    synthesizer_skills: Optional[Iterable[str]] = None,
 ) -> SwarmCreated:
     """Create a durable Kanban swarm graph.
 
@@ -284,16 +319,20 @@ def _create_swarm_uncommitted(
         )
         worker_ids.append(worker_id)
 
-    verifier_body = (
-        "Review every worker handoff and blackboard update. Gate the swarm: "
-        "complete only with metadata {\"gate\": \"pass\"} when evidence is "
-        "sufficient; otherwise block with exact missing work."
-        + context_suffix
+    # #34273: verifier/synthesizer overrides fall back to historical defaults.
+    _verifier_body_base = (
+        verifier_body if verifier_body is not None else _DEFAULT_VERIFIER_BODY
+    )
+    final_verifier_body = _verifier_body_base + context_suffix
+    final_verifier_skills = (
+        list(verifier_skills)
+        if verifier_skills is not None
+        else list(_DEFAULT_VERIFIER_SKILLS)
     )
     verifier = kb.create_task(
         conn,
         title=verifier_title,
-        body=verifier_body,
+        body=final_verifier_body,
         assignee=verifier_assignee,
         created_by=created_by,
         parents=worker_ids,
@@ -301,18 +340,22 @@ def _create_swarm_uncommitted(
         priority=priority,
         workspace_kind=workspace_kind,
         workspace_path=workspace_path,
-        skills=["requesting-code-review"],
+        skills=final_verifier_skills or None,
     )
 
-    synthesizer_body = (
-        "Synthesize the verified worker outputs into the final deliverable. "
-        "Do not start until the verifier has passed the gate."
-        + context_suffix
+    _synthesizer_body_base = (
+        synthesizer_body if synthesizer_body is not None else _DEFAULT_SYNTHESIZER_BODY
+    )
+    final_synthesizer_body = _synthesizer_body_base + context_suffix
+    final_synthesizer_skills = (
+        list(synthesizer_skills)
+        if synthesizer_skills is not None
+        else list(_DEFAULT_SYNTHESIZER_SKILLS)
     )
     synthesizer = kb.create_task(
         conn,
         title=synthesizer_title,
-        body=synthesizer_body,
+        body=final_synthesizer_body,
         assignee=synthesizer_assignee,
         created_by=created_by,
         parents=[verifier],
@@ -320,7 +363,7 @@ def _create_swarm_uncommitted(
         priority=priority,
         workspace_kind=workspace_kind,
         workspace_path=workspace_path,
-        skills=["humanizer"],
+        skills=final_synthesizer_skills or None,
     )
 
     created = SwarmCreated(root, worker_ids, verifier, synthesizer)

--- a/tests/hermes_cli/test_kanban_swarm.py
+++ b/tests/hermes_cli/test_kanban_swarm.py
@@ -260,3 +260,135 @@ def test_swarm_verifier_and_synthesis_are_dependency_gated(tmp_path):
         assert synthesizer.status == "ready"
     finally:
         conn.close()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# #34273 — per-swarm verifier / synthesizer body + skills overrides
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_create_swarm_uses_default_verifier_body_when_unset(tmp_path):
+    """Backward compat: with no overrides, the verifier body matches the
+    historical code-review default."""
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        created = create_swarm(
+            conn,
+            goal="goal",
+            workers=[SwarmWorkerSpec(profile="w", title="t", body="b")],
+            verifier_assignee="v",
+            synthesizer_assignee="s",
+            created_by="orch",
+        )
+        verifier = kb.get_task(conn, created.verifier_id)
+        assert "Review every worker handoff" in verifier.body
+        assert "requesting-code-review" in (verifier.skills or [])
+    finally:
+        conn.close()
+
+
+def test_create_swarm_accepts_custom_verifier_body(tmp_path):
+    """#34273: custom verifier body still gets the swarm context suffix."""
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        custom = "Run merge_scraped.py to combine outputs. Validate. Gate pass/block."
+        created = create_swarm(
+            conn,
+            goal="goal",
+            workers=[SwarmWorkerSpec(profile="w", title="t", body="b")],
+            verifier_assignee="v",
+            synthesizer_assignee="s",
+            verifier_body=custom,
+            created_by="orch",
+        )
+        verifier = kb.get_task(conn, created.verifier_id)
+        assert "Run merge_scraped.py" in verifier.body
+        assert created.root_id in verifier.body
+        assert "Review every worker handoff" not in verifier.body
+    finally:
+        conn.close()
+
+
+def test_create_swarm_accepts_custom_verifier_skills(tmp_path):
+    """#34273: caller can override verifier skills."""
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        created = create_swarm(
+            conn,
+            goal="goal",
+            workers=[SwarmWorkerSpec(profile="w", title="t", body="b")],
+            verifier_assignee="v",
+            synthesizer_assignee="s",
+            verifier_skills=["kanban-worker", "data-merge"],
+            created_by="orch",
+        )
+        verifier = kb.get_task(conn, created.verifier_id)
+        skills = set(verifier.skills or [])
+        assert "kanban-worker" in skills
+        assert "data-merge" in skills
+        assert "requesting-code-review" not in skills
+    finally:
+        conn.close()
+
+
+def test_create_swarm_accepts_custom_synthesizer_body(tmp_path):
+    """#34273: caller can supply a custom synthesizer body."""
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        custom = "Run process_reviews.py, then generate_report.py, then push."
+        created = create_swarm(
+            conn,
+            goal="goal",
+            workers=[SwarmWorkerSpec(profile="w", title="t", body="b")],
+            verifier_assignee="v",
+            synthesizer_assignee="s",
+            synthesizer_body=custom,
+            created_by="orch",
+        )
+        synth = kb.get_task(conn, created.synthesizer_id)
+        assert "process_reviews.py" in synth.body
+        assert "Synthesize the verified worker outputs" not in synth.body
+    finally:
+        conn.close()
+
+
+def test_create_swarm_accepts_custom_synthesizer_skills(tmp_path):
+    """#34273: caller can override synthesizer skills."""
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        created = create_swarm(
+            conn,
+            goal="goal",
+            workers=[SwarmWorkerSpec(profile="w", title="t", body="b")],
+            verifier_assignee="v",
+            synthesizer_assignee="s",
+            synthesizer_skills=["kanban-worker"],
+            created_by="orch",
+        )
+        synth = kb.get_task(conn, created.synthesizer_id)
+        skills = set(synth.skills or [])
+        assert "kanban-worker" in skills
+        assert "humanizer" not in skills
+    finally:
+        conn.close()
+
+
+def test_create_swarm_independent_verifier_and_synthesizer_overrides(tmp_path):
+    """#34273: overriding only the verifier leaves the synthesizer default."""
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        created = create_swarm(
+            conn,
+            goal="goal",
+            workers=[SwarmWorkerSpec(profile="w", title="t", body="b")],
+            verifier_assignee="v",
+            synthesizer_assignee="s",
+            verifier_body="Custom verifier only",
+            created_by="orch",
+        )
+        verifier = kb.get_task(conn, created.verifier_id)
+        synth = kb.get_task(conn, created.synthesizer_id)
+        assert "Custom verifier only" in verifier.body
+        assert "Synthesize the verified worker outputs" in synth.body
+    finally:
+        conn.close()


### PR DESCRIPTION
Closes #34273. Fresh rebuild of #46477 (CONFLICTING/DIRTY after main gained the `create_swarm` / `_create_swarm_uncommitted` activation split).

## Problem
`create_swarm()` still hardcodes verifier + synthesizer task bodies to a code-review flow (`requesting-code-review` / `humanizer`). Non-code-review swarms had to drop to raw `kb.create_task()` and lose orchestration helpers. Issue #34273 remains OPEN; bug still live on `origin/main`.

## Fix
Four optional params on `create_swarm()` (forwarded into `_create_swarm_uncommitted`):
- `verifier_body` / `verifier_skills`
- `synthesizer_body` / `synthesizer_skills`

`None` = historical defaults (fully backward compatible). Custom bodies still get the swarm `context_suffix`. Module-level `_DEFAULT_*` constants exposed for assertions.

## Tests
```
$ python3 -m pytest tests/hermes_cli/test_kanban_swarm.py -q
11 passed
```

🎻 Rebuild of #46477 by @Bartok9 (original salvage of #34381).