### PR TITLE
Main is green again: FAL Grok 2.0 upscale flag follows the opt-in policy

### DIFF
--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -685,7 +685,7 @@ FAL_MODELS: Dict[str, Dict[str, Any]] = {
             "prompt", "aspect_ratio", "num_images", "output_format",
             "resolution", "quality", "sync_mode",
         },
-        "upscale": True,   # 1k native is sub-2MP
+        "upscale": False,  # opt-in only (Aug 2026 policy); 1k native is sub-2MP
         # Edit endpoint takes `image_urls` (max 3) + the same knobs;
         # aspect_ratio defaults to "auto" (follows the first input image),
         # so we don't send it on edits.


### PR DESCRIPTION
## Summary
Fixes the main-branch red introduced by #87465: its `grok-imagine-image-2.0` FAL catalog entry set `upscale: True`, violating the Aug 2026 opt-in-only upscale policy (f06c41522). The entry was authored before the policy landed and its stale-base CI never exercised the policy test.

## Changes
- `tools/image_generation_tool.py`: `upscale: False` on the FAL Grok 2.0 entry

## Validation
| | Before | After |
|---|---|---|
| `TestFalCatalog::test_upscale_defaults_are_all_off` | FAILED on main | 5/5 pass |

## Infographic

![one-line policy fix](https://files.catbox.moe/w8w0o1.jpg)
