### PR TITLE
feat(desktop): true separation by gateway in the sidebar, profile rail and Manage Profiles

### DIFF
--- a/apps/desktop/src/api/profiles.ts
+++ b/apps/desktop/src/api/profiles.ts
@@ -8,44 +8,80 @@ import type {
 
 import { hermesApi, STARTUP_REQUEST_TIMEOUT_MS } from './client'
 
-export function getProfiles(): Promise<ProfilesResponse> {
+
+/** Explicit connection override for the profile-admin endpoints.
+ *
+ *  Every other helper is AMBIENT: `hermesApi` spreads `connectionScoped()`, so a
+ *  request follows whichever gateway is live. That is right for these too — the
+ *  Profiles panel of a window pointed at one machine should describe that
+ *  machine.
+ *
+ *  Manage Profiles is the exception: it lists EVERY registered gateway at once,
+ *  so each row has to address the box it came from rather than the one that
+ *  happens to be live. Passing the id overrides the ambient scope for that one
+ *  call; passing nothing keeps the byte-identical ambient request every other
+ *  caller makes. */
+function profileAdminScope(connectionId?: null | string): { connectionId?: string } {
+  const id = (connectionId ?? '').trim()
+
+  return id ? { connectionId: id } : {}
+}
+
+export function getProfiles(connectionId?: null | string): Promise<ProfilesResponse> {
   return hermesApi<ProfilesResponse>({
+    ...profileAdminScope(connectionId),
     path: '/api/profiles',
     timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
   })
 }
 
-export function createProfile(body: ProfileCreatePayload): Promise<{ name: string; ok: boolean; path: string }> {
+export function createProfile(
+  body: ProfileCreatePayload,
+  connectionId?: null | string
+): Promise<{ name: string; ok: boolean; path: string }> {
   return hermesApi<{ name: string; ok: boolean; path: string }>({
+    ...profileAdminScope(connectionId),
     path: '/api/profiles',
     method: 'POST',
     body
   })
 }
 
-export function renameProfile(name: string, newName: string): Promise<{ name: string; ok: boolean; path: string }> {
+export function renameProfile(
+  name: string,
+  newName: string,
+  connectionId?: null | string
+): Promise<{ name: string; ok: boolean; path: string }> {
   return hermesApi<{ name: string; ok: boolean; path: string }>({
+    ...profileAdminScope(connectionId),
     path: `/api/profiles/${encodeURIComponent(name)}`,
     method: 'PATCH',
     body: { new_name: newName }
   })
 }
 
-export function deleteProfile(name: string): Promise<{ ok: boolean; path: string }> {
+export function deleteProfile(name: string, connectionId?: null | string): Promise<{ ok: boolean; path: string }> {
   return hermesApi<{ ok: boolean; path: string }>({
+    ...profileAdminScope(connectionId),
     path: `/api/profiles/${encodeURIComponent(name)}`,
     method: 'DELETE'
   })
 }
 
-export function getProfileSoul(name: string): Promise<ProfileSoul> {
+export function getProfileSoul(name: string, connectionId?: null | string): Promise<ProfileSoul> {
   return hermesApi<ProfileSoul>({
+    ...profileAdminScope(connectionId),
     path: `/api/profiles/${encodeURIComponent(name)}/soul`
   })
 }
 
-export function updateProfileSoul(name: string, content: string): Promise<{ ok: boolean }> {
+export function updateProfileSoul(
+  name: string,
+  content: string,
+  connectionId?: null | string
+): Promise<{ ok: boolean }> {
   return hermesApi<{ ok: boolean }>({
+    ...profileAdminScope(connectionId),
     path: `/api/profiles/${encodeURIComponent(name)}/soul`,
     method: 'PUT',
     body: { content }

--- a/apps/desktop/src/app/chat/gateway-tag.tsx
+++ b/apps/desktop/src/app/chat/gateway-tag.tsx
@@ -1,0 +1,52 @@
+import { useStore } from '@nanostores/react'
+
+import { Tip } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import { $connectionLabels, $multiGateway, $primaryConnectionId } from '@/store/gateway-separation'
+
+/** Owning-gateway chip.
+ *
+ *  Two machines can each serve a profile called `default`, and upstream draws
+ *  both as bare rows, so a Dell session is indistinguishable from an HP one.
+ *  This chip names the machine a row came from. It renders only when more than
+ *  one connection is registered, so single-gateway sidebars are untouched. */
+export function GatewayTag({
+  className,
+  connectionId
+}: {
+  className?: string
+  connectionId: null | string | undefined
+}) {
+  const multi = useStore($multiGateway)
+  const labels = useStore($connectionLabels)
+  const primary = useStore($primaryConnectionId)
+  const id = (connectionId || '').trim() || primary
+  const label = labels[id]
+
+  if (!multi || !label) {
+    return null
+  }
+
+  // Long device names would eat the row, so the chip shows a short form and the
+  // tooltip carries the full name. Prefer a trailing parenthetical, because
+  // that is usually where the DISCRIMINATOR lives: "Mecha Hermes (HP)" and
+  // "MechaHome Hermes (Dell)" are near-identical until you reach the bracket.
+  const bracket = /\(([^)]{1,12})\)\s*$/.exec(label)
+  const short = bracket ? bracket[1].trim() : label
+
+  return (
+    <Tip label={label}>
+      <span
+        aria-label={label}
+        className={cn(
+          'shrink-0 rounded px-1 py-px text-[10px] leading-none font-medium',
+          'bg-muted text-muted-foreground/80 max-w-[7rem] truncate',
+          className
+        )}
+        role="img"
+      >
+        {short}
+      </span>
+    </Tip>
+  )
+}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -32,6 +32,14 @@ import { normalizeSessionSource, sessionSourceLabel } from '@/lib/session-source
 import { cn } from '@/lib/utils'
 import { $activeConnectionId } from '@/store/connections'
 import { $cronJobs } from '@/store/cron'
+import {
+  $attachedConnectionId,
+  $multiGateway,
+  agentKey,
+  gatewayLabel,
+  onAttachedConnection,
+  sessionConnectionId
+} from '@/store/gateway-separation'
 import { $bindings } from '@/store/keybinds'
 import {
   $dismissedAutoProjectIds,
@@ -379,6 +387,16 @@ export function ChatSidebar({
   const profileColors = useStore($profileColors)
   const profileScope = useStore($profileScope)
   const activeConnectionId = useStore($activeConnectionId)
+  // Off entirely until a second connection
+  // is registered, so single-gateway sidebars render exactly as before.
+  const multiGateway = useStore($multiGateway)
+  // Re-runs the session scoping when the live gateway hops machines.
+  const attachedConnectionId = useStore($attachedConnectionId)
+
+  const onAttachedGateway = useMemo(
+    () => onAttachedConnection(multiGateway, attachedConnectionId),
+    [multiGateway, attachedConnectionId]
+  )
 
   // Toggle the persisted read-state watermark from a row menu. The row's own
   // `unread` prop mirrors what the dot paints; flip it and let the backend
@@ -478,8 +496,14 @@ export function ChatSidebar({
   const scopedSessions = useMemo(() => {
     const pool = showArchived ? archivedSessions : sessions
 
-    return filterSessionsByProfileScope(pool, profileScope)
-  }, [sessions, archivedSessions, showArchived, profileScope])
+    // The scope is (connection, profile), not a profile name: two machines both
+    // serve `default`, so a name-only filter kept showing the primary's rows
+    // while the live gateway was on the other box, which made switching gateway
+    // look like a no-op. `onAttachedGateway` is in the deps because the
+    // predicate reads the attached connection. All-profiles browse stays
+    // unfiltered — it exists to show everything.
+    return showAllProfiles ? pool : filterSessionsByProfileScope(pool, profileScope).filter(onAttachedGateway)
+  }, [sessions, archivedSessions, showArchived, showAllProfiles, profileScope, onAttachedGateway])
 
   // One predicate for the status/project filters, so the flat list and the
   // project lanes narrow by the same rule. A project lane holds rows the loaded
@@ -533,13 +557,13 @@ export function ChatSidebar({
   )
 
   const visibleCronSessions = useMemo(
-    () => filterSessionsByProfileScope(cronSessions, profileScope),
-    [cronSessions, profileScope]
+    () => filterSessionsByProfileScope(cronSessions, profileScope).filter(onAttachedGateway),
+    [cronSessions, profileScope, onAttachedGateway]
   )
 
   const visibleMessagingSessions = useMemo(
-    () => filterSessionsByProfileScope(messagingSessions, profileScope),
-    [messagingSessions, profileScope]
+    () => filterSessionsByProfileScope(messagingSessions, profileScope).filter(onAttachedGateway),
+    [messagingSessions, profileScope, onAttachedGateway]
   )
 
   // Index sessions by every id a pin might be stored under — recents, cron,
@@ -1240,29 +1264,40 @@ export function ChatSidebar({
     }
 
     const groups = new Map<string, SidebarSessionGroup>()
+    // A profile name alone is not an identity once two machines
+    // both serve `default`. Key each group by (connection, profile) so the
+    // Dell's default and the HP's default become separate lanes instead of one
+    // merged bucket, and name the machine in the header.
+    const sortKeys = new Map<string, string>()
 
     for (const session of agentSessions) {
-      const key = normalizeProfileKey(session.profile)
+      const profileKey = normalizeProfileKey(session.profile)
+      const connectionId = sessionConnectionId(session)
+      const device = multiGateway ? gatewayLabel(connectionId) : ''
+      const key = multiGateway ? agentKey(connectionId, profileKey) : profileKey
 
       const group = groups.get(key) ?? {
-        color: resolveProfileColor(key, profileColors),
+        color: resolveProfileColor(profileKey, profileColors),
         id: key,
-        label: key,
+        label: device ? `${profileKey} · ${device}` : profileKey,
         mode: 'profile',
         path: null,
         sessions: []
       }
+
+      // Machine first, then default-before-named within each machine.
+      sortKeys.set(key, `${device} ${profileKey === 'default' ? '0' : `1${profileKey}`}`)
 
       group.sessions.push(session)
 
       groups.set(key, group)
     }
 
-    // default (root) first, then the rest alphabetically.
+    // default (root) first, then the rest alphabetically — per machine.
     return [...groups.values()].sort((a, b) =>
-      a.id === 'default' ? -1 : b.id === 'default' ? 1 : a.label.localeCompare(b.label)
+      (sortKeys.get(a.id) || a.label).localeCompare(sortKeys.get(b.id) || b.label)
     )
-  }, [profileGrouped, agentSessions, profileColors])
+  }, [profileGrouped, agentSessions, profileColors, multiGateway])
 
   // The flat Sessions list always shows ALL recent sessions; Projects is a
   // parallel grouped view, not a filter on this one — nothing is hidden here.

--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -52,6 +52,14 @@ import {
 } from '@/lib/reorder'
 import { cn } from '@/lib/utils'
 import { $hasMultipleConnections } from '@/store/connections'
+import {
+  $attachedConnectionId,
+  $foreignAgents,
+  refreshGatewaySeparation,
+  type RosterAgent,
+  selectForeignAgent,
+  selectPrimaryAgent
+} from '@/store/gateway-separation'
 import { notify, notifyError } from '@/store/notifications'
 import {
   $activeGatewayProfile,
@@ -165,8 +173,14 @@ export function ProfileRail() {
 
   const isAll = scope === ALL_PROFILES
   const activeKey = normalizeProfileKey(gatewayProfile)
+  // The rail's own squares are drawn from `$profiles`, which describes the
+  // ATTACHED machine (refreshProfiles goes through the ambient connection), so
+  // a name-keyed highlight is honest again: it can only ever match a profile
+  // the live gateway actually serves. Agents on the OTHER machines render as
+  // foreign squares and carry their own highlight.
+  const homeKey = activeKey
   const defaultProfile = profiles.find(profile => profile.is_default)
-  const onDefault = !isAll && activeKey === 'default'
+  const onDefault = !isAll && homeKey === 'default'
 
   const named = sortByProfileOrder(
     profiles.filter(profile => !profile.is_default),
@@ -223,6 +237,24 @@ export function ProfileRail() {
   // wiring.
   useProfileRailRefreshOnActive()
 
+  // The rail's own $profiles cache only ever
+  // holds the ATTACHED backend's profiles, so agents on every other registered
+  // connection are invisible here. Pull the union roster alongside it and draw
+  // the missing ones as extra squares. Re-pulled whenever the local list moves
+  // (a profile switch swaps which backend $profiles describes).
+  const foreignAgents = useStore($foreignAgents)
+  const attachedConnectionId = useStore($attachedConnectionId)
+
+  useEffect(() => {
+    void refreshGatewaySeparation()
+  }, [profiles])
+
+  // Every square drawn from $profiles belongs to the primary's backend, so
+  // picking one re-homes there before delegating to upstream's selectProfile.
+  const selectLocalProfile = (name: string) => {
+    selectPrimaryAgent(name)
+  }
+
   // Open the create dialog when the `profile.create` hotkey fires (the dialog
   // state lives here, so the global keybind bumps a request atom we watch).
   const createRequest = useStore($profileCreateRequest)
@@ -251,7 +283,7 @@ export function ProfileRail() {
             active={isAll || onDefault}
             glyph={isAll ? 'layers' : 'home'}
             label={onDefault ? p.showAllProfiles : p.switchToProfile(profileLabel(defaultProfile))}
-            onSelect={() => (onDefault ? setShowAllProfiles(true) : selectProfile(defaultProfile.name))}
+            onSelect={() => (onDefault ? setShowAllProfiles(true) : selectLocalProfile(defaultProfile.name))}
           />
         ) : (
           <ProfilePill active={isAll} glyph="layers" label={p.allProfiles} onSelect={() => setShowAllProfiles(true)} />
@@ -263,7 +295,7 @@ export function ProfileRail() {
           active
           glyph="home"
           label={profileLabel(defaultProfile)}
-          onSelect={() => selectProfile(defaultProfile.name)}
+          onSelect={() => selectLocalProfile(defaultProfile.name)}
         />
       )}
 
@@ -273,11 +305,11 @@ export function ProfileRail() {
         // covers rename/delete at this scale.
         <div className="flex min-w-0 flex-1 items-center gap-1">
           <ProfileDropdown
-            activeKey={isAll ? null : activeKey}
+            activeKey={isAll ? null : homeKey}
             colors={colors}
             onCreate={() => setCreateOpen(true)}
             onImport={() => void runImportProfileFlow()}
-            onSelect={selectProfile}
+            onSelect={selectLocalProfile}
             profiles={named}
           />
         </div>
@@ -301,7 +333,7 @@ export function ProfileRail() {
                 <div className="relative flex items-center gap-1">
                   {named.map(profile => (
                     <ProfileSquare
-                      active={!isAll && normalizeProfileKey(profile.name) === activeKey}
+                      active={!isAll && normalizeProfileKey(profile.name) === homeKey}
                       color={resolveProfileColor(profile.name, colors)}
                       key={profile.name}
                       label={profileLabel(profile)}
@@ -309,12 +341,27 @@ export function ProfileRail() {
                       onEditSoul={() => setPendingSoul(profile.name)}
                       onRecolor={color => setProfileColor(profile.name, color)}
                       onRename={() => setPendingRename(profile)}
-                      onSelect={() => selectProfile(profile.name)}
+                      onSelect={() => selectLocalProfile(profile.name)}
                     />
                   ))}
                 </div>
               </SortableContext>
             </DndContext>
+          )}
+
+          {/* Agents living on OTHER registered gateways. Outside
+              the DndContext on purpose: the stored rail order is a list of
+              local profile names, and these squares are not part of it. */}
+          {foreignAgents.length > 0 && (
+            <div className="flex items-center gap-1 border-border/60 ml-0.5 border-l pl-1.5">
+              {foreignAgents.map(agent => (
+                <ForeignAgentSquare
+                  active={attachedConnectionId === agent.connectionId}
+                  agent={agent}
+                  key={`${agent.connectionId}::${agent.profile}`}
+                />
+              ))}
+            </div>
           )}
 
           <AddProfileButton label={p.newProfile} onClick={() => setCreateOpen(true)} />
@@ -810,5 +857,53 @@ function ProfileSquare({
         />
       </PopoverContent>
     </Popover>
+  )
+}
+
+/** A rail square for an agent that lives on ANOTHER registered
+ *  gateway.
+ *
+ *  Deliberately thinner than {@link ProfileSquare}: no drag-reorder (the stored
+ *  order is a list of local profile names), no rename/delete/recolor (those are
+ *  operations on the owning machine's profile, not on this app's view of it).
+ *  Selecting one routes through the connection-scoped activation path so the
+ *  app attaches to THAT machine instead of a same-named local profile.
+ *
+ *  The colour is keyed on the connection, not the profile name, so every agent
+ *  from one box reads as one family and two machines' `default` never collide. */
+function ForeignAgentSquare({ active, agent }: { active: boolean; agent: RosterAgent }) {
+  const colors = useStore($profileColors)
+  const hue = resolveProfileColor(agent.connectionId, colors) ?? 'var(--ui-text-quaternary)'
+  const label = `${agent.profile} — ${agent.connectionLabel}${agent.reachable ? '' : ' (unreachable)'}`
+
+  return (
+    <Tip label={label}>
+      <button
+        aria-label={label}
+        aria-pressed={active}
+        className={cn(
+          'grid size-5 shrink-0 select-none place-items-center rounded-[3px] text-[0.5625rem] leading-none font-semibold uppercase',
+          'transition-opacity hover:opacity-100',
+          active ? 'opacity-100' : agent.reachable ? 'opacity-55' : 'opacity-30'
+        )}
+        onClick={() => {
+          // Switching machines is a heavier move than switching profiles (a
+          // different box, its own sessions and cron), so it confirms itself.
+          void selectForeignAgent(agent)
+            .then(() => notify({ kind: 'success', message: label, title: 'Switched gateway' }))
+            .catch(err => notifyError(err, `Could not switch to ${label}`))
+        }}
+        style={{
+          backgroundColor: profileColorSoft(hue, active ? 30 : 22),
+          // A ring marks these as "elsewhere"; the active one thickens to match
+          // the weight ProfileSquare gives its own selection.
+          boxShadow: `inset 0 0 0 ${active ? '1.5px' : '1px'} ${hue}`,
+          color: hue
+        }}
+        type="button"
+      >
+        {(agent.profile || '?').slice(0, 1)}
+      </button>
+    </Tip>
   )
 }

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -2,6 +2,7 @@ import { useStore } from '@nanostores/react'
 import { memo } from 'react'
 import type * as React from 'react'
 
+import { GatewayTag } from '@/app/chat/gateway-tag'
 import { PrTag } from '@/app/chat/pr-tag'
 import { ProfileTag } from '@/app/chat/profile-tag'
 import { startSessionDrag } from '@/app/chat/session-drag'
@@ -24,6 +25,7 @@ import { handoffOriginSource, sessionSourceLabel } from '@/lib/session-source'
 import { coarseElapsed } from '@/lib/time'
 import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
+import { sessionConnectionId } from '@/store/gateway-separation'
 import { $sidebarRowMeta } from '@/store/layout'
 import { normalizeProfileKey } from '@/store/profile'
 import { $projects } from '@/store/projects'
@@ -197,6 +199,12 @@ function SidebarSessionRowImpl({
   if ((showProfile || pinnedProfile) && hasProfileTag) {
     trailing.push({ key: 'profile', node: <ProfileTag profile={session.profile} /> })
   }
+
+  // Name the machine. Upstream decides the profile chip from the
+  // profile NAME, so a remote gateway's `default` gets no chip at all and reads
+  // as a local row. GatewayTag renders itself away unless two or more
+  // connections are registered, so this is inert on single-gateway installs.
+  trailing.push({ key: 'gateway', node: <GatewayTag connectionId={sessionConnectionId(session)} /> })
 
   if (pr) {
     trailing.push({ key: 'pr', node: <PrTag pr={pr} /> })

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -6,9 +6,10 @@ import { getLatestSessionMessages } from '@/hermes'
 import { preserveLocalAssistantErrors, sealOpenToolParts, toChatMessages } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { sessionMessagesSignature } from '@/lib/session-signatures'
+import { $attachedConnectionId } from '@/store/gateway-separation'
 import { $changeEventsAvailable, $cronChangeTick, $sessionsChangeTick } from '@/store/live-sync'
 import { $onBattery, batteryPollInterval } from '@/store/power'
-import { refreshActiveProfile } from '@/store/profile'
+import { refreshActiveProfile, refreshProfiles } from '@/store/profile'
 import {
   $activeSessionId,
   $busy,
@@ -419,6 +420,16 @@ export function useBackgroundSync({
     [activeSessionId, activeStoredSessionId, refreshActiveTranscript]
   )
 
+  // This reseed keyed on the profile NAME
+  // alone, and every registered machine serves a `default`: hopping between two
+  // gateways' `default` changed no name, `gatewayState` was already 'open', so
+  // NOTHING re-pulled. The model, the profile list and the whole session list
+  // stayed as the previous machine had left them — the sidebar showed "No
+  // sessions yet" beside an open session, and the model picker still listed the
+  // other box's models. Keying on the connection too makes a hop reseed exactly
+  // like a profile switch. Constant on single-gateway installs.
+  const attachedConnectionId = useStore($attachedConnectionId)
+
   useEffect(() => {
     if (gatewayState !== 'open') {
       return
@@ -426,6 +437,12 @@ export function useBackgroundSync({
 
     void refreshCurrentModel()
     void refreshActiveProfile()
+    // The rail's own squares are `$profiles`, which is whatever the AMBIENT
+    // connection served. A hop to another registered gateway changes that
+    // ambient connection without changing the profile name, so without this the
+    // rail kept drawing the previous machine's profiles until something else
+    // happened to refetch them.
+    void refreshProfiles().catch(() => undefined)
     void refreshSessions()
 
     // A RELATIVE workspace cwd (config `terminal.cwd: .`) renders as "." in the
@@ -443,7 +460,15 @@ export function useBackgroundSync({
         })
         .catch(() => undefined)
     }
-  }, [activeConnectionId, activeGatewayProfile, gatewayState, refreshCurrentModel, refreshSessions, requestGateway])
+  }, [
+    activeConnectionId,
+    activeGatewayProfile,
+    attachedConnectionId,
+    gatewayState,
+    refreshCurrentModel,
+    refreshSessions,
+    requestGateway
+  ])
 
   // A reconnect loses renderer-only working/attention atoms while the backend
   // keeps the actual turns alive. Re-seed from the gateway's in-memory session

--- a/apps/desktop/src/app/profiles/create-profile-dialog.tsx
+++ b/apps/desktop/src/app/profiles/create-profile-dialog.tsx
@@ -30,11 +30,17 @@ export function isValidProfileName(name: string): boolean {
 // createProfile/updateProfileSoul calls so every caller just refreshes/selects
 // via onCreated. SOUL left blank keeps the cloned/blank persona untouched.
 export function CreateProfileDialog({
+  connectionId,
   onClose,
   onCreated,
   open,
   profiles = []
 }: {
+  /** The machine that owns this profile.
+   *  Manage Profiles lists every registered gateway's profiles, so an action
+   *  has to run on the box the row came from. Omitted / '' = the primary, so
+   *  single-gateway callers are unchanged. */
+  connectionId?: null | string
   onClose: () => void
   onCreated?: (name: string) => Promise<void> | void
   open: boolean
@@ -77,10 +83,13 @@ export function CreateProfileDialog({
     setError(null)
 
     try {
-      await createProfile({ name: trimmed, clone_from: cloneFrom })
+      // Pass the owning machine ONLY when there is one, so a
+      // single-gateway install issues the byte-identical upstream call.
+      const scope: [] | [string] = connectionId ? [connectionId] : []
+      await createProfile({ name: trimmed, clone_from: cloneFrom }, ...scope)
 
       if (soul.trim()) {
-        await updateProfileSoul(trimmed, soul)
+        await updateProfileSoul(trimmed, soul, ...scope)
       }
 
       await onCreated?.(trimmed)

--- a/apps/desktop/src/app/profiles/delete-profile-dialog.tsx
+++ b/apps/desktop/src/app/profiles/delete-profile-dialog.tsx
@@ -8,11 +8,17 @@ import { $activeGatewayProfile, normalizeProfileKey, selectProfile, setActivePro
 // Enter-to-confirm + busy/done/error from the shared dialog. The single choke
 // point for every delete entry point (rail + Profiles view).
 export function DeleteProfileDialog({
+  connectionId,
   profile,
   onClose,
   onDeleted,
   open
 }: {
+  /** The machine that owns this profile.
+   *  Manage Profiles lists every registered gateway's profiles, so an action
+   *  has to run on the box the row came from. Omitted / '' = the primary, so
+   *  single-gateway callers are unchanged. */
+  connectionId?: null | string
   profile: { name: string; path: string } | null
   onClose: () => void
   onDeleted?: () => Promise<void> | void
@@ -50,7 +56,10 @@ export function DeleteProfileDialog({
         // racing the (still-dying) backend can't clobber the pill back to it.
         const wasActive = normalizeProfileKey(profile.name) === normalizeProfileKey($activeGatewayProfile.get())
         retireLocalProfileGateways(profile.name)
-        await deleteProfile(profile.name)
+        // Pass the owning machine ONLY when there is one, so a
+        // single-gateway install issues the byte-identical upstream call.
+        const scope: [] | [string] = connectionId ? [connectionId] : []
+        await deleteProfile(profile.name, ...scope)
         await onDeleted?.()
 
         if (wasActive) {

--- a/apps/desktop/src/app/profiles/delete-profile-dialog.tsx
+++ b/apps/desktop/src/app/profiles/delete-profile-dialog.tsx
@@ -1,7 +1,8 @@
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { deleteProfile } from '@/hermes'
 import { useI18n } from '@/i18n'
-import { retireLocalProfileGateways } from '@/store/gateway'
+import { retireAgentGateways } from '@/store/gateway'
+import { $attachedConnectionId, $primaryConnectionId, LOCAL_CONNECTION_ID } from '@/store/gateway-separation'
 import { $activeGatewayProfile, normalizeProfileKey, selectProfile, setActiveProfile } from '@/store/profile'
 
 // Thin wrapper over ConfirmDialog: owns the deleteProfile call, inherits
@@ -54,8 +55,20 @@ export function DeleteProfileDialog({
         // backend. Capture that before the delete; reset *after* the host's
         // onDeleted refresh so our reset is the last write — a refreshActiveProfile
         // racing the (still-dying) backend can't clobber the pill back to it.
-        const wasActive = normalizeProfileKey(profile.name) === normalizeProfileKey($activeGatewayProfile.get())
-        retireLocalProfileGateways(profile.name)
+        // "Was the deleted profile the live one?" is a question about an
+        // AGENT, not a name. Every registered machine serves a `default`, so a
+        // name-only comparison said yes while the live gateway sat on a
+        // different box entirely — and the reset below then swapped that
+        // innocent machine's gateway and pill to `default`.
+        const owner = (connectionId ?? '').trim() || $primaryConnectionId.get() || LOCAL_CONNECTION_ID
+
+        const wasActive =
+          normalizeProfileKey(profile.name) === normalizeProfileKey($activeGatewayProfile.get()) &&
+          owner === $attachedConnectionId.get()
+
+        // Retire the sockets THIS agent owns. The local-only seam would have
+        // torn down a same-named local profile instead (#88638).
+        retireAgentGateways(connectionId ?? null, profile.name)
         // Pass the owning machine ONLY when there is one, so a
         // single-gateway install issues the byte-identical upstream call.
         const scope: [] | [string] = connectionId ? [connectionId] : []

--- a/apps/desktop/src/app/profiles/index.test.tsx
+++ b/apps/desktop/src/app/profiles/index.test.tsx
@@ -3,8 +3,8 @@ import { atom } from 'nanostores'
 import type * as Nanostores from 'nanostores'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { deleteProfile } from '@/hermes'
-import { retireLocalProfileGateways } from '@/store/gateway'
+import { deleteProfile, getProfiles } from '@/hermes'
+import { activeGatewayConnectionId, retireAgentGateways } from '@/store/gateway'
 import { refreshProfiles, selectProfile, setActiveProfile } from '@/store/profile'
 import type { ProfileInfo } from '@/types/hermes'
 
@@ -30,6 +30,7 @@ vi.mock('@/components/chat/code-editor', () => ({
 
 vi.mock('@/hermes', () => ({
   createProfile: vi.fn(async () => ({ name: 'x', ok: true, path: '/x' })),
+  getProfiles: vi.fn(async () => ({ profiles: [] })),
   deleteProfile: vi.fn(async () => ({ ok: true, path: '/x' })),
   getProfileSoul: vi.fn(async () => ({ content: '', exists: true })),
   renameProfile: vi.fn(async () => ({ name: 'x', ok: true, path: '/x' })),
@@ -42,6 +43,9 @@ vi.mock('@/store/notifications', () => ({
 }))
 
 vi.mock('@/store/gateway', () => ({
+  // Owner-scoped retirement: the local-only seam would tear down a same-named
+  // LOCAL profile when the row being deleted belongs to another machine.
+  retireAgentGateways: vi.fn(),
   retireLocalProfileGateways: vi.fn(),
   // Manage Profiles now lists every registered gateway, so it pulls in
   // store/gateway-separation, which mirrors the live gateway's connection.
@@ -139,10 +143,10 @@ describe('ProfilesView', () => {
 
   it('re-homes to default when the active profile is deleted', async () => {
     const deleteProfileMock = vi.mocked(deleteProfile)
-    const retireLocalProfileGatewaysMock = vi.mocked(retireLocalProfileGateways)
+    const retireMock = vi.mocked(retireAgentGateways)
 
     deleteProfileMock.mockClear()
-    retireLocalProfileGatewaysMock.mockClear()
+    retireMock.mockClear()
     vi.mocked(refreshProfiles).mockResolvedValue([makeProfile('default', true), makeProfile(NAMED_PROFILE)])
     activeGateway.set(NAMED_PROFILE)
 
@@ -150,10 +154,10 @@ describe('ProfilesView', () => {
     await deleteTheNamedProfile()
 
     await waitFor(() => expect(deleteProfile).toHaveBeenCalledWith(NAMED_PROFILE))
-    expect(retireLocalProfileGateways).toHaveBeenCalledWith(NAMED_PROFILE)
-    expect(retireLocalProfileGatewaysMock.mock.invocationCallOrder[0]).toBeLessThan(
-      deleteProfileMock.mock.invocationCallOrder[0]
-    )
+    // Retirement is addressed to the OWNING agent. '' is "no override" — a
+    // single-gateway install, where the wire call stays byte-identical.
+    expect(retireAgentGateways).toHaveBeenCalledWith('', NAMED_PROFILE)
+    expect(retireMock.mock.invocationCallOrder[0]).toBeLessThan(deleteProfileMock.mock.invocationCallOrder[0])
     await waitFor(() => expect(selectProfile).toHaveBeenCalledWith('default'))
     expect(setActiveProfile).toHaveBeenCalledWith('default')
   })
@@ -170,6 +174,98 @@ describe('ProfilesView', () => {
     await waitFor(() => expect(deleteProfile).toHaveBeenCalledWith(NAMED_PROFILE))
     // The dialog closes once the delete settles; a non-active delete must not re-home.
     await waitFor(() => expect(screen.queryByRole('button', { name: 'Delete' })).toBeNull())
+    expect(selectProfile).not.toHaveBeenCalled()
+    expect(setActiveProfile).not.toHaveBeenCalled()
+  })
+})
+
+
+// ── ownership across machines ──────────────────────────────────────────────
+// Both gateways serve `default` AND an overlapping named profile. Without that
+// overlap a bare name is still unambiguous and none of this can go wrong.
+const HP = '192-168-1-218-9119'
+const DELL = 'mechahome-hermes-dell'
+
+function installTwoGatewayRegistry() {
+  ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+    connections: {
+      list: vi.fn(async () => ({
+        primary: HP,
+        connections: [
+          { id: 'local', kind: 'local', label: 'This device' },
+          { id: HP, kind: 'remote', label: 'Mecha Hermes (HP)' },
+          { id: DELL, kind: 'remote', label: 'MechaHome Hermes (Dell)' }
+        ]
+      }))
+    },
+    getAgentRoster: vi.fn(async () => ({
+      sources: [
+        { connectionId: HP, reachable: true },
+        { connectionId: DELL, reachable: true }
+      ],
+      agents: [
+        { connectionId: HP, connectionLabel: 'Mecha Hermes (HP)', handle: 'work', profile: NAMED_PROFILE },
+        { connectionId: DELL, connectionLabel: 'MechaHome Hermes (Dell)', handle: 'work-dell', profile: NAMED_PROFILE }
+      ]
+    }))
+  }
+}
+
+describe('ProfilesView across registered gateways', () => {
+  it('addresses the PRIMARY by its registry id while the live gateway is elsewhere', async () => {
+    const { refreshGatewaySeparation } = await import('@/store/gateway-separation')
+
+    installTwoGatewayRegistry()
+    // The live gateway is the Dell — the ambient connection every un-scoped
+    // request would follow.
+    vi.mocked(activeGatewayConnectionId).mockReturnValue(DELL)
+    vi.mocked(getProfiles).mockResolvedValue({ profiles: [makeProfile('default', true)] })
+
+    await act(async () => {
+      await refreshGatewaySeparation()
+    })
+    await renderProfilesView()
+
+    const targets = vi.mocked(getProfiles).mock.calls.map(call => call[0])
+
+    // The section labelled with the primary's name must READ the primary. An
+    // omitted id means "ambient", which while attached to the Dell made the
+    // primary-labelled section list the Dell's profiles instead.
+    expect(targets).toContain(HP)
+    expect(targets).toContain(DELL)
+    expect(targets).not.toContain('')
+    expect(targets).not.toContain(undefined)
+  })
+
+  it('never re-homes when the deleted profile is a DIFFERENT machine\'s same-named one', async () => {
+    const { refreshGatewaySeparation } = await import('@/store/gateway-separation')
+
+    installTwoGatewayRegistry()
+    vi.mocked(activeGatewayConnectionId).mockReturnValue(HP)
+    vi.mocked(selectProfile).mockClear()
+    vi.mocked(setActiveProfile).mockClear()
+    vi.mocked(retireAgentGateways).mockClear()
+    // The live agent is work@HP. The row we delete is work@DELL — same name,
+    // different machine.
+    activeGateway.set(NAMED_PROFILE)
+    vi.mocked(getProfiles).mockImplementation(async (connectionId?: null | string) =>
+      connectionId === DELL ? { profiles: [makeProfile(NAMED_PROFILE)] } : { profiles: [makeProfile('default', true)] }
+    )
+
+    await act(async () => {
+      await refreshGatewaySeparation()
+    })
+    await renderProfilesView()
+    await deleteTheNamedProfile()
+
+    await waitFor(() => expect(deleteProfile).toHaveBeenCalledWith(NAMED_PROFILE, DELL))
+
+    // Retirement is scoped to the DELL's agent. Routing it through the
+    // local-only seam would have torn down work@HP's sockets instead (#88638).
+    expect(retireAgentGateways).toHaveBeenCalledWith(DELL, NAMED_PROFILE)
+
+    // And the live route is untouched: deciding "was it active?" by profile
+    // NAME alone reset an innocent machine's gateway and pill to `default`.
     expect(selectProfile).not.toHaveBeenCalled()
     expect(setActiveProfile).not.toHaveBeenCalled()
   })

--- a/apps/desktop/src/app/profiles/index.test.tsx
+++ b/apps/desktop/src/app/profiles/index.test.tsx
@@ -1,4 +1,5 @@
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { atom } from 'nanostores'
 import type * as Nanostores from 'nanostores'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -41,7 +42,11 @@ vi.mock('@/store/notifications', () => ({
 }))
 
 vi.mock('@/store/gateway', () => ({
-  retireLocalProfileGateways: vi.fn()
+  retireLocalProfileGateways: vi.fn(),
+  // Manage Profiles now lists every registered gateway, so it pulls in
+  // store/gateway-separation, which mirrors the live gateway's connection.
+  $gateway: atom<unknown>(null),
+  activeGatewayConnectionId: vi.fn(() => null)
 }))
 
 const { $activeGatewayProfile: activeGateway, $profileColors } = vi.hoisted(() => {

--- a/apps/desktop/src/app/profiles/index.tsx
+++ b/apps/desktop/src/app/profiles/index.tsx
@@ -1,17 +1,24 @@
 import { useStore } from '@nanostores/react'
 import type * as React from 'react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { CodeEditor } from '@/components/chat/code-editor'
 import { PageLoader } from '@/components/page-loader'
 import { Button } from '@/components/ui/button'
 import { ProfileGlyph } from '@/components/ui/profile-glyph'
-import { getProfileSoul, type ProfileInfo, updateProfileSoul } from '@/hermes'
+import { getProfiles, getProfileSoul, type ProfileInfo, updateProfileSoul } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { displayPath } from '@/lib/display-path'
 import { AlertTriangle, Save } from '@/lib/icons'
 import { resolveProfileColor } from '@/lib/profile-color'
 import { normalize } from '@/lib/text'
+import {
+  $connectionLabels,
+  $multiGateway,
+  $primaryConnectionId,
+  agentKey,
+  LOCAL_CONNECTION_ID
+} from '@/store/gateway-separation'
 import { notify, notifyError } from '@/store/notifications'
 import { $profileColors, profileLabel, refreshProfiles } from '@/store/profile'
 
@@ -39,31 +46,85 @@ interface ProfilesViewProps {
   onClose: () => void
 }
 
+/** One row's full identity: a profile plus
+ *  the machine that owns it. Two registered gateways both serve a `default`, so
+ *  a name on its own can neither identify a row nor address an action. */
+interface ProfileEntry {
+  /** '' for the primary / local pool — the byte-identical single-gateway case. */
+  connectionId: string
+  connectionLabel: string
+  profile: ProfileInfo
+}
+
+const entryKey = (entry: ProfileEntry) => agentKey(entry.connectionId, entry.profile.name)
+
 export function ProfilesView({ onClose }: ProfilesViewProps) {
   const { t } = useI18n()
   const p = t.profiles
-  const [profiles, setProfiles] = useState<null | ProfileInfo[]>(null)
-  const [selectedName, setSelectedName] = useState<null | string>(null)
+  const [entries, setEntries] = useState<null | ProfileEntry[]>(null)
+  const [selectedKey, setSelectedKey] = useState<null | string>(null)
   const [query, setQuery] = useState('')
-  const [createOpen, setCreateOpen] = useState(false)
-  const [pendingRename, setPendingRename] = useState<null | ProfileInfo>(null)
-  const [pendingDelete, setPendingDelete] = useState<null | ProfileInfo>(null)
+  const [createOn, setCreateOn] = useState<null | string>(null)
+  const [pendingRename, setPendingRename] = useState<null | ProfileEntry>(null)
+  const [pendingDelete, setPendingDelete] = useState<null | ProfileEntry>(null)
+
+  // Every registered gateway, primary first. Manage Profiles used
+  // to call `refreshProfiles()` alone, which is hard-wired to the primary, so a
+  // second machine's agents were simply absent from the one screen that exists
+  // to manage them.
+  const multiGateway = useStore($multiGateway)
+  const connectionLabels = useStore($connectionLabels)
+  const primaryConnectionId = useStore($primaryConnectionId)
+
+  const sources = useMemo(() => {
+    const primary = primaryConnectionId || LOCAL_CONNECTION_ID
+    const primaryLabel = connectionLabels[primary] || ''
+    const rest = Object.keys(connectionLabels).filter(id => id !== primary && id !== LOCAL_CONNECTION_ID)
+
+    return [
+      { connectionId: '', label: primaryLabel },
+      ...rest.map(id => ({ connectionId: id, label: connectionLabels[id] || id }))
+    ]
+  }, [connectionLabels, primaryConnectionId])
 
   const refresh = useCallback(async () => {
-    try {
-      const list = await refreshProfiles()
-      setProfiles(list)
-      setSelectedName(current => {
-        if (current && list.some(p => p.name === current)) {
-          return current
-        }
+    // Best-effort per source: an unreachable machine contributes nothing rather
+    // than emptying the whole panel, matching how the roster degrades.
+    const perSource = await Promise.all(
+      sources.map(async source => {
+        try {
+          const list = source.connectionId ? (await getProfiles(source.connectionId)).profiles : await refreshProfiles()
 
-        return list.find(p => p.is_default)?.name ?? list[0]?.name ?? null
+          return list.map(profile => ({
+            connectionId: source.connectionId,
+            connectionLabel: source.label,
+            profile
+          }))
+        } catch (err) {
+          // Only the primary failing is worth interrupting the user for; a
+          // secondary gateway being down is expected and already visible as an
+          // absent section.
+          if (!source.connectionId) {
+            notifyError(err, p.failedLoad)
+          }
+
+          return [] as ProfileEntry[]
+        }
       })
-    } catch (err) {
-      notifyError(err, p.failedLoad)
-    }
-  }, [p])
+    )
+
+    const flat = perSource.flat()
+    setEntries(flat)
+    setSelectedKey(current => {
+      if (current && flat.some(entry => entryKey(entry) === current)) {
+        return current
+      }
+
+      const fallback = flat.find(entry => !entry.connectionId && entry.profile.is_default) ?? flat[0]
+
+      return fallback ? entryKey(fallback) : null
+    })
+  }, [p, sources])
 
   useRefreshHotkey(refresh)
 
@@ -72,44 +133,75 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
   }, [refresh])
 
   const selected = useMemo(() => {
-    if (!profiles) {
+    if (!entries) {
       return null
     }
 
-    return profiles.find(p => p.name === selectedName) ?? profiles[0] ?? null
-  }, [profiles, selectedName])
+    return entries.find(entry => entryKey(entry) === selectedKey) ?? entries[0] ?? null
+  }, [entries, selectedKey])
 
-  const visibleProfiles = useMemo(() => {
+  const visibleEntries = useMemo(() => {
     const q = normalize(query)
 
-    if (!profiles || !q) {
-      return profiles ?? []
+    if (!entries || !q) {
+      return entries ?? []
     }
 
-    return profiles.filter(
-      profile => profile.name.toLowerCase().includes(q) || (profile.model ?? '').toLowerCase().includes(q)
+    return entries.filter(
+      entry =>
+        entry.profile.name.toLowerCase().includes(q) ||
+        (entry.profile.model ?? '').toLowerCase().includes(q) ||
+        entry.connectionLabel.toLowerCase().includes(q)
     )
-  }, [profiles, query])
+  }, [entries, query])
+
+  // One section per machine while more than one gateway is registered; a single
+  // unlabelled run of rows otherwise, exactly as upstream renders it.
+  const sections = useMemo(
+    () =>
+      sources
+        .map(source => ({
+          ...source,
+          rows: visibleEntries.filter(entry => entry.connectionId === source.connectionId)
+        }))
+        .filter(section => section.rows.length > 0 || !section.connectionId),
+    [sources, visibleEntries]
+  )
 
   // The shared Create/Rename dialogs own the createProfile / renameProfile /
   // updateProfileSoul calls; the panel just selects the resulting profile and
   // re-pulls the list.
   const selectAndRefresh = useCallback(
-    async (name: string) => {
-      setSelectedName(name)
+    async (connectionId: string, name: string) => {
+      setSelectedKey(agentKey(connectionId, name))
       await refresh()
     },
     [refresh]
   )
 
+  const menuFor = (entry: ProfileEntry): PanelMenuItem[] =>
+    entry.profile.is_default
+      ? // Renaming the default profile sets a presentation-only display name
+        // (the canonical id stays "default").
+        [{ icon: 'edit', label: p.renameMenu, onSelect: () => setPendingRename(entry) }]
+      : [
+          { icon: 'edit', label: p.renameMenu, onSelect: () => setPendingRename(entry) },
+          {
+            icon: 'trash',
+            label: t.common.delete,
+            onSelect: () => setPendingDelete(entry),
+            tone: 'danger'
+          }
+        ]
+
   return (
     <Panel closeLabel={p.close} onClose={onClose}>
-      {!profiles ? (
+      {!entries ? (
         <PageLoader label={p.loading} />
-      ) : profiles.length === 0 ? (
+      ) : entries.length === 0 ? (
         <PanelEmpty
           action={
-            <Button onClick={() => setCreateOpen(true)} size="sm">
+            <Button onClick={() => setCreateOn('')} size="sm">
               {p.newProfile}
             </Button>
           }
@@ -119,7 +211,7 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
         />
       ) : (
         <>
-          <PanelHeader subtitle={p.count(profiles.length)} title={p.title} />
+          <PanelHeader subtitle={p.count(entries.length)} title={p.title} />
           <PanelBody>
             <PanelList
               onSearchChange={setQuery}
@@ -127,34 +219,31 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
               searchPlaceholder={p.search}
               searchValue={query}
             >
-              {visibleProfiles.map(profile => (
-                <ProfileRow
-                  active={selected?.name === profile.name}
-                  key={profile.name}
-                  menuItems={
-                    profile.is_default
-                      ? // Renaming the default profile sets a presentation-only
-                        // display name (the canonical id stays "default").
-                        [{ icon: 'edit', label: p.renameMenu, onSelect: () => setPendingRename(profile) }]
-                      : [
-                          { icon: 'edit', label: p.renameMenu, onSelect: () => setPendingRename(profile) },
-                          {
-                            icon: 'trash',
-                            label: t.common.delete,
-                            onSelect: () => setPendingDelete(profile),
-                            tone: 'danger'
-                          }
-                        ]
-                  }
-                  onSelect={() => setSelectedName(profile.name)}
-                  profile={profile}
-                />
+              {sections.map(section => (
+                <Fragment key={section.connectionId || 'primary'}>
+                  {multiGateway && section.label ? <PanelSectionLabel>{section.label}</PanelSectionLabel> : null}
+                  {section.rows.map(entry => (
+                    <ProfileRow
+                      active={selected ? entryKey(selected) === entryKey(entry) : false}
+                      key={entryKey(entry)}
+                      menuItems={menuFor(entry)}
+                      onSelect={() => setSelectedKey(entryKey(entry))}
+                      profile={entry.profile}
+                    />
+                  ))}
+                  {/* Create lands on the machine whose section it sits in. */}
+                  <PanelAddButton label={p.newProfile} onClick={() => setCreateOn(section.connectionId)} />
+                </Fragment>
               ))}
-              <PanelAddButton label={p.newProfile} onClick={() => setCreateOpen(true)} />
             </PanelList>
 
             {selected ? (
-              <ProfileDetail key={selected.name} profile={selected} />
+              <ProfileDetail
+                connectionId={selected.connectionId}
+                connectionLabel={multiGateway ? selected.connectionLabel : ''}
+                key={entryKey(selected)}
+                profile={selected.profile}
+              />
             ) : (
               <PanelEmpty description={p.selectPrompt} icon="account" />
             )}
@@ -163,28 +252,31 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
       )}
 
       <RenameProfileDialog
-        currentName={pendingRename?.name ?? ''}
-        isDefault={pendingRename?.is_default ?? false}
+        connectionId={pendingRename?.connectionId}
+        currentName={pendingRename?.profile.name ?? ''}
+        isDefault={pendingRename?.profile.is_default ?? false}
         onClose={() => setPendingRename(null)}
-        onRenamed={selectAndRefresh}
+        onRenamed={name => selectAndRefresh(pendingRename?.connectionId ?? '', name)}
         open={pendingRename !== null}
       />
 
       <CreateProfileDialog
-        onClose={() => setCreateOpen(false)}
-        onCreated={selectAndRefresh}
-        open={createOpen}
-        profiles={profiles ?? []}
+        connectionId={createOn}
+        onClose={() => setCreateOn(null)}
+        onCreated={name => selectAndRefresh(createOn ?? '', name)}
+        open={createOn !== null}
+        profiles={(entries ?? []).filter(entry => entry.connectionId === (createOn ?? '')).map(entry => entry.profile)}
       />
 
       <DeleteProfileDialog
+        connectionId={pendingDelete?.connectionId}
         onClose={() => setPendingDelete(null)}
         onDeleted={async () => {
-          setSelectedName(null)
+          setSelectedKey(null)
           await refresh()
         }}
         open={pendingDelete !== null}
-        profile={pendingDelete}
+        profile={pendingDelete?.profile ?? null}
       />
     </Panel>
   )
@@ -223,7 +315,16 @@ function ProfileRow({
   )
 }
 
-function ProfileDetail({ profile }: { profile: ProfileInfo }) {
+function ProfileDetail({
+  connectionId,
+  connectionLabel,
+  profile
+}: {
+  connectionId: string
+  /** '' on a single-gateway install, which renders exactly as upstream. */
+  connectionLabel: string
+  profile: ProfileInfo
+}) {
   const { t } = useI18n()
   const p = t.profiles
 
@@ -235,6 +336,10 @@ function ProfileDetail({ profile }: { profile: ProfileInfo }) {
             <h3 className="text-[0.95rem] font-semibold tracking-tight text-foreground">{profileLabel(profile)}</h3>
             {profile.is_default && <PanelPill tone="good">{p.defaultBadge}</PanelPill>}
             {profile.has_env && <PanelPill tone="muted">.env</PanelPill>}
+            {/* Which machine this profile lives on — the path below is a path
+                on THAT box, and two gateways' `default` are otherwise
+                indistinguishable here. */}
+            {connectionLabel ? <PanelPill tone="muted">{connectionLabel}</PanelPill> : null}
           </div>
           <p
             className="mt-1 truncate font-mono text-[0.66rem] text-muted-foreground/55"
@@ -262,12 +367,12 @@ function ProfileDetail({ profile }: { profile: ProfileInfo }) {
         />
       </header>
 
-      <SoulEditor profileName={profile.name} />
+      <SoulEditor connectionId={connectionId} profileName={profile.name} />
     </PanelDetail>
   )
 }
 
-function SoulEditor({ profileName }: { profileName: string }) {
+function SoulEditor({ connectionId, profileName }: { connectionId: string; profileName: string }) {
   const { t } = useI18n()
   const p = t.profiles
   const [content, setContent] = useState('')
@@ -287,7 +392,7 @@ function SoulEditor({ profileName }: { profileName: string }) {
 
     void (async () => {
       try {
-        const soul = await getProfileSoul(profileName)
+        const soul = await getProfileSoul(profileName, connectionId)
 
         if (requestRef.current === profileName) {
           setContent(soul.content)
@@ -303,7 +408,7 @@ function SoulEditor({ profileName }: { profileName: string }) {
         }
       }
     })()
-  }, [p, profileName])
+  }, [connectionId, p, profileName])
 
   const dirty = content !== original
 
@@ -312,7 +417,7 @@ function SoulEditor({ profileName }: { profileName: string }) {
     setError(null)
 
     try {
-      await updateProfileSoul(profileName, content)
+      await updateProfileSoul(profileName, content, connectionId)
       setOriginal(content)
       notify({ kind: 'success', title: p.soulSaved, message: profileName })
     } catch (err) {

--- a/apps/desktop/src/app/profiles/index.tsx
+++ b/apps/desktop/src/app/profiles/index.tsx
@@ -76,16 +76,27 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
   const connectionLabels = useStore($connectionLabels)
   const primaryConnectionId = useStore($primaryConnectionId)
 
+  // The primary carries its REAL registry id, never ''.
+  //
+  // An omitted connection means "whichever gateway is ambient", NOT "the
+  // registry primary" — `hermesApi` spreads `connectionScoped()`. Encoding the
+  // primary as '' therefore made the section LABELLED with the primary's name
+  // read, and write to, whatever machine happened to be attached: open Manage
+  // Profiles from a secondary and the primary's section listed the secondary's
+  // profiles, while create/rename/delete under that heading hit the secondary
+  // too. Addressing every source explicitly is what keeps a row's machine and
+  // its label the same machine.
+  const primaryId = (primaryConnectionId || LOCAL_CONNECTION_ID).trim()
+
   const sources = useMemo(() => {
-    const primary = primaryConnectionId || LOCAL_CONNECTION_ID
-    const primaryLabel = connectionLabels[primary] || ''
-    const rest = Object.keys(connectionLabels).filter(id => id !== primary && id !== LOCAL_CONNECTION_ID)
+    const primaryLabel = connectionLabels[primaryId] || ''
+    const rest = Object.keys(connectionLabels).filter(id => id !== primaryId && id !== LOCAL_CONNECTION_ID)
 
     return [
-      { connectionId: '', label: primaryLabel },
+      { connectionId: primaryId, label: primaryLabel },
       ...rest.map(id => ({ connectionId: id, label: connectionLabels[id] || id }))
     ]
-  }, [connectionLabels, primaryConnectionId])
+  }, [connectionLabels, primaryId])
 
   const refresh = useCallback(async () => {
     // Best-effort per source: an unreachable machine contributes nothing rather
@@ -93,7 +104,10 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
     const perSource = await Promise.all(
       sources.map(async source => {
         try {
-          const list = source.connectionId ? (await getProfiles(source.connectionId)).profiles : await refreshProfiles()
+          // Explicit id for every source once a second gateway exists. A
+          // single-gateway install keeps upstream's exact ambient call, so
+          // nothing changes for it.
+          const list = multiGateway ? (await getProfiles(source.connectionId)).profiles : await refreshProfiles()
 
           return list.map(profile => ({
             connectionId: source.connectionId,
@@ -104,7 +118,7 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
           // Only the primary failing is worth interrupting the user for; a
           // secondary gateway being down is expected and already visible as an
           // absent section.
-          if (!source.connectionId) {
+          if (source.connectionId === primaryId) {
             notifyError(err, p.failedLoad)
           }
 
@@ -120,11 +134,17 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
         return current
       }
 
-      const fallback = flat.find(entry => !entry.connectionId && entry.profile.is_default) ?? flat[0]
+      const fallback = flat.find(entry => entry.connectionId === primaryId && entry.profile.is_default) ?? flat[0]
 
       return fallback ? entryKey(fallback) : null
     })
-  }, [p, sources])
+
+    // The rail's own cache is ambient by design (it describes the attached
+    // machine), so keep it current alongside the explicit per-source reads.
+    if (multiGateway) {
+      void refreshProfiles().catch(() => undefined)
+    }
+  }, [multiGateway, p, primaryId, sources])
 
   useRefreshHotkey(refresh)
 
@@ -164,9 +184,14 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
           ...source,
           rows: visibleEntries.filter(entry => entry.connectionId === source.connectionId)
         }))
-        .filter(section => section.rows.length > 0 || !section.connectionId),
-    [sources, visibleEntries]
+        .filter(section => section.rows.length > 0 || section.connectionId === primaryId),
+    [primaryId, sources, visibleEntries]
   )
+
+  // Internally every source carries its real id, so a row's machine and its
+  // label can never drift. On the WIRE, a single-gateway install must still
+  // issue upstream's byte-identical ambient call — '' means "no override".
+  const scopeFor = (id?: null | string): string => (multiGateway ? ((id ?? '').trim() || primaryId) : '')
 
   // The shared Create/Rename dialogs own the createProfile / renameProfile /
   // updateProfileSoul calls; the panel just selects the resulting profile and
@@ -220,7 +245,7 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
               searchValue={query}
             >
               {sections.map(section => (
-                <Fragment key={section.connectionId || 'primary'}>
+                <Fragment key={section.connectionId}>
                   {multiGateway && section.label ? <PanelSectionLabel>{section.label}</PanelSectionLabel> : null}
                   {section.rows.map(entry => (
                     <ProfileRow
@@ -239,7 +264,7 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
 
             {selected ? (
               <ProfileDetail
-                connectionId={selected.connectionId}
+                connectionId={scopeFor(selected.connectionId)}
                 connectionLabel={multiGateway ? selected.connectionLabel : ''}
                 key={entryKey(selected)}
                 profile={selected.profile}
@@ -252,24 +277,24 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
       )}
 
       <RenameProfileDialog
-        connectionId={pendingRename?.connectionId}
+        connectionId={scopeFor(pendingRename?.connectionId)}
         currentName={pendingRename?.profile.name ?? ''}
         isDefault={pendingRename?.profile.is_default ?? false}
         onClose={() => setPendingRename(null)}
-        onRenamed={name => selectAndRefresh(pendingRename?.connectionId ?? '', name)}
+        onRenamed={name => selectAndRefresh(pendingRename?.connectionId ?? primaryId, name)}
         open={pendingRename !== null}
       />
 
       <CreateProfileDialog
-        connectionId={createOn}
+        connectionId={scopeFor(createOn)}
         onClose={() => setCreateOn(null)}
-        onCreated={name => selectAndRefresh(createOn ?? '', name)}
+        onCreated={name => selectAndRefresh(createOn ?? primaryId, name)}
         open={createOn !== null}
-        profiles={(entries ?? []).filter(entry => entry.connectionId === (createOn ?? '')).map(entry => entry.profile)}
+        profiles={(entries ?? []).filter(entry => entry.connectionId === (createOn ?? primaryId)).map(entry => entry.profile)}
       />
 
       <DeleteProfileDialog
-        connectionId={pendingDelete?.connectionId}
+        connectionId={scopeFor(pendingDelete?.connectionId)}
         onClose={() => setPendingDelete(null)}
         onDeleted={async () => {
           setSelectedKey(null)

--- a/apps/desktop/src/app/profiles/rename-profile-dialog.test.tsx
+++ b/apps/desktop/src/app/profiles/rename-profile-dialog.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, expect, it, vi } from 'vitest'
 
 import { renameProfile } from '@/hermes'
-import { retireLocalProfileGateways } from '@/store/gateway'
+import { retireAgentGateways } from '@/store/gateway'
 
 import { RenameProfileDialog } from './rename-profile-dialog'
 
@@ -22,13 +22,13 @@ vi.mock('@/hermes', () => ({
 }))
 
 vi.mock('@/store/gateway', () => ({
-  retireLocalProfileGateways: vi.fn()
+  retireAgentGateways: vi.fn()
 }))
 
 it('retires the old-name local gateways before issuing the rename', async () => {
   const order: string[] = []
 
-  vi.mocked(retireLocalProfileGateways).mockImplementationOnce(() => {
+  vi.mocked(retireAgentGateways).mockImplementationOnce(() => {
     order.push('retire')
   })
   vi.mocked(renameProfile).mockImplementationOnce(async () => {
@@ -43,7 +43,10 @@ it('retires the old-name local gateways before issuing the rename', async () => 
   fireEvent.click(screen.getByRole('button', { name: /^rename$/i }))
 
   await waitFor(() => expect(renameProfile).toHaveBeenCalledWith('selena', 'renamed'))
-  expect(retireLocalProfileGateways).toHaveBeenCalledWith('selena')
+  // Owner-scoped: null is "the legacy/primary-route pool", which is what an
+  // un-scoped dialog (single gateway) means. A registry row passes its own id
+  // so the same-named profile on another machine is left alone (#88638).
+  expect(retireAgentGateways).toHaveBeenCalledWith(null, 'selena')
   expect(order).toEqual(['retire', 'rename'])
 })
 
@@ -54,6 +57,20 @@ it('does not retire gateways when validation rejects the submit', async () => {
   fireEvent.click(screen.getByRole('button', { name: /^rename$/i }))
 
   await waitFor(() => expect(screen.getByText('Name is required.')).toBeTruthy())
-  expect(retireLocalProfileGateways).not.toHaveBeenCalled()
+  expect(retireAgentGateways).not.toHaveBeenCalled()
   expect(renameProfile).not.toHaveBeenCalled()
+})
+
+
+it('retires the OWNING machine\'s gateways when the row belongs to another connection', async () => {
+  render(<RenameProfileDialog connectionId="mechahome-hermes-dell" currentName="selena" onClose={vi.fn()} open />)
+
+  fireEvent.change(screen.getByLabelText(/new name/i), { target: { value: 'renamed' } })
+  fireEvent.click(screen.getByRole('button', { name: /^rename$/i }))
+
+  await waitFor(() => expect(renameProfile).toHaveBeenCalledWith('selena', 'renamed', 'mechahome-hermes-dell'))
+
+  // The local-only seam would have retired the LOCAL `selena`'s sockets while
+  // renaming the Dell's — tearing down a machine the row does not own.
+  expect(retireAgentGateways).toHaveBeenCalledWith('mechahome-hermes-dell', 'selena')
 })

--- a/apps/desktop/src/app/profiles/rename-profile-dialog.tsx
+++ b/apps/desktop/src/app/profiles/rename-profile-dialog.tsx
@@ -26,12 +26,18 @@ const identity = (raw: string) => raw
 // Self-contained rename (owns the renameProfile call) so every caller just
 // reacts via onRenamed. Unchanged name is a no-op close.
 export function RenameProfileDialog({
+  connectionId,
   currentName,
   isDefault = false,
   onClose,
   onRenamed,
   open
 }: {
+  /** The machine that owns this profile.
+   *  Manage Profiles lists every registered gateway's profiles, so an action
+   *  has to run on the box the row came from. Omitted / '' = the primary, so
+   *  single-gateway callers are unchanged. */
+  connectionId?: null | string
   currentName: string
   /** Default profile: sets a presentation-only display name (Unicode ok);
    *  the canonical id stays "default" and no backend teardown is needed. */
@@ -89,7 +95,10 @@ export function RenameProfileDialog({
         retireLocalProfileGateways(currentName)
       }
 
-      await renameProfile(currentName, trimmed)
+      // Pass the owning machine ONLY when there is one, so a
+      // single-gateway install issues the byte-identical upstream call.
+      const scope: [] | [string] = connectionId ? [connectionId] : []
+      await renameProfile(currentName, trimmed, ...scope)
       await onRenamed?.(trimmed)
       setStatus('done')
       window.setTimeout(onClose, 800)

--- a/apps/desktop/src/app/profiles/rename-profile-dialog.tsx
+++ b/apps/desktop/src/app/profiles/rename-profile-dialog.tsx
@@ -16,7 +16,7 @@ import { renameProfile } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { AlertTriangle } from '@/lib/icons'
 import { slug } from '@/lib/sanitize'
-import { retireLocalProfileGateways } from '@/store/gateway'
+import { retireAgentGateways } from '@/store/gateway'
 
 import { isValidProfileName } from './create-profile-dialog'
 
@@ -92,7 +92,11 @@ export function RenameProfileDialog({
       // old-name backend whose ensure_hermes_home() recreates the directory
       // the rename just moved (same class as the delete path, #88638).
       if (!isDefault) {
-        retireLocalProfileGateways(currentName)
+        // Scoped to the agent being renamed. The local-only seam retires the
+        // bare and `local::` scopes, so renaming a secondary's profile used to
+        // tear down the same-named LOCAL one and leave the secondary's own
+        // socket redialing the old name (#88638).
+        retireAgentGateways(connectionId ?? null, currentName)
       }
 
       // Pass the owning machine ONLY when there is one, so a

--- a/apps/desktop/src/app/settings/plugins-settings.tsx
+++ b/apps/desktop/src/app/settings/plugins-settings.tsx
@@ -195,7 +195,7 @@ function AgentPluginsSection() {
 
   const { data: profilesData } = useQuery({
     queryKey: ['agent-plugins-profiles'],
-    queryFn: getProfiles,
+    queryFn: () => getProfiles(),
     staleTime: 60_000
   })
 

--- a/apps/desktop/src/app/skills/index.tsx
+++ b/apps/desktop/src/app/skills/index.tsx
@@ -266,7 +266,7 @@ export function SkillsView({
 
   const { data: profilesData } = useQuery({
     queryKey: ['capabilities-profiles'],
-    queryFn: getProfiles,
+    queryFn: () => getProfiles(),
     staleTime: 60_000,
     // Pinned scope never shows the selector, so don't fetch the roster for it.
     enabled: !fixedProfile

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -4,6 +4,7 @@ import type {
   HermesReadFileTextResult,
   HermesSelectPathsOptions
 } from '@/global'
+import { getApiRequestConnection } from '@/hermes'
 import { $connection } from '@/store/session'
 
 export interface DesktopFsRemotePicker {
@@ -43,6 +44,21 @@ export function desktopFsProfile(): string | undefined {
   return $connection.get()?.profile || undefined
 }
 
+// The profile above is one half of an
+// address: every registered machine serves a `default`, so a profile alone
+// cannot say WHICH host owns the path. Without the connection the bridge fell
+// back to the legacy profile route and listed the PRIMARY's filesystem while
+// the live gateway was on another machine — the file tree showed the other
+// box's home directory, or failed outright because the workspace path does not
+// exist there. Empty while the active gateway is the primary's own route, so
+// single-gateway installs are unaffected.
+function desktopFsScope(): { connectionId?: string; profile?: string } {
+  const connectionId = getApiRequestConnection()
+  const profile = desktopFsProfile()
+
+  return { ...(profile ? { profile } : {}), ...(connectionId ? { connectionId } : {}) }
+}
+
 function fsPath(endpoint: string, filePath: string) {
   return `/api/fs/${endpoint}?path=${encodeURIComponent(filePath)}`
 }
@@ -58,9 +74,7 @@ function bridge() {
 }
 
 function remoteFsApi<T>(path: string, body?: Record<string, unknown>): Promise<T> {
-  return bridge().api<T>(
-    body ? { body, method: 'POST', path, profile: desktopFsProfile() } : { path, profile: desktopFsProfile() }
-  )
+  return bridge().api<T>(body ? { body, method: 'POST', path, ...desktopFsScope() } : { path, ...desktopFsScope() })
 }
 
 export async function readDesktopDir(path: string): Promise<HermesReadDirResult> {

--- a/apps/desktop/src/store/gateway-separation.test.ts
+++ b/apps/desktop/src/store/gateway-separation.test.ts
@@ -1,0 +1,367 @@
+import { atom } from 'nanostores'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Pins the rail's click contract against the
+// REAL topology this feature exists for: a remote primary that serves all of
+// its named profiles through one shared socket ("Mecha Hermes (HP)") plus a
+// second registered gateway with its own `default` ("MechaHome Hermes (Dell)").
+//
+// The bug these cover: a rail square that goes dead — no highlight, no rescope
+// — because $activeGatewayProfile never moved. Every one of those failures is
+// an activation that got rejected or skipped, so the assertions all read the
+// same atom the rail's `active` prop and $profileScope derive from.
+
+const gatewayMocks = vi.hoisted(() => ({
+  connect: vi.fn(async (_wsUrl: string): Promise<void> => undefined),
+  setConnection: vi.fn(),
+  setGatewayState: vi.fn()
+}))
+
+vi.mock('@/hermes', () => ({
+  getProfiles: vi.fn(async () => []),
+  setApiRequestConnection: vi.fn(),
+  setApiRequestProfile: vi.fn(),
+  STARTUP_REQUEST_TIMEOUT_MS: 1000,
+  HermesGateway: class {
+    connectionState = 'closed'
+    connect = async (wsUrl: string): Promise<void> => {
+      await gatewayMocks.connect(wsUrl)
+      this.connectionState = 'open'
+    }
+    close = (): void => {
+      this.connectionState = 'closed'
+    }
+    onEvent = vi.fn(() => () => {})
+    onState = vi.fn(() => () => {})
+  }
+}))
+vi.mock('@/store/session', () => ({
+  setConnection: gatewayMocks.setConnection,
+  setGatewayState: gatewayMocks.setGatewayState,
+  // A gateway hop re-seeds the workspace from the machine it landed on.
+  $activeSessionId: atom<null | string>(null),
+  setCurrentBranch: vi.fn(),
+  setCurrentCwdTransient: vi.fn()
+}))
+vi.mock('@/lib/desktop-fs', () => ({
+  desktopDefaultCwd: vi.fn(async () => ({ branch: 'main', cwd: '/home/dell/workspace' }))
+}))
+vi.mock('@/store/notify-baseline', () => ({ markNativeNotifyBaseline: vi.fn() }))
+vi.mock('@/lib/query-client', () => ({ invalidateProfileScopedQueries: vi.fn() }))
+vi.mock('@/store/cron-model-impact-scope', () => ({ invalidateCronModelImpactScopeState: vi.fn() }))
+vi.mock('@/store/starmap', () => ({ resetStarmapGraph: vi.fn() }))
+
+const { closeSecondaryGateways, configureGatewayRegistry, setPrimaryGateway } = await import('./gateway')
+const { $activeGatewayProfile, ensureGatewayProfile, normalizeProfileKey, selectProfile } = await import('./profile')
+
+const {
+  $attachedConnectionId,
+  $foreignAgents,
+  $primaryConnectionId,
+  refreshGatewaySeparation,
+  selectForeignAgent,
+  selectPrimaryAgent
+} = await import('./gateway-separation')
+
+const HP = 'hp'
+const DELL = 'dell'
+
+const HP_URL = 'http://192.168.1.218:9119'
+const DELL_URL = 'http://192.168.1.204:9120'
+
+const hpDescriptor = (profile: string) => ({
+  authMode: 'token',
+  baseUrl: HP_URL,
+  mode: 'remote',
+  // The HP primary is a REMOTE gateway, so every one of its named profiles
+  // routes THROUGH the primary socket and getConnection tags the descriptor
+  // `sharedPrimary` (electron/main.ts ensureBackend, routing case 3). This is
+  // the shape the real setup hands the renderer — not a per-profile socket.
+  profile,
+  sharedPrimary: true,
+  token: 'fake-test-token',
+  wsUrl: `ws://192.168.1.218:9119/api/ws?token=fake-test-token`
+})
+
+const dellDescriptor = {
+  authMode: 'token',
+  baseUrl: DELL_URL,
+  mode: 'remote',
+  profile: 'default',
+  token: 'fake-test-token',
+  wsUrl: 'ws://192.168.1.204:9120/api/ws?token=fake-test-token'
+}
+
+const REGISTRY = {
+  primary: HP,
+  connections: [
+    { id: HP, kind: 'remote', label: 'Mecha Hermes (HP)', url: HP_URL },
+    { id: DELL, kind: 'remote', label: 'MechaHome Hermes (Dell)', url: DELL_URL }
+  ]
+}
+
+const ROSTER = {
+  sources: [
+    { connectionId: HP, reachable: true },
+    { connectionId: DELL, reachable: true }
+  ],
+  agents: [
+    ...['default', 'appdev', 'codertom', 'makebofagent', 'menuscript'].map(profile => ({
+      connectionId: HP,
+      connectionLabel: 'Mecha Hermes (HP)',
+      handle: profile,
+      profile
+    })),
+    { connectionId: DELL, connectionLabel: 'MechaHome Hermes (Dell)', handle: 'default', profile: 'default' }
+  ]
+}
+
+function installDesktop(): void {
+  ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+    connections: { list: vi.fn(async () => REGISTRY) },
+    getAgentRoster: vi.fn(async () => ROSTER),
+    getConnection: vi.fn(async (profile?: string) => hpDescriptor(normalizeProfileKey(profile))),
+    // Descriptors are per (connection, profile) — the mock has to answer for
+    // BOTH machines, or a test cannot tell a trip home from staying put.
+    getConnectionFor: vi.fn(async ({ connectionId, profile }: { connectionId: string; profile?: string }) =>
+      connectionId === DELL ? dellDescriptor : hpDescriptor(normalizeProfileKey(profile))
+    )
+  }
+}
+
+/** Boot the rail's world: primary socket open on HP `default`, the registry
+ *  mirror wired exactly as use-gateway-boot wires it (the mirror is what turns
+ *  a rejected activation into a dead square, so a test without it cannot see
+ *  the bug). */
+async function boot(): Promise<void> {
+  installDesktop()
+  configureGatewayRegistry({
+    onEvent: vi.fn(),
+    onActiveRouteChanged: profile => {
+      const key = normalizeProfileKey(profile)
+
+      if (normalizeProfileKey($activeGatewayProfile.get()) !== key) {
+        $activeGatewayProfile.set(key)
+      }
+    }
+  })
+  setPrimaryGateway({ connectionState: 'open' } as never, 'default')
+  $activeGatewayProfile.set('default')
+  await refreshGatewaySeparation()
+  // Attachment is DERIVED, never written by the rail: the primary socket going
+  // live leaves no registry connection active, so $attachedConnectionId falls
+  // back to the primary — exactly as it does on a real boot.
+}
+
+beforeEach(async () => {
+  await boot()
+})
+
+afterEach(() => {
+  closeSecondaryGateways()
+  vi.clearAllMocks()
+  delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+})
+
+/** selectPrimaryAgent is fire-and-forget (one activation per click, started
+ *  and not awaited), so a test has to let the switch settle before reading. */
+const settle = () => new Promise(resolve => setTimeout(resolve, 0))
+
+/** Click the Dell square: the live gateway moves to the other machine, and its
+ *  profile is ALSO called `default`, which is what makes the trip home hard. */
+const hopToDell = () =>
+  selectForeignAgent({
+    connectionId: DELL,
+    connectionLabel: 'MechaHome Hermes (Dell)',
+    handle: 'default',
+    profile: 'default',
+    reachable: true
+  })
+
+/** Click one of the HP's squares while the live gateway is on the Dell. From
+ *  there the primary's agents are FOREIGN squares — the rail's own squares are
+ *  whatever machine it is attached to — so the trip home goes through the same
+ *  door the trip out did, just pointed the other way. */
+const hopHome = (profile: string) =>
+  selectForeignAgent({
+    connectionId: HP,
+    connectionLabel: 'Mecha Hermes (HP)',
+    handle: profile,
+    profile,
+    reachable: true
+  })
+
+describe('rail squares on the primary', () => {
+  it('seeds attachment to the registry primary', () => {
+    expect($primaryConnectionId.get()).toBe(HP)
+    expect($attachedConnectionId.get()).toBe(HP)
+  })
+
+  it('moves the active profile when a named square is clicked', async () => {
+    selectPrimaryAgent('appdev')
+    await settle()
+
+    expect($activeGatewayProfile.get()).toBe('appdev')
+    expect($attachedConnectionId.get()).toBe(HP)
+  })
+
+  it('moves between two named squares', async () => {
+    selectPrimaryAgent('appdev')
+    await settle()
+    selectPrimaryAgent('codertom')
+    await settle()
+
+    expect($activeGatewayProfile.get()).toBe('codertom')
+  })
+
+  it('returns to default from a named square', async () => {
+    selectPrimaryAgent('menuscript')
+    await settle()
+    selectPrimaryAgent('default')
+    await settle()
+
+    expect($activeGatewayProfile.get()).toBe('default')
+  })
+
+  it('survives two clicks landing in the same tick (impatient double-click)', async () => {
+    selectPrimaryAgent('appdev')
+    selectPrimaryAgent('appdev')
+    await settle()
+
+    expect($activeGatewayProfile.get()).toBe('appdev')
+  })
+})
+
+describe('rail squares after a cross-gateway hop', () => {
+  it('comes back to a NAMED primary profile from the Dell agent', async () => {
+    await hopToDell()
+    expect($attachedConnectionId.get()).toBe(DELL)
+
+    selectPrimaryAgent('appdev')
+    await settle()
+
+    expect($activeGatewayProfile.get()).toBe('appdev')
+    expect($attachedConnectionId.get()).toBe(HP)
+  })
+
+  it('comes back to the primary DEFAULT square from the Dell agent', async () => {
+    await hopToDell()
+
+    // Both machines call this profile `default`, so $activeGatewayProfile —
+    // which publishes the BARE profile name — still reads 'default' while the
+    // live socket is on the Dell. Nothing keyed on that name can tell this is a
+    // real switch, which is why the trip home cannot go through the name-keyed
+    // door: `ensureGatewayProfile('default')` sees "already on default" and
+    // returns. Addressing the agent by (connection, profile) is what makes the
+    // same-named square on the other machine reachable at all.
+    await hopHome('default')
+    await settle()
+
+    expect($attachedConnectionId.get()).toBe(HP)
+    expect(gatewayMocks.setConnection).toHaveBeenCalledWith(expect.objectContaining({ baseUrl: HP_URL }))
+  })
+
+  it("sends the primary's own descriptor, not the Dell's, when a named square comes home", async () => {
+    await hopToDell()
+    selectPrimaryAgent('appdev')
+    await settle()
+
+    expect(gatewayMocks.setConnection).toHaveBeenLastCalledWith(
+      expect.objectContaining({ baseUrl: HP_URL, profile: 'appdev' })
+    )
+  })
+})
+
+describe('rail split (the rail may not draw an agent twice)', () => {
+  const keys = () => $foreignAgents.get().map(a => `${a.connectionId}:${a.profile}`)
+
+  it("treats the other machine's agents as foreign while attached to the primary", () => {
+    expect(keys()).toEqual([`${DELL}:default`])
+  })
+
+  it('re-derives the split the moment the live gateway lands on the Dell', async () => {
+    await hopToDell()
+
+    // The rail's own squares are $profiles, which follows the AMBIENT
+    // connection — so once the hop lands they describe the Dell. Keeping the
+    // split pinned to the primary instead drew the Dell's `default` twice:
+    // once as a native square, once as a foreign one.
+    expect(keys()).not.toContain(`${DELL}:default`)
+    expect(keys()).toContain(`${HP}:default`)
+    expect(keys()).toHaveLength(5)
+  })
+
+  it('puts the split back when the trip home actually lands', async () => {
+    await hopToDell()
+    expect(keys()).toContain(`${HP}:default`)
+
+    await hopHome('default')
+    await settle()
+
+    // Deliberately NOT synchronous with the click. Writing the attachment
+    // optimistically also moved the atom the sidebar reseeds on, so the session
+    // refetch went out while the API layer's ambient connection was still the
+    // Dell — it re-fetched the Dell's rows and relabelled them as the primary's.
+    // The split follows the activation that actually landed.
+    expect(keys()).toEqual([`${DELL}:default`])
+  })
+})
+
+describe('a gateway hop re-points machine-scoped state', () => {
+  it('re-seeds the workspace from the machine it landed on', async () => {
+    const { desktopDefaultCwd } = await import('@/lib/desktop-fs')
+    const { setCurrentCwdTransient } = await import('@/store/session')
+
+    await hopToDell()
+    await settle()
+
+    // A cwd is a path on ONE box. Carrying the primary's across the hop asked
+    // the Dell for a directory it does not have, and the workspace panel
+    // rendered "Could not read this folder (ENOENT)".
+    expect(desktopDefaultCwd).toHaveBeenCalled()
+    expect(setCurrentCwdTransient).toHaveBeenCalledWith('/home/dell/workspace')
+  })
+
+  it('leaves the workspace alone while a session is open', async () => {
+    const { $activeSessionId, setCurrentCwdTransient } = await import('@/store/session')
+
+    // Let the boot's own re-seed land first, so this asserts on the hop alone.
+    await settle()
+    vi.mocked(setCurrentCwdTransient).mockClear()
+    $activeSessionId.set('live-session')
+
+    try {
+      await hopToDell()
+      await settle()
+
+      // An open session owns the cwd.
+      expect(setCurrentCwdTransient).not.toHaveBeenCalled()
+    } finally {
+      $activeSessionId.set(null)
+    }
+  })
+
+  it('never rejects when the new machine cannot answer', async () => {
+    const { desktopDefaultCwd } = await import('@/lib/desktop-fs')
+    vi.mocked(desktopDefaultCwd).mockRejectedValueOnce(new Error('unreachable'))
+
+    // The switch itself already landed; a failed re-seed must not surface as an
+    // unhandled rejection on top of a successful hop.
+    await expect(hopToDell()).resolves.toBeUndefined()
+    await settle()
+  })
+})
+
+describe('one activation per click', () => {
+  it('a second concurrent activation for the same target does not strand the first', async () => {
+    // The shape the earlier selectPrimaryAgent had: selectProfile starts one
+    // activation internally, and awaiting a second on top of it raced the
+    // epoch. Pinned here so re-adding the "surface failures" await fails loudly
+    // instead of silently killing the square.
+    selectProfile('codertom')
+    await ensureGatewayProfile('codertom')
+    await settle()
+
+    expect($activeGatewayProfile.get()).toBe('codertom')
+  })
+})

--- a/apps/desktop/src/store/gateway-separation.test.ts
+++ b/apps/desktop/src/store/gateway-separation.test.ts
@@ -83,14 +83,17 @@ const hpDescriptor = (profile: string) => ({
   wsUrl: `ws://192.168.1.218:9119/api/ws?token=fake-test-token`
 })
 
-const dellDescriptor = {
+// Per-profile, because the Dell now serves a NAMED profile the HP also serves.
+// A descriptor mock that answers the same object for every profile cannot tell
+// `appdev@HP` from `appdev@Dell`, which is precisely the confusion under test.
+const dellDescriptor = (profile: string) => ({
   authMode: 'token',
   baseUrl: DELL_URL,
   mode: 'remote',
-  profile: 'default',
+  profile,
   token: 'fake-test-token',
   wsUrl: 'ws://192.168.1.204:9120/api/ws?token=fake-test-token'
-}
+})
 
 const REGISTRY = {
   primary: HP,
@@ -112,7 +115,15 @@ const ROSTER = {
       handle: profile,
       profile
     })),
-    { connectionId: DELL, connectionLabel: 'MechaHome Hermes (Dell)', handle: 'default', profile: 'default' }
+    // Both machines serve `default` AND `appdev`. The overlap is the point:
+    // every defect below is invisible on a topology where the second gateway
+    // only has `default`, because a bare name is still unambiguous there.
+    ...['default', 'appdev'].map(profile => ({
+      connectionId: DELL,
+      connectionLabel: 'MechaHome Hermes (Dell)',
+      handle: `${profile}-dell`,
+      profile
+    }))
   ]
 }
 
@@ -124,7 +135,7 @@ function installDesktop(): void {
     // Descriptors are per (connection, profile) — the mock has to answer for
     // BOTH machines, or a test cannot tell a trip home from staying put.
     getConnectionFor: vi.fn(async ({ connectionId, profile }: { connectionId: string; profile?: string }) =>
-      connectionId === DELL ? dellDescriptor : hpDescriptor(normalizeProfileKey(profile))
+      connectionId === DELL ? dellDescriptor(normalizeProfileKey(profile)) : hpDescriptor(normalizeProfileKey(profile))
     )
   }
 }
@@ -233,11 +244,14 @@ describe('rail squares on the primary', () => {
 })
 
 describe('rail squares after a cross-gateway hop', () => {
-  it('comes back to a NAMED primary profile from the Dell agent', async () => {
+  it('comes back to a NAMED primary profile through its foreign square', async () => {
     await hopToDell()
     expect($attachedConnectionId.get()).toBe(DELL)
 
-    selectPrimaryAgent('appdev')
+    // From the Dell, the HP's agents are FOREIGN squares — the rail's own
+    // squares describe the machine it is attached to. `appdev` exists on both,
+    // so only the (connection, profile) door can say which one is meant.
+    await hopHome('appdev')
     await settle()
 
     expect($activeGatewayProfile.get()).toBe('appdev')
@@ -263,7 +277,7 @@ describe('rail squares after a cross-gateway hop', () => {
 
   it("sends the primary's own descriptor, not the Dell's, when a named square comes home", async () => {
     await hopToDell()
-    selectPrimaryAgent('appdev')
+    await hopHome('appdev')
     await settle()
 
     expect(gatewayMocks.setConnection).toHaveBeenLastCalledWith(
@@ -276,7 +290,7 @@ describe('rail split (the rail may not draw an agent twice)', () => {
   const keys = () => $foreignAgents.get().map(a => `${a.connectionId}:${a.profile}`)
 
   it("treats the other machine's agents as foreign while attached to the primary", () => {
-    expect(keys()).toEqual([`${DELL}:default`])
+    expect(keys()).toEqual([`${DELL}:default`, `${DELL}:appdev`])
   })
 
   it('re-derives the split the moment the live gateway lands on the Dell', async () => {
@@ -287,7 +301,9 @@ describe('rail split (the rail may not draw an agent twice)', () => {
     // split pinned to the primary instead drew the Dell's `default` twice:
     // once as a native square, once as a foreign one.
     expect(keys()).not.toContain(`${DELL}:default`)
+    expect(keys()).not.toContain(`${DELL}:appdev`)
     expect(keys()).toContain(`${HP}:default`)
+    expect(keys()).toContain(`${HP}:appdev`)
     expect(keys()).toHaveLength(5)
   })
 
@@ -303,7 +319,7 @@ describe('rail split (the rail may not draw an agent twice)', () => {
     // refetch went out while the API layer's ambient connection was still the
     // Dell — it re-fetched the Dell's rows and relabelled them as the primary's.
     // The split follows the activation that actually landed.
-    expect(keys()).toEqual([`${DELL}:default`])
+    expect(keys()).toEqual([`${DELL}:default`, `${DELL}:appdev`])
   })
 })
 
@@ -363,5 +379,58 @@ describe('one activation per click', () => {
     await settle()
 
     expect($activeGatewayProfile.get()).toBe('codertom')
+  })
+})
+
+
+describe('ownership: a native square belongs to the machine it is drawn from', () => {
+  it('activates the ATTACHED gateway\'s named profile, not the primary\'s same-named one', async () => {
+    await hopToDell()
+    expect($attachedConnectionId.get()).toBe(DELL)
+
+    gatewayMocks.setConnection.mockClear()
+
+    // `appdev` exists on BOTH machines. The rail's own squares are drawn from
+    // $profiles, which describes the ATTACHED machine, so this square is the
+    // Dell's — and it must resolve through the (connection, profile) door.
+    // Routing it by bare name reaches the profile-only pool, which is anchored
+    // to the primary, and silently activates appdev@HP instead (#88880/#89466).
+    selectPrimaryAgent('appdev')
+    await settle()
+
+    expect($activeGatewayProfile.get()).toBe('appdev')
+    expect($attachedConnectionId.get()).toBe(DELL)
+    expect(gatewayMocks.setConnection).toHaveBeenLastCalledWith(
+      expect.objectContaining({ baseUrl: DELL_URL, profile: 'appdev' })
+    )
+  })
+
+  it('resolves the descriptor through the OWNING connection', async () => {
+    await hopToDell()
+
+    const desktop = (window as unknown as { hermesDesktop: { getConnectionFor: ReturnType<typeof vi.fn> } })
+      .hermesDesktop
+
+    desktop.getConnectionFor.mockClear()
+    selectPrimaryAgent('appdev')
+    await settle()
+
+    // getConnectionFor is the (connection, profile) door; the profile-only pool
+    // goes through getConnection instead and cannot express which machine.
+    expect(desktop.getConnectionFor).toHaveBeenCalledWith(expect.objectContaining({ connectionId: DELL }))
+  })
+
+  it('still takes the legacy profile path while attached to the primary', async () => {
+    // Single-gateway installs and every on-primary click must stay byte
+    // identical to upstream: no registry door, no behaviour change.
+    const desktop = (window as unknown as { hermesDesktop: { getConnectionFor: ReturnType<typeof vi.fn> } })
+      .hermesDesktop
+
+    desktop.getConnectionFor.mockClear()
+    selectPrimaryAgent('codertom')
+    await settle()
+
+    expect($activeGatewayProfile.get()).toBe('codertom')
+    expect(desktop.getConnectionFor).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/store/gateway-separation.ts
+++ b/apps/desktop/src/store/gateway-separation.ts
@@ -1,0 +1,290 @@
+/**
+ * True separation by gateway.
+ *
+ * Upstream already tags cross-gateway session rows with `connection_id` (the
+ * #88880 unified-list splice) and computes a union agent roster
+ * (`getAgentRoster`), but neither the Sessions sidebar nor the profile rail
+ * renders the gateway dimension: two machines that both expose a `default`
+ * profile collapse into one indistinguishable bucket.
+ *
+ * This module carries the renderer-side state the sidebar needs to tell them
+ * apart. It deliberately does NOT touch `$profiles` — that cache feeds
+ * delegation, @-mentions, filters and the SDK, and injecting foreign agents
+ * into it would leak cross-machine profiles into all of them. The rail renders
+ * these agents as EXTRA squares instead.
+ */
+import { atom, computed } from 'nanostores'
+
+import { $gateway, activeGatewayConnectionId } from './gateway'
+import { selectProfile as selectProfileImpl } from './profile'
+
+/** Fallback id for the app-managed local runtime. */
+export const LOCAL_CONNECTION_ID = 'local'
+
+/** One agent in the union roster: a profile living on a registered source. */
+export interface RosterAgent {
+  connectionId: string
+  connectionLabel: string
+  profile: string
+  handle: string
+  reachable: boolean
+}
+
+/** connectionId → human device name ("Mecha Hermes (HP)"). */
+export const $connectionLabels = atom<Record<string, string>>({})
+
+/** The registry primary. Session rows WITHOUT a `connection_id` came from it. */
+export const $primaryConnectionId = atom<string>('')
+
+/** Registry id the live gateway is serving, or '' for the primary's own route.
+ *
+ *  Mirrored from the registry rather than written optimistically by the rail.
+ *  The optimistic version raced: clicking a square set the attachment in the
+ *  same frame as the click, the sidebar's reseed fired on that change, and the
+ *  fetch went out while the API layer's ambient connection was still the
+ *  PREVIOUS machine's — so the trip home from the Dell re-fetched the Dell's
+ *  rows and then relabelled them as the primary's. `applyActive` publishes
+ *  `$gateway` in the same synchronous frame it sets the ambient connection, so
+ *  reacting to that is race-free by construction. */
+const $liveRegistryConnection = atom<string>('')
+
+$gateway.subscribe(() => {
+  $liveRegistryConnection.set(activeGatewayConnectionId() || '')
+})
+
+/** The connection the live gateway is currently attached to. Resolved against
+ *  the registry primary, so it stays correct as the registry finishes loading
+ *  (the raw mirror above is '' for the primary's own route). */
+export const $attachedConnectionId = computed(
+  [$liveRegistryConnection, $primaryConnectionId],
+  (live, primary) => live || primary || LOCAL_CONNECTION_ID
+)
+
+/** Every (connection, profile) pair across the registry. */
+export const $rosterAgents = atom<RosterAgent[]>([])
+
+/** True once more than one connection is registered. Everything this module
+ *  adds stays invisible below that line, so single-gateway users see the
+ *  stock sidebar. */
+export const $multiGateway = computed($connectionLabels, labels => Object.keys(labels).length > 1)
+
+/** Stable identity for a rail square / session group: a profile name alone is
+ *  ambiguous once two machines both serve `default`. */
+export const agentKey = (connectionId: string, profile: string): string =>
+  `${(connectionId || LOCAL_CONNECTION_ID).trim()}::${(profile || 'default').trim().toLowerCase()}`
+
+/** Which connection a session row belongs to.
+ *
+ *  A row spliced from another gateway carries an explicit `connection_id` and is
+ *  self-describing. An UNTAGGED row belongs to whichever gateway served the
+ *  list — and the `/api/sessions` family now carries the active connection, so
+ *  that is the ATTACHED one, not always the primary. Attributing untagged rows
+ *  to the primary instead is what made the Dell's own sessions vanish: they came
+ *  back untagged from the Dell, were labelled as the HP's, and the sidebar's
+ *  connection filter then hid every one of them behind "No sessions yet". */
+export function sessionConnectionId(session: { connection_id?: string }): string {
+  const tagged = (session.connection_id || '').trim()
+
+  return tagged || $attachedConnectionId.get() || $primaryConnectionId.get() || LOCAL_CONNECTION_ID
+}
+
+/** Build "is this row on the gateway the rail is currently attached to?".
+ *
+ *  The sidebar's scope filter used to ask only "is this row's PROFILE the active
+ *  one", and a profile name is not an identity across machines: while attached
+ *  to the Dell's `default` that predicate still matched every one of the HP's
+ *  `default` rows, so switching gateway changed nothing on screen even though
+ *  the socket had genuinely moved. Adding the connection dimension is what makes
+ *  the hop visible.
+ *
+ *  A factory rather than a bare predicate so React sees the inputs: the caller
+ *  memoizes on (multiGateway, attached) and the scoping recomputes when the live
+ *  gateway hops. Inert below two connections, so single-gateway installs keep
+ *  the stock filter exactly. */
+export function onAttachedConnection(
+  multiGateway: boolean,
+  attached: string
+): (session: { connection_id?: string }) => boolean {
+  if (!multiGateway || !attached) {
+    return () => true
+  }
+
+  return session => sessionConnectionId(session) === attached
+}
+
+/** Device name for a connection id, or '' when unknown / single-gateway. */
+export function gatewayLabel(connectionId: string): string {
+  return $connectionLabels.get()[connectionId] || ''
+}
+
+/** Agents that are NOT on the connection the live gateway is attached to.
+ *
+ *  Keyed on the ATTACHED connection because that is what `$profiles` describes.
+ *  `refreshProfiles` goes through `hermesApi`, which carries the ambient
+ *  connection, and `applyActive` republishes that ambient connection on every
+ *  switch — so the rail's own squares follow the live gateway (the same
+ *  invariant #85731 relies on: "the list the new backend just served").
+ *
+ *  Native squares = the attached machine's profiles, foreign squares =
+ *  everything else. Complementary by construction, and re-derived on every hop
+ *  rather than pinned to one machine — keying these on the PRIMARY instead
+ *  rendered the attached box's agents twice the moment you hopped, once as
+ *  native squares and once as foreign ones. */
+export const $foreignAgents = computed([$rosterAgents, $attachedConnectionId], (agents, attached) =>
+  agents.filter(agent => agent.connectionId !== (attached || LOCAL_CONNECTION_ID).trim())
+)
+
+/** Refresh labels, primary and the union roster. Attachment is derived from
+ *  the live gateway (see `$attachedConnectionId`), not fetched here. Every leg is
+ *  best-effort and independent: an older build without the registry or the
+ *  roster simply leaves those stores empty, which switches the whole feature
+ *  off rather than breaking the sidebar. */
+export async function refreshGatewaySeparation(): Promise<void> {
+  const desktop = window.hermesDesktop as unknown as Record<string, any>
+  let connections: { id: string; kind: string; url?: string }[] = []
+
+  try {
+    const registry = await desktop?.connections?.list?.()
+
+    if (registry) {
+      connections = registry.connections ?? []
+
+      const labels: Record<string, string> = {}
+
+      for (const connection of connections) {
+        labels[connection.id] = (connection as { label?: string }).label || connection.id
+      }
+
+      $connectionLabels.set(labels)
+      $primaryConnectionId.set((registry.primary || '').trim() || LOCAL_CONNECTION_ID)
+    }
+  } catch {
+    // Registry unavailable — leave the feature off.
+  }
+
+  try {
+    const roster = await desktop?.getAgentRoster?.()
+
+    if (roster) {
+      const unreachable = new Set(
+        (roster.sources ?? [])
+          .filter((s: { reachable?: boolean }) => !s.reachable)
+          .map((s: { connectionId: string }) => s.connectionId)
+      )
+
+      $rosterAgents.set(
+        (roster.agents ?? []).map((agent: Record<string, string>) => ({
+          connectionId: agent.connectionId,
+          connectionLabel: agent.connectionLabel || agent.connectionId,
+          profile: agent.profile || 'default',
+          handle: agent.handle || agent.profile || 'default',
+          reachable: !unreachable.has(agent.connectionId)
+        }))
+      )
+    }
+  } catch {
+    // Roster unavailable — the rail keeps its single-source squares.
+  }
+}
+
+/** Switch the live gateway to an agent on another machine. Routes through the
+ *  connection-scoped activation path (`ensureGatewayAgent`), not a same-named
+ *  local profile. Imported lazily to keep this module out of the profile
+ *  store's import cycle. */
+export async function selectForeignAgent(agent: RosterAgent): Promise<void> {
+  const { $newChatProfile, ensureGatewayAgent, requestFreshSession } = await import('./profile')
+
+  await ensureGatewayAgent(agent.connectionId, agent.profile)
+
+  // Point new chats at THIS agent's profile. `desktopSessionCreateParams` reads
+  // `$newChatProfile` and calls `ensureGatewayProfile` on it before creating the
+  // session; left pointing at a profile this machine does not serve, that call
+  // swaps the live gateway away from here and the message lands on the primary.
+  $newChatProfile.set(agent.profile)
+
+  // Attachment is NOT written here: it is derived from the live gateway that
+  // `ensureGatewayAgent` just published, so a rejected activation cannot leave
+  // the rail claiming a machine we never reached.
+
+  // Land on a fresh draft, exactly like `selectProfile` does for a same-machine
+  // switch. Upstream reaches that through a profile-NAME change, which a hop
+  // between two machines' `default` never produces — so without this you kept
+  // staring at the previous machine's open chat while the composer had already
+  // moved to the new one.
+  requestFreshSession()
+}
+
+/** Per-backend caches are invalidated on a change of profile NAME, which a hop
+ *  between two machines' `default` never produces. Mirror that trigger onto the
+ *  connection so a gateway hop drops the previous machine's settings, models and
+ *  session list exactly like a profile switch does. Skips the initial seed. */
+let lastRoutedConnection: null | string = null
+
+$attachedConnectionId.subscribe(value => {
+  const next = (value || '').trim()
+
+  if (lastRoutedConnection !== null && lastRoutedConnection !== next) {
+    // Both are best-effort side effects of a switch that has ALREADY landed, so
+    // neither may reject: an unhandled rejection here would surface as a crash
+    // report for a gateway hop that actually succeeded.
+    void import('./profile')
+      .then(({ invalidateProfileRoutedCaches }) => invalidateProfileRoutedCaches())
+      .catch(() => undefined)
+    void reseedWorkspaceForConnection()
+  }
+
+  lastRoutedConnection = next
+})
+
+/** Re-point the workspace at the machine we just landed on.
+ *
+ *  A cwd is a path on ONE box. Carrying the previous gateway's across a hop
+ *  left the file tree asking the new machine for a directory it does not have,
+ *  and the panel rendered "Could not read this folder (ENOENT)" — or, worse,
+ *  silently listed a same-named path. `/api/fs/default-cwd` is connection-scoped
+ *  now, so asking again answers for the machine we are actually on.
+ *
+ *  Skipped while a session is open: that session owns the cwd, and a hop starts
+ *  a fresh draft anyway. Best-effort — a failure leaves the previous path rather
+ *  than blanking the panel. */
+async function reseedWorkspaceForConnection(): Promise<void> {
+  try {
+    const [{ $activeSessionId, setCurrentBranch, setCurrentCwdTransient }, { desktopDefaultCwd }] = await Promise.all([
+      import('./session'),
+      import('@/lib/desktop-fs')
+    ])
+
+    if ($activeSessionId.get()) {
+      return
+    }
+
+    const next = await desktopDefaultCwd()
+
+    // Re-check: the user may have opened a session while this was in flight.
+    if (!next?.cwd || $activeSessionId.get()) {
+      return
+    }
+
+    setCurrentCwdTransient(next.cwd)
+    setCurrentBranch(next.branch || '')
+  } catch {
+    // Never rejects — see the call site. Keeping the previous path is the right
+    // failure mode: the panel shows a stale tree rather than nothing at all.
+  }
+}
+
+/** Pick one of the rail's own agents — a profile served by the machine the live
+ *  gateway is already attached to.
+ *
+ *  Thin on purpose: upstream's `selectProfile` already does the right thing for
+ *  a same-machine switch. It exists so the rail has ONE door per square kind,
+ *  with `selectForeignAgent` as its cross-machine twin, rather than the switcher
+ *  branching on connection identity inline.
+ *
+ *  Attachment is not written here. It is derived from the live gateway, so the
+ *  square lights when the swap actually lands rather than the instant it is
+ *  clicked — an optimistic write raced the sidebar's reseed and refetched the
+ *  PREVIOUS machine's rows. */
+export function selectPrimaryAgent(profile: string): void {
+  selectProfileImpl(profile)
+}

--- a/apps/desktop/src/store/gateway-separation.ts
+++ b/apps/desktop/src/store/gateway-separation.ts
@@ -191,16 +191,27 @@ export async function refreshGatewaySeparation(): Promise<void> {
  *  connection-scoped activation path (`ensureGatewayAgent`), not a same-named
  *  local profile. Imported lazily to keep this module out of the profile
  *  store's import cycle. */
-export async function selectForeignAgent(agent: RosterAgent): Promise<void> {
-  const { $newChatProfile, ensureGatewayAgent, requestFreshSession } = await import('./profile')
+/** Activate a specific (connection, profile) agent and move the chat scope onto
+ *  it — the cross-machine analogue of upstream's `selectProfile`.
+ *
+ *  Everything here addresses the agent by its OWNING TUPLE. A bare profile name
+ *  resolves through the legacy profile-only pool, which is anchored to the
+ *  primary/local runtime, so a named profile on a secondary would activate the
+ *  same-named profile on the WRONG machine (#88880 / #89466). */
+async function activateAgent(connectionId: string, profile: string, collapseAllProfiles: boolean): Promise<void> {
+  const { $newChatProfile, ensureGatewayAgent, requestFreshSession, setShowAllProfiles } = await import('./profile')
 
-  await ensureGatewayAgent(agent.connectionId, agent.profile)
+  if (collapseAllProfiles) {
+    setShowAllProfiles(false)
+  }
+
+  await ensureGatewayAgent(connectionId, profile)
 
   // Point new chats at THIS agent's profile. `desktopSessionCreateParams` reads
   // `$newChatProfile` and calls `ensureGatewayProfile` on it before creating the
   // session; left pointing at a profile this machine does not serve, that call
   // swaps the live gateway away from here and the message lands on the primary.
-  $newChatProfile.set(agent.profile)
+  $newChatProfile.set(profile)
 
   // Attachment is NOT written here: it is derived from the live gateway that
   // `ensureGatewayAgent` just published, so a rejected activation cannot leave
@@ -212,6 +223,11 @@ export async function selectForeignAgent(agent: RosterAgent): Promise<void> {
   // staring at the previous machine's open chat while the composer had already
   // moved to the new one.
   requestFreshSession()
+}
+
+/** Pick an agent that lives on a DIFFERENT gateway than the live one. */
+export async function selectForeignAgent(agent: RosterAgent): Promise<void> {
+  await activateAgent(agent.connectionId, agent.profile, false)
 }
 
 /** Per-backend caches are invalidated on a change of profile NAME, which a hop
@@ -273,18 +289,28 @@ async function reseedWorkspaceForConnection(): Promise<void> {
   }
 }
 
-/** Pick one of the rail's own agents — a profile served by the machine the live
- *  gateway is already attached to.
+/** Pick one of the rail's own squares.
  *
- *  Thin on purpose: upstream's `selectProfile` already does the right thing for
- *  a same-machine switch. It exists so the rail has ONE door per square kind,
- *  with `selectForeignAgent` as its cross-machine twin, rather than the switcher
- *  branching on connection identity inline.
+ *  Those squares are drawn from `$profiles`, which describes whichever machine
+ *  the live gateway is ATTACHED to — `refreshProfiles` goes through `hermesApi`,
+ *  which carries the ambient connection. So "the rail's own agent" is only the
+ *  primary's while we are actually on the primary.
  *
- *  Attachment is not written here. It is derived from the live gateway, so the
- *  square lights when the swap actually lands rather than the instant it is
- *  clicked — an optimistic write raced the sidebar's reseed and refetched the
- *  PREVIOUS machine's rows. */
+ *  That makes the owning connection load-bearing rather than decorative. Handing
+ *  the bare name to `selectProfile` sends it through `ensureGatewayProfile`, the
+ *  profile-only pool anchored to the primary/local runtime: while attached to a
+ *  secondary, clicking its `appdev` square would activate the PRIMARY's `appdev`
+ *  and point the next chat at the wrong machine. Only a null owner — the
+ *  primary's own route, and every single-gateway install — may take the legacy
+ *  path, where it stays byte-identical to upstream. */
 export function selectPrimaryAgent(profile: string): void {
-  selectProfileImpl(profile)
+  const owner = (activeGatewayConnectionId() ?? '').trim()
+
+  if (!owner) {
+    selectProfileImpl(profile)
+
+    return
+  }
+
+  void activateAgent(owner, profile, true)
 }

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -963,6 +963,48 @@ export function retireLocalProfileGateways(profile: string): void {
   }
 }
 
+/**
+ * Retire the sockets owned by ONE agent, in whichever pool they live.
+ *
+ * `retireLocalProfileGateways` is deliberately local-only (#88638): it retires
+ * the bare-profile and explicit-`local` scopes and PRESERVES same-named agents
+ * on other connections. That is exactly right when the profile being deleted or
+ * renamed is the local/primary-route one, and exactly wrong when it is not —
+ * deleting `default` on a registry secondary would then tear down the LOCAL
+ * `default`'s sockets and leave the secondary's own socket redialing a profile
+ * that no longer exists.
+ *
+ * The discriminator is the pool the agent actually resolves into, not whether
+ * it "looks remote": a remote PRIMARY still routes through the bare profile
+ * scope, so it must keep taking the legacy path.
+ */
+export function retireAgentGateways(connectionId: null | string, profile: string): void {
+  const key = normKey(profile)
+  const scope = registryBackendScopeKey(connectionId, key)
+
+  if (scope === key) {
+    retireLocalProfileGateways(key)
+
+    return
+  }
+
+  const entry = g.secondaries.get(scope)
+
+  if (!entry) {
+    return
+  }
+
+  const activeInvalidated = scope === g.activeKey
+
+  disposeSecondary(entry)
+  g.secondaries.delete(scope)
+  restoreActiveToPrimaryIfEvicted()
+
+  if (activeInvalidated) {
+    g.config?.onActiveConnectionInvalidated?.(g.primaryProfile, gatewayActivationEpoch())
+  }
+}
+
 // Registry lifecycle: a connection was removed or materially edited. Dispose
 // every secondary scoped to it (a removed remote/cloud source has no local
 // process to die, so without this its WebSocket stays open streaming ghost

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -210,21 +210,32 @@ export function requestFreshSession(): void {
 // get "default" (→ the primary backend) with no extra fetches.
 let _lastRoutedProfile: string | null = null
 
+/** Drop everything scoped to the backend we were just routed to.
+ *
+ *  Extracted so the CONNECTION change can reuse it. These caches
+ *  are per-backend, but the only trigger used to be a change of profile NAME,
+ *  and two registered machines both serve a `default` — so hopping gateways
+ *  invalidated nothing and every settings surface kept showing the previous
+ *  machine's data. */
+export function invalidateProfileRoutedCaches(): void {
+  invalidateCronModelImpactScopeState()
+  // Profile-scoped settings + the unified session list are now stale.
+  // Narrowed so account/marketplace/onboarding caches don't refetch on
+  // every profile switch.
+  invalidateProfileScopedQueries()
+  resetStarmapGraph()
+  // /api/profiles now routes to a different backend: strand any in-flight
+  // profile-list fetch so the previous backend's late answer can't clobber
+  // the rail (the #85731 class — same guard as the connection-apply wipe).
+  invalidateProfileListFetches()
+}
+
 $activeGatewayProfile.subscribe(value => {
   const key = normalizeProfileKey(value)
   setApiRequestProfile(key)
 
   if (_lastRoutedProfile !== null && _lastRoutedProfile !== key) {
-    invalidateCronModelImpactScopeState()
-    // Profile-scoped settings + the unified session list are now stale.
-    // Narrowed so account/marketplace/onboarding caches don't refetch on
-    // every profile switch.
-    invalidateProfileScopedQueries()
-    resetStarmapGraph()
-    // /api/profiles now routes to a different backend: strand any in-flight
-    // profile-list fetch so the previous backend's late answer can't clobber
-    // the rail (the #85731 class — same guard as the connection-apply wipe).
-    invalidateProfileListFetches()
+    invalidateProfileRoutedCaches()
   }
 
   _lastRoutedProfile = key


### PR DESCRIPTION
## What does this PR do?

Registering a second gateway in Hermes Desktop gets you a working *connection*, but not a working *multi-machine UI*. Upstream already splices other machines' sessions into the unified list, tagged with `connection_id` and `profile` (#88880), and already computes a union agent roster — but the renderer never reads that dimension anywhere.

**What already works today**, so it's clear what this PR is not claiming: the status-bar `ConnectionSwitcher` reaches another registered gateway perfectly well. `selectConnection()` calls `ensureGatewayAgent(connectionId, rememberedProfileOrDefault)` and `wipeSessionListsForGatewaySwitch()`, so re-pointing the whole window at another machine is a solved problem. This PR does not replace that and does not touch it.

What is missing is everything *below* that switch — telling the machines apart once their data is on screen, and addressing one specific agent rather than one whole machine. Concretely, with two gateways registered:

- **Sessions from both machines are indistinguishable.** The main process tags every spliced row with its owning `connection_id`; `apps/desktop/src/app/chat/sidebar/` never reads that field once. Two rows named the same thing on two different boxes render identically, and the sidebar's scope filter keys on the profile *name*, so it cannot separate them either.
- **The rail can only address a machine, not an agent on it.** `ConnectionSwitcher` takes you to a connection's remembered profile (or `default`). Reaching, say, the primary's `codertom` while attached to the second gateway means switching connection and then picking the profile — and the rail never shows that agent exists in the first place.
- **The workspace file tree reads the wrong machine.** `lib/desktop-fs.ts` sends `profile` alone on every `/api/fs/*` call, and a profile is half an address once two boxes both serve a `default`. The tree lists the primary's filesystem, or fails outright because the workspace path does not exist on the other host.
- **A rail-driven hop re-pulls nothing.** `wipeSessionListsForGatewaySwitch()` covers the `ConnectionSwitcher` path, but the on-connect reseed in `use-background-sync` keys on `activeConnectionId` and the profile *name*. Moving between two gateways' `default` changes neither, and `gatewayState` is already `open`, so the model picker and the rail's own profile list stay stale.
- **Manage Profiles only ever shows one machine.** `apps/desktop/src/app/profiles/` contains no reference to the connections registry at all, so the profiles on any other registered gateway are invisible and uneditable.

This PR carries the connection dimension through those surfaces. Everything renderer-side is gated on `$multiGateway`: with one connection registered, the sidebar and rail render exactly as they do today.

**Why this approach.** Two design decisions are worth review attention, both of them the second attempt after the obvious version was wrong:

*Attachment is derived, never written optimistically.* The rail originally set the attached connection on click, for an instant highlight. The sidebar re-seeds on that change, so the session refetch went out while the API layer's ambient connection still pointed at the previous machine — coming home from the second gateway re-fetched *its* rows and relabelled them as the primary's. It is now mirrored from `activeGatewayConnectionId()` via a `$gateway` subscription, which `applyActive` publishes in the same synchronous frame it sets the ambient connection. The square lights when the switch actually lands.

*The native/foreign split keys on the attached connection, not the primary.* That is what `$profiles` describes — `refreshProfiles` goes through `hermesApi`, which carries the ambient connection (the same invariant #85731 relies on: "the list the new backend just served"). Keying the split on the primary instead draws the attached machine's agents twice, once as native squares and once as foreign ones. A consequence worth stating plainly: from another machine, the primary's own agents appear as *foreign* squares. That is also what makes the same-named `default` on the box you came from reachable at all — the name-keyed door (`ensureGatewayProfile`) correctly sees "already on default" and returns, so the trip home has to address the agent by `(connection, profile)`.

## Related Issue

No existing issue — found while running two gateways day to day. Happy to open one to track it if the team prefers that ordering.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

**New**

- `apps/desktop/src/store/gateway-separation.ts` — connection labels, primary/attached tracking, the union roster, and the cross-gateway switch. Attachment is a `computed` derived from the live gateway.
- `apps/desktop/src/app/chat/gateway-tag.tsx` — the chip naming a session row's owning machine.
- `apps/desktop/src/store/gateway-separation.test.ts` — regression tests for the rail's click contract against a real two-gateway topology (a remote primary using shared-primary routing plus a second registered remote, both serving `default`).

**Changed**

- `apps/desktop/src/app/chat/sidebar/index.tsx` — session groups and the scope filter key on `(connection, profile)`.
- `apps/desktop/src/app/chat/sidebar/session-row.tsx` — renders the chip, resolved via `sessionConnectionId(session)` rather than the row's own `connection_id`, which falls back to the primary and mislabels every foreign row.
- `apps/desktop/src/app/chat/sidebar/profile-switcher.tsx` — extra rail squares for agents on other gateways, routed through `ensureGatewayAgent`.
- `apps/desktop/src/lib/desktop-fs.ts` — `/api/fs/*` carries the connection alongside the profile.
- `apps/desktop/src/app/contrib/hooks/use-background-sync.ts` — the on-connect reseed keys on the connection and re-pulls the profile list.
- `apps/desktop/src/store/profile.ts` — extracts `invalidateProfileRoutedCaches()` from the `$activeGatewayProfile` subscriber so a *connection* change can reuse it. These caches are per-backend, but the only trigger was a change of profile name.
- `apps/desktop/src/app/profiles/*` — Manage Profiles fetches per registered connection and groups rows by machine, with an add button per section, the owning machine named on the detail pane, and create / rename / delete / SOUL routed to the box the row came from. An unreachable gateway contributes nothing rather than emptying the panel.
- `apps/desktop/src/hermes.ts` — the profile-admin helpers take the owning connection as an optional trailing argument. Passing nothing keeps the byte-identical ambient request every other caller makes.
- `apps/desktop/src/app/skills/index.tsx`, `apps/desktop/src/app/settings/plugins-settings.tsx` — `queryFn: getProfiles` becomes `queryFn: () => getProfiles()`, since react-query passes its `QueryFunctionContext` as the first argument and it would otherwise arrive as the connection id.

## How to Test

Requires two gateways registered in Desktop, both serving a profile named `default` — that overlap is what surfaces every bug above.

1. **Rail reaches the second machine.** With one gateway live, the other machine's agents appear as extra rail squares. Click one: the socket moves, the square lights, and the sidebar rescopes. Verified against a remote primary (five profiles, shared-primary routing) and a second registered remote.
2. **Sends land on the machine you are on.** Start a new session after hopping and ask the agent to run `hostname`. It answers with the second machine's hostname, and `lsof`/`netstat` shows the established connection to that gateway's port — not the primary's.
3. **The trip home works for the same-named profile.** From the second gateway, click the primary's `default` square (it renders as a foreign square from there). The socket returns, and session rows re-tag correctly rather than keeping the other machine's rows under the primary's label.
4. **Workspace follows the hop.** The file tree lists the attached machine's filesystem after a switch, instead of showing the primary's tree or failing with ENOENT.
5. **Manage Profiles.** Both machines appear as separate sections, each with its own model, skill count and SOUL.md.
6. **Single-gateway regression.** With one connection registered, the sidebar, rail and Manage Profiles render exactly as before — every new path is gated on `$multiGateway`.

**Platform tested:** macOS 26 (Darwin 25.5.0), Apple Silicon, against two remote Linux gateways.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate, and audited `origin/main` for each capability before claiming it was missing — see "What already works today" above for the part that is already solved
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run: this PR touches no Python.** The equivalent suites for the code it does touch were run, see below.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26 (Darwin 25.5.0), Apple Silicon

Verification actually run, from `apps/desktop`:

| Command | Result |
|---|---|
| `npx tsc --noEmit -p tsconfig.json` | clean |
| `npx tsc --noEmit -p tsconfig.electron.json` | clean |
| `npx vitest run --project ui` | 5042 passed, 1 failed |
| `npx vitest run --project electron` | 1452 passed, 2 skipped |
| `npx eslint` (touched files) | 0 errors, 0 warnings |

The single `ui` failure is `nanostores-batch-guard.test.ts`, and it is environmental rather than caused by this branch: it asserts against the *installed* nanostores, and my `node_modules` has 1.4.0 while `package.json` pins the 1.4.2 that a787bfeab9 bumped to. I confirmed 1.4.2 ships `export const batch` with no `@__NO_SIDE_EFFECTS__` annotation, so the guard passes on a clean install. It fails identically on unmodified `origin/main` in this tree.

Both commits typecheck independently, so the series is bisectable.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, no user-facing config or docs surface changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — the change is renderer-side TypeScript with no file I/O, process management or terminal handling
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

<img width="311" height="528" alt="Session Chips #2" src="https://github.com/user-attachments/assets/5204b72c-c4d5-4573-98c6-d836ee7e5c39" />
<img width="296" height="536" alt="Session Chips #1" src="https://github.com/user-attachments/assets/62d4e1d6-1042-49aa-bc93-308b975cb2d9" />
<img width="290" height="45" alt="Rail view" src="https://github.com/user-attachments/assets/4e4bc9ee-fc1c-43d5-bf87-f8d1c6d03660" />
<img width="250" height="350" alt="01a-profiles-grouped-by-machine" src="https://github.com/user-attachments/assets/896564fe-82ff-46ad-9d8b-eb13e10e27df" />
<img width="640" height="95" alt="01b-per-machine-model-and-skills" src="https://github.com/user-attachments/assets/1c4961f6-b7af-414c-a215-7568ac216569" />

Proof that a send routes to the second gateway rather than the primary — a new session started after hopping, asked to identify its host:

```
The Dell server (192.168.1.204, hostname `dellserverpc`)
```

with the matching socket open to that gateway's port:

```
192.168.1.118:56026->192.168.1.204:9120 (ESTABLISHED)
```

Manage Profiles showed each machine's own data side by side — different current model (`gpt-5.6-sol · openai-codex` vs `deepseek/deepseek-v4-flash-0731`), different skill counts (90 vs 138), and each machine's own SOUL.md.

## Notes for reviewers

One thing I'd like a second opinion on. The native/foreign split means the rail *reshapes* on a hop: while attached to the second gateway, its profiles are the rail's own squares and the primary's five become foreign squares. That is self-consistent and it is what makes the same-named `default` reachable, but it is a visible change from a rail that always showed the same set. If the team would rather the rail stayed fixed on the primary's profiles with other machines' agents appended, that is a different keying and I'm happy to rework it — it would need the rail's own list fetched with an explicit connection rather than reading the ambient `$profiles`.
