### PR TITLE
fix(desktop): keep remote bot sessions isolated during profile deletion

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1674,6 +1674,19 @@ def delete_profile(name: str, yes: bool = False) -> Path:
     except Exception:
         pass  # best-effort: never block the delete on the release path
 
+    # 2d. A shared serve process also initializes profile-specific rotating log
+    # handlers when it builds that profile's AIAgent. On Windows, the concurrent
+    # handler keeps ``logs/.__agent.lock`` open after the agent itself closes, so
+    # rmtree cannot remove the profile until this process releases the handler.
+    try:
+        from hermes_logging import release_file_handlers_under
+
+        _released = release_file_handlers_under(profile_dir)
+        if _released:
+            print(f"✓ Released {_released} log handler(s) held by this process")
+    except Exception:
+        pass  # best-effort: rmtree below still reports a concrete failure
+
     # 3. Remove wrapper script
     if has_wrapper:
         if remove_wrapper_script(canon):

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -1037,8 +1037,12 @@ async def delete_profile_endpoint(name: str):
     its own dialog before this request, so we always pass ``yes=True`` to
     skip the CLI's interactive prompt."""
     from hermes_cli import profiles as profiles_mod
+    from tui_gateway import server as gateway_server
+
     try:
-        path = profiles_mod.delete_profile(name, yes=True)
+        profile_dir = profiles_mod.get_profile_dir(name)
+        with gateway_server.profile_deletion_scope(profile_dir):
+            path = profiles_mod.delete_profile(name, yes=True)
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except ValueError as e:

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -569,7 +569,7 @@ _queue_atexit_registered = False
 # flush/reset from another thread (gateway init racing a plugin/CLI path).
 # Without this, two threads can interleave listener.stop()/reassign/start()
 # and leave the queue with two live listeners or an orphaned worker thread.
-_queue_state_lock = threading.Lock()
+_queue_state_lock = threading.RLock()
 
 
 class _NonFormattingQueueHandler(QueueHandler):
@@ -700,6 +700,53 @@ def rotating_file_handlers() -> list:
     return list(_queued_file_handlers)
 
 
+def release_file_handlers_under(root: Path) -> int:
+    """Close queued file handlers whose log files live below *root*.
+
+    Long-lived shared backends can initialize agents for several profile homes.
+    Each initialization adds that profile's rotating handlers to the process-wide
+    queue listener, so deleting a profile must explicitly release those handles
+    first (notably the concurrent-log-handler lock file on Windows). Remaining
+    profile and launch-home handlers stay attached and keep receiving records.
+    """
+    global _log_queue, _queue_listener
+    resolved_root = Path(root).resolve()
+
+    with _queue_state_lock:
+        targets = []
+        for handler in _queued_file_handlers:
+            try:
+                Path(handler.baseFilename).resolve().relative_to(resolved_root)
+            except (AttributeError, OSError, ValueError):
+                continue
+            targets.append(handler)
+
+        if not targets:
+            return 0
+
+        _stop_queue_listener_locked()
+        for handler in targets:
+            _queued_file_handlers.remove(handler)
+            try:
+                handler.close()
+            except Exception:
+                pass
+
+        if _queued_file_handlers and _log_queue is not None:
+            _queue_listener = QueueListener(
+                _log_queue, *_queued_file_handlers, respect_handler_level=True
+            )
+            _queue_listener.start()
+        else:
+            root_logger = logging.getLogger()
+            for handler in list(root_logger.handlers):
+                if getattr(handler, "_hermes_queue", False):
+                    root_logger.removeHandler(handler)
+            _log_queue = None
+
+        return len(targets)
+
+
 def _reset_queued_handlers() -> None:
     """Tear down the async logging queue + listener (test-isolation helper)."""
     global _log_queue
