### PR TITLE
fix(profiles): show served profiles as running under shared gateways

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14932,6 +14932,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         only point that sees every profile's resolved credentials together.
         """
         if not getattr(self.config, "multiplex_profiles", False):
+            # ``write_runtime_status`` preserves fields omitted by later writes.
+            # Clear coverage left by a predecessor multiplexer before this
+            # independent gateway refreshes the runtime record with its own PID.
+            from gateway.status import write_runtime_status
+
+            write_runtime_status(served_profiles=[])
             return 0
 
         try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14935,9 +14935,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # ``write_runtime_status`` preserves fields omitted by later writes.
             # Clear coverage left by a predecessor multiplexer before this
             # independent gateway refreshes the runtime record with its own PID.
-            from gateway.status import write_runtime_status
+            try:
+                from gateway.status import write_runtime_status
 
-            write_runtime_status(served_profiles=[])
+                write_runtime_status(served_profiles=[])
+            except Exception:
+                logger.debug("could not clear served_profiles", exc_info=True)
             return 0
 
         try:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -740,6 +740,41 @@ def _check_gateway_running(profile_dir: Path) -> bool:
         return False
 
 
+def _shared_gateway_profile_names(default_home: Path) -> set[str]:
+    """Return profiles served by the live default-profile multiplexer.
+
+    A multiplex gateway owns runtime files only in ``default_home``.  Its
+    ``served_profiles`` record is the authoritative distinction between a
+    shared gateway and an independent default-profile gateway, so validate the
+    record's process identity before applying its coverage to named profiles.
+    """
+    try:
+        from gateway.status import (
+            get_runtime_status_running_pid,
+            read_runtime_status,
+        )
+
+        runtime = read_runtime_status(default_home / "gateway_state.json")
+        if (
+            get_runtime_status_running_pid(runtime, expected_home=default_home)
+            is None
+        ):
+            return set()
+        served = (runtime or {}).get("served_profiles")
+        if not isinstance(served, list):
+            return set()
+        names: set[str] = set()
+        for name in served:
+            if not isinstance(name, str):
+                continue
+            normalized = normalize_profile_name(name)
+            if normalized == "default" or _PROFILE_ID_RE.match(normalized):
+                names.add(normalized)
+        return names
+    except Exception:
+        return set()
+
+
 # In-process cache for skill counts. Walking ``skills_dir.rglob("SKILL.md")``
 # recurses the entire skill tree (each skill carries references/scripts/assets
 # sub-trees); the default profile alone has ~270 skills, and ``list_profiles``
@@ -935,6 +970,7 @@ def list_profiles() -> List[ProfileInfo]:
 
     # Default profile
     default_home = _get_default_hermes_home()
+    shared_gateway_profiles = _shared_gateway_profile_names(default_home)
     if default_home.is_dir():
         model, provider = _read_config_model(default_home)
         dist_name, dist_version, dist_source = _read_distribution_meta(default_home)
@@ -984,7 +1020,10 @@ def list_profiles() -> List[ProfileInfo]:
                 name=name,
                 path=entry,
                 is_default=False,
-                gateway_running=_check_gateway_running(entry),
+                gateway_running=(
+                    _check_gateway_running(entry)
+                    or normalize_profile_name(name) in shared_gateway_profiles
+                ),
                 model=model,
                 provider=provider,
                 has_env=(entry / ".env").exists(),

--- a/tests/gateway/test_multiplex_lifecycle.py
+++ b/tests/gateway/test_multiplex_lifecycle.py
@@ -19,6 +19,28 @@ class TestServedProfilesStatus:
         finally:
             importlib.reload(status)
 
+    @pytest.mark.asyncio
+    async def test_non_multiplex_gateway_clears_previous_served_profiles(
+        self, monkeypatch
+    ):
+        """A replacement independent gateway must not inherit shared coverage."""
+        import gateway.run as gateway_run
+        import gateway.status as status
+
+        runner = object.__new__(gateway_run.GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=False)
+        writes = []
+        monkeypatch.setattr(
+            status,
+            "write_runtime_status",
+            lambda **kwargs: writes.append(kwargs),
+        )
+
+        connected = await runner._start_secondary_profile_adapters()
+
+        assert connected == 0
+        assert writes == [{"served_profiles": []}]
+
 
 def test_cron_profile_homes_follow_allowlist(tmp_path, monkeypatch):
     """The helper wired into in-process cron returns only selected profiles."""

--- a/tests/gateway/test_multiplex_lifecycle.py
+++ b/tests/gateway/test_multiplex_lifecycle.py
@@ -41,6 +41,24 @@ class TestServedProfilesStatus:
         assert connected == 0
         assert writes == [{"served_profiles": []}]
 
+    @pytest.mark.asyncio
+    async def test_non_multiplex_gateway_tolerates_status_write_failure(
+        self, monkeypatch
+    ):
+        """Diagnostic cleanup failures must not abort gateway startup."""
+        import gateway.run as gateway_run
+        import gateway.status as status
+
+        runner = object.__new__(gateway_run.GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=False)
+
+        def fail_write(**_kwargs):
+            raise OSError("runtime state unavailable")
+
+        monkeypatch.setattr(status, "write_runtime_status", fail_write)
+
+        assert await runner._start_secondary_profile_adapters() == 0
+
 
 def test_cron_profile_homes_follow_allowlist(tmp_path, monkeypatch):
     """The helper wired into in-process cron returns only selected profiles."""

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -1007,6 +1007,62 @@ class TestEdgeCases:
         ):
             assert _check_gateway_running(default_home) is True
 
+    def test_profile_list_reports_profiles_served_by_live_shared_gateway(
+        self, profile_env
+    ):
+        """Named profiles inherit liveness only from a validated multiplexer."""
+        import gateway.status as gw_status
+
+        default_home = profile_env / ".hermes"
+        create_profile("collector", no_alias=True)
+        create_profile("writer", no_alias=True)
+        live_pid = os.getpid()
+        (default_home / "gateway_state.json").write_text(
+            json.dumps(
+                {
+                    "pid": live_pid,
+                    "kind": "hermes-gateway",
+                    "argv": ["hermes", "gateway", "run"],
+                    "start_time": gw_status._get_process_start_time(live_pid),
+                    "gateway_state": "running",
+                    "served_profiles": ["default", "collector"],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch("gateway.status.get_running_pid", return_value=None), patch(
+            "gateway.status._read_process_cmdline",
+            return_value="hermes gateway run --replace",
+        ):
+            by_name = {profile.name: profile for profile in list_profiles()}
+
+        assert by_name["default"].gateway_running is True
+        assert by_name["collector"].gateway_running is True
+        assert by_name["writer"].gateway_running is False
+
+    def test_profile_list_rejects_stale_shared_gateway_coverage(self, profile_env):
+        """A dead global runtime record must not make named profiles look live."""
+        default_home = profile_env / ".hermes"
+        create_profile("collector", no_alias=True)
+        (default_home / "gateway_state.json").write_text(
+            json.dumps(
+                {
+                    "pid": 999_999_999,
+                    "kind": "hermes-gateway",
+                    "argv": ["hermes", "gateway", "run"],
+                    "gateway_state": "running",
+                    "served_profiles": ["default", "collector"],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch("gateway.status.get_running_pid", return_value=None):
+            by_name = {profile.name: profile for profile in list_profiles()}
+
+        assert by_name["collector"].gateway_running is False
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

`hermes profile list` now reports named profiles as running when a live default-profile multiplex gateway actually serves them. Without this fix, operators see a stopped status for working shared profiles and may attempt unnecessary restarts. The status remains fail-closed for non-served profiles, dead gateway processes, and independent gateways that replace an earlier multiplexer.

### Symptom

After enabling `gateway.multiplex_profiles` and starting the shared gateway, named profiles served by that gateway still appear as `Gateway: stopped` because they do not own profile-local gateway PID or runtime files.

### Impact

Operators cannot trust profile status to diagnose shared gateway coverage. The incorrect stopped result can lead to unnecessary restart attempts even while the shared gateway is routing the profile successfully.

### Bug Cause

**Trigger:** `hermes_cli/profiles.py:list_profiles()` checks each named profile only through `_check_gateway_running(entry)`.

**Causal chain:**
1. The default profile starts one multiplex gateway and records its live PID plus `served_profiles` in the default runtime state.
2. A served named profile has no profile-local `gateway.pid` or `gateway_state.json`, so its local liveness check returns false.
3. `hermes profile list` renders the served profile as stopped despite the live shared gateway.

**Why it is wrong:** Shared gateway ownership is represented by the default gateway's validated runtime status, not by runtime files under each named profile.

**Working sibling / contrast:** Independent named-profile gateways already report through their own local runtime files. Non-served profiles must not inherit the default gateway's status.

**Ruled out:** Port listening alone is not sufficient evidence because it cannot prove profile coverage. The fix trusts only a live, process-validated default runtime whose authoritative `served_profiles` contains the named profile.

### Fix

Read shared coverage once from the live default gateway runtime and apply it only to listed profiles named in `served_profiles`. Clear inherited coverage when a non-multiplex gateway replaces a multiplexer so stale state cannot create a false running result. Runtime cleanup remains best-effort and cannot abort gateway startup.

## Related Issue

Closes #89726

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/profiles.py` - validate default gateway liveness and map authoritative shared coverage into profile status.
- `gateway/run.py` - clear stale `served_profiles` when starting in non-multiplex mode without making status cleanup startup-critical.
- `tests/hermes_cli/test_profiles.py` - cover live served profiles, non-served profiles, and dead shared runtime state.
- `tests/gateway/test_multiplex_lifecycle.py` - cover stale coverage cleanup and best-effort write failures.

## How to Test

1. Create default, `collector`, and `writer` profiles in an isolated Hermes home.
2. Start a multiplex gateway that serves default and `collector`; run `hermes profile list` and confirm default and `collector` report running while `writer` reports stopped.
3. Replace it with a non-multiplex default gateway and confirm only default reports running.
4. Automated verification already run locally (5 passed):

```bash
scripts/run_tests.sh tests/gateway/test_multiplex_lifecycle.py tests/hermes_cli/test_profiles.py -k 'non_multiplex_gateway or gateway_running_check or profile_list_reports_profiles_served or profile_list_rejects_stale'
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, no user-facing configuration or workflow changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A, no architecture or contributor workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, no model tool changed

## Screenshots / Logs

REAL_ENV verification confirmed live shared coverage for default and `collector`, rejected non-served `writer`, rejected a dead PID record, and cleared stale shared coverage after replacement by an independent gateway.
