### PR TITLE
fix(kanban): dispatcher nonspawnable-assignee alert + respawn-guard event dedupe/escalation

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8012,6 +8012,154 @@ _RESPAWN_GUARD_PR_URL_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Once the SAME respawn_guarded reason has held for this many consecutive
+# ticks, stop logging a fresh event per tick (#respawn-guard-spam 2026-08-19).
+# A single card guarded for hours was writing one `task_events` row every
+# dispatch_interval_seconds (~60s) forever — 1000+ rows/day on one card,
+# purely diagnostic noise once the first occurrence already explained why.
+_RESPAWN_GUARD_EVENT_DEDUPE_AFTER = 1
+
+# Once the SAME respawn_guarded reason has held continuously for this long,
+# the guard is no longer "a few ticks of recovery" (its documented purpose)
+# — it is a card nobody will ever un-stick without a human/orchestrator
+# decision. Escalate it out of the eternal ready/guarded tick instead of
+# reassessing the identical state forever. 3h comfortably exceeds every
+# legitimate transient guard window (`_RESPAWN_GUARD_SUCCESS_WINDOW` 1h,
+# `DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS` 5m) so it never fires on a guard
+# that's about to clear on its own.
+_RESPAWN_GUARD_ESCALATE_AFTER_SECONDS = 3 * 3600  # 3 hours
+_RESPAWN_GUARD_ESCALATE_ENV = "HERMES_KANBAN_RESPAWN_GUARD_ESCALATE_SECONDS"
+
+
+def _resolve_respawn_guard_escalate_seconds() -> int:
+    """Read the escalation threshold, honoring the operator override env var.
+
+    Mirrors ``_resolve_rate_limit_cooldown_seconds``'s pattern: a bad/blank
+    override falls back to the built-in default rather than raising, since
+    this is evaluated on every dispatch tick and must never crash dispatch.
+    """
+    raw = os.environ.get(_RESPAWN_GUARD_ESCALATE_ENV)
+    if not raw:
+        return _RESPAWN_GUARD_ESCALATE_AFTER_SECONDS
+    try:
+        val = int(raw)
+    except (TypeError, ValueError):
+        return _RESPAWN_GUARD_ESCALATE_AFTER_SECONDS
+    return val if val >= 0 else _RESPAWN_GUARD_ESCALATE_AFTER_SECONDS
+
+
+def _respawn_guard_streak(
+    conn: sqlite3.Connection, task_id: str, reason: str,
+) -> tuple[int, Optional[int]]:
+    """Return ``(consecutive_count, first_seen_at)`` for the current guard streak.
+
+    Walks ``task_events`` newest-first and counts contiguous
+    ``respawn_guarded`` rows whose payload ``reason`` matches ``reason``,
+    stopping at the first non-matching event (any other kind, or a
+    ``respawn_guarded`` with a different reason — a reason change resets
+    the streak, since it's a materially different situation each time).
+    ``first_seen_at`` is the ``created_at`` of the oldest event in that
+    contiguous run — i.e. how long ago this exact guard state started.
+    Returns ``(0, None)`` if the most recent event isn't a matching guard
+    (covers the very first occurrence, before any event has been written).
+    """
+    rows = conn.execute(
+        "SELECT kind, payload, created_at FROM task_events "
+        "WHERE task_id = ? ORDER BY created_at DESC, id DESC LIMIT 500",
+        (task_id,),
+    ).fetchall()
+    count = 0
+    first_seen_at: Optional[int] = None
+    for r in rows:
+        if r["kind"] != "respawn_guarded":
+            break
+        try:
+            payload = json.loads(r["payload"]) if r["payload"] else None
+        except Exception:
+            payload = None
+        if not payload or payload.get("reason") != reason:
+            break
+        count += 1
+        first_seen_at = int(r["created_at"])
+    return count, first_seen_at
+
+
+_NONSPAWNABLE_ALERT_AUTHOR = "hermes-dispatcher"
+
+
+def _emit_nonspawnable_alert(
+    conn: sqlite3.Connection, task_id: str, assignee: str,
+) -> None:
+    """First-occurrence event + card comment for a ``skipped_nonspawnable`` task.
+
+    Fixes a silent-deadlock class (#kanban-nonspawnable-deadlock 2026-08-19):
+    when ``task.assignee`` names neither a live Hermes profile nor a
+    registered terminal lane, the dispatcher correctly refuses to spawn it
+    (see the call site) but historically recorded NOTHING on the card —
+    no ``task_event``, no comment. A card stuck this way looks identical,
+    from the card itself, to one a human terminal lane just hasn't pulled
+    yet. One retired profile (a deleted ``upx-*`` role reused as an
+    assignee) silently deadlocked a 6-card dependency chain for hours
+    before anyone noticed, because nothing ever pointed at it.
+
+    Emits once per (task, assignee) pair — re-checked every tick via a
+    cheap event scan, not written every tick — so this stays silent for
+    the long-lived, intentional terminal-lane case (a card legitimately
+    waiting on a human to run ``claim_task`` can sit in this bucket for
+    days without repeat noise) while still surfacing the one-time alert an
+    operator or watchdog needs to catch a typo'd or retired assignee. If
+    the assignee is reassigned and later becomes nonspawnable again (e.g.
+    reassigned back to the same typo), that's a new occurrence and alerts
+    again — the dedupe key includes the assignee, not just the task.
+    """
+    try:
+        already = conn.execute(
+            "SELECT 1 FROM task_events WHERE task_id = ? AND kind = ? "
+            "AND payload LIKE ? LIMIT 1",
+            (
+                task_id,
+                "nonspawnable_alerted",
+                f'%"assignee": "{assignee}"%',
+            ),
+        ).fetchone()
+        if already:
+            return
+        with write_txn(conn):
+            _append_event(
+                conn, task_id, "nonspawnable_alerted",
+                {
+                    "assignee": assignee,
+                    "hint": (
+                        "assignee is not a live Hermes profile and not a "
+                        "registered terminal lane; card will not be "
+                        "auto-spawned until reassigned or the lane is "
+                        "registered"
+                    ),
+                },
+            )
+            add_comment(
+                conn, task_id, _NONSPAWNABLE_ALERT_AUTHOR,
+                (
+                    f"\u26a0\ufe0f Dispatcher: assignee `{assignee}` does not "
+                    "resolve to a Hermes profile or a registered terminal "
+                    "lane. This card will stay in `ready`/`review` "
+                    "indefinitely without auto-spawning until it is "
+                    "reassigned to a valid profile/lane (or the lane is "
+                    "registered). If `" + assignee + "` was recently "
+                    "retired, check for its `absorbed_into` successor and "
+                    "reassign there. (This is a one-time alert; the "
+                    "dispatcher will not repeat it for this assignee.)"
+                ),
+            )
+    except Exception:
+        # Best-effort telemetry must never break the dispatch loop — a
+        # broken alert write should degrade to "silent as before", not
+        # crash dispatch for every ready/review task behind it.
+        _log.debug(
+            "kanban dispatch: failed to emit nonspawnable alert for "
+            "task %s assignee %r", task_id, assignee, exc_info=True,
+        )
+
 
 @dataclass
 class DispatchResult:
