### PR TITLE
[DX-2480] feat: share MCP OAuth pools across profiles

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -85,6 +85,18 @@ def _get_mcp_servers(config: Optional[dict] = None) -> Dict[str, dict]:
     return servers
 
 
+def _oauth_storage_identity(entry: dict) -> tuple:
+    oauth = entry.get("oauth")
+    oauth_identity = dict(oauth) if isinstance(oauth, dict) else {}
+    oauth_identity.pop("share_with_profiles", None)
+    return (
+        entry.get("url"),
+        entry.get("auth"),
+        entry.get("transport"),
+        oauth_identity,
+    )
+
+
 def _save_mcp_server(name: str, server_config: dict) -> bool:
     """Add or update a server entry in config.yaml.
 
@@ -99,8 +111,25 @@ def _save_mcp_server(name: str, server_config: dict) -> bool:
         _warning(f"Server '{name}' was NOT saved due to suspicious configuration.")
         return False
     config = load_config()
+    previous = _get_mcp_servers(config).get(name)
+    if (
+        isinstance(previous, dict)
+        and previous.get("auth") == "oauth"
+        and _oauth_storage_identity(previous) != _oauth_storage_identity(server_config)
+    ):
+        from tools.mcp_oauth_manager import get_manager
+
+        # Revoke under the OLD config so a prior shared pool is resolved
+        # correctly even when no provider is currently cached.
+        get_manager().remove(name)
     config.setdefault("mcp_servers", {})[name] = server_config
     save_config(config)
+    try:
+        from tools.mcp_oauth_manager import get_manager
+
+        get_manager().unblock(name)
+    except Exception:
+        pass
     return True
 
 
@@ -115,6 +144,17 @@ def _remove_mcp_server(name: str) -> bool:
         config.pop("mcp_servers", None)
     save_config(config)
     return True
+
+
+def _remove_mcp_server_with_oauth(name: str) -> bool:
+    """Remove config and its pinned OAuth pool as one governed lifecycle."""
+    if name not in _get_mcp_servers():
+        return False
+    from tools.mcp_oauth_manager import get_manager
+
+    # Resolve/revoke while config still identifies a shared root pool.
+    get_manager().remove(name, block_rebuild=True)
+    return _remove_mcp_server(name)
 
 
 def _replace_mcp_servers(servers: Dict[str, dict]) -> Tuple[bool, List[str]]:
@@ -142,11 +182,47 @@ def _replace_mcp_servers(servers: Dict[str, dict]) -> Tuple[bool, List[str]]:
         return False, issues
 
     config = load_config()
+    existing = _get_mcp_servers(config)
+    removed_oauth = [
+        name
+        for name, entry in existing.items()
+        if name not in servers
+        and isinstance(entry, dict)
+        and entry.get("auth") == "oauth"
+    ]
+    if removed_oauth:
+        from tools.mcp_oauth_manager import get_manager
+
+        manager = get_manager()
+        for name in removed_oauth:
+            manager.remove(name, block_rebuild=True)
+    changed_oauth = [
+        name
+        for name, entry in existing.items()
+        if name in servers
+        and isinstance(entry, dict)
+        and entry.get("auth") == "oauth"
+        and _oauth_storage_identity(entry) != _oauth_storage_identity(servers[name])
+    ]
+    if changed_oauth:
+        from tools.mcp_oauth_manager import get_manager
+
+        manager = get_manager()
+        for name in changed_oauth:
+            manager.remove(name)
     if servers:
         config["mcp_servers"] = dict(servers)
     else:
         config.pop("mcp_servers", None)
     save_config(config)
+    try:
+        from tools.mcp_oauth_manager import get_manager
+
+        manager = get_manager()
+        for name in servers:
+            manager.unblock(name)
+    except Exception:
+        pass
     return True, []
 
 
@@ -413,8 +489,9 @@ def _oauth_tokens_present(name: str) -> bool:
         return HermesTokenStorage(name).has_cached_tokens()
     except Exception as exc:  # pragma: no cover — defensive
         logger.debug("Could not check OAuth tokens for '%s': %s", name, exc)
-        # Be permissive on unexpected errors: don't block a real success.
-        return True
+        # Authentication proof is fail-closed: an unreadable/revoked pool is
+        # not evidence that a usable token exists.
+        return False
 
 
 def _unwrap_exception_group(exc: BaseException) -> Exception:
@@ -658,18 +735,16 @@ def cmd_mcp_remove(args):
         _info("Cancelled.")
         return
 
-    _remove_mcp_server(name)
-    _success(f"Removed '{name}' from config")
-
-    # Clean up OAuth tokens if they exist — route through MCPOAuthManager so
-    # any provider instance cached in the current process (e.g. from an
-    # earlier `hermes mcp test` in the same session) is evicted too.
     try:
-        from tools.mcp_oauth_manager import get_manager
-        get_manager().remove(name)
-        _success("Cleaned up OAuth tokens")
-    except Exception:
-        pass
+        removed = _remove_mcp_server_with_oauth(name)
+    except Exception as exc:
+        _error(f"Could not clean up OAuth state for '{name}': {exc}")
+        return
+    if not removed:
+        _error(f"Server '{name}' was removed concurrently; no changes made")
+        return
+    _success(f"Removed '{name}' from config")
+    _success("Cleaned up OAuth tokens")
 
 
 # ─── hermes mcp list ──────────────────────────────────────────────────────────
@@ -824,11 +899,24 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
         _info("Use `hermes mcp remove` + `hermes mcp add` to reconfigure auth.")
         return False
 
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import get_manager
+
+    manager = get_manager()
+    manager.unblock(name)
+    storage = HermesTokenStorage(name)
+    prior_state = storage.snapshot()
+
+    def _restore_prior_state() -> None:
+        # Drop the failed attempt's provider and restore only if no concurrent
+        # authorization has already written newer state.
+        manager.evict(name)
+        storage.restore(prior_state, only_if_absent=True)
+
     # Wipe both disk and in-memory cache so the next probe forces a fresh
     # OAuth flow.
     try:
-        from tools.mcp_oauth_manager import get_manager
-        get_manager().remove(name)
+        manager.remove(name)
     except Exception as exc:
         _warning(f"Could not clear existing OAuth state: {exc}")
 
@@ -888,6 +976,7 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
             print(color("          client_secret: \"<your-oauth-client-secret>\"", Colors.DIM))
             print()
             _info("Then re-run `hermes mcp login " + name + "`.")
+            _restore_prior_state()
             return False
         if tools:
             _success(f"Authenticated — {len(tools)} tool(s) available")
@@ -904,6 +993,7 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
         except Exception:
             humanized = None
         _error(f"Authentication failed: {humanized or exc}")
+        _restore_prior_state()
         return False
 
 

--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -142,12 +142,12 @@ async def replace_mcp_servers(body: MCPServersReplace, profile: Optional[str] = 
 
 @router.delete("/api/mcp/servers/{name}")
 async def remove_mcp_server(name: str, profile: Optional[str] = None):
-    from hermes_cli.mcp_config import _remove_mcp_server
+    from hermes_cli.mcp_config import _remove_mcp_server_with_oauth
 
     def _run():
         with _profile_scope(profile):
             with _CONFIG_MUTATION_LOCK:
-                return _remove_mcp_server(name)
+                return _remove_mcp_server_with_oauth(name)
 
     removed = await asyncio.to_thread(_run)
     if not removed:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -13379,11 +13379,17 @@ def _run_dashboard_mcp_oauth(flow, cfg: dict) -> None:
             transaction = _mcp_oauth_transaction(flow)
             with transaction, force_interactive_oauth(), dashboard_oauth_flow(flow):
                 manager = get_manager()
-                storage = HermesTokenStorage(flow.server_name)
+                manager.unblock(
+                    flow.server_name,
+                    hermes_home=flow.hermes_home,
+                )
+                storage = HermesTokenStorage(
+                    flow.server_name,
+                    hermes_home=flow.hermes_home,
+                )
                 backup = storage.snapshot()
-                previous_entry = None
                 try:
-                    previous_entry = manager.remove(
+                    manager.remove(
                         flow.server_name,
                         hermes_home=flow.hermes_home,
                     )
@@ -13405,12 +13411,11 @@ def _run_dashboard_mcp_oauth(flow, cfg: dict) -> None:
 
                         reconnect_mcp_server(flow.server_name)
                 except Exception:
-                    storage.restore(backup, only_if_absent=True)
-                    manager.restore_entry(
+                    manager.evict(
                         flow.server_name,
-                        previous_entry,
                         hermes_home=flow.hermes_home,
                     )
+                    storage.restore(backup, only_if_absent=True)
                     raise
         finally:
             reset_secret_scope(secret_token)

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -8,6 +8,7 @@ any actual MCP servers or API keys.
 import argparse
 import os
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -167,6 +168,102 @@ class TestMcpRemove:
 
         cmd_mcp_remove(_make_args(name="oauth-srv"))
         assert not token_file.exists()
+
+    def test_remove_cleans_root_exported_profile_tokens_before_config(self, tmp_path, monkeypatch):
+        import yaml
+
+        root = tmp_path / "hermes"
+        profile = root / "profiles" / "worker"
+        profile.mkdir(parents=True)
+        server = {
+            "url": "https://mcp.example.com/mcp",
+            "auth": "oauth",
+        }
+        (root / "config.yaml").write_text(yaml.safe_dump({
+            "mcp_servers": {
+                "shared": {
+                    **server,
+                    "oauth": {"share_with_profiles": True},
+                },
+            },
+        }))
+        (profile / "config.yaml").write_text(yaml.safe_dump({
+            "mcp_servers": {"shared": server},
+        }))
+        token_dir = root / "mcp-tokens"
+        token_dir.mkdir()
+        token_file = token_dir / "shared.json"
+        token_file.write_text("{}")
+        monkeypatch.setenv("HERMES_HOME", str(profile))
+        monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: profile)
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: profile / "config.yaml")
+        monkeypatch.setattr("hermes_cli.mcp_config.get_hermes_home", lambda: profile)
+        monkeypatch.setattr("builtins.input", lambda _: "y")
+        from hermes_cli.mcp_config import cmd_mcp_remove
+
+        cmd_mcp_remove(_make_args(name="shared"))
+
+        assert not token_file.exists()
+        assert "shared" not in yaml.safe_load((profile / "config.yaml").read_text()).get(
+            "mcp_servers", {}
+        )
+
+
+def test_replace_mcp_servers_revokes_removed_oauth_state(tmp_path, monkeypatch):
+    _seed_config(tmp_path, {
+        "shared": {"url": "https://example.com/mcp", "auth": "oauth"},
+    })
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import get_manager, reset_manager_for_tests
+
+    reset_manager_for_tests()
+    storage = HermesTokenStorage("shared")
+    token = MagicMock()
+    token.model_dump.return_value = {
+        "access_token": "TOKEN",
+        "token_type": "Bearer",
+    }
+    import asyncio
+
+    asyncio.run(storage.set_tokens(token))
+    manager = get_manager()
+    assert manager.get_or_build_provider(
+        "shared", "https://example.com/mcp", {}
+    ) is not None
+    from hermes_cli.mcp_config import _replace_mcp_servers
+
+    assert _replace_mcp_servers({}) == (True, [])
+
+    assert not storage._tokens_path().exists()
+    assert manager._key("shared") not in manager._entries
+
+
+def test_save_changed_oauth_identity_revokes_uncached_tokens(tmp_path, monkeypatch):
+    _seed_config(tmp_path, {
+        "shared": {"url": "https://old.example/mcp", "auth": "oauth"},
+    })
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools.mcp_oauth import HermesTokenStorage
+
+    storage = HermesTokenStorage("shared")
+    token = MagicMock()
+    token.model_dump.return_value = {
+        "access_token": "OLD",
+        "token_type": "Bearer",
+    }
+    import asyncio
+
+    asyncio.run(storage.set_tokens(token))
+    from hermes_cli.mcp_config import _save_mcp_server
+
+    assert _save_mcp_server(
+        "shared",
+        {"url": "https://new.example/mcp", "auth": "oauth"},
+    ) is True
+
+    assert not storage._tokens_path().exists()
 
 
 # ---------------------------------------------------------------------------
@@ -720,6 +817,15 @@ class TestMcpLogin:
         out = capsys.readouterr().out
         assert "not found" in out
 
+    def test_token_presence_check_fails_closed_on_storage_error(self, monkeypatch):
+        monkeypatch.setattr(
+            "tools.mcp_oauth.HermesTokenStorage.has_cached_tokens",
+            lambda self: (_ for _ in ()).throw(RuntimeError("revoked")),
+        )
+        from hermes_cli.mcp_config import _oauth_tokens_present
+
+        assert _oauth_tokens_present("server") is False
+
 
     def test_login_false_success_no_token(self, tmp_path, capsys, monkeypatch):
         """Probe lists tools without auth (Google Drive), but no token landed.
