### PR TITLE
fix(desktop): prefer same-host remote for Bot Mode over SSH

### DIFF
--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -679,7 +679,7 @@ test('roster: collapse prefers the active (primary) connection', () => {
   assert.equal(roster[0].connectionId, 'spark-ts')
 })
 
-test('roster: collapse pick order is local > ssh > remote > cloud, then registration order', () => {
+test('roster: collapse pick order is local > remote > cloud > ssh, then registration order', () => {
   const local = { id: 'local', kind: 'local' as const, label: 'This device' }
   const remote = { id: 'loop', kind: 'remote' as const, label: 'Loopback', url: 'http://127.0.0.1:8642' }
   const cloud = { id: 'cl', kind: 'cloud' as const, label: 'Cloud twin', url: 'http://cl:1' }
@@ -696,14 +696,14 @@ test('roster: collapse pick order is local > ssh > remote > cloud, then registra
   assert.equal(roster.length, 1)
   assert.equal(roster[0].connectionId, 'local')
 
-  // Without the local candidate, ssh wins over remote/cloud.
+  // Without the local candidate, HTTP wins over SSH.
   const noLocal = buildAgentRoster([
     { connection: cloud, profiles: ['default'], installId: 'aaa' },
     { connection: remote, profiles: ['default'], installId: 'aaa' },
     { connection: ssh, profiles: ['default'], installId: 'aaa' }
   ])
 
-  assert.equal(noLocal[0].connectionId, 'tun')
+  assert.equal(noLocal[0].connectionId, 'loop')
 
   // Same kind → earliest-registered (enumeration order) wins.
   const twin = { id: 'loop2', kind: 'remote' as const, label: 'Loopback 2', url: 'http://[::1]:8642' }
@@ -714,6 +714,31 @@ test('roster: collapse pick order is local > ssh > remote > cloud, then registra
   ])
 
   assert.equal(sameKind[0].connectionId, 'loop')
+})
+
+test('roster: same-install remote wins over an SSH primary', () => {
+  const remote = { id: 'gateway', kind: 'remote' as const, label: 'Gateway', url: 'http://box:8642' }
+  const ssh = { id: 'shell', kind: 'ssh' as const, label: 'Shell', host: 'box' }
+
+  const roster = buildAgentRoster(
+    [
+      { connection: ssh, profiles: ['default'], installId: 'aaa' },
+      { connection: remote, profiles: ['default'], installId: 'aaa' }
+    ],
+    { primaryConnectionId: 'shell' }
+  )
+
+  assert.equal(roster.length, 1)
+  assert.equal(roster[0].connectionId, 'gateway')
+})
+
+test('roster: SSH-only same-install group still routes through SSH', () => {
+  const ssh = { id: 'shell', kind: 'ssh' as const, label: 'Shell', host: 'box' }
+
+  const roster = buildAgentRoster([{ connection: ssh, profiles: ['default'], installId: 'aaa' }])
+
+  assert.equal(roster.length, 1)
+  assert.equal(roster[0].connectionId, 'shell')
 })
 
 test('roster: missing install_id bypasses the collapse (older backends keep current behavior)', () => {

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -591,27 +591,34 @@ export function buildAgentRoster(
   return roster
 }
 
-/** Deterministic route priority for same-backend rows: local is definitionally
- * this box; ssh beats HTTP remotes; cloud last. */
-const CANONICAL_KIND_PRIORITY: Record<ConnectionKind, number> = { cloud: 3, local: 0, remote: 2, ssh: 1 }
+/** Deterministic route priority for same-backend Bot Mode rows: local is
+ * definitionally this box; HTTP connections avoid SSH's isolated-bot path;
+ * cloud follows remote; SSH is the connect-on-demand fallback. */
+const CANONICAL_KIND_PRIORITY: Record<ConnectionKind, number> = { cloud: 2, local: 0, remote: 1, ssh: 3 }
 
 /**
  * Which connection represents a collapsed same-backend roster row: the ACTIVE
- * (primary) connection when it is one of the candidates — the row should route
- * where the window already routes — else the highest kind priority, else the
- * earliest-registered (enumeration order follows registry order).
+ * (primary) connection when it is one of the preferred candidates. Local wins
+ * outright; otherwise HTTP connections win over SSH so Bot Mode never routes
+ * a same-install row through SSH just because the window primary is SSH. Ties
+ * use the primary connection, then earliest registration order.
  */
 function pickCanonicalConnection<T extends { connection: RegistryConnection; order: number }>(
   candidates: T[],
   primaryConnectionId?: string
 ): T {
-  const active = primaryConnectionId ? candidates.find(c => c.connection.id === primaryConnectionId) : undefined
+  const local = candidates.filter(candidate => candidate.connection.kind === 'local')
+  const http = candidates.filter(
+    candidate => candidate.connection.kind === 'remote' || candidate.connection.kind === 'cloud'
+  )
+  const preferred = local.length > 0 ? local : http.length > 0 ? http : candidates
+  const active = primaryConnectionId ? preferred.find(c => c.connection.id === primaryConnectionId) : undefined
 
   if (active) {
     return active
   }
 
-  return [...candidates].sort(
+  return [...preferred].sort(
     (a, b) =>
       CANONICAL_KIND_PRIORITY[a.connection.kind] - CANONICAL_KIND_PRIORITY[b.connection.kind] || a.order - b.order
   )[0]

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -8348,7 +8348,12 @@ function BotRow({ bot, onDelete, onEdit, onGroup, showHandle }) {
     .join(' · ')
 
   const warm = () => {
-    // Multi-source row: pre-dial the agent's OWN source (feature-detected).
+    // SSH sources are connect-on-demand: hover must not dial or spawn a bot.
+    if (bot.sourceScoped && bot.connectionKind === 'ssh') {
+      return
+    }
+
+    // Multi-source row: pre-dial the agent's OWN HTTP source (feature-detected).
     if (bot.sourceScoped && typeof host.warmAgent === 'function') {
       try {
         host.warmAgent(bot.connectionId, bot.name)

--- a/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
@@ -220,6 +220,20 @@ test('behavior: a remote Connections row opens through its captured route withou
   assert.equal(opened[0][0].connectionId, 'work')
 })
 
+test('behavior: pointer entry does not warm an SSH Connections row', () => {
+  const { row, warmed } = renderBotRow({
+    connectionId: 'shell',
+    connectionKind: 'ssh',
+    connectionLabel: 'Shell',
+    name: 'research',
+    remoteSource: true,
+    sourceScoped: true
+  })
+
+  row.props.onPointerEnter()
+  assert.deepEqual(warmed, [])
+})
+
 test('behavior: remote default never opens the same-name local chat', async () => {
   const bot = {
     connectionId: 'mac-mini',


### PR DESCRIPTION
## Problem

Bot Mode on a host registered as both SSH and a Remote gateway routed every Bot through SSH whenever SSH was the window primary. Opening/hovering Bots spawned `hermes -p <bot> serve --isolated` per profile and 1012'd the primary chat.

Fixes #89756

## Approach

- Same-`install_id` roster collapse now prefers `local`, then Remote/cloud, then SSH. Window primary still wins among HTTP remotes, but SSH primary no longer beats a same-host Remote.
- Bot Mode hover no longer `warmAgent`s SSH rows (connect-on-demand). Explicit open is unchanged.

## Tests

```
cd apps/desktop
npm test -- electron/connection-registry.test.ts
node src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
```

64 + 6 passing.

## Risk

Low. Roster identity only. Does not change SSH spawn/lock code or undo #88296. SSH-only setups still route through SSH.