@@ -8049,6 +8197,7 @@ class DispatchResult:
     subsequent tick when the assignee has capacity. Separate bucket so
     telemetry / dashboards can show "this profile is busy" vs
     "task is genuinely stuck"."""
+
     crashed: list[str] = field(default_factory=list)
     """Task ids reclaimed because their worker PID disappeared."""
     auto_blocked: list[str] = field(default_factory=list)
@@ -10180,6 +10329,20 @@ def _dispatch_once_locked(
             # multi-lane setups where the ready queue is steadily full
             # of human-pulled work.
             result.skipped_nonspawnable.append(row["id"])
+            # Silent-deadlock fix (#kanban-nonspawnable-deadlock 2026-08-19):
+            # a card whose assignee names neither a live Hermes profile nor
+            # a registered terminal lane used to rot here forever with ZERO
+            # task_event and ZERO comment — indistinguishable on the card
+            # itself from a healthy human-pulled terminal lane. One retired
+            # profile (a deleted `upx-*` role) silently deadlocked a whole
+            # dependency chain because nothing surfaced the skip. Emit once
+            # per assignee (not every tick — this bucket also legitimately
+            # covers long-lived terminal lanes that should stay quiet) so an
+            # operator or watchdog can tell "known lane, waiting for a
+            # human" apart from "assignee doesn't exist, needs rerouting"
+            # without polling every tick.
+            if not dry_run:
+                _emit_nonspawnable_alert(conn, row["id"], row_assignee)
             continue
         # Per-profile concurrency cap (#21582): even if there's global
         # headroom, refuse to spawn for an assignee that's already at
@@ -10205,14 +10368,52 @@ def _dispatch_once_locked(
         guard_reason = check_respawn_guard(conn, row["id"])
         if guard_reason is not None:
             result.respawn_guarded.append((row["id"], guard_reason))
-            # Emit an event so operators can see why the task was
-            # skipped when reading `hermes kanban tail` — without
-            # this the task appears stuck in ready with no diagnosis.
+            # Emit an event so operators can see why the task was skipped
+            # when reading `hermes kanban tail` — without this the task
+            # appears stuck in ready with no diagnosis. BUT: only on the
+            # transition (first occurrence of this reason, or a change
+            # from the previous reason) — a card guarded for hours would
+            # otherwise write one row EVERY tick forever (~1400/day on a
+            # single card observed 2026-08-19), pure noise once the first
+            # event already explains why. And once the SAME reason has
+            # held continuously past the escalation threshold, this is no
+            # longer "a few ticks of recovery" (the guard's documented
+            # purpose) — stop reassessing the identical state forever and
+            # route it to a human/orchestrator decision instead.
             if not dry_run:
-                with write_txn(conn):
-                    _append_event(
-                        conn, row["id"], "respawn_guarded",
-                        {"reason": guard_reason},
+                streak_count, streak_first_seen = _respawn_guard_streak(
+                    conn, row["id"], guard_reason,
+                )
+                is_transition = streak_count < _RESPAWN_GUARD_EVENT_DEDUPE_AFTER
+                escalate_after = _resolve_respawn_guard_escalate_seconds()
+                should_escalate = (
+                    escalate_after > 0
+                    and streak_first_seen is not None
+                    and (int(time.time()) - streak_first_seen) >= escalate_after
+                )
+                if is_transition or should_escalate:
+                    with write_txn(conn):
+                        _append_event(
+                            conn, row["id"], "respawn_guarded",
+                            {
+                                "reason": guard_reason,
+                                "streak": streak_count + 1,
+                            },
+                        )
+                if should_escalate and streak_first_seen is not None:
+                    held_for = int(time.time()) - streak_first_seen
+                    block_task(
+                        conn, row["id"],
+                        kind="needs_input",
+                        reason=(
+                            f"Respawn guard stuck on reason={guard_reason!r} for "
+                            f"{held_for // 60}m across {streak_count + 1} ticks — "
+                            "no human/orchestrator decision has cleared it. "
+                            "Auto-escalated by the dispatcher instead of "
+                            "reassessing the identical state forever; see "
+                            "check_respawn_guard docstring for what each "
+                            "reason means and how to clear it."
+                        ),
                     )
             continue
         if dry_run:
@@ -10328,6 +10529,12 @@ def _dispatch_once_locked(
             profile_exists = None  # type: ignore[assignment]
         if profile_exists is not None and not profile_exists(row["assignee"]):
             result.skipped_nonspawnable.append(row["id"])
+            # See the matching comment on the ready-lane check above: emit
+            # the same once-per-assignee alert so a retired/typo'd reviewer
+            # profile doesn't silently strand a card in the review column
+            # either (#kanban-nonspawnable-deadlock 2026-08-19).
+            if not dry_run:
+                _emit_nonspawnable_alert(conn, row["id"], row["assignee"])
             continue
         if _per_profile_cap is not None:
             current = _per_profile_running.get(row["assignee"], 0)
@@ -10339,11 +10546,43 @@ def _dispatch_once_locked(
         guard_reason = check_respawn_guard(conn, row["id"], lane="review")
         if guard_reason is not None:
             result.respawn_guarded.append((row["id"], guard_reason))
+            # Same dedupe/escalation policy as the ready-lane guard above —
+            # only log on transition, escalate to needs_input if the same
+            # reason holds past the threshold. See the ready-lane comment
+            # for the full rationale (#respawn-guard-spam 2026-08-19).
             if not dry_run:
-                with write_txn(conn):
-                    _append_event(
-                        conn, row["id"], "respawn_guarded",
-                        {"reason": guard_reason},
+                streak_count, streak_first_seen = _respawn_guard_streak(
+                    conn, row["id"], guard_reason,
+                )
+                is_transition = streak_count < _RESPAWN_GUARD_EVENT_DEDUPE_AFTER
+                escalate_after = _resolve_respawn_guard_escalate_seconds()
+                should_escalate = (
+                    escalate_after > 0
+                    and streak_first_seen is not None
+                    and (int(time.time()) - streak_first_seen) >= escalate_after
+                )
+                if is_transition or should_escalate:
+                    with write_txn(conn):
+                        _append_event(
+                            conn, row["id"], "respawn_guarded",
+                            {
+                                "reason": guard_reason,
+                                "streak": streak_count + 1,
+                            },
+                        )
+                if should_escalate and streak_first_seen is not None:
+                    held_for = int(time.time()) - streak_first_seen
+                    block_task(
+                        conn, row["id"],
+                        kind="needs_input",
+                        reason=(
+                            f"Respawn guard (review lane) stuck on "
+                            f"reason={guard_reason!r} for {held_for // 60}m "
+                            f"across {streak_count + 1} ticks — no human/"
+                            "orchestrator decision has cleared it. "
+                            "Auto-escalated instead of reassessing the "
+                            "identical state forever."
+                        ),
                     )
             continue
         if dry_run:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -367,6 +367,127 @@ def test_respawn_guard_defers_rate_limited_within_cooldown(
         assert kb.check_respawn_guard(conn, tid) is None
 
 
+def test_dispatch_once_dedupes_respawn_guarded_events_same_reason(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    """A guard reason that persists tick-over-tick must NOT write a fresh
+    ``respawn_guarded`` event every tick — only the first occurrence (the
+    transition) is logged. Regression for #respawn-guard-spam 2026-08-19:
+    one card guarded for ~20h wrote ~1400 events/day, all identical."""
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="pr-guard", assignee="alice")
+        kb.add_comment(
+            conn, tid, "worker", "Opened https://github.com/org/repo/pull/1",
+        )
+
+        def fake_spawn(task, workspace, board=None):
+            raise AssertionError("must not spawn while active_pr guard holds")
+
+        # Three consecutive dispatch ticks with the same guard reason.
+        for _ in range(3):
+            res = kb.dispatch_once(conn, spawn_fn=fake_spawn, max_in_progress=5)
+            assert res.respawn_guarded == [(tid, "active_pr")]
+
+        events = [e for e in kb.list_events(conn, tid) if e.kind == "respawn_guarded"]
+        assert len(events) == 1, (
+            f"expected exactly one respawn_guarded event across 3 identical "
+            f"ticks, got {len(events)}"
+        )
+        assert events[0].payload["reason"] == "active_pr"
+        assert events[0].payload["streak"] == 1
+
+
+def test_dispatch_once_logs_new_event_on_reason_change(
+    kanban_home, all_assignees_spawnable,
+):
+    """A reason CHANGE (e.g. active_pr -> recent_success) is a materially
+    different situation and must log its own transition event, not be
+    swallowed by the same-reason dedupe."""
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="reason-change", assignee="alice")
+        # Force two different guard reasons back-to-back via direct event
+        # seeding (cheaper/more deterministic than orchestrating two real
+        # guard conditions through dispatch_once).
+        with _kb.write_txn(conn):
+            _kb._append_event(conn, tid, "respawn_guarded", {"reason": "recent_success"})
+        streak_count, first_seen = _kb._respawn_guard_streak(conn, tid, "active_pr")
+        assert streak_count == 0, "different reason must not extend the streak"
+        assert first_seen is None
+
+        same_count, same_first_seen = _kb._respawn_guard_streak(
+            conn, tid, "recent_success",
+        )
+        assert same_count == 1
+        assert same_first_seen is not None
+
+
+def test_dispatch_once_escalates_respawn_guard_after_threshold(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    """Once the SAME guard reason has held past the escalation threshold,
+    the dispatcher must stop looping the card in ready forever and instead
+    route it to ``blocked`` (kind=needs_input) for a human/orchestrator
+    decision — the core fix for #respawn-guard-spam 2026-08-19."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setenv("HERMES_KANBAN_RESPAWN_GUARD_ESCALATE_SECONDS", "600")
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="stuck-guard", assignee="alice")
+        # Comment (the active_pr trigger) must predate the seeded guard
+        # streak, mirroring real dispatch ordering: PR opened, THEN the
+        # guard starts refusing respawns tick after tick. If the comment's
+        # ``commented`` event were newer than the seeded streak it would
+        # (correctly) reset the streak walk, defeating the setup.
+        old_ts = int(_kb.time.time()) - 700
+        kb.add_comment(
+            conn, tid, "worker", "Opened https://github.com/org/repo/pull/2",
+        )
+        # Backdate every pre-existing event (created + commented) so the
+        # streak walk isn't reset by a same/newer-timestamp non-guard event
+        # sitting on top of the seeded guard streak below — mirrors real
+        # dispatch ordering where the PR-open comment predates hours of
+        # guarded ticks.
+        conn.execute(
+            "UPDATE task_events SET created_at = ? WHERE task_id = ?",
+            (old_ts - 10, tid),
+        )
+
+        def fake_spawn(task, workspace, board=None):
+            raise AssertionError("must not spawn while active_pr guard holds")
+
+        # Seed a stale streak: a respawn_guarded/active_pr event older than
+        # the 600s threshold, as if the dispatcher had been ticking on this
+        # reason for a while already.
+        with _kb.write_txn(conn):
+            conn.execute(
+                "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
+                "VALUES (?, NULL, 'respawn_guarded', ?, ?)",
+                (tid, '{"reason": "active_pr", "streak": 1}', old_ts),
+            )
+
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn, max_in_progress=5)
+        assert not res.spawned
+        assert res.respawn_guarded == [(tid, "active_pr")]
+
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked", (
+            "a guard reason held past the escalation threshold must route "
+            f"to blocked, got {task.status!r}"
+        )
+        assert task.block_kind == "needs_input"
+
+        events = [e for e in kb.list_events(conn, tid) if e.kind == "respawn_guarded"]
+        # The seeded stale event + exactly one new escalation-transition event.
+        assert len(events) == 2
+        assert events[-1].payload["reason"] == "active_pr"
+
+
 
 
 

