### PR TITLE
fix(agent): bound historical image payloads per request

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -29,6 +29,7 @@ from typing import Any, Dict, Optional
 
 from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale_timeout
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
+from agent.context_compressor import _strip_old_image_parts
 from agent.error_classifier import (
     FailoverReason,
     PROVIDER_STREAM_NON_JSON_ERROR_CODE,
@@ -2945,6 +2946,12 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         # _thinking_prefill must survive until here so the drop pass can
         # recognize stubs after reasoning fields are stripped.
         api_messages = agent._drop_thinking_only_and_merge_users(api_messages)
+
+        # This path assembles and sends its own transcript instead of passing
+        # through the main conversation loop. Apply the same request-time
+        # image bound so a max-iteration summary cannot re-ship every
+        # historical base64 payload in one oversized request.
+        _strip_old_image_parts(api_messages, keep_recent=3)
 
         # Strip all remaining underscore-prefixed scaffolding keys before the
         # wire. The summary path calls chat.completions.create() directly,

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1466,6 +1466,9 @@ def _truncate_tool_call_args_json(args: str, head_chars: int = 200) -> str:
 
 
 _IMAGE_PART_TYPES = frozenset({"image_url", "input_image", "image"})
+_OLD_REQUEST_IMAGE_PLACEHOLDER = (
+    "[Attached image — stripped from older request context]"
+)
 
 
 def _is_image_part(part: Any) -> bool:
@@ -1486,6 +1489,63 @@ def _content_has_images(content: Any) -> bool:
     if not isinstance(content, list):
         return False
     return any(_is_image_part(p) for p in content)
+
+
+def _strip_old_image_parts(
+    api_messages: List[Dict[str, Any]],
+    keep_recent: int = 3,
+) -> int:
+    """Replace image parts outside the newest image-bearing messages.
+
+    This is a request-time payload bound, independent of context compaction.
+    Long vision runs otherwise re-send every historical inline base64 image on
+    every model call and can hit a provider's HTTP body-size limit while the
+    token estimate remains far below the compression threshold.
+
+    The newest ``keep_recent`` *messages containing images* retain all their
+    image parts. Older image parts become short text placeholders. Message
+    rows are never removed, so assistant/tool-call pairing remains intact.
+    ``api_content`` is dropped from rewritten rows because replaying that
+    sidecar could restore the bytes this pass removed.
+
+    Mutates the per-call ``api_messages`` list and returns the number of image
+    parts replaced. Canonical/persisted history must not be passed here.
+
+    Removing bytes necessarily changes the request prefix once when an image
+    crosses the keep-window boundary. The projection is deterministic, so that
+    message is stable on every later request; running before cache planning
+    ensures cache markers describe the post-eviction payload. This mirrors the
+    existing Anthropic computer-use screenshot policy.
+    """
+    if not isinstance(api_messages, list):
+        return 0
+
+    remaining = max(0, keep_recent)
+    replaced = 0
+    for message in reversed(api_messages):
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if not isinstance(content, list) or not _content_has_images(content):
+            continue
+        if remaining:
+            remaining -= 1
+            continue
+
+        new_content: List[Any] = []
+        for part in content:
+            if _is_image_part(part):
+                new_content.append({
+                    "type": "text",
+                    "text": _OLD_REQUEST_IMAGE_PLACEHOLDER,
+                })
+                replaced += 1
+            else:
+                new_content.append(part)
+        message["content"] = new_content
+        drop_stale_api_content(message)
+
+    return replaced
 
 
 def _strip_images_from_content(content: Any) -> Any:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -36,6 +36,7 @@ from agent.conversation_compression import (
     conversation_history_after_compression,
 )
 from agent.context_engine import automatic_compaction_status_message
+from agent.context_compressor import _strip_old_image_parts
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.message_metadata import append_message
@@ -2389,6 +2390,14 @@ def run_conversation(
         # lone surrogates (U+D800-U+DFFF) that crash json.dumps() inside
         # the OpenAI SDK. Sanitizing here prevents the 3-retry cycle.
         _sanitize_messages_surrogates(api_messages)
+
+        # Bound inline image bytes on every request, not only after context
+        # compaction. Long vision runs can remain below the token threshold
+        # while accumulated base64 tool results exceed the provider's HTTP
+        # body limit. This operates only on the per-call message copy; stored
+        # history remains untouched. Run before cache planning so the request
+        # prefix reflects the exact payload that will be sent.
+        _strip_old_image_parts(api_messages, keep_recent=3)
 
         # NOTE (empty-content class fix): no send-time pad loop here.  The
         # single owner for "never send a turn strict wire validation rejects

--- a/tests/agent/test_request_image_eviction.py
+++ b/tests/agent/test_request_image_eviction.py
@@ -1,0 +1,154 @@
+"""Request-time eviction of historical multimodal image payloads."""
+
+from __future__ import annotations
+
+import copy
+
+from agent.context_compressor import (
+    _content_has_images,
+    _strip_old_image_parts,
+)
+
+
+def _image(label: str) -> dict:
+    return {
+        "type": "image_url",
+        "image_url": {"url": "data:image/png;base64," + label * 100},
+    }
+
+
+def _image_message(role: str, label: str, *, sidecar: bool = False) -> dict:
+    message = {
+        "role": role,
+        "content": [
+            {"type": "text", "text": f"caption {label}"},
+            _image(label),
+        ],
+    }
+    if role == "tool":
+        message["tool_call_id"] = f"call_{label}"
+    if sidecar:
+        message["api_content"] = "stale bytes"
+    return message
+
+
+class TestStripOldImageParts:
+    def test_keeps_three_newest_image_bearing_messages_across_roles(self):
+        messages = [
+            _image_message("user", "old-user"),
+            {"role": "assistant", "content": "one"},
+            _image_message("tool", "old-tool"),
+            {"role": "assistant", "content": "two"},
+            _image_message("user", "new-user"),
+            _image_message("tool", "new-tool-a"),
+            _image_message("tool", "new-tool-b"),
+        ]
+
+        replaced = _strip_old_image_parts(messages, keep_recent=3)
+
+        assert replaced == 2
+        assert not _content_has_images(messages[0]["content"])
+        assert not _content_has_images(messages[2]["content"])
+        for index in (4, 5, 6):
+            assert _content_has_images(messages[index]["content"])
+
+    def test_keep_window_counts_messages_not_individual_image_parts(self):
+        old = _image_message("tool", "old")
+        newest = {
+            "role": "tool",
+            "tool_call_id": "call_new",
+            "content": [_image("new-a"), _image("new-b")],
+        }
+        messages = [old, newest]
+
+        replaced = _strip_old_image_parts(messages, keep_recent=1)
+
+        assert replaced == 1
+        assert not _content_has_images(old["content"])
+        assert sum(1 for part in newest["content"] if part["type"] == "image_url") == 2
+
+    def test_image_only_tool_result_keeps_tool_pair_slot(self):
+        message = {
+            "role": "tool",
+            "tool_call_id": "call_old",
+            "content": [_image("only")],
+        }
+
+        replaced = _strip_old_image_parts([message], keep_recent=0)
+
+        assert replaced == 1
+        assert message["tool_call_id"] == "call_old"
+        assert message["content"] == [
+            {
+                "type": "text",
+                "text": "[Attached image — stripped from older request context]",
+            }
+        ]
+
+    def test_rewrite_drops_stale_api_content_sidecar(self):
+        old = _image_message("user", "old", sidecar=True)
+        messages = [old, _image_message("tool", "new")]
+
+        _strip_old_image_parts(messages, keep_recent=1)
+
+        assert "api_content" not in old
+
+    def test_replaces_all_supported_image_part_shapes(self):
+        message = {
+            "role": "tool",
+            "tool_call_id": "call_formats",
+            "content": [
+                _image("chat"),
+                {"type": "input_image", "image_url": "data:image/png;base64,responses"},
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": "anthropic",
+                    },
+                },
+            ],
+        }
+
+        replaced = _strip_old_image_parts([message], keep_recent=0)
+
+        assert replaced == 3
+        assert not _content_has_images(message["content"])
+        assert all(part["type"] == "text" for part in message["content"])
+
+    def test_no_images_or_images_within_window_are_noops(self):
+        text_only = [{"role": "user", "content": "hello"}]
+        within_window = [_image_message("user", "one"), _image_message("tool", "two")]
+
+        assert _strip_old_image_parts(text_only, keep_recent=3) == 0
+        assert _strip_old_image_parts(within_window, keep_recent=3) == 0
+        assert all(_content_has_images(message["content"]) for message in within_window)
+
+    def test_projection_is_deterministic_and_each_image_ages_out_once(self):
+        """A rolled-out image changes once, then its placeholder stays stable.
+
+        Bounding a historical payload necessarily changes the request prefix
+        when an image first leaves the keep window. The important cache
+        invariant is that the projection is deterministic: repeated requests
+        over the same history are byte-identical, and adding one image changes
+        only the one additional message that just aged out.
+        """
+        canonical = [_image_message("tool", str(index)) for index in range(4)]
+        first = copy.deepcopy(canonical)
+        second = copy.deepcopy(canonical)
+
+        assert _strip_old_image_parts(first, keep_recent=3) == 1
+        assert _strip_old_image_parts(second, keep_recent=3) == 1
+        assert first == second
+        assert all(_content_has_images(message["content"]) for message in canonical)
+
+        canonical.append(_image_message("tool", "4"))
+        rolled = copy.deepcopy(canonical)
+        assert _strip_old_image_parts(rolled, keep_recent=3) == 2
+
+        # Message 0 was already a placeholder and remains byte-identical.
+        assert rolled[0] == first[0]
+        # Only message 1 newly crossed the keep-window boundary.
+        assert _content_has_images(first[1]["content"])
+        assert not _content_has_images(rolled[1]["content"])

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -146,6 +146,100 @@ def test_current_user_turn_is_persisted_before_provider_call(agent):
 class TestHTTP413Compression:
     """413 errors should trigger compression, not abort as generic 4xx."""
 
