### PR TITLE
fix(sdk): return registered connection list

### DIFF
--- a/apps/desktop/src/sdk/index.test.ts
+++ b/apps/desktop/src/sdk/index.test.ts
@@ -112,44 +112,62 @@ describe('host.connections', () => {
   const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
   const originalDesktop = desktopWindow.hermesDesktop
 
+  const connection = (id: string, label: string) => ({
+    id,
+    kind: 'remote' as const,
+    label,
+    tokenPreview: null,
+    tokenSet: true,
+    url: `https://${id}.example`
+  })
+
+  const stubBridge = (list: () => Promise<unknown>) => {
+    desktopWindow.hermesDesktop = {
+      ...originalDesktop,
+      connections: { list }
+    } as unknown as Window['hermesDesktop']
+  }
+
   afterEach(() => {
     desktopWindow.hermesDesktop = originalDesktop
   })
 
-  const stubList = (value: unknown) => {
-    desktopWindow.hermesDesktop = {
-      ...originalDesktop,
-      connections: {
-        ...originalDesktop?.connections,
-        list: async () => value
-      }
-    } as Window['hermesDesktop']
-  }
-
-  it('returns connection rows from the desktop registry envelope (#89823)', async () => {
-    stubList({
-      connections: [
-        { id: 'local', kind: 'local', label: 'This device' },
-        { id: 'remote', kind: 'remote', label: 'Remote gateway' }
-      ],
+  it('returns the registry rows, not the envelope that carries them (#89823)', async () => {
+    stubBridge(async () => ({
+      connections: [connection('local', 'This Mac'), connection('homelab', 'Homelab')],
       primary: 'local',
       secureTokenStorage: true,
       version: 2
-    })
+    }))
 
     const connections = await host.connections()
 
     expect(Array.isArray(connections)).toBe(true)
-    expect(connections.map(connection => connection.id)).toEqual(['local', 'remote'])
+    expect(connections.map(entry => entry.id)).toEqual(['local', 'homelab'])
+    expect(connections[1]).toMatchObject({ kind: 'remote', label: 'Homelab', url: 'https://homelab.example' })
   })
 
-  it('falls back to an empty list when the registry has no connection rows', async () => {
-    stubList({ primary: '', secureTokenStorage: true, version: 1 })
+  it('folds the envelope-level primary id down onto the row that owns it', async () => {
+    stubBridge(async () => ({
+      connections: [connection('local', 'This Mac'), connection('homelab', 'Homelab')],
+      primary: 'homelab',
+      secureTokenStorage: true,
+      version: 2
+    }))
+
+    expect((await host.connections()).map(entry => [entry.id, entry.primary])).toEqual([
+      ['local', false],
+      ['homelab', true]
+    ])
+  })
+
+  it('reads as a single-source desktop when the payload carries no rows', async () => {
+    stubBridge(async () => ({ primary: '', secureTokenStorage: true, version: 1 }))
 
     await expect(host.connections()).resolves.toEqual([])
   })
 
-  it('rejects on desktop builds without the connection registry', async () => {
+  it('still rejects on a Desktop build without the connection registry', async () => {
     desktopWindow.hermesDesktop = undefined
 
     await expect(host.connections()).rejects.toThrow('This Desktop build has no connection registry')

--- a/apps/desktop/src/sdk/index.test.ts
+++ b/apps/desktop/src/sdk/index.test.ts
@@ -107,3 +107,51 @@ describe('host.state turn flags', () => {
     $sessionTiles.set([])
   })
 })
+
+describe('host.connections', () => {
+  const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
+  const originalDesktop = desktopWindow.hermesDesktop
+
+  afterEach(() => {
+    desktopWindow.hermesDesktop = originalDesktop
+  })
+
+  const stubList = (value: unknown) => {
+    desktopWindow.hermesDesktop = {
+      ...originalDesktop,
+      connections: {
+        ...originalDesktop?.connections,
+        list: async () => value
+      }
+    } as Window['hermesDesktop']
+  }
+
+  it('returns connection rows from the desktop registry envelope (#89823)', async () => {
+    stubList({
+      connections: [
+        { id: 'local', kind: 'local', label: 'This device' },
+        { id: 'remote', kind: 'remote', label: 'Remote gateway' }
+      ],
+      primary: 'local',
+      secureTokenStorage: true,
+      version: 2
+    })
+
+    const connections = await host.connections()
+
+    expect(Array.isArray(connections)).toBe(true)
+    expect(connections.map(connection => connection.id)).toEqual(['local', 'remote'])
+  })
+
+  it('falls back to an empty list when the registry has no connection rows', async () => {
+    stubList({ primary: '', secureTokenStorage: true, version: 1 })
+
+    await expect(host.connections()).resolves.toEqual([])
+  })
+
+  it('rejects on desktop builds without the connection registry', async () => {
+    desktopWindow.hermesDesktop = undefined
+
+    await expect(host.connections()).rejects.toThrow('This Desktop build has no connection registry')
+  })
+})

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -499,21 +499,6 @@ export const host = {
   ensureAgent: async (connectionId: null | string, profile: string): Promise<void> =>
     ensureGatewayAgent(connectionId, (profile ?? '').trim() || 'default'),
 
-  /** Open a stored session that belongs to an agent on ANY registered source.
-   *  The connection id + profile are the durable route; the store handles
-   *  dialing / source activation, then the regular session-open path owns
-   *  navigation + hydration. */
-  openAgentSession: async (
-    connectionId: null | string,
-    profile: string,
-    storedSessionId: string,
-    options: Omit<PluginOpenSessionOptions, 'profile'> = {}
-  ): Promise<void> => {
-    await ensureGatewayAgent(connectionId, (profile ?? '').trim() || 'default')
-
-    return host.openSession(storedSessionId, { ...options, profile })
-  },
-
   /** Open a stored session — optionally pre-activating its profile first. */
   openSession: async (storedSessionId: string, options: PluginOpenSessionOptions = {}): Promise<void> => {
     const generation = ++openSessionGeneration

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -464,7 +464,9 @@ export const host = {
       throw new Error('This Desktop build has no connection registry. Update Hermes Desktop.')
     }
 
-    return bridge.list()
+    const registry = await bridge.list()
+
+    return Array.isArray(registry) ? registry : Array.isArray(registry?.connections) ? registry.connections : []
   },
 
   /** The union agent roster across every registered connection: one row per

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -464,9 +464,10 @@ export const host = {
       throw new Error('This Desktop build has no connection registry. Update Hermes Desktop.')
     }
 
-    const registry = await bridge.list()
+    const registryPayload = await bridge.list()
+    const rows = Array.isArray(registryPayload?.connections) ? registryPayload.connections : []
 
-    return Array.isArray(registry) ? registry : Array.isArray(registry?.connections) ? registry.connections : []
+    return rows.map(connection => ({ ...connection, primary: connection.id === registryPayload.primary }))
   },
 
   /** The union agent roster across every registered connection: one row per
@@ -498,6 +499,22 @@ export const host = {
   ensureAgent: async (connectionId: null | string, profile: string): Promise<void> =>
     ensureGatewayAgent(connectionId, (profile ?? '').trim() || 'default'),
 
+  /** Open a stored session that belongs to an agent on ANY registered source.
+   *  The connection id + profile are the durable route; the store handles
+   *  dialing / source activation, then the regular session-open path owns
+   *  navigation + hydration. */
+  openAgentSession: async (
+    connectionId: null | string,
+    profile: string,
+    storedSessionId: string,
+    options: Omit<PluginOpenSessionOptions, 'profile'> = {}
+  ): Promise<void> => {
+    await ensureGatewayAgent(connectionId, (profile ?? '').trim() || 'default')
+
+    return host.openSession(storedSessionId, { ...options, profile })
+  },
+
+  /** Open a stored session — optionally pre-activating its profile first. */
   openSession: async (storedSessionId: string, options: PluginOpenSessionOptions = {}): Promise<void> => {
     const generation = ++openSessionGeneration
     const profile = (options.profile ?? '').trim()


### PR DESCRIPTION
Fixes #89823

`host.connections()` is documented as returning the registered connection list, but the Desktop bridge returns the full registry envelope. Bot Mode therefore receives a non-array value and its multi-connection `Create on` gate never activates.

This fixes the contract at the SDK boundary by:
- unwrapping the registry `connections` rows
- folding the envelope-level `primary` id onto each returned row as `primary: boolean`
- returning an empty list when an older/partial Desktop payload carries no connection rows
- preserving the existing rejection when the Desktop connection registry is unavailable

The SDK now keeps the documented labels/kinds/primary contract without changing the settings screen, which consumes `bridge.list()` directly and still receives the full envelope.

Regression coverage exercises row unwrapping, primary folding, missing rows, and the no-registry rejection.