### PR TITLE
fix(cli): start dashboard MCP discovery only after the listen socket is bound

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11307,20 +11307,31 @@ def cmd_dashboard(args):
     # tool registry — it never starts MCP discovery (the stdio TUI does that in
     # tui_gateway/entry.py, which the dashboard process doesn't run).  Without
     # this, a profile's configured MCP servers never connect, so desktop
-    # sessions show no MCP tools.  Spawn discovery in the background here so a
+    # sessions show no MCP tools.  Discovery runs in the background so a
     # slow/dead server can't block dashboard startup.
-    try:
-        from hermes_cli.mcp_startup import start_background_mcp_discovery
+    #
+    # It is started from start_server's ``on_listening`` hook — i.e. only once
+    # uvicorn actually holds the listen socket — never before.  Starting it
+    # up-front meant every failed bind (port already taken by another
+    # dashboard, auth-gate fail-closed exit, …) had already spawned the stdio
+    # MCP servers and opened a session on every HTTP MCP server, and then
+    # died without closing any of it.  Under a KeepAlive supervisor
+    # (launchd/systemd) that turned a bind failure into a fresh MCP session
+    # every ThrottleInterval, rate-limiting shared MCP servers for every
+    # other client on the host.
+    def _start_dashboard_mcp_discovery() -> None:
+        try:
+            from hermes_cli.mcp_startup import start_background_mcp_discovery
 
-        start_background_mcp_discovery(
-            logger=logger,
-            thread_name="dashboard-mcp-discovery",
-        )
-    except Exception:
-        logger.debug(
-            "Background MCP tool discovery failed at dashboard startup",
-            exc_info=True,
-        )
+            start_background_mcp_discovery(
+                logger=logger,
+                thread_name="dashboard-mcp-discovery",
+            )
+        except Exception:
+            logger.debug(
+                "Background MCP tool discovery failed at dashboard startup",
+                exc_info=True,
+            )
 
     from hermes_cli.web_server import start_server
 
@@ -11343,6 +11354,7 @@ def cmd_dashboard(args):
         headless=_headless_backend,
         ssh_session_token=_ssh_session_token,
         ssh_owner_nonce=_ssh_owner_nonce,
+        on_listening=_start_dashboard_mcp_discovery,
     )
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -48,7 +48,7 @@ import zipfile
 from hermes_cli._subprocess_compat import windows_detach_flags, windows_hide_flags
 import urllib.request
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Tuple
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
 
 import yaml
 
@@ -18737,6 +18737,7 @@ def start_server(
     headless: bool = False,
     ssh_session_token: Optional[str] = None,
     ssh_owner_nonce: Optional[str] = None,
+    on_listening: Optional[Callable[[], None]] = None,
 ):
     """Start the web UI server.
 
@@ -18751,6 +18752,15 @@ def start_server(
 
     ``ssh_session_token`` and ``ssh_owner_nonce`` are process-local Desktop SSH
     bootstrap state. Neither is persisted or exported to child processes.
+
+    ``on_listening`` (optional) is called exactly once, on the event loop,
+    after uvicorn has bound the listen socket and the READY sentinel has been
+    printed — the earliest point at which this process is guaranteed to be
+    *the* dashboard on that port.  Side effects that reach outside the
+    process (MCP discovery: spawning stdio servers, opening HTTP MCP
+    sessions) belong here rather than before ``start_server``, so a failed
+    bind never leaves them behind.  Exceptions are logged and swallowed; the
+    server keeps serving.
     """
     _apply_ssh_session_token(ssh_session_token or "")
     _apply_ssh_owner_nonce(ssh_owner_nonce)
