### PR TITLE
fix(codex): strip unsupported cache retention at wire

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -1305,6 +1305,37 @@ def _consume_codex_event_stream(
     return final
 
 
+def _sanitize_consumer_codex_request(
+    agent: Any,
+    request: dict[str, Any],
+) -> dict[str, Any]:
+    """Drop fields the ChatGPT OAuth Codex endpoint does not accept.
+
+    This guard intentionally lives at the final wire boundary, after Relay or
+    other request middleware has had a chance to transform the request. The
+    normal transport builder already omits ``prompt_cache_retention`` for this
+    endpoint, but a late mutation must not be allowed to turn a valid tool
+    follow-up into a non-retryable HTTP 400.
+
+    Explicit ``request_overrides`` are subject to the same endpoint contract:
+    unsupported retention is dropped with a warning instead of being sent and
+    rejected by the provider.
+    """
+    sanitized = dict(request)
+    backend_predicate = getattr(agent, "_is_codex_backend", None)
+    is_consumer_codex = (
+        bool(backend_predicate()) if callable(backend_predicate) else False
+    )
+    if is_consumer_codex and "prompt_cache_retention" in sanitized:
+        sanitized.pop("prompt_cache_retention", None)
+        logger.warning(
+            "Dropped unsupported prompt_cache_retention at consumer Codex "
+            "wire boundary (model=%s).",
+            sanitized.get("model", getattr(agent, "model", "unknown")),
+        )
+    return sanitized
+
+
 def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta=None):
     """Execute one streaming Responses API request and return the final response.
 
@@ -1347,7 +1378,10 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
         writer_token = {"value": None}
 
         def _open_codex_stream(next_api_kwargs: dict[str, Any]):
-            stream_kwargs = dict(next_api_kwargs)
+            stream_kwargs = _sanitize_consumer_codex_request(
+                agent,
+                next_api_kwargs,
+            )
             stream_kwargs["stream"] = True
             return active_client.responses.create(**stream_kwargs)
 

--- a/tests/agent/test_relay_llm.py
+++ b/tests/agent/test_relay_llm.py
@@ -207,6 +207,33 @@ def test_relay_metadata_preserves_provider_name():
     }
 
 
+def test_provider_request_overlays_interceptor_added_codex_field():
+    """Relay rewrites may introduce provider fields absent from the original."""
+    original = {"model": "gpt-5.6-sol", "input": "hello"}
+    relay_request_body = relay_llm._relay_request_body(
+        original,
+        {"api_mode": "codex_responses"},
+    )
+    intercepted = SimpleNamespace(
+        content={
+            **relay_request_body,
+            "prompt_cache_retention": "24h",
+        },
+        headers={},
+    )
+
+    provider_request = relay_llm._provider_request(
+        original,
+        intercepted,
+        relay_request_body=relay_request_body,
+        codec_baseline_body=dict(relay_request_body),
+        metadata={"api_mode": "codex_responses"},
+    )
+
+    assert "prompt_cache_retention" not in original
+    assert provider_request["prompt_cache_retention"] == "24h"
+
+
 def test_stream_uses_rewritten_request_and_post_intercept_chunks(relay_turn):
     relay, turn = relay_turn
     captured_requests = []

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -537,6 +537,71 @@ def _build_xai_agent_with_slash_enum_tool(monkeypatch):
 
 
 
+def test_run_codex_stream_strips_relay_added_retention_at_consumer_wire(
+    monkeypatch,
+    caplog,
+):
+    """A Relay-added unsupported field cannot reach consumer ChatGPT Codex."""
+    from agent import relay_llm
+
+    agent = _build_agent(monkeypatch)
+    captured = {}
+
+    def _fake_create(**kwargs):
+        captured.update(kwargs)
+        return _FakeCreateStream([
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(status="completed"),
+            )
+        ])
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=_fake_create),
+    )
+    original = _codex_request_kwargs()
+    relay_request_body = relay_llm._relay_request_body(
+        original,
+        {"api_mode": "codex_responses"},
+    )
+    relayed = relay_llm._provider_request(
+        original,
+        SimpleNamespace(
+            content={
+                **relay_request_body,
+                "prompt_cache_retention": "24h",
+            },
+            headers={},
+        ),
+        relay_request_body=relay_request_body,
+        codec_baseline_body=dict(relay_request_body),
+        metadata={"api_mode": "codex_responses"},
+    )
+    assert relayed["prompt_cache_retention"] == "24h"
+
+    with caplog.at_level("WARNING", logger="agent.codex_runtime"):
+        agent._run_codex_stream(relayed)
+
+    assert "prompt_cache_retention" not in captured
+    assert any(
+        "Dropped unsupported prompt_cache_retention at consumer Codex wire boundary"
+        in record.message
+        for record in caplog.records
+    )
+
+
+def test_consumer_codex_wire_guard_preserves_compatible_endpoint_retention():
+    from agent.codex_runtime import _sanitize_consumer_codex_request
+
+    agent = SimpleNamespace(_is_codex_backend=lambda: False)
+    request = {"model": "openai.gpt-5.5", "prompt_cache_retention": "24h"}
+
+    sanitized = _sanitize_consumer_codex_request(agent, request)
+
+    assert sanitized["prompt_cache_retention"] == "24h"
+    assert sanitized is not request
+
+
 def test_run_codex_stream_returns_collected_items_when_stream_ends_without_terminal(monkeypatch):
     """The event-driven path tolerates streams that end without a terminal frame.
 


