### PR TITLE
fix(profiles): show shared gateway status for served profiles

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -707,6 +707,42 @@ def _read_config_model(profile_dir: Path) -> tuple:
         return None, None
 
 
+def _gateway_multiplex_enabled(default_home: Path) -> bool:
+    """Return whether the root gateway is configured to serve named profiles.
+
+    Runtime status records written by current multiplex gateways carry an
+    explicit ``served_profiles`` list. Older records do not, so consult the
+    same environment/config switches used by gateway startup before treating
+    a live root gateway as shared.
+    """
+    override = os.environ.get("GATEWAY_MULTIPLEX_PROFILES")
+    if override is not None:
+        token = override.strip().lower()
+        if token in {"1", "true", "yes", "on"}:
+            return True
+        if token in {"0", "false", "no", "off"}:
+            return False
+
+    try:
+        from hermes_cli.config import read_user_config_raw
+
+        config = read_user_config_raw(default_home / "config.yaml")
+        value = config.get("multiplex_profiles")
+        if value is None:
+            gateway_config = config.get("gateway")
+            if isinstance(gateway_config, dict):
+                value = gateway_config.get("multiplex_profiles")
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+        if isinstance(value, (int, float)):
+            return bool(value)
+    except Exception:
+        pass
+    return False
+
+
 def _check_gateway_running(profile_dir: Path) -> bool:
     """Check if a gateway is running for a given profile directory.
 
@@ -718,7 +754,9 @@ def _check_gateway_running(profile_dir: Path) -> bool:
     no live PID file.  In those cases fall back to validating the PID recorded
     in the profile's own ``gateway_state.json`` against the live process table,
     mirroring the ``/api/status`` sidebar's liveness logic so the two surfaces
-    agree.  Parameterized by ``profile_dir`` so it never mutates ``HERMES_HOME``.
+    agree. When a named profile has no private runtime state, the root status
+    record is also checked for a live multiplex gateway. Parameterized by
+    ``profile_dir`` so it never mutates ``HERMES_HOME``.
     """
     try:
         from gateway.status import get_running_pid
@@ -735,7 +773,38 @@ def _check_gateway_running(profile_dir: Path) -> bool:
             read_runtime_status,
         )
         runtime = read_runtime_status(profile_dir / "gateway_state.json")
-        return get_runtime_status_running_pid(runtime, expected_home=profile_dir) is not None
+        if get_runtime_status_running_pid(runtime, expected_home=profile_dir) is not None:
+            return True
+
+        default_home = _get_default_hermes_home().resolve()
+        profile_path = profile_dir.resolve()
+        if profile_path == default_home:
+            return False
+        try:
+            relative = profile_path.relative_to(_get_profiles_root().resolve())
+        except ValueError:
+            return False
+        if len(relative.parts) != 1:
+            return False
+        profile_name = relative.parts[0]
+        if profile_name == "default" or not _PROFILE_ID_RE.fullmatch(profile_name):
+            return False
+
+        shared_runtime = read_runtime_status(default_home / "gateway_state.json")
+        if (
+            get_runtime_status_running_pid(shared_runtime, expected_home=default_home)
+            is None
+        ):
+            return False
+
+        served_profiles = shared_runtime.get("served_profiles") if isinstance(
+            shared_runtime, dict
+        ) else None
+        if isinstance(served_profiles, list):
+            return profile_name in {
+                entry for entry in served_profiles if isinstance(entry, str)
+            }
+        return _gateway_multiplex_enabled(default_home)
     except Exception:
         return False
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -1002,10 +1002,110 @@ class TestEdgeCases:
         # line to a bare ``gateway run`` (this is the default/root home, which
         # runs the gateway with no profile flag).
         with patch("gateway.status.get_running_pid", return_value=None), patch(
+            "gateway.status._pid_exists", return_value=True
+        ), patch(
             "gateway.status._read_process_cmdline",
             return_value="hermes gateway run --replace",
         ):
             assert _check_gateway_running(default_home) is True
