### PR TITLE
fix(slack): drop message_changed re-emits whose body is unchanged

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -650,29 +650,50 @@ def _serialize_slack_blocks_for_agent(blocks: list, max_chars: int = 6000) -> st
     return f"[Slack Block Kit payload for this message]\n```json\n{payload}\n```"
 
 
+#: Keys Slack sets on an ``attachments`` entry it generated itself while
+#: unfurling a link (``is_msg_unfurl`` for a message permalink, the source URL
+#: and service name for a website preview). An author or app never sets them.
+_SLACK_GENERATED_ATTACHMENT_KEYS = (
+    "is_msg_unfurl",
+    "from_url",
+    "original_url",
+    "app_unfurl_url",
+    "service_name",
+)
+
+
+def _slack_authored_attachments(attachments: Any) -> list:
+    """Return the attachments an author or app set, dropping Slack's unfurls."""
+    return [
+        att
+        for att in attachments or []
+        if isinstance(att, dict)
+        and not any(att.get(key) for key in _SLACK_GENERATED_ATTACHMENT_KEYS)
+    ]
+
+
 def _slack_message_body_signature(message: dict) -> str:
     """Return the part of a message body the agent is shown, as one value.
 
-    The inbound path builds the agent's text from the flat ``text`` *and* the
-    Block Kit payload, so an update that rewrites a bot card while keeping a
-    static fallback text changes what the agent reads even though ``text``
-    compares equal. Link unfurls are deliberately left out: Slack attaches
-    them to the message on its own, and treating that as a body change would
-    turn its own re-emit into another turn.
+    The inbound path builds the agent's text from the flat ``text``, the Block
+    Kit payload *and* the legacy ``attachments``, so an update that rewrites a
+    bot card while keeping a static fallback text changes what the agent reads
+    even though ``text`` compares equal. Link unfurls are deliberately left
+    out: Slack attaches them to the message on its own, and treating that as a
+    body change would turn its own re-emit into another turn.
     """
     text = str((message or {}).get("text") or "")
     blocks = (message or {}).get("blocks") or []
-    if not blocks:
+    attachments = _slack_authored_attachments((message or {}).get("attachments"))
+    if not blocks and not attachments:
         return text
-    return "\n".join(
-        part
-        for part in (
-            text,
-            _extract_text_from_slack_blocks(blocks),
-            _serialize_slack_blocks_for_agent(blocks),
-        )
-        if part
-    )
+    parts = [text]
+    if blocks:
+        parts.append(_extract_text_from_slack_blocks(blocks))
+        parts.append(_serialize_slack_blocks_for_agent(blocks))
+    if attachments:
+        parts.append(_extract_text_from_slack_attachments(attachments))
+    return "\n".join(part for part in parts if part)
 
 
 def _slack_body_digest(body: str) -> str:
@@ -1014,14 +1035,14 @@ class SlackAdapter(BasePlatformAdapter):
         # produce a second reply. max_size bounds memory, so the long window
         # is safe.
         self._dedup = MessageDeduplicator(ttl_seconds=_slack_dedup_ttl_seconds())
-        # Original Slack message timestamps that were routed into the agent.
-        # Used to avoid duplicate responses when an already-addressed message
-        # is later edited.
+        # Workspace-scoped ids of the Slack messages that were routed into
+        # the agent. Used to avoid duplicate responses when an already-
+        # addressed message is later edited.
         self._processed_message_ts: Dict[str, float] = {}
         self._PROCESSED_MESSAGE_TS_MAX = 5000
-        # Digest of the message body last seen for a message ts, recorded
-        # before any await in _handle_slack_message. Lets the message_changed
-        # branch drop a re-emit whose body is unchanged while
+        # Digest of the message body last seen for a workspace-scoped message
+        # id, recorded before any await in _handle_slack_message. Lets the
+        # message_changed branch drop a re-emit whose body is unchanged while
         # _processed_message_ts above is still unarmed. Only the digest is
         # kept, so a rendered Block Kit payload never stays in memory.
         self._seen_message_body_digest: Dict[str, str] = {}
@@ -1189,15 +1210,17 @@ class SlackAdapter(BasePlatformAdapter):
         for old_ts in sorted(timestamps, key=cls._slack_timestamp_sort_key)[:count]:
             timestamps.discard(old_ts)
 
-    def _remember_message_body(self, ts: str, body: str) -> None:
-        """Record a digest of the body last seen for *ts* (bounded).
+    def _remember_message_body(self, message_key: str, body: str) -> None:
+        """Record a digest of the body last seen for *message_key* (bounded).
 