@@ -738,25 +785,26 @@ def _add_rotating_handler(
         for gateway.log).
     """
     resolved = path.resolve()
-    for existing in _queued_file_handlers:
-        if (
-            isinstance(existing, RotatingFileHandler)
-            and Path(getattr(existing, "baseFilename", "")).resolve() == resolved
-        ):
-            return  # already attached
+    with _queue_state_lock:
+        for existing in _queued_file_handlers:
+            if (
+                isinstance(existing, RotatingFileHandler)
+                and Path(getattr(existing, "baseFilename", "")).resolve() == resolved
+            ):
+                return  # already attached
 
-    path.parent.mkdir(parents=True, exist_ok=True)
-    handler = _ManagedRotatingFileHandler(
-        str(path), maxBytes=max_bytes, backupCount=backup_count,
-        encoding="utf-8",
-    )
-    handler.setLevel(level)
-    handler.setFormatter(formatter)
-    if log_filter is not None:
-        handler.addFilter(log_filter)
-    # Route through the async queue instead of ``logger.addHandler(handler)`` so
-    # the rotation-lock wait never runs on the caller's (often event-loop) thread.
-    _register_queued_handler(handler)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        handler = _ManagedRotatingFileHandler(
+            str(path), maxBytes=max_bytes, backupCount=backup_count,
+            encoding="utf-8",
+        )
+        handler.setLevel(level)
+        handler.setFormatter(formatter)
+        if log_filter is not None:
+            handler.addFilter(log_filter)
+        # Route through the async queue instead of ``logger.addHandler(handler)`` so
+        # the rotation-lock wait never runs on the caller's (often event-loop) thread.
+        _register_queued_handler(handler)
 
 
 def _read_logging_config():

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -273,6 +273,18 @@ class TestDeleteProfile:
         assert profile_dir.is_dir()
         assert get_active_profile() == "default"
 
+    def test_releases_profile_log_handlers_before_rmtree(self, profile_env):
+        profile_dir = create_profile("coder", no_alias=True)
+
+        with patch(
+            "hermes_logging.release_file_handlers_under", return_value=2
+        ) as release_handlers:
+            deleted = delete_profile("coder", yes=True)
+
+        assert deleted == profile_dir
+        release_handlers.assert_called_once_with(profile_dir)
+        assert profile_dir.exists() is False
+
 
 
     def test_backend_scan_only_matches_this_profile(self, profile_env, monkeypatch):

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -98,6 +98,29 @@ class TestSetupLogging:
         ]
         assert len(agent_handlers) == 1
 
+    def test_release_file_handlers_under_is_selective_and_reconfigurable(
+        self, tmp_path
+    ):
+        launch_home = tmp_path / "launch"
+        profile_home = tmp_path / "profiles" / "worker"
+        hermes_logging.setup_logging(hermes_home=launch_home)
+        hermes_logging.setup_logging(hermes_home=profile_home)
+
+        assert len(hermes_logging.rotating_file_handlers()) == 4
+        assert hermes_logging.release_file_handlers_under(profile_home) == 2
+        remaining = hermes_logging.rotating_file_handlers()
+        assert len(remaining) == 2
+        assert all(
+            Path(handler.baseFilename).is_relative_to(launch_home)
+            for handler in remaining
+        )
+
+        # A failed delete can leave the profile in place. A later agent build
+        # must be able to attach fresh handlers for it instead of inheriting a
+        # permanently disabled logging target.
+        hermes_logging.setup_logging(hermes_home=profile_home)
+        assert len(hermes_logging.rotating_file_handlers()) == 4
+
 
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -13617,6 +13617,239 @@ def test_teardown_ends_session_in_profile_db(monkeypatch, tmp_path):
     assert str(seen.get("db_path")).endswith("state.db")
 
 
+def test_profile_deletion_scope_drains_target_sessions_and_blocks_new_ones(
+    monkeypatch, tmp_path
+):
+    """A shared serve process must release profile-owned agents before rmtree."""
+    target_home = tmp_path / "profiles" / "worker"
+    other_home = tmp_path / "profiles" / "other"
+    target_home.mkdir(parents=True)
+    other_home.mkdir(parents=True)
+    closed = []
+    interrupted = []
+    reclaimed = []
+
+    class Agent:
+        def __init__(self, name):
+            self.name = name
+
+        def close(self):
+            closed.append(self.name)
+
+        def interrupt(self):
+            interrupted.append(self.name)
+
+    def session(name, home):
+        return {
+            "agent": Agent(name),
+            "history": [],
+            "profile_home": str(home),
+            "session_key": f"{name}-stored",
+            "source": "desktop",
+        }
+
+    server._sessions["target"] = session("target", target_home)
+    server._sessions["other"] = session("other", other_home)
+    monkeypatch.setattr(server, "_finalize_session", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        server,
+        "_broadcast_global_event",
+        lambda method, payload: reclaimed.append((method, payload)),
+    )
+    monkeypatch.setattr(
+        server,
+        "_profile_home",
+        lambda profile: target_home if profile == "worker" else None,
+    )
+    before = set(server._sessions)
+    try:
+        with server.profile_deletion_scope(target_home) as drained:
+            assert drained == 1
+            assert "target" not in server._sessions
+            assert "other" in server._sessions
+            assert interrupted == ["target"]
+            assert closed == ["target"]
+            assert reclaimed == [
+                (
+                    "session.reclaimed",
+                    {
+                        "reason": "profile_delete",
+                        "session_id": "target",
+                        "stored_session_id": "target-stored",
+                    },
+                )
+            ]
+
+            response = server.handle_request(
+                {
+                    "id": "delete-race",
+                    "method": "session.create",
+                    "params": {"profile": "worker"},
+                }
+            )
+            assert response["error"]["code"] == 5037
+            assert "being deleted" in response["error"]["message"]
+            assert set(server._sessions) == {"other"}
+    finally:
+        for sid in set(server._sessions) - before:
+            server._sessions.pop(sid, None)
+        server._sessions.pop("target", None)
+        server._sessions.pop("other", None)
+
+
+def test_explicit_missing_profile_session_create_never_falls_back_to_launch(
+    monkeypatch,
+):
+    """A deleted named profile must fail closed instead of using default state."""
+    monkeypatch.setattr(server, "_profile_home", lambda _profile: None)
+    monkeypatch.setattr(server, "_profile_targets_launch", lambda _profile: False)
+    before = set(server._sessions)
+
+    response = server.handle_request(
+        {
+            "id": "missing-profile",
+            "method": "session.create",
+            "params": {"profile": "deleted-worker"},
+        }
+    )
+
+    assert response["error"]["code"] == 4047
+    assert "does not exist" in response["error"]["message"]
+    assert set(server._sessions) == before
+
+
+def test_explicit_missing_profile_db_lookup_never_uses_launch(monkeypatch):
+    """All session RPCs must fail closed when an explicit profile disappeared."""
+    launch_reads = []
+    monkeypatch.setattr(server, "_profile_home", lambda _profile: None)
+    monkeypatch.setattr(server, "_profile_targets_launch", lambda _profile: False)
+    monkeypatch.setattr(server, "_get_db", lambda: launch_reads.append(True))
+
+    db, owns = server._db_for_profile("deleted-worker")
+
+    assert db is None
+    assert owns is False
+    assert launch_reads == []
+
+
+def test_profile_deletion_scope_blocks_deferred_resume_registration(tmp_path):
+    """A resume that raced the delete cannot register after sessions were drained."""
+    profile_home = tmp_path / "profiles" / "worker"
+    profile_home.mkdir(parents=True)
+    record = {
+        "history": [],
+        "profile_home": str(profile_home),
+        "session_key": "stored-worker",
+    }
+    before = set(server._sessions)
+
+    with server.profile_deletion_scope(profile_home):
+        with pytest.raises(RuntimeError, match="being deleted"):
+            server._claim_or_reuse_live("late-resume", "stored-worker", record, None)
+
+    assert set(server._sessions) == before
+
+
+def test_profile_deletion_waits_for_inflight_profile_operations(tmp_path):
+    """Deletion owns an exclusive lifecycle gate before touching the profile tree."""
+    import threading
+    import time
+
+    profile_home = tmp_path / "profiles" / "worker"
+    profile_home.mkdir(parents=True)
+    operation_entered = threading.Event()
+    release_operation = threading.Event()
+    deletion_entered = threading.Event()
+
+    def run_operation():
+        with server._profile_operation_scope(profile_home):
+            operation_entered.set()
+            assert release_operation.wait(timeout=2)
+
+    def run_deletion():
+        with server.profile_deletion_scope(profile_home):
+            deletion_entered.set()
+
+    operation_thread = threading.Thread(target=run_operation)
+    deletion_thread = threading.Thread(target=run_deletion)
+    try:
+        operation_thread.start()
+        assert operation_entered.wait(timeout=2)
+        deletion_thread.start()
+        deadline = time.monotonic() + 2
+        while not server._profile_deletion_blocks(profile_home) and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert server._profile_deletion_blocks(profile_home)
+        assert deletion_entered.is_set() is False
+
+        with pytest.raises(RuntimeError, match="being deleted"):
+            with server._profile_operation_scope(profile_home):
+                pass
+    finally:
+        release_operation.set()
+        operation_thread.join(timeout=2)
+        deletion_thread.join(timeout=2)
+    assert operation_thread.is_alive() is False
+    assert deletion_thread.is_alive() is False
+    assert deletion_entered.is_set() is True
+
+
+def test_session_db_does_not_recreate_a_deleted_profile(monkeypatch, tmp_path):
+    """Late background persistence must not resurrect a removed profile stub."""
+    profile_home = tmp_path / "profiles" / "deleted-worker"
+    opened = []
+
+    class UnexpectedDB:
+        def __init__(self, *, db_path):
+            opened.append(db_path)
+
+    monkeypatch.setattr("hermes_state.SessionDB", UnexpectedDB)
+
+    with server._session_db({"profile_home": str(profile_home)}) as db:
+        assert db is None
+
+    assert opened == []
+    assert profile_home.exists() is False
+
+
+def test_profile_delete_endpoint_holds_shared_session_deletion_scope(
+    monkeypatch, tmp_path
+):
+    """The REST delete must drain shared-backend sessions before filesystem removal."""
+    import asyncio
+    import contextlib
+
+    from hermes_cli import profiles as profiles_mod
+    from hermes_cli.web_routers.profiles import delete_profile_endpoint
+
+    profile_home = tmp_path / "profiles" / "worker"
+    profile_home.mkdir(parents=True)
+    events = []
+
+    @contextlib.contextmanager
+    def deletion_scope(home):
+        events.append(("enter", home))
+        yield 1
+        events.append(("exit", home))
+
+    def delete_profile(name, *, yes):
+        events.append(("delete", name, yes))
+        return profile_home
+
+    monkeypatch.setattr(server, "profile_deletion_scope", deletion_scope)
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda _name: profile_home)
+    monkeypatch.setattr(profiles_mod, "delete_profile", delete_profile)
+
+    result = asyncio.run(delete_profile_endpoint("worker"))
+
+    assert result == {"ok": True, "path": str(profile_home)}
+    assert events == [
+        ("enter", profile_home),
+        ("delete", "worker", True),
+        ("exit", profile_home),
+    ]
+
+
 def test_session_branch_writes_to_parent_profile_db(monkeypatch, tmp_path):
     """session.branch must copy history into the parent's profile state.db."""
     profile_home = tmp_path / "profiles" / "mlperf"

