### PR TITLE
fix(gateway): expire silent stream owners and rebind live transports

### DIFF
--- a/tests/test_tui_gateway_queue_on_busy.py
+++ b/tests/test_tui_gateway_queue_on_busy.py
@@ -632,6 +632,32 @@ def test_drain_fires_queued_prompt_and_claims_running(monkeypatch):
     assert session["transport"] == "ws-9"
 
 
+def test_drain_does_not_steal_recently_live_owner(monkeypatch):
+    """A queued prompt from an old renderer must not reclaim a stream that a
+    reconnected renderer is now actively driving."""
+    class _FakeWS:
+        def __init__(self):
+            self.closed = False
+            self.last_inbound_at = time.monotonic()
+
+    monkeypatch.setattr(
+        server, "_run_prompt_submit",
+        lambda rid, sid, session, text, **kwargs: None,
+    )
+    owner = _FakeWS()
+    session = _session(queued_prompt={"text": "go", "transport": "ws-old"}, transport=owner)
+    server._live_transports.clear()
+    server.register_live_transport(owner)
+    try:
+        assert server._drain_queued_prompt("r1", "sid", session) is True
+        # The turn still fires, but the recently-live owner keeps the stream.
+        assert session["running"] is True
+        assert session["transport"] is owner
+    finally:
+        server.unregister_live_transport(owner)
+        server._live_transports.clear()
+
+
 def test_drain_compute_host_forwards_queued_image_paths(monkeypatch):
     captured = {}
     monkeypatch.setattr(server, "_session_uses_compute_host", lambda _session: True)

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -153,6 +153,50 @@ def test_ws_starts_mcp_discovery_before_ready(monkeypatch):
     assert events == ["accept", "ready_after_0"]
 
 
+def test_ws_ready_advertises_heartbeat_and_ping_is_inline(monkeypatch):
+    sent = []
+    inbound = iter(
+        [
+            json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": "heartbeat-1",
+                    "method": "gateway.ping",
+                    "params": {},
+                }
+            )
+        ]
+    )
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0)
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            try:
+                return next(inbound)
+            except StopIteration:
+                raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    asyncio.run(ws_mod.handle_ws(FakeWS()))
+
+    ready = sent[0]["params"]
+    assert ready["type"] == "gateway.ready"
+    assert ready["payload"]["heartbeat"] is True
+    assert sent[1] == {
+        "jsonrpc": "2.0",
+        "result": {"ok": True},
+        "id": "heartbeat-1",
+    }
+
+
 def test_ws_transport_serializes_concurrent_sends():
     active_sends = 0
     max_active_sends = 0

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -197,6 +197,75 @@ def test_ws_ready_advertises_heartbeat_and_ping_is_inline(monkeypatch):
     }
 
 
+def test_session_activate_refuses_to_steal_recent_live_ws_transport():
+    class FakeTransport:
+        def __init__(self):
+            self.closed = False
+            self.last_inbound_at = time.monotonic()
+
+        def write(self, obj):
+            return True
+
+        def close(self):
+            self.closed = True
+
+    owner = FakeTransport()
+    contender = FakeTransport()
+    session = {
+        "history_lock": threading.Lock(),
+        "transport": owner,
+    }
+    server._sessions.clear()
+    server._live_transports.clear()
+    server._sessions["sid"] = session
+    server.register_live_transport(owner)
+    try:
+        response = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": "activate-1",
+                "method": "session.activate",
+                "params": {"session_id": "sid"},
+            },
+            contender,
+        )
+
+        assert response["error"]["code"] == 4091
+        assert session["transport"] is owner
+    finally:
+        server.unregister_live_transport(owner)
+        server._sessions.clear()
+        server._live_transports.clear()
+
+
+def test_expired_ws_transport_can_be_rebound():
+    class FakeTransport:
+        def __init__(self, last_inbound_at):
+            self.closed = False
+            self.last_inbound_at = last_inbound_at
+
+        def write(self, obj):
+            return True
+
+        def close(self):
+            self.closed = True
+
+    owner = FakeTransport(time.monotonic() - 46)
+    contender = FakeTransport(time.monotonic())
+    session = {
+        "history_lock": threading.Lock(),
+        "transport": owner,
+    }
+    server._live_transports.clear()
+    server.register_live_transport(owner)
+    try:
+        assert server._bind_session_transport(session, contender) is True
+        assert session["transport"] is contender
+    finally:
+        server.unregister_live_transport(owner)
+        server._live_transports.clear()
+
+
 def test_ws_transport_serializes_concurrent_sends():
     active_sends = 0
     max_active_sends = 0

