### PR TITLE
chore(contributors): map zhangye MacBook email to Ye-Zayne

### DIFF
--- a/contributors/emails/zhangye@zhangyes-MacBook-Pro.local
+++ b/contributors/emails/zhangye@zhangyes-MacBook-Pro.local
@@ -1,0 +1,2 @@
+Ye-Zayne
+# own machine email


### PR DESCRIPTION
## Summary
- Add a contributor mapping for `zhangye@zhangyes-MacBook-Pro.local` → `Ye-Zayne`.
- This PR only adds my own mapping file. Existing `Agents-Mac-mini` attribution files are unchanged.

## Test plan
- [ ] Confirm `contributors/emails/zhangye@zhangyes-MacBook-Pro.local` contains `Ye-Zayne`
- [ ] Confirm the PR diff contains only that file