### PR TITLE
fix(gateway): don't spend LINE's reply token on the fallback-success notice

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -517,6 +517,40 @@ def _gateway_platform_value(platform: Any) -> str:
     return str(getattr(platform, "value", platform) or "").strip().lower()
 
 
+# Platforms where a status bubble is METERED, not merely noisy.
+#
+# LINE is currently the only one. A LINE bot may send either a Reply — free,
+# but it needs the single-use replyToken that arrives with the inbound webhook
+# event and expires in about a minute — or a Push, which is billed PER
+# RECIPIENT against a monthly allowance (200/month on the free plan, so one
+# answer in a 13-member group costs 13). A status bubble sent while the turn
+# is still running consumes that one replyToken, and the real answer then has
+# no free path left.
+#
+# Everywhere else the same bubble is free, so it stays visible: this is a cost
+# rule, not a taste rule, and it must not quietly become a global mute.
+_METERED_STATUS_PLATFORMS = frozenset({"line"})
+
+# The one-shot SUCCESS-path fallback notice (_emit_pending_fallback_notice),
+# which fires only when a fallback RECOVERED the turn — so a real answer is
+# still coming and still needs the token.
+#
+# Deliberately NOT matched: the retry/fallback lines that reach chat through
+# _flush_status_buffer. Those are buffered and DROPPED on success, surfacing
+# only once every retry and fallback is exhausted — they are the failure
+# trace, and by then no answer is competing for the token anyway.
+_METERED_FALLBACK_NOTICE_RE = re.compile(
+    r"switched\s+to\s+fallback\s+model", re.IGNORECASE
+)
+
+
+def _status_message_is_metered_noise(platform: Any, text: str) -> bool:
+    """True when this status would cost the user money on this platform."""
+    if _gateway_platform_value(platform) not in _METERED_STATUS_PLATFORMS:
+        return False
+    return bool(_METERED_FALLBACK_NOTICE_RE.search(text))
+
+
 def _non_conversational_metadata(
     metadata: Optional[Dict[str, Any]] = None,
     *,
@@ -841,6 +875,11 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
             and _COMPRESSION_PROGRESS_STATUS_RE.search(text)
         ):
             return None
