### PR TITLE
fix(compressor): age out stale tool-result images during compaction

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1524,9 +1524,15 @@ def _strip_historical_media(messages: List[Dict[str, Any]]) -> List[Dict[str, An
     placeholder so the outgoing request stops re-shipping the same multi-MB
     base-64 image blobs on every turn.
 
-    If no user message carries images, the list is returned unchanged.
-    If the only user message with images is the very first one (nothing
-    earlier to strip), the list is returned unchanged.
+    Tool results carry their own images (``vision_analyze`` and friends) and
+    are aged out on their own timeline: every image-bearing tool message
+    except the newest one is stripped, wherever it sits. Without that, a
+    session whose images arrive from tools rather than attachments has no
+    anchor to be "before" and keeps every blob forever (#89938).
+
+    If no message carries images at all, the list is returned unchanged. So
+    is a list whose only image-bearing user message is the very first one and
+    which has no tool-result images (nothing to strip in either rule).
 
     Shallow copies of touched messages only; input is never mutated.
     Port of Kilo-Org/kilocode#9434 (adapted for the OpenAI-style message
@@ -1550,15 +1556,48 @@ def _strip_historical_media(messages: List[Dict[str, Any]]) -> List[Dict[str, An
             anchor = i
             break
 
-    if anchor <= 0:
-        # No image-bearing user message, or it's the very first message —
-        # nothing before it to strip.
+    # Newest tool message carrying an image. Tool-result images
+    # (``vision_analyze``, screenshot-returning tools) accumulate on their own
+    # timeline and the user anchor never protects the stale ones: a session
+    # whose only image-bearing user message is the FIRST one leaves
+    # ``anchor <= 0`` and strips nothing at all, so twenty tool results keep
+    # multi-MB of base64 in every request body until the provider answers 413
+    # -- and the 413 handler's recovery compaction lands right back here and
+    # frees nothing, which is the wedge in #89938. Keep the newest tool image,
+    # since that is the one the model is reasoning about, and drop every older
+    # one wherever it sits.
+    tool_anchor = -1
+    for i in range(len(messages) - 1, -1, -1):
+        msg = messages[i]
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") != "tool":
+            continue
+        if _content_has_images(msg.get("content")):
+            tool_anchor = i
+            break
+
+    if anchor <= 0 and tool_anchor < 0:
+        # No image-bearing user message (or it is the very first, with nothing
+        # earlier to strip), and no tool-result images to age out either.
         return messages
+
+    def _is_stale(index: int, message: Dict[str, Any]) -> bool:
+        # Rule 1 (unchanged): everything before the newest image-bearing user
+        # message. Checked first so a tool result that is the newest of its
+        # kind but still sits before that anchor keeps today's behaviour.
+        if 0 < anchor and index < anchor:
+            return True
+        # Rule 2: a tool result whose image has been superseded by a newer
+        # one. Applies inside the protected tail as well -- the tail exists to
+        # preserve conversational continuity, not to pin bytes the model has
+        # already moved past.
+        return message.get("role") == "tool" and index != tool_anchor
 
     changed = False
     result: List[Dict[str, Any]] = []
     for i, msg in enumerate(messages):
-        if i >= anchor or not isinstance(msg, dict):
+        if not isinstance(msg, dict) or not _is_stale(i, msg):
             result.append(msg)
             continue
         content = msg.get("content")

--- a/tests/agent/test_compressor_historical_media.py
+++ b/tests/agent/test_compressor_historical_media.py
@@ -107,6 +107,114 @@ class TestStripHistoricalMedia:
         # Second pass is a no-op — no images left before the anchor.
         assert second is first
 
+    def test_strips_stale_tool_result_images_when_no_user_image_exists(self):
+        """#89938: vision_analyze results are the only images in the session.
+
+        Before this rule the anchor stayed at -1 and the list came back
+        untouched, so every base64 blob rode along on every request.
+        """
+        msgs = [
+            {"role": "user", "content": "look at these"},
+            {"role": "tool", "tool_call_id": "a", "content": [TEXT, IMG_URL]},
+            {"role": "tool", "tool_call_id": "b", "content": [TEXT, IMG_URL]},
+            {"role": "tool", "tool_call_id": "c", "content": [TEXT, IMG_URL]},
+        ]
+        out = _strip_historical_media(msgs)
+
+        assert not _content_has_images(out[1]["content"])
+        assert not _content_has_images(out[2]["content"])
+        # The newest tool image is what the model is reasoning about.
+        assert _content_has_images(out[3]["content"])
+
+    def test_first_message_user_image_no_longer_blocks_tool_stripping(self):
+        """#89938's other half: ``anchor <= 0`` used to return early.
+
+        One attachment on the opening message plus a run of vision tool calls
+        is the exact reproduction in the report - and the old early return
+        meant the 413 recovery compaction freed nothing.
+        """
+        msgs = [
+            {"role": "user", "content": [TEXT, IMG_URL]},
+            {"role": "tool", "tool_call_id": "a", "content": [TEXT, IMG_URL]},
+            {"role": "tool", "tool_call_id": "b", "content": [TEXT, IMG_URL]},
+        ]
+        out = _strip_historical_media(msgs)
+
+        # The opening attachment keeps today's treatment: nothing precedes it.
+        assert _content_has_images(out[0]["content"])
+        assert not _content_has_images(out[1]["content"])
+        assert _content_has_images(out[2]["content"])
+
+    def test_newest_tool_image_survives_inside_the_protected_tail(self):
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "user", "content": [TEXT, IMG_URL]},
+            {"role": "tool", "tool_call_id": "a", "content": [TEXT, IMG_URL]},
+            {"role": "tool", "tool_call_id": "b", "content": [TEXT, IMG_URL]},
+        ]
+        out = _strip_historical_media(msgs)
+
+        # The user anchor is index 1, so nothing before it changes and the
+        # anchor itself is kept byte-for-byte (test_compressor_zero_user_guard
+        # depends on that).
+        assert out[1] is msgs[1]
+        assert not _content_has_images(out[2]["content"])
+        assert _content_has_images(out[3]["content"])
+
+    def test_tool_image_before_the_user_anchor_is_still_stripped(self):
+        """Rule 1 keeps precedence over rule 2 where the two disagree."""
+        msgs = [
+            {"role": "tool", "tool_call_id": "a", "content": [TEXT, IMG_URL]},
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": [TEXT, IMG_URL]},
+        ]
+        out = _strip_historical_media(msgs)
+
+        # Index 0 is the newest *tool* image, but it sits before the user
+        # anchor, which has always stripped it. That must not regress.
+        assert not _content_has_images(out[0]["content"])
+        assert _content_has_images(out[2]["content"])
+
+    def test_unchanged_when_nothing_carries_images(self):
+        msgs = [
+            {"role": "user", "content": [TEXT]},
+            {"role": "tool", "tool_call_id": "a", "content": [TEXT]},
+        ]
+        assert _strip_historical_media(msgs) is msgs
+
+    def test_single_tool_image_is_left_alone(self):
+        msgs = [
+            {"role": "user", "content": "look"},
+            {"role": "tool", "tool_call_id": "a", "content": [TEXT, IMG_URL]},
+        ]
+        assert _strip_historical_media(msgs) is msgs
+
+    def test_idempotent_over_tool_images(self):
+        msgs = [
+            {"role": "tool", "tool_call_id": "a", "content": [TEXT, IMG_URL]},
+            {"role": "tool", "tool_call_id": "b", "content": [TEXT, IMG_URL]},
+        ]
+        first = _strip_historical_media(msgs)
+        assert first is not msgs
+        assert _strip_historical_media(first) is first
+
+    def test_stripped_tool_message_drops_its_api_content_sidecar(self):
+        """Replaying the sidecar would resend the bytes the strip removed."""
+        msgs = [
+            {
+                "role": "tool",
+                "tool_call_id": "a",
+                "content": [TEXT, IMG_URL],
+                "api_content": "the exact multimodal bytes sent last turn",
+            },
+            {"role": "tool", "tool_call_id": "b", "content": [TEXT, IMG_URL]},
+        ]
+        out = _strip_historical_media(msgs)
+
+        assert "api_content" not in out[0]
+        # The input list is never mutated.
+        assert "api_content" in msgs[0]
+
     def test_non_dict_messages_pass_through(self):
         msgs = [
             "not-a-dict",  # shouldn't crash
@@ -166,3 +274,56 @@ class TestCompressIntegration:
             assert not _content_has_images(m.get("content")), (
                 f"Stale image in {m.get('role')!r} message after compression"
             )
+
+    def test_compress_frees_stale_vision_tool_results(self, compressor):
+        """#89938 end to end: the 413 recovery compaction must free bytes.
+
+        The reported session had one attachment on the opening message and a
+        run of ``vision_analyze`` results after it. ``anchor <= 0`` made this
+        pass a no-op, so every recovery compaction returned a body that was
+        still multi-MB and the provider answered 413 again - seven times in
+        thirteen minutes.
+        """
+
+        def call(idx: str):
+            return [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": idx,
+                            "type": "function",
+                            "function": {"name": "vision_analyze", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": idx, "content": [TEXT, IMG_URL]},
+            ]
+
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": [TEXT, IMG_URL]},  # the ONLY user image, first
+            *call("a"),
+            *call("b"),
+            {"role": "user", "content": "and this one?"},
+            *call("c"),
+        ]
+        with patch.object(compressor, "_generate_summary", return_value="SUMMARY TEXT"):
+            out = compressor.compress(msgs, current_tokens=60_000)
+
+        with_images = [m for m in out if isinstance(m, dict) and _content_has_images(m.get("content"))]
+        # Exactly one survivor: the newest vision result. The opening
+        # attachment is protect_first_n material and may or may not survive
+        # the summary window, so assert on what must NOT be there instead.
+        assert len(with_images) <= 2
+        stale_tool_images = [
+            m for m in out
+            if isinstance(m, dict)
+            and m.get("role") == "tool"
+            and _content_has_images(m.get("content"))
+            and m.get("tool_call_id") != "c"
+        ]
+        assert stale_tool_images == [], (
+            "vision_analyze results a, b still carry base64 after compression"
+        )


### PR DESCRIPTION
## Relationship to #89965 - please read this first

**#89965 and this PR fix different halves of #89938 and do not overlap by a single line.** #89965 bounds the image bytes on every outgoing request so the 413 stops happening. This PR fixes the reason the session could not *recover* once it did.

In one sentence: **#89965 prevents the 413; this makes the 413 recovery actually recover.**

`_strip_historical_media` is what the 413 handler's compaction ends up calling, and in the reported session it is a no-op - so every recovery pass returned a body that was still multi-MB and the provider answered 413 again. That is the "7 compactions in 13 minutes, all below 200K tokens" in the report. #89965 does not touch that function, so with only #89965 merged the wedge is unreachable in the common case but still there: any single window that exceeds the provider's body limit (a run of images larger than `keep_recent`, or a provider whose limit is smaller than three screenshots) drops into the same loop with no way out.

I am not proposing this as an alternative to #89965. If you would rather have one change, merge theirs - it is the larger fix and it is the one that stops the 413. This is `Refs #89938`, not `Fixes`, for exactly that reason.

## What does this PR do?

`agent/context_compressor.py:_strip_historical_media` anchors on the newest image-bearing **user** message and strips images from everything before it:

```python
anchor = -1
for i in range(len(messages) - 1, -1, -1):
    ...
    if msg.get("role") == "user" and _content_has_images(msg.get("content")):
        anchor = i
        break

if anchor <= 0:
    return messages          # <-- the whole pass, skipped
```

A session whose images arrive from **tools** rather than attachments has nothing to be "before". The reported reproduction is the worst case of this and trips both exits at once:

- one attachment on the **first** user message, so `anchor == 0` and the early return fires; and
- twenty `vision_analyze` results after it, which the user anchor would not have protected anyway.

So the function returns the list untouched, the ~4MB of base64 rides along on every request, and the compaction the 413 handler invokes as recovery frees nothing.

This ages tool-result images on their own timeline: keep the newest one, strip every older one wherever it sits.

## Related Issue

Refs #89938

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `agent/context_compressor.py` - `_strip_historical_media` gains a second anchor, `tool_anchor`, the newest image-bearing `role: "tool"` message. A message is now stripped if it is before the user anchor (rule 1, unchanged) **or** it is an image-bearing tool message that is not the newest one (rule 2, new). The early return now fires only when neither rule can do anything.
- `tests/agent/test_compressor_historical_media.py` - 9 tests.

### Three decisions worth a maintainer's eye

**1. Rule 1 keeps precedence.** Where the two rules disagree - a tool result that is the newest of its kind but sits *before* the user anchor - rule 1 wins and it is stripped, which is exactly today's behaviour. `test_tool_image_before_the_user_anchor_is_still_stripped` pins that, and it is the test to look at if you think the ordering should go the other way.

**2. The newest tool image survives inside the protected tail; older ones do not.** `protect_last_n` exists to preserve conversational continuity, not to pin bytes the model has already moved past, and a stale screenshot inside the tail is the single largest thing in the payload. This is the one behavioural change to the tail, and it is deliberate. If you would rather the tail stay byte-exact, rule 2 needs an `index >= tail_start` exclusion - and the fix then stops working for the reported session, because all twenty results were in the tail.

**3. User images are untouched.** I deliberately did **not** unify the two anchors into "newest image-bearing message of any role", which would have been the smaller diff. It would let a tool screenshot evict the user's most recent attachment, and `agent/context_compressor.py:7503-7510` documents a live dependency on the user anchor being kept byte-for-byte (the `_force_user_leading` guard reasons about an image-only user message having no text placeholder). Two anchors is more code and fewer surprises.

## How to Test

```bash
uv run pytest tests/agent/test_compressor_historical_media.py -q     # 19 passed
uv run pytest tests/agent/test_compressor_zero_user_guard.py -q      #  6 passed
uv run pytest tests/agent -q -k compress                             # 436 passed, 1 pre-existing failure
uv run ruff check agent/context_compressor.py tests/agent/test_compressor_historical_media.py
```

To see the old behaviour, restore the `if anchor <= 0: return messages` early return and re-run: `test_compress_frees_stale_vision_tool_results` fails with both `vision_analyze` results still carrying their base64.

## Verification

**Mutation proof - 6 mutations, 6 caught:**

| # | Mutation | Caught by |
|---|---|---|
| 1 | restore the original early return + `i >= anchor` loop (the bug) | 6 tests, including the end-to-end `compress()` one |
| 2 | `tool_anchor` scans forward, so the OLDEST tool image is kept | newest-survives-in-tail, sidecar, end-to-end |
| 3 | rule 2 strips every tool image, including the newest | newest-survives-in-tail, single-tool-image, first-message-user-image |
| 4 | rule 2 drops the `role == "tool"` test and applies to all roles | newest-survives-in-tail, rule-1-precedence, the pre-existing user-path integration test |
| 5 | rule 1 removed, rule 2 checked first | rule-1-precedence, non-dict-passthrough, the pre-existing user-path integration test |
| 6 | `drop_stale_api_content` removed from the rewrite | sidecar test |

Mutations 4 and 5 being caught by `test_compress_strips_historical_images` - a test that predates this PR - is the useful signal: the existing user-path contract is still pinned, not merely believed.

**Pre-existing failures, named rather than hidden.** `tests/agent/test_compression_review_76354.py::TestF6ExecutorSaturation::test_cancelled_fence_skips_summary_work_before_start` fails on a pristine checkout of `13ce0c5c67` with this branch stashed, and fails identically with it applied. Same for four in the `-k "image or vision"` sweep (`test_image_routing.py` x2, `test_save_url_image.py`, `test_vision_routing_31179.py`), all of which fail on the clean tree here. This PR touches none of them.

**Platform:** Windows 11, Python 3.12, `uv`. The change is pure list/dict manipulation - no paths, no processes, no platform-specific behaviour.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate: #89965 is the other half and is described at the top; #89776, #87555 and #64440 are the older attempts it names, and none of them touch `_strip_historical_media`'s anchor
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits): one commit, two files
- [x] I've run `pytest tests/ -q` and all tests pass: the compression and multimodal suites are above, and the pre-existing failures are named rather than hidden
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A: the docstring now states both rules and why the tool rule exists
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A: no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) or N/A: pure data transformation
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## Screenshots / Logs

The loop this removes, from the report:

```
09:41:36  API call failed: HTTP 413: request body exceeds configured limit
09:41:36  context compression started: tokens=~183,487
09:44:02  context compression done: messages=185->168 tokens=~165,384
09:44:05  API call failed: HTTP 413: request body exceeds configured limit
...
09:46:02  Compression made no progress, skipping boundary rewrite
```

The token count falls on every pass and the body does not, because the bytes that matter are base64 in tool results and nothing was stripping them.
