### PR TITLE
fix(skills): Desktop hub Uninstall works — uninstall accepts --yes (#84662, salvage #55465)

### DIFF
--- a/contributors/emails/opsdownn@gmail.com
+++ b/contributors/emails/opsdownn@gmail.com
@@ -1,0 +1,1 @@
+noahingh

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1835,7 +1835,7 @@ def skills_command(args) -> None:
         do_audit(name=getattr(args, "name", None),
                  deep=getattr(args, "deep", False))
     elif action == "uninstall":
-        do_uninstall(args.name)
+        do_uninstall(args.name, skip_confirm=getattr(args, "yes", False))
     elif action == "reset":
         do_reset(args.name, restore=getattr(args, "restore", False),
                  skip_confirm=getattr(args, "yes", False))

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -182,6 +182,12 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
         "uninstall", help="Remove a hub-installed skill"
     )
     skills_uninstall.add_argument("name", help="Skill name to remove")
+    skills_uninstall.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        help="Skip confirmation prompt",
+    )
 
     skills_reset = skills_subparsers.add_parser(
         "reset",

--- a/tests/hermes_cli/test_skills_uninstall_flags.py
+++ b/tests/hermes_cli/test_skills_uninstall_flags.py
@@ -1,0 +1,58 @@
+"""
+Tests for --yes / -y flag in `hermes skills uninstall` CLI subcommand.
+
+Verifies the parser registers the flag and the value reaches
+``do_uninstall(skip_confirm=True)`` through the real ``skills_command``
+dispatch path (mirrors ``test_skills_install_flags.py``).
+"""
+
+import sys
+
+
+def _run_uninstall_cli(monkeypatch, argv):
+    captured = {}
+
+    def fake_do_uninstall(name, *, skip_confirm=False, **kwargs):
+        captured["name"] = name
+        captured["skip_confirm"] = skip_confirm
+
+    monkeypatch.setattr("hermes_cli.skills_hub.do_uninstall", fake_do_uninstall)
+    monkeypatch.setattr(sys, "argv", argv)
+
+    from hermes_cli.main import main
+
+    main()
+    return captured
+
+
+def test_cli_skills_uninstall_yes_sets_skip_confirm(monkeypatch):
+    """`--yes` should propagate to do_uninstall(skip_confirm=True)."""
+    captured = _run_uninstall_cli(
+        monkeypatch,
+        ["hermes", "skills", "uninstall", "test-skill", "--yes"],
+    )
+
+    assert captured["name"] == "test-skill"
+    assert captured["skip_confirm"] is True
+
+
+def test_cli_skills_uninstall_y_alias_sets_skip_confirm(monkeypatch):
+    """`-y` should behave the same as `--yes`."""
+    captured = _run_uninstall_cli(
+        monkeypatch,
+        ["hermes", "skills", "uninstall", "test-skill", "-y"],
+    )
+
+    assert captured["name"] == "test-skill"
+    assert captured["skip_confirm"] is True
+
+
+def test_cli_skills_uninstall_no_flags_keeps_prompt(monkeypatch):
+    """Without --yes, skip_confirm must be False (prompt preserved)."""
+    captured = _run_uninstall_cli(
+        monkeypatch,
+        ["hermes", "skills", "uninstall", "test-skill"],
+    )
+
+    assert captured["name"] == "test-skill"
+    assert captured["skip_confirm"] is False


### PR DESCRIPTION
## Summary
`hermes skills uninstall` now accepts `--yes/-y`, so the Desktop skill hub's Uninstall button works — the spawned `hermes skills uninstall <name> --yes` no longer dies on argparse exit 2. Fixes #84662.

Salvage of #55465 by @noahingh (earliest fix, Jun 30) with authorship preserved; #84770 by @webtecnica is the same fix submitted later.

Root cause: `web_routers/skills.py` spawns `skills uninstall <name> --yes`, but the parser never registered the flag → `unrecognized arguments: --yes`, exit 2, nothing uninstalled. (Even without the flag it could never work non-interactively: `do_uninstall`'s `input()` on DEVNULL EOFs → "Cancelled".) Pre-#89847 this failure was also invisible; now it would at least toast — this makes the toast unnecessary.

## Changes
- `hermes_cli/subcommands/skills.py`: `--yes/-y` on the uninstall parser
- `hermes_cli/skills_hub.py`: dispatch passes `skip_confirm=getattr(args, "yes", False)`
- `tests/hermes_cli/test_skills_uninstall_flags.py`: parser + dispatch regression tests (contributor's)

## Validation
| Check | Result |
|---|---|
| Exact desktop argv `skills uninstall ascii-art --yes` | parses; `do_uninstall(skip_confirm=True)` reached (real-import E2E) |
| Without `--yes` | `skip_confirm=False` — interactive prompt preserved |
| `test_skills_uninstall_flags.py` + `test_skills_skip_confirm.py` | 8/8 |

## Infographic

Not embedded: FAL image generation is currently unavailable (account balance exhausted). Will be added via `gh pr edit` once generation is restored.