-        Empty bodies are skipped so that edits to messages carrying only
-        files are never treated as unchanged.
+        *message_key* is workspace-scoped (see ``_workspace_event_id``), since
+        Slack message timestamps are only unique within one workspace. Empty
+        bodies are skipped so that edits to messages carrying only files are
+        never treated as unchanged.
         """
-        if not ts or not body:
+        if not message_key or not body:
             return
-        self._seen_message_body_digest[ts] = _slack_body_digest(body)
+        self._seen_message_body_digest[message_key] = _slack_body_digest(body)
         self._trim_oldest_dict_entries(
             self._seen_message_body_digest, self._SEEN_MESSAGE_BODY_DIGEST_MAX
         )
@@ -5830,17 +5853,32 @@ class SlackAdapter(BasePlatformAdapter):
             if not isinstance(updated_message, dict):
                 return
 
-            original_message_ts = str(updated_message.get("ts") or "")
+            # Normalize the routing fields first: the checks below and the
+            # rest of the method run on this message, so the workspace id
+            # resolved from it is the one the original delivery recorded its
+            # body under.
+            normalized_event = dict(updated_message)
+            for key in ("channel", "channel_type", "team", "team_id"):
+                if not normalized_event.get(key) and event.get(key):
+                    normalized_event[key] = event.get(key)
+
+            original_message_ts = str(normalized_event.get("ts") or "")
+            # Slack message timestamps are unique only within one workspace,
+            # so both guards below look the message up under the same
+            # workspace-scoped id the delivery path records it under.
+            original_message_key = self._workspace_event_id(
+                self._event_team_id(normalized_event, payload), original_message_ts
+            )
             if (
                 original_message_ts
-                and original_message_ts in self._processed_message_ts
+                and original_message_key in self._processed_message_ts
             ):
                 return
-            new_message_body = _slack_message_body_signature(updated_message)
+            new_message_body = _slack_message_body_signature(normalized_event)
             if (
                 original_message_ts
                 and new_message_body
-                and self._seen_message_body_digest.get(original_message_ts)
+                and self._seen_message_body_digest.get(original_message_key)
                 == _slack_body_digest(new_message_body)
             ):
                 # Slack re-dispatches message_changed for its own metadata
@@ -5850,8 +5888,8 @@ class SlackAdapter(BasePlatformAdapter):
                 # neither the guard above nor the dedup below stops it: the
                 # first is armed only after ingress, the second keys on
                 # _slack_changed_event_ts. An edit that changes the body —
-                # including one adding a bot mention, in the text or in the
-                # blocks — still passes.
+                # including one adding a bot mention, in the text, the blocks
+                # or an authored attachment — still passes.
                 logger.info(
                     "[Slack] dropped message_changed with unchanged body "
                     "ts=%s channel=%s",
@@ -5874,10 +5912,6 @@ class SlackAdapter(BasePlatformAdapter):
             if not changed_event_ts and original_message_ts:
                 changed_event_ts = f"{original_message_ts}:changed"
 
-            normalized_event = dict(updated_message)
-            for key in ("channel", "channel_type", "team", "team_id"):
-                if not normalized_event.get(key) and event.get(key):
-                    normalized_event[key] = event.get(key)
             if changed_event_ts:
                 normalized_event["_slack_changed_event_ts"] = changed_event_ts
             event = normalized_event
@@ -5898,18 +5932,22 @@ class SlackAdapter(BasePlatformAdapter):
             logger.info("[Slack] Ignoring message in configured ignored channel %s", channel_id)
             return
 
-        # Baseline for the unchanged-body guard above. Still ahead of the
-        # first await, so a message_changed arriving mid-ingress has
-        # something to compare against, and past the two filters that
-        # precede it — the redelivery dedup and the ignored-channel check —
-        # so neither a replay nor an ignored channel takes a slot. The
-        # sender and content filters below run after this call, so those
-        # bodies are recorded even though the event is then dropped. After
-        # normalization ``event`` is the message body, so a let-through edit
-        # becomes the new baseline.
-        self._remember_message_body(
-            str(event.get("ts") or ""), _slack_message_body_signature(event)
-        )
+        # Baseline for the unchanged-body guard above, under the same
+        # workspace-scoped key that guard reads. Still ahead of the first
+        # await, so a message_changed arriving mid-ingress has something to
+        # compare against, and past the two filters that precede it — the
+        # redelivery dedup and the ignored-channel check — so neither a
+        # replay nor an ignored channel takes a slot. The sender and content
+        # filters below run after this call, so those bodies are recorded
+        # even though the event is then dropped. After normalization
+        # ``event`` is the message body, so a let-through edit becomes the
+        # new baseline.
+        message_body_ts = str(event.get("ts") or "")
+        if message_body_ts:
+            self._remember_message_body(
+                self._workspace_event_id(dedup_team_id, message_body_ts),
+                _slack_message_body_signature(event),
+            )
 
         # Bot/app-authored message filtering (SLACK_ALLOW_BOTS / config
         # allow_bots):
@@ -6943,7 +6981,9 @@ class SlackAdapter(BasePlatformAdapter):
             )
 
         if ts:
-            self._processed_message_ts[ts] = time.time()
+            self._processed_message_ts[
+                self._workspace_event_id(dedup_team_id, ts)
+            ] = time.time()
             if len(self._processed_message_ts) > self._PROCESSED_MESSAGE_TS_MAX:
                 newest_items = sorted(
                     self._processed_message_ts.items(),

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -10,6 +10,7 @@ Uses slack-bolt (Python) with Socket Mode for:
 
 import asyncio
 import contextvars
+import hashlib
 import inspect
 import json
 import logging
@@ -649,6 +650,40 @@ def _serialize_slack_blocks_for_agent(blocks: list, max_chars: int = 6000) -> st
     return f"[Slack Block Kit payload for this message]\n```json\n{payload}\n```"
 
 
+def _slack_message_body_signature(message: dict) -> str:
+    """Return the part of a message body the agent is shown, as one value.
+
+    The inbound path builds the agent's text from the flat ``text`` *and* the
+    Block Kit payload, so an update that rewrites a bot card while keeping a
+    static fallback text changes what the agent reads even though ``text``
+    compares equal. Link unfurls are deliberately left out: Slack attaches
+    them to the message on its own, and treating that as a body change would
+    turn its own re-emit into another turn.
+    """
+    text = str((message or {}).get("text") or "")
+    blocks = (message or {}).get("blocks") or []
+    if not blocks:
+        return text
+    return "\n".join(
+        part
+        for part in (
+            text,
+            _extract_text_from_slack_blocks(blocks),
+            _serialize_slack_blocks_for_agent(blocks),
+        )
+        if part
+    )
+
+
+def _slack_body_digest(body: str) -> str:
+    """Return a fixed-size fingerprint of a rendered message body.
+
+    Encoded with ``surrogatepass`` so an unpaired surrogate in a payload
+    cannot raise.
+    """
+    return hashlib.sha256(body.encode("utf-8", "surrogatepass")).hexdigest()
+
+
 def _extract_urls_from_slack_blocks(blocks: list) -> list[str]:
     """Walk a Block Kit ``blocks`` tree and return URLs found on any element.
 
