### PR TITLE
perf(desktop): eliminate GlyphSpinner-driven document-scale style recalcs

### DIFF
--- a/apps/desktop/e2e/glyph-spinner.spec.ts
+++ b/apps/desktop/e2e/glyph-spinner.spec.ts
@@ -1,0 +1,191 @@
+/**
+ * E2E contract for the compositor-only GlyphSpinner.
+ *
+ * The spinner's whole reason for existing in this shape is a CSS animation:
+ * every frame is in the DOM from mount and a `transform` keyframes animation
+ * scrolls between them, so there is no JS timer and no per-tick DOM mutation
+ * scheduling document-scale style recalculation.
+ *
+ * None of that is observable in jsdom — it has no animation engine, no
+ * cascade resolution for `steps()`, and no `Element.getAnimations()`. The
+ * jsdom suite (src/components/ui/glyph-spinner.test.tsx) therefore pins the
+ * DATA and WIRING, and this spec pins the RENDERED BEHAVIOUR in a real
+ * browser, which is the only place the stylesheet actually runs.
+ *
+ * This replaces three tests that asserted on the TEXT of the stylesheet.
+ * Reading source in a test is banned outright (AGENTS.md) and those tests
+ * proved the point: a var()-fallback edit that changed no rendered pixel
+ * broke one of them, while none of them had ever executed the CSS.
+ *
+ * Prerequisite: `npm run build` must have been run so dist/ exists.
+ */
+
+import { expect, test, type Page } from '@playwright/test'
+
+import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
+
+const STRIP = '.glyph-spinner__strip'
+
+/**
+ * Send a message so a turn is in flight — the composer status stack mounts a
+ * GlyphSpinner while the agent is working. Resolves once a frame strip is in
+ * the DOM.
+ */
+async function mountSpinner(page: Page): Promise<void> {
+  const composer = page.locator('[contenteditable="true"]').first()
+  await composer.waitFor({ state: 'visible', timeout: 10_000 })
+  await composer.click()
+  await composer.type('hello from the glyph spinner spec', { delay: 10 })
+  await page.keyboard.press('Enter')
+
+  await page.waitForSelector(STRIP, { state: 'attached', timeout: 20_000 })
+}
+
+test.describe('GlyphSpinner (compositor animation)', () => {
+  let fixture: MockBackendFixture
+
+  test.beforeAll(async () => {
+    fixture = await setupMockBackend()
+    await waitForAppReady(fixture)
+  })
+
+  test.afterAll(async () => {
+    await fixture?.cleanup()
+  })
+
+  test('animates with a steps() transform keyframes animation, one step per frame', async () => {
+    const { page } = fixture
+    await mountSpinner(page)
+
+    const observed = await page.evaluate(strip => {
+      const el = document.querySelector<HTMLElement>(strip)
+
+      if (!el) {
+        throw new Error('no frame strip in the DOM')
+      }
+
+      const style = getComputedStyle(el)
+      const animations = el.getAnimations()
+
+      return {
+        frameCount: el.querySelectorAll('.glyph-spinner__frame').length,
+        timingFunction: style.animationTimingFunction,
+        iterationCount: style.animationIterationCount,
+        durationMs: animations[0]?.effect?.getTiming().duration ?? null,
+        names: animations.map(a => (a as CSSAnimation).animationName),
+        // A percentage translate makes the animation layout-dependent, which
+        // Chromium refuses to composite. The travel must resolve to a length.
+        transform: style.transform
+      }
+    }, STRIP)
+
+    // The strip carries every frame; `steps(N)` parks on each one in turn.
+    expect(observed.frameCount).toBeGreaterThan(1)
+    // Chromium has serialized jump-end as both `steps(N)` and `steps(N, end)`.
+    expect(observed.timingFunction).toMatch(new RegExp(`^steps\\(${observed.frameCount}\\b`))
+    expect(observed.iterationCount).toBe('infinite')
+    expect(observed.names).toContain('glyph-spinner-advance')
+    // One full cycle is frames x interval, so the duration must be a positive
+    // multiple of the frame count — not the single-frame interval.
+    expect(observed.durationMs).toBeGreaterThan(0)
+    // A resolved matrix, never a percentage: `translateY(-100%)` would keep
+    // the animation off the compositor.
+    expect(observed.transform).not.toContain('%')
+  })
+
+  test('is promoted to a layer while running, and neither animates nor holds a layer when parked', async () => {
+    const { page } = fixture
+    await mountSpinner(page)
+
+    const running = await page.evaluate(strip => {
+      const el = document.querySelector<HTMLElement>(strip)!
+
+      return {
+        playState: getComputedStyle(el).animationPlayState,
+        willChange: getComputedStyle(el).willChange
+      }
+    }, STRIP)
+
+    expect(running.playState).toBe('running')
+    // Scoped to active spinners — a permanently promoted layer per parked
+    // spinner is pure memory at fan-out breadth.
+    expect(running.willChange).toBe('transform')
+
+    // 1. The per-spinner gate: a kept-alive but inactive pane, or an explicit
+    //    `paused` prop (ChatSwapOverlay's fade-out).
+    const parked = await page.evaluate(strip => {
+      const el = document.querySelector<HTMLElement>(strip)!
+      const viewport = el.closest<HTMLElement>('.glyph-spinner')!
+      const previous = viewport.getAttribute('data-paused')
+
+      viewport.setAttribute('data-paused', 'true')
+      const state = {
+        playState: getComputedStyle(el).animationPlayState,
+        willChange: getComputedStyle(el).willChange
+      }
+
+      if (previous === null) {
+        viewport.removeAttribute('data-paused')
+      } else {
+        viewport.setAttribute('data-paused', previous)
+      }
+
+      return state
+    }, STRIP)
+
+    expect(parked.playState).toBe('paused')
+    expect(parked.willChange).toBe('auto')
+
+    // 2. The global gate: window blur / minimize / document-hidden, which
+    //    main.tsx drives by arming this attribute on the root. The strip must
+    //    be named in that rule, or every spinner keeps animating behind an
+    //    inactive window — the CPU burn the original ticker's pause
+    //    controller existed to avoid.
+    const globallyPaused = await page.evaluate(strip => {
+      const root = document.documentElement
+      const had = root.hasAttribute('data-renderer-animations-paused')
+
+      root.setAttribute('data-renderer-animations-paused', '')
+      const playState = getComputedStyle(document.querySelector<HTMLElement>(strip)!).animationPlayState
+
+      if (!had) {
+        root.removeAttribute('data-renderer-animations-paused')
+      }
+
+      return playState
+    }, STRIP)
+
+    expect(globallyPaused).toBe('paused')
+  })
+
+  test('advances in discrete frames and creates no timer-driven DOM churn', async () => {
+    const { page } = fixture
+    await mountSpinner(page)
+
+    // Sample the resolved transform across one full cycle. A steps() animation
+    // holds each value for a whole interval and jumps between them, so the
+    // distinct values it visits must be bounded by the frame count — a linear
+    // animation would produce a new value on every sample.
+    const sampled = await page.evaluate(async strip => {
+      const el = document.querySelector<HTMLElement>(strip)!
+      const frames = el.querySelectorAll('.glyph-spinner__frame').length
+      const duration = Number(el.getAnimations()[0]?.effect?.getTiming().duration ?? 0)
+      const seen = new Set<string>()
+      const textAtStart = el.textContent
+
+      const deadline = performance.now() + duration
+      while (performance.now() < deadline) {
+        seen.add(getComputedStyle(el).transform)
+        await new Promise(resolve => requestAnimationFrame(() => resolve(null)))
+      }
+
+      return { distinct: seen.size, frames, textUnchanged: el.textContent === textAtStart }
+    }, STRIP)
+
+    expect(sampled.distinct).toBeGreaterThan(1)
+    expect(sampled.distinct).toBeLessThanOrEqual(sampled.frames + 1)
+    // The old implementation rewrote textContent ~12x/second. Nothing may
+    // mutate the DOM as this animates — that mutation is the whole incident.
+    expect(sampled.textUnchanged).toBe(true)
+  })
+})

--- a/apps/desktop/e2e/glyph-spinner.spec.ts
+++ b/apps/desktop/e2e/glyph-spinner.spec.ts
@@ -20,7 +20,7 @@
  * Prerequisite: `npm run build` must have been run so dist/ exists.
  */
 
-import { expect, test, type Page } from '@playwright/test'
+import { expect, type Page, test } from '@playwright/test'
 
 import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
 
@@ -74,8 +74,12 @@ test.describe('GlyphSpinner (compositor animation)', () => {
         durationMs: animations[0]?.effect?.getTiming().duration ?? null,
         names: animations.map(a => (a as CSSAnimation).animationName),
         // A percentage translate makes the animation layout-dependent, which
-        // Chromium refuses to composite. The travel must resolve to a length.
-        transform: style.transform
+        // Chromium refuses to composite. Read the engine's own keyframes: a
+        // revert to translateY(-100%) shows up here, while the computed
+        // `style.transform` always serializes to a matrix and can't tell.
+        travel: ((animations[0]?.effect as KeyframeEffect | undefined)?.getKeyframes() ?? [])
+          .map(k => String((k as Keyframe & { transform?: string }).transform ?? ''))
+          .join(' | ')
       }
     }, STRIP)
 
