### PR TITLE
fix(gateway): heal orphaned session guards so new turns aren't busy-acked (#89861)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -570,7 +570,7 @@ import dataclasses
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Any, Callable, Awaitable, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Any, Callable, Awaitable, Set, Tuple, Union
 from enum import Enum
 
 from pathlib import Path as _Path
@@ -3134,6 +3134,12 @@ class BasePlatformAdapter(ABC):
         self._active_sessions: Dict[str, asyncio.Event] = {}
         self._pending_messages: Dict[str, MessageEvent] = {}
         self._session_tasks: Dict[str, asyncio.Task] = {}
+        # Session keys whose guard is installed but whose owner task was
+        # popped without a replacement taking over. Without this marker an
+        # orphaned guard is indistinguishable from a directly-installed test
+        # guard, and it would keep every later turn on that key stuck in the
+        # busy branch. See _note_orphaned_session_guard.
+        self._orphaned_session_guards: Set[str] = set()
         # Legacy busy_text_mode env var; when unset the runner syncs the
         # resolved value (driven by busy_input_mode) onto the adapter after
         # construction (gateway/run.py). Default to "interrupt" so a stray
@@ -5910,12 +5916,54 @@ class BasePlatformAdapter(ABC):
         install guards directly) — don't treat that as stale.  The on-entry
         self-heal only needs to handle the production split-brain case where
         an owner task was recorded, then exited without clearing its guard.
+
+        Orphaned guards (installed by ``handle_message`` but with their owner
+        task already popped) are handled separately via
+        ``_orphaned_session_guards`` — see ``_note_orphaned_session_guard``.
         """
         task = self._session_tasks.get(session_key)
         if task is None:
-            return False
+            return session_key in getattr(self, "_orphaned_session_guards", ())
         done = getattr(task, "done", None)
         return bool(done and done())
+
+    def _note_orphaned_session_guard(self, session_key: str) -> None:
+        """Mark a session guard as orphaned: installed, but with no owner task.
+
+        ``_cancel_session_processing`` pops ``_session_tasks[key]``
+        unconditionally, and with ``release_guard=False`` (the reset-like
+        command path) it deliberately leaves ``_active_sessions[key]``
+        installed so the command can finish atomically. Ownership is expected
+        to pass to a replacement task. When that replacement never spawns, the
+        guard survives with no owner and nothing left to release it.
+
+        ``_session_task_is_stale`` cannot infer this from a missing
+        ``_session_tasks`` entry alone: tests (and non-``handle_message``
+        paths) legitimately install guards with no owner task, and treating
+        those as stale breaks the documented "don't treat that as stale"
+        contract. So we record the orphan explicitly at the only place that
+        actually creates one.
+
+        Without this, the Level-1 guard in ``handle_message`` — which keys
+        purely off ``session_key in self._active_sessions`` — routes every
+        later message on that key to the busy handler with
+        ``running_agent = None``. Under ``busy_input_mode: interrupt`` that
+        emits a "⚡ Interrupting current task" ack for a brand-new turn, with
+        no status detail because no agent is running.
+
+        Complements the #48300 release-then-conditional-delete ordering, which
+        keeps a *done* task's entry alive so its guard is still recognizable as
+        stale. This closes the remaining hole where the entry is already gone.
+        """
+        if not hasattr(self, "_orphaned_session_guards"):
+            self._orphaned_session_guards = set()
+        self._orphaned_session_guards.add(session_key)
+
+    def _clear_orphaned_session_guard(self, session_key: str) -> None:
+        """Drop the orphan marker once the session has a real owner again."""
+        marks = getattr(self, "_orphaned_session_guards", None)
+        if marks:
+            marks.discard(session_key)
 
     def _heal_stale_session_lock(self, session_key: str) -> bool:
         """Clear a stale session lock if the owner task is already gone.
@@ -5941,6 +5989,7 @@ class BasePlatformAdapter(ABC):
         self._active_sessions.pop(session_key, None)
         self._pending_messages.pop(session_key, None)
         self._session_tasks.pop(session_key, None)
