### PR TITLE
feat(mem0): add configurable recall modes

### DIFF
--- a/docs/plans/2026-08-19-0711-feat-mem0-recall-mode-plan.md
+++ b/docs/plans/2026-08-19-0711-feat-mem0-recall-mode-plan.md
@@ -1,0 +1,226 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+type: feat
+---
+
+# Configurable Mem0 Recall Modes
+
+## Goal Capsule
+
+Add a provider-stable `recall_mode` setting to the Mem0 memory provider so users can choose automatic context, explicit tools, or both. Hybrid and context modes must preserve the current-question correctness fix; tools mode deliberately delegates that responsibility to model-triggered search. The runtime policy must remain local to the Mem0 plugin, preserve existing behavior for old configurations, and avoid changing capture/write behavior. The shared memory setup parser may accept provider-specific trailing options because strict top-level parsing otherwise rejects every documented Mem0 setup flag before the plugin can consume it.
+
+Authority order: this plan, the repository `AGENTS.md`, established memory-provider contracts, then local implementation conventions. Stop if the implementation requires a core model tool, mutating a conversation's prompt or tool set after provider construction, or changing Mem0's breaker and timeout semantics. Execution owns implementation and local verification; the shipping workflow owns review, commit, PR creation, and CI follow-through.
+
+## Product Contract
+
+### Summary
+
+Mem0 currently performs one automatic current-question search and also exposes an aggressively described `mem0_search` tool. That combination is useful but can lead a model to repeat retrieval against the same question, consuming search quota without adding context. Add three explicit recall modes, with `hybrid` as the backward-compatible default.
+
+### Problem Frame
+
+The current automatic prefetch was deliberately introduced in [PR #55535](https://github.com/NousResearch/hermes-agent/pull/55535) to correct first-turn empty recall and stale prior-turn recall. Hybrid and context must not reverse that fix. Tools mode is an explicit opt-out from deterministic prefetch: its correctness depends on the model issuing an appropriate search. The feature should let users select that tradeoff and make hybrid guidance less reflexive while retaining explicit search for missing, history-sensitive, or multi-hop information.
+
+An anonymized usage sample reached 580 retrievals and 421 additions in roughly 2.28 days on a 5,000-operation tier. At that pace, projected retrieval volume alone is about 7,892 operations per month. In an equal-window comparison, retrievals rose from 1,945 to 2,761 and explicit searches from 353 to 831. These figures motivate configurability; they are not a performance benchmark or a promise that prompt guidance eliminates every repeated call.
+
+### Key Decisions
+
+- **`hybrid` remains the default.** Existing configurations preserve automatic current-question context and all Mem0 tools. Governs R1, R2, R7.
+- **`context` is context-only.** It performs automatic current-question recall and exposes no Mem0 tool schemas, matching established Honcho and Hindsight semantics. Governs R2, R4.
+- **`tools` is tool-only.** It exposes all Mem0 tools and performs no automatic prefetch or context injection. Governs R2, R5.
+- **Recall policy does not control capture.** Automatic turn synchronization and explicit write behavior remain unchanged. Governs R6.
+- **Three modes are required, not guidance alone.** Prompt guidance can influence hybrid behavior but cannot guarantee a call ceiling. Context and tools provide deterministic automatic-retrieval policies for quota-sensitive users: one current-question attempt or zero automatic attempts, respectively. Governs R3, R4, R5, R9.
+
+### Requirements
+
+- **R1. Configuration contract:** Read `recall_mode` from `$HERMES_HOME/mem0.json`. Accept `hybrid`, `context`, and `tools`. Missing, non-string, or unsupported values resolve safely to `hybrid`; no new environment variable is added.
+- **R2. Stable lifecycle:** Resolve and freeze the effective mode when the provider is constructed so prompt text, schemas, routing, and runtime behavior cannot diverge during that provider/agent lifetime. Changing the file takes effect only after restarting Hermes and constructing a new agent; `/new` may reuse the existing agent and is not an activation boundary. A process or gateway cache eviction that constructs a new agent also establishes a new prompt-cache lifetime.
+- **R3. Hybrid behavior:** Start and consume the existing exact-current-question prefetch, expose all four Mem0 tools in their current order, and instruct the model to use injected context first. Explicit search remains appropriate when injected context is absent or insufficient, when prior conversation state changes the needed query, or when genuine multi-hop retrieval requires targeted follow-ups.
+- **R4. Context behavior:** Start and consume exact-current-question prefetch, expose no Mem0 tools, and provide static guidance to use injected context when available. Timeout, breaker-open, backend-error, and empty-result paths are best-effort failures: inject no Mem0 block, make no backstop call, and do not imply that memory was consulted.
+- **R5. Tools behavior:** Do not start a prefetch thread, call the backend automatically, or wait for a prefetch result. Expose all four Mem0 tools and provide static explicit-search guidance without claiming automatic context is present. This mode intentionally gives up deterministic current-question prefetch and delegates recall correctness to model-triggered `mem0_search`.
+- **R6. Preserved behavior:** Do not change `sync_turn()`, explicit tool handlers, filters, top-k or rerank handling, breaker thresholds/cooldown, timeout values, current-query matching, stale-result rejection, error formatting, or backend selection.
+- **R7. Backward compatibility:** Existing `mem0.json` files without `recall_mode` retain current hybrid runtime behavior. Invalid values do not prevent provider startup.
+- **R8. Setup and discoverability:** Expose the setting through Mem0's configuration schema and custom setup flow, including `--recall-mode` for flag-driven setup paths. Preserve the setting across platform, self-hosted, and OSS reconfiguration.
+- **R9. Documentation:** Document the mode table, default, JSON key, configuration path, unchanged capture behavior, and Hermes restart requirement in both Mem0 plugin and website memory-provider documentation. Explain that hybrid is the compatibility default, context suits users who want one best-effort automatic attempt with no model tools, and tools suits users who accept model-controlled recall in exchange for zero automatic retrievals.
+
+### Flows
+
+1. A user configures Mem0 without `recall_mode`; a new session behaves exactly as current hybrid recall does.
+2. A user selects `context`; registration and post-initialization routing both omit Mem0 tools, while the exact current question is recalled once and injected as volatile context.
+3. A user selects `tools`; no automatic Mem0 search occurs, and the model retrieves only through `mem0_search`.
+4. A user selects `hybrid`; exact-current-question recall still occurs once, and the model searches again only when the injected context cannot answer the distinct retrieval need.
+5. A user changes `recall_mode`; the current provider remains stable and the change is reflected after restarting Hermes so a new agent/provider is constructed.
+
+### Acceptance Examples
+
+- **AE1:** Given no `recall_mode`, when a provider handles a turn, then it performs the same one exact-query automatic search and exposes `mem0_search`, `mem0_add`, `mem0_update`, and `mem0_delete`.
+- **AE2:** Given `context`, when the provider is registered and initialized, then `get_all_tool_schemas()` returns no Mem0 schemas and `has_tool("mem0_search")` is false, while current-query prefetch still works.
+- **AE3:** Given `tools`, when `on_turn_start()` and `prefetch()` are called, then no thread or backend search is created and `prefetch()` returns an empty string immediately.
+- **AE4:** Given `tools` and a context-dependent question, when the model follows its static guidance, then recall occurs through explicit `mem0_search`; if the model does not call the tool, the provider supplies no automatic correctness backstop.
+- **AE5:** Given `hybrid`, when automatic context already answers the current query, then static guidance tells the model not to reflexively repeat the same search; targeted or multi-hop search remains available.
+- **AE6:** Given an invalid value such as an object or unknown string, when the provider is constructed, then its effective mode is `hybrid` and initialization continues.
+- **AE7:** Given any recall mode, when a turn completes, then existing Mem0 capture/synchronization behavior remains enabled.
+- **AE8:** Given `context` and a timeout, open breaker, backend error, or empty result, when prefetch completes, then no Mem0 context is injected, no explicit search is attempted, and static guidance does not claim memory was consulted.
+- **AE9:** Given an active provider and a changed `mem0.json`, when `/new` reuses the same agent, then prompt text and tool schemas remain unchanged; after Hermes restarts, a newly constructed provider uses the new mode.
+
+### Success Criteria
+
+- Users can select all three modes through documented configuration and setup paths.
+- Quota-sensitive users can choose a deterministic automatic-retrieval policy: one best-effort current-question attempt in context mode or zero automatic attempts in tools mode, with the documented correctness tradeoff.
+- Focused tests prove the schema, prompt, prefetch, lifecycle-routing, and setup matrix.
+- Existing Mem0 backend and current-question tests remain green.
+- No core model tools or conversation-loop behavior change. The only shared CLI change is generic pass-through parsing for provider-specific memory setup options.
+
+### Scope Boundaries
+
+In scope: provider-local retrieval policy, static prompt/schema guidance, Mem0 setup configuration, generic parsing of provider-specific memory setup options, tests, and docs. Out of scope: hard deduplication of semantically similar searches, exact quota accounting, write/capture controls, provider-wide config migration, dashboard UI, session-persisted mode snapshots across process or gateway agent reconstruction, changes to other memory providers, and live Mem0 API calls.
+
+### Dependencies
+
+The implementation depends only on existing `MemoryProvider`/`MemoryManager` contracts, Mem0's custom setup flow, and existing test doubles. No new production dependency is allowed.
+
+### Outstanding Questions
+
+None blocking. A future hard-deduplication layer may be considered if prompt/schema guidance is insufficient, but it requires argument/result reconciliation and is outside this change. Production usage can later validate how often hybrid guidance avoids a repeated explicit search; this change guarantees only the provider-side call ceilings of context and tools modes.
+
+### Sources
+
+- Current-question correctness and search backstop: [PR #55535](https://github.com/NousResearch/hermes-agent/pull/55535)
+- Mem0 v3 provider surface: [PR #15624](https://github.com/NousResearch/hermes-agent/pull/15624)
+- Provider-local implementation: `plugins/memory/mem0/__init__.py`
+- Existing recall-mode precedent: `plugins/memory/honcho/__init__.py` and `plugins/memory/hindsight/__init__.py`
+- Manager routing lifecycle: `agent/memory_manager.py`
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- **KTD1. Normalize at construction:** Add a small total normalizer and set the effective mode in `Mem0MemoryProvider.__init__` from `_load_config()`. `initialize()` may reuse that frozen configuration but must not expose a different schema after `MemoryManager.add_provider()` has built routing. The stability boundary is the provider/agent lifetime; restarting Hermes or reconstructing an evicted agent creates a new cache lifetime and may adopt changed configuration.
+- **KTD2. Gate at provider edges:** Keep backend and tool-handler code unchanged. Gate automatic recall in `on_turn_start()`, `_start_prefetch()`, and `prefetch()`, and gate model tool exposure in `get_tool_schemas()`.
+- **KTD3. Use immutable mode-specific guidance:** Use static prompt strings and copied/static search schemas. Do not mutate the module-level `SEARCH_SCHEMA`; repeated prompt/schema calls for one provider must be deterministic.
+- **KTD4. Hide all tools in context mode:** This keeps schema exposure and dispatch routing consistent and matches existing memory-provider semantics. Automatic `sync_turn()` remains independent.
+- **KTD5. Extend every custom setup route consistently:** Add one shared recall-mode selection helper/value path used by platform, self-hosted, and OSS flows, and a `--recall-mode` flag. Do not expose the option in only one backend mode.
+- **KTD6. Preserve provider setup arguments generically:** Let `hermes memory setup <provider>` accept trailing provider-specific options through the shared parser. Keep interpretation inside each provider so this adds no provider-specific branch to the CLI.
+
+### High-Level Design
+
+`Mem0MemoryProvider` owns a normalized, session-stable recall policy. Hybrid/context share the existing automatic prefetch implementation. Tools mode exits before any automatic work. Hybrid/tools return the existing four tool schemas, with a mode-appropriate copied `mem0_search` description; context returns an empty list. The setup code persists `recall_mode` beside other behavioral Mem0 settings. Documentation presents a single semantic table.
+
+### Implementation Constraints
+
+- Preserve prompt-prefix caching: no query, result, breaker state, time, or config reload enters `system_prompt_block()`.
+- Preserve strict current-question behavior and the bounded prefetch wait.
+- Do not add `HERMES_*` or `MEM0_*` behavioral environment variables.
+- Do not add core tool schemas or edit core agent-loop files.
+- Public docs, issue, commit, and PR text must avoid assistant attribution and em/en dashes.
+- Tests must not contact Mem0 or any external service.
+
+### Sequencing
+
+Implement provider behavior and its contract tests first. Then extend setup/config tests, followed by documentation. Run focused verification after each unit and the broader Mem0 suite at the end.
+
+## Implementation Units
+
+### U1. Provider recall policy
+
+**Goal:** Implement stable three-mode behavior at the Mem0 provider boundary.
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R7.
+
+**Files:**
+
+- Modify `plugins/memory/mem0/__init__.py`
+- Modify `tests/plugins/memory/test_mem0_v3.py`
+- Modify or add the narrowest existing manager integration test only if provider-level registration assertions cannot prove routing consistency
+
+**Approach:** Add normalization and frozen provider state, define mode-specific prompt/search guidance without mutating shared schema objects, bypass every automatic prefetch entry in tools mode, and hide schemas in context mode. Reuse existing test doubles and preserve existing current-query tests unchanged where possible.
+
+**Test Scenarios:** AE1 through AE9, repeated prompt/schema stability, schema order, registration before initialization, same-agent config-change stability, slow-prefetch behavior, and breaker behavior on both automatic and explicit paths.
+
+**Verification:**
+
+```bash
+scripts/run_tests.sh tests/plugins/memory/test_mem0_v3.py -q
+```
+
+### U2. Setup and configuration exposure
+
+**Goal:** Make `recall_mode` selectable and persist it consistently across Mem0 setup modes.
+
+**Requirements:** R1, R7, R8.
+
+**Files:**
+
+- Modify `plugins/memory/mem0/_setup.py`
+- Modify `tests/plugins/memory/test_mem0_setup.py`
+- Modify `plugins/memory/mem0/__init__.py` for the provider configuration schema
+- Modify `hermes_cli/subcommands/memory.py` and its parser test so documented provider-specific setup flags reach Mem0's existing `parse_flags()` path
+
+**Approach:** Add the schema choice and CLI flag, normalize setup input to the same three values, and merge-write the selected setting in platform, self-hosted, and OSS paths without disturbing secrets or backend configuration. Existing values remain intact when no new selection is supplied.
+
+**Test Scenarios:** flag parsing, valid mode persistence for each backend path, existing-value preservation, default hybrid behavior, dry-run non-mutation, and invalid flag handling consistent with existing setup conventions.
+
+**Verification:**
+
+```bash
+scripts/run_tests.sh tests/plugins/memory/test_mem0_setup.py -q
+```
+
+### U3. User documentation
+
+**Goal:** Explain the recall tradeoff and configuration contract in both documentation surfaces.
+
+**Requirements:** R9.
+
+**Files:**
+
+- Modify `plugins/memory/mem0/README.md`
+- Modify `website/docs/user-guide/features/memory-providers.md`
+
+**Approach:** Add the same compact mode table and JSON example to both documents, describe `hybrid` as the compatibility default, guide quota-sensitive users toward context or tools with their correctness tradeoffs, state that capture remains enabled in every mode, and require restarting Hermes after changes.
+
+**Test Scenarios:** Manual cross-check that names, defaults, semantics, and JSON spelling match provider/setup code.
+
+**Verification:**
+
+```bash
+rg -n "recall_mode|hybrid|context|tools" plugins/memory/mem0/README.md website/docs/user-guide/features/memory-providers.md
+```
+
+## Verification Contract
+
+Run from the isolated worktree with the repository test runner:
+
+```bash
+scripts/run_tests.sh tests/plugins/memory/test_mem0_v3.py tests/plugins/memory/test_mem0_setup.py tests/plugins/memory/test_mem0_backend.py -q
+ruff check plugins/memory/mem0/__init__.py plugins/memory/mem0/_setup.py tests/plugins/memory/test_mem0_v3.py tests/plugins/memory/test_mem0_setup.py
+git diff --check
+```
+
+Then run the full repository suite before PR handoff if the environment can complete it within the shipping window:
+
+```bash
+scripts/run_tests.sh
+```
+
+Quality gates:
+
+- No live network calls or credentials in tests.
+- Provider prompt and schema outputs are deterministic within a session.
+- Context-mode routing agrees before and after initialization.
+- Tools mode records zero automatic backend searches.
+- Existing exact-current-question, timeout, and breaker tests remain green.
+- The final diff contains no core tool or agent-loop changes and no unrelated formatting.
+
+## Definition of Done
+
+- U1 is done when the full mode matrix and lifecycle invariants pass focused tests without changing backend/tool-handler semantics.
+- U2 is done when configuration is discoverable and persisted consistently across custom setup paths with regression coverage.
+- U3 is done when both documentation surfaces match the executable contract.
+- The feature issue exists and the PR references it.
+- Focused tests, lint, and diff checks pass; full-suite status is reported truthfully.
+- Review findings are resolved or explicitly documented, CI is watched to a terminal merge-ready or evidenced unrelated-failure state, and no merge or deployment occurs.
+- Abandoned experiments, debug output, temporary repository files, and unrelated changes are absent from the final diff.

--- a/hermes_cli/subcommands/memory.py
+++ b/hermes_cli/subcommands/memory.py
@@ -6,6 +6,7 @@ Handler injected to avoid importing ``main``.
 
 from __future__ import annotations
 
+import argparse
 from typing import Callable
 
 
@@ -31,6 +32,11 @@ def build_memory_parser(subparsers, *, cmd_memory: Callable) -> None:
         nargs="?",
         default=None,
         help="Provider to configure directly (e.g. honcho), skipping the picker",
+    )
+    _setup_parser.add_argument(
+        "provider_args",
+        nargs=argparse.REMAINDER,
+        help="Provider-specific setup options",
     )
     memory_sub.add_parser("status", help="Show current memory provider config")
     memory_sub.add_parser("off", help="Disable external provider (built-in only)")

--- a/plugins/memory/mem0/README.md
+++ b/plugins/memory/mem0/README.md
@@ -30,12 +30,35 @@ Behavioral settings live in `$HERMES_HOME/mem0.json` (set them via `hermes memor
 | `user_id` | `hermes-user` | User identifier on Mem0 |
 | `agent_id` | `hermes` | Agent identifier |
 | `rerank` | `false` | Rerank search results for relevance (platform mode only) |
+| `recall_mode` | `hybrid` | `hybrid`, `context`, or `tools` |
 
 The plugin has three connection modes:
 
 - **Platform** — Mem0's hosted cloud (`api.mem0.ai`). Set `MEM0_API_KEY`. (default)
 - **Self-hosted dashboard** — a Mem0 server you run yourself via Docker. Set `host`. See below.
 - **OSS** — run Mem0 in-process with your own LLM + vector store. Set `mode: oss`. See below.
+
+## Recall modes
+
+Set `recall_mode` in `$HERMES_HOME/mem0.json` (normally `~/.hermes/mem0.json`):
+
+```json
+{
+  "recall_mode": "hybrid"
+}
+```
+
+`hybrid` is the compatibility default. Missing or unsupported values also use `hybrid`. For predictable retrieval volume, `hybrid` and `context` allow at most one automatic exact current-question attempt per turn, while `tools` allows zero. Explicit `mem0_search` calls are separate from this ceiling.
+
+| Mode | Automatic retrieval | Mem0 tools | Semantics |
+|------|---------------------|------------|-----------|
+| `hybrid` | At most one exact current-question attempt per turn | All four | Use injected context first when available. Use `mem0_search` when injected context is absent or insufficient, when the needed query depends on prior conversation state, or when a genuine multi-hop question needs targeted follow-up searches. |
+| `context` | At most one exact current-question attempt per turn | None | Context only. The attempt is best effort: empty results, timeouts, an open breaker, or backend errors inject no Mem0 block, make no backstop call, and do not imply memory was consulted. |
+| `tools` | Zero automatic attempts | All four | No automatic context injection is performed. This trades deterministic current-question recall for zero automatic retrievals, so recall correctness depends on the model issuing an appropriate `mem0_search`. |
+
+Automatic turn capture and synchronization remain enabled in every mode. Recall mode does not change capture or existing write behavior; it changes automatic retrieval and tool exposure.
+
+The provider resolves the mode when it is constructed. After changing `mem0.json`, restart Hermes so a new agent and provider are constructed. `/new` may reuse the existing agent and is not a reliable activation boundary. Setup also accepts `--recall-mode`.
 
 ## Self-Hosted Dashboard (Server) Mode
 

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -24,6 +24,8 @@ setup`):
                        store. When unset, the gateway-native id (e.g. Telegram
                        numeric id, Discord snowflake) is used instead.
   agent_id           — Agent identifier (default: hermes)
+  recall_mode        - Recall policy: "hybrid" (default), "context", or
+                       "tools"
 
 The matching MEM0_MODE / MEM0_USER_ID / MEM0_AGENT_ID environment variables are
 still read as a backward-compatible fallback, but mem0.json is the canonical
@@ -33,6 +35,7 @@ home for these non-secret settings.
 from __future__ import annotations
 
 import atexit
+from copy import deepcopy
 import json
 import logging
 import os
@@ -42,6 +45,7 @@ from typing import Any, Dict, List
 
 from agent.memory_provider import MemoryProvider
 from agent.secret_scope import get_secret
+from agent.skill_commands import extract_user_instruction_from_skill_message
 from tools.registry import tool_error
 
 logger = logging.getLogger(__name__)
@@ -60,6 +64,16 @@ _CLIENT_ERROR_TYPES = ("MemoryNotFoundError", "ValidationError")
 # wrote this exact placeholder) still allow gateway-native ids to flow
 # through instead of silently overriding them with the placeholder.
 _DEFAULT_USER_ID = "hermes-user"
+
+_RECALL_MODE_CHOICES = ("hybrid", "context", "tools")
+_VALID_RECALL_MODES = frozenset(_RECALL_MODE_CHOICES)
+
+
+def _normalize_recall_mode(value: Any) -> str:
+    """Return a supported recall mode, defaulting safely to hybrid."""
+    if isinstance(value, str) and value in _VALID_RECALL_MODES:
+        return value
+    return "hybrid"
 
 
 def _is_client_error(exc: Exception) -> bool:
@@ -186,6 +200,22 @@ DELETE_SCHEMA = {
     },
 }
 
+_HYBRID_SEARCH_DESCRIPTION = (
+    "Search the user's memories by meaning when the injected context is absent "
+    "or insufficient, when the needed query depends on prior conversation "
+    "state, or when a genuine multi-hop question needs targeted follow-up "
+    "searches. Use injected context first when it is available; vary the "
+    "wording for distinct follow-up searches."
+)
+
+_TOOLS_SEARCH_DESCRIPTION = (
+    "Search the user's memories by meaning for facts, preferences, history, "
+    "or other context needed to answer the current question. No automatic "
+    "context is injected in this mode, so call this when an answer may "
+    "depend on information outside the chat window. For multi-hop questions, "
+    "vary the wording and run targeted follow-up searches as needed."
+)
+
 
 # ---------------------------------------------------------------------------
 # MemoryProvider implementation
@@ -198,7 +228,14 @@ class Mem0MemoryProvider(MemoryProvider):
     """
 
     def __init__(self):
-        self._config = None
+        # Configuration, including recall policy, is captured before the
+        # provider can be registered with MemoryManager. The manager asks for
+        # schemas during registration, so resolving this in initialize() would
+        # make routing disagree with the provider after config changes.
+        self._config = _load_config()
+        self._recall_mode = _normalize_recall_mode(
+            self._config.get("recall_mode")
+        )
         self._backend = None
         self._mode = "platform"
         self._api_key = ""
@@ -225,13 +262,12 @@ class Mem0MemoryProvider(MemoryProvider):
         return "mem0"
 
     def is_available(self) -> bool:
-        cfg = _load_config()
-        mode = cfg.get("mode", "platform")
+        mode = self._config.get("mode", "platform")
         if mode == "oss":
-            return bool(cfg.get("oss", {}).get("vector_store"))
+            return bool(self._config.get("oss", {}).get("vector_store"))
         # Platform needs an api_key; self-hosted needs a host (api_key optional
         # when the server runs with AUTH_DISABLED).
-        return bool(cfg.get("api_key") or cfg.get("host"))
+        return bool(self._config.get("api_key") or self._config.get("host"))
 
     def save_config(self, values, hermes_home):
         """Write config to $HERMES_HOME/mem0.json."""
@@ -249,8 +285,7 @@ class Mem0MemoryProvider(MemoryProvider):
         atomic_json_write(config_path, existing, mode=0o600)
 
     def get_config_schema(self):
-        cfg = _load_config()
-        mode = cfg.get("mode", "platform")
+        mode = self._config.get("mode", "platform")
         api_key_required = mode != "oss"
         return [
             {"key": "api_key", "description": "Mem0 Platform API key", "secret": True, "required": api_key_required, "env_var": "MEM0_API_KEY", "url": "https://app.mem0.ai"},
@@ -258,6 +293,7 @@ class Mem0MemoryProvider(MemoryProvider):
             {"key": "user_id", "description": "User identifier", "default": "hermes-user"},
             {"key": "agent_id", "description": "Agent identifier", "default": "hermes"},
             {"key": "rerank", "description": "Enable reranking for recall", "default": "false", "choices": ["true", "false"]},
+            {"key": "recall_mode", "description": "Memory recall mode", "default": "hybrid", "choices": list(_RECALL_MODE_CHOICES)},
         ]
 
     def post_setup(self, hermes_home: str, config: dict) -> None:
@@ -335,7 +371,6 @@ class Mem0MemoryProvider(MemoryProvider):
             )
 
     def initialize(self, session_id: str, **kwargs) -> None:
-        self._config = _load_config()
         self._mode = self._config.get("mode", "platform")
         self._api_key = self._config.get("api_key", "")
         self._host = self._config.get("host", "")
@@ -395,24 +430,47 @@ class Mem0MemoryProvider(MemoryProvider):
             mode_label = "platform (cloud API)"
         # Rerank is a Mem0 Platform feature only.
         rerank_note = " Rerank is available on search." if (self._mode == "platform" and not self._host) else ""
-        return (
-            "# Mem0 Memory\n"
-            f"Active. Mode: {mode_label}. User: {self._user_id}.\n"
-            "You have persistent memory of this user from past conversations. "
-            "You should call mem0_search before answering anything that could depend "
-            "on prior context (the user's preferences, facts, history, people, "
-            "projects, or earlier decisions) — do not rely on the chat window "
-            "alone, and do not assume you have no memory.\n"
-            "For multi-part or multi-hop questions, run several searches with "
-            "different wording/angles and follow-up searches on what the first "
-            "results surface; one search is rarely enough. Keep searching until "
-            "you have every fact the question needs before you answer.\n"
+        tools = (
             "Tools: mem0_search to find memories, mem0_add to store facts, "
             f"mem0_update and mem0_delete to manage by ID.{rerank_note}"
         )
+        if self._recall_mode == "context":
+            guidance = (
+                "Relevant memory may be injected for the current question. "
+                "Use injected context when available; if no memory context is "
+                "present, answer from the conversation and other available "
+                "information. No Mem0 tools are available in this mode."
+            )
+            tools = ""
+        elif self._recall_mode == "tools":
+            guidance = (
+                "No automatic context injection is performed. Use mem0_search "
+                "when an answer may depend on the user's preferences, facts, "
+                "history, people, projects, or earlier decisions; do not assume "
+                "memory is available without a tool result."
+            )
+        else:
+            guidance = (
+                "Use injected context first when it is available for the current "
+                "question. Use mem0_search when the injected context is absent "
+                "or insufficient, when the needed query depends on prior "
+                "conversation state, or when a genuine multi-hop question needs "
+                "targeted follow-up searches."
+            )
+
+        return (
+            "# Mem0 Memory\n"
+            f"Active. Mode: {mode_label}. User: {self._user_id}.\n"
+            f"{guidance}"
+            + (f"\n{tools}" if tools else "")
+        )
 
     def on_turn_start(self, turn_number: int, message: str, **kwargs) -> None:
-        self._start_prefetch(message)
+        if self._recall_mode == "tools":
+            return
+        clean_message = extract_user_instruction_from_skill_message(message)
+        if clean_message:
+            self._start_prefetch(clean_message)
 
     def _consume_prefetch_result(self, query: str) -> str | None:
         with self._prefetch_lock:
@@ -424,6 +482,8 @@ class Mem0MemoryProvider(MemoryProvider):
             return result
 
     def _start_prefetch(self, query: str) -> None:
+        if self._recall_mode == "tools":
+            return
         if not query or self._backend is None or self._is_breaker_open():
             return
         backend = self._backend
@@ -462,6 +522,8 @@ class Mem0MemoryProvider(MemoryProvider):
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         """Recall memories for the CURRENT question with a short hot-path wait."""
+        if self._recall_mode == "tools":
+            return ""
         cached = self._consume_prefetch_result(query)
         if cached is not None:
             return cached
@@ -512,7 +574,17 @@ class Mem0MemoryProvider(MemoryProvider):
             self._sync_thread.start()
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
-        return [SEARCH_SCHEMA, ADD_SCHEMA, UPDATE_SCHEMA, DELETE_SCHEMA]
+        if self._recall_mode == "context":
+            return []
+
+        search_description = (
+            _TOOLS_SEARCH_DESCRIPTION
+            if self._recall_mode == "tools"
+            else _HYBRID_SEARCH_DESCRIPTION
+        )
+        schemas = deepcopy([SEARCH_SCHEMA, ADD_SCHEMA, UPDATE_SCHEMA, DELETE_SCHEMA])
+        schemas[0]["description"] = search_description
+        return schemas
 
     def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
         if self._backend is None:

--- a/plugins/memory/mem0/_setup.py
+++ b/plugins/memory/mem0/_setup.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from hermes_constants import get_hermes_home
 
+from . import _RECALL_MODE_CHOICES, _normalize_recall_mode
 from ._oss_providers import (
     LLM_PROVIDERS,
     EMBEDDER_PROVIDERS,
@@ -85,6 +86,7 @@ def parse_flags(argv: list[str] | None = None) -> dict[str, str]:
         "oss_vector_password": "",
         "oss_vector_dbname": "",
         "user_id": "",
+        "recall_mode": "",
         "dry_run": False,
     }
 
@@ -109,6 +111,7 @@ def parse_flags(argv: list[str] | None = None) -> dict[str, str]:
         "--oss-vector-password": "oss_vector_password",
         "--oss-vector-dbname": "oss_vector_dbname",
         "--user-id": "user_id",
+        "--recall-mode": "recall_mode",
     }
 
     i = 0
@@ -231,6 +234,50 @@ def _save_mem0_json(hermes_home: str, data: dict) -> None:
     config_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
 
 
+def _load_mem0_json(hermes_home: str) -> dict:
+    """Read the native Mem0 config, returning an empty mapping on failure."""
+    config_path = Path(hermes_home) / "mem0.json"
+    if config_path.exists():
+        try:
+            existing = json.loads(config_path.read_text(encoding="utf-8"))
+            if isinstance(existing, dict):
+                return existing
+        except Exception:
+            pass
+    return {}
+
+
+_RECALL_MODE_DESCRIPTIONS = {
+    "hybrid": "Auto-injected context plus Mem0 tools (default)",
+    "context": "Auto-injected context only; Mem0 tools hidden",
+    "tools": "Mem0 tools only; no automatic context injection",
+}
+
+
+def _select_recall_mode(
+    existing_config: dict,
+    flags: dict[str, str],
+    *,
+    interactive: bool,
+) -> str:
+    """Resolve recall mode from an optional flag, existing config, or picker."""
+    requested = flags.get("recall_mode")
+    if requested:
+        return _normalize_recall_mode(requested)
+
+    current = _normalize_recall_mode(existing_config.get("recall_mode"))
+    if not interactive:
+        return current
+
+    items = [(_mode, _RECALL_MODE_DESCRIPTIONS[_mode]) for _mode in _RECALL_MODE_CHOICES]
+    selected = _curses_select(
+        "  Recall mode",
+        items,
+        default=_RECALL_MODE_CHOICES.index(current),
+    )
+    return _RECALL_MODE_CHOICES[selected]
+
+
 def _setup_platform(hermes_home: str, config: dict, flags: dict[str, str]) -> None:
     """Platform mode setup — uses the framework's schema-based flow.
 
@@ -242,15 +289,10 @@ def _setup_platform(hermes_home: str, config: dict, flags: dict[str, str]) -> No
         {"key": "user_id", "description": "User identifier", "default": "hermes-user"},
         {"key": "agent_id", "description": "Agent identifier", "default": "hermes"},
         {"key": "rerank", "description": "Enable reranking for recall", "default": "false", "choices": ["true", "false"]},
+        {"key": "recall_mode", "description": "Memory recall mode", "default": "hybrid", "choices": list(_RECALL_MODE_CHOICES)},
     ]
 
