### PR TITLE
fix(gateway): coalesce duplicate failure notifications

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -731,7 +731,7 @@ def _gateway_provider_error_reply(text: str) -> str:
 
 
 _GATEWAY_PROVIDER_ERROR_SHAPE_RE = re.compile(
-    r"^\s*(\W*\s*)?("
+    r"^\s*(?:the\s+request\s+failed:\s*)?(\W*\s*)?("
     r"api\s+(?:call\s+)?failed"
     r"|provider\s+authentication\s+failed"
     r"|non-retryable\s+error"
@@ -842,7 +842,12 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
         ):
             return None
     if _looks_like_gateway_provider_error(text):
-        return _gateway_provider_error_reply(text)
+        # A terminal provider failure is returned through the final-response
+        # rail after this lifecycle callback. Sending its sanitized category
+        # here as well produced two identical chat replies for one failed
+        # request. Keep the final response as the single user-visible result;
+        # raw details remain in gateway logs.
+        return None
     return text
 
 
@@ -3867,6 +3872,44 @@ def _drain_gateway_watch_events(completion_queue) -> "list[dict]":
     for evt in requeue:
         completion_queue.put(evt)
     return watch_events
+
+
+def _watch_notification_route_key(evt: dict) -> Optional[tuple[str, ...]]:
+    """Return a fail-closed routing identity for coalesced watch matches.
+
+    Synthetic delivery prefers a saved session origin, but falls back to the
+    event's platform/chat metadata.  Do not merge two events merely because
+    their session key happens to match: divergent thread, scope, user, or
+    raw-session metadata can target a different recipient after recovery.
+    """
+    session_key = str(evt.get("session_key") or "").strip()
+    if not session_key:
+        return None
+    parsed = _parse_session_key(session_key) or {}
+
+    def normalized(field: str, fallback: str = "", *, lower: bool = False) -> str:
+        raw = str(evt.get(field) or "").strip()
+        value = raw or fallback.strip()
+        if lower:
+            value = value.lower()
+        # A recovered event that omits metadata is not equivalent to one
+        # that explicitly supplies it, even when session-key parsing happens
+        # to produce the same fallback. Keep those asymmetric records on
+        # separate synthetic turns rather than assuming their routes agree.
+        return ("present:" if raw else "missing:") + value
+
+    return (
+        session_key,
+        normalized("platform", str(parsed.get("platform") or ""), lower=True),
+        normalized("chat_type", str(parsed.get("chat_type") or ""), lower=True),
+        normalized("chat_id", str(parsed.get("chat_id") or "")),
+        normalized("thread_id"),
+        normalized("scope_id"),
+        normalized("user_id"),
+        normalized("user_name"),
+        normalized("origin_session_id"),
+        normalized("parent_session_id"),
+    )
 
 
 # Module-level weak reference to the active GatewayRunner instance.
@@ -24736,10 +24779,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if self._load_background_notifications_mode() == "off":
             return
 
+        # Several matching lines can arrive while a foreground turn is still
+        # running. They share the same session route, so injecting each as an
+        # independent synthetic user turn produces repeated assistant replies.
+        # Preserve every formatted match but let the agent handle one combined
+        # notification for that session in this drain pass.
+        ordered_notifications: list[tuple[dict, list[str]]] = []
         for evt in watch_events:
             synth_text = _format_gateway_process_notification(evt)
             if not synth_text:
                 continue
+            if evt.get("type") == "watch_match":
+                route_key = _watch_notification_route_key(evt)
+                if route_key:
+                    if ordered_notifications:
+                        previous_evt, previous_matches = ordered_notifications[-1]
+                        previous_key = _watch_notification_route_key(previous_evt)
+                        if (
+                            previous_evt.get("type") == "watch_match"
+                            and previous_key == route_key
+                        ):
+                            previous_matches.append(synth_text)
+                            continue
+            ordered_notifications.append((evt, [synth_text]))
+
+        for evt, matches in ordered_notifications:
+            synth_text = "\n\n".join(matches)
             try:
                 await self._inject_watch_notification(synth_text, evt)
             except Exception as exc:

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -613,3 +613,113 @@ def test_gateway_drain_retains_and_formats_overflow_events():
     out_released = _format_gateway_process_notification(released)
     assert "notifications resumed" in out_released
     assert "exit code" not in out_released