--- a/tests/test_tui_gateway_ws_recovery.py
+++ b/tests/test_tui_gateway_ws_recovery.py
@@ -1,0 +1,177 @@
+"""hermes-ws-recovery-v1 loopback scenarios for transport-ownership expiry.
+
+These drive the real ``handle_ws`` over a FastAPI loopback to prove the
+server-side ownership contract end to end:
+
+* a renderer that released its socket no longer blocks a replacement from
+  reclaiming the live stream, and
+* a renderer still actively driving the stream is protected from a second
+  client stealing it (JSON-RPC 4091).
+
+The stale-busy-state reconciliation is a separate slice, so nothing here
+asserts a reconciled ``running`` flag.
+"""
+
+import threading
+import time
+import types
+
+from fastapi import FastAPI, WebSocket
+from fastapi.testclient import TestClient
+
+from hermes_state import SessionDB
+from tui_gateway import server
+from tui_gateway.ws import handle_ws
+
+
+def _rpc(ws, request_id: str, method: str, params: dict) -> dict:
+    ws.send_json(
+        {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params,
+        }
+    )
+    return ws.receive_json()
+
+
+def _idle_live_session(tmp_path, stored_id: str, prompt: str, final: str):
+    session = {
+        "agent": types.SimpleNamespace(model="loopback-model"),
+        "cols": 80,
+        "created_at": time.time(),
+        "cwd": str(tmp_path),
+        "display_history_prefix": [],
+        "history": [],
+        "history_lock": threading.Lock(),
+        "inflight_turn": None,
+        "last_active": time.time(),
+        "running": False,
+        "session_key": stored_id,
+        "source": "desktop",
+    }
+    return session
+
+
+def _app():
+    app = FastAPI()
+
+    @app.websocket("/ws")
+    async def websocket_endpoint(ws: WebSocket):
+        await handle_ws(ws)
+
+    return app
+
+
+def test_reconnect_reclaims_released_stream(monkeypatch, tmp_path):
+    """A replacement socket reclaims a stream whose owner already disconnected."""
+    db = SessionDB(tmp_path / "state.db")
+    stored_id = "20260101_010101_a1b2c3"
+    runtime_id = "runtime1"
+    prompt = "return the persisted result"
+    final = "the persisted result"
+
+    db.create_session(stored_id, source="desktop")
+    db.append_message(stored_id, role="user", content=prompt)
+    db.append_message(stored_id, role="assistant", content=final, finish_reason="stop")
+
+    session = _idle_live_session(tmp_path, stored_id, prompt, final)
+
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(
+        server,
+        "_session_info",
+        lambda _agent: {"model": "loopback-model", "desktop_contract": 1},
+    )
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0)
+    server._sessions.clear()
+    server._live_transports.clear()
+    server._sessions[runtime_id] = session
+
+    try:
+        with TestClient(_app()) as client:
+            # First renderer owns the live stream, then drops its socket.
+            with client.websocket_connect("/ws") as first:
+                ready = first.receive_json()
+                assert ready["params"]["payload"]["heartbeat"] is True
+                activated = _rpc(
+                    first,
+                    "activate-first",
+                    "session.activate",
+                    {"session_id": runtime_id},
+                )
+                assert "error" not in activated
+
+            # A replacement socket opens and reclaims the stream without a 4091 —
+            # the released owner no longer blocks the rebind.
+            with client.websocket_connect("/ws") as replacement:
+                replacement.receive_json()  # gateway.ready
+                recovered = _rpc(
+                    replacement,
+                    "activate-replacement",
+                    "session.activate",
+                    {"session_id": runtime_id},
+                )
+                assert "error" not in recovered
+                result = recovered["result"]
+
+        roles = [message["role"] for message in result["messages"]]
+        assert roles == ["user", "assistant"]
+        assert [message["text"] for message in result["messages"]] == [prompt, final]
+    finally:
+        server._sessions.clear()
+        server._live_transports.clear()
+        db.close()
+
+
+def test_recently_live_owner_is_protected_from_steal(monkeypatch, tmp_path):
+    """A second renderer cannot steal a stream the first is actively driving."""
+    db = SessionDB(tmp_path / "state.db")
+    stored_id = "20260101_020202_d4e5f6"
+    runtime_id = "runtime2"
+    prompt = "hold the stream"
+
+    db.create_session(stored_id, source="desktop")
+    db.append_message(stored_id, role="user", content=prompt)
+
+    session = _idle_live_session(tmp_path, stored_id, prompt, prompt)
+
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(
+        server,
+        "_session_info",
+        lambda _agent: {"model": "loopback-model", "desktop_contract": 1},
+    )
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0)
+    server._sessions.clear()
+    server._live_transports.clear()
+    server._sessions[runtime_id] = session
+
+    try:
+        with TestClient(_app()) as client:
+            with client.websocket_connect("/ws") as first:
+                first.receive_json()  # gateway.ready
+                owned = _rpc(
+                    first,
+                    "activate-first",
+                    "session.activate",
+                    {"session_id": runtime_id},
+                )
+                assert "error" not in owned
+
+                # A concurrent renderer opens while the first is still recently
+                # live and tries to take over the same session.
+                with client.websocket_connect("/ws") as contender:
+                    contender.receive_json()  # gateway.ready
+                    stolen = _rpc(
+                        contender,
+                        "activate-contender",
+                        "session.activate",
+                        {"session_id": runtime_id},
+                    )
+                    assert stolen["error"]["code"] == 4091
+    finally:
+        server._sessions.clear()
+        server._live_transports.clear()
+        db.close()

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -342,7 +342,8 @@ def _(rid, params: dict) -> dict:
     # streaming events on the active websocket even if an earlier disconnect
     # or fallback moved the session transport to stdio.
     if (t := current_transport()) is not None:
