### PR TITLE
Image picker no longer crashes on stale cross-provider models; xAI Grok catalog goes live-driven (salvage #77238)

### DIFF
--- a/contributors/emails/zhu2mu@qq.com
+++ b/contributors/emails/zhu2mu@qq.com
@@ -1,0 +1,1 @@
+zhuermu

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -3997,7 +3997,10 @@ def _configure_imagegen_model(backend_name: str, config: dict) -> None:
         config[cfg_key] = cur_cfg
     current_model = cur_cfg.get("model") or default_model
     if current_model not in catalog:
-        current_model = default_model
+        # The saved model may belong to another provider (shared config key)
+        # and the catalog default itself may have drifted — never index the
+        # catalog with a key it doesn't contain.
+        current_model = default_model if default_model in catalog else next(iter(catalog))
 
     model_ids = list(catalog.keys())
     # Put current model at the top so the cursor lands on it by default.
@@ -4228,7 +4231,9 @@ def _configure_videogen_model_for_plugin(plugin_name: str, config: dict) -> None
         config["video_gen"] = cur_cfg
     current_model = cur_cfg.get("model") or default_model
     if current_model not in catalog:
-        current_model = default_model
+        # Same guard as the image pickers: a stale cross-provider model or a
+        # drifted default must not become an unindexable catalog key.
+        current_model = default_model if default_model in catalog else next(iter(catalog))
 
     model_ids = list(catalog.keys())
     ordered = [current_model] + [m for m in model_ids if m != current_model]

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -4081,7 +4081,7 @@ def _configure_imagegen_model_for_plugin(plugin_name: str, config: dict) -> None
         config["image_gen"] = cur_cfg
     current_model = cur_cfg.get("model") or default_model
     if current_model not in catalog:
-        current_model = default_model
+        current_model = default_model if default_model in catalog else next(iter(catalog))
 
     model_ids = list(catalog.keys())
     ordered = [current_model] + [m for m in model_ids if m != current_model]

--- a/plugins/image_gen/openrouter/__init__.py
+++ b/plugins/image_gen/openrouter/__init__.py
@@ -243,7 +243,9 @@ class OpenRouterCompatImageProvider(ImageGenProvider):
         ]
 
     def default_model(self) -> Optional[str]:
-        return self._resolve_model()
+        # This is the catalog default, not the effective runtime model.
+        # Runtime overrides are resolved separately by _resolve_model_chain().
+        return DEFAULT_MODEL
 
     def get_setup_schema(self) -> Dict[str, Any]:
         return dict(self._setup_schema)

--- a/plugins/image_gen/xai/__init__.py
+++ b/plugins/image_gen/xai/__init__.py
@@ -55,6 +55,11 @@ _MODELS: Dict[str, Dict[str, Any]] = {
         "speed": "~5-10s",
         "strengths": "Fast, high-quality",
     },
