### PR TITLE
fix(gateway): reconcile finished prompt-run threads at session teardown

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -14640,6 +14640,45 @@ def test_session_activate_returns_inflight_stream_before_completion(monkeypatch)
         server._sessions.pop("sid-live", None)
 
 
+def test_session_activate_clears_stale_busy_state_after_prompt_worker_exits(monkeypatch):
+    class _DeadThread:
+        @staticmethod
+        def is_alive():
+            return False
+
+    agent = types.SimpleNamespace(model="model-stale")
+    session = _session(
+        agent=agent,
+        running=True,
+        inflight_turn={
+            "assistant": "stale partial",
+            "status": "streaming",
+            "user": "already completed",
+        },
+    )
+    session["_run_thread"] = _DeadThread()
+    server._sessions["sid-stale"] = session
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_session_info", lambda _agent: {"model": "model-stale"})
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "activate",
+                "method": "session.activate",
+                "params": {"session_id": "sid-stale"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid-stale", None)
+
+    assert resp["result"]["running"] is False
+    assert resp["result"]["status"] == "idle"
+    assert "inflight" not in resp["result"]
+    assert session["running"] is False
+    assert session.get("inflight_turn") is None
+
+
 def test_session_activate_returns_prompt_queued_during_busy_turn(monkeypatch):
     """A full client restart must recover an accepted next-turn prompt.
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8824,6 +8824,35 @@ def _live_visible_history(session: dict, db, in_memory_fallback: list[dict]) -> 
     return in_memory_fallback
 
 
+def _reconcile_finished_run_thread(session: dict) -> bool:
+    """Clear a stale busy projection after its prompt worker has exited.
+
+    A dropped transport must not leave ``running`` and ``inflight_turn`` pinned
+    forever after the worker is already dead.  Reconnect callers use the live
+    payload as their authority, so reconcile that impossible state before
+    returning it.  A missing thread is left untouched because other session
+    paths can briefly set ``running`` before their worker is registered.
+    """
+    if not session.get("running"):
+        return False
+
+    run_thread = session.get("_run_thread")
+    if run_thread is None:
+        return False
+
+    try:
+        alive = run_thread.is_alive()
+    except Exception:
+        return False
+
+    if alive:
+        return False
+
+    session["running"] = False
+    _clear_inflight_turn(session)
+    return True
+
+
 def _live_session_payload(
     sid: str,
     session: dict,
@@ -8834,6 +8863,7 @@ def _live_session_payload(
     omit_messages: bool = False,
 ) -> dict:
     with session["history_lock"]:
+        _reconcile_finished_run_thread(session)
         if cols is not None:
             session["cols"] = cols
         if transport is not None:


### PR DESCRIPTION
## What does this PR do?

When a prompt-run worker thread finishes (or dies) but its session still has `running: True` and a stale `_run_thread` reference, the next activation of that session can see it as busy and refuse to dispatch. This reconciles that state at session activation: if the recorded run thread is no longer alive, the inflight-turn state is cleared so the session is usable again.

This is a standalone, self-contained piece of the WebSocket-recovery work in #83166 — it has no dependency on the heartbeat wire contract (#89958) or the transport-ownership machinery, so it's filed on its own.

## Related Issue

Part of the recovery work in #83166.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` — `_reconcile_finished_run_thread(session)` helper (clears inflight state when `_run_thread` is no longer alive), called from `_live_session_payload`.
- `tests/test_tui_gateway_server.py` — one test that activating a session with a dead run thread clears the stale busy state.

## How to Test

```text
scripts/run_tests.sh tests/test_tui_gateway_server.py -k activate_clears_stale_busy
```
Fail-before (reconcile call removed): 1 failed (session still reports `running`). Pass-after: 1 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched existing PRs
- [x] Only changes related to this fix
- [x] Ran the affected test
- [x] Added a test
- [x] Tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] Docs — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform — N/A
- [x] Tool descriptions/schemas — N/A

---

Salvage-friendly: single commit on current main (`13ce0c5c67`), no dependencies — cherry-pick welcome, authorship preservation appreciated but optional.
