### PR TITLE
fix(update): re-exec Windows shim updates via venv python to break launcher self-lock

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -5975,11 +5975,21 @@ class GatewaySlashCommandsMixin:
                         f.write(str(rc))
                     """
                 ).strip()
+                # Spawn the updater via the venv interpreter directly
+                # (`python.exe -m hermes_cli.main update --gateway`) instead
+                # of the `hermes` shim: on Windows the shim runs the
+                # managed-runtime interpreter with hermes.exe itself as its
+                # script/zipapp, which holds the shim open without
+                # FILE_SHARE_DELETE for the whole update — uv then cannot
+                # replace hermes.exe (os error 32) and the update fails
+                # every time. A module invocation maps no shim, so the
+                # entry-point shims can be rewritten freely.
                 subprocess.Popen(
                     [
                         sys.executable, "-c", helper,
                         str(output_path), str(exit_code_path),
-                        *hermes_cmd, "update", "--gateway",
+                        sys.executable, "-m", "hermes_cli.main",
+                        "update", "--gateway",
                     ],
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4644,9 +4644,128 @@ def _rebuild_desktop_after_update(
     return True
 
 
+# Windows console-script shims that run the managed-runtime interpreter
+# with the shim file itself as the script (see
+# ``_maybe_reexec_windows_update_from_shim``).
+_WINDOWS_SHIM_NAMES = frozenset(
+    {"hermes.exe", "hermes-acp.exe", "hermes-agent.exe", "hermes-gateway.exe"}
+)
+# Marker preventing re-exec loops (the re-exec'd child must not re-spawn).
+_REEXEC_ENV = "HERMES_UPDATE_REEXEC"
+
+
+def _current_windows_shim_path() -> Path | None:
+    """Return the venv console-shim path this process was launched from, if any.
+
+    ``venv\\Scripts\\hermes.exe`` is a PE launcher that runs the
+    managed-runtime interpreter with the shim itself as a script/zipapp.
+    Depending on the launch path, ``sys.argv[0]`` is the shim path, the
+    shim's ``__main__.py`` (runpy/``-m`` module launches put the
+    ``__main__`` file path there), or the module spec origin. Check all
+    three so every variant is recognised. The runtime interpreter keeps the
+    shim open for the whole process lifetime without ``FILE_SHARE_DELETE``,
+    so any ``hermes ...`` command locks its own shim while it runs.
+    """
+    candidates: list[Path] = []
+    try:
+        if sys.argv:
+            candidates.append(Path(sys.argv[0]))
+    except Exception:
+        pass
+    try:
+        import __main__  # noqa: PLC0415
+
+        main_file = getattr(__main__, "__file__", None)
+        if main_file:
+            candidates.append(Path(main_file))
+        spec = getattr(__main__, "__spec__", None)
+        origin = getattr(spec, "origin", None) if spec is not None else None
+        if origin:
+            candidates.append(Path(origin))
+    except Exception:
+        pass
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            resolved = candidate
+        name = resolved.name.lower()
+        if name in _WINDOWS_SHIM_NAMES:
+            return resolved
+        if name == "__main__.py" and resolved.parent.name.lower() in _WINDOWS_SHIM_NAMES:
+            return resolved.parent
+    return None
+
+
+def _running_from_windows_shim() -> bool:
+    """Return True when this process was launched through a venv console shim."""
+    if sys.platform != "win32":
+        return False
+    return _current_windows_shim_path() is not None
+
+
+def _maybe_reexec_windows_update_from_shim() -> bool:
+    """Re-exec ``hermes update`` via the venv interpreter when launched from a shim.
+
+    On Windows an update invoked as ``hermes update`` runs inside the
+    managed-runtime interpreter, which holds ``venv\\Scripts\\hermes.exe``
+    open (zipapp/script, no ``FILE_SHARE_DELETE``) until it exits. uv then
+    cannot remove the shim during ``pip install -e .`` (``os error 32``)
+    and the pre-install quarantine rename is denied as well — the update
+    fails on every attempt, regardless of Desktop/gateway/AV state.
+
+    Spawn ``venv\\Scripts\\python.exe -m hermes_cli.main <argv>`` with
+    inherited stdio and return True; the caller then finishes so this
+    process exits and the shim handle is released. The re-exec'd child
+    maps no shim and can replace ``hermes.exe`` freely.
+
+    Exit-code trade-off: the process the user/shell waited on exits
+    immediately (status of the spawn, not of the update). The update
+    reports its own result in its output, and in ``--gateway`` mode the
+    updater writes the true exit code to ``.update_exit_code`` itself
+    before the gateway restart, so the gateway watcher still sees it.
+    """
+    if os.environ.get(_REEXEC_ENV) == "1":
+        return False
+    if not _running_from_windows_shim():
+        return False
+    scripts_dir = _m()._venv_scripts_dir()
+    if scripts_dir is None:
+        return False
+    python_exe = scripts_dir / "python.exe"
+    if not python_exe.is_file():
+        return False
+    env = dict(os.environ)
+    env[_REEXEC_ENV] = "1"
+    cmd = [str(python_exe), "-m", "hermes_cli.main", *sys.argv[1:]]
+    logger.info(
+        "Re-execing Windows update via %s (shim self-lock workaround)", python_exe
+    )
+    try:
+        subprocess.Popen(cmd, env=env)
+    except Exception as exc:  # pragma: no cover - spawn failure path
+        logger.warning(
+            "Re-exec update via %s failed (%s); continuing in-process — "
+            "the Windows shim lock may break dependency sync.",
+            python_exe,
+            exc,
+        )
+        return False
+    return True
+
+
 def _cmd_update_impl(args, gateway_mode: bool):
     """Body of ``cmd_update`` — kept separate so the wrapper can always
     restore stdio even on ``sys.exit``."""
+    # Windows: when this process was launched through a venv console shim
+    # (venv\Scripts\hermes.exe), the managed-runtime interpreter keeps the
+    # shim open as its script file for the whole run — WITHOUT
+    # FILE_SHARE_DELETE. An in-process update would then fail to replace
+    # hermes.exe no matter what (uv: os error 32; quarantine rename:
+    # denied). Re-exec via the venv interpreter, which maps no shim.
+    if _maybe_reexec_windows_update_from_shim():
+        return
+
     # A managed-runtime refresh can replace site-packages before the normal
     # ``.[all]`` install runs. Snapshot while the old environment can still
     # prove which optional backends the user had activated.

--- a/tests/hermes_cli/test_update_shim_reexec.py
+++ b/tests/hermes_cli/test_update_shim_reexec.py
@@ -1,0 +1,154 @@
+"""Regression tests for the Windows console-shim update self-lock.
+
+`venv\\Scripts\\hermes.exe` is a PE launcher that runs the managed-runtime
+interpreter with the shim *itself* as its script/zipapp. The interpreter
+keeps that file open without FILE_SHARE_DELETE for the whole process
+lifetime, so an update launched as `hermes update` locks the very file uv
+must replace (os error 32, quarantine rename denied). The updater must
+re-exec itself via `venv\\Scripts\\python.exe -m hermes_cli.main` so no
+process maps the shim while it is being rewritten.
+
+Detection must recognise every launch variant: sys.argv[0] as the shim
+path, the shim's `__main__.py` (runpy/`-m` zipapp launches), and the
+`__main__.__module__.__spec__.origin` path.
+"""
+
+import pytest
+
+from hermes_cli import update_cmd
+
+
+class _FakeMain:
+    def __init__(self, scripts_dir):
+        self._scripts_dir = scripts_dir
+
+    def _venv_scripts_dir(self):
+        return self._scripts_dir
+
+
+def _patch_base(monkeypatch, tmp_path, argv0):
+    scripts = tmp_path / "Scripts"
+    scripts.mkdir()
+    (scripts / "python.exe").write_bytes(b"fake")
+    monkeypatch.setattr(update_cmd.sys, "platform", "win32")
+    monkeypatch.setattr(update_cmd.sys, "argv", [str(argv0), "update", "--yes"])
+    monkeypatch.delenv(update_cmd._REEXEC_ENV, raising=False)
+    monkeypatch.setattr(update_cmd, "_m", lambda: _FakeMain(scripts))
+    return scripts
+
+
+def _install_popen_capture(monkeypatch):
+    captured = {}
+
+    def fake_popen(cmd, env=None):
+        captured["cmd"] = list(cmd)
+        captured["env"] = dict(env or {})
+        return object()
+
+    monkeypatch.setattr(update_cmd.subprocess, "Popen", fake_popen)
+    return captured
+
+
+@pytest.mark.parametrize(
+    "shim_name",
+    ["hermes.exe", "hermes-acp.exe", "hermes-agent.exe", "hermes-gateway.exe"],
+)
+def test_reexec_fires_when_arg0_is_shim(monkeypatch, tmp_path, shim_name):
+    scripts = _patch_base(monkeypatch, tmp_path, tmp_path / "Scripts" / shim_name)
+    captured = _install_popen_capture(monkeypatch)
+
+    assert update_cmd._maybe_reexec_windows_update_from_shim() is True
+    assert captured["cmd"][0] == str(scripts / "python.exe")
+    assert captured["cmd"][1:3] == ["-m", "hermes_cli.main"]
+    assert captured["cmd"][3:] == ["update", "--yes"]
+    assert captured["env"][update_cmd._REEXEC_ENV] == "1"
+
+
+def test_reexec_fires_when_arg0_is_shim_main_py(monkeypatch, tmp_path):
+    """Zipapp/`-m` launches put the shim's __main__.py into sys.argv[0]."""
+    shim = tmp_path / "Scripts" / "hermes.exe"
+    _patch_base(monkeypatch, tmp_path, shim / "__main__.py")
+    captured = _install_popen_capture(monkeypatch)
+
+    assert update_cmd._maybe_reexec_windows_update_from_shim() is True
+    assert captured["cmd"][3:] == ["update", "--yes"]
+
+
+def test_reexec_fires_via_main_module_file(monkeypatch, tmp_path):
+    """When argv[0] is opaque, __main__.__file__ still reveals the shim."""
+    import __main__ as main_mod
+
+    shim = tmp_path / "Scripts" / "hermes.exe"
+    scripts = _patch_base(monkeypatch, tmp_path, tmp_path / "opaque" / "launcher.exe")
+    monkeypatch.setattr(main_mod, "__file__", str(shim / "__main__.py"))
+    captured = _install_popen_capture(monkeypatch)
+
+    assert update_cmd._maybe_reexec_windows_update_from_shim() is True
+    assert captured["cmd"][3:] == ["update", "--yes"]
+    monkeypatch.undo()
+
+
+def test_reexec_fires_via_spec_origin(monkeypatch, tmp_path):
+    """When argv[0] is opaque, the module spec origin still reveals the shim."""
+    import __main__ as main_mod
+
+    shim = tmp_path / "Scripts" / "hermes.exe"
+    _patch_base(monkeypatch, tmp_path, tmp_path / "opaque" / "launcher.exe")
+    monkeypatch.setattr(main_mod, "__file__", None)
+
+    class _Spec:
+        origin = str(shim)
+
+    monkeypatch.setattr(main_mod, "__spec__", _Spec())
+    captured = _install_popen_capture(monkeypatch)
+
+    assert update_cmd._maybe_reexec_windows_update_from_shim() is True
+    assert captured["cmd"][3:] == ["update", "--yes"]
+    monkeypatch.undo()
+
+
+def test_reexec_skipped_when_marker_already_set(monkeypatch, tmp_path):
+    _patch_base(monkeypatch, tmp_path, tmp_path / "Scripts" / "hermes.exe")
+    monkeypatch.setenv(update_cmd._REEXEC_ENV, "1")
+    captured = _install_popen_capture(monkeypatch)
+
+    assert update_cmd._maybe_reexec_windows_update_from_shim() is False
+    assert "cmd" not in captured
+
+
+def test_reexec_skipped_when_not_launched_from_shim(monkeypatch, tmp_path):
+    _patch_base(monkeypatch, tmp_path, tmp_path / "Scripts" / "python.exe")
+    captured = _install_popen_capture(monkeypatch)
+
+    assert update_cmd._maybe_reexec_windows_update_from_shim() is False
+    assert "cmd" not in captured
+
+
+def test_reexec_skipped_off_windows(monkeypatch, tmp_path):
+    scripts = tmp_path / "Scripts"
+    scripts.mkdir()
+    monkeypatch.setattr(update_cmd.sys, "platform", "linux")
+    monkeypatch.setattr(
+        update_cmd.sys, "argv", [str(scripts / "hermes.exe"), "update"]
+    )
+    monkeypatch.delenv(update_cmd._REEXEC_ENV, raising=False)
+    monkeypatch.setattr(update_cmd, "_m", lambda: _FakeMain(scripts))
+    captured = _install_popen_capture(monkeypatch)
+
+    assert update_cmd._maybe_reexec_windows_update_from_shim() is False
+    assert "cmd" not in captured
+
+
+def test_reexec_skipped_when_scripts_dir_unresolved(monkeypatch, tmp_path):
+    monkeypatch.setattr(update_cmd.sys, "platform", "win32")
+    monkeypatch.setattr(
+        update_cmd.sys,
+        "argv",
+        [str(tmp_path / "Scripts" / "hermes.exe"), "update"],
+    )
+    monkeypatch.delenv(update_cmd._REEXEC_ENV, raising=False)
+    monkeypatch.setattr(update_cmd, "_m", lambda: _FakeMain(None))
+    captured = _install_popen_capture(monkeypatch)
+
+    assert update_cmd._maybe_reexec_windows_update_from_shim() is False
+    assert "cmd" not in captured


