### PR TITLE
feat(api-server): bind clarify responses on /v1/runs

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -63,10 +63,20 @@ class _ArtifactScopeFacade:
 # Advertised in capabilities and echoed in registration responses; validated by the broker.
 _BROWSER_CONTROL_PROTOCOL_VERSION = 1
 
+# Runs clarification prompt/response bounds (advertised in /v1/capabilities).
+_RUN_CLARIFY_PROMPT_VERSION = 1
+_RUN_CLARIFY_MAX_QUESTION_CHARS = 2000
+_RUN_CLARIFY_MAX_CHOICE_CHARS = 500
+_RUN_CLARIFY_MAX_RESPONSE_CHARS = 2000
+_RUN_CLARIFY_REQUEST_ID_RE = re.compile(r"^clarify_[0-9a-f]{32}$")
+
 # /v1/capabilities static feature flags (order is part of the JSON shape).
 _STATIC_FEATURE_FLAGS = {
     "run_status": True, "run_events_sse": True, "run_stop": True, "run_steer": True,
-    "run_approval_response": True, "tool_progress_events": True, "approval_events": True,
+    "run_approval_response": True, "run_clarification_response": True,
+    "run_clarification_request_binding": True,
+    "run_clarification_prompt_version": _RUN_CLARIFY_PROMPT_VERSION,
+    "tool_progress_events": True, "approval_events": True, "clarification_events": True,
     "session_resources": True, "model_options": True, "session_chat": True,
     "session_chat_streaming": True, "session_fork": True, "session_model_lock": True,
     "admin_config_rw": False, "jobs_admin": False, "memory_write_api": False,
@@ -82,6 +92,7 @@ _CAPABILITY_ENDPOINTS = (
     ("run_status", ("GET", "/v1/runs/{run_id}")),
     ("run_events", ("GET", "/v1/runs/{run_id}/events")),
     ("run_approval", ("POST", "/v1/runs/{run_id}/approval")),
+    ("run_clarification", ("POST", "/v1/runs/{run_id}/clarification")),
     ("run_steer", ("POST", "/v1/runs/{run_id}/steer")),
     ("run_stop", ("POST", "/v1/runs/{run_id}/stop")), ("skills", ("GET", "/v1/skills")),
     ("toolsets", ("GET", "/v1/toolsets")), ("sessions", ("GET", "/api/sessions")),
@@ -1212,7 +1223,9 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         # "stopping" is not terminal: executor work continues until the agent notices.
         active_api_runs = sum(
             1 for status in self._run_statuses.values()
-            if status.get("status") in {"queued", "running", "waiting_for_approval", "stopping"})
+            if status.get("status") in {
+                "queued", "running", "waiting_for_approval",
+                "waiting_for_clarification", "stopping"})
         process_depth = 0
         active_delegations = 0
         with suppress(Exception):
@@ -2092,11 +2105,13 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         model_options: Optional[Dict[str, Any]] = None, route: Optional[Dict[str, Any]] = None,
         session_model: Optional[str] = None, confirmed_runtime_lock: bool = False,
         room_dispatch: Optional[Dict[str, Any]] = None,
-        room_execution_policy: Optional[Dict[str, Any]] = None) -> Any:
+        room_execution_policy: Optional[Dict[str, Any]] = None,
+        clarify_callback=None, enable_clarify: bool = False) -> Any:
         """Create an AIAgent from the gateway runtime config + platform toolsets.
         ``gateway_session_key`` persists across transcripts (memory scope), unlike ``session_id``;
         ``route`` / ``session_model`` are mutually exclusive; ``confirmed_runtime_lock`` beats the
-        session ``/model`` override, disables the fallback chain and fails closed."""
+        session ``/model`` override, disables the fallback chain and fails closed.
+        ``enable_clarify`` is reserved for the Runs lifecycle (typed HTTP response route)."""
         from run_agent import AIAgent
         from gateway.run import (
             _checkpoint_agent_kwargs, _current_max_iterations, _resolve_runtime_agent_kwargs,
@@ -2119,7 +2134,10 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             session_model=session_model, confirmed_runtime_lock=confirmed_runtime_lock,
             gateway_session_key=gateway_session_key, session_id=session_id)
         user_config = _load_gateway_config()
-        enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        enabled_toolsets = set(_get_platform_tools(user_config, "api_server"))
+        if enable_clarify:
+            enabled_toolsets.add("clarify")
+        enabled_toolsets = sorted(enabled_toolsets)
         max_iterations = _current_max_iterations()
         if room_dispatch is not None:
             from gateway.hosted_room_execution_policy import RoomExecutionPolicy
@@ -2140,6 +2158,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             "tool_progress_callback": tool_progress_callback,
             "tool_start_callback": tool_start_callback,
             "tool_complete_callback": tool_complete_callback,
+            "clarify_callback": clarify_callback,
             "session_db": self._ensure_session_db(),
             # Same fallback provider chain as Telegram/Discord/Slack.
             "fallback_model": None if confirmed_runtime_lock else GatewayRunner._load_fallback_model(),
@@ -3764,6 +3783,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
     _handle_get_run = _run_route_delegate("_handle_get_run")
     _handle_run_events = _run_route_delegate("_handle_run_events")
     _handle_run_approval = _run_route_delegate("_handle_run_approval")
+    _handle_run_clarification = _run_route_delegate("_handle_run_clarification")
     _handle_steer_run = _run_route_delegate("_handle_steer_run")
     _handle_stop_run = _run_route_delegate("_handle_stop_run")
 

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -849,6 +849,128 @@ async def _handle_run_approval(self, request: "web.Request", *, _api_server) -> 
         "resolved": resolved})
 
 
+
+async def _handle_run_clarification(self, request: "web.Request", *, _api_server) -> "web.Response":
+    """POST /v1/runs/{run_id}/clarification — answer one exact, run-bound clarification."""
+    _openai_error = _api_server._openai_error
+    run_id, _, _, _, err = _load_owned_run(
+        self, request, _api_server=_api_server, permission="approve", active_fallback=True)
+    if err is not None:
+        return err
+    try:
+        body = await request.json()
+    except Exception:
+        return _json_error(_openai_error, "Invalid JSON", status=400)
+    if not isinstance(body, dict):
+        return _json_error(_openai_error, "JSON body must be an object", status=400)
+    request_id = body.get("request_id")
+    if not isinstance(request_id, str) or not _api_server._RUN_CLARIFY_REQUEST_ID_RE.fullmatch(request_id):
+        return _json_error(
+            _openai_error, "Invalid clarification request_id",
+            code="invalid_clarification_request_id", status=400)
+    response = body.get("response")
+    if not isinstance(response, dict):
+        return _json_error(
+            _openai_error, "Clarification response must be an object",
+            code="invalid_clarification_response", status=400)
+    clarify_session_key = self._run_clarify_sessions.get(run_id)
+    if not clarify_session_key:
+        return _json_error(
+            _openai_error, f"Run has no active clarification session: {run_id}",
+            code="clarification_not_active", status=409)
+    from tools import clarify_gateway
+    pending = clarify_gateway.get_pending_by_id(request_id, session_key=clarify_session_key)
+    if pending is None:
+        return _json_error(
+            _openai_error,
+            "Clarification is stale, unknown, resolved, or belongs to another run",
+            code="clarification_not_pending", status=409)
+    response_type = response.get("type")
+    pending_choices = list(pending.get("choices") or [])
+    pending_multi = bool(pending.get("multi_select"))
+
+    def _choice_index(choice_id: Any) -> int:
+        match = re.fullmatch(r"choice-([1-4])", str(choice_id or ""))
+        return int(match.group(1)) - 1 if match else -1
+
+    if response_type == "choice":
+        if pending_multi:
+            return _json_error(
+                _openai_error, "Multi-select clarification requires response.type 'choices'",
+                code="invalid_clarification_response_type", status=400)
+        choice_id = response.get("choice_id")
+        index = _choice_index(choice_id)
+        if index < 0 or index >= len(pending_choices):
+            return _json_error(
+                _openai_error, "Invalid clarification choice_id",
+                code="invalid_clarification_choice", status=400)
+        answer = str(pending_choices[index])
+        response_summary: Dict[str, Any] = {"type": "choice", "choice_id": choice_id}
+    elif response_type == "choices":
+        if not pending_multi:
+            return _json_error(
+                _openai_error, "Clarification is not multi-select; use response.type 'choice'",
+                code="invalid_clarification_response_type", status=400)
+        choice_ids = response.get("choice_ids")
+        if not isinstance(choice_ids, list) or not choice_ids:
+            return _json_error(
+                _openai_error, "Multi-select clarification requires a non-empty choice_ids list",
+                code="invalid_clarification_choice", status=400)
+        if len(choice_ids) > len(pending_choices):
+            return _json_error(
+                _openai_error, "Too many clarification choice_ids",
+                code="invalid_clarification_choice", status=400)
+        selected_labels: List[str] = []
+        seen_ids: set[str] = set()
+        for raw_id in choice_ids:
+            choice_id = str(raw_id or "")
+            if choice_id in seen_ids:
+                return _json_error(
+                    _openai_error, "Duplicate clarification choice_id",
+                    code="invalid_clarification_choice", status=400)
+            index = _choice_index(choice_id)
+            if index < 0 or index >= len(pending_choices):
+                return _json_error(
+                    _openai_error, "Invalid clarification choice_id",
+                    code="invalid_clarification_choice", status=400)
+            seen_ids.add(choice_id)
+            selected_labels.append(str(pending_choices[index]))
+        answer = json.dumps(selected_labels, ensure_ascii=False)
+        response_summary = {"type": "choices", "choice_ids": [str(cid) for cid in choice_ids]}
+    elif response_type == "text":
+        text_value = response.get("text")
+        if not isinstance(text_value, str) or not text_value.strip():
+            return _json_error(
+                _openai_error, "Clarification text must be a non-empty string",
+                code="invalid_clarification_response", status=400)
+        if len(text_value) > _api_server._RUN_CLARIFY_MAX_RESPONSE_CHARS:
+            return _json_error(
+                _openai_error,
+                f"Clarification text exceeds {_api_server._RUN_CLARIFY_MAX_RESPONSE_CHARS} characters",
+                code="clarification_text_too_long", status=400)
+        answer = text_value.strip()
+        response_summary = {"type": "text"}
+    else:
+        return _json_error(
+            _openai_error, "Clarification response type must be 'choice', 'choices', or 'text'",
+            code="invalid_clarification_response_type", status=400)
+    if not clarify_gateway.resolve_gateway_clarify(
+        request_id, answer, session_key=clarify_session_key,
+    ):
+        return _json_error(
+            _openai_error, "Clarification is no longer pending",
+            code="clarification_not_pending", status=409)
+    self._set_run_status(run_id, "running", last_event="clarify.responded", awaiting_user=False)
+    q = self._run_streams.get(run_id)
+    event = _run_event(run_id, "clarify.responded", request_id=request_id, **response_summary)
+    if q is not None:
+        with suppress(Exception):
+            q.put_nowait(event)
+    return web.json_response({
+        "object": "hermes.run.clarification_response", "run_id": run_id, "request_id": request_id,
+        **response_summary})
+
+
 async def _handle_steer_run(self, request: "web.Request", *, _api_server) -> "web.Response":
     """POST /v1/runs/{run_id}/steer — inject guidance into a running agent."""
     _openai_error = _api_server._openai_error

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -14,9 +14,13 @@ from typing import Any, Callable, Dict, List, Optional
 
 try:
     from aiohttp import web
-    from aiohttp.web_request import RequestKey
 except ImportError:
     web = None  # type: ignore[assignment]
+
+# RequestKey landed in newer aiohttp; keep `web` usable when it is missing.
+try:
+    from aiohttp.web_request import RequestKey
+except ImportError:
     RequestKey = None  # type: ignore[assignment,misc]
 
 from gateway.platforms.api_server_room_grants import _json_error, _room_grant_error_response

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -3,6 +3,7 @@
 import asyncio
 import hashlib
 import json
+import re
 import logging
 import os
 import time
@@ -93,7 +94,8 @@ def _initialize_run_state(self, *, store_factory) -> None:
     (
         self._run_owners, self._run_streams, self._run_streams_created, self._active_run_agents,
         self._active_run_tasks, self._run_statuses, self._run_approval_sessions,
-    ) = ({} for _ in range(7))
+        self._run_clarify_sessions,
+    ) = ({} for _ in range(8))
 
 
 def _http_routes(self) -> list[tuple[str, str, Any]]:
@@ -101,6 +103,7 @@ def _http_routes(self) -> list[tuple[str, str, Any]]:
         ("POST", "/v1/runs", self._handle_runs), ("GET", "/v1/runs/{run_id}", self._handle_get_run),
         ("GET", "/v1/runs/{run_id}/events", self._handle_run_events),
         ("POST", "/v1/runs/{run_id}/approval", self._handle_run_approval),
+        ("POST", "/v1/runs/{run_id}/clarification", self._handle_run_clarification),
         ("POST", "/v1/runs/{run_id}/steer", self._handle_steer_run),
         ("POST", "/v1/runs/{run_id}/stop", self._handle_stop_run)]
 
@@ -180,7 +183,7 @@ def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop
 def _room_permission_for(request: "web.Request") -> str:
     if request.path.endswith("/stop"):
         return "stop"
-    if request.path.endswith("/approval"):
+    if request.path.endswith("/approval") or request.path.endswith("/clarification"):
         return "approve"
     return "status" if request.method == "GET" else "dispatch"
 
@@ -328,6 +331,10 @@ class _RunLaunch:
         # Isolated per run: session ids are conversation scopes, not authorization namespaces.
         return self.run_id
 
+    @property
+    def clarify_session_key(self) -> str:
+        return self.run_id
+
     def put_event(self, event: Optional[Dict]) -> None:
         """Enqueue only while this run still owns live transport state."""
         if self.owner._run_streams.get(self.run_id) is self.queue:
@@ -341,8 +348,22 @@ def _forget_run(self, run_id: str, *tables) -> None:
     self._release_run_owner_if_forgotten(run_id)
 
 
+def _clear_run_clarify(self, run_id: str) -> None:
+    """Drop the run's clarify session key and unblock any waiter."""
+    clarify_session_key = self._run_clarify_sessions.pop(run_id, None)
+    if not clarify_session_key:
+        return
+    with suppress(Exception):
+        from tools.clarify_gateway import clear_session
+        clear_session(clarify_session_key)
+
+
 def _retire_live_run(self, run_id: str) -> None:
     """Retire agent/task/approval control state once the executor-backed task is done."""
