### PR TITLE
feat(state): add dormant r0 retry ledger pilot

### DIFF
--- a/agent/retry_ledger.py
+++ b/agent/retry_ledger.py
@@ -1,0 +1,654 @@
+"""R0-only, local SQLite retry-ledger pilot; deliberately has no production caller."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from typing import Any
+
+FINGERPRINT_VERSION = "efp/v1"
+AUTHORITY_MODES = frozenset(("R0", "R1"))
+STRATEGY_MODES = frozenset((
+    "same_strategy",
+    "fresh_context",
+    "different_strategy",
+    "human_escalated",
+))
+CHECK_TYPES = frozenset(("test", "lint", "type", "policy", "build", "custom"))
+RESULT_STATES = frozenset(("pass", "fail", "blocked", "skipped", "timeout"))
+DECISIONS = frozenset(("stop", "retry", "escalate"))
+ERROR_CLASSES = frozenset((
+    "none",
+    "validation_schema",
+    "policy_safety",
+    "auth_permission",
+    "scope_or_authority",
+    "rate_limit",
+    "transient_network",
+    "timeout",
+    "duplicate_fingerprint",
+))
+STOP_REASONS = frozenset((
+    "none",
+    "terminal_pass",
+    "validation_schema",
+    "policy_safety",
+    "auth_permission",
+    "scope_or_authority",
+    "rate_limit_retry_limit",
+    "transient_network_retry_limit",
+    "timeout_retry_limit",
+    "duplicate_second",
+    "duplicate_third_hard_stop",
+    "iteration_cap",
+    "wall_clock_cap",
+    "input_tokens_cap",
+    "output_tokens_cap",
+))
+REQUIRED_FIELDS = (
+    "run_id",
+    "session_id",
+    "repo",
+    "branch",
+    "head_sha",
+    "task_id",
+    "objective_id",
+    "authority_mode",
+    "loop_iteration",
+    "attempt_number",
+    "strategy_mode",
+    "check_name",
+    "check_type",
+    "result_state",
+    "error_class",
+    "error_fingerprint",
+    "decision",
+    "decision_reason",
+    "tool_calls_count",
+    "tokens_used_input",
+    "tokens_used_output",
+    "estimated_cost_usd",
+    "duration_ms",
+    "changed_paths",
+    "stop_reason",
+    "created_at",
+)
+
+_UUID = re.compile(r"\b[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}\b", re.I)
+_ISO_TIME = re.compile(
+    r"\b\d{4}-\d\d-\d\d(?:[ T]\d\d:\d\d(?::\d\d(?:\.\d+)?)?(?:Z|[+-]\d\d:?\d\d)?)?\b",
+    re.I,
+)
+_LINE = re.compile(r"(?::|\bline\s+)\d+\b", re.I)
+_DURATION = re.compile(
+    r"\b\d+(?:\.\d+)?\s*(?:ns|us|µs|ms|msec(?:ond)?s?|millisecond(?:s)?|sec(?:ond)?s?|mins?|minutes?|hours?|hrs?)\b",
+    re.I,
+)
+_REQUEST_ID = re.compile(
+    r"\b(?:request|req|trace|correlation)[_-]?id\s*[=:]\s*[^\s,;]+", re.I
+)
+_UNIX_ABS_PATH = re.compile(r"(?<![\w.])/(?:[^\s'\"<>|]+/)*[^\s'\"<>|:]+")
+_WINDOWS_ABS_PATH = re.compile(r"\b[A-Za-z]:\\(?:[^\s'\"<>|]+\\)*[^\s'\"<>|]+")
+_SPACE = re.compile(r"\s+")
+
+
+class RetryLedgerValidationError(ValueError):
+    """A supplied event is outside the deliberately closed R0 pilot contract."""
+
+
+@dataclass(frozen=True)
+class BudgetConfig:
+    max_iterations: int = 3
+    wall_clock_minutes: int = 20
+    max_input_tokens: int = 75_000
+    max_output_tokens: int = 12_000
+
+
+@dataclass(frozen=True)
+class RetryDecision:
+    decision: str
+    decision_reason: str
+    stop_reason: str
+
+
+def _safe_shape(value: Any) -> Any:
+    """Return a deterministic non-secret diagnostic shape suitable only for hashing."""
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return str(value).lower()
+    if isinstance(value, Mapping):
+        return {
+            str(key).lower(): _safe_shape(item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        }
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_safe_shape(item) for item in value]
+    text = str(value).lower().strip()
+    for pattern, replacement in (
+        (_REQUEST_ID, "request_id=<id>"),
+        (_UUID, "<uuid>"),
+        (_ISO_TIME, "<timestamp>"),
+        (_LINE, ":<line>"),
+        (_DURATION, "<duration>"),
+        (_WINDOWS_ABS_PATH, "<path>"),
+        (_UNIX_ABS_PATH, "<path>"),
+    ):
+        text = pattern.sub(replacement, text)
+    return _SPACE.sub(" ", text)
+
+
+def normalize_fp_v1(error: Mapping[str, Any]) -> str:
+    """Hash a normalized safe diagnostic shape, never persist or return raw diagnostics."""
+    if not isinstance(error, Mapping):
+        raise RetryLedgerValidationError("error shape must be a mapping")
+    safe = {
+        str(key).lower(): _safe_shape(value)
+        for key, value in sorted(error.items(), key=lambda pair: str(pair[0]))
+        if value is not None
+    }
+    blob = json.dumps(safe, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    digest = hashlib.sha256(blob.encode("utf-8")).hexdigest()
+    return f"{FINGERPRINT_VERSION}:{digest}"
+
+
+def decide_r0_retry(
+    ledger_state: Mapping[str, Any], budget: BudgetConfig, error_class: str
+) -> RetryDecision:
+    """Pure policy evaluated before another attempt; it does not inspect a database."""
+    if error_class not in ERROR_CLASSES - {"none"}:
+        raise RetryLedgerValidationError("error_class is not a closed retry enum")
+    if int(ledger_state.get("loop_iteration", 0)) >= budget.max_iterations:
+        return RetryDecision("stop", "budget_cap", "iteration_cap")
+    if int(ledger_state.get("elapsed_ms", 0)) >= budget.wall_clock_minutes * 60_000:
+        return RetryDecision("stop", "budget_cap", "wall_clock_cap")
+    if int(ledger_state.get("input_tokens", 0)) >= budget.max_input_tokens:
+        return RetryDecision("stop", "budget_cap", "input_tokens_cap")
+    if int(ledger_state.get("output_tokens", 0)) >= budget.max_output_tokens:
+        return RetryDecision("stop", "budget_cap", "output_tokens_cap")
+    if error_class in {
+        "validation_schema",
+        "policy_safety",
+        "auth_permission",
+        "scope_or_authority",
+    }:
+        return RetryDecision("stop", error_class, error_class)
+    seen = int(ledger_state.get("fingerprint_count", 0))
+    if seen >= 3:
+        return RetryDecision(
+            "stop", "duplicate_fingerprint", "duplicate_third_hard_stop"
+        )
+    if seen >= 2:
+        return RetryDecision("stop", "duplicate_fingerprint", "duplicate_second")
+    attempts = int(ledger_state.get("attempts_for_check", 0))
+    limit = {"rate_limit": 2, "transient_network": 2, "timeout": 1}.get(error_class)
+    if limit is None:
+        raise RetryLedgerValidationError(
+            "duplicate_fingerprint requires fingerprint_count"
+        )
+    if attempts >= limit:
+        return RetryDecision(
+            "stop", f"{error_class}_retry_limit", f"{error_class}_retry_limit"
+        )
+    return RetryDecision("retry", error_class, "none")
+
+
+def validate_retry_event(event: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate one write and turn only the allowed paths list into canonical JSON."""
+    unknown = set(event) - set(REQUIRED_FIELDS)
+    if unknown:
+        raise RetryLedgerValidationError("raw or unknown event fields are forbidden")
+    missing = [name for name in REQUIRED_FIELDS if name not in event]
+    if missing:
+        raise RetryLedgerValidationError(
+            "missing retry-ledger fields: " + ", ".join(missing)
+        )
+    row = dict(event)
+    enums = {
+        "authority_mode": AUTHORITY_MODES,
+        "strategy_mode": STRATEGY_MODES,
+        "check_type": CHECK_TYPES,
+        "result_state": RESULT_STATES,
+        "error_class": ERROR_CLASSES,
+        "decision": DECISIONS,
+        "stop_reason": STOP_REASONS,
+    }
+    for name, allowed in enums.items():
+        if row[name] not in allowed:
+            raise RetryLedgerValidationError(f"{name} is not a closed enum")
+    if row["authority_mode"] != "R0":
+        raise RetryLedgerValidationError("R0-only writer rejects non-R0 authority")
+    if not isinstance(row["error_fingerprint"], str) or not re.fullmatch(
+        r"efp/v1:[0-9a-f]{64}", row["error_fingerprint"]
+    ):
+        raise RetryLedgerValidationError(
+            "error_fingerprint must be an efp/v1 SHA-256 digest"
+        )
+    for name in ("loop_iteration", "attempt_number", "tool_calls_count", "duration_ms"):
+        if (
+            not isinstance(row[name], int)
+            or isinstance(row[name], bool)
+            or row[name] < (1 if name == "attempt_number" else 0)
+        ):
+            raise RetryLedgerValidationError(
+                f"{name} must be a valid non-negative integer"
+            )
+    for name in ("tokens_used_input", "tokens_used_output"):
+        if row[name] is not None and (
+            not isinstance(row[name], int)
+            or isinstance(row[name], bool)
+            or row[name] < 0
+        ):
+            raise RetryLedgerValidationError(
+                f"{name} must be null or a non-negative integer"
+            )
+    if row["estimated_cost_usd"] is not None and (
+        not isinstance(row["estimated_cost_usd"], (int, float))
+        or isinstance(row["estimated_cost_usd"], bool)
+        or row["estimated_cost_usd"] < 0
+    ):
+        raise RetryLedgerValidationError(
+            "estimated_cost_usd must be null or non-negative"
+        )
+    if not isinstance(row["changed_paths"], list) or any(
+        not isinstance(path, str) or not path for path in row["changed_paths"]
+    ):
+        raise RetryLedgerValidationError(
+            "changed_paths must be a list of non-empty paths"
+        )
+    if row["changed_paths"]:
+        raise RetryLedgerValidationError("R0 changed_paths must be empty")
+    row["changed_paths"] = json.dumps(
+        sorted(row["changed_paths"]), separators=(",", ":")
+    )
+    if row["decision"] == "retry" and row["stop_reason"] != "none":
+        raise RetryLedgerValidationError("retry decision cannot have a stop reason")
+    if row["decision"] == "escalate" and row["stop_reason"] != "none":
+        raise RetryLedgerValidationError("escalate decision cannot have a stop reason")
+    if row["decision"] == "stop" and row["stop_reason"] == "none":
+        raise RetryLedgerValidationError("stop decision requires a stop reason")
+    return row
+
+
+class RetryLedgerWriter:
+    def __init__(self, session_db_or_conn: Any) -> None:
+        self._conn = (
+            session_db_or_conn
+            if isinstance(session_db_or_conn, sqlite3.Connection)
+            else getattr(session_db_or_conn, "_conn", None)
+        )
+        if not isinstance(self._conn, sqlite3.Connection):
+            raise TypeError(
+                "RetryLedgerWriter requires an open SQLite connection or SessionDB"
+            )
+
+    def append(self, event: Mapping[str, Any]) -> int:
+        row = validate_retry_event(event)
+        prior = self._conn.execute(
+            "SELECT MAX(loop_iteration) FROM retry_ledger_events WHERE run_id = ?",
+            (row["run_id"],),
+        ).fetchone()[0]
+        if prior is not None and row["loop_iteration"] < prior:
+            raise RetryLedgerValidationError(
+                "loop_iteration must be monotonic within a run"
+            )
+        expected = self._conn.execute(
+            "SELECT COALESCE(MAX(attempt_number), 0) + 1 FROM retry_ledger_events WHERE run_id = ? AND check_name = ?",
+            (row["run_id"], row["check_name"]),
+        ).fetchone()[0]
+        if row["attempt_number"] != expected:
+            raise RetryLedgerValidationError(
+                "attempt_number must be contiguous by run/check"
+            )
+        cursor = self._conn.execute(
+            f"INSERT INTO retry_ledger_events ({', '.join(REQUIRED_FIELDS)}) VALUES ({', '.join('?' for _ in REQUIRED_FIELDS)})",
+            tuple(row[name] for name in REQUIRED_FIELDS),
+        )
+        self._conn.commit()
+        return int(cursor.lastrowid)
+
+
+def _event(
+    run_id: str,
+    check_name: str,
+    attempt: int,
+    iteration: int,
+    error_class: str,
+    fingerprint: str,
+    decision: RetryDecision,
+    *,
+    result: str = "fail",
+    input_tokens: int | None = 100,
+    output_tokens: int | None = 25,
+    duration_ms: int = 1000,
+) -> dict[str, Any]:
+    return {
+        "run_id": run_id,
+        "session_id": "synthetic-session",
+        "repo": "synthetic/local",
+        "branch": "pilot",
+        "head_sha": "0" * 40,
+        "task_id": "synthetic-task",
+        "objective_id": "synthetic-objective",
+        "authority_mode": "R0",
+        "loop_iteration": iteration,
+        "attempt_number": attempt,
+        "strategy_mode": "same_strategy",
+        "check_name": check_name,
+        "check_type": "test",
+        "result_state": result,
+        "error_class": error_class,
+        "error_fingerprint": fingerprint,
+        "decision": decision.decision,
+        "decision_reason": decision.decision_reason,
+        "tool_calls_count": 0,
+        "tokens_used_input": input_tokens,
+        "tokens_used_output": output_tokens,
+        "estimated_cost_usd": None,
+        "duration_ms": duration_ms,
+        "changed_paths": [],
+        "stop_reason": decision.stop_reason,
+        "created_at": float(attempt + iteration * 10),
+    }
+
+
+def _report_from_rows(conn: sqlite3.Connection) -> dict[str, Any]:
+    rows = [
+        dict(row)
+        for row in conn.execute("SELECT * FROM retry_ledger_events ORDER BY id")
+    ]
+    scenarios: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        paths = json.loads(row["changed_paths"])
+        if not isinstance(paths, list):
+            raise RetryLedgerValidationError(
+                "stored changed_paths did not deserialize to a list"
+            )
+        item = scenarios.setdefault(
+            row["check_name"],
+            {
+                "attempt_count": 0,
+                "consumed_input": 0,
+                "consumed_output": 0,
+                "consumed_duration_ms": 0,
+                "budget_state": asdict(BudgetConfig()),
+                "decision_path": [],
+                "terminal_stop_reason": "none",
+            },
+        )
+        item["attempt_count"] += 1
+        item["consumed_input"] += row["tokens_used_input"] or 0
+        item["consumed_output"] += row["tokens_used_output"] or 0
+        item["consumed_duration_ms"] += row["duration_ms"]
+        item["decision_path"].append({
+            "decision": row["decision"],
+            "decision_reason": row["decision_reason"],
+            "stop_reason": row["stop_reason"],
+        })
+        if row["stop_reason"] != "none":
+            item["terminal_stop_reason"] = row["stop_reason"]
+    return {"synthetic_only": True, "attempt_count": len(rows), "scenarios": scenarios}
+
+
+def run_synthetic_pilot() -> dict[str, Any]:
+    """Run local-memory E2E scenarios through SCHEMA_SQL and the real writer only."""
+    from hermes_state_common import SCHEMA_SQL
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.executescript(SCHEMA_SQL)
+    conn.execute(
+        "INSERT INTO sessions (id, source, started_at) VALUES ('synthetic-session', 'synthetic', 0)"
+    )
+    writer = RetryLedgerWriter(conn)
+    rate_fp = normalize_fp_v1({"kind": "rate", "request_id": "a", "path": "/tmp/a"})
+    rate_first = decide_r0_retry(
+        {"attempts_for_check": 0}, BudgetConfig(), "rate_limit"
+    )
+    writer.append(
+        _event(
+            "rate-run",
+            "rate_limit_retry_to_pass",
+            1,
+            0,
+            "rate_limit",
+            rate_fp,
+            rate_first,
+        )
+    )
+    writer.append(
+        _event(
+            "rate-run",
+            "rate_limit_retry_to_pass",
+            2,
+            1,
+            "none",
+            rate_fp,
+            RetryDecision("stop", "terminal_pass", "terminal_pass"),
+            result="pass",
+            input_tokens=None,
+            output_tokens=None,
+            duration_ms=250,
+        )
+    )
+    validation = decide_r0_retry({}, BudgetConfig(), "validation_schema")
+    writer.append(
+        _event(
+            "validation-run",
+            "validation_stop",
+            1,
+            0,
+            "validation_schema",
+            normalize_fp_v1({"kind": "validation"}),
+            validation,
+            result="blocked",
+        )
+    )
+    dup_fp = normalize_fp_v1({"kind": "duplicate", "line": "x.py:1"})
+    writer.append(
+        _event(
+            "duplicate-run",
+            "duplicate_stop",
+            1,
+            0,
+            "duplicate_fingerprint",
+            dup_fp,
+            RetryDecision("retry", "rate_limit", "none"),
+        )
+    )
+    duplicate = decide_r0_retry(
+        {"fingerprint_count": 2}, BudgetConfig(), "duplicate_fingerprint"
+    )
+    writer.append(
+        _event(
+            "duplicate-run",
+            "duplicate_stop",
+            2,
+            1,
+            "duplicate_fingerprint",
+            dup_fp,
+            duplicate,
+        )
+    )
+    budget = decide_r0_retry(
+        {"input_tokens": 75_000}, BudgetConfig(), "transient_network"
+    )
+    writer.append(
+        _event(
+            "budget-run",
+            "input_budget_stop",
+            1,
+            0,
+            "transient_network",
+            normalize_fp_v1({"kind": "budget"}),
+            budget,
+            result="blocked",
+            input_tokens=75_000,
+        )
+    )
+    report = _report_from_rows(conn)
+    verification = verify_retry_ledger_code(conn, report)
+    return {"report": report, "verifier": verification}
+
+
+def _schema_enum_values(schema: str, field: str) -> frozenset[str] | None:
+    match = re.search(
+        rf"{re.escape(field)}\s+TEXT\s+NOT\s+NULL\s+CHECK\s*\(\s*{re.escape(field)}\s+IN\s*\(([^)]*)\)\s*\)",
+        schema,
+        re.I | re.S,
+    )
+    if not match:
+        return None
+    return frozenset(re.findall(r"'([^']+)'", match.group(1)))
+
+
+def verify_retry_ledger_code(
+    conn: sqlite3.Connection, report: Mapping[str, Any] | None = None
+) -> dict[str, Any]:
+    """Verify the concrete pilot DB, including behavior that DDL text alone cannot prove."""
+    table_sql = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'retry_ledger_events'"
+    ).fetchone()
+    schema = table_sql[0] if table_sql else ""
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(retry_ledger_events)")}
+    indexes = {row[1] for row in conn.execute("PRAGMA index_list(retry_ledger_events)")}
+    expected_enums = {
+        "authority_mode": AUTHORITY_MODES,
+        "strategy_mode": STRATEGY_MODES,
+        "check_type": CHECK_TYPES,
+        "result_state": RESULT_STATES,
+        "decision": DECISIONS,
+        "error_class": ERROR_CLASSES,
+        "stop_reason": STOP_REASONS,
+    }
+    trigger_names = {
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'trigger' AND name LIKE 'retry_ledger_events_no_%'"
+        )
+    }
+    checks = {
+        "schema_exact_enums": all(
+            _schema_enum_values(schema, field) == expected
+            for field, expected in expected_enums.items()
+        ),
+        "required_columns": set(REQUIRED_FIELDS) <= columns,
+        "nullable_usage_fields": all(
+            not row[3]
+            for row in conn.execute("PRAGMA table_info(retry_ledger_events)")
+            if row[1]
+            in {"tokens_used_input", "tokens_used_output", "estimated_cost_usd"}
+        ),
+        "run_check_index": "idx_retry_ledger_events_run_check" in indexes,
+        "append_only_triggers": trigger_names
+        == {"retry_ledger_events_no_update", "retry_ledger_events_no_delete"},
+        "foreign_key_check": not conn.execute("PRAGMA foreign_key_check").fetchall(),
+        "invalid_fk_rejected": False,
+        "invalid_enum_rejected": False,
+        "append_only": False,
+        "sequence_invariants": True,
+        "record_completeness": True,
+        "decision_report_contract": report is not None,
+    }
+    row = conn.execute(
+        "SELECT * FROM retry_ledger_events ORDER BY id LIMIT 1"
+    ).fetchone()
+    if row is not None:
+        values = dict(row)
+        try:
+            conn.execute("SAVEPOINT retry_ledger_verify")
+            bad_fk = dict(values)
+            bad_fk["session_id"] = "missing-session"
+            bad_fk["attempt_number"] = 99
+            conn.execute(
+                f"INSERT INTO retry_ledger_events ({', '.join(REQUIRED_FIELDS)}) VALUES ({', '.join('?' for _ in REQUIRED_FIELDS)})",
+                tuple(bad_fk[name] for name in REQUIRED_FIELDS),
+            )
+        except sqlite3.IntegrityError:
+            checks["invalid_fk_rejected"] = True
+        finally:
+            conn.execute("ROLLBACK TO retry_ledger_verify")
+            conn.execute("RELEASE retry_ledger_verify")
+        try:
+            conn.execute("SAVEPOINT retry_ledger_enum")
+            bad_enum = dict(values)
+            bad_enum["run_id"] = "invalid-enum-run"
+            bad_enum["check_name"] = "invalid-enum-check"
+            bad_enum["decision"] = "invalid"
+            conn.execute(
+                f"INSERT INTO retry_ledger_events ({', '.join(REQUIRED_FIELDS)}) VALUES ({', '.join('?' for _ in REQUIRED_FIELDS)})",
+                tuple(bad_enum[name] for name in REQUIRED_FIELDS),
+            )
+        except sqlite3.IntegrityError:
+            checks["invalid_enum_rejected"] = True
+        finally:
+            conn.execute("ROLLBACK TO retry_ledger_enum")
+            conn.execute("RELEASE retry_ledger_enum")
+        try:
+            conn.execute(
+                "UPDATE retry_ledger_events SET decision = 'stop' WHERE id = ?",
+                (values["id"],),
+            )
+        except sqlite3.IntegrityError:
+            try:
+                conn.execute(
+                    "DELETE FROM retry_ledger_events WHERE id = ?", (values["id"],)
+                )
+            except sqlite3.IntegrityError:
+                checks["append_only"] = True
+        for stored in conn.execute("SELECT * FROM retry_ledger_events ORDER BY id"):
+            event = dict(stored)
+            event.pop("id", None)
+            paths = json.loads(event["changed_paths"])
+            if not isinstance(paths, list):
+                checks["record_completeness"] = False
+            event["changed_paths"] = paths
+            try:
+                validate_retry_event(event)
+            except RetryLedgerValidationError:
+                checks["record_completeness"] = False
+        prior_iterations: dict[str, int] = {}
+        for event_row in conn.execute(
+            "SELECT run_id, loop_iteration FROM retry_ledger_events ORDER BY id"
+        ):
+            run_id, iteration = event_row
+            if run_id in prior_iterations and iteration < prior_iterations[run_id]:
+                checks["sequence_invariants"] = False
+            prior_iterations[run_id] = iteration
+        for run_id, check_name, attempt, iteration in conn.execute(
+            "SELECT run_id, check_name, attempt_number, loop_iteration FROM retry_ledger_events ORDER BY run_id, check_name, attempt_number"
+        ):
+            if (
+                attempt
+                != conn.execute(
+                    "SELECT COUNT(*) FROM retry_ledger_events WHERE run_id = ? AND check_name = ? AND attempt_number <= ?",
+                    (run_id, check_name, attempt),
+                ).fetchone()[0]
+            ):
+                checks["sequence_invariants"] = False
+    if report is not None:
+        needed = {
+            "attempt_count",
+            "consumed_input",
+            "consumed_output",
+            "consumed_duration_ms",
+            "budget_state",
+            "decision_path",
+            "terminal_stop_reason",
+        }
+        checks["decision_report_contract"] = (
+            report.get("synthetic_only") is True
+            and bool(report.get("scenarios"))
+            and all(needed <= set(item) for item in report["scenarios"].values())
+        )
+    return {"ok": all(checks.values()), "checks": checks}
+
+
+# Compatibility name for an earlier isolated test surface; it now exercises real persistence.
+def synthetic_r0_harness() -> dict[str, Any]:
+    return run_synthetic_pilot()["report"]

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -202,8 +202,7 @@ def _sql_session_last_active_by_id(session_id_expr: str) -> str:
         f"WHERE _act_s.id = {session_id_expr})"
     )
     started = (
-        f"(SELECT started_at FROM sessions _act_s "
-        f"WHERE _act_s.id = {session_id_expr})"
+        f"(SELECT started_at FROM sessions _act_s WHERE _act_s.id = {session_id_expr})"
     )
     return (
         f"COALESCE("
@@ -216,7 +215,7 @@ def _sql_session_last_active_by_id(session_id_expr: str) -> str:
     )
 
 
