### PR TITLE
feat: add glm-5.3 to zai, openrouter, and nous picker catalogs

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -116,6 +116,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     # MiniMax
     ("minimax/minimax-m3",                     ""),
     # Z-AI
+    ("z-ai/glm-5.3",                           ""),
     ("z-ai/glm-5.2",                           "default"),
     ("z-ai/glm-5.1",                           ""),
     # Xiaomi
@@ -292,6 +293,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         # MiniMax
         "minimax/minimax-m3",
         # Z-AI
+        "z-ai/glm-5.3",
         "z-ai/glm-5.2",
         "z-ai/glm-5.1",
         # Xiaomi
@@ -366,6 +368,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gemini-3.1-flash-lite-preview",
     ],
     "zai": [
+        "glm-5.3",
         "glm-5.2",
         "glm-5.1",
         "glm-5",

--- a/plugins/model-providers/zai/__init__.py
+++ b/plugins/model-providers/zai/__init__.py
@@ -116,6 +116,7 @@ zai = ZaiProfile(
     description="Z.AI / GLM — Zhipu AI models",
     signup_url="https://z.ai/",
     fallback_models=(
+        "glm-5.3",
         "glm-5.2",
         "glm-5",
         "glm-4-9b",


### PR DESCRIPTION
## Problem

GLM-5.3 is live on both catalogs Hermes already talks to:

- **Z.AI direct:** `GET https://api.z.ai/api/coding/paas/v4/models` returns `glm-5.3`
- **OpenRouter:** `GET https://openrouter.ai/api/v1/models` returns `z-ai/glm-5.3`

…but the curated picker lists top out at glm-5.2. For the `zai` provider the picker merge is **curated-first** (commit 658ac1d86), so a model that only exists in the live fetch is appended to the *tail* of the merged list — in the Telegram/Discord inline keyboard (8 models/page) that puts glm-5.3 on page 2, effectively invisible. And whenever the live fetch fails, it vanishes from the picker entirely.

## Change

4 insertions, no behavior changes otherwise:

- `_PROVIDER_MODELS["zai"]`: prepend `glm-5.3`
- zai provider profile `fallback_models`: prepend `glm-5.3`
- `OPENROUTER_MODELS` in-repo snapshot: add `z-ai/glm-5.3` above glm-5.2
- `nous` curated list: add `z-ai/glm-5.3` above glm-5.2

The `default`/`recommended` badges and `PREFERRED_SILENT_DEFAULT_MODEL` are untouched (still glm-5.2), and the NIM `z-ai/glm-5.2` mapping entry is left alone since build.nvidia.com doesn't host 5.3 yet.

## Verification

- Confirmed `glm-5.3` present in live Z.AI `/models` and `z-ai/glm-5.3` in live OpenRouter `/v1/models` (both support tools per the OpenRouter payload, so it passes the `_openrouter_model_supports_tools` filter)
- `provider_model_ids("zai")` now returns `glm-5.3` first
- `tests/plugins/model_providers/test_zai_profile.py`, `tests/hermes_cli/test_provider_live_curated_merge.py`, `tests/hermes_cli/test_model_provider_persistence.py` — **37 passed**