@@ -984,6 +1019,13 @@ class SlackAdapter(BasePlatformAdapter):
         # is later edited.
         self._processed_message_ts: Dict[str, float] = {}
         self._PROCESSED_MESSAGE_TS_MAX = 5000
+        # Digest of the message body last seen for a message ts, recorded
+        # before any await in _handle_slack_message. Lets the message_changed
+        # branch drop a re-emit whose body is unchanged while
+        # _processed_message_ts above is still unarmed. Only the digest is
+        # kept, so a rendered Block Kit payload never stays in memory.
+        self._seen_message_body_digest: Dict[str, str] = {}
+        self._SEEN_MESSAGE_BODY_DIGEST_MAX = 5000
         # Track pending approval message_ts → resolved flag to prevent
         # double-clicks on approval buttons. Bounded: an approval prompt the
         # user never clicks would otherwise leak its entry forever. Keys may
@@ -1146,6 +1188,19 @@ class SlackAdapter(BasePlatformAdapter):
             return
         for old_ts in sorted(timestamps, key=cls._slack_timestamp_sort_key)[:count]:
             timestamps.discard(old_ts)
+
+    def _remember_message_body(self, ts: str, body: str) -> None:
+        """Record a digest of the body last seen for *ts* (bounded).
+
+        Empty bodies are skipped so that edits to messages carrying only
+        files are never treated as unchanged.
+        """
+        if not ts or not body:
+            return
+        self._seen_message_body_digest[ts] = _slack_body_digest(body)
+        self._trim_oldest_dict_entries(
+            self._seen_message_body_digest, self._SEEN_MESSAGE_BODY_DIGEST_MAX
+        )
 
     def _trim_bot_message_timestamps(self) -> None:
         if len(self._bot_message_ts) <= self._BOT_TS_MAX:
@@ -5781,6 +5836,29 @@ class SlackAdapter(BasePlatformAdapter):
                 and original_message_ts in self._processed_message_ts
             ):
                 return
+            new_message_body = _slack_message_body_signature(updated_message)
+            if (
+                original_message_ts
+                and new_message_body
+                and self._seen_message_body_digest.get(original_message_ts)
+                == _slack_body_digest(new_message_body)
+            ):
+                # Slack re-dispatches message_changed for its own metadata
+                # updates (async language detection, unfurl) with the body
+                # byte-identical, typically while the original message is
+                # still in ingress. Such an event carries nothing new, and
+                # neither the guard above nor the dedup below stops it: the
+                # first is armed only after ingress, the second keys on
+                # _slack_changed_event_ts. An edit that changes the body —
+                # including one adding a bot mention, in the text or in the
+                # blocks — still passes.
+                logger.info(
+                    "[Slack] dropped message_changed with unchanged body "
+                    "ts=%s channel=%s",
+                    original_message_ts,
+                    event.get("channel", ""),
+                )
+                return
             edited = updated_message.get("edited")
             edited_ts = ""
             if isinstance(edited, dict):
@@ -5819,6 +5897,19 @@ class SlackAdapter(BasePlatformAdapter):
         if self._is_ignored_channel(channel_id):
             logger.info("[Slack] Ignoring message in configured ignored channel %s", channel_id)
             return
