### PR TITLE
fix(image_routing): stop fingerprint-probing remote OpenAI-compatible endpoints

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -332,17 +332,39 @@ def _resolve_inference_base_url(
     return ""
 
 
-def _should_probe_ollama_vision(provider: str, base_url: str) -> bool:
-    """True when the active provider likely fronts a local Ollama server."""
+def _should_probe_ollama_vision(
+    provider: str,
+    base_url: str,
+    api_key: str = "",
+) -> bool:
+    """True when the active provider likely fronts a local Ollama server.
+
+    Server-fingerprint probing is only meaningful for *local* endpoints —
+    remote OpenAI-compatible APIs (sglang, vLLM, etc.) should never be probed,
+    and probing them without an api_key sprays 401s at the inference backend
+    (issue #89863).
+    """
     p = (provider or "").strip().lower()
     if p == "ollama":
         return True
     if not base_url:
         return False
+    # Remote endpoints must never be fingerprinted: the probe waterfall is
+    # only valid for local/LM-Studio/Ollama boxes. Non-Ollama remotes (sglang,
+    # vLLM, OpenAI-compat) expose Ollama-compat endpoints that can misidentify
+    # and, without an api_key, return 401 on every leg (issue #89863).
+    if p != "ollama":
+        try:
+            from agent.model_metadata import is_local_endpoint
+
+            if not is_local_endpoint(base_url):
+                return False
+        except Exception:
+            return False
     try:
         from agent.model_metadata import detect_local_server_type
 
-        return detect_local_server_type(base_url) == "ollama"
+        return detect_local_server_type(base_url, api_key=api_key) == "ollama"
     except Exception:
         return False
 
@@ -448,11 +470,24 @@ def _lookup_supports_vision(
     base_url = _resolve_inference_base_url(cfg, provider)
     if not base_url and (provider or "").strip().lower() == "ollama":
         base_url = "http://localhost:11434/v1"
-    if _should_probe_ollama_vision(provider, base_url):
+
+    # Resolve the runtime api_key so probe requests at keyed endpoints carry
+    # Authorization and don't spray 401s (issue #89863).
+    resolved_api_key = ""
+    try:
+        from agent.auxiliary_client import _runtime_main_value
+
+        resolved_api_key = str(_runtime_main_value("api_key") or "").strip()
+    except Exception:
+        pass
+
+    if _should_probe_ollama_vision(provider, base_url, api_key=resolved_api_key):
         try:
             from agent.model_metadata import query_ollama_supports_vision
 
-            ollama_vision = query_ollama_supports_vision(model, base_url)
+            ollama_vision = query_ollama_supports_vision(
+                model, base_url, api_key=resolved_api_key
+            )
             if ollama_vision is not None:
                 return ollama_vision
         except Exception as exc:  # pragma: no cover - defensive

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -12,6 +12,7 @@ from agent.image_routing import (
     _coerce_mode,
     _explicit_aux_vision_override,
     _lookup_supports_vision,
+    _should_probe_ollama_vision,
     _supports_vision_override,
     build_native_content_parts,
     decide_image_input_mode,
@@ -156,6 +157,70 @@ class TestLookupSupportsVisionOverride:
         # Caller didn't pass cfg at all — old call sites must still work.
         with patch("agent.models_dev.get_model_capabilities", return_value=None):
             assert _lookup_supports_vision("openrouter", "x", None) is None
+
+
+# ─── _should_probe_ollama_vision ──────────────────────────────────────────────
+
+
+class TestShouldProbeOllamaVision:
+    """Regression tests for issue #89863: remote OpenAI-compatible endpoints
+    must not be fingerprint-probed (with or without an api_key).
+    """
+
+    def test_ollama_provider_always_probes(self):
+        # provider="ollama" → probe regardless of base_url
+        assert _should_probe_ollama_vision("ollama", "") is True
+
+    def test_empty_base_url_returns_false(self):
+        assert _should_probe_ollama_vision("custom", "") is False
+
+    def test_remote_endpoint_not_probed(self):
+        # A remote sglang/vLLM endpoint must NEVER be fingerprinted — that's
+        # the 401-spray bug from #89863.
+        assert _should_probe_ollama_vision(
+            "custom", "https://my-remote-host/v1"
+        ) is False
+
+    def test_remote_endpoint_not_probed_without_key(self):
+        # Same as above but explicit: no api_key is not a reason to probe.
+        assert _should_probe_ollama_vision(
+            "custom", "https://inference.example.com/v1", api_key=""
+        ) is False
+
+    def test_remote_endpoint_not_probed_with_key(self):
+        # Even WITH an api_key, remote endpoints are not local and must not be
+        # fingerprinted — the key just prevents 401s, it doesn't make the
+        # endpoint local.
+        assert _should_probe_ollama_vision(
+            "custom", "https://inference.example.com/v1", api_key="sk-xxxx"
+        ) is False
+
+    def test_local_endpoint_with_key_passes_key(self):
+        # A local endpoint is still probed; the api_key must be forwarded so
+        # keyed local servers don't 401.
+        with patch(
+            "agent.model_metadata.detect_local_server_type",
+            return_value="ollama",
+        ) as mock_detect:
+            result = _should_probe_ollama_vision(
+                "custom", "http://localhost:11434/v1", api_key="sk-local"
+            )
+        assert result is True
+        mock_detect.assert_called_once_with(
+            "http://localhost:11434/v1", api_key="sk-local"
+        )
+
+    def test_local_endpoint_without_key(self):
+        # Legacy call: no api_key → forwarded as "" (existing behaviour).
+        with patch(
+            "agent.model_metadata.detect_local_server_type",
+            return_value="ollama",
+        ) as mock_detect:
+            result = _should_probe_ollama_vision(
+                "custom", "http://127.0.0.1:11434/v1"
+            )
+        assert result is True
+        mock_detect.assert_called_once_with("http://127.0.0.1:11434/v1", api_key="")
 
 
 # ─── decide_image_input_mode with auto + override ────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #89863. With a `custom:` provider pointing at a remote, API-keyed endpoint (sglang/vLLM/OpenAI-compat), every image turn triggered a 5-request probe waterfall at the inference server **without** the `Authorization` header, spraying 5× `401 Unauthorized` per trigger.

## Root cause

1. `_should_probe_ollama_vision()` called `detect_local_server_type(base_url)` **without forwarding the `api_key`**.
2. There was no guard to skip probing of *remote* endpoints — server-fingerprint probing is only meaningful for local boxes.

## Changes

**`agent/image_routing.py`**
- `_should_probe_ollama_vision()` now takes `api_key: str = ""` and forwards it to `detect_local_server_type()`.
- When `provider != "ollama"`, remote endpoints (per `is_local_endpoint`) are rejected early — no fingerprinting of remote OpenAI-compatible APIs.
- `_lookup_supports_vision()` resolves the runtime `api_key` via `_runtime_main_value("api_key")` and forwards it to both `_should_probe_ollama_vision` and `query_ollama_supports_vision`.

**`tests/agent/test_image_routing.py`**
- New `TestShouldProbeOllamaVision` class with 7 regression tests covering:
  - `ollama` provider always probes
  - empty base_url returns False
  - remote endpoints never probed (with and without api_key)
  - local endpoints still probed with api_key forwarded
  - legacy no-key call still forwards empty string

## Test results

```
============================== 45 passed in 0.72s ==============================
```