### PR TITLE
feat(slash-commands): add /find-skill command

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11599,6 +11599,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         elif canonical == "skills":
             with self._busy_command(self._slow_command_status(cmd_original)):
                 self._handle_skills_command(cmd_original)
+        elif canonical == "find-skill":
+            self._handle_find_skill_command(cmd_original)
         elif canonical == "learn":
             self._handle_learn_command(cmd_original)
         elif canonical == "init":

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2024,6 +2024,32 @@ class CLICommandsMixin:
         from hermes_cli.skills_hub import handle_skills_slash
         handle_skills_slash(cmd, ChatConsole())
 
+    def _handle_find_skill_command(self, cmd: str):
+        """Handle /find-skill — discover and install agent skills.
+
+        The argument is the user's need expressed as a short query, e.g.
+        "/find-skill react performance". We build the find-skills prompt and
+        inject it onto the agent's input queue; the live agent searches the
+        open skills ecosystem and can install a matching skill.
+        """
+        from agent.learn_prompt import build_learn_prompt
+
+        parts = cmd.strip().split(None, 1)
+        user_request = parts[1].strip() if len(parts) > 1 else ""
+
+        prompt = (
+            "Use the find-skills workflow for this request: "
+            + user_request
+            if user_request
+            else "Use the find-skills workflow: help the user discover or install a skill for their need."
+        )
+        msg = build_learn_prompt(prompt)
+        print("\n🔎 Finding a skill for what you described...")
+        if hasattr(self, "_pending_input"):
+            self._pending_input.put(msg)
+        else:  # pragma: no cover - defensive (no live input loop)
+            print("  /find-skill needs an active chat session to run.")
+
     def _handle_learn_command(self, cmd: str):
         """Handle /learn — distill a reusable skill from anything the user describes.
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -318,6 +318,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True, args_hint="[toggle|list|scale <n>|<slug>]", subcommands=("toggle", "list", "scale", "off")),
     CommandDef("hatch", "Generate a new petdex pet from a description",
                "Tools & Skills", cli_only=True, aliases=("generate-pet",), args_hint="[description]"),
+    CommandDef("find-skill", "Discover and install agent skills for your need", "Tools & Skills",
+               args_hint="<query>", busy_policy="dispatch", busy_handler="find-skill"),
     CommandDef("learn", "Learn a reusable skill from anything you describe (dirs, URLs, this chat, notes)",
                "Tools & Skills", args_hint="<what to learn from>"),
     CommandDef("init", "Generate or update AGENTS.md project instructions from a repo scan",


### PR DESCRIPTION
## What
Adds `/find-skill <query>` as a first-class Hermes slash command.

## Why
Users need a fast in-session path to discover and install skills using the installed `find-skills` workflow.

## Files
- `cli.py` — dispatch `canonical == "find-skill"`
- `hermes_cli/cli_commands_mixin.py` — `_handle_find_skill_command`
- `hermes_cli/commands.py` — `CommandDef("find-skill", ...)`

## Behavior
- `/find-skill react performance` → injects the `find-skills` prompt into the active session
- Bare `/find-skill` → prompts the agent to help discover a skill
- No new core tool; uses existing prompt-injection pattern like `/learn`
