### PR TITLE
fix(cli): skip Unix sockets and other special files during profile export

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1432,6 +1432,27 @@ def get_profile_export_path(name: str, *, timestamp: Optional[str] = None) -> Pa
     return export_dir / f"{canon}-{stamp}.tar.gz"
 
 
+def _non_exportable_entries(directory: str, contents: list) -> set:
+    """Entries under *directory* that must never reach an export archive: ``__pycache__``,
+    ``*.sock``/``*.tmp`` names, and anything that is not a regular file, directory, or symlink.
+    :func:`shutil.copytree` cannot copy special files, so a single live Unix socket without a
+    ``.sock`` name (or a FIFO, or a device node) would abort the whole export with
+    ``[Errno 6] No such device or address``. Symlinks survive — copytree recreates them."""
+    ignored: set = set()
+    for entry in contents:
+        if entry == "__pycache__" or entry.endswith((".sock", ".tmp")):
+            ignored.add(entry)
+            continue
+        try:
+            mode = os.lstat(os.path.join(directory, entry)).st_mode
+        except OSError:
+            ignored.add(entry)  # vanished mid-walk — copytree would fail on it anyway
+            continue
+        if not (stat.S_ISREG(mode) or stat.S_ISDIR(mode) or stat.S_ISLNK(mode)):
+            ignored.add(entry)
+    return ignored
+
+
 def _default_export_ignore(root_dir: Path):
     """copytree ignore for the default-profile export: root-level allow-list
     (``_DEFAULT_EXPORT_INCLUDE_ROOT``) plus universal exclusions. Surviving text files are
@@ -1441,17 +1462,14 @@ def _default_export_ignore(root_dir: Path):
     survive. Everything else (such as an unrelated ``x11-dev/`` directory in a Docker deployment where
     HERMES_HOME equals the cwd) is excluded. Blacklisting was tried first and proved unable to anticipate
     every non-Hermes file the user may have lying alongside HERMES_HOME (#58394). * **Universal exclusions
-    at any depth** — ``__pycache__``, sockets, temp files; plus npm lockfiles, which may appear at the root.
+    at any depth** — ``__pycache__``, sockets and other special files, temp files
+    (:func:`_non_exportable_entries`); plus npm lockfiles, which may appear at the root.
     """
 
     def _ignore(directory: str, contents: list) -> set:
         # Universal exclusions (any depth) plus npm lockfiles that can appear at root.
-        ignored: set = {
-            entry for entry in contents
-            if entry == "__pycache__"
-            or entry.endswith((".sock", ".tmp"))
-            or entry in {"package.json", "package-lock.json"}
-        }
+        ignored = _non_exportable_entries(directory, contents)
+        ignored.update({"package.json", "package-lock.json"} & set(contents))
         if Path(directory) == root_dir:
             ignored.update(entry for entry in contents if entry not in _DEFAULT_EXPORT_INCLUDE_ROOT)
         return ignored