### PR DESCRIPTION
## Summary

On Windows, `hermes update` can never succeed when launched through the venv console-script shim (`venv\Scripts\hermes.exe`): that launcher runs the managed-runtime interpreter with the shim **itself** as its script/zipapp, and the interpreter keeps the shim open without `FILE_SHARE_DELETE` for the whole process lifetime. The dependency-install step must replace that file, so `uv pip install -e .` fails with `os error 32` / `Access denied` and the pre-install quarantine rename is denied — **every time**, regardless of Hermes Desktop/gateway/AV state. The existing concurrent-hermes-instance preflight cannot help: it excludes the updater process itself (#88838, #89599).

This PR fixes the whole class with an automatic re-exec:

1. **`hermes_cli/update_cmd.py`** — `_cmd_update_impl` detects that it runs from a venv console shim (checking `sys.argv[0]`, `__main__.__file__`, and the module-spec origin — covering the runpy/zipapp launch variant where argv[0] is `<shim>\__main__.py`, which a plain argv[0] check misses) and re-executes the entire update as `venv\Scripts\python.exe -m hermes_cli.main update …`, then returns so the shim handle is released before uv runs.
2. **`gateway/slash_commands.py`** — the Windows `/update` handler spawns `sys.executable -m hermes_cli.main update --gateway` directly instead of through the `hermes` shim, so no process maps the shim during the update and the helper's exit code remains the true update exit code.
3. **`tests/hermes_cli/test_update_shim_reexec.py`** — regression tests for every launch-variant detection plus all skip conditions.

## Why this approach

- **PR #88121** (the current "active repair" per issue triage) stops before mutation and prints the `python -m hermes_cli.main update` workaround for the user to run manually. This PR performs that re-exec **automatically**, and additionally fixes the `/update` spawn path.
- The re-exec is safe: the child runs with an env marker (`HERMES_UPDATE_REEXEC=1`) so it cannot re-spawn; detection is a pure read-only path check that never runs off-Windows or when not launched from a shim; if the spawn fails, the updater falls back to the previous in-process behavior with a warning.

## Verification

- Live Windows 11 install (editable git install, managed runtime): `hermes update --yes` previously failed every attempt with the exact `os error 32` + quarantine `PermissionError` sequence. With this change the update completes with rc=0 and **zero** lock failures across repeated runs; code, dependencies and launcher shims all refresh correctly.
- 22 targeted tests pass (11 new re-exec tests + 11 existing quarantine tests).

## Known trade-off

The process the user's shell waited on (the shim) exits as soon as the re-exec child is spawned, so the CLI exit code of `hermes update` reflects the spawn, not the update result — the update reports its own result in its output, and in `--gateway` mode the updater writes the true exit code to `.update_exit_code` before the gateway restart, which the gateway watcher still reads correctly.

Fixes #88838
Fixes #89599
Related: #89295, #79561, #88121