+    "grok-imagine-image-2.0": {
+        "display": "Grok Imagine Image 2.0",
+        "speed": "~10-20s",
+        "strengths": "Typography/layout-aware; legible small text; strongest quality.",
+    },
     "grok-imagine-image-quality": {
         "display": "Grok Imagine Image (Quality)",
         "speed": "~10-20s",
@@ -63,6 +68,95 @@ _MODELS: Dict[str, Dict[str, Any]] = {
 }
 
 DEFAULT_MODEL = "grok-imagine-image"
+
+# Live catalog cache: (models_dict, fetched_monotonic). xAI's
+# ``/image-generation-models`` endpoint is the source of truth so newly
+# released Imagine models appear in the picker without a code change;
+# the static ``_MODELS`` table is the offline fallback and supplies curated
+# speed/strengths text for the models we know about.
+_LIVE_CACHE: Optional[Tuple[Dict[str, Dict[str, Any]], float]] = None
+_LIVE_CACHE_TTL = 300.0
+_LIVE_TIMEOUT = 10.0
+
+
+def _fetch_live_models() -> Dict[str, Dict[str, Any]]:
+    """Fetch image models from xAI's ``/image-generation-models`` endpoint.
+
+    Returns ``{model_id: {"input_modalities": [...], "aliases": [...]}}``.
+    Raises on any failure — callers treat that as "use the static table".
+    """
+    creds = resolve_xai_http_credentials()
+    api_key = str(creds.get("api_key") or "").strip()
+    if not api_key:
+        raise RuntimeError("no xAI credentials")
+    base_url = str(creds.get("base_url") or "https://api.x.ai/v1").strip().rstrip("/")
+    response = requests.get(
+        f"{base_url}/image-generation-models",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "User-Agent": hermes_xai_user_agent(),
+        },
+        timeout=_LIVE_TIMEOUT,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    entries = payload.get("models") or payload.get("data") or []
+    out: Dict[str, Dict[str, Any]] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        model_id = entry.get("id") or entry.get("name")
+        if not isinstance(model_id, str) or not model_id.strip():
+            continue
+        out[model_id.strip()] = {
+            "input_modalities": entry.get("input_modalities") or [],
+            "aliases": entry.get("aliases") or [],
+        }
+    return out
+
+
+def _live_models() -> Dict[str, Dict[str, Any]]:
+    """Cached live catalog (``{}`` when unreachable)."""
+    global _LIVE_CACHE
+    import time
+
+    if _LIVE_CACHE is not None and time.monotonic() - _LIVE_CACHE[1] < _LIVE_CACHE_TTL:
+        return _LIVE_CACHE[0]
+    try:
+        live = _fetch_live_models()
+    except Exception as exc:  # noqa: BLE001 - offline/unauth → static fallback
+        logger.debug("xAI live image model catalog unavailable: %s", exc)
+        live = {}
+    _LIVE_CACHE = (live, time.monotonic())
+    return live
+
+
+def _catalog() -> Dict[str, Dict[str, Any]]:
+    """Merged model catalog: live endpoint IDs + curated static metadata.
+
+    Known models keep their curated display/speed/strengths; models xAI
+    ships after this file was written still show up (with generic metadata)
+    so users can pick them the day they launch. Static table alone when the
+    API is unreachable.
+    """
+    live = _live_models()
+    if not live:
+        return dict(_MODELS)
+    merged: Dict[str, Dict[str, Any]] = {}
+    for model_id in live:
+        meta = _MODELS.get(model_id)
+        if meta is None:
+            meta = {
+                "display": model_id,
+                "speed": "",
+                "strengths": "New xAI Imagine model (from live xAI catalog)",
+            }
+        merged[model_id] = dict(meta)
+        merged[model_id]["input_modalities"] = live[model_id].get("input_modalities") or []
+    # Keep curated entries that the live list may momentarily omit.
+    for model_id, meta in _MODELS.items():
+        merged.setdefault(model_id, dict(meta))
+    return merged
 
 # xAI aspect ratios (more options than FAL/OpenAI)
 _XAI_ASPECT_RATIOS = {
@@ -101,17 +195,41 @@ def _load_xai_config() -> Dict[str, Any]:
 
 
 def _resolve_model() -> Tuple[str, Dict[str, Any]]:
-    """Decide which model to use and return ``(model_id, meta)``."""
+    """Decide which model to use and return ``(model_id, meta)``.
+
+    Overrides are validated against the merged live+static catalog, so a
+    newly released xAI model can be selected the day it appears in the
+    live catalog — no code change required.
+    """
+    catalog = _catalog()
     env_override = os.environ.get("XAI_IMAGE_MODEL")
-    if env_override and env_override in _MODELS:
-        return env_override, _MODELS[env_override]
+    if env_override and env_override in catalog:
+        return env_override, catalog[env_override]
 
     cfg = _load_xai_config()
     candidate = cfg.get("model") if isinstance(cfg.get("model"), str) else None
-    if candidate and candidate in _MODELS:
-        return candidate, _MODELS[candidate]
+    if candidate and candidate in catalog:
+        return candidate, catalog[candidate]
 
-    return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
+    return DEFAULT_MODEL, catalog.get(DEFAULT_MODEL, _MODELS[DEFAULT_MODEL])
+
+
+def _resolve_edit_model() -> str:
+    """Model for ``/v1/images/edits`` requests.
+
+    An explicitly selected model (env or config) that accepts image input
+    is honored for edits; otherwise fall back to the quality model, which
+    xAI documents as the edit-capable baseline.
+    """
+    catalog = _catalog()
+    explicit = os.environ.get("XAI_IMAGE_MODEL") or (
+        _load_xai_config().get("model") if isinstance(_load_xai_config().get("model"), str) else None
+    )
+    if explicit and explicit in catalog:
+        modalities = catalog[explicit].get("input_modalities") or []
+        if "image" in modalities:
+            return explicit
+    return "grok-imagine-image-quality"
 
 
 def _resolve_resolution() -> str:
@@ -179,7 +297,7 @@ class XAIImageGenProvider(ImageGenProvider):
                 "speed": meta.get("speed", ""),
                 "strengths": meta.get("strengths", ""),
             }
-            for model_id, meta in _MODELS.items()
+            for model_id, meta in _catalog().items()
         ]
 
     def get_setup_schema(self) -> Dict[str, Any]:
