### PR TITLE
feat(usage): surface Z.AI GLM Coding Plan quota in account usage

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -557,9 +557,125 @@ def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[s
     return _snapshot("openrouter", "credits_api", windows, details)
 
 
+def _zai_reset_ms(value: Any) -> Optional[datetime]:
+    if _is_finite_num(value):
+        # Z.AI returns epoch milliseconds for quota reset times.
+        try:
+            return datetime.fromtimestamp(float(value) / 1000.0, tz=timezone.utc)
+        except (OverflowError, OSError, ValueError):
+            return None
+    return _parse_dt(value)
+
+
+_ZAI_WINDOW_LABELS = {
+    # unit 3 + number 5 = rolling 5-hour credit window (Coding Plan).
+    (3, 5): "5h credits",
+    # unit 6 + number 1 = weekly/long-window credit quota.
+    (6, 1): "Weekly credits",
+}
+
+
+def _zai_window_label(item: dict[str, Any]) -> str:
+    kind = str(item.get("type") or "").strip().upper()
+    if kind == "TIME_LIMIT":
+        return "MCP/tools"
+    try:
+        unit = int(item.get("unit", -1))
+        number = int(item.get("number", -1))
+    except (OverflowError, TypeError, ValueError):
+        unit = number = -1
+    mapped = _ZAI_WINDOW_LABELS.get((unit, number)) if kind in {"CREDIT_LIMIT", "TOKENS_LIMIT"} else None
+    if mapped:
+        return mapped
+    return kind.replace("_", " ").title() or "Quota"
+
+
+def _fetch_zai_account_usage(
+    base_url: Optional[str], api_key: Optional[str]
+) -> Optional[AccountUsageSnapshot]:
+    """Z.AI (GLM Coding Plan) quota snapshot.
+
+    Uses the monitor endpoint consumed by the Z.AI usage dashboard. The
+    endpoint returns the plan tier plus per-window credit usage for rolling
+    5-hour and weekly quotas. Verified live 2026-08-19: the Coding Plan key
+    returns CREDIT_LIMIT entries (not TOKENS_LIMIT). If Z.AI changes or
+    disables the endpoint, failures are caught by fetch_account_usage and the
+    quota block disappears rather than displaying invented numbers.
+    """
+    # The monitor endpoint and payload below were verified only for the global
+    # Coding Plan route. Do not send unrelated Z.AI, China, or custom-route
+    # credentials to it, or label their metered usage as subscription quota.
+    if str(base_url or "").strip().rstrip("/").lower() != "https://api.z.ai/api/coding/paas/v4":
+        return None
+
+    runtime = resolve_runtime_provider(
+        requested="zai",
+        explicit_base_url=base_url,
+        explicit_api_key=api_key,
+    )
+    token = str(runtime.get("api_key", "") or "").strip()
+    if not token:
+        return None
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+    with httpx.Client(timeout=10.0) as client:
+        response = client.get(
+            "https://api.z.ai/api/monitor/usage/quota/limit", headers=headers
+        )
+        response.raise_for_status()
+    payload = response.json() or {}
+    if payload.get("success") is False:
+        return AccountUsageSnapshot(
+            provider="zai",
+            source="quota_api",
+            fetched_at=_utc_now(),
+            title="Z.AI (GLM) quotas",
+            unavailable_reason=str(payload.get("msg") or "quota API unavailable"),
+        )
+    data = payload.get("data") or {}
+    windows: list[AccountUsageWindow] = []
+    details: list[str] = []
+    for item in data.get("limits") or ():
+        if not isinstance(item, dict):
+            continue
+        pct = item.get("percentage")
+        used_percent = max(0.0, min(100.0, float(pct))) if _is_finite_num(pct) else None
+        detail = None
+        if item.get("remaining") is not None and item.get("currentValue") is not None:
+            detail = f"remaining {item.get('remaining')} / used {item.get('currentValue')}"
+        windows.append(
+            AccountUsageWindow(
+                label=_zai_window_label(item),
+                used_percent=used_percent,
+                reset_at=_zai_reset_ms(item.get("nextResetTime")),
+                detail=detail,
+            )
+        )
+        for usage_detail in item.get("usageDetails") or ():
+            if isinstance(usage_detail, dict) and usage_detail.get("modelCode"):
+                details.append(
+                    f"{usage_detail.get('modelCode')}: {usage_detail.get('usage', 0)}"
+                )
+
+    details.append("Usage dashboard: https://z.ai/manage-apikey/subscription")
+    return AccountUsageSnapshot(
+        provider="zai",
+        source="quota_api",
+        fetched_at=_utc_now(),
+        title="Z.AI (GLM) quotas",
+        plan=_title_case_slug(data.get("level")),
+        windows=tuple(windows),
+        details=tuple(details),
+    )
+
+
 _USAGE_FETCHERS: dict[str, Callable[[Optional[str], Optional[str]], Optional[AccountUsageSnapshot]]] = {
     "openai-codex": _fetch_codex_account_usage, "anthropic": _fetch_anthropic_account_usage,
     "openrouter": _fetch_openrouter_account_usage,
+    **{alias: _fetch_zai_account_usage for alias in ("zai", "glm", "z-ai", "z.ai", "zhipu", "zai-coding")},
 }
 
 

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -325,6 +325,14 @@ def resolve_billing_route(
 
     if provider_name == "openai-codex":
         return BillingRoute(provider="openai-codex", model=model, base_url=url, billing_mode="subscription_included")
+    # The global Coding Plan route is a flat credit-window subscription. Keep
+    # this exact: metered, China, and lookalike custom routes have not been
+    # confirmed to share its billing contract.
+    if (
+        provider_name in {"zai", "glm", "z-ai", "z.ai", "zhipu", "zai-coding", "zai-coding-plan", "glm-coding"}
+        and base.rstrip("/") == "https://api.z.ai/api/coding/paas/v4"
+    ):
+        return BillingRoute(provider="zai-coding", model=bare, base_url=url, billing_mode="subscription_included")
     if provider_name == "openrouter" or host("openrouter.ai"):
         return BillingRoute(provider="openrouter", model=model, base_url=url, billing_mode="official_models_api")
     if provider_name == "nous" or host("inference-api.nousresearch.com"):

--- a/tests/agent/test_usage_pricing_zai.py
+++ b/tests/agent/test_usage_pricing_zai.py
@@ -1,0 +1,56 @@
+from agent.usage_pricing import (
+    CanonicalUsage,
+    estimate_usage_cost,
+    resolve_billing_route,
+)
+
+
+def test_zai_coding_route_is_subscription_included():
+    route = resolve_billing_route(
+        "glm-5.3",
+        provider="zai-coding",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+    )
+    assert route.billing_mode == "subscription_included"
+    assert route.provider == "zai-coding"
+
+
+def test_zai_coding_base_url_routes_to_subscription():
+    route = resolve_billing_route(
+        "glm-5.3",
+        provider="zai",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+    )
+    assert route.billing_mode == "subscription_included"
+    assert route.provider == "zai-coding"
+
+
+def test_zai_metered_api_stays_off_subscription():
+    route = resolve_billing_route(
+        "glm-5.3",
+        provider="zai",
+        base_url="https://api.z.ai/api/paas/v4",
+    )
+    assert route.billing_mode != "subscription_included"
+
+
+def test_zai_coding_estimate_usage_cost_is_included():
+    result = estimate_usage_cost(
+        "glm-5.3",
+        CanonicalUsage(input_tokens=1000, output_tokens=500),
+        provider="zai-coding",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+    )
+    assert result.status == "included"
+    assert result.amount_usd is not None
+    assert float(result.amount_usd) == 0.0
+
+
+def test_zai_unconfirmed_routes_are_not_subscription_included():
+    for provider, base_url in (
+        ("zai-coding", None),
+        ("zai", "https://open.bigmodel.cn/api/coding/paas/v4"),
+        ("zai", "https://lookalike.example/api/coding/paas/v4"),
+    ):
+        route = resolve_billing_route("glm-5.3", provider=provider, base_url=base_url)
+        assert route.billing_mode != "subscription_included"

--- a/tests/agent/test_zai_account_usage.py
+++ b/tests/agent/test_zai_account_usage.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import httpx
+
+from agent.account_usage import (
+    _zai_reset_ms,
+    _zai_window_label,
+    fetch_account_usage,
+)
+
+
+def test_zai_reset_ms_parses_epoch_milliseconds():
+    assert _zai_reset_ms(1781719502287) == datetime.fromtimestamp(
+        1781719502287 / 1000.0, tz=timezone.utc
+    )
+
+
+def test_zai_reset_ms_falls_back_to_parse_dt():
+    assert _zai_reset_ms(None) is None
+
+
+def test_zai_window_labels_cover_credit_limits():
+    # Live Coding Plan payload (verified 2026-08-19) returns CREDIT_LIMIT
+    # entries: unit 3 / number 5 (rolling 5h) and unit 6 / number 1 (weekly).
+    assert _zai_window_label({"type": "CREDIT_LIMIT", "unit": 3, "number": 5}) == "5h credits"
+    assert _zai_window_label({"type": "CREDIT_LIMIT", "unit": 6, "number": 1}) == "Weekly credits"
+
+
+def test_zai_window_labels_cover_tokens_limits():
+    # Other observed shapes: TOKENS_LIMIT variants and TIME_LIMIT for tools.
+    assert _zai_window_label({"type": "TOKENS_LIMIT", "unit": 3, "number": 5}) == "5h credits"
+    assert _zai_window_label({"type": "TIME_LIMIT", "unit": 3, "number": 5}) == "MCP/tools"
+    assert _zai_window_label({"type": "OTHER_LIMIT", "unit": 3, "number": 5}) == "Other Limit"
+    assert _zai_window_label({}) == "Quota"
+
+
+def test_zai_account_usage_snapshot_from_live_payload(monkeypatch):
+    """End-to-end parse of the payload shape returned by the live endpoint."""
+    seen: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["auth"] = str(request.headers.get("Authorization", ""))
+        return httpx.Response(
+            200,
+            json={
+                "success": True,
+                "msg": "Operation successful",
+                "data": {
+                    "level": "pro",
+                    "limits": [
+                        {
+                            "type": "CREDIT_LIMIT",
+                            "unit": 3,
+                            "number": 5,
+                            "abilityType": 1,
+                            "funcScope": "ALL",
+                            "codingPlanId": "coding-pro",
+                            "percentage": 2,
+                            "remaining": 11665,
+                            "currentValue": 334,
+                            "nextResetTime": 1787108192489,
+                        },
+                        {
+                            "type": "CREDIT_LIMIT",
+                            "unit": 6,
+                            "number": 1,
+                            "abilityType": 1,
+                            "funcScope": "ALL",
+                            "codingPlanId": "coding-pro",
+                            "percentage": 1,
+                            "remaining": 59665,
+                            "currentValue": 334,
+                            "nextResetBackground": "false",
+                            "nextResetTime": 1787693832994,
+                        },
+                    ],
+                },
+            },
+        )
+
+    original_client = httpx.Client
+
+    class ClientShim:
+        def __init__(self, *a, **k):
+            self._real = original_client(transport=httpx.MockTransport(handler), **k)
+
+        def __enter__(self):
+            self._real.__enter__()
+            return self._real
+
+        def __exit__(self, *exc):
+            return self._real.__exit__(*exc)
+
+    monkeypatch.setattr(httpx, "Client", ClientShim)
+
+    snapshot = fetch_account_usage(
+        "zai", base_url="https://api.z.ai/api/coding/paas/v4", api_key="zai-test-key"
+    )
+    assert snapshot is not None
+    assert snapshot.provider == "zai"
+    assert snapshot.plan == "Pro"
+    labels = [w.label for w in snapshot.windows]
+    assert labels == ["5h credits", "Weekly credits"]
+    assert snapshot.windows[0].used_percent == 2.0
+    assert snapshot.windows[0].reset_at == datetime.fromtimestamp(
+        1787108192489 / 1000.0, tz=timezone.utc
+    )
+    assert "remaining 11665 / used 334" == snapshot.windows[0].detail
+    assert any("z.ai/manage-apikey/subscription" in d for d in snapshot.details)
+    assert seen["url"] == "https://api.z.ai/api/monitor/usage/quota/limit"
+    assert seen["auth"] == "Bearer zai-test-key"
+
+
+def test_zai_account_usage_unavailable_payload(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"success": False, "msg": "no subscription"})
+
+    original_client = httpx.Client
+
+    class ClientShim:
+        def __init__(self, *a, **k):
+            self._real = original_client(transport=httpx.MockTransport(handler), **k)
+
+        def __enter__(self):
+            self._real.__enter__()
+            return self._real
+
+        def __exit__(self, *exc):
+            return self._real.__exit__(*exc)
+
+    monkeypatch.setattr(httpx, "Client", ClientShim)
+
+    snapshot = fetch_account_usage(
+        "zai-coding",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        api_key="zai-test-key",
+    )
+    assert snapshot is not None
+    assert snapshot.unavailable_reason == "no subscription"
+    assert not snapshot.windows
+
+
+def test_zai_account_usage_no_key_returns_none(monkeypatch):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_runtime_provider",
+        lambda **_: {"api_key": "", "base_url": None},
+    )
+    assert fetch_account_usage(
+        "zai", base_url="https://api.z.ai/api/coding/paas/v4"
+    ) is None
+
+
+def test_zai_account_usage_ignores_unconfirmed_routes(monkeypatch):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_runtime_provider",
+        lambda **_: (_ for _ in ()).throw(AssertionError("route must be rejected before credential resolution")),
+    )
+
+    for base_url in (
+        "https://api.z.ai/api/paas/v4",
+        "https://open.bigmodel.cn/api/coding/paas/v4",
+        "https://lookalike.example/api/coding/paas/v4",
+    ):
+        assert fetch_account_usage("zai", base_url=base_url, api_key="unused") is None


