### PR TITLE
fix(kanban): keep profile workers running with service PATHs

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10616,6 +10616,15 @@ def _resolve_hermes_argv() -> list[str]:
     return _module_hermes_argv()
 
 
+def _merge_worker_path(current: str, defaults: str, *, pathsep: str = os.pathsep) -> str:
+    """Append missing baseline search directories without reordering PATH."""
+    entries = current.split(pathsep) if current else []
+    for entry in defaults.split(pathsep):
+        if entry and entry not in entries:
+            entries.append(entry)
+    return pathsep.join(entries)
+
+
 def _worker_terminal_timeout_env(
     max_runtime_seconds: Optional[int],
     current_timeout: Optional[str],
@@ -10734,6 +10743,13 @@ def _default_spawn(
 
     prompt = f"work kanban task {task.id}"
     env = dict(os.environ)
+    if not _IS_WINDOWS:
+        # A gateway started by a service manager can have a PATH containing the
+        # Hermes shim but no system directories. The absolute shim then starts,
+        # yet its `realpath` / `dirname` bootstrap commands exit 127 before the
+        # worker reaches Python. Keep operator entries first and add only the
+        # POSIX baseline directories; no login shell should be needed.
+        env["PATH"] = _merge_worker_path(env.get("PATH", ""), os.defpath)
     # The dispatcher is detached from every conversation. Its worker must never
     # inherit routing mirrored by a previous gateway turn, even before the first
     # session binds ContextVars in this process.

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1142,6 +1142,17 @@ def test_migrate_add_optional_columns_tolerates_concurrent_migration(kanban_home
 # ---------------------------------------------------------------------------
 
 
+def test_merge_worker_path_preserves_custom_order_and_adds_missing_defaults():
+    """A service PATH keeps its entries while workers regain baseline tools."""
+    merged = kb._merge_worker_path(
+        "/home/user/.local/bin:/usr/bin",
+        "/bin:/usr/bin:/usr/local/bin",
+        pathsep=":",
+    )
+
+    assert merged == "/home/user/.local/bin:/usr/bin:/bin:/usr/local/bin"
+
+
 def test_resolve_hermes_argv_falls_back_to_module_form_when_no_path_shim(monkeypatch):
     """When the shim is not on PATH, fall back to `python -m hermes_cli.main`.
 


### PR DESCRIPTION
## What does this PR do?

Kanban profile workers can exit 127 before task code runs when the dispatcher inherits a service-managed PATH that contains the Hermes shim but omits baseline system directories. This change preserves operator-provided PATH ordering while appending only missing POSIX baseline directories, so the shell launcher can resolve its bootstrap tools without loading a user shell.

### Symptom

A task assigned to a non-default profile is claimed, but the worker exits 127 with errors such as `realpath: not found`, `dirname: not found`, and `exec: /python3: not found`. The task produces no agent output.

### Impact

On affected service-managed Linux installations, profile workers cannot start, so Kanban handoffs fail and consume retry budget before any task logic executes.

### Bug Cause

**Trigger:** `hermes_cli/kanban_db.py:10743` / `_default_spawn()` inherits a PATH that contains the absolute Hermes shim but lacks POSIX system directories.

**Causal chain:**
1. A service manager starts the dispatcher with a minimal PATH containing the Hermes shim directory.
2. `_resolve_hermes_argv()` resolves the shim, and `_default_spawn()` copies the minimal environment unchanged into the worker.
3. The shim starts but cannot resolve `realpath` or `dirname`, so it exits 127 before Python or the task begins.

**Why it is wrong:** Copying the parent environment is normally correct, but service-managed PATH values are not guaranteed to include the baseline directories required by the installed shell launcher.

**Working sibling / contrast:** An interactive shell supplies normal system PATH entries, so the same Hermes command starts successfully outside the dispatcher. Ready and review dispatch lanes share `_default_spawn()`, so fixing this seam covers both.

**Ruled out:** The dispatcher does not explicitly strip PATH, and task content is not involved. A trivial task fails at the same launcher bootstrap step under the minimal environment.

### Fix

Add `_merge_worker_path()` to retain custom entries and their order, append only missing entries from `os.defpath`, and apply it to non-Windows worker environments. The regression test verifies ordering, deduplication, and restoration of missing baseline directories.

## Related Issue

Closes #89715

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py` - preserve custom worker PATH entries and append missing POSIX baseline directories.
- `tests/hermes_cli/test_kanban_db.py` - cover custom ordering, deduplication, and missing baseline entries.

## How to Test

1. Start the dispatcher with a PATH containing only a directory that provides the Hermes shim.
2. Dispatch a Kanban task to a profile worker and capture the environment passed to the worker process.
3. Confirm the custom prefix remains first, `/bin` and `/usr/bin` are present, and the launcher reaches Python successfully.
4. Run the related automated tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py -k 'merge_worker_path or dispatcher_spawn_injects_kanban_paths_without_stale_session or resolve_hermes_argv_module_actually_runs' -v
scripts/run_tests.sh tests/hermes_cli/test_kanban_boards.py -k default_spawn_sets_env_vars -v
```

The focused runs passed 3 tests and 1 test respectively. WSL2 verification also reproduced exit 127 with a shim-only PATH before the fix and confirmed the committed worker spawn reaches `hermes --version` successfully after the fix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all related tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 with WSL2 Debian 12

### Documentation & Housekeeping

- [x] Documentation update: N/A - behavior is internal and covered by code comments and tests
- [x] Config example update: N/A - no config keys changed
- [x] Architecture guide update: N/A - no architecture or workflow changed
- [x] I've considered cross-platform impact: the merge is restricted to non-Windows workers and preserves existing Windows behavior
- [x] Tool description/schema update: N/A - no model tool changed

## Screenshots / Logs

N/A - focused test output and the symmetric WSL2 launcher verification are described above.
