### PR TITLE
feat(kanban): direct-command workers via profile-level worker.command

### DIFF
--- a/docs/kanban/worker-command.md
+++ b/docs/kanban/worker-command.md
@@ -1,0 +1,79 @@
+# Direct-command workers (`worker.command`)
+
+A named profile can declare a fixed command as its kanban worker. Cards
+assigned to that profile are then executed by that command instead of the
+Hermes agent — the board, dispatcher, worktree workspaces, logs, crash
+detection and `max_runtime` all behave exactly as they do for agent
+workers. This gives deterministic pipelines (an orchestrator binary, a
+build-and-ship script) a first-class seat on the board without wrapping
+themselves in a prompt.
+
+```yaml
+# ~/.hermes/profiles/engine/config.yaml
+worker:
+  command:
+    - /usr/local/bin/my-pipeline
+    - --from-kanban
+```
+
+## Scope — where the key may live
+
+- **Only a named profile's `config.yaml`** (a home of the shape
+  `.../profiles/<name>`). This is deliberate and different from every
+  `kanban.*` key, which are all read in *dispatcher* scope.
+- Declaring it in the **root config is an error**: the root file is
+  dispatcher scope, and the `default` assignee resolves to it. The spawn
+  fails loudly instead of running for `default` and silently not running
+  for everyone else.
+- The value must be a **list of argv strings** (never a shell string), and
+  `argv[0]` must be an absolute path or a bare `PATH`-resolved name — a
+  relative path would resolve against the per-task workspace, whose
+  content the task's own branch controls. `${VAR}` / `${env:VAR}`
+  references expand against the dispatcher's environment.
+- A declared-but-invalid value — including a config file that no longer
+  parses as YAML — **fails the spawn loudly**. It never silently falls
+  back to the agent: running the wrong worker on a task is worse than
+  running none.
+
+## The completion contract — the exit code is the report
+
+The dispatcher runs the command under a thin supervisor
+(`hermes_cli.kanban_command_worker`) that is its direct parent, waits for
+it, and reports while still alive:
+
+| Command outcome | Card |
+|---|---|
+| exits `0` | `done` (`complete_task`) |
+| exits non-zero (any code) | `blocked`, with the code in the reason. **No retry** — a deterministic pipeline that failed is a fact for a human; the retry loop belongs to the pipeline itself. Unblocking re-runs it. |
+| already moved its card through a canonical channel (`kanban complete` / `block` / review) | that transition stands; the exit-code translation is a no-op |
+| killed by a signal | `blocked`, with the signal named |
+| cannot even start (wrong path, missing binary) | the supervisor's own failure: the card retries as a **crash** up to the failure limit; the message is in the task log |
+| the supervisor itself dies | ordinary crash path — nothing is invented |
+
+Because the supervisor is the direct parent, the exit code is observed in
+every dispatcher constitution: resident gateway, `kanban daemon`, and
+throwaway cron `kanban dispatch` ticks alike.
+
+The command receives the standard worker environment
+(`HERMES_KANBAN_TASK`, `HERMES_KANBAN_WORKSPACE`, `HERMES_KANBAN_DB`,
+`HERMES_KANBAN_BOARD`, `HERMES_KANBAN_RUN_ID`) and runs with the task's
+workspace as its working directory. It does not need to talk to kanban at
+all — exiting is reporting — but it may use the canonical channels for
+richer outcomes (e.g. blocking with a question).
+
+## Stall bound — set `max_runtime`
+
+A direct command emits **no heartbeats**, so `max_runtime_seconds` on the
+card is the **only** stall bound. Set it. On timeout the supervisor
+forwards SIGTERM to the command's whole process group (grandchildren
+included), and after a short grace (3 s, `HERMES_KANBAN_COMMAND_TERM_GRACE`
+to adjust, clamped below the dispatcher's own kill window) SIGKILLs the
+group and reports the death as a block.
+
+## Interaction with agent-only settings
+
+`skills`, `model_override`, `provider_override`, `reasoning_effort` and
+`goal_mode` on a card are meaningless for a direct command and are ignored
+with a warning in the dispatcher log. Everything an operator can influence
+lives in host-side configuration — nothing on the card (title, body,
+comments, attachments) can alter what is executed.

--- a/hermes_cli/kanban_command_worker.py
+++ b/hermes_cli/kanban_command_worker.py
@@ -1,0 +1,184 @@
+"""Supervisor for direct-command kanban workers (``worker.command``).
+
+The dispatcher spawns this module (``python -P -m
+hermes_cli.kanban_command_worker`` — the ``-P`` matters: the supervisor
+runs with the task's workspace as its cwd, and without it Python would
+put that workspace first on ``sys.path``, letting workspace content
+shadow this very module) instead of the command itself. It runs the
+declared argv as its direct child, waits for it, and reports the exit
+code through the same canonical transitions a well-behaved agent worker
+makes — while this process is still alive, so no reaper ever has to
+guess what happened:
+
+* rc=0  → ``complete_task`` (unless the command already moved the task
+  itself through a canonical channel — then the transition is a no-op and
+  the command's own word stands)
+* rc!=0 → ``block_task`` with the code (or signal) in the reason.
+  Deliberately no retry: a deterministic pipeline that failed is a fact
+  for a human, and any retry loop belongs to the pipeline itself.
+  Unblocking re-runs it.
+
+Being the command's direct parent is the whole point: the exit code is
+observed in every dispatcher constitution (resident gateway, ``kanban
+daemon``, throwaway cron ticks), the task leaves ``running`` before this
+process exits so stale-claim reclaim can never race the report, and no
+worker-kind bookkeeping has to be reconstructed at reap time.
+
+Everything this process needs arrives in the environment the dispatcher
+built (host-side values only — nothing here is card-controlled):
+
+* ``HERMES_KANBAN_WORKER_COMMAND`` — JSON argv list, resolved once at
+  spawn time from the assignee profile's config
+* ``HERMES_KANBAN_TASK`` / ``HERMES_KANBAN_RUN_ID`` — the task to report on
+* ``HERMES_KANBAN_DB`` / ``HERMES_KANBAN_BOARD`` — the board to report to
+* ``HERMES_KANBAN_WORKSPACE`` — the working directory (already the cwd)
+
+Termination: the child runs in its own session (process group), so a
+SIGTERM here — ``enforce_max_runtime``'s first shot — is forwarded to
+the whole group, and after a short grace the group is SIGKILLed. The
+handler only forwards and returns; the grace is enforced by the main
+wait loop (calling ``Popen.wait`` inside the handler would deadlock
+against the main thread's own wait and burn the whole grace, observed in
+review). The grace must stay SHORTER than the ~5 seconds
+``enforce_max_runtime`` waits before SIGKILLing the supervisor itself,
+or the report below never runs and the child is orphaned. If the
+supervisor is SIGKILLed anyway, it said nothing — the ordinary crash
+path covers the task without inventing a result.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+
+# Must stay shorter than enforce_max_runtime's term-to-kill window (~5s in
+# hermes_cli.kanban_db) — see the module docstring. Overridable for tests
+# and unusual pipelines via HERMES_KANBAN_COMMAND_TERM_GRACE (seconds).
+_TERM_GRACE_SECONDS = 3.0
+_WAIT_POLL_SECONDS = 0.2
+
+
+def _fail(message: str) -> "int":
+    print(f"kanban_command_worker: {message}", file=sys.stderr, flush=True)
+    return 1
+
+
+def _term_grace() -> float:
+    raw = os.environ.get("HERMES_KANBAN_COMMAND_TERM_GRACE", "")
+    try:
+        value = float(raw)
+        if value > 0:
+            # Clamp: a grace at or beyond enforce_max_runtime's ~5s
+            # term-to-kill window would mean the report never runs and the
+            # child is orphaned — the exact failure the grace exists to
+            # prevent. 4.0 keeps ~1s of reporting headroom.
+            return min(value, 4.0)
+    except ValueError:
+        pass
+    return _TERM_GRACE_SECONDS
+
+
+def _signal_group(pgid: int, signum: int) -> None:
+    try:
+        os.killpg(pgid, signum)
+    except OSError:
+        pass
+
+
+def main() -> int:
+    raw_argv = os.environ.get("HERMES_KANBAN_WORKER_COMMAND", "")
+    task_id = os.environ.get("HERMES_KANBAN_TASK", "")
+    raw_run_id = os.environ.get("HERMES_KANBAN_RUN_ID", "")
+    if not raw_argv or not task_id:
+        return _fail("missing HERMES_KANBAN_WORKER_COMMAND / HERMES_KANBAN_TASK")
+    try:
+        argv = json.loads(raw_argv)
+    except ValueError:
+        return _fail("HERMES_KANBAN_WORKER_COMMAND is not valid JSON")
+    if (
+        not isinstance(argv, list)
+        or not argv
+        or not all(isinstance(part, str) and part for part in argv)
+    ):
+        return _fail("HERMES_KANBAN_WORKER_COMMAND must be a JSON list of strings")
+    try:
+        run_id = int(raw_run_id) if raw_run_id else None
+    except ValueError:
+        run_id = None
+
+    try:
+        # Own session: SIGTERM/SIGKILL forwarding below reaches the whole
+        # process group, grandchildren included, not just the direct child.
+        child = subprocess.Popen(argv, start_new_session=True)  # noqa: S603 -- host-side config
+    except FileNotFoundError:
+        return _fail(f"worker.command executable not found: {argv[0]!r}")
+    except OSError as exc:
+        return _fail(f"worker.command could not start: {exc}")
+
+    term_at: "list[float]" = []
+
+    def _forward_term(_signum, _frame):
+        # Forward and return. No waiting in the handler: the handler runs
+        # on the main thread, whose own Popen.wait holds the waitpid lock —
+        # a timeout wait here can never acquire it and would just burn the
+        # whole grace (found in review). The main loop below enforces the
+        # grace and the SIGKILL escalation.
+        if not term_at:
+            term_at.append(time.monotonic())
+            _signal_group(child.pid, signal.SIGTERM)
+
+    signal.signal(signal.SIGTERM, _forward_term)
+    signal.signal(signal.SIGINT, _forward_term)
+
+    grace = _term_grace()
+    returncode = None
+    while returncode is None:
+        try:
+            returncode = child.wait(timeout=_WAIT_POLL_SECONDS)
+        except subprocess.TimeoutExpired:
+            if term_at and time.monotonic() - term_at[0] >= grace:
+                _signal_group(child.pid, signal.SIGKILL)
+                # No timeout: after a group SIGKILL only an uninterruptible
+                # (D-state) child can stall this, and then the dispatcher's
+                # own SIGKILL ends the supervisor — crash path, safe side.
+                returncode = child.wait()
+
+    # Report through the canonical transitions. Everything from here on is
+    # inside the try: an unreportable exit must end in _fail (message in
+    # the task log), leaving the task to the ordinary crash path.
+    try:
+        from hermes_cli import kanban_db as kb
+
+        with kb.connect() as conn:
+            if returncode == 0:
+                kb.complete_task(
+                    conn,
+                    task_id,
+                    summary="worker command exited 0",
+                    metadata={"exit_code": 0, "worker_kind": "command"},
+                    expected_run_id=run_id,
+                )
+            else:
+                if returncode < 0:
+                    reason = (
+                        f"worker command terminated by signal {-returncode}"
+                    )
+                else:
+                    reason = f"worker command exited with code {returncode}"
+                kb.block_task(
+                    conn,
+                    task_id,
+                    reason=reason,
+                    expected_run_id=run_id,
+                )
+    except Exception as exc:
+        return _fail(f"could not report exit {returncode} for {task_id}: {exc}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10680,6 +10680,138 @@ def _resolve_worker_cli_toolsets(hermes_home: Optional[str]) -> Optional[list[st
         return None
 
 
+def _expand_worker_command_env(parts: Any) -> Any:
+    """Expand ``${VAR}`` / ``${env:VAR}`` references in worker-command argv.
+
+    Self-contained on purpose (no import of the config loader's private
+    helper), but accepting both reference spellings the loader accepts so
+    neither silently passes through as a literal. Unresolved references
+    stay verbatim, which the argv checks below then surface as an
+    executable-not-found error naming the literal ``${VAR}`` text.
+    """
+    if isinstance(parts, list):
+        return [_expand_worker_command_env(part) for part in parts]
+    if isinstance(parts, str):
+        return re.sub(
+            r"\$\{(?:env:)?([A-Za-z_][A-Za-z0-9_]*)\}",
+            lambda match: os.environ.get(match.group(1), match.group(0)),
+            parts,
+        )
+    return parts
+
+
+def _resolve_worker_command(hermes_home: Optional[str]) -> Optional[list[str]]:
+    """Return the assignee profile's ``worker.command`` argv, if declared.
+
+    A profile whose ``config.yaml`` declares a top-level ``worker.command``
+    (a list of argv parts) runs that fixed command as its worker instead of
+    the Hermes agent. The command is host-side configuration: card authors
+    cannot influence it, so the task-creation surface never becomes a
+    command-injection surface. The dispatcher spawns the command through a
+    thin supervisor (``hermes_cli.kanban_command_worker``) that execs it,
+    waits, and reports its exit code through the canonical transitions
+    while the worker process is still alive: rc=0 becomes ``complete``,
+    any other exit becomes ``block`` (deliberately no retry — a
+    deterministic pipeline that failed is a fact for a human, and the
+    retry loop belongs to the pipeline itself; unblock re-runs it). A
+    command that already moved its task through a canonical channel is
+    left alone. Because the supervisor is the command's direct parent,
+    the exit code is observed in every dispatcher constitution — resident
+    gateway, ``kanban daemon`` and throwaway cron ticks alike. The child
+    still receives the full kanban worker environment
+    (``HERMES_KANBAN_TASK`` / ``_WORKSPACE`` / ``_DB`` / ``_BOARD`` /
+    ``_RUN_ID`` / ``_CLAIM_LOCK``), still writes the per-task log, and is
+    still subject to PID crash detection and ``max_runtime`` (it does NOT
+    emit heartbeats, so ``max_runtime_seconds`` is the only stall bound —
+    set it). A command that cannot even start (a wrong path, a missing
+    binary) is the supervisor's own failure: the card is retried as a
+    crash up to the failure limit, not blocked — the message lands in the
+    task log.
+
+    Scope rules:
+
+    * The key lives in a **named profile's** config, deliberately outside
+      the ``kanban:`` namespace — every ``kanban.*`` key is read in
+      dispatcher scope, while this one is assignee scope.
+    * Declaring it in the root config is an error: the root file is
+      dispatcher scope, and the ``default`` assignee resolves to it.
+
+    This reads the profile's ``config.yaml`` directly instead of going
+    through ``load_config()``: that loader swallows YAML parse errors and
+    returns a default/last-known-good config, which would turn a typo in
+    the declaration into a silent agent run — the exact failure this
+    feature must never have. A declared-but-invalid value (or an unparsable
+    config file) raises ``RuntimeError`` so the spawn fails loudly.
+    """
+    if not hermes_home:
+        return None
+    config_path = os.path.join(hermes_home, "config.yaml")
+    try:
+        with open(config_path, "r", encoding="utf-8") as config_file:
+            raw_text = config_file.read()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise RuntimeError(
+            f"worker.command: profile config {config_path!r} is unreadable: {exc}"
+        )
+    from utils import fast_safe_load
+
+    try:
+        parsed = fast_safe_load(raw_text)
+    except Exception as exc:
+        raise RuntimeError(
+            f"worker.command: {config_path!r} does not parse as YAML ({exc}); "
+            "refusing to guess — a broken profile config must not silently "
+            "fall back to the agent"
+        )
+    if not isinstance(parsed, dict):
+        return None
+    worker_cfg = parsed.get("worker")
+    raw = worker_cfg.get("command") if isinstance(worker_cfg, dict) else None
+    if raw is None:
+        return None
+    # Only a *named* profile — a home of the shape ``.../profiles/<name>`` —
+    # may declare a worker command. Judged structurally from the home path
+    # itself, never from ``get_hermes_home()``: the dispatcher may itself be
+    # running with ``HERMES_HOME`` pointing at a profile directory (``hermes
+    # -p x kanban daemon`` does exactly that), which would make any
+    # comparison against the process's own home wrong in both directions.
+    # ``resolve_profile_env("default")`` returns the root home, so this
+    # check is also what keeps a root-level declaration from firing for the
+    # ``default`` assignee while silently not firing for everyone else.
+    home_real = os.path.realpath(hermes_home)
+    if os.path.basename(os.path.dirname(home_real)) != "profiles":
+        raise RuntimeError(
+            "worker.command must be declared in a named profile's config.yaml "
+            "(a home of the shape .../profiles/<name>), never the root config: "
+            "the root file is dispatcher scope and the `default` assignee "
+            "resolves to it"
+        )
+    raw = _expand_worker_command_env(raw)
+    if (
+        not isinstance(raw, list)
+        or not raw
+        or not all(isinstance(part, str) and part for part in raw)
+    ):
+        raise RuntimeError(
+            "worker.command must be a non-empty list of non-empty argv "
+            "strings (a plain string would reintroduce shell-quoting ambiguity)"
+        )
+    head = raw[0]
+    if not os.path.isabs(head) and (
+        os.sep in head or (os.altsep and os.altsep in head)
+    ):
+        raise RuntimeError(
+            "worker.command argv[0] must be an absolute path or a bare name "
+            f"resolved via PATH, got relative path {head!r}: a relative path "
+            "would resolve against the per-task workspace, whose content the "
+            "task's own branch controls"
+        )
+    return list(raw)
+
+
+
 _retagged_workspace_roots: set[str] = set()
 
 
@@ -10838,52 +10970,93 @@ def _default_spawn(
     # older hermes builds on PATH that predate the flag's precedence.
     env.pop("HERMES_TUI", None)
 
-    cmd = [
-        *_resolve_hermes_argv(),
-        "-p", profile_arg,
-        "--cli",
-        # Worker subprocesses switch to a profile-scoped HERMES_HOME above,
-        # so they see that profile's shell-hook allowlist instead of the
-        # dispatcher's root allowlist. Pass --accept-hooks explicitly so
-        # profile-local worker sessions still register configured hooks.
-        "--accept-hooks",
-    ]
-    # Per-task force-loaded skills. Each name goes in its own
-    # `--skills X` pair rather than a single comma-joined arg: the CLI
-    # accepts both forms (action='append' + comma-split), but
-    # per-name pairs are easier to read in `ps` output and avoid any
-    # quoting ambiguity if a skill name ever contains unusual chars.
-    if task.skills:
-        for sk in task.skills:
-            if sk:
-                cmd.extend(["--skills", sk])
-    if task.model_override:
-        cmd.extend(["-m", task.model_override])
-        # Pin the provider too when the override names one, so the worker
-        # resolves the model against the intended backend instead of the
-        # profile's configured provider (mixing model X with provider Y is
-        # the classic mis-set that stalls a board).
-        if task.provider_override:
-            cmd.extend(["--provider", task.provider_override])
-    # Per-task thinking depth. Independent of the model override — a task can
-    # run the profile's own model at a different depth — so this is its own
-    # branch, not a nested one.
-    if task.reasoning_effort:
-        cmd.extend(["--reasoning", task.reasoning_effort])
-    worker_toolsets = _resolve_worker_cli_toolsets(env.get("HERMES_HOME"))
-    if worker_toolsets:
-        cmd.extend(["--toolsets", ",".join(worker_toolsets)])
-    cmd.extend([
-        "chat",
-        "-q", prompt,
-    ])
-    if task.goal_mode:
-        # Goal-mode workers must take the fully-quiet single-query path:
-        # the kanban goal-loop hook (_run_kanban_goal_loop_q) only runs in
-        # cli.py's quiet branch. Without -Q the worker gets exactly one
-        # turn, prints text, exits rc=0, and the dispatcher records a
-        # protocol violation (incident 2026-06-09 t_d9cbe312).
-        cmd.append("-Q")
+    worker_command = _resolve_worker_command(env.get("HERMES_HOME"))
+    if worker_command is not None:
+        # Direct-command worker (worker.command in the assignee profile's
+        # config): the declared argv runs under a thin supervisor
+        # (hermes_cli.kanban_command_worker) that execs it, waits, and
+        # reports the exit code through the canonical transitions while
+        # this worker process is still alive — so the report is observed
+        # in every dispatcher constitution and never races reclaim.
+        # Everything around it — env, workspace cwd, per-task log, PID
+        # tracking, max_runtime — stays identical. Agent-only concerns do
+        # not apply; the command reads its task from HERMES_KANBAN_* env.
+        # The resolved argv travels in the environment so it is decided
+        # exactly once, at spawn time, from host-side configuration.
+        ignored = [
+            name
+            for name, value in (
+                ("skills", task.skills),
+                ("model_override", task.model_override),
+                ("provider_override", task.provider_override),
+                ("reasoning_effort", task.reasoning_effort),
+                ("goal_mode", task.goal_mode),
+            )
+            if value
+        ]
+        if ignored:
+            _log.warning(
+                "kanban worker: task %s runs a direct command; agent-only "
+                "settings ignored: %s",
+                task.id,
+                ", ".join(ignored),
+            )
+        env["HERMES_KANBAN_WORKER_COMMAND"] = json.dumps(worker_command)
+        # -P (Python 3.11+): do NOT prepend the cwd to sys.path. The
+        # supervisor starts with the task's workspace as its cwd, and
+        # without the flag, workspace content — a git branch under
+        # `worktree`, a previous worker's leftovers under `scratch` —
+        # could shadow the supervisor module itself (or its stdlib
+        # imports) and run in its place.
+        cmd = [sys.executable, "-P", "-m", "hermes_cli.kanban_command_worker"]
+    else:
+        env.pop("HERMES_KANBAN_WORKER_COMMAND", None)
+        cmd = [
+            *_resolve_hermes_argv(),
+            "-p", profile_arg,
+            "--cli",
+            # Worker subprocesses switch to a profile-scoped HERMES_HOME above,
+            # so they see that profile's shell-hook allowlist instead of the
+            # dispatcher's root allowlist. Pass --accept-hooks explicitly so
+            # profile-local worker sessions still register configured hooks.
+            "--accept-hooks",
+        ]
+        # Per-task force-loaded skills. Each name goes in its own
+        # `--skills X` pair rather than a single comma-joined arg: the CLI
+        # accepts both forms (action='append' + comma-split), but
+        # per-name pairs are easier to read in `ps` output and avoid any
+        # quoting ambiguity if a skill name ever contains unusual chars.
+        if task.skills:
+            for sk in task.skills:
+                if sk:
+                    cmd.extend(["--skills", sk])
+        if task.model_override:
+            cmd.extend(["-m", task.model_override])
+            # Pin the provider too when the override names one, so the worker
+            # resolves the model against the intended backend instead of the
+            # profile's configured provider (mixing model X with provider Y is
+            # the classic mis-set that stalls a board).
+            if task.provider_override:
+                cmd.extend(["--provider", task.provider_override])
+        # Per-task thinking depth. Independent of the model override — a task can
+        # run the profile's own model at a different depth — so this is its own
+        # branch, not a nested one.
+        if task.reasoning_effort:
+            cmd.extend(["--reasoning", task.reasoning_effort])
+        worker_toolsets = _resolve_worker_cli_toolsets(env.get("HERMES_HOME"))
+        if worker_toolsets:
+            cmd.extend(["--toolsets", ",".join(worker_toolsets)])
+        cmd.extend([
+            "chat",
+            "-q", prompt,
+        ])
+        if task.goal_mode:
+            # Goal-mode workers must take the fully-quiet single-query path:
+            # the kanban goal-loop hook (_run_kanban_goal_loop_q) only runs in
+            # cli.py's quiet branch. Without -Q the worker gets exactly one
+            # turn, prints text, exits rc=0, and the dispatcher records a
+            # protocol violation (incident 2026-06-09 t_d9cbe312).
+            cmd.append("-Q")
     # Redirect output to a per-task log under <board-root>/logs/.
     # Anchored at the board root (not the shared kanban root), so
     # `hermes kanban log` on a specific board reads its own file and

--- a/tests/hermes_cli/test_kanban_worker_command.py
+++ b/tests/hermes_cli/test_kanban_worker_command.py
@@ -1,0 +1,487 @@
+"""Tests for direct-command workers (profile-level ``worker.command``)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+def _make_task(kb_mod, *, assignee: str, goal_mode: bool = False):
+    return kb_mod.Task(
+        id="t_worker_cmd",
+        title="worker command",
+        body=None,
+        assignee=assignee,
+        status="running",
+        priority=0,
+        created_by="test",
+        created_at=1,
+        started_at=None,
+        completed_at=None,
+        workspace_kind="dir",
+        workspace_path=None,
+        claim_lock="lock",
+        claim_expires=None,
+        tenant=None,
+        current_run_id=7,
+        goal_mode=goal_mode,
+    )
+
+
+def _write_profile(root, name: str, config_body: str) -> None:
+    profile = root / "profiles" / name
+    profile.mkdir(parents=True, exist_ok=True)
+    profile.joinpath("config.yaml").write_text(config_body, encoding="utf-8")
+
+
+COMMAND_PROFILE = "worker:\n  command:\n    - /usr/local/bin/lassdas-worker\n    - --stage-all\n"
+
+SUPERVISOR = [sys.executable, "-P", "-m", "hermes_cli.kanban_command_worker"]
+
+
+@pytest.fixture()
+def spawn_env(monkeypatch, tmp_path):
+    root = tmp_path / ".hermes"
+    root.mkdir()
+    root.joinpath("config.yaml").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+
+    captured = {}
+
+    class FakeProc:
+        pid = 4242
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["cmd"] = list(cmd)
+        captured["env"] = dict(kwargs.get("env") or {})
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    return root, str(workspace), captured
+
+
+# ---------------------------------------------------------------------------
+# Spawn: the supervisor replaces the agent argv
+# ---------------------------------------------------------------------------
+
+
+def test_worker_command_spawns_the_supervisor(spawn_env):
+    """A profile-declared worker.command runs under the supervisor module,
+    with the resolved argv frozen into the child environment and the full
+    kanban worker environment still attached."""
+    root, workspace, captured = spawn_env
+    _write_profile(root, "engine", COMMAND_PROFILE)
+
+    pid = kb._default_spawn(_make_task(kb, assignee="engine"), workspace)
+
+    assert pid == 4242
+    assert captured["cmd"] == SUPERVISOR
+    assert json.loads(captured["env"]["HERMES_KANBAN_WORKER_COMMAND"]) == [
+        "/usr/local/bin/lassdas-worker",
+        "--stage-all",
+    ]
+    assert captured["env"]["HERMES_KANBAN_TASK"] == "t_worker_cmd"
+    assert captured["env"]["HERMES_KANBAN_WORKSPACE"] == workspace
+    assert captured["env"]["HERMES_KANBAN_RUN_ID"] == "7"
+    assert captured["env"]["HERMES_KANBAN_CLAIM_LOCK"] == "lock"
+
+
+def test_worker_command_ignores_agent_only_task_settings(spawn_env):
+    """Goal mode is an agent-loop concern; a direct command must not grow
+    agent flags out of it (a warning is logged instead)."""
+    root, workspace, captured = spawn_env
+    _write_profile(root, "engine", "worker:\n  command:\n    - /bin/lassdas-worker\n")
+
+    kb._default_spawn(_make_task(kb, assignee="engine", goal_mode=True), workspace)
+
+    assert captured["cmd"] == SUPERVISOR
+
+
+def test_profile_without_worker_command_keeps_the_agent_argv(spawn_env):
+    root, workspace, captured = spawn_env
+    _write_profile(root, "elias", "toolsets:\n  - hermes-cli\n")
+
+    kb._default_spawn(_make_task(kb, assignee="elias"), workspace)
+
+    assert captured["cmd"][0] == "hermes"
+    assert "chat" in captured["cmd"]
+
+
+def test_env_references_expand_in_worker_command(spawn_env, monkeypatch):
+    root, workspace, captured = spawn_env
+    monkeypatch.setenv("LASSDAS_BIN", "/opt/lassdas/worker")
+    _write_profile(
+        root, "engine", "worker:\n  command:\n    - ${LASSDAS_BIN}\n    - run\n"
+    )
+
+    kb._default_spawn(_make_task(kb, assignee="engine"), workspace)
+
+    assert json.loads(captured["env"]["HERMES_KANBAN_WORKER_COMMAND"]) == [
+        "/opt/lassdas/worker",
+        "run",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Resolution: fail-loud contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "declared",
+    [
+        'worker:\n  command: "/bin/worker --flag"\n',
+        "worker:\n  command: []\n",
+        "worker:\n  command:\n    - /bin/worker\n    - 7\n",
+        "worker:\n  command: {a: b}\n",
+    ],
+    ids=["string", "empty-list", "non-string-part", "dict"],
+)
+def test_invalid_worker_command_fails_loudly(spawn_env, declared):
+    """A declared-but-invalid worker.command must raise, not silently fall
+    back to the agent: running the wrong worker is worse than none."""
+    root, workspace, captured = spawn_env
+    _write_profile(root, "engine", declared)
+
+    with pytest.raises(RuntimeError, match="worker.command"):
+        kb._default_spawn(_make_task(kb, assignee="engine"), workspace)
+    assert "cmd" not in captured
+
+
+def test_unparsable_profile_config_fails_loudly(spawn_env):
+    """The most ordinary way to break the declaration is a YAML indent typo.
+    ``load_config()`` would swallow it and return defaults — the resolver
+    must not, or the declared command silently becomes an agent run."""
+    root, workspace, captured = spawn_env
+    _write_profile(
+        root,
+        "engine",
+        # One line indented by 3 spaces instead of 4 — unparsable YAML.
+        "worker:\n  command:\n    - /bin/worker\n   - --flag\n",
+    )
+
+    with pytest.raises(RuntimeError, match="does not parse as YAML"):
+        kb._default_spawn(_make_task(kb, assignee="engine"), workspace)
+    assert "cmd" not in captured
+
+
+def test_explicit_null_worker_command_means_agent(spawn_env):
+    """``worker.command:`` with no value is an explicit non-declaration —
+    the agent runs. Pinned as intended behaviour, not an accident."""
+    root, workspace, captured = spawn_env
+    _write_profile(root, "engine", "worker:\n  command:\n")
+
+    kb._default_spawn(_make_task(kb, assignee="engine"), workspace)
+
+    assert captured["cmd"][0] == "hermes"
+
+
+def test_root_config_declaration_is_rejected(spawn_env):
+    """``kanban.*`` keys are dispatcher scope; this key is assignee scope.
+    The ``default`` assignee resolves to the root home, so a root-level
+    declaration must fail instead of silently running for ``default`` and
+    silently not running for everyone else."""
+    root, workspace, captured = spawn_env
+    root.joinpath("config.yaml").write_text(COMMAND_PROFILE, encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="root config"):
+        kb._default_spawn(_make_task(kb, assignee="default"), workspace)
+    assert "cmd" not in captured
+
+
+def test_root_guard_holds_when_dispatcher_runs_inside_a_profile_home(
+    spawn_env, monkeypatch
+):
+    """``hermes -p engine kanban daemon`` sets the process HERMES_HOME to the
+    profile directory. The scope guard must not compare against the process
+    home: judged structurally (parent directory named ``profiles``), a named
+    profile stays accepted and a root declaration for ``default`` stays
+    rejected — in this constitution too."""
+    root, workspace, captured = spawn_env
+    _write_profile(root, "engine", COMMAND_PROFILE)
+    root.joinpath("config.yaml").write_text(COMMAND_PROFILE, encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root / "profiles" / "engine"))
+
+    kb._default_spawn(_make_task(kb, assignee="engine"), workspace)
+    assert captured["cmd"] == SUPERVISOR
+
+    captured.clear()
+    with pytest.raises(RuntimeError, match="root config"):
+        kb._default_spawn(_make_task(kb, assignee="default"), workspace)
+    assert "cmd" not in captured
+
+
+def test_relative_argv0_is_rejected(spawn_env):
+    """A relative argv[0] resolves against the per-task workspace, whose
+    content the task's own branch controls — that is workspace-controlled
+    code execution and must be refused."""
+    root, workspace, captured = spawn_env
+    _write_profile(root, "engine", "worker:\n  command:\n    - ./run.sh\n")
+
+    with pytest.raises(RuntimeError, match="argv\\[0\\]"):
+        kb._default_spawn(_make_task(kb, assignee="engine"), workspace)
+    assert "cmd" not in captured
+
+
+# ---------------------------------------------------------------------------
+# The supervisor: rc is the completion report, delivered while alive
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _claim_with_run(conn, tid: str) -> int:
+    host = kb._claimer_id().split(":", 1)[0]
+    kb.claim_task(conn, tid, claimer=f"{host}:w0")
+    row = conn.execute(
+        "SELECT current_run_id FROM tasks WHERE id=?", (tid,)
+    ).fetchone()
+    return row["current_run_id"]
+
+
+def _run_supervisor(kanban_home, tid: str, run_id, argv: list) -> subprocess.CompletedProcess:
+    import os
+
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(kanban_home)
+    env["HERMES_KANBAN_DB"] = str(kb.kanban_db_path())
+    env["HERMES_KANBAN_TASK"] = tid
+    env["HERMES_KANBAN_RUN_ID"] = str(run_id) if run_id is not None else ""
+    env["HERMES_KANBAN_WORKER_COMMAND"] = json.dumps(argv)
+    return subprocess.run(
+        SUPERVISOR, env=env, capture_output=True, text=True, timeout=60
+    )
+
+
+def test_supervisor_reports_rc0_as_complete(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="ok", assignee="engine")
+        run_id = _claim_with_run(conn, tid)
+    proc = _run_supervisor(
+        kanban_home, tid, run_id, [sys.executable, "-c", "pass"]
+    )
+    assert proc.returncode == 0, proc.stderr
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+    assert task.status == "done"
+
+
+def test_supervisor_reports_nonzero_rc_as_block(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="fail", assignee="engine")
+        run_id = _claim_with_run(conn, tid)
+    proc = _run_supervisor(
+        kanban_home, tid, run_id, [sys.executable, "-c", "import sys; sys.exit(3)"]
+    )
+    assert proc.returncode == 0, proc.stderr
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+    assert task.status == "blocked"
+    with kb.connect() as conn:
+        payloads = [
+            r["payload"]
+            for r in conn.execute(
+                "SELECT payload FROM task_events WHERE task_id=? AND kind='blocked'",
+                (tid,),
+            ).fetchall()
+        ]
+    assert any("code 3" in (p or "") for p in payloads)
+
+
+def test_supervisor_missing_executable_exits_nonzero_and_reports_nothing(
+    kanban_home, tmp_path
+):
+    """An unstartable command is the supervisor's own failure: it exits
+    non-zero without transitioning the task, and the ordinary crash path
+    (retry + breaker) covers the card."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="missing", assignee="engine")
+        run_id = _claim_with_run(conn, tid)
+    proc = _run_supervisor(
+        kanban_home, tid, run_id, [str(tmp_path / "definitely-not-here")]
+    )
+    assert proc.returncode != 0
+    assert "not found" in proc.stderr
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+    assert task.status == "running"
+
+
+def test_supervisor_respects_a_transition_the_command_already_made(kanban_home):
+    """A command that already moved its task through a canonical channel is
+    left alone: the command's own word stands, rc translation is a no-op."""
+    script = (
+        "import os, sqlite3\n"
+        "from hermes_cli import kanban_db as kb\n"
+        "conn = kb.connect().__enter__()\n"
+        "kb.block_task(conn, os.environ['HERMES_KANBAN_TASK'],"
+        " reason='needs an answer', kind='needs_input')\n"
+    )
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="self", assignee="engine")
+        run_id = _claim_with_run(conn, tid)
+    proc = _run_supervisor(kanban_home, tid, run_id, [sys.executable, "-c", script])
+    assert proc.returncode == 0, proc.stderr
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+    assert task.status == "blocked"
+    with kb.connect() as conn:
+        payloads = [
+            r["payload"]
+            for r in conn.execute(
+                "SELECT payload FROM task_events WHERE task_id=? AND kind='blocked'",
+                (tid,),
+            ).fetchall()
+        ]
+    assert any("needs an answer" in (p or "") for p in payloads)
+    # The command's own transition stands: no second 'blocked' event from
+    # the supervisor's rc translation.
+    assert len(payloads) == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration: a real dispatch tick end-to-end (no mocks)
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_tick_runs_a_command_worker_to_done(kanban_home, monkeypatch):
+    """The full path: create -> dispatch_once (real spawn) -> supervisor ->
+    complete. Covers the ordering that unit-level reap tests cannot: the
+    completion lands while the worker is alive, so no later reclaim pass
+    can ever see a finished-but-running card."""
+    _write_profile(
+        kanban_home,
+        "engine",
+        f"worker:\n  command:\n    - {sys.executable}\n    - -c\n    - pass\n",
+    )
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="e2e", assignee="engine")
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+        conn.commit()
+
+        result = kb.dispatch_once(conn, max_in_progress=1)
+        assert any(t[0] == tid for t in result.spawned), result
+
+        deadline = time.time() + 30
+        status = None
+        while time.time() < deadline:
+            task = kb.get_task(conn, tid)
+            status = task.status
+            if status == "done":
+                break
+            time.sleep(0.3)
+        assert status == "done", f"worker never completed the card: {status}"
+
+
+# ---------------------------------------------------------------------------
+# The supervisor as a hostile-workspace / termination target (review round 3)
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_cannot_shadow_the_supervisor_module(kanban_home, tmp_path):
+    """The supervisor runs with the task workspace as cwd. Without -P,
+    Python would put that cwd first on sys.path and a planted
+    hermes_cli/kanban_command_worker.py from the workspace — a git branch
+    under worktree, a previous worker's leftovers under scratch — would run
+    instead of the real module."""
+    import os
+
+    workspace = tmp_path / "ws"
+    planted = workspace / "hermes_cli"
+    planted.mkdir(parents=True)
+    planted.joinpath("__init__.py").write_text("", encoding="utf-8")
+    planted.joinpath("kanban_command_worker.py").write_text(
+        "print('PLANTED MODULE EXECUTED')\nraise SystemExit(0)\n",
+        encoding="utf-8",
+    )
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="shadow", assignee="engine")
+        run_id = _claim_with_run(conn, tid)
+
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(kanban_home)
+    env["HERMES_KANBAN_DB"] = str(kb.kanban_db_path())
+    env["HERMES_KANBAN_TASK"] = tid
+    env["HERMES_KANBAN_RUN_ID"] = str(run_id)
+    env["HERMES_KANBAN_WORKER_COMMAND"] = json.dumps([sys.executable, "-c", "pass"])
+    proc = subprocess.run(
+        SUPERVISOR, env=env, cwd=str(workspace),
+        capture_output=True, text=True, timeout=60,
+    )
+    assert "PLANTED" not in proc.stdout
+    assert proc.returncode == 0, proc.stderr
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+    assert task.status == "done"
+
+
+def test_sigterm_forwards_to_the_child_group_within_the_grace(kanban_home):
+    """A SIGTERM to the supervisor must (1) stop the child, (2) finish and
+    report well inside enforce_max_runtime's ~5s term-to-kill window, and
+    (3) leave the card blocked with the signal named. The handler only
+    forwards; the grace is enforced by the main wait loop — a child that
+    ignores SIGTERM is killed via its process group after the grace."""
+    import os
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="term", assignee="engine")
+        run_id = _claim_with_run(conn, tid)
+
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(kanban_home)
+    env["HERMES_KANBAN_DB"] = str(kb.kanban_db_path())
+    env["HERMES_KANBAN_TASK"] = tid
+    env["HERMES_KANBAN_RUN_ID"] = str(run_id)
+    env["HERMES_KANBAN_COMMAND_TERM_GRACE"] = "1.0"
+    # The child ignores SIGTERM, so only the group SIGKILL after the grace
+    # can end it — the worst case for orphaning.
+    stubborn = (
+        "import signal, time\n"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        "time.sleep(120)\n"
+    )
+    env["HERMES_KANBAN_WORKER_COMMAND"] = json.dumps(
+        [sys.executable, "-c", stubborn]
+    )
+    proc = subprocess.Popen(SUPERVISOR, env=env)
+    time.sleep(1.0)  # let the child start
+    proc.send_signal(15)
+    started = time.time()
+    rc = proc.wait(timeout=10)
+    elapsed = time.time() - started
+    assert rc == 0
+    assert elapsed < 4.0, f"supervisor took {elapsed:.1f}s — exceeds the kill window"
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+    assert task.status == "blocked"
+    with kb.connect() as conn:
+        payloads = [
+            r["payload"]
+            for r in conn.execute(
+                "SELECT payload FROM task_events WHERE task_id=? AND kind='blocked'",
+                (tid,),
+            ).fetchall()
+        ]
+    assert any("signal" in (p or "") for p in payloads)