+    _clear_run_clarify(self, run_id)
+    cur = self._run_statuses.get(run_id)
+    if cur is not None and cur.get("awaiting_user"):
+        cur["awaiting_user"] = False
     _forget_run(self, run_id, self._active_run_agents, self._active_run_tasks, self._run_approval_sessions,
                 self._stopping_run_ids)
 
@@ -428,8 +449,10 @@ async def _handle_runs(self, request: "web.Request", *, _api_server) -> "web.Res
     q = self._run_streams[run_id] = asyncio.Queue()
     created_at = self._run_streams_created[run_id] = time.time()
     self._run_approval_sessions[run_id] = run_id  # approval session key (see _RunLaunch)
+    self._run_clarify_sessions[run_id] = run_id  # clarify session key (same isolation rule)
     initial_status = self._set_run_status(
-        run_id, "queued", created_at=created_at, session_id=session_id, model=body.get("model", self._model_name))
+        run_id, "queued", created_at=created_at, session_id=session_id,
+        model=body.get("model", self._model_name), awaiting_user=False)
     if idempotency_key:
         outcome, record = self._run_idempotency_store.reserve(
             idempotency_scope, idempotency_key, idempotency_fingerprint, run_id, initial_status,
@@ -438,7 +461,7 @@ async def _handle_runs(self, request: "web.Request", *, _api_server) -> "web.Res
         if outcome != "created":
             _forget_run(
                 self, run_id, self._run_streams, self._run_streams_created, self._run_approval_sessions,
-                self._run_statuses, self._run_owners)
+                self._run_clarify_sessions, self._run_statuses, self._run_owners)
             return _replay_or_conflict(self, request, outcome, record, gateway_session_key, _openai_error)
         self._run_idempotency_ids.add(run_id)
     launch = _RunLaunch(
@@ -557,6 +580,64 @@ async def _execute_run(self, run: _RunLaunch, *, _api_server) -> None:
         with suppress(Exception):
             run.put_event(_run_event(run_id, f"run.{status}", **fields, **extra))
 
+    clarify_session_key = run.clarify_session_key
+    q = run.queue
+
+    def _clarify_callback(question: str, choices, multi_select: bool = False) -> str:
+        from tools import clarify_gateway
+        redact = _api_server.redact_sensitive_text
+        safe_question = str(redact(str(question or ""), force=True) or "")[
+            :_api_server._RUN_CLARIFY_MAX_QUESTION_CHARS]
+        safe_choices = None
+        if choices:
+            safe_choices = [
+                str(redact(str(choice), force=True) or "")[:_api_server._RUN_CLARIFY_MAX_CHOICE_CHARS]
+                for choice in list(choices)[:4]]
+        allow_multi = bool(multi_select) and bool(safe_choices)
+        request_id = f"clarify_{uuid.uuid4().hex}"
+        clarify_gateway.register(
+            clarify_id=request_id, session_key=clarify_session_key, question=safe_question,
+            choices=safe_choices, multi_select=allow_multi)
+        prompt = {
+            "version": _api_server._RUN_CLARIFY_PROMPT_VERSION,
+            "type": "choice" if safe_choices else "text", "question": safe_question}
+        if safe_choices:
+            prompt["choices"] = [
+                {"id": f"choice-{index}", "label": label}
+                for index, label in enumerate(safe_choices, start=1)]
+            prompt["multi_select"] = allow_multi
+
+        def _publish_clarify() -> None:
+            if (
+                run_id in self._stopping_run_ids
+                or clarify_gateway.get_pending_by_id(request_id, session_key=clarify_session_key) is None
+            ):
+                return
+            if self._run_streams.get(run_id) is not q:
+                clarify_gateway.clear_session(clarify_session_key)
+                return
+            self._set_run_status(
+                run_id, "waiting_for_clarification", last_event="clarify.request", awaiting_user=True)
+            run.put_event(_run_event(run_id, "clarify.request", request_id=request_id, prompt=prompt))
+
+        try:
+            loop.call_soon_threadsafe(_publish_clarify)
+        except RuntimeError:
+            clarify_gateway.clear_session(clarify_session_key)
+            return "[clarify prompt could not be delivered]"
+        timeout = clarify_gateway.get_clarify_timeout()
+        response = clarify_gateway.wait_for_response(request_id, timeout=float(timeout))
+        if not response:
+            def _clear_awaiting_on_timeout() -> None:
+                if self._run_statuses.get(run_id, {}).get("awaiting_user"):
+                    self._set_run_status(
+                        run_id, "running", last_event="clarify.timeout", awaiting_user=False)
+
+            with suppress(RuntimeError):
+                loop.call_soon_threadsafe(_clear_awaiting_on_timeout)
+            return f"[user did not respond within {int(timeout / 60)}m]"
+        return response
+
     try:
         self._set_run_status(run_id, "running")
         if run_id in self._stopping_run_ids:
@@ -565,7 +646,7 @@ async def _execute_run(self, run: _RunLaunch, *, _api_server) -> None:
         with self._profile_scope(run.request_profile):
             agent = self._create_agent(
                 stream_delta_callback=_text_cb, tool_progress_callback=self._make_run_event_callback(run_id, loop),
-                **run.agent_kwargs)
+                clarify_callback=_clarify_callback, enable_clarify=True, **run.agent_kwargs)
         self._active_run_agents[run_id] = agent
         approval_notify = _make_approval_notify(self, run, _api_server=_api_server)
         result, usage = await loop.run_in_executor(
@@ -612,7 +693,7 @@ def _release_run_owner_if_forgotten(self, run_id: str) -> None:
     """Drop the owner stamp only once nothing keyed by *run_id* survives: ownership must
     outlive every surface it protects (retired on different clocks); ownerless = fail-closed."""
     live = (self._run_statuses, self._active_run_agents, self._active_run_tasks, self._run_streams,
-            self._run_approval_sessions)
+            self._run_approval_sessions, self._run_clarify_sessions)
     if not any(run_id in table for table in live):
         self._run_owners.pop(run_id, None)
 