+
+
+@pytest.mark.asyncio
+async def test_watch_matches_for_one_session_coalesce_to_one_synthetic_turn(monkeypatch, tmp_path):
+    """Multiple matches during one foreground turn must not create reply spam."""
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    queue = asyncio.Queue()
+    first = _watch_event("proc_first")
+    second = _watch_event("proc_second")
+    first["thread_id"] = "first-thread"
+    second["thread_id"] = "first-thread"
+    second["pattern"] = "DONE"
+    second["output"] = "DONE\\n"
+    queue.put_nowait(first)
+    queue.put_nowait(second)
+    runner._inject_watch_notification = AsyncMock(return_value=True)
+
+    await runner._drain_watch_notifications(queue)
+
+    runner._inject_watch_notification.assert_awaited_once()
+    text, event = runner._inject_watch_notification.await_args.args
+    assert event is first
+    assert event["thread_id"] == "first-thread"
+    assert 'watch pattern "READY"' in text
+    assert 'watch pattern "DONE"' in text
+
+
+@pytest.mark.asyncio
+async def test_same_session_key_different_thread_watch_events_remain_separate(monkeypatch, tmp_path):
+    """A thread mismatch must not merge notifications into the wrong reply route."""
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    queue = asyncio.Queue()
+    first = _watch_event("proc_first")
+    second = _watch_event("proc_second")
+    first["thread_id"] = "first-thread"
+    second["thread_id"] = "other-thread"
+    queue.put_nowait(first)
+    queue.put_nowait(second)
+    runner._inject_watch_notification = AsyncMock(return_value=True)
+
+    await runner._drain_watch_notifications(queue)
+
+    assert runner._inject_watch_notification.await_count == 2
+    assert [call.args[1] for call in runner._inject_watch_notification.await_args_list] == [
+        first, second,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_asymmetric_route_metadata_does_not_coalesce(monkeypatch, tmp_path):
+    """An explicit route field must not merge with a session-key fallback."""
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    queue = asyncio.Queue()
+    first = _watch_event("proc_first")
+    second = _watch_event("proc_second")
+    second["platform"] = "telegram"
+    queue.put_nowait(first)
+    queue.put_nowait(second)
+    runner._inject_watch_notification = AsyncMock(return_value=True)
+
+    await runner._drain_watch_notifications(queue)
+
+    assert runner._inject_watch_notification.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_interleaved_watch_sessions_preserve_chronological_turn_order(monkeypatch, tmp_path):
+    """A1, B1, A2 must stay three turns rather than reordering A matches."""
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    queue = asyncio.Queue()
+    first_a = _watch_event("proc_first_a")
+    first_b = _watch_event("proc_first_b")
+    first_b["session_key"] = "agent:main:telegram:dm:456:99"
+    second_a = _watch_event("proc_second_a")
+    second_a["pattern"] = "AFTER_B"
+    queue.put_nowait(first_a)
+    queue.put_nowait(first_b)
+    queue.put_nowait(second_a)
+    runner._inject_watch_notification = AsyncMock(return_value=True)
+
+    await runner._drain_watch_notifications(queue)
+
+    assert runner._inject_watch_notification.await_count == 3
+    assert [call.args[1] for call in runner._inject_watch_notification.await_args_list] == [
+        first_a, first_b, second_a,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_mixed_and_blank_key_watch_events_remain_separate(monkeypatch, tmp_path):
+    """Only adjacent nonblank same-session matches may coalesce."""
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    queue = asyncio.Queue()
+    first = _watch_event("proc_first")
+    disabled = {"type": "watch_disabled", "message": "watch disabled", "session_key": first["session_key"]}
+    second = _watch_event("proc_second")
+    blank_one = _watch_event("proc_blank_one")
+    blank_two = _watch_event("proc_blank_two")
+    blank_one["session_key"] = ""
+    blank_two["session_key"] = ""
+    for event in (first, disabled, second, blank_one, blank_two):
+        queue.put_nowait(event)
+    runner._inject_watch_notification = AsyncMock(return_value=True)
+
+    await runner._drain_watch_notifications(queue)
+
+    assert runner._inject_watch_notification.await_count == 5
+    assert [call.args[1] for call in runner._inject_watch_notification.await_args_list] == [
+        first, disabled, second, blank_one, blank_two,
+    ]

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -8,6 +8,7 @@ from agent.conversation_compression import (
 )
 from gateway.config import Platform
 from gateway.run import (
+    _normalize_empty_agent_response,
     _prepare_gateway_status_message,
     _sanitize_gateway_final_response,
 )
@@ -255,20 +256,29 @@ def test_chat_gateways_drop_interrupt_sentinel(platform):
     assert _sanitize_gateway_final_response("local", sentinel) == sentinel
 
 
-def test_telegram_status_sanitizes_raw_provider_security_errors():
-    """Provider policy/security bodies should be replaced before chat delivery."""
+def test_telegram_status_suppresses_terminal_provider_errors():
+    """The final-response rail owns terminal provider failures exactly once."""
     raw = (
         "❌ API failed after 3 retries — HTTP 400: request blocked because "
         "Operation contains cybersecurity risk. request_id=req_123"
     )
 
-    sanitized = _prepare_gateway_status_message(Platform.TELEGRAM, "lifecycle", raw)
+    assert _prepare_gateway_status_message(Platform.TELEGRAM, "lifecycle", raw) is None
+    final = _sanitize_gateway_final_response(Platform.TELEGRAM, raw)
+    assert "provider rejected" in final.lower()
+    assert "HTTP 400" not in final
 
-    assert sanitized is not None
-    assert "provider rejected" in sanitized.lower()
-    assert "cybersecurity risk" not in sanitized.lower()
-    assert "HTTP 400" not in sanitized
-    assert "req_123" not in sanitized
+
+def test_failed_empty_response_uses_the_same_sanitized_final_provider_reply():
+    """The fallback final rail remains visible after lifecycle suppression."""
+    raw = "API failed after 3 retries: HTTP 400 request blocked by safety policy"
+    fallback = _normalize_empty_agent_response({"failed": True, "error": raw}, "")
+
+    final = _sanitize_gateway_final_response(Platform.SLACK, fallback)
+
+    assert "provider rejected" in final.lower()
+    assert "HTTP 400" not in final
+    assert "safety policy" not in final.lower()
 
 
 def test_telegram_final_response_sanitizes_raw_provider_errors():


### PR DESCRIPTION
## What does this PR do?

Fixes #89780.

This removes two gateway paths that can turn one underlying event into repeated user-visible chat replies:

- terminal provider failures now use the sanitised final-response rail as their single chat owner instead of also sending the same category through the lifecycle status callback; and
- adjacent background-process `watch_match` events coalesce into one synthetic turn only when their complete routing identity matches.

Coalescing is deliberately fail-closed. Interleaved sessions, different threads, asymmetric explicit/fallback route metadata, mixed event types and blank session keys remain separate and retain chronological order.

## Type of Change

- [x] Bug fix (non-breaking change that fixes incorrect behaviour)

## Changes Made

- `gateway/run.py`
  - suppress the duplicate terminal provider lifecycle status while retaining raw diagnostics in logs;
  - recognise the normal failed-empty-response prefix at the final sanitisation boundary;
  - add a fail-closed watch-notification route identity; and
  - combine only adjacent, identically routed watch matches.
- `tests/gateway/test_telegram_noise_filter.py`
  - prove the final provider failure remains visible and sanitised, including the failed-empty fallback.
- `tests/gateway/test_background_process_notifications.py`
  - cover matching-route coalescing, conflicting threads, asymmetric metadata, interleaved sessions, mixed events, blank keys, content preservation and first-event routing.

## How to Test

```bash
scripts/run_tests.sh tests/gateway/test_background_process_notifications.py tests/gateway/test_telegram_noise_filter.py -q
```

Result on the submitted commit: 160 passed, 0 failed.

`git diff --check` also passes.

## Review history

The candidate received two independent fail-closed revisions before publication:

1. grouping was changed from whole-drain/session grouping to adjacent-only grouping so A1, B1, A2 remains chronologically ordered; and
2. session-key equality was strengthened to a complete route identity so conflicting thread or recovery metadata can never be merged into the first event's route.

## Checklist

- [x] Read the contributing guide and repository instructions.
- [x] Searched open and closed upstream issues and pull requests for both symptoms.
- [x] Added focused regression coverage.
- [x] Preserved raw diagnostic logging while preventing repeated chat output.
- [x] Did not change provider, credential, configuration, platform-authorisation or production behaviour outside these output rails.