### PR TITLE
feat(skills): add festival optional skill for the fest and camp CLIs

### DIFF
--- a/optional-skills/software-development/festival/SKILL.md
+++ b/optional-skills/software-development/festival/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: festival
+description: "Plan and execute multi-session work with fest and camp."
+version: 1.0.0
+author: Lance Rogers (lancekrogers)
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [Planning, Workflow, Project-Management, Campaign, CLI, Long-Running]
+    category: software-development
+    related_skills: [subagent-driven-development]
+---
+
+# Festival Skill
+
+Festival is a pair of external CLIs, `fest` and `camp`, that keep a plan for
+long-running work in ordinary files inside a git repository, so a session can be
+resumed by a different agent on a different day. This skill covers installing
+them and driving the execution loop through the `terminal` tool. It does not
+cover planning a project from scratch, which the `fest-planning` skill in the
+Festival tap handles.
+
+## When to Use
+
+Use this skill when:
+
+- Work spans more than one session and the plan has to survive the chat history.
+- The user already has a campaign directory, or asks for one, and wants state
+  tracked in files they own rather than in a transcript.
+- A `festivals/` directory, a `fest.yaml`, or an `AGENTS.md` describing a
+  campaign appears in the working tree.
+- The user names `fest`, `camp`, a festival, or a campaign.
+
+Do not use it for a single-session task. A plan that outlives its own execution
+is overhead.
+
+## Prerequisites
+
+Install the binaries first. A skills tap teaches the vocabulary, it does not
+install the CLIs. Pick one, invoked through the `terminal` tool:
+
+```bash
+brew install --cask Obedience-Corp/tap/festival
+npm install -g @obedience-corp/festival
+curl -fsSL https://raw.githubusercontent.com/Obedience-Corp/festival/main/install.sh | bash
+```
+
+Festival publishes 12 skills as a Hermes tap. This one is a pointer; the tap is
+the full set:
+
+```bash
+hermes skills tap add Obedience-Corp/festival
+hermes skills install Obedience-Corp/festival/skills/festival-intake --yes
+hermes skills install Obedience-Corp/festival/skills/fest-planning --yes
+hermes skills install Obedience-Corp/festival/skills/fest-execution --yes
+hermes skills install Obedience-Corp/festival/skills/campaign-commit --yes
+```
+
+Full setup notes, including the commit guard hook and Hermes Desktop, are at
+https://docs.fest.build/getting-started/agents/hermes/
+
+## How to Run
+
+Start the session at the campaign root, so Hermes picks up the campaign's
+`AGENTS.md` from that git root:
+
+```bash
+hermes --in /path/to/my-campaign chat -q "Run fest next and do the task it prints"
+```
+
+`--in` is a global option and goes before the `chat` subcommand.
+
+## Quick Reference
+
+| Command | What it does |
+| --- | --- |
+| `camp init` | Create the campaign layout and its `AGENTS.md` |
+| `fest intro` | Print the getting-started guide for the CLI |
+| `fest next` | Print the next actionable task, with its context |
+| `fest task completed --yes` | Mark the current task done without prompting |
+| `fest task blocked --reason "..."` | Record a blocker and stop |
+| `fest commit -m "..."` | Commit with the festival traceability trailer |
+| `fest validate` | Score the festival structure |
+| `fest status` | Show phase, sequence, and task progress |
+| `fest workflow approve` | Human-only. Do not run it for the user |
+
+## Procedure
+
+1. Confirm both binaries answer (see Verification). If either is missing, stop
+   and install rather than guessing at file layout.
+2. From the campaign root, change into `festivals/active/<festival>`. `fest next`
+   fails at the campaign root.
+3. Run `fest next` and do exactly the task it prints, no more.
+4. Run `fest task completed --yes`.
+5. Run `fest commit -m "<what changed and why>"`.
+6. Run `fest validate` and confirm the score did not drop.
+7. Run `fest next` again and repeat from step 3.
+8. When `fest next` returns a phase gate awaiting approval, report what was done
+   and stop. Approval is the operator's.
+
+## Pitfalls
+
+- `fest next` only works inside a festival directory. At the campaign root it
+  exits with `not inside a festival`. Navigate into
+  `festivals/active/<festival>` and retry.
+- Phase gates are human checkpoints. Submit the gate, report, and stop. Do not
+  run `fest workflow approve` on your own work.
+- Do not drive a campaign with `hermes -z`. Its terminal tool runs in the home
+  directory and ignores both the working directory and `--in`, so every
+  festival command lands in the wrong place. Use `hermes chat` instead.
+- A `docker` terminal backend has neither `fest` nor `camp` on its PATH; the
+  default image (`nikolaik/python-nodejs:python3.11-nodejs20`) fails every
+  Festival command with `command not found`. Bake the binaries into your image
+  or stay on the local backend.
+- Leave `AGENTS.md` as the campaign's only context file. A `.hermes.md`
+  outranks it and replaces it rather than layering on top, and the session then
+  loses the campaign instructions entirely.
+- A tap contributes nothing to `hermes skills browse` and nothing to
+  `hermes skills search`. Install tap skills by their exact name; the full list
+  is in the tap's own README at
+  https://github.com/Obedience-Corp/festival/tree/main/skills
+
+## Verification
+
+```bash
+fest --version && camp --version && fest validate
+```
+
+Both binaries print a version, and `fest validate` prints a score for the
+current festival.

