### PR TITLE
fix(codex): don't record a deadline-truncated turn as success

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -566,6 +566,12 @@ class CodexAppServerSession:
         # within post_tool_quiet_timeout and the turn hasn't completed, we
         # fast-fail and retire the session.
         last_tool_completion_at: Optional[float] = None
+        # Last meaningful signal in this turn, used at the deadline to tell
+        # "assistant message finished but turn/completed never arrived" (a
+        # codex protocol quirk -- safe to accept the text) apart from "a tool
+        # was started or finished after the text" (the turn was truncated
+        # mid-flow -- must surface as a timeout, never as success).
+        last_signal: Optional[str] = None
 
         while time.monotonic() < deadline and not turn_complete:
             if self._interrupt_event.is_set():
@@ -654,8 +660,10 @@ class CodexAppServerSession:
                     if proj.is_tool_iteration:
                         result.tool_iterations += 1
                         last_tool_completion_at = time.monotonic()
+                        last_signal = "tool_done"
                     if proj.final_text is not None:
                         result.final_text = proj.final_text
+                        last_signal = "text"
                         if _has_turn_aborted_marker(proj.final_text):
                             turn_complete = True
                             result.interrupted = True
@@ -710,16 +718,25 @@ class CodexAppServerSession:
                 # Arm/refresh the post-tool quiet watchdog whenever a
                 # tool-shaped item completes.
                 last_tool_completion_at = time.monotonic()
+                last_signal = "tool_done"
             else:
                 # Any non-tool projected activity (assistant message,
                 # status update, etc.) means codex is still producing
                 # output — clear the quiet timer so we don't fast-fail.
                 if projection.messages or projection.final_text is not None:
                     last_tool_completion_at = None
+                    if projection.final_text is None:
+                        last_signal = "activity"
+                elif method == "item/started":
+                    # A newly started item (e.g. a long-blocking shell
+                    # command) means codex is busy executing a tool after
+                    # any earlier assistant text.
+                    last_signal = "tool_start"
             if projection.final_text is not None:
                 # Codex can emit multiple agentMessage items in one turn
                 # (e.g. partial then final). Take the last one as canonical.
                 result.final_text = projection.final_text
+                last_signal = "text"
                 # Some codex builds tear a turn down by emitting a
                 # `<turn_aborted>` marker in the agent message text and
                 # never sending turn/completed. Treat the marker itself
@@ -762,7 +779,13 @@ class CodexAppServerSession:
             and not result.interrupted
             and result.final_text
             and result.error is None
+            and last_signal == "text"
         ):
+            # Only when the assistant text is the LAST thing codex produced.
+            # If a tool started or finished after that text, the turn was
+            # truncated mid-flow (e.g. an hour-scale command cut off by the
+            # ceiling) and accepting the stale text would report a silently
+            # incomplete run as success.
             logger.warning(
                 "codex app-server turn reached deadline after a completed "
                 "assistant message but before turn/completed; accepting "
@@ -779,7 +802,8 @@ class CodexAppServerSession:
             result.interrupted = True
             if not result.error:
                 result.error = self._format_error_with_stderr(
-                    f"turn timed out after {turn_timeout}s"
+                    f"turn timed out after {turn_timeout}s "
+                    f"(last signal: {last_signal or 'none'})"
                 )
             result.should_retire = True
 


### PR DESCRIPTION
## Problem

`codex_app_server_session.py` has a turn-deadline fallback: if the deadline fires before `turn/completed` but an assistant message completed earlier, the text is accepted as the terminal response. The guard only checks that `result.final_text` is non-empty — it cannot tell "the assistant message was the last thing codex produced (the protocol quirk this fallback was built for)" apart from "codex emitted some narration, then started an hour-scale tool that the ceiling cut off".

In the second case the turn surfaces as a clean success carrying stale mid-turn narration. We hit this in production: a scheduled agent run had its long-running shell command truncated at the turn ceiling, the run was recorded as ok, no alert fired, and a downstream consumer read a terminal state that never existed.

## Fix

Track the last meaningful signal in the turn (`text` / `tool_start` / `tool_done` / `activity`, updated in the notification loop and the approval-drain path) and accept the deadline fallback only when `last_signal == "text"`. Any other trailing signal takes the existing timeout error path (interrupt + `should_retire`), with the last signal named in the error message for diagnosis.

- The original quirk case (assistant message completes, `turn/completed` never arrives, then silence) still resolves as success.
- A turn that dies before producing any text already took the error path (the fallback requires non-empty `final_text`); this change only tightens the "text emitted, then truncated" case.

## Testing

- `tests/run_agent/test_codex_app_server_integration.py` and `test_codex_app_server_lifecycle.py` show no new failures vs a clean checkout in the same environment.
- The same patch has been running against our fork's deployment branch (CorgiCortex/hermes-agent#7) where the full transport suite (36 tests) passes.

Marked draft for maintainer routing; happy to adjust to house style.