### PR TITLE
fix(signal): send TTS audio as a native voice note

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -1419,6 +1419,8 @@ class SignalAdapter(BasePlatformAdapter):
         file_path: str,
         media_label: str,
         caption: Optional[str] = None,
+        *,
+        voice_note: bool = False,
     ) -> SendResult:
         """Send any file as a Signal attachment via RPC.
 
@@ -1440,6 +1442,9 @@ class SignalAdapter(BasePlatformAdapter):
             "message": caption or "",
             "attachments": [file_path],
         }
+        if voice_note:
+            # CLI --voice-note → JSON-RPC voiceNote (signal-cli 0.14.2+).
+            params["voiceNote"] = True
 
         if chat_id.startswith("group:"):
             params["groupId"] = chat_id[6:]
@@ -1489,12 +1494,15 @@ class SignalAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         **kwargs,
     ) -> SendResult:
-        """Send an audio file as a Signal attachment.
+        """Send an audio file as a Signal voice note.
 
-        Signal does not distinguish voice messages from file attachments at
-        the API level, so this routes through the same RPC send path.
+        signal-cli JSON-RPC maps CLI ``--voice-note`` to ``voiceNote``.
+        Without it, clients render the file as a generic attachment
+        instead of a native tap-to-play voice bubble.
         """
-        return await self._send_attachment(chat_id, audio_path, "Audio", caption)
+        return await self._send_attachment(
+            chat_id, audio_path, "Audio", caption, voice_note=True
+        )
 
     async def send_video(
         self,

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -380,6 +380,7 @@ class TestSignalSendImageFile:
         assert captured[0]["params"]["recipient"] == ["+155****4567"]
         assert captured[0]["params"]["attachments"] == [str(img_path)]
         assert captured[0]["params"]["message"] == ""  # caption=None → ""
+        assert "voiceNote" not in captured[0]["params"]
         # Typing indicator must be stopped before sending
         adapter._stop_typing_indicator.assert_awaited_once_with("+155****4567")
         # Timestamp must be tracked for echo-back prevention
@@ -461,8 +462,32 @@ class TestSignalSendVoice:
         assert captured[0]["method"] == "send"
         assert captured[0]["params"]["attachments"] == [str(audio_path)]
         assert captured[0]["params"]["message"] == ""  # caption=None → ""
+        # signal-cli JSON-RPC maps CLI --voice-note to camelCase voiceNote.
+        # Without it, clients render TTS audio as a generic file (#89831).
+        assert captured[0]["params"].get("voiceNote") is True
         adapter._stop_typing_indicator.assert_awaited_once_with("+155****4567")
         assert 1234567890 in adapter._recent_sent_timestamps
+
+    @pytest.mark.asyncio
+    async def test_send_voice_marks_group_attachment_as_voice_note(self, monkeypatch, tmp_path):
+        """Group sends use groupId, but still need the voice-note flag."""
+        adapter = _make_signal_adapter(monkeypatch)
+        mock_rpc, captured = _stub_rpc({"timestamp": 1234567890})
+        adapter._rpc = mock_rpc
+        adapter._stop_typing_indicator = AsyncMock()
+
+        audio_path = tmp_path / "reply.ogg"
+        audio_path.write_bytes(b"OggS" + b"\x00" * 100)
+
+        result = await adapter.send_voice(
+            chat_id="group:abc123==", audio_path=str(audio_path)
+        )
+
+        assert result.success is True
+        params = captured[0]["params"]
+        assert params["groupId"] == "abc123=="
+        assert "recipient" not in params
+        assert params.get("voiceNote") is True
 
 
     @pytest.mark.asyncio
@@ -508,6 +533,7 @@ class TestSignalSendVideo:
         assert captured[0]["method"] == "send"
         assert captured[0]["params"]["attachments"] == [str(vid_path)]
         assert captured[0]["params"]["message"] == ""  # caption=None → ""
+        assert "voiceNote" not in captured[0]["params"]
         adapter._stop_typing_indicator.assert_awaited_once_with("+155****4567")
         assert 1234567890 in adapter._recent_sent_timestamps
 

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1615,6 +1615,29 @@ class TestSendSignalChunking:
         # Only the existing file made it into the RPC
         params = fake.calls[0]["payload"]["params"]
         assert len(params["attachments"]) == 1
+        assert "voiceNote" not in params
+
+    def test_voice_media_sets_voice_note_flag(self, tmp_path, monkeypatch):
+        """TTS / voice files must be sent as Signal voice notes (#89831)."""
+        audio = tmp_path / "reply.ogg"
+        audio.write_bytes(b"OggS" + b"\x00" * 16)
+
+        fake = _FakeSignalHttp([{"result": {"timestamp": 1}}])
+        _install_signal_http(monkeypatch, fake)
+
+        result = asyncio.run(
+            _send_signal(
+                {"http_url": "http://localhost:8080", "account": "+15551234567"},
+                "+15557654321",
+                "spoken reply",
+                media_files=[(str(audio), True)],
+            )
+        )
+
+        assert result["success"] is True
+        params = fake.calls[0]["payload"]["params"]
+        assert params["attachments"] == [str(audio)]
+        assert params.get("voiceNote") is True
 
 
 # ── _send_via_adapter standalone fallback ────────────────────────────────

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1787,9 +1787,12 @@ async def _send_signal(extra, chat_id, message, media_files=None):
 
         valid_media = media_files or []
         attachment_paths = []
-        for media_path, _is_voice in valid_media:
+        voice_paths: set[str] = set()
+        for media_path, is_voice in valid_media:
             if os.path.exists(media_path):
                 attachment_paths.append(media_path)
+                if is_voice:
+                    voice_paths.add(media_path)
             else:
                 logger.warning("Signal media file not found, skipping: %s", media_path)
 
@@ -1819,6 +1822,8 @@ async def _send_signal(extra, chat_id, message, media_files=None):
                 params["recipient"] = [chat_id]
             if batch_attachments:
                 params["attachments"] = batch_attachments
+                if any(path in voice_paths for path in batch_attachments):
+                    params["voiceNote"] = True
 
             payload = {
                 "jsonrpc": "2.0",


### PR DESCRIPTION
## What does this PR do?

Signal TTS replies were sent as ordinary file attachments. Official Signal clients then showed a generic `.ogg` file instead of a tap-to-play voice bubble.

`send_voice()` now sets signal-cli JSON-RPC `voiceNote: true` (CLI `--voice-note`, 0.14.2+). Image, document, and video sends are unchanged. The `send_message` Signal path sets the same flag when a media tuple is already tagged as voice.

## Related Issue

Fixes #89831

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/signal.py`: keyword-only `voice_note` on `_send_attachment`; `send_voice()` passes `voice_note=True`.
- `tools/send_message_tool.py`: `_send_signal` honors the existing `is_voice` flag instead of discarding it.
- `tests/gateway/test_signal.py`: DM and group `send_voice` assert `voiceNote`; image/video sends assert it is absent.
- `tests/tools/test_send_message_tool.py`: voice-tagged media sets `voiceNote`.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_signal.py tests/tools/test_send_message_tool.py tests/tools/test_signal_media.py -q`
2. Optional live check: Signal profile with `voice.auto_tts: true`, trigger `[[audio_as_voice]]` / TTS, confirm the official app shows a native voice bubble.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` on the focused Signal suites above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (unit tests; live signal-cli / official app not run)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