@@ -18984,6 +18994,12 @@ def start_server(
             else:
                 print(f"  Hermes Web UI → http://{host}:{actual_port}")
             _maybe_open_browser(host, actual_port, open_browser, initial_profile)
+
+            if on_listening is not None:
+                try:
+                    on_listening()
+                except Exception as exc:  # pragma: no cover - best-effort hook
+                    _log.warning("on_listening hook failed: %s", exc, exc_info=True)
 
             # Collapse the peer-hangup teardown flood (#50005). When the Desktop
             # forcibly closes its WebSocket mid-write, asyncio logs a full

--- a/tests/hermes_cli/test_dashboard_web_dist_validation.py
+++ b/tests/hermes_cli/test_dashboard_web_dist_validation.py
@@ -136,6 +136,51 @@ def test_skip_build_missing_dist_attempts_one_recovery_build(
 
 
 # ---------------------------------------------------------------------------
+# MCP discovery must wait for the listen socket.
+#
+# cmd_dashboard used to kick off background MCP discovery *before* calling
+# start_server. Every failed bind (port held by another dashboard, auth-gate
+# fail-closed exit) had therefore already spawned the stdio MCP servers and
+# opened a session on every HTTP MCP server, then died without closing them.
+# Under a KeepAlive supervisor that became a fresh MCP session per
+# ThrottleInterval and rate-limited a shared MCP server for every client on
+# the host. Discovery now hangs off start_server's post-bind on_listening hook.
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_discovery_deferred_to_on_listening_hook(main_mod, monkeypatch, tmp_path):
+    _wire_common(main_mod, monkeypatch)
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "index.html").write_text("<html></html>", encoding="utf-8")
+    monkeypatch.setenv("HERMES_WEB_DIST", str(dist))
+
+    discovery_calls = []
+    monkeypatch.setattr(
+        "hermes_cli.mcp_startup.start_background_mcp_discovery",
+        lambda **kw: discovery_calls.append(kw),
+    )
+    started = []
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.web_server",
+        types.SimpleNamespace(start_server=lambda **k: started.append(k)),
+    )
+
+    main_mod.cmd_dashboard(_args())
+
+    assert len(started) == 1
+    # Nothing touched MCP before/while start_server was entered …
+    assert discovery_calls == []
+    hook = started[0].get("on_listening")
+    assert callable(hook)
+    # … and the hook is what starts discovery, once the server says it's bound.
+    hook()
+    assert len(discovery_calls) == 1
+    assert discovery_calls[0]["thread_name"] == "dashboard-mcp-discovery"
+
+
+# ---------------------------------------------------------------------------
 # Desktop-inherited env isolation (issue #52945 / supersedes #52948, #67402)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -87,6 +87,77 @@ def test_start_server_applies_process_local_ssh_bootstrap_state(monkeypatch):
     assert captured["port"] == 0
 
 
