### PR TITLE
fix: raw docstrings to silence invalid escape sequence warnings

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2964,7 +2964,7 @@ def _ensure_fhs_path_guard() -> None:
         print("    (reload your shell or run 'source ~/.bashrc' to pick it up)")
 
 def _ensure_acp_launcher() -> None:
-    """Self-heal: install a ``hermes-acp`` launcher next to the ``hermes`` one.
+    r"""Self-heal: install a ``hermes-acp`` launcher next to the ``hermes`` one.
 
     Mirrors the launcher block in ``scripts/install.sh`` so existing installs
     gain the ACP command on ``hermes update`` without a reinstall.  ACP hosts

--- a/tests/agent/test_credits_tracker.py
+++ b/tests/agent/test_credits_tracker.py
@@ -488,7 +488,7 @@ class TestUsdValidation:
         assert state.remaining_usd == "18.00"
 
     def test_usd_one_decimal_returns_none(self):
-        """'18.0' does not match ^-?\d+\.\d{2}$"""
+        r"""'18.0' does not match ^-?\d+\.\d{2}$"""
         headers = _base_headers(**{"x-nous-credits-remaining-usd": "18.0"})
         assert parse_credits_headers(headers) is None
 

--- a/tests/gateway/test_media_tag_separator.py
+++ b/tests/gateway/test_media_tag_separator.py
@@ -1,4 +1,4 @@
-"""Regression tests for #68773 — MEDIA tags without a separator merge paths.
+r"""Regression tests for #68773 — MEDIA tags without a separator merge paths.
 
 Before the fix, ``MEDIA_EXTENSIONLESS_TAG_RE`` used a greedy character class
 ``[^\s\n`\"']+`` that would silently absorb the next ``MEDIA:`` keyword when
@@ -18,7 +18,7 @@ from gateway.platforms.base import (
 
 
 def test_known_extension_regex_splits_glued_tags():
-    """``MEDIA_TAG_CLEANUP_RE`` must stop at the next ``MEDIA:`` keyword (#68773).
+    r"""``MEDIA_TAG_CLEANUP_RE`` must stop at the next ``MEDIA:`` keyword (#68773).
 
     Previously the primary regex used greedy ``\S+`` in the path class,
     so two tags glued together (``MEDIA:/a.pngMEDIA:/b.png``) merged into

--- a/tests/hermes_cli/test_scan_venv_blockers.py
+++ b/tests/hermes_cli/test_scan_venv_blockers.py
@@ -339,7 +339,7 @@ def test_main_desktop_serve_backend_still_blocks(monkeypatch, capsys):
     assert data["pausable_gateways"] == 0
 
 def test_main_gateway_with_long_managed_runtime_path_is_exempt(monkeypatch, capsys):
-    """Regression: the detector must hand the FULL cmdline to the exemption.
+    r"""Regression: the detector must hand the FULL cmdline to the exemption.
 
     Gateways launched via the managed-runtime interpreter carry a >120-char
     exe path (`.hermes-runtime\python\generation-...\cpython-3.11-...`).

--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -633,7 +633,7 @@ class TestContextAwareCorrectness:
 
 
 class TestBackslashDoublingDrift:
-    """Regression tests for the backslash-run doubling guard.
+    r"""Regression tests for the backslash-run doubling guard.
 
     Live failure (Windows, Aug 2026): the model sent old_string/new_string
     whose backslash runs were JSON-escaped one extra time (file had ``\``
@@ -698,7 +698,7 @@ class TestBackslashDoublingDrift:
         assert b * 4 not in result
 
     def test_single_prose_backslash_not_blocked(self):
-        """A lone ``\`` vs ``\\`` in prose is too weak a signal to block."""
+        r"""A lone ``\`` vs ``\\`` in prose is too weak a signal to block."""
         b = "\\"
         content = "text with one " + b + " backslash here\nanother line\n"
         old = "text with one " + b * 2 + " backslash here\nanother line"


### PR DESCRIPTION
## Summary

Python 3.12+ emits `SyntaxWarning: invalid escape sequence` for each of these docstrings, and a future release will turn them into `SyntaxError`. Found by compiling every `.py` in the repo with `warnings.catch_warnings(record=True)` — **7 occurrences across 5 files**, all docstrings containing literal backslashes:

| File | Offending text |
|---|---|
| `hermes_cli/update_cmd.py` | `venv\Scripts`, `$InstallDir\bin` |
| `tests/hermes_cli/test_scan_venv_blockers.py` | `.hermes-runtime\python\generation-...` |
| `tests/gateway/test_media_tag_separator.py` | regex shorthand `\s`, `\S` (x2 docstrings) |
| `tests/tools/test_fuzzy_match.py` | backslash runs `` ``\`` `` / `` ``\\`` `` (x2 docstrings) |
| `tests/agent/test_credits_tracker.py` | regex `^-?\d+\.\d{2}$` |

Beyond the warnings, `\b` in `$InstallDir\bin` was **silently collapsing to a backspace character** inside the `_ensure_acp_launcher` docstring (it's a valid string escape), so `__doc__` did not match the source text.

## Fix

Convert all seven docstrings to raw strings (`r"""`). Zero behaviour change; each `__doc__` now renders byte-identically to the source.

## Testing

- Full-repo scan (compile + `warnings.catch_warnings`) → **0 remaining invalid escape sequences**
- `python -m py_compile` on all touched files → OK
- `pytest tests/hermes_cli/test_scan_venv_blockers.py tests/gateway/test_media_tag_separator.py tests/tools/test_fuzzy_match.py tests/agent/test_credits_tracker.py -o 'addopts=' -q` → **139 passed**

## Relation to #84537

Supersedes #84537: that PR escapes backslashes by doubling them in a single docstring; this PR fixes the whole class (all 7 sites repo-wide) with raw strings, keeping docstring text unchanged.