@@ -1516,9 +1534,14 @@ def export_profile(name: str, output_path: str, extra_files: Optional[Dict[str, 
 
     # The default profile IS ~/.hermes (dir name ".hermes"), so both paths stage a filtered
     # copy under a temp dir named after the canonical id: root allow-list for default,
-    # credential exclusion for named profiles.
+    # credential exclusion for named profiles. The universal exclusions apply to both:
+    # profiles accumulate Unix sockets in normal operation (e.g. an agent-browser control
+    # socket under ``home/.agent-browser/``), and a single one aborts copytree — and with
+    # it the whole export.
     def _ignore_credentials(directory: str, contents: list) -> set:
-        return _EXPORT_CREDENTIAL_FILES & set(contents)
+        ignored = _non_exportable_entries(directory, contents)
+        ignored.update(_EXPORT_CREDENTIAL_FILES & set(contents))
+        return ignored
 
     ignore = _default_export_ignore(profile_dir) if canon == "default" else _ignore_credentials
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/hermes_cli/test_profile_export_special_files.py
+++ b/tests/hermes_cli/test_profile_export_special_files.py
@@ -1,0 +1,97 @@
+"""Tests for special-file handling during profile export.
+
+:func:`shutil.copytree` cannot copy Unix sockets, FIFOs, or device nodes —
+it collects "[Errno 6] No such device or address" and raises
+``shutil.Error`` at the end of the walk. Profiles accumulate such files in
+normal operation (e.g. a stale agent-browser control socket under
+``home/.agent-browser/``), so exports must skip them instead of failing
+the whole archive.
+"""
+
+import os
+import socket
+import sys
+import tarfile
+
+import pytest
+
+from hermes_cli.profiles import export_profile
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Unix sockets and FIFOs are not available on Windows",
+)
+
+
+def _patch_named_profile(monkeypatch, profiles_root, profile_dir):
+    monkeypatch.setattr("hermes_cli.profiles._get_profiles_root", lambda: profiles_root)
+    monkeypatch.setattr("hermes_cli.profiles.get_profile_dir", lambda n: profile_dir)
+    monkeypatch.setattr("hermes_cli.profiles.validate_profile_name", lambda n: None)
+
+
+def _bind_unix_socket(path):
+    """Bind an AF_UNIX socket at *path*.
+
+    Binds via a cwd-relative name so pytest's long tmp paths stay under the
+    ~104-byte ``sun_path`` limit on macOS. The filesystem entry outlives the
+    close — exactly the stale-socket state a real profile ends up with.
+    """
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    cwd = os.getcwd()
+    os.chdir(path.parent)
+    try:
+        sock.bind(path.name)
+    finally:
+        os.chdir(cwd)
+        sock.close()
+
+
+def test_named_profile_export_survives_unix_socket(tmp_path, monkeypatch):
+    """Sockets and FIFOs in a named profile are skipped, not fatal."""
+    profiles_root = tmp_path / "profiles"
+    profile_dir = profiles_root / "sockety"
+    browser_dir = profile_dir / "home" / ".agent-browser"
+    browser_dir.mkdir(parents=True)
+
+    (profile_dir / "config.yaml").write_text("model: gpt-4\n")
+    (browser_dir / "state.json").write_text("{}\n")
+
+    # One socket the *.sock suffix rule catches, one only lstat can catch,
+    # and a FIFO — none of them may fail or enter the export.
+    _bind_unix_socket(browser_dir / "dev-12345.sock")
+    _bind_unix_socket(browser_dir / "control")
+    os.mkfifo(browser_dir / "events")
+
+    _patch_named_profile(monkeypatch, profiles_root, profile_dir)
+
+    result = export_profile("sockety", str(tmp_path / "sockety.tar.gz"))
+
+    with tarfile.open(result, "r:gz") as tf:
+        names = tf.getnames()
+
+    assert any("config.yaml" in n for n in names)
+    assert any("state.json" in n for n in names)
+    assert not any(".sock" in n for n in names)
+    assert not any(n.endswith(("control", "events")) for n in names)
+
+
+def test_default_profile_export_survives_unix_socket(tmp_path, monkeypatch):
+    """The default-profile export skips suffixless sockets in allowed dirs."""
+    profile_dir = tmp_path / "hermes_home"
+    sessions_dir = profile_dir / "sessions"
+    sessions_dir.mkdir(parents=True)
+
+    (profile_dir / "config.yaml").write_text("model: gpt-4\n")
+    (sessions_dir / "log.jsonl").write_text("{}\n")
+    _bind_unix_socket(sessions_dir / "ipc")
+
+    _patch_named_profile(monkeypatch, tmp_path / "profiles", profile_dir)
+
+    result = export_profile("default", str(tmp_path / "default.tar.gz"))
+
+    with tarfile.open(result, "r:gz") as tf:
+        names = tf.getnames()
+
+    assert any("config.yaml" in n for n in names)
+    assert any("log.jsonl" in n for n in names)
+    assert not any(n.endswith("ipc") for n in names)


### PR DESCRIPTION
## What

`hermes profile export <name>` fails outright when the profile contains a Unix socket. Named-profile export stages its copy with `shutil.copytree` using an ignore callable that only excludes credential files (`auth.json`, `.env`), so a stale socket — e.g. an agent-browser control socket at `home/.agent-browser/dev*.sock` — makes `copytree` raise `shutil.Error` with `[Errno 6] No such device or address`, and the whole export fails. Reproduced on v0.20.4 and current `main`.

The default-profile export already excludes `*.sock` by suffix (`_default_export_ignore`), but a socket without that suffix — or a FIFO, or a device node — fails it the same way.

## Why this approach

This extracts the universal exclusions into a shared `_non_exportable_entries()` helper that keeps the existing `__pycache__` / `*.sock` / `*.tmp` name rules and additionally drops any entry that is not a regular file, directory, or symlink (`os.lstat` mode check). Both export branches now use it:

- the named-profile branch composes it with the credential exclusion, fixing the reported failure;
- the default branch gains coverage for special files that don't carry a `.sock`/`.tmp` name.

Special files can't meaningfully travel in a tar.gz share archive anyway, so skipping them (rather than failing) is the correct behavior. Symlinks are unaffected — `copytree(..., symlinks=True)` still recreates them.

## How to test

```
pytest tests/hermes_cli/test_profile_export_special_files.py tests/hermes_cli/test_profile_export_credentials.py -v
```

The new tests create a profile containing a bound `AF_UNIX` socket with a `.sock` name, a suffixless bound socket, and a FIFO, then assert the export succeeds and the archive omits all of them (both named and default profile paths). Both tests fail with `shutil.Error` before this change. They skip on Windows per the contributing guide (no `AF_UNIX` bind / `os.mkfifo`).

Manual repro: create a named profile, `python3 -c "import socket; s=socket.socket(socket.AF_UNIX); s.bind('<profile_dir>/home/.agent-browser/dev.sock')"`, then `hermes profile export <name> out.tar.gz` — fails before, succeeds after.

## Platforms tested

macOS (arm64). Full `tests/hermes_cli/` suite passes (`scripts/run_tests.sh`: 5038 passed, 1 flake in `test_service_manager.py` under the 36-worker parallel run; it passes in isolation both with this change and on clean `main`, and is untouched by this change).
