### PR TITLE
fix(kanban): dispatcher self-review guard + deterministic bootstrap-failure classification

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8013,6 +8013,202 @@ _RESPAWN_GUARD_PR_URL_RE = re.compile(
 )
 
 
+def _review_implementer_and_reviewer(
+    conn: sqlite3.Connection, task_id: str,
+) -> "tuple[Optional[str], Optional[str]]":
+    """Return ``(implementer, reviewer)`` from the task's latest
+    ``review_requested`` event payload, or ``(None, None)`` if none exists.
+
+    ``reviewer`` is ``None`` when the card was submitted for review without
+    an explicit ``reviewer=`` (the common case — see ``request_review``'s
+    docstring: ``assignee`` is left untouched in that case, so the task's
+    ``assignee`` column still names the IMPLEMENTER, not a distinct
+    reviewer). Callers use this to detect the self-review case before
+    auto-spawning the review lane.
+    """
+    row = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id = ? "
+        "AND kind = 'review_requested' ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if row is None or not row["payload"]:
+        return (None, None)
+    try:
+        payload = json.loads(row["payload"])
+    except (ValueError, TypeError):
+        return (None, None)
+    if not isinstance(payload, dict):
+        return (None, None)
+    implementer = payload.get("implementer")
+    reviewer = payload.get("reviewer")
+    implementer = implementer if isinstance(implementer, str) and implementer.strip() else None
+    reviewer = reviewer if isinstance(reviewer, str) and reviewer.strip() else None
+    return (implementer, reviewer)
+
+
+# Shared author name stamped on dispatcher-generated card comments for the
+# one-time alerts below (self-review guard, bootstrap-failure guard). Kept
+# as its own constant — rather than a literal repeated in each function —
+# so every dispatcher alert comment is trivially attributable to "the
+# dispatcher wrote this, not a worker" from one place. NOTE: PR-89973
+# (nonspawnable-assignee alert, landed separately) defines the same-named
+# constant for its own alert function; if both PRs land, keep only one
+# definition — the value is identical.
+_NONSPAWNABLE_ALERT_AUTHOR = "hermes-dispatcher"
+
+
+def _emit_self_review_alert(
+    conn: sqlite3.Connection, task_id: str, assignee: str,
+) -> None:
+    """First-occurrence event + card comment for a ``skipped_self_review`` task.
+
+    Root cause (#kanban-self-review-gaveup 2026-08-19, see t_eee837c7): when
+    a worker calls ``kanban_request_review(...)`` without an explicit
+    ``reviewer=``, ``request_review`` deliberately leaves ``tasks.assignee``
+    unchanged (it still names the IMPLEMENTER — see that function's
+    docstring). The review-lane dispatcher used to key spawn eligibility
+    purely on ``status='review' AND assignee is spawnable``, so it
+    re-spawned the SAME profile onto its OWN just-completed card. That
+    worker has no legitimate transition left to make (the card is already
+    correctly in ``review`` with real work delivered) and either re-issues
+    the same ``kanban_request_review``/``kanban_complete`` calls (rejected:
+    "task is not in running/ready") or exits rc=0 with the task still
+    ``running``. Either way ``detect_crashed_workers`` reaps it as
+    ``crashed`` (clean-exit protocol violation), increments
+    ``consecutive_failures``, and the breaker can trip ``gave_up`` on a
+    card whose work is complete and already handed off — a false negative
+    that also burns the failure budget. Measured case: t_ea832a93, runs
+    5258/5260, both spawned within 68s of run 5256's successful
+    ``kanban_request_review``.
+
+    The dispatcher now skips auto-spawning this case (see the review loop's
+    ``claim_review_task`` call site) — the card just waits in ``review`` for
+    a human or a distinct reviewer profile to pull it, which is exactly the
+    review-gate the card was submitted for. This announces that decision
+    once per (task, assignee) so it isn't mistaken for a stuck queue.
+    """
+    try:
+        already = conn.execute(
+            "SELECT 1 FROM task_events WHERE task_id = ? AND kind = ? "
+            "AND payload LIKE ? LIMIT 1",
+            (
+                task_id,
+                "self_review_alerted",
+                f'%"assignee": "{assignee}"%',
+            ),
+        ).fetchone()
+        if already:
+            return
+        with write_txn(conn):
+            _append_event(
+                conn, task_id, "self_review_alerted",
+                {
+                    "assignee": assignee,
+                    "hint": (
+                        "task was submitted for review without a distinct "
+                        "reviewer= (assignee still names the implementer); "
+                        "dispatcher will not auto-spawn the same profile "
+                        "onto its own completed card — pull it manually or "
+                        "reassign to a reviewer profile"
+                    ),
+                },
+            )
+            add_comment(
+                conn, task_id, _NONSPAWNABLE_ALERT_AUTHOR,
+                (
+                    f"\u26a0\ufe0f Dispatcher: this card is in `review` but "
+                    f"still assigned to `{assignee}`, the same profile that "
+                    "implemented it (no distinct `reviewer=` was passed to "
+                    "`kanban_request_review`). Auto-spawning that profile "
+                    "here would just respawn it onto its own already-"
+                    "delivered work with no valid transition left to make — "
+                    "that previously caused false `crashed`/`gave_up` "
+                    "outcomes on completed cards (see t_eee837c7). This "
+                    "card will stay in `review` until a human pulls it or "
+                    "it is reassigned to a distinct reviewer profile. "
+                    "(One-time alert.)"
+                ),
+            )
+    except Exception:
+        _log.debug(
+            "kanban dispatch: failed to emit self-review alert for "
+            "task %s assignee %r", task_id, assignee, exc_info=True,
+        )
+
+
+def _emit_bootstrap_failure_alert(
+    conn: sqlite3.Connection, task_id: str, assignee: str,
+) -> None:
+    """First-occurrence event + card comment for a ``bootstrap_failed`` task.
+
+    Root cause (#kanban-bootstrap-failure-gaveup 2026-08-19, t_eee837c7,
+    diagnosed against t_ea832a93/t_83812b77/t_ea89769e/t_966f138b/
+    t_f7f32991): a worker spawned with an unresolvable ``--skills``/profile
+    name (e.g. the review lane force-loading ``sdlc-review`` onto a profile
+    that doesn't have it linked) dies during CLI init with ``Error: Unknown
+    skill(s): ...`` / ``Profile '...' does not exist`` before it can call
+    any kanban lifecycle tool. ``detect_crashed_workers`` now recognizes
+    this deterministic signature (see ``_worker_log_bootstrap_failure``)
+    and releases the task WITHOUT counting a failure — retrying spawns the
+    identical crash every time, so the old behavior (counting it as an
+    ordinary crash) could burn ``consecutive_failures`` to the breaker on a
+    card whose actual task work was already complete, a false ``gave_up``.
+
+    Unlike a rate-limit release this never clears on its own — a human has
+    to fix the profile/skill/toolset config — so it is alerted once per
+    (task, assignee) exactly like ``_emit_nonspawnable_alert`` /
+    ``_emit_self_review_alert``, instead of silently bouncing the task
+    between ``running`` and its source phase every tick forever.
+    """
+    try:
+        already = conn.execute(
+            "SELECT 1 FROM task_events WHERE task_id = ? AND kind = ? "
+            "AND payload LIKE ? LIMIT 1",
+            (
+                task_id,
+                "bootstrap_failure_alerted",
+                f'%"assignee": "{assignee}"%',
+            ),
+        ).fetchone()
+        if already:
+            return
+        with write_txn(conn):
+            _append_event(
+                conn, task_id, "bootstrap_failure_alerted",
+                {
+                    "assignee": assignee,
+                    "hint": (
+                        "worker died at CLI init on an unresolvable "
+                        "skill/profile name (deterministic — retrying "
+                        "will not help); consecutive_failures was NOT "
+                        "incremented for this, but the underlying config "
+                        "gap needs a human fix"
+                    ),
+                },
+            )
+            add_comment(
+                conn, task_id, _NONSPAWNABLE_ALERT_AUTHOR,
+                (
+                    f"\u26a0\ufe0f Dispatcher: the worker spawned for "
+                    f"`{assignee}` died at startup with an unresolvable "
+                    "skill or profile name (see `last_failure_error` on "
+                    "this task, or `hermes kanban log` for the exact "
+                    "line). This is deterministic — every retry will "
+                    "crash identically — so it was NOT counted toward "
+                    "the failure breaker, but it also will not fix "
+                    "itself. Check the assignee profile's linked skills "
+                    "(e.g. a force-loaded review skill like `sdlc-review` "
+                    "missing from its skill tree) and re-link before this "
+                    "card can make progress. (One-time alert.)"
+                ),
+            )
+    except Exception:
+        _log.debug(
+            "kanban dispatch: failed to emit bootstrap-failure alert for "
+            "task %s assignee %r", task_id, assignee, exc_info=True,
+        )
+
+
 @dataclass
 class DispatchResult:
     """Outcome of a single ``dispatch`` pass."""