+
+        # Baseline for the unchanged-body guard above. Still ahead of the
+        # first await, so a message_changed arriving mid-ingress has
+        # something to compare against, and past the two filters that
+        # precede it — the redelivery dedup and the ignored-channel check —
+        # so neither a replay nor an ignored channel takes a slot. The
+        # sender and content filters below run after this call, so those
+        # bodies are recorded even though the event is then dropped. After
+        # normalization ``event`` is the message body, so a let-through edit
+        # becomes the new baseline.
+        self._remember_message_body(
+            str(event.get("ts") or ""), _slack_message_body_signature(event)
+        )
 
         # Bot/app-authored message filtering (SLACK_ALLOW_BOTS / config
         # allow_bots):

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2181,6 +2181,190 @@ class TestMessageRouting:
         assert adapter.handle_message.await_count == 2
 
     @pytest.mark.asyncio
+    async def test_attachment_only_update_during_ingress_still_routes(self, adapter):
+        """Authored attachments reach the agent, so a change in them counts."""
+        gate = _IngressGate(adapter)
+        loop = asyncio.get_event_loop()
+
+        fallback_text = "<@U_BOT> deploy status"
+
+        def _card(status: str) -> list:
+            return [{"title": "Deploy", "text": status}]
+
+        original = loop.create_task(
+            adapter._handle_slack_message(
+                {
+                    "text": fallback_text,
+                    "attachments": _card("step 1 running"),
+                    "user": "U_USER",
+                    "channel": "C123",
+                    "channel_type": "channel",
+                    "team": "T123",
+                    "ts": "1234567890.000001",
+                }
+            )
+        )
+        await asyncio.wait_for(gate.entry.wait(), 5)
+
+        update = loop.create_task(
+            adapter._handle_slack_message(
+                {
+                    "subtype": "message_changed",
+                    "channel": "C123",
+                    "channel_type": "channel",
+                    "team": "T123",
+                    "ts": "1234567891.000000",
+                    "event_ts": "1234567891.000000",
+                    "message": {
+                        "text": fallback_text,
+                        "attachments": _card("step 2 failed"),
+                        "user": "U_USER",
+                        "channel": "C123",
+                        "ts": "1234567890.000001",
+                    },
+                }
+            )
+        )
+        # The changed attachment passes the guard, so this one ingresses.
+        await asyncio.wait_for(gate.second_entry.wait(), 5)
+
+        gate.release()
+        await asyncio.wait_for(asyncio.gather(original, update), 5)
+
+        assert adapter.handle_message.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_link_unfurl_during_ingress_routes_once(self, adapter):
+        """A Slack-generated unfurl is not a body change: still one turn."""
+        gate = _IngressGate(adapter)
+        loop = asyncio.get_event_loop()
+
+        body = {
+            "text": "<@U_BOT> see https://example.com/report",
+            "user": "U_USER",
+            "channel": "C123",
+            "ts": "1234567890.000001",
+        }
+
+        original = loop.create_task(
+            adapter._handle_slack_message(
+                {**body, "channel_type": "channel", "team": "T123"}
+            )
+        )
+        await asyncio.wait_for(gate.entry.wait(), 5)
+
+        reemit = loop.create_task(
+            adapter._handle_slack_message(
+                {
+                    "subtype": "message_changed",
+                    "channel": "C123",
+                    "channel_type": "channel",
+                    "team": "T123",
+                    "ts": "1234567891.000000",
+                    "event_ts": "1234567891.000000",
+                    "message": {
+                        **body,
+                        "attachments": [
+                            {
+                                "title": "Report",
+                                "text": "preview body",
+                                "from_url": "https://example.com/report",
+                                "original_url": "https://example.com/report",
+                                "service_name": "example.com",
+                            }
+                        ],
+                    },
+                }
+            )
+        )
+        try:
+            await asyncio.wait_for(reemit, 5)
+        except asyncio.TimeoutError:
+            pytest.fail("the unfurl re-emit entered the ingress instead of being dropped")
+        assert not gate.second_entry.is_set()
+
+        gate.release()
+        await asyncio.wait_for(original, 5)
+
+        adapter.handle_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_same_ts_in_another_workspace_still_routes(self, adapter):
+        """Slack ts values are workspace-local, so both guards are scoped.
+
+        Covers the body baseline, read while the original is still in
+        ingress, and the delivered-message registry, read once it is done.
+        """
+        gate = _IngressGate(adapter)
+        loop = asyncio.get_event_loop()
+
+        body = {
+            "text": "<@U_BOT> check the gateway logs",
+            "user": "U_USER",
+            "channel": "C123",
+            "ts": "1234567890.000001",
+        }
+
+        original = loop.create_task(
+            adapter._handle_slack_message(
+                {**body, "channel_type": "channel", "team": "T123"}
+            )
+        )
+        await asyncio.wait_for(gate.entry.wait(), 5)
+
+        # Same ts and same body, other workspace — a different message.
+        other_workspace = loop.create_task(
+            adapter._handle_slack_message(
+                {
+                    "subtype": "message_changed",
+                    "channel": "C999",
+                    "channel_type": "channel",
+                    "team": "T999",
+                    "ts": "1234567891.000000",
+                    "event_ts": "1234567891.000000",
+                    "message": dict(body, channel="C999"),
+                }
+            )
+        )
+        await asyncio.wait_for(gate.second_entry.wait(), 5)
+
+        gate.release()
+        await asyncio.wait_for(asyncio.gather(original, other_workspace), 5)
+
+        assert adapter.handle_message.await_count == 2
+
+        edit = dict(body, text="<@U_BOT> and the agent log too")
+        # Delivered now, so the registry drops a later edit of the original.
+        await adapter._handle_slack_message(
+            {
+                "subtype": "message_changed",
+                "channel": "C123",
+                "channel_type": "channel",
+                "team": "T123",
+                "ts": "1234567892.000000",
+                "event_ts": "1234567892.000000",
+                "message": edit,
+            }
+        )
+
+        assert adapter.handle_message.await_count == 2
+
+        # A third workspace reusing that ts is a different message, though.
+        await adapter._handle_slack_message(
+            {
+                "subtype": "message_changed",
+                "channel": "C777",
+                "channel_type": "channel",
+                "team": "T777",
+                "ts": "1234567892.000000",
+                "event_ts": "1234567892.000000",
+                "message": dict(edit, channel="C777"),
+            }
+        )
+
+        assert adapter.handle_message.await_count == 3
+
+    @pytest.mark.asyncio
     async def test_ignored_channel_body_is_not_remembered(self, adapter):
         """The baseline is not recorded for a channel the adapter ignores."""
         adapter.config.extra = {"ignored_channels": ["C_IGN"]}

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1834,6 +1834,38 @@ class TestIncomingAudioHandling:
 # ---------------------------------------------------------------------------
 
 
