### PR TITLE
fix(desktop): bound the profile-activation half of a Bot Chat wake

### DIFF
--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -312,6 +312,56 @@ function waitForFocusedSessionHydration({
   })
 }
 
+// Wait for a profile switch, but never longer than the wake budget.
+//
+// ensureGatewayProfile awaits the store's dial, and HermesGateway.connect() has
+// no dial timeout of its own: a backend that accepts the socket and then never
+// completes the handshake leaves this promise pending for the life of the
+// window. That is not merely a slow open. waitForFocusedSessionHydration arms
+// the only timer on this path, and it is armed AFTER this await returns - so an
+// unbounded activation means the wake never settles at all, and the pane wedges
+// with no error, no Retry and no timeout (#89556: `ws accepted` in the gateway
+// log with no matching `ws closed`).
+//
+// The activation gets its OWN budget rather than sharing the hydration one. A
+// cold profile backend can legitimately spend most of the hydration budget
+// painting a large transcript - that race is already tight enough to lose
+// (#89617) - so charging activation to the same clock would turn a wedge into a
+// regression. The trade is that a wake that is slow in BOTH phases can now take
+// up to twice the budget before it surfaces; that is a maintainer call and is
+// called out in the PR rather than buried here.
+async function awaitProfileActivation(profile: string, targetProfile: string, timeoutMs: number): Promise<void> {
+  const activation = ensureGatewayProfile(profile)
+  let timer: number | undefined
+
+  try {
+    await Promise.race([
+      activation,
+      new Promise<never>((_resolve, reject) => {
+        // Same message shape as the hydration timeout on purpose: openSession's
+        // catch keys the core stranded-session surface off this prefix, and a
+        // wedged dial wants exactly that surface. The phase is distinguished in
+        // the [bot-wake] support log, not in the user-facing string.
+        timer = window.setTimeout(
+          () => reject(new Error(`Timed out loading ${targetProfile}'s session history.`)),
+          timeoutMs
+        )
+      })
+    ])
+  } finally {
+    if (timer !== undefined) {
+      window.clearTimeout(timer)
+    }
+  }
+
+  // No extra catch on the abandoned dial: an in-flight activation has no
+  // cancellation handle and keeps running after the budget expires, but
+  // Promise.race subscribes to every input, so a rejection that lands after the
+  // race has settled is already handled and cannot escape as an unhandled
+  // rejection. An explicit `activation.catch()` here was dead code - verified
+  // by mutation: removing it changed no test outcome.
+}
+
 export const host = {
   state: {
     /** Runtime id of the active chat session (null on a fresh draft). */
@@ -507,40 +557,53 @@ export const host = {
     // instead of leaving us to infer it from process spawn timestamps.
     const wakeStartedAt = Date.now()
     let profileActiveAt = wakeStartedAt
-
-    if (profile && profile !== $activeGatewayProfile.get()) {
-      await ensureGatewayProfile(profile)
-      profileActiveAt = Date.now()
-
-      if (options.keepAllProfilesScope !== false) {
-        setShowAllProfiles(true)
-      }
-    }
-
-    if (generation !== openSessionGeneration) {
-      throw new Error('Session open was superseded by a newer selection.')
-    }
-
-    if (options.awaitHydration) {
-      // Keep the target-specific overlay visible through transcript hydration,
-      // not merely through the gateway/profile activation that precedes it.
-      $gatewaySwapTarget.set(targetProfile)
-    }
+    const hydrationTimeoutMs = Math.max(1, options.hydrationTimeoutMs ?? DEFAULT_SESSION_HYDRATION_TIMEOUT_MS)
+    // Which half of the wake a timeout landed in. Only meaningful on the
+    // failure path, where the two phases have different remedies: a stuck dial
+    // is a gateway problem, a slow transcript is a backend-warmup one.
+    let wakePhase: 'activation' | 'hydration' = 'activation'
 
     try {
-      openSession(
-        storedSessionId,
-        (to: string, opts?: { replace?: boolean }) => {
-          const target = to.startsWith('#') ? to : `#${to}`
+      if (profile && profile !== $activeGatewayProfile.get()) {
+        // Bounded only on the hydration contract, which is where a budget and a
+        // Retry surface both already exist. A plain open never asked for a
+        // deadline and has nowhere to render one, so it keeps today's
+        // behaviour rather than gaining a rejection its callers cannot handle.
+        await (options.awaitHydration
+          ? awaitProfileActivation(profile, targetProfile, hydrationTimeoutMs)
+          : ensureGatewayProfile(profile))
+        profileActiveAt = Date.now()
 
-          if (opts?.replace) {
-            window.location.replace(target)
-          } else {
-            window.location.hash = target
-          }
-        },
-        options.intent ?? 'in-place'
-      )
+        if (options.keepAllProfilesScope !== false) {
+          setShowAllProfiles(true)
+        }
+      }
+
+      wakePhase = 'hydration'
+
+      if (generation !== openSessionGeneration) {
+        throw new Error('Session open was superseded by a newer selection.')
+      }
+
+      if (options.awaitHydration) {
+        // Keep the target-specific overlay visible through transcript hydration,
+        // not merely through the gateway/profile activation that precedes it.
+        $gatewaySwapTarget.set(targetProfile)
+      }
+
+      openSession(
+          storedSessionId,
+          (to: string, opts?: { replace?: boolean }) => {
+            const target = to.startsWith('#') ? to : `#${to}`
+
+            if (opts?.replace) {
+              window.location.replace(target)
+            } else {
+              window.location.hash = target
+            }
+          },
+          options.intent ?? 'in-place'
+        )
 
       // Judge the main surface AFTER the open: on a cold start the persisted
       // route can already point at this session while selection has not
@@ -567,7 +630,7 @@ export const host = {
           generation,
           profile: targetProfile,
           storedSessionId,
-          timeoutMs: Math.max(1, options.hydrationTimeoutMs ?? DEFAULT_SESSION_HYDRATION_TIMEOUT_MS)
+          timeoutMs: hydrationTimeoutMs
         })
       }
     } catch (error) {
@@ -577,10 +640,13 @@ export const host = {
         error instanceof Error &&
         error.message.startsWith('Timed out loading ')
       ) {
+        const timedOutAt = Date.now()
+
         console.warn('[bot-wake] hydration timed out', {
-          hydrationWaitMs: Date.now() - profileActiveAt,
+          hydrationWaitMs: wakePhase === 'hydration' ? timedOutAt - profileActiveAt : 0,
+          phase: wakePhase,
           profile: targetProfile,
-          profileActivationMs: profileActiveAt - wakeStartedAt,
+          profileActivationMs: (wakePhase === 'activation' ? timedOutAt : profileActiveAt) - wakeStartedAt,
           runtimeBound: Boolean($activeSessionId.get()),
           selectionSettled: $selectedStoredSessionId.get() === storedSessionId,
           storedSessionId,

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -307,8 +307,12 @@ describe('profile-aware plugin session opens', () => {
         resolved = true
       })
 
-    await Promise.resolve()
-    await Promise.resolve()
+    // Flush a macrotask rather than counting microtask ticks: the profile
+    // activation is now a bounded race, so the number of awaits between the
+    // call and the core open is an implementation detail, and `resolved`
+    // staying false through a full turn of the event loop is the stronger
+    // assertion anyway.
+    await new Promise(resolve => setTimeout(resolve, 0))
 
     expect(openSessionCore).toHaveBeenCalledWith('bot-chat', expect.any(Function), 'in-place')
     expect(resolved).toBe(false)
@@ -356,8 +360,7 @@ describe('profile-aware plugin session opens', () => {
       hydrationTimeoutMs: 1_000
     })
 
-    await Promise.resolve()
-    await Promise.resolve()
+    await new Promise(resolve => setTimeout(resolve, 0))
 
     // The old pre-open "already selected" precondition skipped this request,
     // stranding the pane blank until timeout. It must fire now.
@@ -503,5 +506,168 @@ describe('profile-aware plugin session opens', () => {
     expect($activeGatewayProfile.get()).toBe('hyoseob')
     expect($selectedStoredSessionId.get()).toBe('chat-b')
     expect($gatewaySwapTarget.get()).toBeNull()
+  })
+
+
+  it('surfaces a wedged profile activation instead of waiting on it forever (#89556)', async () => {
+    // The dial the store is waiting on never settles - a backend that accepts
+    // the socket and then never completes the handshake. Before this was
+    // bounded, openSession's await sat here for the life of the window and the
+    // hydration timer, which is armed downstream, never got a chance to fire:
+    // the pane wedged with no error and no Retry rather than timing out.
+    vi.mocked(ensureGatewayProfile).mockImplementationOnce(() => new Promise<void>(() => undefined))
+
+    setMockAtom($selectedStoredSessionId, 'wedged-chat')
+    setMockAtom($activeSessionId, 'runtime-wedged')
+    setMockAtom($messages, [{ id: 'history-1', parts: [], role: 'user' }] as never)
+
+    await expect(
+      host.openSession('wedged-chat', {
+        profile: 'medicina',
+        intent: 'main',
+        awaitHydration: true,
+        expectHistory: true,
+        hydrationTimeoutMs: 60
+      })
+    ).rejects.toThrow("Timed out loading medicina's session history.")
+
+    // The stranded-session surface is the point: a bounded failure the user can
+    // retry, not a frozen pane.
+    expect(setResumeExhaustedSessionId).toHaveBeenCalledWith('wedged-chat')
+    expect($gatewaySwapTarget.get()).toBeNull()
+  })
+
+  it('names the phase in the wake log so a stuck dial is not read as a slow transcript', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    vi.mocked(ensureGatewayProfile).mockImplementationOnce(() => new Promise<void>(() => undefined))
+
+    await expect(
+      host.openSession('wedged-chat', {
+        profile: 'medicina',
+        intent: 'main',
+        awaitHydration: true,
+        expectHistory: true,
+        hydrationTimeoutMs: 60
+      })
+    ).rejects.toThrow('Timed out loading ')
+
+    expect(warn).toHaveBeenCalledWith('[bot-wake] hydration timed out', expect.objectContaining({ phase: 'activation' }))
+
+    const payload = warn.mock.calls.at(-1)?.[1] as { hydrationWaitMs: number; profileActivationMs: number }
+
+    // The whole budget went to activation. Reporting it as hydration wait time
+    // would send a support bundle reader looking at transcript size.
+    expect(payload.profileActivationMs).toBeGreaterThan(0)
+    expect(payload.hydrationWaitMs).toBe(0)
+
+    warn.mockRestore()
+  })
+
+  it('gives hydration its own full budget after a slow but successful activation', async () => {
+    // Guards the choice of a SEPARATE budget per phase over one shared clock.
+    // A cold profile backend can legitimately spend most of the budget getting
+    // its socket up; if hydration then inherited what was left, this wake would
+    // fail even though the transcript painted well inside the documented
+    // 20s-equivalent window.
+    vi.mocked(ensureGatewayProfile).mockImplementationOnce(
+      async (target: null | string | undefined) =>
+        new Promise<void>(resolve => {
+          setTimeout(() => {
+            $activeGatewayProfile.set(target || 'default')
+            resolve()
+          }, 150)
+        })
+    )
+
+    const opening = host.openSession('slow-dial-chat', {
+      profile: 'medicina',
+      intent: 'main',
+      awaitHydration: true,
+      expectHistory: true,
+      hydrationTimeoutMs: 200
+    })
+
+    // 300ms total is past a single shared 200ms budget and inside hydration's
+    // own one, which only starts once the profile is actually active.
+    await new Promise(resolve => setTimeout(resolve, 300))
+    setMockAtom($selectedStoredSessionId, 'slow-dial-chat')
+    setMockAtom($activeSessionId, 'runtime-medicina')
+    setMockAtom($messages, [{ id: 'history-1', parts: [], role: 'user' }] as never)
+
+    await expect(opening).resolves.toBeUndefined()
+    expect(setResumeExhaustedSessionId).not.toHaveBeenCalled()
+  })
+
+  it('absorbs an activation that rejects after its budget has already expired', async () => {
+    // The abandoned race loser keeps running - there is no cancellation handle
+    // for an in-flight dial - so a late rejection must not escape as an
+    // unhandled promise rejection long after the caller gave up.
+    // Node's process-level hook, not window's: under jsdom a rejection that
+    // escapes lands on the runner's process, which is where vitest turns it
+    // into an "Unhandled Rejection" run failure.
+    const unhandled: unknown[] = []
+
+    const onUnhandled = (reason: unknown) => {
+      unhandled.push(reason)
+    }
+
+    const existing = process.listeners('unhandledRejection')
+
+    for (const listener of existing) {
+      process.off('unhandledRejection', listener)
+    }
+
+    process.on('unhandledRejection', onUnhandled)
+
+    vi.mocked(ensureGatewayProfile).mockImplementationOnce(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          setTimeout(() => reject(new Error('dial failed after the caller gave up')), 120)
+        })
+    )
+
+    await expect(
+      host.openSession('late-failure-chat', {
+        profile: 'medicina',
+        intent: 'main',
+        awaitHydration: true,
+        expectHistory: true,
+        hydrationTimeoutMs: 40
+      })
+    ).rejects.toThrow('Timed out loading ')
+
+    await new Promise(resolve => setTimeout(resolve, 200))
+    process.off('unhandledRejection', onUnhandled)
+
+    for (const listener of existing) {
+      process.on('unhandledRejection', listener)
+    }
+
+    expect(unhandled).toEqual([])
+  })
+
+  it('leaves a plain open unbounded, because it has no budget and no Retry surface', async () => {
+    // Deliberate scope line, not an oversight: the activation deadline rides on
+    // the same contract as the hydration one. A caller that never passed
+    // awaitHydration gets exactly the behaviour it had before, since a
+    // rejection here would surface to code with nowhere to render it.
+    vi.mocked(ensureGatewayProfile).mockImplementationOnce(() => new Promise<void>(() => undefined))
+
+    let settled = 'pending'
+
+    void host.openSession('plain-chat', { profile: 'medicina', intent: 'main', hydrationTimeoutMs: 40 }).then(
+      () => {
+        settled = 'resolved'
+      },
+      () => {
+        settled = 'rejected'
+      }
+    )
+
+    await new Promise(resolve => setTimeout(resolve, 200))
+
+    expect(settled).toBe('pending')
+    expect(setResumeExhaustedSessionId).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## What does this PR do?

`host.openSession` awaited the profile switch with no deadline:

```ts
if (profile && profile !== $activeGatewayProfile.get()) {
  await ensureGatewayProfile(profile)   // unbounded
  ...
}
...
await waitForFocusedSessionHydration({ ..., timeoutMs })  // the only timer on this path
```

`HermesGateway.connect()` has no dial timeout of its own, so a backend that accepts the socket and then never completes the handshake leaves that first `await` pending for the life of the window. The hydration timer would have caught it, but it is armed **downstream** of the await it needed to protect - so the open does not fail slowly, it never settles at all. The user gets a frozen pane with no error, no Retry, and no timeout.

That last part is the reason #89556 was hard to place. The reporter noticed it directly: "it never settles at all, so it does not even reach the 20s hydration timeout", with a gateway log showing `ws accepted` and no matching `ws closed`. A bug that hangs *past its own timeout* looks like a different class of bug than one that times out, and it is - the timer was never armed.

This bounds the activation phase with its own copy of the wake budget, so a wedged dial ends in the existing stranded-session Retry surface instead of an indefinite freeze.

## Related Issue

Refs #89556

Deliberately `Refs` and not `Fixes`. The reporter later posted a *second*, unrelated root cause on that thread (a multiplex gateway bug in `_make_default_profile_message_handler` capturing `get_hermes_home()` at handler-construction time) and suggested splitting the issue. Auto-closing #89556 would take that finding down with it. Happy to switch to `Fixes` the moment a maintainer splits the thread.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/sdk/index.ts`
  - New `awaitProfileActivation(profile, targetProfile, timeoutMs)`: races `ensureGatewayProfile` against a timer and clears the timer on either outcome.
  - `host.openSession` now routes the activation through it **when the caller passed `awaitHydration`**, and the whole wake (activation + navigation + hydration) sits inside the one `try` so a timeout in either phase reaches the existing `catch`.
  - The `[bot-wake]` support log gains `phase: 'activation' | 'hydration'`, and `profileActivationMs` / `hydrationWaitMs` are now attributed to the phase that actually expired instead of being computed from a `profileActiveAt` that never moved.
- `apps/desktop/src/sdk/profile-routing.test.ts` - 5 new tests, plus a tick-counting fix to two existing ones (see below).

### Three decisions worth a maintainer's eye

**1. A separate budget per phase, not one shared clock.** The activation gets its own copy of `hydrationTimeoutMs` rather than spending from it. Folding them into one budget would mean a cold profile backend that spends most of the budget getting its socket up leaves hydration almost nothing - and that race is already tight enough to lose (#89617 exists because of it). The cost is real and I would rather state it than bury it: **a wake that is slow in both phases can now take up to 2x the budget before it surfaces.** If you would rather have one 20s ceiling end to end, say so and I will make it one clock; the test `gives hydration its own full budget after a slow but successful activation` is the one that pins this choice and would be the one to change.

**2. Scoped to `awaitHydration` callers.** A plain `host.openSession(id)` still awaits the activation unbounded. It never asked for a deadline and has nowhere to render one - the stranded-session overlay is armed only on the hydration contract - so a rejection would surface to code that cannot handle it. `leaves a plain open unbounded, because it has no budget and no Retry surface` pins that as a decision rather than an oversight. Bounding every open instead is a one-line change if you prefer it.

**3. The timeout reuses the hydration message string.** `Timed out loading <profile>'s session history.` is what `openSession`'s catch matches on to arm `setResumeExhaustedSessionId`, and a wedged dial wants exactly that surface. So the user-facing string is identical in both phases and the distinction lives in the `[bot-wake]` log instead. If you would rather the two read differently to the user, the catch's prefix match has to widen with it.

## How to Test

1. `cd apps/desktop && npx vitest run --project ui src/sdk/` - 32 passed.
2. `npx tsc --noEmit -p tsconfig.json` - clean.
3. `npx eslint src/sdk/index.ts src/sdk/profile-routing.test.ts` - clean.
4. To see the old behaviour: revert `awaitProfileActivation` to a bare `await ensureGatewayProfile(profile)` and re-run. `surfaces a wedged profile activation instead of waiting on it forever (#89556)` does not fail fast - it sits until vitest's own 15s test timeout kills it, which is the bug reproduced in miniature.

## Verification

**Reproduction first.** Before writing the fix I probed the mechanism the issue proposed, because it did not survive reading: the report attributes the hang to `waitForFocusedSessionHydration` never re-firing `check()` when the requested session is the already-focused one. That function calls `check()` synchronously at the end of its constructor, so in exactly that state it resolves on the first call. I wrote a throwaway test for the already-focused case and it **resolved immediately** - the proposed guard would have been a no-op. A second probe, stubbing `ensureGatewayProfile` with a never-settling promise, stayed pending 800ms against a 250ms budget. That is the hang, and it is one `await` earlier than the report placed it. I mention it because a fix for the stated cause would have shipped, passed review, and changed nothing.

**Mutation proof** - 6 mutations, 6 caught, on `npx vitest run --project ui src/sdk/profile-routing.test.ts`:

| # | Mutation | Caught by |
|---|---|---|
| 1 | `await ensureGatewayProfile(profile)` (no bound at all) | wedged-activation, phase-log, late-rejection (all hang to the 15s test timeout) |
| 2 | hydration inherits `budget - activationElapsed` (one shared clock) | `gives hydration its own full budget` |
| 3 | `phase` hard-coded to `'hydration'` | `names the phase in the wake log` |
| 4 | activation elapsed reported as `hydrationWaitMs` | `names the phase in the wake log` |
| 5 | activation timeout message loses the `Timed out loading ` prefix | wedged-activation, phase-log, late-rejection |
| 6 | bound applied to every open, not just `awaitHydration` ones | `leaves a plain open unbounded` |

**One mutation I removed rather than kept.** I originally added `void activation.catch(() => undefined)` in the helper's `finally`, reasoning that the abandoned race loser could reject later as an unhandled rejection. Mutating it out changed no test outcome, in either the `window` or the `process` unhandled-rejection harness. It was dead code: `Promise.race` subscribes to every input, so a rejection landing after the race settles is already handled. It is out of the diff, with a comment saying why. The test that was supposed to cover it stays as a guard on that property, and I want to be explicit that it is **a guard, not a sensitivity-proven regression test** - nothing I can mutate today makes it fail.

**Suite delta.** `npx vitest run --project ui` (all 534 files):

| | Tests | Failed |
|---|---|---|
| clean `upstream/main` | 5011 | 12 |
| with this change | 5015 | 14 |

`+4` total is this PR's tests before the 5th was added. The two extra failures are not mine: both (`loads the machine-level connection config` in `src/app/messaging/index.test.tsx`, `hides the setup-guide button for a plugin platform with no docs URL` in `src/app/settings/gateway-settings.test.tsx`) are 17-second timeouts under full-suite load, and **both pass when their files are run on their own with this change applied**. The 12 baseline failures (`src/app/skills/index.test.tsx`, `src/store/session-unread-tile.test.ts`) are load-dependent timeouts present on a pristine checkout of the same commit and untouched by this PR.

**Platform:** Windows 11, Node 24.18, local gateway. The change is platform-neutral - `window.setTimeout` / `clearTimeout` only, no path or process handling.

## Overlap with #89638

#89638 also edits `apps/desktop/src/sdk/index.ts` and restructures the same `try` block, so these two will need a textual merge. They do not overlap in behaviour, and the difference matters for #89556:

- **#89638 retries a hydration timeout that fired.** It wraps the open in a bounded 2-attempt loop for callers that pass `retryHydrationTimeoutOnce`.
- **This PR arms a timer for the phase where none ever fires.** A wedged activation produces no timeout to retry, so #89638's loop is never entered - the hang happens before it. Conversely this PR does nothing for #89617's cold-backend transcript race, which is entirely #89638's case.

If both land, note that the worst-case wake becomes `2 x activation + 2 x hydration` rather than one budget. I am happy to rebase onto #89638 in whichever order you merge them, or to fold the two into a single budget model if you would rather have one number to reason about.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate - the overlap with #89638 is described above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits) - one commit, two files
- [ ] I've run `pytest tests/ -q` and all tests pass - **N/A, and stated rather than checked**: this PR touches no Python. The desktop equivalents are in How to Test above.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A - N/A; the reasoning lives next to the code it constrains, including the budget trade-off
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A - N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A - timer APIs only, no platform-specific behaviour
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A - `PluginOpenSessionOptions` gains no new option; the existing `hydrationTimeoutMs` now governs one more phase, which is documented at both use sites

## Screenshots / Logs

The `[bot-wake]` line a support bundle now carries when the dial is the problem rather than the transcript:

```
[bot-wake] hydration timed out {
  phase: 'activation',
  profile: 'medicina',
  profileActivationMs: 20003,
  hydrationWaitMs: 0,
  runtimeBound: true,
  selectionSettled: true,
  transcriptPainted: true,
  storedSessionId: '...'
}
```

`runtimeBound` / `selectionSettled` / `transcriptPainted` all true while the wake fails is the signature: the surface was fine, the socket never came up. Before this change that combination produced no log line at all, because nothing ever rejected.
