### PR TITLE
fix(cron): restore per-execution provenance

### DIFF
--- a/cron/executions.py
+++ b/cron/executions.py
@@ -7,11 +7,13 @@ proved gone. Terminal states are immutable.
 
 from __future__ import annotations
 
+import json
 import os
 import sqlite3
 import threading
 import uuid
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
 from hermes_constants import get_hermes_home
@@ -40,30 +42,61 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
     conn.execute("PRAGMA busy_timeout=5000")
     apply_wal_with_fallback(conn, db_label="cron/executions.db")
     conn.execute("PRAGMA synchronous=FULL")
-    conn.execute(
-        """CREATE TABLE IF NOT EXISTS executions (
-             id TEXT PRIMARY KEY,
-             job_id TEXT NOT NULL,
-             source TEXT NOT NULL,
-             process_id TEXT NOT NULL,
-             pid INTEGER NOT NULL,
-             process_started_at INTEGER,
-             status TEXT NOT NULL CHECK(status IN
-               ('claimed','running','completed','failed','unknown')),
-             claimed_at TEXT NOT NULL,
-             started_at TEXT,
-             finished_at TEXT,
-             error TEXT
-           )"""
-    )
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_executions_job_claimed "
-        "ON executions(job_id, claimed_at DESC, id DESC)"
-    )
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_executions_status_claimed "
-        "ON executions(status, claimed_at DESC, id DESC)"
-    )
+    required_columns = {
+        "scheduled_for",
+        "schedule_json",
+        "output_path",
+        "delivery_outcome",
+        "delivery_error",
+    }
+    columns = {row["name"] for row in conn.execute("PRAGMA table_info(executions)")}
+    indexes = {row["name"] for row in conn.execute("PRAGMA index_list(executions)")}
+    required_indexes = {
+        "idx_executions_job_claimed",
+        "idx_executions_status_claimed",
+    }
+    if required_columns <= columns and required_indexes <= indexes:
+        return
+
+    # Only migration/new-database opens reserve the writer slot. Re-read under
+    # the lock so concurrent legacy openers cannot race the same additive DDL.
+    with conn:
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS executions (
+                 id TEXT PRIMARY KEY,
+                 job_id TEXT NOT NULL,
+                 source TEXT NOT NULL,
+                 process_id TEXT NOT NULL,
+                 pid INTEGER NOT NULL,
+                 process_started_at INTEGER,
+                 status TEXT NOT NULL CHECK(status IN
+                   ('claimed','running','completed','failed','unknown')),
+                 claimed_at TEXT NOT NULL,
+                 started_at TEXT,
+                 finished_at TEXT,
+                 error TEXT,
+                 scheduled_for TEXT,
+                 schedule_json TEXT,
+                 output_path TEXT,
+                 delivery_outcome TEXT,
+                 delivery_error TEXT
+               )"""
+        )
+        columns = {
+            row["name"] for row in conn.execute("PRAGMA table_info(executions)")
+        }
+        for column in required_columns:
+            if column not in columns:
+                conn.execute(f"ALTER TABLE executions ADD COLUMN {column} TEXT")
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_executions_job_claimed "
+            "ON executions(job_id, claimed_at DESC, id DESC)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_executions_status_claimed "
+            "ON executions(status, claimed_at DESC, id DESC)"
+        )
 
 
 @contextmanager
@@ -136,7 +169,13 @@ def _prune_unlocked(conn: sqlite3.Connection) -> None:
     )
 
 
-def create_execution(job_id: str, *, source: str) -> Dict[str, Any]:
+def create_execution(
+    job_id: str,
+    *,
+    source: str,
+    scheduled_for: Optional[str] = None,
+    schedule: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """Persist a claimed attempt before executor/provider dispatch."""
     now = _hermes_now().isoformat()
     execution_id = uuid.uuid4().hex
@@ -145,10 +184,13 @@ def create_execution(job_id: str, *, source: str) -> Dict[str, Any]:
         conn.execute(
             """INSERT INTO executions
                (id, job_id, source, process_id, pid, process_started_at,
-                status, claimed_at)
-               VALUES (?, ?, ?, ?, ?, ?, 'claimed', ?)""",
+                status, claimed_at, scheduled_for, schedule_json)
+               VALUES (?, ?, ?, ?, ?, ?, 'claimed', ?, ?, ?)""",
             (execution_id, str(job_id), str(source), _PROCESS_ID, pid,
-             _process_start_time(pid), now),
+             _process_start_time(pid), now,
+             str(scheduled_for) if scheduled_for is not None else None,
+             json.dumps(schedule, sort_keys=True, separators=(",", ":"))
+             if schedule is not None else None),
         )
         row = conn.execute(
             "SELECT * FROM executions WHERE id=?", (execution_id,)
@@ -156,6 +198,37 @@ def create_execution(job_id: str, *, source: str) -> Dict[str, Any]:
     record = _record(row)
     _emit_execution_state(record)
     return record  # type: ignore[return-value]
+
+
+def record_execution_schedule(
+    execution_id: str,
+    *,
+    scheduled_for: Optional[str],
+    schedule: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    """Attach an external claim's atomic pre-advance schedule snapshot."""
+    schedule_json = (
+        json.dumps(schedule, sort_keys=True, separators=(",", ":"))
+        if schedule is not None
+        else None
+    )
+    with _transaction() as conn:
+        cur = conn.execute(
+            """UPDATE executions SET scheduled_for=?, schedule_json=?
+               WHERE id=? AND status='claimed'""",
+            (
+                str(scheduled_for) if scheduled_for is not None else None,
+                schedule_json,
+                execution_id,
+            ),
+        )
+        if cur.rowcount != 1:
+            return None
+        return _record(
+            conn.execute(
+                "SELECT * FROM executions WHERE id=?", (execution_id,)
+            ).fetchone()
+        )
 
 
 def mark_execution_running(execution_id: str) -> Optional[Dict[str, Any]]:
@@ -179,16 +252,37 @@ def mark_execution_running(execution_id: str) -> Optional[Dict[str, Any]]:
 def finish_execution(
     execution_id: str, *, success: bool, error: Optional[str] = None,
     delivery_outcome: Optional[str] = None,
+    delivery_error: Optional[str] = None,
+    output_path: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     """Write a terminal result once; terminal attempts cannot be rewritten."""
     now = _hermes_now().isoformat()
     status = "completed" if success else "failed"
     detail = None if success else (str(error) if error else "unknown failure")
+    safe_delivery_error = None
+    if delivery_error is not None:
+        try:
+            from agent.redact import redact_sensitive_text
+
+            safe_delivery_error = redact_sensitive_text(
+                str(delivery_error), force=True, redact_url_credentials=True
+            )
+        except Exception:
+            safe_delivery_error = "[REDACTED: delivery error redaction failed]"
     with _transaction() as conn:
         cur = conn.execute(
-            """UPDATE executions SET status=?, finished_at=?, error=?
+            """UPDATE executions SET status=?, finished_at=?, error=?,
+               output_path=?, delivery_outcome=?, delivery_error=?
                WHERE id=? AND status IN ('claimed','running')""",
-            (status, now, detail, execution_id),
+            (
+                status,
+                now,
+                detail,
+                str(output_path) if output_path is not None else None,
+                delivery_outcome,
+                safe_delivery_error,
+                execution_id,
+            ),
         )
         if cur.rowcount != 1:
             return None

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2887,13 +2887,20 @@ def _claim_job_for_fire_locked(
             # claim merely because hostname + PID are unchanged.
             owner = f"{_machine_id()}:{uuid.uuid4().hex}"
             job["fire_claim"] = {"at": now.isoformat(), "by": owner}
+            scheduled_for = job.get("next_run_at")
+            schedule_snapshot = copy.deepcopy(job.get("schedule"))
             kind = job.get("schedule", {}).get("kind")
             if kind in {"cron", "interval"}:
                 nxt = compute_next_run(job["schedule"], now.isoformat())
                 if nxt:
                     job["next_run_at"] = nxt
             save_jobs(jobs)
-            return copy.deepcopy(job) if return_job else True
+            if not return_job:
+                return True
+            claimed_job = copy.deepcopy(job)
+            claimed_job["_execution_scheduled_for"] = scheduled_for
+            claimed_job["_execution_schedule"] = schedule_snapshot
+            return claimed_job
         return False
 
 
@@ -3013,6 +3020,49 @@ def _heartbeat_fire_claim_locked(job_id: str, *, expected_owner: str) -> bool:
             claim["at"] = _hermes_now().isoformat()
             save_jobs(jobs)
             return True
+    return False
+
+
+def release_fire_claim_for_retry(
+    job_id: str,
+    *,
+    expected_owner: str,
+    scheduled_for: Optional[str],
+    expected_schedule: Optional[Dict[str, Any]],
+    expected_next_run_at: Optional[str],
+) -> bool:
+    """Owner- and schedule-fenced release of an unstarted external fire.
+
+    Provenance must be durable before dispatch. If that write fails after the
+    store claim advanced a recurring job, restore the claimed occurrence and
+    clear only this acquisition's token so a later callback can retry it. A
+    concurrent schedule edit changes either the schedule or ``next_run_at``;
+    in that case this stale cleanup must leave the replacement state untouched.
+    """
+    with _fire_job_lock(job_id) as acquired:
+        if not acquired:
+            return False
+        with _jobs_lock():
+            jobs = load_jobs()
+            for job in jobs:
+                if job.get("id") != job_id:
+                    continue
+                claim = job.get("fire_claim")
+                if not isinstance(claim, dict) or claim.get("by") != expected_owner:
+                    return False
+                if (
+                    job.get("schedule") != expected_schedule
+                    or job.get("next_run_at") != expected_next_run_at
+                ):
+                    return False
+                if (
+                    job.get("schedule", {}).get("kind") in {"cron", "interval"}
+                    and scheduled_for is not None
+                ):
+                    job["next_run_at"] = scheduled_for
+                job["fire_claim"] = None
+                save_jobs(jobs)
+                return True
     return False
 
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -13,6 +13,7 @@ import atexit
 import concurrent.futures
 import contextlib
 import contextvars
+import copy
 import errno
 import json
 import logging
@@ -6242,6 +6243,7 @@ def _run_one_job_body(
         execution_id = create_execution(job["id"], source="direct")["id"]
     delivery_attempted = False
     delivery_error = None
+    output_file = None
     try:
         # Pre-run dispatch claim (issue #38758): atomically commit a finite
         # one-shot's dispatch BEFORE its side effect runs, so a tick that dies
@@ -6355,6 +6357,8 @@ def _run_one_job_body(
         # swallow the error and leak the agent's subprocesses/clients (#10200).
         blocked_config = False
         side_effect_ownership_lost = False
+        should_deliver = False
+        unresolved_origin = False
         try:
             with _side_effect_fence() as owns_output:
                 if not owns_output:
@@ -6488,6 +6492,18 @@ def _run_one_job_body(
                 _teardown_cron_agent(_deferred_agent, job["id"])
 
         if side_effect_ownership_lost or _fire_claim_ownership_lost():
+            # Preserve the strongest delivery fact known before this terminal
+            # ownership decision. A rejected delivery fence is suppressed, not
+            # delivered; a completed attempt retains its actual outcome.
+            normalized_deliver = _normalize_deliver_value(job.get("deliver", "local"))
+            if delivery_error:
+                delivery_outcome = "failed"
+            elif unresolved_origin:
+                delivery_outcome = "not_configured"
+            elif delivery_attempted and normalized_deliver != "local":
+                delivery_outcome = "delivered"
+            else:
+                delivery_outcome = "suppressed"
             # Same transport-cancel distinction as the pre-side-effect path:
             # if WE still own the claim, record the interruption instead of
             # discarding silently (lingering claim + stale last_status).
@@ -6504,12 +6520,18 @@ def _run_one_job_body(
                     execution_id,
                     success=False,
                     error="Interrupted by shutdown before terminal completion.",
+                    delivery_outcome=delivery_outcome,
+                    delivery_error=delivery_error,
+                    output_path=str(output_file) if output_file is not None else None,
                 )
             else:
                 finish_execution(
                     execution_id,
                     success=False,
                     error="Fire claim ownership lost; stale result was discarded.",
+                    delivery_outcome=delivery_outcome,
+                    delivery_error=delivery_error,
+                    output_path=str(output_file) if output_file is not None else None,
                 )
             return True
 
@@ -6519,6 +6541,16 @@ def _run_one_job_body(
         if success and not final_response.strip():
             success = False
             error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
+
+        normalized_deliver = _normalize_deliver_value(job.get("deliver", "local"))
+        if delivery_error:
+            delivery_outcome = "failed"
+        elif should_deliver and unresolved_origin:
+            delivery_outcome = "not_configured"
+        elif should_deliver and normalized_deliver != "local":
+            delivery_outcome = "delivered"
+        else:
+            delivery_outcome = "suppressed"
 
         interrupted = _consume_interrupted_flag(job["id"], execution_token)
         if interrupted:
@@ -6543,6 +6575,9 @@ def _run_one_job_body(
                 execution_id,
                 success=False,
                 error="Interrupted by gateway shutdown before terminal completion.",
+                delivery_outcome=delivery_outcome,
+                delivery_error=delivery_error,
+                output_path=str(output_file) if output_file is not None else None,
             )
             return True
 
@@ -6557,22 +6592,18 @@ def _run_one_job_body(
                 execution_id,
                 success=False,
                 error="Fire claim ownership lost before terminal completion.",
+                delivery_outcome=delivery_outcome,
+                delivery_error=delivery_error,
+                output_path=str(output_file) if output_file is not None else None,
             )
             return True
-        normalized_deliver = _normalize_deliver_value(job.get("deliver", "local"))
-        if delivery_error:
-            delivery_outcome = "failed"
-        elif should_deliver and unresolved_origin:
-            delivery_outcome = "not_configured"
-        elif should_deliver and normalized_deliver != "local":
-            delivery_outcome = "delivered"
-        else:
-            delivery_outcome = "suppressed"
         finish_execution(
             execution_id,
             success=success,
             error=error,
             delivery_outcome=delivery_outcome,
+            delivery_error=delivery_error,
+            output_path=str(output_file) if output_file is not None else None,
         )
         return True
 
@@ -6645,6 +6676,8 @@ def _run_one_job_body(
                 success=False,
                 error=_err_text,
                 delivery_outcome=delivery_outcome,
+                delivery_error=delivery_error,
+                output_path=str(output_file) if output_file is not None else None,
             )
         except Exception as record_err:
             logger.error(
@@ -6898,6 +6931,9 @@ def tick(
         # cron-kind jobs both compute the same next occurrence; interval jobs
         # re-anchor from their own "now" at claim time (harmless for
         # at-most-once — mark_job_run re-anchors at completion regardless).
+        for job in due_jobs:
+            job["_execution_scheduled_for"] = job.get("next_run_at")
+            job["_execution_schedule"] = copy.deepcopy(job.get("schedule"))
         advance_next_runs([job["id"] for job in due_jobs])
 
         # Resolve max parallel workers: env var > config.yaml > unbounded.
@@ -6947,6 +6983,8 @@ def tick(
             # owner. Bool fallback keeps older test doubles/API overrides
             # compatible; real callers using return_job=True never take it.
             claimed_job = dict(claimed) if isinstance(claimed, dict) else dict(job)
+            claimed_job.pop("_execution_scheduled_for", None)
+            claimed_job.pop("_execution_schedule", None)
             claimed_job["execution_id"] = job["execution_id"]
             return run_one_job(
                 claimed_job,
@@ -7022,7 +7060,12 @@ def tick(
             # Record the attempt before executor dispatch. Recovery classifies
             # abandoned records as unknown; it never automatically retries them.
             try:
-                execution = create_execution(job_id, source="builtin")
+                execution = create_execution(
+                    job_id,
+                    source="builtin",
+                    scheduled_for=job.get("_execution_scheduled_for"),
+                    schedule=job.get("_execution_schedule"),
+                )
                 dispatched_job = dict(job, execution_id=execution["id"])
                 _ctx = contextvars.copy_context()
             except Exception as execution_err:

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -20,9 +20,12 @@ selected via the `cron.provider` config key (empty = built-in).
 from __future__ import annotations
 
 import inspect
+import logging
 import threading
 from abc import ABC, abstractmethod
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 # Cap for the exponential tick backoff applied while consecutive ticks fail
 # with fd exhaustion (EMFILE/ENFILE, #87644).  Base is the tick interval
@@ -179,8 +182,12 @@ class CronScheduler(ABC):
         external scheduler, then pass the exact owner-bearing snapshot to
         ``fire_claimed`` in tracked background work.
         """
-        from cron.executions import create_execution, finish_execution
-        from cron.jobs import claim_job_for_fire
+        from cron.executions import (
+            create_execution,
+            finish_execution,
+            record_execution_schedule,
+        )
+        from cron.jobs import claim_job_for_fire, release_fire_claim_for_retry
 
         execution = create_execution(job_id, source=self.name)
         claim_kwargs = {"return_job": True}
@@ -202,6 +209,72 @@ class CronScheduler(ABC):
                 error="Fire claim was not acquired",
             )
             return None
+        scheduled_for = claimed_job.pop("_execution_scheduled_for", None)
+        schedule = claimed_job.pop("_execution_schedule", None)
+        if not force:
+            owner = claimed_job.get("fire_claim", {}).get("by")
+            advanced_next_run_at = claimed_job.get("next_run_at")
+            release_kwargs = {
+                "expected_owner": owner,
+                "scheduled_for": scheduled_for,
+                "expected_schedule": schedule,
+                "expected_next_run_at": advanced_next_run_at,
+            }
+            try:
+                scheduled = record_execution_schedule(
+                    execution["id"],
+                    scheduled_for=scheduled_for,
+                    schedule=schedule,
+                )
+            except BaseException as exc:
+                released = False
+                try:
+                    released = release_fire_claim_for_retry(job_id, **release_kwargs)
+                except BaseException:
+                    logger.exception(
+                        "Cron job %s: retry claim release failed after provenance error",
+                        job_id,
+                    )
+                try:
+                    finish_execution(
+                        execution["id"],
+                        success=False,
+                        error=(
+                            "Execution schedule snapshot failed before dispatch: "
+                            f"{type(exc).__name__}: {exc}"
+                            + ("" if released else "; fenced claim release failed")
+                        ),
+                    )
+                except BaseException:
+                    logger.exception(
+                        "Cron job %s: execution terminalization failed after provenance error",
+                        job_id,
+                    )
+                raise
+            if scheduled is None:
+                released = False
+                try:
+                    released = release_fire_claim_for_retry(job_id, **release_kwargs)
+                except BaseException:
+                    logger.exception(
+                        "Cron job %s: retry claim release failed after missing provenance",
+                        job_id,
+                    )
+                try:
+                    finish_execution(
+                        execution["id"],
+                        success=False,
+                        error=(
+                            "Execution schedule snapshot was not persisted before dispatch"
+                            + ("" if released else "; fenced claim release failed")
+                        ),
+                    )
+                except BaseException:
+                    logger.exception(
+                        "Cron job %s: execution terminalization failed after missing provenance",
+                        job_id,
+                    )
+                return None
         claimed_job["execution_id"] = execution["id"]
         return claimed_job
 

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -39,6 +39,177 @@ def test_execution_transitions_are_durable(monkeypatch, tmp_path):
     assert persisted == [completed]
 
 
+def test_execution_persists_schedule_output_and_delivery_provenance(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    schedule = {"minutes": 30, "kind": "interval", "z": 1, "a": 2}
+
+    claimed = executions.create_execution(
+        "observed-job",
+        source="builtin",
+        scheduled_for="2026-08-19T10:30:00+00:00",
+        schedule=schedule,
+    )
+    secret = "SyntheticDeliveryPassword123456789"
+    completed = executions.finish_execution(
+        claimed["id"],
+        success=True,
+        output_path="/tmp/observed-job.md",
+        delivery_outcome="failed",
+        delivery_error=f'RuntimeError({{"password": "{secret}"}})',
+    )
+
+    assert claimed["scheduled_for"] == "2026-08-19T10:30:00+00:00"
+    assert claimed["schedule_json"] == '{"a":2,"kind":"interval","minutes":30,"z":1}'
+    assert completed["output_path"] == "/tmp/observed-job.md"
+    assert completed["delivery_outcome"] == "failed"
+    assert "RuntimeError" in completed["delivery_error"]
+    assert secret not in completed["delivery_error"]
+
+
+def test_delivery_error_redacts_url_query_credentials(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    record = executions.create_execution("query-secret", source="builtin")
+
+    completed = executions.finish_execution(
+        record["id"],
+        success=True,
+        delivery_outcome="failed",
+        delivery_error="GET https://example.test/send?token=super-secret-token&mode=fast failed",
+    )
+
+    assert "super-secret-token" not in completed["delivery_error"]
+    assert "example.test" in completed["delivery_error"]
+
+
+def test_delivery_error_redacts_url_userinfo(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    record = executions.create_execution("userinfo-secret", source="builtin")
+
+    completed = executions.finish_execution(
+        record["id"],
+        success=True,
+        delivery_outcome="failed",
+        delivery_error="POST https://alice:hunter2@example.test/hook failed",
+    )
+
+    assert "alice:hunter2@" not in completed["delivery_error"]
+    assert "hunter2" not in completed["delivery_error"]
+    assert "example.test" in completed["delivery_error"]
+
+
+def test_legacy_execution_schema_is_migrated_in_place(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    executions.EXECUTIONS_FILE.parent.mkdir(parents=True)
+    with sqlite3.connect(executions.EXECUTIONS_FILE) as conn:
+        conn.execute(
+            """CREATE TABLE executions (
+                 id TEXT PRIMARY KEY, job_id TEXT NOT NULL, source TEXT NOT NULL,
+                 process_id TEXT NOT NULL, pid INTEGER NOT NULL,
+                 process_started_at INTEGER, status TEXT NOT NULL,
+                 claimed_at TEXT NOT NULL, started_at TEXT, finished_at TEXT,
+                 error TEXT
+               )"""
+        )
+        conn.execute(
+            """INSERT INTO executions
+               (id, job_id, source, process_id, pid, status, claimed_at)
+               VALUES ('legacy', 'old-job', 'builtin', 'old-process', 1,
+                       'completed', '2026-08-18T00:00:00+00:00')"""
+        )
+
+    row = executions.create_execution(
+        "new-job",
+        source="builtin",
+        scheduled_for="2026-08-19T10:30:00+00:00",
+        schedule={"kind": "cron", "expr": "30 10 * * *"},
+    )
+
+    assert row["scheduled_for"] == "2026-08-19T10:30:00+00:00"
+    assert row["schedule_json"] == '{"expr":"30 10 * * *","kind":"cron"}'
+    legacy = executions.latest_execution("old-job")
+    assert legacy["status"] == "completed"
+    assert legacy["delivery_outcome"] is None
+
+
+def test_legacy_execution_schema_migration_is_cross_process_safe(tmp_path):
+    home = tmp_path / "home"
+    db_path = home / "cron" / "executions.db"
+    db_path.parent.mkdir(parents=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """CREATE TABLE executions (
+                 id TEXT PRIMARY KEY, job_id TEXT NOT NULL, source TEXT NOT NULL,
+                 process_id TEXT NOT NULL, pid INTEGER NOT NULL,
+                 process_started_at INTEGER, status TEXT NOT NULL,
+                 claimed_at TEXT NOT NULL, started_at TEXT, finished_at TEXT,
+                 error TEXT
+               )"""
+        )
+
+    repo = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(home)
+    env["PYTHONPATH"] = str(repo)
+    gate = tmp_path / "start-migration"
+    script = (
+        "import os, time; from pathlib import Path; "
+        "gate=Path(os.environ['MIGRATION_GATE']); "
+        "deadline=time.monotonic()+10; "
+        "\nwhile not gate.exists() and time.monotonic() < deadline: time.sleep(0.001)"
+        "\nfrom cron.executions import create_execution; "
+        "create_execution(os.environ['WORKER_ID'], source='test')"
+    )
+    workers = []
+    for index in range(8):
+        worker_env = env.copy()
+        worker_env["MIGRATION_GATE"] = str(gate)
+        worker_env["WORKER_ID"] = f"worker-{index}"
+        workers.append(
+            subprocess.Popen(
+                [sys.executable, "-c", script],
+                cwd=repo,
+                env=worker_env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        )
+
+    gate.touch()
+    results = [worker.communicate(timeout=20) for worker in workers]
+
+    assert [(worker.returncode, stderr) for worker, (_stdout, stderr) in zip(workers, results)] == [
+        (0, "")
+    ] * len(workers)
+    with sqlite3.connect(db_path) as conn:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(executions)")}
+        count = conn.execute("SELECT COUNT(*) FROM executions").fetchone()[0]
+    assert {
+        "scheduled_for",
+        "schedule_json",
+        "output_path",
+        "delivery_outcome",
+        "delivery_error",
+    } <= columns
+    assert count == len(workers)
+
+
+def test_current_schema_read_does_not_acquire_immediate_writer(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    executions.create_execution("current", source="test")
+    statements = []
+    real_connect = executions._connect
+
+    def traced_connect():
+        conn = real_connect()
+        conn.set_trace_callback(statements.append)
+        return conn
+
+    monkeypatch.setattr(executions, "_connect", traced_connect)
+    assert executions.latest_execution("current")["status"] == "claimed"
+    assert not any("BEGIN IMMEDIATE" in sql.upper() for sql in statements)
+
+
 def test_execution_ledger_follows_the_current_profile_home(monkeypatch, tmp_path):
     import cron.executions as executions
 
@@ -67,6 +238,161 @@ def test_terminal_execution_cannot_be_rewritten(monkeypatch, tmp_path):
         record["id"], success=False, error="late writer"
     ) is None
     assert executions.latest_execution("immutable")["status"] == "completed"
+
+
+def test_later_terminal_success_cannot_erase_delivery_failure(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    record = executions.create_execution("immutable-delivery", source="builtin")
+    failed = executions.finish_execution(
+        record["id"],
+        success=False,
+        error="agent failed",
+        output_path="/tmp/first.md",
+        delivery_outcome="failed",
+        delivery_error="first send failed",
+    )
+
+    assert executions.finish_execution(
+        record["id"],
+        success=True,
+        output_path="/tmp/later.md",
+        delivery_outcome="delivered",
+    ) is None
+    persisted = executions.latest_execution("immutable-delivery")
+    assert persisted == failed
+    assert persisted["delivery_outcome"] == "failed"
+    assert persisted["output_path"] == "/tmp/first.md"
+
+
+def test_claimed_execution_can_receive_external_claim_snapshot(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    record = executions.create_execution("external-slot", source="chronos")
+
+    updated = executions.record_execution_schedule(
+        record["id"],
+        scheduled_for="2026-08-19T10:00:00+00:00",
+        schedule={"kind": "cron", "expr": "0 * * * *"},
+    )
+
+    assert updated["scheduled_for"] == "2026-08-19T10:00:00+00:00"
+    assert updated["schedule_json"] == '{"expr":"0 * * * *","kind":"cron"}'
+
+
+def test_external_claim_flows_through_sqlite_ledger_to_terminal_state(monkeypatch, tmp_path):
+    import cron.jobs as jobs
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    executions = _point_ledger(monkeypatch, tmp_path)
+    profile_home = tmp_path / "profile"
+    with jobs.use_cron_store(profile_home):
+        created = jobs.create_job(
+            prompt="record provenance",
+            schedule="every 5m",
+            name="integrated external fire",
+        )
+        original_slot = created["next_run_at"]
+
+        claimed = InProcessCronScheduler().claim_fire(created["id"])
+
+        assert claimed is not None
+        execution_id = claimed["execution_id"]
+        owner = claimed["fire_claim"]["by"]
+        ledger_claim = executions.latest_execution(created["id"])
+        assert ledger_claim["id"] == execution_id
+        assert ledger_claim["status"] == "claimed"
+        assert ledger_claim["scheduled_for"] == original_slot
+        assert json.loads(ledger_claim["schedule_json"])["kind"] == "interval"
+        stored_claim = jobs.get_job(created["id"])
+        assert stored_claim["next_run_at"] != original_slot
+        assert stored_claim["fire_claim"]["by"] == owner
+
+        executions.mark_execution_running(execution_id)
+        terminal = executions.finish_execution(
+            execution_id,
+            success=True,
+            output_path="/tmp/integrated-output.md",
+            delivery_outcome="delivered",
+        )
+        assert jobs.mark_job_run(
+            created["id"], True, expected_fire_owner=owner
+        ) is True
+
+        assert terminal["status"] == "completed"
+        assert terminal["output_path"] == "/tmp/integrated-output.md"
+        assert terminal["delivery_outcome"] == "delivered"
+        assert jobs.get_job(created["id"])["fire_claim"] is None
+
+
+def test_fire_due_runs_shared_body_and_terminalizes_real_ledger(monkeypatch, tmp_path):
+    import cron.jobs as jobs
+    import cron.scheduler as scheduler
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    executions = _point_ledger(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        scheduler,
+        "run_job",
+        lambda *_args, **_kwargs: (True, "full output", "final response", None),
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "save_job_output",
+        lambda job_id, _output: tmp_path / f"{job_id}.md",
+    )
+
+    with jobs.use_cron_store(tmp_path / "profile"):
+        created = jobs.create_job(
+            prompt="run hermetic integration",
+            schedule="every 5m",
+            name="real terminal path",
+            deliver="local",
+        )
+        original_slot = created["next_run_at"]
+
+        assert InProcessCronScheduler().fire_due(created["id"]) is True
+
+        terminal = executions.latest_execution(created["id"])
+        assert terminal["status"] == "completed"
+        assert terminal["scheduled_for"] == original_slot
+        assert terminal["output_path"] == str(tmp_path / f"{created['id']}.md")
+        assert terminal["delivery_outcome"] == "suppressed"
+        stored = jobs.get_job(created["id"])
+        assert stored["fire_claim"] is None
+        assert stored["last_status"] == "ok"
+
+
+def test_external_snapshot_miss_rearms_real_claim_and_fails_ledger(monkeypatch, tmp_path):
+    import cron.jobs as jobs
+    import cron.scheduler as scheduler
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    executions = _point_ledger(monkeypatch, tmp_path)
+    profile_home = tmp_path / "profile"
+    dispatched = []
+    monkeypatch.setattr(executions, "record_execution_schedule", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        scheduler,
+        "run_one_job",
+        lambda job, **kwargs: dispatched.append(job) or True,
+    )
+
+    with jobs.use_cron_store(profile_home):
+        created = jobs.create_job(
+            prompt="retry only after provenance",
+            schedule="every 5m",
+            name="provenance fail closed",
+        )
+        original_slot = created["next_run_at"]
+
+        assert InProcessCronScheduler().fire_due(created["id"]) is False
+
+        stored = jobs.get_job(created["id"])
+        assert stored["next_run_at"] == original_slot
+        assert stored["fire_claim"] is None
+        assert dispatched == []
+        terminal = executions.latest_execution(created["id"])
+        assert terminal["status"] == "failed"
+        assert "not persisted" in terminal["error"]
 
 
 def test_retention_bounds_terminal_history_but_preserves_inflight(monkeypatch, tmp_path):

--- a/tests/cron/test_parallel_pool.py
+++ b/tests/cron/test_parallel_pool.py
@@ -164,7 +164,7 @@ class TestRunningJobGuard:
 
         called = []
 
-        def create_execution_side_effect(job_id, source):
+        def create_execution_side_effect(job_id, source, **_kwargs):
             if job_id == "failing-job":
                 raise RuntimeError("execution ledger unavailable")
             return {"id": f"{job_id}-execution"}

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -56,6 +56,44 @@ def test_tick_process_job_sequence(monkeypatch):
     assert calls[-1] == ("mark", "j1", True)
 
 
+def test_builtin_tick_records_exact_slot_before_advance(monkeypatch):
+    slot_a = "2026-08-19T10:00:00+00:00"
+    slot_b = "2026-08-19T11:00:00+00:00"
+    schedule = {"kind": "cron", "expr": "0 * * * *"}
+    due_job = {"id": "slot-job", "next_run_at": slot_a, "schedule": schedule}
+    captured = {}
+
+    monkeypatch.setattr(s, "get_due_jobs", lambda: [due_job])
+
+    def advance(_job_ids):
+        due_job["next_run_at"] = slot_b
+        due_job["schedule"] = {"kind": "cron", "expr": "5 * * * *"}
+        return 1
+
+    monkeypatch.setattr(s, "advance_next_runs", advance)
+    monkeypatch.setattr(
+        s,
+        "create_execution",
+        lambda job_id, **kwargs: captured.update(kwargs) or {"id": "exec-slot"},
+    )
+    monkeypatch.setattr(
+        s,
+        "claim_job_for_fire",
+        lambda job_id, **kwargs: {
+            "id": job_id,
+            "next_run_at": slot_b,
+            "schedule": due_job["schedule"],
+            "fire_claim": {"by": "owner"},
+        },
+    )
+    monkeypatch.setattr(s, "run_one_job", lambda *_args, **_kwargs: True)
+
+    assert s.tick(verbose=False, sync=True) == 1
+    assert captured["scheduled_for"] == slot_a
+    assert captured["scheduled_for"] != slot_b
+    assert captured["schedule"] == schedule
+
+
 def test_tick_skips_job_when_durable_fire_claim_is_lost(monkeypatch):
     """A manual/external fire that wins the shared CAS must exclude ticker."""
     calls = _patch_pipeline(monkeypatch)
@@ -76,6 +114,206 @@ def test_run_one_job_success_sequence(monkeypatch):
     assert ok is True
     assert [c[0] for c in calls] == ["run_job", "save", "deliver", "mark"]
     assert calls[-1] == ("mark", "j2", True)
+
+
+@pytest.mark.parametrize(
+    ("deliver", "final", "delivery_error", "targets", "expected"),
+    [
+        ("telegram:chat", "report", None, True, "delivered"),
+        ("telegram:chat", "[SILENT]", None, True, "suppressed"),
+        ("origin", "report", None, False, "not_configured"),
+        ("telegram:chat", "report", "send failed", True, "failed"),
+        ("local", "report", None, True, "suppressed"),
+    ],
+)
+def test_run_one_job_persists_output_and_delivery_result(
+    monkeypatch, deliver, final, delivery_error, targets, expected
+):
+    finished = []
+    monkeypatch.setattr(s, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(s, "mark_execution_running", lambda _execution_id: None)
+    monkeypatch.setattr(
+        s,
+        "run_job",
+        lambda *_a, **_kw: (True, "full output", final, None),
+    )
+    monkeypatch.setattr(s, "save_job_output", lambda *_a: "/tmp/job-output.md")
+    monkeypatch.setattr(s, "_resolve_delivery_targets", lambda _job: [object()] if targets else [])
+    monkeypatch.setattr(s, "_deliver_result", lambda *_a, **_kw: delivery_error)
+    monkeypatch.setattr(s, "mark_job_run", lambda *_a, **_kw: True)
+    monkeypatch.setattr(
+        s,
+        "finish_execution",
+        lambda execution_id, **kwargs: finished.append((execution_id, kwargs)),
+    )
+
+    assert s.run_one_job(
+        {"id": "delivery-job", "execution_id": "delivery-exec", "deliver": deliver}
+    ) is True
+    assert finished[-1] == (
+        "delivery-exec",
+        {
+            "success": True,
+            "error": None,
+            "delivery_outcome": expected,
+            "delivery_error": delivery_error,
+            "output_path": "/tmp/job-output.md",
+        },
+    )
+
+
+def test_interrupted_run_keeps_saved_output_and_failed_delivery_provenance(monkeypatch):
+    finished = []
+    monkeypatch.setattr(s, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(s, "mark_execution_running", lambda _execution_id: None)
+    monkeypatch.setattr(
+        s,
+        "run_job",
+        lambda *_a, **_kw: (True, "full output", "report", None),
+    )
+    monkeypatch.setattr(s, "save_job_output", lambda *_a: "/tmp/exact-output.md")
+    monkeypatch.setattr(s, "_deliver_result", lambda *_a, **_kw: "send failed")
+    monkeypatch.setattr(s, "_consume_interrupted_flag", lambda *_a, **_kw: True)
+    monkeypatch.setattr(s, "mark_job_run", lambda *_a, **_kw: True)
+    monkeypatch.setattr(
+        s,
+        "finish_execution",
+        lambda execution_id, **kwargs: finished.append((execution_id, kwargs)),
+    )
+
+    assert s.run_one_job(
+        {
+            "id": "interrupted-job",
+            "execution_id": "interrupted-exec",
+            "deliver": "telegram:chat",
+        }
+    ) is True
+    assert finished[-1] == (
+        "interrupted-exec",
+        {
+            "success": False,
+            "error": "Interrupted by gateway shutdown before terminal completion.",
+            "delivery_outcome": "failed",
+            "delivery_error": "send failed",
+            "output_path": "/tmp/exact-output.md",
+        },
+    )
+
+
+def test_owner_fence_rejection_keeps_saved_output_and_delivery_provenance(monkeypatch):
+    import contextlib
+
+    finished = []
+    monkeypatch.setattr(s, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(s, "mark_execution_running", lambda _execution_id: None)
+    monkeypatch.setattr(
+        s,
+        "run_job",
+        lambda *_a, **_kw: (True, "full output", "report", None),
+    )
+    monkeypatch.setattr(s, "save_job_output", lambda *_a: "/tmp/fenced-output.md")
+    monkeypatch.setattr(s, "_deliver_result", lambda *_a, **_kw: None)
+    monkeypatch.setattr(s, "heartbeat_fire_claim", lambda *_a, **_kw: True)
+    monkeypatch.setattr(s, "fire_claim_fence", lambda *_a, **_kw: contextlib.nullcontext(True))
+    monkeypatch.setattr(s, "mark_job_run", lambda *_a, **_kw: False)
+    monkeypatch.setattr(
+        s,
+        "finish_execution",
+        lambda execution_id, **kwargs: finished.append((execution_id, kwargs)),
+    )
+
+    assert s._run_one_job_body(
+        {
+            "id": "fenced-job",
+            "execution_id": "fenced-exec",
+            "deliver": "telegram:chat",
+            "fire_claim": {"by": "owner-1"},
+        }
+    ) is True
+    assert finished[-1] == (
+        "fenced-exec",
+        {
+            "success": False,
+            "error": "Fire claim ownership lost before terminal completion.",
+            "delivery_outcome": "delivered",
+            "delivery_error": None,
+            "output_path": "/tmp/fenced-output.md",
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    ("ownership_retained", "expected_error"),
+    [
+        (False, "Fire claim ownership lost; stale result was discarded."),
+        (True, "Interrupted by shutdown before terminal completion."),
+    ],
+)
+def test_delivery_fence_rejection_after_save_keeps_output_provenance(
+    monkeypatch, ownership_retained, expected_error
+):
+    import contextlib
+
+    finished = []
+    delivered = []
+    marked = []
+    fences = iter((True, False))
+    heartbeats = iter((True, True, ownership_retained))
+
+    monkeypatch.setattr(s, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(s, "mark_execution_running", lambda _execution_id: None)
+    monkeypatch.setattr(
+        s,
+        "run_job",
+        lambda *_a, **_kw: (True, "full output", "report", None),
+    )
+    monkeypatch.setattr(s, "save_job_output", lambda *_a: "/tmp/post-save-output.md")
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda *_a, **_kw: delivered.append(True) or None,
+    )
+    monkeypatch.setattr(
+        s,
+        "fire_claim_fence",
+        lambda *_a, **_kw: contextlib.nullcontext(next(fences)),
+    )
+    monkeypatch.setattr(
+        s,
+        "heartbeat_fire_claim",
+        lambda *_a, **_kw: next(heartbeats),
+    )
+    monkeypatch.setattr(
+        s,
+        "mark_job_run",
+        lambda *args, **kwargs: marked.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        s,
+        "finish_execution",
+        lambda execution_id, **kwargs: finished.append((execution_id, kwargs)),
+    )
+
+    assert s._run_one_job_body(
+        {
+            "id": "post-save-fenced-job",
+            "execution_id": "post-save-fenced-exec",
+            "deliver": "telegram:chat",
+            "fire_claim": {"by": "owner-1"},
+        }
+    ) is True
+    assert delivered == []
+    assert bool(marked) is ownership_retained
+    assert finished[-1] == (
+        "post-save-fenced-exec",
+        {
+            "success": False,
+            "error": expected_error,
+            "delivery_outcome": "suppressed",
+            "delivery_error": None,
+            "output_path": "/tmp/post-save-output.md",
+        },
+    )
 
 
 def test_run_one_job_exception_delivers_failure_alert(monkeypatch):
@@ -128,6 +366,8 @@ def test_run_one_job_exception_delivers_failure_alert(monkeypatch):
                 "success": False,
                 "error": "Gemini HTTP 503 (UNAVAILABLE)",
                 "delivery_outcome": "delivered",
+                "delivery_error": None,
+                "output_path": None,
             },
         )
     ]
@@ -246,6 +486,8 @@ def test_run_one_job_keyboard_interrupt_skips_delivery_and_reraises(monkeypatch)
                 "success": False,
                 "error": "KeyboardInterrupt",
                 "delivery_outcome": "suppressed",
+                "delivery_error": None,
+                "output_path": None,
             },
         )
     ]

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -407,6 +407,11 @@ def test_claim_fire_persists_attempt_before_fire_claimed(monkeypatch):
         lambda jid, source: events.append("ledger") or {"id": "exec-1"},
     )
     monkeypatch.setattr(
+        executions,
+        "record_execution_schedule",
+        lambda *_args, **_kwargs: {"id": "exec-1"},
+    )
+    monkeypatch.setattr(
         sched,
         "run_one_job",
         lambda job, **kwargs: events.append(("run", job["execution_id"])) or True,
@@ -422,12 +427,283 @@ def test_claim_fire_persists_attempt_before_fire_claimed(monkeypatch):
     assert events == ["ledger", "claim", ("run", "exec-1")]
 
 
+def test_external_claim_records_exact_pre_advance_slot(monkeypatch):
+    import contextlib
+    import copy
+
+    import cron.executions as executions
+    import cron.jobs as jobs
+    import cron.scheduler as sched
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    slot_a = "2026-08-19T10:00:00+00:00"
+    slot_b = "2026-08-19T11:00:00+00:00"
+    schedule = {"kind": "cron", "expr": "0 * * * *"}
+    stored = [{
+        "id": "j1",
+        "enabled": True,
+        "state": "scheduled",
+        "paused_at": None,
+        "next_run_at": slot_a,
+        "schedule": schedule,
+    }]
+    captured = {}
+
+    monkeypatch.setattr(jobs, "_jobs_lock", lambda: contextlib.nullcontext())
+    monkeypatch.setattr(jobs, "load_jobs", lambda: copy.deepcopy(stored))
+    monkeypatch.setattr(
+        jobs,
+        "save_jobs",
+        lambda new_jobs: stored.__setitem__(slice(None), copy.deepcopy(new_jobs)),
+    )
+    monkeypatch.setattr(jobs, "compute_next_run", lambda *_args, **_kwargs: slot_b)
+    monkeypatch.setattr(jobs, "_machine_id", lambda: "test-machine")
+    monkeypatch.setattr(
+        executions,
+        "create_execution", lambda job_id, **kwargs: {"id": "exec-slot"},
+    )
+    monkeypatch.setattr(
+        executions,
+        "record_execution_schedule",
+        lambda execution_id, **kwargs: captured.update(kwargs) or {"id": execution_id},
+        raising=False,
+    )
+    monkeypatch.setattr(sched, "run_one_job", lambda job, **kwargs: True)
+
+    assert InProcessCronScheduler().fire_due("j1") is True
+    assert stored[0]["next_run_at"] == slot_b
+    assert captured["scheduled_for"] == slot_a
+    assert captured["scheduled_for"] != stored[0]["next_run_at"]
+    assert captured["schedule"] == schedule
+
+
+def test_schedule_snapshot_exception_releases_claim_without_dispatch(monkeypatch):
+    import cron.executions as executions
+    import cron.jobs as jobs
+    import cron.scheduler as sched
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    released = []
+    ran = []
+    finished = []
+    monkeypatch.setattr(executions, "create_execution", lambda *_a, **_kw: {"id": "exec-1"})
+    monkeypatch.setattr(
+        jobs,
+        "claim_job_for_fire",
+        lambda *_a, **_kw: {
+            "id": "j1",
+            "fire_claim": {"by": "owner-1"},
+            "next_run_at": "2026-08-19T11:00:00+00:00",
+            "schedule": {"kind": "cron", "expr": "0 * * * *"},
+            "_execution_scheduled_for": "2026-08-19T10:00:00+00:00",
+            "_execution_schedule": {"kind": "cron", "expr": "0 * * * *"},
+        },
+    )
+    monkeypatch.setattr(
+        executions,
+        "record_execution_schedule",
+        lambda *_a, **_kw: (_ for _ in ()).throw(OSError("ledger unavailable")),
+    )
+    monkeypatch.setattr(
+        jobs,
+        "release_fire_claim_for_retry",
+        lambda *args, **kwargs: released.append((args, kwargs)) or True,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        executions,
+        "finish_execution",
+        lambda *args, **kwargs: finished.append((args, kwargs)),
+    )
+    monkeypatch.setattr(sched, "run_one_job", lambda job, **kw: ran.append(job) or True)
+
+    with __import__("pytest").raises(OSError, match="ledger unavailable"):
+        InProcessCronScheduler().fire_due("j1")
+
+    assert released == [(('j1',), {
+        "expected_owner": "owner-1",
+        "scheduled_for": "2026-08-19T10:00:00+00:00",
+        "expected_schedule": {"kind": "cron", "expr": "0 * * * *"},
+        "expected_next_run_at": "2026-08-19T11:00:00+00:00",
+    })]
+    assert ran == []
+    assert finished[-1][1]["success"] is False
+
+
+def test_missing_schedule_snapshot_update_releases_claim_without_dispatch(monkeypatch):
+    import cron.executions as executions
+    import cron.jobs as jobs
+    import cron.scheduler as sched
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    released = []
+    ran = []
+    finished = []
+    monkeypatch.setattr(executions, "create_execution", lambda *_a, **_kw: {"id": "exec-2"})
+    monkeypatch.setattr(
+        jobs,
+        "claim_job_for_fire",
+        lambda *_a, **_kw: {
+            "id": "j2",
+            "fire_claim": {"by": "owner-2"},
+            "next_run_at": "2026-08-19T12:00:00+00:00",
+            "schedule": {"kind": "interval", "minutes": 60},
+            "_execution_scheduled_for": "2026-08-19T11:00:00+00:00",
+            "_execution_schedule": {"kind": "interval", "minutes": 60},
+        },
+    )
+    monkeypatch.setattr(executions, "record_execution_schedule", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        jobs,
+        "release_fire_claim_for_retry",
+        lambda *args, **kwargs: released.append((args, kwargs)) or True,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        executions,
+        "finish_execution",
+        lambda *args, **kwargs: finished.append((args, kwargs)),
+    )
+    monkeypatch.setattr(sched, "run_one_job", lambda job, **kw: ran.append(job) or True)
+
+    assert InProcessCronScheduler().fire_due("j2") is False
+    assert released == [(('j2',), {
+        "expected_owner": "owner-2",
+        "scheduled_for": "2026-08-19T11:00:00+00:00",
+        "expected_schedule": {"kind": "interval", "minutes": 60},
+        "expected_next_run_at": "2026-08-19T12:00:00+00:00",
+    })]
+    assert ran == []
+    assert finished[-1][1]["success"] is False
+
+
+def test_retry_release_cannot_clear_replacement_fire_owner(tmp_path):
+    import cron.jobs as jobs
+
+    with jobs.use_cron_store(tmp_path):
+        created = jobs.create_job(prompt="owner fence", schedule="every 5m")
+        claimed = jobs.claim_job_for_fire(created["id"], return_job=True)
+        assert isinstance(claimed, dict)
+        stale_owner = claimed["fire_claim"]["by"]
+        advanced_slot = claimed["next_run_at"]
+
+        stored = jobs.load_jobs()
+        stored[0]["fire_claim"] = {
+            "at": "2026-08-19T12:00:00+00:00",
+            "by": "new-owner",
+        }
+        jobs.save_jobs(stored)
+
+        assert jobs.release_fire_claim_for_retry(
+            created["id"],
+            expected_owner=stale_owner,
+            scheduled_for=created["next_run_at"],
+            expected_schedule=claimed["schedule"],
+            expected_next_run_at=advanced_slot,
+        ) is False
+        current = jobs.get_job(created["id"])
+        assert current["fire_claim"]["by"] == "new-owner"
+        assert current["next_run_at"] == advanced_slot
+
+
+def test_retry_release_cas_preserves_concurrent_hourly_schedule(tmp_path):
+    import cron.jobs as jobs
+
+    with jobs.use_cron_store(tmp_path):
+        created = jobs.create_job(prompt="schedule fence", schedule="every 5m")
+        claimed = jobs.claim_job_for_fire(created["id"], return_job=True)
+        assert isinstance(claimed, dict)
+        old_slot = created["next_run_at"]
+        owner = claimed["fire_claim"]["by"]
+
+        hourly = jobs.update_job(created["id"], {"schedule": "every 1h"})
+        assert hourly is not None
+        hourly_slot = hourly["next_run_at"]
+
+        assert jobs.release_fire_claim_for_retry(
+            created["id"],
+            expected_owner=owner,
+            scheduled_for=old_slot,
+            expected_schedule=claimed["_execution_schedule"],
+            expected_next_run_at=claimed["next_run_at"],
+        ) is False
+        current = jobs.get_job(created["id"])
+        assert current["schedule"]["minutes"] == 60
+        assert current["next_run_at"] == hourly_slot
+        assert current["next_run_at"] != old_slot
+
+
+def test_snapshot_exception_keeps_primary_when_release_and_finish_raise(monkeypatch):
+    import pytest
+    import cron.executions as executions
+    import cron.jobs as jobs
+    import cron.scheduler as sched
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    cleanup = []
+    monkeypatch.setattr(executions, "create_execution", lambda *_a, **_kw: {"id": "exec"})
+    monkeypatch.setattr(jobs, "claim_job_for_fire", lambda *_a, **_kw: {
+        "id": "job", "fire_claim": {"by": "owner"},
+        "next_run_at": "advanced", "schedule": {"kind": "interval", "minutes": 5},
+        "_execution_scheduled_for": "old",
+        "_execution_schedule": {"kind": "interval", "minutes": 5},
+    })
+    monkeypatch.setattr(
+        executions, "record_execution_schedule",
+        lambda *_a, **_kw: (_ for _ in ()).throw(OSError("provenance failed")),
+    )
+    monkeypatch.setattr(
+        jobs, "release_fire_claim_for_retry",
+        lambda *_a, **_kw: cleanup.append("release") or (_ for _ in ()).throw(RuntimeError("release failed")),
+    )
+    monkeypatch.setattr(
+        executions, "finish_execution",
+        lambda *_a, **_kw: cleanup.append("finish") or (_ for _ in ()).throw(RuntimeError("finish failed")),
+    )
+    monkeypatch.setattr(sched, "run_one_job", lambda *_a, **_kw: pytest.fail("dispatched"))
+
+    with pytest.raises(OSError, match="provenance failed"):
+        InProcessCronScheduler().fire_due("job")
+    assert cleanup == ["release", "finish"]
+
+
+def test_snapshot_none_terminalizes_when_release_raises(monkeypatch):
+    import cron.executions as executions
+    import cron.jobs as jobs
+    import cron.scheduler as sched
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    finished = []
+    monkeypatch.setattr(executions, "create_execution", lambda *_a, **_kw: {"id": "exec"})
+    monkeypatch.setattr(jobs, "claim_job_for_fire", lambda *_a, **_kw: {
+        "id": "job", "fire_claim": {"by": "owner"},
+        "next_run_at": "advanced", "schedule": {"kind": "interval", "minutes": 5},
+        "_execution_scheduled_for": "old",
+        "_execution_schedule": {"kind": "interval", "minutes": 5},
+    })
+    monkeypatch.setattr(executions, "record_execution_schedule", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        jobs, "release_fire_claim_for_retry",
+        lambda *_a, **_kw: (_ for _ in ()).throw(RuntimeError("release failed")),
+    )
+    monkeypatch.setattr(
+        executions, "finish_execution",
+        lambda *args, **kwargs: finished.append((args, kwargs)) or {"status": "failed"},
+    )
+    monkeypatch.setattr(sched, "run_one_job", lambda *_a, **_kw: (_ for _ in ()).throw(AssertionError("dispatched")))
+
+    assert InProcessCronScheduler().fire_due("job") is False
+    assert finished and finished[-1][1]["success"] is False
+
+
 def test_fire_due_forwards_manual_force_to_store_claim(monkeypatch):
+    import cron.executions as executions
     import cron.jobs as jobs
     import cron.scheduler as sched
     from cron.scheduler_provider import InProcessCronScheduler
 
     claims = []
+    scheduled = []
     monkeypatch.setattr(
         jobs,
         "claim_job_for_fire",
@@ -435,9 +711,15 @@ def test_fire_due_forwards_manual_force_to_store_claim(monkeypatch):
         or {"id": jid, "name": "t", "fire_claim": {"by": "manual-owner"}},
     )
     monkeypatch.setattr(sched, "run_one_job", lambda job, **kw: True)
+    monkeypatch.setattr(
+        executions,
+        "record_execution_schedule",
+        lambda *args, **kwargs: scheduled.append((args, kwargs)),
+    )
 
     assert InProcessCronScheduler().fire_due("j1", force=True) is True
     assert claims == [("j1", {"force": True, "return_job": True})]
+    assert scheduled == []
 
 
 def test_fire_due_lost_claim_does_not_run(monkeypatch):

--- a/tests/cron/test_script_claim_heartbeat.py
+++ b/tests/cron/test_script_claim_heartbeat.py
@@ -577,4 +577,7 @@ def test_terminal_owner_cas_failure_marks_ledger_ownership_lost(monkeypatch):
         "execution-cas",
         success=False,
         error="Fire claim ownership lost before terminal completion.",
+        delivery_outcome="suppressed",
+        delivery_error=None,
+        output_path="output.md",
     )


### PR DESCRIPTION
## Summary

- persist exact pre-advance `scheduled_for` and deterministic `schedule_json` for built-in and external-provider fires
- persist real output paths and per-execution delivery outcomes/errors across normal, interrupted, and ownership-loss paths
- redact URL credentials before durable delivery-error storage
- make additive ledger migration cross-process safe
- CAS-fence retry cleanup so provenance failures cannot overwrite concurrent schedule edits or strand claims

## Verification

- full `tests/cron/`: 834 passed, 1 skipped
- concurrent eight-process legacy migration regression
- real external `fire_due` -> shared execution body -> terminal SQLite ledger integration
- strict URL credential redaction and ownership/fencing edge coverage
- `py_compile` and `git diff --check` clean