-        session["transport"] = t
+        if not _bind_session_transport(session, t):
+            return _err(rid, 4091, "session stream is owned by another active client")
     while True:
         busy_transport = None
         with session["history_lock"]:

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -421,13 +421,20 @@ def _(rid, params: dict) -> dict:
             profile_home
         )
 
-        def _reuse_live_payload(sid: str, session: dict) -> dict:
+        def _reuse_live_response(sid: str, session: dict) -> dict:
+            transport = current_transport() or _stdio_transport
+            if not _bind_session_transport(session, transport):
+                return _err(
+                    rid,
+                    4091,
+                    "session stream is owned by another active client",
+                )
             payload = _live_session_payload(
                 sid,
                 session,
                 cols=cols,
                 touch=True,
-                transport=current_transport() or _stdio_transport,
+                transport=None,
                 omit_messages=omit_messages,
             )
             payload["resumed"] = target
@@ -443,13 +450,13 @@ def _(rid, params: dict) -> dict:
             if session.get("agent") is None and _child_run_active(target):
                 payload["running"] = True
                 payload["status"] = "streaming"
-            return payload
+            return _ok(rid, payload)
 
         # Fast path: if the session is already live, reuse it under the lock.
         with _session_resume_lock:
             live = _find_live_session_by_key(target)
             if live is not None:
