### PR TITLE
fix(image-gen): Grok Imagine 2.0 no longer defaults upscale on — unbreaks main CI

### DIFF
--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -685,7 +685,7 @@ FAL_MODELS: Dict[str, Dict[str, Any]] = {
             "prompt", "aspect_ratio", "num_images", "output_format",
             "resolution", "quality", "sync_mode",
         },
-        "upscale": True,   # 1k native is sub-2MP
+        "upscale": False,  # opt-in only (Aug 2026 policy); 1k native is sub-2MP
         # Edit endpoint takes `image_urls` (max 3) + the same knobs;
         # aspect_ratio defaults to "auto" (follows the first input image),
         # so we don't send it on edits.


### PR DESCRIPTION
## Summary
CI is green again on the image-generation suite: the new Grok Imagine Image 2.0 FAL catalog entry (ceabb030f) shipped with `"upscale": True`, tripping the policy-pinning test `test_upscale_defaults_are_all_off` on main and every open PR (e.g. #89931's slice 8/12 red).

Upscaling is opt-in per call only (Aug 2026 policy, f06c41522): the Clarity Upscaler chained by default degraded text/CJK/face fidelity. Sub-2MP native output is not an exemption.

## Changes
- `tools/image_generation_tool.py`: `xai/grok-imagine-image/v2.0/text-to-image` → `"upscale": False`.

## Validation
- Before: `tests/tools/test_image_generation.py` 1 failed on clean main. After: 51 passed.

## Infographic

Infographic generation is DEGRADED this run: FAL account balance exhausted (`User is locked. Exhausted balance`). Will attach on regeneration once the key is topped up.