+    def test_request_evicts_old_images_before_provider_body_can_reach_413(self, agent):
+        """Only three image-bearing messages reach the provider per request."""
+        captured = {}
+
+        def _create(**kwargs):
+            captured.update(kwargs)
+            return _mock_response(content="bounded", finish_reason="stop")
+
+        agent.client.chat.completions.create.side_effect = _create
+
+        def _image(label):
+            return {
+                "type": "image_url",
+                "image_url": {
+                    "url": "data:image/png;base64," + (label * 1000),
+                },
+            }
+
+        prefill = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "inspect these"},
+                    _image("initial"),
+                ],
+            }
+        ]
+        for index in range(5):
+            call_id = f"call_{index}"
+            prefill.extend([
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [{
+                        "id": call_id,
+                        "type": "function",
+                        "function": {
+                            "name": "vision_analyze",
+                            "arguments": "{}",
+                        },
+                    }],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": call_id,
+                    "name": "vision_analyze",
+                    "content": [
+                        {"type": "text", "text": f"result {index}"},
+                        _image(str(index)),
+                    ],
+                },
+            ])
+
+        with (
+            patch.object(agent, "_model_supports_vision", return_value=True),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("continue", conversation_history=prefill)
+
+        assert result["completed"] is True
+        sent = captured["messages"]
+        image_messages = [
+            message
+            for message in sent
+            if isinstance(message.get("content"), list)
+            and any(
+                isinstance(part, dict)
+                and part.get("type") in {"image_url", "input_image", "image"}
+                for part in message["content"]
+            )
+        ]
+        placeholders = [
+            part
+            for message in sent
+            if isinstance(message.get("content"), list)
+            for part in message["content"]
+            if isinstance(part, dict)
+            and "stripped from older request context" in part.get("text", "")
+        ]
+        assert len(image_messages) == 3
+        assert len(placeholders) == 3
+
+        # Request-only: all six originals remain in the caller's history.
+        historical_images = [
+            part
+            for message in prefill
+            if isinstance(message.get("content"), list)
+            for part in message["content"]
+            if isinstance(part, dict) and part.get("type") == "image_url"
+        ]
+        assert len(historical_images) == 6
+
     def test_413_triggers_compression(self, agent):
         """A 413 error should call _compress_context and retry, not abort."""
         # First call raises 413; second call succeeds after compression.

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2513,6 +2513,72 @@ class TestHandleMaxIterations:
         assert len(result) > 0
         assert "summary" in result.lower()
 
+    def test_summary_request_evicts_old_images_without_mutating_history(self, agent):
+        agent.client.chat.completions.create.return_value = _mock_response(content="Summary")
+        agent._cached_system_prompt = "You are helpful."
+
+        def _image(label):
+            return {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64," + (label * 100)},
+            }
+
+        messages: list[dict] = [{"role": "user", "content": "inspect"}]
+        for index in range(5):
+            call_id = f"call_{index}"
+            messages.extend([
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [{
+                        "id": call_id,
+                        "type": "function",
+                        "function": {
+                            "name": "vision_analyze",
+                            "arguments": "{}",
+                        },
+                    }],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": call_id,
+                    "content": [
+                        {"type": "text", "text": f"result {index}"},
+                        _image(str(index)),
+                    ],
+                },
+            ])
+
+        assert agent._handle_max_iterations(messages, 60) == "Summary"
+
+        sent = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        sent_images = [
+            part
+            for message in sent
+            if isinstance(message.get("content"), list)
+            for part in message["content"]
+            if isinstance(part, dict) and part.get("type") == "image_url"
+        ]
+        placeholders = [
+            part
+            for message in sent
+            if isinstance(message.get("content"), list)
+            for part in message["content"]
+            if isinstance(part, dict)
+            and "stripped from older request context" in part.get("text", "")
+        ]
+        history_images = [
+            part
+            for message in messages
+            if isinstance(message.get("content"), list)
+            for part in message["content"]
+            if isinstance(part, dict) and part.get("type") == "image_url"
+        ]
+
+        assert len(sent_images) == 3
+        assert len(placeholders) == 2
+        assert len(history_images) == 5
+
     def test_summary_retries_share_relay_identity(self, agent):
         agent.client.chat.completions.create.side_effect = [
             _mock_response(content=""),


### PR DESCRIPTION
## Summary

Long-running multimodal sessions can accumulate inline base64 images in user and tool-result messages. Every subsequent model request re-sends those images, allowing the HTTP request body to grow by multiple megabytes even while the estimated token count remains well below the context-compression threshold.

This can trigger provider HTTP 413 responses. Compression alone may not recover because the existing `_strip_historical_media` pass only runs during compaction and anchors on the newest image-bearing user message. As a result, tool-result images and images in the first user turn can survive repeated compaction attempts.

This PR adds a request-time image bound independent of context compression:

- Keep all image parts in the newest three image-bearing messages.
- Replace image parts in older messages with a stable text placeholder.
- Preserve the message rows and `tool_call_id` fields so tool-call/result pairing remains valid.
- Apply the transformation only to the per-request API copy; persisted conversation history remains untouched.
- Drop stale `api_content` sidecars from rewritten request messages so removed image bytes cannot be restored during replay.
- Apply the same policy to the main conversation loop and the independently assembled max-iteration summary request.

The transformation supports the three multimodal shapes Hermes currently handles:

- Chat Completions `image_url`
- Responses API `input_image`
- Anthropic-native `image`

Removing an image necessarily changes the request prefix once when that image leaves the retention window. The projection is deterministic afterward: repeated requests over identical history are byte-identical, and each historical image ages out only once. The transformation runs before prompt-cache planning so cache markers describe the actual post-eviction request. This mirrors the existing Anthropic computer-use screenshot retention policy.

---

## Existing PR Relationship

This change was compared against the existing image-payload PRs:

- #64440 focuses on tool-result screenshots in the OpenAI-compatible path.
- #87555 focuses on historical user images.
- #89776 reactively removes vision payloads after a 413 response.

This PR addresses #89938's combined failure mode proactively across user and tool messages, all supported image-part formats, the main request path, and the max-iteration summary path.

---

## Changes Made

**`agent/context_compressor.py`**
- Add `_strip_old_image_parts`.
- Retain the newest three image-bearing messages.
- Replace older image parts with stable placeholders.
- Remove stale `api_content` sidecars from rewritten request rows.
- Preserve message and tool-pair structure.

**`agent/conversation_loop.py`**
- Apply request-time image eviction after message sanitization and before prompt-cache planning.

**`agent/chat_completion_helpers.py`**
- Apply the same image bound to the independently assembled max-iteration summary request.

**`tests/agent/test_request_image_eviction.py`**
- Cover mixed user/tool roles.
- Cover per-message rather than per-image retention counting.
- Cover image-only tool results and tool-pair preservation.
- Cover stale `api_content` cleanup.
- Cover Chat Completions, Responses API, and Anthropic image shapes.
- Verify deterministic request projection and one-time age-out behavior.

**`tests/run_agent/test_413_compression.py`**
- Exercise the real conversation request path.
- Verify only three image-bearing messages reach the provider.
- Verify canonical history retains all original images.

**`tests/run_agent/test_run_agent.py`**
- Exercise the real max-iteration summary path.
- Verify summary requests are bounded while internal history remains unchanged.

---

## How to Test

1. Start a session with a vision-capable model.
2. Attach an image in the first user message.
3. Produce at least five image-bearing `vision_analyze` or other multimodal tool results.
4. Continue the conversation.
5. Verify the provider request contains image parts only in the newest three image-bearing messages.
6. Verify older image parts are represented by text placeholders.
7. Verify the persisted conversation history still contains every original image.

**Focused canonical test suite:**

```bash
scripts/run_tests.sh \
  tests/agent/test_request_image_eviction.py \
  tests/agent/test_compressor_historical_media.py \
  tests/agent/test_prompt_caching.py \
  tests/gateway/test_cached_agent_max_iterations.py \
  tests/run_agent/test_413_compression.py \
  tests/run_agent/test_run_agent.py
```

✅ 334 tests passed, 0 failed

**Adjacent multimodal and compression suites:**

```bash
scripts/run_tests.sh \
  tests/run_agent/test_multimodal_tool_content_recovery.py \
  tests/run_agent/test_vision_aware_preprocessing.py \
  tests/agent/test_context_compressor.py
```

✅ 157 tests passed, 0 failed

**Additional checks:**
ruff check: passed
py_compile: passed
git diff --check: passed


The regression tests were also sabotage-tested with the eviction helper disabled: 4 expected failures, proving the tests exercise the fix.

---

## Checklist

- [x] Follows Contributing Guide and Conventional Commits
- [x] Searched for existing PRs and documented related implementations above
- [x] Changes scoped to this fix/feature only — no unrelated commits
- [ ] `pytest tests/ -q` — pending full-suite CI
- [x] Tests added for the change
- [x] Tested on Ubuntu under WSL2
- [x] Relevant behavior and prompt-cache trade-offs documented in code; no user-facing docs change required
- [x] No configuration keys added or changed
- [x] No contributor workflow or architecture guide changes
- [x] Cross-platform impact considered — transformation operates only on Python message structures
- [x] No tool descriptions or schemas changed

---

## Risk & Impact

**Low.** The transformation applies only to the per-request API copy — persisted conversation history is never touched. Tool-call/result pairing is preserved via retained `tool_call_id` fields. The projection is deterministic: repeated requests over identical history are byte-identical, and prompt-cache markers are computed after eviction so cache planning reflects the actual outgoing request.

**Type:** 🐛 Bug fix / ✅ Tests
**Fixes:** #89938
