### PR TITLE
fix(bot-mode): normalize Create on connection registry

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/connections.js
+++ b/apps/desktop/src/plugins/hermes-bots/connections.js
@@ -1,0 +1,11 @@
+export function normalizeConnectionList(value) {
+  if (Array.isArray(value)) {
+    return value
+  }
+
+  if (Array.isArray(value?.connections)) {
+    return value.connections
+  }
+
+  return []
+}

--- a/apps/desktop/src/plugins/hermes-bots/tests/connections-registry.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/connections-registry.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { normalizeConnectionList } from '../connections.js'
+
+test('normalizes the desktop connection registry object', () => {
+  const connections = [
+    { id: 'local', label: 'This device' },
+    { id: 'remote', label: 'Remote gateway' }
+  ]
+
+  assert.deepEqual(normalizeConnectionList({ version: 2, primary: 'local', connections }), connections)
+})
+
+test('preserves legacy bare connection arrays', () => {
+  const connections = [{ id: 'local' }, { id: 'remote' }]
+  assert.deepEqual(normalizeConnectionList(connections), connections)
+})
+
+test('falls back to an empty list for unsupported shapes', () => {
+  assert.deepEqual(normalizeConnectionList(null), [])
+  assert.deepEqual(normalizeConnectionList({}), [])
+})


### PR DESCRIPTION
Fixes #89823

Normalizes the Desktop connection registry response used by Bot Mode so both the current registry-object shape (`{ connections: [...] }`) and the legacy bare-array shape are handled safely.

Adds focused regression coverage for:
- registry objects with multiple connections
- legacy bare arrays
- unsupported response shapes

Draft while the production `plugin.js` call site is wired to the normalizer and checks are completed.