### PR TITLE
fix(feishu): thread-local WS loop proxy for multiplex event-loop isolation

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1322,14 +1322,162 @@ def _strip_edge_self_mentions(
             return remaining
 
 
+class _ThreadLocalLoopProxy:
+    """Thread-routing stand-in for ``lark_oapi.ws.client.loop``.
+
+    Why this exists: the upstream SDK stores its asyncio event loop in a
+    module-level global and reads it inside ``Client.start()`` /
+    ``_connect()`` / ``_receive_message_loop()`` via module-globals lookup.
+    That global is process-wide, so when the gateway multiplexes two or
+    more feishu websocket adapters (one per profile) the second worker
+    thread overwrites the loop the first one registered, and the first
+    adapter's receive loop crashes with::
+
+        Task ... got Future ... attached to a different loop
+
+    This proxy takes the place of that module global *once* (see
+    ``_install_thread_local_ws_loop_proxy``). Each feishu worker thread
+    then registers its own loop via ``set_thread_loop``; every attribute
+    access on the proxy is forwarded to the calling thread's loop, so
+    ``loop.run_until_complete(...)`` and ``loop.create_task(...)`` inside
+    the SDK always reach the loop that is actually running in *this*
+    thread — never the one another worker thread installed.
+    """
+
+    def __init__(self) -> None:
+        self._local = threading.local()
+
+    def set_thread_loop(self, loop: Any) -> None:
+        self._local.loop = loop
+
+    def get_thread_loop(self) -> Any:
+        return getattr(self._local, "loop", None)
+
+    def __getattr__(self, name: str) -> Any:
+        # Only reached for attributes Python doesn't find normally — i.e. all
+        # asyncio loop methods (run_until_complete, create_task, is_closed,
+        # …). Forward to the thread's registered loop.
+        loop = getattr(self._local, "loop", None)
+        if loop is None:
+            raise RuntimeError(
+                f"_ThreadLocalLoopProxy.{name} accessed from a thread that "
+                f"never called set_thread_loop(). Each feishu websocket "
+                f"worker thread must register its loop before invoking the "
+                f"Lark SDK."
+            )
+        return getattr(loop, name)
+
+
+_WS_LOOP_PROXY_LOCK = threading.Lock()
+
+
+def _install_thread_local_ws_loop_proxy() -> None:
+    """Replace ``lark_oapi.ws.client.loop`` with a thread-local proxy.
+
+    Idempotent (checks the current module attribute each call) and safe
+    to call from any thread. After the first call the SDK's
+    module-global ``loop`` is a :class:`_ThreadLocalLoopProxy`; each
+    feishu worker thread is then expected to register its own loop via
+    ``ws_client_module.loop.set_thread_loop(loop)`` before invoking the
+    SDK.
+    """
+    with _WS_LOOP_PROXY_LOCK:
+        import lark_oapi.ws.client as ws_client_module
+        if not isinstance(ws_client_module.loop, _ThreadLocalLoopProxy):
+            ws_client_module.loop = _ThreadLocalLoopProxy()
+
+
 def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
-    """Run the official Lark WS client in its own thread-local event loop."""
+    """Run the official Lark WS client in its own thread-local event loop.
+
+    The lark_oapi SDK's ws/client.py references a module-level ``loop`` global
+    for ``loop.create_task(...)`` calls inside ``_connect`` and
+    ``_receive_message_loop``. In multiplex mode several adapter threads start
+    near-simultaneously and each overwrites that global with its own loop, so a
+    later reconnect on an earlier client schedules coroutines on the wrong loop
+    ("Task got Future attached to a different loop"). We stash the per-thread
+    loop on the instance and patch the three methods that use the global so
+    they always reach for ``self._hermes_loop`` instead.
+    """
+    import types as _types
+    from urllib.parse import urlparse as _urlparse, parse_qs as _parse_qs
+
     import lark_oapi.ws.client as ws_client_module
+
+    from lark_oapi.ws.exception import (
+        ClientException as _LarkClientException,
+        ConnectionClosedException as _LarkConnectionClosedException,
+    )
+
+    _install_thread_local_ws_loop_proxy()
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-    ws_client_module.loop = loop
+    ws_client_module.loop.set_thread_loop(loop)
     adapter._ws_thread_loop = loop
+
+    ws_client._hermes_loop = loop
+
+    async def _patched_connect(self: Any) -> None:
+        _loop = self._hermes_loop
+        await self._lock.acquire()
+        if self._conn is not None:
+            self._lock.release()
+            return
+        try:
+            conn_url = self._get_conn_url()
+            u = _urlparse(conn_url)
+            q = _parse_qs(u.query)
+            conn_id = q["device_id"][0]
+            service_id = q["service_id"][0]
+            conn = await ws_client_module.websockets.connect(conn_url)
+            self._conn = conn
+            self._conn_url = conn_url
+            self._conn_id = conn_id
+            self._service_id = service_id
+            ws_client_module.logger.info(self._fmt_log("connected to {}", conn_url))
+            _loop.create_task(self._receive_message_loop())
+        except ws_client_module.websockets.InvalidStatusCode as e:
+            ws_client_module._parse_ws_conn_exception(e)
+        finally:
+            self._lock.release()
+
+    async def _patched_receive_message_loop(self: Any) -> None:
+        _loop = self._hermes_loop
+        try:
+            while True:
+                if self._conn is None:
+                    raise _LarkConnectionClosedException("connection is closed")
+                msg = await self._conn.recv()
+                _loop.create_task(self._handle_message(msg))
+        except Exception as e:
+            ws_client_module.logger.error(self._fmt_log("receive message loop exit, err: {}", e))
+            await self._disconnect()
+            if self._auto_reconnect:
+                await self._reconnect()
+            else:
+                raise e
+
+    def _patched_start(self: Any) -> None:
+        _loop = self._hermes_loop
+        try:
+            _loop.run_until_complete(self._connect())
+        except _LarkClientException as e:
+            ws_client_module.logger.error(self._fmt_log("connect failed, err: {}", e))
+            raise e
+        except Exception as e:
+            ws_client_module.logger.error(self._fmt_log("connect failed, err: {}", e))
+            _loop.run_until_complete(self._disconnect())
+            if self._auto_reconnect:
+                _loop.run_until_complete(self._reconnect())
+            else:
+                raise e
+        _loop.create_task(self._ping_loop())
+        _loop.run_until_complete(ws_client_module._select())
+
+    ws_client.start = _types.MethodType(_patched_start, ws_client)
+    ws_client._connect = _types.MethodType(_patched_connect, ws_client)
+    ws_client._receive_message_loop = _types.MethodType(_patched_receive_message_loop, ws_client)
 
     original_connect = ws_client_module.websockets.connect
     original_configure = getattr(ws_client, "_configure", None)

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -310,7 +310,13 @@ class TestAdapterModule(unittest.TestCase):
                 self._reconnect_nonce = 30
                 self._reconnect_interval = 120
                 self._ping_interval = 120
+                self._auto_reconnect = True
+                self._conn = None
+                self._conn_url = ""
+                self._conn_id = ""
+                self._service_id = ""
                 self.configure_calls = []
+                self._lock = asyncio.Lock()
 
             def _configure(self, conf):
                 self.configure_calls.append(conf)
@@ -318,10 +324,25 @@ class TestAdapterModule(unittest.TestCase):
                 self._reconnect_interval = conf.ReconnectInterval
                 self._ping_interval = conf.PingInterval
 
-            def start(self):
+            def _get_conn_url(self):
                 conf = SimpleNamespace(ReconnectNonce=99, ReconnectInterval=88, PingInterval=77)
                 self._configure(conf)
-                raise RuntimeError("stop test client")
+                return "wss://example.test/ws?device_id=device-1&service_id=service-2"
+
+            async def _handle_message(self, _msg):
+                return None
+
+            async def _disconnect(self):
+                self._conn = None
+
+            async def _reconnect(self):
+                return None
+
+            async def _ping_loop(self):
+                await asyncio.sleep(3600)
+
+            def _fmt_log(self, template, *args):
+                return template.format(*args)
 
         fake_client = _FakeWSClient()
         fake_adapter = SimpleNamespace(
@@ -333,7 +354,33 @@ class TestAdapterModule(unittest.TestCase):
         )
         fake_client_module = ModuleType("lark_oapi.ws.client")
         fake_client_module.loop = None
-        fake_client_module.websockets = SimpleNamespace(connect=AsyncMock())
+        fake_client_module.logger = SimpleNamespace(info=lambda *_a, **_k: None, error=lambda *_a, **_k: None)
+        fake_client_module._parse_ws_conn_exception = lambda exc: (_ for _ in ()).throw(exc)
+
+        class _FakeConn:
+            async def recv(self):
+                await asyncio.sleep(3600)
+                return b""
+
+        fake_client_module.websockets = SimpleNamespace(
+            connect=AsyncMock(return_value=_FakeConn()),
+            InvalidStatusCode=RuntimeError,
+        )
+
+        async def _fake_select():
+            return None
+
+        fake_client_module._select = _fake_select
+        fake_exception_module = ModuleType("lark_oapi.ws.exception")
+
+        class _FakeClientException(Exception):
+            pass
+
+        class _FakeConnectionClosedException(Exception):
+            pass
+
+        fake_exception_module.ClientException = _FakeClientException
+        fake_exception_module.ConnectionClosedException = _FakeConnectionClosedException
         fake_ws_module = ModuleType("lark_oapi.ws")
         fake_ws_module.client = fake_client_module
         fake_root_module = ModuleType("lark_oapi")
@@ -343,6 +390,7 @@ class TestAdapterModule(unittest.TestCase):
         sys.modules["lark_oapi"] = fake_root_module
         sys.modules["lark_oapi.ws"] = fake_ws_module
         sys.modules["lark_oapi.ws.client"] = fake_client_module
+        sys.modules["lark_oapi.ws.exception"] = fake_exception_module
         try:
             from plugins.platforms.feishu.adapter import _run_official_feishu_ws_client
 
@@ -355,6 +403,93 @@ class TestAdapterModule(unittest.TestCase):
         self.assertEqual(fake_client._reconnect_nonce, 2)
         self.assertEqual(fake_client._reconnect_interval, 3)
         self.assertEqual(fake_client._ping_interval, 4)
+        # The patched client must carry its thread's loop instance-side, and
+        # the worker must have run the loop through its full lifecycle (the
+        # finally block closes it on the way out).
+        self.assertIsNotNone(getattr(fake_client, "_hermes_loop", None))
+        self.assertTrue(fake_client._hermes_loop.is_closed())
+
+    def test_multiplex_loop_proxy_resolves_per_thread(self):
+        """Multiplex regression (#31367): two adapter worker threads each
+        register their own loop; SDK-style reads through the module-global
+        ``lark_oapi.ws.client.loop`` must resolve to the READING thread's
+        loop — even after the other thread registered later. With the plain
+        module-global assignment the second thread's loop would clobber the
+        first one's and cross-profile tasks would land on the wrong loop
+        ("Task got Future attached to a different loop")."""
+        import sys
+        import threading
+        from types import ModuleType
+
+        fake_client_module = ModuleType("lark_oapi.ws.client")
+        fake_client_module.loop = None
+        fake_ws_module = ModuleType("lark_oapi.ws")
+        fake_ws_module.client = fake_client_module
+        fake_root_module = ModuleType("lark_oapi")
+        fake_root_module.ws = fake_ws_module
+
+        original_modules = sys.modules.copy()
+        sys.modules["lark_oapi"] = fake_root_module
+        sys.modules["lark_oapi.ws"] = fake_ws_module
+        sys.modules["lark_oapi.ws.client"] = fake_client_module
+        try:
+            from plugins.platforms.feishu.adapter import (
+                _ThreadLocalLoopProxy,
+                _install_thread_local_ws_loop_proxy,
+            )
+
+            _install_thread_local_ws_loop_proxy()
+            self.assertIsInstance(fake_client_module.loop, _ThreadLocalLoopProxy)
+            # Idempotent: a second install keeps the same proxy instance.
+            proxy = fake_client_module.loop
+            _install_thread_local_ws_loop_proxy()
+            self.assertIs(fake_client_module.loop, proxy)
+
+            results = {}
+            barrier = threading.Barrier(2)
+
+            def _register(loop):
+                """What _run_official_feishu_ws_client does in each worker."""
+                asyncio.set_event_loop(loop)
+                fake_client_module.loop.set_thread_loop(loop)
+
+            def _sdk_read():
+                """What the lark SDK does: attribute access via module global."""
+                task = fake_client_module.loop.create_task(asyncio.sleep(0))
+                return task.get_loop()
+
+            def worker_a():
+                loop_a = asyncio.new_event_loop()
+                _register(loop_a)
+                barrier.wait()  # let worker B register its loop
+                barrier.wait()  # B finished registering
+                # Read AFTER B registered — must still reach A's own loop.
+                results["a_loop"] = loop_a
+                results["a_read_after_b"] = _sdk_read()
+                loop_a.run_until_complete(asyncio.sleep(0))
+                loop_a.close()
+
+            def worker_b():
+                barrier.wait()  # A registered first
+                loop_b = asyncio.new_event_loop()
+                _register(loop_b)
+                results["b_loop"] = loop_b
+                results["b_read"] = _sdk_read()
+                barrier.wait()  # release A
+                loop_b.run_until_complete(asyncio.sleep(0))
+                loop_b.close()
+
+            ta = threading.Thread(target=worker_a)
+            tb = threading.Thread(target=worker_b)
+            ta.start(); tb.start()
+            ta.join(timeout=10); tb.join(timeout=10)
+
+            self.assertIs(results["b_read"], results["b_loop"])
+            self.assertIs(results["a_read_after_b"], results["a_loop"])
+            self.assertIsNot(results["a_loop"], results["b_loop"])
+        finally:
+            sys.modules.clear()
+            sys.modules.update(original_modules)
 
 
 def _admits_group(adapter, message, sender_id, chat_id=""):


### PR DESCRIPTION
## Problem

The lark_oapi SDK stores its asyncio event loop in a **module-level global** (`lark_oapi.ws.client.loop`) and reads it inside `Client.start()` / `_connect()` / `_receive_message_loop()` via module-globals lookup. The global is process-wide, so when the gateway multiplexes two or more feishu websocket adapters (one per profile), the second worker thread **overwrites** the loop the first one registered, and the first adapter's receive loop dies with:

```
Task ... got Future ... attached to a different loop
```

Public reproduction: #31367 (latest repro supports the event-loop isolation diagnosis).

## Fix (two cooperating layers, current plugin path only)

1. **`_ThreadLocalLoopProxy`** replaces the SDK module global **once** (idempotent, lock-guarded install). Every attribute access is forwarded to the *calling thread's* registered loop, so SDK-internal `loop.create_task(...)` / `run_until_complete(...)` always reach the loop that is actually running in that thread.
2. **Per-instance loop stash + method patching**: `_run_official_feishu_ws_client` stores the per-thread loop on the instance (`ws_client._hermes_loop`) and monkey-patches the three SDK client methods (`start` / `_connect` / `_receive_message_loop`) to use it, covering identity-sensitive uses a proxy cannot forward.

## Regression test

`test_multiplex_loop_proxy_resolves_per_thread` runs two worker threads through the exact registration sequence of `_run_official_feishu_ws_client` and asserts SDK-style reads through the module global resolve per-thread **after the second thread registers** — the precise clobber the plain module-global assignment caused (fail-before / pass-after verified).

## Scope

Split out of #64247 per review (@Seekers2001):
- ✅ event-loop isolation only — focused current-plugin-path patch + multiplex regression test
- ❌ no IP failover (separate PR follows)
- ❌ no secret-scope changes (already covered on main by `_scoped_key_env` / #76573)
- ❌ no adapter-side silent-worker retry policy — the gateway-owned supervisor path (#73202 / #53508) stays the reconnect authority