### PR TITLE
fix(bot-mode): opening a group chat no longer draws the room twice

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -203,6 +203,14 @@ const $groupChats = atom({})
 /** Group whose room view is open in the Bots pane (secondary navigation,
  *  same pattern as $botSessionsWorkspace). */
 const $groupChatWorkspace = atom(null)
+/** Groups whose room is currently rendered by a MAIN-window tab. Selection
+ *  ($groupChatWorkspace) only says which room is highlighted; this says who is
+ *  already DRAWING it. Without the distinction the Bots panel rendered its own
+ *  in-panel copy alongside the main tab — two live rooms, and the roster gone
+ *  (#89788). A plain Map (groupChatMainTabs) can't drive that: the panel needs
+ *  a reactive value to re-render on. */
+const $groupChatMainOwned = atom({})
+
 /** Groups whose latest room activity mentions @user — the needs-you badge. */
 const $groupNeedsYou = atom({})
 
@@ -9333,10 +9341,30 @@ function GroupChatWorkspace({ group, members, onBack }) {
  *  disband (or the room view's own Back) can retire the tab it opened. */
 const groupChatMainTabs = new Map()
 
+/** Reactive mirror of groupChatMainTabs — see $groupChatMainOwned. */
+function setGroupChatMainOwned(group, owned) {
+  const prev = $groupChatMainOwned.get()
+
+  if (Boolean(prev[group]) === Boolean(owned)) {
+    return
+  }
+
+  const next = { ...prev }
+
+  if (owned) {
+    next[group] = true
+  } else {
+    delete next[group]
+  }
+
+  $groupChatMainOwned.set(next)
+}
+
 function closeGroupChatMainTab(group) {
   const close = groupChatMainTabs.get(group)
 
   groupChatMainTabs.delete(group)
+  setGroupChatMainOwned(group, false)
 
   if ($groupChatWorkspace.get() === group) {
     $groupChatWorkspace.set(null)
@@ -9369,7 +9397,6 @@ function GroupChatMainView({ group }) {
  *  view on desktops whose SDK predates the main-area door. */
 function openGroupChat(group) {
   $groupNeedsYou.set({ ...$groupNeedsYou.get(), [group]: false })
-  $groupChatWorkspace.set(group)
 
   if (typeof host.openWorkspace === 'function') {
     try {
@@ -9379,6 +9406,7 @@ function openGroupChat(group) {
         render: () => jsx(GroupChatMainView, { group }),
         onClose: () => {
           groupChatMainTabs.delete(group)
+          setGroupChatMainOwned(group, false)
 
           if ($groupChatWorkspace.get() === group) {
             $groupChatWorkspace.set(null)
@@ -9387,6 +9415,9 @@ function openGroupChat(group) {
       })
 
       groupChatMainTabs.set(group, close)
+      // The main window draws this room now: the panel keeps the roster.
+      setGroupChatMainOwned(group, true)
+      $groupChatWorkspace.set(group)
 
       return
     } catch {
@@ -9394,8 +9425,10 @@ function openGroupChat(group) {
     }
   }
 
-  // The selected-group atom was set before trying the main-window door, so
-  // older desktops naturally render the in-panel room as the fallback.
+  // Older desktops have no main-window door: nobody owns the render, so the
+  // selection alone makes the panel show the in-panel room as the fallback.
+  setGroupChatMainOwned(group, false)
+  $groupChatWorkspace.set(group)
 }
 
 /** One group chat as ONE roster row — the Discord shape: stacked member
@@ -9524,6 +9557,7 @@ function BotsPane() {
   const activityToasts = useValue($activityToasts)
   const sessionsWorkspaceName = useValue($botSessionsWorkspace)
   const groupChatName = useValue($groupChatWorkspace)
+  const groupChatMainOwned = useValue($groupChatMainOwned)
   const groupNeedsYou = useValue($groupNeedsYou)
   const groupRooms = useValue($groupChats)
 
@@ -9622,7 +9656,9 @@ function BotsPane() {
 
   const groupChatMembers = groupChatName ? groupChatMemberBots(groupChatName, roster, allMeta) : []
 
-  if (groupChatName && groupChatMembers.length) {
+  // Selected AND nobody else is drawing it. When the main-window tab owns the
+  // room, rendering here too gave two live rooms and hid the roster (#89788).
+  if (groupChatName && groupChatMembers.length && !groupChatMainOwned[groupChatName]) {
     return jsx(GroupChatWorkspace, { group: groupChatName, members: groupChatMembers })
   }
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -104,7 +104,7 @@ function load(turnScript, { busyUntilResumeCall } = {}) {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, disbandGroupChat, updateGroupChat, openGroupChat, closeGroupChatMainTab, $groupChats, $groupNeedsYou, $groupChatWorkspace, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, disbandGroupChat, updateGroupChat, openGroupChat, closeGroupChatMainTab, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupChatMainOwned, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -821,4 +821,64 @@ test('group room preview renders the bot HANDLE, not the raw profile name', () =
   assert.match(pluginSource, /const lastHandle = botHandle\(lastFrom \|\| 'bot', members\.find\(/)
   assert.match(pluginSource, /\? `\$\{last\.from\?\.kind === 'user' \? 'You' : `@\$\{lastHandle\}`\}/)
   assert.doesNotMatch(pluginSource, /`@\$\{last\.from\?\.name \|\| 'bot'\}`/)
+})
+
+test('main-window tab owns the room: the Bots panel must not draw a second copy', () => {
+  // #89788: selection alone made the panel render its own GroupChatWorkspace
+  // beside the main tab — two live rooms, each with its own composer, and the
+  // bots roster replaced.
+  const gc = load(() => '(pass)')
+
+  gc.host.openWorkspace = () => () => undefined
+  gc.openGroupChat('Core')
+
+  assert.equal(gc.$groupChatWorkspace.get(), 'Core')        // still selected
+  assert.equal(gc.$groupChatMainOwned.get().Core, true)     // main window draws it
+})
+
+test('no main-window door: the in-panel room stays the fallback', () => {
+  const gc = load(() => '(pass)')
+
+  gc.host.openWorkspace = undefined
+  gc.openGroupChat('Core')
+
+  assert.equal(gc.$groupChatWorkspace.get(), 'Core')
+  assert.equal(gc.$groupChatMainOwned.get().Core, undefined)
+})
+
+test('a failed main-window door falls back to the in-panel room', () => {
+  const gc = load(() => '(pass)')
+
+  gc.host.openWorkspace = () => {
+    throw new Error('no main-area door on this desktop')
+  }
+  gc.openGroupChat('Core')
+
+  assert.equal(gc.$groupChatWorkspace.get(), 'Core')
+  assert.equal(gc.$groupChatMainOwned.get().Core, undefined)
+})
+
+test('closing the main tab hands the room back', () => {
+  const gc = load(() => '(pass)')
+  let onClose
+
+  gc.host.openWorkspace = (_id, options) => {
+    onClose = options.onClose
+    return () => onClose()
+  }
+
+  gc.openGroupChat('Core')
+  assert.equal(gc.$groupChatMainOwned.get().Core, true)
+
+  gc.closeGroupChatMainTab('Core')
+  assert.equal(gc.$groupChatMainOwned.get().Core, undefined)
+  assert.equal(gc.$groupChatWorkspace.get(), null)
+})
+
+test('source contract: the panel renders the room only when nothing else owns it', () => {
+  assert.match(
+    pluginSource,
+    /if \(groupChatName && groupChatMembers\.length && !groupChatMainOwned\[groupChatName\]\) \{/
+  )
+  assert.doesNotMatch(pluginSource, /if \(groupChatName && groupChatMembers\.length\) \{/)
 })


### PR DESCRIPTION
## What does this PR do?

Opening **any** group chat from the Bots pane replaced the bots/groups roster with a second, fully live copy of the same room — two Back buttons, two headers, two delete/settings controls, two composers, and either one could send a message. Pressing Back on either restored the roster.

`openGroupChat` sets `$groupChatWorkspace` *before* trying the main-window door, deliberately: that is the fallback for desktops whose SDK predates `host.openWorkspace`. But when the door **succeeds**, the atom stays set — and `BotsPane` renders the in-panel room off exactly that value:

```js
if (groupChatName && groupChatMembers.length) {
  return jsx(GroupChatWorkspace, { group: groupChatName, members: groupChatMembers })
}
```

So the main-window tab and the panel both drew the room.

**The selection itself has to stay.** It drives group-row highlighting and suppresses bot-row highlighting (`isActive = !activeGroup && …`), and three existing tests assert it survives the main-window open. Clearing it on success would trade this bug for a worse one.

So the panel now asks a different question: is anything else already *drawing* this room? `$groupChatMainOwned` is a reactive mirror of `groupChatMainTabs` — that Map can't drive a re-render on its own. It is set when the main-window door succeeds, and cleared on the fallback path, on the tab's `onClose`, and in `closeGroupChatMainTab` (which the rename path routes through, so renames follow the room).

Ownership is marked *before* the selection on the success path: setting the selection first painted the in-panel room for one frame before the marker hid it again.

## Related Issue

Fixes #89788

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.js` — add `$groupChatMainOwned` and `setGroupChatMainOwned()`; mark/clear ownership in `openGroupChat` and `closeGroupChatMainTab`; gate the `BotsPane` in-panel room render on it
- `apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs` — 5 tests, plus `$groupChatMainOwned` in the harness export

## How to Test

1. Open the Bots pane with at least one group chat (any size — a one-member room reproduces it)
2. Click the group

**Before:** the roster is replaced by a second live copy of the room; two Back buttons, two composers.
**After:** the room opens in the main area only; the roster stays visible; the group row is still highlighted as selected.

Back from the room still works, from either the room header or the tab.

```
node --test src/plugins/hermes-bots/tests/*.test.mjs
# 313 pass, 0 fail

npm run check:lint     # typecheck + eslint
# exit 0 — no errors, no warnings from the changed files
```

Each new test was checked against a targeted revert:

- restore the ungated panel render → the source-contract test fails
- drop the ownership marking on the success path → 2 behavioural tests fail

Verified in a local packaged build on macOS 27.0 arm64 (`hermes desktop --build-only`), including the legacy path and Back from both surfaces.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the test suite and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 27.0 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal render path, no user-facing docs)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — renderer-side only, no platform-specific code
- [x] I've updated tool descriptions/schemas — N/A

