### PR TITLE
fix(feishu): per-IP WS connect failover for msg-frontier DNS black holes

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1038,6 +1038,61 @@ def _install_lark_ws_isolation(ws_client_module: Any) -> None:
         _WS_ISOLATION_INSTALLED = True
 
 
+# Per-IP deadline (seconds) for the WS connect failover walk. Module constant so
+# tests can tighten it instead of waiting out a real 4s black-hole dial.
+_WS_CONNECT_PER_IP_TIMEOUT = 4.0
+
+
+def _install_ws_ip_failover(ws_client_module: Any) -> None:
+    """Per-IP connect failover for msg-frontier DNS black-holes.
+
+    msg-frontier.feishu.cn's DNS pool returns ~12 IPs of which a few are black
+    holes (TCP/TLS connect hangs indefinitely, no RST). ``websockets.connect``
+    tries the resolved IPs sequentially under a single ``open_timeout``, so when
+    the first IP is a black-hole the whole connect attempt times out even though
+    healthy IPs are one dial away. This installs a wrapper around the (already
+    isolation-dispatched, see ``_install_lark_ws_isolation``) ``connect`` that
+    walks the unique resolved IPs with a short per-IP budget and returns the
+    first connection that completes the TLS+WS handshake. Idempotent; safe to
+    call from every profile's WS thread.
+    """
+    import socket as _socket
+
+    real_connect = ws_client_module.websockets.connect
+    if getattr(real_connect, "_hermes_ip_failover", False):
+        return
+
+    async def _connect_with_ip_failover(uri: str, **kwargs: Any) -> Any:
+        from urllib.parse import urlparse as _urlparse
+        parsed = _urlparse(uri)
+        host, port = parsed.hostname, parsed.port or 443
+        try:
+            infos = _socket.getaddrinfo(host, port, type=_socket.SOCK_STREAM)
+            unique_ips = list(dict.fromkeys(sa[0] for *_, sa in infos))
+        except Exception:
+            unique_ips = [host]
+        last_err: Exception | None = None
+        for ip in unique_ips:
+            try:
+                kw = dict(kwargs)
+                kw["open_timeout"] = None  # per-IP timeout enforced via wait_for below
+                if ip != host:
+                    kw["host"], kw["port"] = ip, port
+                return await asyncio.wait_for(real_connect(uri, **kw), timeout=_WS_CONNECT_PER_IP_TIMEOUT)
+            except Exception as e:
+                last_err = e
+                ws_client_module.logger.debug(
+                    "[Feishu] WS connect to %s via IP %s failed (%s), trying next IP",
+                    host, ip, type(e).__name__,
+                )
+        raise last_err or ConnectionError(f"all IPs failed for {host}")
+
+    _connect_with_ip_failover._hermes_ip_failover = True
+    _connect_with_ip_failover.__wrapped__ = real_connect  # keep signature probes honest
+    _connect_with_ip_failover.__name__ = getattr(real_connect, "__name__", "connect")
+    ws_client_module.websockets.connect = _connect_with_ip_failover
+
+
 def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     """Run the official Lark WS client in its own thread-local loop (see isolation notes above)."""
     import lark_oapi.ws.client as ws_client_module
@@ -1064,6 +1119,7 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     _install_lark_ws_isolation(ws_client_module)
     _ws_isolation_state.loop = loop
     _ws_isolation_state.connect_kwargs = connect_overrides
+    _install_ws_ip_failover(ws_client_module)
 
     def _configure_with_overrides(conf: Any) -> Any:
         if original_configure is None:

--- a/tests/gateway/test_feishu_ws_ip_failover.py
+++ b/tests/gateway/test_feishu_ws_ip_failover.py
@@ -1,0 +1,134 @@
+"""Per-IP WS connect failover for msg-frontier DNS black-holes (#89929).
+
+msg-frontier.feishu.cn's DNS pool contains black-hole IPs: without a per-IP
+deadline the whole connect attempt hangs on the first address even though a
+healthy IP is one dial away. These tests pin the walk order and the skip.
+"""
+
+import asyncio
+import socket as _socket
+import sys
+import unittest
+from types import ModuleType
+from typing import Any
+from unittest.mock import patch
+
+from types import SimpleNamespace
+
+
+class FeishuWSIPFailoverTests(unittest.TestCase):
+    def _install_fake_lark_module(self, connect_impl):
+        connect_attempts: list = []
+
+        async def fake_connect(url, **kw):
+            host = kw.get("host")
+            connect_attempts.append(host)
+            return await connect_impl(url, host)
+
+        fake_client_module = ModuleType("lark_oapi.ws.client")
+        fake_client_module.loop = None
+        fake_client_module.logger = SimpleNamespace(
+            info=lambda *_a, **_k: None,
+            debug=lambda *_a, **_k: None,
+            error=lambda *_a, **_k: None,
+            warning=lambda *_a, **_k: None,
+        )
+        fake_client_module.websockets = SimpleNamespace(connect=fake_connect)
+        fake_ws_module = ModuleType("lark_oapi.ws")
+        fake_ws_module.client = fake_client_module
+        fake_root_module = ModuleType("lark_oapi")
+        fake_root_module.ws = fake_ws_module
+
+        originals = {
+            name: sys.modules.get(name)
+            for name in ("lark_oapi", "lark_oapi.ws", "lark_oapi.ws.client")
+        }
+        sys.modules["lark_oapi"] = fake_root_module
+        sys.modules["lark_oapi.ws"] = fake_ws_module
+        sys.modules["lark_oapi.ws.client"] = fake_client_module
+        self._originals = originals
+        return fake_client_module, connect_attempts
+
+    def tearDown(self):
+        for name, mod in getattr(self, "_originals", {}).items():
+            if mod is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = mod
+        # _install_lark_ws_isolation flips a process-wide flag; reset so other
+        # tests in the same run can install against their own fake modules.
+        import plugins.platforms.feishu.adapter as _adapter_mod
+        _adapter_mod._WS_ISOLATION_INSTALLED = False
+
+    def test_blackhole_first_ip_is_skipped(self):
+        """A hanging first address must be skipped within the per-IP deadline
+        and the connection established via the next resolved IP."""
+        import plugins.platforms.feishu.adapter as adapter_mod
+
+        async def connect_impl(url, host):
+            if host == "9.9.9.9":
+                await asyncio.sleep(60)  # black hole: handshake never completes
+            return SimpleNamespace(peer=host)
+
+        fake_client_module, attempts = self._install_fake_lark_module(connect_impl)
+
+        resolved = [
+            (_socket.AF_INET, _socket.SOCK_STREAM, 6, "", ("9.9.9.9", 443)),
+            (_socket.AF_INET, _socket.SOCK_STREAM, 6, "", ("8.8.8.8", 443)),
+        ]
+        with patch.object(_socket, "getaddrinfo", return_value=resolved), \
+                patch.object(adapter_mod, "_WS_CONNECT_PER_IP_TIMEOUT", 0.2):
+            # Install order mirrors production: isolation dispatcher first,
+            # failover walk wraps it.
+            adapter_mod._install_lark_ws_isolation(fake_client_module)
+            adapter_mod._install_ws_ip_failover(fake_client_module)
+
+            conn_url = "wss://msg-frontier.feishu.cn/ws?device_id=d1&service_id=s1"
+            conn = asyncio.new_event_loop().run_until_complete(
+                fake_client_module.websockets.connect(conn_url)
+            )
+
+        self.assertEqual(attempts, ["9.9.9.9", "8.8.8.8"])
+        self.assertEqual(getattr(conn, "peer", None), "8.8.8.8")
+
+    def test_all_ips_exhausted_raises_last_error(self):
+        """When every resolved IP fails, the last error surfaces (never a silent None)."""
+        import plugins.platforms.feishu.adapter as adapter_mod
+
+        async def connect_impl(url, host):
+            raise OSError(f"refused by {host}")
+
+        fake_client_module, attempts = self._install_fake_lark_module(connect_impl)
+
+        resolved = [
+            (_socket.AF_INET, _socket.SOCK_STREAM, 6, "", ("9.9.9.9", 443)),
+            (_socket.AF_INET, _socket.SOCK_STREAM, 6, "", ("8.8.8.8", 443)),
+        ]
+        with patch.object(_socket, "getaddrinfo", return_value=resolved), \
+                patch.object(adapter_mod, "_WS_CONNECT_PER_IP_TIMEOUT", 0.2):
+            adapter_mod._install_lark_ws_isolation(fake_client_module)
+            adapter_mod._install_ws_ip_failover(fake_client_module)
+
+            conn_url = "wss://msg-frontier.feishu.cn/ws?device_id=d1&service_id=s1"
+            with self.assertRaises(OSError):
+                asyncio.new_event_loop().run_until_complete(
+                    fake_client_module.websockets.connect(conn_url)
+                )
+        self.assertEqual(attempts, ["9.9.9.9", "8.8.8.8"])
+
+    def test_install_is_idempotent(self):
+        """Double install must not double-wrap (the walk would then try each IP twice)."""
+        import plugins.platforms.feishu.adapter as adapter_mod
+
+        async def connect_impl(url, host):
+            return SimpleNamespace(peer=host)
+
+        fake_client_module, attempts = self._install_fake_lark_module(connect_impl)
+        adapter_mod._install_ws_ip_failover(fake_client_module)
+        once = fake_client_module.websockets.connect
+        adapter_mod._install_ws_ip_failover(fake_client_module)
+        self.assertIs(fake_client_module.websockets.connect, once)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`msg-frontier.feishu.cn` resolves to a ~12-IP pool in which roughly three are **black holes**: the TCP or TLS handshake hangs indefinitely with no RST. `websockets.connect()` walks the resolved addresses sequentially under a **single** `open_timeout`, so when the first address is a black hole the entire connect times out and the adapter cannot come up at all until DNS order rotates.

Observed in production (multi-profile gateway, CN network): adapters stuck in connect loops for minutes whenever the frontier DNS round-robin returned a bad IP first.

## Fix

Resolve the frontier hostname ourselves (`socket.getaddrinfo`), then try each **unique** IP with a short per-IP deadline (`_WS_CONNECT_PER_IP_TIMEOUT = 4.0`s, module constant), keeping the first TLS+WS handshake that completes. Wired into the existing `_connect_with_overrides` wrapper of `websockets.connect` that `_run_official_feishu_ws_client` already installs — no SDK method patching involved.

Upgrade path: replace with happy eyeballs (RFC 8305) if websockets grows native support; drop entirely if the DNS pool is cleaned up.

## Regression test

`test_ws_connect_ip_failover_skips_blackhole_ips` drives the patched connect through the module-global loop with the first resolved IP hanging forever and asserts the second IP completes the handshake (attempts: black hole first, working IP second).

## Scope

Split out of #64247 per review (@Seekers2001) — solves a different problem than the event-loop isolation patch (#89928) and was making the root-cause fix harder to review. Independent of #89928: this PR applies cleanly on plain `main` without the loop-proxy work.