+def test_start_server_on_listening_fires_after_bind(monkeypatch):
+    """The ``on_listening`` hook runs once, after uvicorn's startup() (socket
+    bound). Side effects that reach outside the process — MCP discovery
+    spawning stdio servers / opening HTTP MCP sessions — hang off it so a
+    failed bind never leaves them behind."""
+    events: list = []
+    captured = _stub_uvicorn(monkeypatch)
+    # Record ordering relative to the fake server's startup().
+    server_holder: dict = {}
+    real_server_factory = uvicorn.Server
+
+    def _tracking_server(config):
+        srv = real_server_factory(config)
+        orig_startup = srv.startup
+
+        async def startup(sockets=None):
+            events.append("bind")
+            await orig_startup(sockets)
+
+        srv.startup = startup
+        server_holder["srv"] = srv
+        return srv
+
+    monkeypatch.setattr(uvicorn, "Server", _tracking_server)
+
+    web_server.start_server(
+        host="127.0.0.1", port=0, open_browser=False,
+        on_listening=lambda: events.append("listening"),
+    )
+
+    assert events == ["bind", "listening"]
+    assert captured["port"] == 0
+
+
+def test_start_server_on_listening_skipped_when_startup_bails(monkeypatch):
+    """A failed startup (should_exit — e.g. EADDRINUSE) must not invoke the hook."""
+    events: list = []
+    _stub_uvicorn(monkeypatch)
+    real_server_factory = uvicorn.Server
+
+    def _failing_server(config):
+        srv = real_server_factory(config)
+
+        async def startup(sockets=None):
+            srv.should_exit = True
+
+        srv.startup = startup
+        return srv
+
+    monkeypatch.setattr(uvicorn, "Server", _failing_server)
+
+    web_server.start_server(
+        host="127.0.0.1", port=0, open_browser=False,
+        on_listening=lambda: events.append("listening"),
+    )
+
+    assert events == []
+
+
+def test_start_server_on_listening_error_does_not_kill_server(monkeypatch):
+    _stub_uvicorn(monkeypatch)
+
+    def _boom():
+        raise RuntimeError("hook exploded")
+
+    # Must return normally (server ran its main loop) despite the hook raising.
+    web_server.start_server(
+        host="127.0.0.1", port=0, open_browser=False, on_listening=_boom,
+    )
+
+
 def test_start_server_disables_ws_ping_on_loopback(monkeypatch):
     """Loopback binds (the Desktop case) MUST disable uvicorn's protocol-level
     keepalive ping so an event-loop stall can never trigger a false disconnect.


### PR DESCRIPTION
## What

`cmd_dashboard` (both `hermes dashboard` and the headless `hermes serve` backend) kicked off background MCP discovery *before* calling `start_server`. Any failed bind — port already held by another dashboard, auth-gate fail-closed exit, anything that dies before uvicorn owns the socket — had therefore already spawned every configured stdio MCP server and opened a session on every HTTP MCP server, then exited without closing any of them.

On its own that's just leaked churn. Under a KeepAlive supervisor (a launchd LaunchAgent, a systemd unit) it becomes a fresh MCP session every `ThrottleInterval` seconds for as long as the bind keeps failing. In the field (companion to #89793) that ran for ~45 h and got a shared `n8n-mcp` container rate-limited (429) for **every** client on the host — Claude Code, Codex, other Hermes profiles — because the limiter keys on source IP.

`start_server` already has an explicit "the socket is now live" point: after `await server.startup()` it reads the bound port and prints the READY sentinel. This PR:

- adds an `on_listening: Optional[Callable[[], None]]` parameter to `start_server`, invoked exactly once on the event loop right after that point (skipped when startup bails via `should_exit`; exceptions are logged and swallowed so a bad hook can't take the server down);
- has `cmd_dashboard` start MCP discovery from that hook instead of up-front. Nothing else about discovery changes — same `start_background_mcp_discovery`, same thread name, still a background thread that can't block startup.

Net effect: a dashboard that never binds never reaches outside the process.

## How to test

Repro (any OS): with `mcp_servers` configured (an HTTP one makes it easy to watch), start one dashboard, then start a second on the same port:

```
hermes dashboard --no-open --skip-build --port 9119 &
hermes dashboard --no-open --skip-build --port 9119   # exits 1: address already in use
```

Before: the second process logs `MCP server '…' registered N tool(s)` / `POST http://…/mcp` in `logs/agent.log` and `starting MCP server` lines in `logs/mcp-stderr.log` before dying. After: exit 1 with zero MCP requests and zero stdio spawns (verified on macOS by diffing counts in both logs across the attempt).

Happy path is unchanged: with a free port the log shows the bind, then `MCP server '…' registered …`.

Tests:
- `tests/test_web_server.py`: hook fires after `startup()` (ordering asserted), is skipped when startup sets `should_exit`, and a raising hook doesn't stop the server.
- `tests/hermes_cli/test_dashboard_web_dist_validation.py`: `cmd_dashboard` no longer calls `start_background_mcp_discovery` before/while entering `start_server`, and the `on_listening` it passes is what starts it (thread name `dashboard-mcp-discovery`).

Existing tests that stub `web_server.start_server` with `lambda **k:` are unaffected (new kwarg).

## Platforms

Tested on macOS 26 (Darwin 25.5). No platform-specific code; the hook sits in the shared POSIX/Windows `_serve()` path.

Related: #89793 (launchd-supervised dashboards were being kill+respawned by `hermes update`, which is what turned this into a loop), #44143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
