### PR TITLE
fix(desktop): close the blank hole in the Sessions header

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1681,7 +1681,10 @@ export function ChatSidebar({
                 grouping={showArchived || rankedGlobally ? 'none' : grouping === 'status' ? 'status' : 'date'}
                 groups={displayAgentGroups}
                 headerAction={
-                  <>
+                  // One cluster, not a fragment: the header is justify-between,
+                  // so two children (mark-all + the rest) park the check-all in
+                  // the middle as a blank 24px hole until hover.
+                  <div className="flex shrink-0 items-center gap-0.5">
                     {unreadCount > 0 && (
                       <Tip label={s.markAllRead}>
                         <Button
@@ -1731,7 +1734,7 @@ export function ChatSidebar({
                         </div>
                       </div>
                     ) : (
-                      <div className="flex shrink-0 items-center gap-0.5">
+                      <>
                         {!showAllProfiles ? (
                           <Tip label={agentsGrouped ? s.projects.newButton : s.nav['new-session']}>
                             <Button
@@ -1756,9 +1759,9 @@ export function ChatSidebar({
                         <div className="grid size-6 place-items-center">
                           <SidebarFilterMenu className={HEADER_NAV_BTN} />
                         </div>
-                      </div>
+                      </>
                     )}
-                  </>
+                  </div>
                 }
                 label={sessionsLabel}
                 labelMeta={


### PR DESCRIPTION
## Summary
The Sessions header is `justify-between`. Mark-all was added as a sibling of the +/filter cluster, so with unread sessions it sat in the middle as a 24px empty slot (icon is `opacity-0` until hover). One cluster now, same as Pinned/Projects.

Introduced by [#76504](https://github.com/NousResearch/hermes-agent/pull/76504), landed via [#86772](https://github.com/NousResearch/hermes-agent/pull/86772).

## Test plan
- [ ] With at least one unread session, the Sessions header should show SESSIONS flush left and the check-all / + / filter icons flush right — no empty square in the middle
- [ ] Hover the header: check-all and + fade in next to the filter, not floating mid-row
- [ ] Click check-all: unread dots clear
- [ ] Enter a project: scoped header actions still sit flush right