### PR TITLE
fix(buzz): reply into the existing thread instead of nesting a new one

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -436,6 +436,10 @@ class BuzzAdapter(BasePlatformAdapter):
         self._channel_meta: Dict[str, dict] = {}
         self._user_names: Dict[str, str] = {}
         self._poll_count = 0
+        # inbound event_id -> thread root event id, or None when that message
+        # was itself top-level.  Lets send() mirror the user's own threading
+        # instead of opening a new thread under every reply (see _thread_root).
+        self._thread_roots: "OrderedDict[str, Optional[str]]" = OrderedDict()
 
     @property
     def name(self) -> str:
@@ -609,7 +613,9 @@ class BuzzAdapter(BasePlatformAdapter):
         if not content:
             return SendResult(success=False, error="Empty message")
         args = ["messages", "send", "--channel", str(chat_id), "--content", "-"]
-        reply_target = reply_to or (metadata or {}).get("thread_id")
+        reply_target = self._resolve_reply_anchor(
+            reply_to or (metadata or {}).get("thread_id")
+        )
         if reply_target:
             args += ["--reply-to", str(reply_target)]
         code, out, err = await self._run_cli(args, input_text=content)
@@ -682,7 +688,7 @@ class BuzzAdapter(BasePlatformAdapter):
                 "--content", "-",
             ]
             if reply_to:
-                args += ["--reply-to", str(reply_to)]
+                args += ["--reply-to", str(self._resolve_reply_anchor(reply_to) or reply_to)]
             code, out, err = await self._run_cli(args, input_text=caption or "")
             if code != 0:
                 return SendResult(success=False, error=_cli_error_message(err, code), retryable=code == 2)
@@ -1048,6 +1054,10 @@ class BuzzAdapter(BasePlatformAdapter):
         # strip applies to both chat types.
         dispatch_text = self._strip_mention(content)
 
