### PR TITLE
fix(desktop): scope the ⌘K settings-search catalog to the "Applies to" profile

### DIFF
--- a/apps/desktop/src/app/settings/use-settings-search.test.tsx
+++ b/apps/desktop/src/app/settings/use-settings-search.test.tsx
@@ -1,0 +1,110 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { createElement, type PropsWithChildren } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const hermesMocks = vi.hoisted(() => ({
+  getEnvVars: vi.fn(async () => ({})),
+  getHermesConfigRecord: vi.fn(async () => ({ config: {} })),
+  getHermesConfigSchema: vi.fn(async () => ({ fields: [] }))
+}))
+
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  ...hermesMocks
+}))
+
+const gatewayRequestMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/app/gateway/hooks/use-gateway-request', () => ({
+  useGatewayRequest: () => ({ requestGateway: gatewayRequestMock })
+}))
+
+const loadAgentPluginsMock = vi.hoisted(() => vi.fn(async () => undefined))
+
+vi.mock('@/store/agent-plugins', () => ({
+  $agentPlugins: { get: () => [], listen: () => () => undefined, subscribe: () => () => undefined },
+  isDesktopRelevantPlugin: () => true,
+  loadAgentPlugins: loadAgentPluginsMock
+}))
+
+import { $gatewayState } from '@/store/session'
+import { $settingsScopeOverride } from '@/store/settings-scope'
+
+import { useSettingsSearchCatalog } from './use-settings-search'
+
+// Regression coverage for: the deep ⌘K settings-search catalog (config
+// fields, credentials, agent plugins) ignored the shared "Applies to" scope
+// override and always searched the active profile — so scoping Settings to
+// another profile via the shared selector made that profile's credentials/
+// fields/plugins unfindable via search, contradicting the search-page
+// removal's own justification ("⌘K already finds credentials").
+
+function wrapper({ children }: PropsWithChildren) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+  return createElement(QueryClientProvider, { client }, children)
+}
+
+beforeEach(() => {
+  hermesMocks.getEnvVars.mockClear()
+  hermesMocks.getHermesConfigRecord.mockClear()
+  hermesMocks.getHermesConfigSchema.mockClear()
+  loadAgentPluginsMock.mockClear()
+  $settingsScopeOverride.set(null)
+  $gatewayState.set('open')
+})
+
+afterEach(() => {
+  $settingsScopeOverride.set(null)
+  vi.clearAllMocks()
+})
+
+describe('useSettingsSearchCatalog — settings-scope override', () => {
+  it('fetches config/schema/env for the active profile when no scope override is set', async () => {
+    renderHook(() => useSettingsSearchCatalog(true), { wrapper })
+
+    await waitFor(() => expect(hermesMocks.getEnvVars).toHaveBeenCalled())
+
+    expect(hermesMocks.getEnvVars).toHaveBeenCalledWith(null)
+    expect(hermesMocks.getHermesConfigSchema).toHaveBeenCalledWith(null)
+    // useHermesConfigRecord folds null -> undefined before its own fetch call
+    // ("null/undefined both mean 'no override'"); that's its established
+    // contract, not something this fix changes.
+    expect(hermesMocks.getHermesConfigRecord).toHaveBeenCalledWith(undefined)
+    await waitFor(() => expect(loadAgentPluginsMock).toHaveBeenCalledWith(gatewayRequestMock, null))
+  })
+
+  it('fetches config/schema/env for the scoped profile when Settings is scoped to another one', async () => {
+    $settingsScopeOverride.set('work')
+
+    renderHook(() => useSettingsSearchCatalog(true), { wrapper })
+
+    await waitFor(() => expect(hermesMocks.getEnvVars).toHaveBeenCalled())
+
+    expect(hermesMocks.getEnvVars).toHaveBeenCalledWith('work')
+    expect(hermesMocks.getHermesConfigSchema).toHaveBeenCalledWith('work')
+    expect(hermesMocks.getHermesConfigRecord).toHaveBeenCalledWith('work')
+    await waitFor(() => expect(loadAgentPluginsMock).toHaveBeenCalledWith(gatewayRequestMock, 'work'))
+  })
+
+  it('refetches config/schema/env for the new profile when the scope override changes after mount', async () => {
+    renderHook(() => useSettingsSearchCatalog(true), { wrapper })
+
+    await waitFor(() => expect(hermesMocks.getEnvVars).toHaveBeenCalledWith(null))
+
+    hermesMocks.getEnvVars.mockClear()
+    hermesMocks.getHermesConfigSchema.mockClear()
+    hermesMocks.getHermesConfigRecord.mockClear()
+    loadAgentPluginsMock.mockClear()
+
+    act(() => {
+      $settingsScopeOverride.set('work')
+    })
+
+    await waitFor(() => expect(hermesMocks.getEnvVars).toHaveBeenCalledWith('work'))
+    expect(hermesMocks.getHermesConfigSchema).toHaveBeenCalledWith('work')
+    expect(hermesMocks.getHermesConfigRecord).toHaveBeenCalledWith('work')
+    await waitFor(() => expect(loadAgentPluginsMock).toHaveBeenCalledWith(gatewayRequestMock, 'work'))
+  })
+})

--- a/apps/desktop/src/app/settings/use-settings-search.ts
+++ b/apps/desktop/src/app/settings/use-settings-search.ts
@@ -9,6 +9,7 @@ import { useI18n } from '@/i18n'
 import { Package, Palette, Settings2, Wrench } from '@/lib/icons'
 import { $agentPlugins, isDesktopRelevantPlugin, loadAgentPlugins } from '@/store/agent-plugins'
 import { $gatewayState } from '@/store/session'
