### PR TITLE
fix(cli): include open sessions in export (#89223)

### DIFF
--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -439,7 +439,9 @@ def cmd_sessions(args, sessions_parser=None):
                     return None
                 return [data]
             if filters:
-                candidates = db.list_prune_candidates(**filters)
+                candidates = db.list_prune_candidates(
+                    **filters, include_open=True
+                )
                 if args.dry_run:
                     print(
                         f"Would export {len(candidates)} session(s) "
@@ -571,7 +573,9 @@ def cmd_sessions(args, sessions_parser=None):
             def _trace_ids():
                 if session_id:
                     return [db.resolve_session_id(session_id)]
-                candidates = db.list_prune_candidates(**filters)
+                candidates = db.list_prune_candidates(
+                    **filters, include_open=True
+                )
                 if args.dry_run:
                     print(
                         f"Would export {len(candidates)} session(s) "
@@ -660,7 +664,9 @@ def cmd_sessions(args, sessions_parser=None):
                     print(f"Exported 1 session to {args.output}")
             else:
                 if filters:
-                    candidates = db.list_prune_candidates(**filters)
+                    candidates = db.list_prune_candidates(
+                        **filters, include_open=True
+                    )
                     if args.dry_run:
                         print(
                             f"Would export {len(candidates)} session(s) "
@@ -835,7 +841,9 @@ def cmd_sessions(args, sessions_parser=None):
             )
             db.close()
             return
-        candidates = db.list_prune_candidates(**filters)
+        candidates = db.list_prune_candidates(
+            **filters, include_open=True
+        )
         if args.dry_run:
             print(
                 f"Would export {len(candidates)} session(s) "

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -11692,11 +11692,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         max_cost: Optional[float] = None,
         min_tool_calls: Optional[int] = None,
         max_tool_calls: Optional[int] = None,
+        include_open: bool = False,
     ) -> Tuple[str, list]:
         """Build the shared WHERE clause for bulk prune/archive selection.
 
         All filters AND together. Only ended sessions are ever candidates
         (``ended_at IS NOT NULL``) so a live session is never selected.
+        Pass ``include_open=True`` to lift the ended-session guard for
+        non-destructive operations like export (#89223).
         ``archived`` is a tri-state: ``None`` = both, ``True`` = only
         archived rows, ``False`` = only unarchived rows.
 
@@ -11711,7 +11714,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         The clause references the ``s`` table alias — callers must select
         ``FROM sessions s``.
         """
-        clauses = ["s.ended_at IS NOT NULL"]
+        clauses: list = [] if include_open else ["s.ended_at IS NOT NULL"]
         params: list = []
         if last_active_before is not None:
             clauses.append(
@@ -11824,6 +11827,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         self,
         older_than_days: Optional[float] = None,
         source: str = None,
+        include_open: bool = False,
         **filters,
     ) -> List[Dict[str, Any]]:
         """Return the sessions a matching :meth:`prune_sessions` /
@@ -11836,9 +11840,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         message_count, archived``. ``older_than_days`` is an inactivity
         threshold: it uses the latest message timestamp, falling back to
         ``started_at`` for sessions without messages.
+
+        Pass ``include_open=True`` for non-destructive listing (export)
+        where open sessions should be included (#89223).
         """
         self._apply_prune_age_filter(older_than_days, filters)
-        where, params = self._prune_filter_where(source=source, **filters)
+        where, params = self._prune_filter_where(
+            source=source, include_open=include_open, **filters
+        )
         with self._lock:
             cursor = self._conn.execute(
                 f"""SELECT s.id, s.source, s.title, s.model, s.started_at,


### PR DESCRIPTION
## Summary

`hermes sessions export` reused `list_prune_candidates()` which applies an `ended_at IS NOT NULL` guard — correct for destructive prune/archive but wrong for export: open/live sessions are the ones users most want to back up. Bulk export silently returned 0 sessions when all matching sessions were still open.

## Fix

Add `include_open` parameter to `_prune_filter_where()` and `list_prune_candidates()` (default `False`, backward-compatible). Pass `include_open=True` from all four export call sites in `sessions_cmd.py`. The prune/archive path remains unchanged.

## Changes

- `hermes_state.py`: Added `include_open: bool = False` to `_prune_filter_where()` and `list_prune_candidates()`. When `True`, skips the `ended_at IS NOT NULL` clause.
- `hermes_cli/sessions_cmd.py`: All 4 export call sites pass `include_open=True`

## Testing

- Session delete tests: 4 passed
- Full cron test suite: 805 passed, 1 skipped
- `count_open_prune_matches` still works (doesn't pass `include_open`, guard intact)

Fixes #89223