+        # Remember where this message sits in the thread graph so our reply
+        # can join the SAME thread rather than nesting a new one under it.
+        self._record_thread_root(event_id, event)
+
         await self._dispatch_message(
             text=dispatch_text,
             chat_id=channel_id,
@@ -1209,6 +1219,76 @@ class BuzzAdapter(BasePlatformAdapter):
         if state is not None:
             state["seen"][event_id] = None
             self._trim_seen(state)
+
+    # ── Thread anchoring ──────────────────────────────────────────────────
+    #
+    # NIP-10 marked ``e`` tags: a reply carries ["e", <root>, "", "root"] plus
+    # ["e", <parent>, "", "reply"]; a message that STARTS a thread carries a
+    # single ["e", <parent>, "", "reply"] and no root marker.
+    #
+    # The gateway hands adapters the triggering message's own id as the reply
+    # anchor.  Anchoring to that id is correct for a top-level message (it
+    # opens the thread the user expects), but inside an existing thread it
+    # nests a fresh sub-thread under every single answer.  Buzz renders that
+    # as an endless ladder of one-message threads.
+    #
+    # Fix: remember each inbound message's thread ROOT.  When the trigger was
+    # already inside a thread, reply against that root so our answer lands in
+    # the same thread the user is typing in.  When it was top-level, keep the
+    # existing behaviour and anchor to the message itself.
+
+    _THREAD_ROOT_CACHE = 512
+
+    @staticmethod
+    def _extract_thread_root(event: dict) -> Optional[str]:
+        """Return the NIP-10 thread root of ``event``, or None if top-level."""
+        tags = event.get("tags")
+        if not isinstance(tags, list):
+            return None
+        root = None
+        reply = None
+        for tag in tags:
+            if not isinstance(tag, (list, tuple)) or len(tag) < 2:
+                continue
+            if str(tag[0]) != "e":
+                continue
+            marker = str(tag[3]).lower() if len(tag) > 3 else ""
+            if marker == "root":
+                root = str(tag[1])
+            elif marker == "reply":
+                reply = str(tag[1])
+            elif not marker and reply is None:
+                # Unmarked (deprecated positional) e-tag: treat as the parent.
+                reply = str(tag[1])
+        if root:
+            return root
+        # A lone "reply" e-tag means this message started a thread hanging off
+        # <reply>; that parent IS the thread root for anything that follows.
+        return reply
+
+    def _record_thread_root(self, event_id: str, event: dict) -> None:
+        """Cache the thread root for an inbound message id."""
+        if not event_id:
+            return
+        roots = getattr(self, "_thread_roots", None)
+        if roots is None:
+            roots = self._thread_roots = OrderedDict()
+        roots[event_id] = self._extract_thread_root(event)
+        roots.move_to_end(event_id)
+        while len(roots) > self._THREAD_ROOT_CACHE:
+            roots.popitem(last=False)
+
+    def _resolve_reply_anchor(self, anchor: Optional[str]) -> Optional[str]:
+        """Map a gateway reply anchor onto the right Buzz thread anchor.
+
+        Returns the thread root when the triggering message was already inside
+        a thread (so the reply joins it), otherwise the anchor unchanged (so a
+        reply to a top-level message opens one thread, as before).
+        """
+        if not anchor:
+            return anchor
+        roots = getattr(self, "_thread_roots", None) or {}
+        return roots.get(str(anchor)) or anchor
 
     async def _dispatch_message(
         self,

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -422,6 +422,81 @@ class TestBuzzAdapterSend:
         assert args[args.index("--file") + 1] == str(img)
 
 
+# ── Thread anchoring ──────────────────────────────────────────────────────
+
+
+class TestThreadAnchoring:
+    """A reply must JOIN the thread it was triggered from, not nest a new one.
+
+    The gateway hands adapters the triggering message's own id as the reply
+    anchor. For a top-level message that correctly opens a thread; for a
+    message already inside a thread it used to nest a fresh sub-thread under
+    every answer (an endless ladder of one-message threads in Buzz).
+    """
+
+    @staticmethod
+    def _event(eid, *e_tags):
+        return {"id": eid, "tags": [["h", CHANNEL], *e_tags]}
+
+    def test_top_level_message_has_no_root(self):
+        a = _make_adapter()
+        assert a._extract_thread_root(self._event("m1")) is None
+
+    def test_thread_opener_roots_at_its_parent(self):
+        a = _make_adapter()
+        ev = self._event("m2", ["e", "root1", "", "reply"])
+        assert a._extract_thread_root(ev) == "root1"
+
+    def test_in_thread_message_uses_root_marker_not_parent(self):
+        a = _make_adapter()
+        ev = self._event("m3", ["e", "root1", "", "root"], ["e", "m2", "", "reply"])
+        assert a._extract_thread_root(ev) == "root1"
+
+    def test_legacy_unmarked_etag_treated_as_parent(self):
+        a = _make_adapter()
+        assert a._extract_thread_root(self._event("m4", ["e", "root1"])) == "root1"
+
+    def test_reply_to_top_level_still_opens_a_thread(self):
+        """Regression guard: the original (correct) behaviour must survive."""
+        a = _make_adapter()
+        a._record_thread_root("m1", self._event("m1"))
+        assert a._resolve_reply_anchor("m1") == "m1"
+
+    def test_reply_inside_thread_joins_that_thread(self):
+        a = _make_adapter()
+        a._record_thread_root("m3", self._event(
+            "m3", ["e", "root1", "", "root"], ["e", "m2", "", "reply"]))
+        assert a._resolve_reply_anchor("m3") == "root1"
+
+    def test_unknown_and_empty_anchors_pass_through(self):
+        a = _make_adapter()
+        assert a._resolve_reply_anchor("never-seen") == "never-seen"
+        assert a._resolve_reply_anchor(None) is None
+
+    def test_root_cache_is_bounded_and_evicts_oldest(self):
+        a = _make_adapter()
+        for i in range(a._THREAD_ROOT_CACHE + 50):
+            a._record_thread_root(f"id{i}", self._event(f"id{i}"))
+        assert len(a._thread_roots) == a._THREAD_ROOT_CACHE
+        assert "id0" not in a._thread_roots
+        assert f"id{a._THREAD_ROOT_CACHE + 49}" in a._thread_roots
+
+    @pytest.mark.asyncio
+    async def test_send_anchors_to_root_not_trigger(self):
+        """End-to-end through send(): argv must carry the thread root."""
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "dm", "last_ts": 0, "seen": {}}
+        adapter._record_thread_root("m3", self._event(
+            "m3", ["e", "root1", "", "root"], ["e", "m2", "", "reply"]))
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "e9", "message": ""})
+        adapter._run_cli = cli
+
+        await adapter.send(CHANNEL, "in-thread answer", reply_to="m3")
+        args, _stdin = cli.calls[0]
+        assert args[args.index("--reply-to") + 1] == "root1"
+
+
 # ── Lifecycle ─────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Symptom

