### PR TITLE
fix(acp): surface a failed turn instead of reporting it as an answer

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2216,6 +2216,28 @@ class HermesACPAgent(acp.Agent):
         await self._send_usage_update(state)
 
         stop_reason = "cancelled" if cancelled else "end_turn"
+        if result.get("failed"):
+            # A non-retryable provider error (model retired, missing key, billing)
+            # already lands in ``result`` as failed/error — see
+            # ``agent.conversation_loop``. Without surfacing it, the only thing the
+            # client receives is ``final_response`` (the error summary) delivered as
+            # an ordinary assistant message plus stop_reason=end_turn, i.e. the
+            # failure is indistinguishable from a real answer.
+            #
+            # ``_meta`` rather than stop_reason="refusal": refusal means the model
+            # refused, and it is already used above for "session not found", so
+            # reusing it would conflate two very different outcomes. ``_meta`` is
+            # additive and ignored by clients that do not know about it.
+            return PromptResponse(
+                stop_reason=stop_reason,
+                usage=usage,
+                field_meta={
+                    "hermes": {
+                        "failed": True,
+                        "error": str(result.get("error") or "")[:500],
+                    }
+                },
+            )
         return PromptResponse(stop_reason=stop_reason, usage=usage)
 
     # ---- Slash commands (headless) -------------------------------------------

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -446,6 +446,71 @@ class TestPrompt:
 
         assert captured.get("child") == resp.session_id
 
+    @pytest.mark.asyncio
+    async def test_prompt_surfaces_failed_turn_in_meta(self, agent, mock_manager):
+        """A failed turn must be distinguishable from a real answer.
+
+        ``agent.conversation_loop`` already reports non-retryable provider errors
+        (model retired, missing key, billing) as ``failed``/``error`` in the result.
+        Before this, ``prompt()`` read neither: the error summary went out as an
+        ordinary assistant message and stop_reason stayed ``end_turn``, so a client
+        had no way to tell the turn had failed — it looked exactly like a reply
+        whose text happened to be ``HTTP 400: ...``.
+        """
+        resp = await agent.new_session(cwd=".")
+        state = mock_manager.get_session(resp.session_id)
+
+        summary = 'HTTP 400: {"error":{"message":"model not found"}}'
+        state.agent.run_conversation = lambda *a, **k: {
+            "final_response": summary,
+            "messages": [],
+            "completed": False,
+            "failed": True,
+            "error": summary,
+        }
+        state.agent.model = "test-model"
+        state.agent.provider = "openrouter"
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        out = await agent.prompt(
+            prompt=[TextContentBlock(type="text", text="hi")],
+            session_id=resp.session_id,
+        )
+
+        assert isinstance(out, PromptResponse)
+        meta = (out.field_meta or {}).get("hermes") or {}
+        assert meta.get("failed") is True
+        assert "model not found" in (meta.get("error") or "")
+        # stop_reason stays end_turn on purpose: "refusal" means the model refused
+        # and is already used for unknown sessions, so it must not be overloaded.
+        assert out.stop_reason == "end_turn"
+
+    @pytest.mark.asyncio
+    async def test_prompt_leaves_meta_unset_on_success(self, agent, mock_manager):
+        """A normal turn must not grow a failure marker."""
+        resp = await agent.new_session(cwd=".")
+        state = mock_manager.get_session(resp.session_id)
+        state.agent.run_conversation = lambda *a, **k: {
+            "final_response": "ok",
+            "messages": [],
+        }
+        state.agent.model = "test-model"
+        state.agent.provider = "openrouter"
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        out = await agent.prompt(
+            prompt=[TextContentBlock(type="text", text="hi")],
+            session_id=resp.session_id,
+        )
+
+        assert ((out.field_meta or {}).get("hermes") or {}).get("failed") is not True
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Reports a failed turn to the ACP client instead of letting the error summary pass for an answer.

`agent/conversation_loop.py` already classifies non-retryable provider errors and returns `failed: True` plus `error` in the conversation result. `acp_adapter/server.py::prompt()` reads neither — it takes `final_response`, ships it via `update_agent_message_text`, and returns `stop_reason="end_turn"`. The client therefore sees a normal assistant message whose text happens to be `HTTP 400: ...`, with nothing marking the turn as failed.

## Related Issue

Fixes #89948.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes

- `acp_adapter/server.py` — when `result.get("failed")`, return the verdict in `PromptResponse.field_meta` (`_meta`):

  ```json
  {"stopReason": "end_turn", "_meta": {"hermes": {"failed": true, "error": "HTTP 400: ..."}}}
  ```

  `error` is truncated to 500 chars; the summary is already redacted upstream by `_summarize_api_error`.

- `tests/acp/test_server.py` — `test_prompt_surfaces_failed_turn_in_meta` asserts the marker and that `stop_reason` stays `end_turn`; `test_prompt_leaves_meta_unset_on_success` asserts a normal turn does not grow the marker.

## Why `_meta` and not `stop_reason="refusal"`

`refusal` means the model refused, and `prompt()` already returns it for an unknown session (`return PromptResponse(stop_reason="refusal")`), so overloading it would make "the model declined", "no such session" and "the provider call failed" indistinguishable. `_meta` is additive, ignored by clients that do not know about it, and is already how this method reports provenance — so no client contract changes.

## Testing

`pytest tests/acp` — 137 passed.

Also running downstream against 0.19.0 (`3ef6bbd2`) as a local patch, where it is what lets our layer mark such turns as failed and stop presenting them as answers.

## Note

`stop_reason` deliberately stays `end_turn` — the turn did end normally as far as the protocol is concerned. If you would rather express this in the stop reason (a new enum member, say `error`), happy to switch; that just needs a spec-level decision I did not want to take unilaterally.
