### PR TITLE
fix(skills/xlsx): never emit a sheet autofilter overlapping a native table

### DIFF
--- a/skills/productivity/xlsx/SKILL.md
+++ b/skills/productivity/xlsx/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: xlsx
 description: Create, read, edit Excel .xlsx workbooks and CSVs.
-version: 1.1.0
+version: 1.1.1
 author: Nous Research
 license: MIT
 platforms: [linux, macos, windows]
@@ -162,6 +162,15 @@ LibreOffice or hand the file to the user unconverted.
   it cannot move chart anchors, images, or conditional-format RULE
   formulas; read its JSON report's `not_shifted` list and
   `references/restructuring.md`.
+- **Never set a sheet `autofilter` over a native table range.** Excel
+  treats a sheet-level autofilter overlapping a table as invalid
+  content and demands repair on open ("We found a problem with some
+  content"), stripping the table — tables already carry their own
+  filter UI. `xlsx_create.py` and `xlsx_edit.py` guard this: the
+  overlapping sheet autofilter is dropped and reported under
+  `"warnings"` in the JSON summary. Table header cells must also be
+  non-empty and unique (another repair trigger); the scripts reject
+  violations.
 - **Sheet protection is NOT security.** `--protect` sets the standard
   xlsx sheet-protection hash: it signals "don't edit this" to
   well-behaved apps and nothing more. Anyone can strip it by editing

--- a/skills/productivity/xlsx/scripts/xlsx_create.py
+++ b/skills/productivity/xlsx/scripts/xlsx_create.py
@@ -31,6 +31,9 @@ Spec (JSON object):
           {"name": "Sales", "range": "A1:C4",
            "style": "TableStyleMedium9"}        # native Excel table
         ],
+        # NOTE: table header cells must be non-empty and unique, and a
+        # sheet "autofilter" overlapping a table range is dropped with a
+        # warning -- Excel repair-strips files that carry both.
         "protection": {"password": "your-password",   # NOT security --
                        "unlock": ["B2:B9"]}           # see SKILL.md Pitfalls
       }
@@ -72,7 +75,8 @@ from openpyxl.comments import Comment
 from openpyxl.formatting.rule import CellIsRule, ColorScaleRule
 from openpyxl.styles import (Alignment, Border, Font, PatternFill,
                              Protection, Side)
-from openpyxl.utils import column_index_from_string, range_boundaries
+from openpyxl.utils import (column_index_from_string, get_column_letter,
+                            range_boundaries)
 from openpyxl.workbook.defined_name import DefinedName
 from openpyxl.worksheet.datavalidation import DataValidation
 from openpyxl.worksheet.table import Table, TableStyleInfo
@@ -155,6 +159,31 @@ def add_chart(ws, spec):
     ws.add_chart(chart, spec.get("anchor", "H2"))
 
 
+def ranges_intersect(a, b):
+    a_min_col, a_min_row, a_max_col, a_max_row = range_boundaries(a)
+    b_min_col, b_min_row, b_max_col, b_max_row = range_boundaries(b)
+    return (a_min_col <= b_max_col and b_min_col <= a_max_col
+            and a_min_row <= b_max_row and b_min_row <= a_max_row)
+
+
+def check_table_header(ws, name, ref):
+    """Excel repair-strips tables whose header cells are empty/duplicated."""
+    min_col, min_row, max_col, _ = range_boundaries(ref)
+    seen = set()
+    for col in range(min_col, max_col + 1):
+        coord = f"{get_column_letter(col)}{min_row}"
+        value = ws[coord].value
+        if value is None or str(value).strip() == "":
+            raise ValueError(
+                f"table {name!r}: header cell {coord} is empty -- every "
+                "table column needs a non-empty, unique header")
+        if str(value) in seen:
+            raise ValueError(
+                f"table {name!r}: duplicate header {str(value)!r} at {coord}"
+                " -- table column headers must be unique")
+        seen.add(str(value))
+
+
 def add_conditional(ws, spec):
     rng = spec["range"]
     kind = spec.get("type", "cell_is")