--- a/tui_gateway/method_ctx.py
+++ b/tui_gateway/method_ctx.py
@@ -38,6 +38,11 @@ class HandlerRegistry:
         fn._hermes_profile_scoped = True
         return fn
 
+    def profile_lifecycle(self, fn):
+        """Mark a handler to hold a shared profile lifecycle lease at install."""
+        fn._hermes_profile_lifecycle = True
+        return fn
+
     def install(self, server) -> None:
         """Rebind pending handlers onto ``server``'s globals and register them."""
         g = vars(server)
@@ -50,4 +55,6 @@ class HandlerRegistry:
             real.__dict__.update(fn.__dict__)
             if getattr(fn, "_hermes_profile_scoped", False):
                 real = server._profile_scoped(real)
+            if getattr(fn, "_hermes_profile_lifecycle", False):
+                real = server._profile_lifecycle(real)
             server._methods[name] = real

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -9,9 +9,11 @@ from .method_ctx import HandlerRegistry
 _registry = HandlerRegistry()
 method = _registry.method
 _profile_scoped = _registry.profile_scoped
+_profile_lifecycle = _registry.profile_lifecycle
 
 
 @method("session.create")
+@_profile_lifecycle
 def _(rid, params: dict) -> dict:
     sid = uuid.uuid4().hex[:8]
     key = _new_session_key()