-SCHEMA_VERSION = 26
+SCHEMA_VERSION = 27
 
 
 # FTS storage-layout version, tracked INDEPENDENTLY of SCHEMA_VERSION in the
@@ -417,6 +416,51 @@ CREATE TABLE IF NOT EXISTS async_delegations (
     delivery_claim TEXT,
     delivery_claimed_at REAL
 );
+
+CREATE TABLE IF NOT EXISTS retry_ledger_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id TEXT NOT NULL,
+    session_id TEXT NOT NULL REFERENCES sessions(id),
+    repo TEXT NOT NULL,
+    branch TEXT NOT NULL,
+    head_sha TEXT NOT NULL,
+    task_id TEXT NOT NULL,
+    objective_id TEXT NOT NULL,
+    authority_mode TEXT NOT NULL CHECK (authority_mode IN ('R0', 'R1')),
+    loop_iteration INTEGER NOT NULL CHECK (loop_iteration >= 0),
+    attempt_number INTEGER NOT NULL CHECK (attempt_number >= 1),
+    strategy_mode TEXT NOT NULL CHECK (strategy_mode IN ('same_strategy', 'fresh_context', 'different_strategy', 'human_escalated')),
+    check_name TEXT NOT NULL,
+    check_type TEXT NOT NULL CHECK (check_type IN ('test', 'lint', 'type', 'policy', 'build', 'custom')),
+    result_state TEXT NOT NULL CHECK (result_state IN ('pass', 'fail', 'blocked', 'skipped', 'timeout')),
+    error_class TEXT NOT NULL CHECK (error_class IN ('none', 'validation_schema', 'policy_safety', 'auth_permission', 'scope_or_authority', 'rate_limit', 'transient_network', 'timeout', 'duplicate_fingerprint')),
+    error_fingerprint TEXT NOT NULL CHECK (error_fingerprint GLOB 'efp/v1:[0-9a-f]*'),
+    decision TEXT NOT NULL CHECK (decision IN ('stop', 'retry', 'escalate')),
+    decision_reason TEXT NOT NULL,
+    tool_calls_count INTEGER NOT NULL CHECK (tool_calls_count >= 0),
+    tokens_used_input INTEGER CHECK (tokens_used_input IS NULL OR tokens_used_input >= 0),
+    tokens_used_output INTEGER CHECK (tokens_used_output IS NULL OR tokens_used_output >= 0),
+    estimated_cost_usd REAL CHECK (estimated_cost_usd IS NULL OR estimated_cost_usd >= 0),
+    duration_ms INTEGER NOT NULL CHECK (duration_ms >= 0),
+    changed_paths TEXT NOT NULL CHECK (json_valid(changed_paths) AND json_type(changed_paths) = 'array'),
+    stop_reason TEXT NOT NULL CHECK (stop_reason IN ('none', 'terminal_pass', 'validation_schema', 'policy_safety', 'auth_permission', 'scope_or_authority', 'rate_limit_retry_limit', 'transient_network_retry_limit', 'timeout_retry_limit', 'duplicate_second', 'duplicate_third_hard_stop', 'iteration_cap', 'wall_clock_cap', 'input_tokens_cap', 'output_tokens_cap')),
+    created_at REAL NOT NULL
+);
+
+CREATE TRIGGER IF NOT EXISTS retry_ledger_events_no_update
+BEFORE UPDATE ON retry_ledger_events
+BEGIN
+    SELECT RAISE(ABORT, 'retry_ledger_events is append-only');
+END;
+
+CREATE TRIGGER IF NOT EXISTS retry_ledger_events_no_delete
+BEFORE DELETE ON retry_ledger_events
+BEGIN
+    SELECT RAISE(ABORT, 'retry_ledger_events is append-only');
+END;
+
+CREATE INDEX IF NOT EXISTS idx_retry_ledger_events_run_check
+    ON retry_ledger_events(run_id, check_name, attempt_number, id);
 
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_sessions_source_id ON sessions(source, id);

