### PR TITLE
fix(cron): re-parse own "once at"/"once in" display strings (#89560)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -712,7 +712,22 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
     schedule = schedule.strip()
     original = schedule
     schedule_lower = schedule.lower()
-    
+
+    # "once at <YYYY-MM-DD HH:MM>" — round-trip from display string (#89560)
+    _once_at_match = re.match(
+        r'^once\s+at\s+(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}(?::\d{2})?)',
+        schedule_lower,
+    )
+    if _once_at_match:
+        schedule = _once_at_match.group(1)  # fall through to ISO parser below
+        original = schedule
+
+    # "once in <duration>" — round-trip from display string (#89560)
+    _once_in_match = re.match(r'^once\s+in\s+(.+)$', schedule_lower)
+    if _once_in_match:
+        schedule = _once_in_match.group(1).strip()  # fall through to duration parser below
+        original = schedule
+
     # "every X" pattern → recurring interval
     if schedule_lower.startswith("every "):
         duration_str = schedule[6:].strip()


### PR DESCRIPTION
## Summary

`parse_schedule()` in `cron/jobs.py` emits human-readable display strings like `once at 2026-08-19 08:00` and `once in 30m` but cannot re-parse them when fed back as schedule input. This causes `ValueError` / HTTP 500 when editing one-shot cron jobs through a UI that round-trips the display string.

## Fix

Add extraction guards at the top of `parse_schedule()` that strip the `once at` / `once in` prefix and fall through to the existing ISO-timestamp and duration parsers respectively.

- `"once at 2026-08-19 08:00"` → extracts `"2026-08-19 08:00"` → ISO parser
- `"once in 30m"` → extracts `"30m"` → duration parser

## Testing

- Verified round-trip: `parse_schedule(parse_schedule("2026-08-19T08:00")["display"])` succeeds
- Verified round-trip: `parse_schedule(parse_schedule("30m")["display"])` succeeds
- Full cron test suite: 805 passed, 1 skipped

Fixes #89560