### PR TITLE
fix(feishu): 规范 webhook 卡片操作响应的处理逻辑

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2729,6 +2729,13 @@ class FeishuAdapter(BasePlatformAdapter):
         event = getattr(data, "event", None)
         action = getattr(event, "action", None)
         action_value = getattr(action, "value", {}) or {}
+        # The webhook transport rebuilds the payload through
+        # _namespace_from_mapping, which turns nested dicts into
+        # SimpleNamespace. Without normalizing, the isinstance(dict) checks
+        # below fail and approval clicks fall through to the generic
+        # synthetic-command path instead of resolving the approval.
+        if isinstance(action_value, SimpleNamespace):
+            action_value = vars(action_value)
         hermes_action = action_value.get("hermes_action") if isinstance(action_value, dict) else None
         update_prompt_action = (
             action_value.get("hermes_update_prompt_action")
@@ -3652,7 +3659,15 @@ class FeishuAdapter(BasePlatformAdapter):
         elif event_type in {"im.message.reaction.created_v1", "im.message.reaction.deleted_v1"}:
             self._on_reaction_event(event_type, data)
         elif event_type == "card.action.trigger":
-            self._on_card_action_trigger(data)
+            # Feishu refreshes the card in every client only when the callback
+            # response body carries the updated card. The WS transport lets the
+            # SDK serialize the handler's return value; in webhook mode we are
+            # the transport, so the response must be forwarded explicitly or
+            # the buttons stay live and re-clickable.
+            card_response = self._on_card_action_trigger(data)
+            payload = self._serialize_card_action_response(card_response)
+            if payload is not None:
+                return web.json_response(payload)
         elif event_type == "drive.notice.comment_add_v1":
             self._on_drive_comment_event(data)
         elif event_type == "vc.bot.meeting_invited_v1":
@@ -3660,6 +3675,33 @@ class FeishuAdapter(BasePlatformAdapter):
         else:
             logger.debug("[Feishu] Ignoring webhook event type: %s", event_type or "unknown")
         return web.json_response({"code": 0, "msg": "ok"})
+
+    @staticmethod
+    def _serialize_card_action_response(response: Any) -> Optional[Dict[str, Any]]:
+        """Convert a P2CardActionTriggerResponse into a webhook response body.
+
+        Returns ``None`` when the handler produced nothing worth returning, so
+        the caller falls through to the generic ``{"code": 0, "msg": "ok"}``
+        acknowledgement.
+
+        The lark_oapi marshaller is used rather than reading ``card``/``toast``
+        by hand: it strips unset fields and keeps every response field the SDK
+        knows about, so a ``toast`` (or a field added in a later SDK release) is
+        not silently dropped on the webhook path.
+        """
+        if response is None:
+            return None
+        try:
+            marshalled = lark.JSON.marshal(response)
+            payload = json.loads(marshalled) if marshalled else None
+        except Exception:
+            logger.warning(
+                "[Feishu] Failed to serialize card action response", exc_info=True,
+            )
+            return None
+        if not isinstance(payload, dict) or not payload:
+            return None
+        return payload
 
     def _is_webhook_signature_valid(self, headers: Any, body_bytes: bytes) -> bool:
         """Verify Feishu webhook signature using timing-safe comparison.
@@ -4963,6 +5005,7 @@ class FeishuAdapter(BasePlatformAdapter):
         if not FEISHU_WEBHOOK_AVAILABLE:
             raise RuntimeError("aiohttp not installed; webhook mode unavailable")
         domain = FEISHU_DOMAIN if self._domain_name != "lark" else LARK_DOMAIN
+        self._loop = asyncio.get_running_loop()
         self._client = self._build_lark_client(domain)
         self._event_handler = self._build_event_handler()
         if self._event_handler is None:

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -447,3 +447,89 @@ class TestResolveUpdatePrompt:
         assert 1 not in adapter._update_prompt_state
 
 
+# ===========================================================================
+# _serialize_card_action_response — webhook transport must forward the card
+# ===========================================================================
+
+class _StubToast:
+    def __init__(self, type_=None, content=None):
+        self.type = type_
+        self.content = content
+
+
+class TestSerializeCardActionResponse:
+    """The webhook path must forward the handler's card, not swallow it.
+
+    In WS mode the SDK serializes the handler return value; in webhook mode the
+    adapter is the transport, so a dropped response leaves the buttons live and
+    re-clickable in every client.
+    """
+
+    @staticmethod
+    def _marshal(payload):
+        """Stand in for lark.JSON.marshal over the stub response objects."""
+        out = {}
+        toast = getattr(payload, "toast", None)
+        if toast is not None and getattr(toast, "type", None):
+            out["toast"] = {"type": toast.type, "content": toast.content}
+        card = getattr(payload, "card", None)
+        if card is not None and getattr(card, "type", None):
+            out["card"] = {"type": card.type, "data": card.data}
+        return json.dumps(out)
+
+    @pytest.fixture()
+    def _stub_marshal(self, monkeypatch):
+        monkeypatch.setattr(
+            feishu_module, "lark",
+            SimpleNamespace(JSON=SimpleNamespace(marshal=self._marshal)),
+            raising=False,
+        )
+
+    def test_returns_none_for_missing_response(self, _stub_marshal):
+        assert FeishuAdapter._serialize_card_action_response(None) is None
+
+    def test_returns_none_for_empty_response(self, _stub_marshal):
+        """An acknowledgement with no card must fall through to code/msg ok."""
+        assert FeishuAdapter._serialize_card_action_response(_FakeP2Response()) is None
+
+    def test_forwards_resolved_card(self, _stub_marshal):
+        response = _FakeP2Response()
+        card = _FakeCallBackCard()
+        card.type = "raw"
+        card.data = {"header": {"template": "green"}}
+        response.card = card
+
+        payload = FeishuAdapter._serialize_card_action_response(response)
+
+        assert payload == {
+            "card": {"type": "raw", "data": {"header": {"template": "green"}}},
+        }
+
+    def test_preserves_toast_alongside_card(self, _stub_marshal):
+        """Regression: a hand-rolled card-only walk silently dropped toast."""
+        response = _FakeP2Response()
+        card = _FakeCallBackCard()
+        card.type = "raw"
+        card.data = {"header": {"template": "red"}}
+        response.card = card
+        response.toast = _StubToast("error", "Denied")
+
+        payload = FeishuAdapter._serialize_card_action_response(response)
+
+        assert payload["toast"] == {"type": "error", "content": "Denied"}
+        assert payload["card"]["data"] == {"header": {"template": "red"}}
+
+    def test_marshal_failure_degrades_to_none(self, monkeypatch):
+        """A serializer error must not break the callback with a 500."""
+        def _boom(_payload):
+            raise RuntimeError("marshal exploded")
+
+        monkeypatch.setattr(
+            feishu_module, "lark",
+            SimpleNamespace(JSON=SimpleNamespace(marshal=_boom)),
+            raising=False,
+        )
+        response = _FakeP2Response()
+        response.card = _FakeCallBackCard()
+
+        assert FeishuAdapter._serialize_card_action_response(response) is None


### PR DESCRIPTION
- 解决了 SimpleNamespace 类型的 action_value 未被正确处理的问题，保证审批点击能正确识别
- 新增 _serialize_card_action_response 静态方法，用于将卡片操作响应序列化为 webhook 需要的响应体
- 在 webhook 模式下显式返回序列化后的响应内容，防止按钮因响应缺失而保持可点击状态
- 添加对 lark_oapi marshaller 的使用，保证响应字段完整且避免手动错误处理
- 增加异常捕获，防止序列化失败导致回调异常
- 在测试中新增对序列化功能的覆盖，包括成功和失败情景，验证卡片和提示消息的完整转发

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

