### PR TITLE
feat(plugins): support identity-bound profile state

### DIFF
--- a/hermes_cli/plugin_state_policy.py
+++ b/hermes_cli/plugin_state_policy.py
@@ -1,0 +1,29 @@
+"""Filesystem protocol for profile-scoped plugin state clone policy."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+
+IDENTITY_BOUND_STATE_MARKER = ".hermes-identity-bound-state"
+
+
+def namespace_declares_identity_bound_state(data_dir: Path) -> bool:
+    """Return whether a real plugin-data directory has the durable marker.
+
+    Any filesystem uncertainty fails open: clone callers must preserve the
+    namespace unless the declaration can be proven without following links.
+    """
+    try:
+        namespace_stat = os.stat(data_dir, follow_symlinks=False)
+        if not stat.S_ISDIR(namespace_stat.st_mode):
+            return False
+        marker_stat = os.stat(
+            data_dir / IDENTITY_BOUND_STATE_MARKER,
+            follow_symlinks=False,
+        )
+    except (OSError, ValueError):
+        return False
+    return stat.S_ISREG(marker_stat.st_mode)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -71,6 +71,7 @@ from hermes_cli.plugin_capabilities import (  # noqa: F401 — re-exported
 from hermes_cli.plugin_capabilities import (
     parse_declared_capabilities as _parse_declared_capabilities,
 )
+from hermes_cli.plugin_state_policy import IDENTITY_BOUND_STATE_MARKER
 
 
 def get_bundled_plugins_dir() -> Path:
@@ -1330,6 +1331,21 @@ class PluginState:
     @property
     def quota_bytes(self) -> int:
         return _PLUGIN_STATE_QUOTA_BYTES
+
+    def declare_identity_bound(self) -> None:
+        """Keep this plugin's state namespace out of future ``--clone-all`` copies.
+
+        The declaration is durable and profile-scoped. Plugins should call it
+        before storing credentials or other state bound to this profile's
+        identity. Ordinary plugin state remains clonable by default.
+        """
+        from utils import atomic_write_text
+
+        atomic_write_text(
+            self.data_dir / IDENTITY_BOUND_STATE_MARKER,
+            "identity-bound-v1\n",
+            create_mode=0o600,
+        )
 
     @staticmethod
     def _validate_key(key: str) -> None:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -34,6 +34,7 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Dict, List, Optional, Tuple
 
 from agent.skill_utils import is_excluded_skill_path
+from hermes_cli.plugin_state_policy import namespace_declares_identity_bound_state
 
 logger = logging.getLogger(__name__)
 
@@ -149,7 +150,7 @@ def has_bundled_skills_opt_out(profile_dir: Path) -> bool:
 def _clone_all_copytree_ignore(source_dir: Path):
     """Exclude infrastructure artifacts when cloning a profile via --clone-all.
 
-    Three categories:
+    Four categories:
       1. Root-level entries in ``_CLONE_ALL_HISTORY_EXCLUDE_ROOT`` — session
          history, backups, and snapshots that belong to the SOURCE profile
          and should never carry into a fresh clone.  Applies to any source.
@@ -161,6 +162,9 @@ def _clone_all_copytree_ignore(source_dir: Path):
       3. Universal exclusions at any depth — Python bytecode caches that
          are stale or regenerable (``__pycache__``, ``*.pyc``, ``*.pyo``)
          and runtime sockets / temp files (``*.sock``, ``*.tmp``).
+      4. Immediate namespaces under ``plugin-data/`` whose owning plugin has
+         durably declared its state identity-bound through ``PluginState``.
+         Marker probe failures fail open so uncertain state is copied.
 
     The export-side ignore (``_default_export_ignore``) uses the same
     two-tier pattern with the broader ``_DEFAULT_EXPORT_EXCLUDE_ROOT`` set