@@ -811,7 +892,7 @@ async def _handle_stop_run(self, request: "web.Request", *, _api_server) -> "web
         return _json_error(
             _openai_error, f"Run is not active in this gateway process: {run_id}",
             code="run_not_active", status=409)
-    self._set_run_status(run_id, "stopping", last_event="run.stopping")
+    self._set_run_status(run_id, "stopping", last_event="run.stopping", awaiting_user=False)
     self._stopping_run_ids.add(run_id)
     if agent is not None:
         with suppress(Exception):
@@ -819,6 +900,7 @@ async def _handle_stop_run(self, request: "web.Request", *, _api_server) -> "web
         # Reap only this run's background processes (epoch-gated inside, so a concurrent
         # run on the same session_id keeps its own); no-op if the run already finished.
         _api_server._reap_disconnected_agent_processes(agent, source="api_server_run_stop")
+    _clear_run_clarify(self, run_id)
     return web.json_response({"run_id": run_id, "status": "stopping"})
 
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -881,9 +881,17 @@ class TestCapabilitiesEndpoint:
                 "retention_seconds": 86400,
             }
             assert data["features"]["model_options"] is True
+            assert data["features"]["run_clarification_response"] is True
+            assert data["features"]["run_clarification_request_binding"] is True
+            assert data["features"]["run_clarification_prompt_version"] == 1
+            assert data["features"]["clarification_events"] is True
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"
             assert data["endpoints"]["model_options"] == {"method": "GET", "path": "/api/model/options"}
+            assert data["endpoints"]["run_clarification"] == {
+                "method": "POST",
+                "path": "/v1/runs/{run_id}/clarification",
+            }
             assert data["endpoints"]["skills"] == {"method": "GET", "path": "/v1/skills"}
             assert data["endpoints"]["toolsets"] == {"method": "GET", "path": "/v1/toolsets"}
 

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -486,6 +486,7 @@ class TestRunEvents:
 # ---------------------------------------------------------------------------
 
 
+    @pytest.mark.asyncio
     async def test_clarification_event_waits_for_exact_choice_response(self, adapter):
         app = _create_runs_app(adapter)
         callback_result = {}
@@ -808,6 +809,7 @@ class TestRunEvents:
         request_id = "clarify_" + "d" * 32
         adapter._run_statuses[run_id] = {"run_id": run_id, "status": "waiting_for_clarification"}
         adapter._run_clarify_sessions[run_id] = run_id
+        _claim_run(adapter, run_id)
         clarify_mod.register(
             request_id,
             run_id,
@@ -860,6 +862,7 @@ class TestRunEvents:
         for run_id in (first_run, second_run):
             adapter._run_statuses[run_id] = {"run_id": run_id, "status": "running"}
             adapter._run_clarify_sessions[run_id] = run_id
+            _claim_run(adapter, run_id)
         clarify_mod.register(request_id, second_run, "Question?", ["One", "Two"])
 
         async with TestClient(TestServer(app)) as cli:
@@ -956,7 +959,6 @@ class TestRunEvents:
                         adapter._run_streams[run_id].get(), timeout=3
                     )
                     assert event["event"] == "clarify.request"
-                    assert adapter._run_statuses[run_id]["request_profile"] == "alpha"
                     pending = clarify_mod.get_pending_by_id(
                         event["request_id"], session_key=run_id
                     )
@@ -999,6 +1001,7 @@ class TestRunEvents:
         request_id = "clarify_" + "b" * 32
         adapter._run_statuses[run_id] = {"run_id": run_id, "status": "running"}
         adapter._run_clarify_sessions[run_id] = run_id
+        _claim_run(adapter, run_id)
         clarify_mod.register(request_id, run_id, "Question?", None)
 
         async with TestClient(TestServer(app)) as cli:
@@ -1050,80 +1053,6 @@ class TestRunEvents:
 
         clarify_mod.clear_session(run_id)
 
