### PR TITLE
fix(cron): skip model/provider snapshot for inherit-mode jobs (#89242)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1717,6 +1717,12 @@ def _compute_provider_model_snapshots(
 
     provider_snapshot: Optional[str] = None
     model_snapshot: Optional[str] = None
+    # Only snapshot an axis when it is explicitly pinned.  Inherit-mode axes
+    # (None) are *expected* to follow the global default, so recording a
+    # snapshot would cause a false drift-guard failure when the global later
+    # changes (#89242).
+    if normalized_provider is None and normalized_model is None:
+        return None, None
     if normalized_provider is None:
         try:
             from hermes_cli.runtime_provider import resolve_runtime_provider

--- a/tests/cron/test_cron_provider_pin.py
+++ b/tests/cron/test_cron_provider_pin.py
@@ -191,17 +191,25 @@ class TestCreateJobSnapshot:
         monkeypatch.setattr(jobs, "save_jobs", lambda j: None, raising=True)
         return jobs
 
-    def test_unpinned_job_captures_snapshot(self, monkeypatch):
+    def test_unpinned_job_skips_snapshot(self, monkeypatch):
+        """Inherit-mode jobs (both axes None) skip snapshotting entirely (#89242).
+
+        Recording a snapshot for an inherit-mode job would cause a false
+        drift-guard failure when the global model/provider later changes.
+        """
         jobs = self._isolate_storage(monkeypatch)
 
+        resolver = MagicMock(return_value={"provider": "openrouter"})
         with patch(
             "hermes_cli.runtime_provider.resolve_runtime_provider",
-            return_value={"provider": "openrouter"},
+            resolver,
         ):
             job = jobs.create_job(prompt="do a thing", schedule="every 1 hour")
 
         assert job["provider"] is None
-        assert job["provider_snapshot"] == "openrouter"
+        assert job["provider_snapshot"] is None
+        assert job["model_snapshot"] is None
+        resolver.assert_not_called()
 
     def test_pinned_job_skips_snapshot(self, monkeypatch):
         jobs = self._isolate_storage(monkeypatch)


### PR DESCRIPTION
## Summary

`_compute_provider_model_snapshots()` unconditionally records a `model_snapshot` and `provider_snapshot` for every agent cron job, including inherit-mode jobs where both `model` and `provider` are `None`. When the user later changes the global default model, the drift guard compares the stale snapshot against the new global, sees a mismatch, and fails closed — skipping the run — even though the job was always intended to inherit.

## Fix

Skip snapshotting entirely when both axes are unpinned (pure inherit mode). The drift guard still applies to partially-pinned jobs where one axis is explicit and the other inherits.

## Changes

- `cron/jobs.py`: Early return `(None, None)` when both `normalized_provider` and `normalized_model` are `None`
- `tests/cron/test_cron_provider_pin.py`: Updated `test_unpinned_job_skips_snapshot` to verify inherit-mode jobs get no snapshot and the resolver is not called

## Testing

- Full cron test suite: 805 passed, 1 skipped
- Provider pin tests: 16 passed

Fixes #89242