### PR TITLE
fix(models): route opencode-go muse-spark-contributor to chat_completions

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -5075,10 +5075,17 @@ def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str])
         return "chat_completions"
 
     if provider == "opencode-go":
-        if normalized.startswith("gpt-"):
-            # GPT models on Go (gpt-5.6-luna) are served via /v1/responses
-            # per the published Go endpoint table, same as GPT on Zen:
-            # https://opencode.ai/docs/go/#endpoints
+        if normalized.startswith("gpt-") or normalized.startswith("muse-"):
+            # GPT + Muse Spark on Go are served via /v1/responses per
+            # https://opencode.ai/docs/go/#api-%E7%AB%AF%E7%82%B9
+            # Muse Spark 1.2 is listed with endpoint /v1/responses and
+            # requires reasoning-aware max_output_tokens.
+            # Hotfix (2026-08-19): Muse Spark "-contributor" checkpoints on
+            # opencode-go only answer on /v1/chat/completions; /v1/responses
+            # returns 404/auth errors. Keep non-contributor muse/gpt on
+            # codex_responses so a future standard muse-spark-1.2 still works.
+            if normalized.endswith("-contributor"):
+                return "chat_completions"
             return "codex_responses"
         if normalized.startswith("minimax-"):
             return "anthropic_messages"


### PR DESCRIPTION
opencode-go lists Muse Spark 1.2 on `/v1/responses`, but the `-contributor` checkpoint (contributor-priced tier, $0.10/$0.20 per 1M) only serves `/v1/chat/completions`; calling `/v1/responses` returns 404/auth and Hermes silently falls back to the backup model.\n\nRoute `*-contributor` on opencode-go to `chat_completions` while keeping non-contributor `muse-*/gpt-*` on `codex_responses`, so a future standard `muse-spark-1.2` still uses responses.\n\nContext: local hotfix on 2026-08-19 showed `muse-spark-1.2-contributor` via `opencode_model_api_mode` hit responses and failed; flipping the suffix to chat_completions verified OK via OpenAI SDK direct call and `test_opencode_api_mode.py`.\n\nChange is limited to `hermes_cli/models.py:opencode_model_api_mode` (7-line branch).\n