### PR TITLE
fix(desktop): release builds keep profile-switch publications — nanostores 1.4.2 (salvage #89690)

### DIFF
--- a/apps/bootstrap-installer/package.json
+++ b/apps/bootstrap-installer/package.json
@@ -32,7 +32,7 @@
     "clsx": "2.1.1",
     "katex": "0.16.47",
     "lucide-react": "0.577.0",
-    "nanostores": "1.4.0",
+    "nanostores": "1.4.2",
     "radix-ui": "1.6.7",
     "react": "19.2.7",
     "react-dom": "19.2.7",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -130,7 +130,7 @@
     "katex": "0.16.47",
     "mermaid": "11.16.1",
     "motion": "12.42.2",
-    "nanostores": "1.4.0",
+    "nanostores": "1.4.2",
     "node-pty": "1.1.0",
     "radix-ui": "1.6.7",
     "react": "19.2.7",

--- a/apps/desktop/src/store/nanostores-batch-guard.test.ts
+++ b/apps/desktop/src/store/nanostores-batch-guard.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Regression guard: the desktop's gateway-switch publication runs inside
+ * nanostores' batch(). nanostores 1.4.0–1.4.1 annotated batch() with
+ * `/* @__NO_SIDE_EFFECTS__ *\/`, which let production bundlers (Rollup, via
+ * `vite build`) erase result-unused batch(...) calls — callback included —
+ * deleting the entire publication from release builds and freezing
+ * profile/agent switching there. Dev builds and vitest run unminified, so
+ * only the packaged app broke. nanostores 1.4.2 removed the annotation;
+ * this test fails if the installed version ever carries it again.
+ */
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+
+describe('nanostores batch()', () => {
+  it('is not annotated @__NO_SIDE_EFFECTS__ — bundlers would erase its calls', () => {
+    const nanostoresEntry = require.resolve('nanostores')
+    const atomSource = readFileSync(path.join(path.dirname(nanostoresEntry), 'atom/index.js'), 'utf8')
+
+    // Capture any block comment immediately preceding the batch export.
+    const match = atomSource.match(/(\/\*(?:[^*]|\*(?!\/))*\*\/\s*)?export const batch\b/)
+
+    expect(match, 'nanostores atom/index.js should export const batch').toBeTruthy()
+    expect(match![1] ?? '').not.toContain('__NO_SIDE_EFFECTS')
+    expect(match![1] ?? '').not.toContain('__PURE__')
+  })
+})

--- a/contributors/emails/royzhrxy-glitch@users.noreply.github.com
+++ b/contributors/emails/royzhrxy-glitch@users.noreply.github.com
@@ -1,0 +1,1 @@
+royzhrxy-glitch

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "clsx": "2.1.1",
         "katex": "0.16.47",
         "lucide-react": "0.577.0",
-        "nanostores": "1.4.0",
+        "nanostores": "1.4.2",
         "radix-ui": "1.6.7",
         "react": "19.2.7",
         "react-dom": "19.2.7",
@@ -116,7 +116,7 @@
         "katex": "0.16.47",
         "mermaid": "11.16.1",
         "motion": "12.42.2",
-        "nanostores": "1.4.0",
+        "nanostores": "1.4.2",
         "node-pty": "1.1.0",
         "radix-ui": "1.6.7",
         "react": "19.2.7",
@@ -14527,9 +14527,9 @@
       }
     },
     "node_modules/nanostores": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.4.0.tgz",
-      "integrity": "sha512-i0tloweeudshAEuddpDxcg9Ik6pkPfVsHIgKyf143JrgG7/MOh0+q7BypdLXZPoOP7fOYt1eTcwGkyiVmhJFkA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.4.2.tgz",
+      "integrity": "sha512-Wxv8Roefr2nqtiRG0bnaFlpYqpIVtOEeJZHaH+4nGgOK1/7n6OHOuHCb/bhqrNQgZM8fyd0s1PqhdrJc9Ib44g==",
       "funding": [
         {
           "type": "github",
@@ -19127,7 +19127,7 @@
         "@hermes/shared": "file:../apps/shared",
         "@nanostores/react": "1.1.0",
         "ink-text-input": "6.0.0",
-        "nanostores": "1.4.0",
+        "nanostores": "1.4.2",
         "react": "19.2.7",
         "undici": "6.28.0",
         "unicode-animations": "1.0.3"

--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -23,7 +23,7 @@
     "@hermes/shared": "file:../apps/shared",
     "@nanostores/react": "1.1.0",
     "ink-text-input": "6.0.0",
-    "nanostores": "1.4.0",
+    "nanostores": "1.4.2",
     "react": "19.2.7",
     "undici": "6.28.0",
     "unicode-animations": "1.0.3"


### PR DESCRIPTION
## Summary
Release (minified) desktop builds get their profile-switch publications back: bumps nanostores 1.4.0 → 1.4.2 everywhere it's pinned. Salvaged from #89690 (@royzhrxy-glitch) with authorship preserved — his find, from a minified bundle diff.

Root cause (verified in an isolated repro AND our own build artifacts): nanostores 1.4.0 annotates `batch()` with `/* @__NO_SIDE_EFFECTS__ */`. Rollup honors it during `vite build` and deletes any result-unused `batch(...)` call — callback included — from release bundles. Dev builds and vitest run unminified, which is why the #89483 series tested green while shipping a dead profile switcher (#89622), and why the just-merged #89797's `$connection` descriptor sync (the #46651 half) was dead code in packaged builds. 1.4.2 removes the annotation from `batch` (it stays on the pure creation functions, where it's correct).

## Changes
- `apps/desktop/package.json`, `apps/bootstrap-installer/package.json`, `ui-tui/package.json`: nanostores 1.4.0 → 1.4.2 (+ lock entries)
- `apps/desktop/src/store/nanostores-batch-guard.test.ts` (contributor's): CI fails if a purity annotation ever returns to `batch`
- `contributors/emails/`: attribution mapping

## Validation
| | Result |
|---|---|
| Isolated repro (same source, vite build) | 1.4.0: batched publication ERASED from bundle · 1.4.2: present |
| Our minified `profile-*.js` after bump | `batch()` publication present (was absent on 1.4.0) |
| Live E2E on the bumped minified build | switches land (warm 0.3s / cold 1.2s), interleave last-click-wins, descriptor resolves for the switched profile |
| Targeted vitest (guard + lease + profile suites) | 19/19 |

## Infographic

_Not included: FAL image account balance exhausted at PR time (`User is locked. Exhausted balance`). Can be added via `gh pr edit` after top-up._