--- a/tests/hermes_cli/test_kanban_nonspawnable_alert.py
+++ b/tests/hermes_cli/test_kanban_nonspawnable_alert.py
@@ -1,0 +1,125 @@
+"""Silent-deadlock fix: skipped_nonspawnable must alert, not rot silently.
+
+Regression coverage for #kanban-nonspawnable-deadlock (2026-08-19): a card
+whose ``assignee`` names neither a live Hermes profile nor a registered
+terminal lane used to be bucketed into ``skipped_nonspawnable`` with ZERO
+``task_event`` and ZERO comment written to the card — indistinguishable,
+from the card itself, from a healthy human-pulled terminal lane. A single
+retired profile silently deadlocked a whole dependency chain because
+nothing ever surfaced the skip.
+
+Fix: ``_emit_nonspawnable_alert`` writes one ``nonspawnable_alerted``
+task_event + one card comment the first time a given (task, assignee)
+pair is skipped as nonspawnable, then stays silent on later ticks for the
+same assignee (so long-lived, intentional terminal lanes don't get
+repeat noise).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _fake_spawn_factory(spawns):
+    def _spawn(task, workspace, **kwargs):
+        spawns.append(task.id)
+        return 4242
+
+    return _spawn
+
+
+def test_nonspawnable_ready_task_gets_event_and_comment(kanban_home, monkeypatch):
+    import hermes_cli.profiles as profmod
+
+    monkeypatch.setattr(profmod, "profile_exists", lambda name: False)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn, title="orphaned card", assignee="upx-product-owner",
+        )
+        res = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn_factory([]), max_in_progress=2,
+        )
+        assert task_id in res.skipped_nonspawnable
+
+        events = kb.list_events(conn, task_id)
+        alert_events = [e for e in events if e.kind == "nonspawnable_alerted"]
+        assert len(alert_events) == 1
+        assert alert_events[0].payload["assignee"] == "upx-product-owner"
+
+        comments = kb.list_comments(conn, task_id)
+        assert len(comments) == 1
+        assert "upx-product-owner" in comments[0].body
+        assert "does not resolve" in comments[0].body
+
+
+def test_nonspawnable_alert_does_not_repeat_across_ticks(kanban_home, monkeypatch):
+    import hermes_cli.profiles as profmod
+
+    monkeypatch.setattr(profmod, "profile_exists", lambda name: False)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn, title="orphaned card", assignee="upx-devops",
+        )
+        for _ in range(3):
+            res = kb.dispatch_once(
+                conn, spawn_fn=_fake_spawn_factory([]), max_in_progress=2,
+            )
+            assert task_id in res.skipped_nonspawnable
+
+        events = kb.list_events(conn, task_id)
+        alert_events = [e for e in events if e.kind == "nonspawnable_alerted"]
+        assert len(alert_events) == 1, (
+            "alert must fire once per assignee, not once per dispatch tick "
+            "(the whole point is not spamming a long-lived terminal lane)"
+        )
+        comments = kb.list_comments(conn, task_id)
+        assert len(comments) == 1
+
+
+def test_nonspawnable_review_task_gets_event_and_comment(kanban_home, monkeypatch):
+    """The review-lane skip site gets the same alert, independently."""
+    import hermes_cli.config as cfgmod
+    import hermes_cli.profiles as profmod
+
+    monkeypatch.setattr(
+        cfgmod, "load_config",
+        lambda *a, **k: {"kanban": {"review_dispatch": True}},
+    )
+    monkeypatch.setattr(profmod, "profile_exists", lambda name: False)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn, title="review card", assignee="upx-product-owner",
+        )
+        conn.execute(
+            "UPDATE tasks SET status = 'review' WHERE id = ?", (task_id,)
+        )
+        conn.commit()
+        res = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn_factory([]), max_in_progress=2,
+        )
+        assert task_id in res.skipped_nonspawnable
+
+        events = kb.list_events(conn, task_id)
+        alert_events = [e for e in events if e.kind == "nonspawnable_alerted"]
+        assert len(alert_events) == 1
+
+        comments = kb.list_comments(conn, task_id)
+        assert len(comments) == 1


### PR DESCRIPTION
## Summary

Two independent dispatcher fixes for silent-loop/silent-deadlock failure classes observed 2026-08-19 on the `uss-platform-staging` kanban board. Both were implemented and verified live but only existed as **uncommitted diffs** on a container checkout of this repo — lost on the next image rebuild. This PR commits them properly.

### 1. Nonspawnable-assignee alert (`_emit_nonspawnable_alert`)

When a task's `assignee` names neither a live Hermes profile nor a registered terminal lane, the dispatcher correctly refuses to auto-spawn it — but historically recorded **nothing** on the card: no `task_event`, no comment. From the card alone, that state is indistinguishable from "a human terminal lane just hasn't pulled it yet" — a genuinely fine, common state. In one real case a retired profile (a deleted `upx-*` role reused as an assignee) silently deadlocked a 6-card dependency chain for hours before a human noticed, purely because nothing pointed at it.

Now: a one-time `task_event` + card comment is emitted per `(task, assignee)` pair on first occurrence, for both the ready-lane and review-lane dispatch checks. Re-checked via a cheap event scan each tick (not written every tick), so the long-lived intentional terminal-lane case stays silent — a card can legitimately wait days in this bucket without repeat noise — while a typo'd/retired assignee still gets a one-time surfaced alert.

### 2. `respawn_guarded` event dedupe + escalation (`_respawn_guard_streak`)

The dispatcher wrote a fresh `respawn_guarded` `task_event` on **every** dispatch tick a guard held, even when the reason was byte-identical to the previous tick. Measured case: one card guarded for ~20h wrote ~1400 near-duplicate events/day — pure diagnostic noise once the first occurrence already explained why, and it drowns the event log for anyone reading it.

Now: logs only on the first occurrence of a reason (the transition) or when the reason changes. If the *same* reason holds continuously past `HERMES_KANBAN_RESPAWN_GUARD_ESCALATE_SECONDS` (default 3h — comfortably past every legitimate transient guard window such as the 1h respawn-guard success window or the 5m rate-limit cooldown), the task auto-escalates to a `needs_input` block instead of being silently reassessed forever, surfacing it for a human/orchestrator decision. Applied to both the ready-lane and review-lane guard checks.

## Relationship to PR #89966

This repo currently has a third, unrelated dispatcher fix in flight: `fix/kanban-dependency-block-loop-backoff` (PR #89966, draft, same author) — a dependency-block backoff/escalation mechanism, additive schema columns, disjoint hunks in the same file. Verified no overlap:

- `gh pr diff 89966` touches only `VALID_BLOCK_KINDS`/`Task` dataclass/`SCHEMA_SQL`/`_migrate_add_optional_columns`/`recompute_ready`/`complete_task`/`block_task`'s dependency branch.
- This PR touches only the respawn-guard helpers and the ready/review dispatch call sites (~line 8000+ region), reverse-applying #89966's diff onto this branch's `kanban_db.py` leaves it byte-identical to `origin/main`.
- The two branches were built independently from a shared container diff containing all fixes; extraction was verified by reverse-applying PR #89966's diff and confirming zero leftover references to its symbols (`dependency_block_streak`, `dependency_backoff_until`, `DEPENDENCY_BLOCK_ESCALATION_LIMIT`) in this branch.

## Test plan

New tests (6):
- `tests/hermes_cli/test_kanban_nonspawnable_alert.py` (new file): ready-lane alert fires with event+comment, dedupes across ticks, review-lane alert fires.
- `tests/hermes_cli/test_kanban_db.py`: dedupes `respawn_guarded` events for a persisting reason, logs a fresh event when the reason changes, escalates to `needs_input` after the threshold.

Verified against a clean worktree of `origin/main` (`13ce0c5c6`), isolated from PR #89966's changes:

```
tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_block_kinds.py \
tests/hermes_cli/test_kanban_nonspawnable_alert.py tests/hermes_cli/test_kanban_blocked_sticky.py \
tests/hermes_cli/test_kanban_promote.py tests/hermes_cli/test_kanban_review_lifecycle.py
=> 61 passed, 1 skipped
```

A broader `-k kanban` sweep (`pytest tests/hermes_cli/ -k kanban`) shows 15 pre-existing failures that reproduce identically on clean `origin/main` without this diff applied (test-order/global-state pollution unrelated to this change, e.g. `test_kanban_write_guard.py`, `test_kanban_worker_lifecycle_hooks.py`) — confirmed by running the same sweep with this diff stashed out.

## Scope note

The container diff this was extracted from also contained a fourth, undertested mechanism (a "self-review dispatch guard" that skips auto-spawning a review-lane task back onto its own implementer when no distinct `reviewer=` was set). That piece is **deliberately excluded** from this PR: it regressed 4 existing `test_kanban_review_lifecycle.py` cases and needs its own fix + test coverage before it's safe to ship. Filed as follow-up work, not included here.

## Agent disclosure

Implemented and verified by an autonomous coding agent (Hermes `upx-senior-dev` profile, Claude) extracting and testing a pre-existing container diff; human review requested before merge (draft PR, no push access to this repo confirmed via 403 on collaborator-permission check).