+class _IngressGate:
+    """Holds ``users.info`` open so a second event races an in-flight ingress.
+
+    ``entry`` fires when a handler reaches the ingress, ``second_entry`` when
+    another one does; :meth:`release` lets them all finish.
+    """
+
+    def __init__(self, adapter):
+        self.entry = asyncio.Event()
+        self.second_entry = asyncio.Event()
+        self._release = asyncio.Event()
+        self._entered = 0
+        adapter._app.client.users_info = AsyncMock(side_effect=self._users_info)
+
+    async def _users_info(self, *_args, **_kwargs):
+        self._entered += 1
+        if self._entered >= 2:
+            self.second_entry.set()
+        self.entry.set()
+        await self._release.wait()
+        return {
+            "user": {
+                "is_bot": False,
+                "profile": {"display_name": "Test User"},
+                "real_name": "Test User",
+            }
+        }
+
+    def release(self) -> None:
+        self._release.set()
+
+
 class TestMessageRouting:
     @pytest.mark.asyncio
     async def test_dm_processed_without_mention(self, adapter):
@@ -1966,6 +1998,206 @@ class TestMessageRouting:
         msg_event = adapter.handle_message.call_args[0][0]
         assert msg_event.text == "whats the rapchat summary for last 12 hours"
         assert msg_event.message_id == "1234567890.000001"
