### PR TITLE
fix: honor disabled profile toolsets

### DIFF
--- a/tests/tui_gateway/test_gui_surface_toolsets.py
+++ b/tests/tui_gateway/test_gui_surface_toolsets.py
@@ -109,6 +109,51 @@ class TestResolverPlumbing:
         assert "desktop_ui" in desktop
         assert "desktop_ui" not in tui
 
+    def test_config_denylist_wins_over_desktop_surface_injection(self, no_desktop_env):
+        """A GUI session must not resurrect capabilities the profile denied."""
+        import agent.coding_context as cc
+        import hermes_cli.config as config_mod
+
+        no_desktop_env.setattr(cc, "coding_selection", lambda **_: None)
+        no_desktop_env.setattr(
+            config_mod,
+            "load_config",
+            lambda: {
+                "agent": {"disabled_toolsets": ["desktop_ui", "project"]},
+                "platform_toolsets": {"cli": ["memory"]},
+            },
+        )
+
+        enabled = server._load_enabled_toolsets("desktop")
+
+        assert enabled is not None
+        assert "memory" in enabled
+        assert "desktop_ui" not in enabled
+        assert "project" not in enabled
+
+    def test_focus_posture_cannot_bypass_serialized_profile_denylist(
+        self, no_desktop_env
+    ):
+        """The posture early-return obeys the same hard suppression contract."""
+        import agent.coding_context as cc
+        import hermes_cli.config as config_mod
+
+        no_desktop_env.setattr(
+            cc, "coding_selection", lambda **_: ["coding", "figma"]
+        )
+        no_desktop_env.setattr(
+            config_mod,
+            "load_config",
+            lambda: {
+                # Config editors may persist the list as a JSON-array string.
+                "agent": {
+                    "disabled_toolsets": '["coding", "figma", "desktop_ui", "project"]'
+                }
+            },
+        )
+
+        assert server._load_enabled_toolsets("desktop") == []
+
     def test_explicit_env_pin_still_wins(self, no_desktop_env):
         """HERMES_TUI_TOOLSETS is an operator override; surface can't re-add."""
         no_desktop_env.setenv("HERMES_TUI_TOOLSETS", "web,memory")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4570,6 +4570,36 @@ def _gui_surface_toolsets(platform: str) -> set[str]:
     return surfaces
 
 
+def _disabled_toolsets_from_config(config: dict | None) -> set[str]:
+    """Return the profile's hard toolset denylist in its normalized form.
+
+    GUI capabilities are injected after the normal CLI tool resolver runs, and
+    focus posture returns before that resolver entirely.  Both paths therefore
+    need the same final denylist pass that ``_get_platform_tools`` applies.
+    """
+    if not isinstance(config, dict):
+        return set()
+
+    agent_cfg = config.get("agent") or {}
+    if not isinstance(agent_cfg, dict):
+        return set()
+
+    raw = agent_cfg.get("disabled_toolsets")
+    if not raw:
+        return set()
+
+    try:
+        from agent.skill_utils import parse_config_string_list
+
+        return {
+            name.strip()
+            for name in parse_config_string_list(raw)
+            if name.strip()
+        }
+    except Exception:
+        return set()
+
+
 def _load_enabled_toolsets(platform: str | None = None) -> list[str] | None:
     session_platform = platform or _resolve_session_platform()
     explicit = [
@@ -4596,7 +4626,14 @@ def _load_enabled_toolsets(platform: str | None = None) -> list[str] | None:
                 # coding posture returns before the fallback path that normally
                 # adds them — without this the desktop loses its pane/project
                 # tools exactly when sitting in a repo (see below).
-                return sorted({*selection, *_gui_surface_toolsets(session_platform)})
+                try:
+                    from hermes_cli.config import load_config
+
+                    cfg = load_config()
+                except Exception:
+                    cfg = None
+                enabled = {*selection, *_gui_surface_toolsets(session_platform)}
+                return sorted(enabled - _disabled_toolsets_from_config(cfg))
         except Exception:
             pass
 
@@ -4713,7 +4750,9 @@ def _load_enabled_toolsets(platform: str | None = None) -> list[str] | None:
         # surface them. This resolver runs ONLY in the desktop/TUI gateway, so
         # folding them in here is the gate that exposes them on exactly the
         # surface that can answer them.
-        return sorted(enabled | _gui_surface_toolsets(session_platform))
+        enabled |= _gui_surface_toolsets(session_platform)
+        enabled -= _disabled_toolsets_from_config(cfg)
+        return sorted(enabled)
     except Exception:
         if fallback_notice is not None:
             print(


### PR DESCRIPTION
## Summary

- enforce `agent.disabled_toolsets` after desktop GUI surface toolsets are injected
- apply the same denylist to the coding-focus early-return path
- normalize both YAML lists and config-editor JSON-array strings with the existing parser

## Root cause

The desktop/TUI gateway adds `project` and `desktop_ui` after the normal CLI tool resolver has applied the profile denylist. The coding-focus path returns even earlier, before config is loaded. Both paths could therefore resurrect toolsets that a profile explicitly disabled.

This made a restricted desktop bot receive capabilities that were absent from its configured allowlist. Explicit `HERMES_TUI_TOOLSETS` remains an operator override and is unchanged.

## Impact

Profile-level capability isolation now remains effective in desktop sessions, including coding-focus sessions. Toolsets disabled in profile config no longer appear in the agent's enabled toolsets merely because the client is the desktop app.

## Validation

- `scripts/run_tests.sh tests/tui_gateway/test_gui_surface_toolsets.py -q` — 12 passed
- manual desktop E2E with a restricted profile: the actual agent schema contained only the configured toolsets and excluded `desktop_ui` and `project`