-    existing_config = {}
-    config_path = Path(hermes_home) / "mem0.json"
-    if config_path.exists():
-        try:
-            existing_config = json.loads(config_path.read_text(encoding="utf-8"))
-        except Exception:
-            pass
+    existing_config = _load_mem0_json(hermes_home)
 
     provider_config = dict(existing_config)
     env_writes: dict[str, str] = {}
@@ -265,6 +307,14 @@ def _setup_platform(hermes_home: str, config: dict, flags: dict[str, str]) -> No
         choices = field.get("choices")
         env_var = field.get("env_var")
         url = field.get("url")
+
+        if key == "recall_mode":
+            provider_config[key] = _select_recall_mode(
+                existing_config,
+                flags,
+                interactive=not bool(flags.get("_mode_from_flag") or flags.get("mode")),
+            )
+            continue
 
         if flags.get("api_key") and key == "api_key":
             env_writes["MEM0_API_KEY"] = flags["api_key"]
@@ -339,7 +389,7 @@ def _setup_platform(hermes_home: str, config: dict, flags: dict[str, str]) -> No
     print("  Provider config saved")
     if env_writes:
         print("  API keys saved to .env")
-    print("\n  Start a new session to activate.\n")
+    print("\n  Restart Hermes to activate.\n")
 
 
 def _check_selfhosted_server(host: str) -> None:
@@ -365,13 +415,7 @@ def _setup_selfhosted(hermes_home: str, config: dict, flags: dict[str, str]) -> 
     server URL (behavioral -> mem0.json) and an optional API key
     (secret -> .env as MEM0_API_KEY).
     """
-    existing_config = {}
-    config_path = Path(hermes_home) / "mem0.json"
-    if config_path.exists():
-        try:
-            existing_config = json.loads(config_path.read_text(encoding="utf-8"))
-        except Exception:
-            pass
+    existing_config = _load_mem0_json(hermes_home)
 
     provider_config = dict(existing_config)
 
@@ -403,6 +447,11 @@ def _setup_selfhosted(hermes_home: str, config: dict, flags: dict[str, str]) -> 
         "User identifier", default=provider_config.get("user_id") or "hermes-user"
     )
     agent_id = _prompt("Agent identifier", default=provider_config.get("agent_id") or "hermes")
+    provider_config["recall_mode"] = _select_recall_mode(
+        existing_config,
+        flags,
+        interactive=not bool(flags.get("_mode_from_flag") or flags.get("mode")),
+    )
 
     if flags.get("dry_run"):
         print(f"\n  [dry-run] Would save config: host={host}, user_id={user_id}, agent_id={agent_id}")
@@ -435,7 +484,7 @@ def _setup_selfhosted(hermes_home: str, config: dict, flags: dict[str, str]) -> 
     print("  Provider config saved")
     if env_writes:
         print("  API key saved to .env")
-    print("\n  Start a new session to activate.\n")
+    print("\n  Restart Hermes to activate.\n")
 
 
 def _setup_oss(hermes_home: str, config: dict, flags: dict[str, str]) -> None:
@@ -444,10 +493,11 @@ def _setup_oss(hermes_home: str, config: dict, flags: dict[str, str]) -> None:
     Non-interactive when --mode was set explicitly via flags (post_setup already
     resolved mode). Interactive only when mode was chosen via curses picker.
     """