### PR DESCRIPTION
## Summary

- sanitize the final Relay-mediated ChatGPT Codex request before `responses.create()`
- drop unsupported `prompt_cache_retention` with an explicit warning, including values supplied through `request_overrides`
- cover both the Relay overlay entry mechanism and the endpoint-specific wire guard while preserving retention on compatible endpoints

Fixes #89897.

## Root cause

Hermes' normal Codex transport never enables `prompt_cache_retention` for `chatgpt.com/backend-api/codex`. The field can enter later when a Relay interceptor rewrites a request: `_provider_request()` overlays changed fields against the codec baseline, and its `key not in baseline` branch admits newly introduced provider fields.

That makes the symptom structural rather than random: pristine requests pass through untouched, while rewritten requests can acquire a field the original Hermes request never contained.

Credit to @jackulau for identifying and documenting the Relay overlay mechanism in the issue thread.

## Why the guard is at this boundary

`agent/codex_runtime.py::_open_codex_stream()` is the only Relay-mediated `responses.create()` send site. Sanitizing immediately before that call enforces the consumer endpoint contract after all middleware transformations.

The guard uses `_is_codex_backend()`, which is specific to the `chatgpt.com/backend-api/codex` hostname and path. Meta Model API, Bedrock Mantle, and other compatible Responses endpoints therefore retain their supported `24h` value.

A user-supplied `request_overrides.prompt_cache_retention` is intentionally dropped on consumer Codex and logged. Sending it would deterministically produce HTTP 400, so warning and continuing is safer than honoring an invalid override.

## Tests

- RED before implementation: Relay-added retention reached `responses.create()`; compatible-guard helper was absent
- focused Relay/Codex regression and transport suites: 180 passed
- full repository suite: 34,954 passed, 1 failed, 322 skipped
  - the sole failure is pre-existing on `origin/main`: `tests/tools/test_image_generation.py::TestFalCatalog::test_upscale_defaults_are_all_off` (`xai/grok-imagine-image/v2.0/text-to-image` currently has `upscale: true`)
  - reproduced from a separate detached worktree at `13ce0c5c6`; this PR does not touch image-generation files
- `ruff check` on changed files: passed
- `git diff --check`: passed

## Scope

No Relay overlay semantics are changed: interceptors may still add provider fields. This PR only enforces the known ChatGPT Codex endpoint contract at its final send boundary. No fallback-provider or auxiliary-routing changes are included.
