### PR TITLE
fix(agent): drop vision payloads before compressing on a 413

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5449,6 +5449,32 @@ def run_conversation(
                     )
 
                 if is_payload_too_large:
+                    # Drop retained vision payloads BEFORE spending a
+                    # compression attempt. A 413 is a byte-size verdict on
+                    # this request body, and on a screenshot-heavy session
+                    # base64 image parts are the bulk of those bytes — text
+                    # summarization cannot shrink them. Compressing first
+                    # burns ~50-70s of LLM round-trip per attempt, reports
+                    # "no reduction" because the images are untouched, and
+                    # walks the session into a 413 -> compress -> 413 loop
+                    # against a context window it is nowhere near (#89286).
+                    # Stripping is instant, local, and targets the actual
+                    # bytes, so it goes first; text compression still runs
+                    # on the next pass when there was no image left to drop.
+                    #
+                    # remember_model=False: 413 means this BODY was too
+                    # large, not that the provider rejects list-type tool
+                    # content in general (the #27344 recovery path).
+                    if agent._try_strip_image_parts_from_tool_messages(
+                        api_messages,
+                        remember_model=False,
+                    ):
+                        agent._buffer_status(
+                            "📐 Request payload too large (413) — dropped retained "
+                            "vision payloads and retrying before compressing..."
+                        )
+                        continue
+
                     compression_attempts += 1
                     if compression_attempts > max_compression_attempts:
                         # Terminal — surface the buffered retry trace.