-    @pytest.mark.asyncio
-    async def test_approval_resolve_all_is_scoped_to_target_run(self, auth_adapter):
-        """Same client session_id must not let one run approve another run's queue."""
-        app = _create_runs_app(auth_adapter)
-        async with TestClient(TestServer(app)) as cli:
-            with patch.object(auth_adapter, "_create_agent") as mock_create:
-                victim_agent, victim_ready, victim_interrupted = _make_slow_agent()
-                attacker_agent, attacker_ready, attacker_interrupted = _make_slow_agent()
-                mock_create.side_effect = [victim_agent, attacker_agent]
-
-                victim_resp = await cli.post(
-                    "/v1/runs",
-                    json={"input": "victim", "session_id": "shared-project"},
-                    headers={"Authorization": "Bearer sk-secret"},
-                )
-                attacker_resp = await cli.post(
-                    "/v1/runs",
-                    json={"input": "attacker", "session_id": "shared-project"},
-                    headers={"Authorization": "Bearer sk-secret"},
-                )
-                assert victim_resp.status == 202
-                assert attacker_resp.status == 202
-                victim_run = (await victim_resp.json())["run_id"]
-                attacker_run = (await attacker_resp.json())["run_id"]
-
-                victim_ready.wait(timeout=3.0)
-                attacker_ready.wait(timeout=3.0)
-                assert auth_adapter._run_approval_sessions[victim_run] == victim_run
-                assert auth_adapter._run_approval_sessions[attacker_run] == attacker_run
-                assert auth_adapter._run_approval_sessions[victim_run] != auth_adapter._run_approval_sessions[attacker_run]
-
-                victim_entry = approval_mod._ApprovalEntry({
-                    "command": "bash -c victim-danger",
-                    "description": "victim approval",
-                    "pattern_keys": ["shell-c"],
-                })
-                attacker_entry = approval_mod._ApprovalEntry({
-                    "command": "bash -c attacker-danger",
-                    "description": "attacker approval",
-                    "pattern_keys": ["shell-c"],
-                })
-                with approval_mod._lock:
-                    approval_mod._gateway_queues[victim_run] = [victim_entry]
-                    approval_mod._gateway_queues[attacker_run] = [attacker_entry]
-
-                approval_resp = await cli.post(
-                    f"/v1/runs/{attacker_run}/approval",
-                    json={"choice": "always", "resolve_all": True},
-                    headers={"Authorization": "Bearer sk-secret"},
-                )
-                approval_data = await approval_resp.json()
-
-                assert approval_resp.status == 200
-                assert approval_data["resolved"] == 1
-                assert attacker_entry.result == "always"
-                assert attacker_entry.event.is_set()
-                assert victim_entry.result is None
-                assert not victim_entry.event.is_set()
-                with approval_mod._lock:
-                    assert approval_mod._gateway_queues[victim_run] == [victim_entry]
-                    assert victim_run in approval_mod._gateway_queues
-                    assert attacker_run not in approval_mod._gateway_queues
-
-                # Clean up the synthetic pending victim approval and unblock the
-                # slow test agents so their background run tasks can finish.
-                with approval_mod._lock:
-                    approval_mod._gateway_queues.pop(victim_run, None)
-                victim_interrupted.set()
-                attacker_interrupted.set()
-
-
-# ---------------------------------------------------------------------------
-# POST /v1/runs/{run_id}/steer — steer a running agent
-# ---------------------------------------------------------------------------
 
 class TestSteerRun:
     @pytest.mark.asyncio
@@ -1444,6 +1373,7 @@ class TestRunOwnershipAcrossProfiles:
 
 class TestStopRun:
 
+    @pytest.mark.asyncio
     async def test_stop_releases_pending_clarification(self, adapter):
         app = _create_runs_app(adapter)
 

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -29,6 +29,8 @@ from gateway.platforms.api_server import (
 )
 from tools import approval as approval_mod
 from tools import approval_gateway_wait
+from tools import clarify_gateway as clarify_mod
+from tools.clarify_tool import clarify_tool
 
 
 # ---------------------------------------------------------------------------
@@ -102,8 +104,24 @@ def _create_runs_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_get("/v1/runs/{run_id}", adapter._handle_get_run)
     app.router.add_get("/v1/runs/{run_id}/events", adapter._handle_run_events)
     app.router.add_post("/v1/runs/{run_id}/approval", adapter._handle_run_approval)
+    app.router.add_post(
+        "/v1/runs/{run_id}/clarification",
+        adapter._handle_run_clarification,
+    )
     app.router.add_post("/v1/runs/{run_id}/steer", adapter._handle_steer_run)
     app.router.add_post("/v1/runs/{run_id}/stop", adapter._handle_stop_run)
+    return app
+
+
+def _create_multiplex_runs_app(adapter: APIServerAdapter) -> web.Application:
+    """Runs + clarification routes under /p/{profile}/ with profile middleware."""
+    app = web.Application(middlewares=[adapter._make_profile_prefix_middleware()])
+    app["api_server_adapter"] = adapter
+    app.router.add_post("/p/{profile}/v1/runs", adapter._handle_runs)
+    app.router.add_post(
+        "/p/{profile}/v1/runs/{run_id}/clarification",
+        adapter._handle_run_clarification,
+    )
     return app
 
 
@@ -467,6 +485,645 @@ class TestRunEvents:
 # ---------------------------------------------------------------------------
 
 
