### PR TITLE
fix(desktop): profile clicks land again — lease switch targets against the socket pruner (#89622)

### DIFF
--- a/apps/desktop/src/store/gateway-activation-prune-lease.test.ts
+++ b/apps/desktop/src/store/gateway-activation-prune-lease.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Regression suite for #89622: clicking a profile in the rail did nothing.
+// The live-work pruner (pruneSecondaryGateways) disposed the switch target's
+// secondary entry while its socket was still dialing — the target is not yet
+// the active key, has no live sessions, and holds no request lease, so every
+// prune recompute during the ~3s cold backend spawn saw it as idle garbage.
+// The activation thunk then declined and the fail-closed switch published
+// nothing. These tests pin the activation lease that spares a mid-dial entry,
+// its release once the activation settles, and its bounded self-heal.
+
+const secondaryGateways: Array<{
+  close: ReturnType<typeof vi.fn>
+  connect: ReturnType<typeof vi.fn>
+  connectionState: string
+  request: ReturnType<typeof vi.fn>
+}> = []
+
+let connectGate: Promise<void> | null = null
+
+vi.mock('@/hermes', () => ({
+  HermesGateway: class {
+    connectionState = 'closed'
+    connect = vi.fn(async () => {
+      if (this.connectionState === 'connecting') {
+        return
+      }
+
+      this.connectionState = 'connecting'
+
+      if (connectGate) {
+        await connectGate
+      }
+
+      this.connectionState = 'open'
+    })
+    request = vi.fn(async (method: string, params: Record<string, unknown>) => ({ method, params }))
+    close = vi.fn()
+    onEvent = vi.fn(() => () => {})
+    onState = vi.fn(() => () => {})
+
+    constructor() {
+      secondaryGateways.push(this)
+    }
+  },
+  setApiRequestConnection: vi.fn()
+}))
+vi.mock('@/store/session', () => ({ setConnection: vi.fn(), setGatewayState: vi.fn() }))
+vi.mock('@/store/notify-baseline', () => ({ markNativeNotifyBaseline: vi.fn() }))
+
+const {
+  closeSecondaryGateways,
+  configureGatewayRegistry,
+  prepareGatewayForAgent,
+  prepareGatewayForProfile,
+  pruneSecondaryGateways,
+  setPrimaryGateway
+} = await import('./gateway')
+
+function installDesktop(): void {
+  ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+    getConnection: vi.fn(async (profile: null | string) =>
+      profile ? { port: 5151, profile, token: 'secondary-token' } : { port: 4242, token: 'primary-token' }
+    ),
+    getConnectionFor: vi.fn(async ({ profile }: { connectionId: string; profile: string }) => ({
+      port: 6161,
+      profile,
+      token: 'registry-token'
+    })),
+    getGatewayWsUrlFor: vi.fn(async () => 'ws://127.0.0.1:6161/ws'),
+    touchBackend: vi.fn(async () => undefined)
+  }
+}
+
+function makePrimary() {
+  return {
+    connectionState: 'open',
+    request: vi.fn(async (method: string, params: Record<string, unknown>) => ({ method, params }))
+  }
+}
+
+beforeEach(() => {
+  secondaryGateways.length = 0
+  connectGate = null
+  configureGatewayRegistry({ onEvent: vi.fn() })
+  closeSecondaryGateways()
+  installDesktop()
+  setPrimaryGateway(makePrimary() as never, 'default')
+})
+
+afterEach(() => {
+  closeSecondaryGateways()
+  vi.clearAllMocks()
+  vi.useRealTimers()
+  delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+})
+
+describe('activation lease vs. the live-work pruner (#89622)', () => {
+  it('a prune during the switch dial does not dispose the target and the activation lands', async () => {
+    let releaseConnect: () => void = () => undefined
+    connectGate = new Promise<void>(resolve => {
+      releaseConnect = resolve
+    })
+
+    const preparing = prepareGatewayForProfile('bot')
+    // Let the dial start (createSecondary + connect() now pending on the gate).
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(secondaryGateways).toHaveLength(1)
+
+    // The exact recompute that killed the switch: no live sessions, target not
+    // active yet, empty keep-set. The mid-dial entry must survive it.
+    pruneSecondaryGateways(new Set())
+    expect(secondaryGateways[0].close).not.toHaveBeenCalled()
+
+    releaseConnect()
+    const activate = await preparing
+
+    expect(activate()).toBe(true)
+  })
+
+  it('the agent door leases its entry against the pruner too', async () => {
+    let releaseConnect: () => void = () => undefined
+    connectGate = new Promise<void>(resolve => {
+      releaseConnect = resolve
+    })
+
+    const preparing = prepareGatewayForAgent('homelab', 'research')
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(secondaryGateways).toHaveLength(1)
+
+    pruneSecondaryGateways(new Set())
+    expect(secondaryGateways[0].close).not.toHaveBeenCalled()
+
+    releaseConnect()
+    const activate = await preparing
+
+    expect(activate()).toBe(true)
+  })
+
+  it('the lease is released once the activation settles — a later prune reclaims the idle entry', async () => {
+    const activate = await prepareGatewayForProfile('bot')
+    expect(activate()).toBe(true)
+
+    // Move away so 'bot' is neither active nor kept, then prune: with the
+    // lease released, the idle entry must be disposed as before the fix.
+    setPrimaryGateway(makePrimary() as never, 'default')
+    const backToPrimary = await prepareGatewayForProfile('default')
+    expect(backToPrimary()).toBe(true)
+
+    pruneSecondaryGateways(new Set())
+
+    expect(secondaryGateways[0].close).toHaveBeenCalled()
+  })
+
+  it('an orphaned lease expires — the pruner is not permanently locked out', async () => {
+    vi.useFakeTimers()
+
+    let releaseConnect: () => void = () => undefined
+    connectGate = new Promise<void>(resolve => {
+      releaseConnect = resolve
+    })
+
+    // Dial starts, then the caller never runs the thunk (dropped switch).
+    void prepareGatewayForProfile('bot')
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(secondaryGateways).toHaveLength(1)
+
+    // Inside the lease window: spared.
+    pruneSecondaryGateways(new Set())
+    expect(secondaryGateways[0].close).not.toHaveBeenCalled()
+
+    // Past the lease window: reclaimed. (Lease is wall-clock bounded so a
+    // leaked lease cannot pin a dead entry forever.)
+    vi.setSystemTime(Date.now() + 31_000)
+    pruneSecondaryGateways(new Set())
+    expect(secondaryGateways[0].close).toHaveBeenCalled()
+
+    releaseConnect()
+  })
+})

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -59,7 +59,23 @@ interface Secondary {
   // While true the entry auto-reconnects on drop; pruning flips it off so a
   // deliberate close doesn't trigger the backoff loop.
   wantOpen: boolean
+  /**
+   * Epoch-ms deadline while an activation (prepareGatewayFor*) is mid-dial.
+   * The live-work pruner must not dispose an entry the user is actively
+   * switching to: the target of a switch is by definition not yet the active
+   * key, has no live sessions and holds no request lease, so during a cold
+   * spawn (~3s) every recompute tick saw it as idle garbage, disposed it
+   * mid-dial, and the activation thunk then declined — a dead profile click
+   * with no error (#89622). Cleared when the activation thunk settles;
+   * bounded so an orphaned lease (caller dropped the thunk) self-heals.
+   */
+  activationLeaseUntil: number
 }
