### PR TITLE
fix(execute-code): expose documented helpers

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -18,6 +18,8 @@ import pytest
 import json
 import os
 import socket
+import subprocess
+import tempfile
 import time
 
 os.environ["TERMINAL_ENV"] = "local"
@@ -118,6 +120,65 @@ class TestHermesToolsGeneration(unittest.TestCase):
 
 
 class TestExecuteCodeRemoteTempDir(unittest.TestCase):
+    def test_generated_remote_module_injects_helpers_without_breaking_explicit_imports(self):
+        """Run the file-transport module and untouched user source for real."""
+        class LocalRemoteEnv:
+            def __init__(self, temp_dir):
+                self.temp_dir = temp_dir
+
+            def get_temp_dir(self):
+                return self.temp_dir
+
+            def execute(self, command, cwd=None, timeout=None):
+                completed = subprocess.run(
+                    command,
+                    cwd=cwd,
+                    shell=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                )
+                return {
+                    "output": completed.stdout + completed.stderr,
+                    "returncode": completed.returncode,
+                }
+
+        code = """from hermes_tools import json_parse as imported_json_parse
+attempts = 0
+
+def flaky():
+    global attempts
+    attempts += 1
+    if attempts == 1:
+        raise RuntimeError("retry me")
+    return "retried"
+
+assert imported_json_parse('{"explicit": true}')["explicit"] is True
+assert json_parse('{"direct": true}')["direct"] is True
+assert shell_quote("a b") == "'a b'"
+assert retry(flaky, max_attempts=2, delay=0) == "retried"
+assert "runpy" not in globals()
+assert "hermes_tools" not in globals()
+print("remote helpers ok", attempts)
+"""
+        with tempfile.TemporaryDirectory() as td:
+            env = LocalRemoteEnv(td)
+            fake_thread = MagicMock()
+            with patch(
+                "tools.code_execution_tool._load_config",
+                return_value={"timeout": 30, "max_tool_calls": 5},
+            ), patch(
+                "tools.code_execution_tool._get_or_create_env",
+                return_value=(env, "ssh"),
+            ), patch(
+                "tools.code_execution_tool.threading.Thread",
+                return_value=fake_thread,
+            ):
+                result = json.loads(_execute_remote(code, "task-remote-builtins", []))
+
+        self.assertEqual(result["status"], "success", msg=result)
+        self.assertIn("remote helpers ok 2", result["output"])
+
     def test_execute_remote_uses_backend_temp_dir_for_sandbox(self):
         class FakeEnv:
             def __init__(self):
@@ -130,7 +191,7 @@ class TestExecuteCodeRemoteTempDir(unittest.TestCase):
                 self.commands.append((command, cwd, timeout))
                 if "command -v python3" in command:
                     return {"output": "OK\n"}
-                if "python3 script.py" in command:
+                if "runpy.run_path" in command:
                     return {"output": "hello\n", "returncode": 0}
                 return {"output": ""}
 
@@ -148,7 +209,7 @@ class TestExecuteCodeRemoteTempDir(unittest.TestCase):
         self.assertFalse(result["stdout_truncated"])
         self.assertEqual(result["stdout_bytes_total"], len("hello\n".encode("utf-8")))
         mkdir_cmd = env.commands[1][0]
-        run_cmd = next(cmd for cmd, _, _ in env.commands if "python3 script.py" in cmd)
+        run_cmd = next(cmd for cmd, _, _ in env.commands if "runpy.run_path" in cmd)
         cleanup_cmd = env.commands[-1][0]
         self.assertIn("mkdir -p /data/data/com.termux/files/usr/tmp/hermes_exec_", mkdir_cmd)
         self.assertIn("HERMES_RPC_DIR=/data/data/com.termux/files/usr/tmp/hermes_exec_", run_cmd)
@@ -168,7 +229,7 @@ class TestExecuteCodeRemoteTempDir(unittest.TestCase):
                 self.commands.append((command, cwd, timeout))
                 if "command -v python3" in command:
                     return {"output": "OK\n"}
-                if "python3 script.py" in command:
+                if "runpy.run_path" in command:
                     return {"output": "hello\n", "returncode": 0}
                 return {"output": ""}
 
@@ -188,7 +249,7 @@ class TestExecuteCodeRemoteTempDir(unittest.TestCase):
             result = json.loads(_execute_remote("print('hello')", "task-1", ["terminal"]))
 
         self.assertEqual(result["status"], "success")
-        run_cmd = next(cmd for cmd, _, _ in env.commands if "python3 script.py" in cmd)
+        run_cmd = next(cmd for cmd, _, _ in env.commands if "runpy.run_path" in cmd)
         # The TZ value must be shell-quoted — it should NOT contain unescaped semicolons
         self.assertNotIn("TZ=US/Eastern; echo PWNED", run_cmd,
                          "TZ value with shell metacharacters must not appear unquoted")
@@ -322,6 +383,34 @@ raise RuntimeError("deliberate crash")
         self.assertIn("before error", result["output"])
         self.assertIn("RuntimeError", result.get("error", "") + result.get("output", ""))
 
