### PR TITLE
fix(weixin): cap international long polls

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -103,6 +103,10 @@ EP_GET_BOT_QR = "ilink/bot/get_bot_qrcode"
 EP_GET_QR_STATUS = "ilink/bot/get_qrcode_status"
 
 LONG_POLL_TIMEOUT_MS = 35_000
+# The international iLink endpoint is fronted by an edge proxy that closes
+# requests before the normal 35-second poll completes. Keep enough margin for
+# the endpoint to return a normal empty poll instead of surfacing HTTP 524.
+WECHAT_LONG_POLL_TIMEOUT_MS = 10_000
 API_TIMEOUT_MS = 15_000
 CONFIG_TIMEOUT_MS = 10_000
 QR_TIMEOUT_MS = 35_000
@@ -113,6 +117,14 @@ BACKOFF_DELAY_SECONDS = 30
 SESSION_EXPIRED_ERRCODE = -14
 RATE_LIMIT_ERRCODE = -2  # iLink frequency limit — backoff and retry
 MESSAGE_DEDUP_TTL_SECONDS = 300
+
+
+def _long_poll_timeout_ms(base_url: str) -> int:
+    """Return the safe long-poll ceiling for an iLink endpoint."""
+    hostname = (urlparse(base_url).hostname or "").lower()
+    if hostname == "ilinkai.wechat.com":
+        return WECHAT_LONG_POLL_TIMEOUT_MS
+    return LONG_POLL_TIMEOUT_MS
 
 
 def _is_stale_session_ret(
@@ -1371,7 +1383,8 @@ class WeixinAdapter(BasePlatformAdapter):
     async def _poll_loop(self) -> None:
         assert self._poll_session is not None
         sync_buf = _load_sync_buf(self._hermes_home, self._account_id)
-        timeout_ms = LONG_POLL_TIMEOUT_MS
+        max_timeout_ms = _long_poll_timeout_ms(self._base_url)
+        timeout_ms = max_timeout_ms
         consecutive_failures = 0
 
         while self._running:
@@ -1385,7 +1398,7 @@ class WeixinAdapter(BasePlatformAdapter):
                 )
                 suggested_timeout = response.get("longpolling_timeout_ms")
                 if isinstance(suggested_timeout, int) and suggested_timeout > 0:
-                    timeout_ms = suggested_timeout
+                    timeout_ms = min(suggested_timeout, max_timeout_ms)
 
                 ret = response.get("ret", 0)
                 errcode = response.get("errcode", 0)

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -511,6 +511,42 @@ class TestIsStaleSessionRet:
         assert weixin._is_stale_session_ret(-14, None, "session expired") is False
 
 
+class TestWeixinLongPollTimeout:
+    def test_international_endpoint_uses_edge_safe_timeout(self):
+        assert (
+            weixin._long_poll_timeout_ms("https://ilinkai.wechat.com")
+            == weixin.WECHAT_LONG_POLL_TIMEOUT_MS
+        )
+
+    def test_default_endpoint_keeps_standard_timeout(self):
+        assert (
+            weixin._long_poll_timeout_ms("https://ilinkai.weixin.qq.com")
+            == weixin.LONG_POLL_TIMEOUT_MS
+        )
+
+    @patch("gateway.platforms.weixin._get_updates", new_callable=AsyncMock)
+    def test_server_suggestion_cannot_exceed_endpoint_ceiling(self, get_updates_mock):
+        adapter = _make_adapter()
+        adapter._base_url = "https://ilinkai.wechat.com"
+        adapter._poll_session = object()
+        adapter._running = True
+        get_updates_mock.side_effect = [
+            {"ret": 0, "longpolling_timeout_ms": weixin.LONG_POLL_TIMEOUT_MS},
+            asyncio.CancelledError(),
+        ]
+
+        asyncio.run(adapter._poll_loop())
+
+        assert get_updates_mock.await_count == 2
+        assert [
+            call.kwargs["timeout_ms"]
+            for call in get_updates_mock.await_args_list
+        ] == [
+            weixin.WECHAT_LONG_POLL_TIMEOUT_MS,
+            weixin.WECHAT_LONG_POLL_TIMEOUT_MS,
+        ]
+
+
 class TestWeixinContentDedup:
     """Regression tests for Issue #16182 — upstream API sends duplicate content
     with different message_ids, bypassing message_id deduplication.
@@ -827,4 +863,3 @@ class TestWeixinVoiceGatewayHandoff:
             "VOICE event body leaked Tencent's STT text — runner would trust "
             "the wrong transcript instead of re-transcribing (#27300)."
         )
-


### PR DESCRIPTION
## What changed

- Use a 10-second long-poll ceiling for the QR-issued international iLink endpoint, `ilinkai.wechat.com`.
- Keep the existing 35-second timeout for `ilinkai.weixin.qq.com` and other endpoints.
- Cap server-suggested follow-up timeouts at the endpoint-specific ceiling.
- Add regression coverage for endpoint selection and suggested-timeout capping.

## Root cause and impact

Some QR logins return `https://ilinkai.wechat.com` as the account's `base_url`. A 35-second `getupdates` request to that endpoint is terminated by its edge proxy with HTTP 524 after roughly 16 seconds, so an otherwise valid account remains in the poll error retry loop and cannot receive messages reliably.

Against the same live account and token, 5-second and 10-second polls returned `ret=0` with an empty message list, while the existing 35-second poll returned HTTP 524. The endpoint-specific ceiling preserves long polling while staying below the observed edge timeout.

## Validation

- `scripts/run_tests.sh tests/gateway/test_weixin.py -q` against the deployed v0.19.0 checkout: 83 passed.
- `python3 -m py_compile gateway/platforms/weixin.py tests/gateway/test_weixin.py`
- `git diff --check`