-                return _ok(rid, _reuse_live_payload(*live))
+                return _reuse_live_response(*live)
 
         # Lazy/watch resume: register the live session WITHOUT building an agent.
         # Used by the desktop's subagent windows — the child runs inside the
@@ -490,7 +497,7 @@ def _(rid, params: dict) -> dict:
                 lazy=True,
             )
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
-                return _ok(rid, _reuse_live_payload(*live))
+                return _reuse_live_response(*live)
             # A delegated child mid-run emits no session events of its own — report
             # its liveness from the relay registry so the window shows a busy turn.
             child_running = _child_run_active(target)
@@ -561,7 +568,7 @@ def _(rid, params: dict) -> dict:
             record["resume_hydrating"] = True
             record["resume_message_count"] = int(found.get("message_count") or 0)
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
-                return _ok(rid, _reuse_live_payload(*live))
+                return _reuse_live_response(*live)
 
             _schedule_resume_hydration(sid, target, db, close_db=owns_db)
             # The hydration worker now owns a profile-scoped handle and closes it
@@ -654,7 +661,7 @@ def _(rid, params: dict) -> dict:
                 resume_runtime_overrides=overrides or None,
             )
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
-                return _ok(rid, _reuse_live_payload(*live))
+                return _reuse_live_response(*live)
 
             _schedule_agent_build(sid)
             _schedule_session_cap_enforcement()  # trim detached idle sessions over the cap
@@ -765,12 +772,19 @@ def _(rid, params: dict) -> dict:
                 if lease is not None:
                     lease.release()
                 other_sid, other_session = live
+                transport = current_transport() or _stdio_transport
+                if not _bind_session_transport(other_session, transport):
+                    return _err(
+                        rid,
+                        4091,
+                        "session stream is owned by another active client",
+                    )
                 payload = _live_session_payload(
                     other_sid,
                     other_session,
                     cols=cols,
                     touch=True,
-                    transport=current_transport() or _stdio_transport,
+                    transport=None,
                     omit_messages=omit_messages,
                 )
                 payload["resumed"] = target
@@ -1039,6 +1053,9 @@ def _(rid, params: dict) -> dict:
     if err:
         return err
     assert session is not None
+    transport = current_transport() or _stdio_transport
+    if not _bind_session_transport(session, transport):
+        return _err(rid, 4091, "session stream is owned by another active client")
 
     return _ok(
         rid,
@@ -1046,7 +1063,7 @@ def _(rid, params: dict) -> dict:
             sid,
             session,
             touch=True,
-            transport=current_transport() or _stdio_transport,
+            transport=None,
             omit_messages=is_truthy_value(params.get("omit_messages", False)),
         ),
     )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1676,6 +1676,11 @@ def _emit(event: str, sid: str, payload: dict | None = None):
 # is how such events reach WS clients at all. See _broadcast_global_event.
 _live_transports: set[Transport] = set()
 _live_transports_lock = threading.Lock()
+# Match the negotiated client heartbeat deadline. Once a silent transport has
+# missed 45 seconds of inbound activity, a replacement socket must be able to
+# activate immediately instead of waiting behind an owner the client already
+# declared dead.
+_TRANSPORT_OWNERSHIP_LIVE_S = 45.0
 
 
 def register_live_transport(transport: Transport | None) -> None:
@@ -1690,6 +1695,47 @@ def unregister_live_transport(transport: Transport | None) -> None:
     """Stop tracking a transport (call on disconnect). Idempotent."""
     with _live_transports_lock:
         _live_transports.discard(transport)