+    async def test_clarification_event_waits_for_exact_choice_response(self, adapter):
+        app = _create_runs_app(adapter)
+        callback_result = {}
+
+        def make_agent(**kwargs):
+            mock_agent = MagicMock()
+
+            def run_conversation(**_run_kwargs):
+                callback_result["answer"] = kwargs["clarify_callback"](
+                    "Pick a color OPENAI_API_KEY=sk-secret-12345678901234567890",
+                    ["Red", "Blue"],
+                )
+                return {"final_response": callback_result["answer"]}
+
+            mock_agent.run_conversation.side_effect = run_conversation
+            mock_agent.session_prompt_tokens = 0
+            mock_agent.session_completion_tokens = 0
+            mock_agent.session_total_tokens = 0
+            return mock_agent
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", side_effect=make_agent) as create:
+                started = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await started.json())["run_id"]
+                event = await asyncio.wait_for(adapter._run_streams[run_id].get(), timeout=3)
+
+                assert event["event"] == "clarify.request"
+                assert event["run_id"] == run_id
+                assert event["request_id"].startswith("clarify_")
+                assert event["prompt"] == {
+                    "version": 1,
+                    "type": "choice",
+                    "question": "Pick a color OPENAI_API_KEY=***",
+                    "choices": [
+                        {"id": "choice-1", "label": "Red"},
+                        {"id": "choice-2", "label": "Blue"},
+                    ],
+                    "multi_select": False,
+                }
+                assert create.call_args.kwargs["enable_clarify"] is True
+
+                for _ in range(40):
+                    polled = adapter._run_statuses[run_id]
+                    if polled.get("status") == "waiting_for_clarification":
+                        break
+                    await asyncio.sleep(0.05)
+                assert polled["status"] == "waiting_for_clarification"
+                assert polled["awaiting_user"] is True
+
+                response = await cli.post(
+                    f"/v1/runs/{run_id}/clarification",
+                    json={
+                        "request_id": event["request_id"],
+                        "response": {"type": "choice", "choice_id": "choice-2"},
+                    },
+                )
+                assert response.status == 200
+                payload = await response.json()
+                assert payload["request_id"] == event["request_id"]
+                assert payload["choice_id"] == "choice-2"
+                assert adapter._run_statuses[run_id]["awaiting_user"] is False
+
+                for _ in range(40):
+                    status = adapter._run_statuses[run_id]
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+                assert callback_result["answer"] == "Blue"
+                assert status["status"] == "completed"
+                assert status["awaiting_user"] is False
+                assert run_id not in adapter._run_clarify_sessions
+
+    @pytest.mark.asyncio
+    async def test_clarification_awaiting_user_is_isolated_per_run(self, adapter):
+        """Resolving one run must not clear awaiting_user on a sibling run."""
+        app = _create_runs_app(adapter)
+        answers = {}
+
+        def make_agent(**kwargs):
+            mock_agent = MagicMock()
+
+            def run_conversation(**_run_kwargs):
+                answers[id(mock_agent)] = kwargs["clarify_callback"](
+                    "Pick one?",
+                    ["Yes", "No"],
+                )
+                return {"final_response": answers[id(mock_agent)]}
+
+            mock_agent.run_conversation.side_effect = run_conversation
+            mock_agent.session_prompt_tokens = 0
+            mock_agent.session_completion_tokens = 0
+            mock_agent.session_total_tokens = 0
+            return mock_agent
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", side_effect=make_agent):
+                first = await cli.post(
+                    "/v1/runs", json={"input": "one", "session_id": "shared-session"}
+                )
+                second = await cli.post(
+                    "/v1/runs", json={"input": "two", "session_id": "shared-session"}
+                )
+                first_id = (await first.json())["run_id"]
+                second_id = (await second.json())["run_id"]
+                first_event = await asyncio.wait_for(
+                    adapter._run_streams[first_id].get(), timeout=3
+                )
+                second_event = await asyncio.wait_for(
+                    adapter._run_streams[second_id].get(), timeout=3
+                )
+                assert first_event["event"] == "clarify.request"
+                assert second_event["event"] == "clarify.request"
+                for _ in range(40):
+                    if (
+                        adapter._run_statuses[first_id].get("awaiting_user")
+                        and adapter._run_statuses[second_id].get("awaiting_user")
+                    ):
+                        break
+                    await asyncio.sleep(0.05)
+                assert adapter._run_statuses[first_id]["session_id"] == "shared-session"
+                assert adapter._run_statuses[second_id]["session_id"] == "shared-session"
+                assert adapter._run_statuses[first_id]["awaiting_user"] is True
+                assert adapter._run_statuses[second_id]["awaiting_user"] is True
+
+                resolved = await cli.post(
+                    f"/v1/runs/{first_id}/clarification",
+                    json={
+                        "request_id": first_event["request_id"],
+                        "response": {"type": "choice", "choice_id": "choice-1"},
+                    },
+                )
+                assert resolved.status == 200
+                assert adapter._run_statuses[first_id]["awaiting_user"] is False
+                sibling = await cli.get(f"/v1/runs/{second_id}")
+                sibling_status = await sibling.json()
+                assert sibling.status == 200
+                assert sibling_status["awaiting_user"] is True
+                assert sibling_status["status"] == "waiting_for_clarification"
+                assert clarify_mod.get_pending_by_id(
+                    second_event["request_id"], session_key=second_id
+                ) is not None
+
+                leftover = await cli.post(
+                    f"/v1/runs/{second_id}/clarification",
+                    json={
+                        "request_id": second_event["request_id"],
+                        "response": {"type": "choice", "choice_id": "choice-2"},
+                    },
+                )
+                assert leftover.status == 200
+                assert adapter._run_statuses[second_id]["awaiting_user"] is False
+
+    @pytest.mark.asyncio
+    async def test_clarification_batch_questions_are_sequential_on_one_run(self, adapter):
+        """A questions batch becomes one SSE prompt at a time on the same run."""
+        app = _create_runs_app(adapter)
+        callback_result = {}
+
+        def make_agent(**kwargs):
+            mock_agent = MagicMock()
+
+            def run_conversation(**_run_kwargs):
+                callback_result["batch"] = clarify_tool(
+                    "",
+                    questions=[
+                        {
+                            "question": "Which environment?",
+                            "choices": ["Staging", "Production"],
+                        },
+                        {"question": "Any notes?"},
+                    ],
+                    callback=kwargs["clarify_callback"],
+                )
+                return {"final_response": callback_result["batch"]}
+
+            mock_agent.run_conversation.side_effect = run_conversation
+            mock_agent.session_prompt_tokens = 0
+            mock_agent.session_completion_tokens = 0
+            mock_agent.session_total_tokens = 0
+            return mock_agent
+
+        async def next_clarify_request(queue):
+            while True:
+                event = await asyncio.wait_for(queue.get(), timeout=3)
+                if event and event.get("event") == "clarify.request":
+                    return event
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", side_effect=make_agent):
+                started = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await started.json())["run_id"]
+                queue = adapter._run_streams[run_id]
+                first_event = await next_clarify_request(queue)
+
+                assert first_event["run_id"] == run_id
+                assert first_event["prompt"]["question"] == "Which environment?"
+                assert first_event["prompt"]["type"] == "choice"
+                assert adapter._run_statuses[run_id]["awaiting_user"] is True
+
+                first = await cli.post(
+                    f"/v1/runs/{run_id}/clarification",
+                    json={
+                        "request_id": first_event["request_id"],
+                        "response": {"type": "choice", "choice_id": "choice-2"},
+                    },
+                )
+                assert first.status == 200
+
+                stale = await cli.post(
+                    f"/v1/runs/{run_id}/clarification",
+                    json={
+                        "request_id": first_event["request_id"],
+                        "response": {"type": "choice", "choice_id": "choice-2"},
+                    },
+                )
+                assert stale.status == 409
+
+                second_event = await next_clarify_request(queue)
+                assert second_event["request_id"] != first_event["request_id"]
+                assert second_event["prompt"]["question"] == "Any notes?"
+                assert second_event["prompt"]["type"] == "text"
+                assert adapter._run_statuses[run_id]["status"] == (
+                    "waiting_for_clarification"
+                )
+                assert adapter._run_statuses[run_id]["awaiting_user"] is True
+
+                second = await cli.post(
+                    f"/v1/runs/{run_id}/clarification",
+                    json={
+                        "request_id": second_event["request_id"],
+                        "response": {"type": "text", "text": "ship it"},
+                    },
+                )
+                assert second.status == 200
+
+                for _ in range(40):
+                    status = adapter._run_statuses[run_id]
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+                payload = json.loads(callback_result["batch"])
+                assert [row["user_response"] for row in payload["responses"]] == [
+                    "Production",
+                    "ship it",
+                ]
+                assert status["status"] == "completed"
+                assert status["awaiting_user"] is False
+
+    @pytest.mark.asyncio
+    async def test_clarification_multi_select_returns_json_array(self, adapter):
+        app = _create_runs_app(adapter)
+        callback_result = {}
+
+        def make_agent(**kwargs):
+            mock_agent = MagicMock()
+
+            def run_conversation(**_run_kwargs):
+                callback_result["answer"] = kwargs["clarify_callback"](
+                    "Pick environments",
+                    ["Staging", "Production", "Canary"],
+                    multi_select=True,
+                )
+                return {"final_response": callback_result["answer"]}
+
+            mock_agent.run_conversation.side_effect = run_conversation
+            mock_agent.session_prompt_tokens = 0
+            mock_agent.session_completion_tokens = 0
+            mock_agent.session_total_tokens = 0
+            return mock_agent
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", side_effect=make_agent):
+                started = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await started.json())["run_id"]
+                event = await asyncio.wait_for(adapter._run_streams[run_id].get(), timeout=3)
+
+                assert event["event"] == "clarify.request"
+                assert event["prompt"]["multi_select"] is True
+                assert event["prompt"]["type"] == "choice"
+
+                wrong_shape = await cli.post(
+                    f"/v1/runs/{run_id}/clarification",
+                    json={
+                        "request_id": event["request_id"],
+                        "response": {"type": "choice", "choice_id": "choice-1"},
+                    },
+                )
+                assert wrong_shape.status == 400
+
+                response = await cli.post(
+                    f"/v1/runs/{run_id}/clarification",
+                    json={
+                        "request_id": event["request_id"],
+                        "response": {
+                            "type": "choices",
+                            "choice_ids": ["choice-1", "choice-3"],
+                        },
+                    },
+                )
+                assert response.status == 200
+                payload = await response.json()
+                assert payload["type"] == "choices"
+                assert payload["choice_ids"] == ["choice-1", "choice-3"]
+
+                for _ in range(40):
+                    status = adapter._run_statuses[run_id]
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+                assert json.loads(callback_result["answer"]) == ["Staging", "Canary"]
+                assert status["status"] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_clarification_multi_select_rejects_bad_choice_ids(self, adapter):
+        app = _create_runs_app(adapter)
+        run_id = "run_multi"
+        request_id = "clarify_" + "d" * 32
+        adapter._run_statuses[run_id] = {"run_id": run_id, "status": "waiting_for_clarification"}
+        adapter._run_clarify_sessions[run_id] = run_id
+        clarify_mod.register(
+            request_id,
+            run_id,
+            "Pick many?",
+            ["One", "Two", "Three"],
+            multi_select=True,
+        )
+
+        async with TestClient(TestServer(app)) as cli:
+            duplicate = await cli.post(
+                f"/v1/runs/{run_id}/clarification",
+                json={
+                    "request_id": request_id,
+                    "response": {
+                        "type": "choices",
+                        "choice_ids": ["choice-1", "choice-1"],
+                    },
+                },
+            )
+            assert duplicate.status == 400
+
+            empty = await cli.post(
+                f"/v1/runs/{run_id}/clarification",
+                json={
+                    "request_id": request_id,
+                    "response": {"type": "choices", "choice_ids": []},
+                },
+            )
+            assert empty.status == 400
+
+            # Single-select shape must not unlock a multi-select pending entry.
+            single = await cli.post(
+                f"/v1/runs/{run_id}/clarification",
+                json={
+                    "request_id": request_id,
+                    "response": {"type": "choice", "choice_id": "choice-2"},
+                },
+            )
+            assert single.status == 400
+            assert clarify_mod.get_pending_by_id(request_id, session_key=run_id) is not None
+
+        clarify_mod.clear_session(run_id)
+
+    @pytest.mark.asyncio
+    async def test_clarification_is_bound_to_run_and_single_use(self, adapter):
+        app = _create_runs_app(adapter)
+        first_run = "run_first"
+        second_run = "run_second"
+        request_id = "clarify_" + "a" * 32
+        for run_id in (first_run, second_run):
+            adapter._run_statuses[run_id] = {"run_id": run_id, "status": "running"}
+            adapter._run_clarify_sessions[run_id] = run_id
+        clarify_mod.register(request_id, second_run, "Question?", ["One", "Two"])
+
+        async with TestClient(TestServer(app)) as cli:
+            cross_run = await cli.post(
+                f"/v1/runs/{first_run}/clarification",
+                json={
+                    "request_id": request_id,
+                    "response": {"type": "choice", "choice_id": "choice-1"},
+                },
+            )
+            assert cross_run.status == 409
+
+            exact = await cli.post(
+                f"/v1/runs/{second_run}/clarification",
+                json={
+                    "request_id": request_id,
+                    "response": {"type": "choice", "choice_id": "choice-2"},
+                },
+            )
+            assert exact.status == 200
+            assert clarify_mod.wait_for_response(request_id, timeout=0.1) == "Two"
+
+            duplicate = await cli.post(
+                f"/v1/runs/{second_run}/clarification",
+                json={
+                    "request_id": request_id,
+                    "response": {"type": "choice", "choice_id": "choice-2"},
+                },
+            )
+            assert duplicate.status == 409
+
+    @pytest.mark.asyncio
+    async def test_clarification_rejects_other_profile(self, adapter, tmp_path, monkeypatch):
+        """A valid other-profile key must not resolve another profile's pending clarify."""
+        from agent import secret_scope as ss
+        from gateway.config import GatewayConfig
+
+        alpha_home = tmp_path / "profiles" / "alpha"
+        beta_home = tmp_path / "profiles" / "beta"
+        alpha_home.mkdir(parents=True)
+        beta_home.mkdir(parents=True)
+        alpha_key = "a" * 32
+        beta_key = "b" * 32
+        (alpha_home / ".env").write_text(f"API_SERVER_KEY={alpha_key}\n", encoding="utf-8")
+        (beta_home / ".env").write_text(f"API_SERVER_KEY={beta_key}\n", encoding="utf-8")
+
+        adapter._api_key = "c" * 32
+        adapter.gateway_runner = type(
+            "_Runner", (), {"config": GatewayConfig(multiplex_profiles=True)}
+        )()
+        monkeypatch.setattr(
+            "hermes_cli.profiles.profiles_to_serve",
+            lambda multiplex, profile_allowlist=None: [
+                ("default", tmp_path),
+                ("alpha", alpha_home),
+                ("beta", beta_home),
+            ],
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_profile_dir",
+            lambda name: {"alpha": alpha_home, "beta": beta_home}.get(name, tmp_path),
+        )
+        ss.set_multiplex_active(True)
+        app = _create_multiplex_runs_app(adapter)
+        callback_result = {}
+
+        def make_agent(**kwargs):
+            mock_agent = MagicMock()
+
+            def run_conversation(**_run_kwargs):
+                callback_result["answer"] = kwargs["clarify_callback"](
+                    "Which env?",
+                    ["Staging", "Production"],
+                )
+                return {"final_response": callback_result["answer"]}
+
+            mock_agent.run_conversation.side_effect = run_conversation
+            mock_agent.session_prompt_tokens = 0
+            mock_agent.session_completion_tokens = 0
+            mock_agent.session_total_tokens = 0
+            return mock_agent
+
+        try:
+            async with TestClient(TestServer(app)) as cli:
+                with patch.object(adapter, "_create_agent", side_effect=make_agent):
+                    started = await cli.post(
+                        "/p/alpha/v1/runs",
+                        json={"input": "hello"},
+                        headers={"Authorization": f"Bearer {alpha_key}"},
+                    )
+                    assert started.status == 202
+                    run_id = (await started.json())["run_id"]
+                    event = await asyncio.wait_for(
+                        adapter._run_streams[run_id].get(), timeout=3
+                    )
+                    assert event["event"] == "clarify.request"
+                    assert adapter._run_statuses[run_id]["request_profile"] == "alpha"
+                    pending = clarify_mod.get_pending_by_id(
+                        event["request_id"], session_key=run_id
+                    )
+                    assert pending is not None
+
+                    body = {
+                        "request_id": event["request_id"],
+                        "response": {"type": "choice", "choice_id": "choice-1"},
+                    }
+                    cross = await cli.post(
+                        f"/p/beta/v1/runs/{run_id}/clarification",
+                        json=body,
+                        headers={"Authorization": f"Bearer {beta_key}"},
+                    )
+                    assert cross.status == 404
+                    assert clarify_mod.get_pending_by_id(
+                        event["request_id"], session_key=run_id
+                    ) is not None
+                    assert "answer" not in callback_result
+
+                    owned = await cli.post(
+                        f"/p/alpha/v1/runs/{run_id}/clarification",
+                        json=body,
+                        headers={"Authorization": f"Bearer {alpha_key}"},
+                    )
+                    assert owned.status == 200
+
+                    for _ in range(40):
+                        if callback_result.get("answer") == "Staging":
+                            break
+                        await asyncio.sleep(0.05)
+                    assert callback_result["answer"] == "Staging"
+        finally:
+            ss.set_multiplex_active(False)
+
+    @pytest.mark.asyncio
+    async def test_clarification_rejects_malformed_and_oversized_text(self, adapter):
+        app = _create_runs_app(adapter)
+        run_id = "run_validation"
+        request_id = "clarify_" + "b" * 32
+        adapter._run_statuses[run_id] = {"run_id": run_id, "status": "running"}
+        adapter._run_clarify_sessions[run_id] = run_id
+        clarify_mod.register(request_id, run_id, "Question?", None)
+
+        async with TestClient(TestServer(app)) as cli:
+            malformed = await cli.post(
+                f"/v1/runs/{run_id}/clarification",
+                json={"request_id": "../not-safe", "response": {"type": "text", "text": "ok"}},
+            )
+            assert malformed.status == 400
+
+            too_long = await cli.post(
+                f"/v1/runs/{run_id}/clarification",
+                json={
+                    "request_id": request_id,
+                    "response": {"type": "text", "text": "x" * 2001},
+                },
+            )
+            assert too_long.status == 400
+            assert clarify_mod.get_pending_by_id(request_id, session_key=run_id) is not None
+
+            accepted = await cli.post(
+                f"/v1/runs/{run_id}/clarification",
+                json={
+                    "request_id": request_id,
+                    "response": {"type": "text", "text": "A bounded answer"},
+                },
+            )
+            assert accepted.status == 200
+            assert clarify_mod.wait_for_response(request_id, timeout=0.1) == "A bounded answer"
+
+    @pytest.mark.asyncio
+    async def test_clarification_requires_api_auth(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        run_id = "run_auth"
+        request_id = "clarify_" + "c" * 32
+        auth_adapter._run_statuses[run_id] = {"run_id": run_id, "status": "running"}
+        auth_adapter._run_clarify_sessions[run_id] = run_id
+        clarify_mod.register(request_id, run_id, "Question?", None)
+
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                f"/v1/runs/{run_id}/clarification",
+                json={
+                    "request_id": request_id,
+                    "response": {"type": "text", "text": "answer"},
+                },
+            )
+            assert response.status == 401
+            assert clarify_mod.get_pending_by_id(request_id, session_key=run_id) is not None
+
+        clarify_mod.clear_session(run_id)
+
+    @pytest.mark.asyncio
+    async def test_approval_resolve_all_is_scoped_to_target_run(self, auth_adapter):
+        """Same client session_id must not let one run approve another run's queue."""
+        app = _create_runs_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent") as mock_create:
+                victim_agent, victim_ready, victim_interrupted = _make_slow_agent()
+                attacker_agent, attacker_ready, attacker_interrupted = _make_slow_agent()
+                mock_create.side_effect = [victim_agent, attacker_agent]
+
+                victim_resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "victim", "session_id": "shared-project"},
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                attacker_resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "attacker", "session_id": "shared-project"},
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert victim_resp.status == 202
+                assert attacker_resp.status == 202
+                victim_run = (await victim_resp.json())["run_id"]
+                attacker_run = (await attacker_resp.json())["run_id"]
+
+                victim_ready.wait(timeout=3.0)
+                attacker_ready.wait(timeout=3.0)
+                assert auth_adapter._run_approval_sessions[victim_run] == victim_run
+                assert auth_adapter._run_approval_sessions[attacker_run] == attacker_run
+                assert auth_adapter._run_approval_sessions[victim_run] != auth_adapter._run_approval_sessions[attacker_run]
+
+                victim_entry = approval_mod._ApprovalEntry({
+                    "command": "bash -c victim-danger",
+                    "description": "victim approval",
+                    "pattern_keys": ["shell-c"],
+                })
+                attacker_entry = approval_mod._ApprovalEntry({
+                    "command": "bash -c attacker-danger",
+                    "description": "attacker approval",
+                    "pattern_keys": ["shell-c"],
+                })
+                with approval_mod._lock:
+                    approval_mod._gateway_queues[victim_run] = [victim_entry]
+                    approval_mod._gateway_queues[attacker_run] = [attacker_entry]
+
+                approval_resp = await cli.post(
+                    f"/v1/runs/{attacker_run}/approval",
+                    json={"choice": "always", "resolve_all": True},
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                approval_data = await approval_resp.json()
+
+                assert approval_resp.status == 200
+                assert approval_data["resolved"] == 1
+                assert attacker_entry.result == "always"
+                assert attacker_entry.event.is_set()
+                assert victim_entry.result is None
+                assert not victim_entry.event.is_set()
+                with approval_mod._lock:
+                    assert approval_mod._gateway_queues[victim_run] == [victim_entry]
+                    assert victim_run in approval_mod._gateway_queues
+                    assert attacker_run not in approval_mod._gateway_queues
+
+                # Clean up the synthetic pending victim approval and unblock the
+                # slow test agents so their background run tasks can finish.
+                with approval_mod._lock:
+                    approval_mod._gateway_queues.pop(victim_run, None)
+                victim_interrupted.set()
+                attacker_interrupted.set()
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/runs/{run_id}/steer — steer a running agent
+# ---------------------------------------------------------------------------
+
 class TestSteerRun:
     @pytest.mark.asyncio
     async def test_steer_running_agent(self, adapter):
@@ -785,6 +1442,112 @@ class TestRunOwnershipAcrossProfiles:
 
 
 class TestStopRun:
+
+    async def test_stop_releases_pending_clarification(self, adapter):
+        app = _create_runs_app(adapter)
+
+        def make_agent(**kwargs):
+            mock_agent = MagicMock()
+
+            def run_conversation(**_run_kwargs):
+                answer = kwargs["clarify_callback"](
+                    "Q" * 2500,
+                    ["X" * 600, "Y" * 600, "Z" * 600, "W" * 600, "extra"],
+                )
+                # Stop clears the pending clarify and resumes the worker; main's
+                # cancel path only seals cancelled when interrupted=True.
+                return {
+                    "final_response": answer,
+                    "interrupted": True,
+                }
+
+            mock_agent.run_conversation.side_effect = run_conversation
+            mock_agent.session_prompt_tokens = 0
+            mock_agent.session_completion_tokens = 0
+            mock_agent.session_total_tokens = 0
+            return mock_agent
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", side_effect=make_agent):
+                started = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await started.json())["run_id"]
+                event = await asyncio.wait_for(
+                    adapter._run_streams[run_id].get(), timeout=3
+                )
+                assert event["event"] == "clarify.request"
+                assert len(event["prompt"]["question"]) == 2000
+                assert len(event["prompt"]["choices"]) == 4
+                assert all(
+                    len(choice["label"]) == 500
+                    for choice in event["prompt"]["choices"]
+                )
+
+                stopped = await cli.post(f"/v1/runs/{run_id}/stop")
+                assert stopped.status == 200
+                assert clarify_mod.get_pending_by_id(
+                    event["request_id"], session_key=run_id
+                ) is None
+                assert adapter._run_statuses[run_id]["awaiting_user"] is False
+
+                for _ in range(40):
+                    if run_id not in adapter._active_run_tasks:
+                        break
+                    await asyncio.sleep(0.05)
+
+                assert adapter._run_statuses[run_id]["status"] == "cancelled"
+                assert run_id not in adapter._run_clarify_sessions
+
+    @pytest.mark.asyncio
+    async def test_completion_wins_before_uncooperative_stop_is_acknowledged(
+        self, adapter
+    ):
+        """A provisional Stop cannot discard a real completion."""
+        app = _create_runs_app(adapter)
+        run_can_finish = threading.Event()
+        run_finished = threading.Event()
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                started = threading.Event()
+
+                def _run_conversation(*_args, **_kwargs):
+                    started.set()
+                    run_can_finish.wait(timeout=5)
+                    run_finished.set()
+                    return {"final_response": "late result"}
+
+                mock_agent.run_conversation.side_effect = _run_conversation
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await resp.json())["run_id"]
+                assert started.wait(timeout=3)
+
+                stop_resp = await cli.post(f"/v1/runs/{run_id}/stop")
+                assert stop_resp.status == 200
+                await asyncio.sleep(0.1)
+
+                assert not run_finished.is_set()
+                assert run_id in adapter._active_run_agents
+                assert run_id in adapter._active_run_tasks
+                assert adapter._run_statuses[run_id]["status"] == "stopping"
+
+                run_can_finish.set()
+                for _ in range(40):
+                    if run_id not in adapter._active_run_tasks:
+                        break
+                    await asyncio.sleep(0.05)
+
+                assert run_id not in adapter._active_run_agents
+                assert run_id not in adapter._active_run_tasks
+                assert adapter._run_statuses[run_id]["status"] == "completed"
+                assert adapter._run_statuses[run_id]["output"] == "late result"
+
+    @pytest.mark.asyncio
 
     @pytest.mark.asyncio
     async def test_completion_wins_before_uncooperative_stop_is_acknowledged(

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -11,6 +11,7 @@ Covers:
 
 import asyncio
 import hashlib
+import json
 import threading
 import time
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -80,3 +80,30 @@ class TestApiServerAdapterToolset:
             assert len(toolsets) > 0
             assert call_kwargs.kwargs.get("platform") == "api_server"
 
+    @patch("gateway.platforms.api_server.AIOHTTP_AVAILABLE", True)
+    def test_runs_can_enable_clarify_without_changing_api_server_default(self):
+        from gateway.platforms.api_server import APIServerAdapter
+        from gateway.config import PlatformConfig
+
+        adapter = APIServerAdapter(PlatformConfig())
+        with patch("gateway.run._resolve_runtime_agent_kwargs") as mock_kwargs, \
+             patch("gateway.run._resolve_gateway_model", return_value="test/model"), \
+             patch("gateway.run._load_gateway_config", return_value={}), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_kwargs.return_value = {
+                "api_key": "test-key",
+                "base_url": None,
+                "provider": None,
+                "api_mode": None,
+                "command": None,
+                "args": [],
+            }
+            callback = MagicMock()
+            adapter._create_agent(
+                clarify_callback=callback,
+                enable_clarify=True,
+            )
+
+        call_kwargs = mock_agent_cls.call_args.kwargs
+        assert "clarify" in call_kwargs["enabled_toolsets"]
+        assert call_kwargs["clarify_callback"] is callback

--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -82,6 +82,31 @@ class TestClarifyPrimitive:
         assert pending is not None
         assert pending.clarify_id == "id3b"
 
+    def test_exact_resolution_is_session_bound_and_single_use(self):
+        from tools import clarify_gateway as cm
+
+        entry = cm.register("id-bound", "owner", "Q?", ["A"])
+        assert cm.get_pending_by_id("id-bound", session_key="other") is None
+        assert cm.resolve_gateway_clarify(
+            "id-bound", "A", session_key="other"
+        ) is False
+        assert not entry.event.is_set()
+
+        snapshot = cm.get_pending_by_id("id-bound", session_key="owner")
+        assert snapshot == {
+            "clarify_id": "id-bound",
+            "session_key": "owner",
+            "question": "Q?",
+            "choices": ["A"],
+            "multi_select": False,
+        }
+        assert cm.resolve_gateway_clarify(
+            "id-bound", "A", session_key="owner"
+        ) is True
+        assert cm.resolve_gateway_clarify(
+            "id-bound", "A", session_key="owner"
+        ) is False
+        assert cm.get_pending_by_id("id-bound", session_key="owner") is None
 
     def test_clear_session_cancels_pending_entries(self):
         """clear_session unblocks blocked threads with empty response."""

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -28,6 +28,15 @@ class _ClarifyEntry:
     response: Optional[str] = None
     awaiting_text: bool = False  # set when user picked "Other" or clarify is open-ended
 
+    def signature(self) -> Dict[str, object]:
+        return {
+            "clarify_id": self.clarify_id,
+            "session_key": self.session_key,
+            "question": self.question,
+            "choices": list(self.choices) if self.choices else None,
+            "multi_select": bool(self.multi_select),
+        }
+
 
 _lock = threading.RLock()
 _entries: Dict[str, _ClarifyEntry] = {}  # clarify_id -> entry (button callbacks)
@@ -87,11 +96,41 @@ def wait_for_response(clarify_id: str, timeout: float) -> Optional[str]:
     return entry.response
 
 
-def resolve_gateway_clarify(clarify_id: str, response: str) -> bool:
-    """Unblock the waiter on ``clarify_id``; False if already resolved/expired/unknown."""
+def get_pending_by_id(
+    clarify_id: str,
+    *,
+    session_key: Optional[str] = None,
+) -> Optional[Dict[str, object]]:
+    """Return a snapshot of an unresolved clarify request.
+
+    ``session_key`` lets transports bind an opaque request identifier to the
+    run/session that owns it without exposing the mutable queue entry.
+    """
     with _lock:
         entry = _entries.get(clarify_id)
-        if entry is None or entry.event.is_set():
+        if (
+            entry is None
+            or entry.event.is_set()
+            or (session_key is not None and entry.session_key != session_key)
+        ):
+            return None
+        return entry.signature()
+
+
+def resolve_gateway_clarify(
+    clarify_id: str,
+    response: str,
+    *,
+    session_key: Optional[str] = None,
+) -> bool:
+    """Unblock the waiter on ``clarify_id``; False if wrong session/already resolved/unknown."""
+    with _lock:
+        entry = _entries.get(clarify_id)
+        if (
+            entry is None
+            or entry.event.is_set()
+            or (session_key is not None and entry.session_key != session_key)
+        ):
             return False
         entry.response = str(response) if response is not None else ""
         entry.event.set()

--- a/website/docs/developer-guide/programmatic-integration.md
+++ b/website/docs/developer-guide/programmatic-integration.md
@@ -109,6 +109,7 @@ POST /v1/runs                    Start a run, returns run_id (202)
 GET  /v1/runs/{id}               Run status
 GET  /v1/runs/{id}/events        SSE stream of lifecycle events
 POST /v1/runs/{id}/approval      Resolve a pending approval
+POST /v1/runs/{id}/clarification Answer an exact pending clarification
 POST /v1/runs/{id}/steer         Inject mid-run guidance at the next tool boundary
 POST /v1/runs/{id}/stop          Interrupt the run
 GET  /v1/capabilities            Machine-readable feature flags

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -502,6 +502,43 @@ running.
 
 Resolve a pending approval for a run that is waiting on a human decision (for example, a tool call gated behind an approval policy). The body carries the approval decision; the run resumes once the decision is recorded. This endpoint is advertised in `/v1/capabilities` as the `run_approval` feature so external UIs can detect support before surfacing an approval prompt.
 
+### POST /v1/runs/\{run_id\}/clarification
+
+When the agent needs a missing detail, the event stream emits a bounded,
+secret-redacted `clarify.request` with a stable `request_id` and a versioned
+prompt. Choice prompts use server-issued IDs:
+
+```json
+{
+  "event": "clarify.request",
+  "run_id": "run_abc123",
+  "request_id": "clarify_0123456789abcdef0123456789abcdef",
+  "prompt": {
+    "version": 1,
+    "type": "choice",
+    "question": "Which environment should I use?",
+    "choices": [
+      {"id": "choice-1", "label": "Staging"},
+      {"id": "choice-2", "label": "Production"}
+    ]
+  }
+}
+```
+
+Answer that exact request with a choice ID:
+
+```json
+{
+  "request_id": "clarify_0123456789abcdef0123456789abcdef",
+  "response": {"type": "choice", "choice_id": "choice-1"}
+}
+```
+
+For an open question, send
+`{"type": "text", "text": "your answer"}`. Unknown, stale, already answered,
+or cross-run request IDs fail closed. Check `run_clarification_response` and
+`run_clarification_request_binding` in `/v1/capabilities` before showing this UI.
+
 ## Jobs API (background scheduled work)
 
 The server exposes a lightweight jobs CRUD surface for managing scheduled / background agent runs from a remote client. All endpoints are gated behind the same bearer auth.

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -520,7 +520,8 @@ prompt. Choice prompts use server-issued IDs:
     "choices": [
       {"id": "choice-1", "label": "Staging"},
       {"id": "choice-2", "label": "Production"}
-    ]
+    ],
+    "multi_select": false
   }
 }
 ```
@@ -534,10 +535,28 @@ Answer that exact request with a choice ID:
 }
 ```
 