@@ -41,6 +43,8 @@ def _(rid, params: dict) -> dict:
     # and each turn re-bind HERMES_HOME. None/own profile → launch (unchanged).
     profile = (params.get("profile") or "").strip() or None
     profile_home = _profile_home(profile)
+    if profile and profile_home is None and not _profile_targets_launch(profile):
+        return _err(rid, 4047, f'Profile "{profile}" does not exist')
 
     # The desktop composer owns its model/effort/fast as plain UI state and ships
     # it on every session.create. Honor each as a PER-SESSION override (built into
@@ -75,6 +79,8 @@ def _(rid, params: dict) -> dict:
     lease = None  # claimed lazily on the first turn (_ensure_active_session_slot)
 
     with _sessions_lock:
+        if profile_home is not None and _profile_deletion_blocks(profile_home):
+            return _err(rid, 5037, f'Profile "{profile}" is being deleted')
         _sessions[sid] = {
             "agent": None,
             "agent_error": None,
@@ -311,6 +317,7 @@ def _(rid, params: dict) -> dict:
 
 
 @method("session.resume")
+@_profile_lifecycle
 def _(rid, params: dict) -> dict:
     target = params.get("session_id", "")
     if not target:
@@ -323,6 +330,10 @@ def _(rid, params: dict) -> dict:
     # local profile's state.db. None/own profile → the launch profile (unchanged).
     profile = (params.get("profile") or "").strip() or None
     profile_home = _profile_home(profile)
+    if profile and profile_home is None and not _profile_targets_launch(profile):
+        return _err(rid, 4047, f'Profile "{profile}" does not exist')
+    if profile_home is not None and _profile_deletion_blocks(profile_home):
+        return _err(rid, 5037, f'Profile "{profile}" is being deleted')
     defer_history = is_truthy_value(params.get("defer_history", False))
     # Desktop hydrates persisted transcripts through the authenticated REST
     # route in parallel. Suppress the duplicate WebSocket transcript only when
@@ -796,6 +807,7 @@ def _(rid, params: dict) -> dict:
                         cwd=profile_resume_cwd,
                         session_db=db,
                         source=source,
+                        profile_home=str(profile_home) if profile_home is not None else None,
                     )
                     # Ownership TRANSFER — the registered session's agent now
                     # holds this handle for its whole life, and _init_session