+
+// How long a mid-dial activation holds its prune lease: covers a cold pool
+// backend spawn + socket connect with margin, while still letting a leaked
+// lease expire quickly enough for the reaper to reclaim the entry.
+const ACTIVATION_LEASE_MS = 30_000
 
 // ── HMR-stable module state ─────────────────────────────────────────────────
 // All mutable singletons (live sockets, active-profile routing, the event
@@ -432,7 +448,8 @@ function createSecondary(profile: string, connectionId: null | string = null): S
     reconnectAttempt: 0,
     reconnecting: false,
     retained: false,
-    wantOpen: true
+    wantOpen: true,
+    activationLeaseUntil: 0
   }
 
   // Events keep carrying the bare profile — session routing is profile-keyed
@@ -704,6 +721,11 @@ export async function prepareGatewayForAgent(connectionId: null | string, profil
 
   entry.retained = true
   entry.wantOpen = true
+  // Lease the entry against the live-work pruner for the whole dial: the
+  // switch target is not yet active and has no live sessions, so a prune
+  // recompute firing mid-spawn would otherwise dispose it and this
+  // activation would decline (#89622).
+  entry.activationLeaseUntil = Date.now() + ACTIVATION_LEASE_MS
 
   if (!isOpen(entry.gateway)) {
     clearTimer(entry)
@@ -720,6 +742,9 @@ export async function prepareGatewayForAgent(connectionId: null | string, profil
   const prepared = entry
 
   return () => {
+    // The activation is settling either way — release the prune lease.
+    prepared.activationLeaseUntil = 0
+
     // A source edit/remove may dispose this entry while its dial is still in
     // flight. Only the still-registered, still-owned activation may publish.
     const activated =
@@ -774,6 +799,9 @@ export async function prepareGatewayForProfile(profile: string): Promise<() => b
 
   entry.retained = true
   entry.wantOpen = true
+  // Lease the entry against the live-work pruner for the whole dial — the
+  // profile-door twin of the agent path's lease above (#89622).
+  entry.activationLeaseUntil = Date.now() + ACTIVATION_LEASE_MS
 
   if (!isOpen(entry.gateway)) {
     clearTimer(entry)
@@ -800,6 +828,9 @@ export async function prepareGatewayForProfile(profile: string): Promise<() => b
   // epoch superseded by a newer switch while this one was dialing) must leave
   // every companion store alone.
   return () => {
+    // The activation is settling either way — release the prune lease.
+    prepared.activationLeaseUntil = 0
+
     const activated = prepared.wantOpen && g.secondaries.get(key) === prepared && applyActive(key, activationEpoch)
 
     if (activated && prepared.connection) {
@@ -913,12 +944,20 @@ function restoreActiveToPrimaryIfEvicted(): void {
 // bare profile name kept gateway B's 'default' socket alive off gateway A's
 // 'default' activity (and vice versa) — cross-connection attribution.
 export function pruneSecondaryGateways(keep: Set<string>): void {
+  const now = Date.now()
+
   for (const [key, entry] of [...g.secondaries]) {
     if (
       key === g.activeKey ||
       keep.has(key) ||
       (!entry.connectionId && keep.has(entry.profile)) ||
-      entry.activeRequests > 0
+      entry.activeRequests > 0 ||
+      // Mid-dial activation target (prepareGatewayFor*): the profile being
+      // switched TO is not yet active and has no live work, so without this
+      // lease any recompute during its cold spawn disposed the entry and the
+      // switch silently declined (#89622). Number guard: dev-HMR entries
+      // predate the field. Bounded: an orphaned lease expires on its own.
+      (Number.isFinite(entry.activationLeaseUntil) && entry.activationLeaseUntil > now)
     ) {
       continue
     }

--- a/apps/desktop/src/store/profile-agent-activation.test.ts
+++ b/apps/desktop/src/store/profile-agent-activation.test.ts
@@ -152,7 +152,9 @@ describe('ensureGatewayAgent → $connection / $activeGatewayProfile sync', () =
 
   it('does not republish a registry identity invalidated during activation', async () => {
     // The thunk reports false: the entry was disposed (source edited/removed)
-    // between dial and publish. Nothing may publish, $gateway included.
+    // between dial and publish. Nothing may publish, $gateway included. Two
+    // declines: the switch retries a transient decline once (#89622).
+    prepareGatewayForAgent.mockResolvedValueOnce(() => false)
     prepareGatewayForAgent.mockResolvedValueOnce(() => false)
 
     await ensureGatewayAgent('removed-source', 'research')
@@ -166,8 +168,9 @@ describe('ensureGatewayAgent → $connection / $activeGatewayProfile sync', () =
     // live entry) would put an await between the identity check and the
     // publication and reopen the gap. The cost is one redundant read-only
     // lookup in the rare disposed-entry case; the invariant that matters -
-    // nothing is PUBLISHED - is asserted above.
-    expect(getConnectionFor).toHaveBeenCalledTimes(1)
+    // nothing is PUBLISHED - is asserted above. Two lookups here: one per
+    // decline-then-retry attempt.
+    expect(getConnectionFor).toHaveBeenCalledTimes(2)
   })
 
   it('never shows a $gateway listener the new backend beside stale companions', async () => {
@@ -268,6 +271,10 @@ describe('ensureGatewayProfile publishes under the same activation guard', () =>
     // descriptor. Atomicity cannot make a rejected activation correct, so the
     // caller has to decline to publish at all.
     getConnection.mockResolvedValue(localConn({ profile: 'worker' }))
+    // Both attempts decline: the switch retries a transient decline once
+    // (#89622), so pinning the publish-nothing contract requires exhausting
+    // the retry too.
+    prepareGatewayForProfile.mockResolvedValueOnce(() => false)
     prepareGatewayForProfile.mockResolvedValueOnce(() => false)
 
     const seen: unknown[] = []

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -168,6 +168,66 @@ describe('ensureGatewayProfile → $connection sync (#46651)', () => {
   })
 })
 
+describe('declined activation retry (#89622)', () => {
+  it('retries once with a fresh prepare when the first activation declines, then publishes', async () => {
+    // The field failure: the live-work pruner disposed the switch target's
+    // entry mid-dial, so the first activation thunk declined. The switch must
+    // not resolve as a silent no-op — one fresh prepare (new entry, new
+    // epoch) lands the switch.
+    getConnection.mockResolvedValue(remoteConn())
+    prepareGatewayForProfile.mockResolvedValueOnce(() => false)
+
+    await ensureGatewayProfile('vps-remote')
+
+    expect(prepareGatewayForProfile).toHaveBeenCalledTimes(2)
+    expect(activateGateway).toHaveBeenCalledTimes(1)
+    expect($activeGatewayProfile.get()).toBe('vps-remote')
+    expect($connection.get()?.mode).toBe('remote')
+  })
+
+  it('publishes nothing and warns when the activation declines twice', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    getConnection.mockResolvedValue(remoteConn())
+    prepareGatewayForProfile.mockResolvedValueOnce(() => false)
+    prepareGatewayForProfile.mockResolvedValueOnce(() => false)
+
+    await ensureGatewayProfile('vps-remote')
+
+    expect(prepareGatewayForProfile).toHaveBeenCalledTimes(2)
+    expect($activeGatewayProfile.get()).toBe('default')
+    expect($connection.get()?.mode).toBe('local')
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('declined twice'))
+
+    warn.mockRestore()
+  })
+
+  it('a declined-then-retried switch leaves the mutex clear — the next switch works', async () => {
+    getConnection.mockResolvedValue(remoteConn())
+    prepareGatewayForProfile.mockResolvedValueOnce(() => false)
+    prepareGatewayForProfile.mockResolvedValueOnce(() => false)
+
+    await ensureGatewayProfile('vps-remote')
+    expect($activeGatewayProfile.get()).toBe('default')
+
+    // Second click after the failure must go through cleanly.
+    await ensureGatewayProfile('vps-remote')
+
+    expect($activeGatewayProfile.get()).toBe('vps-remote')
+  })
+
+  it('logs the reason when the descriptor lookup rejects instead of swallowing it', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    getConnection.mockRejectedValue(new Error('backend unreachable'))
+
+    await ensureGatewayProfile('vps-remote')
+
+    expect($activeGatewayProfile.get()).toBe('default')
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('gateway switch to "vps-remote" failed'), expect.any(Error))
+
+    warn.mockRestore()
+  })
+})
+
 describe('profile-scoped cache invalidation', () => {
   it('drops the memory graph cache when the active gateway profile changes', () => {
     $activeGatewayProfile.set('coder')

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -326,45 +326,66 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
 
   $gatewaySwapTarget.set(target)
   gatewaySwitch = (async () => {
-    // Resolve the target's connection descriptor and open (or reuse) its
-    // socket BEFORE anything is published — without closing the profile you
-    // came from. The gateway used to be activated (and the profile atom set)
-    // while the descriptor fetch was still in flight, so during that window
-    // $gateway already targeted the new backend while $connection still
-    // described the previous one — and any request or plugin mode-listener
-    // firing then announced the WRONG mode to the new backend.
-    const [connection, activate] = await Promise.all([
-      resolveConnectionForProfile(target),
-      prepareGatewayForProfile(target)
-    ])
+    // Two attempts: a declined activation while we HOLD the switch mutex can
+    // only come from a registry-internal event (an eviction fallback or a
+    // teardown superseding our epoch mid-dial) — never from a newer user
+    // switch, which would be queued behind this promise. Those are transient,
+    // and before the fail-closed hardening the unconditional publish papered
+    // over them — so one fresh prepare (new entry, new epoch) restores the
+    // old reliability without publishing a torn tuple. A second decline is
+    // reported instead of silently swallowed (#89622).
+    for (let attempt = 0; attempt < 2; attempt++) {
+      // Resolve the target's connection descriptor and open (or reuse) its
+      // socket BEFORE anything is published — without closing the profile you
+      // came from. The gateway used to be activated (and the profile atom set)
+      // while the descriptor fetch was still in flight, so during that window
+      // $gateway already targeted the new backend while $connection still
+      // described the previous one — and any request or plugin mode-listener
+      // firing then announced the WRONG mode to the new backend.
+      const [connection, activate] = await Promise.all([
+        resolveConnectionForProfile(target),
+        prepareGatewayForProfile(target)
+      ])
 
-    // ONE publication. batch() defers Nanostores' notifications to the end of
-    // the callback, so the active gateway, $activeGatewayProfile and
-    // $connection become visible together. Without it these are sequential
-    // .set() calls that each drain their listeners synchronously, and a
-    // $gateway listener runs while the other two still name the old backend.
-    batch(() => {
-      // A rejected activation publishes NOTHING, exactly like the agent path.
-      // applyActive() returns false when its captured epoch was superseded --
-      // a newer switch (or a teardown) landed while this one was awaiting its
-      // route or socket. Publishing the companions anyway would leave the
-      // CURRENT gateway paired with the stale profile pointer and descriptor,
-      // and batch() cannot rescue that: it would make the mismatched tuple
-      // atomically observable rather than prevent it.
-      if (!activate()) {
+      let published = false
+
+      // ONE publication. batch() defers Nanostores' notifications to the end of
+      // the callback, so the active gateway, $activeGatewayProfile and
+      // $connection become visible together. Without it these are sequential
+      // .set() calls that each drain their listeners synchronously, and a
+      // $gateway listener runs while the other two still name the old backend.
+      batch(() => {
+        // A rejected activation publishes NOTHING, exactly like the agent path.
+        // applyActive() returns false when its captured epoch was superseded --
+        // a newer switch (or a teardown) landed while this one was awaiting its
+        // route or socket. Publishing the companions anyway would leave the
+        // CURRENT gateway paired with the stale profile pointer and descriptor,
+        // and batch() cannot rescue that: it would make the mismatched tuple
+        // atomically observable rather than prevent it.
+        if (!activate()) {
+          return
+        }
+
+        published = true
+        $activeGatewayProfile.set(target)
+
+        if (connection) {
+          setConnection(connection)
+        }
+      })
+
+      if (published) {
         return
       }
+    }
 
-      $activeGatewayProfile.set(target)
-
-      if (connection) {
-        setConnection(connection)
-      }
-    })
-  })().catch(() => {
+    console.warn(`[profile] gateway switch to "${target}" was declined twice; staying on the current profile`)
+  })().catch(err => {
     // Descriptor lookup failed: the switch fails as a unit. Nothing was
     // published, so every atom still consistently describes the previous
-    // profile; the user can retry the switch.
+    // profile; the user can retry the switch. Log the reason — an empty
+    // catch here made a failing switch indistinguishable from a working one.
+    console.warn(`[profile] gateway switch to "${target}" failed`, err)
   })
 
   try {
@@ -430,40 +451,56 @@ export async function ensureGatewayAgent(connectionId: null | string, profile: s
 
   $gatewaySwapTarget.set(target)
   gatewaySwitch = (async () => {
-    // Dial the agent's socket and resolve its descriptor without publishing
-    // either, exactly like the profile path above. Activating first and then
-    // awaiting the descriptor left $gateway on the new backend while
-    // $connection still described the old one, so anything requesting during
-    // that window announced the WRONG mode to the new backend.
-    const [descriptor, activate] = await Promise.all([
-      resolveConnectionForActiveAgent(connection, target),
-      prepareGatewayForAgent(connection, target)
-    ])
+    // Same two-attempt shape as the profile door above: a decline while we
+    // hold the mutex is registry-internal and transient; retry once with a
+    // fresh entry + epoch, and report a second decline instead of silence.
+    for (let attempt = 0; attempt < 2; attempt++) {
+      // Dial the agent's socket and resolve its descriptor without publishing
+      // either, exactly like the profile path above. Activating first and then
+      // awaiting the descriptor left $gateway on the new backend while
+      // $connection still described the old one, so anything requesting during
+      // that window announced the WRONG mode to the new backend.
+      const [descriptor, activate] = await Promise.all([
+        resolveConnectionForActiveAgent(connection, target),
+        prepareGatewayForAgent(connection, target)
+      ])
 
-    // ONE publication. batch() defers Nanostores' notifications to the end of
-    // the callback, so a $gateway listener cannot run while the profile
-    // pointer and the connection descriptor still name the previous backend.
-    // Without it these are three sequential .set() calls, each draining its
-    // listeners synchronously, and the first listener observes exactly the
-    // mismatch this seam exists to prevent.
-    batch(() => {
-      // A disposed target (source edited/removed mid-dial) publishes nothing
-      // at all, rather than moving the profile pointer to a backend that no
-      // longer has a socket.
-      if (!activate()) {
+      let published = false
+
+      // ONE publication. batch() defers Nanostores' notifications to the end of
+      // the callback, so a $gateway listener cannot run while the profile
+      // pointer and the connection descriptor still name the previous backend.
+      // Without it these are three sequential .set() calls, each draining its
+      // listeners synchronously, and the first listener observes exactly the
+      // mismatch this seam exists to prevent.
+      batch(() => {
+        // A disposed target (source edited/removed mid-dial) publishes nothing
+        // at all, rather than moving the profile pointer to a backend that no
+        // longer has a socket.
+        if (!activate()) {
+          return
+        }
+
+        published = true
+        $activeGatewayProfile.set(target)
+
+        // Remote-aware paths (image.attach_bytes vs image.attach, /api/fs/*,
+        // /api/media) follow $connection. Null here is only the no-bridge case,
+        // so keeping the previous descriptor is correct; a failed lookup
+        // rejected above and never reached this frame.
+        if (descriptor) {
+          setConnection(descriptor)
+        }
+      })
+
+      if (published) {
         return
       }
+    }
 
-      $activeGatewayProfile.set(target)
-
-      // Remote-aware paths (image.attach_bytes vs image.attach, /api/fs/*,
-      // /api/media) follow $connection. Null here is only the no-bridge case,
-      // so keeping the previous descriptor is correct; a failed lookup
-      // rejected above and never reached this frame.
-      if (descriptor) {
-        setConnection(descriptor)
-      }
-    })
+    console.warn(
+      `[profile] agent gateway switch to "${connection}:${target}" was declined twice; staying on the current profile`
+    )
   })()
 
   try {


### PR DESCRIPTION
## Summary
Desktop profile switching works again on current main: clicking a profile in the rail lands the switch instead of dying as a silent no-op (#89622, regression window opened by the fail-closed activation hardening in #89483).

Root cause: the live-work socket pruner (`pruneSecondaryGateways`, re-run on every working/attention/active-profile recompute) disposed the switch target's secondary entry **while its socket was still dialing**. A switch target is by definition not yet the active key, has no live sessions, and holds no request lease — so during the ~3s cold pool-backend spawn every recompute saw it as idle garbage and tore it down. Before #89483 the unconditional publish papered over this (the UI re-scoped and per-request routing healed the socket); after it, the activation thunk correctly declined and the fail-closed switch published nothing: no state change, no error, no log. Matches the field traces exactly — backends spawn and report `HERMES_BACKEND_READY`, but the renderer never attempts the WS handshake.

## Changes
- `store/gateway.ts`: `prepareGatewayForProfile` / `prepareGatewayForAgent` lease their entry (`activationLeaseUntil`, 30s bound) for the duration of the dial; `pruneSecondaryGateways` spares leased entries; the activation thunk releases the lease when it settles. Bounded, so an orphaned lease (dropped thunk) self-heals and cannot pin a dead entry.
- `store/profile.ts`: `ensureGatewayProfile` / `ensureGatewayAgent` retry a declined activation once with a fresh prepare (a decline while holding the switch mutex is registry-internal and transient — a newer user switch queues behind the mutex and can't be the cause), `console.warn` on a second decline, and log the previously-swallowed descriptor-lookup rejection.
- Tests: new `gateway-activation-prune-lease.test.ts` (mid-dial prune survival on both doors, lease release, lease expiry via fake timers); decline-retry / double-decline / mutex-clear / failure-logging cases in `profile.test.ts`; the two single-decline pins in `profile-agent-activation.test.ts` now exhaust the retry.

## Validation
| | Result |
|---|---|
| New lease suite + profile/activation suites | 34/34 pass |
| Sabotage run (pruner guard reverted) | 3 lease tests fail, as required |
| `src/store/` + boot/routing suites | 1027/1027 pass |

Relationship to the open cluster: #89609 (@jackulau) surfaces the decline verdict, #89621/#89634 surface switch errors — all complementary observability; none removes the decline. This PR fixes why activations decline on a normal single click.

## Infographic

![Profile switch restored — activation lease vs socket pruner](https://v3b.fal.media/files/b/0aa6ec98/UNkEuYe_AbEaDHXgq-eXs_6csNJSEg.png)
