### PR TITLE
fix(model-metadata): converge output-cap retry on vLLM

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1726,11 +1726,28 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
     # Available output = window - input. When the input alone is at or over
     # the window this stays None, so the caller correctly falls through to
     # compression instead of futilely shrinking the output cap.
+    #
+    # Caveat: when max_tokens is the BINDING constraint, vLLM does not report
+    # the real prompt size at all.  It back-computes a lower bound from the
+    # constraint itself -- "at least N input tokens" where
+    # N == window + 1 - requested_output -- so window - N is always exactly
+    # requested_output - 1.  Subtracting the caller's safety margin then walks
+    # the cap down ~65 tokens per retry while the reported input walks up by
+    # the same amount, burning every compression attempt without ever fitting.
+    # Detect that degenerate case and halve the requested cap instead: it
+    # carries the same guarantee (strictly below what was rejected) and
+    # converges in one or two retries.
     _m_vllm_input = re.search(
         r'prompt contains (?:at least )?(\d+)\s*input tokens', error_lower
     )
     if _m_ctx_tok and _m_vllm_input:
         _available = int(_m_ctx_tok.group(1)) - int(_m_vllm_input.group(1))
+        _m_requested_out = re.search(r'requested (\d+)\s*output tokens', error_lower)
+        if 'at least' in error_lower and _m_requested_out:
+            _requested_out = int(_m_requested_out.group(1))
+            if _available >= _requested_out - 1:
+                # The budget is derived from the constraint, not measured.
+                return max(1, _requested_out // 2)
         if _available >= 1:
             return _available
 

--- a/tests/test_output_cap_parsing.py
+++ b/tests/test_output_cap_parsing.py
@@ -121,14 +121,57 @@ class TestParseVllmTokenBasedOutputCap:
         "output tokens."
     )
 
-    def test_vllm_token_based_format(self):
-        # available output = 131072 - 65537 = 65535
-        assert parse_available_output_tokens_from_error(self._VLLM_MSG) == 65535
+    # Verbatim vLLM response where the input is MEASURED, not back-computed:
+    # window - input != requested - 1, so the reported figure is real.
+    _VLLM_MSG_REAL_INPUT = (
+        "This model's maximum context length is 131072 tokens. However, you "
+        "requested 65536 output tokens and your prompt contains 100000 "
+        "input tokens, for a total of 165536 tokens. Please reduce the length "
+        "of the input prompt or the number of requested output tokens."
+    )
 
+    def test_vllm_token_based_format(self):
+        # The reported input is a LOWER BOUND that vLLM back-computes from the
+        # constraint (65537 == 131072 + 1 - 65536), so window - input is just
+        # requested - 1 and carries no information about the real prompt.
+        # Halve the requested cap instead so the retry actually converges.
+        assert parse_available_output_tokens_from_error(self._VLLM_MSG) == 32768
+
+    def test_vllm_measured_input_is_trusted(self):
+        # When the input is measured rather than derived, use it as-is.
+        # available output = 131072 - 100000 = 31072
+        assert parse_available_output_tokens_from_error(
+            self._VLLM_MSG_REAL_INPUT
+        ) == 31072
 
     def test_vllm_retry_fits_inside_window(self):
         # The retried cap plus the reported input must fit in the window.
         available = parse_available_output_tokens_from_error(self._VLLM_MSG)
         assert available is not None
         assert available + 65537 <= 131072
+
+    def test_vllm_retry_converges(self):
+        """The retry sequence must reach a working cap in a few attempts.
+
+        Regression test for the 65-tokens-per-retry crawl: with a 102400
+        window and a real prompt of ~37000 tokens, retrying from a 65536 cap
+        used to produce 65471 -> 65406 -> 65341 and exhaust the compression
+        budget without ever fitting.
+        """
+        window, real_input, cap = 102400, 37000, 65536
+        for _ in range(5):
+            if real_input + cap <= window:
+                break
+            # vLLM's message when max_tokens is the binding constraint.
+            msg = (
+                f"This model's maximum context length is {window} tokens. "
+                f"However, you requested {cap} output tokens and your prompt "
+                f"contains at least {window + 1 - cap} input tokens, for a "
+                f"total of at least {window + 1} tokens."
+            )
+            available = parse_available_output_tokens_from_error(msg)
+            assert available is not None
+            assert available < cap, "each retry must lower the cap"
+            cap = available
+        assert real_input + cap <= window, f"did not converge: cap={cap}"
 


### PR DESCRIPTION
## What does this PR do?

Stops the output-cap retry loop from spinning forever on vLLM, which currently
kills the session with `Context length exceeded: max compression attempts (3)
reached` even though a smaller `max_tokens` would have worked straight away.

The thing that makes this one confusing is that vLLM does not report your real
prompt size when `max_tokens` is the binding constraint. It works the number
backwards from the constraint it just failed:

```
This model's maximum context length is 102400 tokens. However, you requested
65536 output tokens and your prompt contains at least 36865 input tokens,
for a total of at least 102401 tokens.
```

`36865` is just `window + 1 - requested`, and the total is always exactly
`window + 1`. So `window - reported_input` gives back `requested - 1` every
time, no matter how big the prompt really is.

