### PR TITLE
fix(codex): keep strict endpoints working after reasoning tool calls

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -625,19 +625,14 @@ def _chat_messages_to_responses_input(
                         items.append(replay_item)
                         replayed_message_items += 1
 
-                if replayed_message_items > 0:
-                    pass
-                elif content_parts:
-                    items.append({"role": "assistant", "content": content_parts})
-                elif content_text.strip():
-                    items.append({"role": "assistant", "content": content_text})
-                elif has_codex_reasoning:
-                    # The Responses API requires a following item after each
-                    # reasoning item (otherwise: missing_following_item error).
-                    # When the assistant produced only reasoning with no visible
-                    # content, emit an empty assistant message as the required
-                    # following item.
-                    items.append({"role": "assistant", "content": ""})
+                has_following_item = replayed_message_items > 0
+                if not has_following_item:
+                    if content_parts:
+                        items.append({"role": "assistant", "content": content_parts})
+                        has_following_item = True
+                    elif content_text.strip():
+                        items.append({"role": "assistant", "content": content_text})
+                        has_following_item = True
 
                 tool_calls = msg.get("tool_calls")
                 if isinstance(tool_calls, list):
@@ -680,6 +675,14 @@ def _chat_messages_to_responses_input(
                             "name": fn_name,
                             "arguments": arguments,
                         })
+                        has_following_item = True
+
+                if has_codex_reasoning and not has_following_item:
+                    # A replayed reasoning item must have a following item.
+                    # Valid function calls satisfy that requirement themselves;
+                    # pure-reasoning turns need a non-empty inert message for
+                    # strict Responses-compatible validators.
+                    items.append({"role": "assistant", "content": " "})
                 continue
 
             # Non-assistant (user) role: emit multimodal parts when present,

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -270,6 +270,68 @@ _VALID_ITEM_ID = "msg_abc123"
 _OVERSIZED_CALL_ID = "codex_mcp__hermes-tools__web_search_exec-" + "0" * 43
 
 
+def test_chat_messages_to_responses_input_uses_tool_call_after_reasoning():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [
+                {
+                    "type": "reasoning",
+                    "id": "rs_1",
+                    "encrypted_content": "opaque-reasoning",
+                    "summary": [],
+                }
+            ],
+            "tool_calls": [
+                {
+                    "call_id": "call_1",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": '{"path":"README.md"}',
+                    },
+                }
+            ],
+        }
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    assert items == [
+        {
+            "type": "reasoning",
+            "encrypted_content": "opaque-reasoning",
+            "summary": [],
+        },
+        {
+            "type": "function_call",
+            "call_id": "call_1",
+            "name": "read_file",
+            "arguments": '{"path":"README.md"}',
+        },
+    ]
+
+
+def test_chat_messages_to_responses_input_uses_nonempty_pure_reasoning_follower():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [
+                {
+                    "type": "reasoning",
+                    "encrypted_content": "opaque-reasoning",
+                    "summary": [],
+                }
+            ],
+        }
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    assert items[-1] == {"role": "assistant", "content": " "}
+
+
 def test_chat_messages_to_responses_input_clamps_oversized_call_id():
     """An oversized call_id must be clamped to <=64 chars on BOTH the
     function_call and its matching function_call_output, to the same surrogate,


### PR DESCRIPTION
## What does this PR do?

Strict Responses-compatible endpoints no longer receive an empty assistant content item between replayed reasoning and a same-turn function call. Those endpoints reject that wire shape with HTTP 400, interrupting the agent turn after reasoning; the adapter now lets the valid function call satisfy the following-item requirement and reserves a non-empty inert follower for pure-reasoning turns.

### Symptom

After an assistant turn produces encrypted reasoning and a tool call, the next Codex Responses request can replay an assistant item with `content: ""`. Strict-compatible endpoints such as Volcengine Ark reject the request because the item has no accepted input content.

### Impact

Users of strict Codex Responses-compatible endpoints cannot continue affected tool-calling turns because the endpoint returns HTTP 400 before processing the valid function call.

### Bug Cause

**Trigger:** `agent/codex_responses_adapter.py` / `_chat_messages_to_responses_input()` / replayed reasoning with no visible assistant text

**Causal chain:**
1. A stored assistant turn contains encrypted reasoning, empty visible content, and a valid same-turn tool call.
2. The converter appends an empty assistant message immediately after the reasoning item before converting the tool call.
3. A strict-compatible endpoint rejects the empty content item, so the valid function call is never processed.

**Why it is wrong:** A valid following function call already satisfies the Responses ordering requirement, while an empty assistant content value is not accepted by stricter validators.

**Working sibling / contrast:** Assistant turns with visible text already emit non-empty content, and tool calls without replayed reasoning do not require a reasoning follower.

**Ruled out:** This is not a Desktop rendering issue; the invalid item is produced by the shared Codex Responses message converter before transport.

### Fix

Track whether replayed assistant content or a valid function call already follows the reasoning item. Emit no placeholder when either exists, and use a single-space inert assistant message only when a turn contains pure reasoning with no other valid follower. Focused regression tests cover both wire shapes.

## Related Issue

Closes #89761

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/codex_responses_adapter.py` - avoid empty reasoning followers and recognize valid function calls as following items.
- `tests/agent/test_codex_responses_adapter.py` - cover reasoning with a tool call and pure-reasoning fallback behavior.

## How to Test

1. Run the focused Codex Responses adapter test file:

```bash
scripts/run_tests.sh tests/agent/test_codex_responses_adapter.py
```

2. Confirm all 65 tests pass, including the two new wire-shape regressions.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant adapter tests and all 65 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A because this fixes internal request conversion behavior
- [x] `cli-config.yaml.example` updates are N/A because no configuration keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because no architecture or workflow changed
- [x] I've considered cross-platform impact; the converter behavior is platform-independent
- [x] Tool description and schema updates are N/A because no tool behavior changed
