### PR TITLE
feat(delegation): subagents can be spawned with their own reasoning level (port prime-agent#1510, salvage #81921)

### DIFF
--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -53,6 +53,7 @@ class SubagentLaunchRequest:
     context: Optional[str] = None
     role: str = "leaf"
     model: Optional[str] = None
+    reasoning_effort: Optional[str] = None
     allowed_toolsets: Optional[tuple[str, ...]] = None
     blocked_tools: tuple[str, ...] = ()
     working_directory: Optional[str] = None
@@ -74,6 +75,7 @@ class SubagentHandle:
     role: str
     depth: int
     capability: str
+    reasoning_effort: Optional[str] = None
 
     def to_dict(self) -> dict[str, Any]:
         return dataclasses.asdict(self)
@@ -230,6 +232,7 @@ class SubagentLifecycleService:
             if request.allowed_toolsets
             else None,
             model=request.model,
+            override_reasoning_effort=request.reasoning_effort,
             max_iterations=DEFAULT_MAX_ITERATIONS,
             task_count=1,
             parent_agent=parent,
@@ -250,6 +253,7 @@ class SubagentLifecycleService:
             getattr(child, "_delegate_role", request.role),
             int(getattr(child, "_delegate_depth", 1) or 1),
             self._capability(subagent_id, parent_session_id, created),
+            self._reasoning_effort(child),
         )
         record = _Record(handle, SubagentState.PENDING, created, agent=child)
         with _REGISTRY.lock:
@@ -367,6 +371,10 @@ class SubagentLifecycleService:
             or not math.isfinite(handle.created_at)
             or (handle.provider is not None and not isinstance(handle.provider, str))
             or (handle.model is not None and not isinstance(handle.model, str))
+            or (
+                handle.reasoning_effort is not None
+                and handle.reasoning_effort not in {"low", "medium", "high"}
+            )
             or not isinstance(handle.role, str)
             or type(handle.depth) is not int
             or not isinstance(handle.capability, str)
@@ -385,6 +393,14 @@ class SubagentLifecycleService:
             return None
         with _REGISTRY.lock:
             return _REGISTRY.records.get(handle.subagent_id)
+
+    @staticmethod
+    def _reasoning_effort(child: Any) -> Optional[str]:
+        config = getattr(child, "reasoning_config", None)
+        if not isinstance(config, Mapping) or not config.get("enabled"):
+            return None
+        effort = config.get("effort")
+        return str(effort) if effort in {"low", "medium", "high"} else None
 
     @staticmethod
     def _cleanup_locked() -> None:
@@ -503,6 +519,14 @@ class SubagentLifecycleService:
             )
         if request.role not in {"leaf", "orchestrator"}:
             raise SubagentLifecycleError("role must be 'leaf' or 'orchestrator'.")
+        if request.reasoning_effort is not None and request.reasoning_effort not in {
+            "low",
+            "medium",
+            "high",
+        }:
+            raise SubagentLifecycleError(
+                "reasoning_effort must be 'low', 'medium', or 'high'."
+            )
         if request.timeout_seconds is not None:
             raise SubagentLifecycleError(
                 "Per-launch timeout is not supported; configure delegation timeout explicitly."

--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -22,6 +22,7 @@ from concurrent.futures import Future, TimeoutError
 from typing import Any, Callable, Mapping, Optional
 
 from agent.interrupt_compat import request_hard_interrupt
+from hermes_constants import VALID_REASONING_EFFORTS
 
 PUBLIC_CONTRACT_VERSION = 1
 _MAX_GOAL_CHARS = 16_000
@@ -29,6 +30,11 @@ _MAX_CONTEXT_CHARS = 32_000
 _MAX_METADATA_BYTES = 8_192
 _MAX_RESULT_CHARS = 32_000
 _TERMINAL_RETENTION_SECONDS = 3_600
+
+# Effort levels a caller may pin on a child. "none" disables thinking for the
+# child outright (parse_reasoning_effort maps it to {"enabled": False}); the
+# rest are the same ladder the main agent accepts.
+_VALID_CHILD_EFFORTS = frozenset(VALID_REASONING_EFFORTS) | {"none"}
 
 
 class SubagentLifecycleError(ValueError):
@@ -373,7 +379,7 @@ class SubagentLifecycleService:
             or (handle.model is not None and not isinstance(handle.model, str))
             or (
                 handle.reasoning_effort is not None
-                and handle.reasoning_effort not in {"low", "medium", "high"}
+                and handle.reasoning_effort not in _VALID_CHILD_EFFORTS
             )
             or not isinstance(handle.role, str)
             or type(handle.depth) is not int
@@ -400,7 +406,7 @@ class SubagentLifecycleService:
         if not isinstance(config, Mapping) or not config.get("enabled"):
             return None
         effort = config.get("effort")
-        return str(effort) if effort in {"low", "medium", "high"} else None
+        return str(effort) if effort in _VALID_CHILD_EFFORTS else None
 
     @staticmethod
     def _cleanup_locked() -> None:
@@ -519,13 +525,14 @@ class SubagentLifecycleService:
             )
         if request.role not in {"leaf", "orchestrator"}:
             raise SubagentLifecycleError("role must be 'leaf' or 'orchestrator'.")
