### PR TITLE
fix(config): recognize extra known root keys in config set validation

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5130,6 +5130,7 @@ def _known_top_level_keys() -> set[str]:
     known shape.
     """
     keys = set(DEFAULT_CONFIG.keys())
+    keys.update(_EXTRA_KNOWN_ROOT_KEYS)
     keys.update(_OPEN_DICT_TOP_LEVEL_KEYS)
     keys.update(_DYNAMIC_TOP_LEVEL_KEYS)
     keys.update(_SCHEMA_DEFINED_DICT_KEYS)

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -523,6 +523,18 @@ class TestValidateConfigKey:
         "platforms.discord.enabled",
         "gateway.platforms.my_platform.extra.token",
         "approvals.mode",
+        # Extra known roots absent from DEFAULT_CONFIG but read by the
+        # runtime (setup wizard / tools_config save flow) must validate too —
+        # previously they tripped the false "not a recognized config key"
+        # notice with a bogus suggestion (e.g. platform_hints.cli).
+        "platform_toolsets.cli",
+        "platform_toolsets.telegram",
+        "known_plugin_toolsets.cli",
+        "known_builtin_toolsets.cli",
+        "smart_model_routing.enabled",
+        "session_reset.mode",
+        "group_sessions_per_user",
+        "plugins.enabled",
     ])
     def test_known_keys_pass(self, key):
         from hermes_cli.config import _validate_config_key


### PR DESCRIPTION
## Summary

`hermes config set platform_toolsets.cli '["browser","file"]'` prints a false warning:

```
⚠ 'platform_toolsets.cli' is not a recognized config key — it was saved anyway, but Hermes may not read it.
  Did you mean: platform_hints.cli
```

The key IS recognized by the runtime — it's written by the setup wizard (`hermes_cli/setup.py`) and read by the `hermes_cli/tools_config.py` save flow. The warning is a validation false positive, and the suggested alternative (`platform_hints.cli`) is a misdirection.

## Root cause

`_known_top_level_keys()` (hermes_cli/config.py) builds the known-key set from `DEFAULT_CONFIG` plus the open-dict/dynamic/schema-defined categories, but omits `_EXTRA_KNOWN_ROOT_KEYS` — the module-level set that exists precisely to document roots that are valid on disk yet intentionally absent from `DEFAULT_CONFIG` (`platform_toolsets`, `known_plugin_toolsets`, `known_builtin_toolsets`, `smart_model_routing`, `session_reset`, `group_sessions_per_user`, `require_mention`, etc.). So `_validate_config_key()` reports every one of these documented keys as unknown, and `difflib` then invents a close-match suggestion (`platform_hints`).

Note the sibling set `_KNOWN_ROOT_KEYS` (line 2016) already unions `_EXTRA_KNOWN_ROOT_KEYS` correctly — the helper just doesn't use it.

## Fix

One line: include `_EXTRA_KNOWN_ROOT_KEYS` in the union inside `_known_top_level_keys()`.

```python
keys = set(DEFAULT_CONFIG.keys())
keys.update(_EXTRA_KNOWN_ROOT_KEYS)
keys.update(_OPEN_DICT_TOP_LEVEL_KEYS)
...
```

## Verification

- Extended `TestValidateConfigKey.test_known_keys_pass` with the extra roots (`platform_toolsets.cli`, `known_plugin_toolsets.cli`, `smart_model_routing.enabled`, `session_reset.mode`, `group_sessions_per_user`, `plugins.enabled`, …).
- Full file run: `92 passed` (includes the pre-existing unknown-key-with-suggestion and underscore-escape cases, confirming no suggestion behavior regressed).
- Live check with `set_config_value('platform_toolsets.cli', '["browser","file","terminal"]')` in a temp HERMES_HOME: no warning printed, config.yaml gets a real YAML list.

## Impact

Removes a misleading warning + wrong autocomplete suggestion on every `hermes config set platform_toolsets.* ...` / `known_plugin_toolsets.*` / `smart_model_routing.*` write. No behavior change for genuinely unknown keys (those still warn, `--force` still bypasses).