@@ -3036,6 +3048,8 @@ def _(rid, params: dict) -> dict:
     # unbound, whatever raises inside.
     branch_db = None
     branch_owns_db = False
+    branch_operation = None
+    branch_operation_entered = False
     try:
         # Bind the branched AGENT to the parent's profile, mirroring
         # session.create/resume: home override so config/skills/memory resolve
@@ -3046,6 +3060,9 @@ def _(rid, params: dict) -> dict:
         # recreate the cross-profile split one turn later.
         parent_home = session.get("profile_home")
         if parent_home:
+            branch_operation = _profile_operation_scope(parent_home)
+            branch_operation.__enter__()
+            branch_operation_entered = True
             from hermes_state import SessionDB
 
             # DEDICATED handle, same ownership rule as session.resume: ours
@@ -3111,6 +3128,8 @@ def _(rid, params: dict) -> dict:
         if branch_owns_db and branch_db is not None:
             with contextlib.suppress(Exception):
                 branch_db.close()
+        if branch_operation_entered:
+            branch_operation.__exit__(None, None, None)
     branched_session = _sessions.get(new_sid)
     return _ok(
         rid,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -154,6 +154,9 @@ _db_error: str | None = None
 _stdout_lock = threading.Lock()
 _cfg_lock = threading.Lock()
 _sessions_lock = threading.RLock()  # reentrant: _close_session_by_id may run under callers that already hold it
+_profile_deletions: dict[str, int] = {}
+_profile_operations: dict[str, int] = {}
+_profile_lifecycle_changed = threading.Condition(_sessions_lock)
 _prompt_lock = threading.Lock()
 _cfg_cache: dict | None = None
 _cfg_mtime: float | None = None
@@ -887,7 +890,9 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
 # against an id the backend has already forgotten, which reads as the session
 # silently vanishing rather than being reclaimed. ``tui_close`` and friends are
 # deliberately absent: the client initiated those and already knows.
-_RECLAIM_END_REASONS = frozenset({"idle_timeout", "lru_evict", "ws_orphan_reap"})
+_RECLAIM_END_REASONS = frozenset(
+    {"idle_timeout", "lru_evict", "profile_delete", "ws_orphan_reap"}
+)
 
 
 def _announce_session_reclaimed(session: dict, end_reason: str) -> None:
@@ -1035,6 +1040,97 @@ def _close_session_by_id(
                 return False
             session = _pop_session_by_id(sid)
     return _teardown_popped_session(session, end_reason=end_reason)
+
+
+def _profile_home_key(profile_home: str | os.PathLike | None) -> str:
+    if not profile_home:
+        return ""
+    try:
+        return os.path.normcase(str(Path(profile_home).resolve()))
+    except Exception:
+        return os.path.normcase(os.path.abspath(os.fspath(profile_home)))
+
+
+def _profile_deletion_blocks(profile_home: str | os.PathLike | None) -> bool:
+    key = _profile_home_key(profile_home)
+    with _sessions_lock:
+        return bool(key and _profile_deletions.get(key, 0) > 0)
+
+
+class _ProfileDeletingError(RuntimeError):
+    pass
+
+
+class _ProfileMissingError(RuntimeError):
+    pass
+
+
+def _assert_profile_registration_allowed(profile_home: str | os.PathLike | None) -> None:
+    if _profile_deletion_blocks(profile_home):
+        raise _ProfileDeletingError("profile is being deleted")
+
+
+@contextlib.contextmanager
+def _profile_operation_scope(profile_home: str | os.PathLike | None):
+    """Hold a shared profile lifecycle lease against concurrent deletion."""
+    key = _profile_home_key(profile_home)
+    if not key:
+        yield
+        return
+    with _profile_lifecycle_changed:
+        if _profile_deletions.get(key, 0) > 0:
+            raise _ProfileDeletingError("profile is being deleted")
+        if not Path(profile_home).exists():
+            raise _ProfileMissingError("profile does not exist")
+        _profile_operations[key] = _profile_operations.get(key, 0) + 1
+    try:
+        yield
+    finally:
+        with _profile_lifecycle_changed:
+            remaining = _profile_operations.get(key, 1) - 1
+            if remaining > 0:
+                _profile_operations[key] = remaining
+            else:
+                _profile_operations.pop(key, None)
+            _profile_lifecycle_changed.notify_all()
+
+
+@contextlib.contextmanager
+def profile_deletion_scope(profile_home: str | os.PathLike):
+    """Drain and block live sessions while a shared backend deletes a profile."""
+    key = _profile_home_key(profile_home)
+    if not key:
+        raise ValueError("profile home is required")
+
+    with _profile_lifecycle_changed:
+        _profile_deletions[key] = _profile_deletions.get(key, 0) + 1
+        while _profile_operations.get(key, 0) > 0:
+            _profile_lifecycle_changed.wait()
+        victims = [
+            sid
+            for sid, session in _sessions.items()
+            if _profile_home_key(session.get("profile_home")) == key
+        ]
+        popped = [_pop_session_by_id(sid) for sid in victims]
+
+    try:
+        from agent.interrupt_compat import request_hard_interrupt
+
+        for session in popped:
+            if session is not None and session.get("agent") is not None:
+                with contextlib.suppress(Exception):
+                    request_hard_interrupt(session["agent"])
+        for session in popped:
+            _teardown_popped_session(session, end_reason="profile_delete")
+        yield sum(session is not None for session in popped)
+    finally:
+        with _profile_lifecycle_changed:
+            remaining = _profile_deletions.get(key, 1) - 1
+            if remaining > 0:
+                _profile_deletions[key] = remaining
+            else:
+                _profile_deletions.pop(key, None)
+            _profile_lifecycle_changed.notify_all()
 
 
 def _ws_session_is_orphaned(session: dict | None) -> bool:
@@ -1430,6 +1526,8 @@ def _db_for_profile(profile: str | None = None):
     """
     profile_home = _profile_home(profile)
     if profile_home is None:
+        if profile and not _profile_targets_launch(profile):
+            return None, False
         return _get_db(), False
     try:
         from hermes_state import SessionDB
@@ -1482,6 +1580,16 @@ def _profile_db(params: dict | None = None):
     profile = None
     if isinstance(params, dict):
         profile = (params.get("profile") or "").strip() or None
+    profile_home = _profile_home(profile)
+    if profile and profile_home is None and not _profile_targets_launch(profile):
+        yield None
+        return
+    operation = _profile_operation_scope(profile_home)
+    try:
+        operation.__enter__()
+    except (_ProfileDeletingError, _ProfileMissingError):
+        yield None
+        return
     db, owns = _db_for_profile(profile)
     try:
         yield db
@@ -1489,6 +1597,7 @@ def _profile_db(params: dict | None = None):
         if owns and db is not None:
             with contextlib.suppress(Exception):
                 db.close()
+        operation.__exit__(None, None, None)
 
 
 def _response_profile_name(profile: str | None = None) -> str:
@@ -1531,6 +1640,38 @@ def _profile_home(profile: str | None) -> Path | None:
     if home.resolve() == Path(_hermes_home).resolve():
         return None
     return home if (home / "state.db").exists() or home.exists() else None
+
+
+def _profile_targets_launch(profile: str | None) -> bool:
+    """Whether an explicit profile name resolves to this process's launch home."""
+    name = (profile or "").strip()
+    if not name:
+        return True
+    try:
+        from hermes_cli import profiles as profiles_mod
+
+        return Path(profiles_mod.get_profile_dir(name)).resolve() == Path(_hermes_home).resolve()
+    except Exception:
+        return False
+
+
+def _profile_lifecycle(handler):
+    """Keep an explicit profile alive for the full duration of a session RPC."""
+
+    def wrapper(rid, params):
+        profile = (params.get("profile") or "").strip() or None
+        profile_home = _profile_home(profile)
+        if profile and profile_home is None and not _profile_targets_launch(profile):
+            return _err(rid, 4047, f'Profile "{profile}" does not exist')
+        try:
+            with _profile_operation_scope(profile_home):
+                return handler(rid, params)
+        except _ProfileDeletingError:
+            return _err(rid, 5037, f'Profile "{profile}" is being deleted')
+        except _ProfileMissingError:
+            return _err(rid, 4047, f'Profile "{profile}" does not exist')
+
+    return wrapper
 
 
 def _profile_scoped(handler):
@@ -2318,6 +2459,8 @@ def _start_agent_build(sid: str, session: dict) -> None:
         session_db = None
         owns_db = False
         profile_home = current.get("profile_home")
+        profile_operation = None
+        profile_operation_entered = False
         try:
             history_ready = current.get("resume_history_ready")
             if history_ready is not None:
@@ -2334,6 +2477,9 @@ def _start_agent_build(sid: str, session: dict) -> None:
             # agent that profile's db so turns persist to the right state.db.
             session_db = None
             if profile_home:
+                profile_operation = _profile_operation_scope(profile_home)
+                profile_operation.__enter__()
+                profile_operation_entered = True
                 home_token = set_hermes_home_override(profile_home)
                 try:
                     from agent.secret_scope import build_profile_secret_scope, set_secret_scope
@@ -2505,6 +2651,8 @@ def _start_agent_build(sid: str, session: dict) -> None:
                 if not _transfer_db_to_agent(built, session_db):
                     with contextlib.suppress(Exception):
                         session_db.close()
+            if profile_operation_entered:
+                profile_operation.__exit__(None, None, None)
             ready.set()
 
     build_thread = threading.Thread(target=_build, daemon=True)
@@ -2936,20 +3084,6 @@ def _ensure_session_db_row(session: dict) -> None:
     # launch profile's — otherwise the row lands in the wrong state.db, the
     # unified list mis-tags it, and resume 404s ("session not found").
     profile_home = session.get("profile_home")
-    if profile_home:
-        from hermes_state import SessionDB
-
-        try:
-            db = SessionDB(db_path=Path(profile_home) / "state.db")
-        except Exception:
-            logger.debug("failed to open profile db for session row", exc_info=True)
-            return
-        close_db = True
-    else:
-        db = _get_db()
-        close_db = False
-    if db is None:
-        return
     # The session's own model/effort/fast pick — the composer override shipped on
     # session.create, or a restored /model switch — must own the row's model +
     # model_config. The agent isn't built yet at first prompt.submit, so derive
@@ -3009,6 +3143,27 @@ def _ensure_session_db_row(session: dict) -> None:
     parent_session_id = session.get("parent_session_id") or None
     if parent_session_id:
         model_config["_branched_from"] = parent_session_id
+    profile_operation = None
+    if profile_home:
+        profile_operation = _profile_operation_scope(profile_home)
+        try:
+            profile_operation.__enter__()
+        except (_ProfileDeletingError, _ProfileMissingError):
+            return
+        from hermes_state import SessionDB
+
+        try:
+            db = SessionDB(db_path=Path(profile_home) / "state.db")
+        except Exception:
+            logger.debug("failed to open profile db for session row", exc_info=True)
+            profile_operation.__exit__(None, None, None)
+            return
+        close_db = True
+    else:
+        db = _get_db()
+        close_db = False
+    if db is None:
+        return
     try:
         db.create_session(
             key,
@@ -3045,6 +3200,8 @@ def _ensure_session_db_row(session: dict) -> None:
                 db.close()
             except Exception:
                 pass
+        if profile_operation is not None:
+            profile_operation.__exit__(None, None, None)
 
 
 def _persist_branch_seed(session: dict) -> None:
@@ -3122,12 +3279,30 @@ def _session_db(session: dict):
     db, close_db = None, False
     profile_home = session.get("profile_home")
     if profile_home:
+        home = Path(profile_home)
+        if not home.exists():
+            yield None
+            return
+        operation = _profile_operation_scope(home)
+        try:
+            operation.__enter__()
+        except (_ProfileDeletingError, _ProfileMissingError):
+            yield None
+            return
         from hermes_state import SessionDB
 
         try:
-            db, close_db = SessionDB(db_path=Path(profile_home) / "state.db"), True
+            db, close_db = SessionDB(db_path=home / "state.db"), True
         except Exception:
             logger.debug("failed to open profile db for session", exc_info=True)
+        try:
+            yield db
+        finally:
+            if close_db and db is not None:
+                with contextlib.suppress(Exception):
+                    db.close()
+            operation.__exit__(None, None, None)
+        return
     else:
         db = _get_db()
     try:
@@ -7110,6 +7285,7 @@ def _init_session(
 ):
     now = time.time()
     with _sessions_lock:
+        _assert_profile_registration_allowed(profile_home)
         _sessions[sid] = {
             "agent": agent,
             "session_key": key,
@@ -8521,6 +8697,7 @@ def _claim_or_reuse_live(
                 lease.release()
             return live
         with _sessions_lock:
+            _assert_profile_registration_allowed(record.get("profile_home"))
             _sessions[sid] = record
             _register_session_cwd(_sessions[sid])
     return None


### PR DESCRIPTION
## What does this PR do?

Remote Desktop bot profiles that share a URL or SSH backend can keep live sessions and SQLite/logging handles after the profile is deleted. That leaves stale session ownership, can recreate an empty profile database, and on Windows can make deletion fail because the shared process still holds the profile log lock.

This change adds a profile lifecycle gate to the shared TUI gateway. Profile deletion now blocks new profile operations, drains only that profile's live sessions, releases its process-wide log handlers, and then removes the profile. Explicit requests for a missing or deleting profile fail closed instead of falling back to the launch/default profile.

### Symptom

A non-default remote bot can stop resuming correctly, appear owned by the default profile, or leave state behind after deletion. On Windows, deleting a profile with a live shared-backend session can fail because `logs/.__agent.lock` remains open.

### Impact

Users running multiple Desktop bot profiles through one remote URL or SSH backend can lose stable access to a bot session and can retain or recreate deleted profile state. The affected deletion path can also fail outright on Windows.

### Bug Cause

**Trigger:** `hermes_cli/web_routers/profiles.py:delete_profile_endpoint` deleting a profile while `tui_gateway.server` still owns profile-scoped sessions and process-wide log handlers.

**Causal chain:**
1. Desktop routes several bot profiles through one long-lived shared backend.
2. A named profile creates live agents, SQLite handles, and rotating log handlers in that shared process.
3. The profile REST endpoint removes the profile filesystem without first excluding concurrent session RPCs or draining all process-owned resources.
4. Late session work can reopen state under the deleted path, explicit missing-profile requests can fall back to the launch database, and Windows refuses to remove the open logging lock.

**Why it is wrong:** Filesystem deletion was not coordinated with the shared process lifecycle, and explicit profile resolution treated a missing named profile like an implicit launch-profile request.

**Working sibling / contrast:** Dedicated local profile deletion stops the profile process before removing files. Shared URL and SSH profiles intentionally reuse one primary backend, so they need selective in-process teardown instead.

**Ruled out:** The shared-primary routing itself is not the cause. Existing URL and SSH routing tests pass, and both transports use the same profile-scoped session protocol. Replacing shared routing would regress the intended remote backend design.

### Fix

- Add per-profile operation and deletion scopes around session create, resume, branch, persistence, and registration paths.
- Reclaim only sessions owned by the profile being deleted while preserving unrelated live sessions.
- Return explicit missing/deleting profile errors instead of reading or writing the launch profile database.
- Selectively stop and rebuild the logging queue so handlers below the deleted profile are closed without disrupting other profiles.
- Cover lifecycle races, fail-closed routing, selective session teardown, and selective log-handler release with regression tests.

## Related Issue

Closes #89729

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` - coordinate profile-scoped operations, deletion, session teardown, and database access.
- `tui_gateway/method_ctx.py` and `tui_gateway/methods_session.py` - apply lifecycle guards to session RPCs and fail closed for missing profiles.
- `hermes_cli/web_routers/profiles.py` and `hermes_cli/profiles.py` - drain shared-backend resources before removing a profile.
- `hermes_logging.py` - selectively release queued file handlers below a deleted profile while preserving other logging targets.
- `tests/` - add shared gateway, profile deletion, and logging lifecycle regressions.

## How to Test

1. Start a shared `hermes serve` backend, create two named profiles, and create a live Desktop-style session for each through the primary WebSocket.
2. Delete one profile through `DELETE /api/profiles/<name>` and verify its session is reclaimed, its directory and `state.db` stay absent, and the unrelated profile session remains live.
3. Verify delayed `session.create` and `session.resume` calls for the deleted profile return profile-not-found errors and never fall back to default.
4. Run the related automated suites:

```bash
scripts/run_tests.sh tests/test_tui_gateway_server.py
scripts/run_tests.sh tests/hermes_cli/test_web_server.py -k profile
scripts/run_tests.sh tests/test_hermes_logging.py
cd apps/desktop
npx vitest run src/store/gateway-shared-remote.test.ts src/store/gateway-profile-request.test.ts src/store/session-request-router.test.ts
```

Verified results include 592 gateway tests, 12 web profile tests, 19 Desktop routing tests, focused profile deletion and log-release regressions, and a live Windows 11 shared-backend deletion run. The broader logging suite reported one pre-existing Windows managed-mode expectation failure unrelated to this change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the related suites and documented the results above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, no user-facing configuration or API documentation changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A, no contributor workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, no model tool schema changed

## Screenshots / Logs

Live Windows verification returned HTTP 200 for profile deletion, emitted `session.reclaimed` with reason `profile_delete`, preserved the unrelated live profile session, kept the deleted profile directory absent, and returned code 4047 for delayed create/resume calls.