-        if request.reasoning_effort is not None and request.reasoning_effort not in {
-            "low",
-            "medium",
-            "high",
-        }:
+        if (
+            request.reasoning_effort is not None
+            and request.reasoning_effort not in _VALID_CHILD_EFFORTS
+        ):
             raise SubagentLifecycleError(
-                "reasoning_effort must be 'low', 'medium', or 'high'."
+                "reasoning_effort must be one of: "
+                + ", ".join(sorted(_VALID_CHILD_EFFORTS))
+                + "."
             )
         if request.timeout_seconds is not None:
             raise SubagentLifecycleError(

--- a/contributors/emails/daveinturkey15-byte@users.noreply.github.com
+++ b/contributors/emails/daveinturkey15-byte@users.noreply.github.com
@@ -1,0 +1,1 @@
+daveinturkey15-byte

--- a/run_agent.py
+++ b/run_agent.py
@@ -8243,6 +8243,7 @@ class AIAgent:
             action=function_args.get("action"),
             subagent_id=function_args.get("subagent_id"),
             message=function_args.get("message"),
+            reasoning_effort=function_args.get("reasoning_effort"),
             parent_agent=self,
         )
 

--- a/tests/agent/test_subagent_lifecycle.py
+++ b/tests/agent/test_subagent_lifecycle.py
@@ -17,12 +17,13 @@ from agent.subagent_lifecycle import (
 
 
 class FakeChild:
-    def __init__(self, ident="sa-test"):
+    def __init__(self, ident="sa-test", reasoning_config=None):
         self._subagent_id = ident
         self._delegate_role = "leaf"
         self._delegate_depth = 1
         self.provider = "test"
         self.model = "test-model"
+        self.reasoning_config = reasoning_config
         self.interrupted = False
         self.interrupt_kind = None
 
@@ -80,6 +81,44 @@ def test_cancel_is_cooperative_and_forged_handle_is_unknown(lifecycle):
     other_parent = SimpleNamespace(session_id="different-parent")
     other_service = SubagentLifecycleService(lambda: other_parent)
     assert other_service.status(handle).state is SubagentState.UNKNOWN
+
+
+def test_public_lifecycle_applies_and_attributes_exact_reasoning(monkeypatch):
+    parent = SimpleNamespace(session_id="parent-reasoning", enabled_toolsets=["file"])
+    captured = {}
+
+    def build(**kwargs):
+        captured.update(kwargs)
+        return FakeChild(
+            "sa-reasoning",
+            reasoning_config={
+                "enabled": True,
+                "effort": kwargs["override_reasoning_effort"],
+            },
+        )
+
+    monkeypatch.setattr("tools.delegate_tool._build_child_agent", build)
+    monkeypatch.setattr(
+        "tools.delegate_tool._run_single_child",
+        lambda *_args, **_kwargs: {
+            "status": "completed",
+            "summary": "ok",
+            "api_calls": 1,
+            "duration_seconds": 0.01,
+        },
+    )
+    service = SubagentLifecycleService(lambda: parent)
+    handle = service.launch(
+        SubagentLaunchRequest(goal="reason", reasoning_effort="high")
+    )
+    assert captured["override_reasoning_effort"] == "high"
+    assert handle.reasoning_effort == "high"
+    assert service.wait(handle, timeout_seconds=1).state is SubagentState.SUCCEEDED
+
+
+def test_public_lifecycle_rejects_unknown_reasoning(lifecycle):
+    with pytest.raises(SubagentLifecycleError, match="reasoning_effort"):
+        lifecycle.launch(SubagentLaunchRequest(goal="x", reasoning_effort="extreme"))
 
 
 def test_cancel_uses_explicit_hard_interrupt(lifecycle):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1343,6 +1343,29 @@ class TestDelegationReasoningEffort(unittest.TestCase):
         call_kwargs = MockAgent.call_args[1]
         self.assertEqual(call_kwargs["reasoning_config"], {"enabled": True, "effort": "low"})
 
+    @patch("tools.delegate_tool._load_config")
+    @patch("run_agent.AIAgent")
+    def test_public_lifecycle_override_beats_delegation_config(self, MockAgent, mock_cfg):
+        """An explicit public lifecycle effort is exact for this child only."""
+        mock_cfg.return_value = {"max_iterations": 50, "reasoning_effort": "low"}
+        MockAgent.return_value = MagicMock()
+        parent = _make_mock_parent()
+        parent.reasoning_config = {"enabled": True, "effort": "xhigh"}
+
+        _build_child_agent(
+            task_index=0,
+            goal="test",
+            context=None,
+            toolsets=None,
+            model=None,
+            max_iterations=50,
+            parent_agent=parent,
+            task_count=1,
+            override_reasoning_effort="high",
+        )
+        call_kwargs = MockAgent.call_args[1]
+        self.assertEqual(call_kwargs["reasoning_config"], {"enabled": True, "effort": "high"})
+
 # =========================================================================
 # Dispatch helper, progress events, concurrency
 # =========================================================================

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1366,6 +1366,56 @@ class TestDelegationReasoningEffort(unittest.TestCase):
         call_kwargs = MockAgent.call_args[1]
         self.assertEqual(call_kwargs["reasoning_config"], {"enabled": True, "effort": "high"})
 
+    @patch("tools.delegate_tool._load_config")
+    @patch("run_agent.AIAgent")
+    def test_override_none_disables_child_thinking(self, MockAgent, mock_cfg):
+        """override_reasoning_effort='none' disables thinking for the child."""
+        mock_cfg.return_value = {"max_iterations": 50, "reasoning_effort": ""}
+        MockAgent.return_value = MagicMock()
+        parent = _make_mock_parent()
+        parent.reasoning_config = {"enabled": True, "effort": "high"}
+
+        _build_child_agent(
+            task_index=0, goal="test", context=None, toolsets=None,
+            model=None, max_iterations=50, parent_agent=parent,
+            task_count=1, override_reasoning_effort="none",
+        )
+        call_kwargs = MockAgent.call_args[1]
+        self.assertEqual(call_kwargs["reasoning_config"], {"enabled": False})
+
+
+class TestChildReasoningEffortNormalization(unittest.TestCase):
+    """Model-facing reasoning_effort param normalization."""
+
+    def test_valid_levels_pass_through_lowercased(self):
+        from tools.delegate_tool import _normalize_child_reasoning_effort
+        self.assertEqual(_normalize_child_reasoning_effort("HIGH"), "high")
+        self.assertEqual(_normalize_child_reasoning_effort(" xhigh "), "xhigh")
+        self.assertEqual(_normalize_child_reasoning_effort("none"), "none")
+
+    def test_empty_and_none_inherit(self):
+        from tools.delegate_tool import _normalize_child_reasoning_effort
+        self.assertIsNone(_normalize_child_reasoning_effort(None))
+        self.assertIsNone(_normalize_child_reasoning_effort(""))
+        self.assertIsNone(_normalize_child_reasoning_effort("   "))
+
+    def test_unknown_degrades_to_inherit(self):
+        from tools.delegate_tool import _normalize_child_reasoning_effort
+        self.assertIsNone(_normalize_child_reasoning_effort("extreme"))
+        self.assertIsNone(_normalize_child_reasoning_effort("42"))
+
+    def test_schema_exposes_reasoning_effort(self):
+        from tools.delegate_tool import DELEGATE_TASK_SCHEMA
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        self.assertIn("reasoning_effort", props)
+        task_props = props["tasks"]["items"]["properties"]
+        self.assertIn("reasoning_effort", task_props)
+        # Enum stays in sync with the constants ladder (+ "none").
+        from hermes_constants import VALID_REASONING_EFFORTS
+        expected = set(VALID_REASONING_EFFORTS) | {"none"}
+        self.assertEqual(set(props["reasoning_effort"]["enum"]), expected)
+        self.assertEqual(set(task_props["reasoning_effort"]["enum"]), expected)
+
 # =========================================================================
 # Dispatch helper, progress events, concurrency
 # =========================================================================

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1591,6 +1591,9 @@ def _build_child_agent(
     override_api_mode: Optional[str] = None,
     override_request_overrides: Optional[Dict[str, Any]] = None,
     override_max_tokens: Optional[int] = None,
+    # Public lifecycle callers may request an exact per-child effort without
+    # changing global delegation config. None preserves existing inheritance.
+    override_reasoning_effort: Optional[str] = None,
     # ACP transport overrides from trusted delegation config.
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
@@ -1819,7 +1822,8 @@ def _build_child_agent(
         effective_provider = "copilot-acp"
         effective_api_mode = "chat_completions"
 
-    # Resolve reasoning config: delegation override > parent inherit
+    # Resolve reasoning config: explicit public-lifecycle override >
+    # delegation config > parent inherit.
     parent_reasoning = getattr(parent_agent, "reasoning_config", None)
     child_reasoning = parent_reasoning
     try:
@@ -1827,19 +1831,24 @@ def _build_child_agent(
         # False (``reasoning_effort: false``) to "" and inherit the parent
         # instead of disabling thinking for children.
         delegation_effort = delegation_cfg.get("reasoning_effort")
-        if delegation_effort or delegation_effort is False:
+        selected_effort = (
+            override_reasoning_effort
+            if override_reasoning_effort is not None
+            else delegation_effort
+        )
+        if selected_effort or selected_effort is False:
             from hermes_constants import parse_reasoning_effort
 
-            parsed = parse_reasoning_effort(delegation_effort)
+            parsed = parse_reasoning_effort(selected_effort)
             if parsed is not None:
                 child_reasoning = parsed
             else:
                 logger.warning(
-                    "Unknown delegation.reasoning_effort '%s', inheriting parent level",
-                    delegation_effort,
+                    "Unknown child reasoning effort '%s', inheriting parent level",
+                    selected_effort,
                 )
     except Exception as exc:
-        logger.debug("Could not load delegation reasoning_effort: %s", exc)
+        logger.debug("Could not load child reasoning effort: %s", exc)
 
     # Inherit the parent's fallback provider chain so subagents can recover
     # from rate-limits and credential exhaustion exactly like the top-level

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -843,6 +843,28 @@ def _normalize_role(r: Optional[str]) -> str:
     return "leaf"
 
 
+def _normalize_child_reasoning_effort(value: Optional[str]) -> Optional[str]:
+    """Normalise a caller-provided child reasoning level.
+
+    None/empty -> None (inherit). Valid levels (plus "none" = disable
+    thinking) pass through lowercased. Unknown strings degrade to None with
+    a warning so a typo inherits instead of failing the spawn — matching
+    the silent-degrade pattern of _normalize_role and the existing
+    delegation.reasoning_effort config handling in _build_child_agent.
+    """
+    if value is None or not str(value).strip():
+        return None
+    from hermes_constants import VALID_REASONING_EFFORTS
+
+    norm = str(value).strip().lower()
+    if norm in VALID_REASONING_EFFORTS or norm in {"none", "false", "disabled"}:
+        return norm
+    logger.warning(
+        "Unknown delegate_task reasoning_effort=%r, inheriting parent level", value
+    )
+    return None
+
+
 def _get_max_concurrent_children() -> int:
     """Read delegation.max_concurrent_children from config, falling back to
     DELEGATION_MAX_CONCURRENT_CHILDREN env var, then the default (10).
@@ -3614,6 +3636,7 @@ def delegate_task(
     action: Optional[str] = None,
     subagent_id: Optional[str] = None,
     message: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -3634,6 +3657,10 @@ def delegate_task(
     'leaf' (default) cannot; 'orchestrator' retains the delegation
     toolset and can spawn its own workers, bounded by
     delegation.max_spawn_depth.  Per-task role beats the top-level one.
+
+    The optional 'reasoning_effort' pins the child's thinking level
+    ("none" disables it); omitted, children inherit the parent's level or
+    the delegation.reasoning_effort config. Per-task beats top-level.
 
     Returns JSON with results array, one entry per task.
     """
@@ -3664,6 +3691,8 @@ def delegate_task(
 
     # Normalise the top-level role once; per-task overrides re-normalise.
     top_role = _normalize_role(role)
+    # Same treatment for the optional child reasoning level (None = inherit).
+    top_reasoning_effort = _normalize_child_reasoning_effort(reasoning_effort)
 
     # Background (async) delegation now applies to BOTH single tasks and
     # batches. A batch is dispatched as ONE async unit: the whole fan-out runs
@@ -3838,6 +3867,12 @@ def delegate_task(
         # Per-task role beats top-level; normalise again so unknown
         # per-task values warn and degrade to leaf uniformly.
         effective_role = _normalize_role(t.get("role") or top_role)
+        # Per-task reasoning beats top-level; None inherits (parent level or
+        # delegation.reasoning_effort config, resolved in _build_child_agent).
+        effective_reasoning = (
+            _normalize_child_reasoning_effort(t.get("reasoning_effort"))
+            or top_reasoning_effort
+        )
         # T1-24: schema'd tasks get the contract appended to their context
         # so the child knows the expected output shape before it starts.
         _task_schema = task_schemas[i] if i < len(task_schemas) else None
@@ -3866,6 +3901,7 @@ def delegate_task(
                 override_max_tokens=creds.get("max_output_tokens"),
                 override_acp_command=creds.get("command"),
                 override_acp_args=creds.get("args"),
+                override_reasoning_effort=effective_reasoning,
                 role=effective_role,
             )
         except ValueError as exc:
@@ -4785,6 +4821,18 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "reasoning_effort": {
+                            "type": "string",
+                            "enum": [
+                                "none", "minimal", "low", "medium",
+                                "high", "xhigh", "max", "ultra",
+                            ],
+                            "description": (
+                                "Per-task reasoning override. See top-level "
+                                "'reasoning_effort' for semantics; beats the "
+                                "top-level value for this task."
+                            ),
+                        },
                         "output_schema": {
                             "type": "object",
                             "description": (
@@ -4810,6 +4858,24 @@ DELEGATE_TASK_SCHEMA = {
                 "type": "string",
                 "enum": ["leaf", "orchestrator"],
                 "description": "(rebuilt at get_definitions() time)",
+            },
+            "reasoning_effort": {
+                "type": "string",
+                "enum": [
+                    "none", "minimal", "low", "medium",
+                    "high", "xhigh", "max", "ultra",
+                ],
+                "description": (
+                    "Optional reasoning level for the child(ren). Omit to "
+                    "inherit the parent's level (or the "
+                    "delegation.reasoning_effort config, when set). Use a "
+                    "lower level ('low', 'minimal') for mechanical subtasks "
+                    "and a higher one ('high', 'xhigh') for analysis-heavy "
+                    "work; 'none' disables thinking for the child. Levels "
+                    "the child's model cannot honor degrade the same way "
+                    "the main agent's do. Per-task reasoning_effort beats "
+                    "this top-level value."
+                ),
             },
             "output_schema": {
                 "type": "object",
@@ -4927,6 +4993,7 @@ registry.register(
         action=args.get("action"),
         subagent_id=args.get("subagent_id"),
         message=args.get("message"),
+        reasoning_effort=args.get("reasoning_effort"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -360,6 +360,25 @@ delegate_task(
 
 **Cost warning:** With `max_spawn_depth: 3` and `max_concurrent_children: 3`, the tree can reach 3×3×3 = 27 concurrent leaf agents. Each extra level multiplies spend — raise `max_spawn_depth` intentionally.
 
+## Per-Spawn Reasoning Level
+
+Children inherit the parent's thinking level by default (or the `delegation.reasoning_effort` config when set). The spawning agent can pin a different level per spawn — cheap, shallow thinking for mechanical subtasks, deep thinking for analysis — without touching config:
+
+```python
+delegate_task(
+    tasks=[
+        {"goal": "Deep-review the locking design in store.py", "reasoning_effort": "xhigh"},
+        {"goal": "Rename the deprecated helpers across tests"},  # falls back to top-level
+    ],
+    reasoning_effort="low",  # top-level default for tasks that don't set their own
+)
+```
+
+- Valid levels: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, `ultra` — the same ladder as `agent.reasoning_effort`. `none` disables thinking for the child.
+- Per-task `reasoning_effort` beats the top-level parameter; both beat `delegation.reasoning_effort` config; omitted entirely, the child inherits the parent's level.
+- Unknown values degrade to inherit (with a warning log) instead of failing the spawn.
+- Plugins using the public subagent lifecycle API (`SubagentLaunchRequest`) can pass the same `reasoning_effort` field; invalid values there fail the launch loudly, and the resulting `SubagentHandle` reports the child's effective level.
+
 ## Lifetime and Durability
 
 :::warning Background completion durability is not durable execution


### PR DESCRIPTION
## Summary
The orchestrating agent can now pin each subagent's thinking level at spawn time — `delegate_task(reasoning_effort=...)` top-level and per-task — so mechanical subtasks run cheap (`low`/`none`) while analysis-heavy children think at `xhigh`, without touching config.

Port of PrimeIntellect-ai/prime-agent#1510 ("Let subagents be spawned with their own reasoning level"), built on top of open PR #81921 by @daveinturkey15-byte (cherry-picked, authorship preserved) which added the plugin-facing lifecycle plumbing (`SubagentLaunchRequest.reasoning_effort` → `_build_child_agent(override_reasoning_effort=...)`).

## Changes
- `tools/delegate_tool.py`: model-facing `reasoning_effort` param (top-level + per-task, per-task wins), `_normalize_child_reasoning_effort()` with warn-and-inherit degradation matching the `role` pattern, schema enums for both sites, registry handler wiring.
- `run_agent.py`: `_dispatch_delegate_task` forwards the new field (single dispatch site per the schema-field comment there).
- `agent/subagent_lifecycle.py` (hardened from the salvaged base): validation widened from `{low, medium, high}` to the full `VALID_REASONING_EFFORTS` ladder + `none`, sourced from `hermes_constants` instead of a hand-rolled set — the cherry-picked version rejected `minimal`/`xhigh`/`max`/`ultra` and couldn't disable child thinking.
- `website/docs/user-guide/features/delegation.md`: new "Per-Spawn Reasoning Level" section.

## Precedence
per-task `reasoning_effort` > top-level `reasoning_effort` > `delegation.reasoning_effort` config > inherit parent. Unknown values degrade to inherit with a warning (model-facing path); the public plugin lifecycle API keeps loud validation failures.

## Validation
| Check | Result |
|---|---|
| `tests/tools/test_delegate.py` | 75/75 pass |
| `tests/agent/test_subagent_lifecycle.py` | 6/6 pass |
| E2E (real `delegate_task` call, batch + single, mocked child build) | per-task `xhigh` wins, top-level `low` falls back, invalid `EXTREME` inherits |
| `py_compile` all touched files | clean |

## Infographic

_Infographic generation unavailable this run: FAL account balance exhausted (hard fail from the image backend). Can be regenerated and added once billing is topped up._

## Credit
- Base lifecycle plumbing: #81921 by @daveinturkey15-byte (cherry-picked with authorship preserved).
- Feature design reference: PrimeIntellect-ai/prime-agent#1510 by Sebastian Müller (MIT).

Opened by the weekly Prime Agent PR scout cron — awaiting Teknium's review; not merged.
