### PR TITLE
fix(gateway): sync /voice state on secondary profile initial connect

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15128,6 +15128,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                 if success:
                     profile_map[platform] = adapter
+                    # Push persisted /voice state (enabled/disabled chat sets +
+                    # global voice.auto_tts default) onto this secondary
+                    # profile's adapter at INITIAL connect. Mirror of the
+                    # reconnect path (line ~13338); without it a multiplex
+                    # secondary profile's adapter boots with empty auto-TTS
+                    # opt-in state and never voice-replies to voice input.
+                    self._sync_voice_mode_state_to_adapter(adapter)
                     if credential_claim is not None:
                         claimed[credential_claim] = profile_name
                     if listener_claim is not None:


### PR DESCRIPTION
Splitting PR #84873. The voice fix is a 7-line, self-contained change that was bundled with a larger webhook event-dedup feature (which still has review points). Extracting it so the voice half can be reviewed and merged independently.

## What this PR does
In multiplex mode, a secondary profile's platform adapter was stored into `_profile_adapters` at initial connect without calling `sync_voice_state`, so `/voice` settings from a secondary profile were not applied. This mirrors the fix already applied for the primary profile.

## Verification
- 1 file changed, 7 insertions — `gateway/run.py`
- Cherry-picked cleanly onto current `main` (8505559fa)