### PR DESCRIPTION
## What

A named profile can declare a fixed argv as its kanban worker:

```yaml
# ~/.hermes/profiles/engine/config.yaml
worker:
  command:
    - /usr/local/bin/my-pipeline
    - --from-kanban
```

Cards assigned to that profile are executed by that command instead of the Hermes agent, with the board machinery unchanged — dispatcher, worktree workspaces, per-task logs, crash detection and `max_runtime` all behave exactly as for agent workers. Deterministic pipelines (an orchestrator binary, a build-and-ship script) get a first-class seat on the board without wrapping themselves in a prompt, and without being forced to speak kanban either: **the command's exit code is its completion report** (rc=0 → `complete`, anything else → `block` with the code/signal named, no retry — unblock re-runs). A command that already moved its card through a canonical channel keeps its own word; the translation is then a no-op, pinned by `expected_run_id`.

## How

The dispatcher spawns a thin supervisor (`hermes_cli.kanban_command_worker`, launched with `-P` so the task workspace on cwd can never shadow the module) that runs the declared argv as its **direct child**, waits, and reports through the canonical transitions **while still alive**. That single decision is what makes the contract hold everywhere: the exit code is observed under every dispatcher constitution (resident gateway, `kanban daemon`, throwaway cron ticks), the card leaves `running` before the supervisor exits so no reclaim pass can race the report, and nothing about the worker is ever reconstructed at reap time — `detect_crashed_workers` is untouched.