+import { $settingsScopeOverride } from '@/store/settings-scope'
 
 import { useHermesConfigRecord } from '../hooks/use-config-record'
 import { useOnProfileSwitch } from '../hooks/use-on-profile-switch'
@@ -28,11 +29,19 @@ import {
  */
 export function useSettingsSearchCatalog(enabled: boolean) {
   const { t } = useI18n()
-  const configQuery = useHermesConfigRecord()
+  // Shared settings "Applies to" scope: search the selected profile's config/
+  // schema/env store, not always the active one (null → active, the default
+  // path — matches every other config-backed settings page's own pattern,
+  // e.g. KeysSettings' useEnvCredentials(scopeProfile)). Without this, ⌘K
+  // silently searched the active profile even while the user had scoped
+  // Settings to another one, so a credential/field that only exists (or is
+  // only set) on the scoped profile was unfindable.
+  const scopeProfile = useStore($settingsScopeOverride)
+  const configQuery = useHermesConfigRecord(scopeProfile)
 
   const schemaQuery = useQuery({
-    queryKey: ['hermes-config-schema'],
-    queryFn: () => getHermesConfigSchema(),
+    queryKey: ['hermes-config-schema', scopeProfile],
+    queryFn: () => getHermesConfigSchema(scopeProfile),
     enabled,
     staleTime: 5 * 60 * 1000
   })
@@ -43,14 +52,30 @@ export function useSettingsSearchCatalog(enabled: boolean) {
     isFetching: envVarsFetching,
     refetch: refetchEnvVars
   } = useQuery({
-    queryKey: ['desktop-settings-search-env-vars'],
-    queryFn: () => getEnvVars(),
+    queryKey: ['desktop-settings-search-env-vars', scopeProfile],
+    queryFn: () => getEnvVars(scopeProfile),
     enabled,
     staleTime: 5 * 60 * 1000
   })
 
+  // scopeProfile changes are already covered by the query keys above (a new
+  // key naturally refetches). This covers the OTHER staleness case: scope
+  // still following the active profile (scopeProfile === null, key
+  // unchanged) while the active profile itself switches underneath —
+  // config/schema use the app-wide base cache key in that case, so nothing
+  // else would tell them to refetch.
   const refreshCatalog = useCallback(() => {
+    void configQuery.refetch()
+    void schemaQuery.refetch()
     void refetchEnvVars()
+    // configQuery/schemaQuery are fresh objects every render, but their
+    // `refetch` re-asks the query client for that query's CURRENT key/state
+    // (not a value frozen at closure-capture time), so omitting them from
+    // deps doesn't risk refetching against a stale scope. Matches the
+    // pre-existing refetchEnvVars-only version of this callback, which
+    // useOnProfileSwitch's own contract already treats this way ("onSwitch
+    // identity is intentionally ignored").
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [refetchEnvVars])
 
   useOnProfileSwitch(refreshCatalog)
@@ -66,9 +91,12 @@ export function useSettingsSearchCatalog(enabled: boolean) {
 
   useEffect(() => {
     if (enabled && gatewayState === 'open') {
-      void loadAgentPlugins(requestGateway)
+      // Same "Applies to" scope as config/schema/env above — an agent
+      // plugin can be installed/enabled on one profile only, so an unscoped
+      // load left it unfindable while Settings was scoped to that profile.
+      void loadAgentPlugins(requestGateway, scopeProfile)
     }
-  }, [enabled, gatewayState, requestGateway])
+  }, [enabled, gatewayState, requestGateway, scopeProfile])
 
   const pluginContext = t.settings.nav.plugins
 


### PR DESCRIPTION
## Summary

\`useSettingsSearchCatalog\` (the deep field/credential/plugin catalog ⌘K's Settings palette searches, added the same day the old in-page Tools & Keys search was removed with "⌘K already finds credentials") never read the shared "Applies to" scope override (\`\$settingsScopeOverride\`) that every other config-backed settings page (Model, Workspace, Safety, Memory & Context, Voice, Tools & Keys) already honors. \`getEnvVars()\`, \`getHermesConfigSchema()\`, \`useHermesConfigRecord()\`, and \`loadAgentPlugins()\` were all called with no profile argument, so the catalog always searched the active profile.

A multi-profile user who scopes Settings to another profile (via the shared selector, e.g. on the Tools & Keys page itself) and then presses ⌘K to find a credential/field/plugin that only exists — or is only set — on that scoped profile gets nothing: the catalog was built from the active profile's data. This directly contradicts the removal's own justification.

## Fix

Thread \`\$settingsScopeOverride\` through all four data sources, matching the established per-surface pattern (e.g. \`KeysSettings\`' own \`useEnvCredentials(scopeProfile)\`). Query keys include the scope so a scope change naturally refetches; \`refreshCatalog\` (already wired to \`useOnProfileSwitch\` for the env-vars query) is extended to also refetch config/schema, covering the other staleness case — scope still following the active profile while the active profile itself switches underneath, where the base cache key doesn't change on its own.

## Testing

- Regression tests cover: unscoped fetch uses null/undefined (matching \`useHermesConfigRecord\`'s own null→undefined contract), scoped fetch uses the override profile, and changing the override after mount triggers a refetch with the new profile — for all four data sources (env vars, schema, config record, agent plugins).
- **Mutation-verified**: reverted the production change, confirmed all three tests fail (unscoped calls, e.g. \`getEnvVars()\` with zero arguments, instead of the expected explicit profile), restored and confirmed green.
- Full \`apps/desktop/src/app/settings/\` suite: 295/295 pass (32 files, no regressions).
- \`tsc --noEmit\` clean.

## Competitor check

Fresh search right before opening: no open PR or issue touches \`use-settings-search.ts\`/\`\$settingsScopeOverride\` in this context.