### PR TITLE
fix(image_gen): call _load_xai_config() once in _resolve_edit_model

### DIFF
--- a/plugins/image_gen/xai/__init__.py
+++ b/plugins/image_gen/xai/__init__.py
@@ -233,8 +233,9 @@ def _resolve_edit_model(caller_model: Optional[str] = None) -> str:
     model, which xAI documents as the edit-capable baseline.
     """
     catalog = _catalog()
+    cfg = _load_xai_config()
     explicit = caller_model or os.environ.get("XAI_IMAGE_MODEL") or (
-        _load_xai_config().get("model") if isinstance(_load_xai_config().get("model"), str) else None
+        cfg.get("model") if isinstance(cfg.get("model"), str) else None
     )
     if explicit and explicit in catalog:
         modalities = catalog[explicit].get("input_modalities") or []

--- a/tests/plugins/image_gen/test_xai_provider.py
+++ b/tests/plugins/image_gen/test_xai_provider.py
@@ -239,6 +239,28 @@ class TestLiveCatalog:
         assert xai_mod._resolve_edit_model("grok-imagine-image-2.0") == "grok-imagine-image-quality"
 
 
+    def test_edit_model_calls_load_xai_config_once(self, monkeypatch):
+        """_resolve_edit_model must call _load_xai_config() exactly once.
+        The previous implementation called it twice — once for isinstance()
+        and once for .get() — causing two deepcopies and a TOCTOU window.
+        """
+        import plugins.image_gen.xai as xai_mod
+        call_count = []
+        original = xai_mod._load_xai_config
+
+        def counting_load():
+            call_count.append(1)
+            return original()
+
+        monkeypatch.setattr(xai_mod, "_load_xai_config", counting_load)
+        monkeypatch.setattr(xai_mod, "_LIVE_CACHE", None)
+        monkeypatch.delenv("XAI_IMAGE_MODEL", raising=False)
+        xai_mod._resolve_edit_model()
+        assert len(call_count) == 1, (
+            f"_load_xai_config() called {len(call_count)} times; expected 1"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Generate tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

`_resolve_edit_model` called `_load_xai_config()` twice in the same expression — once for `isinstance()` and once for `.get()`:

```python
# Before (buggy)
explicit = caller_model or os.environ.get("XAI_IMAGE_MODEL") or (
    _load_xai_config().get("model") if isinstance(_load_xai_config().get("model"), str) else None
)
```

Each call to `_load_xai_config()` performs a `deepcopy` of the entire config. Two effects:

1. **Performance**: two unnecessary deepcopies on every image-edit call where no env override is set and `image_gen.xai.model` is configured.
2. **TOCTOU**: if `config.yaml` changes on-disk between the two calls, the cache invalidates and the file is re-read — the `isinstance()` type check passes on the first call's value but the returned value comes from the second call's re-read.

The sibling functions `_resolve_model()` and `_resolve_resolution()` in the same file already use the correct single-call pattern. This fix aligns `_resolve_edit_model()` with its neighbors.

## Related Issue

Fixes #

## Type of Change

* 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

* `plugins/image_gen/xai/__init__.py`: cache `_load_xai_config()` result in `cfg` before the expression, matching `_resolve_model()` and `_resolve_resolution()`.
* `tests/plugins/image_gen/test_xai_provider.py`: add `test_edit_model_calls_load_xai_config_once` — monkeypatches `_load_xai_config` with a call counter and asserts it is invoked exactly once.

## How to Test

1. Run `uv run pytest tests/plugins/image_gen/test_xai_provider.py -v -k "edit_model"`
2. All 4 tests pass

## Checklist

### Code

* Contributing Guide read
* Conventional Commits followed
* No duplicate PRs found
* Only this fix in the PR
* 4 tests pass (`pytest tests/plugins/image_gen/test_xai_provider.py -k edit_model`)
* Tested on: WSL2 Ubuntu

### Documentation & Housekeeping

* No docs changes needed — N/A
* No config key changes — N/A
* Security impact: none — performance and correctness fix only