+
+
+def _transport_is_recently_live(transport: Transport | None) -> bool:
+    """Whether a transport still owns a session stream.
+
+    WebSocket transports publish their last inbound activity. A transport that
+    is closed, unregistered, detached, or beyond the heartbeat recovery window
+    no longer blocks a reconnecting renderer from reclaiming the stream.
+    """
+    if transport is None or transport is _detached_ws_transport:
+        return False
+    if bool(getattr(transport, "closed", False)):
+        return False
+
+    last_inbound = getattr(transport, "last_inbound_at", None)
+    if isinstance(last_inbound, (int, float)):
+        with _live_transports_lock:
+            registered = transport in _live_transports
+        return registered and (time.monotonic() - float(last_inbound)) <= _TRANSPORT_OWNERSHIP_LIVE_S
+
+    # Stdio and test transports have no application heartbeat. Preserve their
+    # historical behavior; the conflict contract is for competing WS clients.
+    return False
+
+
+def _bind_session_transport(session: dict, candidate: Transport | None) -> bool:
+    """Atomically rebind a session unless another recently-live WS owns it."""
+    if candidate is None:
+        return True
+
+    # Partially-constructed sessions (and synthetic ones in tests) may not carry
+    # a history_lock yet. Fall back to a throwaway lock, matching the defensive
+    # reads elsewhere in this module, rather than raising KeyError.
+    with session.get("history_lock") or threading.Lock():
+        current = session.get("transport")
+        if current is candidate:
+            return True
+        if _transport_is_recently_live(current):
+            return False
+        session["transport"] = candidate
+        return True
 
 
 def _broadcast_global_event(event: str, payload: dict | None = None) -> None:
@@ -8261,8 +8307,17 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
         if not queued_prompts:
             session.pop("queued_prompts", None)
         session["running"] = True
-        if queued.get("transport") is not None:
-            session["transport"] = queued["transport"]
+        # A queued prompt carries the transport of the renderer that submitted
+        # it. Restore that stream when draining, but never steal one a *different*
+        # renderer is still actively driving (the same ownership contract enforced
+        # inline here because we already hold history_lock, which
+        # _bind_session_transport re-acquires).
+        queued_transport = queued.get("transport")
+        if queued_transport is not None and not (
+            queued_transport is not session.get("transport")
+            and _transport_is_recently_live(session.get("transport"))
+        ):
+            session["transport"] = queued_transport
     use_compute_host = _session_uses_compute_host(session)
     with session["history_lock"]:
         if int(session.get("_queued_prompt_generation", 0)) != queue_generation:
@@ -8833,11 +8888,11 @@ def _live_session_payload(
     transport: Transport | None = None,
     omit_messages: bool = False,
 ) -> dict:
+    if transport is not None:
+        _bind_session_transport(session, transport)
     with session["history_lock"]:
         if cols is not None:
             session["cols"] = cols
-        if transport is not None:
-            session["transport"] = transport
         if touch:
             session["last_active"] = time.time()
         in_memory_history = list(session.get("display_history_prefix") or []) + list(

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -29,6 +29,7 @@ import json
 import logging
 import socket
 import threading
+import time
 from typing import Any
 
 from tui_gateway import server
@@ -94,6 +95,7 @@ class WSTransport:
         self._loop = loop
         self._peer = peer
         self._closed = False
+        self._last_inbound_at = time.monotonic()
         # Token-coalescing buffer (CF-2). Streamed token frames land here and a
         # short timer flushes the batch. The lock guards the buffer + the
         # "armed" flag against the worker threads that call write(); the timer
@@ -106,6 +108,17 @@ class WSTransport:
         # writes need an async boundary because several batches can be queued on
         # the owning loop while it recovers from a stall.
         self._send_lock = asyncio.Lock()
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    @property
+    def last_inbound_at(self) -> float:
+        return self._last_inbound_at
+
+    def mark_inbound(self) -> None:
+        self._last_inbound_at = time.monotonic()
 
     @staticmethod
     def _is_streaming_frame(obj: dict) -> bool:
@@ -320,7 +333,11 @@ async def handle_ws(ws: Any) -> None:
                     # change_events: this backend broadcasts pet.changed /
                     # cron.changed / sessions.changed, so clients can demote
                     # their legacy polls to slow backstops.
-                    "payload": {"skin": skin_payload, "change_events": True},
+                    "payload": {
+                        "skin": skin_payload,
+                        "change_events": True,
+                        "heartbeat": True,
+                    },
                 },
             }
         )