@@ -88,9 +92,10 @@ test.describe('GlyphSpinner (compositor animation)', () => {
     // One full cycle is frames x interval, so the duration must be a positive
     // multiple of the frame count — not the single-frame interval.
     expect(observed.durationMs).toBeGreaterThan(0)
-    // A resolved matrix, never a percentage: `translateY(-100%)` would keep
+    // Length-typed travel, never a percentage: `translateY(-100%)` would keep
     // the animation off the compositor.
-    expect(observed.transform).not.toContain('%')
+    expect(observed.travel).toContain('calc(')
+    expect(observed.travel).not.toContain('%')
   })
 
   test('is promoted to a layer while running, and neither animates nor holds a layer when parked', async () => {
@@ -119,6 +124,7 @@ test.describe('GlyphSpinner (compositor animation)', () => {
       const previous = viewport.getAttribute('data-paused')
 
       viewport.setAttribute('data-paused', 'true')
+
       const state = {
         playState: getComputedStyle(el).animationPlayState,
         willChange: getComputedStyle(el).willChange
@@ -174,6 +180,7 @@ test.describe('GlyphSpinner (compositor animation)', () => {
       const textAtStart = el.textContent
 
       const deadline = performance.now() + duration
+
       while (performance.now() < deadline) {
         seen.add(getComputedStyle(el).transform)
         await new Promise(resolve => requestAnimationFrame(() => resolve(null)))

--- a/apps/desktop/scripts/run-short-session-hang-repro.mjs
+++ b/apps/desktop/scripts/run-short-session-hang-repro.mjs
@@ -928,9 +928,16 @@ async function runRealChatChecks(cdp, timed, measure, mock, runDir, appPid, nati
         // Settled = no streaming marker anywhere in the row's subtree. The
         // marker moved off the message root onto a hidden leaf inside it — a
         // per-flip attribute write on the root widened style recalc across the
-        // whole message subtree — so this matches the descendant instead of the
+        // whole message subtree — so this counts the descendant instead of the
         // root's own attribute. Same rows, same gate.
-        `document.querySelectorAll('[data-slot="aui_assistant-message-root"]:not(:has([data-message-streaming="true"]))').length`
+        //
+        // Counted by subtraction rather than with
+        // `:not(:has([data-message-streaming="true"]))`, which makes the engine
+        // walk every row's subtree on each evaluation — and this probe runs
+        // inside the very latency window it is measuring, so that cost lands in
+        // the number. At most one marker per row carries the attribute, so
+        // roots - streaming is exactly the settled count.
+        `document.querySelectorAll('[data-slot="aui_assistant-message-root"]').length - document.querySelectorAll('[data-message-streaming="true"]').length`
       )
     )
     const composer = await timed(`real-chat.composer-focus.${exchange}`, () =>
@@ -1025,7 +1032,9 @@ async function runRealChatChecks(cdp, timed, measure, mock, runDir, appPid, nati
     await measure(`real-chat.assistant-response.${exchange}`, () =>
       waitForResponsive(
         cdp,
-        `document.querySelectorAll('[data-slot="aui_assistant-message-root"]:not(:has([data-message-streaming="true"]))').length > ${beforeAssistant}`,
+        // Same count-by-subtraction as the pre-send probe above: no `:has()`
+        // subtree walk inside the responsiveness measurement window.
+        `document.querySelectorAll('[data-slot="aui_assistant-message-root"]').length - document.querySelectorAll('[data-message-streaming="true"]').length > ${beforeAssistant}`,
         STREAM_RESPONSE_TIMEOUT_MS,
         `real assistant response ${exchange}`,
         STREAM_RESPONSE_EVALUATION_TIMEOUT_MS

--- a/apps/desktop/scripts/run-short-session-hang-repro.mjs
+++ b/apps/desktop/scripts/run-short-session-hang-repro.mjs
@@ -925,7 +925,12 @@ async function runRealChatChecks(cdp, timed, measure, mock, runDir, appPid, nati
     const streamingRequestsBefore = mock.streamingCompletionRequests()
     const beforeAssistant = await timed(`real-chat.assistant-count.${exchange}`, () =>
       cdp.eval(
-        `document.querySelectorAll('[data-slot="aui_assistant-message-root"]:not([data-streaming="true"])').length`
+        // Settled = no streaming marker anywhere in the row's subtree. The
+        // marker moved off the message root onto a hidden leaf inside it — a
+        // per-flip attribute write on the root widened style recalc across the
+        // whole message subtree — so this matches the descendant instead of the
+        // root's own attribute. Same rows, same gate.
+        `document.querySelectorAll('[data-slot="aui_assistant-message-root"]:not(:has([data-message-streaming="true"]))').length`
       )
     )
     const composer = await timed(`real-chat.composer-focus.${exchange}`, () =>
@@ -1020,7 +1025,7 @@ async function runRealChatChecks(cdp, timed, measure, mock, runDir, appPid, nati
     await measure(`real-chat.assistant-response.${exchange}`, () =>
       waitForResponsive(
         cdp,
-        `document.querySelectorAll('[data-slot="aui_assistant-message-root"]:not([data-streaming="true"])').length > ${beforeAssistant}`,
+        `document.querySelectorAll('[data-slot="aui_assistant-message-root"]:not(:has([data-message-streaming="true"]))').length > ${beforeAssistant}`,
         STREAM_RESPONSE_TIMEOUT_MS,
         `real assistant response ${exchange}`,
         STREAM_RESPONSE_EVALUATION_TIMEOUT_MS

--- a/apps/desktop/src/app/chat/chat-swap-overlay.test.tsx
+++ b/apps/desktop/src/app/chat/chat-swap-overlay.test.tsx
@@ -1,0 +1,54 @@
+// The overlay used to run its own 80ms setInterval + setState braille ticker —
+// the same mechanism class (per-tick DOM mutation scheduling a style recalc)
+// that GlyphSpinner was rewritten to remove. It now renders GlyphSpinner, so
+// what needs pinning is that no timer comes back, that the label still survives
+// the fade-out, and that the spinner stops animating once the swap is done.
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ChatSwapOverlay } from './chat-swap-overlay'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('ChatSwapOverlay', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('animates the glyph without any timer', () => {
+    const { container } = render(<ChatSwapOverlay profile="turqoise" />)
+
+    expect(container.querySelector('.glyph-spinner__strip')).toBeTruthy()
+    expect(vi.getTimerCount()).toBe(0)
+
+    vi.advanceTimersByTime(5_000)
+
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('names the waking profile', () => {
+    render(<ChatSwapOverlay profile="turqoise" />)
+
+    expect(screen.getByText(/turqoise/)).toBeTruthy()
+  })
+
+  it('keeps the last profile name through the fade-out, with the glyph frozen', () => {
+    const { container, rerender } = render(<ChatSwapOverlay profile="turqoise" />)
+
+    expect(container.querySelector('.glyph-spinner')?.hasAttribute('data-paused')).toBe(false)
+
+    rerender(<ChatSwapOverlay profile={null} />)
+
+    // Label held so the overlay doesn't blank while it fades.
+    expect(screen.getByText(/turqoise/)).toBeTruthy()
+    // ...and the spinner stops, the way clearing the interval used to stop it.
+    expect(container.querySelector('.glyph-spinner')?.getAttribute('data-paused')).toBe('true')
+  })
+})

--- a/apps/desktop/src/app/chat/chat-swap-overlay.tsx
+++ b/apps/desktop/src/app/chat/chat-swap-overlay.tsx
@@ -1,33 +1,20 @@
 import { useEffect, useState } from 'react'
 
+import { GlyphSpinner } from '@/components/ui/glyph-spinner'
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
-
-// Braille spinner frames — reads as a tiny ASCII loader in monospace.
-const FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
 
 // Shown over the conversation while the live gateway swaps to another profile's
 // backend (lazily spawned). Keeps the last profile name through the fade-out so
 // the label doesn't blank. Purely visual — pointer-events-none.
 export function ChatSwapOverlay({ profile }: { profile: string | null }) {
   const { t } = useI18n()
-  const [frame, setFrame] = useState(0)
   const [label, setLabel] = useState<null | string>(profile)
 
   useEffect(() => {
     if (profile) {
       setLabel(profile)
     }
-  }, [profile])
-
-  useEffect(() => {
-    if (!profile) {
-      return
-    }
-
-    const id = window.setInterval(() => setFrame(value => (value + 1) % FRAMES.length), 80)
-
-    return () => window.clearInterval(id)
   }, [profile])
 
   return (
@@ -39,7 +26,14 @@ export function ChatSwapOverlay({ profile }: { profile: string | null }) {
       )}
     >
       <div className="flex items-center gap-2 bg-[color-mix(in_srgb,var(--dt-card)_92%,transparent)] px-4 py-2 font-mono text-[0.8125rem] text-foreground shadow-composer">
-        <span className="w-3 text-(--ui-accent)">{FRAMES[frame]}</span>
+        {/* Was a local 80ms setInterval + setState braille ticker — the same
+            mechanism class (per-tick DOM mutation scheduling style recalc)
+            that GlyphSpinner was rewritten to remove. `braille` is exactly the
+            frame set and 80ms cadence this used. `justify-start` keeps the
+            glyph left-aligned in its w-3 box the way the bare span was, and
+            `paused` restores the old "no ticking once the swap is done"
+            behaviour while the overlay fades out still mounted. */}
+        <GlyphSpinner className="w-3 justify-start text-(--ui-accent)" paused={!profile} spinner="braille" />
         {t.composer.wakingProfile(label ?? '')}
       </div>
     </div>

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -40,6 +40,14 @@ import { $voicePlayback } from '@/store/voice-playback'
 // would re-derive the changed-files card on every message re-render.
 const EMPTY_PARTS: readonly unknown[] = []
 
+// PERF: hoisted to module scope so the element OBJECT is identical on every
+// render of every assistant message. React bails out of re-rendering a child
+// whose element identity is unchanged, so a status flip on the message root
+// (pending -> complete and back, N rows per stream flush) can no longer
+// descend into the parts subtree at all. Its props were already the module
+// constant MESSAGE_PARTS_COMPONENTS, so nothing per-message is captured here.
+const MESSAGE_PARTS = <MessagePrimitive.Parts components={MESSAGE_PARTS_COMPONENTS} />
+
 interface MessageActionProps {
   messageId: string
   /** Lazy accessor — reads the live message text at action time. Passing the
@@ -97,9 +105,14 @@ export const AssistantMessage: FC<{
   // token flushes (booleans, status strings, '' while running), so the
   // 30 Hz delta stream only re-renders the markdown part and the tiny
   // TurnActivityIndicator leaf — not the footer/preview/root subtree.
-  const messageStatus = useAuiState(s => s.message.status?.type)
-  const isRunning = messageStatus === 'running'
-  const isPlaceholder = useAuiState(s => s.message.status?.type === 'running' && s.message.content.length === 0)
+  //
+  // `isRunning` is the one status read left at this level, and only because
+  // two things genuinely need it HERE: the inter-agent collapse gate below (a
+  // running reply must stay expanded) and the mount-time `enabled` of
+  // useEnterAnimation. Every other status-derived read moved down into
+  // AssistantStatusSlot / SettledChangedFiles, so a pending flip no longer
+  // descends into the parts subtree or the changed-files card from here.
+  const isRunning = useAuiState(s => s.message.status?.type === 'running')
   const hasVisibleText = useAuiState(s => contentHasVisibleText(s.message.content))
   // Sealed mid-turn commentary keeps its text but not the footer, so a
   // tool-heavy turn doesn't grow a copy/refresh bar per paragraph (see
@@ -109,13 +122,6 @@ export const AssistantMessage: FC<{
   // Whole-turn wall-clock seconds (set once at completion — referentially
   // stable across the 30 Hz delta stream, so this adds no per-token renders).
   const turnDurationS = useAuiState(s => s.message.metadata?.custom?.durationS as number | undefined)
-
-  // The thinking/stall indicator belongs to the TAIL of the thread, period. A
-  // stale pending bubble mid-transcript (a turn that ended without its settle
-  // event, a steer race) must never show one — a spinner above a later user
-  // message reads as the agent answering out of order. Booleans are stable
-  // across token flushes, so this selector adds no streaming re-renders.
-  const isLastMessage = useAuiState(s => s.thread.messages[s.thread.messages.length - 1]?.id === s.message.id)
 
   // Preview targets only materialize once the turn completes — while running
   // the selector returns '' (stable), so per-token flushes skip the regex
@@ -133,21 +139,6 @@ export const AssistantMessage: FC<{
   }, [completedText])
 
   const getMessageText = useCallback(() => messageContentText(messageRuntime.getState().content), [messageRuntime])
-
-  // Cursor's changed-files card only appears once the turn settles: while the
-  // agent is still editing, the tool rows narrate each patch and a card that
-  // grew a row per write would thrash the transcript. `[]` while running keeps
-  // this selector referentially stable across the 30 Hz delta stream.
-  //
-  // It also only rides the LAST turn. The card is a "here's what just landed"
-  // summary, not a per-turn artifact: leaving one behind on every reply would
-  // stack a wall of stale cards down the transcript. Sending the next message
-  // retires it — the working tree it describes is already history by then.
-  const settledParts = useAuiState(s => {
-    const isLastMessage = s.thread.messages[s.thread.messages.length - 1]?.id === s.message.id
-
-    return s.message.status?.type === 'running' || !isLastMessage ? EMPTY_PARTS : s.message.parts
-  })
 
   const enterRef = useEnterAnimation(isRunning, `assistant-message:${messageId}`)
 
@@ -176,7 +167,7 @@ export const AssistantMessage: FC<{
               show reply
             </summary>
             <div className="mt-1 max-w-[36rem] rounded-lg border border-(--ui-stroke-tertiary) px-3 py-2 text-left text-[0.75rem] leading-5 text-foreground/85">
-              <MessagePrimitive.Parts components={MESSAGE_PARTS_COMPONENTS} />
+              {MESSAGE_PARTS}
             </div>
           </details>
         </div>
@@ -198,15 +189,8 @@ export const AssistantMessage: FC<{
         data-slot="aui_assistant-message-content"
       >
         {/* Todos render in the composer status stack now, not inline. */}
-        <MessagePrimitive.Parts components={MESSAGE_PARTS_COMPONENTS} />
-        {/* The activity row is mounted by the TAIL of the thread and decides
-            for itself whether the turn owes the user a line. Gating the mount
-            on this bubble's own `running` status was the hole: a turn that
-            seals a bubble mid-flight (message.interim) or finishes one while
-            the agent keeps going leaves a settled message at the tail, so the
-            row unmounted and the seconds went uncounted while the composer's
-            arc border and Stop button said work was still happening. */}
-        {isLastMessage && (isPlaceholder ? <ResponseLoadingIndicator /> : <TurnActivityIndicator />)}
+        {MESSAGE_PARTS}
+        <AssistantStatusSlot />
         {previewTargets.length > 0 && (
           <div className="mt-3 flex flex-wrap gap-2">
             {previewTargets.map(target => (
@@ -244,9 +228,77 @@ export const AssistantMessage: FC<{
       )}
       {/* Last thing in the turn — under the action bar, the way Cursor ends a
           turn on its summary rather than burying it above the controls. */}
-      <ChangedFilesCard parts={settledParts} />
+      <SettledChangedFiles />
     </MessagePrimitive.Root>
   )
+}
+
+/**
+ * PERF leaf: the only subscriber to this message's streaming status inside the
+ * message content. Previously `messageStatus` / `isPlaceholder` /
+ * `isLastMessage` were read by AssistantMessage itself, so every pending flip
+ * re-rendered the whole message subtree — at stream breadth N, N subtrees in a
+ * single commit, which is what widened the recalc scope. Reading them here
+ * confines the flip to this leaf; the sibling parts subtree is a hoisted
+ * constant element and bails out.
+ *
+ * Behaviour is byte-identical to the old inline expression, including the
+ * TAIL-ONLY rule: the activity row belongs to the tail of the thread, period.
+ * A stale pending bubble mid-transcript (a turn that ended without its settle
+ * event, a steer race) must never show one — a spinner above a later user
+ * message reads as the agent answering out of order.
+ *
+ * The activity row is mounted by the TAIL of the thread and decides for itself
+ * whether the turn owes the user a line, so there is deliberately no
+ * `isRunning` gate on the mount here. Gating it on this bubble's own `running`
+ * status was the hole: a turn that seals a bubble mid-flight (message.interim)
+ * or finishes one while the agent keeps going leaves a settled message at the
+ * tail, so the row unmounted and the seconds went uncounted while the
+ * composer's arc border and Stop button said work was still happening.
+ * TurnActivityIndicator subscribes to the status it needs internally, so it is
+ * itself a leaf and this stays off the message root either way.
+ */
+const AssistantStatusSlot: FC = () => {
+  const isLastMessage = useAuiState(s => s.thread.messages[s.thread.messages.length - 1]?.id === s.message.id)
+  const isPlaceholder = useAuiState(s => s.message.status?.type === 'running' && s.message.content.length === 0)
+
+  if (!isLastMessage) {
+    return null
+  }
+
+  if (isPlaceholder) {
+    return <ResponseLoadingIndicator />
+  }
+
+  return <TurnActivityIndicator />
+}
+
+/**
+ * PERF leaf: owns the `settledParts` selector so the tail's settle stops
+ * re-rendering the message root. This is the one status-derived selector that
+ * returns an OBJECT (`s.message.parts`) rather than a primitive, so it cannot
+ * bail out on identity churn — keeping it at the root meant every settle
+ * re-rendered the root and everything under it.
+ *
+ * Cursor's changed-files card only appears once the turn settles: while the
+ * agent is still editing, the tool rows narrate each patch and a card that
+ * grew a row per write would thrash the transcript. `EMPTY_PARTS` while
+ * running keeps this selector referentially stable across the 30 Hz delta
+ * stream.
+ *
+ * It also only rides the LAST turn. The card is a "here's what just landed"
+ * summary, not a per-turn artifact: leaving one behind on every reply would
+ * stack a wall of stale cards down the transcript. Sending the next message
+ * retires it — the working tree it describes is already history by then.
+ */
+const SettledChangedFiles: FC = () => {
+  const settledParts = useAuiState(s => {
+    const isLastMessage = s.thread.messages[s.thread.messages.length - 1]?.id === s.message.id
+
+    return s.message.status?.type === 'running' || !isLastMessage ? EMPTY_PARTS : s.message.parts
+  })
+
+  return <ChangedFilesCard parts={settledParts} />
 }
 
 const AssistantActionBar: FC<MessageActionProps> = ({ messageId, getMessageText, onBranchInNewChat }) => {

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -7,7 +7,7 @@ import {
   useMessageRuntime
 } from '@assistant-ui/react'
 import { useStore } from '@nanostores/react'
-import { type FC, useCallback, useMemo, useState } from 'react'
+import { type FC, type ReactNode, useCallback, useMemo, useState } from 'react'
 
 import { ChangedFilesCard } from '@/components/assistant-ui/thread/changed-files-card'
 import {
@@ -109,47 +109,56 @@ export const AssistantMessage: FC<AssistantMessageProps> = props => {
   )
 }
 
+/** The compact stand-in a settled inter-agent reply collapses to (Grok-bots
+ *  parity — the transcript shows the event; the text is one click away). */
+const InterAgentCollapsedNotice: FC<{ sender: string }> = ({ sender }) => (
+  <div className="flex max-w-[min(86%,44rem)] flex-col gap-0.5 self-center px-2 py-0.5 text-[0.6875rem] leading-5 text-muted-foreground/60">
+    <span className="flex items-center justify-center gap-1.5">
+      <Codicon className="shrink-0 text-muted-foreground/55" name="arrow-small-right" size="0.8125rem" />
+      <span className="wrap-anywhere">Replied to {sender}</span>
+    </span>
+    <details className="self-center">
+      <summary className="cursor-pointer select-none text-center text-muted-foreground/45 hover:text-muted-foreground/70">
+        show reply
+      </summary>
+      <div className="mt-1 max-w-[36rem] rounded-lg border border-(--ui-stroke-tertiary) px-3 py-2 text-left text-[0.75rem] leading-5 text-foreground/85">
+        {MESSAGE_PARTS}
+      </div>
+    </details>
+  </div>
+)
+
 /**
  * An assistant reply that answers an inter-agent delivery. Owns the only
  * root-level `isRunning` subscription left in this file, and it is confined to
  * the rare inter-agent case: the reply renders collapsed once it settles, so
  * the gate genuinely needs live status. Never collapse while streaming — the
  * user should see progress.
+ *
+ * The collapse is expressed as a CHILD of the normal body, not as a competing
+ * root. Returning a bare MessagePrimitive.Root here for the settled case put a
+ * different element type in this position than the running case
+ * (AssistantMessageBody), so settling unmounted the whole row and mounted a
+ * fresh one — throwing away the DOM the scroll anchor was holding, which can
+ * jump the transcript under the reader. One component, one root, children
+ * vary: settling is now a prop change React applies in place.
  */
 const InterAgentAssistantMessage: FC<AssistantMessageProps & { sender: string }> = ({ sender, ...props }) => {
   const isRunning = useAuiState(s => s.message.status?.type === 'running')
 
-  if (isRunning) {
-    return <AssistantMessageBody {...props} />
-  }
-
-  // Render collapsed (Grok-bots parity — the transcript shows the event; the
-  // text is one click away).
   return (
-    <MessagePrimitive.Root
-      className="group flex w-full min-w-0 max-w-full flex-col gap-0 self-start overflow-hidden pb-(--conversation-turn-gap)"
-      data-role="assistant"
-      data-slot="aui_assistant-message-root"
-    >
-      <div className="flex max-w-[min(86%,44rem)] flex-col gap-0.5 self-center px-2 py-0.5 text-[0.6875rem] leading-5 text-muted-foreground/60">
-        <span className="flex items-center justify-center gap-1.5">
-          <Codicon className="shrink-0 text-muted-foreground/55" name="arrow-small-right" size="0.8125rem" />
-          <span className="wrap-anywhere">Replied to {sender}</span>
-        </span>
-        <details className="self-center">
-          <summary className="cursor-pointer select-none text-center text-muted-foreground/45 hover:text-muted-foreground/70">
-            show reply
-          </summary>
-          <div className="mt-1 max-w-[36rem] rounded-lg border border-(--ui-stroke-tertiary) px-3 py-2 text-left text-[0.75rem] leading-5 text-foreground/85">
-            {MESSAGE_PARTS}
-          </div>
-        </details>
-      </div>
-    </MessagePrimitive.Root>
+    <AssistantMessageBody
+      {...props}
+      collapsedNotice={isRunning ? null : <InterAgentCollapsedNotice sender={sender} />}
+    />
   )
 }
 
-const AssistantMessageBody: FC<AssistantMessageProps> = ({ onBranchInNewChat, onDismissError }) => {
+const AssistantMessageBody: FC<AssistantMessageProps & { collapsedNotice?: null | ReactNode }> = ({
+  collapsedNotice = null,
+  onBranchInNewChat,
+  onDismissError
+}) => {
   const messageId = useAuiState(s => s.message.id)
   const messageRuntime = useMessageRuntime()
   const { t } = useI18n()
@@ -189,52 +198,62 @@ const AssistantMessageBody: FC<AssistantMessageProps> = ({ onBranchInNewChat, on
 
   return (
     <MessagePrimitive.Root
-      className="group flex w-full min-w-0 max-w-full flex-col gap-0 self-start overflow-hidden"
+      className={cn(
+        'group flex w-full min-w-0 max-w-full flex-col gap-0 self-start overflow-hidden',
+        collapsedNotice && 'pb-(--conversation-turn-gap)'
+      )}
       data-role="assistant"
       data-slot="aui_assistant-message-root"
-      onDoubleClick={onDoubleClick}
+      // Collapsed inter-agent rows never carried the tapback listener; keeping
+      // that exact truth table means gating it on the notice rather than on
+      // whether the hook returned a handler.
+      onDoubleClick={collapsedNotice ? undefined : onDoubleClick}
       ref={enterRef}
     >
-      <div
-        className="wrap-anywhere min-w-0 max-w-full overflow-hidden text-pretty text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground"
-        data-slot="aui_assistant-message-content"
-      >
-        {/* Todos render in the composer status stack now, not inline. */}
-        {MESSAGE_PARTS}
-        <AssistantStatusSlot />
-        <AssistantPreviewEmbeds />
-        <MessagePrimitive.Error>
-          <ErrorPrimitive.Root
-            className="mt-1.5 flex items-start gap-1.5 text-[0.78rem] leading-5 text-[color-mix(in_srgb,var(--dt-destructive)_78%,var(--ui-text-secondary))]"
-            role="alert"
+      {collapsedNotice ?? (
+        <>
+          <div
+            className="wrap-anywhere min-w-0 max-w-full overflow-hidden text-pretty text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground"
+            data-slot="aui_assistant-message-content"
           >
-            <ErrorPrimitive.Message className="min-w-0 flex-1" />
-            {onDismissError && (
-              <TooltipIconButton
-                className="-my-0.5 shrink-0 text-current opacity-70 hover:opacity-100"
-                onClick={() => onDismissError(messageId)}
-                side="top"
-                tooltip={t.assistant.thread.dismissError}
+            {/* Todos render in the composer status stack now, not inline. */}
+            {MESSAGE_PARTS}
+            <AssistantStatusSlot />
+            <AssistantPreviewEmbeds />
+            <MessagePrimitive.Error>
+              <ErrorPrimitive.Root
+                className="mt-1.5 flex items-start gap-1.5 text-[0.78rem] leading-5 text-[color-mix(in_srgb,var(--dt-destructive)_78%,var(--ui-text-secondary))]"
+                role="alert"
               >
-                <XIcon className="size-3.5" />
-              </TooltipIconButton>
-            )}
-          </ErrorPrimitive.Root>
-        </MessagePrimitive.Error>
-      </div>
-      <MessageTimelineTimestamp className="px-(--message-text-indent) pt-0.5" suppressIfDuplicatePart />
-      {hasVisibleText && !isInterim && (
-        <AssistantFooter
-          durationS={turnDurationS}
-          getMessageText={getMessageText}
-          messageId={messageId}
-          onBranchInNewChat={onBranchInNewChat}
-        />
-      )}
-      {/* Last thing in the turn — under the action bar, the way Cursor ends a
+                <ErrorPrimitive.Message className="min-w-0 flex-1" />
+                {onDismissError && (
+                  <TooltipIconButton
+                    className="-my-0.5 shrink-0 text-current opacity-70 hover:opacity-100"
+                    onClick={() => onDismissError(messageId)}
+                    side="top"
+                    tooltip={t.assistant.thread.dismissError}
+                  >
+                    <XIcon className="size-3.5" />
+                  </TooltipIconButton>
+                )}
+              </ErrorPrimitive.Root>
+            </MessagePrimitive.Error>
+          </div>
+          <MessageTimelineTimestamp className="px-(--message-text-indent) pt-0.5" suppressIfDuplicatePart />
+          {hasVisibleText && !isInterim && (
+            <AssistantFooter
+              durationS={turnDurationS}
+              getMessageText={getMessageText}
+              messageId={messageId}
+              onBranchInNewChat={onBranchInNewChat}
+            />
+          )}
+          {/* Last thing in the turn — under the action bar, the way Cursor ends a
           turn on its summary rather than burying it above the controls. */}
-      <SettledChangedFiles />
-      <StreamingMarker />
+          <SettledChangedFiles />
+          <StreamingMarker />
+        </>
+      )}
     </MessagePrimitive.Root>
   )
 }
@@ -265,18 +284,25 @@ const AssistantMessageBody: FC<AssistantMessageProps> = ({ onBranchInNewChat, on
  * itself a leaf and this stays off the message root either way.
  */
 const AssistantStatusSlot: FC = () => {
-  const isLastMessage = useAuiState(s => s.thread.messages[s.thread.messages.length - 1]?.id === s.message.id)
-  const isPlaceholder = useAuiState(s => s.message.status?.type === 'running' && s.message.content.length === 0)
+  // ONE subscription, not one per input. Each useAuiState is a separate store
+  // subscription with its own equality check and its own chance to schedule a
+  // render, and these inputs always move together on a status flip — so
+  // reading them separately just multiplies the wake-ups for a single logical
+  // change. The selector collapses them to one stable string, which bails out
+  // on every flush that does not actually change what this slot renders.
+  const slot = useAuiState(s => {
+    if (s.thread.messages[s.thread.messages.length - 1]?.id !== s.message.id) {
+      return 'none'
+    }
 
-  if (!isLastMessage) {
+    return s.message.status?.type === 'running' && s.message.content.length === 0 ? 'placeholder' : 'activity'
+  })
+
+  if (slot === 'none') {
     return null
   }
 
-  if (isPlaceholder) {
-    return <ResponseLoadingIndicator />
-  }
-
-  return <TurnActivityIndicator />
+  return slot === 'placeholder' ? <ResponseLoadingIndicator /> : <TurnActivityIndicator />
 }
 
 /**
@@ -360,11 +386,13 @@ const SettledChangedFiles: FC = () => {
  *
  * The flag has no CSS behind it (every `[data-streaming='true']` rule targets
  * `[data-slot='code-card']`), but it is not dead: it is the settled-row signal
- * for the short-session hang repro, which counts
- * `[data-slot='aui_assistant-message-root']:not(:has([data-message-streaming='true']))`
- * and gates the assistant-response wait on that count growing.
+ * for the short-session hang repro, which derives the settled count by
+ * subtracting the number of `[data-message-streaming='true']` markers from the
+ * number of message roots, and gates the assistant-response wait on that count
+ * growing. At most one marker per row carries the attribute, which is what
+ * makes the subtraction exact.
  *
- * Deliberately NOT named `data-streaming`: shiki-highlighter.tsx:148 puts that
+ * Deliberately NOT named `data-streaming`: shiki-highlighter.tsx puts that
  * exact attribute on a deferred `[data-slot='code-card']`, which is a
  * descendant of this root. Once the repro matches on a descendant rather than
  * the root's own attribute, a shared name would make any message holding a
@@ -375,12 +403,12 @@ const SettledChangedFiles: FC = () => {
  * whole message subtree, which is the invalidation this prong exists to remove.
  * Three properties make this placement cheap and behaviour-neutral:
  *
- *  - A ROOT-LEVEL sibling, not a child of the message content. The rules at
- *    styles.css:1995-2003 match the first/last block *inside*
- *    `[data-slot='aui_assistant-message-content']`; a node added there would
- *    steal `:last-child` from the stall indicator and silently change the gap
- *    between bubbles mid-stream. No rule selects message-root children by
- *    position, so this slot is inert.
+ *  - A ROOT-LEVEL sibling, not a child of the message content. The
+ *    `:first-child` / `:last-child` margin rules in styles.css match blocks
+ *    *inside* `[data-slot='aui_assistant-message-content']`; a node added
+ *    there would steal `:last-child` from the status indicator and silently
+ *    change the gap between bubbles mid-stream. No rule selects message-root
+ *    children by position, so this slot is inert.
  *  - PERMANENTLY MOUNTED, toggling only the attribute. Mounting/unmounting per
  *    flip would be a DOM structure change and dirty its siblings; an attribute
  *    write on a childless node invalidates exactly one element.
@@ -393,7 +421,14 @@ const SettledChangedFiles: FC = () => {
 const StreamingMarker: FC = () => {
   const isRunning = useAuiState(s => s.message.status?.type === 'running')
 
-  return <span aria-hidden="true" className="hidden" data-message-streaming={isRunning ? 'true' : undefined} />
+  return (
+    <span
+      aria-hidden="true"
+      className="hidden"
+      data-message-streaming={isRunning ? 'true' : undefined}
+      data-slot="aui_message-streaming-marker"
+    />
+  )
 }
 
 const AssistantActionBar: FC<MessageActionProps> = ({ messageId, getMessageText, onBranchInNewChat }) => {

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -170,21 +170,6 @@ const AssistantMessageBody: FC<AssistantMessageProps> = ({ onBranchInNewChat, on
   // stable across the 30 Hz delta stream, so this adds no per-token renders).
   const turnDurationS = useAuiState(s => s.message.metadata?.custom?.durationS as number | undefined)
 
-  // Preview targets only materialize once the turn completes — while running
-  // the selector returns '' (stable), so per-token flushes skip the regex
-  // scan and the re-render it would cause.
-  const completedText = useAuiState(s =>
-    s.message.status?.type === 'running' ? '' : messageContentText(s.message.content)
-  )
-
-  const previewTargets = useMemo(() => {
-    if (!completedText || !/(https?:\/\/|file:\/\/)/i.test(completedText)) {
-      return []
-    }
-
-    return pickPrimaryPreviewTarget(extractPreviewTargets(completedText))
-  }, [completedText])
-
   const getMessageText = useCallback(() => messageContentText(messageRuntime.getState().content), [messageRuntime])
 
   // useEnterAnimation consults `enabled` ONLY when its callback ref fires,
@@ -217,13 +202,7 @@ const AssistantMessageBody: FC<AssistantMessageProps> = ({ onBranchInNewChat, on
         {/* Todos render in the composer status stack now, not inline. */}
         {MESSAGE_PARTS}
         <AssistantStatusSlot />
-        {previewTargets.length > 0 && (
-          <div className="mt-3 flex flex-wrap gap-2">
-            {previewTargets.map(target => (
-              <PreviewAttachment key={target} source="explicit-link" target={target} />
-            ))}
-          </div>
-        )}
+        <AssistantPreviewEmbeds />
         <MessagePrimitive.Error>
           <ErrorPrimitive.Root
             className="mt-1.5 flex items-start gap-1.5 text-[0.78rem] leading-5 text-[color-mix(in_srgb,var(--dt-destructive)_78%,var(--ui-text-secondary))]"
@@ -298,6 +277,53 @@ const AssistantStatusSlot: FC = () => {
   }
 
   return <TurnActivityIndicator />
+}
+
+/**
+ * PERF leaf: owns the settled-text selector that feeds the link previews.
+ *
+ * This was the last status-dependent read at the message root, and the most
+ * expensive one: the selector flips between '' while running and the full
+ * `messageContentText(content)` join once settled, so every running <-> settled
+ * transition re-ran the join for the whole message AND re-rendered the root.
+ * At stream breadth N that is N joins plus N root re-renders per flip. Reading
+ * it here confines both to this leaf, which renders nothing at all in the
+ * common case.
+ *
+ * The streaming-side optimization is unchanged and still the point of the ''
+ * branch: preview targets only materialize once the turn completes, so while
+ * running the selector returns a stable '' and per-token flushes skip the
+ * regex scan and the re-render it would cause.
+ *
+ * Renders exactly what the root used to render at this position — the same
+ * wrapper div with the same classes, or nothing when there are no targets —
+ * so the DOM is byte-identical either way. A component boundary adds no node
+ * of its own, so unlike StreamingMarker this needs no placement care.
+ */
+const AssistantPreviewEmbeds: FC = () => {
+  const completedText = useAuiState(s =>
+    s.message.status?.type === 'running' ? '' : messageContentText(s.message.content)
+  )
+
+  const previewTargets = useMemo(() => {
+    if (!completedText || !/(https?:\/\/|file:\/\/)/i.test(completedText)) {
+      return []
+    }
+
+    return pickPrimaryPreviewTarget(extractPreviewTargets(completedText))
+  }, [completedText])
+
+  if (previewTargets.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="mt-3 flex flex-wrap gap-2">
+      {previewTargets.map(target => (
+        <PreviewAttachment key={target} source="explicit-link" target={target} />
+      ))}
+    </div>
+  )
 }
 
 /**

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -58,14 +58,12 @@ interface MessageActionProps {
   onBranchInNewChat?: (messageId: string) => void
 }
 
-export const AssistantMessage: FC<{
+interface AssistantMessageProps {
   onBranchInNewChat?: (messageId: string) => void
   onDismissError?: (messageId: string) => void
-}> = ({ onBranchInNewChat, onDismissError }) => {
-  const messageId = useAuiState(s => s.message.id)
-  const messageRuntime = useMessageRuntime()
-  const { t } = useI18n()
+}
 
+export const AssistantMessage: FC<AssistantMessageProps> = props => {
   // A reply to an inter-agent delivery is part of that exchange, not part of
   // the human conversation — collapse it under a compact notice ("Reply to
   // <sender>", expandable), mirroring the sender-side notice the previous
@@ -100,19 +98,68 @@ export const AssistantMessage: FC<{
     return null
   })
 
-  // PERF: this component must NOT subscribe to the streaming text. Every
-  // selector here returns a value that stays referentially stable across
-  // token flushes (booleans, status strings, '' while running), so the
-  // 30 Hz delta stream only re-renders the markdown part and the tiny
-  // TurnActivityIndicator leaf — not the footer/preview/root subtree.
-  //
-  // `isRunning` is the one status read left at this level, and only because
-  // two things genuinely need it HERE: the inter-agent collapse gate below (a
-  // running reply must stay expanded) and the mount-time `enabled` of
-  // useEnterAnimation. Every other status-derived read moved down into
-  // AssistantStatusSlot / SettledChangedFiles, so a pending flip no longer
-  // descends into the parts subtree or the changed-files card from here.
+  // The collapse gate below needs the LIVE running status, but only an
+  // inter-agent reply can ever be collapsed. Dispatching on that first keeps
+  // the status subscription out of the standard path entirely — the standard
+  // message root now re-renders for content, never for a pending flip.
+  return interAgentSender ? (
+    <InterAgentAssistantMessage {...props} sender={interAgentSender} />
+  ) : (
+    <AssistantMessageBody {...props} />
+  )
+}
+
+/**
+ * An assistant reply that answers an inter-agent delivery. Owns the only
+ * root-level `isRunning` subscription left in this file, and it is confined to
+ * the rare inter-agent case: the reply renders collapsed once it settles, so
+ * the gate genuinely needs live status. Never collapse while streaming — the
+ * user should see progress.
+ */
+const InterAgentAssistantMessage: FC<AssistantMessageProps & { sender: string }> = ({ sender, ...props }) => {
   const isRunning = useAuiState(s => s.message.status?.type === 'running')
+
+  if (isRunning) {
+    return <AssistantMessageBody {...props} />
+  }
+
+  // Render collapsed (Grok-bots parity — the transcript shows the event; the
+  // text is one click away).
+  return (
+    <MessagePrimitive.Root
+      className="group flex w-full min-w-0 max-w-full flex-col gap-0 self-start overflow-hidden pb-(--conversation-turn-gap)"
+      data-role="assistant"
+      data-slot="aui_assistant-message-root"
+    >
+      <div className="flex max-w-[min(86%,44rem)] flex-col gap-0.5 self-center px-2 py-0.5 text-[0.6875rem] leading-5 text-muted-foreground/60">
+        <span className="flex items-center justify-center gap-1.5">
+          <Codicon className="shrink-0 text-muted-foreground/55" name="arrow-small-right" size="0.8125rem" />
+          <span className="wrap-anywhere">Replied to {sender}</span>
+        </span>
+        <details className="self-center">
+          <summary className="cursor-pointer select-none text-center text-muted-foreground/45 hover:text-muted-foreground/70">
+            show reply
+          </summary>
+          <div className="mt-1 max-w-[36rem] rounded-lg border border-(--ui-stroke-tertiary) px-3 py-2 text-left text-[0.75rem] leading-5 text-foreground/85">
+            {MESSAGE_PARTS}
+          </div>
+        </details>
+      </div>
+    </MessagePrimitive.Root>
+  )
+}
+
+const AssistantMessageBody: FC<AssistantMessageProps> = ({ onBranchInNewChat, onDismissError }) => {
+  const messageId = useAuiState(s => s.message.id)
+  const messageRuntime = useMessageRuntime()
+  const { t } = useI18n()
+
+  // PERF: this component must NOT subscribe to the streaming text, and no
+  // longer subscribes to the streaming STATUS either. Every selector here
+  // returns a value that stays referentially stable across token flushes
+  // (booleans, '' while running), so the 30 Hz delta stream only re-renders
+  // the markdown part and the tiny status leaves — not the footer, the
+  // preview block, or this root.
   const hasVisibleText = useAuiState(s => contentHasVisibleText(s.message.content))
   // Sealed mid-turn commentary keeps its text but not the footer, so a
   // tool-heavy turn doesn't grow a copy/refresh bar per paragraph (see
@@ -140,47 +187,26 @@ export const AssistantMessage: FC<{
 
   const getMessageText = useCallback(() => messageContentText(messageRuntime.getState().content), [messageRuntime])
 
-  const enterRef = useEnterAnimation(isRunning, `assistant-message:${messageId}`)
+  // useEnterAnimation consults `enabled` ONLY when its callback ref fires,
+  // i.e. at mount: the hook parks the value in a ref and returns a
+  // useCallback([]) identity, and its own contract is "`enabled` is captured
+  // at mount-time only — flipping it later doesn't suddenly play the animation
+  // on existing nodes" (see lib/use-enter-animation.ts). So a live
+  // subscription here would re-render this root on every pending flip to feed
+  // a value the hook already ignores. Capture it once, off the runtime, with
+  // no subscription at all.
+  const [initiallyRunning] = useState(() => messageRuntime.getState().status?.type === 'running')
+  const enterRef = useEnterAnimation(initiallyRunning, `assistant-message:${messageId}`)
 
   // Double-click the reply to heart it (iMessage). Undefined while reactions
   // are off, so the root carries no listener at all.
   const onDoubleClick = useTapbackDoubleClick(messageId, 'assistant')
-
-  // Reply inside an inter-agent exchange: render collapsed (Grok-bots
-  // parity — the transcript shows the event; the text is one click away).
-  // Never collapse while streaming: the user should see progress, and the
-  // status selectors above stay live either way.
-  if (interAgentSender && !isRunning) {
-    return (
-      <MessagePrimitive.Root
-        className="group flex w-full min-w-0 max-w-full flex-col gap-0 self-start overflow-hidden pb-(--conversation-turn-gap)"
-        data-role="assistant"
-        data-slot="aui_assistant-message-root"
-      >
-        <div className="flex max-w-[min(86%,44rem)] flex-col gap-0.5 self-center px-2 py-0.5 text-[0.6875rem] leading-5 text-muted-foreground/60">
-          <span className="flex items-center justify-center gap-1.5">
-            <Codicon className="shrink-0 text-muted-foreground/55" name="arrow-small-right" size="0.8125rem" />
-            <span className="wrap-anywhere">Replied to {interAgentSender}</span>
-          </span>
-          <details className="self-center">
-            <summary className="cursor-pointer select-none text-center text-muted-foreground/45 hover:text-muted-foreground/70">
-              show reply
-            </summary>
-            <div className="mt-1 max-w-[36rem] rounded-lg border border-(--ui-stroke-tertiary) px-3 py-2 text-left text-[0.75rem] leading-5 text-foreground/85">
-              {MESSAGE_PARTS}
-            </div>
-          </details>
-        </div>
-      </MessagePrimitive.Root>
-    )
-  }
 
   return (
     <MessagePrimitive.Root
       className="group flex w-full min-w-0 max-w-full flex-col gap-0 self-start overflow-hidden"
       data-role="assistant"
       data-slot="aui_assistant-message-root"
-      data-streaming={isRunning ? 'true' : undefined}
       onDoubleClick={onDoubleClick}
       ref={enterRef}
     >
@@ -229,6 +255,7 @@ export const AssistantMessage: FC<{
       {/* Last thing in the turn — under the action bar, the way Cursor ends a
           turn on its summary rather than burying it above the controls. */}
       <SettledChangedFiles />
+      <StreamingMarker />
     </MessagePrimitive.Root>
   )
 }
@@ -299,6 +326,48 @@ const SettledChangedFiles: FC = () => {
   })
 
   return <ChangedFilesCard parts={settledParts} />
+}
+
+/**
+ * Carries the streaming flag that used to sit on the message root as
+ * `data-streaming`.
+ *
+ * The flag has no CSS behind it (every `[data-streaming='true']` rule targets
+ * `[data-slot='code-card']`), but it is not dead: it is the settled-row signal
+ * for the short-session hang repro, which counts
+ * `[data-slot='aui_assistant-message-root']:not(:has([data-message-streaming='true']))`
+ * and gates the assistant-response wait on that count growing.
+ *
+ * Deliberately NOT named `data-streaming`: shiki-highlighter.tsx:148 puts that
+ * exact attribute on a deferred `[data-slot='code-card']`, which is a
+ * descendant of this root. Once the repro matches on a descendant rather than
+ * the root's own attribute, a shared name would make any message holding a
+ * still-deferred code card read as "still streaming". A distinct name keeps
+ * the signal about the MESSAGE and immune to how deep it sits.
+ *
+ * On the root it was a per-flip attribute write on the element that owns the
+ * whole message subtree, which is the invalidation this prong exists to remove.
+ * Three properties make this placement cheap and behaviour-neutral:
+ *
+ *  - A ROOT-LEVEL sibling, not a child of the message content. The rules at
+ *    styles.css:1995-2003 match the first/last block *inside*
+ *    `[data-slot='aui_assistant-message-content']`; a node added there would
+ *    steal `:last-child` from the stall indicator and silently change the gap
+ *    between bubbles mid-stream. No rule selects message-root children by
+ *    position, so this slot is inert.
+ *  - PERMANENTLY MOUNTED, toggling only the attribute. Mounting/unmounting per
+ *    flip would be a DOM structure change and dirty its siblings; an attribute
+ *    write on a childless node invalidates exactly one element.
+ *  - `display: none`, so it costs no layout or paint. `querySelectorAll` and
+ *    `:has()` still match it — they read the DOM, not the box tree.
+ *
+ * Tracks plain `isRunning` (not tail-only), exactly like the old root
+ * attribute, so the repro's row accounting is unchanged.
+ */
+const StreamingMarker: FC = () => {
+  const isRunning = useAuiState(s => s.message.status?.type === 'running')
+
+  return <span aria-hidden="true" className="hidden" data-message-streaming={isRunning ? 'true' : undefined} />
 }
 
 const AssistantActionBar: FC<MessageActionProps> = ({ messageId, getMessageText, onBranchInNewChat }) => {

--- a/apps/desktop/src/components/assistant-ui/thread/inter-agent-collapse.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/inter-agent-collapse.test.tsx
@@ -1,0 +1,117 @@
+// Two contracts with no coverage before the invalidation-scoping work split
+// AssistantMessage into InterAgentAssistantMessage + AssistantMessageBody:
+//
+// 1. The collapse gate. A reply to an inter-agent delivery renders collapsed
+//    ("Replied to <sender>", expandable) ONLY once it settles — never while it
+//    streams, because the user should see progress. That gate is the sole
+//    remaining root-level `isRunning` subscription, so it is the thing most
+//    likely to break if the split is revisited.
+// 2. The streaming marker. `data-message-streaming` moved off the message root
+//    onto a permanently-mounted hidden leaf, and
+//    scripts/run-short-session-hang-repro.mjs counts settled rows with
+//    `[data-slot="aui_assistant-message-root"]:not(:has([data-message-streaming="true"]))`.
+//    Nothing in the app itself reads it, so without this test a delete would
+//    look free and would silently regress that repro's response gate.
+import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { Thread } from '.'
+
+const createdAt = new Date('2026-05-01T00:00:00.000Z')
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
+  window.setTimeout(() => callback(performance.now()), 0)
+)
+vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id))
+vi.stubGlobal('CSS', { escape: (str: string) => str })
+
+Element.prototype.scrollTo = function scrollTo() {}
+
+Element.prototype.animate = function animate() {
+  return { cancel() {}, finished: Promise.resolve() } as unknown as Animation
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+const assistantMetadata = { unstable_state: null, unstable_annotations: [], unstable_data: [], steps: [], custom: {} }
+
+function user(id: string, text: string): ThreadMessage {
+  return {
+    id,
+    role: 'user',
+    content: [{ type: 'text', text }],
+    attachments: [],
+    createdAt,
+    metadata: { custom: {} }
+  } as ThreadMessage
+}
+
+function assistant(id: string, text: string, running: boolean): ThreadMessage {
+  return {
+    id,
+    role: 'assistant',
+    content: text ? [{ type: 'text', text }] : [],
+    status: running ? { type: 'running' } : { type: 'complete', reason: 'stop' },
+    createdAt,
+    metadata: assistantMetadata
+  } as ThreadMessage
+}
+
+function Harness({ messages }: { messages: ThreadMessage[] }) {
+  const runtime = useExternalStoreRuntime<ThreadMessage>({
+    messages,
+    isRunning: messages.at(-1)?.status?.type === 'running',
+    onNew: async () => {}
+  })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  )
+}
+
+const DELIVERY = 'Message from 🤖 Hermes (@hermes): please check the build'
+
+describe('inter-agent collapse gate', () => {
+  it('collapses a settled reply to an inter-agent delivery', async () => {
+    render(<Harness messages={[user('u1', DELIVERY), assistant('a1', 'build is green', false)]} />)
+
+    expect(await screen.findByText(/Replied to/)).toBeTruthy()
+    expect(screen.getByText('show reply')).toBeTruthy()
+  })
+
+  it('does NOT collapse while that reply is still streaming', async () => {
+    const { container } = render(<Harness messages={[user('u1', DELIVERY), assistant('a1', 'working on it', true)]} />)
+
+    await screen.findByText('working on it')
+    expect(screen.queryByText('show reply')).toBeNull()
+    // Expanded => the full body root, which carries the streaming marker.
+    expect(container.querySelector('[data-message-streaming="true"]')).toBeTruthy()
+  })
+
+  it('leaves an ordinary reply expanded', async () => {
+    render(<Harness messages={[user('u1', 'ordinary question'), assistant('a1', 'ordinary answer', false)]} />)
+
+    await screen.findByText('ordinary answer')
+    expect(screen.queryByText(/Replied to/)).toBeNull()
+  })
+
+  it('clears the streaming marker once the turn settles', async () => {
+    const { container } = render(<Harness messages={[user('u1', 'q'), assistant('a1', 'done', false)]} />)
+
+    await screen.findByText('done')
+    expect(container.querySelector('[data-message-streaming="true"]')).toBeNull()
+    // The marker element itself stays mounted (attribute toggles, no remount).
+    expect(container.querySelector('[data-slot="aui_assistant-message-root"] span.hidden')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/inter-agent-collapse.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/inter-agent-collapse.test.tsx
@@ -8,8 +8,8 @@
 //    likely to break if the split is revisited.
 // 2. The streaming marker. `data-message-streaming` moved off the message root
 //    onto a permanently-mounted hidden leaf, and
-//    scripts/run-short-session-hang-repro.mjs counts settled rows with
-//    `[data-slot="aui_assistant-message-root"]:not(:has([data-message-streaming="true"]))`.
+//    scripts/run-short-session-hang-repro.mjs derives its settled-row count by
+//    subtracting `[data-message-streaming="true"]` markers from message roots.
 //    Nothing in the app itself reads it, so without this test a delete would
 //    look free and would silently regress that repro's response gate.
 import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
@@ -112,6 +112,8 @@ describe('inter-agent collapse gate', () => {
     await screen.findByText('done')
     expect(container.querySelector('[data-message-streaming="true"]')).toBeNull()
     // The marker element itself stays mounted (attribute toggles, no remount).
-    expect(container.querySelector('[data-slot="aui_assistant-message-root"] span.hidden')).toBeTruthy()
+    expect(
+      container.querySelector('[data-slot="aui_assistant-message-root"] [data-slot="aui_message-streaming-marker"]')
+    ).toBeTruthy()
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/preview-embeds.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/preview-embeds.test.tsx
@@ -1,0 +1,100 @@
+// Link previews moved off the message root into the AssistantPreviewEmbeds
+// leaf, because the selector behind them (`'' while running`, the full
+// `messageContentText(content)` join once settled) flipped on every
+// running <-> settled transition and re-rendered the root with it.
+//
+// Two things are pinned here. That the embed still renders at all — the move
+// was verbatim JSX and had no coverage before. And that it renders ONLY once
+// the turn settles: the '' branch is a deliberate streaming optimization (it
+// keeps the selector referentially stable so per-token flushes skip the regex
+// scan), so a rewrite that drops it would make previews flicker in mid-stream
+// with nothing to catch it.
+import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { Thread } from '.'
+
+const createdAt = new Date('2026-05-01T00:00:00.000Z')
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
+  window.setTimeout(() => callback(performance.now()), 0)
+)
+vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id))
+vi.stubGlobal('CSS', { escape: (str: string) => str })
+
+Element.prototype.scrollTo = function scrollTo() {}
+
+Element.prototype.animate = function animate() {
+  return { cancel() {}, finished: Promise.resolve() } as unknown as Animation
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+const assistantMetadata = { unstable_state: null, unstable_annotations: [], unstable_data: [], steps: [], custom: {} }
+
+function user(id: string, text: string): ThreadMessage {
+  return {
+    id,
+    role: 'user',
+    content: [{ type: 'text', text }],
+    attachments: [],
+    createdAt,
+    metadata: { custom: {} }
+  } as ThreadMessage
+}
+
+function assistant(id: string, text: string, running: boolean): ThreadMessage {
+  return {
+    id,
+    role: 'assistant',
+    content: text ? [{ type: 'text', text }] : [],
+    status: running ? { type: 'running' } : { type: 'complete', reason: 'stop' },
+    createdAt,
+    metadata: assistantMetadata
+  } as ThreadMessage
+}
+
+function Harness({ messages }: { messages: ThreadMessage[] }) {
+  const runtime = useExternalStoreRuntime<ThreadMessage>({
+    messages,
+    isRunning: messages.at(-1)?.status?.type === 'running',
+    onNew: async () => {}
+  })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  )
+}
+
+const TARGET = 'https://example.com/docs'
+const WITH_PREVIEW = `Serving now: [Preview: example](#preview/${TARGET})`
+
+describe('settled-turn link previews', () => {
+  it('renders the embed once the turn has settled', async () => {
+    const { container } = render(<Harness messages={[user('u1', 'start it'), assistant('a1', WITH_PREVIEW, false)]} />)
+
+    await screen.findByText('Serving now:', { exact: false })
+
+    expect(container.querySelector(`[title="${TARGET}"]`)).toBeTruthy()
+  })
+
+  it('does not render the embed while the turn is still running', async () => {
+    const { container } = render(<Harness messages={[user('u1', 'start it'), assistant('a1', WITH_PREVIEW, true)]} />)
+
+    await screen.findByText('Serving now:', { exact: false })
+
+    expect(container.querySelector(`[title="${TARGET}"]`)).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/status-invalidation-scope.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/status-invalidation-scope.test.tsx
@@ -1,0 +1,164 @@
+// The invalidation-scoping property, as a render-count contract.
+//
+// A streaming turn flips its message status many times a second, and at
+// stream breadth N that is N status flips per flush. The whole point of this
+// work is that a flip re-renders only the small leaves that actually display
+// status — never the message ROOT, whose subtree is the entire rendered
+// message and whose re-render is what widened style recalculation to document
+// scope.
+//
+// That property is invisible to a DOM assertion: the transcript looks
+// identical either way. So this counts renders instead. AssistantMessageBody
+// is the root component, and `useTapbackDoubleClick` is called by it and by
+// nothing else in the tree, which makes it an exact render counter for the
+// root without needing to export or wrap an internal component.
+import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Thread } from '.'
+
+let rootRenders = 0
+
+vi.mock('@/components/assistant-ui/thread/use-message-reactions', async importActual => {
+  const actual = await importActual<typeof import('@/components/assistant-ui/thread/use-message-reactions')>()
+
+  return {
+    ...actual,
+    useTapbackDoubleClick: (messageId: string, role: 'assistant' | 'user') => {
+      if (role === 'assistant') {
+        rootRenders += 1
+      }
+
+      return actual.useTapbackDoubleClick(messageId, role)
+    }
+  }
+})
+
+const createdAt = new Date('2026-05-01T00:00:00.000Z')
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
+  window.setTimeout(() => callback(performance.now()), 0)
+)
+vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id))
+vi.stubGlobal('CSS', { escape: (str: string) => str })
+
+Element.prototype.scrollTo = function scrollTo() {}
+
+Element.prototype.animate = function animate() {
+  return { cancel() {}, finished: Promise.resolve() } as unknown as Animation
+}
+
+beforeEach(() => {
+  rootRenders = 0
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+const assistantMetadata = { unstable_state: null, unstable_annotations: [], unstable_data: [], steps: [], custom: {} }
+
+function user(id: string, text: string): ThreadMessage {
+  return {
+    id,
+    role: 'user',
+    content: [{ type: 'text', text }],
+    attachments: [],
+    createdAt,
+    metadata: { custom: {} }
+  } as ThreadMessage
+}
+
+function assistant(id: string, text: string, running: boolean): ThreadMessage {
+  return {
+    id,
+    role: 'assistant',
+    content: text ? [{ type: 'text', text }] : [],
+    status: running ? { type: 'running' } : { type: 'complete', reason: 'stop' },
+    createdAt,
+    metadata: assistantMetadata
+  } as ThreadMessage
+}
+
+function Harness({ messages }: { messages: ThreadMessage[] }) {
+  const runtime = useExternalStoreRuntime<ThreadMessage>({
+    messages,
+    isRunning: messages.at(-1)?.status?.type === 'running',
+    onNew: async () => {}
+  })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  )
+}
+
+describe('streaming-status invalidation scope', () => {
+  it('does not re-render the message root when the turn settles', async () => {
+    const messages = [user('u1', 'question'), assistant('a1', 'partial answer', true)]
+    const { container, findByText, rerender } = render(<Harness messages={messages} />)
+
+    await findByText('partial answer')
+    // The leaf carries the streaming flag while the turn is in flight.
+    expect(container.querySelector('[data-message-streaming="true"]')).toBeTruthy()
+
+    const rendersWhileStreaming = rootRenders
+
+    rerender(<Harness messages={[messages[0], assistant('a1', 'partial answer', false)]} />)
+
+    // The leaf saw the flip...
+    await waitFor(() => {
+      expect(container.querySelector('[data-message-streaming="true"]')).toBeNull()
+    })
+    // ...on the same permanently-mounted node (attribute toggle, no remount)...
+    expect(container.querySelector('[data-slot="aui_message-streaming-marker"]')).toBeTruthy()
+    // ...and the root did not re-render for it.
+    expect(rootRenders).toBe(rendersWhileStreaming)
+  })
+
+  it('does not re-render the message root when streaming text arrives', async () => {
+    const messages = [user('u1', 'question'), assistant('a1', 'one', true)]
+    const { findByText, rerender } = render(<Harness messages={messages} />)
+
+    await findByText('one')
+    const rendersAfterFirstToken = rootRenders
+
+    // A delta flush: same status, more text. The root must not subscribe to
+    // the streaming text either — only the markdown part re-renders.
+    rerender(<Harness messages={[messages[0], assistant('a1', 'one two', true)]} />)
+    await findByText('one two')
+
+    expect(rootRenders).toBe(rendersAfterFirstToken)
+  })
+
+  it('keeps the same root DOM node across the settle transition', async () => {
+    // The inter-agent reply collapses once it settles. Rendering that as a
+    // competing root swapped the element type at this position, so React
+    // unmounted the row and mounted a fresh one — discarding the DOM the
+    // scroll anchor was holding.
+    const delivery = 'Message from 🤖 Hermes (@hermes): please check the build'
+    const messages = [user('u1', delivery), assistant('a1', 'working on it', true)]
+    const { container, findByText, rerender } = render(<Harness messages={messages} />)
+
+    await findByText('working on it')
+    const before = container.querySelector('[data-slot="aui_assistant-message-root"]')
+
+    expect(before).toBeTruthy()
+
+    rerender(<Harness messages={[messages[0], assistant('a1', 'working on it', false)]} />)
+    await findByText(/Replied to/)
+
+    const after = container.querySelector('[data-slot="aui_assistant-message-root"]')
+
+    // Same element, updated in place — not a remount.
+    expect(after).toBe(before)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/status-invalidation-scope.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/status-invalidation-scope.test.tsx
@@ -16,12 +16,14 @@ import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime }
 import { cleanup, render, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type * as messageReactionsModule from '@/components/assistant-ui/thread/use-message-reactions'
+
 import { Thread } from '.'
 
 let rootRenders = 0
 
 vi.mock('@/components/assistant-ui/thread/use-message-reactions', async importActual => {
-  const actual = await importActual<typeof import('@/components/assistant-ui/thread/use-message-reactions')>()
+  const actual = await importActual<typeof messageReactionsModule>()
 
   return {
     ...actual,

--- a/apps/desktop/src/components/ui/glyph-spinner.css
+++ b/apps/desktop/src/components/ui/glyph-spinner.css
@@ -4,22 +4,25 @@
  * `glyph.textContent` every frame. Replacing a text node is a structural DOM
  * mutation, so each tick scheduled a style recalculation — and because these
  * spinners sit inside the transcript, that recalc resolved against the whole
- * document. Scheduler attribution on the incident trace put 133 of 138 wide
- * document-scale recalcs on this ticker (0 of 254 cheap ones), which is the
- * incident.
+ * document. Scheduler attribution on an incident trace put the large majority
+ * of the wide document-scale recalcs on this ticker, and none of the cheap
+ * scoped ones; the trace numbers are in the PR that introduced this file.
  *
  * Every frame is now in the DOM from mount as a vertical strip, and a
  * `transform: translateY` keyframes animation scrolls it one frame at a time.
  * Transform animations run on the compositor: no JS timer, no text mutation,
  * no style recalc, no layout, nothing scheduled per frame.
  *
- * The strip is N frames tall and each frame is exactly 1em, so translating by
- * -100% travels exactly N frames. `steps(N)` (jump-end) samples that travel at
- * 0, 1/N, ... (N-1)/N, i.e. it parks on frame 0..N-1 for one interval each and
- * then wraps — the same sequence and cadence the ticker produced. Both N and
- * the duration arrive as custom properties set inline per spinner, so all 18
- * spinner variants (16 distinct frame/interval shapes) share this one rule set
- * with no generated or colliding per-variant keyframes.
+ * The strip is N frames tall and each frame is exactly 1em, so travelling N
+ * frame-heights scrolls through the whole strip exactly once. `steps(N)`
+ * (jump-end) samples that travel at 0, 1/N, ... (N-1)/N, i.e. it parks on
+ * frame 0..N-1 for one interval each and then wraps — the same sequence and
+ * cadence the ticker produced. Both N and the duration arrive as custom
+ * properties set inline per spinner, so all 18 spinner variants (16 distinct
+ * frame/interval shapes) share this one rule set with no generated or
+ * colliding per-variant keyframes. Every var() carries the braille default as
+ * its fallback, so a missing custom property degrades to a working spinner
+ * rather than an invalid declaration.
  */
 
 .glyph-spinner {
@@ -31,37 +34,58 @@
   --glyph-spinner-frame-height: 1em;
 
   display: block;
-  height: var(--glyph-spinner-frame-height);
+  height: var(--glyph-spinner-frame-height, 1em);
   overflow: hidden;
   line-height: 1;
-  /* Decorative and aria-hidden, so it must not land in a transcript copy.
-     These spinners sit inside [data-selectable-text] subtrees (tool/delegate,
-     tool/fallback), where the strip would otherwise contribute all N glyphs to
-     a selection where the old one-character implementation contributed one. */
+}
+
+/* Decorative and aria-hidden, so it must not land in a transcript copy. These
+   spinners sit inside [data-selectable-text] subtrees (tool/delegate,
+   tool/fallback), where the strip would otherwise contribute all N glyphs to a
+   selection where the old one-character implementation contributed one.
+   Descendants are named explicitly rather than left to inherit: the competing
+   `[data-selectable-text='true'] *` rule carries the same (0,1,0) specificity,
+   so relying on inheritance would make the winner depend on stylesheet order. */
+.glyph-spinner,
+.glyph-spinner * {
   -webkit-user-select: none;
   user-select: none;
 }
 
 .glyph-spinner__strip {
   display: block;
-  animation: glyph-spinner-advance var(--glyph-spinner-duration) steps(var(--glyph-spinner-frames)) infinite;
-  /* Promote to a compositor layer. Without it, trace instrumentation recorded
-     a non-zero compositeFailed on every animation record. */
+  animation: glyph-spinner-advance var(--glyph-spinner-duration, 800ms) steps(var(--glyph-spinner-frames, 10)) infinite;
+}
+
+/* Promote to a compositor layer — without it, trace instrumentation recorded a
+   non-zero compositeFailed on every animation record. Scoped to spinners that
+   are actually animating: a permanently promoted layer per parked spinner is
+   pure memory at fan-out breadth, where many spinners sit mounted and paused
+   at once. */
+.glyph-spinner:not([data-paused='true']) .glyph-spinner__strip {
   will-change: transform;
 }
 
 .glyph-spinner__frame {
   display: block;
-  height: var(--glyph-spinner-frame-height);
+  height: var(--glyph-spinner-frame-height, 1em);
+  /* Clip each frame to its own box. Braille (U+2800..U+28FF) renders from a
+     system fallback face — JetBrains Mono has no glyphs in that block — and
+     fallback metrics are not guaranteed to fit the 1em box, so ink from the
+     neighbouring frames could otherwise bleed into the viewport. */
+  overflow: hidden;
   line-height: 1;
 }
 
-/* Kept-alive pane that is currently an inactive tab. Hidden panes normally get
-   `content-visibility: hidden`, which already stops animations in the skipped
-   subtree, but that containment has a runtime kill switch and older pane layers
-   only set `visibility: hidden` — which does NOT stop an animation. This keeps
-   the original explicit guarantee ("N mounted tabs each ticking burns CPU for
-   pixels nobody can see") independent of which of those is in play. */
+/* Parked, for either of two reasons: the pane is a kept-alive but inactive tab
+   (usePaneVisible), or the caller passed `paused` to hold the spinner still
+   while it stays mounted through a fade-out (ChatSwapOverlay). Hidden panes
+   normally get `content-visibility: hidden`, which already stops animations in
+   the skipped subtree, but that containment has a runtime kill switch and
+   older pane layers only set `visibility: hidden` — which does NOT stop an
+   animation. This keeps the original explicit guarantee ("N mounted tabs each
+   ticking burns CPU for pixels nobody can see") independent of which of those
+   is in play. */
 .glyph-spinner[data-paused='true'] .glyph-spinner__strip {
   animation-play-state: paused;
 }
@@ -69,16 +93,17 @@
 /* The travel MUST be an absolute length, never a percentage. A percentage
    translate resolves against the strip's own box, so Chromium treats the
    animation as layout-dependent and refuses to composite it — trace
-   instrumentation showed compositeFailed set on 184/184 records (codes
-   131072 / 131104) with translateY(-100%), while a sibling transform
-   animation using an absolute length composited clean. N frames x the frame
-   height is the same distance, computed rather than box-relative. */
+   instrumentation showed compositeFailed set on every record while the
+   keyframes used translateY(-100%), and clean compositing on a sibling
+   transform animation that travelled an absolute length (numbers in the PR).
+   N frames x the frame height is the same distance, computed rather than
+   box-relative. */
 @keyframes glyph-spinner-advance {
   from {
     transform: translateY(0);
   }
 
   to {
-    transform: translateY(calc(var(--glyph-spinner-frames) * -1 * var(--glyph-spinner-frame-height)));
+    transform: translateY(calc(var(--glyph-spinner-frames, 10) * -1 * var(--glyph-spinner-frame-height, 1em)));
   }
 }

--- a/apps/desktop/src/components/ui/glyph-spinner.css
+++ b/apps/desktop/src/components/ui/glyph-spinner.css
@@ -23,20 +23,36 @@
  */
 
 .glyph-spinner {
+  /* Single source of truth for the frame metric: the clip viewport, each frame
+     box, and the keyframe travel all derive from this, so they cannot drift
+     apart. `em` resolves against the element it is used on, and font-size is
+     uniform across this subtree — nothing below .glyph-spinner declares one —
+     so the strip's `em` and the frame's `em` are the same length. */
+  --glyph-spinner-frame-height: 1em;
+
   display: block;
-  height: 1em;
+  height: var(--glyph-spinner-frame-height);
   overflow: hidden;
   line-height: 1;
+  /* Decorative and aria-hidden, so it must not land in a transcript copy.
+     These spinners sit inside [data-selectable-text] subtrees (tool/delegate,
+     tool/fallback), where the strip would otherwise contribute all N glyphs to
+     a selection where the old one-character implementation contributed one. */
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 .glyph-spinner__strip {
   display: block;
   animation: glyph-spinner-advance var(--glyph-spinner-duration) steps(var(--glyph-spinner-frames)) infinite;
+  /* Promote to a compositor layer. Without it, trace instrumentation recorded
+     a non-zero compositeFailed on every animation record. */
+  will-change: transform;
 }
 
 .glyph-spinner__frame {
   display: block;
-  height: 1em;
+  height: var(--glyph-spinner-frame-height);
   line-height: 1;
 }
 
@@ -50,12 +66,19 @@
   animation-play-state: paused;
 }
 
+/* The travel MUST be an absolute length, never a percentage. A percentage
+   translate resolves against the strip's own box, so Chromium treats the
+   animation as layout-dependent and refuses to composite it — trace
+   instrumentation showed compositeFailed set on 184/184 records (codes
+   131072 / 131104) with translateY(-100%), while a sibling transform
+   animation using an absolute length composited clean. N frames x the frame
+   height is the same distance, computed rather than box-relative. */
 @keyframes glyph-spinner-advance {
   from {
     transform: translateY(0);
   }
 
   to {
-    transform: translateY(-100%);
+    transform: translateY(calc(var(--glyph-spinner-frames) * -1 * var(--glyph-spinner-frame-height)));
   }
 }

--- a/apps/desktop/src/components/ui/glyph-spinner.css
+++ b/apps/desktop/src/components/ui/glyph-spinner.css
@@ -47,7 +47,9 @@
    `[data-selectable-text='true'] *` rule carries the same (0,1,0) specificity,
    so relying on inheritance would make the winner depend on stylesheet order. */
 .glyph-spinner,
-.glyph-spinner * {
+.glyph-spinner *,
+[data-selectable-text='true'] .glyph-spinner,
+[data-selectable-text='true'] .glyph-spinner * {
   -webkit-user-select: none;
   user-select: none;
 }
@@ -64,6 +66,18 @@
    at once. */
 .glyph-spinner:not([data-paused='true']) .glyph-spinner__strip {
   will-change: transform;
+}
+
+/* The global renderer pause and the reduced-motion freeze stop the animation;
+   drop the layer hint there too, so parked spinners hold no compositor layer. */
+:root[data-renderer-animations-paused] .glyph-spinner__strip {
+  will-change: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glyph-spinner__strip {
+    will-change: auto;
+  }
 }
 
 .glyph-spinner__frame {

--- a/apps/desktop/src/components/ui/glyph-spinner.css
+++ b/apps/desktop/src/components/ui/glyph-spinner.css
@@ -1,0 +1,61 @@
+/* Compositor-only glyph spinner.
+ *
+ * The previous implementation ticked a setInterval and replaced
+ * `glyph.textContent` every frame. Replacing a text node is a structural DOM
+ * mutation, so each tick scheduled a style recalculation — and because these
+ * spinners sit inside the transcript, that recalc resolved against the whole
+ * document. Scheduler attribution on the incident trace put 133 of 138 wide
+ * document-scale recalcs on this ticker (0 of 254 cheap ones), which is the
+ * incident.
+ *
+ * Every frame is now in the DOM from mount as a vertical strip, and a
+ * `transform: translateY` keyframes animation scrolls it one frame at a time.
+ * Transform animations run on the compositor: no JS timer, no text mutation,
+ * no style recalc, no layout, nothing scheduled per frame.
+ *
+ * The strip is N frames tall and each frame is exactly 1em, so translating by
+ * -100% travels exactly N frames. `steps(N)` (jump-end) samples that travel at
+ * 0, 1/N, ... (N-1)/N, i.e. it parks on frame 0..N-1 for one interval each and
+ * then wraps — the same sequence and cadence the ticker produced. Both N and
+ * the duration arrive as custom properties set inline per spinner, so all 18
+ * spinner variants (16 distinct frame/interval shapes) share this one rule set
+ * with no generated or colliding per-variant keyframes.
+ */
+
+.glyph-spinner {
+  display: block;
+  height: 1em;
+  overflow: hidden;
+  line-height: 1;
+}
+
+.glyph-spinner__strip {
+  display: block;
+  animation: glyph-spinner-advance var(--glyph-spinner-duration) steps(var(--glyph-spinner-frames)) infinite;
+}
+
+.glyph-spinner__frame {
+  display: block;
+  height: 1em;
+  line-height: 1;
+}
+
+/* Kept-alive pane that is currently an inactive tab. Hidden panes normally get
+   `content-visibility: hidden`, which already stops animations in the skipped
+   subtree, but that containment has a runtime kill switch and older pane layers
+   only set `visibility: hidden` — which does NOT stop an animation. This keeps
+   the original explicit guarantee ("N mounted tabs each ticking burns CPU for
+   pixels nobody can see") independent of which of those is in play. */
+.glyph-spinner[data-paused='true'] .glyph-spinner__strip {
+  animation-play-state: paused;
+}
+
+@keyframes glyph-spinner-advance {
+  from {
+    transform: translateY(0);
+  }
+
+  to {
+    transform: translateY(-100%);
+  }
+}

--- a/apps/desktop/src/components/ui/glyph-spinner.test.tsx
+++ b/apps/desktop/src/components/ui/glyph-spinner.test.tsx
@@ -143,6 +143,43 @@ describe('GlyphSpinner', () => {
     expect(status.querySelector('.glyph-spinner')?.getAttribute('aria-hidden')).toBe('true')
   })
 
+  it('pauses on request while staying mounted', () => {
+    // For a caller that keeps the spinner in the tree through a fade-out
+    // (ChatSwapOverlay) and does not want it animating once the wait is over.
+    const { rerender } = render(<GlyphSpinner paused spinner="braille" />)
+    const viewport = () => screen.getByRole('status', { name: 'Loading' }).querySelector('.glyph-spinner')
+
+    expect(viewport()?.getAttribute('data-paused')).toBe('true')
+
+    rerender(<GlyphSpinner paused={false} spinner="braille" />)
+
+    expect(viewport()?.hasAttribute('data-paused')).toBe(false)
+  })
+
+  it('travels an absolute length, so the animation can be composited', () => {
+    // A percentage translate resolves against the strip's own box, which makes
+    // the animation layout-dependent and Chromium refuses to composite it:
+    // instrumentation recorded compositeFailed on 184/184 records while the
+    // keyframes used translateY(-100%). This guards the regression back to it,
+    // which is invisible in jsdom and subtle on screen.
+    const css = readFileSync(resolve(process.cwd(), 'src/components/ui/glyph-spinner.css'), 'utf8')
+    const keyframes = css.slice(css.indexOf('@keyframes glyph-spinner-advance'))
+
+    expect(keyframes).not.toMatch(/translateY\(\s*-?\d+%/)
+    expect(keyframes).toContain('var(--glyph-spinner-frame-height)')
+    expect(css).toContain('will-change: transform')
+  })
+
+  it('keeps the decorative strip out of text selection', () => {
+    // These sit inside [data-selectable-text] subtrees; without this a
+    // transcript copy would pick up all N glyphs of every spinner.
+    const css = readFileSync(resolve(process.cwd(), 'src/components/ui/glyph-spinner.css'), 'utf8')
+
+    expect(css.slice(css.indexOf('.glyph-spinner {'), css.indexOf('.glyph-spinner__strip'))).toContain(
+      'user-select: none'
+    )
+  })
+
   it('is wired into the global renderer-animation pause rule', () => {
     // Window blur / minimize / document-hidden suspension now comes from this
     // rule rather than from a per-spinner pause controller. Dropping the class

--- a/apps/desktop/src/components/ui/glyph-spinner.test.tsx
+++ b/apps/desktop/src/components/ui/glyph-spinner.test.tsx
@@ -1,15 +1,52 @@
-import { act, render, screen } from '@testing-library/react'
+// GlyphSpinner animates on the compositor: every frame is in the DOM from
+// mount and a transform keyframes animation scrolls between them. It has no
+// timer and performs no per-frame DOM write, because the setInterval +
+// `glyph.textContent` ticker this replaced was scheduling a document-scale
+// style recalculation on every tick (133 of 138 wide recalcs on the incident
+// trace).
+//
+// These tests therefore pin the DATA and WIRING that make the CSS correct,
+// which is all jsdom can see — it has no animation engine, so the motion
+// itself is not observable here:
+//
+//  - the strip carries every frame, in order, so `steps(N)` lands on each one;
+//  - the custom properties feeding `steps()` / duration match the source data,
+//    so cadence per variant is preserved;
+//  - no timer is ever created (the ticker is really gone);
+//  - the kept-alive-tab gate still resolves to a paused animation;
+//  - the strip is named in the global renderer-pause rule, which is what now
+//    delivers the window-blur / minimize / document-hidden suspension that
+//    this component used to implement itself via
+//    createRendererLoopPauseController. That mechanism has its own coverage in
+//    lib/renderer-loop-pause.test.ts.
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { render, screen } from '@testing-library/react'
 import { Profiler, type ProfilerOnRenderCallback } from 'react'
+import spinners from 'unicode-animations'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { PaneVisibleContext } from '@/components/pane-shell/pane-visibility'
 
 import { GlyphSpinner } from './glyph-spinner'
 
+const BRAILLE = spinners.braille
+
+function strip(): HTMLElement {
+  const status = screen.getByRole('status', { name: 'Loading' })
+  const found = status.querySelector<HTMLElement>('.glyph-spinner__strip')
+
+  if (!found) {
+    throw new Error('no frame strip rendered')
+  }
+
+  return found
+}
+
 describe('GlyphSpinner', () => {
   beforeEach(() => {
     vi.useFakeTimers()
-    vi.spyOn(globalThis.document, 'hasFocus').mockReturnValue(true)
   })
 
   afterEach(() => {
@@ -18,7 +55,41 @@ describe('GlyphSpinner', () => {
     vi.useRealTimers()
   })
 
-  it('advances its glyph without an update-phase React commit', () => {
+  it('renders every frame in source order as the scroll strip', () => {
+    render(<GlyphSpinner spinner="braille" />)
+
+    const frames = [...strip().querySelectorAll('.glyph-spinner__frame')].map(node => node.textContent)
+
+    expect(frames).toEqual([...BRAILLE.frames])
+    // The old ticker started on frame 0; steps() starts the strip there too.
+    expect(frames[0]).toBe('⠋')
+  })
+
+  it('feeds steps() and the duration from the spinner data, so cadence is unchanged', () => {
+    render(<GlyphSpinner spinner="braille" />)
+
+    const style = strip().style
+
+    // One full cycle is frames x interval; steps(frames) parks on each frame
+    // for exactly `interval` ms, which is what the setInterval did.
+    expect(style.getPropertyValue('--glyph-spinner-frames')).toBe(String(BRAILLE.frames.length))
+    expect(style.getPropertyValue('--glyph-spinner-duration')).toBe(`${BRAILLE.frames.length * BRAILLE.interval}ms`)
+  })
+
+  it('keeps per-variant cadence distinct', () => {
+    render(<GlyphSpinner ariaLabel="Working" spinner="breathe" />)
+
+    const node = screen.getByRole('status', { name: 'Working' })
+    const found = node.querySelector<HTMLElement>('.glyph-spinner__strip')!
+    const breathe = spinners.breathe
+
+    expect(found.querySelectorAll('.glyph-spinner__frame')).toHaveLength(breathe.frames.length)
+    expect(found.style.getPropertyValue('--glyph-spinner-duration')).toBe(
+      `${breathe.frames.length * breathe.interval}ms`
+    )
+  })
+
+  it('creates no timer and no update-phase React commit', () => {
     let updateCommits = 0
 
     const onRender: ProfilerOnRenderCallback = (_id, phase) => {
@@ -33,135 +104,53 @@ describe('GlyphSpinner', () => {
       </Profiler>
     )
 
-    const status = screen.getByRole('status', { name: 'Loading' })
-    expect(status.textContent).toBe('⠋')
+    // The whole point: the ticker is gone, so nothing is scheduled at all.
+    expect(vi.getTimerCount()).toBe(0)
 
-    act(() => vi.advanceTimersByTime(80))
+    vi.advanceTimersByTime(5_000)
 
-    expect(status.textContent).toBe('⠙')
+    expect(vi.getTimerCount()).toBe(0)
     expect(updateCommits).toBe(0)
   })
 
-  it('does not tick while its kept-alive pane is hidden', () => {
+  it('pauses while its kept-alive pane is hidden, and resumes when shown', () => {
     const { rerender } = render(
       <PaneVisibleContext.Provider value={false}>
         <GlyphSpinner spinner="braille" />
       </PaneVisibleContext.Provider>
     )
 
-    const status = screen.getByRole('status', { name: 'Loading' })
+    const viewport = () => screen.getByRole('status', { name: 'Loading' }).querySelector('.glyph-spinner')
 
-    expect(status.textContent).toBe('⠋')
-    expect(vi.getTimerCount()).toBe(0)
+    expect(viewport()?.getAttribute('data-paused')).toBe('true')
 
     rerender(
       <PaneVisibleContext.Provider value>
         <GlyphSpinner spinner="braille" />
       </PaneVisibleContext.Provider>
     )
-    expect(vi.getTimerCount()).toBe(1)
 
-    act(() => vi.advanceTimersByTime(80))
-    expect(status.textContent).toBe('⠙')
-
-    rerender(
-      <PaneVisibleContext.Provider value={false}>
-        <GlyphSpinner spinner="braille" />
-      </PaneVisibleContext.Provider>
-    )
-    expect(vi.getTimerCount()).toBe(0)
-
-    const frozen = status.textContent
-    act(() => vi.advanceTimersByTime(800))
-    expect(status.textContent).toBe(frozen)
+    expect(viewport()?.hasAttribute('data-paused')).toBe(false)
   })
 
-  it('suspends animation while the Desktop window is inactive', () => {
+  it('hides the decorative frames from assistive tech', () => {
     render(<GlyphSpinner spinner="braille" />)
 
+    // role="status" is a live region. The frames must not be announced — the
+    // old implementation rewrote this region's text ~12x/second.
     const status = screen.getByRole('status', { name: 'Loading' })
-    expect(vi.getTimerCount()).toBe(1)
 
-    act(() => window.dispatchEvent(new Event('blur')))
-    expect(vi.getTimerCount()).toBe(0)
-
-    const frozen = status.textContent
-    act(() => vi.advanceTimersByTime(800))
-    expect(status.textContent).toBe(frozen)
-
-    act(() => window.dispatchEvent(new Event('focus')))
-    expect(vi.getTimerCount()).toBe(1)
-
-    act(() => vi.advanceTimersByTime(80))
-    expect(status.textContent).not.toBe(frozen)
+    expect(status.querySelector('.glyph-spinner')?.getAttribute('aria-hidden')).toBe('true')
   })
 
-  it('suspends animation while the Electron window is minimized or hidden, then resumes on restore', () => {
-    let windowStateCallback: ((payload: { isMinimized?: boolean; isVisible?: boolean }) => void) | null = null
+  it('is wired into the global renderer-animation pause rule', () => {
+    // Window blur / minimize / document-hidden suspension now comes from this
+    // rule rather than from a per-spinner pause controller. Dropping the class
+    // from it would silently leave every spinner animating behind an inactive
+    // window — the CPU burn the original implementation existed to avoid.
+    const css = readFileSync(resolve(process.cwd(), 'src/styles.css'), 'utf8')
+    const pauseRule = css.slice(css.indexOf(':root[data-renderer-animations-paused]'))
 
-    Object.defineProperty(window, 'hermesDesktop', {
-      configurable: true,
-      value: {
-        onWindowStateChanged: vi.fn((callback: typeof windowStateCallback) => {
-          windowStateCallback = callback
-
-          return () => {
-            if (windowStateCallback === callback) {
-              windowStateCallback = null
-            }
-          }
-        })
-      }
-    })
-
-    try {
-      render(<GlyphSpinner spinner="braille" />)
-
-      const status = screen.getByRole('status', { name: 'Loading' })
-      expect(windowStateCallback).not.toBeNull()
-      expect(vi.getTimerCount()).toBe(1)
-
-      act(() => windowStateCallback?.({ isMinimized: true, isVisible: false }))
-      expect(vi.getTimerCount()).toBe(0)
-
-      const frozen = status.textContent
-      act(() => vi.advanceTimersByTime(800))
-      expect(status.textContent).toBe(frozen)
-
-      act(() => windowStateCallback?.({ isMinimized: false, isVisible: true }))
-      expect(vi.getTimerCount()).toBe(1)
-
-      act(() => vi.advanceTimersByTime(80))
-      expect(status.textContent).not.toBe(frozen)
-    } finally {
-      delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
-    }
-  })
-
-  it('suspends animation while the document is hidden', () => {
-    render(<GlyphSpinner spinner="braille" />)
-
-    const status = screen.getByRole('status', { name: 'Loading' })
-    expect(vi.getTimerCount()).toBe(1)
-
-    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'hidden' })
-
-    try {
-      act(() => document.dispatchEvent(new Event('visibilitychange')))
-      expect(vi.getTimerCount()).toBe(0)
-
-      const frozen = status.textContent
-      act(() => vi.advanceTimersByTime(800))
-      expect(status.textContent).toBe(frozen)
-
-      Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' })
-      act(() => document.dispatchEvent(new Event('visibilitychange')))
-      expect(vi.getTimerCount()).toBe(1)
-
-      act(() => vi.advanceTimersByTime(80))
-      expect(status.textContent).not.toBe(frozen)
-    } finally {
-      Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' })
-    }
+    expect(pauseRule.slice(0, pauseRule.indexOf('animation-play-state'))).toContain('.glyph-spinner__strip')
   })
 })

--- a/apps/desktop/src/components/ui/glyph-spinner.test.tsx
+++ b/apps/desktop/src/components/ui/glyph-spinner.test.tsx
@@ -13,15 +13,13 @@
 //  - the custom properties feeding `steps()` / duration match the source data,
 //    so cadence per variant is preserved;
 //  - no timer is ever created (the ticker is really gone);
-//  - the kept-alive-tab gate still resolves to a paused animation;
-//  - the strip is named in the global renderer-pause rule, which is what now
-//    delivers the window-blur / minimize / document-hidden suspension that
-//    this component used to implement itself via
-//    createRendererLoopPauseController. That mechanism has its own coverage in
-//    lib/renderer-loop-pause.test.ts.
-import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
-
+//  - the kept-alive-tab gate still resolves to a paused animation.
+//
+// The CSS itself is verified where it can actually run: e2e/glyph-spinner.spec.ts
+// reads getComputedStyle / getAnimations in a real browser. Asserting on the
+// text of the stylesheet from here would test the shape of the source rather
+// than its behaviour (banned outright — see AGENTS.md), and did in fact break
+// on a pure var()-fallback edit that changed no rendered pixel.
 import { render, screen } from '@testing-library/react'
 import { Profiler, type ProfilerOnRenderCallback } from 'react'
 import spinners from 'unicode-animations'
@@ -156,38 +154,4 @@ describe('GlyphSpinner', () => {
     expect(viewport()?.hasAttribute('data-paused')).toBe(false)
   })
 
-  it('travels an absolute length, so the animation can be composited', () => {
-    // A percentage translate resolves against the strip's own box, which makes
-    // the animation layout-dependent and Chromium refuses to composite it:
-    // instrumentation recorded compositeFailed on 184/184 records while the
-    // keyframes used translateY(-100%). This guards the regression back to it,
-    // which is invisible in jsdom and subtle on screen.
-    const css = readFileSync(resolve(process.cwd(), 'src/components/ui/glyph-spinner.css'), 'utf8')
-    const keyframes = css.slice(css.indexOf('@keyframes glyph-spinner-advance'))
-
-    expect(keyframes).not.toMatch(/translateY\(\s*-?\d+%/)
-    expect(keyframes).toContain('var(--glyph-spinner-frame-height)')
-    expect(css).toContain('will-change: transform')
-  })
-
-  it('keeps the decorative strip out of text selection', () => {
-    // These sit inside [data-selectable-text] subtrees; without this a
-    // transcript copy would pick up all N glyphs of every spinner.
-    const css = readFileSync(resolve(process.cwd(), 'src/components/ui/glyph-spinner.css'), 'utf8')
-
-    expect(css.slice(css.indexOf('.glyph-spinner {'), css.indexOf('.glyph-spinner__strip'))).toContain(
-      'user-select: none'
-    )
-  })
-
-  it('is wired into the global renderer-animation pause rule', () => {
-    // Window blur / minimize / document-hidden suspension now comes from this
-    // rule rather than from a per-spinner pause controller. Dropping the class
-    // from it would silently leave every spinner animating behind an inactive
-    // window — the CPU burn the original implementation existed to avoid.
-    const css = readFileSync(resolve(process.cwd(), 'src/styles.css'), 'utf8')
-    const pauseRule = css.slice(css.indexOf(':root[data-renderer-animations-paused]'))
-
-    expect(pauseRule.slice(0, pauseRule.indexOf('animation-play-state'))).toContain('.glyph-spinner__strip')
-  })
 })

--- a/apps/desktop/src/components/ui/glyph-spinner.test.tsx
+++ b/apps/desktop/src/components/ui/glyph-spinner.test.tsx
@@ -2,8 +2,7 @@
 // mount and a transform keyframes animation scrolls between them. It has no
 // timer and performs no per-frame DOM write, because the setInterval +
 // `glyph.textContent` ticker this replaced was scheduling a document-scale
-// style recalculation on every tick (133 of 138 wide recalcs on the incident
-// trace).
+// style recalculation on every tick.
 //
 // These tests therefore pin the DATA and WIRING that make the CSS correct,
 // which is all jsdom can see — it has no animation engine, so the motion
@@ -153,5 +152,4 @@ describe('GlyphSpinner', () => {
 
     expect(viewport()?.hasAttribute('data-paused')).toBe(false)
   })
-
 })

--- a/apps/desktop/src/components/ui/glyph-spinner.tsx
+++ b/apps/desktop/src/components/ui/glyph-spinner.tsx
@@ -33,6 +33,10 @@ const FRAMES_BY_NAME: Record<SpinnerName, NormalisedSpinner> = (() => {
 interface GlyphSpinnerProps {
   ariaLabel?: string
   className?: string
+  /** Freeze the animation while the spinner stays mounted — for a caller that
+   *  keeps it in the tree through a fade-out and does not want it animating
+   *  once it is no longer the thing being waited on. */
+  paused?: boolean
   spinner?: SpinnerName
 }
 
@@ -53,7 +57,12 @@ interface GlyphSpinnerProps {
  * clipping viewport is centred inside it by the same `items-center` that used
  * to centre the single glyph.
  */
-export function GlyphSpinner({ ariaLabel = 'Loading', className, spinner = 'braille' }: GlyphSpinnerProps) {
+export function GlyphSpinner({
+  ariaLabel = 'Loading',
+  className,
+  paused = false,
+  spinner = 'braille'
+}: GlyphSpinnerProps) {
   const spin = FRAMES_BY_NAME[spinner] ?? FRAMES_BY_NAME.braille!
   // Pause when this surface is a hidden (kept-alive) tab: N mounted tabs each
   // animating burns CPU for pixels nobody can see. Window blur / minimize /
@@ -73,7 +82,7 @@ export function GlyphSpinner({ ariaLabel = 'Loading', className, spinner = 'brai
           The frames are decorative, and this is a live region — the old
           implementation rewrote its text ~12x/second, which would announce a
           new glyph on every tick. */}
-      <span aria-hidden="true" className="glyph-spinner" data-paused={visible ? undefined : 'true'}>
+      <span aria-hidden="true" className="glyph-spinner" data-paused={paused || !visible ? 'true' : undefined}>
         <span
           className="glyph-spinner__strip"
           style={

--- a/apps/desktop/src/components/ui/glyph-spinner.tsx
+++ b/apps/desktop/src/components/ui/glyph-spinner.tsx
@@ -13,6 +13,18 @@ interface NormalisedSpinner {
   interval: number
 }
 
+/**
+ * The two custom properties `glyph-spinner.css` reads off the strip to size
+ * `steps()` and the cycle duration. Naming them in a type, rather than casting
+ * the inline style with a bare `as CSSProperties`, makes a typo in a property
+ * name a compile error instead of a silently dead declaration that falls back
+ * to the braille defaults at runtime.
+ */
+export type GlyphSpinnerVars = CSSProperties & {
+  '--glyph-spinner-duration': string
+  '--glyph-spinner-frames': number
+}
+
 // Some spinners ship multi-character frames. Pull the first cell so each
 // frame fits in one monospace box — matches how the TUI uses them.
 const FRAMES_BY_NAME: Record<SpinnerName, NormalisedSpinner> = (() => {
@@ -70,7 +82,15 @@ export function GlyphSpinner({
   // `:root[data-renderer-animations-paused]` rule in styles.css that
   // main.tsx's installRendererAnimationPauseState() drives — the same
   // mechanism every other continuous decorative animation already uses.
+  // Note that only the primary window arms that attribute: a spinner mounted
+  // in an overlay / quick / wake window keeps animating while its window is
+  // blurred, exactly as the other decorative animations there do.
   const visible = usePaneVisible()
+
+  const vars: GlyphSpinnerVars = {
+    '--glyph-spinner-duration': `${spin.frames.length * spin.interval}ms`,
+    '--glyph-spinner-frames': spin.frames.length
+  }
 
   return (
     <span
@@ -83,15 +103,7 @@ export function GlyphSpinner({
           implementation rewrote its text ~12x/second, which would announce a
           new glyph on every tick. */}
       <span aria-hidden="true" className="glyph-spinner" data-paused={paused || !visible ? 'true' : undefined}>
-        <span
-          className="glyph-spinner__strip"
-          style={
-            {
-              '--glyph-spinner-duration': `${spin.frames.length * spin.interval}ms`,
-              '--glyph-spinner-frames': spin.frames.length
-            } as CSSProperties
-          }
-        >
+        <span className="glyph-spinner__strip" style={vars}>
           {spin.frames.map((frame, index) => (
             <span className="glyph-spinner__frame" key={`${index}:${frame}`}>
               {frame}

--- a/apps/desktop/src/components/ui/glyph-spinner.tsx
+++ b/apps/desktop/src/components/ui/glyph-spinner.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef } from 'react'
+import './glyph-spinner.css'
+
+import type { CSSProperties } from 'react'
 import spinners, { type BrailleSpinnerName as SpinnerName } from 'unicode-animations'
 
 import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
-import { createRendererLoopPauseController } from '@/lib/renderer-loop-pause'
 import { cn } from '@/lib/utils'
 
 export type { SpinnerName }
@@ -41,69 +42,54 @@ interface GlyphSpinnerProps {
  * the desktop and terminal experiences read the same visually. Renders inside
  * an `inline-flex` cell with `leading-none` and `items-center` so it sits
  * vertically centred inside its parent's line-box.
+ *
+ * Animated entirely on the compositor — every frame is in the DOM from mount
+ * and a transform keyframes animation scrolls between them. There is no timer
+ * and no per-frame DOM write, because the ticker this replaced was scheduling
+ * document-scale style recalculation on every tick (see glyph-spinner.css).
+ *
+ * The outer cell keeps the exact classes it always had, so consumer sizing
+ * (`size-3`, `text-[0.75rem]`, colour, opacity) lands unchanged; the 1em-tall
+ * clipping viewport is centred inside it by the same `items-center` that used
+ * to centre the single glyph.
  */
 export function GlyphSpinner({ ariaLabel = 'Loading', className, spinner = 'braille' }: GlyphSpinnerProps) {
   const spin = FRAMES_BY_NAME[spinner] ?? FRAMES_BY_NAME.braille!
-  const glyphRef = useRef<HTMLSpanElement>(null)
   // Pause when this surface is a hidden (kept-alive) tab: N mounted tabs each
-  // ticking a setInterval burns CPU for pixels nobody can see.
+  // animating burns CPU for pixels nobody can see. Window blur / minimize /
+  // document-hidden are handled globally instead, by the
+  // `:root[data-renderer-animations-paused]` rule in styles.css that
+  // main.tsx's installRendererAnimationPauseState() drives — the same
+  // mechanism every other continuous decorative animation already uses.
   const visible = usePaneVisible()
-
-  useEffect(() => {
-    const glyph = glyphRef.current
-
-    if (!visible || !glyph) {
-      return
-    }
-
-    let frame = 0
-    let timer: number | undefined
-    let pauseController: ReturnType<typeof createRendererLoopPauseController> | undefined
-    glyph.textContent = spin.frames[frame]
-
-    const stopAnimation = () => {
-      if (timer === undefined) {
-        return
-      }
-
-      window.clearInterval(timer)
-      timer = undefined
-    }
-
-    const syncAnimation = () => {
-      if (pauseController?.isPaused()) {
-        stopAnimation()
-
-        return
-      }
-
-      if (timer !== undefined) {
-        return
-      }
-
-      timer = window.setInterval(() => {
-        frame = (frame + 1) % spin.frames.length
-        glyph.textContent = spin.frames[frame]
-      }, spin.interval)
-    }
-
-    pauseController = createRendererLoopPauseController(syncAnimation)
-    syncAnimation()
-
-    return () => {
-      pauseController.dispose()
-      stopAnimation()
-    }
-  }, [spin, visible])
 
   return (
     <span
       aria-label={ariaLabel}
       className={cn('inline-flex items-center justify-center font-mono leading-none tabular-nums', className)}
-      ref={glyphRef}
       role="status"
     >
-      {spin.frames[0]}
+      {/* Hidden from assistive tech: the accessible name is the label above.
+          The frames are decorative, and this is a live region — the old
+          implementation rewrote its text ~12x/second, which would announce a
+          new glyph on every tick. */}
+      <span aria-hidden="true" className="glyph-spinner" data-paused={visible ? undefined : 'true'}>
+        <span
+          className="glyph-spinner__strip"
+          style={
+            {
+              '--glyph-spinner-duration': `${spin.frames.length * spin.interval}ms`,
+              '--glyph-spinner-frames': spin.frames.length
+            } as CSSProperties
+          }
+        >
+          {spin.frames.map((frame, index) => (
+            <span className="glyph-spinner__frame" key={`${index}:${frame}`}>
+              {frame}
+            </span>
+          ))}
+        </span>
+      </span>
     </span>
   )
 }

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -32,7 +32,17 @@
    behind another app. main.tsx owns this attribute only for the primary
    window; wake/pet overlays retain their purpose-built visibility behavior. */
 :root[data-renderer-animations-paused]
-  :is(.shimmer, .quest-glow, .pet-egg, .pet-egg__glow, .pet-egg-shadow, .pet-wobble, .progress-slide, .kanban-arc),
+  :is(
+    .shimmer,
+    .quest-glow,
+    .pet-egg,
+    .pet-egg__glow,
+    .pet-egg-shadow,
+    .pet-wobble,
+    .progress-slide,
+    .kanban-arc,
+    .glyph-spinner__strip
+  ),
 :root[data-renderer-animations-paused] .arc-border::before,
 :root[data-renderer-animations-paused]
   [data-slot='aui_assistant-message-content']


### PR DESCRIPTION
## Summary

Fixes #72844.

Related: #73082 and #52950 — both look related and are likely improved by this change, but that is an inference from the shared mechanism. The fix is verified for the streaming-lag shape; it was not separately A/B'd against those symptoms.

During heavy multi-subagent streaming, the desktop renderer would collapse — multi-second input latency, with style recalculation dominating the main thread. Root-causing a captured incident trace via scheduler-stack attribution showed **133 of 138 document-scale `UpdateLayoutTree` events were scheduled by `GlyphSpinner`**: its per-instance `setInterval` replaces the glyph via `textContent` — a structural DOM mutation that invalidates style at document scope through the transcript's sibling/`:has()` rules.

That wide class is where the time went: document-scale recalcs carried **23.96 s of the trace's 27.1 s of total `UpdateLayoutTree` time (88%)**. They averaged **62.9 ms** each, and their element-count p95 was around **4,560 elements** — two separate distributions, not one "63 ms over 4,500 elements" event.

The ticker self-starves under the saturation it causes, so its observed cadence (~4.4/s) doesn't match its nominal rate — which is what had previously masked the attribution. The default `braille` variant ticks every **80 ms**; across the 18 variants the frame counts range 4–26 at 60–250 ms intervals.

## Fix

- **GlyphSpinner**: render all frames once as a clipped vertical strip and animate with a compositor-only `transform` `steps()` animation — no JS timer, no per-tick DOM mutation, no per-frame style recalc. The frame strip is `aria-hidden`, and parked spinners neither animate nor hold a compositor layer.
- **Same-mechanism sweep**: the chat-swap overlay ran its own 80 ms braille `setInterval` ticker; converted to the same component with identical visible behavior.
- **Supporting invalidation scoping**: streaming-status reads moved off the assistant message root into leaf components, so per-message status flips no longer re-render whole message subtrees.

## Validation

- Scheduler-stack attribution on identical synthetic streaming workloads, before/after: spinner-scheduled `ScheduleStyleRecalculation` events **384 → 0**, and 0 across every post-fix cell — including one with 21 concurrently running spinners under incident-like load.
- Live CDP verification: the animation computes as `steps(N)` and advances in discrete frames; hidden/inactive spinners are paused and do no work.
- Full desktop UI suite green at parent `671bc361`: 538 files / 5,025 tests, zero failures. The final head adds only the three reviewed follow-up files; lint, formatting, targeted tests, and build are green on final head `a988d05d`. The real-browser e2e lane was not executed because it is disabled repository-wide.
- New contract tests: an e2e spec that reads `getComputedStyle` / `getAnimations` in a real browser (steps(N), both pause gates, layer promotion scoped to running spinners, and no DOM mutation while animating), plus a jsdom render-count test pinning the invalidation scoping — verified by mutation, since reinstating a root-level status subscription makes it fail.

## Notes and trade-offs

- **The settled-row marker moved.** `data-streaming` was a per-flip attribute write on the message root — exactly the invalidation this removes. It now lives on a permanently-mounted hidden leaf as `data-message-streaming`, and its only consumer, `scripts/run-short-session-hang-repro.mjs`, is updated in the same change to derive the settled-row count by subtracting markers from roots.
- **The strip renders every frame.** Roughly 10–26 nodes per spinner instead of one; the 21-spinner validation cell rendered about 210 frame nodes. That is a deliberate trade of a few static nodes for zero per-frame work. Compositor-layer memory was not separately profiled; `will-change` is scoped to actively animating spinners so parked ones hold no layer.
- **Reduced motion behaves differently now, by construction.** The old JS ticker ignored `prefers-reduced-motion` outright. As a CSS animation the strip falls under the app's existing global reduce rule, so under reduced motion it now freezes on frame 0 instead of spinning. This also applies to Playwright captures, which run with reduced motion.
- **Accessibility wants a second look.** The outer labelled `role="status"` element is unchanged; the frame strip is `aria-hidden`, so the per-tick announcements the old implementation caused (it rewrote a live region roughly 12×/s) stop. Whether a screen reader now announces the label exactly once has not been verified — flagging for a11y review, including whether `role="img"` would describe this element more accurately than `role="status"`.
- **One known cosmetic change.** In the chat-swap overlay the glyph now occupies a real 12 px box: the old bare inline `<span className="w-3">` could not honor a width, and the replacement is `inline-flex`, so the adjacent label shifts slightly.

Found via an isolated reproduction harness and a multi-round adversarial review loop; the full investigation record (traces, analyzers, per-round verdicts) is available on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
Supersedes #89805, whose head-ref sync GitHub lost (it stayed pinned to the first push and could not be reopened after a close/reopen nudge).
