### PR TITLE
fix(whatsapp): preserve recovery after bridge exit

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -869,7 +869,36 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             logger.error("[%s] %s", self.name, message)
             self._set_fatal_error("whatsapp_bridge_exited", message, retryable=True)
             self._close_bridge_log()
-            await self._notify_fatal_error()
+            if asyncio.current_task() is getattr(self, "_poll_task", None):
+                # The runner's fatal handler disconnects this adapter, and
+                # disconnect() cancels the poll task.  Awaiting the handler
+                # from that same poll task creates a cancellation cycle:
+                # poll -> fatal handler -> disconnect -> poll.  Hand recovery
+                # to an independently owned task so teardown can finish and
+                # the runner can queue WhatsApp for reconnection.
+                notification_task = asyncio.create_task(
+                    self._notify_fatal_error()
+                )
+                background_tasks = getattr(self, "_background_tasks", None)
+                if isinstance(background_tasks, set):
+                    background_tasks.add(notification_task)
+
+                def finish_notification(task: asyncio.Task) -> None:
+                    if isinstance(background_tasks, set):
+                        background_tasks.discard(task)
+                    try:
+                        task.result()
+                    except asyncio.CancelledError:
+                        pass
+                    except Exception:
+                        logger.exception(
+                            "[%s] Fatal-error notification task failed",
+                            self.name,
+                        )
+
+                notification_task.add_done_callback(finish_notification)
+            else:
+                await self._notify_fatal_error()
         return self.fatal_error_message or message
 
     async def disconnect(self) -> None:

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -19,7 +19,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from gateway.config import Platform
+from gateway.config import GatewayConfig, Platform, PlatformConfig
 
 
 # ---------------------------------------------------------------------------
@@ -128,6 +128,66 @@ class TestCloseBridgeLog:
 
         mock_fh.close.assert_called_once()
         assert adapter._bridge_log_fh is None
+
+
+@pytest.mark.asyncio
+async def test_poll_detected_bridge_exit_completes_real_runner_recovery(
+    monkeypatch, tmp_path
+):
+    """A bridge crash detected by the poll task must reach the reconnect queue.
+
+    The real fatal handler disconnects the failed adapter.  If the poll task
+    awaits that handler inline, ``disconnect()`` cancels the same poll task and
+    cancellation aborts the handler before it can queue WhatsApp for recovery.
+    """
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from gateway.run import GatewayRunner
+
+    adapter = _make_adapter()
+    adapter._running = True
+    adapter._http_session = MagicMock(closed=True)
+    adapter._poll_task = None
+    adapter._shutting_down = False
+    adapter._platform_lock_identity = None
+
+    bridge_process = MagicMock()
+    bridge_process.poll.return_value = 1
+    adapter._bridge_process = bridge_process
+
+    config = GatewayConfig(
+        platforms={
+            Platform.WHATSAPP: PlatformConfig(enabled=True, token="token")
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+    runner.adapters = {Platform.WHATSAPP: adapter}
+    runner.delivery_router.adapters = runner.adapters
+    runner.stop = AsyncMock()
+    adapter.set_fatal_error_handler(runner._handle_adapter_fatal_error)
+
+    with patch(
+        "plugins.platforms.whatsapp.adapter._terminate_bridge_process"
+    ):
+        poll_task = asyncio.create_task(adapter._poll_messages())
+        adapter._poll_task = poll_task
+        done, _pending = await asyncio.wait({poll_task}, timeout=0.5)
+        assert poll_task in done
+
+        for _ in range(100):
+            if (
+                Platform.WHATSAPP in runner._failed_platforms
+                and adapter._http_session is None
+            ):
+                break
+            await asyncio.sleep(0.005)
+
+    assert runner.adapters == {}
+    assert Platform.WHATSAPP in runner._failed_platforms
+    assert runner._failed_platforms[Platform.WHATSAPP]["attempts"] == 0
+    assert adapter._http_session is None
+    assert adapter._poll_task is None
+    runner.stop.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

- Dispatch a poll-detected WhatsApp bridge fatal notification from an independently owned task.
- Track and consume that task so teardown errors are not lost.
- Add an integration regression using the real WhatsApp adapter and the real gateway fatal-error handler.

## Root cause

The WhatsApp poll task awaited the gateway fatal-error handler inline. The handler disconnects the failed adapter, and `disconnect()` cancels and awaits the poll task. This formed a cancellation cycle (`poll -> fatal handler -> disconnect -> poll`) that prevented the handler from reaching the background reconnect queue while the parent gateway remained alive.

## Impact

After a managed WhatsApp bridge child exited, the channel could remain permanently stuck in `retrying` until the entire gateway was manually restarted.

## Validation

`scripts/run_tests.sh tests/gateway/test_whatsapp_connect.py tests/gateway/test_runner_fatal_adapter.py tests/gateway/test_platform_reconnect.py -q`

Result: 37 passed, 1 platform-specific skip, 0 failed on Windows.
