### PR TITLE
fix(codex): honor response end_turn continuation

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -1296,6 +1296,43 @@ def _format_responses_error(error_obj: Any, response_status: str) -> str:
 # Full response normalization
 # ---------------------------------------------------------------------------
 
+def merge_codex_assistant_samples(
+    prior: Dict[str, Any],
+    newer: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Combine two Responses samplings from one logical assistant turn.
+
+    The newer sampling owns visible content and terminal metadata. Ordered
+    message items accumulate for exact replay; opaque reasoning uses the
+    existing checkpoint-aware merge contract.
+    """
+    merged = dict(newer)
+
+    message_items = list(prior.get("codex_message_items") or [])
+    message_items.extend(newer.get("codex_message_items") or [])
+    if message_items:
+        merged["codex_message_items"] = message_items
+
+    reasoning_texts = []
+    for message in (prior, newer):
+        reasoning = message.get("reasoning")
+        if isinstance(reasoning, str) and reasoning.strip():
+            reasoning_texts.append(reasoning.strip())
+    if reasoning_texts:
+        merged["reasoning"] = "\n\n".join(reasoning_texts)
+
+    from agent.native_compaction import merge_interim_reasoning_items
+
+    reasoning_items = merge_interim_reasoning_items(
+        prior.get("codex_reasoning_items"),
+        newer.get("codex_reasoning_items"),
+    )
+    if reasoning_items:
+        merged["codex_reasoning_items"] = reasoning_items
+
+    return merged
+
+
 def _normalize_codex_response(
     response: Any,
     *,
@@ -1639,6 +1676,11 @@ def _normalize_codex_response(
         finish_reason = "tool_calls"
     elif response_incomplete_content_filter:
         finish_reason = "content_filter"
+    elif getattr(response, "end_turn", None) is False:
+        # ChatGPT's Codex backend can finish one Responses sampling without
+        # finishing the enclosing user turn.  Preserve that explicit protocol
+        # signal instead of treating an ordinary message item as a final answer.
+        finish_reason = "incomplete"
     elif leaked_tool_call_text:
         finish_reason = "incomplete"
     elif saw_streaming_or_item_incomplete:

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -1060,6 +1060,7 @@ def _consume_codex_event_stream(
     * ``status``: ``completed`` / ``incomplete`` / ``failed`` (or ``completed`` if
       the stream ended without a terminal frame but produced content).
     * ``id``: ``response.id`` when present.
+    * ``end_turn``: optional Codex backend turn-boundary signal.
     * ``incomplete_details``: passed through for ``response.incomplete`` frames.
     * ``error``: passed through for ``response.failed`` frames.
     * ``model``: from kwargs (the wire model name is not authoritative).
@@ -1096,6 +1097,7 @@ def _consume_codex_event_stream(
     terminal_status: str = "completed"
     terminal_usage: Any = None
     terminal_response_id: str = None
+    terminal_end_turn: bool | None = None
     terminal_incomplete_details: Any = None
     terminal_error: Any = None
     saw_terminal = False
@@ -1241,6 +1243,11 @@ def _consume_codex_event_stream(
                 if rid is None and isinstance(resp_obj, dict):
                     rid = resp_obj.get("id")
                 terminal_response_id = rid
+                end_turn = getattr(resp_obj, "end_turn", None)
+                if end_turn is None and isinstance(resp_obj, dict):
+                    end_turn = resp_obj.get("end_turn")
+                if isinstance(end_turn, bool):
+                    terminal_end_turn = end_turn
                 rstatus = getattr(resp_obj, "status", None)
                 if rstatus is None and isinstance(resp_obj, dict):
                     rstatus = resp_obj.get("status")
@@ -1298,6 +1305,7 @@ def _consume_codex_event_stream(
         usage=terminal_usage,
         status=terminal_status,
         id=terminal_response_id,
+        end_turn=terminal_end_turn,
         model=model,
         incomplete_details=terminal_incomplete_details,
         error=terminal_error,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1097,6 +1097,10 @@ _CODEX_ACK_CONTINUATION_NUDGE = (
     "send your final answer after completing the task.]"
 )
 
+# Marks interim Responses samplings whose terminal frame explicitly kept the
+# enclosing user turn open. These samples are merged into one assistant turn.
+_CODEX_END_TURN_CONTINUATION_FLAG = "_codex_end_turn_continuation"
+
 # Re-prompt sent when a provider returns finish_reason="tool_calls" with an
 # empty tool_calls array (dropped-tool-call recovery, see the retry loop
 # below). Named for the same reason as _CODEX_ACK_CONTINUATION_NUDGE — this
@@ -6645,6 +6649,8 @@ def run_conversation(
                 agent._codex_incomplete_retries += 1
 
                 interim_msg = agent._build_assistant_message(assistant_message, finish_reason)
+                if getattr(response, "end_turn", None) is False:
+                    interim_msg[_CODEX_END_TURN_CONTINUATION_FLAG] = True
                 interim_has_content = bool((interim_msg.get("content") or "").strip())
                 interim_has_reasoning = bool(interim_msg.get("reasoning", "").strip()) if isinstance(interim_msg.get("reasoning"), str) else False
                 interim_has_codex_reasoning = bool(interim_msg.get("codex_reasoning_items"))
@@ -6684,7 +6690,27 @@ def run_conversation(
                         and last_msg.get("finish_reason") == "incomplete"
                         and same_visible_output
                     )
-                    if visible_duplicate:
+                    end_turn_chain = (
+                        isinstance(last_msg, dict)
+                        and (
+                            last_msg.get(_CODEX_END_TURN_CONTINUATION_FLAG) is True
+                            or interim_msg.get(_CODEX_END_TURN_CONTINUATION_FLAG) is True
+                        )
+                    )
+                    if end_turn_chain:
+                        from agent.codex_responses_adapter import (
+                            merge_codex_assistant_samples,
+                        )
+
+                        merged_interim = merge_codex_assistant_samples(
+                            last_msg,
+                            interim_msg,
+                        )
+                        merged_interim[_CODEX_END_TURN_CONTINUATION_FLAG] = True
+                        messages[-1] = merged_interim
+                        if not visible_duplicate:
+                            agent._emit_interim_assistant_message(interim_msg)
+                    elif visible_duplicate:
                         # Update replay state in-place so the latest provider
                         # payload is preserved without re-emitting identical
                         # user-visible commentary.
@@ -7124,6 +7150,20 @@ def run_conversation(
                     and previous_msg.get("finish_reason") == "incomplete"
                     and previous_interim_visible == current_interim_visible
                 )
+                if (
+                    agent.api_mode == "codex_responses"
+                    and isinstance(previous_msg, dict)
+                    and previous_msg.get(_CODEX_END_TURN_CONTINUATION_FLAG) is True
+                ):
+                    from agent.codex_responses_adapter import (
+                        merge_codex_assistant_samples,
+                    )
+
+                    messages.pop()
+                    assistant_msg = merge_codex_assistant_samples(
+                        previous_msg,
+                        assistant_msg,
+                    )
                 append_message(messages, assistant_msg)
 
                 # Mixed batch: error-result the invalid calls and strip them
@@ -7886,6 +7926,30 @@ def run_conversation(
                     )
                 ):
                     messages.pop()
+
+                # A Codex user turn may span multiple Responses samplings.
+                # ``end_turn=false`` records each sampling as interim assistant
+                # state so its opaque response items can be replayed on the
+                # next request.
+                # Once a final answer arrives those samples are one logical
+                # assistant turn, not consecutive durable assistant turns.
+                # Collapse the trailing interim run into the final message,
+                # retaining every ordered Codex replay item while keeping the
+                # user-facing content equal to the actual final answer.
+                if (
+                    agent.api_mode == "codex_responses"
+                    and messages
+                    and isinstance(messages[-1], dict)
+                    and messages[-1].get(_CODEX_END_TURN_CONTINUATION_FLAG) is True
+                ):
+                    from agent.codex_responses_adapter import (
+                        merge_codex_assistant_samples,
+                    )
+
+                    final_msg = merge_codex_assistant_samples(
+                        messages.pop(),
+                        final_msg,
+                    )
 
                 try:
                     from agent.verification_stop import (

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -662,6 +662,40 @@ def test_consume_codex_stream_separates_commentary_from_analysis(monkeypatch):
     assert response.output == [commentary_item]
 
 
+def test_consume_codex_stream_preserves_end_turn_false(monkeypatch):
+    """A completed sampling can still require another Codex sampling."""
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    message_item = SimpleNamespace(
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[
+            SimpleNamespace(
+                type="output_text",
+                text="I will inspect the repository now.",
+            )
+        ],
+    )
+
+    response = _consume_codex_event_stream(
+        _FakeCreateStream([
+            SimpleNamespace(type="response.output_item.done", item=message_item),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(
+                    id="resp_continue",
+                    status="completed",
+                    end_turn=False,
+                ),
+            ),
+        ]),
+        model="gpt-5.6-sol",
+    )
+
+    assert response.end_turn is False
+
+
 
 
 def test_run_codex_stream_delivers_redacted_commentary_once(monkeypatch):
@@ -1434,6 +1468,101 @@ def test_run_conversation_codex_replay_payload_keeps_call_id(monkeypatch):
     assert function_output["call_id"] == "call_1"
 
 
+def test_codex_end_turn_false_then_tool_call_keeps_one_assistant_turn(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    progress = _codex_message_response("I will inspect the repository now.")
+    progress.end_turn = False
+    responses = [
+        progress,
+        _codex_tool_call_response(),
+        _codex_message_response("Inspection complete."),
+    ]
+    requests = []
+    live_role_sequences = []
+
+    def model_call(api_kwargs):
+        requests.append(api_kwargs)
+        live_role_sequences.append(
+            [message["role"] for message in agent._session_messages]
+        )
+        return responses.pop(0)
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", model_call)
+
+    def fake_execute(assistant_message, messages, effective_task_id, *_args):
+        for call in assistant_message.tool_calls:
+            messages.append({
+                "role": "tool",
+                "tool_call_id": call.id,
+                "content": '{"ok":true}',
+            })
+
+    monkeypatch.setattr(agent, "_execute_tool_calls", fake_execute)
+
+    result = agent.run_conversation("Inspect the repository.")
+    assert result["completed"] is True
+    assert len(requests) == 3
+    assert all(
+        all(left != right for left, right in zip(roles, roles[1:]))
+        for roles in live_role_sequences
+    ), live_role_sequences
+    roles = [message["role"] for message in result["messages"]]
+    assert all(left != right for left, right in zip(roles, roles[1:])), roles
+    assert any(item.get("type") == "function_call" for item in requests[2]["input"])
+
+
+def test_codex_end_turn_false_continuation_is_bounded(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    responses = []
+    for index in range(3):
+        response = _codex_message_response(f"Progress sample {index + 1}.")
+        response.end_turn = False
+        responses.append(response)
+    calls = []
+    monkeypatch.setattr(
+        agent,
+        "_interruptible_api_call",
+        lambda api_kwargs: calls.append(api_kwargs) or responses.pop(0),
+    )
+
+    result = agent.run_conversation("Inspect the repository.")
+
+    assert len(calls) == 3
+    assert result["completed"] is False
+    assert result["partial"] is True
+    assert "remained incomplete after 3" in result["error"]
+
+
+def test_codex_open_turn_merges_followup_commentary_without_end_turn(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    first = _codex_message_response("I will inspect the repository now.")
+    first.end_turn = False
+    responses = [
+        first,
+        _codex_commentary_message_response("Still inspecting."),
+        _codex_message_response("Inspection complete."),
+    ]
+    live_role_sequences = []
+
+    def model_call(api_kwargs):
+        live_role_sequences.append(
+            [message["role"] for message in agent._session_messages]
+        )
+        return responses.pop(0)
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", model_call)
+
+    result = agent.run_conversation("Inspect the repository.")
+
+    assert result["completed"] is True
+    assert all(
+        all(left != right for left, right in zip(roles, roles[1:]))
+        for roles in live_role_sequences
+    ), live_role_sequences
+    roles = [message["role"] for message in result["messages"]]
+    assert all(left != right for left, right in zip(roles, roles[1:])), roles
+
+
 
 
 
@@ -1662,6 +1791,92 @@ def test_normalize_codex_response_marks_commentary_only_message_as_incomplete(mo
     assert assistant_message.codex_message_items
     assert assistant_message.codex_message_items[0]["phase"] == "commentary"
     assert "inspect the repository" in assistant_message.codex_message_items[0]["content"][0]["text"]
+
+
+def test_normalize_codex_response_marks_end_turn_false_as_incomplete(monkeypatch):
+    """Codex can complete one sampling while keeping the user turn open."""
+    from agent.codex_responses_adapter import _normalize_codex_response
+
+    response = _codex_message_response("I will inspect the repository now.")
+    response.end_turn = False
+
+    assistant_message, finish_reason = _normalize_codex_response(response)
+
+    assert assistant_message.content == "I will inspect the repository now."
+    assert finish_reason == "incomplete"
+
+
+def test_codex_end_turn_false_continues_sampling_until_final(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    first = _codex_message_response("I will inspect the repository now.")
+    first.end_turn = False
+    second = _codex_message_response("I found the relevant module.")
+    second.end_turn = False
+    responses = [first, second, _codex_message_response("Inspection complete.")]
+    calls = []
+    live_role_sequences = []
+
+    def model_call(api_kwargs):
+        calls.append(api_kwargs)
+        live_role_sequences.append(
+            [message["role"] for message in agent._session_messages]
+        )
+        return responses.pop(0)
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", model_call)
+
+    result = agent.run_conversation("Inspect the repository.")
+
+    assert len(calls) == 3
+    assert all(
+        all(left != right for left, right in zip(roles, roles[1:]))
+        for roles in live_role_sequences
+    ), live_role_sequences
+    assert result["completed"] is True
+    assert result["final_response"] == "Inspection complete."
+    roles = [message["role"] for message in result["messages"]]
+    assert all(left != right for left, right in zip(roles, roles[1:])), roles
+    final_message = result["messages"][-1]
+    assert not final_message.get("_codex_end_turn_continuation")
+    replay_texts = [
+        part["text"]
+        for item in final_message.get("codex_message_items") or []
+        for part in item.get("content") or []
+    ]
+    assert replay_texts == [
+        "I will inspect the repository now.",
+        "I found the relevant module.",
+        "Inspection complete.",
+    ]
+
+
+@pytest.mark.parametrize("end_turn", [True, None])
+def test_normalize_codex_response_stops_when_turn_is_not_explicitly_open(
+    monkeypatch,
+    end_turn,
+):
+    from agent.codex_responses_adapter import _normalize_codex_response
+
+    response = _codex_message_response("Inspection complete.")
+    if end_turn is not None:
+        response.end_turn = end_turn
+
+    assistant_message, finish_reason = _normalize_codex_response(response)
+
+    assert assistant_message.content == "Inspection complete."
+    assert finish_reason == "stop"
+
+
+def test_normalize_codex_response_keeps_tool_call_precedence_over_end_turn(monkeypatch):
+    from agent.codex_responses_adapter import _normalize_codex_response
+
+    response = _codex_tool_call_response()
+    response.end_turn = False
+
+    assistant_message, finish_reason = _normalize_codex_response(response)
+
+    assert len(assistant_message.tool_calls) == 1
+    assert finish_reason == "tool_calls"
 
 
 def test_normalize_codex_response_does_not_fallback_to_output_text_for_commentary_only(monkeypatch):


### PR DESCRIPTION
## Summary

- preserve the optional Codex Responses end_turn field from response.completed
- treat end_turn=false as an explicit bounded continuation signal
- merge multi-sampling message, reasoning, and tool-call state into one logical assistant turn
- preserve role alternation and exact replay items across text, commentary, and tool-call continuations

## Why

The ChatGPT Codex backend can complete one Responses sampling while leaving the enclosing user turn open. Hermes discarded end_turn, normalized the first message as finish_reason=stop, and ended the turn after a progress message.

## Tests

- message plus end_turn=false continues until a final response
- end_turn=true or missing keeps normal stop behavior
- tool-call precedence remains intact
- consecutive and mixed continuation samples preserve role alternation
- end_turn=false followed by a function call preserves replay and tool-result pairing
- continuation remains bounded at three attempts

Verification: 444 related tests passed; Ruff and git diff check passed.