### PR TITLE
fix(desktop): skill hub installs no longer 404 on non-default profiles or fail silently

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -718,6 +718,37 @@ test('resolveProfileApiRequest scopes complete safe families according to their 
   )
 })
 
+test('resolveProfileApiRequest routes action-status polls with the action-spawning routes', () => {
+  // /api/actions/{name}/status must land on the SAME backend as the endpoints
+  // that spawn actions (skills hub install/uninstall/update, mcp catalog
+  // install): _spawn_hermes_action registers the dynamic action name only in
+  // the spawning process. Splitting the pair 404s the poll with
+  // "Unknown action: skills-install-<slug>-<hash>".
+  assert.deepEqual(
+    resolveProfileApiRequest('iris', '/api/actions/skills-install-ascii-art-dd7bccf1/status?lines=200', {
+      requestMethod: 'GET'
+    }),
+    {
+      backendProfile: null,
+      requestPath: '/api/actions/skills-install-ascii-art-dd7bccf1/status?lines=200&profile=iris'
+    }
+  )
+  // The spawn side (hub install) and the poll side must agree on the backend.
+  assert.deepEqual(
+    resolveProfileApiRequest('iris', '/api/skills/hub/install', {
+      requestMethod: 'POST'
+    }),
+    { backendProfile: null, requestPath: '/api/skills/hub/install?profile=iris' }
+  )
+  // MCP catalog installs spawn background actions too — same pairing rule.
+  assert.deepEqual(
+    resolveProfileApiRequest('iris', '/api/mcp/catalog/install', {
+      requestMethod: 'POST'
+    }),
+    { backendProfile: null, requestPath: '/api/mcp/catalog/install?profile=iris' }
+  )
+})
+
 test('resolveProfileApiRequest preserves remote routing precedence', () => {
   assert.deepEqual(
     resolveProfileApiRequest('iris', '/api/memory/reset', {

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -548,7 +548,11 @@ const LOCAL_PRIMARY_SCOPED_ROUTES = new Set([
   'GET /api/skills/hub/search',
   'GET /api/skills/hub/sources',
   'POST /api/skills/hub/uninstall',
-  'POST /api/skills/hub/update'
+  'POST /api/skills/hub/update',
+  // Spawns a background action polled via /api/actions/{name}/status — must
+  // live on the SAME backend as that poll family (below), or the poll asks a
+  // backend that never registered the dynamic action name and 404s.
+  'POST /api/mcp/catalog/install'
 ])
 
 function localPrimaryRequestScope(opts: ProfileRouteOptions): boolean | null {
@@ -569,6 +573,16 @@ function localPrimaryRequestScope(opts: ProfileRouteOptions): boolean | null {
   const method = String(opts.requestMethod || 'GET').toUpperCase()
 
   if (LOCAL_PRIMARY_SCOPED_ROUTES.has(`${method} ${pathname}`)) {
+    return true
+  }
+
+  // Action-status polls MUST land on the same backend as the endpoints that
+  // spawned them: `_spawn_hermes_action` registers the (often dynamic, e.g.
+  // `skills-install-<slug>-<hash>`) action name only in the spawning
+  // process's memory. Every action-spawning route above scopes to the
+  // primary, so the poll family follows — a pooled-backend poll 404s with
+  // "Unknown action" even though the install itself succeeded (#89xxx).
+  if (pathname.startsWith('/api/actions/')) {
     return true
   }
 

--- a/apps/desktop/src/contrib/runtime-loader.test.ts
+++ b/apps/desktop/src/contrib/runtime-loader.test.ts
@@ -3,8 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { HermesReadDirResult } from '@/global'
 import type * as HermesModule from '@/hermes'
 
-import { $pluginRecords, setPluginEnabled } from './plugins-store'
-import { discoverRuntimePlugins, watchRuntimePlugins } from './runtime-loader'
+import { $pluginRecords, publishPlugin, setPluginEnabled } from './plugins-store'
+import { discoverRuntimePlugins, loadRuntimePlugin, watchRuntimePlugins } from './runtime-loader'
 
 // getStatus would supply the connected backend's hermes_home — a REMOTE path in
 // remote mode. The disk scanner must NOT derive the plugin root from it (#66899).
@@ -176,5 +176,56 @@ describe('watchRuntimePlugins dir watch (#66899)', () => {
     expect(watchDirectory).toHaveBeenCalledWith('/local/.hermes/plugins')
     expect(watchDirectory).not.toHaveBeenCalledWith('/remote/box/.hermes/desktop-plugins')
     expect(getStatus).not.toHaveBeenCalled()
+  })
+})
+
+describe('bundled-shadowed disk copies', () => {
+  it('skips a disk copy of a bundled plugin but publishes a visible inventory row', async () => {
+    // The bundled twin is already registered (build-time glob).
+    publishPlugin({ id: 'hermes-bots', name: 'Bot Mode', kind: 'bundled', status: 'loaded' })
+
+    // Same blob→data: URL reroute as the opt-in test above.
+    const createObjectURL = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockImplementation(
+        blob =>
+          `data:text/javascript;base64,${Buffer.from((blob as unknown as { parts: string[] }).parts.join('')).toString('base64')}`
+      )
+
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined)
+    const RealBlob = globalThis.Blob
+    vi.stubGlobal(
+      'Blob',
+      class {
+        parts: string[]
+        constructor(parts: string[]) {
+          this.parts = parts
+        }
+      }
+    )
+
+    try {
+      const id = await loadRuntimePlugin(
+        'export default { id: "hermes-bots", name: "Bot Mode", register() {} }',
+        'hermes-bots',
+        { file: '/local/.hermes/desktop-plugins/hermes-bots/plugin.js' }
+      )
+
+      // Skipped — the bundled copy stays the only live registration...
+      expect(id).toBeNull()
+      expect($pluginRecords.get()['hermes-bots']).toMatchObject({ kind: 'bundled', status: 'loaded' })
+
+      // ...but the stale folder is DISCOVERABLE: an inventory row names it,
+      // carries its path (reveal/delete affordance), and can never activate.
+      expect($pluginRecords.get()['hermes-bots:disk-shadowed']).toMatchObject({
+        kind: 'disk',
+        status: 'disabled',
+        file: '/local/.hermes/desktop-plugins/hermes-bots/plugin.js'
+      })
+    } finally {
+      createObjectURL.mockRestore()
+      revokeObjectURL.mockRestore()
+      vi.stubGlobal('Blob', RealBlob)
+    }
   })
 })

--- a/apps/desktop/src/contrib/runtime-loader.ts
+++ b/apps/desktop/src/contrib/runtime-loader.ts
@@ -146,9 +146,20 @@ export async function loadRuntimePlugin(
     // standalone install of hermes-bots predating its adoption in-tree) must
     // not register a second time: contributions would double up and the two
     // copies would fight over storage. The bundled copy wins; the disk copy
-    // is skipped quietly so stale installs keep working after an app update.
+    // is skipped — but VISIBLY: a silent skip left the stale folder
+    // undiscoverable while (on shells without the bundled twin) the same
+    // folder actively breaks the feature it shadows. The inventory row
+    // carries the file path so Settings → Plugins can reveal it for deletion.
     if ($pluginRecords.get()[plugin.id]?.kind === 'bundled') {
       console.info(`[plugins] ${origin} skipped — "${plugin.id}" already ships bundled with the app`)
+      publishPlugin({
+        id: `${plugin.id}:disk-shadowed`,
+        name: `${plugin.name ?? plugin.id} (stale disk copy)`,
+        description: `Shadowed by the bundled "${plugin.id}" plugin — this folder is no longer used and can be deleted.`,
+        kind: options.kind ?? 'disk',
+        file: options.file,
+        status: 'disabled'
+      })
 
       return null
     }

--- a/apps/desktop/src/store/hub-actions.test.ts
+++ b/apps/desktop/src/store/hub-actions.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// A failed hub action (non-zero subprocess exit) must REJECT so callers toast
+// it — the Aug 2026 report shape was a scan-gated/failed `hermes skills
+// install` exiting non-zero with no toast, no list change, and no error
+// anywhere in the UI: the user read it as "install did nothing".
+
+const getActionStatus = vi.fn()
+const installSkillFromHub = vi.fn()
+
+vi.mock('@/hermes', () => ({
+  getActionStatus: (...args: unknown[]) => getActionStatus(...args),
+  installSkillFromHub: (...args: unknown[]) => installSkillFromHub(...args),
+  uninstallSkillFromHub: vi.fn(),
+  updateSkillsFromHub: vi.fn()
+}))
+
+vi.mock('@/lib/query-client', () => ({
+  queryClient: { invalidateQueries: vi.fn() }
+}))
+
+vi.mock('@/lib/slash-completion-cache', () => ({
+  invalidateSlashCompletions: vi.fn()
+}))
+
+vi.mock('@/store/activity', () => ({
+  upsertDesktopActionTask: vi.fn()
+}))
+
+// hub-actions subscribes to the active gateway profile at module scope (its
+// per-profile state wipe); a minimal stub keeps this test off the real store.
+vi.mock('@/store/profile', () => ({
+  $activeGatewayProfile: { subscribe: vi.fn() },
+  normalizeProfileKey: (value: unknown) => String(value ?? '') || 'default'
+}))
+
+import { $hubActions, $hubInstalledOverride, installHubSkill } from './hub-actions'
+
+describe('installHubSkill failure surfacing', () => {
+  beforeEach(() => {
+    getActionStatus.mockReset()
+    installSkillFromHub.mockReset()
+    $hubActions.set({})
+    $hubInstalledOverride.set({})
+  })
+
+  it('rejects with the action log tail when the subprocess exits non-zero', async () => {
+    installSkillFromHub.mockResolvedValue({ name: 'skills-install-ascii-art-dd7bccf1' })
+    getActionStatus.mockResolvedValue({
+      name: 'skills-install-ascii-art-dd7bccf1',
+      running: false,
+      exit_code: 1,
+      pid: 4242,
+      lines: ['Resolving ascii-art...', 'Error: security scan blocked install']
+    })
+
+    await expect(installHubSkill('ascii-art')).rejects.toThrow('security scan blocked install')
+
+    // A failed install must not paint the row as installed.
+    expect($hubInstalledOverride.get()['ascii-art']).toBeUndefined()
+    // ...but the row's running flag still settles to false for the button.
+    expect($hubActions.get()['ascii-art']?.running).toBe(false)
+  })
+
+  it('rejects with the exit code when the log carries no detail', async () => {
+    installSkillFromHub.mockResolvedValue({ name: 'skills-install-x-00000000' })
+    getActionStatus.mockResolvedValue({
+      name: 'skills-install-x-00000000',
+      running: false,
+      exit_code: 7,
+      pid: 4242,
+      lines: []
+    })
+
+    await expect(installHubSkill('x')).rejects.toThrow('exited with code 7')
+  })
+
+  it('resolves and flips the row on a clean exit', async () => {
+    installSkillFromHub.mockResolvedValue({ name: 'skills-install-ok-11111111' })
+    getActionStatus.mockResolvedValue({
+      name: 'skills-install-ok-11111111',
+      running: false,
+      exit_code: 0,
+      pid: 4242,
+      lines: ['Installed ok']
+    })
+
+    await expect(installHubSkill('ok')).resolves.toBeUndefined()
+    expect($hubInstalledOverride.get()['ok']).toBe(true)
+  })
+})

--- a/apps/desktop/src/store/hub-actions.ts
+++ b/apps/desktop/src/store/hub-actions.ts
@@ -122,6 +122,17 @@ async function runHubAction(
     // …and the composer's `/` list, which caches the command catalog for an
     // hour and would otherwise keep offering the skill we just removed.
     invalidateSlashCompletions()
+
+    // A non-zero exit is a real failure — throw so the caller's catch toasts
+    // it. Before this, a failed subprocess (scan gate, network, bad
+    // identifier) just stopped silently: no flip, no toast, and the user read
+    // the unchanged skills list as "install did nothing" (Aug 2026 report).
+    // The last log lines carry the subprocess's actual error.
+    if (exitCode !== null && exitCode !== 0) {
+      const detail = ($hubActions.get()[key]?.lines ?? []).slice(-3).join('\n').trim()
+
+      throw new Error(detail || `Action exited with code ${exitCode}`)
+    }
   } catch (err) {
     // A profile switch points the next poll at the new backend, which 404s the
     // old action name — that's an abandonment, not a failure, so swallow it


### PR DESCRIPTION
## Summary
Skill hub "Install on this agent" now works on non-default profiles, and a failed install can never again look like a silent no-op.

Root cause (routing half): `POST /api/skills/hub/install` is a primary-scoped route, but its follow-up `GET /api/actions/{name}/status` poll wasn't — for a non-default profile the poll routed to the profile's pooled backend, which never registered the dynamic action name (`skills-install-<slug>-<hash>` lives only in the spawning process's memory) → toast `Skill action failed: Unknown action: skills-install-ascii-art-dd7bccf1` even though the install succeeded.

## Changes
- `electron/connection-config.ts`: `/api/actions/` poll family now routes with the action-spawning routes (primary + `?profile=` scope); `POST /api/mcp/catalog/install` joins the scoped table — it spawns background actions polled the same way.
- `src/store/hub-actions.ts`: non-zero action exit now rejects with the action-log tail, so `notifyError` toasts the subprocess's real error. Before: silent stop, no row flip, skills list unchanged — read as "install did nothing" (the second half of this report, on Windows).
- `src/contrib/runtime-loader.ts`: a disk plugin copy shadowed by a bundled twin now publishes a visible "(stale disk copy)" inventory row with the folder path in Settings → Plugins, instead of a `console.info` nobody sees. Those stale `desktop-plugins/` leftovers actively break features on shells without the bundled twin (the third half of this report: a stale hermes-bots deploy crashing `HubSkillsSection` behind the ContribBoundary).

## Validation
| Check | Result |
|---|---|
| `connection-config.test.ts` (vitest, electron project) | 107/107 — new routing test fails under sabotage (rule removed), passes with fix |
| `hub-actions.test.ts` (new) | 3/3 — both failure tests fail under sabotage, pass with fix |
| `runtime-loader.test.ts` | 7/7 — new shadowed-row test fails under sabotage, passes with fix |
| `npm run check:lint` (tsc ×3 + eslint) | 0 errors |

## Infographic

![Skill hub install fixed — routing, no silent fails, stale copies](https://v3b.fal.media/files/b/0aa6efc8/GayV63G4IAtbdVk4HgjiG_hVo7Niis.png)