@@ -169,9 +173,20 @@ def _clone_all_copytree_ignore(source_dir: Path):
     """
     source_resolved = source_dir.resolve()
     is_default_source = source_resolved == _get_default_hermes_home().resolve()
+    plugin_data_resolved = source_resolved / "plugin-data"
 
     def _ignore(directory: str, names: List[str]) -> List[str]:
         ignored: list[str] = []
+        try:
+            directory_resolved = Path(directory).resolve()
+            at_root = directory_resolved == source_resolved
+            at_plugin_data_root = directory_resolved == plugin_data_resolved
+        except (OSError, ValueError):
+            # ``resolve()`` can fail on unusual FS layouts (broken symlinks,
+            # missing parents). Fail open — better to over-copy than silently
+            # drop user data.
+            at_root = False
+            at_plugin_data_root = False
         for entry in names:
             # Universal exclusions at any depth.
             if (
@@ -180,13 +195,6 @@ def _clone_all_copytree_ignore(source_dir: Path):
             ):
                 ignored.append(entry)
                 continue
-            try:
-                at_root = Path(directory).resolve() == source_resolved
-            except (OSError, ValueError):
-                # ``resolve()`` can fail on unusual FS layouts (broken
-                # symlinks, missing parents).  Fail open — better to
-                # over-copy than silently drop user data.
-                at_root = False
             if at_root:
                 # History artifacts: excluded for ANY source profile.
                 if entry in _CLONE_ALL_HISTORY_EXCLUDE_ROOT:
@@ -195,6 +203,11 @@ def _clone_all_copytree_ignore(source_dir: Path):
                 # Infrastructure: only the default profile contains these.
                 if is_default_source and entry in _CLONE_ALL_DEFAULT_EXCLUDE_ROOT:
                     ignored.append(entry)
+                    continue
+            if at_plugin_data_root and namespace_declares_identity_bound_state(
+                Path(directory) / entry
+            ):
+                ignored.append(entry)
         return ignored
 
     return _ignore

--- a/tests/hermes_cli/test_plugin_state_clone_policy.py
+++ b/tests/hermes_cli/test_plugin_state_clone_policy.py
@@ -1,0 +1,116 @@
+"""Public behavior tests for plugin-owned profile clone policy."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+from hermes_cli.profiles import create_profile
+
+
+def _context(name: str) -> PluginContext:
+    return PluginContext(PluginManifest(name=name), PluginManager())
+
+
+def _file_bytes(root: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+@pytest.fixture()
+def profile_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    token = set_hermes_home_override(home)
+    try:
+        yield home
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_clone_all_excludes_declared_state_and_preserves_undeclared_bytes(
+    profile_home: Path,
+) -> None:
+    identity_bound = _context("identity-bound-plugin")
+    identity_bound.state.declare_identity_bound()
+    identity_bound.state.set("credential", {"token": "profile-secret"})
+
+    ordinary = _context("ordinary-plugin")
+    ordinary.state.set("cursor", {"page": 7})
+    (ordinary.state.data_dir / "nested").mkdir()
+    (ordinary.state.data_dir / "nested" / "opaque.bin").write_bytes(
+        b"\x00\xffplugin-owned\r\n"
+    )
+    ordinary_before = _file_bytes(ordinary.state.data_dir)
+
+    clone = create_profile("clone-all", clone_all=True, no_alias=True)
+
+    identity_relative = identity_bound.state.data_dir.relative_to(profile_home)
+    ordinary_relative = ordinary.state.data_dir.relative_to(profile_home)
+    assert not (clone / identity_relative).exists()
+    assert _file_bytes(clone / ordinary_relative) == ordinary_before
+
+
+def test_fresh_and_ordinary_clone_keep_existing_plugin_state_semantics(
+    profile_home: Path,
+) -> None:
+    (profile_home / "config.yaml").write_text("model: source-model\n", encoding="utf-8")
+    identity_bound = _context("identity-bound-plugin")
+    identity_bound.state.declare_identity_bound()
+    identity_bound.state.set("credential", "profile-secret")
+    ordinary = _context("ordinary-plugin")
+    ordinary.state.set("cursor", 7)
+
+    fresh = create_profile("fresh", no_alias=True)
+    cloned = create_profile("ordinary-clone", clone_config=True, no_alias=True)
+
+    assert not (fresh / "plugin-data").exists()
+    assert not (cloned / "plugin-data").exists()
+    assert not (fresh / "config.yaml").exists()
+    cloned_config = yaml.safe_load((cloned / "config.yaml").read_text(encoding="utf-8"))
+    assert cloned_config["model"] == "source-model"
+
+
+def test_clone_all_copies_declared_state_when_policy_probe_fails(
+    profile_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identity_bound = _context("identity-bound-plugin")
+    identity_bound.state.declare_identity_bound()
+    identity_bound.state.set("credential", "profile-secret")
+    state_before = _file_bytes(identity_bound.state.data_dir)
+
+    policy_artifacts = [
+        path
+        for path in identity_bound.state.data_dir.iterdir()
+        if path.name not in {"state.json", ".state.json.lock"}
+    ]
+    assert len(policy_artifacts) == 1
+    policy_artifact = policy_artifacts[0]
+    real_stat = os.stat
+    probe_failed = False
+
+    def fail_policy_probe_once(path, *args, **kwargs):
+        nonlocal probe_failed
+        if not probe_failed and Path(path) == policy_artifact:
+            probe_failed = True
+            raise OSError("simulated filesystem metadata failure")
+        return real_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(os, "stat", fail_policy_probe_once)
+
+    clone = create_profile("fail-open-clone", clone_all=True, no_alias=True)
+
+    assert probe_failed is True
+    relative = identity_bound.state.data_dir.relative_to(profile_home)
+    assert _file_bytes(clone / relative) == state_before

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -558,6 +558,24 @@ def register(ctx):
     ctx.state.set("cursor", {"page": cursor["page"] + 1})
 ```
 
+State is cloned by `hermes profile create --clone-all` unless the plugin
+declares that its entire namespace is bound to the current profile's identity.
+Declare that policy before writing credentials or other identity-bound state:
+
+```python
+def register(ctx):
+    ctx.state.declare_identity_bound()
+    ctx.state.set("credential_binding", provision_for_this_profile())
+```
+
+The declaration is a durable marker in that plugin's profile-local data
+directory, so clone creation can enforce it without importing plugin code. A
+declared namespace is absent from a `--clone-all` destination; undeclared
+namespaces retain the default full-copy behavior. If Hermes cannot verify a
+marker because of a filesystem error, it fails open and copies the namespace
+instead of risking data loss. Fresh profiles and ordinary `--clone` copies do
+not copy plugin state, as before.
+
 State is profile-scoped, atomically replaced, safe across concurrent writers,
 and limited to 10 MiB per plugin. Portable packages share the same directory as
 their `PLUGIN_DATA`; native plugins receive a collision-resistant,


### PR DESCRIPTION
## Symptom

`hermes profile create --clone-all` copies every plugin state namespace. That is correct for ordinary portable plugin data, but it silently duplicates credentials, remote identity bindings, revocation state, and spend-policy identity when a plugin owns state that belongs to exactly one profile.

## Root cause

Plugins have no public way to tell profile cloning that their state is identity-bound. Clone creation also should not import arbitrary plugin code just to decide which directories are safe to copy.

## Change

- Add `ctx.state.declare_identity_bound()` as an additive public declaration.
- Persist that policy as a profile-local marker beside the plugin namespace.
- Make `--clone-all` exclude only immediate plugin namespaces with a proven regular marker in a real directory.
- Preserve the current full-copy default for every undeclared namespace.
- Fail open on filesystem uncertainty, copying data instead of risking silent loss.
- Document the plugin API and unchanged fresh/ordinary-clone behavior.

## Validation

- 143 focused profile, plugin-state, plugin-loader, and compatibility tests passed; 2 Windows-only tests skipped on macOS.
- Ruff passed.
- Windows footgun scan passed for all changed Python/test files.
- Staged diff check passed.

The new public behavior test drives `create_profile()` against real temporary profile directories and verifies declared exclusion, byte-for-byte preservation of undeclared state, unchanged fresh/ordinary clone behavior, and fail-open copying when the policy probe raises.