-    if not flags.get("_mode_from_flag"):
-        _setup_oss_interactive(hermes_home, config)
+    if not flags.get("_mode_from_flag") and flags.get("mode") != "oss":
+        _setup_oss_interactive(hermes_home, config, flags)
         return
 
+    existing_config = _load_mem0_json(hermes_home)
     oss_config, env_writes = build_oss_config(flags)
     errors = validate_oss_config(oss_config)
     if errors:
@@ -456,25 +506,24 @@ def _setup_oss(hermes_home: str, config: dict, flags: dict[str, str]) -> None:
         sys.exit(1)
 
     user_id = flags.get("user_id") or os.getenv("USER", "hermes-user")
+    recall_mode = _select_recall_mode(existing_config, flags, interactive=False)
 
     llm_id = oss_config["llm"]["provider"]
     embedder_id = oss_config["embedder"]["provider"]
     vector_id = oss_config["vector_store"]["provider"]
 
     if flags.get("dry_run"):
-        print("\n  [dry-run] OSS config would be:")
-        print(f"    LLM: {oss_config['llm']['provider']} ({oss_config['llm']['config'].get('model', '')})")
-        print(f"    Embedder: {oss_config['embedder']['provider']} ({oss_config['embedder']['config'].get('model', '')})")
-        print(f"    Vector: {vector_id}")
-        if env_writes:
-            print(f"    Env vars: {', '.join(env_writes.keys())}")
-        _run_connectivity_checks(oss_config)
-        print("  [dry-run] No files written.\n")
+        _print_oss_dry_run(oss_config, vector_id, recall_mode, env_writes)
         return
 
