### PR TITLE
fix(slack): surface rejected streamed attachments

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -860,7 +860,10 @@ PLATFORM_HINTS = {
         "You can send media files natively: include MEDIA:/absolute/path/to/file "
         "in your response. Images (.png, .jpg, .webp) are uploaded as photo "
         "attachments, audio as file attachments. You can also include image URLs "
-        "in markdown format ![alt](url) and they will be uploaded as attachments."
+        "in markdown format ![alt](url) and they will be uploaded as attachments. "
+        "Before a final MEDIA: directive, create or copy the deliverable into the "
+        "active approved $HERMES_HOME/cache/documents delivery cache. If it "
+        "cannot be attached, say so plainly and do not claim it was delivered."
     ),
     "signal": (
         "You are on a text messaging communication platform, Signal. "

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21983,7 +21983,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             from gateway.platforms.base import BasePlatformAdapter, should_send_media_as_audio
 
             media_files, cleaned = adapter.extract_media(response)
-            media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+            safe_media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+            # The streamed text has already been shown.  Slack otherwise only
+            # gets a gateway log entry when an explicit attachment directive is
+            # rejected by the safety boundary, which looks like a successful
+            # delivery to the user.  Keep the rejected path in logs only.
+            delivery_failed = len(safe_media_files) != len(media_files)
+            media_files = safe_media_files
             # Do NOT deduplicate explicit MEDIA tags against prior turns here
             # (#73771). This rescan is already EXPLICIT-ONLY (see docstring):
             # a MEDIA: directive in the final streamed reply is the model
@@ -22029,37 +22035,53 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if image_paths:
                 try:
                     images = [(f"file://{_quote(p)}", "") for p in image_paths]
-                    await adapter.send_multiple_images(
+                    result = await adapter.send_multiple_images(
                         chat_id=event.source.chat_id,
                         images=images,
                         metadata=_thread_meta,
                     )
+                    if result is False or getattr(result, "success", True) is False:
+                        delivery_failed = True
                 except Exception as e:
+                    delivery_failed = True
                     logger.warning("[%s] Post-stream image batch delivery failed: %s", adapter.name, e)
 
             for media_path, is_voice in non_image_media:
                 try:
                     ext = Path(media_path).suffix.lower()
                     if should_send_media_as_audio(event.source.platform, ext, is_voice=is_voice):
-                        await adapter.send_voice(
+                        result = await adapter.send_voice(
                             chat_id=event.source.chat_id,
                             audio_path=media_path,
                             metadata=_thread_meta,
                         )
                     elif ext in _VIDEO_EXTS:
-                        await adapter.send_video(
+                        result = await adapter.send_video(
                             chat_id=event.source.chat_id,
                             video_path=media_path,
                             metadata=_thread_meta,
                         )
                     else:
-                        await adapter.send_document(
+                        result = await adapter.send_document(
                             chat_id=event.source.chat_id,
                             file_path=media_path,
                             metadata=_thread_meta,
                         )
+                    if result is False or getattr(result, "success", True) is False:
+                        delivery_failed = True
                 except Exception as e:
+                    delivery_failed = True
                     logger.warning("[%s] Post-stream media delivery failed: %s", adapter.name, e)
+
+            if delivery_failed and event.source.platform == Platform.SLACK:
+                try:
+                    await adapter.send(
+                        event.source.chat_id,
+                        "I couldn't attach one or more requested files, so they were not delivered.",
+                        metadata=_thread_meta,
+                    )
+                except Exception:
+                    logger.debug("[%s] Post-stream delivery failure notice failed", adapter.name)
 
         except Exception as e:
             logger.warning("Post-stream media extraction failed: %s", e)

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -44,6 +44,11 @@ from hermes_cli.nous_subscription import NousFeatureState, NousSubscriptionFeatu
 
 
 class TestGuidanceConstants:
+    def test_slack_attachment_guidance_uses_approved_document_cache(self):
+        slack = PLATFORM_HINTS["slack"]
+        assert "$HERMES_HOME/cache/documents" in slack
+        assert "do not claim it was delivered" in slack
+
     def test_memory_guidance_discourages_task_logs(self):
         assert "durable facts" in MEMORY_GUIDANCE
         assert "Do NOT save task progress" in MEMORY_GUIDANCE
@@ -1011,5 +1016,4 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
 

--- a/tests/gateway/test_post_stream_media_delivery.py
+++ b/tests/gateway/test_post_stream_media_delivery.py
@@ -14,6 +14,7 @@ there. This file pins the asymmetry.
 
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
+from urllib.parse import quote
 
 import pytest
 
@@ -56,6 +57,7 @@ def _adapter():
         send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
         send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
         send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="imgs")),
+        send=AsyncMock(return_value=SendResult(success=True, message_id="notice")),
     )
 
 
@@ -108,6 +110,87 @@ async def test_explicit_media_tag_still_delivers_post_stream(tmp_path, monkeypat
     adapter.send_multiple_images.assert_awaited_once()
     images_kwargs = adapter.send_multiple_images.await_args.kwargs
     assert images_kwargs["chat_id"] == "C123CHAN"
-    assert str(media_file) in images_kwargs["images"][0][0]
+    assert images_kwargs["images"][0][0] == f"file://{quote(str(media_file))}"
 
 
+@pytest.mark.asyncio
+async def test_streamed_slack_delivers_one_cached_pdf(tmp_path, monkeypatch):
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "report.pdf")
+    adapter = _adapter()
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner({}), f"Your report is ready.\nMEDIA:{media_file}", _event(), adapter,
+    )
+
+    adapter.send_document.assert_awaited_once()
+    assert adapter.send_document.await_args.kwargs["file_path"] == str(media_file)
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_streamed_slack_delivers_multiple_cached_pdfs(tmp_path, monkeypatch):
+    first = _allowed_media_path(tmp_path, monkeypatch, "first.pdf")
+    second = _allowed_media_path(tmp_path, monkeypatch, "second.pdf")
+    adapter = _adapter()
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner({}), f"MEDIA:{first}\nMEDIA:{second}", _event(), adapter,
+    )
+
+    assert adapter.send_document.await_count == 2
+    assert [call.kwargs["file_path"] for call in adapter.send_document.await_args_list] == [
+        str(first), str(second),
+    ]
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_streamed_slack_rejected_media_path_gets_generic_failure_notice(tmp_path, monkeypatch):
+    _allowed_media_path(tmp_path, monkeypatch, "allowed.pdf")
+    monkeypatch.setenv("HERMES_MEDIA_DELIVERY_STRICT", "1")
+    monkeypatch.setenv("HERMES_MEDIA_TRUST_RECENT_FILES", "0")
+    rejected = tmp_path / "outside-cache.pdf"
+    rejected.write_bytes(b"pdf")
+    adapter = _adapter()
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner({}), f"MEDIA:{rejected}", _event(), adapter,
+    )
+
+    adapter.send_document.assert_not_awaited()
+    adapter.send.assert_awaited_once()
+    notice = adapter.send.await_args.args[1]
+    assert "couldn't attach" in notice
+    assert str(rejected) not in notice
+
+
+@pytest.mark.asyncio
+async def test_streamed_slack_failed_pdf_upload_gets_generic_failure_notice(tmp_path, monkeypatch):
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "report.pdf")
+    adapter = _adapter()
+    adapter.send_document.return_value = SendResult(success=False, error="upload failed")
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner({}), f"MEDIA:{media_file}", _event(), adapter,
+    )
+
+    adapter.send.assert_awaited_once()
+    notice = adapter.send.await_args.args[1]
+    assert "couldn't attach" in notice
+    assert str(media_file) not in notice
+
+
+@pytest.mark.asyncio
+async def test_streamed_slack_raised_pdf_upload_gets_generic_failure_notice(tmp_path, monkeypatch):
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "report.pdf")
+    adapter = _adapter()
+    adapter.send_document.side_effect = RuntimeError("provider unavailable")
+
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner({}), f"MEDIA:{media_file}", _event(), adapter,
+    )
+
+    adapter.send.assert_awaited_once()
+    notice = adapter.send.await_args.args[1]
+    assert "couldn't attach" in notice
+    assert str(media_file) not in notice


