### PR TITLE
fix(vision): honor supports_vision_tool_messages=False in tool-result media gates

### DIFF
--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -43,6 +43,39 @@ class TestSupportsMediaInToolResults:
         assert _supports_media_in_tool_results("", "anything") is False
         assert _supports_media_in_tool_results(None, "anything") is False  # type: ignore[arg-type]
 
+    def test_profile_tool_message_veto_overrides_supports_vision(self):
+        """An explicit supports_vision_tool_messages=False is a hard veto (#89981).
+
+        xiaomi/MiMo declares supports_vision=True (user-message images work)
+        alongside supports_vision_tool_messages=False (list-type tool-result
+        content answers 400 "text is not set"). supports_vision alone used to
+        flip this gate to True, so the multimodal envelope 400'd every turn
+        instead of falling back to the legacy aux-LLM path.
+        """
+        # "xiaomi" resolves through the registered provider profile.
+        assert _supports_media_in_tool_results("xiaomi", "mimo-v2.5") is False
+        assert _supports_media_in_tool_results("mimo", "mimo-v2.5") is False
+
+    def test_profile_veto_applies_even_when_vision_capable_lookup_agrees(self):
+        """The veto also blocks the native fast path's second gate: a
+        capability source marking the model vision-capable must not re-open
+        the multimodal-envelope route for a provider that rejects list-type
+        tool-result content."""
+        from tools.vision_tools import _should_use_native_vision_fast_path
+        from agent.auxiliary_client import set_runtime_main, clear_runtime_main
+        from agent import image_routing
+
+        set_runtime_main("xiaomi", "mimo-v2.5")
+        try:
+            with patch.object(
+                image_routing, "decide_image_input_mode", return_value="native"
+            ), patch.object(
+                image_routing, "_lookup_supports_vision", return_value=True
+            ):
+                assert _should_use_native_vision_fast_path() is False
+        finally:
+            clear_runtime_main()
+
 
 # ─── _build_native_vision_tool_result ────────────────────────────────────────
 

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1025,8 +1025,17 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
     try:
         from providers import get_provider_profile
         profile = get_provider_profile(p)
-        if profile is not None and profile.supports_vision:
-            return True
+        if profile is not None:
+            # An explicit supports_vision_tool_messages=False is a hard veto:
+            # the provider accepts images in user messages but rejects
+            # list-type tool-result content outright (xiaomi/MiMo answers
+            # 400 "text is not set"). supports_vision alone must not
+            # override that — the multimodal tool-result envelope would
+            # 400 every turn and the image never enters context (#89981).
+            if getattr(profile, "supports_vision_tool_messages", True) is False:
+                return False
+            if profile.supports_vision:
+                return True
     except Exception:
         pass
 
@@ -1057,6 +1066,21 @@ def _should_use_native_vision_fast_path() -> bool:
         cfg = load_config()
         if decide_image_input_mode(provider, model, cfg) != "native":
             return False
+        # The profile veto applies here too, ahead of the capability lookup:
+        # a provider that rejects list-type tool-result content must not
+        # take the native multimodal-envelope fast path just because a
+        # capability source (models.dev, custom_providers models entry)
+        # marks the model vision-capable (#89981).
+        try:
+            from providers import get_provider_profile
+            _profile = get_provider_profile(str(provider or "").strip().lower())
+            if (
+                _profile is not None
+                and getattr(_profile, "supports_vision_tool_messages", True) is False
+            ):
+                return False
+        except Exception:
+            pass
         return (
             _supports_media_in_tool_results(provider, model)
             or _lookup_supports_vision(provider, model, cfg) is True


### PR DESCRIPTION
## What does this PR do?

Fixes the native vision fast path sending image media in tool-result messages to providers that only accept images in user messages (#47742, re-reported as #89981 — same root cause, fixing the canonical issue).

A provider profile can declare `supports_vision=True` (user-message images work) together with `supports_vision_tool_messages=False` (list-type tool-result content is rejected). xiaomi/MiMo does exactly this and answers such content with `400 "text is not set"`. But `_supports_media_in_tool_results()` only read `supports_vision` from the profile, so the gate flipped to True, the fast path wrapped every vision result in the multimodal tool-result envelope, and the provider rejected it outright — the image never entered context and the turn errored.

Two gates now treat an explicit `supports_vision_tool_messages=False` as a hard veto:

- `_supports_media_in_tool_results` returns False before the `supports_vision` check. Providers that do not declare the flag at all default to True and keep the existing behavior.
- `_should_use_native_vision_fast_path` applies the same veto ahead of its capability-lookup escape hatch, so a models.dev / custom_providers vision-capable marking cannot re-open the envelope route for a provider that rejects the wire shape.

With the veto, these providers take the legacy aux-LLM vision path — the designed degradation for tool-result-media-incapable providers (images are analyzed by the aux vision model and return as text). The report's suggested deeper enhancement (re-injecting the image as a synthetic user message in `tool_executor`) composes on top of this and is intentionally left out of scope.

## Related Issue

Fixes #47742
(also resolves the re-report #89981, marked duplicate of it)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/vision_tools.py`: `_supports_media_in_tool_results` — the profile branch checks `supports_vision_tool_messages` first and returns False on an explicit False; `_should_use_native_vision_fast_path` — the same veto is applied before the capability-lookup disjunction.

## How to Test

1. `pytest tests/tools/test_vision_native_fast_path.py -q` — 14 passed (2 new tests).
2. Fail-on-main verified: with the source stashed, both new tests fail on the unmodified tree (`xiaomi`/`mimo` resolve to True; the fast path fires even with the capability lookup patched to True).
3. Adjacent suites: `tests/tools/test_vision_tools.py` 34 passed, `tests/agent/test_image_routing.py` 38 passed.
4. Observed result: `_supports_media_in_tool_results("xiaomi", "mimo-v2.5")` is now False, so the fast path falls through to the aux-LLM path instead of emitting the multimodal envelope that the provider 400s.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A