### PR TITLE
perf(state): two-phase page for order_by_last_active session list

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8853,6 +8853,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     f"{where_sql} AND {combined}" if where_sql else f"WHERE {combined}"
                 )
             _sel = self._compact_session_cols() if compact_rows else "s.*"
+            # Two-phase page: phase 1 ranks every listable root by its
+            # effective (chain-max) last activity and picks the LIMIT/OFFSET
+            # page using the cheap columns only. Phase 2 re-fetches just the
+            # page's rows, which is where the expensive _preview_raw
+            # subquery runs (REPLACE over full message content per session).
+            # Inlining it in a single query made SQLite evaluate previews for
+            # every listable root (thousands) to return a 50-row page; the
+            # split bounds that work to the page size.
             query = f"""
                 WITH RECURSIVE chain(root_id, cur_id) AS (
                     SELECT s.id, s.id FROM sessions s {where_sql}
@@ -8873,19 +8881,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     FROM chain
                     GROUP BY root_id
                 )
-                SELECT {_sel}{prompt_select},
-                    COALESCE(
-                        (SELECT {_PREVIEW_RAW_SELECT}
-                         FROM messages m
-                         WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
-                         ORDER BY m.timestamp, m.id LIMIT 1),
-                        ''
-                    ) AS _preview_raw,
+                SELECT s.id,
                     {_sql_session_last_active("s")} AS last_active,
                     COALESCE(cm.effective_last_active, s.started_at) AS _effective_last_active
                 FROM sessions s
                 LEFT JOIN chain_max cm ON cm.root_id = s.id
-                {prompt_join}
                 {outer_where}
                 ORDER BY _effective_last_active DESC, s.started_at DESC, s.id DESC
                 LIMIT ? OFFSET ?
@@ -8915,6 +8915,43 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         with self._read_ctx() as conn:
             cursor = conn.execute(query, params)
             rows = cursor.fetchall()
+        if order_by_last_active:
+            page_ids = [row["id"] for row in rows]
+            if page_ids:
+                # Phase 2: re-fetch just the page's rows (full columns + the
+                # expensive _preview_raw subquery). Phase 1 already ordered and
+                # filtered these ids, so no CTE, join, or re-filtering here —
+                # the id list is the page. A row deleted between phases is
+                # simply dropped, matching the single-query behaviour.
+                id_placeholders = ",".join("?" for _ in page_ids)
+                detail_where = (
+                    f"{where_sql} AND s.id IN ({id_placeholders})"
+                    if where_sql
+                    else f"WHERE s.id IN ({id_placeholders})"
+                )
+                detail_query = f"""
+                    SELECT {_sel}{prompt_select},
+                        COALESCE(
+                            (SELECT {_PREVIEW_RAW_SELECT}
+                             FROM messages m
+                             WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                             ORDER BY m.timestamp, m.id LIMIT 1),
+                            ''
+                        ) AS _preview_raw,
+                        {_sql_session_last_active("s")} AS last_active
+                    FROM sessions s
+                    {prompt_join}
+                    {detail_where}
+                """
+                with self._read_ctx() as conn:
+                    detail_cursor = conn.execute(
+                        detail_query, list(base_where_params) + list(page_ids)
+                    )
+                    detail_rows = detail_cursor.fetchall()
+                rows = {row["id"]: row for row in detail_rows}
+                rows = [rows[row_id] for row_id in page_ids if row_id in rows]
+            else:
+                rows = []
         sessions = []
         for row in rows:
             s = self._session_row_dict(row)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2069,6 +2069,68 @@ class TestListSessionsRich:
 
 
 
+    def test_rich_list_order_by_last_active_two_phase_keeps_order_and_previews(self, db):
+        # The order_by_last_active path is two-phase: phase 1 selects the page
+        # by effective last-active, phase 2 re-fetches full rows + previews for
+        # just those ids. This guards a phase 2 that silently reorders, drops
+        # rows, or empties the previews.
+        db.create_session("a", "cli")
+        db.create_session("b", "cli")
+        db.create_session("c", "cli")
+        db.append_message("a", "user", "alpha first user line")
+        db.append_message("b", "user", "beta first user line")
+        db.append_message("c", "user", "gamma first user line")
+        # Deterministic last-active ordering: c > b > a.
+        base = 1_700_000_000.0
+        with db._lock:
+            for sid, ts in (("a", base + 10.0), ("b", base + 20.0), ("c", base + 30.0)):
+                db._conn.execute(
+                    "UPDATE messages SET timestamp=? WHERE session_id=?",
+                    (ts, sid),
+                )
+                db._conn.execute(
+                    "UPDATE sessions SET last_activity_at=? WHERE id=?",
+                    (ts, sid),
+                )
+            db._conn.commit()
+
+        rows = db.list_sessions_rich(order_by_last_active=True, limit=2)
+
+        # Page order follows last-active, not creation order.
+        assert [r["id"] for r in rows] == ["c", "b"]
+        # Phase 2 still populates the first-user-message previews.
+        assert rows[0]["preview"].startswith("gamma")
+        assert rows[1]["preview"].startswith("beta")
+        # The paged-out session is absent.
+        assert all(r["id"] != "a" for r in rows)
+
+    def test_rich_list_order_by_last_active_two_phase_offset_page(self, db):
+        # offset must still skip correctly through the two-phase path.
+        for sid in ("a", "b", "c", "d"):
+            db.create_session(sid, "cli")
+            db.append_message(sid, "user", f"{sid} first user line")
+        base = 1_700_000_000.0
+        with db._lock:
+            for i, sid in enumerate(("a", "b", "c", "d")):
+                ts = base + float(i * 10.0)
+                db._conn.execute(
+                    "UPDATE messages SET timestamp=? WHERE session_id=?",
+                    (ts, sid),
+                )
+                db._conn.execute(
+                    "UPDATE sessions SET last_activity_at=? WHERE id=?",
+                    (ts, sid),
+                )
+            db._conn.commit()
+
+        page = db.list_sessions_rich(
+            order_by_last_active=True, limit=2, offset=1
+        )
+        # full order is d,c,b,a; offset=1 limit=2 -> c,b
+        assert [r["id"] for r in page] == ["c", "b"]
+        assert page[0]["preview"].startswith("c")
+        assert page[1]["preview"].startswith("b")
+
     def test_rich_list_session_key_filter_precedes_limit(self, db):
         lane_key = "agent:main:telegram:dm:lane"
         db.create_session(


### PR DESCRIPTION
## What

Split the `order_by_last_active` session-list query into two phases so the
expensive `_preview_raw` subquery runs only for the rows on the page, not
for every listable session.

## Why

`list_sessions_rich(order_by_last_active=True)` — the desktop sidebar and
`/api/profiles/sessions` — inlined the `_preview_raw` correlated subquery in
a single statement. SQLite therefore evaluated the preview (a `REPLACE` over
full message content) for every listable root to return a 50-row page.

Measured on a 4,629-session / 382,472-message `state.db`:

| component | cost |
|---|---|
| full endpoint | 220 ms |
| `_preview_raw` subquery (all 2,179 roots) | ~215 ms |
| chain CTE walk | ~13 ms |
| base row scan | ~3.5 ms |

So ~98% of the endpoint's cost was previews for rows that were never
returned. The `LIMIT 50` was applied, but SQLite materializes the full
result (with subquery columns) before limiting.

## How

- Phase 1: rank every listable root by its effective (chain-max) last
  activity using only cheap columns, apply the `id_query`/`search_query`
  filters, and select the `LIMIT ? OFFSET ?` page.
- Phase 2: re-fetch just the page's ids with full columns and the
  `_preview_raw` subquery. No CTE, no re-filtering — the id list is the page.

`id` is primary key, so phase 2 is bounded by page size. A row deleted
between phases is dropped, matching single-query behaviour.

## Verification

- Equivalence harness on the live DB: 8 call shapes
  (limit 20/25/50, offset 20, `id_query`, `search_query`, `exclude_sources`,
  `sources`) — **all returned identical rows** (same order, same content,
  same previews).
- New regression tests `test_rich_list_order_by_last_active_two_phase_*`
  pin order, page, offset, and non-empty previews through the two-phase path.
- Full `tests/test_hermes_state.py` (239), `tests/hermes_state/` +
  `tests/gateway/test_session.py` (216), and the 8 session-listing test files
  (296) all pass. 15 pre-existing failures in
  `test_tui_gateway_server.py` (config-save, unrelated) are identical with
  the change stashed.
- No open upstream PR touches this region (`hermes_state.py` lines
  ~8856–8960). PR #87560 edits `list_sessions_rich`'s signature/docstring
  area (~8620–8771), not the query body.

## Result

Endpoint: **220 ms → ~30 ms** on the measured DB (~7× faster) for the
default sidebar shape.