Every Buzz reply opens a new thread — including when the user is already replying *inside* a thread. A threaded client fills with an endless ladder of one-message threads and the conversation becomes unreadable.

Reported by a user on a live hosted relay (`*.communities.buzz.xyz`): *"you always reply in a thread in Buzz, even when we're already in a thread"*.

## Cause

The Buzz adapter never had threading logic of its own — the behaviour comes from the generic gateway default.

`_reply_anchor_for_event()` in `gateway/platforms/base.py` returns `event.message_id` (line 167). That is correct for reply-style platforms (Telegram/Discord "reply to this message"), but wrong for a thread-style one: anchoring to the message you are answering nests a fresh sub-thread under every single turn.

`BuzzAdapter.send()` passed that anchor straight through to `messages send --reply-to`:

```python
reply_target = reply_to or (metadata or {}).get("thread_id")
```

Confirmed against real events from a live relay — replies carried `["e", <the user's message id>, "", "reply"]` rather than pointing at the thread root.

## Fix

Buzz threads are NIP-10, so the information needed is already on the inbound event. The adapter now records each inbound message's thread root from its `e` tags and resolves the outbound anchor to that root, so a reply joins the thread the user is typing in.

When the trigger was itself top-level there is no root and the anchor passes through unchanged — preserving the existing behaviour of opening exactly one thread from a top-level message.

Deliberately fixed in the adapter rather than in `_reply_anchor_for_event()`: Buzz is a plugin-supplied platform, and its NIP-10 tag semantics do not belong in core.

Details:
- Root extraction prefers an explicit `root` marker; falls back to a lone `reply` marker (a message bearing only `reply` *started* the thread, so that parent is the root for everything after it); treats a legacy unmarked `e` tag as the parent. A mention-only `p` tag is not a reply.
- The root cache is an `OrderedDict` bounded at 512 entries with FIFO eviction, so a long-lived gateway cannot leak.
- The resolver is applied to the image send path as well as `send()`.
- Both helpers tolerate a missing `_thread_roots` attribute, since the standalone/cron send path constructs an adapter without running `__init__`.

## Verification

Reproduced on current `main` (`63565fa26`) with a harness replaying the real relay event shape — a message inside thread `root1`, handed to the adapter exactly as `_reply_anchor_for_event` does:

```
                        UNPATCHED main        PATCHED
thread the user is in : root1                 root1
their message id      : m3                    m3
adapter --reply-to    : m3        <-- BUG     root1   <-- joins the thread
```

Tests added to `tests/gateway/test_buzz_adapter.py` cover root extraction (top-level, thread opener, nested, legacy unmarked tag), the top-level passthrough that guards the existing behaviour, unknown/None anchors, cache bounding and eviction, and an end-to-end assertion through `send()` that `--reply-to` carries the root.

```
tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py
36 passed
```

Reverting the adapter change fails all 9 new tests; the existing 27 continue to pass unchanged.

Running live on the reporter's gateway since the fix landed.