-    if env_writes:
-        _write_env(Path(hermes_home) / ".env", env_writes)
-    _save_mem0_json(hermes_home, {"mode": "oss", "user_id": user_id, "agent_id": "hermes", "oss": oss_config})
+    _persist_oss_config(
+        hermes_home,
+        env_writes,
+        user_id=user_id,
+        agent_id="hermes",
+        recall_mode=recall_mode,
+        oss_config=oss_config,
+    )
 
     _install_provider_deps(llm_id, embedder_id, vector_id)
 
@@ -491,7 +540,7 @@ def _setup_oss(hermes_home: str, config: dict, flags: dict[str, str]) -> None:
         print("    API keys saved to .env")
     print("    Config saved to mem0.json")
     print("    Provider set in config.yaml")
-    print("\n  Start a new session to activate.\n")
+    print("\n  Restart Hermes to activate.\n")
 
 
 def _prompt_api_key(label: str, env_var: str, hermes_home: str) -> str:
@@ -731,8 +780,56 @@ def _vector_description(pid: str, v: dict) -> str:
     return pid
 
 
-def _setup_oss_interactive(hermes_home: str, config: dict) -> None:
+def _print_oss_dry_run(
+    oss_config: dict,
+    vector_id: str,
+    recall_mode: str,
+    env_writes: dict[str, str],
+) -> None:
+    """Print the shared non-mutating OSS setup preview."""
+    print("\n  [dry-run] OSS config would be:")
+    print(f"    LLM: {oss_config['llm']['provider']} ({oss_config['llm']['config'].get('model', '')})")
+    print(f"    Embedder: {oss_config['embedder']['provider']} ({oss_config['embedder']['config'].get('model', '')})")
+    print(f"    Vector: {vector_id}")
+    print(f"    Recall: {recall_mode}")
+    if env_writes:
+        print(f"    Env vars: {', '.join(env_writes.keys())}")
+    print("  [dry-run] No files written.\n")
+
+
+def _persist_oss_config(
+    hermes_home: str,
+    env_writes: dict[str, str],
+    *,
+    user_id: str,
+    agent_id: str,
+    recall_mode: str,
+    oss_config: dict,
+) -> None:
+    """Persist the shared OSS credentials and behavioral configuration."""
+    if env_writes:
+        _write_env(Path(hermes_home) / ".env", env_writes)
+    _save_mem0_json(
+        hermes_home,
+        {
+            "mode": "oss",
+            "user_id": user_id,
+            "agent_id": agent_id,
+            "recall_mode": recall_mode,
+            "oss": oss_config,
+        },
+    )
+
+
+def _setup_oss_interactive(
+    hermes_home: str,
+    config: dict,
+    setup_flags: dict[str, str] | None = None,
+) -> None:
     """Interactive OSS setup using curses pickers."""
+    setup_flags = setup_flags or {}
+    dry_run = bool(setup_flags.get("dry_run"))
+    existing_config = _load_mem0_json(hermes_home)
     llm_items = [(v["label"], _provider_description(v)) for pid, v in LLM_PROVIDERS.items()]
     llm_idx = _curses_select("LLM Provider", llm_items, 0)
     llm_id = list(LLM_PROVIDERS.keys())[llm_idx]
@@ -777,12 +874,12 @@ def _setup_oss_interactive(hermes_home: str, config: dict) -> None:
         ollama_models.append(llm_model)
     if embedder_id == "ollama":
         ollama_models.append(embedder_model)
-    if ollama_models:
+    if ollama_models and not dry_run:
         _ensure_ollama(ollama_models)
 
     # Auto-setup: ensure pgvector is reachable (offer Docker if not)
     pgvector_config = None
-    if vector_id == "pgvector":
+    if vector_id == "pgvector" and not dry_run:
         pgvector_config = _ensure_pgvector()
         if not pgvector_config:
             # Native PostgreSQL — prompt for connection details
@@ -804,8 +901,13 @@ def _setup_oss_interactive(hermes_home: str, config: dict) -> None:
 
     agent_id = input("  Agent ID [hermes]: ").strip()
     agent_id = agent_id or "hermes"
+    recall_mode = _select_recall_mode(
+        existing_config,
+        setup_flags,
+        interactive=not bool(setup_flags.get("recall_mode")),
+    )
 
