### PR TITLE
feat(gateway,desktop): expose cache_read in per-session usage

### DIFF
--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -699,6 +699,8 @@ export interface SessionRuntimeInfo {
 }
 
 export interface UsageStats {
+  /** Cache-read prompt tokens (prompt cache hit). Absent on older backends. */
+  cache_read?: number
   calls: number
   context_max?: number
   context_percent?: number

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5435,6 +5435,7 @@ def _get_usage(agent) -> dict:
         "completion": g("session_completion_tokens"),
         "total": g("session_total_tokens"),
         "calls": g("session_api_calls"),
+        "cache_read": g("session_cache_read_tokens"),
     }
     comp = getattr(agent, "context_compressor", None)
     if comp:


### PR DESCRIPTION
## What

Add `cache_read` (prompt cache read tokens) to the gateway's `_get_usage()` response and the desktop `UsageStats` TypeScript interface.

## Why

The CLI status bar already tracks `session_cache_read_tokens` and displays prompt-cache hit rates. However, the gateway's per-session usage payload omits this field, so the desktop app (and desktop plugins) cannot access it. This is a gap — the data is already collected by the agent but never surfaces past the gateway boundary.

## Changes

- **`tui_gateway/server.py`**: add `"cache_read": g("session_cache_read_tokens")` to `_get_usage()` (1 line)
- **`apps/desktop/src/types/hermes.ts`**: add `cache_read?: number` to the `UsageStats` interface (2 lines, optional for backward compat)

## Compatibility

- The field is **optional** (`cache_read?` in TypeScript) so existing desktop code and older backends that don't emit it continue to work unchanged.
- The gateway change is additive — it adds a key to an existing dict, no shape change.

## Use case

This enables desktop status-bar items and plugins (e.g. a cache-hit-rate chip) to show real-time prompt-cache efficiency, matching what the CLI already displays.