### PR TITLE
fix(model): memoize _load_model_overrides on config file signature

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -880,22 +880,49 @@ class ModelCapabilities:
 
 _OVERRIDE_WARNED_KEYS: set = set()
 
+# Memo for :func:`_load_model_overrides`, keyed on the config file's identity
+# (path, mtime_ns, size). The /model picker calls this once per provider row
+# (~4k rows); the upstream (mtime, size) cache in ``load_config_readonly()``
+# still pays a stat + lock + signature build per call, and an ``id(cfg)``-keyed
+# layer can serve stale overrides when CPython reuses a freed dict's address.
+# A file-signature key is immune to both. _MISSING distinguishes "not loaded
+# yet" from a legitimate empty ``{}`` result.
+_OVERRIDES_MEMO_MISSING = object()
+_OVERRIDES_MEMO: Dict[str, Any] = {"sig": None, "val": _OVERRIDES_MEMO_MISSING}
+
 
 def _load_model_overrides() -> Dict[str, Any]:
     """Load the ``model_overrides`` config section.
 
-    No local memoization on purpose: ``load_config_readonly()`` is already
-    (mtime, size)-cached upstream (a hit is ~one stat, no deepcopy, no
-    parse), and an ``id(cfg)``-keyed layer here can serve stale overrides
-    after a config reload when CPython reuses the freed dict's address.
-    Returns empty dict on any failure.
+    Memoized on the config file's (path, mtime, size) signature: a change to
+    the file bumps the signature and forces one reload, so edits are picked up
+    on the next call while the ~4k repeated reads in a single model-picker
+    build cost one stat each instead of a full upstream cache hit. Returns
+    empty dict on any failure.
     """
+    from hermes_cli.config import cfg_get, get_config_path, load_config_readonly
+
+    path = get_config_path()
     try:
-        from hermes_cli.config import cfg_get, load_config_readonly
+        st = path.stat()
+        sig: Optional[Tuple[Any, ...]] = (str(path), st.st_mtime_ns, st.st_size)
+    except FileNotFoundError:
+        sig = (str(path),)
+    except OSError:
+        sig = None  # unreadable: fall through to the live load each time
+
+    if sig is not None and sig == _OVERRIDES_MEMO["sig"] and _OVERRIDES_MEMO["val"] is not _OVERRIDES_MEMO_MISSING:
+        return _OVERRIDES_MEMO["val"]
+
+    try:
         raw = cfg_get(load_config_readonly(), "model_overrides", default={})
-        return raw if isinstance(raw, dict) else {}
+        result = raw if isinstance(raw, dict) else {}
     except Exception:
-        return {}
+        result = {}
+    if sig is not None:
+        _OVERRIDES_MEMO["sig"] = sig
+        _OVERRIDES_MEMO["val"] = result
+    return result
 
 
 def _provider_override_section(provider: str) -> Optional[Dict[str, Any]]:

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -1244,6 +1244,66 @@ class TestModelOverrides:
             ctx = lookup_models_dev_context("upstage", "solar-pro4")
         assert ctx == 524288
 
+    # --- memoization (file-signature keyed) ---
+
+    @staticmethod
+    def _reset_overrides_memo():
+        """Clear the _load_model_overrides memo between tests so the module-level
+        cache never leaks one profile's config into another test's."""
+        import agent.models_dev as md
+
+        md._OVERRIDES_MEMO["sig"] = None
+        md._OVERRIDES_MEMO["val"] = md._OVERRIDES_MEMO_MISSING
+
+    @pytest.fixture(autouse=True)
+    def _reset_overrides_memo_fixture(self):
+        self._reset_overrides_memo()
+        yield
+        self._reset_overrides_memo()
+
+    def test_memo_reuses_result_until_config_file_changes(self, tmp_path, monkeypatch):
+        """Repeated reads cost one stat each (no upstream cache-hit plumbing),
+        and a change to config.yaml invalidates the memo on the next call."""
+        import agent.models_dev as md
+        import hermes_cli.config as hc
+
+        home = tmp_path / "hermes"
+        home.mkdir()
+        cfg = home / "config.yaml"
+        cfg.write_text(
+            "model_overrides:\n"
+            "  upstage:\n"
+            "    solar-pro4:\n"
+            "      context_window: 524288\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        hc_cache = getattr(hc, "_LOAD_CONFIG_CACHE", None)
+        if isinstance(hc_cache, dict):
+            hc_cache.clear()
+
+        first = md._load_model_overrides()
+        assert first["upstage"]["solar-pro4"]["context_window"] == 524288
+
+        # A second read must be a memo hit: same value, and the upstream
+        # load_config_readonly must NOT be called again.
+        with patch.object(hc, "load_config_readonly", wraps=hc.load_config_readonly) as spy:
+            second = md._load_model_overrides()
+        assert second == first
+        assert spy.call_count == 0, "memo hit must not re-load config"
+
+        # Rewrite the file: the signature changes, so the next call reloads.
+        time.sleep(0.01)  # guarantee an mtime change
+        cfg.write_text(
+            "model_overrides:\n"
+            "  upstage:\n"
+            "    solar-pro4:\n"
+            "      context_window: 999999\n",
+            encoding="utf-8",
+        )
+        third = md._load_model_overrides()
+        assert third["upstage"]["solar-pro4"]["context_window"] == 999999
+
     def test_suffix_keyed_model_counts_as_catalog_hit(self):
         """A suffix-keyed catalog model (kimi-k2.6:cloud) is KNOWN: a
         _default must not displace its capabilities."""


### PR DESCRIPTION
## What

Memoize `_load_model_overrides()` on the config file's `(path, mtime_ns, size)`
signature.

## Why

The `/model` picker builds ~4,000 provider rows; each row calls
`_load_model_overrides() -> load_config_readonly()`. That function is already
`(mtime, size)`-cached upstream, but a cache **hit** still acquires the config
lock, stats the file, and rebuilds the cache signature. Across one warm
model-picker build that is ~4,100 redundant config reads — **~76ms, ~47% of the
build's CPU** — re-reading the same immutable `model_overrides` section that
cannot change mid-build.

The old comment declined local memoization because an `id(cfg)`-keyed layer can
serve stale overrides when CPython reuses a freed dict's address. Keying on the
config file's on-disk signature (path + mtime_ns + size) is immune to that: any
edit bumps the signature and forces exactly one reload, so overrides edits are
still picked up on the next call.

## How it works

- Hit path: one `stat` + tuple compare (no lock, no upstream call).
- Miss / file changed / file absent: one real load, then memo.
- Unreadable file: falls through to a live load each time (no caching of a
  possibly-transient state).

## Measured

Warm model-picker build (backend-equivalent env, `.env` loaded):
- before: **160ms**
- after: **112ms**

This change removes the 76ms re-read. The remaining ~33ms is residual per-row
capability work, out of scope for this focused change.

## How to test

`python -m pytest tests/agent/test_models_dev.py` — includes a new
`test_memo_reuses_result_until_config_file_changes` that asserts:
1. a memo hit returns the same value **without** calling `load_config_readonly`
   again,
2. rewriting `config.yaml` invalidates the memo and the next call returns the
   new value,
3. the module-level memo is reset per test so profiles don't leak across tests.

## Platforms tested

Linux (Fedora, Python 3.11). Pure-stdlib file `stat` + in-memory dict — no
platform-specific behavior, no new I/O, no signal/process handling.