### PR TITLE
feat(memory): near-full memory stores now trigger an early consolidation review (port omo #7006/#7008)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1778,6 +1778,12 @@ def init_agent(
             agent._memory_enabled = mem_config.get("memory_enabled", False)
             agent._user_profile_enabled = mem_config.get("user_profile_enabled", False)
             agent._memory_nudge_interval = int(mem_config.get("nudge_interval", 10))
+            try:
+                agent._memory_pressure_review_ratio = float(
+                    mem_config.get("pressure_review_ratio", 0.9)
+                )
+            except (TypeError, ValueError):
+                agent._memory_pressure_review_ratio = 0.9
             if agent._memory_enabled or agent._user_profile_enabled:
                 from tools.memory_tool import MemoryStore
                 agent._memory_store = MemoryStore(

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -1358,6 +1358,23 @@ def spawn_background_review_thread(
             f"{focus}"
         )
 
+    # Memory-pressure steering: when the trigger that fired this review was a
+    # near-full memory store (turn_context sets ``_memory_pressure_focus``),
+    # tell the fork up front so it prioritizes consolidation over new saves.
+    # Consumed once — cleared here so a later interval-triggered review does
+    # not repeat a stale pressure line.
+    pressure_focus = getattr(agent, "_memory_pressure_focus", None)
+    if review_memory and isinstance(pressure_focus, str) and pressure_focus.strip():
+        agent._memory_pressure_focus = None
+        prompt = (
+            f"{prompt}\n\n"
+            f"MEMORY PRESSURE: {pressure_focus}. This review fired early "
+            f"because the store is nearly full. Prioritize consolidating "
+            f"existing entries — merge overlapping facts, drop stale or "
+            f"superseded ones — over adding new content. Free enough room "
+            f"that the next save does not hit the hard cap."
+        )
+
     def _target() -> None:
         _run_review_in_thread(agent, messages_snapshot, prompt, task_cfg)
 

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -710,6 +710,40 @@ def build_turn_context(
             should_review_memory = True
             agent._turns_since_memory = 0
 
+    # Memory-pressure trigger: when a memory store is nearly full, fire the
+    # review early instead of waiting out the turn interval, and steer the
+    # fork toward consolidation. Ported from code-yeongyu/oh-my-openagent's
+    # memory-pressure surfacing (omo-senpi #7006/#7008), adapted to Hermes'
+    # background-review architecture: omo injects a pressure line into the
+    # per-run system prompt, which Hermes cannot do (prefix-cache integrity),
+    # so the pressure signal routes to the post-turn review fork instead —
+    # the main conversation's context is never touched. Edge-triggered: one
+    # review per threshold crossing, re-armed only after pressure clears.
+    if (not should_review_memory
+            and agent._memory_nudge_interval > 0
+            and "memory" in agent.valid_tool_names
+            and agent._memory_store):
+        try:
+            ratio = getattr(agent, "_memory_pressure_review_ratio", 0.9)
+            pressure = (
+                agent._memory_store.pressure_report(ratio) if ratio > 0 else []
+            )
+            if pressure:
+                if not getattr(agent, "_memory_pressure_review_fired", False):
+                    agent._memory_pressure_review_fired = True
+                    should_review_memory = True
+                    agent._turns_since_memory = 0
+                    agent._memory_pressure_focus = "; ".join(
+                        f"{p['target'].upper()} store at {p['pct']}% "
+                        f"({p['current']:,}/{p['limit']:,} chars)"
+                        for p in pressure
+                    )
+            else:
+                # Pressure cleared (consolidation or pruning) — re-arm.
+                agent._memory_pressure_review_fired = False
+        except Exception:
+            pass  # Pressure check is best-effort; never block the turn.
+
     # Cosmetic side-signal: detect an affection "reaction" (ily / <3 / good bot)
     # and notify the host so it can play hearts. Token-free, never touches the
     # conversation, and never fatal — a purely optional UI beat.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1811,6 +1811,13 @@ DEFAULT_CONFIG = {
         "write_approval": False,
         "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
         "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
+        # Fire the background memory review EARLY when a store reaches this
+        # fill ratio (0.9 = 90%), steering the fork toward consolidation so
+        # writes never slam into the hard cap. 0 disables the pressure
+        # trigger (interval-based review still runs). Ported from
+        # code-yeongyu/oh-my-openagent's memory-pressure surfacing, adapted
+        # to the background-review fork (prefix-cache safe).
+        "pressure_review_ratio": 0.9,
         # External memory provider plugin (empty = built-in only).
         # Set to a provider name to activate: "openviking", "mem0",
         # "hindsight", "holographic", "retaindb", "byterover".

--- a/tests/agent/test_memory_pressure_review.py
+++ b/tests/agent/test_memory_pressure_review.py
@@ -1,0 +1,134 @@
+"""Memory-pressure early background review.
+
+Port of code-yeongyu/oh-my-openagent's memory-pressure surfacing
+(omo-senpi PRs #7006/#7008), adapted to Hermes' background-review fork:
+when a memory store crosses the pressure threshold, the post-turn review
+fires early with a consolidation-steering prompt instead of waiting out
+the turn interval. The main conversation's system prompt is never touched
+(prefix-cache invariant).
+"""
+
+from unittest.mock import MagicMock
+
+from agent.background_review import (
+    _MEMORY_REVIEW_PROMPT,
+    spawn_background_review_thread,
+)
+from tools.memory_tool import MemoryStore
+
+
+def _bare_agent():
+    agent = MagicMock()
+    del agent._COMBINED_REVIEW_PROMPT
+    del agent._MEMORY_REVIEW_PROMPT
+    del agent._SKILL_REVIEW_PROMPT
+    return agent
+
+
+class TestPressureReport:
+    def test_empty_store_reports_no_pressure(self):
+        store = MemoryStore(memory_char_limit=100, user_char_limit=100)
+        assert store.pressure_report(0.9) == []
+
+    def test_store_below_threshold_reports_nothing(self):
+        store = MemoryStore(memory_char_limit=100, user_char_limit=100)
+        store.memory_entries = ["x" * 50]
+        assert store.pressure_report(0.9) == []
+
+    def test_store_at_threshold_reports_pressure(self):
+        store = MemoryStore(memory_char_limit=100, user_char_limit=100)
+        store.memory_entries = ["x" * 95]
+        report = store.pressure_report(0.9)
+        assert len(report) == 1
+        assert report[0]["target"] == "memory"
+        assert report[0]["pct"] == 95
+        assert report[0]["current"] == 95
+        assert report[0]["limit"] == 100
+
+    def test_both_stores_reported_most_full_first(self):
+        store = MemoryStore(memory_char_limit=100, user_char_limit=100)
+        store.memory_entries = ["x" * 91]
+        store.user_entries = ["y" * 99]
+        report = store.pressure_report(0.9)
+        assert [r["target"] for r in report] == ["user", "memory"]
+
+    def test_zero_limit_never_pressures(self):
+        store = MemoryStore(memory_char_limit=0, user_char_limit=0)
+        store.memory_entries = ["anything"]
+        assert store.usage_ratio("memory") == 0.0
+        assert store.pressure_report(0.9) == []
+
+    def test_usage_ratio_reads_live_entries(self):
+        store = MemoryStore(memory_char_limit=100, user_char_limit=100)
+        assert store.usage_ratio("memory") == 0.0
+        store.memory_entries = ["x" * 80]
+        assert store.usage_ratio("memory") == 0.8
+
+
+class TestPressurePromptSteering:
+    def test_pressure_focus_appended_and_consumed(self):
+        agent = _bare_agent()
+        agent._memory_pressure_focus = "MEMORY store at 95% (95/100 chars)"
+        _target, prompt = spawn_background_review_thread(
+            agent, [], review_memory=True, review_skills=False
+        )
+        assert prompt.startswith(_MEMORY_REVIEW_PROMPT)
+        assert "MEMORY PRESSURE:" in prompt
+        assert "95%" in prompt
+        assert "consolidating" in prompt
+        # Consumed once — cleared for the next (interval) review.
+        assert agent._memory_pressure_focus is None
+
+    def test_no_pressure_line_without_flag(self):
+        agent = _bare_agent()
+        agent._memory_pressure_focus = None
+        _target, prompt = spawn_background_review_thread(
+            agent, [], review_memory=True, review_skills=False
+        )
+        assert prompt == _MEMORY_REVIEW_PROMPT
+
+    def test_skill_only_review_ignores_pressure_focus(self):
+        agent = _bare_agent()
+        agent._memory_pressure_focus = "MEMORY store at 95% (95/100 chars)"
+        _target, prompt = spawn_background_review_thread(
+            agent, [], review_memory=False, review_skills=True
+        )
+        assert "MEMORY PRESSURE:" not in prompt
+
+    def test_non_string_pressure_focus_ignored(self):
+        # MagicMock attribute leakage or other junk must never inject.
+        agent = _bare_agent()
+        agent._memory_pressure_focus = object()
+        _target, prompt = spawn_background_review_thread(
+            agent, [], review_memory=True, review_skills=False
+        )
+        assert prompt == _MEMORY_REVIEW_PROMPT
+
+
+class TestTurnContextPressureTrigger:
+    """Exercise the edge-trigger logic in turn_context via a minimal stand-in.
+
+    The real seam is inline in build_turn_context; replicating its exact
+    guard here would be a change-detector. Instead we verify the two
+    contract pieces it composes: pressure_report threshold behavior (above)
+    and the fired/re-arm latch semantics on a real MemoryStore.
+    """
+
+    def test_edge_trigger_latch_semantics(self):
+        store = MemoryStore(memory_char_limit=100, user_char_limit=100)
+        store.memory_entries = ["x" * 95]
+
+        fired = False
+        # First crossing fires.
+        pressure = store.pressure_report(0.9)
+        assert pressure and not fired
+        fired = True
+        # While still under pressure, latch prevents refire.
+        assert store.pressure_report(0.9) and fired
+        # Consolidation clears pressure — latch re-arms.
+        store.memory_entries = ["x" * 40]
+        assert store.pressure_report(0.9) == []
+        fired = False
+        # A later re-crossing fires again.
+        store.memory_entries = ["x" * 96]
+        assert store.pressure_report(0.9) and not fired

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -387,6 +387,40 @@ class MemoryStore:
             return self.user_char_limit
         return self.memory_char_limit
 
+    def usage_ratio(self, target: str) -> float:
+        """Live fill ratio of one store (0.0-1.0+), from current entries.
+
+        Reads the LIVE entry lists (not the frozen system-prompt snapshot),
+        so mid-session writes are reflected. A zero/negative limit reads as
+        0.0 — an unbounded store can never signal pressure.
+        """
+        limit = self._char_limit(target)
+        if limit <= 0:
+            return 0.0
+        return self._char_count(target) / limit
+
+    def pressure_report(self, threshold: float) -> List[Dict[str, Any]]:
+        """Stores at or above ``threshold`` fill ratio, most-full first.
+
+        Returns ``[{"target", "pct", "current", "limit"}, ...]`` — empty when
+        nothing is under pressure. Used by the turn-start pressure trigger
+        (ported from code-yeongyu/oh-my-openagent's memory-pressure line,
+        adapted to fire the background review instead of mutating the
+        system prompt, which would break prefix caching).
+        """
+        report: List[Dict[str, Any]] = []
+        for target in ("memory", "user"):
+            ratio = self.usage_ratio(target)
+            if ratio >= threshold:
+                report.append({
+                    "target": target,
+                    "pct": min(100, int(ratio * 100)),
+                    "current": self._char_count(target),
+                    "limit": self._char_limit(target),
+                })
+        report.sort(key=lambda r: r["pct"], reverse=True)
+        return report
+
     def add(self, target: str, content: str) -> Dict[str, Any]:
         """Append a new entry. Returns error if it would exceed the char limit."""
         content = content.strip()

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -679,6 +679,7 @@ memory:
   memory_char_limit: 2200   # ~800 tokens
   user_char_limit: 1375     # ~500 tokens
   write_approval: false     # true = require approval before any memory write
+  pressure_review_ratio: 0.9  # early consolidation review when a store hits 90% (0 = off)
 ```
 
 With `memory.write_approval: true`, memory writes need your approval before they land: interactive CLI turns prompt inline; messaging sessions and the background self-improvement review stage the write for `/memory pending` → `/memory approve <id>` / `/memory reject <id>` review. Toggle at runtime with `/memory approval on|off`. See [Controlling memory writes](/user-guide/features/memory#controlling-memory-writes-write_approval).

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -238,7 +238,25 @@ memory:
   memory_char_limit: 2200   # ~800 tokens
   user_char_limit: 1375     # ~500 tokens
   write_approval: false     # false = write freely (default) | true = require approval
+  pressure_review_ratio: 0.9  # fire an early consolidation review at 90% full (0 = off)
 ```
+
+### Memory pressure (`pressure_review_ratio`)
+
+Both stores are hard-capped, and a store that silently fills up eventually
+rejects writes until the model consolidates mid-turn. To get ahead of that,
+Hermes checks fill level at the start of each turn: when either store crosses
+`pressure_review_ratio` (default `0.9`, i.e. 90% of its char limit), the
+post-turn background review fires **early** — without waiting out the
+`nudge_interval` — and its prompt is steered toward consolidation (merge
+overlapping facts, drop stale ones) instead of new saves.
+
+The trigger is edge-based: it fires once per threshold crossing and re-arms
+only after consolidation brings the store back under the ratio, so a
+persistently full store doesn't spawn a review every turn. Set
+`pressure_review_ratio: 0` to disable the pressure trigger; the interval-based
+review is unaffected. The pressure signal only ever reaches the background
+fork — the main conversation's system prompt is never modified mid-session.
 
 ## Controlling memory writes (`write_approval`)
 


### PR DESCRIPTION
## Summary

Memory stores that hit 90% full now trigger an early background consolidation review, so writes stop slamming into the hard cap mid-turn. Port of code-yeongyu/oh-my-openagent's memory-pressure surfacing (omo-senpi [#7006](https://github.com/code-yeongyu/oh-my-openagent/pull/7006) + [#7008](https://github.com/code-yeongyu/oh-my-openagent/pull/7008)), adapted to Hermes' background-review architecture.

Today the built-in memory review fires only every `memory.nudge_interval` user turns (default 10). A store can fill to the cap between reviews; the model then discovers the wall mid-turn when an `add` fails, and burns tool iterations on emergency consolidation (the #42405 failure-loop class this codebase already guards against downstream). This PR moves the signal upstream: detect pressure at turn start, consolidate in the background before the wall is hit.

## Ours vs theirs

| | oh-my-openagent | this port |
|---|---|---|
| Signal | injects a "memory pressure: N%" line into the per-run system prompt | routes pressure to the post-turn background review fork |
| Why different | omo rebuilds prompts per run | Hermes' system prompt is byte-stable per session (prefix-cache invariant) — mid-session prompt mutation is banned |
| Response | agent nudged to consolidate in the live conversation | review fork gets a `MEMORY PRESSURE` steering block: consolidate, don't add |
| Trigger cadence | every run while under pressure | edge-triggered latch: one review per crossing, re-arms only after pressure clears |

## Changes

- `tools/memory_tool.py`: `MemoryStore.usage_ratio()` + `pressure_report(threshold)` — live fill levels for both stores, most-full first; zero/negative limits never pressure.
- `agent/turn_context.py`: turn-start pressure check beside the existing nudge counter. Crossing the threshold sets `should_review_memory` early (interval counter reset, so no double review), records a human-readable focus string, and latches until pressure clears. Wrapped in try/except — never blocks a turn.
- `agent/background_review.py`: when the fired review carries a pressure focus, the review prompt gains a `MEMORY PRESSURE:` block steering the fork toward consolidation (merge/drop) over new saves. Consumed once; type-checked so mock/junk attributes can't inject.
- `agent/agent_init.py` + `hermes_cli/config_defaults.py`: `memory.pressure_review_ratio` (default `0.9`, `0` disables). No `_config_version` bump needed — deep-merge supplies the default to existing installs.
- Docs: `memory.md` (new "Memory pressure" section) + `configuration.md` key.

Both spawn sites (default conversation loop via `turn_finalizer`, codex app-server runtime) consume the same `should_review_memory` computed in `turn_context`, so the trigger covers both runtimes with one change.

## Cache safety

The pressure path only ever touches the background fork's prompt (a separate AIAgent). The main conversation's system prompt, message history, and toolset are untouched — checked against the prompt-cache invariants in AGENTS.md.

## Validation

| | Result |
|---|---|
| `tests/agent/test_memory_pressure_review.py` (new, 11 tests) | pass |
| `tests/agent/test_refine_focus.py` + `test_background_review_usage.py` + `test_turn_context.py` | 32 pass |
| `tests/tools/test_memory_tool.py` | pass (55 total across the memory set) |
| `py_compile` all touched files | clean |

## Related open PRs

#83766 / #60909 add a 90% warning **inside the memory tool's success response** (visible to the model mid-turn). Complementary, not duplicate: that half warns the model when it happens to write; this half acts even when the model isn't writing, and does the consolidation off-turn where it doesn't compete with the user's task.

## Infographic

_(degraded: FAL image generation unavailable this run — account balance exhausted; can be added on request)_
