### PR TITLE
fix(desktop): Bot Mode chats no longer paint blank when switching between running bots

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
@@ -62,14 +62,31 @@ describe('resolveStoredSession profile ownership', () => {
   it('treats a profile-less cache hit as unresolved when multiple profiles exist', async () => {
     $sessions.set([session({ id: 's1' })])
     mockGetSession.mockRejectedValueOnce(new Error('404: Session not found'))
+    mockGetSession.mockRejectedValueOnce(new Error('404: Session not found'))
     mockGetSession.mockResolvedValueOnce(session({ id: 's1', profile: 'default' }))
 
     const resolved = await resolveStoredSession('s1')
 
     expect(resolved?.profile).toBe('default')
-    // rung 2 (bare) then rung 3 (stamped cross-profile probe)
+    // rung 2 (bare) then rung 3 (stamped probes: active profile first)
     expect(mockGetSession).toHaveBeenNthCalledWith(1, 's1')
-    expect(mockGetSession).toHaveBeenNthCalledWith(2, 's1', 'default')
+    expect(mockGetSession).toHaveBeenNthCalledWith(2, 's1', 'meta')
+    expect(mockGetSession).toHaveBeenNthCalledWith(3, 's1', 'default')
+  })
+
+  it('probes the ACTIVE profile when the unscoped lookup 404s (hidden Bot Mode chat)', async () => {
+    // A hidden Bot Mode canonical chat is never in the sidebar cache, and the
+    // unscoped GET routes to the PRIMARY backend (404). The owner is the
+    // active profile itself — it must be probed, not skipped.
+    mockGetSession.mockRejectedValueOnce(new Error('404: Session not found'))
+    mockGetSession.mockResolvedValueOnce(session({ id: 's1', message_count: 2 }))
+
+    const resolved = await resolveStoredSession('s1')
+
+    expect(resolved?.profile).toBe('meta')
+    expect(mockGetSession).toHaveBeenNthCalledWith(1, 's1')
+    expect(mockGetSession).toHaveBeenNthCalledWith(2, 's1', 'meta')
+    expect($sessions.get().find(s => s.id === 's1')?.profile).toBe('meta')
   })
 
   it('accepts a profile-less cache hit for single-profile users', async () => {
@@ -96,6 +113,7 @@ describe('resolveStoredSession profile ownership', () => {
     // Per-profile remote override: Electron strips the desktop alias before
     // forwarding, so the standalone backend stamps its backend-local root.
     mockGetSession.mockRejectedValueOnce(new Error('404: Session not found'))
+    mockGetSession.mockRejectedValueOnce(new Error('404: Session not found'))
     mockGetSession.mockResolvedValueOnce(session({ id: 's1', profile: 'default' }))
     $activeGatewayProfile.set('default')
     $profiles.set(profiles('default', 'meta'))
@@ -108,6 +126,7 @@ describe('resolveStoredSession profile ownership', () => {
 
   it('stamps the probed profile on a scoped hit from an older backend that omits it', async () => {
     mockGetSession.mockRejectedValueOnce(new Error('404: Session not found'))
+    mockGetSession.mockRejectedValueOnce(new Error('404: Session not found'))
     mockGetSession.mockResolvedValueOnce(session({ id: 's1' }))
 
     const resolved = await resolveStoredSession('s1')
@@ -118,6 +137,7 @@ describe('resolveStoredSession profile ownership', () => {
   })
 
   it('resolveSessionProfile routes a default-profile session from a non-default gateway', async () => {
+    mockGetSession.mockRejectedValueOnce(new Error('404: Session not found'))
     mockGetSession.mockRejectedValueOnce(new Error('404: Session not found'))
     mockGetSession.mockResolvedValueOnce(session({ id: 's1', profile: 'default' }))
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1326,17 +1326,30 @@ export async function resolveStoredSession(storedSessionId: string): Promise<Ses
     // Not on the active profile — fall through to the cross-profile probe.
   }
 
-  // Multi-profile only: probe each other profile by id (still one cheap lookup
+  // Multi-profile only: probe each profile by id (still one cheap lookup
   // each) rather than pulling every profile's recent sessions. The first hit
   // carries its owning `profile`, which routes the resume to the right backend.
+  //
+  // The ACTIVE profile is probed too, and first. The unscoped rung above does
+  // NOT cover it: Electron routes a profile-less /api/sessions GET to the
+  // PRIMARY backend, not the active gateway's, so a session owned by the
+  // active non-primary profile 404s there. Skipping the active key then left
+  // it as the ONE profile never probed — a hidden Bot Mode chat (never in the
+  // sidebar cache) owned by the focused bot resolved to undefined on every
+  // switch, the transcript prefetch went unscoped to the primary, and the
+  // thread painted empty until an explicitly-profiled row (right-click →
+  // Sessions) seeded the cache.
   const activeKey = normalizeProfileKey($activeGatewayProfile.get())
 
-  const otherProfiles = $profiles
-    .get()
-    .map(profile => normalizeProfileKey(profile.name))
-    .filter(key => key !== activeKey)
+  const probeProfiles = [
+    activeKey,
+    ...$profiles
+      .get()
+      .map(profile => normalizeProfileKey(profile.name))
+      .filter(key => key !== activeKey)
+  ]
 
-  for (const profile of otherProfiles) {
+  for (const profile of probeProfiles) {
     try {
       const session = await getSession(storedSessionId, profile)
 


### PR DESCRIPTION
## Summary
Bot Mode chats no longer paint a blank thread when switching focus between bots — the session resolver now probes the ACTIVE profile, which was the one profile it never checked.

Reported by @tbkbossswaglord on X: with 3 bots running, focusing another bot left the middle pane empty; the only workaround was right-click → Sessions → reopen (and only when the bot had multiple sessions).

Root cause: `resolveStoredSession`'s by-id ladder assumed the unscoped `/api/sessions/{id}` GET covered the active profile, but Electron routes profile-less REST to the PRIMARY backend — so a session owned by the active non-primary profile 404s there, and the cross-profile probe loop explicitly skipped the active key. Hidden Bot Mode canonical chats are never in the sidebar cache, so every focus switch resolved to `undefined`, the transcript prefetch went unscoped to the primary backend, 404'd, and the thread painted empty. Opening via right-click → Sessions seeded the cache with a profile-stamped row, which is exactly why the reporter's workaround worked.

## Changes
- `apps/desktop/src/app/session/hooks/use-session-actions/utils.ts`: probe the active profile first in the by-id resolution ladder instead of skipping it.
- `apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts`: regression test for the hidden-Bot-Mode-chat shape (unscoped 404 → active-profile probe resolves ownership); existing probe-order tests updated for the new sequence.

## Validation
| | Before | After |
|---|---|---|
| Live CDP repro (3 bots, focus-switch mid-turn) | blank thread, "Waking up <bot>…" latched, prefetch 404 on primary | full transcript paints on every switch |
| resolve-stored-session tests | 9 passed | 10 passed (new regression test red on old code) |
| use-prompt-actions utils tests | 54 passed | 54 passed |

Repro was fully headless: built desktop from this branch, seeded 3 bot profiles in a scratch HERMES_HOME, drove real clicks + prompts over CDP, and diffed the painted DOM against each profile's state.db. Console tracing pinned the exact drop point (`resolved profile: undefined` → unscoped prefetch) before the fix; after the fix the trace shows `probe hit on <bot>` and the transcript paints.

## Infographic

Infographic generation unavailable this session (FAL balance exhausted — image_generate returned "User is locked. Exhausted balance."). Will attach on regeneration.
