### PR TITLE
fix(memory): flush Hindsight's buffered turns when a session ends

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -2245,6 +2245,162 @@ class HindsightMemoryProvider(MemoryProvider):
 
         return tool_error(f"Unknown tool: {tool_name}")
 
+    def _flush_buffered_turns(self, *, reason: str, respect_watermark: bool) -> bool:
+        """Enqueue whatever is sitting in ``_session_turns`` and clear it.
+
+        With ``retain_every_n_turns > 1`` turns accumulate in RAM and are only
+        persisted at every Nth-turn boundary. Anything buffered past the last
+        boundary lives nowhere else, so every lifecycle path that can end a
+        session has to drain it or the turns are lost outright (#88944).
+
+        Clearing the buffer here is what makes the hook safe to call from more
+        than one place. ``MemoryManager.commit_session_boundary_async`` delivers
+        ``on_session_end`` strictly BEFORE ``on_session_switch``; without the
+        clear, the switch would re-flush the same turns and double-ingest them
+        into the bank — the exact hazard that method's docstring warns about.
+        A second call finds an empty buffer and no-ops.
+
+        Snapshots every ``self._*`` field the retain depends on before the
+        caller mutates them, so metadata, tags, and ``document_id`` all
+        describe the session the turns actually came from.
+
+        ``respect_watermark`` selects how much of the buffer to ship, mirroring
+        the branch in ``sync_turn``:
+
+        * True — on append-capable APIs ship only the turns added since
+          ``_last_retained_turn_count``, because the server appends to the
+          existing document and re-sending retained turns duplicates them.
+          Legacy/overwrite APIs still ship the whole buffer: there each retain
+          REPLACES the document, so a delta would drop the earlier turns.
+        * False — always ship the whole buffer. This is what the extracted
+          flush-on-switch did, and ``on_session_switch`` keeps passing False so
+          this refactor is behavior-preserving for that path. Making the switch
+          watermark exact is #41911, which is already open.
+
+        Returns True when a flush was enqueued.
+        """
+        if not self._session_turns:
+            return False
+
+        if respect_watermark:
+            # Has anything accumulated PAST the last Nth-turn boundary? This
+            # mirrors sync_turn's buffering gate, and it is the only signal
+            # that works in both modes: _last_retained_turn_count is advanced
+            # only on append-capable APIs (see sync_turn), so on legacy it sits
+            # at 0 forever and cannot answer this question.
+            every_n = max(1, int(self._retain_every_n_turns or 1))
+            already_retained = self._turn_counter % every_n == 0
+            _, _probe_mode = self._resolve_retain_target(self._document_id)
+            if _probe_mode == "append":
+                already_retained = (
+                    already_retained
+                    or self._last_retained_turn_count >= len(self._session_turns)
+                )
+            if already_retained:
+                # The document already holds these turns. Re-sending them
+                # appends duplicates on >=0.5.0 and burns a pointless
+                # overwrite on legacy. Clear so a later hook sees no stale
+                # buffer.
+                self._session_turns = []
+                self._last_retained_turn_count = 0
+                return False
+            # Append APIs take just the un-retained tail. Legacy/overwrite APIs
+            # must resend the whole session because each retain REPLACES the
+            # document — a delta there would drop every earlier turn.
+            old_turns = (
+                self._session_turns[self._last_retained_turn_count:]
+                if _probe_mode == "append"
+                else list(self._session_turns)
+            )
+        else:
+            old_turns = list(self._session_turns)
+
+        old_session_id = self._session_id
+        old_parent_session_id = self._parent_session_id
+        old_turn_index = self._turn_index
+        old_metadata = self._build_metadata(
+            message_count=len(old_turns) * 2,
+            turn_index=old_turn_index,
+        )
+        old_lineage_tags: list[str] = []
+        if old_session_id:
+            old_lineage_tags.append(f"session:{old_session_id}")
+        if old_parent_session_id:
+            old_lineage_tags.append(f"parent:{old_parent_session_id}")
+        old_content = "[" + ",".join(old_turns) + "]"
+        # Resolve doc_id + update_mode against the OLD session BEFORE the
+        # caller rotates _session_id, so the flush lands in the old session's
+        # document either way (legacy: per-process unique; >=0.5.0: stable
+        # session-scoped + append).
+        old_document_id, old_update_mode = self._resolve_retain_target(
+            self._document_id
+        )
+
+        def _flush():
+            try:
+                item = self._build_retain_kwargs(
+                    old_content,
+                    context=self._retain_context,
+                    metadata=old_metadata,
+                    tags=old_lineage_tags or None,
+                )
+                item.pop("bank_id", None)
+                item.pop("retain_async", None)
+                if old_update_mode is not None:
+                    item["update_mode"] = old_update_mode
+                logger.debug(
+                    "Hindsight flush-on-%s: bank=%s, doc=%s, mode=%s, num_turns=%d",
+                    reason, self._bank_id, old_document_id, old_update_mode,
+                    len(old_turns),
+                )
+                self._run_hindsight_operation(
+                    lambda client: client.aretain_batch(
+                        bank_id=self._bank_id,
+                        items=[item],
+                        document_id=old_document_id,
+                        retain_async=self._retain_async,
+                    )
+                )
+            except Exception as e:
+                logger.warning(
+                    "Hindsight flush-on-%s failed: %s", reason, e, exc_info=True
+                )
+
+        # Route the flush through the same writer queue sync_turn uses. That
+        # serializes it behind any still-queued retains from the old session
+        # (FIFO by document_id), avoids racing two threads on aretain_batch
+        # against the same document, and keeps shutdown's drain semantics
+        # intact. Skip enqueue if shutdown has already fired — the writer is
+        # draining/gone, so shutdown() must flush BEFORE it sets that flag.
+        enqueued = False
+        if not self._shutting_down.is_set():
+            self._ensure_writer()
+            self._register_atexit()
+            self._retain_queue.put(_flush)
+            enqueued = True
+
+        # Clear unconditionally. If the enqueue was skipped the writer is
+        # already gone and re-flushing later cannot help — keeping the turns
+        # would only risk a duplicate ingest from a subsequent hook.
+        self._session_turns = []
+        self._last_retained_turn_count = 0
+        return enqueued
+
+    def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
+        """Persist buffered turns when a session actually ends.
+
+        Hindsight is the only bundled memory provider that batches turns in
+        RAM, and it was the only one not implementing this hook. Sessions that
+        ended on a path which does NOT rotate session_id — desktop
+        ``session.close``, the WS orphan reaper, gateway session expiry — never
+        reached ``on_session_switch``, so every turn buffered since the last
+        Nth-turn boundary died with the process (#88944).
+
+        ``messages`` is unused: the buffer already holds this session's turns
+        in the retain format, formatted by ``sync_turn``.
+        """
+        self._flush_buffered_turns(reason="session-end", respect_watermark=True)
+
     def on_session_switch(
         self,
         new_session_id: str,
@@ -2288,69 +2444,8 @@ class HindsightMemoryProvider(MemoryProvider):
         if not new_id:
             return
 
-        # 1. Flush any buffered turns under the OLD identifiers. Snapshot
-        # everything before mutating self._* so metadata + tags + doc_id
-        # all reference the old session consistently.
-        if self._session_turns:
-            old_turns = list(self._session_turns)
-            old_session_id = self._session_id
-            old_parent_session_id = self._parent_session_id
-            old_turn_index = self._turn_index
-            old_metadata = self._build_metadata(
-                message_count=len(old_turns) * 2,
-                turn_index=old_turn_index,
-            )
-            old_lineage_tags: list[str] = []
-            if old_session_id:
-                old_lineage_tags.append(f"session:{old_session_id}")
-            if old_parent_session_id:
-                old_lineage_tags.append(f"parent:{old_parent_session_id}")
-            old_content = "[" + ",".join(old_turns) + "]"
-            # Resolve doc_id + update_mode against the OLD session BEFORE
-            # we rotate _session_id, so the flush lands in the old
-            # session's document either way (legacy: per-process unique;
-            # ≥0.5.0: stable session-scoped + append).
-            old_document_id, old_update_mode = self._resolve_retain_target(
-                self._document_id
-            )
-
-            def _flush():
-                try:
-                    item = self._build_retain_kwargs(
-                        old_content,
-                        context=self._retain_context,
-                        metadata=old_metadata,
-                        tags=old_lineage_tags or None,
-                    )
-                    item.pop("bank_id", None)
-                    item.pop("retain_async", None)
-                    if old_update_mode is not None:
-                        item["update_mode"] = old_update_mode
-                    logger.debug(
-                        "Hindsight flush-on-switch: bank=%s, doc=%s, mode=%s, num_turns=%d",
-                        self._bank_id, old_document_id, old_update_mode, len(old_turns),
-                    )
-                    self._run_hindsight_operation(
-                        lambda client: client.aretain_batch(
-                            bank_id=self._bank_id,
-                            items=[item],
-                            document_id=old_document_id,
-                            retain_async=self._retain_async,
-                        )
-                    )
-                except Exception as e:
-                    logger.warning("Hindsight flush-on-switch failed: %s", e, exc_info=True)
-
-            # Route the flush through the same writer queue sync_turn
-            # uses. That serializes it behind any still-queued retains
-            # from the old session (FIFO by document_id), avoids racing
-            # two threads on aretain_batch against the same document, and
-            # keeps shutdown's drain semantics intact. Skip enqueue if
-            # shutdown has already fired — the writer is draining/gone.
-            if not self._shutting_down.is_set():
-                self._ensure_writer()
-                self._register_atexit()
-                self._retain_queue.put(_flush)
+        # 1. Flush any buffered turns under the OLD identifiers.
+        self._flush_buffered_turns(reason="switch", respect_watermark=False)
 
         # 2. Drain any in-flight prefetch from the old session and drop
         # its cached result so the new session doesn't see stale recall.
@@ -2376,7 +2471,14 @@ class HindsightMemoryProvider(MemoryProvider):
 
     def shutdown(self) -> None:
         logger.debug("Hindsight shutdown: stopping writer + waiting for background threads")
-        # Stop accepting new retain jobs first so anyone still calling
+        # Drain the turn buffer BEFORE the shutdown flag goes up. Ordering is
+        # load-bearing: _flush_buffered_turns refuses to enqueue once
+        # _shutting_down is set, so flushing after it would silently discard
+        # everything buffered since the last Nth-turn boundary — the shutdown
+        # half of #88944. The writer drain below then carries this final
+        # retain out with the rest of the queue.
+        self._flush_buffered_turns(reason="shutdown", respect_watermark=True)
+        # Stop accepting new retain jobs so anyone still calling
         # sync_turn() during teardown is dropped, not enqueued.
         self._shutting_down.set()
         # Drain the writer: it will finish in-flight work, then exit on

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1016,6 +1016,94 @@ class TestShutdownRace:
 
 
 # ---------------------------------------------------------------------------
+# Session-end / shutdown buffer flush (#88944)
+# ---------------------------------------------------------------------------
+
+
+class TestSessionEndBufferFlush:
+    """retain_every_n_turns > 1 buffers turns in RAM. Every path that can end
+    a session has to drain that buffer or the turns are lost outright."""
+
+    def test_on_session_end_flushes_buffered_turns(self, provider_with_config):
+        """Sessions that end WITHOUT rotating session_id (desktop
+        session.close, the WS orphan reaper, gateway expiry) never reach
+        on_session_switch. Without on_session_end nothing flushes them."""
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+        doc = p._document_id
+
+        # Two turns buffered; the boundary is at turn 3, so no retain yet.
+        p.sync_turn("turn1-user", "turn1-asst")
+        p.sync_turn("turn2-user", "turn2-asst")
+        p._client.aretain_batch.assert_not_called()
+
+        p.on_session_end([])
+        p._retain_queue.join()
+
+        p._client.aretain_batch.assert_called_once()
+        kw = p._client.aretain_batch.call_args.kwargs
+        assert kw["document_id"] == doc
+        flat = json.dumps(json.loads(kw["items"][0]["content"]))
+        assert "turn1-user" in flat
+        assert "turn2-user" in flat
+        # Buffer drained, so a later hook can't re-ship the same turns.
+        assert p._session_turns == []
+
+    def test_shutdown_flushes_buffered_turns(self, provider_with_config):
+        """The gateway/dashboard die on SIGTERM without running atexit, so
+        shutdown() is the last chance to persist a partial buffer."""
+        p = provider_with_config(retain_every_n_turns=5, retain_async=False)
+        doc = p._document_id
+
+        p.sync_turn("only-user", "only-asst")
+        p._client.aretain_batch.assert_not_called()
+
+        # shutdown() drops the client reference — hold it to assert afterwards.
+        client = p._client
+        p.shutdown()
+
+        client.aretain_batch.assert_called_once()
+        kw = client.aretain_batch.call_args.kwargs
+        assert kw["document_id"] == doc
+        assert "only-user" in json.dumps(json.loads(kw["items"][0]["content"]))
+
+    def test_session_end_then_switch_does_not_double_ingest(
+        self, provider_with_config
+    ):
+        """MemoryManager.commit_session_boundary_async delivers on_session_end
+        strictly BEFORE on_session_switch. The end-flush must clear the buffer
+        so the switch doesn't re-ship the same turns into the bank."""
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+
+        p.sync_turn("turn1-user", "turn1-asst")
+        p.sync_turn("turn2-user", "turn2-asst")
+
+        p.on_session_end([])
+        p.on_session_switch("new-sid", parent_session_id="test-session", reset=True)
+        p._retain_queue.join()
+
+        assert p._client.aretain_batch.call_count == 1
+
+    def test_no_flush_when_last_turn_hit_a_retain_boundary(
+        self, provider_with_config
+    ):
+        """A turn count landing exactly on the boundary already retained
+        everything. Flushing again would duplicate it."""
+        p = provider_with_config(retain_every_n_turns=2, retain_async=False)
+
+        p.sync_turn("turn1-user", "turn1-asst")
+        p.sync_turn("turn2-user", "turn2-asst")
+        p._retain_queue.join()
+        assert p._client.aretain_batch.call_count == 1
+
+        client = p._client
+        p.on_session_end([])
+        p.shutdown()
+
+        # Still one — no duplicate ingest from either hook.
+        assert client.aretain_batch.call_count == 1
+
+
+# ---------------------------------------------------------------------------
 # on_session_switch — flush + prefetch reset behavior
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

Stops the Hindsight memory provider silently dropping buffered turns when a session ends.

**The causal chain.** With `retain_every_n_turns > 1`, `sync_turn()` accumulates turns in `_session_turns` and only dispatches a retain at every Nth-turn boundary. Anything buffered past that boundary exists nowhere but RAM. Two gaps meant it was never drained:

1. **No `on_session_end`.** `MemoryProvider.on_session_end` (`agent/memory_provider.py:251`) is the base-class hook for exactly this, and the other bundled providers implement it (`holographic`, `honcho`, `openviking`, `supermemory`). Hindsight — the only one that *batches* — did not. Its sole flush point was `on_session_switch`, which fires only when `session_id` rotates. Sessions that end without rotating (desktop `session.close`, the WS orphan reaper, gateway session expiry) never reached it.
2. **`shutdown()` never flushed.** It set `_shutting_down`, then drained the writer queue — but the buffer was never enqueued, so only *already-dispatched* retains survived. The gateway and dashboard are killed by SIGTERM and do not run `atexit`, so every restart dropped the buffer.

**The fix** extracts the flush `on_session_switch` already performed into `_flush_buffered_turns()` and calls it from a new `on_session_end()` and from `shutdown()`.

**Why the helper clears the buffer.** `MemoryManager.commit_session_boundary_async` (`agent/memory_manager.py:927`) deliberately delivers `on_session_end` **strictly before** `on_session_switch`, and its docstring names "double-ingest of the old turn buffer" as the hazard it is guarding against. Clearing on flush is what makes the hook safe to call from several paths: the switch then finds an empty buffer and no-ops.

**Ordering in `shutdown()` is load-bearing.** The helper refuses to enqueue once `_shutting_down` is set (the writer is draining/gone), so the flush runs *before* that flag goes up. Reversed, it would silently discard the very buffer it exists to save.

**Why the new call sites use a watermark and the old one doesn't.** `sync_turn` skips a retain when the turn count hasn't reached a boundary, so `on_session_end`/`shutdown` must not re-ship turns already persisted. The guard mirrors `sync_turn`'s own gate (`_turn_counter % retain_every_n_turns`) rather than `_last_retained_turn_count`, because **that watermark is advanced only on append-capable APIs** (`sync_turn`, guarded by `if update_mode == "append"`) — on legacy/overwrite it stays at `0` forever and cannot answer the question. On append the watermark is checked as well, since it is the more precise signal there.

`on_session_switch` passes `respect_watermark=False` and so keeps its previous whole-buffer behavior byte-for-byte. Tightening *that* path is [#41911](https://github.com/NousResearch/hermes-agent/pull/41911), which is already open — this PR deliberately does not touch it.

## Related Issue

Fixes #88944

Scope note: the linked issue reports three defects. This PR fixes defect **#3** (the provider-level flush) only, which is self-contained and testable. Defects #1 and #2 are process-lifecycle changes in `gateway/run.py` and the serve teardown, and they touch a file with several other open PRs — they belong in their own change.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/hindsight/__init__.py`
  - Extracted the inline flush in `on_session_switch` into `_flush_buffered_turns(reason, respect_watermark)`, which now also clears the buffer.
  - Added `on_session_end()` implementing the base-class hook.
  - `shutdown()` flushes before setting `_shutting_down`.
- `tests/plugins/memory/test_hindsight_provider.py` — added `TestSessionEndBufferFlush` (4 tests).

## How to Test

```
pytest tests/plugins/memory/test_hindsight_provider.py::TestSessionEndBufferFlush -q
```

**4 passed** on this branch. With `plugins/memory/hindsight/__init__.py` reverted to `main`, two fail:

```
FAILED ...::test_on_session_end_flushes_buffered_turns
FAILED ...::test_shutdown_flushes_buffered_turns
2 failed, 2 passed
```

- `test_on_session_end_flushes_buffered_turns` — buffers 2 turns with `retain_every_n_turns=3`, calls `on_session_end`, asserts both turns land under the original `document_id`. On `main` no retain is dispatched at all.
- `test_shutdown_flushes_buffered_turns` — one buffered turn with `retain_every_n_turns=5`, then `shutdown()`. On `main` the turn dies with the process.
- `test_session_end_then_switch_does_not_double_ingest` — asserts exactly one `aretain_batch` across the manager's `end → switch` ordering.
- `test_no_flush_when_last_turn_hit_a_retain_boundary` — turn count landing exactly on the boundary must not flush again.

The last two pass both with and without the fix **by design** — they are regression guards for the duplicate-ingest failure mode, not proof of the fix. I'm calling that out rather than implying all four bite.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **left unchecked deliberately.** I have not run the whole suite green on this Windows box; it carries pre-existing failures unrelated to this change. What I did run:
  - `tests/plugins/memory/` → **343 passed, 7 failed, 7 skipped**. The identical 7 failures occur on clean `main` with my changes stashed (**339 passed, 7 failed** — the +4 is this PR's new tests). Same failure set, no regressions.
  - `tests/agent/test_memory_session_switch.py` → **4 passed**
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (build 26100), Python 3.12.10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new helper and hook carry the ordering and watermark rationale inline; no user-facing docs describe this path
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure in-process buffer/lifecycle logic, no file I/O, process, or shell surface. `check-windows-footguns.py` reports the same 9 pre-existing findings in these two files on `main` as on this branch; this change adds none.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Behavior on `main` — the turns are buffered and then never persisted:

```
DEBUG plugins.memory.hindsight: sync_turn: buffered turn 1 (will retain at turn 3)
DEBUG plugins.memory.hindsight: sync_turn: buffered turn 2 (will retain at turn 3)
DEBUG plugins.memory.hindsight: Hindsight shutdown: stopping writer + waiting for background threads
   (no retain dispatched — turns 1 and 2 are gone)
```

With this change the same teardown emits:

```
DEBUG plugins.memory.hindsight: Hindsight flush-on-shutdown: bank=..., doc=..., mode=..., num_turns=2
```