### PR DESCRIPTION
## What does this PR do?

Fixes #89760.

On Slack's streamed-response path, an explicit `MEDIA:` attachment can be removed by the existing delivery safety filter after the reply text has already been shown. Before this change, the rejection was visible only in gateway logs, so a reply that said a PDF was attached could remain visible even though Slack received no file.

This PR:

- detects when explicit streamed media paths were rejected by the existing filter;
- checks unsuccessful or raised post-stream upload results;
- sends one generic, path-free Slack notice when any requested attachment was not delivered;
- guides Slack agents to create or copy deliverables into the approved `$HERMES_HOME/cache/documents` cache before the final `MEDIA:` directive; and
- adds one-PDF, multi-PDF, validation-rejection, false-result and raised-upload regressions.

It does not widen any allowed delivery root or weaken the protected-path boundary.

## Related work

PR #80264 fixes a complementary Slack adapter contract: upload exceptions currently return the success result of the adapter's own failure notice. This PR does not duplicate that adapter change. It covers pre-send path rejection and makes the streamed caller recognise an unsuccessful result once the adapter reports one.

PR #42892 previously described the broader symptom but was closed because its submitted branch did not contain the gateway changes described in its body.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: track filtered or failed explicit post-stream attachments and send a generic Slack delivery-failure notice.
- `agent/prompt_builder.py`: direct Slack deliverables to the approved document cache and forbid false delivery claims.
- `tests/gateway/test_post_stream_media_delivery.py`: cover valid one/multiple PDFs and rejection/failure cases.
- `tests/agent/test_prompt_builder.py`: lock in the document-cache and delivery-honesty guidance.

## How to Test

```bash
scripts/run_tests.sh tests/gateway/test_post_stream_media_delivery.py tests/agent/test_prompt_builder.py -q
```

Result on the submitted commit: 71 passed, 0 failed, 1 skipped.

Python bytecode compilation and `git diff --check` also pass.

## Checklist

### Code

- [x] I read the contributing guide and repository instructions.
- [x] The commit follows Conventional Commits.
- [x] I searched open and closed issues and pull requests.
- [x] The PR contains only this attachment-delivery fix and its tests.
- [x] Focused tests pass through the required repository wrapper.
- [x] Cross-platform file-URI quoting is covered by the existing image assertion.

### Safety and scope

- [x] No allowed-root, deny-prefix or `/var/lib` protection was changed.
- [x] Rejected host paths are not shown in the Slack failure notice.
- [x] No provider, credential or configuration behaviour is added.