### PR TITLE
fix(cli): kickstart launchd-supervised dashboards on update instead of respawning

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -321,6 +321,15 @@ def _kill_stale_dashboard_processes(
     restarted after the kill, because systemd treats our SIGTERM as a clean
     stop and ``Restart=on-failure`` would never fire (#68934).
 
+    macOS mirrors that for launchd: a killed PID owned by a launchd job (a
+    user LaunchAgent plist running ``hermes dashboard``) is brought back with
+    ``launchctl kickstart`` and is never respawned by argv.  Respawning it
+    used to race the job's own ``KeepAlive`` restart for the listen port; the
+    loser then crash-looped every ``ThrottleInterval`` seconds, and because
+    the dashboard runs MCP discovery before binding, each attempt opened a
+    fresh session on every configured MCP server (rate-limiting them for
+    every client on the host).
+
     *already_restarted_units* names units (no ``.service`` suffix) the
     caller already restarted directly — e.g. ``hermes update``'s systemd
     fleet-restart loop, which restarts ``hermes-serve*`` units before this
@@ -363,14 +372,21 @@ def _kill_stale_dashboard_processes(
     # stay a stop, not a restart.
     pid_cgroup: dict[int, str | None] = {}
     pid_service: dict[int, str | None] = {}
+    pid_launchd: dict[int, tuple[str, str] | None] = {}
     pid_cmdline: dict[int, list[str]] = {}
     pid_home: dict[int, str | None] = {}
+    if sys.platform != "win32":
+        # launchd ownership is cheap to detect (no-op off macOS) and matters
+        # on BOTH paths: update needs it to kickstart instead of respawn, and
+        # --stop needs it to warn that KeepAlive will undo a raw kill.
+        for pid in pids:
+            pid_launchd[pid] = _m()._get_launchd_service_for_pid(pid)
     if restart_managed and sys.platform != "win32":
         for pid in pids:
             cg_path = _m()._get_pid_cgroup_path(pid)
             pid_cgroup[pid] = cg_path
             pid_service[pid] = _m()._get_systemd_service_for_pid(pid)
-            if not pid_service[pid]:
+            if not pid_service[pid] and not pid_launchd.get(pid):
                 # Manually-started process: preserve its exact argv so we
                 # can respawn it after the update (#40449, #68934).
                 # Snapshot HERMES_HOME before the kill so per-profile caps
@@ -471,6 +487,7 @@ def _kill_stale_dashboard_processes(
     #    Filtered so Desktop ``serve|dashboard --port 0`` backends are not
     #    resurrected and duplicates collapse to one per profile (#78821).
     restarted_services: list[str] = []
+    restarted_launchd: list[str] = []
     unrecovered: list[int] = []
     if killed and restart_managed:
         failed_restarts: list[tuple[str, str]] = []
@@ -478,6 +495,7 @@ def _kill_stale_dashboard_processes(
         respawn_candidates: list[tuple[int, list[str], str | None]] = []
         for pid in killed:
             svc_name = pid_service.get(pid)
+            launchd_job = pid_launchd.get(pid)
             if svc_name:
                 if svc_name in seen_services:
                     continue
@@ -486,6 +504,19 @@ def _kill_stale_dashboard_processes(
                     restarted_services.append(svc_name)
                 else:
                     failed_restarts.append((svc_name, "systemctl restart returned non-zero"))
+                    unrecovered.append(pid)
+            elif launchd_job:
+                domain, label = launchd_job
+                target = f"{domain}/{label}"
+                if target in seen_services:
+                    continue
+                seen_services.add(target)
+                if _m()._try_restart_launchd_service(domain, label):
+                    restarted_launchd.append(target)
+                else:
+                    failed_restarts.append(
+                        (target, "launchctl kickstart returned non-zero")
+                    )
                     unrecovered.append(pid)
             elif pid in pid_cmdline:
                 respawn_candidates.append(
@@ -496,6 +527,8 @@ def _kill_stale_dashboard_processes(
 
         for svc in restarted_services:
             print(f"    ✓ restarted systemd service {svc}")
+        for target in restarted_launchd:
+            print(f"    ✓ restarted launchd job {target}")
         for svc, err in failed_restarts:
             print(f"    ⚠ {svc}: {err}")
 
@@ -510,6 +543,14 @@ def _kill_stale_dashboard_processes(
             print("    hermes dashboard --port <port>")
     elif killed:
         unrecovered = list(killed)
+        launchd_targets: set[str] = set()
+        for pid in killed:
+            job = pid_launchd.get(pid)
+            if job:
+                launchd_targets.add(f"{job[0]}/{job[1]}")
+        for target in sorted(launchd_targets):
+            print(f"  ⚠ PID(s) supervised by launchd job {target} — a KeepAlive job")
+            print(f"    will restart itself. To keep it down: launchctl bootout {target}")
         print("  Restart the dashboard when you're ready:")
         print("    hermes dashboard --port <port>")
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8340,6 +8340,157 @@ def _try_restart_systemd_service(svc_name: str, cgroup_path: str | None = None) 
         return False
 
 
+def _launchd_pid_label_map() -> dict[int, str]:
+    """Map ``pid -> label`` for every running job ``launchctl list`` reports.
+
+    ``launchctl list`` (no label) prints ``PID<TAB>Status<TAB>Label`` for the
+    caller's launchd domain (``gui/<uid>`` in an Aqua session, ``user/<uid>``
+    over SSH).  Jobs that are loaded but not currently running show ``-`` in
+    the PID column and are skipped.  Returns an empty dict on any failure or
+    off-macOS.
+    """
+    if sys.platform != "darwin":
+        return {}
+    try:
+        result = subprocess.run(
+            ["launchctl", "list"],
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return {}
+    if result.returncode != 0:
+        return {}
+    mapping: dict[int, str] = {}
+    for line in (result.stdout or "").splitlines():
+        parts = line.strip().split(None, 2)
+        if len(parts) != 3:
+            continue
+        pid_str, _status, label = parts
+        try:
+            pid = int(pid_str)
+        except ValueError:
+            # Header row ("PID") or a loaded-but-idle job ("-").
+            continue
+        if pid > 0 and label:
+            mapping[pid] = label
+    return mapping
+
+
+def _launchd_parent_pid(pid: int) -> int | None:
+    """Return *pid*'s parent PID via ``ps`` (macOS has no ``/proc``)."""
+    try:
+        result = subprocess.run(
+            ["ps", "-o", "ppid=", "-p", str(pid)],
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        return int((result.stdout or "").strip())
+    except ValueError:
+        return None
+
+
+_LAUNCHD_SUPERVISED_JOB_TYPES = frozenset({"LaunchAgent", "LaunchDaemon"})
+
+
+def _launchd_job_type(domain: str, label: str) -> str | None:
+    """Return the ``type = …`` reported by ``launchctl print domain/label``.
+
+    ``LaunchAgent`` / ``LaunchDaemon`` are plist-backed jobs that launchd
+    supervises (``KeepAlive`` restarts).  GUI apps show up as ``Submitted``
+    (``path = (submitted by runningboardd)``) — every process started from a
+    Terminal/VS Code/Hermes.app window has one of those as an ancestor, so
+    the type is what separates "supervised dashboard" from "dashboard started
+    by hand from an app's terminal".  Returns ``None`` when the job is not
+    loaded in *domain* or the output has no type line.
+    """
+    try:
+        result = subprocess.run(
+            ["launchctl", "print", f"{domain}/{label}"],
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    for line in (result.stdout or "").splitlines():
+        key, sep, value = line.strip().partition("=")
+        if sep and key.strip() == "type":
+            return value.strip() or None
+    return None
+
+
+def _get_launchd_service_for_pid(pid: int) -> tuple[str, str] | None:
+    """If *pid* is supervised by a launchd job, return ``(domain, label)``.
+
+    macOS analog of :func:`_get_systemd_service_for_pid`.  Checks *pid* and
+    then its ancestors (a plist may wrap the dashboard in ``/bin/sh -c``
+    without ``exec``) against the jobs ``launchctl list`` reports as running,
+    stopping at PID 1.  The first matching label is then looked up with
+    ``launchctl print`` in ``gui/<uid>`` and ``user/<uid>``; only a
+    ``LaunchAgent``/``LaunchDaemon`` job counts as supervised — a
+    ``Submitted`` application job (Terminal.app, VS Code, Hermes.app…) means
+    the dashboard was merely started from inside that app, and ``None`` is
+    returned so the caller keeps the manual kill+respawn path.
+    """
+    if sys.platform != "darwin":
+        return None
+    label_by_pid = _launchd_pid_label_map()
+    if not label_by_pid:
+        return None
+
+    label: str | None = None
+    current: int | None = pid
+    for _ in range(8):
+        if current is None or current <= 1:
+            break
+        label = label_by_pid.get(current)
+        if label:
+            break
+        current = _launchd_parent_pid(current)
+    if not label:
+        return None
+
+    uid = os.getuid()  # windows-footgun: ok — darwin-only helper (guarded above)
+    for domain in (f"gui/{uid}", f"user/{uid}"):
+        job_type = _launchd_job_type(domain, label)
+        if job_type is None:
+            continue
+        if job_type in _LAUNCHD_SUPERVISED_JOB_TYPES:
+            return domain, label
+        return None
+    return None
+
+
+def _try_restart_launchd_service(domain: str, label: str) -> bool:
+    """Restart the launchd job ``domain/label`` via ``launchctl kickstart``.
+
+    Called after the job's process has already been SIGTERM'd, so no ``-k``:
+    if ``KeepAlive`` already relaunched the job this is a no-op, otherwise it
+    starts it now (bypassing ``ThrottleInterval``).  Returns ``True`` when
+    launchctl exits 0.
+    """
+    try:
+        r = subprocess.run(
+            ["launchctl", "kickstart", f"{domain}/{label}"],
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+            timeout=30,
+        )
+        return r.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return False
+
+
 def _dashboard_cmdline_for_pid(pid: int) -> list[str] | None:
     """Return the exact argv of a running process, when recoverable.
 

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -21,6 +21,8 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
+_real_get_launchd_service_for_pid = None  # set by the autouse fixture below
+
 from hermes_cli.main import (
     _finish_dashboard_update_cleanup,
     _find_stale_dashboard_pids,
@@ -63,7 +65,14 @@ def _refresh_bindings_against_live_module():
     _kill_stale_dashboard_processes = live._kill_stale_dashboard_processes
     _restart_managed_dashboard_service = live._restart_managed_dashboard_service
     _warn_stale_dashboard_processes = live._warn_stale_dashboard_processes
-    yield
+    # Launchd ownership is probed for every candidate PID on POSIX; stub it
+    # to "not supervised" so tests with fake PIDs never shell out to
+    # launchctl on macOS runners.  Launchd-path tests re-patch it locally;
+    # the parser tests reach the real function via _real_get_launchd_service_for_pid.
+    global _real_get_launchd_service_for_pid
+    _real_get_launchd_service_for_pid = live._get_launchd_service_for_pid
+    with patch.object(live, "_get_launchd_service_for_pid", return_value=None):
+        yield
 
 
 def _ps_line(pid: int, cmd: str) -> str:
@@ -361,6 +370,178 @@ class TestSupervisedBackendRestart:
         kill.assert_not_called()
         restart.assert_not_called()
         assert result == {"matched": [], "killed": [], "failed": []}
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX kill + launchd kickstart")
+class TestLaunchdSupervisedBackendRestart:
+    """macOS analog of the systemd path: a dashboard owned by a LaunchAgent
+    plist is kickstarted after the kill and never respawned by argv.
+    Respawning it raced the job's KeepAlive restart for the port; the loser
+    crash-looped every ThrottleInterval and, because the dashboard runs MCP
+    discovery before binding, hammered every configured MCP server."""
+
+    def _live(self):
+        return sys.modules["hermes_cli.main"]
+
+    def test_launchd_pid_is_kickstarted_not_respawned(self, capsys):
+        live = self._live()
+        argv = ["hermes", "dashboard", "--host", "0.0.0.0", "--port", "9119"]
+
+        def fake_kill(pid, sig):
+            if sig == 0:
+                raise ProcessLookupError
+
+        with patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[9001]), \
+             patch.object(live, "_get_pid_cgroup_path", return_value=None), \
+             patch.object(live, "_get_systemd_service_for_pid", return_value=None), \
+             patch.object(live, "_get_launchd_service_for_pid",
+                          return_value=("gui/501", "com.example.hermes-dashboard")), \
+             patch.object(live, "_try_restart_launchd_service", return_value=True) as kick, \
+             patch.object(live, "_dashboard_cmdline_for_pid", return_value=argv) as argv_probe, \
+             patch.object(live, "_respawn_dashboard_processes") as respawn, \
+             patch("os.kill", side_effect=fake_kill), \
+             patch("time.sleep"):
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        kick.assert_called_once_with("gui/501", "com.example.hermes-dashboard")
+        respawn.assert_not_called()
+        # argv is only snapshotted for manual (unsupervised) processes.
+        argv_probe.assert_not_called()
+        assert result["killed"] == [9001]
+        assert result["unrecovered"] == []
+        out = capsys.readouterr().out
+        assert "✓ restarted launchd job gui/501/com.example.hermes-dashboard" in out
+        assert "when you're ready" not in out
+
+    def test_two_pids_of_one_job_kickstart_once(self):
+        """A shell-wrapped plist (sh -c … hermes dashboard) matches two PIDs
+        (the shell and the python child); the job is restarted once."""
+        live = self._live()
+
+        def fake_kill(pid, sig):
+            if sig == 0:
+                raise ProcessLookupError
+
+        with patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[9001, 9002]), \
+             patch.object(live, "_get_pid_cgroup_path", return_value=None), \
+             patch.object(live, "_get_systemd_service_for_pid", return_value=None), \
+             patch.object(live, "_get_launchd_service_for_pid",
+                          return_value=("gui/501", "com.example.hermes-dashboard")), \
+             patch.object(live, "_try_restart_launchd_service", return_value=True) as kick, \
+             patch.object(live, "_respawn_dashboard_processes") as respawn, \
+             patch("os.kill", side_effect=fake_kill), \
+             patch("time.sleep"):
+            _kill_stale_dashboard_processes(restart_managed=True)
+
+        assert kick.call_count == 1
+        respawn.assert_not_called()
+
+    def test_kickstart_failure_reports_and_leaves_hint(self, capsys):
+        live = self._live()
+
+        def fake_kill(pid, sig):
+            if sig == 0:
+                raise ProcessLookupError
+
+        with patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[9001]), \
+             patch.object(live, "_get_pid_cgroup_path", return_value=None), \
+             patch.object(live, "_get_systemd_service_for_pid", return_value=None), \
+             patch.object(live, "_get_launchd_service_for_pid",
+                          return_value=("gui/501", "com.example.hermes-dashboard")), \
+             patch.object(live, "_try_restart_launchd_service", return_value=False), \
+             patch.object(live, "_respawn_dashboard_processes") as respawn, \
+             patch("os.kill", side_effect=fake_kill), \
+             patch("time.sleep"):
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        # Even on failure we must not spawn a duplicate that races KeepAlive.
+        respawn.assert_not_called()
+        assert result["unrecovered"] == [9001]
+        out = capsys.readouterr().out
+        assert "launchctl kickstart returned non-zero" in out
+        assert "Restart anything not auto-restarted" in out
+
+    def test_stop_path_warns_that_keepalive_will_undo_the_kill(self, capsys):
+        """`hermes dashboard --stop` still stops (no restart), but tells the
+        user the job will come back and how to keep it down."""
+        live = self._live()
+
+        def fake_kill(pid, sig):
+            if sig == 0:
+                raise ProcessLookupError
+
+        with patch.object(live, "_find_stale_dashboard_pids", return_value=[9001]), \
+             patch.object(live, "_get_launchd_service_for_pid",
+                          return_value=("gui/501", "com.example.hermes-dashboard")), \
+             patch.object(live, "_try_restart_launchd_service") as kick, \
+             patch("os.kill", side_effect=fake_kill), \
+             patch("time.sleep"):
+            _kill_stale_dashboard_processes(reason="--stop", restart_managed=False)
+
+        kick.assert_not_called()
+        out = capsys.readouterr().out
+        assert "launchctl bootout gui/501/com.example.hermes-dashboard" in out
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="launchctl parsing is macOS-only")
+class TestGetLaunchdServiceForPid:
+    """Unit tests for the launchctl-backed owner lookup (all subprocess calls stubbed)."""
+
+    LIST_OUT = (
+        "PID\tStatus\tLabel\n"
+        "-\t0\tcom.apple.SafariHistoryServiceAgent\n"
+        "4242\t0\tcom.example.hermes-dashboard\n"
+        "777\t0\tapplication.com.microsoft.VSCode.1.2\n"
+    )
+
+    def _runner(self, *, ppid_of: dict[int, int], print_types: dict[str, str]):
+        def _side_effect(args, *a, **kw):
+            if args[:2] == ["launchctl", "list"]:
+                return MagicMock(returncode=0, stdout=self.LIST_OUT, stderr="")
+            if args[:2] == ["launchctl", "print"]:
+                target = args[2]
+                if target in print_types:
+                    return MagicMock(returncode=0, stdout=f"\tpath = x\n\ttype = {print_types[target]}\n")
+                return MagicMock(returncode=113, stdout="", stderr="Could not find service")
+            if args[:1] == ["ps"]:
+                pid = int(args[-1])
+                if pid in ppid_of:
+                    return MagicMock(returncode=0, stdout=f"{ppid_of[pid]}\n")
+                return MagicMock(returncode=1, stdout="", stderr="")
+            raise AssertionError(f"unexpected subprocess: {args}")
+        return _side_effect
+
+    def test_direct_launchagent_pid(self):
+        with patch("subprocess.run", side_effect=self._runner(
+                ppid_of={}, print_types={"gui/%d/com.example.hermes-dashboard" % os.getuid(): "LaunchAgent"})):
+            assert _real_get_launchd_service_for_pid(4242) == (
+                f"gui/{os.getuid()}", "com.example.hermes-dashboard"
+            )
+
+    def test_child_of_launchagent_shell_wrapper(self):
+        """/bin/sh -c '… hermes dashboard' without exec: python child, shell = job PID."""
+        with patch("subprocess.run", side_effect=self._runner(
+                ppid_of={5000: 4242}, print_types={"user/%d/com.example.hermes-dashboard" % os.getuid(): "LaunchAgent"})):
+            assert _real_get_launchd_service_for_pid(5000) == (
+                f"user/{os.getuid()}", "com.example.hermes-dashboard"
+            )
+
+    def test_process_started_from_an_app_terminal_is_not_supervised(self):
+        """Ancestor chain reaches VS Code's `Submitted` app job → not a plist job → None."""
+        with patch("subprocess.run", side_effect=self._runner(
+                ppid_of={6000: 6001, 6001: 777}, print_types={"gui/%d/application.com.microsoft.VSCode.1.2" % os.getuid(): "Submitted"})):
+            assert _real_get_launchd_service_for_pid(6000) is None
+
+    def test_unknown_pid_returns_none(self):
+        with patch("subprocess.run", side_effect=self._runner(ppid_of={8000: 1}, print_types={})):
+            assert _real_get_launchd_service_for_pid(8000) is None
+
+    def test_launchctl_missing_returns_none(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            assert _real_get_launchd_service_for_pid(4242) is None
 
 
 class TestManualBackendRespawn:


### PR DESCRIPTION
## What

`hermes update` (and the Desktop update handoff that runs it) kills every running `hermes dashboard` / `hermes serve` and respawns the ones it can't attribute to a systemd unit from their captured argv (#40449). On macOS a dashboard supervised by a user **LaunchAgent plist** (`KeepAlive`) is invisible to that check, so update SIGTERMs launchd's child *and* spawns a manual, detached duplicate with the same `--port`.

launchd's KeepAlive relaunch then races the duplicate for the port. Whichever loses crash-loops every `ThrottleInterval` seconds forever. On my machine: `runs = 10974`, ~45 h of `[Errno 48] error while attempting to bind on address ('0.0.0.0', 9119)` every 15 s — and because the dashboard starts MCP discovery before it binds, every attempt opened a fresh MCP session on every configured server, which got a shared `n8n-mcp` container rate-limited (429) for every other client on the host.

This PR mirrors the existing systemd handling (#68934) for launchd:

- **`_get_launchd_service_for_pid(pid)`** (darwin-only, in `hermes_cli/main.py` next to the systemd helpers): maps the PID — or an ancestor, for `sh -c … hermes dashboard` wrapper plists — to a label via `launchctl list`, then confirms with `launchctl print gui|user/<uid>/<label>` that the job's `type` is `LaunchAgent`/`LaunchDaemon`. `Submitted` application jobs (Terminal.app, VS Code, Hermes.app — every process started from an app window has one as an ancestor) return `None`, so hand-started dashboards keep today's respawn path.
- **`_try_restart_launchd_service(domain, label)`**: `launchctl kickstart domain/label` after the SIGTERM (no-op if KeepAlive already relaunched it, otherwise starts it now).
- **`_kill_stale_dashboard_processes`**: launchd-owned PIDs are never argv-respawned. Update path → kickstart (deduped per job). `--stop` path → still a plain stop, plus a hint that a KeepAlive job will come back and the `launchctl bootout` to keep it down.

Related: #44143 (Desktop update starts an extra dashboard next to a launchd-managed one — this is the update-side half of that), #44106 (first-class LaunchAgent lifecycle for the dashboard; this makes update safe for the hand-written plists people use today).

## How to test

Repro (macOS):
1. `~/Library/LaunchAgents/com.example.hermes-dashboard.plist` running `hermes dashboard --no-open --skip-build --host 0.0.0.0 --port 9119` with `KeepAlive` true, `ThrottleInterval` 15; `launchctl bootstrap gui/$(id -u) …`.
2. `hermes update` (or from a venv python: `from hermes_cli import main as m; m._kill_stale_dashboard_processes(restart_managed=True)`).
3. Before: `✓ restarted: … hermes dashboard … --port 9119` (a detached duplicate) and then `launchctl print gui/$(id -u)/com.example.hermes-dashboard` shows `runs` climbing every 15 s with `dashboard.launchd.err` full of `Errno 48`.
   After: `✓ restarted launchd job gui/501/com.example.hermes-dashboard`, `lsof -nP -iTCP:9119 -sTCP:LISTEN` shows exactly one listener (launchd's), `runs` stays put.

Tests: `pytest tests/hermes_cli/test_update_stale_dashboard.py` — new `TestLaunchdSupervisedBackendRestart` (kickstart / no respawn / dedupe per job / kickstart failure → hint, no duplicate / `--stop` hint) and `TestGetLaunchdServiceForPid` (stubbed `launchctl`/`ps`: direct job PID, shell-wrapped child, app-terminal ancestor → None, unknown PID, missing launchctl). Existing tests stub launchd detection to `None` in the autouse fixture so macOS runners never shell out for fake PIDs.

## Platforms

Tested on macOS 26 (Darwin 25.5). Linux/Windows: helpers are `sys.platform == "darwin"` guarded and return `None` immediately, so the existing systemd / taskkill paths are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
