### PR TITLE
docs(mcp): explicit platform_toolsets is an allowlist that excludes mcp-* toolsets

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/references/native-mcp.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/native-mcp.md
@@ -119,6 +119,17 @@ Examples:
 
 After discovery, MCP tools are automatically injected into all `hermes-*` platform toolsets (CLI, Discord, Telegram, etc.). This means MCP tools are available in every conversation without any additional configuration.
 
+> **Caveat — an explicit `platform_toolsets` acts as an allowlist.** Auto-injection only reaches a platform that has *not* pinned its toolsets. Each MCP server registers its tools into a dedicated `mcp-<server>` toolset (e.g. server `github` → toolset `mcp-github`; the model calls the tools as `mcp_github_*`). If you configure `platform_toolsets` for a platform, that list becomes an allowlist and the `mcp-*` toolsets are **not** added automatically — you must list them explicitly:
+>
+> ```yaml
+> platform_toolsets:
+>   whatsapp:
+>     - hermes-whatsapp   # the platform's built-in tools
+>     - mcp-github        # add each mcp-<server> you want exposed on this platform
+> ```
+>
+> This is easy to miss because `hermes tools --summary` merges base and per-profile config, so a profile that omits the `mcp-*` entries can *display* as enabled while its running sessions lack the tools. Symptom: MCP tools work in the CLI (or one profile) but not on a messaging platform (or another profile). Fix: add the `mcp-<server>` toolsets to that platform/profile's `platform_toolsets`.
+
 ### Connection Lifecycle
 
 - Each server runs as a long-lived asyncio Task in a background daemon thread


### PR DESCRIPTION
## What

Adds a caveat to the **Auto-Injection** section of `native-mcp.md`.

## Why

The doc states MCP tools are auto-injected into all `hermes-*` platform toolsets and "available in every conversation without any additional configuration." That is true only when a platform has **not** pinned its toolsets. When `platform_toolsets` is configured for a platform (or profile), that list acts as an **allowlist**, and the per-server `mcp-<server>` toolsets are not added automatically — so MCP tools silently vanish from that platform's sessions.

This bites in practice: on a multi-profile WhatsApp gateway, the base config had `platform_toolsets` set but the group profiles didn't list the `mcp-*` toolsets, so DB tools worked in DMs (base) but were missing in groups. `hermes tools --summary` merges base+profile config, so it *displayed* the tools as enabled while the running group sessions lacked them — masking the cause.

## Change

Docs only. Adds the caveat, a YAML example, and the symptom→fix ("works in CLI/one profile but not a messaging platform/another profile → add `mcp-<server>` to that platform's `platform_toolsets`").

🤖 Generated with [Claude Code](https://claude.com/claude-code)