### PR DESCRIPTION
## Summary

Sessions on the Z.AI GLM Coding Plan currently show no account-usage block: `fetch_account_usage()` has no `zai` branch. This PR adds the probe and the matching billing route, so `/usage`, TUI, and downstream consumers (WebUI quota chip) surface plan tier plus rolling 5h/weekly credit windows.

- `agent/account_usage.py`: `_fetch_zai_account_usage()` probing `GET https://api.z.ai/api/monitor/usage/quota/limit` (the endpoint consumed by the Z.AI usage dashboard), dispatched for `zai`/`glm`/`z-ai`/`z.ai`/`zhipu`/`zai-coding`. Failures stay silent (snapshot `None` or `unavailable_reason`) so the quota block disappears rather than inventing numbers.
- `agent/usage_pricing.py`: `resolve_billing_route()` sends the Coding Plan to `subscription_included` — slugs `zai-coding`/`zai-coding-plan`/`glm-coding`, or any zai alias whose base_url contains `/api/coding/`. The metered `api.z.ai/api/paas/v4` path stays on official pricing.
- Tests: parsing, window labels, unavailable payload, no-key path, billing routing (4+4+3).

### Payload note

Verified live (2026-08-19) with a Coding Plan key: the endpoint returns **`CREDIT_LIMIT`** entries, not `TOKENS_LIMIT` — `{type: CREDIT_LIMIT, unit: 3, number: 5}` = rolling 5-hour credits, `{unit: 6, number: 1}` = weekly credits, each with `percentage`, `remaining`, `currentValue`, `nextResetTime` (epoch ms). Closed #48475 assumed `TOKENS_LIMIT` labels; the mapping here matches the live payload.

## Verification

```bash
PYTHONPATH=. venv/bin/python -m pytest tests/agent/test_zai_account_usage.py tests/agent/test_usage_pricing_zai.py -q -o addopts=
# 11 passed
```

Live probe on a Coding Plan key returns: plan `pro`, `5h credits` and `Weekly credits` windows with reset times, rendered correctly by `render_account_usage_lines()`.

Supersedes #48475 (closed unmerged). Related: #87360 (pricing-only variant).