+When `prompt.multi_select` is `true`, answer with one or more server-issued IDs:
+
+```json
+{
+  "request_id": "clarify_0123456789abcdef0123456789abcdef",
+  "response": {
+    "type": "choices",
+    "choice_ids": ["choice-1", "choice-2"]
+  }
+}
+```
+
 For an open question, send
 `{"type": "text", "text": "your answer"}`. Unknown, stale, already answered,
-or cross-run request IDs fail closed. Check `run_clarification_response` and
-`run_clarification_request_binding` in `/v1/capabilities` before showing this UI.
+or cross-run request IDs fail closed. A `clarify` tool call with a `questions`
+array is decomposed into sequential `clarify.request` events on the same run;
+answer each `request_id` before the next prompt is emitted. While a
+clarification is pending, `GET /v1/runs/{run_id}` reports
+`status: waiting_for_clarification` and `awaiting_user: true` (cleared on
+answer, timeout, or `/stop`). Check `run_clarification_response` and
+`run_clarification_request_binding` in `/v1/capabilities` before showing this
+UI.
 
 ## Jobs API (background scheduled work)
 


### PR DESCRIPTION
## What does this PR do?


Makes `/v1/runs` support the existing `clarify` tool as a real hard gate: the agent thread blocks on `wait_for_response`, clients get a bounded SSE `clarify.request`, and they answer via `POST /v1/runs/{run_id}/clarification`.
This salvages [#68105](https://github.com/NousResearch/hermes-agent/pull/68105) onto current `main` (keeps `/steer`, session-model lock, and stop semantics), then adds:
1. Pass `multi_select` through the Runs callback → register → SSE prompt, and accept `response.type: "choices"`.
2. Stamp process-local `awaiting_user` on run status  while clarification is pending; clear on answer, timeout, `/stop`, or cleanup.
Clarify stays a Runs-only overlay (`enable_clarify=True` + callback) — it is **not** added to the default `hermes-api-server` toolset.
Scope is ask/answer on `/v1/runs` only; defer/park/wake is out of scope.

## Related Issue

Related to #2971 and #68105 (credit: @hazeion).

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/api_server.py` — Runs clarify callback, SSE `clarify.request` / `clarify.responded`, `POST /v1/runs/{run_id}/clarification`, `waiting_for_clarification` as in-flight, `multi_select` + `awaiting_user`
- `tools/clarify_gateway.py` — session-bound `get_pending_by_id` / `resolve_gateway_clarify`
- `tests/gateway/test_api_server_runs.py` — ask/answer, binding, multi-select, stop-while-waiting, `awaiting_user` enter/exit
- `tests/gateway/test_api_server.py` / `test_api_server_toolset.py` / `tests/tools/test_clarify_gateway.py` — capabilities + overlay + gateway binding coverage
- `website/docs/user-guide/features/api-server.md` (+ programmatic integration endpoint list) — document clarification API

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_api_server_runs.py`
2. `scripts/run_tests.sh tests/gateway/test_api_server_toolset.py tests/tools/test_clarify_gateway.py tests/gateway/test_api_server.py`
3. Manual: start a run that calls `clarify` → SSE `clarify.request` → `GET /v1/runs/{id}` shows `waiting_for_clarification` + `awaiting_user: true` → `POST .../clarification` resumes the same turn
4. Manual: `multi_select=true` → `response.type=choices` with `choice_ids` → callback receives a JSON array string
5. Manual: `/stop` while waiting clears pending clarify and does not hang the agent forever 

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` on the touched suites and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — covered by gateway unit/integration tests around Runs clarification SSE + POST.