@@ -296,10 +414,12 @@ class XAIImageGenProvider(ImageGenProvider):
         storage_cfg = read_xai_imagine_storage_config("image_gen")
 
         if is_edit:
-            # Editing requires the quality model per xAI docs. The source
-            # image may be a public URL or a base64 data URI; local file paths
-            # are converted to a data URI here.
-            edit_model = "grok-imagine-image-quality"
+            # Editing needs an image-input-capable model. An explicit user
+            # selection that accepts image input (e.g. grok-imagine-image-2.0)
+            # is honored; otherwise the documented quality baseline is used.
+            # The source image may be a public URL or a base64 data URI;
+            # local file paths are converted to a data URI here.
+            edit_model = _resolve_edit_model()
             try:
                 image_fields = [_xai_image_field(source) for source in source_images]
             except Exception as exc:

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -760,6 +760,26 @@ class TestImagegenModelPicker:
         assert isinstance(config["image_gen"], dict)
         assert config["image_gen"]["model"] == "fal-ai/flux-2/klein/9b"
 
+    def test_plugin_picker_falls_back_when_default_is_missing_from_catalog(self):
+        """A stale cross-provider model must not become an unindexable row."""
+        from hermes_cli.tools_config import _configure_imagegen_model_for_plugin
+
+        catalog = {
+            "openai/gpt-5.4-image-2": {"strengths": "quality"},
+            "google/gemini-3-pro-image": {"strengths": "fallback"},
+        }
+        config = {"image_gen": {"model": "gpt-image-2-medium"}}
+        with (
+            patch(
+                "hermes_cli.tools_config._plugin_image_gen_catalog",
+                return_value=(catalog, "also-missing"),
+            ),
+            patch("hermes_cli.tools_config._prompt_choice", return_value=0),
+        ):
+            _configure_imagegen_model_for_plugin("openrouter", config)
+
+        assert config["image_gen"]["model"] == "openai/gpt-5.4-image-2"
+
 
 
 

--- a/tests/plugins/image_gen/test_openrouter_compat_provider.py
+++ b/tests/plugins/image_gen/test_openrouter_compat_provider.py
@@ -95,6 +95,17 @@ class TestProviderClass:
             # Default must be an image-output model id (provider/model form).
             assert "/" in DEFAULT_MODEL and "image" in DEFAULT_MODEL
 
+    def test_default_model_ignores_runtime_overrides(self, monkeypatch):
+        """Catalog defaults must not inherit another provider's saved model."""
+        from plugins.image_gen.openrouter import DEFAULT_MODEL
+
+        monkeypatch.setenv("OPENROUTER_IMAGE_MODEL", "custom/provider-image-model")
+        stale = {"model": "gpt-image-2-medium"}
+        with patch("plugins.image_gen.openrouter._load_image_gen_config", return_value=stale):
+            provider = _openrouter()
+            assert provider.default_model() == DEFAULT_MODEL
+            assert provider._resolve_model() == "custom/provider-image-model"
+
 
     def test_model_env_override(self, monkeypatch):
         monkeypatch.setenv("OPENROUTER_IMAGE_MODEL", "black-forest-labs/flux.2-pro")

--- a/tests/plugins/image_gen/test_xai_provider.py
+++ b/tests/plugins/image_gen/test_xai_provider.py
@@ -29,6 +29,25 @@ def _fake_api_key(monkeypatch, tmp_path):
         pass
 
 
