### PR TITLE
fix(cli): keep the /model picker resolving cached catalogs for Ollama providers

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -331,6 +331,24 @@ def _fetch_picker_live_models(
             api_url, timeout=timeout, headers=resolved_headers
         )
         if native_models is not None:
+            # Persist the natively discovered catalog so the next cache_only
+            # picker open (no live probe of non-current providers) still sees
+            # it (#89874): /api/tags returned the list to THIS caller only.
+            # The fingerprint uses the caller's configured ``headers`` — not
+            # resolved_headers, which may carry a synthesized Authorization
+            # the later lookup will not reproduce.
+            try:
+                from hermes_cli.models import seed_custom_endpoint_cache
+
+                seed_custom_endpoint_cache(
+                    api_url,
+                    native_models,
+                    api_key=api_key,
+                    api_mode=api_mode,
+                    headers=headers,
+                )
+            except Exception:
+                pass
             return _NativePickerModelList(native_models)
         # A failed native probe is not authoritative: retry the cached generic
         # OpenAI-compatible catalog before reporting no models.
@@ -3413,7 +3431,7 @@ def list_authenticated_providers(
                         has_explicit_models,
                         headers=_extra_headers_from_config(ep_cfg) or None,
                         timeout=(1.5 if for_picker else 5.0),
-                        api_mode=ep_cfg.get("api_mode"),
+                        api_mode=grp.get("api_mode"),
                     )
                     if isinstance(live_models, _NativePickerModelList):
                         native_catalog_empty = not live_models
@@ -3435,7 +3453,7 @@ def list_authenticated_providers(
                         cache_only=True,
                         timeout=(1.5 if for_picker else 5.0),
                         headers=_extra_headers_from_config(ep_cfg) or None,
-                        api_mode=ep_cfg.get("api_mode"),
+                        api_mode=grp.get("api_mode"),
                     )
                     if cached_models:
                         models_list = cached_models

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3948,6 +3948,11 @@ def _spawn_swr_refresh(cache_key: str, refresh_fn=None) -> None:
             entry = (refresh_fn or _default_refresh)()
             if entry:
                 cache = _load_provider_models_cache()
+                # Skip the disk write when nothing actually changed — every
+                # --refresh picker open lands here, and rewriting an identical
+                # catalog just churns the file's mtime (review on #89874).
+                if cache.get(cache_key) == entry:
+                    return
                 cache[cache_key] = entry
                 _save_provider_models_cache(cache)
         except Exception:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4097,6 +4097,49 @@ def _save_provider_models_cache(data: dict) -> None:
         pass
 
 
