### PR TITLE
fix(desktop): restore statusbar context menu

### DIFF
--- a/apps/desktop/scripts/diag-live-state.mjs
+++ b/apps/desktop/scripts/diag-live-state.mjs
@@ -10,7 +10,7 @@ try {
     const rc = !!window.__RENDER_COUNTS__
     const pl = !!window.__PERF_LIVE__
     const tiles = window.__HERMES_SESSION_TILES__ ? Object.keys(window.__HERMES_SESSION_TILES__.states()).length : -1
-    const gw = document.querySelector('[data-slot="statusbar"]')?.textContent?.slice(0, 120) ?? '(no statusbar)'
+    const gw = document.querySelector('[data-statusbar]')?.textContent?.slice(0, 120) ?? '(no statusbar)'
     const sidebarRows = document.querySelectorAll('[data-slot="sidebar"] [data-session-id], [data-tree-group] a').length
     return JSON.stringify({ rc, pl, tiles, gw, sidebarRows, title: document.title, url: location.href.slice(0, 80) })
   })()`)

--- a/apps/desktop/src/app/shell/statusbar-context-menu.test.tsx
+++ b/apps/desktop/src/app/shell/statusbar-context-menu.test.tsx
@@ -1,0 +1,60 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { AppContextMenu } from '@/app/context-menu/app-context-menu'
+import { StatusbarControls } from '@/app/shell/statusbar-controls'
+import { $contextMenu } from '@/app/context-menu/store'
+import { $statusbarHiddenIds, STATUSBAR_HIDDEN_BY_DEFAULT } from '@/store/statusbar-prefs'
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  vi.stubGlobal('ResizeObserver', TestResizeObserver)
+  Element.prototype.hasPointerCapture ??= () => false
+  Element.prototype.setPointerCapture ??= () => undefined
+  Element.prototype.releasePointerCapture ??= () => undefined
+  HTMLElement.prototype.scrollIntoView ??= () => undefined
+})
+
+afterEach(() => {
+  cleanup()
+  $contextMenu.set(null)
+  $statusbarHiddenIds.set([...STATUSBAR_HIDDEN_BY_DEFAULT])
+})
+
+describe('statusbar context menu coordination', () => {
+  it('lets the statusbar Radix menu handle right-clicks instead of the app fallback (#89953)', async () => {
+    render(
+      <MemoryRouter>
+        <AppContextMenu />
+        <StatusbarControls
+          items={[
+            {
+              id: 'context-usage',
+              label: 'Context meter',
+              toggleLabel: 'Context meter',
+              variant: 'menu'
+            }
+          ]}
+        />
+      </MemoryRouter>
+    )
+
+    const statusbar = screen.getByRole('contentinfo')
+
+    expect(statusbar.getAttribute('data-slot')).toBe('context-menu-trigger')
+    expect(statusbar.hasAttribute('data-statusbar')).toBe(true)
+
+    fireEvent.pointerDown(statusbar, { button: 2, ctrlKey: false, pointerType: 'mouse' })
+    fireEvent.contextMenu(statusbar, { button: 2 })
+
+    expect(await screen.findByRole('menuitemcheckbox', { name: 'Context meter' })).toBeTruthy()
+    expect(screen.queryByText('Settings')).toBeNull()
+    expect($contextMenu.get()).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/shell/statusbar-controls.tsx
+++ b/apps/desktop/src/app/shell/statusbar-controls.tsx
@@ -104,7 +104,8 @@ export function StatusbarControls({ className, leftItems = [], items = [], ...pr
             'flex h-5 shrink-0 items-stretch justify-between gap-2 bg-(--ui-sidebar-surface-background) px-1 py-0 text-(--ui-text-tertiary) [-webkit-app-region:no-drag]',
             className
           )}
-          data-slot="statusbar"
+          data-slot="context-menu-trigger"
+          data-statusbar=""
           {...props}
         >
           {/* `overflow-x-clip` (not `overflow-x-auto`) so a wide status item — for

--- a/apps/desktop/src/components/pet/roam-geometry.ts
+++ b/apps/desktop/src/components/pet/roam-geometry.ts
@@ -27,7 +27,7 @@ const PERCH_SELECTORS = ['[data-slot="composer-surface"]', '[data-slot="profile-
 // A full-width bar pinned to the window bottom (the status bar). When present,
 // the pet walks along its TOP edge instead of the window edge, so it stands on
 // the bar rather than covering it.
-const FLOOR_BAR_SELECTOR = '[data-slot="statusbar"]'
+const FLOOR_BAR_SELECTOR = '[data-statusbar]'
 
 // Sprites carry a few px of transparent padding below the feet; sink the pet by
 // this much so the visible feet meet the surface instead of hovering above it.


### PR DESCRIPTION
Fixes #89953

The status bar renders `ContextMenuTrigger asChild` over a `<footer data-slot="statusbar">`. Radix Slot lets the child `data-slot` win, so the app-wide capture-phase context-menu coordinator cannot recognize the status bar as a Radix-owned surface and opens the shell fallback menu instead.

This keeps the status bar recognizable by the coordinator by using `data-slot="context-menu-trigger"` on the rendered footer, while preserving a dedicated `data-statusbar` marker for the two non-menu consumers that locate the bar (pet floor geometry and the live-state diagnostic script).

Also adds an integration regression test that mounts both `AppContextMenu` and `StatusbarControls`, right-clicks the bar, and verifies the status bar checkbox menu wins while the app fallback stays closed.

Duplicate check: no open PR referencing #89953 was found immediately before opening this PR.

CI is expected to validate the new test and the affected desktop suite.