### PR TITLE
fix(windows): decode schtasks output with locale encoding

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -55,11 +55,15 @@ _GATEWAY_ENV = (("PYTHONIOENCODING", "utf-8"), ("HERMES_GATEWAY_DETACHED", "1"),
 
 
 def _schtasks_encoding() -> str:
-    """Console encoding for ``schtasks.exe`` output: localized Windows emits the OEM/ANSI code page,
-    not UTF-8, and decoding with the wrong codec raised UnicodeDecodeError in subprocess' reader
-    threads. Prefer the locale's preferred encoding, fall back to UTF-8."""
+    """Best-effort console encoding for decoding ``schtasks.exe`` output.
+
+    On localized Windows (e.g. Chinese), ``schtasks`` emits text in the OEM/ANSI
+    code page rather than UTF-8. Decoding with the wrong codec raised
+    ``UnicodeDecodeError`` inside ``subprocess``' reader threads. Use the locale
+    encoding without honoring Python UTF-8 Mode, and fall back to UTF-8.
+    """
     try:
-        return locale.getpreferredencoding(False) or "utf-8"
+        return locale.getencoding() or "utf-8"
     except Exception:
         return "utf-8"
 

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -17,16 +17,29 @@ _BREAKAWAY_MARKER = "_HERMES_GATEWAY_BREAKAWAY"
 
 
 
+def test_schtasks_encoding_ignores_python_utf8_mode(monkeypatch):
+    """Use the Windows locale encoding even when UTF-8 Mode changes the preferred encoding."""
+
+    monkeypatch.setattr(gateway_windows.locale, "getencoding", lambda: "cp932")
+    monkeypatch.setattr(
+        gateway_windows.locale,
+        "getpreferredencoding",
+        lambda *a, **k: "utf-8",
+    )
+
+    assert gateway_windows._schtasks_encoding() == "cp932"
+
+
 def test_schtasks_encoding_falls_back_to_utf8(monkeypatch):
     """A broken/empty locale must not leave us without a decoder (issue #38172)."""
 
-    monkeypatch.setattr(gateway_windows.locale, "getpreferredencoding", lambda *a, **k: "")
+    monkeypatch.setattr(gateway_windows.locale, "getencoding", lambda: "")
     assert gateway_windows._schtasks_encoding() == "utf-8"
 
     def _boom(*args, **kwargs):
         raise RuntimeError("locale exploded")
 
-    monkeypatch.setattr(gateway_windows.locale, "getpreferredencoding", _boom)
+    monkeypatch.setattr(gateway_windows.locale, "getencoding", _boom)
     assert gateway_windows._schtasks_encoding() == "utf-8"
 
 
@@ -362,7 +375,6 @@ def test_gateway_vbs_script_is_console_less(monkeypatch):
 # the gateway's marker-watcher thread to drain + exit cleanly, then escalates
 # to taskkill if drain times out.
 # ---------------------------------------------------------------------------
-
 
 
 


### PR DESCRIPTION
## What does this PR do?

`_schtasks_encoding()` used `locale.getpreferredencoding(False)`, which honors
Python UTF-8 Mode. On localized Windows hosts, that can select UTF-8 while
`schtasks.exe` still emits the system locale code page, silently corrupting
diagnostic output because the subprocess reader uses `errors="replace"`.

This changes the gateway path to `locale.getencoding()`, matching the supported
Python 3.11+ runtime contract and keeping the locale encoding independent of
Python UTF-8 Mode.

## Related Issue

Fixes #89878

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Update `hermes_cli/gateway_windows.py` to use `locale.getencoding()` for
  `schtasks.exe` output.
- Add a regression test proving UTF-8 Mode cannot override the locale encoding.
- Keep the existing UTF-8 fallback for empty or failing locale lookups.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_gateway_windows.py -q`.
2. Run Ruff on the two changed Python files.
3. Run `scripts/check-windows-footguns.py` on the two changed files.

On this Linux host: 6 focused tests passed and 4 native-Windows tests were
skipped; Ruff and the Windows footgun scan passed. Native Windows CP932/GBK
execution was not available locally.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and issues to avoid a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (focused validation only;
  full suite not run)
- [x] I've added tests for my changes
- [ ] I've tested on my platform: native Windows validation remains pending

## Documentation & Housekeeping

- [x] Documentation update is not needed; the behavior is covered by the
  function docstring and regression test.
- [x] Cross-platform impact was considered; native Windows CI remains required.