+def seed_custom_endpoint_cache(
+    base_url: Optional[str],
+    models: list,
+    *,
+    api_key: Optional[str] = None,
+    api_mode: Optional[str] = None,
+    headers: Optional[dict[str, str]] = None,
+) -> None:
+    """Persist a natively discovered catalog into the custom-endpoint cache.
+
+    The Ollama native ``/api/tags`` discovery returns its list to the
+    current caller only — unlike the generic ``/v1/models`` path, nothing
+    wrote ``provider_models_cache.json`` — so after a ``--refresh`` wiped
+    the cache, the next plain ``/model`` open (which must not live-probe
+    non-current providers) found nothing cached and collapsed to 0 models
+    (#89874). Seed the same ``custom:<normalized-url>`` entry shape that
+    :func:`cached_fetch_api_models` reads.
+
+    The fingerprint is computed from the CALLER'S configured headers —
+    ``headers`` as passed in, not any probe-synthesized Authorization — so
+    a later ``cache_only=True`` lookup with the same configured headers
+    matches this entry. Thread-safe and best-effort, like every other
+    cache writer here. An authoritative empty list is stored as-is: a
+    fresh same-fingerprint entry shadows any stale non-empty one, so the
+    stale catalog cannot resurrect while this marker is valid.
+    """
+    try:
+        normalized_url = str(base_url or "").strip().rstrip("/").lower()
+        if not normalized_url:
+            return
+        fp = _custom_endpoint_fingerprint(api_key, api_mode, headers)
+        with _cache_write_lock:
+            cache = _load_provider_models_cache()
+            cache[f"custom:{normalized_url}"] = {
+                "fp": fp,
+                "at": time.time(),
+                "models": list(models or []),
+            }
+            _save_provider_models_cache(cache)
+    except Exception:
+        pass
+
+
 def update_provider_cache_entry(provider: str, models: list[str]) -> None:
     """Thread-safe single-entry update of the provider-models disk cache.
 

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -2168,3 +2168,134 @@ def test_legacy_sentinel_catalog_still_resolves_and_migrates(tmp_path, monkeypat
     assert list(saved["models"]) == _LOCAL_CATALOG
     assert "__discovered_model_catalog__" not in saved["models"]
     assert "__explicit_model_allowlist__" not in saved["models"]
+
+
+def test_transport_field_uses_grouped_api_mode_for_cache_lookup(monkeypatch):
+    """A provider declared with ``transport:`` (not ``api_mode:``) must read
+    its cached catalog (#89874).
+
+    The grouped row resolves ``transport: chat_completions`` into the
+    canonical ``api_mode`` identity that also keys the cache fingerprint.
+    The regressed cache lookups read ``ep_cfg.get("api_mode")`` — None for a
+    transport-declared provider — so the fingerprint never matched the one
+    the catalog was written under and the picker showed 0 models.
+    """
+    import hermes_cli.models as models_mod
+
+    catalog = ["llama-x", "qwen-y"]
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    # Warm cache written under the GROUPED identity (transport-resolved).
+    fp = models_mod._custom_endpoint_fingerprint(
+        "sk-t", "chat_completions", None
+    )
+    cache = {
+        "custom:https://ollama.example.com/v1": {
+            "fp": fp,
+            "at": time.time() - 10,
+            "models": list(catalog),
+        }
+    }
+    monkeypatch.setattr(models_mod, "_load_provider_models_cache", lambda: cache)
+
+    providers = list_authenticated_providers(
+        current_provider="nous",
+        user_providers={
+            "local-ollama": {
+                "name": "Local Ollama",
+                "api": "https://ollama.example.com/v1",
+                "api_key": "sk-t",
+                "transport": "chat_completions",
+                "model": "llama-x",
+            }
+        },
+        custom_providers=[],
+        for_picker=True,
+        refresh=False,
+        probe_custom_providers=False,
+    )
+    row = next(
+        (p for p in providers if "ollama.example.com" in str(p.get("api_url", ""))),
+        None,
+    )
+    assert row is not None
+    assert row["models"] == catalog, (
+        "a transport-declared provider must resolve its cached catalog via "
+        "the grouped api_mode identity, not ep_cfg's absent api_mode key"
+    )
+
+
+def test_native_ollama_discovery_seeds_custom_endpoint_cache(monkeypatch):
+    """The native /api/tags picker discovery must persist its catalog (#89874).
+
+    The native path used to return the list to the current caller only —
+    nothing wrote provider_models_cache.json — so a subsequent plain
+    ``/model`` open (cache_only, no live probe) collapsed to 0 models.
+    The seed must fingerprint the CALLER'S headers so the later lookup
+    matches, not the probe's synthesized Authorization header.
+    """
+    written = {}
+
+    def fake_seed(base_url, models, *, api_key=None, api_mode=None, headers=None):
+        written["args"] = (base_url, list(models), api_key, api_mode, headers)
+
+    monkeypatch.setattr(
+        "hermes_cli.models.seed_custom_endpoint_cache", fake_seed
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_ollama_local_models",
+        lambda url, **_kw: ["llama-a", "llama-b"],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.should_use_ollama_native_catalog",
+        lambda *_a, **_kw: True,
+    )
+    from hermes_cli.model_switch import _NativePickerModelList
+
+    result = _fetch_picker_live_models(
+        "sk-n",
+        "https://ollama.example.com/v1",
+        "custom",
+        False,
+        headers={"X-Custom": "cfg"},
+        api_mode="chat_completions",
+    )
+    assert isinstance(result, _NativePickerModelList)
+    assert list(result) == ["llama-a", "llama-b"]
+    base_url, models, api_key, api_mode, headers = written["args"]
+    assert base_url == "https://ollama.example.com/v1"
+    assert models == ["llama-a", "llama-b"]
+    assert api_key == "sk-n"
+    assert api_mode == "chat_completions"
+    # The seed must use the caller's configured headers verbatim — a
+    # synthesized Authorization here would produce a fingerprint the later
+    # cache_only lookup can never match.
+    assert headers == {"X-Custom": "cfg"}
+
+
+def test_seed_custom_endpoint_cache_round_trips(monkeypatch, tmp_path):
+    """seed_custom_endpoint_cache writes the exact entry shape that a later
+    cache_only cached_fetch_api_models lookup resolves (#89874)."""
+    import hermes_cli.models as models_mod
+
+    monkeypatch.setattr(
+        models_mod, "_provider_models_cache_path", lambda: tmp_path / "pmc.json"
+    )
+
+    models_mod.seed_custom_endpoint_cache(
+        "https://ollama.example.com/v1",
+        ["llama-a", "llama-b"],
+        api_key="sk-n",
+        api_mode="chat_completions",
+        headers=None,
+    )
+
+    served = models_mod.cached_fetch_api_models(
+        "sk-n",
+        "https://ollama.example.com/v1",
+        cache_only=True,
+        api_mode="chat_completions",
+        headers=None,
+    )
+    assert served == ["llama-a", "llama-b"]


### PR DESCRIPTION
## What does this PR do?

Fixes the two regressions that made the `/model` picker show 0 models for a custom local Ollama provider after 0.20.1 (#89874), reproducing the reported sequence exactly: `--refresh` shows the full list once, the next plain `/model` open shows the config-declared subset (or nothing) again.

1. **Cache fingerprint mismatch.** The user-providers (providers-dict) picker branch read `ep_cfg.get("api_mode")` when keying the model cache, but a provider declared with `transport:` (no `api_mode:` key — the reporter's exact config) resolves its canonical wire identity through the grouped value `grp["api_mode"]`, which the group dict builds for precisely this purpose (its comment says so). The raw lookup returned `None`, so the fingerprint never matched the one the catalog was written under and every warm-cache read was a miss. Both call sites now use `grp.get("api_mode")`, matching the sibling builtin-providers branch that never regressed.

2. **Native discovery never persisted.** The Ollama `/api/tags` discovery path returned its list to the current caller only — unlike the generic `/v1/models` path it never wrote `provider_models_cache.json` — so after a `--refresh` wiped the cache there was nothing for the next `cache_only` picker open to read. A new thread-safe `seed_custom_endpoint_cache` helper persists the discovered catalog under the same `custom:<normalized-url>` entry shape `cached_fetch_api_models` reads, fingerprinting the CALLER'S configured headers — not the probe's synthesized `Authorization` — so the later `cache_only` lookup with the same configured headers matches.

## Related Issue

Fixes #89874

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_switch.py`: the two `api_mode=ep_cfg.get("api_mode")` cache-key call sites in the user-providers branch now use `grp.get("api_mode")`; the native `/api/tags` success path in `_fetch_picker_live_models` seeds the custom-endpoint cache with the caller's headers/api_key/api_mode before returning the list.
- `hermes_cli/models.py`: new `seed_custom_endpoint_cache` helper (thread-safe via `_cache_write_lock`, best-effort, same entry shape as the generic writer; a fresh same-fingerprint entry shadows stale catalogs so an authoritative result cannot be resurrected from underneath).

## How to Test

1. `pytest tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_cached_fetch_api_models.py tests/hermes_cli/test_picker_prewarm.py -q` — 97 passed (3 new tests).
2. Fail-on-main verified for both regressions: with the source stashed, `test_transport_field_uses_grouped_api_mode_for_cache_lookup` (providers-dict row declared with `transport:`, warm cache under the grouped fingerprint) fails — the diagnosis spy shows the regressed call passing `api_mode=None`; `test_native_ollama_discovery_seeds_custom_endpoint_cache` fails — no seed happens on main.
3. `test_seed_custom_endpoint_cache_round_trips` seeds against a temp cache file and asserts a subsequent `cache_only` lookup serves the seeded list.
4. Observed result: a providers-dict Ollama provider with `transport: chat_completions` and a warm cache renders the full cached catalog; the native discovery path persists its list so the next plain picker open resolves it without a live probe.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A