+@pytest.fixture(autouse=True)
+def _no_live_catalog(monkeypatch):
+    """Keep unit tests hermetic: never hit xAI's live model-list endpoint.
+
+    The fake XAI_API_KEY above would otherwise let ``_fetch_live_models``
+    fire a real GET. Individual tests that exercise the live-merge path
+    re-patch ``_fetch_live_models`` themselves.
+    """
+    import plugins.image_gen.xai as xai_mod
+
+    def _offline():
+        raise RuntimeError("offline (test)")
+
+    monkeypatch.setattr(xai_mod, "_fetch_live_models", _offline)
+    monkeypatch.setattr(xai_mod, "_LIVE_CACHE", None)
+    yield
+    xai_mod._LIVE_CACHE = None
+
+
 # ---------------------------------------------------------------------------
 # Provider class tests
 # ---------------------------------------------------------------------------
@@ -104,6 +123,66 @@ class TestConfig:
 
         model_id, _ = _resolve_model()
         assert model_id == "grok-imagine-image"
+
+
+# ---------------------------------------------------------------------------
+# Live catalog merge tests
+# ---------------------------------------------------------------------------
+
+
+class TestLiveCatalog:
+    def test_static_catalog_includes_image_2_0(self):
+        """Curated table carries the 2.0 model even offline."""
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        ids = [m["id"] for m in XAIImageGenProvider().list_models()]
+        assert "grok-imagine-image-2.0" in ids
+
+    def test_unknown_live_model_appears_in_catalog(self, monkeypatch):
+        """A model xAI ships tomorrow shows up without a code change."""
+        import plugins.image_gen.xai as xai_mod
+
+        live = {
+            "grok-imagine-image": {"input_modalities": ["text", "image"], "aliases": []},
+            "grok-imagine-image-3.0": {"input_modalities": ["text", "image"], "aliases": []},
+        }
+        monkeypatch.setattr(xai_mod, "_fetch_live_models", lambda: live)
+        monkeypatch.setattr(xai_mod, "_LIVE_CACHE", None)
+
+        catalog = xai_mod._catalog()
+        assert "grok-imagine-image-3.0" in catalog
+        # Curated metadata survives the merge for known models.
+        assert catalog["grok-imagine-image"]["display"] == "Grok Imagine Image"
+        # And the new model is selectable end to end.
+        monkeypatch.setenv("XAI_IMAGE_MODEL", "grok-imagine-image-3.0")
+        model_id, _ = xai_mod._resolve_model()
+        assert model_id == "grok-imagine-image-3.0"
+
+    def test_live_failure_falls_back_to_static(self, monkeypatch):
+        import plugins.image_gen.xai as xai_mod
+
+        monkeypatch.setattr(xai_mod, "_LIVE_CACHE", None)
+        catalog = xai_mod._catalog()  # autouse fixture makes fetch raise
+        assert set(catalog) == set(xai_mod._MODELS)
+
+    def test_edit_model_honors_image_capable_selection(self, monkeypatch):
+        import plugins.image_gen.xai as xai_mod
+
+        live = {
+            "grok-imagine-image-2.0": {"input_modalities": ["text", "image"], "aliases": []},
+            "grok-imagine-image-quality": {"input_modalities": ["text", "image"], "aliases": []},
+        }
+        monkeypatch.setattr(xai_mod, "_fetch_live_models", lambda: live)
+        monkeypatch.setattr(xai_mod, "_LIVE_CACHE", None)
+        monkeypatch.setenv("XAI_IMAGE_MODEL", "grok-imagine-image-2.0")
+        assert xai_mod._resolve_edit_model() == "grok-imagine-image-2.0"
+
+    def test_edit_model_defaults_to_quality(self, monkeypatch):
+        import plugins.image_gen.xai as xai_mod
+
+        monkeypatch.setattr(xai_mod, "_LIVE_CACHE", None)
+        monkeypatch.delenv("XAI_IMAGE_MODEL", raising=False)
+        assert xai_mod._resolve_edit_model() == "grok-imagine-image-quality"
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/guides/xai-grok-oauth.md
+++ b/website/docs/guides/xai-grok-oauth.md
@@ -161,6 +161,7 @@ The `x_search` toolset auto-enables whenever xAI credentials (a SuperGrok / X Pr
 | Chat | `grok-4.20-0309-non-reasoning` | Non-reasoning variant |
 | Chat | `grok-4.20-multi-agent-0309` | Multi-agent variant |
 | Image | `grok-imagine-image` | Default; ~5–10 s |
+| Image | `grok-imagine-image-2.0` | Typography/layout-aware; strongest quality; ~10–20 s |
 | Image | `grok-imagine-image-quality` | Higher fidelity; ~10–20 s |
 | Video | `grok-imagine-video` | Text-to-video |
 | Video | `grok-imagine-video-1.5-preview` | Image-to-video; dated alias `grok-imagine-video-1.5-2026-05-30` |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/xai-grok-oauth.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/xai-grok-oauth.md
@@ -161,6 +161,7 @@ hermes tools
 | 对话 | `grok-4.20-0309-non-reasoning` | 非推理变体 |
 | 对话 | `grok-4.20-multi-agent-0309` | 多 agent 变体 |
 | 图像 | `grok-imagine-image` | 默认；约 5–10 秒 |
+| 图像 | `grok-imagine-image-2.0` | 版式/排版感知；最强画质；约 10–20 秒 |
 | 图像 | `grok-imagine-image-quality` | 更高保真度；约 10–20 秒 |
 | 视频 | `grok-imagine-video` | 文本转视频 |
 | 视频 | `grok-imagine-video-1.5-preview` | 图像转视频；日期别名 `grok-imagine-video-1.5-2026-05-30` |


### PR DESCRIPTION
## Summary
`hermes tools` → Image Generation no longer crashes with `KeyError` when the saved `image_gen.model` belongs to another provider, and the xAI Grok image picker now lists models from xAI's live catalog — including `grok-imagine-image-2.0` — so newly released Imagine models are selectable the day they launch, with no code change.

Root cause of the crash: the OpenRouter image plugin's `default_model()` returned the runtime-resolved model (which reads the shared `image_gen.model` config key), so a stale cross-provider value (e.g. `grok-imagine-image` left over from an xAI selection) survived both the config check and the default fallback, then indexed a catalog it isn't in (`tools_config.py:4106`).

Salvages #77238 by @zhuermu (crash fix + tests, cherry-picked with authorship preserved).

## Changes
- `plugins/image_gen/openrouter`: `default_model()` returns the static catalog default, not the runtime-resolved override (salvaged #77238)
- `hermes_cli/tools_config.py`: unindexable-key guard (`default if default in catalog else next(iter(catalog))`) applied to the plugin image picker (salvaged) and widened to the two sibling sites with the same bug shape: `_configure_imagegen_model` (legacy) and `_configure_videogen_model_for_plugin`
- `plugins/image_gen/xai`: model catalog is now merged live+static — fetches `/v1/image-generation-models` (5-min cache, 10s timeout, static fallback offline/unauth); unknown future models appear with generic metadata; `grok-imagine-image-2.0` added to the curated table; edits honor an explicitly selected image-input-capable model instead of always forcing `grok-imagine-image-quality`
- Tests: salvaged coverage for both crash halves; new xAI tests for live-merge, future-model selection, offline fallback, edit-model resolution; hermetic autouse fixture keeps unit runs off the network
- Docs: xAI Grok OAuth model table (en + zh-Hans) gains the 2.0 row

## Validation
| Scenario | Before | After |
|---|---|---|
| openrouter picker with stale `grok-imagine-image` in config | `KeyError` crash, setup aborts | picker renders, selection saved (E2E, real imports) |
| video picker with drifted default | same latent crash | guarded (E2E) |
| xAI picker rows (live creds) | 2 hardcoded models | `grok-imagine-image`, `grok-imagine-image-2.0`, `grok-imagine-image-quality` from live API |
| generation with `grok-imagine-image-2.0` | not selectable | live generation succeeded end to end |
| targeted tests | — | 52 passed (image_gen plugins) + 51 passed (tools_config) |

## Infographic

![Image picker crash fixed + live Grok catalog](https://v3b.fal.media/files/b/0aa6ef61/FO-GQOZx00bxL7LTSBKYC_xAHsqyhg.png)
