### PR TITLE
fix(gateway): make Windows Scheduled Task install work on workgroup machines

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -580,13 +580,20 @@ def _write_task_script() -> Path:
 # ---------------------------------------------------------------------------
 
 def _resolve_task_user() -> str | None:
-    """Return ``DOMAIN\\USER`` if available, else bare USERNAME, else None."""
+    """Return ``DOMAIN\\USER`` if available, else bare USERNAME, else None.
+
+    Workgroup machines report ``USERDOMAIN=WORKGROUP``; schtasks rejects
+    ``WORKGROUP\\user`` as a task principal ("No mapping between account
+    names and security IDs"), so local accounts must use the bare username.
+    """
     username = os.environ.get("USERNAME") or os.environ.get("USER") or os.environ.get("LOGNAME")
     if not username:
         return None
     if "\\" in username:
         return username
     domain = os.environ.get("USERDOMAIN")
+    if not domain or domain.upper() in {"WORKGROUP", "MICROSOFTACCOUNT"}:
+        return username
     return f"{domain}\\{username}" if domain else username
 
 
@@ -679,7 +686,12 @@ def _install_scheduled_task(task_name: str, script_path: Path) -> tuple[bool, st
     launcher_path = script_path.with_suffix(".vbs")
     xml_path = _write_scheduled_task_xml(task_name, launcher_path, user)
     base = ["/Create", "/F", "/TN", task_name, "/XML", str(xml_path)]
-    variants = [[*base, "/RU", user, "/NP", "/IT"]] if user else []
+    # Do not combine /NP with /IT: newer Windows builds reject the pair
+    # ("/IT switch cannot be used with /NP"), and /NP alone makes schtasks
+    # prompt for a run-as password instead of creating the task. The XML
+    # already declares the principal (InteractiveToken), so /IT alone keeps
+    # the task interactive without requiring a stored password.
+    variants = [[*base, "/RU", user, "/IT"]] if user else []
     variants.append(base)
 
     last_code = 1

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -296,6 +296,7 @@ def test_install_scheduled_task_recreates_instead_of_change(monkeypatch, tmp_pat
     assert "/Change" not in [arg for call in calls for arg in call]
     assert calls[0][:4] == ("/Delete", "/F", "/TN", "Hermes_Gateway_alice")
     assert calls[1][0] == "/Create"
+    assert "/IT" in calls[1] and "/NP" not in calls[1]
     assert "/XML" in calls[1]
     assert "/SC" not in calls[1]
     assert "<Delay>PT30S</Delay>" in xml_seen["text"]
@@ -390,7 +391,6 @@ def test_resolve_task_user_passes_through_qualified_username(monkeypatch):
 
 
 
-
 # ---------------------------------------------------------------------------
 # stop() drain semantics — issue #33778
 #
@@ -401,6 +401,7 @@ def test_resolve_task_user_passes_through_qualified_username(monkeypatch):
 # the gateway's marker-watcher thread to drain + exit cleanly, then escalates
 # to taskkill if drain times out.
 # ---------------------------------------------------------------------------
+
 
 
 

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -340,6 +340,45 @@ def test_gateway_vbs_script_is_console_less(monkeypatch):
     assert content.endswith("\r\n")
 
 
+@pytest.mark.parametrize(
+    ("userdomain", "username", "expected"),
+    [
+        ("WORKGROUP", "alice", "alice"),
+        ("workgroup", "alice", "alice"),
+        ("MICROSOFTACCOUNT", "alice", "alice"),
+        (None, "alice", "alice"),
+        ("CORP", "alice", r"CORP\alice"),
+        ("HELEN_REDMI", "qiaoa", r"HELEN_REDMI\qiaoa"),
+    ],
+)
+def test_resolve_task_user_workgroup_uses_bare_username(monkeypatch, userdomain, username, expected):
+    """Workgroup/local accounts must not be prefixed with the WORKGROUP domain:
+    schtasks cannot map ``WORKGROUP\\user`` to a SID, so the task principal
+    falls back to the bare username (issue #89807)."""
+
+    monkeypatch.delenv("USER", raising=False)
+    monkeypatch.delenv("LOGNAME", raising=False)
+    monkeypatch.setenv("USERNAME", username)
+    if userdomain is None:
+        monkeypatch.delenv("USERDOMAIN", raising=False)
+    else:
+        monkeypatch.setenv("USERDOMAIN", userdomain)
+    assert gateway_windows._resolve_task_user() == expected
+
+
+def test_resolve_task_user_returns_none_without_username(monkeypatch):
+    monkeypatch.delenv("USERNAME", raising=False)
+    monkeypatch.delenv("USER", raising=False)
+    monkeypatch.delenv("LOGNAME", raising=False)
+    assert gateway_windows._resolve_task_user() is None
+
+
+def test_resolve_task_user_passes_through_qualified_username(monkeypatch):
+    monkeypatch.delenv("USERDOMAIN", raising=False)
+    monkeypatch.setenv("USERNAME", r"DOMAIN\bob")
+    assert gateway_windows._resolve_task_user() == r"DOMAIN\bob"
+
+
 
 
 
@@ -362,7 +401,6 @@ def test_gateway_vbs_script_is_console_less(monkeypatch):
 # the gateway's marker-watcher thread to drain + exit cleanly, then escalates
 # to taskkill if drain times out.
 # ---------------------------------------------------------------------------
-
 
 
 


### PR DESCRIPTION
## Summary

`hermes gateway install` fails on Windows workgroup machines with "Windows gateway install failed". Two root causes in `hermes_cli/gateway_windows.py`:

1. **`_resolve_task_user()` returns `WORKGROUP\user` on workgroup machines.** Task Scheduler cannot map that principal to a security ID, so `schtasks /Create /XML` rejects the generated task at the `<UserId>` element:

   ```
   (17,8):UserId:
   ERROR: No mapping between account names and security IDs was done.
   ```

   Reproduced on Windows 11 build 10.0.26200 (workgroup machine, local account).

2. **The `/RU` create variant combines `/NP` with `/IT`.** On newer Windows builds schtasks rejects the pair (`/IT switch cannot be used with /NP`), and `/NP` alone makes schtasks prompt for a run-as password, which hangs non-interactive installs.

## Changes

- `_resolve_task_user()`: return the bare username when `USERDOMAIN` is unset or a workgroup sentinel (`WORKGROUP` / `MICROSOFTACCOUNT`), so the task principal is a valid local account.
- `_install_scheduled_task()`: drop `/NP` from the `/RU` variant. The generated task XML already declares the principal (`InteractiveToken`), so `/IT` alone keeps the task interactive without a stored password. The XML-only fallback variant is unchanged.

## Verification

On Windows 11 build 26200 (workgroup machine, Hermes v0.18.2):

- Before: `hermes gateway install --start-now --start-on-login` exits 1 with `RuntimeError: Windows gateway install failed`; no task is created.
- After: install exits 0, creates the `Hermes_Gateway` ONLOGON task (Logon Mode: Interactive only), and the gateway starts.

schtasks variant matrix on the affected machine:

| XML `UserId` / CLI flags | Result |
| --- | --- |
| `qiaoa` (bare) | success |
| `helen_redmi\qiaoa` | success |
| `WORKGROUP\qiaoa` | fail — no mapping between account names and security IDs |
| `.\qiaoa` | fail — no mapping between account names and security IDs |
| `/RU user /IT` | success |
| `/RU user /NP` | prompts for a run-as password |
| `/RU user /NP /IT` | rejected — `/IT switch cannot be used with /NP` |

Unit tests added for `_resolve_task_user()` (workgroup / domain / unset-domain /
missing-username / pre-qualified username cases) and verified against the patched
code in the Hermes venv on the affected machine.

Fixes #89807