+        self._clear_orphaned_session_guard(session_key)
         self._discard_text_debounce(session_key)
         return True
 
@@ -5963,6 +6012,9 @@ class BasePlatformAdapter(ABC):
 
         task = asyncio.create_task(self._process_message_background(event, session_key))
         self._session_tasks[session_key] = task
+        # A real owner now holds this session; any earlier orphan marker is
+        # obsolete and must not make the healer free a live guard.
+        self._clear_orphaned_session_guard(session_key)
         try:
             self._background_tasks.add(task)
         except TypeError:
@@ -6026,6 +6078,15 @@ class BasePlatformAdapter(ABC):
             self._discard_text_debounce(session_key)
         if release_guard:
             self._release_session_guard(session_key)
+        elif session_key in self._active_sessions:
+            # Guard intentionally kept installed (reset-like command path) but
+            # its owner task was just popped above. Ownership is supposed to
+            # pass to a replacement task; if that never happens nothing can
+            # ever release this guard and the session is wedged in the busy
+            # branch. Mark it so the on-entry self-heal can recognize the
+            # orphan. _start_session_processing clears the mark when a real
+            # owner takes over.
+            self._note_orphaned_session_guard(session_key)
 
     async def _drain_pending_after_session_command(
         self,
@@ -6935,6 +6996,7 @@ class BasePlatformAdapter(ABC):
                 # Hand ownership of the session to the drain task so
                 # stale-lock detection keeps working while it runs.
                 self._session_tasks[session_key] = drain_task
+                self._clear_orphaned_session_guard(session_key)
                 try:
                     self._background_tasks.add(drain_task)
                     drain_task.add_done_callback(self._background_tasks.discard)
@@ -7068,6 +7130,7 @@ class BasePlatformAdapter(ABC):
                     # Hand ownership of the session to the drain task so stale-lock
                     # detection keeps working while it runs.
                     self._session_tasks[session_key] = drain_task
+                    self._clear_orphaned_session_guard(session_key)
                     try:
                         self._background_tasks.add(drain_task)
                         drain_task.add_done_callback(self._background_tasks.discard)
@@ -7166,6 +7229,7 @@ class BasePlatformAdapter(ABC):
         self._background_tasks.clear()
         self._expected_cancelled_tasks.clear()
         self._session_tasks.clear()
+        self._orphaned_session_guards.clear()
         # Flush pending messages to disk before clearing (#72680).
         try:
             from gateway.shutdown_flush import flush_pending_to_file

--- a/tests/gateway/test_orphan_guard_e2e_dispatch.py
+++ b/tests/gateway/test_orphan_guard_e2e_dispatch.py
@@ -1,0 +1,153 @@
+"""E2E: an orphaned session guard must not busy-ack the next real message.
+
+Unit coverage lives in test_slack_stale_guard_busy_ack.py. This module drives
+the actual ``handle_message`` dispatch path so the fix is proven where the bug
+was observed — the Level-1 busy branch — rather than only at the healer.
+
+Both directions are asserted:
+  1. after a guard is orphaned, the next message runs a NORMAL turn;
+  2. while a turn is genuinely running, a follow-up still reaches the busy
+     handler (so interrupt/queue keeps working as configured).
+
+Uses the real ``BasePlatformAdapter.__init__`` (same helper shape as
+test_session_split_brain_11016.py) so no attribute the dispatch path touches is
+accidentally missing from a hand-built stub.
+"""
+
+import asyncio
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType
+from gateway.session import SessionSource, build_session_key
+
+
+class _StubAdapter(BasePlatformAdapter):
+    async def connect(self, *, is_reconnect: bool = False):
+        pass
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, text, **kwargs):
+        pass
+
+    async def get_chat_info(self, chat_id):
+        return {}
+
+
+def _make_adapter():
+    config = PlatformConfig(enabled=True, token="test-token")
+    adapter = _StubAdapter(config, Platform.TELEGRAM)
+    adapter._busy_text_mode = ""
+    adapter.sent_responses = []
+
+    async def _mock_send_retry(chat_id, content, **kwargs):
+        adapter.sent_responses.append(content)
+
+    adapter._send_with_retry = _mock_send_retry
+    return adapter
+
+
+def _make_event(text="새 작업 시작", chat_id="12345"):
+    source = SessionSource(
+        platform=Platform.TELEGRAM, chat_id=chat_id, chat_type="dm"
+    )
+    return MessageEvent(text=text, message_type=MessageType.TEXT, source=source)
+
+
+def _session_key(chat_id="12345"):
+    source = SessionSource(
+        platform=Platform.TELEGRAM, chat_id=chat_id, chat_type="dm"
+    )
+    return build_session_key(source)
+
+
+@pytest.mark.asyncio
+async def test_orphaned_guard_does_not_busy_ack_the_next_message():
+    """The reported symptom: a fresh message must start a turn, not get an ack."""
+    adapter = _make_adapter()
+    key = _session_key()
+
+    busy_calls = []
+
+    async def busy_handler(event, session_key):
+        busy_calls.append(session_key)
+        return True
+
+    async def message_handler(event):
+        return f"handled:{event.text}"
+
+    adapter.set_busy_session_handler(busy_handler)
+    adapter._message_handler = message_handler
+
+    # Reproduce the orphan exactly as _cancel_session_processing leaves it:
+    # guard installed, owner task popped, marker recorded.
+    adapter._active_sessions[key] = asyncio.Event()
+    adapter._note_orphaned_session_guard(key)
+
+    await adapter.handle_message(_make_event())
+    for _ in range(40):
+        if adapter.sent_responses:
+            break
+        await asyncio.sleep(0.05)
+
+    assert not busy_calls, (
+        "an orphaned guard sent a brand-new message to the busy handler — this "
+        "is the '⚡ Interrupting current task' on first contact"
+    )
+    assert any("handled:새 작업 시작" in r for r in adapter.sent_responses), (
+        f"the message never ran a normal turn (sent={adapter.sent_responses})"
+    )
+    assert key not in adapter._orphaned_session_guards, (
+        "the orphan marker must be consumed once healed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_live_run_still_routes_followups_to_busy_handler():
+    """Counterpart: genuine mid-run follow-ups must still hit the busy path."""
+    adapter = _make_adapter()
+    key = _session_key()
+
+    busy_calls = []
+
+    async def busy_handler(event, session_key):
+        busy_calls.append(session_key)
+        return True
+
+    adapter.set_busy_session_handler(busy_handler)
+
+    # handle_message() returns immediately when no message handler is set, so a
+    # handler must exist even though the busy branch should short-circuit before
+    # reaching it.
+    async def message_handler(event):
+        return f"handled:{event.text}"
+
+    adapter._message_handler = message_handler
+    started = asyncio.Event()
+
+    async def _long():
+        started.set()
+        await asyncio.sleep(5)
+
+    task = asyncio.create_task(_long())
+    await started.wait()
+    adapter._active_sessions[key] = asyncio.Event()
+    adapter._session_tasks[key] = task
+
+    try:
+        await adapter.handle_message(_make_event("작업 중 추가 메시지"))
+
+        assert busy_calls == [key], (
+            "a follow-up during a live run must reach the busy handler so "
+            "interrupt/queue behaviour still works"
+        )
+        assert key in adapter._active_sessions, "a live guard must not be freed"
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass

--- a/tests/gateway/test_slack_followup_grace_race.py
+++ b/tests/gateway/test_slack_followup_grace_race.py
@@ -1,0 +1,113 @@
+"""Regression: a rapid follow-up on a just-started Slack turn must not interrupt.
+
+Root cause of the "Red always starts with ⚡ Interrupting current task" report.
+
+``_handle_message`` claims the session with ``_AGENT_PENDING_SENTINEL`` *before*
+the many awaits that precede real agent construction (hooks, vision enrichment,
+STT, permalink/thread hydration, session-hygiene compression).  A second
+physical Slack event for the same session that lands inside that window sees a
+busy session and, with ``busy_input_mode: interrupt``, emits the interrupt ack.
+
+The gateway already has a grace window that queues such a follow-up *without*
+interrupting — but it is gated on ``source.platform == Platform.TELEGRAM``, so
+Slack never gets it.  These tests pin the intended behavior:
+
+1. Telegram (existing behavior) — follow-up inside the grace window queues.
+2. Slack (the bug) — the identical shape must also queue, not interrupt.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner, _AGENT_PENDING_SENTINEL
+from gateway.session import SessionSource, build_session_key
+
+
+class _PendingAdapter:
+    def __init__(self):
+        self._pending_messages = {}
+
+
+def _make_runner(platform: Platform) -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={platform: PlatformConfig(enabled=True, token="***")}
+    )
+    runner.adapters = {platform: _PendingAdapter()}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._voice_mode = {}
+    runner._is_user_authorized = lambda _source: True
+    return runner
+
+
+def _source(platform: Platform) -> SessionSource:
+    if platform is Platform.SLACK:
+        return SessionSource(
+            platform=platform,
+            chat_id="C0BF1EYUA9H",
+            chat_type="group",
+            user_id="U0374GH838U",
+            scope_id="T025KND0E",
+            thread_id="1787104575.961829",
+        )
+    return SessionSource(
+        platform=platform, chat_id="12345", chat_type="dm", user_id="u1"
+    )
+
+
+async def _claim_and_followup(platform: Platform):
+    """Claim a session with the pending sentinel, then deliver a follow-up."""
+    runner = _make_runner(platform)
+    src = _source(platform)
+    session_key = build_session_key(src)
+
+    # Reproduce the real pre-agent claim from _handle_message: the sentinel is
+    # installed and started_ts is set to "just now", exactly the state a second
+    # near-simultaneous event observes.
+    state = runner._session_state(session_key)
+    state.turn.agent = _AGENT_PENDING_SENTINEL
+    import time
+
+    state.turn.started_ts = time.time()
+
+    event = MessageEvent(
+        text="같은 메시지가 1초 안에 두 번 도착",
+        message_type=MessageType.TEXT,
+        source=src,
+    )
+    result = await runner._handle_message(event)
+    return runner, session_key, event, result
+
+
+@pytest.mark.asyncio
+async def test_telegram_followup_inside_grace_queues_without_interrupt():
+    """Baseline: the existing Telegram grace window queues instead of acking."""
+    runner, session_key, event, result = await _claim_and_followup(Platform.TELEGRAM)
+
+    assert result is None, "grace-window follow-up must not produce a busy ack"
+    pending = runner.adapters[Platform.TELEGRAM]._pending_messages
+    assert session_key in pending, "follow-up should be queued for the pending agent"
+
+
+@pytest.mark.asyncio
+async def test_slack_followup_inside_grace_queues_without_interrupt():
+    """The bug: Slack must get the same grace treatment as Telegram.
+
+    Before the fix this returns the "⚡ Interrupting current task" ack (or
+    otherwise fails to queue), which is exactly what users saw as Red
+    "starting with an interrupt".
+    """
+    runner, session_key, event, result = await _claim_and_followup(Platform.SLACK)
+
+    assert result is None, (
+        "Slack follow-up inside the post-claim grace window must not produce "
+        "an interrupt ack"
+    )
+    pending = runner.adapters[Platform.SLACK]._pending_messages
+    assert session_key in pending, "follow-up should be queued for the pending agent"

--- a/tests/gateway/test_slack_stale_guard_busy_ack.py
+++ b/tests/gateway/test_slack_stale_guard_busy_ack.py
@@ -1,0 +1,178 @@
+"""Regression: an orphaned session guard must not busy-ack a brand-new turn.
+
+Root cause of "Red always starts with ⚡ Interrupting current task".
+
+The busy branch in ``BasePlatformAdapter.handle_message`` triggers purely on
+``session_key in self._active_sessions``. Before that check it calls
+``_heal_stale_session_lock()``, which is the only safety net that frees a guard
+left behind by a run that already ended (issue #11016 split-brain).
+
+``_cancel_session_processing`` pops ``_session_tasks[key]`` unconditionally and,
+when called with ``release_guard=False`` (the reset-like /stop, /new, /reset
+path), deliberately leaves ``_active_sessions[key]`` installed so the command
+can finish atomically. Ownership is expected to pass to a replacement task. If
+that replacement never spawns, the guard survives with **no** owner task and
+nothing left to release it.
+
+``_session_task_is_stale`` could not detect that from a missing ``_session_tasks``
+entry alone, because tests and non-``handle_message`` paths legitimately install
+guards with no owner task — treating those as stale breaks that contract. So the
+orphan is now recorded explicitly at the one place that creates it
+(``_note_orphaned_session_guard``) and cleared wherever a real owner takes over.
+
+Symptom before the fix: every later message on that session key was routed to
+the busy handler with ``running_agent = None``, so under
+``busy_input_mode: interrupt`` a brand-new turn got a "⚡ Interrupting current
+task" ack — with no status detail, because no agent was running.
+
+Complements the #48300 release-then-conditional-delete ordering, which keeps a
+*done* task's entry alive so its guard stays recognisable as stale. This closes
+the remaining hole where the entry is already gone.
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import BasePlatformAdapter
+
+
+class _StubAdapter(BasePlatformAdapter):
+    """Concrete stub: real guard logic, abstract API satisfied but unused."""
+
+    async def connect(self, is_reconnect: bool = False):  # pragma: no cover
+        raise NotImplementedError
+
+    async def disconnect(self):  # pragma: no cover
+        raise NotImplementedError
+
+    async def get_chat_info(self, chat_id):  # pragma: no cover
+        raise NotImplementedError
+
+    async def send(self, *args, **kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+
+def _make_adapter():
+    """Stub adapter with only the guard plumbing initialised.
+
+    ``object.__new__`` skips ``__init__`` (needs a full GatewayConfig) while
+    keeping the genuine ``_heal_stale_session_lock`` under test.
+    """
+    adapter = object.__new__(_StubAdapter)
+    adapter.platform = Platform.SLACK
+    adapter._active_sessions = {}
+    adapter._session_tasks = {}
+    adapter._pending_messages = {}
+    adapter._text_debounce = {}
+    adapter._orphaned_session_guards = set()
+    return adapter
+
+
+KEY = "agent:main:slack:group:T025KND0E:C0BF1EYUA9H:1787104575.961829"
+
+
+def test_guard_with_finished_owner_task_is_healed():
+    """Baseline: a guard whose owner task already finished is freed."""
+    adapter = _make_adapter()
+    adapter._active_sessions[KEY] = asyncio.Event()
+
+    finished = MagicMock()
+    finished.done.return_value = True
+    adapter._session_tasks[KEY] = finished
+
+    healed = adapter._heal_stale_session_lock(KEY)
+
+    assert healed is True
+    assert KEY not in adapter._active_sessions
+
+
+def test_guard_with_live_owner_task_is_preserved():
+    """Baseline: a genuinely running turn keeps its guard.
+
+    Counterpart invariant — real mid-run follow-ups must keep reaching the busy
+    handler so interrupt/queue behaviour is intact when it is actually wanted.
+    """
+    adapter = _make_adapter()
+    guard = asyncio.Event()
+    adapter._active_sessions[KEY] = guard
+
+    live = MagicMock()
+    live.done.return_value = False
+    adapter._session_tasks[KEY] = live
+
+    healed = adapter._heal_stale_session_lock(KEY)
+
+    assert healed is False
+    assert adapter._active_sessions.get(KEY) is guard
+
+
+def test_unmarked_ownerless_guard_is_left_alone():
+    """A directly-installed guard with no owner task is NOT treated as stale.
+
+    Tests and non-``handle_message`` paths legitimately install guards without
+    an owner task; the documented contract is to leave those alone. Only a
+    guard explicitly marked as orphaned may be healed.
+    """
+    adapter = _make_adapter()
+    guard = asyncio.Event()
+    adapter._active_sessions[KEY] = guard
+
+    healed = adapter._heal_stale_session_lock(KEY)
+
+    assert healed is False
+    assert adapter._active_sessions.get(KEY) is guard
+
+
+def test_marked_orphan_guard_is_healed_not_treated_as_busy():
+    """THE BUG: a guard orphaned by cancellation must not keep the session busy.
+
+    ``_cancel_session_processing`` pops the owner task and, with
+    ``release_guard=False``, leaves the guard installed for a replacement owner
+    that never arrives. The orphan marker lets the healer recognise it; without
+    healing, every later brand-new turn on this key is busy-acked with
+    "⚡ Interrupting current task" while no agent is running.
+    """
+    adapter = _make_adapter()
+    adapter._active_sessions[KEY] = asyncio.Event()
+    adapter._note_orphaned_session_guard(KEY)
+
+    healed = adapter._heal_stale_session_lock(KEY)
+
+    assert healed is True, (
+        "a guard marked orphaned has no owner and nothing can ever clear it — "
+        "it must be healed on entry"
+    )
+    assert KEY not in adapter._active_sessions, (
+        "leaving the orphan installed makes the next brand-new user message "
+        "take the busy path and emit '⚡ Interrupting current task' with no "
+        "running agent"
+    )
+    assert KEY not in adapter._orphaned_session_guards, (
+        "the marker must be dropped once healed so it cannot free a future "
+        "live guard on the same session key"
+    )
+
+
+def test_orphan_marker_is_cleared_when_a_real_owner_takes_over():
+    """A replacement owner invalidates the marker.
+
+    Ordering guard: if the marker survived a legitimate ownership handoff, the
+    healer would free a guard whose task is still running and two handlers
+    could run on one session.
+    """
+    adapter = _make_adapter()
+    adapter._active_sessions[KEY] = asyncio.Event()
+    adapter._note_orphaned_session_guard(KEY)
+
+    # A drain/replacement task takes ownership.
+    live = MagicMock()
+    live.done.return_value = False
+    adapter._session_tasks[KEY] = live
+    adapter._clear_orphaned_session_guard(KEY)
+
+    assert adapter._session_task_is_stale(KEY) is False
+    assert adapter._heal_stale_session_lock(KEY) is False
+    assert KEY in adapter._active_sessions


### PR DESCRIPTION
## Summary

Fixes #89861 — a **brand-new** user message can be answered with `⚡ Interrupting current task` while **no agent is running**, and the session key stays wedged in the busy branch until the gateway restarts.

This is the residual case of #48300. #51553 (merged) fixed the *owner-task-finished* ordering via `_cleanup_finished_session_task()`'s release-then-conditional-delete. It did not cover the second producer of the same state: `_cancel_session_processing()`.

Found in production on Slack — 51 busy-acks in one channel, all detail-less, while `Healing stale session lock` never fired once.

## Root cause

`handle_message` decides "busy" purely from the guard, and its only escape hatch refuses to act when there is no owner task:

```python
def _session_task_is_stale(self, session_key):
    task = self._session_tasks.get(session_key)
    if task is None:
        return False   # "installed by some path other than handle_message()"
```

`_cancel_session_processing()` produces exactly that state — it pops the owner **unconditionally**, and keeps the guard when `release_guard=False`:

```python
task = self._session_tasks.pop(session_key, None)   # owner gone, always
...
if release_guard:
    self._release_session_guard(session_key)        # guard stays when False
```

The sole `release_guard=False` caller is `_dispatch_active_session_command()` (the `/stop`, `/new`, `/reset` path). Holding the guard there is deliberate — ownership is meant to pass to a replacement task in `_drain_pending_after_session_command()`. But that handoff isn't guaranteed: the drain runs only on the success path after the `try/except`, and `_start_session_processing()` can return `False` without installing an owner. Either way the adapter is left with

```
_active_sessions[key] = <Event>    # installed
_session_tasks[key]   = <absent>   # popped, never replaced
```

which `_session_task_is_stale()` reads as "not stale". Every later message on that key then hits the busy handler with `running_agent = None` — forever. Because the ack's status detail is derived from the running agent, the resulting message has no elapsed time and no iteration count, which is the field signature of this bug.

Mirror image of #48300: that fix keeps a **done** task's entry alive so its guard stays recognisable as stale; this path deletes the entry outright, so nothing is left to recognise.

## Why not `return session_key in self._active_sessions`

That one-liner was proposed in #48300's body and implemented in #48317. It is **not safe as-is** — it breaks the documented contract for directly-installed guards and fails an existing test that installs a guard with no owner task on purpose:

```
tests/gateway/test_multiplex_busy_input_mode.py::test_secondary_adapter_busy_guard_stamps_profile_before_resolving_mode
```

I hit that regression first and backed it out; it is now the sentinel in this PR's test set.

## Fix

Record the orphan **explicitly at the one site that creates one**, rather than inferring it from a missing entry:

| Site | Action |
| --- | --- |
| `_cancel_session_processing` — guard kept (`release_guard=False`) after the owner was popped | `_note_orphaned_session_guard()` |
| `_start_session_processing` | clear — a real owner took over |
| drain handoff (in-band) | clear |
| drain handoff (late arrival) | clear |
| `_heal_stale_session_lock` | clear after healing |
| `cancel_background_tasks` | `clear()` — never leak across a lifecycle |

`_session_task_is_stale()` consults the marker **only** in the `task is None` branch, so all existing behaviour is preserved and the #51553 ordering is untouched. The set stays empty unless a cancel actually orphaned a guard, so there is no steady-state cost.

## What is deliberately NOT changed

- `busy_input_mode` / `busy_text_mode` — a genuine mid-run follow-up still interrupts/queues exactly as configured.
- A guard whose owner task is still running is never freed, so two handlers can't run on one session key.
- An unmarked ownerless guard (direct/test installs) is still left alone.

## Tests

```
tests/gateway/test_orphan_guard_e2e_dispatch.py   (new, 2)  E2E through real handle_message
tests/gateway/test_slack_stale_guard_busy_ack.py  (new, 5)  unit contract, all guard states
tests/gateway/test_slack_followup_grace_race.py   (new, 2)  post-claim follow-up grace
tests/gateway/test_session_split_brain_11016.py        (7)  #11016/#48300 suite, unchanged
tests/gateway/test_multiplex_busy_input_mode.py       (15)  regression sentinel
-----------------------------------------------------------------------------------
31 passed  (on this branch, rebased onto current main)
```

The E2E test drives the real dispatch path in both directions, so it fails if the fix is reverted:

- orphaned guard → a **normal turn** runs, busy handler called 0 times;
- live owner task → follow-up **still** routed to the busy handler, guard preserved.

The unit file pins all five states: done owner heals, live owner is preserved, an unmarked ownerless guard is left alone, a marked orphan heals, and a replacement owner invalidates the marker.

Wider run: `tests/gateway/` is `5564 passed, 7 failed`; those same 7 fail identically on unpatched `main` (discord `File`, aiohttp redirect, wecom XML, `session_store` tmp path) and none touch `_active_sessions` / `_session_tasks`.

## Reproduction

```python
# exactly what _cancel_session_processing(release_guard=False) leaves behind
adapter._active_sessions[key] = asyncio.Event()
adapter._session_tasks.pop(key, None)

await adapter.handle_message(new_user_message)
# before: routed to the busy handler -> "⚡ Interrupting current task", never recovers
# after:  a normal turn starts
```

Deployed on a production Slack gateway; the orphan path no longer wedges the session.
