### PR TITLE
fix(desktop): resolve approvals from Windows toast clicks and thread request_id through the notification path

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -13697,6 +13697,21 @@ ipcMain.handle('hermes:notify', (_event, payload) => {
       mainWindow.webContents.send('hermes:focus-session', payload.sessionId)
     }
 
+    // Windows (and Linux) drop notification action buttons — only signed macOS
+    // builds render them. For an approval toast the body click is the only
+    // affordance, so treat it as an explicit Approve (once) instead of a
+    // no-op that strands the agent until the approval timeout (#89111). The
+    // renderer still clears the parked prompt and the in-app bar stands down.
+    if (payload?.kind === 'approval' && payload?.sessionId && !payload?.notifyId && !payload?.activate) {
+      mainWindow.webContents.send('hermes:notification-action', {
+        actionId: 'approve',
+        requestId: payload?.requestId,
+        sessionId: payload.sessionId
+      })
+
+      return
+    }
+
     // Plugin / session-less activation — serializable path (+ optional notifyId
     // for renderer callbacks). Same vocabulary as hermes://index-network/….
     if (payload?.activate || payload?.notifyId) {
@@ -13720,7 +13735,11 @@ ipcMain.handle('hermes:notify', (_event, payload) => {
 
     // Approvals keep the existing session-scoped channel.
     if (payload?.sessionId && !payload?.notifyId && !payload?.activate) {
-      mainWindow.webContents.send('hermes:notification-action', { sessionId: payload.sessionId, actionId: action.id })
+      mainWindow.webContents.send('hermes:notification-action', {
+        actionId: action.id,
+        requestId: payload?.requestId,
+        sessionId: payload.sessionId
+      })
 
       return
     }

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -195,8 +195,8 @@ export function useDesktopIntegrations({
   }, [navigate, runtimeIdByStoredSessionId])
 
   useEffect(() => {
-    const unsubscribe = window.hermesDesktop?.onNotificationAction?.(({ actionId, sessionId }) => {
-      void respondToApprovalAction(sessionId ?? null, actionId)
+    const unsubscribe = window.hermesDesktop?.onNotificationAction?.(({ actionId, requestId, sessionId }) => {
+      void respondToApprovalAction(sessionId ?? null, actionId, requestId)
     })
 
     return () => unsubscribe?.()

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -1348,6 +1348,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           ],
           body: command || description,
           kind: 'approval',
+          requestId: typeof payload?.request_id === 'string' ? payload.request_id : undefined,
           sessionId,
           title: translateNow('notifications.native.approvalTitle')
         })

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -398,7 +398,7 @@ declare global {
       }) => Promise<{ ok: boolean; pluginName?: string; path?: string; error?: string }>
       onWindowStateChanged?: (callback: (payload: HermesWindowState) => void) => () => void
       onFocusSession?: (callback: (sessionId: string) => void) => () => void
-      onNotificationAction?: (callback: (payload: { actionId: string; sessionId?: string }) => void) => () => void
+      onNotificationAction?: (callback: (payload: { actionId: string; requestId?: string; sessionId?: string }) => void) => () => void
       /** Plugin (and other session-less) notification body/action activation. */
       onNotificationActivate?: (
         callback: (payload: { actionId?: string; activate?: string; notifyId?: string; tag?: string }) => void
@@ -1109,6 +1109,9 @@ export interface HermesNotification {
   activate?: string
   /** Renderer handle for onActivate / onAction callbacks. */
   notifyId?: string
+  /** Approval correlation id — echoed back on action/body-click so the
+   *  renderer can resolve the exact pending approval (not just FIFO). */
+  requestId?: string
   actions?: { id: string; text: string; activate?: string }[]
 }
 

--- a/apps/desktop/src/store/native-notifications.test.ts
+++ b/apps/desktop/src/store/native-notifications.test.ts
@@ -324,6 +324,26 @@ describe('respondToApprovalAction', () => {
     expect($approvalRequest.get()).toBeNull()
   })
 
+  it('threads request_id through to approval.respond when provided', async () => {
+    setActiveSessionId('bg')
+    setApprovalRequest({ command: 'rm -rf /', description: 'dangerous', requestId: 'r-123', sessionId: 'bg' })
+
+    await respondToApprovalAction('bg', 'approve', 'r-123')
+
+    expect(request).toHaveBeenCalledWith('approval.respond', {
+      choice: 'once',
+      request_id: 'r-123',
+      session_id: 'bg'
+    })
+    expect($approvalRequest.get()).toBeNull()
+  })
+
+  it('omits request_id when absent (legacy FIFO path)', async () => {
+    await respondToApprovalAction('bg', 'approve', null)
+
+    expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'once', session_id: 'bg' })
+  })
+
   it('rejects via approval.respond {choice: "deny"}', async () => {
     await respondToApprovalAction('bg', 'reject')
     expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'deny', session_id: 'bg' })

--- a/apps/desktop/src/store/native-notifications.ts
+++ b/apps/desktop/src/store/native-notifications.ts
@@ -182,6 +182,9 @@ export interface NativeNotificationInput {
   activate?: string
   /** Renderer-side handle so click/action can invoke registered callbacks. */
   notifyId?: string
+  /** Approval correlation id — echoed back on action/body-click so the
+   *  renderer can resolve the exact pending approval (not just FIFO). */
+  requestId?: string
 }
 
 /** Returns true when the notification passed every guard and was handed to the
@@ -213,6 +216,7 @@ export function dispatchNativeNotification(input: NativeNotificationInput): bool
     icon: input.icon,
     kind: input.kind,
     notifyId: input.notifyId,
+    requestId: input.requestId,
     sessionId: input.sessionId ?? undefined,
     silent: input.silent,
     tag: input.tag,
@@ -345,7 +349,13 @@ export function dispatchPluginNativeNotification(pluginId: string, input: Plugin
 
 // Resolve a pending approval from a notification button, mirroring the in-app
 // Run/Reject bar. Keyed by session id — a background approval has no local guard.
-export async function respondToApprovalAction(sessionId: null | string, actionId: string): Promise<void> {
+// `requestId` (when present) pins the response to the exact pending approval
+// instead of the FIFO fallback, matching the in-app bar's correlation contract.
+export async function respondToApprovalAction(
+  sessionId: null | string,
+  actionId: string,
+  requestId?: null | string
+): Promise<void> {
   const choice = actionId === 'approve' ? 'once' : actionId === 'reject' ? 'deny' : null
 
   if (!choice) {
@@ -359,7 +369,11 @@ export async function respondToApprovalAction(sessionId: null | string, actionId
   }
 
   try {
-    await gateway.request('approval.respond', { choice, session_id: sessionId ?? undefined })
+    await gateway.request('approval.respond', {
+      choice,
+      request_id: requestId || undefined,
+      session_id: sessionId ?? undefined
+    })
     clearApprovalRequest(sessionId)
   } catch {
     // Leave the prompt parked so the user can still resolve it in-app.

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -6,7 +6,10 @@ are rebound onto server.py's globals at install time — see method_ctx.py.
 
 from .method_ctx import HandlerRegistry
 
+import logging
 import types
+
+logger = logging.getLogger(__name__)
 
 _registry = HandlerRegistry()
 method = _registry.method
@@ -1497,10 +1500,27 @@ def _(rid, params: dict) -> dict:
 def _(rid, params: dict) -> dict:
     session, err = _sess(params, rid)
     if err:
+        # Diagnostic (#89111): an approval.respond that cannot resolve its
+        # session is the #89206 routing class — the click landed on a backend
+        # that never heard of the session. Log it loudly.
+        logger.warning(
+            "APPROVAL_RESPOND session lookup failed: params=%s err=%s",
+            {k: v for k, v in (params or {}).items() if k != "choice"},
+            err,
+        )
         return err
     try:
         from tools.approval import resolve_gateway_approval
 
+        # Diagnostic (#89111): log the resolution attempt with the session key
+        # and request id so a wrong-key / empty-queue miss is visible.
+        logger.info(
+            "APPROVAL_RESPOND session_key=%s choice=%s request_id=%s resolve_all=%s",
+            session.get("session_key"),
+            params.get("choice", "deny"),
+            params.get("request_id"),
+            params.get("all", False),
+        )
         return _ok(
             rid,
             {

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -356,6 +356,33 @@ class _DropTransport:
     """Detached WS sink: keep sessions resumable without writing stale frames."""
 
     def write(self, obj: dict) -> bool:
+        # Diagnostic (#89111): a high-stakes interactive prompt (approval /
+        # clarify / sudo / secret) dropped here means the user never saw it —
+        # the agent will block until its approval timeout. Log the drop with
+        # enough correlation to find the session and the event.
+        try:
+            if isinstance(obj, dict) and obj.get("method") == "event":
+                params = obj.get("params") or {}
+                etype = params.get("type") or ""
+                if etype in {
+                    "approval.request",
+                    "clarify.request",
+                    "sudo.request",
+                    "secret.request",
+                    "mcp.setup.request",
+                }:
+                    sid = params.get("session_id") or ""
+                    payload = params.get("payload") or {}
+                    rid = payload.get("request_id") if isinstance(payload, dict) else None
+                    logger.warning(
+                        "DROP_TRANSPORT interactive prompt %s dropped (session=%s request_id=%s) — "
+                        "client transport detached; agent will block until approval timeout",
+                        etype,
+                        sid,
+                        rid,
+                    )
+        except Exception:
+            pass
         return False
 
     def close(self) -> None:
@@ -1987,6 +2014,23 @@ def _emit_approval_request(sid: str, data: dict | None) -> None:
     platforms and the SSE/API stream fixed in #50767). Reuse the shared gateway
     seam so all approval transports redact consistently."""
     payload = _approval_request_payload(data)
+    # Diagnostic (#89111): record which transport the approval event is routed
+    # to so a dropped/detached delivery is visible in the logs. The session's
+    # stored transport is what write_json() will use (see write_json).
+    try:
+        sess = _sessions.get(sid) or {}
+        t = sess.get("transport")
+        tname = type(t).__name__ if t is not None else "none"
+        rid = payload.get("request_id") if isinstance(payload, dict) else None
+        logger.info(
+            "APPROVAL_EMIT session=%s request_id=%s transport=%s payload_keys=%s",
+            sid,
+            rid,
+            tname,
+            sorted(payload.keys()) if isinstance(payload, dict) else [],
+        )
+    except Exception:
+        pass
     _emit("approval.request", sid, payload)
 
 


### PR DESCRIPTION
## Problem

Approval prompts for protected file changes (e.g. profile `SOUL.md`) time out when the user clicks the **Windows desktop toast** instead of the in-app Run/Reject bar (#89111).

## Root cause

Windows (and Linux) drop Electron notification **action buttons** — only signed macOS builds render them. The approval toast's body click only focused the window (`hermes:focus-session`); it never resolved the pending approval. The agent blocked until the approval timeout (60s default) and the write was rejected with `Silence is not consent`.

Additionally, the notification path sent `approval.respond` **without** `request_id`, so even a working click resolved by FIFO rather than correlating to the exact pending approval.

## Fix

- **Electron main** (`apps/desktop/electron/main.ts`): an approval-kind toast body click now sends `hermes:notification-action {actionId:'approve'}` so the renderer resolves the approval instead of stranding it.
- **request_id threading**: `requestId` now rides the full notification path (renderer → preload → main → renderer → `approval.respond`), matching the in-app bar's correlation contract.
- **Backend diagnostics** (#89111): `APPROVAL_EMIT` (session/request_id/transport), `APPROVAL_RESPOND` (session_key/choice/request_id), and a `DROP_TRANSPORT` warning when an interactive prompt is emitted to a detached transport.

## Verification

- 6481 renderer tests + 1452 electron tests pass; typecheck clean.
- 3 new unit tests cover request_id threading through `respondToApprovalAction`.
- Live repro on the instrumented backend confirmed the before-fix failure: `APPROVAL_EMIT … transport=WSTransport` then 60s timeout with **no** `APPROVAL_RESPOND` — the toast click never reached the backend.

Fixes #89111