### PR TITLE
fix(desktop): route remote file requests by connection

### DIFF
--- a/apps/desktop/src/lib/desktop-fs.test.ts
+++ b/apps/desktop/src/lib/desktop-fs.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { setApiRequestConnection } from '@/hermes'
 import { $connection } from '@/store/session'
 
 import {
@@ -12,7 +13,8 @@ import {
   readDesktopFileDataUrlLocalFirst,
   readDesktopFileText,
   selectDesktopPaths,
-  setDesktopFsRemotePicker
+  setDesktopFsRemotePicker,
+  writeDesktopFileText
 } from './desktop-fs'
 
 const readDir = vi.fn(async () => ({ entries: [{ name: 'local', path: '/local', isDirectory: true }] }))
@@ -42,6 +44,10 @@ const api = vi.fn(async ({ path }: { path: string }) => {
     return { cwd: '/backend/project', branch: 'main' }
   }
 
+  if (path === '/api/fs/write-text') {
+    return { ok: true, path: '/remote/file.txt' }
+  }
+
   if (path.startsWith('/api/git/file-diff?')) {
     return { diff: 'remote diff' }
   }
@@ -69,6 +75,7 @@ describe('desktop filesystem facade', () => {
   })
 
   afterEach(() => {
+    setApiRequestConnection(null)
     vi.unstubAllGlobals()
     vi.clearAllMocks()
     $connection.set(null)
@@ -142,6 +149,27 @@ describe('desktop filesystem facade', () => {
 
     expect(api).toHaveBeenCalledWith({ path: '/api/fs/list?path=%2Fsrv%2Fproject', profile: 'remote-docker' })
     expect(api).toHaveBeenCalledWith({ path: '/api/fs/default-cwd', profile: 'remote-docker' })
+  })
+
+  it('routes remote filesystem reads and writes through the active registered gateway', async () => {
+    setApiRequestConnection('remote-user')
+    $connection.set({ mode: 'remote', profile: 'default' } as never)
+
+    await readDesktopFileText('/remote/file.txt')
+    await writeDesktopFileText('/remote/file.txt', 'updated')
+
+    expect(api).toHaveBeenCalledWith({
+      connectionId: 'remote-user',
+      path: '/api/fs/read-text?path=%2Fremote%2Ffile.txt',
+      profile: 'default'
+    })
+    expect(api).toHaveBeenCalledWith({
+      body: { content: 'updated', path: '/remote/file.txt' },
+      connectionId: 'remote-user',
+      method: 'POST',
+      path: '/api/fs/write-text',
+      profile: 'default'
+    })
   })
 
   it('keys SSH filesystem caches by stable host identity instead of the forwarded port', () => {

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -4,6 +4,7 @@ import type {
   HermesReadFileTextResult,
   HermesSelectPathsOptions
 } from '@/global'
+import { hermesApi } from '@/hermes'
 import { $connection } from '@/store/session'
 
 export interface DesktopFsRemotePicker {
@@ -58,7 +59,9 @@ function bridge() {
 }
 
 function remoteFsApi<T>(path: string, body?: Record<string, unknown>): Promise<T> {
-  return bridge().api<T>(
+  bridge()
+
+  return hermesApi<T>(
     body ? { body, method: 'POST', path, profile: desktopFsProfile() } : { path, profile: desktopFsProfile() }
   )
 }

--- a/apps/desktop/src/lib/desktop-git.test.ts
+++ b/apps/desktop/src/lib/desktop-git.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { setApiRequestConnection } from '@/hermes'
 import { $connection } from '@/store/session'
 
 import { desktopGit } from './desktop-git'
@@ -37,6 +38,7 @@ describe('desktop git facade', () => {
   })
 
   afterEach(() => {
+    setApiRequestConnection(null)
     vi.unstubAllGlobals()
     vi.clearAllMocks()
     $connection.set(null)
@@ -87,6 +89,27 @@ describe('desktop git facade', () => {
       method: 'POST',
       path: '/api/git/review/stage',
       profile: 'remote-docker'
+    })
+  })
+
+  it('routes remote git reads and writes through the active registered gateway', async () => {
+    setApiRequestConnection('remote-user')
+    $connection.set({ mode: 'remote', profile: 'default' } as never)
+
+    await desktopGit()?.repoStatus('/srv/work')
+    await desktopGit()?.review.stage('/srv/work', 'a.txt')
+
+    expect(api).toHaveBeenCalledWith({
+      connectionId: 'remote-user',
+      path: '/api/git/status?path=%2Fsrv%2Fwork',
+      profile: 'default'
+    })
+    expect(api).toHaveBeenCalledWith({
+      body: { file: 'a.txt', path: '/srv/work' },
+      connectionId: 'remote-user',
+      method: 'POST',
+      path: '/api/git/review/stage',
+      profile: 'default'
     })
   })
 

--- a/apps/desktop/src/lib/desktop-git.ts
+++ b/apps/desktop/src/lib/desktop-git.ts
@@ -7,6 +7,7 @@ import type {
   HermesReviewList,
   HermesReviewShipInfo
 } from '@/global'
+import { hermesApi } from '@/hermes'
 
 import { desktopFsProfile, isDesktopFsRemoteMode } from './desktop-fs'
 
@@ -25,7 +26,7 @@ function desktopApi<T>(path: string, body?: Record<string, unknown>): Promise<T>
     throw new Error('Hermes Desktop bridge is unavailable')
   }
 
-  return desktop.api<T>(
+  return hermesApi<T>(
     body ? { body, method: 'POST', path, profile: desktopFsProfile() } : { path, profile: desktopFsProfile() }
   )
 }


### PR DESCRIPTION
## What does this PR do?

Fixes #89916.

Hermes Desktop's remote filesystem and Git facades called the Electron API bridge directly with a profile but no registered-gateway `connectionId`. When **This device** remained the registry primary and a session belonged to another registered gateway, Electron therefore sent artifact reads to the local backend. The local backend then returned the misleading `403: File is not readable` for a valid path on the remote host.

This change routes both facades through the existing connection-aware `hermesApi()` seam. It keeps the explicit profile while adding the active registry connection, so the request reaches the machine that owns the session and file. Local Electron filesystem/Git behavior is unchanged.

## Related Issue

Fixes #89916

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/lib/desktop-fs.ts`
  - Route remote filesystem GET/POST requests through `hermesApi()` so registered gateway ownership is preserved.
- `apps/desktop/src/lib/desktop-git.ts`
  - Apply the same connection-aware routing to the sibling remote Git facade.
- `apps/desktop/src/lib/desktop-fs.test.ts`
  - Cover registered-gateway filesystem reads and writes, including profile preservation.
- `apps/desktop/src/lib/desktop-git.test.ts`
  - Cover registered-gateway Git reads and mutations, including profile preservation.

## How to Test

1. Keep **This device** as the primary connection and register a remote gateway.
2. Open a session owned by that remote gateway and click a file artifact.
3. Confirm the preview reads the file from the remote gateway instead of returning `403: File is not readable`.
4. Run:

```bash
cd apps/desktop
NODE_ENV=test NODE_OPTIONS='--max-old-space-size=8192 --localstorage-file=/tmp/hermes-vitest-remote-fs.json' \
  npx vitest run --project ui src/lib/desktop-fs.test.ts src/lib/desktop-git.test.ts src/lib/media.remote.test.ts
NODE_ENV=test npm run typecheck
NODE_ENV=test npx eslint src/lib/desktop-fs.ts src/lib/desktop-fs.test.ts src/lib/desktop-git.ts src/lib/desktop-git.test.ts
NODE_ENV=production npm run build
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant Desktop tests and checks; `pytest tests/ -q` is N/A because this PR changes only the Desktop TypeScript workspace
- [x] I've added tests for my changes
- [x] I've tested on my platform: CachyOS Linux, Node.js 22.23.2

### Documentation & Housekeeping

- [x] Documentation update — N/A; no user-facing contract or configuration changed
- [x] `cli-config.yaml.example` update — N/A; no configuration keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; the change reuses the documented connection-aware REST seam
- [x] Cross-platform impact considered — the renderer routing change is platform-neutral and preserves native local IPC on Linux, macOS, and Windows
- [x] Tool descriptions/schemas update — N/A; no model tool behavior or schema changed

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

Regression evidence on parent `1a19fedb5ae5d8f875dc2c14d302c251f8a7f542`:

- Both new tests fail because filesystem and Git requests omit `connectionId: "remote-user"`.

Verification on this branch:

- Focused UI regression: **40/40 passed** across 3 files.
- Desktop TypeScript typecheck: **passed**.
- ESLint on all four changed files: **passed**.
- Production Desktop build: **passed**.
- Full Desktop UI suite: **5030/5035 passed**. The five failures are unrelated and reproduce identically on the clean parent: locale-dependent number/currency formatting (4 assertions) and the installed `nanostores` side-effect annotation guard (1 assertion).
- `git diff --check`: **passed**.
