### PR TITLE
feat: opt-in multi-bubble replies split on blank lines (telegram/whatsapp/photon)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -9,6 +9,7 @@ import asyncio
 import inspect
 import ipaddress
 import logging
+import math
 import os
 import random
 import re
@@ -7184,7 +7185,136 @@ class BasePlatformAdapter(ABC):
         Default implementation returns content as-is.
         """
         return content
-    
+
+    # ------------------------------------------------------------------
+    # Shared ``config.extra`` coercion + opt-in conversational splitting.
+    #
+    # The ``split_outgoing_*`` keys are a channel-agnostic opt-in shared by
+    # the Telegram, WhatsApp, and Photon adapters: blank-line-separated
+    # paragraphs in a reply are delivered as separate platform messages
+    # ("bubbles") instead of one long message.
+
+    def _coerce_bool_extra(self, key: str, default: bool = False) -> bool:
+        """Read a bool from ``config.extra``, accepting common string spellings."""
+        value = self.config.extra.get(key) if getattr(self.config, "extra", None) else None
+        if value is None:
+            return default
+        if isinstance(value, str):
+            lowered = value.strip().lower()
+            if lowered in {"true", "1", "yes", "on"}:
+                return True
+            if lowered in {"false", "0", "no", "off"}:
+                return False
+            return default
+        return bool(value)
+
+    def _coerce_float_extra(
+        self,
+        key: str,
+        default: float,
+        *,
+        min_value: Optional[float] = None,
+        max_value: Optional[float] = None,
+    ) -> float:
+        """Read a float from ``config.extra``, guarding against bad values.
+
+        The result is typically fed to ``asyncio.sleep()``, so NaN/Inf and
+        unparseable values fall back to ``default``. With an explicit
+        ``min_value``/``max_value`` the parsed value is clamped into range;
+        without an explicit floor, negative values fall back to ``default``.
+        """
+        value = self.config.extra.get(key) if getattr(self.config, "extra", None) else None
+        if value is None:
+            return float(default)
+        try:
+            parsed = float(value)
+        except (TypeError, ValueError):
+            return float(default)
+        if not math.isfinite(parsed):
+            return float(default)
+        if min_value is None and parsed < 0:
+            return float(default)
+        if min_value is not None:
+            parsed = max(parsed, min_value)
+        if max_value is not None:
+            parsed = min(parsed, max_value)
+        return parsed
+
+    def _init_conversational_split_config(self) -> None:
+        """Read the shared opt-in ``split_outgoing_*`` extra keys.
+
+        Adapters that support conversational multi-bubble replies call this
+        from ``__init__`` and route their outbound text through
+        ``_outgoing_message_parts()`` in ``send()``. Same keys and defaults
+        on every platform:
+
+        - ``split_outgoing_on_blank_lines`` (default ``False``)
+        - ``split_outgoing_delay_seconds`` (default ``0.6``)
+        - ``split_outgoing_max_parts`` (default ``4``)
+        """
+        self._split_outgoing_on_blank_lines: bool = self._coerce_bool_extra(
+            "split_outgoing_on_blank_lines", False
+        )
+        self._split_outgoing_delay_seconds: float = self._coerce_float_extra(
+            "split_outgoing_delay_seconds", 0.6, min_value=0.0
+        )
+        extra = getattr(self.config, "extra", None) or {}
+        try:
+            self._split_outgoing_max_parts = int(
+                extra.get("split_outgoing_max_parts", 4)
+            )
+        except (TypeError, ValueError):
+            self._split_outgoing_max_parts = 4
+        if self._split_outgoing_max_parts < 1:
+            self._split_outgoing_max_parts = 4
+
+    def _outgoing_message_parts(self, formatted: str) -> List[str]:
+        """Split on blank lines outside triple-backtick fenced code blocks.
+
+        Returns ``[formatted]`` unchanged unless the adapter opted into
+        ``split_outgoing_on_blank_lines`` (see
+        ``_init_conversational_split_config``). Reads the split attributes
+        via ``getattr`` because tests build adapters via ``__new__`` without
+        running ``__init__``.
+        """
+        if not getattr(self, "_split_outgoing_on_blank_lines", False):
+            return [formatted]
+
+        parts: List[str] = []
+        current: List[str] = []
+        in_fence = False
+
+        for line in formatted.split("\n"):
+            stripped = line.lstrip()
+            indent = len(line) - len(stripped)
+
+            if indent <= 3 and re.match(r"```(?!`)", stripped):
+                if in_fence:
+                    if re.fullmatch(r"[ \t]{0,3}```[ \t]*", line):
+                        in_fence = False
+                else:
+                    in_fence = True
+
+            if not line.strip() and not in_fence:
+                part = "\n".join(current).strip()
+                if part:
+                    parts.append(part)
+                current = []
+                continue
+
+            current.append(line)
+
+        final_part = "\n".join(current).strip()
+        if final_part:
+            parts.append(final_part)
+        if len(parts) <= 1:
+            return [formatted]
+
+        max_parts = getattr(self, "_split_outgoing_max_parts", 4)
+        if max_parts > 0 and len(parts) > max_parts:
+            return parts[: max_parts - 1] + ["\n\n".join(parts[max_parts - 1 :])]
+        return parts
+
     @staticmethod
     def truncate_message(
         content: str,

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1266,25 +1266,6 @@ class WeixinAdapter(BasePlatformAdapter):
                 self._token = str(persisted.get("token") or "").strip()
                 self._base_url = str(persisted.get("base_url") or self._base_url).strip().rstrip("/")
 
-    def _coerce_float_extra(self, key: str, default: float) -> float:
-        """Read a float from ``config.extra``, guarding against bad/non-finite values.
-
-        The result is fed directly to ``asyncio.sleep()``, so NaN/Inf and
-        unparseable values fall back to ``default``.
-        """
-        import math
-
-        value = self.config.extra.get(key) if getattr(self.config, "extra", None) else None
-        if value is None:
-            return float(default)
-        try:
-            parsed = float(value)
-        except (TypeError, ValueError):
-            return float(default)
-        if not math.isfinite(parsed) or parsed < 0:
-            return float(default)
-        return parsed
-
     @staticmethod
     def _coerce_list(value: Any) -> List[str]:
         if value is None:

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -801,6 +801,11 @@ class PhotonAdapter(BasePlatformAdapter):
         # markdown() builder renders them (or degrades them readably).
         self.supports_code_blocks = _markdown_enabled()
 
+        # Opt-in conversational splitting: deliver blank-line-separated
+        # paragraphs as separate iMessage/Photon bubbles instead of one long
+        # message. Shared split_outgoing_* extra keys (see BasePlatformAdapter).
+        self._init_conversational_split_config()
+
         # Runtime state
         self._sidecar_proc: Optional[subprocess.Popen] = None
         self._sidecar_supervisor_task: Optional[asyncio.Task] = None
@@ -1992,7 +1997,34 @@ class PhotonAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        return await self._sidecar_send(chat_id, self.format_message(content))
+        # Opt-in conversational splitting (shared split_outgoing_* keys):
+        # blank-line-separated paragraphs become separate bubbles. With the
+        # opt-in off (default) parts == [formatted] and this is exactly one
+        # _sidecar_send call, as before. Each part is still individually
+        # truncated by _sidecar_send's MAX_MESSAGE_LENGTH guard.
+        parts = self._outgoing_message_parts(self.format_message(content))
+        if len(parts) == 1:
+            return await self._sidecar_send(chat_id, parts[0])
+
+        message_ids: List[str] = []
+        for i, part in enumerate(parts):
+            result = await self._sidecar_send(chat_id, part)
+            if not result.success:
+                # Surface the failing part's result unchanged (error class /
+                # retryability); earlier bubbles were already delivered —
+                # same mid-sequence contract as Telegram's chunked send.
+                return result
+            if result.message_id:
+                message_ids.append(str(result.message_id))
+            if i < len(parts) - 1:
+                await asyncio.sleep(
+                    getattr(self, "_split_outgoing_delay_seconds", 0.6)
+                )
+        return SendResult(
+            success=True,
+            message_id=message_ids[0] if message_ids else None,
+            raw_response={"message_ids": message_ids},
+        )
 
     # -- Clarify (native iMessage poll) ------------------------------------
     #

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -752,22 +752,8 @@ class TelegramAdapter(BasePlatformAdapter):
         self._rich_drafts_enabled: bool = self._coerce_bool_extra("rich_drafts", False)
         # Opt-in conversational splitting (#4445): deliver blank-line-separated
         # paragraphs as separate Telegram bubbles instead of one long message.
-        # Mirrors the WhatsApp adapter's split_outgoing_* extra keys.
-        self._split_outgoing_on_blank_lines: bool = self._coerce_bool_extra(
-            "split_outgoing_on_blank_lines", False
-        )
-        self._split_outgoing_delay_seconds: float = self._coerce_float_extra(
-            "split_outgoing_delay_seconds", 0.6, min_value=0.0
-        )
-        _split_extra = getattr(config, "extra", None) or {}
-        try:
-            self._split_outgoing_max_parts = int(
-                _split_extra.get("split_outgoing_max_parts", 4)
-            )
-        except (TypeError, ValueError):
-            self._split_outgoing_max_parts = 4
-        if self._split_outgoing_max_parts < 1:
-            self._split_outgoing_max_parts = 4
+        # Shared split_outgoing_* extra keys (see BasePlatformAdapter).
+        self._init_conversational_split_config()
         # Latched off after a capability failure on sendRichMessage /
         # sendRichMessageDraft (e.g. older python-telegram-bot without the
         # endpoint) so later sends skip the doomed rich attempt entirely.
@@ -1904,40 +1890,6 @@ class TelegramAdapter(BasePlatformAdapter):
             if context is not None:
                 stack.append(context)
         return False
-
-    def _coerce_bool_extra(self, key: str, default: bool = False) -> bool:
-        value = self.config.extra.get(key) if getattr(self.config, "extra", None) else None
-        if value is None:
-            return default
-        if isinstance(value, str):
-            lowered = value.strip().lower()
-            if lowered in {"true", "1", "yes", "on"}:
-                return True
-            if lowered in {"false", "0", "no", "off"}:
-                return False
-            return default
-        return bool(value)
-
-    def _coerce_float_extra(
-        self,
-        key: str,
-        default: float,
-        *,
-        min_value: Optional[float] = None,
-        max_value: Optional[float] = None,
-    ) -> float:
-        value = self.config.extra.get(key) if getattr(self.config, "extra", None) else None
-        if value is None:
-            return default
-        try:
-            parsed = float(value)
-        except (TypeError, ValueError):
-            return default
-        if min_value is not None:
-            parsed = max(parsed, min_value)
-        if max_value is not None:
-            parsed = min(parsed, max_value)
-        return parsed
 
     def _link_preview_kwargs(self) -> Dict[str, Any]:
         if not getattr(self, "_disable_link_previews", False):
@@ -5134,46 +5086,6 @@ class TelegramAdapter(BasePlatformAdapter):
             return True
         else:  # "first" (default)
             return chunk_index == 0
-
-    def _outgoing_message_parts(self, formatted: str) -> List[str]:
-        """Split on blank lines outside triple-backtick fenced code blocks."""
-        if not getattr(self, "_split_outgoing_on_blank_lines", False):
-            return [formatted]
-
-        parts: List[str] = []
-        current: List[str] = []
-        in_fence = False
-
-        for line in formatted.split("\n"):
-            stripped = line.lstrip()
-            indent = len(line) - len(stripped)
-
-            if indent <= 3 and re.match(r"```(?!`)", stripped):
-                if in_fence:
-                    if re.fullmatch(r"[ \t]{0,3}```[ \t]*", line):
-                        in_fence = False
-                else:
-                    in_fence = True
-
-            if not line.strip() and not in_fence:
-                part = "\n".join(current).strip()
-                if part:
-                    parts.append(part)
-                current = []
-                continue
-
-            current.append(line)
-
-        final_part = "\n".join(current).strip()
-        if final_part:
-            parts.append(final_part)
-        if len(parts) <= 1:
-            return [formatted]
-
-        max_parts = getattr(self, "_split_outgoing_max_parts", 4)
-        if max_parts > 0 and len(parts) > max_parts:
-            return parts[: max_parts - 1] + ["\n\n".join(parts[max_parts - 1 :])]
-        return parts
 
     async def send(
         self,

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -750,6 +750,24 @@ class TelegramAdapter(BasePlatformAdapter):
         # declines drafts so transport=auto uses edit-in-place + rich finalize
         # instead of MDV2 drafts that jump to sendRichMessage at the end.
         self._rich_drafts_enabled: bool = self._coerce_bool_extra("rich_drafts", False)
+        # Opt-in conversational splitting (#4445): deliver blank-line-separated
+        # paragraphs as separate Telegram bubbles instead of one long message.
+        # Mirrors the WhatsApp adapter's split_outgoing_* extra keys.
+        self._split_outgoing_on_blank_lines: bool = self._coerce_bool_extra(
+            "split_outgoing_on_blank_lines", False
+        )
+        self._split_outgoing_delay_seconds: float = self._coerce_float_extra(
+            "split_outgoing_delay_seconds", 0.6, min_value=0.0
+        )
+        _split_extra = getattr(config, "extra", None) or {}
+        try:
+            self._split_outgoing_max_parts = int(
+                _split_extra.get("split_outgoing_max_parts", 4)
+            )
+        except (TypeError, ValueError):
+            self._split_outgoing_max_parts = 4
+        if self._split_outgoing_max_parts < 1:
+            self._split_outgoing_max_parts = 4
         # Latched off after a capability failure on sendRichMessage /
         # sendRichMessageDraft (e.g. older python-telegram-bot without the
         # endpoint) so later sends skip the doomed rich attempt entirely.
@@ -5117,6 +5135,46 @@ class TelegramAdapter(BasePlatformAdapter):
         else:  # "first" (default)
             return chunk_index == 0
 
+    def _outgoing_message_parts(self, formatted: str) -> List[str]:
+        """Split on blank lines outside triple-backtick fenced code blocks."""
+        if not getattr(self, "_split_outgoing_on_blank_lines", False):
+            return [formatted]
+
+        parts: List[str] = []
+        current: List[str] = []
+        in_fence = False
+
+        for line in formatted.split("\n"):
+            stripped = line.lstrip()
+            indent = len(line) - len(stripped)
+
+            if indent <= 3 and re.match(r"```(?!`)", stripped):
+                if in_fence:
+                    if re.fullmatch(r"[ \t]{0,3}```[ \t]*", line):
+                        in_fence = False
+                else:
+                    in_fence = True
+
+            if not line.strip() and not in_fence:
+                part = "\n".join(current).strip()
+                if part:
+                    parts.append(part)
+                current = []
+                continue
+
+            current.append(line)
+
+        final_part = "\n".join(current).strip()
+        if final_part:
+            parts.append(final_part)
+        if len(parts) <= 1:
+            return [formatted]
+
+        max_parts = getattr(self, "_split_outgoing_max_parts", 4)
+        if max_parts > 0 and len(parts) > max_parts:
+            return parts[: max_parts - 1] + ["\n\n".join(parts[max_parts - 1 :])]
+        return parts
+
     async def send(
         self,
         chat_id: str,
@@ -5159,11 +5217,14 @@ class TelegramAdapter(BasePlatformAdapter):
                                 pass  # Typing failures are non-fatal
                     return rich_result
 
-            # Format and split message if needed
+            # Format, optionally split into conversational bubbles, then apply
+            # the existing length chunking to every part.
             formatted = self.format_message(content)
-            chunks = self.truncate_message(
-                formatted, self.MAX_MESSAGE_LENGTH, len_fn=utf16_len,
-            )
+            chunks = []
+            for part in self._outgoing_message_parts(formatted):
+                chunks.extend(self.truncate_message(
+                    part, self.MAX_MESSAGE_LENGTH, len_fn=utf16_len,
+                ))
             if len(chunks) > 1:
                 # truncate_message appends a raw " (1/2)" suffix. Escape the
                 # MarkdownV2-special parentheses so Telegram doesn't reject the
@@ -5388,6 +5449,16 @@ class TelegramAdapter(BasePlatformAdapter):
                                 continue
                         raise
                 message_ids.append(str(msg.message_id))
+
+                # Pace multi-bubble delivery when conversational splitting is
+                # enabled; the legacy multi-chunk path stays delay-free.
+                if (
+                    i < len(chunks) - 1
+                    and getattr(self, "_split_outgoing_on_blank_lines", False)
+                ):
+                    await asyncio.sleep(
+                        getattr(self, "_split_outgoing_delay_seconds", 0.6)
+                    )
 
             # Re-trigger typing indicator after sending a message.
             # Telegram clears the typing state when a new message is delivered,

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -487,24 +487,10 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
 
-    def _coerce_float_extra(self, key: str, default: float) -> float:
-        """Read a float from ``config.extra``, guarding against bad/non-finite values.
-
-        The result is fed directly to ``asyncio.sleep()``, so NaN/Inf and
-        unparseable values fall back to ``default``.
-        """
-        import math
-
-        value = self.config.extra.get(key) if getattr(self.config, "extra", None) else None
-        if value is None:
-            return float(default)
-        try:
-            parsed = float(value)
-        except (TypeError, ValueError):
-            return float(default)
-        if not math.isfinite(parsed) or parsed < 0:
-            return float(default)
-        return parsed
+        # Opt-in conversational splitting: deliver blank-line-separated
+        # paragraphs as separate WhatsApp bubbles instead of one long message.
+        # Shared split_outgoing_* extra keys (see BasePlatformAdapter).
+        self._init_conversational_split_config()
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """
@@ -949,9 +935,16 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         try:
             import aiohttp
 