+
+    def test_helpers_are_available_without_import_alongside_explicit_tool_import(self):
+        """Documented helpers live in user globals; tools remain importable."""
+        code = """import sys
+from hermes_tools import terminal
+attempts = 0
+
+def flaky():
+    global attempts
+    attempts += 1
+    if attempts == 1:
+        raise RuntimeError("retry me")
+    return "retried"
+
+parsed = json_parse('\\ufeff{"value": "ok"}')
+quoted = shell_quote("a b")
+result = retry(flaky, max_attempts=2, delay=0)
+assert len(sys.argv) == 1, sys.argv
+assert "runpy" not in globals()
+assert "hermes_tools" not in globals()
+tool_result = terminal("echo explicit-import")
+print(parsed["value"], quoted, result, attempts)
+print(tool_result["output"])
+"""
+        result = self._run(code)
+        self.assertEqual(result["status"], "success", msg=result)
+        self.assertIn("ok 'a b' retried 2", result["output"])
+        self.assertIn("mock output for: echo explicit-import", result["output"])
 
     def test_shell_quote_helper(self):
         """shell_quote properly escapes dangerous characters."""
@@ -741,7 +830,7 @@ class TestHeadTailTruncation(unittest.TestCase):
                 self.commands.append((command, cwd, timeout))
                 if "command -v python3" in command:
                     return {"output": "OK\n"}
-                if "python3 script.py" in command:
+                if "runpy.run_path" in command:
                     return {"output": "HEAD\n" + ("x" * 80_000) + "\nTAIL\n", "returncode": 0}
                 return {"output": ""}
 

--- a/tests/tools/test_code_execution_modes.py
+++ b/tests/tools/test_code_execution_modes.py
@@ -534,8 +534,8 @@ class TestPythonPathComposition(unittest.TestCase):
         def _fake_popen(cmd, **kwargs):
             env = kwargs.get("env") or {}
             captured["PYTHONPATH"] = env.get("PYTHONPATH", "")
-            # cmd is [python, <staging_dir>/script.py]
-            captured["staging_dir"] = os.path.dirname(cmd[1])
+            # The untouched user script remains the final runner argument.
+            captured["staging_dir"] = os.path.dirname(cmd[-1])
             mock_proc = unittest.mock.MagicMock()
             mock_proc.stdout.read.return_value = b""
             mock_proc.stderr.read.return_value = b""

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -699,7 +699,7 @@ class TestPythonpathSelectiveStrip:
 
         def _fake_popen(cmd, **kwargs):
             captured["env"] = kwargs.get("env", {})
-            captured["staging"] = os.path.dirname(cmd[1])
+            captured["staging"] = os.path.dirname(cmd[-1])
             proc = MagicMock()
             proc.stdout.read.return_value = b""
             proc.stderr.read.return_value = b""

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -506,6 +506,29 @@ def retry(fn, max_attempts=3, delay=2):
 
 '''
 
+# Execute the user's untouched source with only the three documented helpers
+# added to its module globals.  ``runpy`` compiles script.py directly, so
+# traceback line numbers continue to match the source the user submitted.
+# Keeping this bootstrap outside script.py also avoids exposing its imports in
+# user globals; explicit ``from hermes_tools import ...`` imports still work.
+_USER_SCRIPT_RUNNER = (
+    "import runpy,sys;"
+    "from hermes_tools import json_parse,shell_quote,retry;"
+    "path=sys.argv.pop(1);sys.argv[0]=path;"
+    "runpy.run_path(path,run_name='__main__',init_globals={"
+    "'json_parse':json_parse,'shell_quote':shell_quote,'retry':retry})"
+)
+
+
+def _user_script_argv(python: str, script_path: str) -> List[str]:
+    """Build an argv that executes user source with documented helper globals."""
+    return [python, "-c", _USER_SCRIPT_RUNNER, script_path]
+
+
+def _user_script_shell_command(python: str, script_path: str) -> str:
+    """Build the remote shell form of :func:`_user_script_argv`."""
+    return " ".join(shlex.quote(arg) for arg in _user_script_argv(python, script_path))
+
 # ---- UDS transport (local backend) ---------------------------------------
 
 _UDS_TRANSPORT_HEADER = '''\
@@ -1156,7 +1179,8 @@ def _execute_remote(
         logger.info("Executing code on %s backend (task %s)...",
                      env_type, effective_task_id[:8])
         script_result = env.execute(
-            f"cd {quoted_sandbox_dir} && {env_prefix} python3 script.py",
+            f"cd {quoted_sandbox_dir} && {env_prefix} "
+            f"{_user_script_shell_command('python3', 'script.py')}",
             timeout=timeout,
         )
 
@@ -1512,7 +1536,7 @@ def execute_code(
         child_env["PYTHONPATH"] = os.pathsep.join(_pp_parts)
 
         proc = subprocess.Popen(
-            [_child_python, _script_path],
+            _user_script_argv(_child_python, _script_path),
             cwd=_child_cwd,
             env=child_env,
             stdout=subprocess.PIPE,


### PR DESCRIPTION
## Summary
- inject the documented `json_parse`, `shell_quote`, and `retry` helpers into user-script globals
- cover both local UDS/TCP and remote generated-module execution
- preserve explicit `hermes_tools` imports, source tracebacks, argv behavior, and environment blocklists

## Verification
- `uv run pytest -q tests/tools/test_code_execution.py tests/tools/test_code_execution_modes.py tests/tools/test_local_env_blocklist.py` — 200 passed, 5 skipped
- Ruff, py_compile, and diff checks passed
- `ty` retains 13 pre-existing diagnostics outside the changed code

Fixes local papercut `cut_20260819T045243_e3b1ca26`.