@@ -354,6 +371,7 @@ async def handle_ws(ws: Any) -> None:
             line = raw.strip()
             if not line:
                 continue
+            transport.mark_inbound()
             messages += 1
 
             try:
@@ -388,6 +406,22 @@ async def handle_ws(ws: Any) -> None:
             # response dict, which we write here from the loop.
             req_id = req.get("id") if isinstance(req, dict) else None
             req_method = req.get("method") if isinstance(req, dict) else None
+
+            if req_method == "gateway.ping":
+                ok = await transport.write_async(
+                    {
+                        "jsonrpc": "2.0",
+                        "result": {"ok": True},
+                        "id": req_id,
+                    }
+                )
+                if not ok:
+                    disconnect_reason = "send_failed_after_heartbeat"
+                    send_failures += 1
+                    _log.warning("ws heartbeat reply send failed peer=%s id=%s", peer, req_id)
+                    break
+                continue
+
             try:
                 resp = await asyncio.to_thread(server.dispatch, req, transport)
             except Exception:


### PR DESCRIPTION
## What does this PR do?

Makes the TUI gateway rebind a session's stream to a new client when the previous owner's transport has gone silent, and refuses a steal from a stale renderer while the current owner is still live. Without this, a session whose renderer dropped silently can stay "owned" by a dead transport, and a reconnecting client can't take it back over.

This is the server-side half of the WebSocket-recovery work in #83166, and it **stacks on #89958** (the `gateway.ping` heartbeat) — it reads the `closed` / `last_inbound_at` liveness signals that PR adds to the transport.

## Related Issue

Part of #83166; depends on #89958.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` — `_TRANSPORT_OWNERSHIP_LIVE_S`, `_transport_is_recently_live`, `_bind_session_transport`, the `_live_session_payload` bind move, and a queued-prompt-drain guard.
- `tui_gateway/methods_session.py` — `_reuse_live_payload`→`_reuse_live_response` rebind; adopt / plain-activate / resume guards.
- `tui_gateway/methods_prompt.py` — `prompt.submit` bind guard.
- Tests: steal-refusal + expired-rebind units, two WS-loopback recovery tests, and a queued-prompt-cannot-steal test.

## Scope — read this

The guard covers the **session.activate / session.resume / prompt.submit WS ingress paths plus the queued-prompt drain**. Two deliberate exclusions, stated up front so a reviewer doesn't flag them:

- The queued-prompt-drain site (`server.py:8265`) is guarded **inline** rather than via `_bind_session_transport`, because that assignment runs under a held non-reentrant `history_lock` that `_bind_session_transport` would re-acquire (deadlock). Behavior is identical; covered by `test_drain_does_not_steal_recently_live_owner`.
- The two `compute_host.py` reattach sites are **not** guarded. They're the single-owner compute-host channel rebinding its own transport, not a competing-renderer steal; guarding them would break the compute-host attach path. Covering that would need a distinct single-owner ownership model — a separate change, not this one.

`_reconcile_finished_run_thread` (the dead-run-thread cleanup) is intentionally not here — it's #89978, filed standalone.

## How to Test

```text
scripts/run_tests.sh tests/test_tui_gateway_ws.py tests/test_tui_gateway_ws_recovery.py tests/test_tui_gateway_queue_on_busy.py -q   → 43 passed
scripts/run_tests.sh tests/test_tui_gateway_server.py tests/test_tui_gateway_ws_recovery.py -q                                       → 587 passed
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched existing PRs
- [x] Only changes related to this fix (reconcile piece is a separate PR)
- [x] Ran the tui_gateway suites
- [x] Added tests
- [x] Tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] Docs — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform — N/A
- [x] Tool descriptions/schemas — N/A

---

Salvage note: one commit on top of #89958. Take the heartbeat wire contract first, then this rebases cleanly.
