### PR TITLE
fix(desktop): avoid macOS Safe Storage prompts on config reads

### DIFF
--- a/apps/desktop/electron/hardening.test.ts
+++ b/apps/desktop/electron/hardening.test.ts
@@ -20,6 +20,7 @@ import {
   resolveReadableFileForIpc,
   resolveRequestedPathForIpc,
   resolveTimeoutMs,
+  safeStorageEncryptionAvailable,
   SAFE_STORAGE_ENCODING,
   SECRET_FILE_MODE,
   sensitiveFileBlockReason,
@@ -622,6 +623,32 @@ test('tightenSecretFileMode leaves Windows alone rather than flipping the read-o
   // suppressed it above.
   assert.equal(tightenSecretFileMode('/home/me/connection.json', { fs: fakeFs, platform: 'linux' }), true)
   assert.ok(chmods.includes('/home/me/connection.json'), 'the POSIX path was tightened')
+})
+
+test('safeStorage capability checks do not initialize the macOS keychain', () => {
+  let probes = 0
+  const safeStorageApi = {
+    isEncryptionAvailable: () => {
+      probes += 1
+      return true
+    }
+  }
+
+  assert.equal(safeStorageEncryptionAvailable('darwin', safeStorageApi), true)
+  assert.equal(probes, 0, 'macOS capability checks must not create a Safe Storage keychain item')
+})
+
+test('safeStorage capability checks still probe Linux keyrings', () => {
+  let probes = 0
+  const safeStorageApi = {
+    isEncryptionAvailable: () => {
+      probes += 1
+      return false
+    }
+  }
+
+  assert.equal(safeStorageEncryptionAvailable('linux', safeStorageApi), false)
+  assert.equal(probes, 1)
 })
 
 test('a token is never persisted in plaintext when safeStorage is unavailable', () => {

--- a/apps/desktop/electron/hardening.ts
+++ b/apps/desktop/electron/hardening.ts
@@ -161,6 +161,29 @@ function resolveTimeoutMs(timeoutMs, fallbackMs = DEFAULT_FETCH_TIMEOUT_MS) {
   return fallback
 }
 
+/**
+ * Report whether safeStorage can encrypt without creating credential state as
+ * a side effect. Electron's macOS implementation creates the app's
+ * "Safe Storage" Keychain item when isEncryptionAvailable() is queried, so a
+ * capability-only UI read must not call it. Keychain-backed encryption is a
+ * platform capability on macOS; an actual encryptString() still surfaces any
+ * locked/unavailable-keychain failure when a secret is intentionally saved.
+ */
+function safeStorageEncryptionAvailable(
+  platform: string,
+  safeStorageApi: { isEncryptionAvailable?: () => boolean } | null | undefined
+) {
+  if (platform === 'darwin') {
+    return true
+  }
+
+  try {
+    return Boolean(safeStorageApi?.isEncryptionAvailable?.())
+  } catch {
+    return false
+  }
+}
+
 function encryptDesktopSecret(value, safeStorageApi, options: { allowPlainText?: boolean } = {}) {
   const raw = String(value || '')
 
@@ -553,6 +576,7 @@ export {
   resolveReadableFileForIpc,
   resolveRequestedPathForIpc,
   resolveTimeoutMs,
+  safeStorageEncryptionAvailable,
   SAFE_STORAGE_ENCODING,
   SECRET_FILE_MODE,
   sensitiveFileBlockReason,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -200,6 +200,7 @@ import {
   resolveReadableFileForIpc,
   resolveRequestedPathForIpc,
   resolveTimeoutMs,
+  safeStorageEncryptionAvailable,
   SAFE_STORAGE_ENCODING,
   TEXT_PREVIEW_SOURCE_MAX_BYTES,
   tightenSecretFileMode,
@@ -8357,13 +8358,7 @@ function sanitizeRegistryConnection(entry) {
 function sanitizeConnectionsRegistry(registry = readDesktopConnectionsRegistry()) {
   // Same keyring probe the v1 sanitize exposes: lets the Connections panel
   // offer the plain-text opt-in on keyring-less Linux instead of failing.
-  let secureTokenStorage = false
-
-  try {
-    secureTokenStorage = Boolean(safeStorage.isEncryptionAvailable())
-  } catch {
-    secureTokenStorage = false
-  }
+  const secureTokenStorage = safeStorageEncryptionAvailable(process.platform, safeStorage)
 
   return {
     version: registry.version,
@@ -8487,15 +8482,10 @@ async function sanitizeDesktopConnectionConfig(config = readDesktopConnectionCon
 
   // Whether the OS keyring (safeStorage) can encrypt the saved token. When
   // false the renderer knows to offer the plain-text opt-in in Settings →
-  // Gateway. safeStorage.isEncryptionAvailable can throw on some platforms, so
-  // treat any failure as "not available".
-  let secureTokenStorage = false
-
-  try {
-    secureTokenStorage = Boolean(safeStorage.isEncryptionAvailable())
-  } catch {
-    secureTokenStorage = false
-  }
+  // Gateway. On macOS the raw Electron capability probe creates the app's Safe
+  // Storage Keychain item, so the helper answers from the platform capability
+  // without touching Keychain. Other platforms keep the guarded runtime probe.
+  const secureTokenStorage = safeStorageEncryptionAvailable(process.platform, safeStorage)
 
   // Whether the currently saved token is stored in plain text (the keyring-less
   // opt-in path). The env override supplies its token from the environment, not


### PR DESCRIPTION
## Summary
- avoid calling `safeStorage.isEncryptionAvailable()` for capability-only config reads on macOS
- report macOS Keychain-backed encryption as available without initializing the `Hermes Safe Storage` item
- preserve the guarded runtime probe on Linux and other platforms

## Why
Electron documents/implements `safeStorage.isEncryptionAvailable()` on macOS by creating the app's Safe Storage Keychain entry. Desktop calls the probe while sanitizing connection settings and the connection registry, so users with plain owner-only cockpit tokens can get a new Keychain item—and repeated password prompts—without saving any encrypted secret.

Reference: https://github.com/electron/electron/issues/45328

## Verification
- `npm -w apps/desktop run typecheck`
- `npm -w apps/desktop test -- --run electron/hardening.test.ts` (46 passed)
- `npm -w apps/desktop run test:desktop:platforms` (1452 passed, 2 skipped)
