### PR TITLE
fix(desktop): load disk plugins via data: URLs to survive Electron blob-import bug

### DIFF
--- a/apps/desktop/src/contrib/runtime-loader.ts
+++ b/apps/desktop/src/contrib/runtime-loader.ts
@@ -126,19 +126,32 @@ export async function loadRuntimePlugin(
       )
     }
 
-    const url = URL.createObjectURL(new Blob([rewriteSpecifiers(source)], { type: 'text/javascript' }))
+    // data: URL, not blob: — matches the shim modules (see sdk/runtime.ts) so
+    // the runtime plugin and its shims import through the same mechanism that
+    // works reliably in Electron. Blob: modules importing other blob: modules
+    // can fail to resolve their default export in some Chromium builds.
+    const url = 'data:text/javascript,' + encodeURIComponent(rewriteSpecifiers(source))
 
     let mod: { default?: HermesPlugin }
 
     try {
       mod = await import(/* @vite-ignore */ url)
-    } finally {
-      URL.revokeObjectURL(url)
+    } catch (importError) {
+      console.error(`[plugins] ${origin} import rejected`, importError)
+      throw importError
     }
 
     const plugin = mod.default
 
     if (!plugin?.id || typeof plugin.register !== 'function') {
+      console.error(`[plugins] ${origin} loaded but default export invalid`, {
+        namespaceKeys: Object.keys(mod ?? {}),
+        defaultType: typeof plugin,
+        defaultIsNull: plugin === null,
+        defaultKeys: plugin && typeof plugin === 'object' ? Object.keys(plugin) : null,
+        id: (plugin as any)?.id,
+        registerType: typeof (plugin as any)?.register
+      })
       throw new Error(`${origin} has no valid default HermesPlugin export`)
     }
 

--- a/apps/desktop/src/sdk/runtime.ts
+++ b/apps/desktop/src/sdk/runtime.ts
@@ -36,7 +36,10 @@ function shimUrl(globalKey: keyof typeof GLOBALS): string {
     // only emit it when the namespace actually has named exports.
     (names.length ? `export const { ${names.join(', ')} } = m;\n` : '')
 
-  return URL.createObjectURL(new Blob([source], { type: 'text/javascript' }))
+  // data: URL, not blob: — some Electron/Chromium builds fail to resolve the
+  // default export of a blob: module that itself imports another blob: module
+  // (nested blob imports). data: URLs import cleanly and need no revocation.
+  return 'data:text/javascript,' + encodeURIComponent(source)
 }
 
 let cached: Record<string, string> | null = null


### PR DESCRIPTION
## Summary

Disk-loaded desktop plugins (those in `~/.hermes/desktop-plugins/`) fail to load in the packaged Electron build. Every plugin is rejected at boot with:

```
[plugins] runtime load failed (<name>) Error: <name> has no valid default HermesPlugin export
```

## Root cause

The runtime loader builds the plugin module (and the SDK shim modules, in `sdk/runtime.ts`) as `blob:` URLs via `URL.createObjectURL(new Blob([source], { type: 'text/javascript' }))`. In the packaged Chromium build, a `blob:` module that itself `import`s another `blob:` module fails to resolve its `default` export — so `mod.default` comes back `undefined` and the loader's validation rejects the plugin even though the plugin file is valid.

## Fix

- `apps/desktop/src/contrib/runtime-loader.ts` — load the plugin from a `data:` URL instead of a `blob:` URL.
- `apps/desktop/src/sdk/runtime.ts` — emit the SDK shim modules as `data:` URLs instead of `blob:` URLs.

`data:` URLs import cleanly in Electron, need no `URL.revokeObjectURL` lifecycle, and are used consistently across the plugin and its shims. Also added failure diagnostics to the default-export validation so a future load failure logs *what* the loader actually saw (namespace keys, `default` type, `id`, `register` type) rather than only the generic message.

## Test plan

- Reproduced the failure on current `main`: any disk plugin logs `no valid default HermesPlugin export` immediately at boot.
- Confirmed the plugin source itself is valid (a Node repro of the same import returns a valid `{ id, name, register }` module), isolating the failure to the packaged `blob:` import path.
- Applied the change, rebuilt the desktop app (`hermes desktop --build-only --force-build`), and launched with a separate user-data dir: the plugin now loads with **no** `runtime load failed` entry, and the pane renders in the running app.
