### PR TITLE
fix(telegram): keep approval callback UI resilient to ACK timeouts

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -7114,7 +7114,15 @@ class TelegramAdapter(BasePlatformAdapter):
                         f"It already timed out (and was denied) or was resolved elsewhere."
                     )
 
-                await query.answer(text=label)
+                try:
+                    await query.answer(text=label)
+                except Exception as exc:
+                    logger.warning(
+                        "[%s] Telegram approval callback ACK failed; continuing to edit "
+                        "the approval message so buttons are removed: %s",
+                        self.name,
+                        _redact_telegram_error_text(exc),
+                    )
 
                 # Edit message to show decision, remove buttons
                 try:

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -270,6 +270,44 @@ class TestTelegramApprovalCallback:
 
 
     @pytest.mark.asyncio
+    async def test_approval_callback_edits_message_when_ack_times_out(self):
+        """A Telegram callback ACK timeout must not leave stale buttons visible.
+
+        The approval has already been resolved before ``query.answer()`` runs.
+        If Telegram times out on that short ACK, the handler must still edit the
+        original approval message to show the decision and remove the keyboard.
+        """
+        adapter = _make_adapter()
+        adapter._approval_state[7] = "agent:main:telegram:group:12345:99"
+        adapter.pause_typing_for_chat("12345")
+
+        query = AsyncMock()
+        query.data = "ea:session:7"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.from_user = MagicMock()
+        query.from_user.first_name = "Ivan"
+        query.from_user.id = "12345"
+        query.answer = AsyncMock(side_effect=TimeoutError("callback ack timeout"))
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch("tools.approval.resolve_gateway_approval", return_value=1):
+                await adapter._handle_callback_query(update, context)
+
+        query.answer.assert_called_once()
+        query.edit_message_text.assert_called_once()
+        edit_kwargs = query.edit_message_text.call_args[1]
+        assert "Approved for session" in edit_kwargs["text"]
+        assert edit_kwargs["reply_markup"] is None
+        assert "12345" not in adapter._typing_paused
+
+
+    @pytest.mark.asyncio
     async def test_update_prompt_callback_not_affected(self, tmp_path):
         """Ensure update prompt callbacks still work."""
         adapter = _make_adapter()


### PR DESCRIPTION
## Summary

Fix Telegram approval-button callbacks so a transient `answerCallbackQuery` timeout does not leave stale inline buttons visible.

Today the approval callback resolves the pending command first, then calls `query.answer(text=label)`, and only after that edits the original approval message to show the selected decision and remove the keyboard. If Telegram times out on the short callback ACK, the handler exits before `edit_message_text(..., reply_markup=None)`, so the user sees the old buttons even though the approval may already have been applied.

This patch wraps the ACK in a best-effort `try/except` and always continues to the message edit path.

## Why

Observed on a live Telegram gateway:

- user tapped `Session` on an approval prompt;
- logs showed `telegram.error.TimedOut` from `query.answer(text=label)`;
- the approval message was not edited, so the buttons stayed visible and the selected choice was not shown.

The callback ACK is nice-to-have UI feedback. The durable UX state is the edited approval message. A transient ACK timeout should not block that edit.

## Changes

- Catch exceptions from `query.answer(text=label)` in the approval callback path.
- Log a warning with Telegram error redaction.
- Continue to `query.edit_message_text(..., reply_markup=None)` so the decision is rendered and buttons are removed.
- Add a regression test covering ACK timeout with `ea:session:<id>`.

## Tests

Run locally:

```text
python3 -m py_compile plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_approval_buttons.py
```

Direct regression scenario executed with `asyncio` and mocks:

```text
PR_BRANCH_REGRESSION_SCENARIO_OK
```

`pytest` was not available in this local Hermes venv:

```text
No module named pytest
```

## Risk

Low. The approval is already resolved before `query.answer()` runs. This change only prevents a transient Telegram ACK failure from skipping the existing message-edit cleanup path.