@@ -750,6 +856,42 @@ class TestMcpLogin:
         assert "no OAuth token was obtained" in out
         assert "Authenticated" not in out
         assert "client_id" in out
+
+    @pytest.mark.parametrize("failure_mode", ["no-token", "exception"])
+    def test_login_failure_restores_prior_oauth_state(
+        self, tmp_path, capsys, monkeypatch, failure_mode
+    ):
+        _seed_config(tmp_path, {
+            "server": {"url": "https://mcp.example.com/mcp", "auth": "oauth"},
+        })
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        token_dir = tmp_path / "mcp-tokens"
+        token_dir.mkdir()
+        expected = {
+            "server.json": b'{"access_token":"old"}',
+            "server.client.json": b'{"client_id":"old-client"}',
+            "server.meta.json": b'{"token_endpoint":"https://old.example/token"}',
+            "server.cimd-off": b"",
+        }
+        for name, content in expected.items():
+            (token_dir / name).write_bytes(content)
+
+        def failed_probe(name, cfg, connect_timeout=30):
+            if failure_mode == "exception":
+                raise RuntimeError("authorization failed")
+            return [("public_tool", "available without authentication")]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", failed_probe
+        )
+        from hermes_cli.mcp_config import cmd_mcp_login
+
+        cmd_mcp_login(_make_args(name="server"))
+
+        out = capsys.readouterr().out
+        assert "Authenticated" not in out
+        for name, content in expected.items():
+            assert (token_dir / name).read_bytes() == content
 
     def test_login_genuine_success_with_token(self, tmp_path, capsys, monkeypatch):
         """Probe lists tools AND a token exists → report real success."""

--- a/tests/hermes_cli/test_mcp_dashboard_oauth.py
+++ b/tests/hermes_cli/test_mcp_dashboard_oauth.py
@@ -55,6 +55,33 @@ def test_hosted_auth_start_returns_public_authorization_url(monkeypatch):
     assert flow.redirect_uri == "https://agent.example/api/mcp/oauth/callback/reports"
 
 