+    if _status_message_is_metered_noise(platform, text):
+        # The switch stays visible where it is free: in the logs via
+        # logger.info("Fallback activated: ...") at the emit site, and on the
+        # terminal path via the flushed retry/fallback trace.
+        return None
     if _looks_like_gateway_provider_error(text):
         return _gateway_provider_error_reply(text)
     return text

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -177,6 +177,98 @@ def test_manual_compress_feedback_and_failure_notices_stay_visible(platform, mes
     assert _prepare_gateway_status_message(platform, "warn", message) == message
 
 
+# The retry/fallback trace. These reach chat ONLY through
+# _flush_status_buffer, which runs when every retry and fallback is exhausted
+# ("Surfaces the full retry/fallback trace so the user can see what was tried
+# before the turn gave up"); on success they are dropped unseen. So they are
+# the failure trace, not chatter — suppressing them would blind the user at
+# exactly the moment the turn gave up, and on LINE they cost nothing then
+# because no answer is competing for the reply token.
+TERMINAL_FAILURE_TRACE_MESSAGES = [
+    "🔄 Primary model failed — switching to fallback: gemini-3.6-flash via gemini",
+    "⚠️ Provider safety filter blocked this request — trying fallback...",
+    "⚠️ TLS certificate verification failed — trying fallback...",
+    "⚠️ Empty/malformed response — switching to fallback...",
+    "❌ Provider safety filter blocked this request: HTTP 400 content policy.",
+    "❌ TLS certificate verification failed: self-signed certificate in chain.",
+]
+
+
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+@pytest.mark.parametrize(
+    "message", TERMINAL_FAILURE_TRACE_MESSAGES, ids=lambda m: m[:34]
+)
+def test_terminal_failure_trace_stays_visible(platform, message):
+    """Suppressing the success notice must not eat the failure trace.
+
+    The success notice and these lines all say "fallback", so a regex widened
+    by one careless word swallows the trace too — and the user is left with a
+    bare error, or silence, at the one moment the detail matters.
+    """
+    assert _prepare_gateway_status_message(platform, "warn", message) == message
+
+
+FALLBACK_SUCCESS_NOTICE = (
+    "🔄 Switched to fallback model: gpt-5.4-mini via openai-codex → glm-5.3 via zai"
+)
+
+
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+def test_fallback_notice_stays_visible_where_status_is_free(platform):
+    """The success notice is suppressed ONLY where a bubble costs money.
+
+    Upstream emits it so an operator sees a durable provider change even when
+    the fallback succeeded. On Telegram/Slack/Feishu that bubble is free, so
+    the notice must survive — this is a cost rule, not a global mute.
+    """
+    assert (
+        _prepare_gateway_status_message(platform, "lifecycle", FALLBACK_SUCCESS_NOTICE)
+        == FALLBACK_SUCCESS_NOTICE
+    )
+
+
+def test_fallback_notice_suppressed_on_line_where_it_costs_the_reply_token():
+    """On LINE the same bubble spends the turn's only free delivery.
+
+    A LINE bot replies for free only with the single-use replyToken from the
+    inbound event; spending it on a status message forces the real answer onto
+    the metered Push API, billed per recipient.
+    """
+    assert (
+        _prepare_gateway_status_message("line", "lifecycle", FALLBACK_SUCCESS_NOTICE)
+        is None
+    )
+
+
+@pytest.mark.parametrize("message", TERMINAL_FAILURE_TRACE_MESSAGES, ids=lambda m: m[:34])
+def test_line_keeps_the_failure_trace(message):
+    """Suppressing the success notice on LINE must not eat the failure trace.
+
+    Those lines only reach chat once every retry and fallback is exhausted, so
+    they are the one explanation the user gets — and they are free to deliver
+    then, because no answer is competing for the token.
+    """
+    assert _prepare_gateway_status_message("line", "warn", message) == message
+
+
+# Trace lines the pre-existing provider-error sanitizer REWRITES rather than
+# passing through (raw provider text must never reach chat users). Asserted
+# separately because byte-equality does not hold — the property under test is
+# that the noise filter did not swallow them on the way.
+SANITIZED_TRACE_MESSAGES = [
+    "❌ Non-retryable error (HTTP 401): Your authentication token has been invalidated.",
+    "⚠️ Non-retryable error (HTTP 400) — trying fallback...",
+]
+
+
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+@pytest.mark.parametrize("message", SANITIZED_TRACE_MESSAGES, ids=lambda m: m[:34])
+def test_sanitized_failures_still_reach_the_user(platform, message):
+    assert _prepare_gateway_status_message(platform, "warn", message) is not None, (
+        "a terminal failure was swallowed as noise"
+    )
+
+
 @pytest.mark.parametrize("platform", ["slack", "matrix"])
 def test_chat_gateways_redact_secret_in_provider_error(platform):
     """Provider-error bodies carrying secrets must never reach chat users.


### PR DESCRIPTION
## What does this PR do?

A fallback that **succeeds** emits `🔄 Switched to fallback model: ...` (and the `— trying fallback...` lines before it) through `status_callback`, so it lands in the chat as a user-facing bubble. That's operator observability — but on a messaging surface there is no operator, only end users, and on some platforms that bubble is not free.

On LINE it costs twice over. A bot can send either a **Reply** (free, but it needs the single-use `replyToken` that arrives with the inbound webhook event and expires in about a minute) or a **Push** (metered). A status bubble consumes that one `replyToken`, so the real answer has none left and falls back to Push — and Push is billed **per recipient**, so a single answer in a 13-member group costs 13 of the free plan's 200 monthly messages.

Measured on identical questions in a 1-member test group:

| primary | fallback? | delivery | quota |
|---|---|---|---|
| exhausted (429) | yes | push | +1 |
| exhausted (429) | yes | push | +1 |
| healthy | no | reply | 0 |

The fix suppresses the **non-terminal** chatter on chat surfaces, using the existing `_TELEGRAM_NOISY_STATUS_RE`, which already collects exactly this class ("transient/auxiliary status that should stay in logs, not gateway chats"). The switch stays fully visible where an operator actually looks: `logger.info("Fallback activated: ...")` at the emit site is untouched.

Terminal `❌ ...` notices are deliberately **not** matched. When the run is over and no answer is coming, the user has to be told — and in that case there is no final response competing for the token anyway, so it costs nothing to deliver.

## Related Issue

No existing issue — searched open and closed issues/PRs for `LINE reply token`, `replyToken push quota`, and `Switched to fallback model status`; the only hit was the closed LINE adapter feature request #6081.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` — three alternatives added to `_TELEGRAM_NOISY_STATUS_RE`: `switched to fallback model`, `primary model failed — switching to fallback`, `— trying fallback...`
- `tests/gateway/test_telegram_noise_filter.py` — the five provider-switch lines added to `NOISY_STATUS_MESSAGES`, plus `test_terminal_provider_failures_stay_visible` pinning the carve-out

## How to Test

1. `pytest tests/gateway/test_telegram_noise_filter.py -q` → 157 passed.
2. Revert the `gateway/run.py` hunk and re-run: 15 failures. The new assertions genuinely constrain the change rather than passing either way.
3. Full suite, `tests/gateway/` (minus `test_teams.py`, which fails to collect on `main` in this environment, unrelated): the set of failing tests is **identical** with and without this change — no new failures introduced.

The carve-out test matters because the terminal and non-terminal lines differ by one leading character and share the words the regex keys on, so a careless widening swallows both and leaves the user with silence exactly when the bot has stopped working.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the gateway suite and compared failures against `main` — no new failures
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (Linux 6.8), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no config keys or user-facing docs change; the rationale lives in the code comment)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (pure regex/filter logic, no platform-specific calls)
- [x] I've updated tool descriptions/schemas — N/A