@@ -169,7 +198,7 @@ def add_conditional(ws, spec):
     ws.conditional_formatting.add(rng, rule)
 
 
-def build_sheet(ws, spec):
+def build_sheet(ws, spec, warnings):
     for row in spec.get("rows", []):
         values, styled = [], []
         for item in row:
@@ -194,8 +223,18 @@ def build_sheet(ws, spec):
         ws.merge_cells(rng)
     if spec.get("freeze_panes"):
         ws.freeze_panes = spec["freeze_panes"]
-    if spec.get("autofilter"):
-        ws.auto_filter.ref = spec["autofilter"]
+    autofilter = spec.get("autofilter")
+    if autofilter:
+        overlapping = [t["name"] for t in spec.get("tables", [])
+                       if ranges_intersect(autofilter, t["range"])]
+        if overlapping:
+            warnings.append(
+                f"sheet {ws.title!r}: dropped autofilter {autofilter} -- it "
+                f"overlaps table(s) {', '.join(overlapping)}, and Excel "
+                "repair-strips files that carry both (tables have their own "
+                "filter UI)")
+        else:
+            ws.auto_filter.ref = autofilter
     for cf in spec.get("conditional_formats", []):
         add_conditional(ws, cf)
     for ch in spec.get("charts", []):
@@ -207,6 +246,7 @@ def build_sheet(ws, spec):
         dv.add(dv_spec["range"])
         ws.add_data_validation(dv)
     for t_spec in spec.get("tables", []):