+
+    @pytest.mark.parametrize("with_blocks", [False, True])
+    @pytest.mark.asyncio
+    async def test_metadata_only_edit_during_ingress_routes_once(
+        self, adapter, with_blocks
+    ):
+        """A metadata-only message_changed must not become a second turn.
+
+        Slack re-dispatches it with the body untouched while the original is
+        still in ingress, i.e. before ``_processed_message_ts`` is armed and
+        with a dedup key of its own. Runs with and without the ``rich_text``
+        blocks a composed message carries, since they feed the compared body.
+        """
+        gate = _IngressGate(adapter)
+        loop = asyncio.get_event_loop()
+
+        text = "<@U_BOT> check the gateway logs"
+        body: dict = {
+            "text": text,
+            "user": "U_USER",
+            "channel": "C123",
+            "ts": "1234567890.000001",
+        }
+        if with_blocks:
+            body["blocks"] = [
+                {
+                    "type": "rich_text",
+                    "elements": [
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                {"type": "user", "user_id": "U_BOT"},
+                                {"type": "text", "text": " check the gateway logs"},
+                            ],
+                        }
+                    ],
+                }
+            ]
+
+        original = loop.create_task(
+            adapter._handle_slack_message(
+                {
+                    **body,
+                    "channel_type": "channel",
+                    "team": "T123",
+                }
+            )
+        )
+        await asyncio.wait_for(gate.entry.wait(), 5)
+
+        # Same body, new event ts, no ``edited`` marker. Runs as its own task
+        # because unguarded it blocks in the ingress instead of returning.
+        reemit = loop.create_task(
+            adapter._handle_slack_message(
+                {
+                    "subtype": "message_changed",
+                    "channel": "C123",
+                    "channel_type": "channel",
+                    "team": "T123",
+                    "ts": "1234567891.000000",
+                    "event_ts": "1234567891.000000",
+                    "message": dict(body),
+                }
+            )
+        )
+        # The guard drops it, so it returns instead of reaching the ingress.
+        try:
+            await asyncio.wait_for(reemit, 5)
+        except asyncio.TimeoutError:
+            pytest.fail("the re-emit entered the ingress instead of being dropped")
+        assert not gate.second_entry.is_set()
+
+        gate.release()
+        await asyncio.wait_for(original, 5)
+
+        adapter.handle_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_real_edit_during_ingress_still_routes(self, adapter):
+        """The guard keys on the body, so a genuine edit is not swallowed."""
+        gate = _IngressGate(adapter)
+        loop = asyncio.get_event_loop()
+
+        original = loop.create_task(
+            adapter._handle_slack_message(
+                {
+                    "text": "<@U_BOT> check the gateway logs",
+                    "user": "U_USER",
+                    "channel": "C123",
+                    "channel_type": "channel",
+                    "team": "T123",
+                    "ts": "1234567890.000001",
+                }
+            )
+        )
+        await asyncio.wait_for(gate.entry.wait(), 5)
+
+        edit = loop.create_task(
+            adapter._handle_slack_message(
+                {
+                    "subtype": "message_changed",
+                    "channel": "C123",
+                    "channel_type": "channel",
+                    "team": "T123",
+                    "ts": "1234567891.000000",
+                    "event_ts": "1234567891.000000",
+                    "message": {
+                        "text": "<@U_BOT> check the agent logs instead",
+                        "user": "U_USER",
+                        "channel": "C123",
+                        "ts": "1234567890.000001",
+                        "edited": {"user": "U_USER", "ts": "1234567891.000000"},
+                    },
+                }
+            )
+        )
+        # Past the unchanged-body guard, both handlers now block on users.info.
+        await asyncio.wait_for(gate.second_entry.wait(), 5)
+
+        gate.release()
+        await asyncio.wait_for(asyncio.gather(original, edit), 5)
+
+        assert adapter.handle_message.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_block_only_update_during_ingress_still_routes(self, adapter):
+        """Blocks reach the agent too, so a static fallback text is not enough."""
+        gate = _IngressGate(adapter)
+        loop = asyncio.get_event_loop()
+
+        fallback_text = "<@U_BOT> deploy status"
+
+        def _card(step: str) -> list:
+            return [
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": step},
+                }
+            ]
+
+        original = loop.create_task(
+            adapter._handle_slack_message(
+                {
+                    "text": fallback_text,
+                    "blocks": _card("step 1 running"),
+                    "user": "U_USER",
+                    "channel": "C123",
+                    "channel_type": "channel",
+                    "team": "T123",
+                    "ts": "1234567890.000001",
+                }
+            )
+        )
+        await asyncio.wait_for(gate.entry.wait(), 5)
+
+        update = loop.create_task(
+            adapter._handle_slack_message(
+                {
+                    "subtype": "message_changed",
+                    "channel": "C123",
+                    "channel_type": "channel",
+                    "team": "T123",
+                    "ts": "1234567891.000000",
+                    "event_ts": "1234567891.000000",
+                    "message": {
+                        "text": fallback_text,
+                        "blocks": _card("step 2 failed"),
+                        "user": "U_USER",
+                        "channel": "C123",
+                        "ts": "1234567890.000001",
+                    },
+                }
+            )
+        )
+        # The changed blocks pass the guard, so this one reaches the ingress.
+        await asyncio.wait_for(gate.second_entry.wait(), 5)
+
+        gate.release()
+        await asyncio.wait_for(asyncio.gather(original, update), 5)
+
+        assert adapter.handle_message.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_ignored_channel_body_is_not_remembered(self, adapter):
+        """The baseline is not recorded for a channel the adapter ignores."""
+        adapter.config.extra = {"ignored_channels": ["C_IGN"]}
+
+        await adapter._handle_slack_message(
+            {
+                "text": "<@U_BOT> check the gateway logs",
+                "user": "U_USER",
+                "channel": "C_IGN",
+                "channel_type": "channel",
+                "team": "T123",
+                "ts": "1234567890.000001",
+            }
+        )
+
+        adapter.handle_message.assert_not_awaited()
+        assert adapter._seen_message_body_digest == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -78,6 +78,10 @@ def _make_adapter(require_mention=None, strict_mention=None, free_response_chann
     adapter.config = PlatformConfig(enabled=True, extra=extra)
     adapter._bot_user_id = BOT_USER_ID
     adapter._team_bot_user_ids = {}
+    # Written in _handle_slack_message for the unchanged-body
+    # message_changed guard.
+    adapter._seen_message_body_digest = {}
+    adapter._SEEN_MESSAGE_BODY_DIGEST_MAX = 5000
     return adapter
 
 


### PR DESCRIPTION
## What does this PR do?

Stops Slack from turning **one** user message into **two** agent turns.

Slack re-dispatches `message_changed` for updates it makes to a message *on its own*, with the body byte-identical and nobody having touched the message. This is documented behavior: "This event can also sometimes be triggered by our automatic language detection, which can add or update language or locale information to the metadata for the message, prompting the event to be dispatched" ([`message_changed` reference](https://docs.slack.dev/reference/events/message/message_changed)). The re-emit arrives about a second after the original — while the original is still being ingested.

Neither barrier in `_handle_slack_message()` stops it:

- The `_processed_message_ts` guard at the top of the `message_changed` branch is armed only at the **very end** of the method, after `users.info`, thread-context hydration and attachment downloads. That leg takes 0.2–2s, and the re-emit lands inside it, so the guard sees an empty map and lets the event through.
- The redelivery dedup below it keys this event under the synthetic `_slack_changed_event_ts`, not under the message ts — deliberately, otherwise an edit that adds a bot mention would be swallowed. So it does not match the original delivery either.

The event is then normalized into a plain message and handed to the gateway a second time. The gateway parks it as a follow-up and drains it as a brand-new turn: a second identical answer to the user, a second full API call, and a duplicated user turn in the transcript.

**Evidence from a production workspace** (one gateway session, five days of `gateway.log` plus the session DB):

- 319 distinct message ts reached the gateway; **40 of them reached it twice** (12.5%), and all 40 went on through `queued follow-up (FIFO)` → `Draining queued follow-up … as a new turn`. One inbound message, two turns, every time.
- The arithmetic of the events is always the same: `message` + optional `app_mention` (suppressed by the dedup — same ts, same key) + `message_changed` (a different key — the one that gets through). If a proxy or a second listener were duplicating traffic, the `app_mention` twin would be dropped twice; it never is.
- 33 of the 40 second copies entered the handler while the first copy was still in ingress.
- Of 127 `message_changed` events in that window, 108 arrived less than 2s after the original (median 0.8s) — machine speed, no human involved. The only three that arrived minutes later (172s, 417s, 417s) were genuine edits.
- Every duplicated pair compared byte-identical, text and blocks.
- The re-emit correlates with message **length** (79% of re-emitted messages were long, against 10% at baseline) and not with links (9% vs 5%) or with mentioning the bot (50% vs 48%) — the signature of language detection, not of an unfurl and not of anything the app itself does.

Because the body is always identical, the fix does not have to reason about timing at all: record a digest of the rendered body before the first `await`, and drop a `message_changed` whose body is unchanged. An edit that genuinely changes the body — including one that adds a bot mention, in the text, the blocks or an authored attachment — passes this new guard, so the edited-in-mention behavior is untouched. (To be precise about the scope: once the original has finished ingress, the pre-existing `_processed_message_ts` guard from `49497bcddb` still drops every `message_changed` for it, edits included. That behavior is on `main` today and this PR does not change it — see Notes.)

## Related Issue

No linked issue — diagnosed from production logs, mechanism confirmed against the Slack documentation above. The same trigger has bitten other Slack integrations: n8n issue 23782 describes Slack's asynchronous locale enrichment re-triggering a bot reply for a message nobody edited.

Adjacent open PRs, complementary rather than overlapping:

- #83501 (*ignore metadata-only parent updates*) and #73450 (*prevent thread parent edit replays*) classify **hidden thread-parent** `message_changed` events by comparing the event's own `previous_message` snapshot, and target replay after a restart. This PR is about the message the process is ingesting **right now**: it compares against the body this process actually saw, needs no `previous_message` (Slack's metadata re-emit does not have to carry a usable one), and closes the in-flight race those PRs do not touch. The guards are independent and compose — if both land, an unchanged body is simply dropped one check earlier.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/slack/adapter.py`: new `_slack_message_body_signature(message)` — the part of a message body the agent is actually shown, as one value: the flat `text` plus the same renderings the inbound path uses for blocks (`_extract_text_from_slack_blocks`, `_serialize_slack_blocks_for_agent`) and for the legacy `attachments` (`_extract_text_from_slack_attachments`). Keying on `text` alone would silently drop a `chat.update` that rewrites a bot card while keeping a static fallback text, which under `allow_bots=all` is real content.
- `plugins/platforms/slack/adapter.py`: new `_slack_authored_attachments(attachments)` — only the attachments an author or an app set take part in the signature. The ones Slack generates itself while unfurling a link are recognised by the keys only it sets (`_SLACK_GENERATED_ATTACHMENT_KEYS`: `is_msg_unfurl`, `from_url`, `original_url`, `app_unfurl_url`, `service_name`) and are deliberately left out: Slack attaches them on its own, so counting them as a body change would hand its own re-emit a turn — exactly the bug being fixed.
- `plugins/platforms/slack/adapter.py`: new `_slack_body_digest(body)` (SHA-256, `surrogatepass` so an unpaired surrogate in a payload cannot raise) and the bounded `self._seen_message_body_digest` map (`_SEEN_MESSAGE_BODY_DIGEST_MAX = 5000`, evicted oldest-first through the existing `_trim_oldest_dict_entries`). Only the digest is stored — a rendered Block Kit payload can be 6 KB and never needs to stay in memory.
- `plugins/platforms/slack/adapter.py`: `_remember_message_body(message_key, body)` is called in `_handle_slack_message()` **before the first `await`**, which is the whole point — that is why a baseline exists while `_processed_message_ts` is still unarmed. It sits below the two synchronous filters that precede it (the redelivery dedup and the ignored-channel check), so neither a replay nor an ignored channel takes a slot. An empty body is never recorded, so a message carrying only files is never mistaken for "unchanged".
- `plugins/platforms/slack/adapter.py`: both maps are keyed by `_workspace_event_id(team_id, ts)`, not by the bare Slack `ts` — a timestamp identifies a message only within one workspace, and the adapter already scopes its other markers that way. This covers `_seen_message_body_digest` and, on the same key, the pre-existing `_processed_message_ts` registry, on read and on write; the `message_changed` branch normalizes the routing fields before either guard so the id it resolves is the one the delivery path recorded under.
- `plugins/platforms/slack/adapter.py`: the `message_changed` branch gains a second guard — when the body digest matches the one recorded for that message, the event is dropped with one INFO line (`[Slack] dropped message_changed with unchanged body ts=… channel=…`), so a future duplicate report can be told apart from this class by the presence or absence of that line.
- `tests/gateway/test_slack.py`: seven new tests around a shared `_IngressGate` helper that holds `users.info` open so the second event genuinely races an in-flight ingress (`asyncio.Event`-driven, no polling). `test_metadata_only_edit_during_ingress_routes_once` (parametrized with and without the `rich_text` blocks a composed message really carries) and `test_link_unfurl_during_ingress_routes_once` assert a single `handle_message`; `test_real_edit_during_ingress_still_routes`, `test_block_only_update_during_ingress_still_routes` and `test_attachment_only_update_during_ingress_still_routes` assert two, for a changed text, changed blocks and a changed authored card under a static fallback text; `test_same_ts_in_another_workspace_still_routes` covers the same inner `ts` in another workspace against both maps — while the original is still in ingress and after it has been delivered; `test_ignored_channel_body_is_not_remembered` asserts the baseline is not recorded for an ignored channel.
- `tests/gateway/test_slack_mention.py`: the hand-built adapter stub gains the two new attributes.

No config key, no env var, no schema change, and nothing in `gateway/` — no other platform's behavior moves.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_slack.py tests/gateway/test_slack_mention.py` — **200 passed, 0 failed** on this branch.
2. Mutation check that the tests bind to the fix and not to timing: make the digest comparison never match (`== "mutation-never-matches"`) and both parametrizations of `test_metadata_only_edit_during_ingress_routes_once` fail with `the re-emit entered the ingress instead of being dropped`; restore it and they pass. The tests asserting two turns stay green either way, which is the point — they prove the guard does not swallow real changes. Two more mutations pin the other half: drop `attachments` back out of the signature and `test_attachment_only_update_during_ingress_still_routes` fails; unscope either the read or the write of `_processed_message_ts` and `test_same_ts_in_another_workspace_still_routes` fails.
3. Live reproduction, no code changes needed: from a workspace whose locale differs from the language being typed, send a longer message that @mentions the bot where the adapter's ingress is slow (thread context, an attachment). On `main`, `gateway.log` shows two `delivering event to gateway` lines with the same `ts`, a queued follow-up drained as a new turn, and the user gets two identical answers. On this branch the second event ends at `dropped message_changed with unchanged body` and there is exactly one turn.
4. The behavior this must not break: edit a message the bot ignored so that it now @mentions the bot — the bot still answers exactly once (`test_message_edit_with_new_mention_processed`, unchanged, plus `test_real_edit_during_ingress_still_routes` for the racing variant).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — the closest are #83501 and #73450, compared above; neither guards the in-ingress race
- [x] My PR contains **only** changes related to this fix (three files, two commits — the fix and the review follow-up — branched off `main`)
- [x] I've run `pytest tests/` for the affected area and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no user-facing setting or documented behavior changes; the reasoning lives in the new helpers' docstrings
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure Python, no platform-specific paths or primitives
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Notes

Deliberately out of scope, to keep the change on the confirmed mechanism:

- No barrier in the gateway (`_queue_or_replace_pending_event`). A cross-platform "this message_id is already the running turn" guard would cover more, but it drops inbound messages on a key the platforms do not all populate the same way — a worse failure than a duplicate if the key is wrong.
- No symmetric guard on plain `message` events: `_processed_message_ts` is already armed before `handle_message()` on that path, and a body-equality drop there could suppress a legitimate re-delivery.
- The pre-existing `_processed_message_ts` short circuit is left as it is. It drops every `message_changed` for a message that has finished ingress, genuine edits included — behavior introduced with the `message_changed` branch itself in `49497bcddb` and live on `main`. Replacing it with a content/revision decision would make every later edit a new agent turn, which is a behavioral change for the edit flow rather than a fix for the duplicate-turn bug.
- Identity is scoped to workspace + message ts, not workspace + channel + ts. A Slack `ts` is already unique inside a workspace, and `channel` is not carried on every `message_changed` shape the adapter accepts, so adding it buys no discrimination and adds a way to miss the lookup and let a duplicate through.
- The baseline is arrival-ordered, not revision-ordered: if a `message_changed` is delivered before the original (reconnect replay), it records the edited body and the original then overwrites it. Both events already produce a turn on `main` in that ordering, so this is not a regression; closing it needs a stored Slack revision (`edited.ts`) and a version comparison, which is more machinery than the confirmed mechanism justifies.
- Trade-off worth naming: when Slack sends `message_changed` *only* to attach a link unfurl, the agent no longer sees that preview — by design, since the alternative is an entire extra turn per link. The URL itself is still in the message text and can be fetched.