--- a/tests/agent/test_retry_ledger.py
+++ b/tests/agent/test_retry_ledger.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+
+def _conn() -> sqlite3.Connection:
+    from hermes_state_common import SCHEMA_SQL
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.executescript(SCHEMA_SQL)
+    conn.execute(
+        "INSERT INTO sessions (id, source, started_at) VALUES ('s-1', 'test', 0)"
+    )
+    return conn
+
+
+def _event(**overrides):
+    from agent.retry_ledger import normalize_fp_v1
+
+    event = {
+        "run_id": "run-1",
+        "session_id": "s-1",
+        "repo": "local",
+        "branch": "main",
+        "head_sha": "a" * 40,
+        "task_id": "task",
+        "objective_id": "objective",
+        "authority_mode": "R0",
+        "loop_iteration": 0,
+        "attempt_number": 1,
+        "strategy_mode": "same_strategy",
+        "check_name": "unit",
+        "check_type": "test",
+        "result_state": "fail",
+        "error_class": "rate_limit",
+        "error_fingerprint": normalize_fp_v1({"kind": "rate"}),
+        "decision": "retry",
+        "decision_reason": "rate_limit",
+        "tool_calls_count": 0,
+        "tokens_used_input": None,
+        "tokens_used_output": None,
+        "estimated_cost_usd": None,
+        "duration_ms": 1,
+        "changed_paths": [],
+        "stop_reason": "none",
+        "created_at": 1.0,
+    }
+    event.update(overrides)
+    return event
+
+
+def test_schema_has_exact_v1_enums_nullable_usage_fk_and_index() -> None:
+    from agent.retry_ledger import verify_retry_ledger_code
+
+    conn = _conn()
+    schema = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='retry_ledger_events'"
+    ).fetchone()[0]
+    assert "'R0', 'R1'" in schema
+    assert (
+        "'same_strategy', 'fresh_context', 'different_strategy', 'human_escalated'"
+        in schema
+    )
+    assert "'test', 'lint', 'type', 'policy', 'build', 'custom'" in schema
+    assert "'pass', 'fail', 'blocked', 'skipped', 'timeout'" in schema
+    assert "'stop', 'retry', 'escalate'" in schema
+    nullable = {
+        row[1]: row[3] for row in conn.execute("PRAGMA table_info(retry_ledger_events)")
+    }
+    assert (
+        nullable["tokens_used_input"]
+        == nullable["tokens_used_output"]
+        == nullable["estimated_cost_usd"]
+        == 0
+    )
+    assert {
+        row[2] for row in conn.execute("PRAGMA foreign_key_list(retry_ledger_events)")
+    } == {"sessions"}
+    assert "idx_retry_ledger_events_run_check" in {
+        row[1] for row in conn.execute("PRAGMA index_list(retry_ledger_events)")
+    }
+    assert verify_retry_ledger_code(conn)["checks"]["schema_exact_enums"]
+
+
+def test_writer_r0_contract_nulls_canonical_paths_sequences_and_append_only() -> None:
+    from agent.retry_ledger import RetryLedgerValidationError, RetryLedgerWriter
+
+    conn = _conn()
+    writer = RetryLedgerWriter(conn)
+    writer.append(_event())
+    row = conn.execute(
+        "SELECT tokens_used_input, tokens_used_output, estimated_cost_usd, changed_paths FROM retry_ledger_events"
+    ).fetchone()
+    assert tuple(row[:3]) == (None, None, None)
+    assert json.loads(row[3]) == []
+    with pytest.raises(RetryLedgerValidationError, match="R0-only"):
+        writer.append(_event(run_id="r0", authority_mode="R1"))
+    with pytest.raises(RetryLedgerValidationError, match="raw or unknown"):
+        writer.append(_event(payload="diagnostic"))
+    with pytest.raises(RetryLedgerValidationError, match="empty"):
+        writer.append(_event(attempt_number=2, changed_paths=["x.py"]))
+    with pytest.raises(RetryLedgerValidationError, match="contiguous"):
+        writer.append(_event(attempt_number=3))
+    writer.append(_event(check_name="other", loop_iteration=1))
+    with pytest.raises(RetryLedgerValidationError, match="monotonic"):
+        writer.append(_event(check_name="third", loop_iteration=0))
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute("UPDATE retry_ledger_events SET decision='stop'")
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute("DELETE FROM retry_ledger_events")
+
+
+def test_fingerprint_normalizes_arbitrary_safe_values_without_raw_output() -> None:
+    from agent.retry_ledger import normalize_fp_v1
+
+    mac_root = chr(47) + "Users"
+    left = normalize_fp_v1({
+        "message": {
+            "value": f"Timeout {mac_root}/a/x.py:42 request_id=a after 12ms at 2026-01-01T00:00:00Z",
+            "uuid": "123e4567-e89b-12d3-a456-426614174000",
+        },
+        "code": 429,
+    })
+    right = normalize_fp_v1({
+        "code": "429",
+        "message": {
+            "uuid": "abcdefab-cdef-abcd-efab-cdefabcdefab",
+            "value": f"timeout {mac_root}/b/y.py:7 request_id=b after 999 milliseconds at 2027-01-01T00:00:00Z",
+        },
+    })
+    assert left == right
+    assert left.startswith("efp/v1:") and "timeout" not in left
+
+
+def test_decision_units_cover_all_caps_classes_and_duplicate_levels() -> None:
+    from agent.retry_ledger import BudgetConfig, decide_r0_retry
+
+    budget = BudgetConfig()
+    base = {
+        "loop_iteration": 0,
+        "elapsed_ms": 0,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "attempts_for_check": 0,
+    }
+    assert (
+        budget.max_iterations,
+        budget.wall_clock_minutes,
+        budget.max_input_tokens,
+        budget.max_output_tokens,
+    ) == (3, 20, 75_000, 12_000)
+    for error in (
+        "validation_schema",
+        "policy_safety",
+        "auth_permission",
+        "scope_or_authority",
+    ):
+        assert decide_r0_retry(base, budget, error).stop_reason == error
+    assert (
+        decide_r0_retry(
+            {**base, "attempts_for_check": 1}, budget, "transient_network"
+        ).decision
+        == "retry"
+    )
+    assert (
+        decide_r0_retry(
+            {**base, "attempts_for_check": 2}, budget, "rate_limit"
+        ).stop_reason
+        == "rate_limit_retry_limit"
+    )
+    assert (
+        decide_r0_retry(
+            {**base, "attempts_for_check": 1}, budget, "timeout"
+        ).stop_reason
+        == "timeout_retry_limit"
+    )
+    assert (
+        decide_r0_retry(
+            {**base, "fingerprint_count": 2}, budget, "duplicate_fingerprint"
+        ).stop_reason
+        == "duplicate_second"
+    )
+    assert (
+        decide_r0_retry(
+            {**base, "fingerprint_count": 3}, budget, "duplicate_fingerprint"
+        ).stop_reason
+        == "duplicate_third_hard_stop"
+    )
+    for state, reason in (
+        ({"loop_iteration": 3}, "iteration_cap"),
+        ({"elapsed_ms": 1_200_000}, "wall_clock_cap"),
+        ({"input_tokens": 75_000}, "input_tokens_cap"),
+        ({"output_tokens": 12_000}, "output_tokens_cap"),
+    ):
+        assert (
+            decide_r0_retry({**base, **state}, budget, "rate_limit").stop_reason
+            == reason
+        )
+
+
+def test_real_synthetic_pilot_derives_report_and_passes_full_verifier() -> None:
+    from agent.retry_ledger import run_synthetic_pilot
+
+    result = run_synthetic_pilot()
+    report, verifier = result["report"], result["verifier"]
+    assert report["attempt_count"] == 6
+    assert set(report["scenarios"]) == {
+        "rate_limit_retry_to_pass",
+        "validation_stop",
+        "duplicate_stop",
+        "input_budget_stop",
+    }
+    assert (
+        report["scenarios"]["rate_limit_retry_to_pass"]["terminal_stop_reason"]
+        == "terminal_pass"
+    )
+    assert (
+        report["scenarios"]["validation_stop"]["terminal_stop_reason"]
+        == "validation_schema"
+    )
+    assert (
+        report["scenarios"]["duplicate_stop"]["terminal_stop_reason"]
+        == "duplicate_second"
+    )
+    assert (
+        report["scenarios"]["input_budget_stop"]["terminal_stop_reason"]
+        == "input_tokens_cap"
+    )
+    assert verifier["ok"] is True
+    assert all(verifier["checks"].values())


### PR DESCRIPTION
## Scope
- Adds a dormant SessionDB retry-ledger schema and local-only R0 synthetic pilot primitives.
- Adds focused tests for schema constraints, writer invariants, fingerprint normalization, budgets, decision policy, and synthetic reporting.

## R0 safety boundary
- No caller is wired into run_agent, CLI, cron, scheduler, tools, GitHub, or external systems.
- No automatic retry, repository operation, CI action, merge, deployment, telemetry export, or runtime activation is introduced.
- The synthetic pilot uses in-memory SQLite only.

## Validation
- Playbook source bound: blob 82a8176af85378cc30c6a072942775a780d8f3e4.
- Independent local verifier context passed the schema, FK, enum, append-only, sequence, fingerprint, budget, and synthetic-report contract.
- Focused synthetic run: 6 persisted attempts; rate-limit to pass, validation stop, duplicate stop, and input-budget stop.
- Ruff check and format check passed.
- The repository wrapper exited 0 but did not surface a collection/result summary locally; GitHub-hosted CI is the remaining canonical test evidence.

No merge or deployment is authorized by this Draft PR.