+def test_web_delete_revokes_oauth_state(tmp_path, monkeypatch):
+    import asyncio
+    from unittest.mock import MagicMock
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    client = _client()
+    response = client.post(
+        "/api/mcp/servers",
+        json={"name": "reports", "url": "https://mcp.example/mcp", "auth": "oauth"},
+    )
+    assert response.status_code == 200
+    from tools.mcp_oauth import HermesTokenStorage
+
+    storage = HermesTokenStorage("reports")
+    token = MagicMock()
+    token.model_dump.return_value = {
+        "access_token": "TOKEN",
+        "token_type": "Bearer",
+    }
+    asyncio.run(storage.set_tokens(token))
+
+    response = client.delete("/api/mcp/servers/reports")
+
+    assert response.status_code == 200
+    assert not storage._tokens_path().exists()
+
+
 def test_hosted_callback_bypasses_gated_cookie_auth(monkeypatch):
     import asyncio
 

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -13,6 +13,7 @@ import asyncio
 from tools.mcp_oauth import (
     HermesTokenStorage,
     OAuthNonInteractiveError,
+    OAuthStorageRevokedError,
     build_oauth_auth,
     remove_oauth_tokens,
     _find_free_port,
@@ -56,6 +57,282 @@ def _hit_callback_when_ready(url: str, timeout: float = 15.0) -> None:
 # ---------------------------------------------------------------------------
 
 class TestHermesTokenStorage:
+    @staticmethod
+    def _configure_profile_server(root, profile, *, shared, profile_url="https://mcp.example.com/mcp"):
+        root.mkdir(parents=True, exist_ok=True)
+        profile.mkdir(parents=True, exist_ok=True)
+        (root / "config.yaml").write_text(json.dumps({
+            "mcp_servers": {
+                "team": {
+                    "url": "https://mcp.example.com/mcp",
+                    "auth": "oauth",
+                    "oauth": {"share_with_profiles": shared},
+                },
+            },
+        }))
+        (profile / "config.yaml").write_text(json.dumps({
+            "mcp_servers": {
+                "team": {
+                    "url": profile_url,
+                    "auth": "oauth",
+                },
+            },
+        }))
+
+    def test_profile_uses_root_token_pool_when_root_exports_matching_server(self, tmp_path, monkeypatch):
+        root = tmp_path / "hermes"
+        profile = root / "profiles" / "worker"
+        self._configure_profile_server(root, profile, shared=True)
+        monkeypatch.setenv("HERMES_HOME", str(profile))
+        storage = HermesTokenStorage("team")
+        mock_token = MagicMock()
+        mock_token.model_dump.return_value = {
+            "access_token": "shared-token",
+            "token_type": "Bearer",
+            "refresh_token": "shared-refresh",
+        }
+
+        asyncio.run(storage.set_tokens(mock_token))
+
+        assert (root / "mcp-tokens" / "team.json").exists()
+        assert not (profile / "mcp-tokens" / "team.json").exists()
+        loaded = asyncio.run(storage.get_tokens())
+        assert loaded is not None
+        assert loaded.access_token == "shared-token"
+
+        (profile / "config.yaml").unlink()
+        assert storage._tokens_path() == root / "mcp-tokens" / "team.json"
+
+        storage.remove()
+
+        assert not (root / "mcp-tokens" / "team.json").exists()
+
+    def test_profile_keeps_local_token_pool_without_root_export(self, tmp_path, monkeypatch):
+        root = tmp_path / "hermes"
+        profile = root / "profiles" / "worker"
+        self._configure_profile_server(root, profile, shared=False)
+        monkeypatch.setenv("HERMES_HOME", str(profile))
+        storage = HermesTokenStorage("team")
+        mock_token = MagicMock()
+        mock_token.model_dump.return_value = {
+            "access_token": "profile-token",
+            "token_type": "Bearer",
+        }
+
+        asyncio.run(storage.set_tokens(mock_token))
+
+        assert (profile / "mcp-tokens" / "team.json").exists()
+        assert not (root / "mcp-tokens" / "team.json").exists()
+
+    def test_profile_rejects_shared_pool_when_server_endpoint_differs(self, tmp_path, monkeypatch):
+        root = tmp_path / "hermes"
+        profile = root / "profiles" / "worker"
+        self._configure_profile_server(
+            root,
+            profile,
+            shared=True,
+            profile_url="https://other.example.com/mcp",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(profile))
+        storage = HermesTokenStorage("team")
+        mock_token = MagicMock()
+        mock_token.model_dump.return_value = {
+            "access_token": "profile-token",
+            "token_type": "Bearer",
+        }
+
+        asyncio.run(storage.set_tokens(mock_token))
+
+        assert (profile / "mcp-tokens" / "team.json").exists()
+        assert not (root / "mcp-tokens" / "team.json").exists()
+
+    def test_profile_rejects_shared_pool_for_templated_endpoint(self, tmp_path, monkeypatch):
+        root = tmp_path / "hermes"
+        profile = root / "profiles" / "worker"
+        root.mkdir(parents=True)
+        profile.mkdir(parents=True)
+        server = {
+            "url": "${MCP_URL}",
+            "auth": "oauth",
+        }
+        (root / "config.yaml").write_text(json.dumps({
+            "mcp_servers": {
+                "team": {
+                    **server,
+                    "oauth": {"share_with_profiles": True},
+                },
+            },
+        }))
+        (profile / "config.yaml").write_text(json.dumps({
+            "mcp_servers": {"team": server},
+        }))
+        monkeypatch.setenv("HERMES_HOME", str(profile))
+        monkeypatch.setenv("MCP_URL", "https://profile.example.com/mcp")
+        storage = HermesTokenStorage("team")
+        mock_token = MagicMock()
+        mock_token.model_dump.return_value = {
+            "access_token": "profile-token",
+            "token_type": "Bearer",
+        }
+
+        asyncio.run(storage.set_tokens(mock_token))
+
+        assert (profile / "mcp-tokens" / "team.json").exists()
+        assert not (root / "mcp-tokens" / "team.json").exists()
+
+    def test_profile_rejects_shared_pool_for_templated_transport(self, tmp_path, monkeypatch):
+        root = tmp_path / "hermes"
+        profile = root / "profiles" / "worker"
+        root.mkdir(parents=True)
+        profile.mkdir(parents=True)
+        server = {
+            "url": "https://example.com/mcp",
+            "auth": "oauth",
+            "transport": "${MCP_TRANSPORT}",
+        }
+        (root / "config.yaml").write_text(json.dumps({
+            "mcp_servers": {
+                "team": {
+                    **server,
+                    "oauth": {"share_with_profiles": True},
+                },
+            },
+        }))
+        (profile / "config.yaml").write_text(json.dumps({
+            "mcp_servers": {"team": server},
+        }))
+        monkeypatch.setenv("HERMES_HOME", str(profile))
+        storage = HermesTokenStorage("team")
+        mock_token = MagicMock()
+        mock_token.model_dump.return_value = {
+            "access_token": "profile-token",
+            "token_type": "Bearer",
+        }
+
+        asyncio.run(storage.set_tokens(mock_token))
+
+        assert (profile / "mcp-tokens" / "team.json").exists()
+        assert not (root / "mcp-tokens" / "team.json").exists()
+
+    def test_profile_rejects_shared_pool_when_oauth_client_settings_differ(self, tmp_path, monkeypatch):
+        root = tmp_path / "hermes"
+        profile = root / "profiles" / "worker"
+        self._configure_profile_server(root, profile, shared=True)
+        profile_config = json.loads((profile / "config.yaml").read_text())
+        profile_config["mcp_servers"]["team"]["oauth"] = {
+            "client_id": "profile-client",
+        }
+        (profile / "config.yaml").write_text(json.dumps(profile_config))
+        monkeypatch.setenv("HERMES_HOME", str(profile))
+        storage = HermesTokenStorage("team")
+        mock_token = MagicMock()
+        mock_token.model_dump.return_value = {
+            "access_token": "profile-token",
+            "token_type": "Bearer",
+        }
+
+        asyncio.run(storage.set_tokens(mock_token))
+
+        assert (profile / "mcp-tokens" / "team.json").exists()
+        assert not (root / "mcp-tokens" / "team.json").exists()
+
+    def test_snapshot_restores_cimd_rejection_marker(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("team")
+        storage._tokens_path().parent.mkdir(parents=True)
+        storage._tokens_path().write_text("token")
+        storage._client_info_path().write_text("client")
+        storage._meta_path().write_text("meta")
+        storage.mark_cimd_rejected()
+
+        snapshot = storage.snapshot()
+        storage.remove()
+        storage.restore(snapshot)
+
+        assert storage._tokens_path().read_text() == "token"
+        assert storage._client_info_path().read_text() == "client"
+        assert storage._meta_path().read_text() == "meta"
+        assert storage.cimd_rejected() is True
+
+    def test_removed_storage_cannot_resurrect_oauth_state(self, tmp_path, monkeypatch):
+        from tools.mcp_oauth import OAuthStorageRevokedError
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        old_storage = HermesTokenStorage("team")
+        remover = HermesTokenStorage("team")
+        old_token = MagicMock()
+        old_token.model_dump.return_value = {
+            "access_token": "old-token",
+            "token_type": "Bearer",
+        }
+        asyncio.run(old_storage.set_tokens(old_token))
+
+        remover.remove()
+
+        with pytest.raises(OAuthStorageRevokedError):
+            asyncio.run(old_storage.set_tokens(old_token))
+        assert not old_storage._tokens_path().exists()
+
+    def test_rollback_does_not_overwrite_concurrent_success(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        original = HermesTokenStorage("team")
+        old_token = MagicMock()
+        old_token.model_dump.return_value = {
+            "access_token": "old-token",
+            "token_type": "Bearer",
+        }
+        asyncio.run(original.set_tokens(old_token))
+        snapshot = original.snapshot()
+        original.remove()
+
+        successful = HermesTokenStorage("team")
+        new_token = MagicMock()
+        new_token.model_dump.return_value = {
+            "access_token": "new-token",
+            "token_type": "Bearer",
+        }
+        asyncio.run(successful.set_tokens(new_token))
+
+        original.restore(snapshot, only_if_absent=True)
+
+        assert json.loads(successful._tokens_path().read_text())["access_token"] == "new-token"
+
+    def test_rollback_replaces_failed_attempt_auxiliary_state(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        original = HermesTokenStorage("team")
+        original._tokens_path().parent.mkdir(parents=True, exist_ok=True)
+        original._tokens_path().write_bytes(b"OLD-TOKEN")
+        original._client_info_path().write_bytes(b"OLD-CLIENT")
+        snapshot = original.snapshot()
+        original.remove()
+
+        failed_attempt = HermesTokenStorage("team")
+        failed_attempt._client_info_path().write_bytes(b"FAILED-CLIENT")
+        failed_attempt._meta_path().write_bytes(b"FAILED-METADATA")
+
+        original.restore(snapshot, only_if_absent=True)
+
+        assert original._tokens_path().read_bytes() == b"OLD-TOKEN"
+        assert original._client_info_path().read_bytes() == b"OLD-CLIENT"
+        assert not original._meta_path().exists()
+
+    def test_permanent_removal_tombstone_blocks_stale_restore(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("team")
+        token = MagicMock()
+        token.model_dump.return_value = {
+            "access_token": "OLD",
+            "token_type": "Bearer",
+        }
+        asyncio.run(storage.set_tokens(token))
+        snapshot = storage.snapshot()
+        storage.remove(permanent=True)
+
+        with pytest.raises(OAuthStorageRevokedError):
+            storage.restore(snapshot)
+
+        assert not storage._tokens_path().exists()
+
     def test_roundtrip_tokens(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         storage = HermesTokenStorage("test-server")
@@ -1057,8 +1334,14 @@ class TestPoisonClientRegistration:
         assert not (d / "srv.meta.json").exists()
         # Backup of the client file kept for recovery.
         assert (d / "srv.client.json.bak").read_text() == '{"client_id": "dead"}'
+        if not sys.platform.startswith("win"):
+            assert stat.S_IMODE((d / "srv.client.json.bak").stat().st_mode) == 0o600
         # Tokens are intentionally preserved.
         assert (d / "srv.json").read_text() == '{"access_token": "keep-me"}'
+
+        storage.remove()
+
+        assert not (d / "srv.client.json.bak").exists()
 
 
 def test_wait_for_callback_port_in_use_reports_clear_error(monkeypatch):

--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -7,6 +7,8 @@ cache. See `tools/mcp_oauth_manager.py` for design rationale.
 import json
 import os
 import time
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -47,20 +49,285 @@ def test_manager_isolates_same_named_servers_by_profile_home(tmp_path, monkeypat
     assert providers[1].context.current_tokens.access_token == "TOKEN_B"
 
 
-def test_manager_restore_entry_preserves_newer_concurrent_entry(tmp_path, monkeypatch):
+def test_remove_shared_pool_evicts_every_participating_profile(tmp_path, monkeypatch):
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
     from tools.mcp_oauth_manager import MCPOAuthManager
 
-    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    _set_interactive_stdin(monkeypatch)
+    root = tmp_path / "hermes"
+    profiles = [root / "profiles" / name for name in ("worker-a", "worker-b")]
+    server = {
+        "url": "https://mcp.example/mcp",
+        "auth": "oauth",
+    }
+    root.mkdir(parents=True)
+    (root / "config.yaml").write_text(json.dumps({
+        "mcp_servers": {
+            "shared": {
+                **server,
+                "oauth": {"share_with_profiles": True},
+            },
+        },
+    }))
+    for profile in profiles:
+        profile.mkdir(parents=True)
+        (profile / "config.yaml").write_text(json.dumps({
+            "mcp_servers": {"shared": server},
+        }))
+    token_dir = root / "mcp-tokens"
+    token_dir.mkdir()
+    token_file = token_dir / "shared.json"
+    token_file.write_text(json.dumps({
+        "access_token": "SHARED",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+    }))
+
     manager = MCPOAuthManager()
-    old_provider = manager.get_or_build_provider("shared", "https://old.example", {})
-    old_entry = manager.remove("shared")
-    new_provider = manager.get_or_build_provider("shared", "https://new.example", {})
+    providers = []
+    for profile in profiles:
+        token = set_hermes_home_override(profile)
+        try:
+            provider = manager.get_or_build_provider("shared", server["url"], {})
+            assert provider is not None
+            asyncio.run(provider._initialize())
+            providers.append(provider)
+        finally:
+            reset_hermes_home_override(token)
 
-    manager.restore_entry("shared", old_entry)
+    removed = manager.remove("shared", hermes_home=profiles[0])
 
-    assert manager.get_or_build_provider("shared", "https://new.example", {}) is new_provider
+    assert removed is not None
+    assert not token_file.exists()
+    assert manager._key("shared", profiles[0]) not in manager._entries
+    assert manager._key("shared", profiles[1]) not in manager._entries
+    assert all(provider.context.current_tokens is None for provider in providers)
+
+
+def test_server_names_with_unsafe_characters_use_distinct_storage(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    token = MagicMock()
+    token.model_dump.return_value = {
+        "access_token": "TOKEN",
+        "token_type": "Bearer",
+    }
+    slash_storage = HermesTokenStorage("a/b")
+    underscore_storage = HermesTokenStorage("a_b")
+    assert slash_storage._tokens_path() != underscore_storage._tokens_path()
+    crafted_storage = HermesTokenStorage(slash_storage._tokens_path().stem)
+    assert slash_storage._tokens_path() != crafted_storage._tokens_path()
+    asyncio.run(slash_storage.set_tokens(token))
+    asyncio.run(underscore_storage.set_tokens(token))
+    manager = MCPOAuthManager()
+    for name in ("a/b", "a_b"):
+        assert manager.get_or_build_provider(
+            name, "https://example.com/mcp", {}
+        ) is not None
+
+    manager.remove("a/b")
+
+    assert manager._key("a/b") not in manager._entries
+    assert manager._key("a_b") in manager._entries
+    assert underscore_storage._tokens_path().exists()
+
+
+def test_permanent_remove_blocks_rebuild_until_server_is_readded(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools.mcp_oauth import HermesTokenStorage, OAuthStorageRevokedError
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    token = MagicMock()
+    token.model_dump.return_value = {
+        "access_token": "TOKEN",
+        "token_type": "Bearer",
+    }
+    stale_storage = HermesTokenStorage("shared")
+    asyncio.run(stale_storage.set_tokens(token))
+    manager = MCPOAuthManager()
+    assert manager.get_or_build_provider(
+        "shared", "https://example.com/mcp", {}
+    ) is not None
+
+    manager.remove("shared", block_rebuild=True)
+
+    with pytest.raises(OAuthStorageRevokedError):
+        asyncio.run(stale_storage.get_tokens())
+    assert manager.get_or_build_provider(
+        "shared", "https://example.com/mcp", {}
+    ) is None
+    # A fresh manager simulates a second local Hermes process: the on-disk
+    # tombstone must block it too.
+    fresh_manager = MCPOAuthManager()
+    assert fresh_manager.get_or_build_provider(
+        "shared", "https://example.com/mcp", {}
+    ) is None
+    fresh_manager.unblock("shared")
+    asyncio.run(HermesTokenStorage("shared").set_tokens(token))
+    assert fresh_manager.get_or_build_provider(
+        "shared", "https://example.com/mcp", {}
+    ) is not None
+
+
+def test_manager_rebuilds_provider_when_oauth_config_changes(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    manager = MCPOAuthManager()
+    monkeypatch.setattr(
+        manager,
+        "_build_provider",
+        lambda server_name, entry, *, hermes_home: SimpleNamespace(),
+    )
+
+    old_provider = manager.get_or_build_provider(
+        "shared",
+        "https://example.com/mcp",
+        {"client_id": "old-client"},
+    )
+    new_provider = manager.get_or_build_provider(
+        "shared",
+        "https://example.com/mcp",
+        {"client_id": "new-client"},
+    )
+
     assert new_provider is not old_provider
+    assert manager._entries[manager._key("shared")].oauth_config == {
+        "client_id": "new-client"
+    }
+
+
+def test_manager_discards_persisted_tokens_when_endpoint_changes(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    token = MagicMock()
+    token.model_dump.return_value = {
+        "access_token": "OLD",
+        "token_type": "Bearer",
+    }
+    storage = HermesTokenStorage("shared")
+    asyncio.run(storage.set_tokens(token))
+    manager = MCPOAuthManager()
+
+    def fake_build(server_name, entry, *, hermes_home):
+        pinned = HermesTokenStorage(server_name, hermes_home=hermes_home)
+        return SimpleNamespace(
+            context=SimpleNamespace(storage=pinned, current_tokens=None),
+            _initialized=True,
+        )
+
+    monkeypatch.setattr(manager, "_build_provider", fake_build)
+    manager.get_or_build_provider("shared", "https://old.example/mcp", {})
+
+    manager.get_or_build_provider("shared", "https://new.example/mcp", {})
+
+    assert not storage._tokens_path().exists()
+
+
+def test_remove_uses_provider_pinned_pool_after_profile_config_changes(tmp_path, monkeypatch):
+    root = tmp_path / "hermes"
+    profile = root / "profiles" / "worker"
+    profile.mkdir(parents=True)
+    shared = {"url": "https://old.example/mcp", "auth": "oauth"}
+    (root / "config.yaml").write_text(json.dumps({
+        "mcp_servers": {
+            "shared": {
+                **shared,
+                "oauth": {"share_with_profiles": True},
+            },
+        },
+    }))
+    (profile / "config.yaml").write_text(json.dumps({
+        "mcp_servers": {"shared": shared},
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(profile))
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    token = MagicMock()
+    token.model_dump.return_value = {
+        "access_token": "SHARED",
+        "token_type": "Bearer",
+    }
+    storage = HermesTokenStorage("shared")
+    asyncio.run(storage.set_tokens(token))
+    manager = MCPOAuthManager()
+
+    def fake_build(server_name, entry, *, hermes_home):
+        pinned = HermesTokenStorage(server_name, hermes_home=hermes_home)
+        return SimpleNamespace(
+            context=SimpleNamespace(storage=pinned, current_tokens=None),
+            _initialized=True,
+        )
+
+    monkeypatch.setattr(manager, "_build_provider", fake_build)
+    manager.get_or_build_provider("shared", shared["url"], {})
+    (profile / "config.yaml").write_text(json.dumps({
+        "mcp_servers": {
+            "shared": {"url": "https://new.example/mcp", "auth": "oauth"},
+        },
+    }))
+
+    manager.remove("shared", hermes_home=profile)
+
+    assert not storage._tokens_path().exists()
+
+
+def test_profile_detach_preserves_root_shared_grant(tmp_path, monkeypatch):
+    root = tmp_path / "hermes"
+    profile = root / "profiles" / "worker"
+    profile.mkdir(parents=True)
+    shared = {"url": "https://old.example/mcp", "auth": "oauth"}
+    (root / "config.yaml").write_text(json.dumps({
+        "mcp_servers": {
+            "shared": {
+                **shared,
+                "oauth": {"share_with_profiles": True},
+            },
+        },
+    }))
+    (profile / "config.yaml").write_text(json.dumps({
+        "mcp_servers": {"shared": shared},
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(profile))
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    token = MagicMock()
+    token.model_dump.return_value = {
+        "access_token": "ROOT-SHARED",
+        "token_type": "Bearer",
+    }
+    root_storage = HermesTokenStorage("shared")
+    asyncio.run(root_storage.set_tokens(token))
+    manager = MCPOAuthManager()
+
+    def fake_build(server_name, entry, *, hermes_home):
+        pinned = HermesTokenStorage(
+            server_name,
+            hermes_home=hermes_home,
+            token_dir=Path(entry.pool_path).parent,
+        )
+        return SimpleNamespace(
+            context=SimpleNamespace(storage=pinned, current_tokens=None),
+            _initialized=True,
+        )
+
+    monkeypatch.setattr(manager, "_build_provider", fake_build)
+    manager.get_or_build_provider("shared", shared["url"], {})
+    (profile / "config.yaml").write_text(json.dumps({
+        "mcp_servers": {
+            "shared": {"url": "https://new.example/mcp", "auth": "oauth"},
+        },
+    }))
+
+    manager.get_or_build_provider("shared", "https://new.example/mcp", {})
+
+    assert root_storage._tokens_path().exists()
+
 
 pytest.importorskip(
     "mcp.client.auth.oauth2",
@@ -124,6 +391,62 @@ async def test_disk_watch_invalidates_on_mtime_change(tmp_path, monkeypatch):
     assert changed3 is True
     # _initialized flipped — next async_auth_flow will re-read from disk
     assert provider._initialized is False
+
+
+@pytest.mark.asyncio
+async def test_disk_watch_tracks_root_exported_profile_tokens(tmp_path, monkeypatch):
+    root = tmp_path / "hermes"
+    profile = root / "profiles" / "worker"
+    profile.mkdir(parents=True)
+    (root / "config.yaml").write_text(json.dumps({
+        "mcp_servers": {
+            "srv": {
+                "url": "https://example.com/mcp",
+                "auth": "oauth",
+                "oauth": {"share_with_profiles": True},
+            },
+        },
+    }))
+    (profile / "config.yaml").write_text(json.dumps({
+        "mcp_servers": {
+            "srv": {
+                "url": "https://example.com/mcp",
+                "auth": "oauth",
+            },
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(profile))
+    from tools.mcp_oauth_manager import MCPOAuthManager, reset_manager_for_tests
+
+    reset_manager_for_tests()
+    token_dir = root / "mcp-tokens"
+    token_dir.mkdir()
+    tokens_file = token_dir / "srv.json"
+    tokens_file.write_text(json.dumps({
+        "access_token": "SHARED",
+        "token_type": "Bearer",
+    }))
+
+    manager = MCPOAuthManager()
+    provider = manager.get_or_build_provider("srv", "https://example.com/mcp", None)
+    assert provider is not None
+    await provider._initialize()
+    assert provider.context.current_tokens.access_token == "SHARED"
+    assert await manager.invalidate_if_disk_changed("srv") is True
+
+    # A live provider keeps watching the root pool it resolved at build time,
+    # even if its profile config disappears before the next request.
+    (profile / "config.yaml").unlink()
+    future_mtime = time.time() + 10
+    os.utime(tokens_file, (future_mtime, future_mtime))
+
+    assert await manager.invalidate_if_disk_changed("srv") is True
+    assert provider._initialized is False
+
+    tokens_file.unlink()
+
+    assert await manager.invalidate_if_disk_changed("srv") is True
+    assert provider.context.current_tokens is None
 
 
 @pytest.mark.asyncio

--- a/tests/tui_gateway/test_mcp_profile_rpcs.py
+++ b/tests/tui_gateway/test_mcp_profile_rpcs.py
@@ -199,7 +199,47 @@ def test_remove_scoped_to_profile(hermes_root):
     assert "temp" in _read_yaml(root / "profiles" / "other" / "config.yaml").get("mcp_servers", {})
 
 
+def test_remove_cleans_root_exported_oauth_pool(hermes_root):
+    import yaml
+
+    root = hermes_root
+    server = {
+        "url": "https://mcp.example.com/shared",
+        "auth": "oauth",
+    }
+    (root / "config.yaml").write_text(yaml.safe_dump({
+        "mcp_servers": {
+            "shared": {
+                **server,
+                "oauth": {"share_with_profiles": True},
+            },
+        },
+    }))
+    _result(
+        _call(
+            "mcp.servers.add",
+            {"profile": "work", "name": "shared", "config": server},
+        )
+    )
+    token_dir = root / "mcp-tokens"
+    token_dir.mkdir(exist_ok=True)
+    token_file = token_dir / "shared.json"
+    token_file.write_text("{}")
+
+    resp = _result(_call("mcp.servers.remove", {"profile": "work", "name": "shared"}))
+
+    assert resp["removed"] is True
+    assert not token_file.exists()
+    assert "shared" not in _read_yaml(root / "profiles" / "work" / "config.yaml").get(
+        "mcp_servers", {}
+    )
+
+
 def test_add_duplicate_and_missing_errors(hermes_root):
+    stale_dir = hermes_root / "profiles" / "work" / "mcp-tokens"
+    stale_dir.mkdir()
+    stale_token = stale_dir / "nope.json"
+    stale_token.write_text("{}")
     _result(
         _call(
             "mcp.servers.add",
@@ -216,6 +256,7 @@ def test_add_duplicate_and_missing_errors(hermes_root):
     missing = _call("mcp.servers.remove", {"profile": "work", "name": "nope"})
     assert "error" in missing
     assert missing["error"]["code"] == 4064
+    assert stale_token.exists()
 
     bad_profile = _call(
         "mcp.servers.add",

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -44,6 +44,7 @@ Configuration in config.yaml::
 
 import asyncio
 import contextvars
+import hashlib
 import json
 import logging
 import os
@@ -189,21 +190,129 @@ _USER_SKIPPED_SENTINEL = "__hermes_user_skipped__"
 # ---------------------------------------------------------------------------
 
 
-def _get_token_dir(hermes_home: str | Path | None = None) -> Path:
+def _load_mcp_server_config(home: Path, server_name: str) -> dict[str, Any] | None:
+    """Read one raw MCP server entry without inheriting profile config."""
+    try:
+        import yaml
+    except ImportError:
+        return None
+
+    try:
+        data = yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8"))
+    except (OSError, TypeError, ValueError, yaml.YAMLError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    servers = data.get("mcp_servers")
+    if not isinstance(servers, dict):
+        return None
+    entry = servers.get(server_name)
+    return entry if isinstance(entry, dict) else None
+
+
+def _contains_config_reference(value: Any) -> bool:
+    if isinstance(value, str):
+        return bool(re.search(r"\${[^}]+}", value))
+    if isinstance(value, dict):
+        return any(_contains_config_reference(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_contains_config_reference(item) for item in value)
+    return False
+
+
+def _shared_server_identity(entry: dict[str, Any]) -> tuple[Any, ...] | None:
+    """Return a fail-closed identity for one shareable OAuth server entry."""
+    url = entry.get("url")
+    auth = entry.get("auth")
+    if not isinstance(url, str) or auth != "oauth" or _contains_config_reference(url):
+        return None
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return None
+
+    oauth = entry.get("oauth")
+    if oauth is None:
+        oauth_identity: dict[str, Any] = {}
+    elif isinstance(oauth, dict):
+        oauth_identity = {
+            key: value
+            for key, value in oauth.items()
+            if key != "share_with_profiles"
+        }
+    else:
+        return None
+    if _contains_config_reference(oauth_identity):
+        return None
+
+    transport = entry.get("transport")
+    if _contains_config_reference(transport):
+        return None
+
+    return (url, auth, transport, oauth_identity)
+
+
+def _shared_token_home(active_home: Path, server_name: str) -> Path:
+    """Resolve an explicitly exported root OAuth pool for a named profile."""
+    if active_home.parent.name != "profiles":
+        return active_home
+
+    root_home = active_home.parent.parent
+    root_entry = _load_mcp_server_config(root_home, server_name)
+    profile_entry = _load_mcp_server_config(active_home, server_name)
+    if root_entry is None or profile_entry is None:
+        return active_home
+
+    oauth = root_entry.get("oauth")
+    if not isinstance(oauth, dict) or oauth.get("share_with_profiles") is not True:
+        return active_home
+
+    root_identity = _shared_server_identity(root_entry)
+    profile_identity = _shared_server_identity(profile_entry)
+    if root_identity is None or root_identity != profile_identity:
+        logger.warning(
+            "MCP OAuth '%s': root token pool export ignored because profile OAuth identity "
+            "differs or contains a dynamic config reference",
+            server_name,
+        )
+        return active_home
+
+    return root_home
+
+
+def _get_token_dir(
+    hermes_home: str | Path | None = None,
+    *,
+    server_name: str | None = None,
+) -> Path:
     """Return the directory for MCP OAuth token files.
 
-    Uses HERMES_HOME so each profile gets its own OAuth tokens.
+    Profiles use isolated storage by default. A root profile may explicitly
+    export one matching MCP server's token pool with
+    ``oauth.share_with_profiles: true``; no other config is inherited.
     Layout: ``HERMES_HOME/mcp-tokens/``
     """
     from hermes_constants import get_hermes_home
 
     base = Path(hermes_home) if hermes_home is not None else Path(get_hermes_home())
+    if server_name is not None:
+        base = _shared_token_home(base, server_name)
     return base / "mcp-tokens"
 
 
 def _safe_filename(name: str) -> str:
-    """Sanitize a server name for use as a filename (no path separators)."""
-    return re.sub(r"[^\w\-]", "_", name).strip("_")[:128] or "default"
+    """Return a collision-resistant filename component for a server name.
+
+    Existing simple names retain their historical paths. Names requiring
+    sanitization receive a digest of the original value so e.g. ``a/b`` and
+    ``a_b`` can never share OAuth credentials.
+    """
+    if re.fullmatch(r"[\w-]{1,128}", name) and name.strip("_"):
+        return name
+    stem = re.sub(r"[^\w-]", "_", name).strip("_") or "default"
+    digest = hashlib.sha256(name.encode("utf-8")).hexdigest()[:12]
+    # ``~`` is deliberately outside the accepted safe-name alphabet, so no
+    # already-safe server name can impersonate this encoded namespace.
+    return f"~u~{stem[:111]}-{digest}"
 
 
 def _find_free_port() -> int:
@@ -283,8 +392,8 @@ def _cached_redirect_port(storage: "HermesTokenStorage | None") -> int | None:
         return None
 
     try:
-        data = _read_json(storage._client_info_path())
-    except (AttributeError, TypeError, ValueError):
+        data = storage.read_client_info_data()
+    except (AttributeError, RuntimeError, TypeError, ValueError):
         return None
     if not data:
         return None
@@ -309,8 +418,8 @@ def _cached_redirect_uri(storage: "HermesTokenStorage | None") -> str | None:
     if storage is None:
         return None
     try:
-        data = _read_json(storage._client_info_path())
-    except (AttributeError, TypeError, ValueError):
+        data = storage.read_client_info_data()
+    except (AttributeError, RuntimeError, TypeError, ValueError):
         return None
     for uri in (data or {}).get("redirect_uris") or []:
         try:
@@ -448,6 +557,77 @@ def _write_json(path: Path, data: dict) -> None:
         raise
 
 
+def _write_bytes(path: Path, data: bytes) -> None:
+    """Atomically write sensitive bytes with owner-only permissions."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    secure_parent_dir(path)
+    tmp = path.with_suffix(f".tmp.{os.getpid()}.{secrets.token_hex(4)}")
+    try:
+        fd = os.open(
+            str(tmp),
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            stat.S_IRUSR | stat.S_IWUSR,
+        )
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+    except OSError:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+_oauth_state_locks: dict[str, threading.RLock] = {}
+_oauth_state_locks_guard = threading.Lock()
+
+
+@contextmanager
+def _exclusive_oauth_state_lock(path: Path):
+    """Serialize one OAuth pool across threads and local processes."""
+    key = str(path.expanduser().resolve(strict=False))
+    with _oauth_state_locks_guard:
+        thread_lock = _oauth_state_locks.setdefault(key, threading.RLock())
+    with thread_lock:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        secure_parent_dir(path)
+        fd = os.open(
+            str(path),
+            os.O_RDWR | os.O_CREAT,
+            stat.S_IRUSR | stat.S_IWUSR,
+        )
+        with os.fdopen(fd, "r+b", buffering=0) as handle:
+            if os.fstat(handle.fileno()).st_size == 0:
+                handle.write(b"\0")
+                handle.flush()
+                os.fsync(handle.fileno())
+            handle.seek(0)
+            if sys.platform == "win32":  # pragma: no cover - Windows CI
+                import msvcrt
+
+                msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                handle.seek(0)
+                if sys.platform == "win32":  # pragma: no cover - Windows CI
+                    import msvcrt
+
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+class OAuthStorageRevokedError(RuntimeError):
+    """Raised when a superseded provider attempts to rewrite OAuth state."""
+
+
 # ---------------------------------------------------------------------------
 # HermesTokenStorage -- persistent token/client-info on disk
 # ---------------------------------------------------------------------------
@@ -464,26 +644,110 @@ class HermesTokenStorage:
         HERMES_HOME/mcp-tokens/<server_name>.cimd-off      -- CIMD refused here
     """
 
-    def __init__(self, server_name: str, *, hermes_home: str | Path | None = None):
+    def __init__(
+        self,
+        server_name: str,
+        *,
+        hermes_home: str | Path | None = None,
+        token_dir: str | Path | None = None,
+    ):
+        from hermes_constants import get_hermes_home
+
+        self._config_server_name = server_name
         self._server_name = _safe_filename(server_name)
-        self._hermes_home = Path(hermes_home) if hermes_home is not None else None
+        self._hermes_home = (
+            Path(hermes_home) if hermes_home is not None else Path(get_hermes_home())
+        )
+        # Resolve once. A live provider must not switch credential stores
+        # midway through a request because its profile config changed.
+        self._token_dir = (
+            Path(token_dir)
+            if token_dir is not None
+            else _get_token_dir(
+                self._hermes_home,
+                server_name=self._config_server_name,
+            )
+        )
+        self._state_lock_path = self._token_dir / f".{self._server_name}.lock"
+        self._generation_path = self._token_dir / f".{self._server_name}.generation.json"
+        self._blocked_path = self._token_dir / f".{self._server_name}.blocked.json"
+        self._generation: str | None = None
+        self._revoked = False
+
+    def revoke_instance(self) -> None:
+        """Prevent this provider instance from touching its pool again."""
+        self._revoked = True
+
+    def _assert_current_generation_locked(self) -> None:
+        if self._revoked:
+            raise OAuthStorageRevokedError(
+                f"OAuth storage for '{self._config_server_name}' was detached"
+            )
+        if self._blocked_path.exists():
+            raise OAuthStorageRevokedError(
+                f"OAuth storage for '{self._config_server_name}' was removed"
+            )
+        generation = _read_json(self._generation_path)
+        generation_id = generation.get("id") if isinstance(generation, dict) else None
+        if self._generation is None:
+            if not isinstance(generation_id, str) or not generation_id:
+                generation_id = secrets.token_hex(16)
+                _write_json(self._generation_path, {"id": generation_id})
+            self._generation = generation_id
+            return
+        if generation_id != self._generation:
+            raise OAuthStorageRevokedError(
+                f"OAuth storage for '{self._config_server_name}' was superseded"
+            )
+
+    def _rotate_generation_locked(self) -> None:
+        self._generation = secrets.token_hex(16)
+        _write_json(self._generation_path, {"id": self._generation})
+
+    def _client_backup_path(self) -> Path:
+        client_path = self._client_info_path()
+        return client_path.with_name(client_path.name + ".bak")
+
+    def _state_paths(self) -> tuple[Path, ...]:
+        return (
+            self._tokens_path(),
+            self._client_info_path(),
+            self._meta_path(),
+            self._cimd_rejected_path(),
+            self._client_backup_path(),
+        )
+
+    def _remove_files_locked(self) -> None:
+        for path in self._state_paths():
+            path.unlink(missing_ok=True)
+
+    def unblock_rebuild(self) -> None:
+        """Clear the tombstone after an explicit re-add or reauthorization."""
+        with _exclusive_oauth_state_lock(self._state_lock_path):
+            self._blocked_path.unlink(missing_ok=True)
+
+    def rebuild_blocked(self) -> bool:
+        with _exclusive_oauth_state_lock(self._state_lock_path):
+            return self._blocked_path.exists()
 
     def _tokens_path(self) -> Path:
-        return _get_token_dir(self._hermes_home) / f"{self._server_name}.json"
+        return self._token_dir / f"{self._server_name}.json"
 
     def _client_info_path(self) -> Path:
-        return _get_token_dir(self._hermes_home) / f"{self._server_name}.client.json"
+        return self._token_dir / f"{self._server_name}.client.json"
 
     def _meta_path(self) -> Path:
-        return _get_token_dir(self._hermes_home) / f"{self._server_name}.meta.json"
+        return self._token_dir / f"{self._server_name}.meta.json"
 
     def _cimd_rejected_path(self) -> Path:
-        return _get_token_dir(self._hermes_home) / f"{self._server_name}.cimd-off"
+        return self._token_dir / f"{self._server_name}.cimd-off"
 
     # -- tokens ------------------------------------------------------------
 
     async def get_tokens(self) -> "OAuthToken | None":
-        data = _read_json(self._tokens_path())
+        with _exclusive_oauth_state_lock(self._state_lock_path):
+            self._assert_current_generation_locked()
+            data = _read_json(self._tokens_path())
         if data is None:
             return None
         if OAuthToken is None and not _ensure_sdk_loaded():
@@ -540,13 +804,72 @@ class HermesTokenStorage:
                 # Mock tokens or unusual shapes: skip the expires_at write
                 # rather than fail persistence.
                 pass
-        _write_json(self._tokens_path(), payload)
+        with _exclusive_oauth_state_lock(self._state_lock_path):
+            self._assert_current_generation_locked()
+            _write_json(self._tokens_path(), payload)
         logger.debug("OAuth tokens saved for %s", self._server_name)
 
     # -- client info -------------------------------------------------------
 
+    def read_client_info_data(self) -> dict | None:
+        """Read raw client registration under the pool generation lock."""
+        with _exclusive_oauth_state_lock(self._state_lock_path):
+            self._assert_current_generation_locked()
+            return _read_json(self._client_info_path())
+
+    def has_cached_client_info(self) -> bool:
+        return self.read_client_info_data() is not None
+
+    @staticmethod
+    def _client_identity(data: dict | None) -> tuple[Any, Any]:
+        if not isinstance(data, dict):
+            return (None, None)
+        return (data.get("client_id"), data.get("client_secret") or None)
+
+    def invalidate_tokens_for_client_change(
+        self,
+        new_client_id: str,
+        new_client_secret: str | None,
+    ) -> bool:
+        """Atomically revoke token/metadata when OAuth client identity changes."""
+        with _exclusive_oauth_state_lock(self._state_lock_path):
+            self._assert_current_generation_locked()
+            existing = _read_json(self._client_info_path())
+            old_identity = self._client_identity(existing)
+            if old_identity[0] is None or old_identity == (
+                new_client_id,
+                new_client_secret or None,
+            ):
+                return False
+            removed = False
+            for path in (self._tokens_path(), self._meta_path()):
+                if path.exists():
+                    path.unlink()
+                    removed = True
+            return removed
+
+    def save_preregistered_client_info(
+        self,
+        client_info: Any,
+    ) -> bool:
+        """Atomically revoke stale tokens and install configured client info."""
+        data = client_info.model_dump(mode="json", exclude_none=True)
+        new_identity = self._client_identity(data)
+        with _exclusive_oauth_state_lock(self._state_lock_path):
+            self._assert_current_generation_locked()
+            existing = _read_json(self._client_info_path())
+            old_identity = self._client_identity(existing)
+            removed = False
+            if old_identity[0] is not None and old_identity != new_identity:
+                for path in (self._tokens_path(), self._meta_path()):
+                    if path.exists():
+                        path.unlink()
+                        removed = True
+            _write_json(self._client_info_path(), data)
+            return removed
+
     async def get_client_info(self) -> "OAuthClientInformationFull | None":
-        data = _read_json(self._client_info_path())
+        data = self.read_client_info_data()
         if data is None:
             return None
         if OAuthClientInformationFull is None and not _ensure_sdk_loaded():
@@ -562,7 +885,12 @@ class HermesTokenStorage:
             if getattr(info, "client_secret", None) and data.get("token_endpoint_auth_method") in (None, "none", ""):
                 data["token_endpoint_auth_method"] = "client_secret_post"
                 info = OAuthClientInformationFull.model_validate(data)
-                _write_json(self._client_info_path(), info.model_dump(mode="json", exclude_none=True))
+                with _exclusive_oauth_state_lock(self._state_lock_path):
+                    self._assert_current_generation_locked()
+                    _write_json(
+                        self._client_info_path(),
+                        info.model_dump(mode="json", exclude_none=True),
+                    )
             return info
         except (ValueError, TypeError, KeyError) as exc:
             logger.warning("Corrupt client info at %s -- ignoring: %s", self._client_info_path(), exc)
@@ -577,7 +905,9 @@ class HermesTokenStorage:
         # so this flow and subsequent retries use client_secret_post.
         if data.get("client_secret") and data.get("token_endpoint_auth_method") in (None, "none", ""):
             data["token_endpoint_auth_method"] = "client_secret_post"
-        _write_json(self._client_info_path(), data)
+        with _exclusive_oauth_state_lock(self._state_lock_path):
+            self._assert_current_generation_locked()
+            _write_json(self._client_info_path(), data)
         logger.debug("OAuth client info saved for %s", self._server_name)
 
     # -- oauth server metadata --------------------------------------------
@@ -589,11 +919,18 @@ class HermesTokenStorage:
     # forces a full browser re-authorization.
 
     def save_oauth_metadata(self, metadata: "OAuthMetadata") -> None:
-        _write_json(self._meta_path(), metadata.model_dump(exclude_none=True, mode="json"))
+        with _exclusive_oauth_state_lock(self._state_lock_path):
+            self._assert_current_generation_locked()
+            _write_json(
+                self._meta_path(),
+                metadata.model_dump(exclude_none=True, mode="json"),
+            )
         logger.debug("OAuth metadata saved for %s", self._server_name)
 
     def load_oauth_metadata(self) -> "OAuthMetadata | None":
-        data = _read_json(self._meta_path())
+        with _exclusive_oauth_state_lock(self._state_lock_path):
+            self._assert_current_generation_locked()
+            data = _read_json(self._meta_path())
         if data is None:
             return None
         if OAuthMetadata is None and not _ensure_sdk_loaded():
@@ -617,70 +954,77 @@ class HermesTokenStorage:
         """
         path = self._cimd_rejected_path()
         try:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.touch()
+            with _exclusive_oauth_state_lock(self._state_lock_path):
+                self._assert_current_generation_locked()
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.touch()
         except OSError as exc:  # non-fatal — worst case we retry CIMD later
             logger.debug("Could not record CIMD rejection at %s: %s", path, exc)
 
     def cimd_rejected(self) -> bool:
         """True when this server has refused our metadata document before."""
-        return self._cimd_rejected_path().exists()
+        with _exclusive_oauth_state_lock(self._state_lock_path):
+            self._assert_current_generation_locked()
+            return self._cimd_rejected_path().exists()
 
     # -- cleanup -----------------------------------------------------------
 
-    def remove(self) -> None:
-        """Delete all stored OAuth state for this server."""
-        for p in (
-            self._tokens_path(),
-            self._client_info_path(),
-            self._meta_path(),
-            self._cimd_rejected_path(),
-        ):
-            p.unlink(missing_ok=True)
+    def remove(self, *, permanent: bool = False) -> None:
+        """Delete OAuth state; optionally tombstone the pool atomically."""
+        with _exclusive_oauth_state_lock(self._state_lock_path):
+            self._rotate_generation_locked()
+            self._remove_files_locked()
+            if permanent:
+                _write_json(self._blocked_path, {"blocked": True})
 
     def snapshot(self) -> dict[str, bytes]:
         """Capture on-disk OAuth state so a failed re-auth can restore it.
 
-        Maps filename -> bytes for whichever of the three state files exist.
+        Maps filename -> bytes for whichever OAuth state files exist.
         Feed back to ``restore()`` to undo an intervening ``remove()`` when a
         re-authentication attempt fails, so a still-valid token isn't destroyed.
         """
         snap: dict[str, bytes] = {}
-        for p in (self._tokens_path(), self._client_info_path(), self._meta_path()):
-            try:
-                snap[p.name] = p.read_bytes()
-            except OSError:
-                pass
+        with _exclusive_oauth_state_lock(self._state_lock_path):
+            self._assert_current_generation_locked()
+            for path in self._state_paths():
+                try:
+                    snap[path.name] = path.read_bytes()
+                except OSError:
+                    pass
         return snap
 
     def restore(self, snapshot: dict[str, bytes], *, only_if_absent: bool = False) -> None:
         """Revert to a snapshot without overwriting a concurrent successful write."""
-        if only_if_absent and any(
-            path.exists()
-            for path in (self._tokens_path(), self._client_info_path(), self._meta_path())
-        ):
-            logger.info(
-                "Skipping OAuth rollback for %s because newer state exists",
-                self._server_name,
-            )
-            return
-        self.remove()
-        if not snapshot:
-            return
-        token_dir = _get_token_dir(self._hermes_home)
-        token_dir.mkdir(parents=True, exist_ok=True)
-        for fname, data in snapshot.items():
-            path = token_dir / fname
-            try:
-                fd = os.open(
-                    str(path),
-                    os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-                    stat.S_IRUSR | stat.S_IWUSR,
+        with _exclusive_oauth_state_lock(self._state_lock_path):
+            # A reauth rollback is allowed to cross the generation rotation
+            # caused by its own reset. It must never cross a permanent-removal
+            # tombstone or revive a provider instance explicitly detached from
+            # a shared pool.
+            if self._revoked or self._blocked_path.exists():
+                raise OAuthStorageRevokedError(
+                    f"OAuth storage for '{self._config_server_name}' cannot be restored"
                 )
-                with os.fdopen(fd, "wb") as fh:
-                    fh.write(data)
-            except OSError as exc:
-                logger.warning("Failed to restore OAuth state %s: %s", fname, exc)
+            # Only a token commit proves a newer authorization succeeded.
+            # Failed attempts commonly leave client/meta files behind; those
+            # must not suppress restoration of the previous valid token.
+            if only_if_absent and self._tokens_path().exists():
+                logger.info(
+                    "Skipping OAuth rollback for %s because a newer token exists",
+                    self._server_name,
+                )
+                return
+            self._rotate_generation_locked()
+            self._remove_files_locked()
+            if not snapshot:
+                return
+            self._token_dir.mkdir(parents=True, exist_ok=True)
+            for fname, data in snapshot.items():
+                path = self._token_dir / fname
+                try:
+                    _write_bytes(path, data)
+                except OSError as exc:
+                    logger.warning("Failed to restore OAuth state %s: %s", fname, exc)
 
     def poison_client_registration(self) -> bool:
         """Discard a dead dynamically-registered client so it gets re-created.
@@ -700,16 +1044,18 @@ class HermesTokenStorage:
         A single ``.bak`` copy of the client file is kept for recovery.
         Returns True if a client file was present and removed.
         """
-        client_path = self._client_info_path()
-        if not client_path.exists():
-            return False
-        backup = client_path.with_name(client_path.name + ".bak")
-        try:
-            backup.write_bytes(client_path.read_bytes())
-        except OSError as exc:  # non-fatal — proceed with the removal anyway
-            logger.warning("Could not back up client info at %s: %s", client_path, exc)
-        client_path.unlink(missing_ok=True)
-        self._meta_path().unlink(missing_ok=True)
+        with _exclusive_oauth_state_lock(self._state_lock_path):
+            self._assert_current_generation_locked()
+            client_path = self._client_info_path()
+            if not client_path.exists():
+                return False
+            backup = self._client_backup_path()
+            try:
+                _write_bytes(backup, client_path.read_bytes())
+            except OSError as exc:  # non-fatal — proceed with the removal anyway
+                logger.warning("Could not back up client info at %s: %s", client_path, exc)
+            client_path.unlink(missing_ok=True)
+            self._meta_path().unlink(missing_ok=True)
         logger.warning(
             "MCP OAuth '%s': cached client registration rejected as invalid_client; "
             "removed client.json + meta.json (backup at %s) to force re-registration",
@@ -719,7 +1065,9 @@ class HermesTokenStorage:
 
     def has_cached_tokens(self) -> bool:
         """Return True if we have tokens on disk (may be expired)."""
-        return self._tokens_path().exists()
+        with _exclusive_oauth_state_lock(self._state_lock_path):
+            self._assert_current_generation_locked()
+            return self._tokens_path().exists()
 
 
 # ---------------------------------------------------------------------------
@@ -1408,8 +1756,8 @@ def _has_cached_client_info(storage: "HermesTokenStorage | None") -> bool:
     if storage is None:
         return False
     try:
-        return _read_json(storage._client_info_path()) is not None
-    except (AttributeError, TypeError, ValueError):
+        return storage.has_cached_client_info()
+    except (AttributeError, RuntimeError, TypeError, ValueError):
         return False
 
 
@@ -1429,7 +1777,7 @@ def _server_declined_cimd(storage: "HermesTokenStorage | None") -> bool:
         return False
     try:
         metadata = storage.load_oauth_metadata()
-    except (AttributeError, TypeError, ValueError):
+    except (AttributeError, RuntimeError, TypeError, ValueError):
         return False
     if metadata is None:
         return False
@@ -1758,34 +2106,16 @@ def _invalidate_tokens_on_client_change(
     Port of cline/cline#12983's "invalidate tokens when OAuth client
     changes" invariant.
     """
-    existing = _read_json(storage._client_info_path())
-    if not isinstance(existing, dict):
-        return
-    old_client_id = existing.get("client_id")
-    if not old_client_id:
-        return
-    old_client_secret = existing.get("client_secret") or None
-    if old_client_id == new_client_id and old_client_secret == (
-        new_client_secret or None
-    ):
-        return
-    removed = False
-    for path in (storage._tokens_path(), storage._meta_path()):
-        try:
-            if path.exists():
-                path.unlink()
-                removed = True
-        except OSError as exc:  # non-fatal — stale tokens fail later anyway
-            logger.warning(
-                "MCP OAuth '%s': could not remove stale %s after client "
-                "change: %s", storage._server_name, path.name, exc,
-            )
+    removed = storage.invalidate_tokens_for_client_change(
+        new_client_id,
+        new_client_secret,
+    )
     if removed:
         logger.warning(
-            "MCP OAuth '%s': configured OAuth client changed (client_id %r "
-            "-> %r); discarded tokens minted under the previous client. "
+            "MCP OAuth '%s': configured OAuth client changed to %r; discarded "
+            "tokens minted under the previous client. "
             "Re-authorize with: hermes mcp login %s",
-            storage._server_name, old_client_id, new_client_id,
+            storage._server_name, new_client_id,
             storage._server_name,
         )
 
@@ -1801,9 +2131,7 @@ def _maybe_preregister_client(
         return
     if OAuthClientInformationFull is None:
         _ensure_sdk_loaded()
-    _invalidate_tokens_on_client_change(
-        storage, client_id, cfg.get("client_secret")
-    )
+
     port = cfg["_resolved_port"]
     redirect_uri = _resolve_redirect_uri(cfg, port)
 
@@ -1822,7 +2150,13 @@ def _maybe_preregister_client(
         info_dict["scope"] = cfg["scope"]
 
     client_info = OAuthClientInformationFull.model_validate(info_dict)
-    _write_json(storage._client_info_path(), client_info.model_dump(mode="json", exclude_none=True))
+    removed = storage.save_preregistered_client_info(client_info)
+    if removed:
+        logger.warning(
+            "MCP OAuth '%s': configured OAuth client changed; discarded tokens "
+            "minted under the previous client",
+            storage._server_name,
+        )
     logger.debug("Pre-registered client_id=%s for '%s'", client_id, storage._server_name)
 
 

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -35,6 +35,7 @@ Design reference:
 from __future__ import annotations
 
 import asyncio
+import copy
 import logging
 import re
 import threading
@@ -92,6 +93,7 @@ class _ProviderEntry:
 
     server_url: str
     oauth_config: Optional[dict]
+    pool_path: str = ""
     provider: Optional[Any] = None
     last_mtime_ns: int = 0
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
@@ -583,31 +585,77 @@ class MCPOAuthManager:
     ) -> Optional[Any]:
         """Return a cached OAuth provider for ``server_name`` or build one.
 
-        Idempotent: repeat calls with the same name return the same instance.
-        If ``server_url`` changes for a given name, the cached entry is
-        discarded and a fresh provider is built.
+        Idempotent: repeat calls with the same name and configuration return
+        the same instance. If ``server_url`` or ``oauth_config`` changes, the
+        cached entry is discarded and a fresh provider is built.
 
         Returns None if the MCP SDK's OAuth support is unavailable.
         """
+        from tools.mcp_oauth import HermesTokenStorage
+
         key = self._key(server_name)
+        requested_oauth_config = copy.deepcopy(oauth_config or {})
+        requested_storage = HermesTokenStorage(server_name, hermes_home=key[0])
+        requested_pool_path = str(
+            requested_storage._tokens_path().resolve(strict=False)
+        )
         with self._entries_lock:
-            entry = self._entries.get(key)
-            if entry is not None and entry.server_url != server_url:
+            if requested_storage.rebuild_blocked():
                 logger.info(
-                    "MCP OAuth '%s': URL changed from %s to %s, discarding cache",
-                    server_name, entry.server_url, server_url,
+                    "MCP OAuth '%s': provider rebuild blocked after permanent removal",
+                    server_name,
                 )
+                return None
+            entry = self._entries.get(key)
+            if entry is not None and (
+                entry.server_url != server_url
+                or (entry.oauth_config or {}) != requested_oauth_config
+                or entry.pool_path != requested_pool_path
+            ):
+                logger.info(
+                    "MCP OAuth '%s': server or OAuth configuration changed, "
+                    "discarding cache",
+                    server_name,
+                )
+                if entry.provider is not None:
+                    old_storage = getattr(
+                        getattr(entry.provider, "context", None),
+                        "storage",
+                        None,
+                    )
+                    self._clear_provider_oauth_state(entry.provider)
+                else:
+                    old_storage = None
+                if not isinstance(old_storage, HermesTokenStorage):
+                    old_storage = HermesTokenStorage(
+                        server_name,
+                        hermes_home=key[0],
+                        token_dir=Path(entry.pool_path).parent,
+                    )
+                old_storage.revoke_instance()
+                # Moving one profile away from a shared pool must not delete
+                # the root grant used by remaining participants. Revoke this
+                # provider instance only. If the pool path is unchanged, the
+                # new endpoint/client would otherwise reload the old token, so
+                # rotate and delete that pool state.
+                if entry.pool_path == requested_pool_path:
+                    old_storage.remove()
                 entry = None
 
             if entry is None:
                 entry = _ProviderEntry(
                     server_url=server_url,
-                    oauth_config=oauth_config,
+                    oauth_config=requested_oauth_config,
+                    pool_path=requested_pool_path,
                 )
                 self._entries[key] = entry
 
             if entry.provider is None:
-                entry.provider = self._build_provider(server_name, entry)
+                entry.provider = self._build_provider(
+                    server_name,
+                    entry,
+                    hermes_home=key[0],
+                )
                 if entry.provider is not None:
                     entry.provider._hermes_home = key[0]
 
@@ -627,6 +675,8 @@ class MCPOAuthManager:
         self,
         server_name: str,
         entry: _ProviderEntry,
+        *,
+        hermes_home: str | Path,
     ) -> Optional[Any]:
         """Build the underlying OAuth provider.
 
@@ -667,7 +717,11 @@ class MCPOAuthManager:
         apply_oauth_provider_defaults(
             cfg, server_name=server_name, server_url=entry.server_url
         )
-        storage = HermesTokenStorage(server_name)
+        storage = HermesTokenStorage(
+            server_name,
+            hermes_home=hermes_home,
+            token_dir=Path(entry.pool_path).parent,
+        )
 
         from tools.mcp_dashboard_oauth import get_dashboard_oauth_flow
 
@@ -709,40 +763,87 @@ class MCPOAuthManager:
             **cimd_provider_kwargs(cfg),
         )
 
+    @staticmethod
+    def _clear_provider_oauth_state(provider: Any) -> None:
+        """Prevent an evicted provider from continuing with in-memory tokens."""
+        context = getattr(provider, "context", None)
+        if context is not None:
+            try:
+                context.clear_tokens()
+            except (AttributeError, TypeError, ValueError):
+                pass
+        if hasattr(provider, "_initialized"):
+            provider._initialized = False  # noqa: SLF001
+
     def remove(
         self,
         server_name: str,
         *,
         hermes_home: str | Path | None = None,
+        block_rebuild: bool = False,
     ) -> _ProviderEntry | None:
         """Evict the provider from cache AND delete tokens from disk.
 
         Called by ``hermes mcp remove <name>`` and (indirectly) by
         ``hermes mcp login <name>`` during forced re-auth.
         """
-        with self._entries_lock:
-            entry = self._entries.pop(self._key(server_name, hermes_home), None)
+        from tools.mcp_oauth import HermesTokenStorage
 
-        from tools.mcp_oauth import remove_oauth_tokens
-        remove_oauth_tokens(server_name, hermes_home=hermes_home)
+        requested_key = self._key(server_name, hermes_home)
+        current_storage = HermesTokenStorage(server_name, hermes_home=hermes_home)
+        with self._entries_lock:
+            entry = self._entries.get(requested_key)
+            pinned_storage = getattr(
+                getattr(getattr(entry, "provider", None), "context", None),
+                "storage",
+                None,
+            )
+            if isinstance(pinned_storage, HermesTokenStorage):
+                target_storage = pinned_storage
+            elif entry is not None and entry.pool_path:
+                target_storage = HermesTokenStorage(
+                    server_name,
+                    hermes_home=hermes_home,
+                    token_dir=Path(entry.pool_path).parent,
+                )
+            else:
+                target_storage = current_storage
+            target_path = str(target_storage._tokens_path().resolve(strict=False))
+            affected_keys = []
+            for key, candidate in self._entries.items():
+                provider = candidate.provider
+                storage = getattr(getattr(provider, "context", None), "storage", None)
+                if key == requested_key or (
+                    candidate.pool_path == target_path
+                    or (
+                        isinstance(storage, HermesTokenStorage)
+                        and str(storage._tokens_path().resolve(strict=False)) == target_path
+                    )
+                ):
+                    affected_keys.append(key)
+            for key in affected_keys:
+                affected = self._entries.pop(key)
+                if affected.provider is not None:
+                    self._clear_provider_oauth_state(affected.provider)
+            target_storage.remove(permanent=block_rebuild)
         logger.info(
-            "MCP OAuth '%s': evicted from cache and removed from disk",
-            server_name,
+            "MCP OAuth '%s': evicted %d provider(s) sharing %s and removed disk state",
+            server_name, len(affected_keys), target_path,
         )
         return entry
 
-    def restore_entry(
+    def unblock(
         self,
         server_name: str,
-        entry: _ProviderEntry | None,
         *,
         hermes_home: str | Path | None = None,
     ) -> None:
-        """Restore a provider entry removed for a failed reauthorization."""
-        if entry is None:
-            return
+        """Allow a deliberately re-added server to build an OAuth provider."""
+        from tools.mcp_oauth import HermesTokenStorage
+
+        storage = HermesTokenStorage(server_name, hermes_home=hermes_home)
         with self._entries_lock:
-            self._entries.setdefault(self._key(server_name, hermes_home), entry)
+            storage.unblock_rebuild()
 
     def evict(
         self,
@@ -770,17 +871,35 @@ class MCPOAuthManager:
         fresh tokens to disk, and on the next tool call the running MCP
         session picks them up without a restart.
         """
-        from tools.mcp_oauth import _get_token_dir, _safe_filename
-
         entry = self._entries.get(self._key(server_name, hermes_home))
         if entry is None or entry.provider is None:
             return False
 
         async with entry.lock:
-            tokens_path = _get_token_dir(hermes_home) / f"{_safe_filename(server_name)}.json"
+            context = getattr(entry.provider, "context", None)
+            storage = getattr(context, "storage", None)
+            tokens_path_fn = getattr(storage, "_tokens_path", None)
+            tokens_path: Any = tokens_path_fn() if callable(tokens_path_fn) else None
+            if tokens_path is None:
+                from tools.mcp_oauth import HermesTokenStorage
+
+                tokens_path = HermesTokenStorage(
+                    server_name,
+                    hermes_home=hermes_home,
+                )._tokens_path()
             try:
                 mtime_ns = tokens_path.stat().st_mtime_ns
             except (FileNotFoundError, OSError):
+                if entry.last_mtime_ns != 0 or getattr(context, "current_tokens", None) is not None:
+                    old = entry.last_mtime_ns
+                    entry.last_mtime_ns = 0
+                    self._clear_provider_oauth_state(entry.provider)
+                    logger.info(
+                        "MCP OAuth '%s': tokens file disappeared (mtime %d -> missing), "
+                        "forcing unauthenticated reload",
+                        server_name, old,
+                    )
+                    return True
                 return False
 
             if mtime_ns != entry.last_mtime_ns:

--- a/tui_gateway/mcp_oauth_sessions.py
+++ b/tui_gateway/mcp_oauth_sessions.py
@@ -159,11 +159,14 @@ def _worker(session_id: str, hermes_home: str, server_name: str, cfg: dict, reco
                 from tools.mcp_oauth import HermesTokenStorage
 
                 manager = get_manager()
-                storage = HermesTokenStorage(server_name)
+                manager.unblock(server_name, hermes_home=hermes_home)
+                storage = HermesTokenStorage(
+                    server_name,
+                    hermes_home=hermes_home,
+                )
                 backup = storage.snapshot()
-                previous_entry = None
                 try:
-                    previous_entry = manager.remove(server_name, hermes_home=hermes_home)
+                    manager.remove(server_name, hermes_home=hermes_home)
                     tools = _probe_single_server(
                         server_name,
                         cfg,
@@ -183,8 +186,8 @@ def _worker(session_id: str, hermes_home: str, server_name: str, cfg: dict, reco
 
                         reconnect_mcp_server(server_name)
                 except Exception:
+                    manager.evict(server_name, hermes_home=hermes_home)
                     storage.restore(backup, only_if_absent=True)
-                    manager.restore_entry(server_name, previous_entry, hermes_home=hermes_home)
                     raise
         finally:
             reset_secret_scope(secret_token)

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -2254,9 +2254,9 @@ def _(rid, params: dict) -> dict:
     if err:
         return err
     try:
-        from hermes_cli.mcp_config import _remove_mcp_server
+        from hermes_cli.mcp_config import _remove_mcp_server_with_oauth
 
-        removed = _remove_mcp_server(name)
+        removed = _remove_mcp_server_with_oauth(name)
         if not removed:
             return _err(rid, 4064, f"server '{name}' not found")
         return _ok(rid, {"ok": True, "removed": True})

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -337,6 +337,33 @@ Behavior:
 - Token refresh is automatic; re-authorization only happens when refresh fails
 - Only applies to HTTP/StreamableHTTP transport (`url`-based servers)
 
+### Root-owned token pools for named profiles
+
+OAuth state is profile-local by default. The root profile can explicitly share
+one server's OAuth grant with named profiles:
+
+```yaml
+mcp_servers:
+  protected_api:
+    url: "https://mcp.example.com/mcp"
+    auth: oauth
+    oauth:
+      share_with_profiles: true
+```
+
+`share_with_profiles` is honored only from the root config. A named profile
+uses the root token pool only when it also defines the same server name,
+literal URL, `auth: oauth`, transport, and OAuth client settings. Mismatches or
+dynamic `${...}` references keep that profile isolated and produce a warning.
+No other root settings are inherited.
+
+Shared grants are one credential lifecycle: login, refresh, and removal from
+any participating profile affect every participant. Use this only for profiles
+inside the same trust boundary. Hermes serializes shared-pool updates across
+threads and local processes; removal revokes older provider instances so an
+in-flight refresh cannot recreate deleted credentials. A failed reauthorization
+restores the previous state only when no newer authorization has succeeded.
+
 ### Client identification: CIMD and DCR
 
 Hermes identifies itself to authorization servers with a **Client ID Metadata Document** (CIMD), the mechanism the MCP `2026-07-28` spec adopted in place of Dynamic Client Registration. The document is published at

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -264,6 +264,35 @@ mcp_servers:
 
 On first connect, Hermes prints an authorize URL, opens your browser when possible, and waits for the OAuth callback on a local loopback port. Tokens are cached at `~/.hermes/mcp-tokens/<server>.json` with 0o600 perms; subsequent runs reuse them silently until refresh fails.
 
+#### Share one OAuth grant with named profiles (opt-in)
+
+Named profiles keep separate MCP OAuth grants by default. To let profiles use
+one root-owned grant for a specific server, export that server's token pool in
+the **root** `~/.hermes/config.yaml`:
+
+```yaml
+mcp_servers:
+  atlassian:
+    url: "https://mcp.atlassian.com/v1/mcp/authv2"
+    auth: oauth
+    oauth:
+      share_with_profiles: true
+```
+
+Each consuming profile must still configure the same server name, literal URL,
+`auth: oauth`, transport, and OAuth client settings. Hermes shares only the
+OAuth files for that exact matching server; it does not inherit any other root
+config. Mismatches and dynamic `${...}` references stay profile-local and emit
+a warning.
+
+The root profile owns the shared grant. Re-authenticating or removing that MCP
+from any participating profile updates the same root token pool for every
+participant. Enable this only for profiles in the same operator and trust
+boundary. Shared-pool writes are serialized across local processes, and removal
+revokes older provider instances so a concurrent refresh cannot resurrect the
+deleted grant. If reauthorization fails, Hermes restores the prior grant only
+when no newer authorization has already succeeded.
+
 **Remote / headless hosts.** When Hermes runs on a different machine than your browser, the loopback callback can't reach your laptop. Two ways to complete the flow:
 
 - **Paste-back (no setup):** on an interactive terminal Hermes prints "Or paste the redirect URL here…" alongside the authorize URL. Open the URL in your browser, approve, copy the full URL the browser ends up on (the redirect will show a connection error — that's expected), paste it at the prompt. Bare `?code=…&state=…` query strings work too.


### PR DESCRIPTION
## Summary

- add opt-in root-owned MCP OAuth pools for trusted named profiles
- preserve profile-local isolation by default and require exact server/OAuth identity matching
- govern token lifecycle across CLI, desktop/TUI, dashboard, and web configuration surfaces
- add cross-process locking, generation revocation, persistent removal tombstones, atomic rollback, and collision-resistant state paths

## Security model

- profiles never inherit arbitrary root MCP configuration
- dynamic `${...}` endpoint, transport, or OAuth identity references fail closed
- endpoint/client changes revoke incompatible persisted credentials
- stale providers and processes cannot rewrite or restore permanently removed grants
- shared-pool removal and tombstone creation occur under one pool lock
- sensitive files and backups use atomic owner-only writes

## Verification

- `scripts/run_tests.sh tests/tools/test_mcp_oauth.py tests/tools/test_mcp_oauth_manager.py tests/tools/test_mcp_oauth_integration.py tests/tools/test_mcp_oauth_metadata.py tests/tools/test_mcp_cimd.py tests/tools/test_mcp_dashboard_oauth.py tests/hermes_cli/test_mcp_dashboard_oauth.py tests/hermes_cli/test_mcp_config.py tests/tui_gateway/test_mcp_profile_rpcs.py -q`
  - 208 passed, 0 failed, 1 skipped
- Ruff: passed
- `git diff --check`: passed
- Gitleaks on diff: no leaks
- independent fail-closed review: passed

The repository-wide suite currently has unrelated failures in optional/lazy integration areas such as Daytona, media generation, CUA, and voice. No affected MCP test failed.

## Tracking

DX-2480
