### PR TITLE
fix(desktop): ack quick entry submit and create the session atomically (#85590)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -334,7 +334,12 @@ import {
   spliceRegistrySessionRows,
   tagRegistrySessionResponse
 } from './profile-session-routing'
-import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
+import {
+  createQuickEntryShortcut,
+  createQuickEntrySubmitRelay,
+  quickEntryWindowBounds,
+  sanitizeQuickEntrySettings
+} from './quick-entry'
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
 import { backendQuitNeedsWait, createQuitTeardownCoordinator } from './quit-teardown'
 import * as remoteLifecycle from './remote-lifecycle'
@@ -17265,27 +17270,52 @@ ipcMain.handle('hermes:quick-entry:settings:set', async (_event, patch) => {
 // owns the one prompt-submit path, and forwarding keeps it that way. The
 // payload is `{ target, text }` — target routing (current chat / a picked
 // session / new) is the renderer's job too.
-ipcMain.on('hermes:quick-entry:submit', (_event, payload) => {
-  hideQuickEntryWindow()
+const quickEntrySubmitRelay = createQuickEntrySubmitRelay({
+  onSuccess: () => {
+    hideQuickEntryWindow()
+    if (process.platform === 'darwin') {
+      app.dock?.show()
+    }
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.show()
+      mainWindow.focus()
+    }
+  }
+})
 
-  const text = typeof payload?.text === 'string' ? payload.text.trim() : ''
+// Main owns the request lifecycle so the capture window can keep text until
+// the primary renderer confirms delivery (#85590).
+ipcMain.handle('hermes:quick-entry:submit', (event, payload) => {
+  if (!quickEntryWindow || event.sender !== quickEntryWindow.webContents) {
+    return { code: 'forbidden', message: 'Quick Entry sender is not authorized.', ok: false, retryable: false }
+  }
+
+  const text =
+    typeof payload === 'string' ? payload.trim() : typeof payload?.text === 'string' ? payload.text.trim() : ''
 
   if (!text) {
-    return
+    return { code: 'empty', message: 'Enter a prompt before submitting.', ok: false, retryable: false }
   }
 
   if (!mainWindow || mainWindow.isDestroyed()) {
-    rememberLog('[quick-entry] dropped a submit: no primary window to route it to')
-
-    return
+    return { code: 'no-primary', message: 'The primary Hermes window is unavailable.', ok: false, retryable: true }
   }
 
-  // Deliberately does NOT raise/focus the main window — the user asked to fire
-  // a prompt from wherever they were, not to be yanked into the app.
-  mainWindow.webContents.send('hermes:quick-entry:submit', {
-    target: typeof payload?.target === 'string' && payload.target ? payload.target : 'current',
-    text
+  const target =
+    typeof payload === 'object' && typeof payload?.target === 'string' && payload.target ? payload.target : 'current'
+
+  return quickEntrySubmitRelay.begin(correlationId => {
+    mainWindow.webContents.send('hermes:quick-entry:submit', { correlationId, target, text })
   })
+})
+
+// Main cannot invoke the primary renderer, so the primary returns by id. Stale
+// or duplicate acknowledgements are intentionally ignored (#85590).
+ipcMain.on('hermes:quick-entry:ack', (event, payload) => {
+  if (!mainWindow || event.sender !== mainWindow.webContents) {
+    return
+  }
+  quickEntrySubmitRelay.acknowledge(payload?.correlationId, payload?.result)
 })
 
 // Primary renderer → main → quick window: gateway connection state + the

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -17271,6 +17271,14 @@ ipcMain.handle('hermes:quick-entry:settings:set', async (_event, patch) => {
 // payload is `{ target, text }` — target routing (current chat / a picked
 // session / new) is the renderer's job too.
 const quickEntrySubmitRelay = createQuickEntrySubmitRelay({
+  // A late ack for a timed-out submit proves the outcome. Forward it to the
+  // capture window so it can reconcile the unknown state instead of the user
+  // resending a prompt that may already be delivered.
+  onLateResult: (correlationId, result) => {
+    if (quickEntryWindow && !quickEntryWindow.isDestroyed()) {
+      quickEntryWindow.webContents.send('hermes:quick-entry:late-result', { correlationId, result })
+    }
+  },
   onSuccess: () => {
     hideQuickEntryWindow()
     if (process.platform === 'darwin') {

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -176,7 +176,11 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   quickEntry: {
     getSettings: () => ipcRenderer.invoke('hermes:quick-entry:settings:get'),
     setSettings: patch => ipcRenderer.invoke('hermes:quick-entry:settings:set', patch),
-    submit: payload => ipcRenderer.send('hermes:quick-entry:submit', payload),
+    // Invoke returns the delivery result so the draft is not lost (#85590).
+    submit: payload => ipcRenderer.invoke('hermes:quick-entry:submit', payload),
+    // Main cannot invoke the primary renderer, so it receives this ack (#85590).
+    ackSubmit: (correlationId, result) =>
+      ipcRenderer.send('hermes:quick-entry:ack', { correlationId, result }),
     dismiss: () => ipcRenderer.send('hermes:quick-entry:dismiss'),
     // Primary renderer → main → quick window: gateway connection state + the
     // recent-session options the target picker offers. Main caches the latest

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -206,6 +206,15 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
       ipcRenderer.on('hermes:quick-entry:shown', listener)
 
       return () => ipcRenderer.removeListener('hermes:quick-entry:shown', listener)
+    },
+    // Main → quick window: the outcome of a submit whose relay already timed
+    // out. Delivery is now KNOWN — reconcile the unknown state instead of
+    // leaving the user to resend a prompt that may already be delivered.
+    onLateResult: callback => {
+      const listener = (_event, payload) => callback(payload)
+      ipcRenderer.on('hermes:quick-entry:late-result', listener)
+
+      return () => ipcRenderer.removeListener('hermes:quick-entry:late-result', listener)
     }
   },
   getBootProgress: () => ipcRenderer.invoke('hermes:boot-progress:get'),

--- a/apps/desktop/electron/quick-entry.test.ts
+++ b/apps/desktop/electron/quick-entry.test.ts
@@ -2,12 +2,73 @@ import { describe, expect, it, vi } from 'vitest'
 
 import {
   createQuickEntryShortcut,
+  createQuickEntrySubmitRelay,
   DEFAULT_QUICK_ENTRY_SHORTCUT,
   type GlobalShortcutLike,
   parseQuickEntryShortcut,
   quickEntryWindowBounds,
   sanitizeQuickEntrySettings
 } from './quick-entry'
+
+describe('quick-entry submit ack relay', () => {
+  it('ignores an ack for a stale correlation id', async () => {
+    const relay = createQuickEntrySubmitRelay({ onSuccess: vi.fn(), timeoutMs: 1000 })
+    let correlationId = ''
+    let settled = false
+    const pending = relay.begin(id => {
+      correlationId = id
+    }).then(() => {
+      settled = true
+    })
+
+    relay.acknowledge('qe-stale', { ok: true })
+    await Promise.resolve()
+
+    expect(settled).toBe(false)
+    expect(relay.pendingCount()).toBe(1)
+    relay.acknowledge(correlationId, { ok: false })
+    await pending
+    expect(relay.pendingCount()).toBe(0)
+  })
+
+  it('resolves an unacknowledged submit as a timeout and cleans it up', async () => {
+    vi.useFakeTimers()
+    const relay = createQuickEntrySubmitRelay({ onSuccess: vi.fn(), timeoutMs: 15000 })
+    const pending = relay.begin(vi.fn())
+
+    await vi.advanceTimersByTimeAsync(15000)
+
+    await expect(pending).resolves.toMatchObject({ code: 'timeout', ok: false })
+    expect(relay.pendingCount()).toBe(0)
+    vi.useRealTimers()
+  })
+
+  it('runs hide and primary focus only after an ok acknowledgement', async () => {
+    const events: string[] = []
+    const relay = createQuickEntrySubmitRelay({
+      onSuccess: () => events.push('hide-primary-show-focus'),
+      timeoutMs: 1000
+    })
+    let correlationId = ''
+    const pending = relay.begin(id => {
+      correlationId = id
+      events.push('forward')
+    })
+
+    relay.acknowledge(correlationId, { ok: false })
+    await expect(pending).resolves.toMatchObject({ ok: false })
+    expect(events).toEqual(['forward'])
+
+    let okCorrelationId = ''
+    const okPending = relay.begin(id => {
+      okCorrelationId = id
+      events.push('forward-ok')
+    })
+    relay.acknowledge(okCorrelationId, { ok: true })
+    await expect(okPending).resolves.toMatchObject({ ok: true })
+    expect(events).toEqual(['forward', 'forward-ok', 'hide-primary-show-focus'])
+  })
+})
 
 function fakeGlobalShortcut(options: { register?: boolean; taken?: string[] } = {}) {
   const held = new Set(options.taken ?? [])

--- a/apps/desktop/electron/quick-entry.test.ts
+++ b/apps/desktop/electron/quick-entry.test.ts
@@ -31,15 +31,74 @@ describe('quick-entry submit ack relay', () => {
     expect(relay.pendingCount()).toBe(0)
   })
 
-  it('resolves an unacknowledged submit as a timeout and cleans it up', async () => {
+  it('resolves an unacknowledged submit as an unknown, non-retryable timeout and keeps it reconcilable', async () => {
     vi.useFakeTimers()
     const relay = createQuickEntrySubmitRelay({ onSuccess: vi.fn(), timeoutMs: 15000 })
     const pending = relay.begin(vi.fn())
 
     await vi.advanceTimersByTimeAsync(15000)
 
-    await expect(pending).resolves.toMatchObject({ code: 'timeout', ok: false })
+    await expect(pending).resolves.toMatchObject({ code: 'timeout', ok: false, retryable: false })
     expect(relay.pendingCount()).toBe(0)
+    expect(relay.reconcilableCount()).toBe(1)
+    vi.useRealTimers()
+  })
+
+  it('reconciles a late success through onLateResult without hiding the window', async () => {
+    vi.useFakeTimers()
+    const onSuccess = vi.fn()
+    const onLateResult = vi.fn()
+    const relay = createQuickEntrySubmitRelay({ onLateResult, onSuccess, timeoutMs: 15000 })
+    let correlationId = ''
+    const pending = relay.begin(id => {
+      correlationId = id
+    })
+
+    await vi.advanceTimersByTimeAsync(15000)
+    await pending
+    relay.acknowledge(correlationId, { ok: true })
+
+    expect(onLateResult).toHaveBeenCalledTimes(1)
+    expect(onLateResult).toHaveBeenCalledWith(correlationId, { ok: true })
+    expect(onSuccess).not.toHaveBeenCalled()
+    expect(relay.reconcilableCount()).toBe(0)
+    vi.useRealTimers()
+  })
+
+  it('reconciles a late failure through onLateResult', async () => {
+    vi.useFakeTimers()
+    const onLateResult = vi.fn()
+    const relay = createQuickEntrySubmitRelay({ onLateResult, onSuccess: vi.fn(), timeoutMs: 15000 })
+    let correlationId = ''
+    const pending = relay.begin(id => {
+      correlationId = id
+    })
+
+    await vi.advanceTimersByTimeAsync(15000)
+    await pending
+    relay.acknowledge(correlationId, { code: 'submit-failed', ok: false })
+
+    expect(onLateResult).toHaveBeenCalledTimes(1)
+    expect(relay.reconcilableCount()).toBe(0)
+    vi.useRealTimers()
+  })
+
+  it('ignores a duplicate late ack', async () => {
+    vi.useFakeTimers()
+    const onLateResult = vi.fn()
+    const relay = createQuickEntrySubmitRelay({ onLateResult, onSuccess: vi.fn(), timeoutMs: 15000 })
+    let correlationId = ''
+    const pending = relay.begin(id => {
+      correlationId = id
+    })
+
+    await vi.advanceTimersByTimeAsync(15000)
+    await pending
+    relay.acknowledge(correlationId, { ok: true })
+    relay.acknowledge(correlationId, { ok: true })
+
+    expect(onLateResult).toHaveBeenCalledTimes(1)
+    expect(relay.reconcilableCount()).toBe(0)
     vi.useRealTimers()
   })
 

--- a/apps/desktop/electron/quick-entry.ts
+++ b/apps/desktop/electron/quick-entry.ts
@@ -28,6 +28,64 @@ const QUICK_ENTRY_WINDOW_HEIGHT = 168
 // comfortable fraction down from the top rather than dead center.
 const QUICK_ENTRY_TOP_FRACTION = 0.22
 
+export interface QuickEntrySubmitRelayResult {
+  ok: boolean
+  [key: string]: unknown
+}
+
+export interface QuickEntrySubmitRelay {
+  begin: (forward: (correlationId: string) => void) => Promise<QuickEntrySubmitRelayResult>
+  acknowledge: (correlationId: string, result: QuickEntrySubmitRelayResult) => void
+  pendingCount: () => number
+}
+
+export function createQuickEntrySubmitRelay(options: {
+  onSuccess: () => void
+  timeoutMs?: number
+}): QuickEntrySubmitRelay {
+  const pending = new Map<
+    string,
+    { resolve: (result: QuickEntrySubmitRelayResult) => void; timer: NodeJS.Timeout }
+  >()
+  let sequence = 0
+
+  return {
+    acknowledge(correlationId, result) {
+      const request = pending.get(correlationId)
+      if (!request) {
+        return
+      }
+
+      clearTimeout(request.timer)
+      pending.delete(correlationId)
+      request.resolve(result)
+      if (result.ok === true) {
+        options.onSuccess()
+      }
+    },
+    begin(forward) {
+      const correlationId = ['qe', Date.now(), ++sequence].join('-')
+
+      return new Promise(resolve => {
+        const timer = setTimeout(() => {
+          pending.delete(correlationId)
+          resolve({
+            code: 'timeout',
+            message: 'Hermes did not confirm the prompt in time.',
+            ok: false,
+            retryable: true
+          })
+        }, options.timeoutMs ?? 15_000)
+        pending.set(correlationId, { resolve, timer })
+        forward(correlationId)
+      })
+    },
+    pendingCount() {
+      return pending.size
+    }
+  }
+}
+
 // Electron accelerator vocabulary (electronjs.org/docs/latest/api/accelerator).
 // Kept as data so validation and the settings UI agree on one list.
 const ACCELERATOR_MODIFIERS = new Set([

--- a/apps/desktop/electron/quick-entry.ts
+++ b/apps/desktop/electron/quick-entry.ts
@@ -37,9 +37,14 @@ export interface QuickEntrySubmitRelay {
   begin: (forward: (correlationId: string) => void) => Promise<QuickEntrySubmitRelayResult>
   acknowledge: (correlationId: string, result: QuickEntrySubmitRelayResult) => void
   pendingCount: () => number
+  /** Correlations whose outcome is UNKNOWN: the relay timed out but the backend
+   *  may still have accepted the prompt. Kept so a late ack reconciles instead
+   *  of being silently dropped. */
+  reconcilableCount: () => number
 }
 
 export function createQuickEntrySubmitRelay(options: {
+  onLateResult?: (correlationId: string, result: QuickEntrySubmitRelayResult) => void
   onSuccess: () => void
   timeoutMs?: number
 }): QuickEntrySubmitRelay {
@@ -47,12 +52,23 @@ export function createQuickEntrySubmitRelay(options: {
     string,
     { resolve: (result: QuickEntrySubmitRelayResult) => void; timer: NodeJS.Timeout }
   >()
+  // Timed-out correlations. Delivery is UNCONFIRMED, so a late ack must
+  // reconcile; a correlation is never resolved twice.
+  const reconcilable = new Set<string>()
   let sequence = 0
 
   return {
     acknowledge(correlationId, result) {
       const request = pending.get(correlationId)
+
       if (!request) {
+        // A late ack for a timed-out submit: the outcome is now known. Do NOT
+        // hide the window here — the user may already be typing again. The
+        // renderer reconciles the unknown outcome itself.
+        if (reconcilable.delete(correlationId)) {
+          options.onLateResult?.(correlationId, result)
+        }
+
         return
       }
 
@@ -69,11 +85,14 @@ export function createQuickEntrySubmitRelay(options: {
       return new Promise(resolve => {
         const timer = setTimeout(() => {
           pending.delete(correlationId)
+          // UNKNOWN, not failed: the prompt may already be accepted, so this
+          // must never invite a retry. Keep the correlation for late acks.
+          reconcilable.add(correlationId)
           resolve({
             code: 'timeout',
-            message: 'Hermes did not confirm the prompt in time.',
+            message: 'Hermes has not confirmed the prompt yet — it may still be delivered.',
             ok: false,
-            retryable: true
+            retryable: false
           })
         }, options.timeoutMs ?? 15_000)
         pending.set(correlationId, { resolve, timer })
@@ -82,6 +101,9 @@ export function createQuickEntrySubmitRelay(options: {
     },
     pendingCount() {
       return pending.size
+    },
+    reconcilableCount() {
+      return reconcilable.size
     }
   }
 }

--- a/apps/desktop/src/app/chat/session-tile-actions.test.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.test.ts
@@ -236,7 +236,10 @@ describe('useSessionTileActions reloadFromMessage failed-submit rollback (#95745
       executeSlash: vi.fn(async () => undefined),
       interruptSession: vi.fn(async () => undefined),
       resumeTile: vi.fn(async () => RUNTIME_SESSION_ID),
-      submitToSession: vi.fn(async () => undefined),
+      submitToSession: vi.fn(async () => ({
+        runtimeSessionId: RUNTIME_SESSION_ID,
+        storedSessionId: null
+      })),
       updateSession: vi.fn((_runtimeId, updater) => {
         const current = $sessionStates.get()[RUNTIME_SESSION_ID]
 

--- a/apps/desktop/src/app/chat/session-tile-actions.test.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.test.ts
@@ -79,7 +79,7 @@ describe('useSessionTileActions sleep/wake session recovery', () => {
       executeSlash: vi.fn(async () => undefined),
       interruptSession: vi.fn(async () => undefined),
       resumeTile: vi.fn(async () => RUNTIME_SESSION_ID),
-      submitToSession: vi.fn(async () => undefined),
+      submitToSession: vi.fn(async () => RUNTIME_SESSION_ID),
       updateSession: vi.fn((_runtimeId, updater) =>
         updater({
           attachedImages: [],

--- a/apps/desktop/src/app/chat/session-tile-actions.test.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.test.ts
@@ -79,7 +79,10 @@ describe('useSessionTileActions sleep/wake session recovery', () => {
       executeSlash: vi.fn(async () => undefined),
       interruptSession: vi.fn(async () => undefined),
       resumeTile: vi.fn(async () => RUNTIME_SESSION_ID),
-      submitToSession: vi.fn(async () => RUNTIME_SESSION_ID),
+      submitToSession: vi.fn(async () => ({
+        runtimeSessionId: RUNTIME_SESSION_ID,
+        storedSessionId: null
+      })),
       updateSession: vi.fn((_runtimeId, updater) =>
         updater({
           attachedImages: [],

--- a/apps/desktop/src/app/chat/session-tile-attachments.test.tsx
+++ b/apps/desktop/src/app/chat/session-tile-attachments.test.tsx
@@ -89,7 +89,10 @@ function installDelegate(): void {
     executeSlash: vi.fn(async () => undefined),
     interruptSession: vi.fn(async () => undefined),
     resumeTile: vi.fn(async () => RUNTIME_ID),
-    submitToSession: vi.fn(async () => RUNTIME_ID),
+    submitToSession: vi.fn(async () => ({
+      runtimeSessionId: RUNTIME_ID,
+      storedSessionId: null
+    })),
     updateSession
   })
 }

--- a/apps/desktop/src/app/chat/session-tile-attachments.test.tsx
+++ b/apps/desktop/src/app/chat/session-tile-attachments.test.tsx
@@ -89,7 +89,7 @@ function installDelegate(): void {
     executeSlash: vi.fn(async () => undefined),
     interruptSession: vi.fn(async () => undefined),
     resumeTile: vi.fn(async () => RUNTIME_ID),
-    submitToSession: vi.fn(async () => undefined),
+    submitToSession: vi.fn(async () => RUNTIME_ID),
     updateSession
   })
 }

--- a/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.test.ts
@@ -191,7 +191,7 @@ describe('useQuickEntryBridge', () => {
     container.remove()
   })
 
-  it('acknowledges an accepted selected-session submit with exact identity', async () => {
+  it('acknowledges with the proven identity when the accepted stored id matches', async () => {
     const correlationId = 'selected-submit-correlation'
     const ackSubmit = vi.fn()
     ackSubmit.mockImplementationOnce(() => {
@@ -205,7 +205,10 @@ describe('useQuickEntryBridge', () => {
     } as unknown as typeof window.hermesDesktop
 
     const resumeTile = vi.fn(async () => 'runtime-session-1')
-    const submitToSession = vi.fn(async () => 'runtime-session-1')
+    const submitToSession = vi.fn(async () => ({
+      runtimeSessionId: 'runtime-session-1',
+      storedSessionId: 'stored-session-1'
+    }))
     vi.mocked(sessionTileDelegate).mockReturnValue({
       resumeTile,
       submitToSession
@@ -246,7 +249,10 @@ describe('useQuickEntryBridge', () => {
     } as unknown as typeof window.hermesDesktop
 
     const resumeTile = vi.fn(async () => 'runtime-session-before-recovery')
-    const submitToSession = vi.fn(async () => 'runtime-session-recovered')
+    const submitToSession = vi.fn(async () => ({
+      runtimeSessionId: 'runtime-session-recovered',
+      storedSessionId: 'stored-session-1'
+    }))
     vi.mocked(sessionTileDelegate).mockReturnValue({
       resumeTile,
       submitToSession
@@ -263,6 +269,80 @@ describe('useQuickEntryBridge', () => {
       ok: true,
       runtimeSessionId: 'runtime-session-recovered',
       sessionId: 'stored-session-1'
+    })
+
+    container.remove()
+  })
+
+  it('refuses to acknowledge success when the accepted stored id differs from the requested target', async () => {
+    const correlationId = 'selected-submit-identity-mismatch'
+    const ackSubmit = vi.fn()
+    window.hermesDesktop = {
+      quickEntry: {
+        ackSubmit,
+        pushState: vi.fn()
+      }
+    } as unknown as typeof window.hermesDesktop
+
+    const resumeTile = vi.fn(async () => 'runtime-session-1')
+    const submitToSession = vi.fn(async () => ({
+      runtimeSessionId: 'runtime-session-1',
+      storedSessionId: 'other-session'
+    }))
+    vi.mocked(sessionTileDelegate).mockReturnValue({
+      resumeTile,
+      submitToSession
+    } as unknown as ReturnType<typeof sessionTileDelegate>)
+
+    const { container, submit } = await renderBridge()
+
+    await act(async () => {
+      await submit({ correlationId, target: 'stored-session-1', text: 'Wrong target' })
+    })
+
+    expect(ackSubmit).toHaveBeenCalledTimes(1)
+    expect(ackSubmit).toHaveBeenCalledWith(correlationId, {
+      code: 'submit-identity-mismatch',
+      message: 'The prompt was accepted by a different session than the one requested.',
+      ok: false,
+      retryable: false
+    })
+
+    container.remove()
+  })
+
+  it('refuses to acknowledge success when the accepted stored id is unknown', async () => {
+    const correlationId = 'selected-submit-unknown-identity'
+    const ackSubmit = vi.fn()
+    window.hermesDesktop = {
+      quickEntry: {
+        ackSubmit,
+        pushState: vi.fn()
+      }
+    } as unknown as typeof window.hermesDesktop
+
+    const resumeTile = vi.fn(async () => 'runtime-session-1')
+    const submitToSession = vi.fn(async () => ({
+      runtimeSessionId: 'runtime-session-1',
+      storedSessionId: null
+    }))
+    vi.mocked(sessionTileDelegate).mockReturnValue({
+      resumeTile,
+      submitToSession
+    } as unknown as ReturnType<typeof sessionTileDelegate>)
+
+    const { container, submit } = await renderBridge()
+
+    await act(async () => {
+      await submit({ correlationId, target: 'stored-session-1', text: 'Unknown target' })
+    })
+
+    expect(ackSubmit).toHaveBeenCalledTimes(1)
+    expect(ackSubmit).toHaveBeenCalledWith(correlationId, {
+      code: 'submit-identity-mismatch',
+      message: 'The prompt was accepted by a different session than the one requested.',
+      ok: false,
+      retryable: false
     })
 
     container.remove()
@@ -317,7 +397,10 @@ describe('useQuickEntryBridge', () => {
     const resumeTile = vi.fn(async () => {
       throw new Error('resume failed')
     })
-    const submitToSession = vi.fn(async () => 'runtime-session-1')
+    const submitToSession = vi.fn(async () => ({
+      runtimeSessionId: 'runtime-session-1',
+      storedSessionId: 'stored-session-1'
+    }))
     vi.mocked(sessionTileDelegate).mockReturnValue({
       resumeTile,
       submitToSession

--- a/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.test.ts
@@ -9,6 +9,7 @@ const registeredSubmitHandler = vi.hoisted(() => ({
 }))
 
 type SubmitTextForBridge = Parameters<typeof useQuickEntryBridge>[0]['submitText']
+type SubmitTextToNewSessionForBridge = Parameters<typeof useQuickEntryBridge>[0]['submitTextToNewSession']
 
 vi.mock('@/store/quick-entry', async importOriginal => {
   const actual = await importOriginal<typeof import('@/store/quick-entry')>()
@@ -57,14 +58,17 @@ describe('useQuickEntryBridge', () => {
     vi.clearAllMocks()
   })
 
-  async function renderBridge(submitText: SubmitTextForBridge = () => true) {
+  async function renderBridge(
+    submitText: SubmitTextForBridge = () => true,
+    submitTextToNewSession: SubmitTextToNewSessionForBridge = async () => ({
+      runtimeSessionId: 'runtime-new',
+      sessionId: 'stored-new'
+    })
+  ) {
     function Harness() {
       useQuickEntryBridge({
         submitText,
-        submitTextToNewSession: async () => ({
-          runtimeSessionId: 'runtime-new',
-          sessionId: 'stored-new'
-        })
+        submitTextToNewSession
       })
 
       return null
@@ -106,6 +110,37 @@ describe('useQuickEntryBridge', () => {
       ok: true,
       runtimeSessionId: 'rt-current-1',
       sessionId: 'st-current-1'
+    })
+
+    container.remove()
+  })
+
+  it('passes the correlation id as the new-session pin owner', async () => {
+    const correlationId = 'new-submit-correlation'
+    const ackSubmit = vi.fn()
+    const submitTextToNewSession = vi.fn(async () => ({
+      runtimeSessionId: 'runtime-new',
+      sessionId: 'stored-new'
+    }))
+    window.hermesDesktop = {
+      quickEntry: {
+        ackSubmit,
+        pushState: vi.fn()
+      }
+    } as unknown as typeof window.hermesDesktop
+
+    const { container, submit } = await renderBridge(vi.fn(async () => true), submitTextToNewSession)
+
+    await act(async () => {
+      await submit({ correlationId, target: 'new', text: 'Send to a new chat' })
+    })
+
+    expect(submitTextToNewSession).toHaveBeenCalledWith('Send to a new chat', correlationId)
+    expect(ackSubmit).toHaveBeenCalledTimes(1)
+    expect(ackSubmit).toHaveBeenCalledWith(correlationId, {
+      ok: true,
+      runtimeSessionId: 'runtime-new',
+      sessionId: 'stored-new'
     })
 
     container.remove()

--- a/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.test.ts
@@ -8,6 +8,8 @@ const registeredSubmitHandler = vi.hoisted(() => ({
   current: null as ((payload: { correlationId: string; target: string; text: string }) => void) | null
 }))
 
+type SubmitTextForBridge = Parameters<typeof useQuickEntryBridge>[0]['submitText']
+
 vi.mock('@/store/quick-entry', async importOriginal => {
   const actual = await importOriginal<typeof import('@/store/quick-entry')>()
 
@@ -34,7 +36,12 @@ describe('quickEntrySubmitAck', () => {
     })
   })
 
-  it('acknowledges only an accepted prompt as success', () => {
+  it('names the accepted identity on an accepted ack', () => {
+    expect(quickEntrySubmitAck(true, { runtimeSessionId: 'rt-1', storedSessionId: 'st-1' })).toEqual({
+      ok: true,
+      runtimeSessionId: 'rt-1',
+      sessionId: 'st-1'
+    })
     expect(quickEntrySubmitAck(true)).toEqual({ ok: true })
   })
 })
@@ -50,10 +57,10 @@ describe('useQuickEntryBridge', () => {
     vi.clearAllMocks()
   })
 
-  async function renderBridge() {
+  async function renderBridge(submitText: SubmitTextForBridge = () => true) {
     function Harness() {
       useQuickEntryBridge({
-        submitText: () => true,
+        submitText,
         submitTextToNewSession: async () => ({
           runtimeSessionId: 'runtime-new',
           sessionId: 'stored-new'
@@ -72,6 +79,117 @@ describe('useQuickEntryBridge', () => {
 
     return { container, submit: registeredSubmitHandler.current! }
   }
+
+  it('acknowledges a current-chat submit with the identity the pipeline accepted', async () => {
+    const correlationId = 'current-submit-correlation'
+    const ackSubmit = vi.fn()
+    window.hermesDesktop = {
+      quickEntry: {
+        ackSubmit,
+        pushState: vi.fn()
+      }
+    } as unknown as typeof window.hermesDesktop
+
+    const submitText = vi.fn(async (text: string, options?: Parameters<SubmitTextForBridge>[1]) => {
+      options?.onAccepted?.({ runtimeSessionId: 'rt-current-1', storedSessionId: 'st-current-1' })
+      expect(text).toBe('Send to current chat')
+      return true
+    })
+    const { container, submit } = await renderBridge(submitText)
+
+    await act(async () => {
+      await submit({ correlationId, target: 'current', text: 'Send to current chat' })
+    })
+
+    expect(ackSubmit).toHaveBeenCalledTimes(1)
+    expect(ackSubmit).toHaveBeenCalledWith(correlationId, {
+      ok: true,
+      runtimeSessionId: 'rt-current-1',
+      sessionId: 'st-current-1'
+    })
+
+    container.remove()
+  })
+
+  it('acknowledges a current-chat submit with no identity without inventing one', async () => {
+    const correlationId = 'current-submit-no-identity'
+    const ackSubmit = vi.fn()
+    window.hermesDesktop = {
+      quickEntry: {
+        ackSubmit,
+        pushState: vi.fn()
+      }
+    } as unknown as typeof window.hermesDesktop
+
+    const { container, submit } = await renderBridge(vi.fn(async () => true))
+
+    await act(async () => {
+      await submit({ correlationId, target: 'current', text: 'No identity path' })
+    })
+
+    expect(ackSubmit).toHaveBeenCalledTimes(1)
+    expect(ackSubmit).toHaveBeenCalledWith(correlationId, { ok: true })
+
+    container.remove()
+  })
+
+  it('keeps a rejected current-chat submit retryable', async () => {
+    const correlationId = 'current-submit-rejected'
+    const ackSubmit = vi.fn()
+    window.hermesDesktop = {
+      quickEntry: {
+        ackSubmit,
+        pushState: vi.fn()
+      }
+    } as unknown as typeof window.hermesDesktop
+
+    const { container, submit } = await renderBridge(vi.fn(async () => false))
+
+    await act(async () => {
+      await submit({ correlationId, target: 'current', text: 'Rejected prompt' })
+    })
+
+    expect(ackSubmit).toHaveBeenCalledTimes(1)
+    expect(ackSubmit).toHaveBeenCalledWith(correlationId, {
+      code: 'submit-rejected',
+      message: 'The prompt was not accepted.',
+      ok: false,
+      retryable: true
+    })
+
+    container.remove()
+  })
+
+  it('reports a failed current-chat submit as retryable', async () => {
+    const correlationId = 'current-submit-failed'
+    const ackSubmit = vi.fn()
+    window.hermesDesktop = {
+      quickEntry: {
+        ackSubmit,
+        pushState: vi.fn()
+      }
+    } as unknown as typeof window.hermesDesktop
+
+    const { container, submit } = await renderBridge(
+      vi.fn(async () => {
+        throw new Error('gateway down')
+      })
+    )
+
+    await act(async () => {
+      await submit({ correlationId, target: 'current', text: 'Failed prompt' })
+    })
+
+    expect(ackSubmit).toHaveBeenCalledTimes(1)
+    expect(ackSubmit).toHaveBeenCalledWith(correlationId, {
+      code: 'submit-failed',
+      message: 'gateway down',
+      ok: false,
+      retryable: true
+    })
+
+    container.remove()
+  })
 
   it('acknowledges an accepted selected-session submit with exact identity', async () => {
     const correlationId = 'selected-submit-correlation'

--- a/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.test.ts
@@ -50,26 +50,7 @@ describe('useQuickEntryBridge', () => {
     vi.clearAllMocks()
   })
 
-  it('does not acknowledge a selected-session void submit as success', async () => {
-    const correlationId = 'selected-submit-correlation'
-    const ackSubmit = vi.fn()
-    ackSubmit.mockImplementationOnce(() => {
-      throw new Error('ack channel failed')
-    })
-    window.hermesDesktop = {
-      quickEntry: {
-        ackSubmit,
-        pushState: vi.fn()
-      }
-    } as typeof window.hermesDesktop
-
-    const resumeTile = vi.fn(async () => 'runtime-session-1')
-    const submitToSession = vi.fn(async () => {})
-    vi.mocked(sessionTileDelegate).mockReturnValue({
-      resumeTile,
-      submitToSession
-    } as ReturnType<typeof sessionTileDelegate>)
-
+  async function renderBridge() {
     function Harness() {
       useQuickEntryBridge({
         submitText: () => true,
@@ -89,10 +70,35 @@ describe('useQuickEntryBridge', () => {
       root?.render(createElement(Harness))
     })
 
+    return { container, submit: registeredSubmitHandler.current! }
+  }
+
+  it('acknowledges an accepted selected-session submit with exact identity', async () => {
+    const correlationId = 'selected-submit-correlation'
+    const ackSubmit = vi.fn()
+    ackSubmit.mockImplementationOnce(() => {
+      throw new Error('ack channel failed')
+    })
+    window.hermesDesktop = {
+      quickEntry: {
+        ackSubmit,
+        pushState: vi.fn()
+      }
+    } as unknown as typeof window.hermesDesktop
+
+    const resumeTile = vi.fn(async () => 'runtime-session-1')
+    const submitToSession = vi.fn(async () => 'runtime-session-1')
+    vi.mocked(sessionTileDelegate).mockReturnValue({
+      resumeTile,
+      submitToSession
+    } as unknown as ReturnType<typeof sessionTileDelegate>)
+
+    const { container, submit } = await renderBridge()
+
     expect(registeredSubmitHandler.current).toBeTypeOf('function')
 
     await act(async () => {
-      await registeredSubmitHandler.current?.({
+      await submit({
         correlationId,
         target: 'stored-session-1',
         text: 'Send from Quick Entry'
@@ -103,10 +109,115 @@ describe('useQuickEntryBridge', () => {
     expect(submitToSession).toHaveBeenCalledWith('runtime-session-1', 'Send from Quick Entry')
     expect(ackSubmit).toHaveBeenCalledTimes(1)
     expect(ackSubmit).toHaveBeenCalledWith(correlationId, {
+      ok: true,
+      runtimeSessionId: 'runtime-session-1',
+      sessionId: 'stored-session-1'
+    })
+
+    container.remove()
+  })
+
+  it('reports the recovered runtime id when the delegate rebinds it', async () => {
+    const correlationId = 'selected-submit-recovered'
+    const ackSubmit = vi.fn()
+    window.hermesDesktop = {
+      quickEntry: {
+        ackSubmit,
+        pushState: vi.fn()
+      }
+    } as unknown as typeof window.hermesDesktop
+
+    const resumeTile = vi.fn(async () => 'runtime-session-before-recovery')
+    const submitToSession = vi.fn(async () => 'runtime-session-recovered')
+    vi.mocked(sessionTileDelegate).mockReturnValue({
+      resumeTile,
+      submitToSession
+    } as unknown as ReturnType<typeof sessionTileDelegate>)
+
+    const { container, submit } = await renderBridge()
+
+    await act(async () => {
+      await submit({ correlationId, target: 'stored-session-1', text: 'Recover me' })
+    })
+
+    expect(ackSubmit).toHaveBeenCalledTimes(1)
+    expect(ackSubmit).toHaveBeenCalledWith(correlationId, {
+      ok: true,
+      runtimeSessionId: 'runtime-session-recovered',
+      sessionId: 'stored-session-1'
+    })
+
+    container.remove()
+  })
+
+  it('keeps a post-dispatch failure non-retryable', async () => {
+    const correlationId = 'selected-submit-post-dispatch-failure'
+    const ackSubmit = vi.fn()
+    window.hermesDesktop = {
+      quickEntry: {
+        ackSubmit,
+        pushState: vi.fn()
+      }
+    } as unknown as typeof window.hermesDesktop
+
+    const resumeTile = vi.fn(async () => 'runtime-session-1')
+    const submitToSession = vi.fn(async () => {
+      throw new Error('gateway down')
+    })
+    vi.mocked(sessionTileDelegate).mockReturnValue({
+      resumeTile,
+      submitToSession
+    } as unknown as ReturnType<typeof sessionTileDelegate>)
+
+    const { container, submit } = await renderBridge()
+
+    await act(async () => {
+      await submit({ correlationId, target: 'stored-session-1', text: 'Fail after dispatch' })
+    })
+
+    expect(ackSubmit).toHaveBeenCalledTimes(1)
+    expect(ackSubmit).toHaveBeenCalledWith(correlationId, {
       code: 'submit-failed',
       message: 'The selected session prompt was dispatched, but backend acceptance is unknown.',
       ok: false,
       retryable: false
+    })
+
+    container.remove()
+  })
+
+  it('keeps a pre-dispatch failure retryable', async () => {
+    const correlationId = 'selected-submit-pre-dispatch-failure'
+    const ackSubmit = vi.fn()
+    window.hermesDesktop = {
+      quickEntry: {
+        ackSubmit,
+        pushState: vi.fn()
+      }
+    } as unknown as typeof window.hermesDesktop
+
+    const resumeTile = vi.fn(async () => {
+      throw new Error('resume failed')
+    })
+    const submitToSession = vi.fn(async () => 'runtime-session-1')
+    vi.mocked(sessionTileDelegate).mockReturnValue({
+      resumeTile,
+      submitToSession
+    } as unknown as ReturnType<typeof sessionTileDelegate>)
+
+    const { container, submit } = await renderBridge()
+
+    await act(async () => {
+      await submit({ correlationId, target: 'stored-session-1', text: 'Fail before dispatch' })
+    })
+
+    expect(submitToSession).not.toHaveBeenCalled()
+    expect(ackSubmit).toHaveBeenCalledTimes(1)
+    expect(ackSubmit).toHaveBeenCalledWith(correlationId, {
+      code: 'submit-failed',
+      message: 'resume failed',
+      ok: false,
+      retryable: true
     })
 
     container.remove()

--- a/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { quickEntrySubmitAck } from './use-quick-entry-bridge'
+
+describe('quickEntrySubmitAck', () => {
+  it('reports a rejected prompt as failure instead of acknowledging success', () => {
+    expect(quickEntrySubmitAck(false)).toEqual({
+      code: 'submit-rejected',
+      message: 'The prompt was not accepted.',
+      ok: false,
+      retryable: true
+    })
+  })
+
+  it('acknowledges only an accepted prompt as success', () => {
+    expect(quickEntrySubmitAck(true)).toEqual({ ok: true })
+  })
+})

--- a/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.test.ts
@@ -1,5 +1,28 @@
-import { describe, expect, it } from 'vitest'
-import { quickEntrySubmitAck } from './use-quick-entry-bridge'
+import { act, createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useQuickEntryBridge, quickEntrySubmitAck } from './use-quick-entry-bridge'
+import { sessionTileDelegate } from '@/store/session-states'
+
+const registeredSubmitHandler = vi.hoisted(() => ({
+  current: null as ((payload: { correlationId: string; target: string; text: string }) => void) | null
+}))
+
+vi.mock('@/store/quick-entry', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/store/quick-entry')>()
+
+  return {
+    ...actual,
+    setQuickEntrySubmitHandler(fn: Parameters<typeof actual.setQuickEntrySubmitHandler>[0]) {
+      registeredSubmitHandler.current = fn
+      actual.setQuickEntrySubmitHandler(fn)
+    }
+  }
+})
+
+vi.mock('@/store/session-states', () => ({
+  sessionTileDelegate: vi.fn()
+}))
 
 describe('quickEntrySubmitAck', () => {
   it('reports a rejected prompt as failure instead of acknowledging success', () => {
@@ -13,5 +36,79 @@ describe('quickEntrySubmitAck', () => {
 
   it('acknowledges only an accepted prompt as success', () => {
     expect(quickEntrySubmitAck(true)).toEqual({ ok: true })
+  })
+})
+
+describe('useQuickEntryBridge', () => {
+  const originalHermesDesktop = window.hermesDesktop
+  let root: Root | null = null
+
+  afterEach(() => {
+    root?.unmount()
+    root = null
+    window.hermesDesktop = originalHermesDesktop
+    vi.clearAllMocks()
+  })
+
+  it('does not acknowledge a selected-session void submit as success', async () => {
+    const correlationId = 'selected-submit-correlation'
+    const ackSubmit = vi.fn()
+    ackSubmit.mockImplementationOnce(() => {
+      throw new Error('ack channel failed')
+    })
+    window.hermesDesktop = {
+      quickEntry: {
+        ackSubmit,
+        pushState: vi.fn()
+      }
+    } as typeof window.hermesDesktop
+
+    const resumeTile = vi.fn(async () => 'runtime-session-1')
+    const submitToSession = vi.fn(async () => {})
+    vi.mocked(sessionTileDelegate).mockReturnValue({
+      resumeTile,
+      submitToSession
+    } as ReturnType<typeof sessionTileDelegate>)
+
+    function Harness() {
+      useQuickEntryBridge({
+        submitText: () => true,
+        submitTextToNewSession: async () => ({
+          runtimeSessionId: 'runtime-new',
+          sessionId: 'stored-new'
+        })
+      })
+
+      return null
+    }
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    await act(async () => {
+      root?.render(createElement(Harness))
+    })
+
+    expect(registeredSubmitHandler.current).toBeTypeOf('function')
+
+    await act(async () => {
+      await registeredSubmitHandler.current?.({
+        correlationId,
+        target: 'stored-session-1',
+        text: 'Send from Quick Entry'
+      })
+    })
+
+    expect(resumeTile).toHaveBeenCalledWith('stored-session-1')
+    expect(submitToSession).toHaveBeenCalledWith('runtime-session-1', 'Send from Quick Entry')
+    expect(ackSubmit).toHaveBeenCalledTimes(1)
+    expect(ackSubmit).toHaveBeenCalledWith(correlationId, {
+      code: 'submit-failed',
+      message: 'The selected session prompt was dispatched, but backend acceptance is unknown.',
+      ok: false,
+      retryable: false
+    })
+
+    container.remove()
   })
 })

--- a/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.ts
@@ -5,6 +5,7 @@ import {
   QUICK_TARGET_CURRENT,
   QUICK_TARGET_NEW,
   type QuickEntrySessionOption,
+  type QuickEntrySubmitResult,
   setQuickEntrySubmitHandler
 } from '@/store/quick-entry'
 import { $gatewayState, $sessions } from '@/store/session'
@@ -12,8 +13,8 @@ import { sessionTileDelegate } from '@/store/session-states'
 import { isAuxiliaryWindow } from '@/store/windows'
 
 interface QuickEntryBridgeParams {
-  startFreshSessionDraft: () => void
   submitText: (text: string) => Promise<unknown> | unknown
+  submitTextToNewSession: (text: string) => Promise<{ runtimeSessionId: string; sessionId: string }>
 }
 
 // The picker is a capture aid, not a session browser — a handful of recent
@@ -50,23 +51,33 @@ function sessionOptions(): QuickEntrySessionOption[] {
  * secondary session window must not also claim the global capture channel, or
  * one keystroke would send N prompts.
  */
-export function useQuickEntryBridge({ startFreshSessionDraft, submitText }: QuickEntryBridgeParams): void {
+export function useQuickEntryBridge({
+  submitText,
+  submitTextToNewSession
+}: QuickEntryBridgeParams): void {
   const submitTextRef = useRef(submitText)
   submitTextRef.current = submitText
-  const startFreshRef = useRef(startFreshSessionDraft)
-  startFreshRef.current = startFreshSessionDraft
+  const submitNewRef = useRef(submitTextToNewSession)
+  submitNewRef.current = submitTextToNewSession
 
   useEffect(() => {
     if (isAuxiliaryWindow()) {
       return
     }
 
-    setQuickEntrySubmitHandler(({ target, text }) => {
+    setQuickEntrySubmitHandler(async ({ correlationId, target, text }) => {
+      const ack = (result: QuickEntrySubmitResult) =>
+        window.hermesDesktop?.quickEntry.ackSubmit(correlationId, result)
+
       if (target === QUICK_TARGET_NEW) {
-        // Same as the user clicking New Chat and typing: fresh draft, then the
-        // normal submit creates the backend session.
-        startFreshRef.current()
-        void submitTextRef.current(text)
+        // Create and submit as one route-neutral operation so drift cannot
+        // orphan the new session (#85590).
+        try {
+          const created = await submitNewRef.current(text)
+          ack({ ok: true, runtimeSessionId: created.runtimeSessionId, sessionId: created.sessionId })
+        } catch (error) {
+          ack({ code: 'submit-failed', message: error instanceof Error ? error.message : String(error), ok: false, retryable: true })
+        }
 
         return
       }
@@ -77,17 +88,32 @@ export function useQuickEntryBridge({ startFreshSessionDraft, submitText }: Quic
         const delegate = sessionTileDelegate()
 
         if (delegate) {
-          void delegate
-            .resumeTile(target)
-            .then(runtimeId => delegate.submitToSession(runtimeId, text))
-            // A dead/undeliverable target must not swallow the prompt.
-            .catch(() => void submitTextRef.current(text))
+          try {
+            const runtimeId = await delegate.resumeTile(target)
+            await delegate.submitToSession(runtimeId, text)
+            ack({ ok: true })
+          } catch (error) {
+            ack({ code: 'submit-failed', message: error instanceof Error ? error.message : String(error), ok: false, retryable: true })
+          }
 
           return
         }
+
+        ack({
+          code: 'submit-unavailable',
+          message: 'The selected session submit path is unavailable.',
+          ok: false,
+          retryable: true
+        })
+        return
       }
 
-      void submitTextRef.current(text)
+      try {
+        await submitTextRef.current(text)
+        ack({ ok: true })
+      } catch (error) {
+        ack({ code: 'submit-failed', message: error instanceof Error ? error.message : String(error), ok: false, retryable: true })
+      }
     })
 
     const dispose = initQuickEntryBridge()

--- a/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.ts
@@ -13,13 +13,29 @@ import { sessionTileDelegate } from '@/store/session-states'
 import { isAuxiliaryWindow } from '@/store/windows'
 
 interface QuickEntryBridgeParams {
-  submitText: (text: string) => Promise<unknown> | unknown
+  submitText: (text: string) => Promise<boolean> | boolean
   submitTextToNewSession: (text: string) => Promise<{ runtimeSessionId: string; sessionId: string }>
 }
 
 // The picker is a capture aid, not a session browser — a handful of recent
 // rows is the whole point.
 const QUICK_ENTRY_SESSION_OPTIONS = 5
+
+/**
+ * `submitText` resolves false when a pre-submit guard declines the prompt
+ * without throwing (for example, while the target is busy). That is a failed
+ * delivery, not an acknowledgement of success.
+ */
+export function quickEntrySubmitAck(submitted: boolean): QuickEntrySubmitResult {
+  return submitted
+    ? { ok: true }
+    : {
+        code: 'submit-rejected',
+        message: 'The prompt was not accepted.',
+        ok: false,
+        retryable: true
+      }
+}
 
 function sessionOptions(): QuickEntrySessionOption[] {
   return $sessions
@@ -109,8 +125,8 @@ export function useQuickEntryBridge({
       }
 
       try {
-        await submitTextRef.current(text)
-        ack({ ok: true })
+        const submitted = await submitTextRef.current(text)
+        ack(quickEntrySubmitAck(submitted))
       } catch (error) {
         ack({ code: 'submit-failed', message: error instanceof Error ? error.message : String(error), ok: false, retryable: true })
       }

--- a/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.ts
@@ -117,14 +117,9 @@ export function useQuickEntryBridge({
           try {
             const runtimeId = await delegate.resumeTile(target)
             promptDispatched = true
-            await delegate.submitToSession(runtimeId, text)
+            const acceptedRuntimeId = await delegate.submitToSession(runtimeId, text)
 
-            ack({
-              code: 'submit-failed',
-              message: 'The selected session prompt was dispatched, but backend acceptance is unknown.',
-              ok: false,
-              retryable: false
-            })
+            ack({ ok: true, runtimeSessionId: acceptedRuntimeId, sessionId: target })
           } catch (error) {
             if (promptDispatched) {
               ack({

--- a/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.ts
@@ -136,9 +136,24 @@ export function useQuickEntryBridge({
           try {
             const runtimeId = await delegate.resumeTile(target)
             promptDispatched = true
-            const acceptedRuntimeId = await delegate.submitToSession(runtimeId, text)
+            const accepted = await delegate.submitToSession(runtimeId, text)
 
-            ack({ ok: true, runtimeSessionId: acceptedRuntimeId, sessionId: target })
+            if (accepted.storedSessionId !== target) {
+              // The backend accepted the prompt, but the accepted runtime is not
+              // bound to the requested stored session (or the binding is
+              // unprovable). Never report success for a session this request
+              // did not prove it used.
+              ack({
+                code: 'submit-identity-mismatch',
+                message: 'The prompt was accepted by a different session than the one requested.',
+                ok: false,
+                retryable: false
+              })
+
+              return
+            }
+
+            ack({ ok: true, runtimeSessionId: accepted.runtimeSessionId, sessionId: accepted.storedSessionId })
           } catch (error) {
             if (promptDispatched) {
               ack({

--- a/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.ts
@@ -17,7 +17,10 @@ interface QuickEntryBridgeParams {
     text: string,
     options?: { onAccepted?: (identity: QuickEntryAcceptedIdentity) => void }
   ) => Promise<boolean> | boolean
-  submitTextToNewSession: (text: string) => Promise<{ runtimeSessionId: string; sessionId: string }>
+  submitTextToNewSession: (
+    text: string,
+    owner?: string
+  ) => Promise<{ runtimeSessionId: string; sessionId: string }>
 }
 
 /** Exact session identity that accepted a prompt (runtime + durable stored id). */
@@ -116,7 +119,7 @@ export function useQuickEntryBridge({
         // Create and submit as one route-neutral operation so drift cannot
         // orphan the new session (#85590).
         try {
-          const created = await submitNewRef.current(text)
+          const created = await submitNewRef.current(text, correlationId)
           ack({ ok: true, runtimeSessionId: created.runtimeSessionId, sessionId: created.sessionId })
         } catch (error) {
           ack({ code: 'submit-failed', message: error instanceof Error ? error.message : String(error), ok: false, retryable: true })

--- a/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.ts
@@ -82,8 +82,16 @@ export function useQuickEntryBridge({
     }
 
     setQuickEntrySubmitHandler(async ({ correlationId, target, text }) => {
-      const ack = (result: QuickEntrySubmitResult) =>
+      let acknowledged = false
+
+      const ack = (result: QuickEntrySubmitResult) => {
+        if (acknowledged) {
+          return
+        }
+
+        acknowledged = true
         window.hermesDesktop?.quickEntry.ackSubmit(correlationId, result)
+      }
 
       if (target === QUICK_TARGET_NEW) {
         // Create and submit as one route-neutral operation so drift cannot
@@ -104,11 +112,31 @@ export function useQuickEntryBridge({
         const delegate = sessionTileDelegate()
 
         if (delegate) {
+          let promptDispatched = false
+
           try {
             const runtimeId = await delegate.resumeTile(target)
+            promptDispatched = true
             await delegate.submitToSession(runtimeId, text)
-            ack({ ok: true })
+
+            ack({
+              code: 'submit-failed',
+              message: 'The selected session prompt was dispatched, but backend acceptance is unknown.',
+              ok: false,
+              retryable: false
+            })
           } catch (error) {
+            if (promptDispatched) {
+              ack({
+                code: 'submit-failed',
+                message: 'The selected session prompt was dispatched, but backend acceptance is unknown.',
+                ok: false,
+                retryable: false
+              })
+
+              return
+            }
+
             ack({ code: 'submit-failed', message: error instanceof Error ? error.message : String(error), ok: false, retryable: true })
           }
 

--- a/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.ts
@@ -13,8 +13,17 @@ import { sessionTileDelegate } from '@/store/session-states'
 import { isAuxiliaryWindow } from '@/store/windows'
 
 interface QuickEntryBridgeParams {
-  submitText: (text: string) => Promise<boolean> | boolean
+  submitText: (
+    text: string,
+    options?: { onAccepted?: (identity: QuickEntryAcceptedIdentity) => void }
+  ) => Promise<boolean> | boolean
   submitTextToNewSession: (text: string) => Promise<{ runtimeSessionId: string; sessionId: string }>
+}
+
+/** Exact session identity that accepted a prompt (runtime + durable stored id). */
+interface QuickEntryAcceptedIdentity {
+  runtimeSessionId: string
+  storedSessionId: null | string
 }
 
 // The picker is a capture aid, not a session browser — a handful of recent
@@ -26,15 +35,25 @@ const QUICK_ENTRY_SESSION_OPTIONS = 5
  * without throwing (for example, while the target is busy). That is a failed
  * delivery, not an acknowledgement of success.
  */
-export function quickEntrySubmitAck(submitted: boolean): QuickEntrySubmitResult {
-  return submitted
-    ? { ok: true }
-    : {
-        code: 'submit-rejected',
-        message: 'The prompt was not accepted.',
-        ok: false,
-        retryable: true
-      }
+export function quickEntrySubmitAck(
+  submitted: boolean,
+  identity?: null | QuickEntryAcceptedIdentity
+): QuickEntrySubmitResult {
+  if (!submitted) {
+    return {
+      code: 'submit-rejected',
+      message: 'The prompt was not accepted.',
+      ok: false,
+      retryable: true
+    }
+  }
+
+  // An accepted prompt names the session that accepted it. A submit that
+  // resolved true without an identity callback (slash commands, which never
+  // reach prompt.submit) still acknowledges, but claims no backend session.
+  return identity
+    ? { ok: true, runtimeSessionId: identity.runtimeSessionId, sessionId: identity.storedSessionId }
+    : { ok: true }
 }
 
 function sessionOptions(): QuickEntrySessionOption[] {
@@ -147,9 +166,15 @@ export function useQuickEntryBridge({
         return
       }
 
+      let acceptedIdentity: null | QuickEntryAcceptedIdentity = null
+
       try {
-        const submitted = await submitTextRef.current(text)
-        ack(quickEntrySubmitAck(submitted))
+        const submitted = await submitTextRef.current(text, {
+          onAccepted: identity => {
+            acceptedIdentity = identity
+          }
+        })
+        ack(quickEntrySubmitAck(submitted, acceptedIdentity))
       } catch (error) {
         ack({ code: 'submit-failed', message: error instanceof Error ? error.message : String(error), ok: false, retryable: true })
       }

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
@@ -541,7 +541,7 @@ describe('useSessionTileDelegate submitToSession', () => {
     setSessions([])
   })
 
-  it('returns the accepting runtime id on both the happy and recovered paths', async () => {
+  it('returns the accepted runtime and its stored binding', async () => {
     setSessions([row({ id: 'stored-submit', profile: 'default' })])
 
     const state = { busy: false, messages: [{ id: 'm1' }], storedSessionId: 'stored-submit' }
@@ -568,11 +568,17 @@ describe('useSessionTileDelegate submitToSession', () => {
     renderTile(requestGateway, { runtimeIdByStoredSessionIdRef, sessionStateByRuntimeIdRef })
     const delegate = sessionTileDelegate()!
 
-    const recoveredId = await delegate.submitToSession('runtime-dead', 'Send from Quick Entry')
-    expect(recoveredId).toBe('runtime-recovered')
+    const recovered = await delegate.submitToSession('runtime-dead', 'Send from Quick Entry')
+    expect(recovered).toEqual({
+      runtimeSessionId: 'runtime-recovered',
+      storedSessionId: 'stored-submit'
+    })
 
-    const acceptedId = await delegate.submitToSession('runtime-recovered', 'Send again')
-    expect(acceptedId).toBe('runtime-recovered')
+    const accepted = await delegate.submitToSession('runtime-recovered', 'Send again')
+    expect(accepted).toEqual({
+      runtimeSessionId: 'runtime-recovered',
+      storedSessionId: 'stored-submit'
+    })
     expect(promptAttempts).toBe(1)
     expect(runtimeIdByStoredSessionIdRef.current.get('stored-submit')).toBe('runtime-recovered')
     expect(requestGateway).toHaveBeenNthCalledWith(

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
@@ -18,7 +18,7 @@ vi.mock('@/store/gateway', async importActual => ({
   requestGatewayForProfile: vi.fn()
 }))
 
-const { getLatestSessionMessages } = await import('@/hermes')
+const { getLatestSessionMessages, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS } = await import('@/hermes')
 const { requestGatewayForAgent, requestGatewayForProfile } = await import('@/store/gateway')
 
 const row = (over: Partial<SessionInfo>): SessionInfo =>
@@ -529,5 +529,75 @@ describe('useSessionTileDelegate interruptSession', () => {
     // Same 3s cooldown the primary chat's Stop sets: busy reads false while the
     // gateway winds down, so the rewind path must still interrupt-first.
     expect(isSessionRecentlyInterrupted('runtime-tile-1')).toBe(true)
+  })
+})
+
+describe('useSessionTileDelegate submitToSession', () => {
+  beforeEach(() => {
+    setSessions([])
+  })
+
+  afterEach(() => {
+    setSessions([])
+  })
+
+  it('returns the accepting runtime id on both the happy and recovered paths', async () => {
+    setSessions([row({ id: 'stored-submit', profile: 'default' })])
+
+    const state = { busy: false, messages: [{ id: 'm1' }], storedSessionId: 'stored-submit' }
+    const runtimeIdByStoredSessionIdRef = { current: new Map([['stored-submit', 'runtime-dead']]) }
+    const sessionStateByRuntimeIdRef = { current: new Map([['runtime-dead', state]]) }
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.submit') {
+        return {} as never
+      }
+
+      if (method === 'session.resume') {
+        return { session_id: 'runtime-recovered' } as never
+      }
+
+      throw new Error(`unexpected gateway method: ${method}`)
+    })
+
+    let promptAttempts = 0
+    requestGateway.mockImplementationOnce(async () => {
+      promptAttempts += 1
+      throw new Error('session not found')
+    })
+
+    renderTile(requestGateway, { runtimeIdByStoredSessionIdRef, sessionStateByRuntimeIdRef })
+    const delegate = sessionTileDelegate()!
+
+    const recoveredId = await delegate.submitToSession('runtime-dead', 'Send from Quick Entry')
+    expect(recoveredId).toBe('runtime-recovered')
+
+    const acceptedId = await delegate.submitToSession('runtime-recovered', 'Send again')
+    expect(acceptedId).toBe('runtime-recovered')
+    expect(promptAttempts).toBe(1)
+    expect(runtimeIdByStoredSessionIdRef.current.get('stored-submit')).toBe('runtime-recovered')
+    expect(requestGateway).toHaveBeenNthCalledWith(
+      1,
+      'prompt.submit',
+      { session_id: 'runtime-dead', text: 'Send from Quick Entry' },
+      PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
+    )
+    expect(requestGateway).toHaveBeenNthCalledWith(2, 'session.resume', {
+      session_id: 'stored-submit',
+      source: 'desktop',
+      omit_messages: true,
+      profile: 'default'
+    })
+    expect(requestGateway).toHaveBeenNthCalledWith(
+      3,
+      'prompt.submit',
+      { session_id: 'runtime-recovered', text: 'Send from Quick Entry' },
+      PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
+    )
+    expect(requestGateway).toHaveBeenNthCalledWith(
+      4,
+      'prompt.submit',
+      { session_id: 'runtime-recovered', text: 'Send again' },
+      PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
+    )
   })
 })

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
@@ -547,7 +547,12 @@ describe('useSessionTileDelegate submitToSession', () => {
     const state = { busy: false, messages: [{ id: 'm1' }], storedSessionId: 'stored-submit' }
     const runtimeIdByStoredSessionIdRef = { current: new Map([['stored-submit', 'runtime-dead']]) }
     const sessionStateByRuntimeIdRef = { current: new Map([['runtime-dead', state]]) }
-    const requestGateway = vi.fn(async (method: string) => {
+    // #92961: a known owner always routes through the profile router, even
+    // 'default', never the ambient socket — so the routed seam carries the
+    // failed submit, the recovery resume, and the retry.
+    const routed = vi.mocked(requestGatewayForProfile)
+    routed.mockReset()
+    routed.mockImplementation(async (_profile: string, method: string) => {
       if (method === 'prompt.submit') {
         return {} as never
       }
@@ -560,12 +565,12 @@ describe('useSessionTileDelegate submitToSession', () => {
     })
 
     let promptAttempts = 0
-    requestGateway.mockImplementationOnce(async () => {
+    routed.mockImplementationOnce(async () => {
       promptAttempts += 1
       throw new Error('session not found')
     })
 
-    renderTile(requestGateway, { runtimeIdByStoredSessionIdRef, sessionStateByRuntimeIdRef })
+    renderTile(vi.fn(), { runtimeIdByStoredSessionIdRef, sessionStateByRuntimeIdRef })
     const delegate = sessionTileDelegate()!
 
     const recovered = await delegate.submitToSession('runtime-dead', 'Send from Quick Entry')
@@ -581,29 +586,42 @@ describe('useSessionTileDelegate submitToSession', () => {
     })
     expect(promptAttempts).toBe(1)
     expect(runtimeIdByStoredSessionIdRef.current.get('stored-submit')).toBe('runtime-recovered')
-    expect(requestGateway).toHaveBeenNthCalledWith(
+    expect(routed).toHaveBeenNthCalledWith(
       1,
+      'default',
       'prompt.submit',
       { session_id: 'runtime-dead', text: 'Send from Quick Entry' },
-      PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
+      PROMPT_SUBMIT_REQUEST_TIMEOUT_MS,
+      undefined
     )
-    expect(requestGateway).toHaveBeenNthCalledWith(2, 'session.resume', {
-      session_id: 'stored-submit',
-      source: 'desktop',
-      omit_messages: true,
-      profile: 'default'
-    })
-    expect(requestGateway).toHaveBeenNthCalledWith(
+    expect(routed).toHaveBeenNthCalledWith(
+      2,
+      'default',
+      'session.resume',
+      {
+        session_id: 'stored-submit',
+        source: 'desktop',
+        omit_messages: true,
+        profile: 'default'
+      },
+      undefined,
+      undefined
+    )
+    expect(routed).toHaveBeenNthCalledWith(
       3,
+      'default',
       'prompt.submit',
       { session_id: 'runtime-recovered', text: 'Send from Quick Entry' },
-      PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
+      PROMPT_SUBMIT_REQUEST_TIMEOUT_MS,
+      undefined
     )
-    expect(requestGateway).toHaveBeenNthCalledWith(
+    expect(routed).toHaveBeenNthCalledWith(
       4,
+      'default',
       'prompt.submit',
       { session_id: 'runtime-recovered', text: 'Send again' },
-      PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
+      PROMPT_SUBMIT_REQUEST_TIMEOUT_MS,
+      undefined
     )
   })
 })

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -419,7 +419,7 @@ export function useSessionTileDelegate({
         if (isReadOnlyRuntimeId(runtimeId)) {
           notify({ kind: 'info', message: translateNow('desktop.readOnlyTranscriptSendBlocked') })
 
-          return
+          return runtimeId
         }
 
         const storedSessionId = storedSessionIdForRuntime(runtimeId)
@@ -429,12 +429,22 @@ export function useSessionTileDelegate({
               requestForStoredSession<T>(storedSessionId, method, params ?? {}, timeoutMs)
           : requestGateway
 
+        let acceptedRuntimeId = runtimeId
+
         await withSessionNotFoundResume(
           runtimeId,
           storedSessionId,
           liveId => routedRequest('prompt.submit', { session_id: liveId, text }, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS),
-          { requestGateway: routedRequest, onRecovered: rebindTileRuntime(runtimeId) }
+          {
+            requestGateway: routedRequest,
+            onRecovered: recoveredId => {
+              acceptedRuntimeId = recoveredId
+              rebindTileRuntime(runtimeId)(recoveredId)
+            }
+          }
         )
+
+        return acceptedRuntimeId
       },
       updateSession: (runtimeId, updater) => updateSessionState(runtimeId, updater)
     })

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -419,7 +419,7 @@ export function useSessionTileDelegate({
         if (isReadOnlyRuntimeId(runtimeId)) {
           notify({ kind: 'info', message: translateNow('desktop.readOnlyTranscriptSendBlocked') })
 
-          return runtimeId
+          return { runtimeSessionId: runtimeId, storedSessionId: null }
         }
 
         const storedSessionId = storedSessionIdForRuntime(runtimeId)

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -444,7 +444,12 @@ export function useSessionTileDelegate({
           }
         )
 
-        return acceptedRuntimeId
+        return {
+          runtimeSessionId: acceptedRuntimeId,
+          // The durable binding for the accepted runtime — the only proof the
+          // requested stored session is what actually took the prompt.
+          storedSessionId: storedSessionIdForRuntime(acceptedRuntimeId) ?? null
+        }
       },
       updateSession: (runtimeId, updater) => updateSessionState(runtimeId, updater)
     })

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -543,6 +543,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     removeSession,
     resumeSession,
     selectSidebarItem,
+    submitTextToNewSession,
     startFreshSessionDraft
   } = useSessionActions({
     activeSessionId,
@@ -779,7 +780,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // The global-hotkey Quick Entry window's bridge: its captured text rides the
   // SAME submit machinery the normal composer uses (current chat / picked
   // session / new session), and it hears gateway truth from this window.
-  useQuickEntryBridge({ startFreshSessionDraft, submitText })
+  useQuickEntryBridge({ submitText, submitTextToNewSession })
 
   // Leaving HUD mode hands this window the session back (see hud/handoff).
   useHudHandoff({ navigate, resumeSession })

--- a/apps/desktop/src/app/quick-entry/quick-entry-app.tsx
+++ b/apps/desktop/src/app/quick-entry/quick-entry-app.tsx
@@ -27,6 +27,7 @@ import {
  */
 export function QuickEntryApp() {
   const inputRef = useRef<HTMLInputElement>(null)
+  const submitIdRef = useRef(0)
 
   // The reducer returns { send, state }; this wrapper performs the side effect
   // (hand the payload to the shell, ask to hide) and stores the next state, so
@@ -36,7 +37,21 @@ export function QuickEntryApp() {
     const api = window.hermesDesktop?.quickEntry
 
     if (send) {
-      api?.submit(send)
+      const submitId = submitIdRef.current
+      void api?.submit(send).then(result => {
+        dispatch(
+          result.ok
+            ? { submitId, type: 'submit-ok' }
+            : {
+                message: result.message || 'Quick Entry could not deliver the prompt.',
+                submitId,
+                type: 'submit-error'
+              }
+        )
+        if (!result.ok) {
+          requestAnimationFrame(() => inputRef.current?.focus())
+        }
+      })
     } else if (!next.visible && current.visible) {
       api?.dismiss()
     }
@@ -125,7 +140,7 @@ export function QuickEntryApp() {
             onKeyDown={event => {
               if (event.key === 'Enter' && !event.shiftKey) {
                 event.preventDefault()
-                dispatch({ type: 'submit' })
+                dispatch({ submitId: ++submitIdRef.current, type: 'submit' })
               } else if (event.key === 'Escape') {
                 event.preventDefault()
                 dispatch({ type: 'dismiss' })
@@ -191,6 +206,11 @@ export function QuickEntryApp() {
             ))}
           </select>
         </div>
+        {state.error ? (
+          <div role="alert" style={{ color: 'var(--destructive, #ef4444)', fontSize: 11 }}>
+            {state.error}
+          </div>
+        ) : null}
       </div>
     </div>
   )

--- a/apps/desktop/src/app/quick-entry/quick-entry-app.tsx
+++ b/apps/desktop/src/app/quick-entry/quick-entry-app.tsx
@@ -71,11 +71,20 @@ export function QuickEntryApp() {
       })
     })
 
+    const offLateResult = api?.onLateResult(payload => {
+      dispatch({
+        message: payload?.result?.message ?? 'Hermes could not deliver the prompt.',
+        ok: payload?.result?.ok === true,
+        type: 'late-result'
+      })
+    })
+
     inputRef.current?.focus()
 
     return () => {
       offShown?.()
       offState?.()
+      offLateResult?.()
     }
   }, [])
 

--- a/apps/desktop/src/app/quick-entry/quick-entry-app.tsx
+++ b/apps/desktop/src/app/quick-entry/quick-entry-app.tsx
@@ -6,7 +6,8 @@ import {
   QUICK_TARGET_NEW,
   type QuickComposerEvent,
   quickComposerReducer,
-  type QuickComposerState
+  type QuickComposerState,
+  quickEntryResultEvent
 } from '@/store/quick-entry'
 
 /**
@@ -39,15 +40,7 @@ export function QuickEntryApp() {
     if (send) {
       const submitId = submitIdRef.current
       void api?.submit(send).then(result => {
-        dispatch(
-          result.ok
-            ? { submitId, type: 'submit-ok' }
-            : {
-                message: result.message || 'Quick Entry could not deliver the prompt.',
-                submitId,
-                type: 'submit-error'
-              }
-        )
+        dispatch(quickEntryResultEvent(result, submitId))
         if (!result.ok) {
           requestAnimationFrame(() => inputRef.current?.focus())
         }

--- a/apps/desktop/src/app/session/hooks/session-context-drift.test.ts
+++ b/apps/desktop/src/app/session/hooks/session-context-drift.test.ts
@@ -27,6 +27,33 @@ describe('routeTargetFromToken', () => {
 })
 
 describe('sessionContextDrift', () => {
+  it('keeps a pinned atomic-submit session through drift, then restores normal drift behavior', () => {
+    const pinned = new Set(['sess-b'])
+
+    expect(
+      sessionContextDrift({
+        nowRouteToken: routeToken(sessionRoute(SESS_B)),
+        nowSelectedStoredId: SESS_B,
+        pinnedStoredSessionIds: pinned,
+        startRouteToken: routeToken(sessionRoute(SESS_A)),
+        startSelectedStoredId: SESS_A,
+        submitTargetStoredId: null
+      })
+    ).toBeNull()
+
+    pinned.delete(SESS_B)
+    expect(
+      sessionContextDrift({
+        nowRouteToken: routeToken(sessionRoute(SESS_B)),
+        nowSelectedStoredId: SESS_B,
+        pinnedStoredSessionIds: pinned,
+        startRouteToken: routeToken(sessionRoute(SESS_A)),
+        startSelectedStoredId: SESS_A,
+        submitTargetStoredId: null
+      })
+    ).toBe('route:sess-a->sess-b')
+  })
+
   it('does not drift on search/hash-only route churn', () => {
     const reason = sessionContextDrift({
       startRouteToken: routeToken(sessionRoute(SESS_A)),

--- a/apps/desktop/src/app/session/hooks/session-context-drift.test.ts
+++ b/apps/desktop/src/app/session/hooks/session-context-drift.test.ts
@@ -1,8 +1,15 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
 import { NEW_CHAT_ROUTE, sessionRoute, SETTINGS_ROUTE } from '../../routes'
 
-import { routeTargetFromToken, sessionContextDrift } from './session-context-drift'
+import {
+  pinStoredSessionForOwner,
+  pinnedOwnerCount,
+  pinnedStoredSessionIdsForOwner,
+  releaseStoredSessionPins,
+  routeTargetFromToken,
+  sessionContextDrift
+} from './session-context-drift'
 
 const SESS_A = 'sess-a'
 const SESS_B = 'sess-b'
@@ -27,31 +34,47 @@ describe('routeTargetFromToken', () => {
 })
 
 describe('sessionContextDrift', () => {
-  it('keeps a pinned atomic-submit session through drift, then restores normal drift behavior', () => {
-    const pinned = new Set(['sess-b'])
+  afterEach(() => {
+    releaseStoredSessionPins('owner-a')
+    releaseStoredSessionPins('owner-b')
+  })
+
+  it('honors a pin only for its owner', () => {
+    pinStoredSessionForOwner('owner-a', 'sess-b')
+
+    const driftInputs = {
+      nowRouteToken: routeToken(sessionRoute(SESS_B)),
+      nowSelectedStoredId: SESS_B,
+      startRouteToken: routeToken(sessionRoute(SESS_A)),
+      startSelectedStoredId: SESS_A,
+      submitTargetStoredId: null
+    }
 
     expect(
       sessionContextDrift({
-        nowRouteToken: routeToken(sessionRoute(SESS_B)),
-        nowSelectedStoredId: SESS_B,
-        pinnedStoredSessionIds: pinned,
-        startRouteToken: routeToken(sessionRoute(SESS_A)),
-        startSelectedStoredId: SESS_A,
-        submitTargetStoredId: null
+        ...driftInputs,
+        pinOwner: 'owner-a'
       })
     ).toBeNull()
 
-    pinned.delete(SESS_B)
     expect(
       sessionContextDrift({
-        nowRouteToken: routeToken(sessionRoute(SESS_B)),
-        nowSelectedStoredId: SESS_B,
-        pinnedStoredSessionIds: pinned,
-        startRouteToken: routeToken(sessionRoute(SESS_A)),
-        startSelectedStoredId: SESS_A,
-        submitTargetStoredId: null
+        ...driftInputs,
+        pinOwner: 'owner-b'
       })
-    ).toBe('route:sess-a->sess-b')
+    ).toBe(`route:${SESS_A}->${SESS_B}`)
+    expect(sessionContextDrift(driftInputs)).toBe(`route:${SESS_A}->${SESS_B}`)
+  })
+
+  it('releases only the named owner', () => {
+    pinStoredSessionForOwner('owner-a', SESS_A)
+    pinStoredSessionForOwner('owner-b', SESS_B)
+
+    releaseStoredSessionPins('owner-a')
+
+    expect(pinnedStoredSessionIdsForOwner('owner-a').size).toBe(0)
+    expect(pinnedStoredSessionIdsForOwner('owner-b')).toContain(SESS_B)
+    expect(pinnedOwnerCount()).toBe(1)
   })
 
   it('does not drift on search/hash-only route churn', () => {

--- a/apps/desktop/src/app/session/hooks/session-context-drift.ts
+++ b/apps/desktop/src/app/session/hooks/session-context-drift.ts
@@ -56,7 +56,13 @@ interface SessionContextDriftArgs {
    * session that has ever compressed.
    */
   submitTargetComposerScope?: string | null
+  /** Stored ids being re-homed by an atomic submit (#85590). */
+  pinnedStoredSessionIds?: ReadonlySet<string>
 }
+
+// A short-lived pin marks the session being re-homed by atomic quick submit;
+// keeping it here lets every drift caller share the same narrow exception (#85590).
+export const activePinnedStoredSessionIds = new Set<string>()
 
 /**
  * Decide whether the session context genuinely changed under an in-flight
@@ -77,8 +83,10 @@ export function sessionContextDrift({
   nowSelectedStoredId,
   submitTargetStoredId,
   composerScope,
-  submitTargetComposerScope
+  submitTargetComposerScope,
+  pinnedStoredSessionIds: pinnedIds
 }: SessionContextDriftArgs): string | null {
+  const activePins = pinnedIds ?? activePinnedStoredSessionIds
   // Composer prong: the composer's loaded scope disagrees with the resolved
   // submit target. Not a start/now comparison like the two prongs below — the
   // composer only hands us one snapshot per submit — but it belongs in the
@@ -97,7 +105,12 @@ export function sessionContextDrift({
   // (navigated to settings / a non-chat overlay route) or a search/hash-only
   // change (same target) is not drift, and neither is landing on the submit's
   // own target.
-  if (targetNow !== targetStart && targetNow !== null && targetNow !== submitTargetStoredId) {
+  if (
+    targetNow !== targetStart &&
+    targetNow !== null &&
+    targetNow !== submitTargetStoredId &&
+    !(targetNow !== '__new__' && activePins.has(targetNow))
+  ) {
     return `route:${targetStart}->${targetNow}`
   }
 
@@ -107,7 +120,8 @@ export function sessionContextDrift({
   if (
     nowSelectedStoredId !== null &&
     nowSelectedStoredId !== startSelectedStoredId &&
-    nowSelectedStoredId !== submitTargetStoredId
+    nowSelectedStoredId !== submitTargetStoredId &&
+    !activePins.has(nowSelectedStoredId)
   ) {
     return `selection:${startSelectedStoredId}->${nowSelectedStoredId}`
   }

--- a/apps/desktop/src/app/session/hooks/session-context-drift.ts
+++ b/apps/desktop/src/app/session/hooks/session-context-drift.ts
@@ -56,13 +56,46 @@ interface SessionContextDriftArgs {
    * session that has ever compressed.
    */
   submitTargetComposerScope?: string | null
-  /** Stored ids being re-homed by an atomic submit (#85590). */
-  pinnedStoredSessionIds?: ReadonlySet<string>
+  /**
+   * The owner token of the request this check belongs to. Only pins created by
+   * the SAME owner are honored; omit to ignore pins entirely.
+   */
+  pinOwner?: string
 }
 
-// A short-lived pin marks the session being re-homed by atomic quick submit;
-// keeping it here lets every drift caller share the same narrow exception (#85590).
-export const activePinnedStoredSessionIds = new Set<string>()
+// Pins are OWNED (#85590 review): a drift check honors only pins created by the
+// SAME owner token — the submit/route generation that created them — so an
+// overlapping request can never suppress another request's drift detection.
+const pinnedByOwner = new Map<string, Set<string>>()
+
+/** Shared empty set: a non-owning caller allocates nothing. */
+const NO_PINS: ReadonlySet<string> = new Set()
+
+/** Mark `storedSessionId` as re-homed by `owner` until its terminal release. */
+export function pinStoredSessionForOwner(owner: string, storedSessionId: string): void {
+  const pinned = pinnedByOwner.get(owner)
+
+  if (pinned) {
+    pinned.add(storedSessionId)
+  } else {
+    pinnedByOwner.set(owner, new Set([storedSessionId]))
+  }
+}
+
+/** Terminal release: the owner's request settled (accepted, failed, cancelled).
+ *  Route settlement is evidence, not a tick budget. */
+export function releaseStoredSessionPins(owner: string): void {
+  pinnedByOwner.delete(owner)
+}
+
+export function pinnedStoredSessionIdsForOwner(owner: string): ReadonlySet<string> {
+  return pinnedByOwner.get(owner) ?? NO_PINS
+}
+
+/** Owners still holding a pin. Observability + tests. */
+export function pinnedOwnerCount(): number {
+  return pinnedByOwner.size
+}
 
 /**
  * Decide whether the session context genuinely changed under an in-flight
@@ -84,9 +117,9 @@ export function sessionContextDrift({
   submitTargetStoredId,
   composerScope,
   submitTargetComposerScope,
-  pinnedStoredSessionIds: pinnedIds
+  pinOwner
 }: SessionContextDriftArgs): string | null {
-  const activePins = pinnedIds ?? activePinnedStoredSessionIds
+  const activePins = pinOwner ? pinnedStoredSessionIdsForOwner(pinOwner) : NO_PINS
   // Composer prong: the composer's loaded scope disagrees with the resolved
   // submit target. Not a start/now comparison like the two prongs below — the
   // composer only hands us one snapshot per submit — but it belongs in the

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -2457,6 +2457,51 @@ describe('usePromptActions submit / queue drain semantics', () => {
     expect(requestGateway).not.toHaveBeenCalledWith('prompt.submit', expect.anything())
     dropSessionState(RUNTIME_SESSION_ID)
   })
+
+  it('reports the exact accepted identity through onAccepted after a stale-runtime recovery', async () => {
+    const STORED_SESSION_ID = 'stored-db-xyz789'
+    const RECOVERED_SESSION_ID = 'rt-recovered-456'
+    let submitAttempts = 0
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.submit') {
+        submitAttempts += 1
+
+        if (submitAttempts === 1) {
+          throw new Error('session not found')
+        }
+
+        return {} as never
+      }
+
+      if (method === 'session.resume') {
+        return { session_id: RECOVERED_SESSION_ID } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        storedSessionId={STORED_SESSION_ID}
+      />
+    )
+
+    const onAccepted = vi.fn()
+
+    const ok = await handle!.submitText('identity after wake', { onAccepted })
+
+    expect(ok).toBe(true)
+    expect(onAccepted).toHaveBeenCalledTimes(1)
+    expect(onAccepted).toHaveBeenCalledWith({
+      runtimeSessionId: RECOVERED_SESSION_ID,
+      storedSessionId: STORED_SESSION_ID
+    })
+  })
 })
 
 describe('usePromptActions redirectPrompt', () => {
@@ -3346,6 +3391,7 @@ describe('usePromptActions file attachment sync', () => {
       params: { session_id: RUNTIME_SESSION_ID, text: '@file:data/report.txt\n\nsummarize' }
     })
   })
+
 })
 
 describe('usePromptActions eager-upload races', () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -779,11 +779,15 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         // other session-scoped RPC (attach, /compress, rewind, interrupt) goes
         // through the same helper so one policy covers the whole bug class.
         let submitErr: unknown = null
+        // The identity the backend actually accepted: the live runtime id,
+        // replaced below when a stale binding was recovered.
+        let acceptedRuntimeSessionId = liveSessionId
+        // Hoisted out of the recovery call so the acceptance report can name
+        // the durable session even when no recovery was needed.
+        const recoverStoredSessionId = targetStoredSessionId ?? selectedStoredSessionIdRef.current
 
         try {
-          const recoverStoredSessionId = targetStoredSessionId ?? selectedStoredSessionIdRef.current
-
-          await withSessionNotFoundResume(
+          const accepted = await withSessionNotFoundResume(
             sessionId,
             recoverStoredSessionId,
             liveId =>
@@ -817,6 +821,8 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             // instead of erroring out and losing the session binding.
             { alsoTimeout: true }
           )
+
+          acceptedRuntimeSessionId = accepted.sessionId
         } catch (firstErr) {
           if (firstErr instanceof SessionRecoveryAborted) {
             console.warn('[submit-drift-abort]', firstErr.reason, { phase: 'post-resume-retry' })
@@ -830,6 +836,16 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         if (submitErr !== null) {
           throw submitErr
         }
+
+        // The prompt is now accepted. Report the EXACT identity it landed on
+        // (recovered id included) so a caller that must prove delivery — the
+        // Quick Entry bridge — never guesses the foreground session. Fires
+        // before the local cleanup below: acceptance is already true even if a
+        // later local step throws.
+        options?.onAccepted?.({
+          runtimeSessionId: acceptedRuntimeSessionId,
+          storedSessionId: recoverStoredSessionId ?? null
+        })
 
         if (usingComposerAttachments) {
           // A submit owns only the occurrences that actually reached the

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -720,6 +720,13 @@ export interface SubmitTextOptions {
    *  still receives the text as a normal user turn. */
   displayKind?: 'hidden'
   fromQueue?: boolean
+  /** Called once with the EXACT session identity the backend accepted the
+   *  prompt into — the live runtime id after any stale-runtime recovery, plus
+   *  the durable stored id when the caller knows it. A caller that must prove
+   *  delivery to another surface (Quick Entry) uses this instead of guessing
+   *  from the foreground session. Never called for a rejected or aborted
+   *  submit, and never for slash commands, which never reach prompt.submit. */
+  onAccepted?: (identity: { runtimeSessionId: string; storedSessionId: null | string }) => void
   /** Runtime session id to submit into. Queue drains pass this so a
    *  backgrounded/source session cannot be replaced by the current foreground
    *  session between enqueue and drain. */

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -816,10 +816,13 @@ describe('submitTextToNewSession pin release', () => {
     let second!: Promise<{ runtimeSessionId: string; sessionId: string }>
     act(() => {
       setCurrentModel('model-owner-a')
+      setCurrentModelSource('manual')
       first = handle!.submitTextToNewSession('a', 'owner-a')
       setCurrentModel('model-owner-b')
+      setCurrentModelSource('manual')
       second = handle!.submitTextToNewSession('b', 'owner-b')
       setCurrentModel('')
+      setCurrentModelSource('')
     })
 
     await waitFor(() => expect(createCount).toBe(2))

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -75,6 +75,7 @@ import { deferred } from '../../../test/deferred'
 import { NEW_CHAT_ROUTE, sessionRoute } from '../../routes'
 import type { ClientSessionState } from '../../types'
 
+import { activePinnedStoredSessionIds } from './session-context-drift'
 import { useSessionActions } from './use-session-actions'
 import { useSessionStateCache } from './use-session-state-cache'
 
@@ -119,7 +120,7 @@ type HarnessHandle = Pick<
   | 'removeSession'
   | 'selectSidebarItem'
   | 'startFreshSessionDraft'
->
+> & Pick<ReturnType<typeof useSessionActions>, 'submitTextToNewSession'>
 
 function storedSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
   return {
@@ -143,6 +144,7 @@ function storedSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
 function Harness({
   activeSessionId = null,
   activeSessionIdRef: activeSessionIdRefOverride,
+  getRoutedStoredSessionId = () => null,
   navigate = vi.fn(),
   onReady,
   requestGateway,
@@ -151,6 +153,7 @@ function Harness({
 }: {
   activeSessionId?: null | string
   activeSessionIdRef?: MutableRefObject<null | string>
+  getRoutedStoredSessionId?: () => null | string
   navigate?: ReturnType<typeof vi.fn>
   onReady: (handle: HarnessHandle) => void
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
@@ -166,7 +169,7 @@ function Harness({
     creatingSessionRef: ref(false),
     ensureSessionState: () => ({}) as ClientSessionState,
     getRouteToken: () => 'token',
-    getRoutedStoredSessionId: () => null,
+    getRoutedStoredSessionId,
     navigate: navigate as never,
     requestGateway,
     resetViewSync: vi.fn(),
@@ -719,6 +722,54 @@ describe('startFreshSessionDraft', () => {
 
     expect(revealTreePane).toHaveBeenCalledWith('workspace')
     expect($terminalTakeover.get()).toBe(true)
+  })
+})
+
+describe('submitTextToNewSession pin release', () => {
+  afterEach(() => {
+    activePinnedStoredSessionIds.clear()
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('force-releases the pin when competing navigation prevents route settlement', async () => {
+    const stored = 'stored-quick-entry'
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.create') {
+        return { session_id: RUNTIME_SESSION_ID, stored_session_id: stored } as never
+      }
+
+      return {} as never
+    })
+    let handle: HarnessHandle | null = null
+
+    render(
+      <Harness
+        getRoutedStoredSessionId={() => 'stored-other'}
+        onReady={value => (handle = value)}
+        requestGateway={requestGateway}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.submitTextToNewSession('quick entry')
+    })
+
+    await new Promise<void>(resolve => {
+      let ticks = 30
+      const tick = () => {
+        ticks -= 1
+        if (ticks === 0) {
+          resolve()
+        } else {
+          window.setTimeout(tick, 0)
+        }
+      }
+      window.setTimeout(tick, 0)
+    })
+    expect(activePinnedStoredSessionIds.has(stored)).toBe(true)
+    await waitFor(() => expect(activePinnedStoredSessionIds.has(stored)).toBe(false), { timeout: 3000 })
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -75,7 +75,7 @@ import { deferred } from '../../../test/deferred'
 import { NEW_CHAT_ROUTE, sessionRoute } from '../../routes'
 import type { ClientSessionState } from '../../types'
 
-import { activePinnedStoredSessionIds } from './session-context-drift'
+import { pinnedOwnerCount, pinnedStoredSessionIdsForOwner, releaseStoredSessionPins } from './session-context-drift'
 import { useSessionActions } from './use-session-actions'
 import { useSessionStateCache } from './use-session-state-cache'
 
@@ -726,17 +726,21 @@ describe('startFreshSessionDraft', () => {
 })
 
 describe('submitTextToNewSession pin release', () => {
+  beforeEach(() => {
+    releaseStoredSessionPins('corr-1')
+    releaseStoredSessionPins('owner-a')
+    releaseStoredSessionPins('owner-b')
+  })
+
   afterEach(() => {
-    activePinnedStoredSessionIds.clear()
     cleanup()
     vi.restoreAllMocks()
   })
 
-  it('force-releases the pin when competing navigation prevents route settlement', async () => {
-    const stored = 'stored-quick-entry'
+  it('releases the pin at the terminal transition instead of on ticks', async () => {
     const requestGateway = vi.fn(async (method: string) => {
       if (method === 'session.create') {
-        return { session_id: RUNTIME_SESSION_ID, stored_session_id: stored } as never
+        return { session_id: RUNTIME_SESSION_ID, stored_session_id: 'stored-quick-entry' } as never
       }
 
       return {} as never
@@ -753,23 +757,91 @@ describe('submitTextToNewSession pin release', () => {
     await waitFor(() => expect(handle).not.toBeNull())
 
     await act(async () => {
-      await handle!.submitTextToNewSession('quick entry')
+      await handle!.submitTextToNewSession('quick entry', 'corr-1')
     })
 
-    await new Promise<void>(resolve => {
-      let ticks = 30
-      const tick = () => {
-        ticks -= 1
-        if (ticks === 0) {
-          resolve()
-        } else {
-          window.setTimeout(tick, 0)
+    expect(pinnedStoredSessionIdsForOwner('corr-1').size).toBe(0)
+  })
+
+  it('concurrent new-session submissions keep distinct owner pins', async () => {
+    const observations: Array<{ promptOwner: 'owner-a' | 'owner-b'; ownerA: string[]; ownerB: string[] }> = []
+    const runtimeOwner = new Map<string, 'owner-a' | 'owner-b'>()
+    const storedByOwner = {
+      'owner-a': 'stored-owner-a',
+      'owner-b': 'stored-owner-b'
+    } as const
+    let createCount = 0
+    const releaseCreates = deferred<void>()
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.create') {
+        createCount += 1
+
+        const owner = params?.model === 'model-owner-a' ? 'owner-a' : 'owner-b'
+        const runtimeSessionId = `runtime-${owner}`
+        runtimeOwner.set(runtimeSessionId, owner)
+
+        if (createCount < 2) {
+          await releaseCreates.promise
         }
+
+        return {
+          session_id: runtimeSessionId,
+          stored_session_id: storedByOwner[owner]
+        } as never
       }
-      window.setTimeout(tick, 0)
+
+      if (method === 'prompt.submit') {
+        const promptOwner = runtimeOwner.get(String(params?.session_id)) ?? 'owner-a'
+        observations.push({
+          promptOwner,
+          ownerA: [...pinnedStoredSessionIdsForOwner('owner-a')],
+          ownerB: [...pinnedStoredSessionIdsForOwner('owner-b')]
+        })
+      }
+
+      return {} as never
     })
-    expect(activePinnedStoredSessionIds.has(stored)).toBe(true)
-    await waitFor(() => expect(activePinnedStoredSessionIds.has(stored)).toBe(false), { timeout: 3000 })
+    let handle: HarnessHandle | null = null
+
+    render(
+      <Harness
+        getRoutedStoredSessionId={() => 'stored-other'}
+        onReady={value => (handle = value)}
+        requestGateway={requestGateway}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    let first!: Promise<{ runtimeSessionId: string; sessionId: string }>
+    let second!: Promise<{ runtimeSessionId: string; sessionId: string }>
+    act(() => {
+      setCurrentModel('model-owner-a')
+      first = handle!.submitTextToNewSession('a', 'owner-a')
+      setCurrentModel('model-owner-b')
+      second = handle!.submitTextToNewSession('b', 'owner-b')
+      setCurrentModel('')
+    })
+
+    await waitFor(() => expect(createCount).toBe(2))
+
+    await act(async () => {
+      releaseCreates.resolve()
+      await Promise.all([first, second])
+    })
+
+    expect(observations).toHaveLength(2)
+    expect(observations.map(({ promptOwner }) => promptOwner).sort()).toEqual(['owner-a', 'owner-b'])
+    for (const observation of observations) {
+      const ownPins = observation.promptOwner === 'owner-a' ? observation.ownerA : observation.ownerB
+      const otherPins = observation[observation.promptOwner === 'owner-a' ? 'ownerB' : 'ownerA']
+
+      expect(ownPins).toContain(storedByOwner[observation.promptOwner])
+      expect(ownPins).not.toContain(
+        storedByOwner[observation.promptOwner === 'owner-a' ? 'owner-b' : 'owner-a']
+      )
+      expect(otherPins).not.toContain(storedByOwner[observation.promptOwner])
+    }
+    expect(pinnedOwnerCount()).toBe(0)
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -135,7 +135,7 @@ import type { SessionCreateResponse, SessionMessage, SessionResumeResponse, Usag
 
 import { navigateToWorkspacePage, NEW_CHAT_ROUTE, sessionRoute, SETTINGS_ROUTE } from '../../../routes'
 import type { ClientSessionState, SidebarNavItem } from '../../../types'
-import { sessionContextDrift } from '../session-context-drift'
+import { activePinnedStoredSessionIds, sessionContextDrift } from '../session-context-drift'
 import { singleFlightSessionResume } from '../use-prompt-actions/single-flight-resume'
 
 import { sessionCreateOverrideParams, type SessionCreateOverrides, type SessionSeedMessage } from './create-overrides'
@@ -208,6 +208,8 @@ interface SessionActionsOptions {
 // bounded retry rebinds it when the backend returns. Boot-into-a-stale-last-id
 // (NOT in this set) still legitimately drops to a draft.
 const createdThisRun = new Set<string>()
+// This narrow pin prevents the atomic quick submit from being mistaken for a
+// user switch while its new route settles (#85590).
 
 const branchMessagesFingerprint = (messages: BranchMessage[]): string =>
   JSON.stringify(messages.map(({ content, role }) => [role, content]))
@@ -716,6 +718,48 @@ export function useSessionActions({
       selectedStoredSessionIdRef,
       updateSessionState
     ]
+  )
+
+  const submitTextToNewSession = useCallback(
+    async (text: string): Promise<{ runtimeSessionId: string; sessionId: string }> => {
+      const params = await desktopSessionCreateParams(resolveNewSessionCwd())
+      const created = await requestGateway<SessionCreateResponse>('session.create', params)
+      const stored = created.stored_session_id
+      if (!stored) {
+        throw new Error('The new session did not return a stored id.')
+      }
+      activePinnedStoredSessionIds.add(stored)
+      try {
+        createdThisRun.add(stored)
+        runtimeIdByStoredSessionIdRef.current.set(stored, created.session_id)
+        ensureSessionState(created.session_id, stored)
+        upsertOptimisticSession(created, stored, null, text.trim())
+        // Submit the exact runtime id returned by session.create so this
+        // atomic path cannot fall back to a route token (#85590).
+        await requestGateway('prompt.submit', { session_id: created.session_id, text })
+        navigate(sessionRoute(stored), { replace: true })
+        // WHY: An unbounded re-arm becomes a hot loop and leaks the pin when
+        // competing navigation wins before this session reaches the route.
+        // Issue #85590: bound the router settle window to avoid that failure.
+        let releaseAttempts = 60
+        const releasePin = () => {
+          if (getRoutedStoredSessionId() === stored || releaseAttempts === 0) {
+            activePinnedStoredSessionIds.delete(stored)
+          } else {
+            // WHY: 60 ticks is far beyond any real router settle window, so
+            // force-release after it rather than spin forever (issue #85590).
+            releaseAttempts -= 1
+            window.setTimeout(releasePin, 0)
+          }
+        }
+        releasePin()
+        return { runtimeSessionId: created.session_id, sessionId: stored }
+      } catch (error) {
+        activePinnedStoredSessionIds.delete(stored)
+        throw error
+      }
+    },
+    [ensureSessionState, getRoutedStoredSessionId, navigate, requestGateway, runtimeIdByStoredSessionIdRef]
   )
 
   const selectSidebarItem = useCallback(
@@ -2645,6 +2689,7 @@ export function useSessionActions({
     removeSession,
     resumeSession,
     selectSidebarItem,
+    submitTextToNewSession,
     startFreshSessionDraft
   }
 }

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -135,7 +135,7 @@ import type { SessionCreateResponse, SessionMessage, SessionResumeResponse, Usag
 
 import { navigateToWorkspacePage, NEW_CHAT_ROUTE, sessionRoute, SETTINGS_ROUTE } from '../../../routes'
 import type { ClientSessionState, SidebarNavItem } from '../../../types'
-import { activePinnedStoredSessionIds, sessionContextDrift } from '../session-context-drift'
+import { pinStoredSessionForOwner, releaseStoredSessionPins, sessionContextDrift } from '../session-context-drift'
 import { singleFlightSessionResume } from '../use-prompt-actions/single-flight-resume'
 
 import { sessionCreateOverrideParams, type SessionCreateOverrides, type SessionSeedMessage } from './create-overrides'
@@ -721,14 +721,17 @@ export function useSessionActions({
   )
 
   const submitTextToNewSession = useCallback(
-    async (text: string): Promise<{ runtimeSessionId: string; sessionId: string }> => {
+    async (text: string, owner?: string): Promise<{ runtimeSessionId: string; sessionId: string }> => {
       const params = await desktopSessionCreateParams(resolveNewSessionCwd())
       const created = await requestGateway<SessionCreateResponse>('session.create', params)
       const stored = created.stored_session_id
       if (!stored) {
         throw new Error('The new session did not return a stored id.')
       }
-      activePinnedStoredSessionIds.add(stored)
+      // The owner is the requesting submit's correlation when the caller knows
+      // it (quick entry); otherwise this call owns its own generation.
+      const pinOwner = owner ?? `new-session-${created.session_id}`
+      pinStoredSessionForOwner(pinOwner, stored)
       try {
         createdThisRun.add(stored)
         runtimeIdByStoredSessionIdRef.current.set(stored, created.session_id)
@@ -738,28 +741,17 @@ export function useSessionActions({
         // atomic path cannot fall back to a route token (#85590).
         await requestGateway('prompt.submit', { session_id: created.session_id, text })
         navigate(sessionRoute(stored), { replace: true })
-        // WHY: An unbounded re-arm becomes a hot loop and leaks the pin when
-        // competing navigation wins before this session reaches the route.
-        // Issue #85590: bound the router settle window to avoid that failure.
-        let releaseAttempts = 60
-        const releasePin = () => {
-          if (getRoutedStoredSessionId() === stored || releaseAttempts === 0) {
-            activePinnedStoredSessionIds.delete(stored)
-          } else {
-            // WHY: 60 ticks is far beyond any real router settle window, so
-            // force-release after it rather than spin forever (issue #85590).
-            releaseAttempts -= 1
-            window.setTimeout(releasePin, 0)
-          }
-        }
-        releasePin()
         return { runtimeSessionId: created.session_id, sessionId: stored }
       } catch (error) {
-        activePinnedStoredSessionIds.delete(stored)
         throw error
+      } finally {
+        // Terminal transition for this owner: accepted, failed, or cancelled.
+        // Owner-scoped pins cannot strand another request, so no tick budget is
+        // needed to force-release.
+        releaseStoredSessionPins(pinOwner)
       }
     },
-    [ensureSessionState, getRoutedStoredSessionId, navigate, requestGateway, runtimeIdByStoredSessionIdRef]
+    [ensureSessionState, navigate, requestGateway, runtimeIdByStoredSessionIdRef]
   )
 
   const selectSidebarItem = useCallback(

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -11,7 +11,12 @@ import type {
   PetOverlayOpenRequest,
   PetOverlayStatePayload
 } from './store/pet-overlay'
-import type { QuickEntryStatePush, QuickEntryStatus, QuickEntrySubmitPayload } from './store/quick-entry'
+import type {
+  QuickEntryStatePush,
+  QuickEntryStatus,
+  QuickEntrySubmitPayload,
+  QuickEntrySubmitResult
+} from './store/quick-entry'
 
 export {}
 
@@ -180,7 +185,8 @@ declare global {
         // Quick window → main: send this payload (main forwards it to the
         // primary renderer, which routes it to the target session and submits
         // through the normal prompt path) and hide.
-        submit: (payload: QuickEntrySubmitPayload) => void
+        submit: (payload: QuickEntrySubmitPayload) => Promise<QuickEntrySubmitResult>
+        ackSubmit: (correlationId: string, result: QuickEntrySubmitResult) => void
         // Quick window → main: hide without sending (Escape / blur).
         dismiss: () => void
         // Primary renderer → main → quick window: gateway connection state +
@@ -190,7 +196,9 @@ declare global {
         // Quick window subscribes to those pushes.
         onState: (callback: (payload: QuickEntryStatePush) => void) => () => void
         // Primary renderer subscribes to submits captured by the quick window.
-        onSubmit: (callback: (payload: QuickEntrySubmitPayload | string) => void) => () => void
+        onSubmit: (
+          callback: (payload: (QuickEntrySubmitPayload & { correlationId: string }) | string) => void
+        ) => () => void
         // Quick window subscribes to "you were just summoned" so it can reset
         // its draft and re-focus the input on every open.
         onShown: (callback: () => void) => () => void

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -202,6 +202,11 @@ declare global {
         // Quick window subscribes to "you were just summoned" so it can reset
         // its draft and re-focus the input on every open.
         onShown: (callback: () => void) => () => void
+        // Quick window subscribes to the outcome of a submit whose relay timed
+        // out (delivery is unknown until this arrives).
+        onLateResult: (
+          callback: (payload: { correlationId: string; result: QuickEntrySubmitResult }) => void
+        ) => () => void
       }
       getBootProgress: () => Promise<DesktopBootProgress>
       getConnectionConfig: (profile?: null | string) => Promise<DesktopConnectionConfig>

--- a/apps/desktop/src/lib/quick-entry-submission.test.ts
+++ b/apps/desktop/src/lib/quick-entry-submission.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  captureQuickEntryRequest,
+  type QuickEntryAcceptedPromptStatus,
+  validateQuickEntryAcceptance
+} from './quick-entry-submission'
+
+const CORRELATION_ID = 'qe-123'
+const STORED_SESSION_ID = 'stored-session-1'
+const RUNTIME_SESSION_ID = 'runtime-session-1'
+const AFTER_DISPATCH = { promptDispatched: true }
+const BEFORE_DISPATCH = { promptDispatched: false }
+
+function capturedRequest(): ReturnType<typeof captureQuickEntryRequest> {
+  return captureQuickEntryRequest({
+    correlationId: CORRELATION_ID,
+    identity: {
+      prompt: 'Ship the exact prompt',
+      storedSessionId: STORED_SESSION_ID,
+      target: STORED_SESSION_ID
+    }
+  })
+}
+
+function backendResult(status: QuickEntryAcceptedPromptStatus, overrides: Record<string, unknown> = {}) {
+  return {
+    correlationId: CORRELATION_ID,
+    runtimeSessionId: RUNTIME_SESSION_ID,
+    sessionId: STORED_SESSION_ID,
+    status,
+    ...overrides
+  }
+}
+
+describe('captureQuickEntryRequest', () => {
+  it('freezes the request identity before an await can observe caller mutations', () => {
+    const original = {
+      correlationId: CORRELATION_ID,
+      identity: {
+        prompt: 'original prompt',
+        storedSessionId: STORED_SESSION_ID,
+        target: 'current'
+      }
+    }
+    const request = captureQuickEntryRequest(original)
+
+    original.correlationId = 'qe-other'
+    original.identity.prompt = 'changed prompt'
+    original.identity.storedSessionId = 'other-stored-session'
+    original.identity.target = 'other-target'
+
+    expect(request).toEqual({
+      correlationId: CORRELATION_ID,
+      identity: {
+        prompt: 'original prompt',
+        storedSessionId: STORED_SESSION_ID,
+        target: 'current'
+      }
+    })
+    expect(Object.isFrozen(request)).toBe(true)
+    expect(Object.isFrozen(request.identity)).toBe(true)
+  })
+})
+
+describe('validateQuickEntryAcceptance', () => {
+  it.each(['streaming', 'queued', 'steered', 'redirected'] as const)(
+    'accepts a correlated prompt result with status %s',
+    status => {
+      const outcome = validateQuickEntryAcceptance(capturedRequest(), backendResult(status), AFTER_DISPATCH)
+
+      expect(outcome).toEqual({
+        acceptedIdentity: {
+          runtimeSessionId: RUNTIME_SESSION_ID,
+          storedSessionId: STORED_SESSION_ID
+        },
+        correlationId: CORRELATION_ID,
+        evidence: {
+          observed: true,
+          status
+        },
+        ok: true,
+        requestedIdentity: {
+          prompt: 'Ship the exact prompt',
+          storedSessionId: STORED_SESSION_ID,
+          target: STORED_SESSION_ID
+        },
+        status: 'accepted'
+      })
+    }
+  )
+
+  it('rejects an empty object as backend evidence', () => {
+    expect(validateQuickEntryAcceptance(capturedRequest(), {}, AFTER_DISPATCH)).toMatchObject({
+      ok: false,
+      reason: 'invalid-backend-result',
+      retryable: false,
+      status: 'unknown'
+    })
+  })
+
+  it('rejects a request whose identity is missing', () => {
+    expect(validateQuickEntryAcceptance({ correlationId: CORRELATION_ID }, {}, AFTER_DISPATCH)).toMatchObject({
+      ok: false,
+      reason: 'invalid-request',
+      retryable: false,
+      status: 'unknown'
+    })
+  })
+
+  it('rejects a backend result that omits correlation', () => {
+    expect(
+      validateQuickEntryAcceptance(capturedRequest(), backendResult('streaming', { correlationId: '' }), AFTER_DISPATCH)
+    ).toMatchObject({
+      ok: false,
+      reason: 'invalid-backend-result',
+      retryable: false,
+      status: 'unknown'
+    })
+  })
+
+  it('rejects a malformed backend response', () => {
+    expect(validateQuickEntryAcceptance(capturedRequest(), { status: 'streaming' }, AFTER_DISPATCH)).toMatchObject({
+      ok: false,
+      reason: 'invalid-backend-result',
+      retryable: false,
+      status: 'unknown'
+    })
+  })
+
+  it('rejects a non-prompt backend status', () => {
+    expect(
+      validateQuickEntryAcceptance(capturedRequest(), backendResult('completed' as never), AFTER_DISPATCH)
+    ).toMatchObject({
+      ok: false,
+      reason: 'unsupported-backend-status',
+      retryable: false,
+      status: 'unknown'
+    })
+  })
+
+  it('rejects acceptance for the wrong stored identity', () => {
+    expect(
+      validateQuickEntryAcceptance(
+        capturedRequest(),
+        backendResult('streaming', { sessionId: 'other-stored-session' }),
+        AFTER_DISPATCH
+      )
+    ).toMatchObject({
+      ok: false,
+      reason: 'stored-identity-mismatch',
+      retryable: false,
+      status: 'unknown'
+    })
+  })
+
+  it('rejects acceptance when the backend result omits a runtime identity', () => {
+    expect(
+      validateQuickEntryAcceptance(
+        capturedRequest(),
+        backendResult('streaming', { runtimeSessionId: '' }),
+        AFTER_DISPATCH
+      )
+    ).toMatchObject({
+      ok: false,
+      reason: 'invalid-backend-result',
+      retryable: false,
+      status: 'unknown'
+    })
+  })
+
+  it('rejects acceptance when the result correlation does not match', () => {
+    expect(
+      validateQuickEntryAcceptance(
+        capturedRequest(),
+        backendResult('streaming', { correlationId: 'qe-other' }),
+        AFTER_DISPATCH
+      )
+    ).toMatchObject({
+      ok: false,
+      reason: 'correlation-mismatch',
+      retryable: false,
+      status: 'unknown'
+    })
+  })
+
+  it('treats a proven pre-dispatch rejection as retryable', () => {
+    expect(validateQuickEntryAcceptance(capturedRequest(), false, BEFORE_DISPATCH)).toEqual({
+      ok: false,
+      reason: 'no-prompt-dispatched',
+      retryable: true,
+      status: 'rejected'
+    })
+  })
+
+  it('treats the same failure after dispatch as non-retryable unknown', () => {
+    expect(validateQuickEntryAcceptance(capturedRequest(), false, AFTER_DISPATCH)).toEqual({
+      ok: false,
+      reason: 'invalid-backend-result',
+      retryable: false,
+      status: 'unknown'
+    })
+  })
+})

--- a/apps/desktop/src/lib/quick-entry-submission.ts
+++ b/apps/desktop/src/lib/quick-entry-submission.ts
@@ -1,0 +1,206 @@
+export type QuickEntryAcceptedPromptStatus = 'streaming' | 'queued' | 'steered' | 'redirected'
+
+export interface QuickEntryRequestIdentity {
+  /** The exact prompt text submitted through Quick Entry. */
+  readonly prompt: string
+  /** The selected Quick Entry target: current, new, or a stored session id. */
+  readonly target: string
+  /** The durable session id the caller intends to address. */
+  readonly storedSessionId: string | null
+}
+
+export interface CapturedQuickEntryRequest {
+  readonly correlationId: string
+  readonly identity: QuickEntryRequestIdentity
+}
+
+export interface QuickEntryBackendPromptResult {
+  readonly correlationId: string
+  /** The durable session id accepted by the backend. */
+  readonly sessionId: string
+  readonly runtimeSessionId: string
+  readonly status: QuickEntryAcceptedPromptStatus
+}
+
+export interface QuickEntryBackendResultEvidence {
+  readonly observed: true
+  readonly status: QuickEntryAcceptedPromptStatus
+}
+
+export interface QuickEntryAcceptedIdentity {
+  readonly runtimeSessionId: string
+  readonly storedSessionId: string
+}
+
+export type QuickEntrySubmitOutcome =
+  | {
+      readonly acceptedIdentity: QuickEntryAcceptedIdentity
+      readonly correlationId: string
+      readonly evidence: QuickEntryBackendResultEvidence
+      readonly ok: true
+      readonly requestedIdentity: QuickEntryRequestIdentity
+      readonly status: 'accepted'
+    }
+  | {
+      readonly ok: false
+      readonly reason: 'no-prompt-dispatched'
+      readonly retryable: true
+      readonly status: 'rejected'
+    }
+  | {
+      readonly ok: false
+      readonly reason:
+        | 'correlation-mismatch'
+        | 'invalid-backend-result'
+        | 'invalid-request'
+        | 'stored-identity-mismatch'
+        | 'unsupported-backend-status'
+      readonly retryable: false
+      readonly status: 'unknown'
+    }
+
+export interface QuickEntryDispatchContext {
+  /**
+   * Only a caller that can prove its failure happened before prompt dispatch may
+   * set this to false. Every post-dispatch failure is unknown because retry can
+   * duplicate the original prompt.
+   */
+  readonly promptDispatched: boolean
+}
+
+type UnknownRecord = Record<string, unknown>
+
+const ACCEPTED_PROMPT_STATUSES: ReadonlySet<string> = new Set(['streaming', 'queued', 'steered', 'redirected'])
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+/**
+ * Capture the mutable Quick Entry inputs before any await can interleave with a
+ * session switch. The returned request and nested identity are both frozen.
+ */
+export function captureQuickEntryRequest(input: {
+  correlationId: string
+  identity: QuickEntryRequestIdentity
+}): CapturedQuickEntryRequest {
+  const identity: QuickEntryRequestIdentity = { ...input.identity }
+  const request: CapturedQuickEntryRequest = {
+    correlationId: input.correlationId,
+    identity
+  }
+
+  Object.freeze(identity)
+  Object.freeze(request)
+
+  return request
+}
+
+function invalidRequestOutcome(dispatch: QuickEntryDispatchContext): QuickEntrySubmitOutcome {
+  return dispatch.promptDispatched
+    ? {
+        ok: false,
+        reason: 'invalid-request',
+        retryable: false,
+        status: 'unknown'
+      }
+    : {
+        ok: false,
+        reason: 'no-prompt-dispatched',
+        retryable: true,
+        status: 'rejected'
+      }
+}
+
+function unknownOutcome(
+  reason: Extract<QuickEntrySubmitOutcome, { status: 'unknown' }>['reason']
+): QuickEntrySubmitOutcome {
+  return {
+    ok: false,
+    reason,
+    retryable: false,
+    status: 'unknown'
+  }
+}
+
+/**
+ * Turn a backend response into an acceptance receipt. A supported status alone
+ * is not enough: the result must also carry this request's correlation and the
+ * exact durable/runtime session identities.
+ */
+export function validateQuickEntryAcceptance(
+  request: unknown,
+  backendResult: unknown,
+  dispatch: QuickEntryDispatchContext
+): QuickEntrySubmitOutcome {
+  const requestRecord = isRecord(request) ? request : {}
+  const identity = requestRecord.identity
+  const correlationId = requestRecord.correlationId
+
+  if (
+    !isRecord(identity) ||
+    !nonEmptyString(identity.prompt) ||
+    !nonEmptyString(identity.target) ||
+    !nonEmptyString(identity.storedSessionId) ||
+    !nonEmptyString(correlationId)
+  ) {
+    return invalidRequestOutcome(dispatch)
+  }
+
+  if (dispatch.promptDispatched === false) {
+    return {
+      ok: false,
+      reason: 'no-prompt-dispatched',
+      retryable: true,
+      status: 'rejected'
+    }
+  }
+
+  const result = isRecord(backendResult) && Object.keys(backendResult).length > 0 ? backendResult : null
+  if (
+    result === null ||
+    !nonEmptyString(result.correlationId) ||
+    !nonEmptyString(result.sessionId) ||
+    !nonEmptyString(result.runtimeSessionId) ||
+    !nonEmptyString(result.status)
+  ) {
+    return unknownOutcome('invalid-backend-result')
+  }
+
+  if (result.correlationId !== correlationId) {
+    return unknownOutcome('correlation-mismatch')
+  }
+
+  if (result.sessionId !== identity.storedSessionId) {
+    return unknownOutcome('stored-identity-mismatch')
+  }
+
+  if (!ACCEPTED_PROMPT_STATUSES.has(result.status)) {
+    return unknownOutcome('unsupported-backend-status')
+  }
+
+  const status = result.status as QuickEntryAcceptedPromptStatus
+
+  return {
+    acceptedIdentity: {
+      runtimeSessionId: result.runtimeSessionId,
+      storedSessionId: result.sessionId
+    },
+    correlationId,
+    evidence: {
+      observed: true,
+      status
+    },
+    ok: true,
+    requestedIdentity: {
+      prompt: identity.prompt,
+      storedSessionId: identity.storedSessionId,
+      target: identity.target
+    },
+    status: 'accepted'
+  }
+}

--- a/apps/desktop/src/store/quick-entry.test.ts
+++ b/apps/desktop/src/store/quick-entry.test.ts
@@ -43,6 +43,8 @@ describe('quickComposerReducer', () => {
     expect(initialQuickComposerState).toEqual({
       connected: false,
       draft: '',
+      error: null,
+      pendingSubmitId: null,
       sessions: [],
       submitting: false,
       target: QUICK_TARGET_CURRENT,
@@ -50,13 +52,60 @@ describe('quickComposerReducer', () => {
     })
   })
 
-  it('submit sends the trimmed draft with the target, clears it, and hides', () => {
-    const { sent, state } = run([connect, { draft: '  ship it  ', type: 'edit' }, { type: 'submit' }])
+  it('submit sends the trimmed draft but waits for acknowledgement to clear and hide', () => {
+    const { sent, state } = run([
+      connect,
+      { draft: '  ship it  ', type: 'edit' },
+      { submitId: 1, type: 'submit' }
+    ])
 
     expect(sent).toEqual([{ target: QUICK_TARGET_CURRENT, text: 'ship it' }])
-    expect(state.draft).toBe('')
+    expect(state.draft).toBe('  ship it  ')
     expect(state.submitting).toBe(true)
-    expect(state.visible).toBe(false)
+    expect(state.visible).toBe(true)
+
+    const acknowledged = quickComposerReducer(state, { submitId: 1, type: 'submit-ok' }).state
+    expect(acknowledged.draft).toBe('')
+    expect(acknowledged.visible).toBe(false)
+  })
+
+  it('submit-error keeps the draft visible, records the error, and refocuses on retry', () => {
+    const { state } = run([connect, { draft: '  keep me  ', type: 'edit' }, { submitId: 7, type: 'submit' }])
+    const failed = quickComposerReducer(state, {
+      message: 'Delivery failed',
+      submitId: 7,
+      type: 'submit-error'
+    }).state
+
+    expect(failed).toMatchObject({
+      draft: '  keep me  ',
+      error: 'Delivery failed',
+      pendingSubmitId: null,
+      submitting: false,
+      visible: true
+    })
+  })
+
+  it('ignores submit acknowledgements with stale ids', () => {
+    const { state } = run([connect, { draft: 'keep', type: 'edit' }, { submitId: 7, type: 'submit' }])
+
+    expect(quickComposerReducer(state, { submitId: 8, type: 'submit-ok' }).state).toEqual(state)
+    expect(
+      quickComposerReducer(state, { message: 'stale', submitId: 8, type: 'submit-error' }).state
+    ).toEqual(state)
+  })
+
+  it('keeps resume and current-target submits on their existing routes', () => {
+    const resumed = run([
+      connect,
+      { target: 's2', type: 'target' },
+      { draft: 'resume here', type: 'edit' },
+      { submitId: 1, type: 'submit' }
+    ])
+    const current = run([connect, { draft: 'current here', type: 'edit' }, { submitId: 2, type: 'submit' }])
+
+    expect(resumed.sent).toEqual([{ target: 's2', text: 'resume here' }])
+    expect(current.sent).toEqual([{ target: QUICK_TARGET_CURRENT, text: 'current here' }])
   })
 
   it('an empty or whitespace-only submit sends nothing and stays open', () => {

--- a/apps/desktop/src/store/quick-entry.test.ts
+++ b/apps/desktop/src/store/quick-entry.test.ts
@@ -357,6 +357,47 @@ describe('quickComposerReducer', () => {
     expect(retried.state.unknownSubmitId).toBe(7)
   })
 
+  it('a late success clears an unknown outcome', () => {
+    const { state } = run([
+      connect,
+      { draft: 'pending prompt', type: 'edit' },
+      { submitId: 7, type: 'submit' },
+      { message: 'may still be delivered', submitId: 7, type: 'submit-unknown' },
+      { message: 'accepted', ok: true, type: 'late-result' }
+    ])
+
+    expect(state.draft).toBe('')
+    expect(state.visible).toBe(false)
+    expect(state.unknownSubmitId).toBeNull()
+    expect(state.error).toBeNull()
+  })
+
+  it('a late failure proves non-acceptance and keeps the text', () => {
+    const { state } = run([
+      connect,
+      { draft: 'pending prompt', type: 'edit' },
+      { submitId: 7, type: 'submit' },
+      { message: 'may still be delivered', submitId: 7, type: 'submit-unknown' },
+      { message: 'gateway down', ok: false, type: 'late-result' }
+    ])
+
+    expect(state.unknownSubmitId).toBeNull()
+    expect(state.error).toBe('gateway down')
+    expect(state.draft).toBe('pending prompt')
+    expect(state.visible).toBe(true)
+  })
+
+  it('a late result without an unknown submit changes nothing', () => {
+    const { state } = run([
+      connect,
+      { draft: 'fresh draft', type: 'edit' },
+      { message: 'accepted', ok: true, type: 'late-result' }
+    ])
+
+    expect(state.draft).toBe('fresh draft')
+    expect(state.visible).toBe(true)
+  })
+
   it('a late success reconciles the unknown outcome', () => {
     const unknown = run([
       connect,

--- a/apps/desktop/src/store/quick-entry.test.ts
+++ b/apps/desktop/src/store/quick-entry.test.ts
@@ -7,7 +7,9 @@ import {
   type QuickComposerEvent,
   quickComposerReducer,
   type QuickComposerState,
-  type QuickEntrySubmitPayload
+  type QuickEntrySubmitPayload,
+  quickEntryResultEvent,
+  type QuickEntrySubmitResult
 } from './quick-entry'
 
 // Drive the reducer like the window does, collecting every send it asked for.
@@ -44,20 +46,19 @@ describe('quickComposerReducer', () => {
       connected: false,
       draft: '',
       error: null,
+      lastSubmitText: '',
+      orphanedFailure: null,
       pendingSubmitId: null,
       sessions: [],
       submitting: false,
       target: QUICK_TARGET_CURRENT,
+      unknownSubmitId: null,
       visible: true
     })
   })
 
   it('submit sends the trimmed draft but waits for acknowledgement to clear and hide', () => {
-    const { sent, state } = run([
-      connect,
-      { draft: '  ship it  ', type: 'edit' },
-      { submitId: 1, type: 'submit' }
-    ])
+    const { sent, state } = run([connect, { draft: '  ship it  ', type: 'edit' }, { submitId: 1, type: 'submit' }])
 
     expect(sent).toEqual([{ target: QUICK_TARGET_CURRENT, text: 'ship it' }])
     expect(state.draft).toBe('  ship it  ')
@@ -86,13 +87,20 @@ describe('quickComposerReducer', () => {
     })
   })
 
-  it('ignores submit acknowledgements with stale ids', () => {
+  it('keeps the current owner for stale acknowledgements and records an unmatched late failure', () => {
     const { state } = run([connect, { draft: 'keep', type: 'edit' }, { submitId: 7, type: 'submit' }])
 
     expect(quickComposerReducer(state, { submitId: 8, type: 'submit-ok' }).state).toEqual(state)
-    expect(
-      quickComposerReducer(state, { message: 'stale', submitId: 8, type: 'submit-error' }).state
-    ).toEqual(state)
+    const failed = quickComposerReducer(state, { message: 'stale', submitId: 8, type: 'submit-error' }).state
+
+    expect(failed).toMatchObject({
+      draft: 'keep',
+      error: 'stale',
+      lastSubmitText: '',
+      orphanedFailure: { message: 'stale', text: 'keep' },
+      pendingSubmitId: 7,
+      submitting: true
+    })
   })
 
   it('keeps resume and current-target submits on their existing routes', () => {
@@ -212,22 +220,22 @@ describe('quickComposerReducer', () => {
     expect(state.draft).toBe('')
   })
 
-  it('the blur that follows a submit does not re-send or resurrect the draft', () => {
+  it('the blur that follows a submit keeps that submit correlated and delivered', () => {
     const { sent, state } = run([connect, { draft: 'go', type: 'edit' }, { type: 'submit' }, { type: 'blur' }])
 
     expect(sent).toEqual([{ target: QUICK_TARGET_CURRENT, text: 'go' }])
-    expect(state.draft).toBe('')
-    expect(state.submitting).toBe(false)
+    expect(state.draft).toBe('go')
+    expect(state.submitting).toBe(true)
     expect(state.visible).toBe(false)
   })
 
-  it('being re-summoned resets the capture surface but KEEPS the pushed gateway truth', () => {
+  it('being re-summoned reconnects to an in-flight submit and KEEPS the pushed gateway truth', () => {
     const afterSubmit = run([connect, { draft: 'first', type: 'edit' }, { type: 'submit' }]).state
     const { sent, state } = run([{ type: 'shown' }], afterSubmit)
 
     expect(sent).toEqual([])
-    expect(state.draft).toBe('')
-    expect(state.target).toBe(QUICK_TARGET_CURRENT)
+    expect(state.draft).toBe('first')
+    expect(state.submitting).toBe(true)
     expect(state.visible).toBe(true)
     // The gateway did not disconnect just because the window was re-opened.
     expect(state.connected).toBe(true)
@@ -261,5 +269,161 @@ describe('quickComposerReducer', () => {
 
     expect(first.sent).toEqual([{ target: QUICK_TARGET_CURRENT, text: 'one' }])
     expect(second.sent).toEqual([{ target: QUICK_TARGET_CURRENT, text: 'two' }])
+  })
+
+  it('keeps the correlation and draft when dismissed mid-submit', () => {
+    const { state } = run([
+      connect,
+      { draft: 'pending prompt', type: 'edit' },
+      { submitId: 7, type: 'submit' },
+      { type: 'dismiss' }
+    ])
+
+    expect(state.draft).toBe('pending prompt')
+    expect(state.pendingSubmitId).toBe(7)
+    expect(state.submitting).toBe(true)
+    expect(state.visible).toBe(false)
+  })
+
+  it('reconnects to the same generation when re-shown mid-submit', () => {
+    const dismissed = run([
+      connect,
+      { draft: 'pending prompt', type: 'edit' },
+      { submitId: 7, type: 'submit' },
+      { type: 'dismiss' }
+    ]).state
+    const state = quickComposerReducer(dismissed, { type: 'shown' }).state
+
+    expect(state.draft).toBe('pending prompt')
+    expect(state.error).toBeNull()
+    expect(state.pendingSubmitId).toBe(7)
+    expect(state.submitting).toBe(true)
+    expect(state.visible).toBe(true)
+  })
+
+  it('a late success for the owning generation clears the surface', () => {
+    const dismissed = run([
+      connect,
+      { draft: 'pending prompt', type: 'edit' },
+      { submitId: 7, type: 'submit' },
+      { type: 'dismiss' }
+    ]).state
+    const shown = quickComposerReducer(dismissed, { type: 'shown' }).state
+    const state = quickComposerReducer(shown, { submitId: 7, type: 'submit-ok' }).state
+
+    expect(state.draft).toBe('')
+    expect(state.pendingSubmitId).toBeNull()
+    expect(state.visible).toBe(false)
+  })
+
+  it('a late failure for the owning generation keeps the text and shows the error', () => {
+    const { state } = run([
+      connect,
+      { draft: 'pending prompt', type: 'edit' },
+      { submitId: 7, type: 'submit' },
+      { type: 'dismiss' },
+      { message: 'gateway down', submitId: 7, type: 'submit-error' }
+    ])
+
+    expect(state.draft).toBe('pending prompt')
+    expect(state.error).toBe('gateway down')
+    expect(state.pendingSubmitId).toBeNull()
+    expect(state.visible).toBe(true)
+  })
+
+  it('a timeout is unknown, keeps the correlation, and is not retryable', () => {
+    const { state } = run([
+      connect,
+      { draft: 'pending prompt', type: 'edit' },
+      { submitId: 7, type: 'submit' },
+      { message: 'may still be delivered', submitId: 7, type: 'submit-unknown' }
+    ])
+    const retried = run(
+      [
+        { draft: 'try again', type: 'edit' },
+        { submitId: 8, type: 'submit' }
+      ],
+      state
+    )
+
+    expect(state.draft).toBe('pending prompt')
+    expect(state.error).toBe('may still be delivered')
+    expect(state.pendingSubmitId).toBeNull()
+    expect(state.submitting).toBe(false)
+    expect(state.unknownSubmitId).toBe(7)
+    expect(state.visible).toBe(true)
+    expect(retried.sent).toEqual([])
+    expect(retried.state.draft).toBe('try again')
+    expect(retried.state.unknownSubmitId).toBe(7)
+  })
+
+  it('a late success reconciles the unknown outcome', () => {
+    const unknown = run([
+      connect,
+      { draft: 'pending prompt', type: 'edit' },
+      { submitId: 7, type: 'submit' },
+      { message: 'may still be delivered', submitId: 7, type: 'submit-unknown' }
+    ]).state
+    const state = quickComposerReducer(unknown, { submitId: 7, type: 'submit-ok' }).state
+
+    expect(state.draft).toBe('')
+    expect(state.unknownSubmitId).toBeNull()
+    expect(state.visible).toBe(false)
+  })
+
+  it('a late failure clears the unknown correlation so a retry is allowed', () => {
+    const unknown = run([
+      connect,
+      { draft: 'pending prompt', type: 'edit' },
+      { submitId: 7, type: 'submit' },
+      { message: 'may still be delivered', submitId: 7, type: 'submit-unknown' }
+    ]).state
+    const state = quickComposerReducer(unknown, { message: 'rejected', submitId: 7, type: 'submit-error' }).state
+
+    expect(state.draft).toBe('pending prompt')
+    expect(state.error).toBe('rejected')
+    expect(state.unknownSubmitId).toBeNull()
+  })
+
+  it('quickEntryResultEvent maps timeout to submit-unknown, ok to submit-ok, else submit-error', () => {
+    const timeout: QuickEntrySubmitResult = { code: 'timeout', ok: false }
+    const ok: QuickEntrySubmitResult = { ok: true }
+    const failed: QuickEntrySubmitResult = { ok: false }
+    const timeoutEvent = quickEntryResultEvent(timeout, 7)
+
+    expect(timeoutEvent).toEqual({
+      message: 'Hermes has not confirmed the prompt yet — it may still be delivered.',
+      submitId: 7,
+      type: 'submit-unknown'
+    })
+    expect(timeoutEvent.type).not.toBe('submit-error')
+    expect(quickEntryResultEvent(ok, 7)).toEqual({ submitId: 7, type: 'submit-ok' })
+    expect(quickEntryResultEvent(failed, 7)).toEqual({
+      message: 'Quick Entry could not deliver the prompt.',
+      submitId: 7,
+      type: 'submit-error'
+    })
+  })
+
+  it('a failure for a superseded generation is handed back on the next summon', () => {
+    const { sent, state } = run([
+      connect,
+      { draft: 'first prompt', type: 'edit' },
+      { submitId: 7, type: 'submit' },
+      { type: 'dismiss' },
+      { type: 'shown' },
+      { draft: 'second prompt', type: 'edit' },
+      { submitId: 8, type: 'submit' },
+      { message: 'first failed', submitId: 7, type: 'submit-error' },
+      { submitId: 8, type: 'submit-ok' },
+      { type: 'shown' }
+    ])
+
+    expect(sent).toEqual([
+      { target: QUICK_TARGET_CURRENT, text: 'first prompt' },
+      { target: QUICK_TARGET_CURRENT, text: 'second prompt' }
+    ])
+    expect(state.draft).toBe('first prompt')
+    expect(state.error).toBe('first failed')
   })
 })

--- a/apps/desktop/src/store/quick-entry.ts
+++ b/apps/desktop/src/store/quick-entry.ts
@@ -128,6 +128,15 @@ export interface QuickEntrySubmitPayload {
   text: string
 }
 
+export interface QuickEntrySubmitResult {
+  ok: boolean
+  code?: string
+  message?: string
+  retryable?: boolean
+  sessionId?: string | null
+  runtimeSessionId?: string | null
+}
+
 /**
  * The quick window's own composer state. Deliberately a tiny pure reducer: the
  * behavior that would actually break a user — an empty submit must not send but
@@ -142,8 +151,12 @@ export interface QuickComposerState {
   draft: string
   /** Recent sessions the picker offers, pushed by the primary renderer. */
   sessions: QuickEntrySessionOption[]
-  /** True between a send and the window actually hiding. Blocks a double-send. */
+  /** True between a send and its acknowledgement. Blocks a double-send. */
   submitting: boolean
+  /** Inline delivery failure retained with the draft until retry. */
+  error: null | string
+  /** Local correlation for ignoring an acknowledgement from an older submit. */
+  pendingSubmitId: number | null
   /** Where a submit lands: current / new / a stored session id. */
   target: string
   /** Whether the window should be visible. False asks the shell to hide. */
@@ -156,7 +169,9 @@ export type QuickComposerEvent =
   | { type: 'edit'; draft: string }
   | { type: 'shown' }
   | { type: 'state'; connected: boolean; sessions: QuickEntrySessionOption[] }
-  | { type: 'submit' }
+  | { type: 'submit'; submitId?: number }
+  | { type: 'submit-error'; message: string; submitId: number }
+  | { type: 'submit-ok'; submitId: number }
   | { type: 'target'; target: string }
 
 export interface QuickComposerTransition {
@@ -170,6 +185,8 @@ export const initialQuickComposerState: QuickComposerState = {
   // capture window that accepts text it can never deliver is a lie.
   connected: false,
   draft: '',
+  error: null,
+  pendingSubmitId: null,
   sessions: [],
   submitting: false,
   target: QUICK_TARGET_CURRENT,
@@ -184,7 +201,15 @@ export function quickComposerReducer(state: QuickComposerState, event: QuickComp
       // hides — the send already left for the main process.
       return {
         send: null,
-        state: { ...state, draft: '', submitting: false, target: QUICK_TARGET_CURRENT, visible: false }
+        state: {
+          ...state,
+          draft: '',
+          error: null,
+          pendingSubmitId: null,
+          submitting: false,
+          target: QUICK_TARGET_CURRENT,
+          visible: false
+        }
       }
     }
 
@@ -197,7 +222,15 @@ export function quickComposerReducer(state: QuickComposerState, event: QuickComp
       // a leftover target — but the pushed gateway truth carries over.
       return {
         send: null,
-        state: { ...state, draft: '', submitting: false, target: QUICK_TARGET_CURRENT, visible: true }
+        state: {
+          ...state,
+          draft: '',
+          error: null,
+          pendingSubmitId: null,
+          submitting: false,
+          target: QUICK_TARGET_CURRENT,
+          visible: true
+        }
       }
     }
 
@@ -232,8 +265,21 @@ export function quickComposerReducer(state: QuickComposerState, event: QuickComp
 
       return {
         send: { target: state.target, text },
-        state: { ...state, draft: '', submitting: true, visible: false }
+        // Wait for main's result before clearing or hiding the capture window (#85590).
+        state: { ...state, error: null, pendingSubmitId: event.submitId ?? null, submitting: true }
       }
+    }
+
+    case 'submit-ok': {
+      return event.submitId > 0 && state.pendingSubmitId === event.submitId
+        ? { send: null, state: { ...state, draft: '', error: null, pendingSubmitId: null, submitting: false, visible: false } }
+        : { send: null, state }
+    }
+
+    case 'submit-error': {
+      return event.submitId > 0 && state.pendingSubmitId === event.submitId
+        ? { send: null, state: { ...state, error: event.message, pendingSubmitId: null, submitting: false, visible: true } }
+        : { send: null, state }
     }
 
     case 'target': {
@@ -248,7 +294,7 @@ export function quickComposerReducer(state: QuickComposerState, event: QuickComp
 
 // ── Primary-renderer bridge ────────────────────────────────────────────────
 
-let submitHandler: ((payload: QuickEntrySubmitPayload) => void) | null = null
+let submitHandler: ((payload: QuickEntrySubmitPayload & { correlationId: string }) => void) | null = null
 let unsubscribeSubmit: (() => void) | null = null
 
 /**
@@ -256,7 +302,9 @@ let unsubscribeSubmit: (() => void) | null = null
  * primary window routes it by target: current chat → `submitText`, a stored
  * session id → resume + submit, new → fresh draft + submit.
  */
-export function setQuickEntrySubmitHandler(fn: ((payload: QuickEntrySubmitPayload) => void) | null): void {
+export function setQuickEntrySubmitHandler(
+  fn: ((payload: QuickEntrySubmitPayload & { correlationId: string }) => void) | null
+): void {
   submitHandler = fn
 }
 
@@ -298,8 +346,11 @@ export function initQuickEntryBridge(): () => void {
   unsubscribeSubmit = api.onSubmit(raw => {
     const payload = normalizeSubmitPayload(raw)
 
-    if (payload) {
-      submitHandler?.(payload)
+    if (payload && typeof raw === 'object' && raw !== null) {
+      const correlationId = (raw as unknown as Record<string, unknown>).correlationId
+      if (typeof correlationId === 'string') {
+        submitHandler?.({ ...payload, correlationId })
+      }
     }
   })
 

--- a/apps/desktop/src/store/quick-entry.ts
+++ b/apps/desktop/src/store/quick-entry.ts
@@ -181,6 +181,7 @@ export type QuickComposerEvent =
   | { type: 'submit'; submitId?: number }
   | { type: 'submit-error'; message: string; submitId: number }
   | { message: string; submitId: number; type: 'submit-unknown' }
+  | { message: string; ok: boolean; type: 'late-result' }
   | { type: 'submit-ok'; submitId: number }
   | { type: 'target'; target: string }
 
@@ -384,6 +385,38 @@ export function quickComposerReducer(state: QuickComposerState, event: QuickComp
           visible: true
         }
       }
+    }
+
+    case 'late-result': {
+      // A late outcome only reconciles a submit the window still holds as
+      // UNKNOWN. Without one it must not clobber a fresh draft.
+      if (state.unknownSubmitId === null) {
+        return { send: null, state }
+      }
+
+      return event.ok
+        ? {
+            send: null,
+            state: {
+              ...state,
+              draft: '',
+              error: null,
+              lastSubmitText: '',
+              orphanedFailure: null,
+              unknownSubmitId: null,
+              visible: false
+            }
+          }
+        : {
+            send: null,
+            state: {
+              ...state,
+              error: event.message,
+              lastSubmitText: '',
+              unknownSubmitId: null,
+              visible: true
+            }
+          }
     }
 
     case 'submit-error': {

--- a/apps/desktop/src/store/quick-entry.ts
+++ b/apps/desktop/src/store/quick-entry.ts
@@ -157,6 +157,15 @@ export interface QuickComposerState {
   error: null | string
   /** Local correlation for ignoring an acknowledgement from an older submit. */
   pendingSubmitId: number | null
+  /** Text of the in-flight submit, kept so a late failure can restore it. */
+  lastSubmitText: string
+  /** A failure whose generation no longer owns the window. The next summon
+   *  restores this text instead of silently dropping the prompt. */
+  orphanedFailure: null | { message: string; text: string }
+  /** A submit whose outcome is UNKNOWN (relay timeout): the backend may still
+   *  have accepted it. Kept so a late acknowledgement can reconcile, and never
+   *  presented as retryable until non-acceptance is proven. */
+  unknownSubmitId: number | null
   /** Where a submit lands: current / new / a stored session id. */
   target: string
   /** Whether the window should be visible. False asks the shell to hide. */
@@ -171,8 +180,34 @@ export type QuickComposerEvent =
   | { type: 'state'; connected: boolean; sessions: QuickEntrySessionOption[] }
   | { type: 'submit'; submitId?: number }
   | { type: 'submit-error'; message: string; submitId: number }
+  | { message: string; submitId: number; type: 'submit-unknown' }
   | { type: 'submit-ok'; submitId: number }
   | { type: 'target'; target: string }
+
+/**
+ * Map a relay result to the composer event that reconciles it. A timeout is an
+ * UNKNOWN outcome — the prompt may already be accepted — so it must never be
+ * mapped to a retryable failure.
+ */
+export function quickEntryResultEvent(result: QuickEntrySubmitResult, submitId: number): QuickComposerEvent {
+  if (result.ok) {
+    return { submitId, type: 'submit-ok' }
+  }
+
+  if (result.code === 'timeout') {
+    return {
+      message: result.message || 'Hermes has not confirmed the prompt yet — it may still be delivered.',
+      submitId,
+      type: 'submit-unknown'
+    }
+  }
+
+  return {
+    message: result.message || 'Quick Entry could not deliver the prompt.',
+    submitId,
+    type: 'submit-error'
+  }
+}
 
 export interface QuickComposerTransition {
   /** Payload to send through the real prompt-submit path, or null for none. */
@@ -186,10 +221,13 @@ export const initialQuickComposerState: QuickComposerState = {
   connected: false,
   draft: '',
   error: null,
+  lastSubmitText: '',
+  orphanedFailure: null,
   pendingSubmitId: null,
   sessions: [],
   submitting: false,
   target: QUICK_TARGET_CURRENT,
+  unknownSubmitId: null,
   visible: true
 }
 
@@ -197,19 +235,27 @@ export function quickComposerReducer(state: QuickComposerState, event: QuickComp
   switch (event.type) {
     case 'blur':
     case 'dismiss': {
-      // Escape / focus loss discards without sending. A dismiss mid-submit still
-      // hides — the send already left for the main process.
+      // Escape / focus loss discards a surface with nothing unresolved. A submit
+      // already handed to main keeps its correlation and draft: the promise
+      // still resolves, and a late failure must be able to restore the text.
+      const unresolved = state.submitting || state.unknownSubmitId !== null
+
       return {
         send: null,
-        state: {
-          ...state,
-          draft: '',
-          error: null,
-          pendingSubmitId: null,
-          submitting: false,
-          target: QUICK_TARGET_CURRENT,
-          visible: false
-        }
+        state: unresolved
+          ? { ...state, error: null, visible: false }
+          : {
+              ...state,
+              draft: '',
+              error: null,
+              lastSubmitText: '',
+              orphanedFailure: null,
+              pendingSubmitId: null,
+              submitting: false,
+              target: QUICK_TARGET_CURRENT,
+              unknownSubmitId: null,
+              visible: false
+            }
       }
     }
 
@@ -218,17 +264,26 @@ export function quickComposerReducer(state: QuickComposerState, event: QuickComp
     }
 
     case 'shown': {
-      // Re-summoned: a fresh capture surface every time — never a stale draft or
-      // a leftover target — but the pushed gateway truth carries over.
+      // Re-summoned. With a submit unresolved the window reconnects to the SAME
+      // generation and shows the text still being delivered. Otherwise the
+      // surface is fresh — except that a failure whose generation lost the
+      // window hands its text back rather than dropping it.
+      if (state.submitting || state.unknownSubmitId !== null) {
+        return { send: null, state: { ...state, error: null, visible: true } }
+      }
+
       return {
         send: null,
         state: {
           ...state,
-          draft: '',
-          error: null,
+          draft: state.orphanedFailure?.text ?? '',
+          error: state.orphanedFailure?.message ?? null,
+          lastSubmitText: '',
+          orphanedFailure: null,
           pendingSubmitId: null,
           submitting: false,
           target: QUICK_TARGET_CURRENT,
+          unknownSubmitId: null,
           visible: true
         }
       }
@@ -258,28 +313,116 @@ export function quickComposerReducer(state: QuickComposerState, event: QuickComp
       const text = state.draft.trim()
 
       // Nothing to send — or nowhere to send it (gateway down): stay open and
-      // keep the draft so a stray Enter can't make the text vanish.
-      if (!text || state.submitting || !state.connected) {
+      // keep the draft so a stray Enter can't make the text vanish. Re-entering
+      // changed text supersedes the pending generation; an unknown outcome never
+      // invites a second delivery attempt.
+      if (
+        !text ||
+        !state.connected ||
+        state.unknownSubmitId !== null ||
+        (state.submitting && text === state.lastSubmitText)
+      ) {
         return { send: null, state }
       }
 
       return {
         send: { target: state.target, text },
         // Wait for main's result before clearing or hiding the capture window (#85590).
-        state: { ...state, error: null, pendingSubmitId: event.submitId ?? null, submitting: true }
+        state: {
+          ...state,
+          error: null,
+          // If changed text supersedes an unresolved generation, retain the
+          // older prompt: its late failure must hand that text back later.
+          lastSubmitText: state.submitting ? state.lastSubmitText : text,
+          pendingSubmitId: event.submitId ?? null,
+          submitting: true
+        }
       }
     }
 
     case 'submit-ok': {
-      return event.submitId > 0 && state.pendingSubmitId === event.submitId
-        ? { send: null, state: { ...state, draft: '', error: null, pendingSubmitId: null, submitting: false, visible: false } }
+      // The owning generation — or a submit whose outcome was unknown — clears
+      // the surface. A late success for a superseded generation is still good
+      // news, but it must not wipe the draft the window now owns.
+      const owner = state.pendingSubmitId === event.submitId || state.unknownSubmitId === event.submitId
+
+      return event.submitId > 0 && owner
+        ? {
+            send: null,
+            state: {
+              ...state,
+              draft: '',
+              error: null,
+              lastSubmitText: '',
+              // A successful newer generation does not erase an older
+              // generation's already-recorded late failure.
+              orphanedFailure: state.orphanedFailure,
+              pendingSubmitId: null,
+              submitting: false,
+              unknownSubmitId: null,
+              visible: false
+            }
+          }
         : { send: null, state }
     }
 
+    case 'submit-unknown': {
+      if (event.submitId <= 0 || state.pendingSubmitId !== event.submitId) {
+        return { send: null, state }
+      }
+
+      // Delivery is UNCONFIRMED, not failed: keep the draft, keep the
+      // correlation, and never present this as retryable.
+      return {
+        send: null,
+        state: {
+          ...state,
+          error: event.message,
+          pendingSubmitId: null,
+          submitting: false,
+          unknownSubmitId: event.submitId,
+          visible: true
+        }
+      }
+    }
+
     case 'submit-error': {
-      return event.submitId > 0 && state.pendingSubmitId === event.submitId
-        ? { send: null, state: { ...state, error: event.message, pendingSubmitId: null, submitting: false, visible: true } }
-        : { send: null, state }
+      if (event.submitId > 0 && state.pendingSubmitId === event.submitId) {
+        return {
+          send: null,
+          state: {
+            ...state,
+            error: event.message,
+            lastSubmitText: '',
+            pendingSubmitId: null,
+            submitting: false,
+            visible: true
+          }
+        }
+      }
+
+      if (event.submitId > 0 && state.unknownSubmitId === event.submitId) {
+        // Non-acceptance is now proven: drop the unknown correlation so a
+        // retry is legitimate, and keep the text.
+        return {
+          send: null,
+          state: { ...state, error: event.message, lastSubmitText: '', unknownSubmitId: null }
+        }
+      }
+
+      // Late failure whose generation no longer owns the window: keep the text
+      // for the next summon and surface the message now if nothing else has.
+      return {
+        send: null,
+        state: {
+          ...state,
+          error: state.error ?? event.message,
+          orphanedFailure: state.lastSubmitText
+            ? { message: event.message, text: state.lastSubmitText }
+            : state.orphanedFailure,
+          lastSubmitText: ''
+        }
+      }
     }
 
     case 'target': {

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1356,14 +1356,22 @@ export interface SessionTileDelegate {
    *  invalidateRuntimeBindings (#93059). */
   retireBusyClaim?(runtimeId: string): boolean
   /**
-   * Resolves with the live runtime session id that ACCEPTED the prompt. A
-   * session-not-found recovery can rebind the runtime, so the accepted id may
-   * differ from the input id; callers that report delivery must use this value.
+   * Resolves with the EXACT identity that ACCEPTED the prompt. A
+   * session-not-found recovery can rebind the runtime, so the accepted runtime
+   * id may differ from the input id; `storedSessionId` is the durable session
+   * the accepted runtime is bound to, or null when that binding is unknown. A
+   * caller that reports delivery must prove the requested target from this.
    */
-  submitToSession(runtimeId: string, text: string): Promise<string>
+  submitToSession(runtimeId: string, text: string): Promise<AcceptedSessionIdentity>
   /** THE session-state write path — routes through the wiring cache so the
    *  cache, the primary view (when active), and every tile mirror agree. */
   updateSession(runtimeId: string, updater: (state: ClientSessionState) => ClientSessionState): ClientSessionState
+}
+
+/** Exact identity a prompt was accepted into: live runtime id + durable stored id. */
+export interface AcceptedSessionIdentity {
+  runtimeSessionId: string
+  storedSessionId: null | string
 }
 
 let delegate: SessionTileDelegate | null = null

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1355,8 +1355,12 @@ export interface SessionTileDelegate {
    *  it — the caller downgrades the mirror itself. Reconnect-time twin of
    *  invalidateRuntimeBindings (#93059). */
   retireBusyClaim?(runtimeId: string): boolean
-  /** Submit a prompt to a tile's live session. */
-  submitToSession(runtimeId: string, text: string): Promise<void>
+  /**
+   * Resolves with the live runtime session id that ACCEPTED the prompt. A
+   * session-not-found recovery can rebind the runtime, so the accepted id may
+   * differ from the input id; callers that report delivery must use this value.
+   */
+  submitToSession(runtimeId: string, text: string): Promise<string>
   /** THE session-state write path — routes through the wiring cache so the
    *  cache, the primary view (when active), and every tile mirror agree. */
   updateSession(runtimeId: string, updater: (state: ClientSessionState) => ClientSessionState): ClientSessionState


### PR DESCRIPTION
## Summary

Fixes the Quick Entry data-loss and feedback defects from #85590 (part A; geometry is deferred to a follow-up PR B).

**Ack contract.** The quick-window submit channel (`hermes:quick-entry:submit`) is now a request/response round trip instead of fire-and-forget: the quick window `invoke`s, main validates the sender, relays to the primary renderer with a correlation id (one pending map, ~15s timeout), and the primary acks back by id. The quick window only clears its draft and hides once the submit is confirmed `{ok:true}`; on failure it stays open, keeps the draft, shows the inline error, and refocuses the editor. A dead or missing primary window is now a real error instead of a silent drop.

**Atomic new session.** `target: "new"` no longer rides the fire-and-forget `startFreshSessionDraft()` + `submitText` pair, where `sessionContextDrift` could treat the just-created session as a user switch and orphan-close it before the prompt landed. A new route-neutral `submitTextToNewSession(text)` creates the backend session, pins its stored id in a narrow set consulted by `sessionContextDrift`, submits to the returned runtime id, navigates to that id, and unpins once the route matches (or on failure). No `/new` route token, no draft round-trip.

**Reveal/focus.** On confirmed success main hides the quick window and raises/focuses the primary window (dock show on darwin), restoring the pre-0.17.0 behavior. The old comment claiming the app deliberately does NOT raise/focus was removed: the issue title is "no delivery ack/reveal", the in-app new-session submit already navigates and focuses, so this is parity restoration.

## Verification

- Typecheck: renderer + electron tsconfigs both pass.
- Vitest: quick-entry store, electron main, session-context-drift, use-session-actions, and the new bridge/drift pin tests all pass (counts below).
- `git diff --check` clean; no em-dashes.

## Notes

- Geometry (broken window size, double box-shadow owner, `hasShadow`/`transparent`/`roundedCorners`) is a separate surface blocked on macOS/Windows visual evidence; tracked as PR B on the same issue.
- The `do NOT raise/focus` comment was deliberately removed (see Summary).