-            # Format and chunk the message
+            # Format, optionally split into conversational bubbles (shared
+            # split_outgoing_* opt-in), then apply length chunking to every
+            # part. With splitting off (default), parts == [formatted] and the
+            # chunk list is identical to the pre-split behavior.
             formatted = self.format_message(content)
-            chunks = self.truncate_message(formatted, self._outgoing_chunk_limit())
+            chunks: list[str] = []
+            for part in self._outgoing_message_parts(formatted):
+                chunks.extend(
+                    self.truncate_message(part, self._outgoing_chunk_limit())
+                )
 
             sent_message_ids: list[str] = []
             last_message_id = None
@@ -979,8 +972,15 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         error = await resp.text()
                         return SendResult(success=False, error=error)
 
-                # Small delay between chunks to avoid rate limiting
-                if len(chunks) > 1:
+                # Small delay between chunks to avoid rate limiting. With
+                # conversational splitting opted in, bubbles are paced with
+                # the configured split delay instead (between sends only).
+                if getattr(self, "_split_outgoing_on_blank_lines", False):
+                    if idx < len(chunks) - 1:
+                        await asyncio.sleep(
+                            getattr(self, "_split_outgoing_delay_seconds", 0.6)
+                        )
+                elif len(chunks) > 1:
                     await asyncio.sleep(0.3)
 
             return SendResult(

--- a/tests/gateway/test_base_adapter_conversational_split.py
+++ b/tests/gateway/test_base_adapter_conversational_split.py
@@ -1,0 +1,166 @@
+"""Tests for the shared conversational-split infrastructure on the base adapter.
+
+The ``split_outgoing_*`` extra keys, the fence-aware blank-line splitter
+(``_outgoing_message_parts``), and the ``config.extra`` coercion helpers were
+lifted from the Telegram/WhatsApp adapters onto ``BasePlatformAdapter`` so
+every platform (Telegram, WhatsApp, Photon/iMessage) shares one
+implementation. These tests exercise the shared methods directly against a
+minimal concrete subclass, independent of any specific platform.
+"""
+from typing import Any, Dict, Optional
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+
+
+class _StubAdapter(BasePlatformAdapter):
+    """Minimal concrete adapter — just enough to instantiate the base class."""
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        pass
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        return SendResult(success=True)
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        return {}
+
+
+def _make_adapter(**extra) -> _StubAdapter:
+    adapter = _StubAdapter(
+        PlatformConfig(enabled=True, token="t", extra=dict(extra)),
+        Platform.TELEGRAM,
+    )
+    adapter._init_conversational_split_config()
+    return adapter
+
+
+class TestCoerceBoolExtra:
+    def test_missing_key_returns_default(self):
+        adapter = _make_adapter()
+        assert adapter._coerce_bool_extra("nope", False) is False
+        assert adapter._coerce_bool_extra("nope", True) is True
+
+    def test_string_spellings(self):
+        for raw in ("true", "1", "yes", "on", " True "):
+            assert _make_adapter(k=raw)._coerce_bool_extra("k") is True
+        for raw in ("false", "0", "no", "off", " OFF "):
+            assert _make_adapter(k=raw)._coerce_bool_extra("k") is False
+
+    def test_unrecognized_string_falls_back_to_default(self):
+        assert _make_adapter(k="sometimes")._coerce_bool_extra("k", True) is True
+        assert _make_adapter(k="sometimes")._coerce_bool_extra("k", False) is False
+
+    def test_non_string_values_are_boolified(self):
+        assert _make_adapter(k=1)._coerce_bool_extra("k") is True
+        assert _make_adapter(k=0)._coerce_bool_extra("k", True) is False
+
+
+class TestCoerceFloatExtra:
+    def test_missing_and_unparseable_fall_back_to_default(self):
+        assert _make_adapter()._coerce_float_extra("k", 0.6) == 0.6
+        assert _make_adapter(k="not-a-number")._coerce_float_extra("k", 0.6) == 0.6
+
+    def test_parses_numeric_strings(self):
+        assert _make_adapter(k="1.25")._coerce_float_extra("k", 0.6) == 1.25
+
+    def test_non_finite_values_fall_back_to_default(self):
+        assert _make_adapter(k="nan")._coerce_float_extra("k", 0.6) == 0.6
+        assert _make_adapter(k="inf")._coerce_float_extra("k", 0.6) == 0.6
+        assert (
+            _make_adapter(k="nan")._coerce_float_extra("k", 0.6, min_value=0.0) == 0.6
+        )
+
+    def test_min_and_max_clamp(self):
+        adapter = _make_adapter(k="-5")
+        assert adapter._coerce_float_extra("k", 0.6, min_value=0.0) == 0.0
+        adapter = _make_adapter(k="900")
+        assert (
+            adapter._coerce_float_extra("k", 30.0, min_value=1.0, max_value=300.0)
+            == 300.0
+        )
+
+    def test_negative_without_explicit_floor_falls_back_to_default(self):
+        # WhatsApp semantics: delays feed asyncio.sleep(), so a negative
+        # value without a declared floor is rejected rather than clamped.
+        assert _make_adapter(k="-5")._coerce_float_extra("k", 5.0) == 5.0
+
+
+class TestInitConversationalSplitConfig:
+    def test_defaults_are_opt_out_with_documented_values(self):
+        adapter = _make_adapter()
+        assert adapter._split_outgoing_on_blank_lines is False
+        assert adapter._split_outgoing_delay_seconds == 0.6
+        assert adapter._split_outgoing_max_parts == 4
+
+    def test_values_are_config_backed_and_invalid_values_fall_back_safely(self):
+        configured = _make_adapter(
+            split_outgoing_on_blank_lines="yes",
+            split_outgoing_delay_seconds="1.25",
+            split_outgoing_max_parts="7",
+        )
+        invalid = _make_adapter(
+            split_outgoing_on_blank_lines="sometimes",
+            split_outgoing_delay_seconds="not-a-number",
+            split_outgoing_max_parts=-2,
+        )
+        malformed_max = _make_adapter(split_outgoing_max_parts="many")
+
+        assert configured._split_outgoing_on_blank_lines is True
+        assert configured._split_outgoing_delay_seconds == 1.25
+        assert configured._split_outgoing_max_parts == 7
+        assert invalid._split_outgoing_on_blank_lines is False
+        assert invalid._split_outgoing_delay_seconds == 0.6
+        assert invalid._split_outgoing_max_parts == 4
+        assert malformed_max._split_outgoing_max_parts == 4
+
+
+class TestOutgoingMessageParts:
+    def test_opt_out_returns_input_unchanged(self):
+        adapter = _make_adapter()
+        assert adapter._outgoing_message_parts("one\n\ntwo") == ["one\n\ntwo"]
+
+    def test_blank_lines_split_but_single_newlines_do_not(self):
+        adapter = _make_adapter(split_outgoing_on_blank_lines=True)
+        assert adapter._outgoing_message_parts("one\n\ntwo\nthree") == [
+            "one",
+            "two\nthree",
+        ]
+
+    def test_single_paragraph_passes_through_verbatim(self):
+        adapter = _make_adapter(split_outgoing_on_blank_lines=True)
+        assert adapter._outgoing_message_parts("\none\ntwo\n") == ["\none\ntwo\n"]
+
+    def test_blank_lines_inside_fenced_code_do_not_split(self):
+        adapter = _make_adapter(split_outgoing_on_blank_lines=True)
+        content = "intro\n\n```python\nfirst\n\nsecond\n```\n\noutro"
+        assert adapter._outgoing_message_parts(content) == [
+            "intro",
+            "```python\nfirst\n\nsecond\n```",
+            "outro",
+        ]
+
+    def test_max_parts_merges_remainder_into_final_part(self):
+        adapter = _make_adapter(
+            split_outgoing_on_blank_lines=True, split_outgoing_max_parts=3
+        )
+        assert adapter._outgoing_message_parts("one\n\ntwo\n\nthree\n\nfour") == [
+            "one",
+            "two",
+            "three\n\nfour",
+        ]
+
+    def test_uninitialized_adapter_defaults_to_passthrough(self):
+        # send() paths must stay safe for adapters built via __new__ in tests
+        # (no __init__, so no _split_outgoing_* attributes).
+        adapter = _StubAdapter.__new__(_StubAdapter)
+        assert adapter._outgoing_message_parts("one\n\ntwo") == ["one\n\ntwo"]

--- a/tests/gateway/test_telegram_conversational_split.py
+++ b/tests/gateway/test_telegram_conversational_split.py
@@ -1,0 +1,192 @@
+"""Tests for Telegram opt-in conversational blank-line splitting (#4445).
+
+Ports the WhatsApp ``split_outgoing_*`` pattern (PR #46314) to Telegram:
+replies are optionally split on blank lines outside fenced code blocks and
+delivered as separate bubbles, before the existing 4096-char
+``truncate_message()`` chunking runs on every part.
+"""
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_telegram_mock():
+    """Mock the telegram package if it's not installed."""
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.constants.ChatType.PRIVATE = "private"
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+
+
+_ensure_telegram_mock()
+
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+
+
+def _make_adapter(**extra):
+    adapter = TelegramAdapter(
+        PlatformConfig(enabled=True, token="test-token", extra=extra)
+    )
+    adapter._bot = MagicMock()
+    adapter._bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
+    return adapter
+
+
+def _sent_texts(adapter):
+    return [c.kwargs["text"] for c in adapter._bot.send_message.call_args_list]
+
+
+class TestSplitConfig:
+    """split_outgoing_* extra keys are opt-in with safe fallbacks."""
+
+    def test_defaults_are_opt_out_with_documented_values(self):
+        adapter = TelegramAdapter(PlatformConfig(enabled=True, token="t"))
+
+        assert adapter._split_outgoing_on_blank_lines is False
+        assert adapter._split_outgoing_delay_seconds == 0.6
+        assert adapter._split_outgoing_max_parts == 4
+
+    def test_values_are_config_backed_and_invalid_values_fall_back_safely(self):
+        configured = TelegramAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="t",
+                extra={
+                    "split_outgoing_on_blank_lines": "yes",
+                    "split_outgoing_delay_seconds": "1.25",
+                    "split_outgoing_max_parts": "7",
+                },
+            )
+        )
+        invalid = TelegramAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="t",
+                extra={
+                    "split_outgoing_on_blank_lines": "sometimes",
+                    "split_outgoing_delay_seconds": "not-a-number",
+                    "split_outgoing_max_parts": -2,
+                },
+            )
+        )
+        malformed_max = TelegramAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="t",
+                extra={"split_outgoing_max_parts": "many"},
+            )
+        )
+
+        assert configured._split_outgoing_on_blank_lines is True
+        assert configured._split_outgoing_delay_seconds == 1.25
+        assert configured._split_outgoing_max_parts == 7
+        assert invalid._split_outgoing_on_blank_lines is False
+        assert invalid._split_outgoing_delay_seconds == 0.6
+        assert invalid._split_outgoing_max_parts == 4
+        assert malformed_max._split_outgoing_max_parts == 4
+
+
+class TestSendConversationalSplit:
+    """send() bubble splitting behavior."""
+
+    @pytest.mark.asyncio
+    async def test_blank_line_split_is_opt_in(self):
+        adapter = _make_adapter()
+
+        await adapter.send("12345", "one\n\ntwo")
+
+        assert _sent_texts(adapter) == ["one\n\ntwo"]
+
+    @pytest.mark.asyncio
+    async def test_blank_lines_split_bubbles_but_single_newlines_do_not(self):
+        adapter = _make_adapter(split_outgoing_on_blank_lines=True)
+
+        await adapter.send("12345", "one\n\ntwo\nthree")
+
+        assert _sent_texts(adapter) == ["one", "two\nthree"]
+
+    @pytest.mark.asyncio
+    async def test_blank_line_split_merges_remainder_at_max_parts(self):
+        adapter = _make_adapter(
+            split_outgoing_on_blank_lines=True,
+            split_outgoing_max_parts=3,
+        )
+
+        await adapter.send("12345", "one\n\ntwo\n\nthree\n\nfour")
+
+        assert _sent_texts(adapter) == ["one", "two", "three\n\nfour"]
+
+    @pytest.mark.asyncio
+    async def test_blank_lines_inside_fenced_code_stay_in_one_bubble(self):
+        adapter = _make_adapter(split_outgoing_on_blank_lines=True)
+        content = "intro\n\n```python\nfirst\n\nsecond\n```\n\noutro"
+
+        await adapter.send("12345", content)
+
+        assert _sent_texts(adapter) == [
+            "intro",
+            "```python\nfirst\n\nsecond\n```",
+            "outro",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_reply_to_only_threads_on_first_bubble(self):
+        adapter = _make_adapter(split_outgoing_on_blank_lines=True)
+
+        await adapter.send("12345", "one\n\ntwo\n\nthree", reply_to="999")
+
+        calls = adapter._bot.send_message.call_args_list
+        assert len(calls) == 3
+        assert calls[0].kwargs.get("reply_to_message_id") == 999
+        assert calls[1].kwargs.get("reply_to_message_id") is None
+        assert calls[2].kwargs.get("reply_to_message_id") is None
+
+    @pytest.mark.asyncio
+    async def test_configured_split_delay_is_used_when_opted_in(self, monkeypatch):
+        adapter = _make_adapter(
+            split_outgoing_on_blank_lines=True,
+            split_outgoing_delay_seconds=1.25,
+        )
+        sleep = AsyncMock()
+        monkeypatch.setattr(asyncio, "sleep", sleep)
+
+        await adapter.send("12345", "one\n\ntwo", metadata={"notify": True})
+
+        assert len(_sent_texts(adapter)) == 2
+        assert [c.args[0] for c in sleep.await_args_list] == [1.25]
+
+    @pytest.mark.asyncio
+    async def test_legacy_multi_chunk_path_stays_delay_free_when_opted_out(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(split_outgoing_delay_seconds=1.25)
+        sleep = AsyncMock()
+        monkeypatch.setattr(asyncio, "sleep", sleep)
+
+        await adapter.send("12345", "a " * 3000, metadata={"notify": True})
+
+        assert len(_sent_texts(adapter)) > 1
+        sleep.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_length_chunking_still_applies_to_each_bubble(self):
+        adapter = _make_adapter(split_outgoing_on_blank_lines=True)
+
+        await adapter.send("12345", "intro\n\n" + "a " * 3000)
+
+        texts = _sent_texts(adapter)
+        assert texts[0] == "intro"
+        assert len(texts) == 3
+        assert texts[1].endswith(" \\(1/2\\)")
+        assert texts[2].endswith(" \\(2/2\\)")

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -183,6 +183,71 @@ class TestSendChunking:
 
 
 # ---------------------------------------------------------------------------
+# send() conversational splitting (shared split_outgoing_* opt-in)
+# ---------------------------------------------------------------------------
+
+class TestSendConversationalSplit:
+    """Opt-in blank-line splitting shared via BasePlatformAdapter."""
+
+    def _mock_bridge(self, adapter):
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+    def _sent_texts(self, adapter):
+        return [
+            c.kwargs["json"]["message"]
+            for c in adapter._http_session.post.call_args_list
+        ]
+
+    @pytest.mark.asyncio
+    async def test_blank_line_split_is_opt_in(self):
+        adapter = _make_adapter()
+        self._mock_bridge(adapter)
+
+        await adapter.send("chat1", "one\n\ntwo")
+
+        assert self._sent_texts(adapter) == ["one\n\ntwo"]
+
+    @pytest.mark.asyncio
+    async def test_blank_lines_split_bubbles_but_single_newlines_do_not(self):
+        adapter = _make_adapter()
+        adapter._split_outgoing_on_blank_lines = True
+        adapter._split_outgoing_delay_seconds = 0.0
+        self._mock_bridge(adapter)
+
+        await adapter.send("chat1", "one\n\ntwo\nthree")
+
+        assert self._sent_texts(adapter) == ["one", "two\nthree"]
+
+    @pytest.mark.asyncio
+    async def test_configured_split_delay_paces_bubbles(self, monkeypatch):
+        adapter = _make_adapter()
+        adapter._split_outgoing_on_blank_lines = True
+        adapter._split_outgoing_delay_seconds = 1.25
+        self._mock_bridge(adapter)
+        sleep = AsyncMock()
+        monkeypatch.setattr(asyncio, "sleep", sleep)
+
+        await adapter.send("chat1", "one\n\ntwo")
+
+        assert len(self._sent_texts(adapter)) == 2
+        assert [c.args[0] for c in sleep.await_args_list] == [1.25]
+
+    @pytest.mark.asyncio
+    async def test_legacy_chunk_delay_unchanged_when_opted_out(self, monkeypatch):
+        adapter = _make_adapter()
+        self._mock_bridge(adapter)
+        sleep = AsyncMock()
+        monkeypatch.setattr(asyncio, "sleep", sleep)
+
+        await adapter.send("chat1", "a " * 3000)
+
+        assert len(self._sent_texts(adapter)) > 1
+        assert all(c.args[0] == 0.3 for c in sleep.await_args_list)
+
+
+# ---------------------------------------------------------------------------
 # bridge event metadata
 # ---------------------------------------------------------------------------
 

--- a/tests/plugins/platforms/photon/test_conversational_split.py
+++ b/tests/plugins/platforms/photon/test_conversational_split.py
@@ -1,0 +1,128 @@
+"""Opt-in conversational blank-line splitting for PhotonAdapter.send().
+
+Photon shares the ``split_outgoing_*`` extra keys with Telegram/WhatsApp (see
+``BasePlatformAdapter._init_conversational_split_config``). With the opt-in
+off (default), ``send()`` makes exactly one ``_sidecar_send`` call as before;
+opted in, blank-line-separated paragraphs go out as separate iMessage/Photon
+bubbles paced by ``split_outgoing_delay_seconds``, and each part is still
+individually truncated by ``_sidecar_send``'s MAX_MESSAGE_LENGTH guard.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
+from plugins.platforms.photon.adapter import PhotonAdapter
+
+
+def _make_adapter(
+    monkeypatch: pytest.MonkeyPatch, **extra
+) -> PhotonAdapter:
+    monkeypatch.setenv("PHOTON_PROJECT_ID", "test-project-id")
+    monkeypatch.setenv("PHOTON_PROJECT_SECRET", "test-project-secret")
+    adapter = PhotonAdapter(PlatformConfig(enabled=True, token="", extra=dict(extra)))
+    adapter._sidecar_send = AsyncMock(
+        side_effect=[
+            SendResult(success=True, message_id=f"msg-{i}") for i in range(10)
+        ]
+    )
+    return adapter
+
+
+def _sent_texts(adapter: PhotonAdapter) -> list:
+    return [c.args[1] for c in adapter._sidecar_send.call_args_list]
+
+
+@pytest.mark.asyncio
+async def test_split_is_opt_out_by_default_single_sidecar_call(monkeypatch):
+    adapter = _make_adapter(monkeypatch)
+
+    result = await adapter.send("space-1", "one\n\ntwo")
+
+    assert result.success
+    assert result.message_id == "msg-0"
+    assert _sent_texts(adapter) == ["one\n\ntwo"]
+
+
+@pytest.mark.asyncio
+async def test_opt_in_splits_on_blank_lines_one_sidecar_call_per_part(monkeypatch):
+    adapter = _make_adapter(monkeypatch, split_outgoing_on_blank_lines=True)
+
+    result = await adapter.send("space-1", "one\n\ntwo\nthree")
+
+    assert _sent_texts(adapter) == ["one", "two\nthree"]
+    assert result.success
+    assert result.message_id == "msg-0"
+    assert result.raw_response == {"message_ids": ["msg-0", "msg-1"]}
+
+
+@pytest.mark.asyncio
+async def test_configured_delay_sleeps_between_parts_only(monkeypatch):
+    adapter = _make_adapter(
+        monkeypatch,
+        split_outgoing_on_blank_lines=True,
+        split_outgoing_delay_seconds=1.25,
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr(asyncio, "sleep", sleep)
+
+    await adapter.send("space-1", "one\n\ntwo\n\nthree")
+
+    assert len(_sent_texts(adapter)) == 3
+    assert [c.args[0] for c in sleep.await_args_list] == [1.25, 1.25]
+
+
+@pytest.mark.asyncio
+async def test_no_delay_when_split_produces_single_part(monkeypatch):
+    adapter = _make_adapter(monkeypatch, split_outgoing_on_blank_lines=True)
+    sleep = AsyncMock()
+    monkeypatch.setattr(asyncio, "sleep", sleep)
+
+    await adapter.send("space-1", "one\ntwo")
+
+    assert _sent_texts(adapter) == ["one\ntwo"]
+    sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_blank_lines_inside_fenced_code_stay_in_one_bubble(monkeypatch):
+    adapter = _make_adapter(monkeypatch, split_outgoing_on_blank_lines=True)
+
+    await adapter.send("space-1", "intro\n\n```python\nfirst\n\nsecond\n```\n\noutro")
+
+    assert _sent_texts(adapter) == [
+        "intro",
+        "```python\nfirst\n\nsecond\n```",
+        "outro",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_max_parts_merges_remainder_into_final_bubble(monkeypatch):
+    adapter = _make_adapter(
+        monkeypatch,
+        split_outgoing_on_blank_lines=True,
+        split_outgoing_max_parts=3,
+    )
+
+    await adapter.send("space-1", "one\n\ntwo\n\nthree\n\nfour")
+
+    assert _sent_texts(adapter) == ["one", "two", "three\n\nfour"]
+
+
+@pytest.mark.asyncio
+async def test_mid_sequence_failure_returns_failing_result_and_stops(monkeypatch):
+    adapter = _make_adapter(monkeypatch, split_outgoing_on_blank_lines=True)
+    failure = SendResult(success=False, error="sidecar down", retryable=True)
+    adapter._sidecar_send = AsyncMock(
+        side_effect=[SendResult(success=True, message_id="msg-0"), failure]
+    )
+
+    result = await adapter.send("space-1", "one\n\ntwo\n\nthree")
+
+    assert result is failure
+    assert adapter._sidecar_send.await_count == 2

--- a/website/docs/user-guide/messaging/photon.md
+++ b/website/docs/user-guide/messaging/photon.md
@@ -195,6 +195,34 @@ Common issues:
 - **Sidecar won't start** — confirm `node --version` is 18.17+ and that
   `hermes photon install-sidecar` completed without errors.
 
+## Optional Multi-Bubble Replies
+
+By default, Hermes sends one message per reply. You can opt into splitting a
+reply at blank lines so separate paragraphs arrive as separate iMessage /
+Photon bubbles:
+
+```yaml
+# ~/.hermes/config.yaml
+gateway:
+  platforms:
+    photon:
+      extra:
+        split_outgoing_on_blank_lines: true
+        split_outgoing_delay_seconds: 0.6
+        split_outgoing_max_parts: 4
+```
+
+With this option enabled, `First paragraph.\n\nSecond paragraph.` sends two
+bubbles. A single newline stays within one bubble, and blank lines inside
+triple-backtick fenced code blocks do not split the code block.
+
+`split_outgoing_max_parts` limits the number of paragraph-based parts
+(default `4`); any remaining paragraphs are merged into the final part rather
+than discarded. `split_outgoing_delay_seconds` controls the pause between
+bubbles (default `0.6`). Each bubble is still subject to the adapter's usual
+per-message length limit. The same three keys (same defaults) work on
+Telegram and WhatsApp.
+
 ## Limits today
 
 - **Inbound attachments are metadata-only.** Inbound events carry the

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -993,6 +993,25 @@ gateway:
 
 When enabled, Hermes attaches Telegram's `LinkPreviewOptions(is_disabled=True)` to every outgoing message and falls back to the legacy `disable_web_page_preview` parameter on older `python-telegram-bot` versions.
 
+## Optional Multi-Bubble Replies
+
+By default, Hermes sends one formatted reply and only creates additional messages when the reply exceeds Telegram's 4,096-character limit. You can opt into splitting a reply at blank lines so separate paragraphs arrive as separate Telegram bubbles:
+
+```yaml
+# ~/.hermes/config.yaml
+gateway:
+  platforms:
+    telegram:
+      extra:
+        split_outgoing_on_blank_lines: true
+        split_outgoing_delay_seconds: 0.6
+        split_outgoing_max_parts: 4
+```
+
+With this option enabled, `First paragraph.\n\nSecond paragraph.` sends two bubbles. A single newline stays within one bubble. Blank lines inside triple-backtick fenced code blocks do not split the code block.
+
+`split_outgoing_max_parts` limits the number of paragraph-based parts (default `4`); any remaining paragraphs are merged into the final part rather than discarded. `split_outgoing_delay_seconds` controls the delay between sends while this mode is enabled (default `0.6`). Length-based chunking still applies to every resulting part, and each bubble keeps the usual per-chunk handling (MarkdownV2 escaping with plain-text fallback, `reply_to_mode` threading, topic routing).
+
 ## Group Allowlisting
 
 Telegram groups and forum chats have two orthogonal gates you can configure:

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -1010,7 +1010,7 @@ gateway:
 
 With this option enabled, `First paragraph.\n\nSecond paragraph.` sends two bubbles. A single newline stays within one bubble. Blank lines inside triple-backtick fenced code blocks do not split the code block.
 
-`split_outgoing_max_parts` limits the number of paragraph-based parts (default `4`); any remaining paragraphs are merged into the final part rather than discarded. `split_outgoing_delay_seconds` controls the delay between sends while this mode is enabled (default `0.6`). Length-based chunking still applies to every resulting part, and each bubble keeps the usual per-chunk handling (MarkdownV2 escaping with plain-text fallback, `reply_to_mode` threading, topic routing).
+`split_outgoing_max_parts` limits the number of paragraph-based parts (default `4`); any remaining paragraphs are merged into the final part rather than discarded. `split_outgoing_delay_seconds` controls the delay between sends while this mode is enabled (default `0.6`). Length-based chunking still applies to every resulting part, and each bubble keeps the usual per-chunk handling (MarkdownV2 escaping with plain-text fallback, `reply_to_mode` threading, topic routing). The same three keys (same defaults) work on WhatsApp and Photon/iMessage.
 
 ## Group Allowlisting
 

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -208,6 +208,23 @@ Standard Markdown in AI responses is automatically converted to WhatsApp's nativ
 
 Code blocks and inline code are preserved as-is since WhatsApp supports triple-backtick formatting natively.
 
+### Multi-Bubble Replies (Optional)
+
+By default, Hermes sends one formatted reply per response (plus additional chunks only when it exceeds the length limit above). You can opt into splitting a reply at blank lines so separate paragraphs arrive as separate WhatsApp bubbles:
+
+```yaml
+# ~/.hermes/config.yaml
+gateway:
+  platforms:
+    whatsapp:
+      extra:
+        split_outgoing_on_blank_lines: true
+        split_outgoing_delay_seconds: 0.6
+        split_outgoing_max_parts: 4
+```
+
+A single newline stays within one bubble, and blank lines inside triple-backtick fenced code blocks do not split the code block. `split_outgoing_max_parts` limits the number of paragraph-based parts (default `4`); any remaining paragraphs are merged into the final part rather than discarded. `split_outgoing_delay_seconds` controls the pause between bubbles (default `0.6`); length-based chunking still applies to every part. The same three keys (same defaults) work on Telegram and Photon/iMessage.
+
 ### Tool Progress
 
 When the agent calls tools (web search, file operations, etc.), WhatsApp displays real-time progress indicators showing which tool is running. This is enabled by default — no configuration needed.


### PR DESCRIPTION
## Summary

Opt-in "conversational" replies: split an outgoing reply at blank lines and deliver each paragraph as its own message bubble — now **channel-agnostic**, covering **Telegram, WhatsApp, and Photon (photon-native + iMessage)** through one shared implementation on `BasePlatformAdapter`.

This PR originally added the feature for Telegram only. Per AGENTS.md ("when several PRs integrate the same category, design one shared interface instead of merging them one at a time"), the second commit lifts the mechanism onto the base adapter and wires all three platforms into it.

### Config (same three keys, same defaults, on all three platforms)

```yaml
gateway:
  platforms:
    telegram:   # or whatsapp / photon
      extra:
        split_outgoing_on_blank_lines: true   # default: false (opt-in)
        split_outgoing_delay_seconds: 0.6     # pause between bubbles
        split_outgoing_max_parts: 4           # remainder merges into last part
```

Blank lines split bubbles; single newlines don't; blank lines inside triple-backtick fences never split a code block; parts beyond `split_outgoing_max_parts` merge into the final bubble.

### Shared infrastructure (`gateway/platforms/base.py`)

- `_outgoing_message_parts()` — the fence-aware blank-line splitter, moved verbatim from the Telegram adapter.
- `_init_conversational_split_config()` — reads the three `split_outgoing_*` extra keys; called from each participating adapter's `__init__`.
- `_coerce_bool_extra` / `_coerce_float_extra` — previously duplicated (with slight drift) in the Telegram, WhatsApp, and Weixin adapters; now defined once. Reconciliation: keeps Telegram's `min_value`/`max_value` clamping, adopts the WhatsApp/Weixin NaN/Inf guard, and without an explicit floor negative values fall back to the default (WhatsApp/Weixin semantics) — every existing call site keeps its behavior. All three adapters' local copies are deleted.

### Per-platform wiring

- **Telegram** — unchanged observable behavior; its send path now calls the shared helpers instead of local copies. Chunk pacing, MarkdownV2 fallback, threading, and topic routing are untouched.
- **WhatsApp** — gains the opt-in (the Telegram commit's comment referenced a WhatsApp `split_outgoing_*` implementation that never actually landed — the adapter only had the float coercer). Parts are length-chunked exactly as before; when the opt-in is on, bubbles are paced with the configured split delay; when off, the legacy 0.3s inter-chunk pacing is byte-identical to before.
- **Photon (iMessage)** — new capability: `send()` splits the formatted reply into parts and makes one `_sidecar_send()` call per part, sleeping the configured delay between parts, aggregating ids as `message_id` = first + `raw_response.message_ids` (Telegram's pattern). Off (default) it remains exactly one `_sidecar_send` call. Each part keeps `_sidecar_send`'s existing `MAX_MESSAGE_LENGTH` truncation, rich-link detection, markdown flag, and error handling.

### Docs

`website/docs/user-guide/messaging/{telegram,whatsapp,photon}.md` all document the same three keys (Telegram section extended with a cross-platform note; WhatsApp gets a "Multi-Bubble Replies" subsection under Message Formatting & Delivery; Photon gets an "Optional Multi-Bubble Replies" section).

### Tests

- `tests/gateway/test_base_adapter_conversational_split.py` (new) — shared splitter + coercers directly against a minimal `BasePlatformAdapter` subclass.
- `tests/plugins/platforms/photon/test_conversational_split.py` (new) — opt-out default (single sidecar call), opt-in split, delay pacing, fenced code, max-parts merge, mid-sequence failure.
- `tests/gateway/test_whatsapp_formatting.py` — new `TestSendConversationalSplit` class; existing chunking tests unchanged.
- `tests/gateway/test_telegram_conversational_split.py` — passes **unchanged** after the extraction.

## Verification

```
$ uv run pytest tests/gateway/test_telegram_conversational_split.py tests/gateway/test_whatsapp_formatting.py tests/gateway/test_base_adapter_conversational_split.py -q
41 passed in 7.32s

$ uv run pytest tests/plugins/platforms/photon/ -q
136 passed in 5.15s

$ uv run pytest tests/gateway/test_telegram_reply_mode.py tests/gateway/test_telegram_format.py tests/gateway/test_telegram_final_delivery.py tests/gateway/test_telegram_thread_fallback.py tests/gateway/test_telegram_rich_messages.py tests/gateway/test_telegram_network.py tests/gateway/test_telegram_overflow_partial.py tests/gateway/test_telegram_send_path_health.py tests/gateway/test_telegram_error_redaction.py -q
151 passed in 2.19s

$ uv run pytest tests/gateway/test_whatsapp_text_batching.py tests/gateway/test_weixin.py tests/gateway/test_weixin_typing.py -q
36 passed in 1.71s

$ uv run ruff check plugins/platforms/telegram/adapter.py plugins/platforms/whatsapp/adapter.py plugins/platforms/photon/adapter.py gateway/platforms/base.py gateway/platforms/weixin.py tests/gateway/test_base_adapter_conversational_split.py tests/plugins/platforms/photon/test_conversational_split.py tests/gateway/test_whatsapp_formatting.py
All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
