### PR TITLE
fix(desktop): keep recents when ALL-profiles scope has one profile (supersedes #84313)

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -467,16 +467,19 @@ export function ChatSidebar({
 
   // Profile scope = the "workspace switcher" context. Concrete scope shows only
   // that profile's sessions (clean rows, no per-row tags); ALL fans every
-  // profile in, grouped by profile below. Single-profile users land here with
-  // scope === their only profile, so nothing is filtered out.
+  // profile in. Grouped rendering stays gated on `showAllProfiles` (multi-profile
+  // + ALL) so a single-profile user is never stranded in a grouped view with no
+  // rail — but the *data* still has to fan in when the persisted scope is ALL
+  // (Grouping → Profile). Filtering that pool against the `__all__` sentinel
+  // matches nothing and empties recents + pins.
   // Archived rows are excluded from the sessions query, so Archived is a view of
   // its own set rather than a filter over this one — a flat list of archived
   // rows, no project tree, no date or status dividers.
   const scopedSessions = useMemo(() => {
     const pool = showArchived ? archivedSessions : sessions
 
-    return showAllProfiles ? pool : pool.filter(s => normalizeProfileKey(s.profile) === profileScope)
-  }, [sessions, archivedSessions, showArchived, showAllProfiles, profileScope])
+    return filterSessionsByProfileScope(pool, profileScope)
+  }, [sessions, archivedSessions, showArchived, profileScope])
 
   // One predicate for the status/project filters, so the flat list and the
   // project lanes narrow by the same rule. A project lane holds rows the loaded

--- a/apps/desktop/src/app/chat/sidebar/profile-scope.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/profile-scope.test.ts
@@ -27,4 +27,12 @@ describe('filterSessionsByProfileScope', () => {
 
     expect(filterSessionsByProfileScope(rows, ALL_PROFILES)).toBe(rows)
   })
+
+  it('does not empty ALL scope when every row is one profile', () => {
+    // Grouping → Profile persists ALL even with one profile. Filtering
+    // against the `__all__` sentinel would empty recents and pins.
+    const rows = [row('a', 'default'), row('b', 'default'), row('c', 'default')]
+
+    expect(filterSessionsByProfileScope(rows, ALL_PROFILES)).toBe(rows)
+  })
 })

--- a/apps/desktop/src/app/chat/sidebar/profile-scope.ts
+++ b/apps/desktop/src/app/chat/sidebar/profile-scope.ts
@@ -1,7 +1,13 @@
 import { ALL_PROFILES, normalizeProfileKey } from '@/store/profile'
 import type { SessionInfo } from '@/types/hermes'
 
-/** Return the sessions visible in one sidebar profile scope, or the original unified list for All profiles. */
+/**
+ * Sessions visible in one sidebar profile scope.
+ *
+ * ALL (`__all__`) returns the caller's list unchanged — including the
+ * single-profile case, where Grouping → Profile persists that sentinel
+ * while grouped rendering stays off. Never filter against `__all__`.
+ */
 export function filterSessionsByProfileScope(sessions: SessionInfo[], profileScope: string): SessionInfo[] {
   if (profileScope === ALL_PROFILES) {
     return sessions


### PR DESCRIPTION
## What does this PR do?

Supersedes #84313.

Filters > Grouping > Profile persists the all-profiles scope even when there is only one profile (`default`). Recents still gated that list on `showAllProfiles` (multi-profile AND all-scope), then filtered leftover rows against the `__all__` sentinel. Nothing matched, so pinned and recent sessions vanished even though the backend returned every row. Clicking the `default` chip left ALL scope and restored the list.

Cron and messaging already used `filterSessionsByProfileScope`, which treats ALL as include-everything. Recents now use the same helper. Grouped rendering stays gated on `multiProfile` so a single-profile user is not stuck in a grouped view with no rail.

#84313 had the right diagnosis. It added a second helper (`selectVisibleSessions`) instead of wiring the one already on main.

## Related Issue

Fixes #84305

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scopedSessions` in `apps/desktop/src/app/chat/sidebar/index.tsx` uses `filterSessionsByProfileScope`
- Regression: ALL scope with only `default` rows must not empty the list

### What was dropped from #84313

- New `session-scope.ts` / `selectVisibleSessions` duplicate of the existing helper

## How to Test

1. Single `default` profile. Filters > Grouping > Profile. Recents and pins should stay visible (flat list).
2. Click the `default` chip, then Grouping > Profile again. Same rows, not the empty state.
3. With two profiles, Grouping > Profile should still group by profile.
4. `npx vitest run src/app/chat/sidebar/profile-scope.test.ts` (4 tests)

## Checklist

### Code

- [x] Conventional commit
- [x] Searched existing PRs (salvage of #84313)
- [x] Only this fix
- [x] Tests for the bug class

Credit: @andyst-dev