--- a/optional-skills/software-development/festival/SKILL.md
+++ b/optional-skills/software-development/festival/SKILL.md
@@ -21,6 +21,9 @@ them and driving the execution loop through the `terminal` tool. It does not
 cover planning a project from scratch, which the `fest-planning` skill in the
 Festival tap handles.
 
+This skill file is MIT like the rest of this repository; the `fest` and `camp`
+binaries it points at are Apache-2.0.
+
 ## When to Use
 
 Use this skill when:


### PR DESCRIPTION
## What does this PR do?

Adds one optional skill, `optional-skills/software-development/festival/SKILL.md`.

Festival is a pair of open source CLIs, `fest` and `camp`, that keep the plan for long-running work in ordinary files inside a git repository, so a session can be picked up later by a different agent on a different day instead of living in a chat history. The skill teaches Hermes to install the binaries and drive the execution loop (`fest next`, do the task, `fest task completed`, `fest commit`, `fest validate`), and where the loop stops for a human.

It wraps an installable external CLI pair rather than adding anything to this repo: prose only, no scripts, no new dependencies, no core changes. That follows the precedent already in `optional-skills/` for external CLI wrappers (`autonomous-ai-agents/grok`, `autonomous-ai-agents/openhands`, `software-development/ast-grep`).

Festival publishes its full 12 skill set as a Hermes tap at [Obedience-Corp/festival](https://github.com/Obedience-Corp/festival/tree/main/skills), so this submission is deliberately one pointer skill rather than a copy of that set. Setup docs are at https://docs.fest.build/getting-started/agents/hermes/

## Related Issue

None. `gh search issues` and `gh search prs` against this repo for "festival", "fest", and "camp" returned no matches, so this is not a duplicate.

## Type of Change

- [x] New skill (bundled or hub)

## Changes Made

- `optional-skills/software-development/festival/SKILL.md` (new, 131 lines)

Category: `software-development`, alongside `subagent-driven-development`, because Festival is a development workflow the agent runs itself. Not `autonomous-ai-agents`, whose `DESCRIPTION.md` scopes that directory to "external coding agent CLIs that can be delegated to for independent coding tasks". Please move it if another category fits better.

`platforms: [linux, macos]`. The `fest` and `camp` binaries have no Windows support yet, so the skill is gated rather than claiming coverage it does not have.

Every line in `## Pitfalls` comes from a recorded hands-on run against a scratch campaign, not from guesswork. One of them may interest you directly: `hermes -z` ran its terminal tool in `$HOME` and ignored both the process working directory and `--in`, while `hermes chat -q` honored both. The skill therefore points users at `hermes chat`. Happy to file that separately as an issue if it is not already known.

## How to Test

1. `hermes skills install official/software-development/festival --yes`
2. Install the binaries with any one of:
   - `brew install --cask Obedience-Corp/tap/festival`
   - `npm install -g @obedience-corp/festival`
   - `curl -fsSL https://raw.githubusercontent.com/Obedience-Corp/festival/main/install.sh | bash`
3. `mkdir demo && cd demo && camp init`
4. Start a session at that root and ask the agent to run the loop the skill documents. `fest validate` and `fest status` show the result.

Tested on macOS 15 (Darwin 25).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass. I ran the checks that cover this change rather than the whole suite: `pytest tests/skills/test_authoring_standards.py -q` passes (1202 passed, including the six parametrized cases for this skill) and `scripts/check-windows-footguns.py` reports clean.
- [x] I've added tests for my changes. No new test module: the skill is prose only with no scripts, and `tests/skills/test_authoring_standards.py` already covers it mechanically.
- [x] I've tested on my platform: macOS 15.2 (Darwin 25)

### Documentation and housekeeping

- [x] I've updated relevant documentation, or N/A. N/A: no repo docs change. The user facing setup guide lives at https://docs.fest.build/getting-started/agents/hermes/
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, or N/A. N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows, or N/A. N/A
- [x] I've considered cross-platform impact, or N/A. Gated to `[linux, macos]` because the binaries have no Windows build yet.
- [x] I've updated tool descriptions/schemas if I changed tool behavior, or N/A. N/A

## For New Skills

- [x] This skill is broadly useful to most users (if bundled). Submitted to `optional-skills/` rather than `skills/` precisely because it is not universal: it is only useful once someone installs the two CLIs.
- [x] SKILL.md follows the standard format. It uses the HARDLINE section order from `CONTRIBUTING.md` (When to Use, Prerequisites, How to Run, Quick Reference, Procedure, Pitfalls, Verification). The description is 55 characters, one sentence, ends with a period.
- [x] No external dependencies that aren't already available. The skill adds none to this repo; it points at an installable CLI pair.
- [ ] I've tested the skill end-to-end with `hermes --toolsets skills -q "..."`. Stating this plainly: the full `fest next` loop was driven end to end by Hermes against a scratch campaign while this skill was being written, which is where every pitfall came from, but that run used the tap copies of the Festival skills rather than this file. This exact file has not been loaded into a live session.