@@ -8049,6 +8245,17 @@ class DispatchResult:
     subsequent tick when the assignee has capacity. Separate bucket so
     telemetry / dashboards can show "this profile is busy" vs
     "task is genuinely stuck"."""
+
+    skipped_self_review: list[str] = field(default_factory=list)
+    """Review-lane task ids skipped because ``assignee`` still names the
+    IMPLEMENTER (no distinct ``reviewer=`` was passed to
+    ``kanban_request_review`` — see ``request_review``'s docstring).
+    Auto-spawning here would respawn the same profile onto its own
+    just-completed card with no valid transition left to make, which used
+    to surface as a false ``crashed``/``gave_up`` on finished work
+    (#kanban-self-review-gaveup 2026-08-19, t_eee837c7). NOT an
+    operator-actionable failure by itself — the card is correctly waiting
+    in ``review`` for a human or a distinct reviewer profile."""
     crashed: list[str] = field(default_factory=list)
     """Task ids reclaimed because their worker PID disappeared."""
     auto_blocked: list[str] = field(default_factory=list)
@@ -8069,6 +8276,15 @@ class DispatchResult:
     (EX_TEMPFAIL sentinel exit) and were released back to ``ready`` WITHOUT
     counting a failure. These never trip the circuit breaker — a long quota
     window just makes the task bounce cheaply until the window clears."""
+    bootstrap_failed: list[str] = field(default_factory=list)
+    """Task ids whose workers died at CLI init on a deterministic
+    unresolvable skill/profile name (see ``_worker_log_bootstrap_failure``,
+    #kanban-bootstrap-failure-gaveup 2026-08-19, t_eee837c7) and were
+    released back to their source phase WITHOUT counting a failure — the
+    same crash would repeat on every retry, so counting it would just
+    false-trip the breaker on work that may already be complete. Unlike
+    ``rate_limited`` this never self-clears; each occurrence gets a
+    one-time alert (event + comment) pointing at the config gap."""
     skipped_locked: bool = False
     """True when this tick was skipped because another process already held
     the board's dispatch lock (issue #35240). A losing dispatcher does no
@@ -8849,7 +9065,62 @@ def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
     return streak
 
 
-def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
+_BOOTSTRAP_FAILURE_LOG_TAIL_BYTES = 8192
+# How much of the worker's log to read from the end when checking for a
+# deterministic startup-failure signature. Generous enough to catch the
+# banner even behind normal startup chatter, small enough to stay cheap on
+# every crashed-worker reclaim.
+
+
+def _worker_log_bootstrap_failure(
+    task_id: str, board: Optional[str] = None,
+) -> Optional[str]:
+    """Tail the task's worker log for a deterministic bootstrap-failure
+    signature (unresolvable skill/profile at CLI init) and return the
+    matching line, or ``None`` if the log is absent or shows no such
+    signature.
+
+    #kanban-bootstrap-failure-gaveup (2026-08-19, t_eee837c7): a worker
+    requested with an unresolvable skill/toolset/profile name dies during
+    CLI init, before it can call kanban_block/kanban_complete — no amount
+    of retrying fixes a name that doesn't exist on the target profile.
+    Measured case: force-loaded ``sdlc-review`` was missing from 8 review
+    profiles (a PR #145 allowlist gap), crashing every review-lane spawn
+    with ``Error: Unknown skill(s): sdlc-review`` in ~60s, which
+    ``detect_crashed_workers`` was then counting as an ordinary
+    ``consecutive_failures`` tick toward the ``gave_up`` breaker — even
+    though the underlying card's actual work was already complete.
+
+    Best-effort: any I/O error degrades to ``None`` (fall back to the
+    ordinary crash/protocol-violation classification) rather than raising
+    into the dispatch loop.
+    """
+    try:
+        log_path = worker_logs_dir(board=board) / f"{task_id}.log"
+        if not log_path.exists():
+            return None
+        with open(log_path, "rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            size = fh.tell()
+            fh.seek(max(0, size - _BOOTSTRAP_FAILURE_LOG_TAIL_BYTES))
+            tail = fh.read().decode("utf-8", errors="replace")
+        for line in tail.splitlines():
+            if "Unknown skill(s):" in line:
+                return line.strip()[:500]
+            if "Profile '" in line and "does not exist" in line:
+                return line.strip()[:500]
+        return None
+    except Exception:
+        _log.debug(
+            "kanban dispatch: failed to tail worker log for bootstrap "
+            "failure check (task %s)", task_id, exc_info=True,
+        )
+        return None
+
+
+def detect_crashed_workers(
+    conn: sqlite3.Connection, board: Optional[str] = None,
+) -> list[str]:
     """Reclaim ``running`` tasks whose worker PID is no longer alive.
 
     Appends a ``crashed`` event and restores the task's source phase.
@@ -8876,9 +9147,21 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     ``check_respawn_guard`` defers their respawn until the window clears.
     The ids are returned via the ``_last_rate_limited`` function attribute
     (the public return stays the crashed-only ``list[str]``).
+
+    When the worker's log shows a deterministic bootstrap-failure signature
+    (unresolvable ``--skills``/profile name at CLI init — see
+    ``_worker_log_bootstrap_failure``), that is likewise released WITHOUT
+    counting a failure: retrying spawns the identical crash every time, so
+    burning ``consecutive_failures`` on it only serves to false-trip the
+    breaker on a card whose actual task work may already be complete
+    (#kanban-bootstrap-failure-gaveup 2026-08-19, t_eee837c7). Unlike a
+    quota wall this never self-clears, so it is also alerted once via
+    ``_emit_bootstrap_failure_alert`` and surfaced through the
+    ``_last_bootstrap_failed`` function attribute.
     """
     crashed: list[str] = []
     rate_limited: list[str] = []
+    bootstrap_failed: list[str] = []
     # Per-crash details collected inside the main txn, used after it
     # closes to run ``_record_task_failure`` (which needs its own
     # write_txn so can't nest). ``protocol_violation`` flags the
@@ -8916,7 +9199,41 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
             pid = int(row["worker_pid"])
             kind, code = _classify_worker_exit(pid)
             rate_limited_exit = False
-            if kind == "clean_exit":
+            bootstrap_failure_line = None
+            if kind in ("clean_exit", "nonzero_exit"):
+                # Check for a deterministic bootstrap failure (unresolvable
+                # skill/profile at CLI init) BEFORE the ordinary clean_exit /
+                # nonzero_exit classification below — see
+                # _worker_log_bootstrap_failure's docstring
+                # (#kanban-bootstrap-failure-gaveup 2026-08-19, t_eee837c7).
+                # This can present as either exit kind depending on which
+                # code path in cli.py raises, so both are checked.
+                bootstrap_failure_line = _worker_log_bootstrap_failure(
+                    row["id"], board=board,
+                )
+            if bootstrap_failure_line is not None:
+                # Deterministic startup failure — retrying spawns the exact
+                # same crash every time, so this must NOT consume
+                # consecutive_failures / the protocol-violation streak (both
+                # exist to bound RETRYABLE failures) and must NOT loop
+                # silently. Requeue to source phase like a rate-limit release
+                # (no failure counted) but keep it visibly distinct via its
+                # own outcome/event kind and an operator alert, since unlike
+                # a quota wall this never clears on its own — it needs a
+                # human to fix the profile/skill/toolset config.
+                protocol_violation = False
+                error_text = (
+                    f"pid {pid} bootstrap failure (deterministic, not "
+                    f"retried as a normal failure): {bootstrap_failure_line}"
+                )
+                event_kind = "bootstrap_failed"
+                event_payload = {
+                    "pid": pid,
+                    "claimer": row["claim_lock"],
+                    "exit_code": code,
+                    "log_line": bootstrap_failure_line,
+                }
+            elif kind == "clean_exit":
                 # Worker subprocess returned 0 but its task is still
                 # ``running`` in the DB — it exited without calling
                 # ``kanban_complete`` / ``kanban_block``. Overwhelmingly the
@@ -8987,10 +9304,16 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 (retry_status, row["id"], pid, row["claim_lock"]),
             )
             if cur.rowcount == 1:
-                # Rate-limited requeues are a clean release, not a crash —
-                # record the run outcome as ``rate_limited`` so the board
-                # history doesn't show a phantom crash for a quota wall.
-                _run_outcome = "rate_limited" if rate_limited_exit else "crashed"
+                # Rate-limited / bootstrap-failure requeues are a clean
+                # release, not a crash — record the run outcome accordingly
+                # so the board history doesn't show a phantom crash for a
+                # quota wall or a deterministic startup failure.
+                if rate_limited_exit:
+                    _run_outcome = "rate_limited"
+                elif bootstrap_failure_line is not None:
+                    _run_outcome = "bootstrap_failed"
+                else:
+                    _run_outcome = "crashed"
                 run_id = _end_run(
                     conn, row["id"],
                     outcome=_run_outcome, status=_run_outcome,
@@ -9023,6 +9346,17 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                         (error_text[:500], row["id"]),
                     )
                     rate_limited.append(row["id"])
+                elif bootstrap_failure_line is not None:
+                    # Same "no failure counted" treatment as rate-limited,
+                    # but this needs a human, not a wait — the respawn guard
+                    # doesn't have a bespoke "bootstrap blocker" reason yet,
+                    # so the alert (below, once per task+assignee) is the
+                    # actionable signal rather than a silent auto-requeue.
+                    conn.execute(
+                        "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+                        (error_text[:500], row["id"]),
+                    )
+                    bootstrap_failed.append(row["id"])
                 else:
                     if protocol_violation:
                         # Stamp the failure error now: a below-budget
@@ -9132,6 +9466,17 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # Same side-channel for rate-limited requeues — these did NOT count a
     # failure and are NOT crashes, so they stay out of the ``crashed`` return.
     detect_crashed_workers._last_rate_limited = rate_limited  # type: ignore[attr-defined]
+    # Same side-channel for deterministic bootstrap failures (unresolvable
+    # skill/profile at CLI init) — also did NOT count a failure, also not a
+    # real crash. Each gets a one-time alert (event + comment), since unlike
+    # a rate limit this needs a human to fix the config, not a wait.
+    detect_crashed_workers._last_bootstrap_failed = bootstrap_failed  # type: ignore[attr-defined]
+    for _bf_tid in bootstrap_failed:
+        _bf_row = conn.execute(
+            "SELECT assignee FROM tasks WHERE id = ?", (_bf_tid,),
+        ).fetchone()
+        if _bf_row is not None and _bf_row["assignee"]:
+            _emit_bootstrap_failure_alert(conn, _bf_tid, _bf_row["assignee"])
     # Worker-lifecycle observer (RFC #58548): exit events are tick-derived
     # from this reclaim pass — fired only now, after the main reclaim txn
     # AND the breaker accounting above have committed, so subscribers always
@@ -9951,7 +10296,7 @@ def _dispatch_once_locked(
     result.stale = detect_stale_running(
         conn, stale_timeout_seconds=stale_timeout_seconds,
     )
-    result.crashed = detect_crashed_workers(conn)
+    result.crashed = detect_crashed_workers(conn, board=board)
     # detect_crashed_workers stashes protocol-violation auto-blocks on
     # itself so the public list-return stays stable. Pull them into the
     # DispatchResult here so telemetry / tests see the trip.
@@ -9968,6 +10313,15 @@ def _dispatch_once_locked(
     )
     if _crash_rate_limited:
         result.rate_limited.extend(_crash_rate_limited)
+    # Bootstrap-failure requeues (deterministic unresolvable skill/profile
+    # at CLI init, no failure counted) — surface for telemetry / tests.
+    # See DispatchResult.bootstrap_failed and
+    # _worker_log_bootstrap_failure's docstring.
+    _crash_bootstrap_failed = getattr(
+        detect_crashed_workers, "_last_bootstrap_failed", []
+    )
+    if _crash_bootstrap_failed:
+        result.bootstrap_failed.extend(_crash_bootstrap_failed)
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
 
@@ -10345,6 +10699,27 @@ def _dispatch_once_locked(
                         conn, row["id"], "respawn_guarded",
                         {"reason": guard_reason},
                     )
+            continue
+        # Self-review guard (#kanban-self-review-gaveup 2026-08-19,
+        # t_eee837c7): when the card was submitted for review without a
+        # distinct ``reviewer=``, ``request_review`` deliberately leaves
+        # ``assignee`` naming the IMPLEMENTER (see its docstring). Spawning
+        # here would hand the same profile its own just-completed card with
+        # no valid transition left to make — the worker either redundantly
+        # re-issues kanban_request_review/kanban_complete (both rejected:
+        # "task is not in running/ready") or exits rc=0 with the task still
+        # 'running', and detect_crashed_workers then reaps that as a
+        # protocol-violation crash, ticking consecutive_failures toward a
+        # false gave_up on genuinely completed work. Measured case:
+        # t_ea832a93 runs 5258/5260, both within 68s of run 5256's
+        # successful kanban_request_review. Skip the auto-spawn instead;
+        # the card waits in review for a human or a distinct reviewer
+        # profile to pull it, which is the review gate working as intended.
+        _impl, _revr = _review_implementer_and_reviewer(conn, row["id"])
+        if _revr is None and _impl is not None and _impl == row["assignee"]:
+            result.skipped_self_review.append(row["id"])
+            if not dry_run:
+                _emit_self_review_alert(conn, row["id"], row["assignee"])
             continue
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))

--- a/tests/hermes_cli/test_kanban_bootstrap_failure_guard.py
+++ b/tests/hermes_cli/test_kanban_bootstrap_failure_guard.py
@@ -1,0 +1,193 @@
+"""Bootstrap-failure guard: a worker that dies at CLI init on an
+unresolvable ``--skills``/profile name must not burn ``consecutive_failures``
+toward the ``gave_up`` circuit breaker.
+
+Regression coverage for #kanban-bootstrap-failure-gaveup (2026-08-19,
+t_eee837c7, diagnosed against t_ea832a93/t_83812b77/t_ea89769e/t_966f138b/
+t_f7f32991): the dispatcher force-injects a skill (e.g. ``sdlc-review``) into
+every review-lane worker's ``--skills`` list. When that skill isn't linked on
+the target profile, the worker process dies during CLI init with
+``Error: Unknown skill(s): ...`` (or ``Profile '...' does not exist``) in
+well under a minute, before it can call ANY kanban lifecycle tool
+(``kanban_block`` / ``kanban_complete``). Before this fix,
+``detect_crashed_workers`` classified that exit as an ordinary
+``clean_exit``/``nonzero_exit`` protocol violation and counted it toward
+``consecutive_failures`` — but retrying is pointless: the same unresolvable
+name crashes identically every time, so the counter marches straight to
+``gave_up`` on a card whose actual task work may already be complete.
+Measured case: 19 crashes across 5 review-lane cards in one 24h window, all
+sharing this exact log signature.
+
+Fix: ``_worker_log_bootstrap_failure`` tails the worker's log for the
+deterministic signature BEFORE the ordinary clean_exit/nonzero_exit
+classification runs. When found, ``detect_crashed_workers`` requeues the
+task to its source phase (like a rate-limit release) WITHOUT incrementing
+``consecutive_failures``, records the outcome as ``bootstrap_failed`` (not
+``crashed``), and emits a one-time event + card comment via
+``_emit_bootstrap_failure_alert`` so a human can fix the underlying
+profile/skill config — unlike a quota wall, this never clears on its own.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    # Existing crash-detection tests (and this one) pre-date the reap grace
+    # window; pin to 0 for immediate-reclaim semantics — see the identical
+    # fixture note in test_kanban_core_functionality.py.
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _plant_worker_log(task_id: str, text: str, board=None) -> Path:
+    log_dir = kb.worker_logs_dir(board=board)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / f"{task_id}.log"
+    log_path.write_text(text)
+    return log_path
+
+
+def test_unknown_skill_bootstrap_failure_not_counted_as_failure(
+    kanban_home, monkeypatch,
+):
+    """The deterministic 'Unknown skill(s): ...' signature must release the
+    task WITHOUT touching consecutive_failures, and classify as
+    bootstrap_failed rather than an ordinary crash."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="review this", assignee="worker")
+        kb.claim_task(conn, tid)
+        kb._set_worker_pid(conn, tid, 55501)
+
+        _plant_worker_log(
+            tid,
+            "some startup banner\n"
+            "Error: Unknown skill(s): sdlc-review\n"
+            "more trailing noise\n",
+        )
+
+        monkeypatch.setattr(kb, "_pid_alive", lambda pid: False)
+        monkeypatch.setattr(
+            kb, "_classify_worker_exit", lambda pid: ("clean_exit", 0),
+        )
+
+        before = kb.get_task(conn, tid)
+        assert before.consecutive_failures == 0
+
+        crashed = kb.detect_crashed_workers(conn)
+
+        # Not reported via the ordinary crashed list...
+        assert tid not in crashed
+        # ...but IS surfaced via the bootstrap-failed side channel.
+        bootstrap_failed = getattr(
+            kb.detect_crashed_workers, "_last_bootstrap_failed", [],
+        )
+        assert tid in bootstrap_failed
+
+        after = kb.get_task(conn, tid)
+        assert after.consecutive_failures == 0, (
+            "a deterministic bootstrap failure must NOT increment "
+            "consecutive_failures — retrying can't fix an unresolvable name"
+        )
+        assert after.status in ("ready", "todo")
+
+        runs = kb.list_runs(conn, tid)
+        assert runs[-1].outcome == "bootstrap_failed"
+
+        events = kb.list_events(conn, tid)
+        alert_events = [e for e in events if e.kind == "bootstrap_failure_alerted"]
+        assert len(alert_events) == 1
+        assert alert_events[0].payload["assignee"] == "worker"
+
+        comments = kb.list_comments(conn, tid)
+        assert len(comments) == 1
+        assert "Unknown skill" in comments[0].body or "unresolvable" in comments[0].body
+
+
+def test_unknown_profile_bootstrap_failure_also_detected(kanban_home, monkeypatch):
+    """The second deterministic signature — 'Profile '...' does not exist'
+    — must be recognized too (both come from the same CLI-init failure
+    class, just different missing-name flavors)."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="review this too", assignee="worker")
+        kb.claim_task(conn, tid)
+        kb._set_worker_pid(conn, tid, 55502)
+
+        _plant_worker_log(
+            tid, "Profile 'retired-role' does not exist\n",
+        )
+
+        monkeypatch.setattr(kb, "_pid_alive", lambda pid: False)
+        monkeypatch.setattr(
+            kb, "_classify_worker_exit", lambda pid: ("nonzero_exit", 1),
+        )
+
+        kb.detect_crashed_workers(conn)
+        bootstrap_failed = getattr(
+            kb.detect_crashed_workers, "_last_bootstrap_failed", [],
+        )
+        assert tid in bootstrap_failed
+        assert kb.get_task(conn, tid).consecutive_failures == 0
+
+
+def test_bootstrap_failure_alert_does_not_repeat_across_ticks(
+    kanban_home, monkeypatch,
+):
+    """Re-crashing on the identical bootstrap failure (e.g. the operator
+    hasn't fixed the config yet and the card gets re-dispatched) must only
+    alert once per (task, assignee) — not spam a comment every reclaim."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="loops on bad skill", assignee="worker")
+
+        for pid in (66601, 66602):
+            kb.claim_task(conn, tid)
+            kb._set_worker_pid(conn, tid, pid)
+            _plant_worker_log(
+                tid, "Error: Unknown skill(s): sdlc-review\n",
+            )
+            monkeypatch.setattr(kb, "_pid_alive", lambda pid: False)
+            monkeypatch.setattr(
+                kb, "_classify_worker_exit", lambda pid: ("clean_exit", 0),
+            )
+            kb.detect_crashed_workers(conn)
+
+        events = kb.list_events(conn, tid)
+        alert_events = [e for e in events if e.kind == "bootstrap_failure_alerted"]
+        assert len(alert_events) == 1
+
+
+def test_ordinary_crash_without_bootstrap_signature_still_counts_failure(
+    kanban_home, monkeypatch,
+):
+    """Sanity check: a real crash with NO deterministic signature in the
+    log is unaffected by this guard and still increments
+    consecutive_failures via the pre-existing protocol-violation path."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="genuinely crashes", assignee="worker")
+        kb.claim_task(conn, tid)
+        kb._set_worker_pid(conn, tid, 77701)
+
+        _plant_worker_log(tid, "some ordinary traceback, nothing deterministic\n")
+
+        monkeypatch.setattr(kb, "_pid_alive", lambda pid: False)
+        monkeypatch.setattr(
+            kb, "_classify_worker_exit", lambda pid: ("clean_exit", 0),
+        )
+
+        crashed = kb.detect_crashed_workers(conn)
+        assert tid in crashed
+        bootstrap_failed = getattr(
+            kb.detect_crashed_workers, "_last_bootstrap_failed", [],
+        )
+        assert tid not in bootstrap_failed

--- a/tests/hermes_cli/test_kanban_review_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle.py
@@ -386,7 +386,7 @@ def test_review_dispatch_gate_prevents_phantom_reviewer(
         tid = kb.create_task(conn, title="park", assignee="worker")
         kb.claim_task(conn, tid)
         kb.request_review(
-            conn, tid, summary="done",
+            conn, tid, summary="done", reviewer="reviewer",
             expected_run_id=kb.get_task(conn, tid).current_run_id,
         )
         assert kb.get_task(conn, tid).status == "review"
@@ -437,12 +437,12 @@ def test_active_pr_guard_skipped_for_review_lane_but_defers_ready_lane(
 
     with kb.connect() as conn:
         # Review-lane task with a fresh PR comment.
-        review_id = kb.create_task(conn, title="review me", assignee="reviewer")
+        review_id = kb.create_task(conn, title="review me", assignee="worker")
         claimed = kb.claim_task(conn, review_id)
         assert claimed is not None
         kb.add_comment(conn, review_id, author="worker", body=pr_comment)
         assert kb.request_review(
-            conn, review_id, summary="PR ready",
+            conn, review_id, summary="PR ready", reviewer="reviewer",
             expected_run_id=claimed.current_run_id,
         )
         # Ready-lane task with the same fresh PR comment.
@@ -497,7 +497,7 @@ def test_review_dispatch_preserves_task_skills_and_adds_reviewer_skill(
         task_id = kb.create_task(
             conn,
             title="domain review",
-            assignee="reviewer",
+            assignee="implementer",
             skills=["domain-specific-review"],
         )
         implementation = kb.claim_task(conn, task_id)
@@ -506,6 +506,7 @@ def test_review_dispatch_preserves_task_skills_and_adds_reviewer_skill(
             conn,
             task_id,
             summary="ready",
+            reviewer="reviewer",
             expected_run_id=implementation.current_run_id,
         )
         monkeypatch.setattr(
@@ -548,13 +549,14 @@ def test_review_dispatch_honors_global_and_per_profile_caps(
 
         review_ids: list[str] = []
         for title in ("review one", "review two"):
-            task_id = kb.create_task(conn, title=title, assignee="reviewer")
+            task_id = kb.create_task(conn, title=title, assignee="implementer")
             implementation = kb.claim_task(conn, task_id)
             assert implementation is not None
             assert kb.request_review(
                 conn,
                 task_id,
                 summary="ready",
+                reviewer="reviewer",
                 expected_run_id=implementation.current_run_id,
             )
             review_ids.append(task_id)

--- a/tests/hermes_cli/test_kanban_self_review_guard.py
+++ b/tests/hermes_cli/test_kanban_self_review_guard.py
@@ -1,0 +1,208 @@
+"""Self-review guard: dispatcher must not respawn the implementer onto its
+own just-completed review card.
+
+Regression coverage for #kanban-self-review-gaveup (2026-08-19, t_eee837c7):
+when a worker calls ``kanban_request_review(...)`` WITHOUT an explicit
+``reviewer=``, ``request_review`` deliberately leaves ``tasks.assignee``
+unchanged — it still names the IMPLEMENTER, not a distinct reviewer (see
+``request_review``'s docstring). Before this fix, the review-lane dispatcher
+keyed spawn eligibility purely on ``status='review' AND assignee is
+spawnable``, so it re-spawned the SAME profile onto its OWN just-completed
+card. That worker has no legitimate transition left to make (the card
+already correctly holds real, delivered work) and either:
+
+* re-issues ``kanban_request_review``/``kanban_complete`` — both correctly
+  rejected with "task is not in running/ready" — then exits rc=0 with the
+  task still ``running``, OR
+* exits rc=0 outright without a terminal call.
+
+Either way ``detect_crashed_workers`` reaped that exit as a clean-exit
+protocol-violation ``crashed`` outcome, ticking ``consecutive_failures``
+toward the circuit breaker — a false negative (``gave_up``) on a card whose
+work was already complete and handed off. Measured case: t_ea832a93, runs
+5258 and 5260, both spawned within 68s of run 5256's successful
+``kanban_request_review``.
+
+Fix: the review dispatch loop now checks the latest ``review_requested``
+event's ``(implementer, reviewer)`` payload before calling
+``claim_review_task``. When ``reviewer`` is ``None`` and ``implementer``
+still equals the task's current ``assignee``, the spawn is skipped
+(bucketed as ``skipped_self_review``, NOT a failure) and a one-time
+event + comment explain why — mirroring the existing
+``skipped_nonspawnable`` / ``_emit_nonspawnable_alert`` pattern. A review
+submitted WITH a distinct ``reviewer=`` is unaffected and still spawns
+normally.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _fake_spawn_factory(spawns):
+    def _spawn(task, workspace, **kwargs):
+        spawns.append(task.id)
+        return 4242
+
+    return _spawn
+
+
+def _submit_for_review(conn, tid, *, reviewer=None):
+    """Claim + request_review a task, mirroring what a real worker does."""
+    claimed = kb.claim_task(conn, tid)
+    assert claimed is not None
+    run_id = kb.get_task(conn, tid).current_run_id
+    assert run_id is not None
+    ok = kb.request_review(
+        conn, tid,
+        summary="work complete",
+        reviewer=reviewer,
+        expected_run_id=run_id,
+    )
+    assert ok is True
+
+
+def test_self_review_card_is_skipped_not_spawned(kanban_home, monkeypatch):
+    import hermes_cli.profiles as profmod
+
+    monkeypatch.setattr(profmod, "profile_exists", lambda name: True)
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="ship a fix", assignee="upx-senior-dev")
+        _submit_for_review(conn, tid)  # no reviewer= passed
+
+        row = conn.execute(
+            "SELECT status, assignee FROM tasks WHERE id = ?", (tid,),
+        ).fetchone()
+        assert row["status"] == "review"
+        assert row["assignee"] == "upx-senior-dev"
+
+        spawns: list[str] = []
+        res = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn_factory(spawns), max_in_progress=2,
+        )
+
+        # The dispatcher must NOT hand the implementer its own card back.
+        assert tid not in spawns
+        assert tid in res.skipped_self_review
+        assert tid not in res.crashed
+
+        # Card stays put in review — not spawned, not blocked, not crashed.
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (tid,),
+        ).fetchone()
+        assert row["status"] == "review"
+
+        events = kb.list_events(conn, tid)
+        alert_events = [e for e in events if e.kind == "self_review_alerted"]
+        assert len(alert_events) == 1
+        assert alert_events[0].payload["assignee"] == "upx-senior-dev"
+
+        comments = kb.list_comments(conn, tid)
+        assert len(comments) == 1
+        assert "upx-senior-dev" in comments[0].body
+        assert "same profile that implemented it" in comments[0].body
+
+
+def test_self_review_alert_does_not_repeat_across_ticks(kanban_home, monkeypatch):
+    import hermes_cli.profiles as profmod
+
+    monkeypatch.setattr(profmod, "profile_exists", lambda name: True)
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="ship a fix", assignee="upx-senior-dev")
+        _submit_for_review(conn, tid)
+
+        for _ in range(3):
+            kb.dispatch_once(
+                conn, spawn_fn=_fake_spawn_factory([]), max_in_progress=2,
+            )
+
+        events = kb.list_events(conn, tid)
+        alert_events = [e for e in events if e.kind == "self_review_alerted"]
+        assert len(alert_events) == 1
+
+
+def test_distinct_reviewer_still_spawns_normally(kanban_home, monkeypatch):
+    import hermes_cli.profiles as profmod
+
+    monkeypatch.setattr(profmod, "profile_exists", lambda name: True)
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="ship a fix", assignee="upx-senior-dev")
+        _submit_for_review(conn, tid, reviewer="upx-reviewer")
+
+        row = conn.execute(
+            "SELECT assignee FROM tasks WHERE id = ?", (tid,),
+        ).fetchone()
+        assert row["assignee"] == "upx-reviewer"
+
+        spawns: list[str] = []
+        res = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn_factory(spawns), max_in_progress=2,
+        )
+
+        assert tid in spawns
+        assert tid not in res.skipped_self_review
+
+
+def test_reopened_review_after_changes_requested_still_self_review_guarded(
+    kanban_home, monkeypatch,
+):
+    """A re-review cycle (changes_requested -> fixed -> request_review again
+    with no reviewer=) must still resolve the ORIGINAL reviewer from
+    provenance, not silently treat it as self-review just because the
+    latest event lacks an explicit reviewer= on the second call. This
+    guards against over-tightening the fix into a new false block."""
+    import hermes_cli.profiles as profmod
+
+    monkeypatch.setattr(profmod, "profile_exists", lambda name: True)
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="ship a fix", assignee="upx-senior-dev")
+        _submit_for_review(conn, tid, reviewer="upx-reviewer")
+
+        # Reviewer claims and requests changes.
+        claimed = kb.claim_review_task(conn, tid)
+        assert claimed is not None
+        ok, reason = kb.request_changes(
+            conn, tid, reason="needs another pass",
+            expected_run_id=kb.get_task(conn, tid).current_run_id,
+        )
+        assert ok, reason
+
+        row = conn.execute(
+            "SELECT assignee FROM tasks WHERE id = ?", (tid,),
+        ).fetchone()
+        assert row["assignee"] == "upx-senior-dev"  # restored to implementer
+
+        # Implementer fixes and re-submits WITHOUT reviewer= — request_review
+        # reuses the durable reviewer provenance from the changes_requested
+        # event, so assignee flips back to upx-reviewer, not self-review.
+        _submit_for_review(conn, tid)
+
+        row = conn.execute(
+            "SELECT assignee FROM tasks WHERE id = ?", (tid,),
+        ).fetchone()
+        assert row["assignee"] == "upx-reviewer"
+
+        spawns: list[str] = []
+        res = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn_factory(spawns), max_in_progress=2,
+        )
+        assert tid in spawns
+        assert tid not in res.skipped_self_review


### PR DESCRIPTION
## Problem

Two independent classes of false `gave_up` on the kanban dispatcher, both
diagnosed against a live production incident (board `uss-platform-staging`,
2026-08-19): a card whose work was already complete and correctly handed
off was reaped as `crashed` by `detect_crashed_workers` on subsequent
stale/doomed respawns, ticking `consecutive_failures` until the breaker
tripped `gave_up` — a false negative that hides real, delivered work.

### 1. Self-review respawn guard

`kanban_request_review(...)` called **without** an explicit `reviewer=`
deliberately leaves `tasks.assignee` naming the **implementer** (see
`request_review`'s docstring — this is intentional design, not a bug). The
review-lane dispatcher used to key spawn eligibility purely on
`status='review' AND assignee is spawnable`, so it re-spawned the **same**
profile onto its **own** just-completed card. That worker has no
legitimate transition left to make — the card is already correctly in
`review` with real work delivered — and either:
- re-issues `kanban_request_review`/`kanban_complete`, both correctly
  rejected with `"task is not in running/ready"`, then exits `rc=0` with
  the task still `running`, or
- exits `rc=0` outright without a terminal call.

Either way `detect_crashed_workers` reaps that as a clean-exit protocol
violation. Measured case: runs 5258 and 5260 both spawned within 68s of an
already-successful `kanban_request_review` on the same card.

**Fix:** the review dispatch loop now resolves the latest
`review_requested` event's `(implementer, reviewer)` payload before
calling `claim_review_task`. When `reviewer is None` and `implementer`
still equals the task's current `assignee`, the spawn is skipped (bucketed
as `skipped_self_review`, **not** a failure) and a one-time event + card
comment explain why — mirroring the existing `skipped_nonspawnable` /
`_emit_nonspawnable_alert` pattern.

`request_review` was also extended to persist reviewer provenance across a
`changes_requested -> re-submit` cycle: a re-review that omits `reviewer=`
now correctly reuses the **original** reviewer from the latest
`changes_requested` event instead of being misclassified as self-review
just because the second call didn't repeat `reviewer=`.

### 2. Deterministic bootstrap-failure classification

A worker spawned with an unresolvable `--skills`/profile name (e.g. a
review lane force-loading a skill that isn't linked on the target profile)
dies during CLI init with `Error: Unknown skill(s): ...` or
`Profile '...' does not exist`, in well under a minute, before it can call
**any** kanban lifecycle tool. `detect_crashed_workers` counted this as an
ordinary crash/protocol-violation — but retrying is pointless, the same
unresolvable name crashes identically every time. Measured case: a
force-loaded review skill missing from the review-lane profiles crashed
**every** review-lane spawn, 19 crashes across 5 cards in one 24h window,
each one ticking the breaker toward `gave_up` on cards whose actual work
was often already complete.

**Fix:** `detect_crashed_workers` now tails the worker's log for this
deterministic signature *before* the ordinary `clean_exit`/`nonzero_exit`
classification runs. When found: the task requeues to its source phase
like a rate-limit release (no failure counted), the run outcome records as
`bootstrap_failed` (not `crashed`), and a one-time event + card comment
alert a human to the config gap — unlike a quota wall this never
self-clears, so it needs a human fix, not a wait.

## Testing

- `tests/hermes_cli/test_kanban_self_review_guard.py` (new, 4 tests):
  self-review card is skipped not spawned; alert doesn't repeat across
  ticks; a distinct `reviewer=` still spawns normally; a re-review after
  `changes_requested` still resolves the original reviewer (guards against
  over-tightening the fix into a new false block).
- `tests/hermes_cli/test_kanban_bootstrap_failure_guard.py` (new, 4
  tests): both log signatures detected; alert doesn't repeat across
  ticks; `consecutive_failures` untouched; sanity check that an ordinary
  crash with no deterministic signature is unaffected.
- `tests/hermes_cli/test_kanban_review_lifecycle.py` (4 existing tests
  updated): pass explicit `reviewer=` where the test's intent is a
  distinct-reviewer review — these previously relied on the
  implementer/reviewer field being interchangeable, which the new guard
  correctly distinguishes.

Full relevant suite (self-review guard + bootstrap-failure guard + review
lifecycle + core kanban_db + block_kinds), isolated against a clean
`main` checkout at `13ce0c5c6`: **63 passed, 1 skipped**. Also verified
against the wider `tests/hermes_cli/` directory to confirm no unrelated
regressions were introduced (pre-existing failures in that run — npm
build, TUI gateway teardown, missing optional `acp` module — are
reproducible identically without this diff applied).

## Scope note

This PR is deliberately narrower than the full uncommitted diff that was
sitting in the live `/opt/hermes` container checkout (which also
contained a nonspawnable-assignee alert and a respawn-guard event-dedupe
fix, already shipped separately as #89973, and a dependency-block loop
backoff, already shipped as #89966). Those three mechanisms coexist with
this one in the same file without merge conflict (verified via a real
local three-way merge) but are independent fixes with their own test
coverage, submitted as separate reviewable units.