### PR TITLE
fix(tools): stop flagging & inside comments and arithmetic expansions as backgrounding

### DIFF
--- a/tests/tools/test_blocked_command_guidance.py
+++ b/tests/tools/test_blocked_command_guidance.py
@@ -79,3 +79,54 @@ class TestBackgroundGuidanceRecipes:
 
     def test_quoted_ampersand_not_flagged(self):
         assert _foreground_background_guidance('git commit -m "a & b"') is None
+
+    def test_redirect_both_streams_not_flagged(self):
+        assert _foreground_background_guidance("cmd &>/dev/null") is None
+
+    def test_fd_redirect_not_flagged(self):
+        assert _foreground_background_guidance("cmd 2>&1") is None
+
+    def test_single_quoted_ampersand_not_flagged(self):
+        assert _foreground_background_guidance("echo 'a & b'") is None
+
+    def test_backslash_escaped_ampersand_not_flagged(self):
+        assert _foreground_background_guidance(r"echo a \& b") is None
+
+    def test_pipe_stderr_operator_not_flagged(self):
+        # |& pipes stdout+stderr to the next command — not backgrounding.
+        assert _foreground_background_guidance("make |& tee build.log") is None
+
+    def test_trailing_pipe_stderr_not_flagged(self):
+        # A trailing |& must not be confused with job-control &.
+        assert _foreground_background_guidance("cmd |&") is None
+
+    def test_arithmetic_bitwise_and_tight_spacing_not_flagged(self):
+        assert _foreground_background_guidance("x=$((5&3))") is None
+
+    def test_arithmetic_bitwise_and_spaced_not_flagged(self):
+        # Regression: $((a & b)) was wrongly flagged before this fix.
+        assert _foreground_background_guidance("echo $((a & b))") is None
+
+    def test_case_fallthrough_not_flagged(self):
+        # ;& is the case-statement fallthrough operator, not backgrounding.
+        cmd = "case $x in\n  a) echo a;&\n  b) echo b;;\nesac"
+        assert _foreground_background_guidance(cmd) is None
+
+    def test_case_test_next_not_flagged(self):
+        # ;;& tests the next pattern too — also not backgrounding.
+        cmd = "case $x in\n  a) echo a;;&\n  b) echo b;;\nesac"
+        assert _foreground_background_guidance(cmd) is None
+
+    def test_comment_ampersand_not_flagged(self):
+        # Regression: a bare & inside a # comment was wrongly flagged
+        # before this fix.
+        assert _foreground_background_guidance("echo hi # start &") is None
+
+    def test_trailing_ampersand_with_comment_still_flagged(self):
+        # Sanity check: comment-stripping must not eat a REAL trailing &.
+        assert _foreground_background_guidance("cmd & # comment") is not None
+
+    def test_parallel_jobs_with_wait_flagged(self):
+        # job1 & job2 & wait — legitimate parallel pattern, still real
+        # backgrounding and should still get the guidance.
+        assert _foreground_background_guidance("job1 & job2 & wait") is not None

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2446,13 +2446,24 @@ _SHELL_LEVEL_BACKGROUND_RE = re.compile(
 _INLINE_BACKGROUND_AMP_RE = re.compile(r"\s&\s")
 _TRAILING_BACKGROUND_AMP_RE = re.compile(r"\s&\s*(?:#.*)?$")
 
+# $((...)) arithmetic expansion — & inside it is bitwise-AND, not job
+# control. Handles one level of nested parens (covers realistic
+# expressions like $((a + (b & c))); deeper nesting is out of scope for a
+# lexical check, same tradeoff strip_inert_heredoc_bodies documents).
+_ARITHMETIC_EXPANSION_RE = re.compile(r"\$\(\((?:[^()]|\([^()]*\))*\)\)")
+# A genuine shell comment: '#' at the start of a word (start of string,
+# after whitespace, or after ;&|() — mirrors the same word-boundary check
+# strip_inert_heredoc_bodies uses for its own comment detection).
+_SHELL_COMMENT_RE = re.compile(r"(?:^|(?<=\s)|(?<=[;&|()]))#[^\n]*", re.MULTILINE)
+
 
 def _strip_quotes(command: str) -> str:
     """Remove single- and double-quoted content so regex checks don't match inside strings.
 
     This prevents false positives when keywords like 'nohup' or 'setsid' appear
     in commit messages, Python -c code, echo arguments, or PR body text.
-    Also strips backtick-quoted content and provably-inert heredoc body text.
+    Also strips backtick-quoted content, provably-inert heredoc body text,
+    arithmetic expansions, and shell comments.
     """
     # Mask inert heredoc bodies FIRST (before quote-stripping — a heredoc
     # delimiter may be quoted, e.g. <<'EOF', and the body commonly contains
@@ -2469,6 +2480,17 @@ def _strip_quotes(command: str) -> str:
     result = re.sub(r'"(?:[^"\\]|\\.)*"', '""', result)
     # Remove backtick-quoted strings
     result = re.sub(r"`[^`]*`", "``", result)
+    # Blank arithmetic expansions: $((a & b)) uses & as bitwise-AND, not a
+    # job-control operator, and the amp regexes below can't tell the
+    # difference from surrounding whitespace alone.
+    result = _ARITHMETIC_EXPANSION_RE.sub(
+        lambda m: "$((" + " " * (len(m.group(0)) - 4) + "))", result
+    )
+    # Blank shell comments: '&' after a genuine word-boundary '#' is literal
+    # comment text, not a job-control operator.
+    result = _SHELL_COMMENT_RE.sub(
+        lambda m: "#" + " " * (len(m.group(0)) - 1), result
+    )
     return result
 
 


### PR DESCRIPTION
## What does this PR do?

`_foreground_background_guidance()` uses `_strip_quotes()` to mask inert content before running two regexes that detect job-control `&`. Two gaps remained:

1. **Shell comments** — `echo hi # start &` triggered the "use `background=true`" guidance even though the `&` is plain comment text, not an operator.
2. **Arithmetic expansions** — `echo $((a & b))` also triggered it because `&` inside `$((...))` is bitwise-AND and `_strip_quotes()` had no rule for arithmetic context.

Fix: extend `_strip_quotes()` with two length-preserving substitutions (matching the existing convention used by `strip_inert_heredoc_bodies`) that blank out `$((...))` arithmetic expansions and genuine shell comments before the `&` regexes run. A real trailing `&` followed by a comment (`cmd & # comment`) is still correctly flagged — comment blanking leaves the operator visible.

13 regression tests are added to `TestBackgroundGuidanceRecipes` in `tests/tools/test_blocked_command_guidance.py`, covering the two fixed bugs plus 11 currently-correct-but-untested shell grammar corners (`&>`, `2>&1`, `|&`, `\&`, single quoted `&`, `;& / ;;&` case operators, and parallel fan-out).

## Related Issue

Related to #78596 (closed) and #84402 (merged). These edge-case tests were welcomed in the #78596 review thread.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tools/terminal_tool.py`: add `_ARITHMETIC_EXPANSION_RE` and `_SHELL_COMMENT_RE` module-level patterns; extend `_strip_quotes()` to blank them before the `&` regexes run
- `tests/tools/test_blocked_command_guidance.py`: 13 new test methods in `TestBackgroundGuidanceRecipes`

## How to Test

scripts/run_tests.sh tests/tools/test_blocked_command_guidance.py 

tests/tools/test_terminal_heredoc_background_guard.py 

tests/tools/test_terminal_compound_background.py


To confirm the two bugs specifically:
```python
# Both should return None after this fix (both wrongly returned guidance before)
from tools.terminal_tool import _foreground_background_guidance
print(_foreground_background_guidance("echo hi # start &"))   # None ✓
print(_foreground_background_guidance("echo $((a & b))"))     # None ✓
```

## Checklist

- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs — this is a direct follow-up to #78596/#84402
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q`
- [x] I've added tests for my changes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (internal helper only)
- [x] I've considered cross-platform impact — regex-only change, no platform dependency

