### PR TITLE
fix(profiles): validate profile name before joining it into the profiles root

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -376,7 +376,19 @@ def get_profile_dir(name: str) -> Path:
     canon = normalize_profile_name(name)
     if canon == "default":
         return _get_default_hermes_home()
-    return _get_profiles_root() / canon
+    # Defense-in-depth: normalize_profile_name only lowercases/strips, so a
+    # malformed or relative name (``..``, ``../x``, ``a/b``) would otherwise be
+    # joined straight into the profiles root and resolve outside ``profiles/``.
+    # validate_profile_name (via _PROFILE_ID_RE) already exists but was never
+    # called on this path. Enforce a plain basename first, then validate, so
+    # the joined component is always a single safe id. Fail closed.
+    safe_name = os.path.basename(canon)
+    if safe_name != canon:
+        raise ValueError(
+            f"Invalid profile name {name!r}: path components are not allowed"
+        )
+    validate_profile_name(safe_name)
+    return _get_profiles_root() / safe_name
 
 
 def profile_exists(name: str) -> bool:
@@ -384,7 +396,18 @@ def profile_exists(name: str) -> bool:
     canon = normalize_profile_name(name)
     if canon == "default":
         return True
-    return get_profile_dir(canon).is_dir()
+    # Validate before touching the filesystem so a malformed/relative name can
+    # never confirm an out-of-tree directory, and compare the validated name
+    # against existing entries instead of joining request-derived text into a
+    # path (avoids the path-injection shape entirely).
+    validate_profile_name(canon)
+    try:
+        return any(
+            entry.name == canon and entry.is_dir()
+            for entry in _get_profiles_root().iterdir()
+        )
+    except FileNotFoundError:
+        return False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -106,6 +106,46 @@ class TestGetProfileDir:
         result = get_profile_dir("default")
         assert result == tmp_path / ".hermes"
 
+    def test_named_profile_is_normalized_and_contained(self, profile_env):
+        # Valid names still resolve, and title-case input is normalized to the
+        # lowercase on-disk id under profiles/.
+        tmp_path = profile_env
+        result = get_profile_dir("Coder")
+        assert result == tmp_path / ".hermes" / "profiles" / "coder"
+
+    @pytest.mark.parametrize(
+        "name", ["..", "../x", "../../.bashrc", "a/b", "/tmp/escape", "has space"]
+    )
+    def test_unsafe_profile_name_cannot_escape_profiles_root(self, profile_env, name):
+        # Hardening: a malformed or relative profile name must be rejected
+        # before it is joined into the profiles root, so it can never resolve
+        # outside profiles/ (e.g. get_profile_dir("..") used to return the
+        # profiles-root parent).
+        with pytest.raises(ValueError):
+            get_profile_dir(name)
+
+
+class TestProfileExists:
+    """Tests for profile_exists()."""
+
+    def test_default_always_exists(self, profile_env):
+        assert profiles.profile_exists("default") is True
+
+    def test_existing_named_profile_found_and_normalized(self, profile_env):
+        create_profile("coder", no_alias=True)
+        assert profiles.profile_exists("coder") is True
+        assert profiles.profile_exists("Coder") is True
+
+    def test_missing_named_profile_is_false(self, profile_env):
+        assert profiles.profile_exists("ghost") is False
+
+    @pytest.mark.parametrize("name", ["..", "../x", "a/b"])
+    def test_traversal_name_does_not_confirm(self, profile_env, name):
+        # Must never report an out-of-tree directory as an existing profile;
+        # a traversal name is rejected rather than confirmed.
+        with pytest.raises(ValueError):
+            profiles.profile_exists(name)
+
 
 # ===================================================================
 # TestCreateProfile


### PR DESCRIPTION
## What does this PR do?

`get_profile_dir()` normalized a profile name (lowercase/strip) and joined it straight into the profiles root without validating it, even though a validator (`validate_profile_name`, backed by `_PROFILE_ID_RE`) already exists in the same module and was simply not called on this path. A relative or traversal-shaped name therefore resolved outside `~/.hermes/profiles/`: `get_profile_dir("..")` returned the parent `.hermes` directory, and `profile_exists("..")` confirmed it. This validates the name before the join and compares `profile_exists` against real directory entries instead of a request-derived path.

To be clear about scope: under SECURITY.md §2.6 this is not a boundary crossing — the surfaces that reach `get_profile_dir` (the TUI gateway over local IPC, loopback dashboard/kanban endpoints) are already inside the host-user trust envelope, where callers are equally trusted. This is defense-in-depth hardening: a malformed or relative profile name should fail closed rather than silently resolve somewhere it shouldn't, regardless of who supplied it.

## Related Issue

No open issue — closing a gap where an existing validator wasn't applied.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/profiles.py`:
  - `get_profile_dir()` — enforce basename and run `validate_profile_name` before the join (`default` still special-cased; invalid names raise `ValueError`, fail-closed).
  - `profile_exists()` — validate first, then match against `profiles_root.iterdir()` entries instead of joining request-derived text.
  - `_PROFILE_ID_RE` unchanged.

## How to Test

```text
# Before: these resolve outside the profiles root
get_profile_dir("..")     -> ~/.hermes            (escapes)
get_profile_dir("../x")   -> ~/.hermes/x          (escapes)
profile_exists("..")      -> True

# After: rejected
get_profile_dir("..")     -> ValueError
profile_exists("..")      -> False
```
```text
bash scripts/run_tests.sh tests/hermes_cli/test_profiles.py -q   → 67 passed, 2 skipped
# with direct callers (describer, distribution):                  140 passed, 2 skipped
```
Fail-before (new tests, no fix): 9 failed (every traversal shape "did not raise").

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched existing PRs
- [x] Only changes related to this fix
- [x] Ran `tests/hermes_cli/test_profiles.py` and adjacent callers
- [x] Added tests
- [x] Tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] Docs — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform — validation is platform-neutral
- [x] Tool descriptions/schemas — N/A

---

Salvage-friendly: single commit on current main (`13ce0c5c67`), no dependencies — cherry-pick welcome, authorship preservation appreciated but optional.
