### PR TITLE
fix(image_gen): Grok Imagine 2.0 upscale default no longer breaks main CI (opt-in policy)

### DIFF
--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -685,7 +685,10 @@ FAL_MODELS: Dict[str, Dict[str, Any]] = {
             "prompt", "aspect_ratio", "num_images", "output_format",
             "resolution", "quality", "sync_mode",
         },
-        "upscale": True,   # 1k native is sub-2MP
+        # Opt-in only (policy: default-on upscaling was disabled everywhere
+        # Aug 2026; the upscaler is a creative enhancer that can alter fine
+        # detail). 1k native is sub-2MP — pass upscale=true when needed.
+        "upscale": False,
         # Edit endpoint takes `image_urls` (max 3) + the same knobs;
         # aspect_ratio defaults to "auto" (follows the first input image),
         # so we don't send it on edits.


### PR DESCRIPTION
## Summary
Main's test suite is red: `test_upscale_defaults_are_all_off` fails on every PR because the Grok Imagine Image 2.0 catalog entry (ceabb030f) shipped with `upscale: True`, violating the Aug 2026 opt-in-only upscaling policy (f06c41522). This flips it to `False` with a policy comment.

## Changes
- `tools/image_generation_tool.py`: Grok Imagine 2.0 `upscale` default True → False (opt-in only)

## Validation
| | Before | After |
|---|---|---|
| `tests/tools/test_image_generation.py` | 1 failed (upscale default) | 51 passed |
| Every PR's CI slice 12/12 | red via main | unblocked |

## Infographic

_Infographic generation unavailable this run (FAL balance exhausted). Will attach on regeneration._