+    def test_named_profile_uses_shared_gateway_runtime_status(self, profile_env):
+        """A multiplex gateway reports served named profiles as running."""
+        import gateway.status as gw_status
+
+        tmp_path = profile_env
+        default_home = tmp_path / ".hermes"
+        named_home = default_home / "profiles" / "collector"
+        named_home.mkdir(parents=True)
+        live_pid = os.getpid()
+        (default_home / "gateway_state.json").write_text(
+            json.dumps(
+                {
+                    "pid": live_pid,
+                    "kind": "hermes-gateway",
+                    "argv": ["hermes", "gateway", "run"],
+                    "start_time": gw_status._get_process_start_time(live_pid),
+                    "gateway_state": "running",
+                    "served_profiles": ["default", "collector"],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch("gateway.status.get_running_pid", return_value=None), patch(
+            "gateway.status._pid_exists", return_value=True
+        ), patch(
+            "gateway.status._read_process_cmdline",
+            return_value="hermes gateway run --replace",
+        ):
+            assert profiles._check_gateway_running(named_home) is True
+
+
+    def test_shared_gateway_status_does_not_cover_unserved_profile(self, profile_env):
+        """A multiplex allowlist must not mark an excluded profile running."""
+        import gateway.status as gw_status
+
+        tmp_path = profile_env
+        default_home = tmp_path / ".hermes"
+        named_home = default_home / "profiles" / "collector"
+        named_home.mkdir(parents=True)
+        live_pid = os.getpid()
+        (default_home / "gateway_state.json").write_text(
+            json.dumps(
+                {
+                    "pid": live_pid,
+                    "kind": "hermes-gateway",
+                    "argv": ["hermes", "gateway", "run"],
+                    "start_time": gw_status._get_process_start_time(live_pid),
+                    "gateway_state": "running",
+                    "served_profiles": ["default", "other"],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch("gateway.status.get_running_pid", return_value=None), patch(
+            "gateway.status._pid_exists", return_value=True
+        ), patch(
+            "gateway.status._read_process_cmdline",
+            return_value="hermes gateway run --replace",
+        ):
+            assert profiles._check_gateway_running(named_home) is False
+
+
+    def test_legacy_shared_gateway_status_uses_multiplex_config(self, profile_env):
+        """Older root status records still work when config enables multiplexing."""
+        import gateway.status as gw_status
+
+        tmp_path = profile_env
+        default_home = tmp_path / ".hermes"
+        named_home = default_home / "profiles" / "collector"
+        named_home.mkdir(parents=True)
+        (default_home / "config.yaml").write_text(
+            "gateway:\n  multiplex_profiles: true\n",
+            encoding="utf-8",
+        )
+        live_pid = os.getpid()
+        (default_home / "gateway_state.json").write_text(
+            json.dumps(
+                {
+                    "pid": live_pid,
+                    "kind": "hermes-gateway",
+                    "argv": ["hermes", "gateway", "run"],
+                    "start_time": gw_status._get_process_start_time(live_pid),
+                    "gateway_state": "running",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch("gateway.status.get_running_pid", return_value=None), patch(
+            "gateway.status._pid_exists", return_value=True
+        ), patch(
+            "gateway.status._read_process_cmdline",
+            return_value="hermes gateway run --replace",
+        ):
+            assert profiles._check_gateway_running(named_home) is True
+
 
 
 
@@ -1123,5 +1223,4 @@ class TestResolveProfileEnvSpelling:
         # No HERMES_HOME: the platform default root applies (existing contract).
         monkeypatch.delenv("HERMES_HOME", raising=False)
         assert Path(resolve_profile_env("default")) == _get_default_hermes_home()
-
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -1008,6 +1008,8 @@ class TestEdgeCases:
             return_value="hermes gateway run --replace",
         ):
             assert _check_gateway_running(default_home) is True
+
+
     def test_named_profile_uses_shared_gateway_runtime_status(self, profile_env):
         """A multiplex gateway reports served named profiles as running."""
         import gateway.status as gw_status


### PR DESCRIPTION
## Summary

Fix the profile list's Gateway status for named profiles served by the shared default gateway.

## Root cause

`_check_gateway_running()` only inspected the named profile's private `gateway.pid` and `gateway_state.json`. A multiplexed gateway stores its live runtime state in the root HERMES_HOME, so named profiles were shown as stopped even while the shared gateway was serving them.

## Fix

- Fall back to the root gateway runtime status for named profiles with no private runtime state.
- Validate the shared gateway PID through the existing liveness checks.
- Respect the runtime `served_profiles` set and support older status records when multiplexing is explicitly configured.
- Add regression coverage for served, excluded, and legacy shared-profile status cases.

## Testing

- `scripts/run_tests.sh tests/hermes_cli/test_profiles.py tests/gateway/test_multiplex_lifecycle.py tests/hermes_cli/test_web_server_gateway_topology.py -q` — 82 passed, 2 skipped
- `scripts/run_tests.sh tests/hermes_cli/test_web_server_profile_unification.py tests/hermes_cli/test_profiles_sidebar_cache.py tests/hermes_cli/test_profiles_sidebar_scope.py -q` — 39 passed

Fixes #89726