-    flags = {
+    build_flags = {
         "oss_llm": llm_id,
         "oss_llm_key": env_writes.get(llm_def["env_var"], "") if llm_def.get("env_var") else "",
         "oss_llm_model": llm_model,
@@ -815,21 +917,32 @@ def _setup_oss_interactive(hermes_home: str, config: dict) -> None:
         "oss_embedder_url": embedder_url or "",
         "oss_vector": vector_id,
         "user_id": user_id,
+        "recall_mode": recall_mode,
+        "dry_run": dry_run,
     }
 
     if pgvector_config:
-        flags["oss_vector_host"] = pgvector_config["host"]
-        flags["oss_vector_port"] = str(pgvector_config["port"])
-        flags["oss_vector_user"] = pgvector_config["user"]
+        build_flags["oss_vector_host"] = pgvector_config["host"]
+        build_flags["oss_vector_port"] = str(pgvector_config["port"])
+        build_flags["oss_vector_user"] = pgvector_config["user"]
         if pgvector_config.get("password"):
-            flags["oss_vector_password"] = pgvector_config["password"]
-        flags["oss_vector_dbname"] = pgvector_config["dbname"]
+            build_flags["oss_vector_password"] = pgvector_config["password"]
+        build_flags["oss_vector_dbname"] = pgvector_config["dbname"]
 
-    oss_config, _ = build_oss_config(flags)
+    oss_config, _ = build_oss_config(build_flags)
 
-    if env_writes:
-        _write_env(Path(hermes_home) / ".env", env_writes)
-    _save_mem0_json(hermes_home, {"mode": "oss", "user_id": user_id, "agent_id": agent_id, "oss": oss_config})
+    if dry_run:
+        _print_oss_dry_run(oss_config, vector_id, recall_mode, env_writes)
+        return
+
+    _persist_oss_config(
+        hermes_home,
+        env_writes,
+        user_id=user_id,
+        agent_id=agent_id,
+        recall_mode=recall_mode,
+        oss_config=oss_config,
+    )
 
     _install_provider_deps(llm_id, embedder_id, vector_id)
 
@@ -849,7 +962,7 @@ def _setup_oss_interactive(hermes_home: str, config: dict) -> None:
         print("    API keys saved to .env")
     print("    Config saved to mem0.json")
     print("    Provider set in config.yaml")
-    print("\n  Start a new session to activate.\n")
+    print("\n  Restart Hermes to activate.\n")
 
 
 def _install_provider_deps(llm_id: str, embedder_id: str, vector_id: str) -> None:
@@ -978,10 +1091,12 @@ def post_setup(hermes_home: str, config: dict) -> None:
         return
 
     if flags["mode"] in ("selfhosted", "self-hosted"):
+        flags["_mode_from_flag"] = True
         _setup_selfhosted(hermes_home, config, flags)
         return
 
     if flags["mode"] == "platform":
+        flags["_mode_from_flag"] = True
         _setup_platform(hermes_home, config, flags)
         return
 

--- a/tests/hermes_cli/test_subcommands_followup.py
+++ b/tests/hermes_cli/test_subcommands_followup.py
@@ -64,3 +64,16 @@ def test_mcp_and_acp_accept_hooks_flag():
     # acp takes --accept-hooks at top level
     ns = parser.parse_args(["acp", "--accept-hooks"])
     assert ns.accept_hooks is True
+
+
+def test_memory_setup_accepts_provider_specific_options():
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    build_memory_parser(sub, cmd_memory=_h("memory"))
+
+    ns = parser.parse_args(
+        ["memory", "setup", "mem0", "--recall-mode", "tools", "--mode", "oss"]
+    )
+
+    assert ns.provider == "mem0"
+    assert ns.provider_args == ["--recall-mode", "tools", "--mode", "oss"]

--- a/tests/plugins/memory/test_mem0_setup.py
+++ b/tests/plugins/memory/test_mem0_setup.py
@@ -17,6 +17,7 @@ from plugins.memory.mem0._setup import (
     _check_ollama,
     _check_pgvector,
 )
+from plugins.memory.mem0 import Mem0MemoryProvider
 
 
 def _inject_fake_hermes_cli(monkeypatch):
@@ -56,6 +57,23 @@ class TestParseFlags:
     def test_oss_vector_path_flag(self):
         flags = parse_flags(["--mode", "oss", "--oss-vector-path", "/data/qdrant"])
         assert flags["oss_vector_path"] == "/data/qdrant"
+
+    def test_recall_mode_flag(self):
+        flags = parse_flags(["--mode", "oss", "--recall-mode", "tools"])
+        assert flags["recall_mode"] == "tools"
+
+
+class TestRecallModeSchema:
+
+    def test_schema_exposes_choices_without_environment_setting(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        provider = Mem0MemoryProvider()
+
+        fields = {field["key"]: field for field in provider.get_config_schema()}
+
+        assert fields["recall_mode"]["default"] == "hybrid"
+        assert fields["recall_mode"]["choices"] == ["hybrid", "context", "tools"]
+        assert "env_var" not in fields["recall_mode"]
 
 
 class TestBuildOSSConfig:
@@ -216,6 +234,160 @@ class TestPostSetup:
         assert mem0_json["host"] == "http://localhost:8888"  # trailing slash stripped
         assert mem0_json["user_id"] == "hermes-user"
 
+    @pytest.mark.parametrize(
+        ("setup_fn", "flags"),
+        [
+            (
+                "_setup_platform",
+                {"api_key": "sk-test", "recall_mode": "tools", "dry_run": False},
+            ),
+            (
+                "_setup_selfhosted",
+                {
+                    "host": "http://localhost:8888/",
+                    "api_key": "admin-key",
+                    "user_id": "user-1",
+                    "recall_mode": "context",
+                    "dry_run": False,
+                },
+            ),
+            (
+                "_setup_oss",
+                {
+                    "_mode_from_flag": True,
+                    "oss_llm": "ollama",
+                    "oss_embedder": "ollama",
+                    "oss_vector": "qdrant",
+                    "recall_mode": "context",
+                    "user_id": "user-1",
+                    "dry_run": False,
+                },
+            ),
+        ],
+    )
+    def test_flag_driven_setup_persists_recall_mode_and_unknown_keys(
+        self, tmp_path, monkeypatch, setup_fn, flags
+    ):
+        from plugins.memory.mem0 import _setup
+
+        existing = {"recall_mode": "hybrid", "future_setting": {"keep": True}}
+        (tmp_path / "mem0.json").write_text(json.dumps(existing), encoding="utf-8")
+        _inject_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr("plugins.memory.mem0._setup._check_selfhosted_server", lambda h: None)
+        monkeypatch.setattr("plugins.memory.mem0._setup._install_provider_deps", lambda *a: None)
+        monkeypatch.setattr("plugins.memory.mem0._setup._run_connectivity_checks", lambda *a: None)
+        monkeypatch.setattr("plugins.memory.mem0._setup.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr("plugins.memory.mem0._setup._check_min_dep_version", lambda: None)
+        monkeypatch.setattr("sys.argv", ["hermes"])
+        config = {"memory": {}}
+
+        getattr(_setup, setup_fn)(str(tmp_path), config, flags)
+
+        saved = json.loads((tmp_path / "mem0.json").read_text(encoding="utf-8"))
+        assert saved["recall_mode"] == flags["recall_mode"]
+        assert saved["future_setting"] == {"keep": True}
+
+    def test_selfhosted_without_flag_preserves_existing_recall_mode(self, tmp_path, monkeypatch):
+        from plugins.memory.mem0 import _setup
+
+        (tmp_path / "mem0.json").write_text(
+            json.dumps({"recall_mode": "tools", "future_setting": 7}), encoding="utf-8"
+        )
+        _inject_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(_setup, "_check_selfhosted_server", lambda h: None)
+        monkeypatch.setattr("plugins.memory.mem0._setup.get_hermes_home", lambda: tmp_path)
+        config = {"memory": {}}
+        flags = {
+            "_mode_from_flag": True,
+            "host": "http://localhost:8888/",
+            "api_key": "admin-key",
+            "user_id": "",
+        }
+
+        _setup._setup_selfhosted(str(tmp_path), config, flags)
+
+        saved = json.loads((tmp_path / "mem0.json").read_text(encoding="utf-8"))
+        assert saved["recall_mode"] == "tools"
+        assert saved["future_setting"] == 7
+
+    def test_oss_interactive_persists_selected_recall_mode(self, tmp_path, monkeypatch):
+        from plugins.memory.mem0 import _setup
+
+        (tmp_path / "mem0.json").write_text(
+            json.dumps({"future_setting": "keep"}), encoding="utf-8"
+        )
+        _inject_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(_setup, "_prompt_api_key", lambda *a: "")
+        monkeypatch.setattr(_setup, "_install_provider_deps", lambda *a: None)
+        monkeypatch.setattr(_setup, "_run_connectivity_checks", lambda *a: None)
+        monkeypatch.setattr(
+            _setup,
+            "_curses_select",
+            lambda title, items, default=0: 1 if "Recall mode" in title else 0,
+        )
+        monkeypatch.setattr("builtins.input", lambda prompt="": "")
+        config = {"memory": {}}
+
+        _setup._setup_oss_interactive(str(tmp_path), config)
+
+        saved = json.loads((tmp_path / "mem0.json").read_text(encoding="utf-8"))
+        assert saved["recall_mode"] == "context"
+        assert saved["future_setting"] == "keep"
+
+    @pytest.mark.parametrize("setup_fn", ["_setup_platform", "_setup_selfhosted"])
+    def test_interactive_setup_persists_selected_recall_mode(
+        self, tmp_path, monkeypatch, setup_fn
+    ):
+        from plugins.memory.mem0 import _setup
+
+        (tmp_path / "mem0.json").write_text(
+            json.dumps({"future_setting": "keep"}), encoding="utf-8"
+        )
+        _inject_fake_hermes_cli(monkeypatch)
+        monkeypatch.setenv("MEM0_API_KEY", "existing-key")
+        monkeypatch.setattr(_setup, "_check_selfhosted_server", lambda h: None)
+        monkeypatch.setattr(
+            _setup,
+            "_curses_select",
+            lambda title, items, default=0: 2 if "Recall mode" in title else default,
+        )
+        monkeypatch.setattr(
+            _setup,
+            "_prompt",
+            lambda label, default=None, secret=False: default or (
+                "http://localhost:8888" if "server URL" in label else ""
+            ),
+        )
+        config = {"memory": {}}
+
+        getattr(_setup, setup_fn)(str(tmp_path), config, {})
+
+        saved = json.loads((tmp_path / "mem0.json").read_text(encoding="utf-8"))
+        assert saved["recall_mode"] == "tools"
+        assert saved["future_setting"] == "keep"
+
+    def test_invalid_recall_mode_flag_defaults_to_hybrid(self, tmp_path, monkeypatch):
+        from plugins.memory.mem0 import _setup
+
+        _inject_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr("plugins.memory.mem0._setup._install_provider_deps", lambda *a: None)
+        monkeypatch.setattr("plugins.memory.mem0._setup._run_connectivity_checks", lambda *a: None)
+        config = {"memory": {}}
+        flags = {
+            "_mode_from_flag": True,
+            "oss_llm": "ollama",
+            "oss_embedder": "ollama",
+            "oss_vector": "qdrant",
+            "recall_mode": "not-a-mode",
+            "user_id": "user-1",
+            "dry_run": False,
+        }
+
+        _setup._setup_oss(str(tmp_path), config, flags)
+
+        saved = json.loads((tmp_path / "mem0.json").read_text(encoding="utf-8"))
+        assert saved["recall_mode"] == "hybrid"
+
 
 class TestDryRun:
 
@@ -223,11 +395,36 @@ class TestDryRun:
         flags = parse_flags(["--mode", "oss", "--oss-llm-key", "sk-oai", "--dry-run"])
         assert flags["dry_run"] is True
 
+    def test_oss_dry_run_does_not_write_recall_mode_or_secrets(self, tmp_path, monkeypatch):
+        from plugins.memory.mem0 import _setup
+
+        original = {"recall_mode": "tools", "future_setting": {"keep": True}}
+        config_path = tmp_path / "mem0.json"
+        config_path.write_text(json.dumps(original), encoding="utf-8")
+        env_path = tmp_path / ".env"
+        env_path.write_text("OPENAI_API_KEY=old\n", encoding="utf-8")
+        monkeypatch.setattr(_setup, "_run_connectivity_checks", lambda *a: None)
+        config = {"memory": {}}
+        flags = {
+            "_mode_from_flag": True,
+            "oss_llm": "openai",
+            "oss_llm_key": "new",
+            "oss_embedder": "openai",
+            "oss_vector": "qdrant",
+            "recall_mode": "context",
+            "user_id": "user-1",
+            "dry_run": True,
+        }
+
+        _setup._setup_oss(str(tmp_path), config, flags)
+
+        assert json.loads(config_path.read_text(encoding="utf-8")) == original
+        assert env_path.read_text(encoding="utf-8") == "OPENAI_API_KEY=old\n"
+        assert config == {"memory": {}}
+
 
 class TestConnectivityChecks:
 
     def test_qdrant_path_writable(self, tmp_path):
         ok, msg = _check_qdrant_path(str(tmp_path / "qdrant"))
         assert ok is True
-
-

--- a/tests/plugins/memory/test_mem0_v3.py
+++ b/tests/plugins/memory/test_mem0_v3.py
@@ -5,6 +5,7 @@ import threading
 import time
 import pytest
 
+from agent.memory_manager import MemoryManager
 import plugins.memory.mem0 as mem0_plugin
 from plugins.memory.mem0 import Mem0MemoryProvider
 
@@ -261,6 +262,241 @@ class TestMem0V3Config:
         assert "mem0_conclude" not in block
 
 
+class TestMem0RecallModes:
+    """Recall policy is resolved once and gates only the provider edges."""
+
+    def _provider(self, monkeypatch, tmp_path, mode, backend=None):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        (tmp_path / "mem0.json").write_text(
+            json.dumps({"recall_mode": mode}), encoding="utf-8"
+        )
+        provider = Mem0MemoryProvider()
+        if backend is not None:
+            provider._create_backend = lambda: backend
+        provider.initialize("test-session")
+        provider._user_id = "u123"
+        provider._agent_id = "hermes"
+        return provider
+
+    @pytest.mark.parametrize(
+        "configured",
+        [None, "unsupported", {"mode": "context"}],
+    )
+    def test_invalid_or_missing_mode_defaults_to_hybrid(
+        self, monkeypatch, tmp_path, configured
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        config = {} if configured is None else {"recall_mode": configured}
+        (tmp_path / "mem0.json").write_text(json.dumps(config), encoding="utf-8")
+
+        provider = Mem0MemoryProvider()
+
+        assert provider._recall_mode == "hybrid"
+
+    @pytest.mark.parametrize(
+        ("mode", "expected_tools"),
+        [("context", []), ("tools", ["mem0_search", "mem0_add", "mem0_update", "mem0_delete"])],
+    )
+    def test_manager_registration_uses_mode_before_initialize(
+        self, monkeypatch, tmp_path, mode, expected_tools
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        (tmp_path / "mem0.json").write_text(
+            json.dumps({"recall_mode": mode}), encoding="utf-8"
+        )
+        provider = Mem0MemoryProvider()
+        manager = MemoryManager()
+
+        # MemoryManager builds its routing table before provider initialization.
+        manager.add_provider(provider)
+
+        assert [schema["name"] for schema in manager.get_all_tool_schemas()] == expected_tools
+        assert {name: manager.has_tool(name) for name in expected_tools} == {
+            name: True for name in expected_tools
+        }
+        if mode == "context":
+            assert not manager.has_tool("mem0_search")
+
+    def test_context_mode_prefetches_current_query_without_tools(self, monkeypatch, tmp_path):
+        backend = FakeBackend(
+            search_results=[{"id": "m1", "memory": "user prefers dark mode"}]
+        )
+        provider = self._provider(monkeypatch, tmp_path, "context", backend)
+
+        assert provider.get_tool_schemas() == []
+        provider.on_turn_start(1, "what theme do I like?")
+        provider._prefetch_thread.join(timeout=1)
+
+        result = provider.prefetch("what theme do I like?")
+
+        assert "user prefers dark mode" in result
+        assert [call[1] for call in backend.captured if call[0] == "search"] == [
+            "what theme do I like?"
+        ]
+
+    def test_skill_expansion_prefetches_clean_current_query_once(
+        self, monkeypatch, tmp_path
+    ):
+        backend = FakeBackend(
+            search_results=[{"id": "m1", "memory": "release triage preference"}]
+        )
+        provider = self._provider(monkeypatch, tmp_path, "hybrid", backend)
+        manager = MemoryManager()
+        manager.add_provider(provider)
+        expanded = (
+            '[IMPORTANT: The user has invoked the "skill-creator" skill, indicating '
+            "they want you to follow its instructions. The full skill content is loaded below.]\n\n"
+            "# Skill Creator\n\nLarge skill body.\n\n"
+            "The user has provided the following instruction alongside the skill invocation: "
+            "make a skill for release triage"
+        )
+
+        manager.on_turn_start(1, expanded)
+        provider._prefetch_thread.join(timeout=1)
+        result = manager.prefetch_all(expanded)
+
+        assert "release triage preference" in result
+        assert [call[1] for call in backend.captured if call[0] == "search"] == [
+            "make a skill for release triage"
+        ]
+
+    def test_bare_skill_expansion_starts_no_prefetch(self, monkeypatch, tmp_path):
+        backend = FakeBackend(search_results=[{"id": "m1", "memory": "unused"}])
+        provider = self._provider(monkeypatch, tmp_path, "context", backend)
+        expanded = (
+            '[IMPORTANT: The user has invoked the "skill-creator" skill, indicating '
+            "they want you to follow its instructions. The full skill content is loaded below.]\n\n"
+            "# Skill Creator\n\nLarge skill body, no user instruction."
+        )
+
+        provider.on_turn_start(1, expanded)
+
+        assert provider._prefetch_thread is None
+        assert backend.captured == []
+
+    @pytest.mark.parametrize("failure", ["empty", "error", "breaker"])
+    def test_context_mode_failures_inject_nothing_and_do_not_retry(
+        self, monkeypatch, tmp_path, failure
+    ):
+        class FailingBackend(FakeBackend):
+            def search(self, query, *, filters, top_k=10, rerank=True):
+                self.captured.append(
+                    ("search", query, {"filters": filters, "top_k": top_k, "rerank": rerank})
+                )
+                if failure == "error":
+                    raise ConnectionError("offline")
+                return []
+
+        backend = FailingBackend()
+        provider = self._provider(monkeypatch, tmp_path, "context", backend)
+        if failure == "breaker":
+            provider._consecutive_failures = mem0_plugin._BREAKER_THRESHOLD
+            provider._breaker_open_until = time.monotonic() + 60
+
+        provider.on_turn_start(1, "what theme do I like?")
+        if provider._prefetch_thread is not None:
+            provider._prefetch_thread.join(timeout=1)
+
+        assert provider.prefetch("what theme do I like?") == ""
+        expected_searches = 0 if failure == "breaker" else 1
+        assert len([call for call in backend.captured if call[0] == "search"]) == expected_searches
+
+    def test_context_mode_timeout_injects_nothing_without_backstop(
+        self, monkeypatch, tmp_path
+    ):
+        release = threading.Event()
+        entered = threading.Event()
+
+        class SlowBackend(FakeBackend):
+            def search(self, query, *, filters, top_k=10, rerank=True):
+                self.captured.append(
+                    ("search", query, {"filters": filters, "top_k": top_k, "rerank": rerank})
+                )
+                entered.set()
+                release.wait(timeout=1)
+                return [{"id": "m1", "memory": "too late"}]
+
+        backend = SlowBackend()
+        provider = self._provider(monkeypatch, tmp_path, "context", backend)
+        monkeypatch.setattr(mem0_plugin, "_PREFETCH_WAIT_SECS", 0.01)
+
+        try:
+            assert provider.prefetch("what theme do I like?") == ""
+            assert entered.wait(timeout=1)
+            assert len([call for call in backend.captured if call[0] == "search"]) == 1
+        finally:
+            release.set()
+            provider._prefetch_thread.join(timeout=1)
+
+    def test_tools_mode_never_starts_automatic_prefetch(self, monkeypatch, tmp_path):
+        backend = FakeBackend(
+            search_results=[{"id": "m1", "memory": "user prefers dark mode"}]
+        )
+        provider = self._provider(monkeypatch, tmp_path, "tools", backend)
+
+        provider.on_turn_start(1, "what theme do I like?")
+        provider._start_prefetch("what theme do I like?")
+
+        assert provider.prefetch("what theme do I like?") == ""
+        assert provider._prefetch_thread is None
+        assert backend.captured == []
+
+    @pytest.mark.parametrize("mode", ["hybrid", "tools"])
+    def test_search_schema_is_mode_specific_without_mutating_global(
+        self, monkeypatch, tmp_path, mode
+    ):
+        provider = self._provider(monkeypatch, tmp_path, mode, FakeBackend())
+        original = json.loads(json.dumps(mem0_plugin.SEARCH_SCHEMA))
+
+        first = provider.get_tool_schemas()
+        second = provider.get_tool_schemas()
+
+        assert first == second
+        assert first[0] is not mem0_plugin.SEARCH_SCHEMA
+        assert mem0_plugin.SEARCH_SCHEMA == original
+        if mode == "hybrid":
+            assert "injected context" in first[0]["description"]
+        else:
+            assert "automatic context" in first[0]["description"]
+
+    @pytest.mark.parametrize("mode", ["hybrid", "context", "tools"])
+    def test_system_prompt_guidance_matches_mode(self, monkeypatch, tmp_path, mode):
+        provider = self._provider(monkeypatch, tmp_path, mode, FakeBackend())
+
+        first = provider.system_prompt_block()
+        second = provider.system_prompt_block()
+
+        assert first == second
+        if mode == "hybrid":
+            assert "Use injected context first" in first
+            assert "before answering anything" not in first
+        elif mode == "context":
+            assert "Use injected context when available" in first
+            assert "memory was consulted" not in first
+        else:
+            assert "No automatic context injection" in first
+            assert "mem0_search" in first
+
+    def test_recall_mode_stays_frozen_when_config_changes_before_initialize(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        config_path = tmp_path / "mem0.json"
+        config_path.write_text(json.dumps({"recall_mode": "context"}), encoding="utf-8")
+        provider = Mem0MemoryProvider()
+        config_path.write_text(json.dumps({"recall_mode": "tools"}), encoding="utf-8")
+        provider._create_backend = lambda: None
+
+        provider.initialize("test-session")
+
+        assert provider._recall_mode == "context"
+        assert provider.get_tool_schemas() == []
+
+
 class TestMem0ModeSwitch:
 
     def test_default_mode_is_platform(self, monkeypatch, tmp_path):
@@ -407,5 +643,3 @@ class TestSelfHostedConfig:
     def test_load_config_reads_mem0_host_env(self, monkeypatch):
         monkeypatch.setenv("MEM0_HOST", "http://localhost:8888")
         assert mem0_plugin._load_config()["host"] == "http://localhost:8888"
-
-

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -398,6 +398,29 @@ The plugin authenticates with `X-API-Key` and uses the server's `/search` / `/me
 | `user_id` | `hermes-user` | User identifier |
 | `agent_id` | `hermes` | Agent identifier |
 | `rerank` | `false` | Rerank search results for relevance (platform mode only) |
+| `recall_mode` | `hybrid` | `hybrid`, `context`, or `tools` |
+
+#### Recall modes
+
+Set `recall_mode` in `$HERMES_HOME/mem0.json` (normally `~/.hermes/mem0.json`):
+
+```json
+{
+  "recall_mode": "hybrid"
+}
+```
+
+`hybrid` is the compatibility default. Missing or unsupported values also use `hybrid`. For predictable retrieval volume, `hybrid` and `context` allow at most one automatic exact current-question attempt per turn, while `tools` allows zero. Explicit `mem0_search` calls are separate from this ceiling.
+
+| Mode | Automatic retrieval | Mem0 tools | Semantics |
+|------|---------------------|------------|-----------|
+| `hybrid` | At most one exact current-question attempt per turn | All four | Use injected context first when available. Use `mem0_search` when injected context is absent or insufficient, when the needed query depends on prior conversation state, or when a genuine multi-hop question needs targeted follow-up searches. |
+| `context` | At most one exact current-question attempt per turn | None | Context only. The attempt is best effort: empty results, timeouts, an open breaker, or backend errors inject no Mem0 block, make no backstop call, and do not imply memory was consulted. |
+| `tools` | Zero automatic attempts | All four | No automatic context injection is performed. This trades deterministic current-question recall for zero automatic retrievals, so recall correctness depends on the model issuing an appropriate `mem0_search`. |
+
+Automatic turn capture and synchronization remain enabled in every mode. Recall mode does not change capture or existing write behavior; it changes automatic retrieval and tool exposure.
+
+The provider resolves the mode when it is constructed. After changing `mem0.json`, restart Hermes so a new agent and provider are constructed. `/new` may reuse the existing agent and is not a reliable activation boundary. Setup also accepts `--recall-mode`.
 
 **OSS supported providers:**
 


### PR DESCRIPTION
## What does this PR do?

Mem0 users can now choose how recall reaches the model. `hybrid` preserves automatic current-question context and all four Mem0 tools, `context` keeps one best-effort automatic attempt and hides the tools, and `tools` disables automatic retrieval while retaining explicit tool access.

The mode is frozen when the provider is constructed, so prompt text and tool schemas stay stable for that agent lifetime. Existing configurations remain on `hybrid`, capture and synchronization are unchanged, and invalid values fall back safely. Hybrid guidance now asks the model to use injected context first instead of reflexively repeating the same search.

An anonymized usage sample reached 580 retrievals in roughly 2.28 days on a 5,000-operation tier. This makes the retrieval/correctness tradeoff worth exposing without removing the current-question correctness path added in #55535.

cc @kartik-mem0

## Related Issue

Fixes #89775

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added provider-stable `hybrid`, `context`, and `tools` recall policies without changing the core conversation loop or model tool surface.
- Added generic pass-through parsing for provider-specific `hermes memory setup` options, then exposed `--recall-mode` across Mem0 platform, self-hosted, and OSS setup paths.
- Added lifecycle, routing, prefetch, failure-path, setup, parser, and compatibility coverage.
- Documented defaults, retrieval ceilings, correctness tradeoffs, unchanged capture behavior, and restart requirements in both Mem0 documentation surfaces.

## How to Test

1. Run `scripts/run_tests.sh tests/agent/test_memory_skill_scaffolding.py tests/plugins/memory/test_mem0_v3.py tests/plugins/memory/test_mem0_setup.py tests/plugins/memory/test_mem0_backend.py tests/hermes_cli/test_subcommands_followup.py -q`.
2. Run `python -m ruff check hermes_cli/subcommands/memory.py plugins/memory/mem0/__init__.py plugins/memory/mem0/_setup.py tests/hermes_cli/test_subcommands_followup.py tests/plugins/memory/test_mem0_setup.py tests/plugins/memory/test_mem0_v3.py`.
3. Configure each mode with `hermes memory setup mem0 --recall-mode <hybrid|context|tools>`, restart Hermes, and inspect automatic context plus available Mem0 tools.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, this is plugin-local `mem0.json` configuration
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - no platform-specific runtime behavior added
- [x] I've updated tool descriptions/schemas if I changed tool behavior - mode-specific Mem0 schema guidance is covered

## Screenshots / Logs

Focused verification passed: 95 tests, Ruff, and `git diff --check`.

The full repository runner completed all 3,063 files: 35,056 passed, 27 failed, and 264 skipped. The 18 failing files are unchanged from the fetched base. The failures are outside this change and include installed SDK/API drift, relay metadata compatibility, root permission assumptions, live-process guards, and environment-sensitive path tests.