@@ -5512,16 +5538,15 @@ def run_conversation(
                         _retry.restart_with_compressed_messages = True
                         break
                     else:
-                        if agent._try_strip_image_parts_from_tool_messages(
-                            api_messages,
-                            remember_model=False,
-                        ):
-                            agent._buffer_status(
-                                "📐 Compression could not reduce the request further — "
-                                "removed retained vision payloads and retrying..."
-                            )
-                            continue
-
+                        # No image-strip retry here any more: the strip now
+                        # runs at the top of this branch, so by the time
+                        # compression has failed to reduce, api_messages is
+                        # already image-free and a second call is a no-op.
+                        # (api_messages is built once, above the retry loop,
+                        # and _compress_context rewrites `messages` — not
+                        # api_messages — so the strip above persists across
+                        # this `continue`.)
+                        #
                         # Terminal — surface buffered context so the user
                         # sees what compression attempts were made.
                         agent._flush_status_buffer()

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -178,13 +178,16 @@ class TestHTTP413Compression:
 
 
 
-    def test_413_strips_vision_payloads_when_compression_cannot_reduce_messages(self, agent):
-        """If compression leaves image payloads behind, strip them and retry.
+    def test_413_strips_vision_payloads_before_compressing(self, agent):
+        """A 413 evicts retained image payloads BEFORE spending a compression pass.
 
-        Browser vision tool results can contain base64 image parts. A 413 can
-        persist even after summarisation when the remaining recent tool result
-        still carries binary data; Hermes should evict the image payload and
-        keep the text/placeholder context instead of failing immediately.
+        Browser vision tool results carry base64 image parts, which are
+        typically the bulk of an oversized request body. Text summarisation
+        cannot shrink base64, so compressing first burns a slow LLM round-trip
+        that reliably reports "no reduction" and walks the session into a
+        413 -> compress -> 413 loop (#89286). Stripping is instant and targets
+        the actual bytes, so it runs first and compression is not called at all
+        when dropping the images is enough to recover.
         """
         err_413 = _make_413_error()
         ok_resp = _mock_response(content="Recovered after image eviction", finish_reason="stop")
@@ -232,12 +235,15 @@ class TestHTTP413Compression:
             patch.object(agent, "_save_trajectory"),
             patch.object(agent, "_cleanup_task_resources"),
         ):
-            # Simulate the bad production case: compression ran, but the
-            # recent vision tool message survived so message count did not drop.
+            # Kept as a guard: if the ordering ever regresses, compression
+            # runs here and (as in production) fails to shrink the base64,
+            # which the assert_not_called below catches.
             mock_compress.side_effect = lambda msgs, *_a, **_k: (msgs, "compressed prompt")
             result = agent.run_conversation("continue", conversation_history=prefill)
 
-        mock_compress.assert_called_once()
+        # The image strip alone recovered the request — no slow summarisation
+        # round-trip, and no compression attempt consumed.
+        mock_compress.assert_not_called()
         assert result["completed"] is True
         assert result["final_response"] == "Recovered after image eviction"
         assert len(request_payloads) == 2
@@ -247,6 +253,102 @@ class TestHTTP413Compression:
         assert "data:image" not in str(retried_tool["content"])
         assert "Screenshot of the dashboard" in str(retried_tool["content"])
         assert not getattr(agent, "_no_list_tool_content_models", set())
+
+    def test_413_still_compresses_when_there_is_no_image_to_drop(self, agent):
+        """Text-only sessions must keep reaching compression (#89286).
+
+        Running the image strip first must not become a way to skip
+        compression: on a text-heavy 413 the strip finds nothing, reports
+        False, and the branch falls through to summarisation exactly as
+        before.
+        """
+        err_413 = _make_413_error()
+        ok_resp = _mock_response(content="Recovered after compression", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [err_413, ok_resp]
+
+        prefill = [
+            {"role": "user", "content": "a very long text question"},
+            {"role": "assistant", "content": "a very long text answer"},
+        ]
+
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            mock_compress.return_value = (
+                [{"role": "user", "content": "summary"}],
+                "compressed prompt",
+            )
+            result = agent.run_conversation("continue", conversation_history=prefill)
+
+        mock_compress.assert_called_once()
+        assert result["completed"] is True
+        assert result["final_response"] == "Recovered after compression"
+
+    def test_413_image_strip_does_not_consume_a_compression_attempt(self, agent):
+        """Dropping images must not burn one of max_compression_attempts.
+
+        The pre-#89286 order spent an attempt on every futile summarisation
+        pass, so a screenshot-heavy session could exhaust the budget and hard
+        fail with "max compression attempts reached" while the images — the
+        actual bytes — were still in the body. A budget of 0 stands in for
+        that already-exhausted state: dropping images is free, so recovery
+        must not depend on having an attempt left to spend.
+        """
+        agent.max_compression_attempts = 0
+        err_413 = _make_413_error()
+        ok_resp = _mock_response(content="Recovered on a budget of one", finish_reason="stop")
+        calls = []
+
+        def _side_effect(**kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise err_413
+            return ok_resp
+
+        agent.client.chat.completions.create.side_effect = _side_effect
+
+        prefill = [
+            {"role": "user", "content": "look at this"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_v",
+                        "type": "function",
+                        "function": {"name": "browser_vision", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_v",
+                "name": "browser_vision",
+                "content": [
+                    {"type": "text", "text": "page text"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64," + ("b" * 4000)},
+                    },
+                ],
+            },
+        ]
+
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            mock_compress.side_effect = lambda msgs, *_a, **_k: (msgs, "compressed prompt")
+            result = agent.run_conversation("continue", conversation_history=prefill)
+
+        assert result["completed"] is True
+        assert result.get("compression_exhausted") is not True
+        assert result["final_response"] == "Recovered on a budget of one"
 
     def test_413_clears_conversation_history_on_persist(self, agent):
         """After 413-triggered compression, _persist_session must receive None history.


### PR DESCRIPTION
## What does this PR do?

Fixes the `413 -> compress -> 413` loop a screenshot-heavy session can wedge in, far below its context window.

**The causal chain.** In `agent/conversation_loop.py` the `is_payload_too_large` branch was ordered:

1. `compression_attempts += 1`
2. `agent._compress_context(...)` — a slow LLM round-trip
3. did messages/tokens actually shrink?
4. **only if step 3 showed no progress** → `_try_strip_image_parts_from_tool_messages(...)`

A 413 is a verdict on the **byte size** of this request body. On a session carrying browser/vision tool results, retained base64 `image_url` parts are typically the bulk of those bytes — and text summarization cannot shrink base64. So steps 1–3 reliably no-op, each pass costing ~50–70s of wall clock and one of `max_compression_attempts`, before the code reaches the one operation that would have helped. From the reported session (context window 1,000,000, threshold 468,000):

```
context compression started: messages=112 tokens=~83,832
context compression done:    messages=112->51
context compression started: messages=51  tokens=~47,641
context compression done:    messages=51->48
context compression started: messages=48  tokens=~46,261
context compression done:    messages=48->48      <-- zero progress
```

Repeated compaction at ~84K tokens against a 1M window, because the trigger was the provider's byte cap, not the token threshold.

**The fix** inverts the order: attempt the vision-payload strip first (instant, local, targets the actual bytes), and fall through to text compression only when there was no image left to drop.

**Why hoisting the strip is safe** — verified rather than assumed:

- *The mutation survives the retry.* `api_messages` is built once **above** the `while retry_count < max_retries` loop and is never reassigned inside it; `_compress_context` rewrites `messages`, not `api_messages`. So the strip persists across the `continue`.
- *It cannot spin.* `_try_strip_image_parts_from_tool_messages` only rewrites tool messages whose `content` is a **list** containing image parts, and replaces that content with a **string**. A second call therefore finds no list content and returns `False`, falling through to compression. At most one extra round-trip.
- *Text-only 413s are unaffected.* No image parts → strip returns `False` → the branch proceeds to compression exactly as before, including the existing lock-defer and terminal paths.
- *`remember_model=False` is preserved* — already the convention here. A 413 means this body was too large, not that the provider rejects list-type tool content in general (the #27344 recovery path). The test asserts `_no_list_tool_content_models` stays empty.

**One deletion worth calling out:** the post-compression strip retry (the old step 4) is removed as dead code. With the strip hoisted, by the time compression has failed to reduce, `api_messages` is already image-free and that call is provably a no-op — leaving it would also emit a status message ("Compression could not reduce the request further — removed retained vision payloads") that can no longer be true. A comment records why it is gone.

## Related Issue

Fixes #89286

Related: #59587 covers the *threshold* semantics (the `0.95` progress gate) of the same branch. This change is about *ordering* and is independent — even with a perfect threshold, an image-heavy request never reached the stripper until compression had already failed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/conversation_loop.py` — in the `is_payload_too_large` branch, run `_try_strip_image_parts_from_tool_messages(api_messages, remember_model=False)` before `compression_attempts += 1`; `continue` on success. Removed the now-unreachable post-compression strip retry, with a comment explaining why it cannot fire.
- `tests/run_agent/test_413_compression.py` — updated the existing vision-strip test to the corrected ordering and added two tests (details below).

## How to Test

```
pytest tests/run_agent/test_413_compression.py -q
```

**28 passed** on this branch. On `main`, two of them fail:

```
FAILED ...::test_413_strips_vision_payloads_before_compressing
FAILED ...::test_413_image_strip_does_not_consume_a_compression_attempt
2 failed, 26 passed
```

- `test_413_strips_vision_payloads_before_compressing` — the **existing** test, updated. It already proved images get evicted and text survives; it previously also asserted `_compress_context` was called once, which encoded the ordering this issue reports as wrong. It now asserts `_compress_context` is **not** called: dropping the images alone recovers the request, with no summarization round-trip. Every outcome assertion it made before (image gone, text preserved, model not blacklisted) is unchanged.
- `test_413_image_strip_does_not_consume_a_compression_attempt` — new. Sets `max_compression_attempts = 0` to stand in for a budget already exhausted by earlier futile passes, then sends a 413 with an image-bearing tool result. On `main` this hard-fails with `413 compression failed after 0 attempts` while the base64 is still in the body; with the fix it recovers, because dropping images costs nothing.
- `test_413_still_compresses_when_there_is_no_image_to_drop` — new guard for the fallthrough. A text-only 413 must still reach compression, so the reorder cannot become a way to skip it. (This one passes both ways by design — it exists to stop a future change from turning the strip into an unconditional bypass.)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **left unchecked deliberately.** I have not run the whole suite green on this Windows box; it carries pre-existing failures unrelated to this change. What I did run:
  - `tests/run_agent/test_413_compression.py` → **28 passed**
  - `tests/run_agent/` → **266 passed**, plus `tests/run_agent/test_callable_api_key.py`, which fails identically (**4 failed, 8 passed**) on clean `main` with my changes stashed — pre-existing and unrelated to this branch.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (build 26100), Python 3.12.10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — inline comments record the ordering rationale and why the removed branch is unreachable; no user-facing docs describe this path
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure control-flow reorder in provider-error recovery, no file I/O, process, or shell surface. `scripts/check-windows-footguns.py --diff main` is clean.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Behavior on `main` with an image-bearing 413 and no compression budget left — the request fails while the base64 is still in the body:

```
WARNING agent.conversation_loop: API call failed (attempt 1/3) summary=HTTP 413: Request entity too large
ERROR   agent.conversation_loop: 413 compression failed after 0 attempts.
```

With this change the same request recovers on the next round-trip, with no summarization call.