`parse_available_output_tokens_from_error` took that at face value and returned
`requested - 1`. The caller in `agent/conversation_loop.py` then subtracts its
64 token safety margin and retries, so the cap creeps down 65 tokens per
attempt while the reported input creeps up by the same 65:

```
retrying with max_tokens=65,471   (provider_available=65,535)
retrying with max_tokens=65,406   (provider_available=65,470)
retrying with max_tokens=65,341   (provider_available=65,405)
Max compression attempts (3) reached.
```

Three attempts close 195 tokens of a roughly 28,000 token gap. Compression
cannot help either, because the input always fit, which is why the compressor
sensibly refuses with "summary would have GROWN".

I went with halving the requested cap because the error genuinely contains no
measurement of the real input, so there is no arithmetic you can do on it to
recover the true budget. Halving keeps the same guarantee (strictly under the
value that was just rejected) but converges geometrically instead of 65 tokens
at a time. It is gated on the degenerate shape, so no other provider wording is
affected.

### Relationship to existing issues and PRs

This is the same loop described in #61761, where the reporter noted that the
"underlying cause of the input-count drift itself [is] not fully isolated". I
think this is that cause: the input is not drifting. It is a derived number,
and it moves because we moved `max_tokens`. That also explains why their trace
lands on exactly `context_length + 1` every attempt, and why the drift is
exactly 65 rather than some varying amount.

#89777 and #61846 fix the same loop from the caller side in
`conversation_loop.py`, by clamping to the configured cap and by growing the
margin. This PR touches `model_metadata.py` instead, so it does not conflict
with either, and it works even when no `model.max_tokens` is configured. If a
maintainer would rather take one of those, the root cause note above is
probably still worth keeping.

## Related Issue

Fixes #61761

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py`, in `parse_available_output_tokens_from_error`:
  spot the degenerate vLLM case (the `at least` wording plus a budget that
  works out to `requested - 1`) and return `requested // 2` rather than the
  useless `requested - 1`.
- `tests/test_output_cap_parsing.py`: `test_vllm_token_based_format` asserted
  the bogus `65535`, so it now asserts `32768` with a comment on why the
  reported figure cannot be trusted. Added `test_vllm_measured_input_is_trusted`
  and `test_vllm_retry_converges`.

Behaviour that does not change:

- a measured input (where `window - input != requested - 1`) is still trusted
- a real input overflow still returns `None`, so the caller still falls through
  to compression

## How to Test

1. To reproduce, point Hermes at a vLLM server whose window is smaller than
   `default_max_tokens` plus your history. Mine was vLLM 0.27.1 serving
   Qwen3-Coder-30B-A3B at `max_model_len=102400`, against the provider default
   `max_tokens=65536`. Once history reaches about 37k tokens every call 400s and
   the session dies after three retries.
2. Or just watch the parser converge:
   ```python
   from agent.model_metadata import parse_available_output_tokens_from_error as f
   msg = lambda cap: (
       "This model's maximum context length is 102400 tokens. However, you "
       f"requested {cap} output tokens and your prompt contains at least "
       f"{102401 - cap} input tokens, for a total of at least 102401 tokens.")
   cap, real_input = 65536, 36865
   while real_input + cap > 102400:
       cap = f(msg(cap))     # main: 65535, 65534, ...   here: 32768
   ```
   On main that does not finish inside the retry budget. With this PR it lands
   on the first retry, since 32768 + 36865 = 69633, under the 102400 window.
3. `scripts/run_tests.sh tests/test_output_cap_parsing.py`, 15 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (see the
      note above on #61761, #89777 and #61846)
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q`, with the caveat below
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu, Linux 6.8.0, Python 3.11.16

On the test run: `scripts/run_tests.sh` gives me 34843 passed, 94 failed, 303
skipped. Those 94 are pre-existing and come from optional extras I do not have
installed locally (fal, daytona, modal, hindsight, mcp, the web providers). I
ran the same 29 affected files against unmodified `origin/main` and got an
identical 1037 passed, 94 failed, so nothing here is a regression. `ruff check`
is clean on both changed files. I left `ruff format` alone, since the diffs it
wants are all in pre-existing code and CI does not run it.

### Documentation & Housekeeping

- [x] I've updated relevant documentation, or N/A: N/A, it is an internal
      parsing helper and the reasoning is in the comments next to the code
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, or N/A: N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md`, or N/A: N/A
- [x] I've considered cross-platform impact, or N/A: N/A, it is string and
      integer logic with no platform-specific calls
- [x] I've updated tool descriptions/schemas, or N/A: N/A

## Screenshots / Logs

Before, on vLLM 0.27.1 with Qwen3-Coder-30B-A3B and a 102400 window:

```
⚠️  Output cap too large for current prompt — retrying with max_tokens=65,471
    (provider_available=65,535, estimated_request_tokens=34,354)
⚠️  Output cap too large for current prompt — retrying with max_tokens=65,406
    (provider_available=65,470, estimated_request_tokens=34,354)
⚠️  Output cap too large for current prompt — retrying with max_tokens=65,341
    (provider_available=65,405, estimated_request_tokens=34,354)
❌ Max compression attempts (3) reached.
Context length exceeded: max compression attempts (3) reached.
```

After, the first retry drops the cap to 32,768 and the call goes through.