+        check_table_header(ws, t_spec["name"], t_spec["range"])
         table = Table(displayName=t_spec["name"], ref=t_spec["range"])
         table.tableStyleInfo = TableStyleInfo(
             name=t_spec.get("style", "TableStyleMedium9"),
@@ -238,16 +278,19 @@ def main(argv=None):
 
     wb = Workbook()
     wb.remove(wb.active)
+    warnings = []
     for sheet_spec in spec.get("sheets", []):
         ws = wb.create_sheet(sheet_spec.get("name", "Sheet1"))
-        build_sheet(ws, sheet_spec)
+        build_sheet(ws, sheet_spec, warnings)
     for name, ref in spec.get("defined_names", {}).items():
         wb.defined_names[name] = DefinedName(name, attr_text=ref)
     if spec.get("full_calc_on_load"):
         wb.calculation.fullCalcOnLoad = True
     wb.save(args.output)
-    print(json.dumps({"ok": True, "output": args.output,
-                      "sheets": wb.sheetnames}, ensure_ascii=False))
+    summary = {"ok": True, "output": args.output, "sheets": wb.sheetnames}
+    if warnings:
+        summary["warnings"] = warnings
+    print(json.dumps(summary, ensure_ascii=False))
     return 0
 
 

--- a/skills/productivity/xlsx/scripts/xlsx_create.py
+++ b/skills/productivity/xlsx/scripts/xlsx_create.py
@@ -159,6 +159,9 @@ def add_chart(ws, spec):
     ws.add_chart(chart, spec.get("anchor", "H2"))
 
 
+# NOTE: ranges_intersect / check_table_header are duplicated in
+# scripts/xlsx_edit.py -- these skill scripts run standalone (no shared
+# import), so any change to these helpers must be mirrored there.
 def ranges_intersect(a, b):
     a_min_col, a_min_row, a_max_col, a_max_row = range_boundaries(a)
     b_min_col, b_min_row, b_max_col, b_max_row = range_boundaries(b)

--- a/skills/productivity/xlsx/scripts/xlsx_edit.py
+++ b/skills/productivity/xlsx/scripts/xlsx_edit.py
@@ -11,9 +11,15 @@ Operations (repeatable where noted, applied in the order listed below):
   --set CELL=VALUE              repeatable; type-inferred (int, float, bool,
                                 ISO date, else string). '=...' sets a formula.
   --append ROWJSON              repeatable; JSON array appended as a row
-  --add-table NAME:RANGE[:STYLE]  create a native Excel table (ListObject)
+  --add-table NAME:RANGE[:STYLE]  create a native Excel table (ListObject).
+                                Header cells must be non-empty and unique;
+                                a sheet autofilter overlapping the range is
+                                dropped with a warning (Excel repair-strips
+                                files that carry both)
   --table-append NAME=ROWJSON   append a row inside a table, auto-extending
-                                the table's range (repeatable)
+                                the table's range (repeatable); drops a
+                                sheet autofilter the extended range would
+                                overlap, with a warning
   --list-tables                 print tables on the target sheet and exit
   --define-name NAME=REF        workbook-scope defined name, e.g.
                                 "Rates='Data'!$B$2:$B$9" (repeatable)
@@ -80,19 +86,56 @@ def parse_idx(arg):
     return int(arg), 1
 
 
-def add_table(ws, spec):
+def ranges_intersect(a, b):
+    a_min_col, a_min_row, a_max_col, a_max_row = range_boundaries(a)
+    b_min_col, b_min_row, b_max_col, b_max_row = range_boundaries(b)
+    return (a_min_col <= b_max_col and b_min_col <= a_max_col
+            and a_min_row <= b_max_row and b_min_row <= a_max_row)
+
+
+def check_table_header(ws, name, ref):
+    """Excel repair-strips tables whose header cells are empty/duplicated."""
+    min_col, min_row, max_col, _ = range_boundaries(ref)
+    seen = set()
+    for col in range(min_col, max_col + 1):
+        coord = f"{get_column_letter(col)}{min_row}"
+        value = ws[coord].value
+        if value is None or str(value).strip() == "":
+            raise ValueError(
+                f"table {name!r}: header cell {coord} is empty -- every "
+                "table column needs a non-empty, unique header")
+        if str(value) in seen:
+            raise ValueError(
+                f"table {name!r}: duplicate header {str(value)!r} at {coord}"
+                " -- table column headers must be unique")
+        seen.add(str(value))
+
+
+def drop_overlapping_autofilter(ws, name, rng, warnings):
+    if ws.auto_filter.ref and ranges_intersect(ws.auto_filter.ref, rng):
+        warnings.append(
+            f"sheet {ws.title!r}: dropped autofilter {ws.auto_filter.ref} "
+            f"-- it overlaps table {name!r} at {rng}, and Excel "
+            "repair-strips files that carry both (tables have their own "
+            "filter UI)")
+        ws.auto_filter.ref = None
+
+
+def add_table(ws, spec, warnings):
     parts = spec.split(":")
     if len(parts) < 3:
         raise ValueError("--add-table needs NAME:RANGE like Sales:A1:C9")
     name = parts[0]
     rng = ":".join(parts[1:3])
     style = parts[3] if len(parts) > 3 else "TableStyleMedium9"
+    check_table_header(ws, name, rng)
+    drop_overlapping_autofilter(ws, name, rng, warnings)
     table = Table(displayName=name, ref=rng)
     table.tableStyleInfo = TableStyleInfo(name=style, showRowStripes=True)
     ws.add_table(table)
 
 
-def table_append(ws, name, row_values):
+def table_append(ws, name, row_values, warnings):
     table = ws.tables[name]
     min_col, min_row, max_col, max_row = range_boundaries(table.ref)
     new_row = max_row + 1
@@ -100,6 +143,7 @@ def table_append(ws, name, row_values):
         ws.cell(row=new_row, column=min_col + offset, value=value)
     table.ref = (f"{get_column_letter(min_col)}{min_row}:"
                  f"{get_column_letter(max_col)}{new_row}")
+    drop_overlapping_autofilter(ws, name, table.ref, warnings)
 
 
 def main(argv=None):
@@ -151,6 +195,7 @@ def main(argv=None):
 
     wb = load_workbook(args.file)
     changes = []
+    warnings = []
 
     for pair in args.rename_sheet:
         old, new = pair.split(":", 1)
@@ -200,11 +245,11 @@ def main(argv=None):
         changes.append(f"append row {ws.max_row}")
 
     for spec in args.add_table:
-        add_table(ws, spec)
+        add_table(ws, spec, warnings)
         changes.append(f"add_table {spec.split(':')[0]}")
     for spec in args.table_append:
         name, row_json = spec.split("=", 1)
-        table_append(ws, name, json.loads(row_json))
+        table_append(ws, name, json.loads(row_json), warnings)
         changes.append(f"table_append {name} -> {ws.tables[name].ref}")
 
     for spec in args.define_name:
@@ -250,8 +295,11 @@ def main(argv=None):
 
     out = args.out or args.file
     wb.save(out)
-    print(json.dumps({"ok": True, "output": out, "sheet": ws.title,
-                      "changes": changes}, ensure_ascii=False))
+    summary = {"ok": True, "output": out, "sheet": ws.title,
+               "changes": changes}
+    if warnings:
+        summary["warnings"] = warnings
+    print(json.dumps(summary, ensure_ascii=False))
     return 0
 
 

--- a/skills/productivity/xlsx/scripts/xlsx_edit.py
+++ b/skills/productivity/xlsx/scripts/xlsx_edit.py
@@ -86,6 +86,11 @@ def parse_idx(arg):
     return int(arg), 1
 
 
+# NOTE: ranges_intersect / check_table_header are duplicated in
+# scripts/xlsx_create.py (which applies the drop_overlapping_autofilter
+# guard inline at its autofilter spec) -- these skill scripts run
+# standalone (no shared import), so any change to these helpers must be
+# mirrored there.
 def ranges_intersect(a, b):
     a_min_col, a_min_row, a_max_col, a_max_row = range_boundaries(a)
     b_min_col, b_min_row, b_max_col, b_max_row = range_boundaries(b)

--- a/skills/productivity/xlsx/tests/test_xlsx_skill.py
+++ b/skills/productivity/xlsx/tests/test_xlsx_skill.py
@@ -276,6 +276,10 @@ RESTRUCTURE_SPEC = {
                 "D6": {"formula": "LOG10(B4)"},
                 "E6": {"formula": "SUM(B:B)"},
                 "F6": {"formula": '"row B2: "&B2'},
+                "H1": "Item", "I1": "Qty",
+                "H2": "a", "I2": 1,
+                "H3": "b", "I3": 2,
+                "H4": "c", "I4": 3,
             },
             "merges": ["E2:E4", "A7:B7"],
             "freeze_panes": "A2",
@@ -289,8 +293,10 @@ RESTRUCTURE_SPEC = {
                 {"range": "C2:C4", "type": "list",
                  "formula1": '"0.2,0.3,0.5"'},
             ],
+            # disjoint from the autofilter range: Excel forbids a sheet
+            # autofilter overlapping a table (see the overlap-guard tests)
             "tables": [
-                {"name": "SalesTbl", "range": "A1:C4"},
+                {"name": "SalesTbl", "range": "H1:I4"},
             ],
         },
         {
@@ -353,7 +359,7 @@ def test_restructure_insert_rows_shifts_everything(restructure_book):
     cf = list(data.conditional_formatting)[0]
     assert str(cf.sqref) == "B2:B6"
     # native table expanded
-    assert data.tables["SalesTbl"].ref == "A1:C6"
+    assert data.tables["SalesTbl"].ref == "H1:I6"
     # defined name rewritten
     assert wb.defined_names["SalesRange"].attr_text == "'Data'!$B$2:$B$6"
     # report is honest about limits
@@ -372,7 +378,7 @@ def test_restructure_delete_rows_and_ref_errors(restructure_book):
     # single-cell ref into the deleted row becomes #REF!
     assert summary["B2"].value == "='Data'!#REF!"
     assert summary["B1"].value == "=SUM(Data!B2:B3)"
-    assert data.tables["SalesTbl"].ref == "A1:C3"
+    assert data.tables["SalesTbl"].ref == "H1:I3"
 
 
 def test_restructure_insert_cols(restructure_book):
@@ -390,6 +396,7 @@ def test_restructure_insert_cols(restructure_book):
     merged = [str(r) for r in data.merged_cells.ranges]
     assert "F2:F4" in merged                    # merge shifted right
     assert "A7:C7" in merged                    # merge expanded across col B
+    assert data.tables["SalesTbl"].ref == "I1:J4"   # table shifted right
 
 
 # ---------------------------------------------------------------------------
@@ -412,7 +419,9 @@ def test_tables_create_append_list(tmp_path):
     assert tbl.tableStyleInfo.name == "TableStyleLight1"
 
     # --add-table + --table-append auto-extends the range
+    # (--set runs before --add-table, so headers land first)
     run("xlsx_edit.py", book, "--sheet", "T",
+        "--set", "D1=Part", "--set", "E1=Count",
         "--add-table", "Extra:D1:E2",
         "--table-append", 'Stock=["c", 3]')
     wb = load_workbook(book)
@@ -428,6 +437,103 @@ def test_tables_create_append_list(tmp_path):
     # tables also appear in the read inventory
     inv = json.loads(run("xlsx_read.py", book, "--sheets").stdout)
     assert inv["sheets"][0]["tables"]["Stock"] == "A1:B4"
+
+
+def test_create_drops_autofilter_overlapping_table(tmp_path):
+    # Excel repair-strips workbooks carrying a sheet autofilter AND a
+    # table over intersecting cells ("We found a problem with some
+    # content"); the builder must keep the table and drop the filter.
+    spec = {"sheets": [{"name": "G",
+                        "rows": [["Item", "Qty"], ["a", 1], ["b", 2]],
+                        "autofilter": "A1:B3",
+                        "tables": [{"name": "Stock", "range": "A1:B3"}]}]}
+    spec_path = tmp_path / "gspec.json"
+    spec_path.write_text(json.dumps(spec), encoding="utf-8")
+    book = tmp_path / "guard.xlsx"
+    summary = json.loads(run("xlsx_create.py", spec_path, book).stdout)
+    assert summary["ok"]
+    assert any("autofilter" in w and "Stock" in w
+               for w in summary["warnings"])
+    wb = load_workbook(book)
+    ws = wb["G"]
+    assert ws.auto_filter.ref is None           # dropped by the guard
+    assert ws.tables["Stock"].ref == "A1:B3"    # table kept
+
+    # disjoint autofilter + table coexist with no warning
+    spec["sheets"][0]["autofilter"] = "D1:E3"
+    spec_path.write_text(json.dumps(spec), encoding="utf-8")
+    summary = json.loads(run("xlsx_create.py", spec_path, book).stdout)
+    assert "warnings" not in summary
+    assert load_workbook(book)["G"].auto_filter.ref == "D1:E3"
+
+
+def test_edit_add_table_drops_overlapping_autofilter(tmp_path):
+    spec = {"sheets": [{"name": "E",
+                        "rows": [["Item", "Qty"], ["a", 1]],
+                        "autofilter": "A1:B2"}]}
+    spec_path = tmp_path / "espec.json"
+    spec_path.write_text(json.dumps(spec), encoding="utf-8")
+    book = tmp_path / "edit_guard.xlsx"
+    run("xlsx_create.py", spec_path, book)
+
+    result = json.loads(run("xlsx_edit.py", book, "--sheet", "E",
+                            "--add-table", "Items:A1:B2").stdout)
+    assert any("autofilter" in w and "Items" in w
+               for w in result["warnings"])
+    ws = load_workbook(book)["E"]
+    assert ws.auto_filter.ref is None
+    assert ws.tables["Items"].ref == "A1:B2"
+
+
+def test_edit_table_append_extending_into_autofilter(tmp_path):
+    # appending extends the table range downward into cells covered by
+    # a sheet autofilter -> the filter must go
+    spec = {"sheets": [{"name": "E",
+                        "rows": [["Item", "Qty"], ["a", 1],
+                                 ["Col", "Val"], ["x", 9]],
+                        "autofilter": "A3:B4",
+                        "tables": [{"name": "Items", "range": "A1:B2"}]}]}
+    spec_path = tmp_path / "aspec.json"
+    spec_path.write_text(json.dumps(spec), encoding="utf-8")
+    book = tmp_path / "append_guard.xlsx"
+    run("xlsx_create.py", spec_path, book)
+    assert load_workbook(book)["E"].auto_filter.ref == "A3:B4"
+
+    result = json.loads(run("xlsx_edit.py", book, "--sheet", "E",
+                            "--table-append", 'Items=["b", 2]').stdout)
+    assert any("autofilter" in w and "Items" in w
+               for w in result["warnings"])
+    ws = load_workbook(book)["E"]
+    assert ws.auto_filter.ref is None
+    assert ws.tables["Items"].ref == "A1:B3"
+    assert ws["A3"].value == "b" and ws["B3"].value == 2
+
+
+def test_table_header_cells_validated(tmp_path):
+    # empty header cell -> hard error (Excel repairs such tables)
+    spec = {"sheets": [{"name": "H", "rows": [["Item", None], ["a", 1]],
+                        "tables": [{"name": "Bad", "range": "A1:B2"}]}]}
+    spec_path = tmp_path / "hspec.json"
+    spec_path.write_text(json.dumps(spec), encoding="utf-8")
+    book = tmp_path / "hdr.xlsx"
+    bad = run("xlsx_create.py", spec_path, book, expect_ok=False)
+    assert bad.returncode != 0
+    err = json.loads(bad.stderr)
+    assert err["ok"] is False and "empty" in err["error"]
+
+    # duplicate headers -> hard error
+    spec["sheets"][0]["rows"][0] = ["Item", "Item"]
+    spec_path.write_text(json.dumps(spec), encoding="utf-8")
+    bad = run("xlsx_create.py", spec_path, book, expect_ok=False)
+    assert "unique" in json.loads(bad.stderr)["error"]
+
+    # same checks on the edit path
+    spec["sheets"][0] = {"name": "H", "rows": [["Item", None], ["a", 1]]}
+    spec_path.write_text(json.dumps(spec), encoding="utf-8")
+    run("xlsx_create.py", spec_path, book)
+    bad = run("xlsx_edit.py", book, "--sheet", "H",
+              "--add-table", "Bad:A1:B2", expect_ok=False)
+    assert "empty" in json.loads(bad.stderr)["error"]
 
 
 def test_names_hyperlinks_notes(tmp_path):


### PR DESCRIPTION
## What does this PR do?

Hardens the bundled `xlsx` skill against a defect class that makes Excel demand repair on open. A workbook carrying BOTH a worksheet-level `<autoFilter>` and a native table (`<tablePart>`) over intersecting cells is treated by Excel as invalid content: the user gets the **"We found a problem with some content"** repair prompt and the repair strips the table. The combination is impossible to build in the Excel UI (tables ship their own filter UI), but the skill's scripts emitted it whenever asked:

- `xlsx_create.py` — a spec combining `"autofilter"` with an overlapping entry in `"tables"`
- `xlsx_edit.py --add-table` — a new table over an existing sheet autofilter
- `xlsx_edit.py --table-append` — extending a table's range into a sheet-autofiltered area

We hit this defect class in a production deployment (an agent hand-rolled the same openpyxl construct and the delivered workbook opened with the repair prompt; byte-level forensics confirmed the mechanism). The bundled skill wasn't the cause there, but it reproduces the identical bytes when a spec asks for both — and "a filterable table" is exactly what agents get asked for.

Fix strategy: **keep the table, drop the sheet autofilter, and say so** — a `"warnings"` array in the scripts' JSON summary — since the table's own filter UI preserves the user-visible behavior. Additionally, table header cells are now validated non-empty and unique before `add_table` (empty/duplicate headers make openpyxl write `tableColumn` names that don't match the sheet and are another repair trigger).

## Related Issue

Fixes #89925

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `skills/productivity/xlsx/scripts/xlsx_create.py`: overlap guard in the sheet builder (autofilter dropped + warning when it intersects any declared table range); `check_table_header()` validation; JSON summary gains `"warnings"` when non-empty; spec docstring note.
- `skills/productivity/xlsx/scripts/xlsx_edit.py`: same guard + header validation in `--add-table`; `--table-append` drops a sheet autofilter its extended range would overlap; JSON summary gains `"warnings"`; docstring notes.
- `skills/productivity/xlsx/SKILL.md`: new Pitfalls bullet (never set a sheet autofilter over a native table range — Excel will demand repair); version 1.1.0 → 1.1.1.
- `skills/productivity/xlsx/tests/test_xlsx_skill.py`: 4 new tests (create-path guard incl. disjoint-range negative case, `--add-table` guard, `--table-append` extension guard, header validation on both paths). The restructure fixture previously declared `autofilter A1:C4` **and** `SalesTbl A1:C4` — i.e. the test suite itself built the repair-triggering workbook; the table now lives on a disjoint range (`H1:I4`) so both the autofilter- and table-shifting assertions still run. `test_tables_create_append_list` now populates `D1`/`E1` headers before `--add-table Extra:D1:E2` (they were empty, which the new validation rejects).

## How to Test

1. `pytest skills/productivity/xlsx/tests/test_xlsx_skill.py -q` → 16 passed (12 pre-existing + 4 new).
2. Reproduce the defect on `main` (unpatched):
   ```bash
   cat > defect_spec.json <<'EOF'
   {"sheets": [{"name": "Data",
                "rows": [["Item", "Qty"], ["a", 1], ["b", 2]],
                "autofilter": "A1:B3",
                "tables": [{"name": "Stock", "range": "A1:B3"}]}]}
   EOF
   python skills/productivity/xlsx/scripts/xlsx_create.py defect_spec.json out.xlsx
   python - <<'EOF'
   import re, zipfile
   xml = zipfile.ZipFile("out.xlsx").read("xl/worksheets/sheet1.xml").decode()
   print([m.group(0) for m in re.finditer(r"<[^>]*(autoFilter|tablePart)[^>]*>", xml)])
   EOF
   ```
   On `main` this prints both `<autoFilter ref="A1:B3" />` and a `<tablePart>` (opening the file in Excel triggers the repair prompt). On this branch the same spec produces a clean file, the table is kept, and the summary reports:
   ```json
   {"ok": true, "output": "out.xlsx", "sheets": ["Data"], "warnings": ["sheet 'Data': dropped autofilter A1:B3 -- it overlaps table(s) Stock, and Excel repair-strips files that carry both (tables have their own filter UI)"]}
   ```
3. Same check via the edit path: build a sheet with only `"autofilter": "A1:B2"`, then `xlsx_edit.py out.xlsx --sheet Data --add-table Items:A1:B2` — defective on `main`, guarded (warning + filter dropped) on this branch.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the skill's test suite (`pytest skills/productivity/xlsx/tests -q`) and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (WSL2), Python 3.12, openpyxl 3.1.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (SKILL.md Pitfalls + script docstrings)
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact considered — pure-Python range arithmetic, no I/O or platform-specific behavior added
