### PR TITLE
feat(gateway): add gateway.ping heartbeat wire contract

### DIFF
--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -153,6 +153,50 @@ def test_ws_starts_mcp_discovery_before_ready(monkeypatch):
     assert events == ["accept", "ready_after_0"]
 
 
+def test_ws_ready_advertises_heartbeat_and_ping_is_inline(monkeypatch):
+    sent = []
+    inbound = iter(
+        [
+            json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": "heartbeat-1",
+                    "method": "gateway.ping",
+                    "params": {},
+                }
+            )
+        ]
+    )
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0)
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            try:
+                return next(inbound)
+            except StopIteration:
+                raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    asyncio.run(ws_mod.handle_ws(FakeWS()))
+
+    ready = sent[0]["params"]
+    assert ready["type"] == "gateway.ready"
+    assert ready["payload"]["heartbeat"] is True
+    assert sent[1] == {
+        "jsonrpc": "2.0",
+        "result": {"ok": True},
+        "id": "heartbeat-1",
+    }
+
+
 def test_ws_transport_serializes_concurrent_sends():
     active_sends = 0
     max_active_sends = 0

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -29,6 +29,7 @@ import json
 import logging
 import socket
 import threading
+import time
 from typing import Any
 
 from tui_gateway import server
@@ -94,6 +95,7 @@ class WSTransport:
         self._loop = loop
         self._peer = peer
         self._closed = False
+        self._last_inbound_at = time.monotonic()
         # Token-coalescing buffer (CF-2). Streamed token frames land here and a
         # short timer flushes the batch. The lock guards the buffer + the
         # "armed" flag against the worker threads that call write(); the timer
@@ -106,6 +108,17 @@ class WSTransport:
         # writes need an async boundary because several batches can be queued on
         # the owning loop while it recovers from a stall.
         self._send_lock = asyncio.Lock()
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    @property
+    def last_inbound_at(self) -> float:
+        return self._last_inbound_at
+
+    def mark_inbound(self) -> None:
+        self._last_inbound_at = time.monotonic()
 
     @staticmethod
     def _is_streaming_frame(obj: dict) -> bool:
@@ -320,7 +333,11 @@ async def handle_ws(ws: Any) -> None:
                     # change_events: this backend broadcasts pet.changed /
                     # cron.changed / sessions.changed, so clients can demote
                     # their legacy polls to slow backstops.
-                    "payload": {"skin": skin_payload, "change_events": True},
+                    "payload": {
+                        "skin": skin_payload,
+                        "change_events": True,
+                        "heartbeat": True,
+                    },
                 },
             }
         )
@@ -354,6 +371,7 @@ async def handle_ws(ws: Any) -> None:
             line = raw.strip()
             if not line:
                 continue
+            transport.mark_inbound()
             messages += 1
 
             try:
@@ -388,6 +406,22 @@ async def handle_ws(ws: Any) -> None:
             # response dict, which we write here from the loop.
             req_id = req.get("id") if isinstance(req, dict) else None
             req_method = req.get("method") if isinstance(req, dict) else None
+
+            if req_method == "gateway.ping":
+                ok = await transport.write_async(
+                    {
+                        "jsonrpc": "2.0",
+                        "result": {"ok": True},
+                        "id": req_id,
+                    }
+                )
+                if not ok:
+                    disconnect_reason = "send_failed_after_heartbeat"
+                    send_failures += 1
+                    _log.warning("ws heartbeat reply send failed peer=%s id=%s", peer, req_id)
+                    break
+                continue
+
             try:
                 resp = await asyncio.to_thread(server.dispatch, req, transport)
             except Exception:


### PR DESCRIPTION
## What does this PR do?

Adds a `gateway.ping` / heartbeat wire contract to the TUI gateway WebSocket, so a client can detect a silently-dropped connection and a server can tell a live transport from a stale one. This is the wire primitive on its own — no client timer and no server-side expiry logic yet; those are follow-ons that consume it.

This is the first slice of a WebSocket-recovery series I'm splitting out of a larger PR (#83166) for single-concern review.

## Related Issue

Part of the recovery work tracked in #83166.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tui_gateway/ws.py`:
  - `WSTransport` gains `closed` and `last_inbound_at` properties and a `mark_inbound()` method; the read loop stamps inbound activity.
  - The `gateway.ready` payload advertises `"heartbeat": True`.
  - A `gateway.ping` request is answered inline with a pong before dispatch, so it never enters the method layer.
- `tests/test_tui_gateway_ws.py`: one test that `gateway.ready` advertises the flag and that `gateway.ping` is answered inline.

## How to Test

```text
bash scripts/run_tests.sh tests/test_tui_gateway_ws.py -q
→ 7 passed
```

## Backward compatibility

Purely additive in both directions: an old client never sends `gateway.ping`, and an old server never advertises `heartbeat`, so nothing starts relying on a capability the peer lacks.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched existing PRs
- [x] Only changes related to this feature (one slice)
- [x] Ran `tests/test_tui_gateway_ws.py`
- [x] Added a test
- [x] Tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] Docs — N/A (internal wire contract; consumers arrive with the follow-on slices)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform — N/A
- [x] Tool descriptions/schemas — N/A

---

Salvage-friendly: single additive commit on current main (`13ce0c5c67`), no dependencies — cherry-pick welcome, authorship preservation appreciated but optional.
