### PR TITLE
fix(desktop): "Show earlier" does nothing on sessions with hidden rows — clamp cancels the budget expansion

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -9,12 +9,31 @@ import {
   liveTailStart,
   type MessageGroup,
   resolveThreadScrollTarget,
+  shouldClampTranscriptBudget,
   subscribeToThreadForeground,
   transcriptPaneBudget
 } from './list'
 
 afterEach(() => {
   vi.restoreAllMocks()
+})
+
+describe('shouldClampTranscriptBudget', () => {
+  it('clamps a hot-hidden pane back to its hidden budget', () => {
+    expect(shouldClampTranscriptBudget(1200, HIDDEN_TRANSCRIPT_RENDER_BUDGET, true)).toBe(true)
+  })
+
+  it('never clamps a VISIBLE pane — "Show earlier" expands past paneBudget on purpose', () => {
+    // Regression: the clamp used to fire unconditionally, cancelling the
+    // "Show earlier" budget expansion on the very next render, so the button
+    // did nothing on any session heavy enough to have hidden rows.
+    expect(shouldClampTranscriptBudget(1200, 600, false)).toBe(false)
+  })
+
+  it('leaves a budget at or under the pane budget alone', () => {
+    expect(shouldClampTranscriptBudget(600, 600, true)).toBe(false)
+    expect(shouldClampTranscriptBudget(599, 600, true)).toBe(false)
+  })
 })
 
 describe('subscribeToThreadForeground', () => {

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -105,6 +105,19 @@ export const transcriptPaneBudget = (mountedPanes: number, hidden: boolean): num
   hidden
     ? HIDDEN_TRANSCRIPT_RENDER_BUDGET
     : Math.max(Math.ceil(RENDER_BUDGET / Math.max(1, mountedPanes)), RENDER_BUDGET / 4)
+
+/**
+ * Whether the render-phase budget clamp should fire: only when the pane is
+ * actually HOT-HIDDEN (kept mounted in the background, where a stale full
+ * transcript must never commit in one go). A VISIBLE pane expands its budget
+ * beyond `paneBudget` on purpose — the "Show earlier" click adds a page each
+ * time — and clamping there would cancel that expansion on the very next
+ * render, leaving the affordance dead on every session heavy enough to have
+ * hidden rows (click shows nothing).
+ */
+export function shouldClampTranscriptBudget(renderBudget: number, paneBudget: number, paneHidden: boolean): boolean {
+  return paneHidden && renderBudget > paneBudget
+}
 // Units the backfill adds per committed step (see the backfill effect). ~8-15
 // ordinary turns or 1-2 tool-heavy ones per frame — big enough to fill a page
 // in ~10 frames, small enough that no single commit approaches a frame budget.
@@ -433,9 +446,13 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     setBudgetSessionKey(sessionKey)
     setHadGroups(hasGroups)
     setRenderBudget(FIRST_PAINT_BUDGET)
-  } else if (renderBudget > paneBudget) {
+  } else if (shouldClampTranscriptBudget(renderBudget, paneBudget, paneLifecycle === 'hot-hidden')) {
     // Apply the hidden budget during render so React never first commits the
-    // stale full transcript after this pane moves to the background.
+    // stale full transcript after this pane moves to the background. Guarded
+    // on the pane being hot-hidden: a visible pane's "Show earlier" expands
+    // renderBudget past paneBudget on purpose, and an unconditional clamp
+    // cancelled that expansion on the next render (the affordance did nothing
+    // on sessions heavy enough to have hidden rows).
     setRenderBudget(paneBudget)
   } else if (hadGroups !== hasGroups) {
     setHadGroups(hasGroups)


### PR DESCRIPTION
## Summary

On any session heavy enough to have transcript rows hidden behind the DOM render budget, the "Show earlier" affordance (shown at the top of the thread when `hiddenCount > 0 || olderAvailable`) does **nothing** when clicked. No new messages appear, no error — the click is silently swallowed.

## Root cause

`apps/desktop/src/components/assistant-ui/thread/list.tsx` clamps the transcript DOM budget **during render**:

```
} else if (renderBudget > paneBudget) {
  setRenderBudget(paneBudget)
}
```

The clamp exists so a **hot-hidden** pane (kept mounted in the background) never commits its stale full transcript in one go after moving to an inactive tab. But it fires **unconditionally** whenever `renderBudget > paneBudget` — including on a **visible** pane where "Show earlier" just expanded the budget on purpose:

1. Steady state: `renderBudget === paneBudget` (600 for a single visible pane).
2. Click "Show earlier" → `setRenderBudget(paneBudget + paneBudget)`.
3. Next render: `renderBudget > paneBudget` → clamp fires → `setRenderBudget(paneBudget)`.
4. The expansion never commits; `hiddenCount` is unchanged; the UI does not move.

The "window" branch (store-window expansion / REST backfill) is hit only after `hiddenCount` reaches 0, which requires the DOM budget to grow first — so the dead click blocks both branches on heavy sessions.

## Fix

Gate the clamp on the pane actually being hot-hidden:

```
} else if (shouldClampTranscriptBudget(renderBudget, paneBudget, paneLifecycle === 'hot-hidden')) {
```

The hidden-pane behavior is preserved exactly; a visible pane's "Show earlier" expansion now survives to commit. This also aligns the code with the comment two lines up in the same file: "Panes that already backfilled keep their mounted content when the count changes — the share only caps where NEW backfills stop."

## Test

Added `shouldClampTranscriptBudget` as a pure, exported decision function and covered it with three unit tests, including the regression: a visible pane with `renderBudget > paneBudget` must **not** clamp.

```
Test Files  1 passed (1)
Tests       28 passed (28)   (25 pre-existing + 3 new)
```

## Repro

1. Open any session whose transcript exceeds the render budget (600 units — a tool-heavy session reaches this quickly).
2. Scroll to the top; the "Show earlier" button is present.
3. Click it repeatedly — nothing happens.