### PR TITLE
fix(image): keep grok upscale opt-in

### DIFF
--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -685,7 +685,7 @@ FAL_MODELS: Dict[str, Dict[str, Any]] = {
             "prompt", "aspect_ratio", "num_images", "output_format",
             "resolution", "quality", "sync_mode",
         },
-        "upscale": True,   # 1k native is sub-2MP
+        "upscale": False,  # opt-in only; catalog defaults must not chain creative upscalers
         # Edit endpoint takes `image_urls` (max 3) + the same knobs;
         # aspect_ratio defaults to "auto" (follows the first input image),
         # so we don't send it on edits.


### PR DESCRIPTION
## Summary
Grok Imagine Image 2.0 no longer defaults to the creative upscaler, restoring the catalog-wide opt-in-only upscaling policy.

## Changes
- `tools/image_generation_tool.py`: set the Grok Imagine catalog entry's `upscale` flag to `False`.

## Validation
| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/tools/test_image_generation.py -q` | 51 passed |

## Context
This was exposed as a pre-existing CI failure while watching PR #89937; it is unrelated to that pairing-code port but currently blocks the shared test matrix.