Safety properties, each with a test:

- The declaration is host-side configuration only. Nothing on a card (title, body, comments, attachments) can alter what is executed.
- It must live in a **named profile's** config (`.../profiles/<name>`), judged structurally from the home path — a root-config declaration is rejected (the `default` assignee resolves to the root home), and the guard stays correct when the dispatcher itself runs inside a profile home.
- The profile config is parsed directly, not via `load_config()`: a YAML typo raises instead of silently running the agent via the loader's default/last-known-good fallback.
- `argv[0]` must be absolute or a bare PATH name — a relative path would resolve against the per-task workspace, whose content the task's own branch controls.
- On SIGTERM (`enforce_max_runtime`'s first shot) the supervisor forwards to the child's whole process group (own session — grandchildren die too) and, after a grace clamped under the dispatcher's term-to-kill window, SIGKILLs the group and still reports. The handler only forwards; the grace lives in the main wait loop (a `Popen.wait` inside the handler deadlocks against the main thread's own wait).

## Review

Developed under four rounds of adversarial review (nine must-fix findings, all resolved and pinned by tests), including: the silent-fallback config loader, an `EX_TEMPFAIL` requeue loop, the kanban-namespace scope inconsistency, a root-guard inversion under profile-home dispatchers, unobservable exit statuses under throwaway dispatchers, a reclaim-before-translation race, reap-time worker-kind guessing, workspace shadowing of the supervisor module via `-m`'s cwd injection, and a handler-deadlocked termination grace.

## Tests

20 new tests: spawn/argv-freezing, fail-loud resolution (invalid shapes, YAML parse failure, root rejection in both constitutions, relative argv[0]), the supervisor as a real subprocess (rc0→done, rc3→blocked, missing executable → its own failure with no transition, respecting the command's own transition), a mock-free `dispatch_once` integration test to `done`, workspace-shadowing A/B, and SIGTERM against a SIGTERM-ignoring child finishing reported and child-dead inside the kill window. `tests/hermes_cli -k kanban`: 310 passed; the pre-existing failure set is byte-identical to `main`. The agent spawn path is byte-identical to `main` throughout.

https://claude.ai/code/session_018ao2GE6xFgExNgzQBsZib3