### PR TITLE
fix(desktop): wrap toast titles so long errors stay readable

### DIFF
--- a/apps/desktop/src/components/notifications.test.tsx
+++ b/apps/desktop/src/components/notifications.test.tsx
@@ -1,0 +1,50 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import { clearNotifications, notify } from '@/store/notifications'
+
+import { NotificationStack, toastTitleClassName } from './notifications'
+
+const LONG_TITLE = 'This turn is no longer in server history (it may have been compressed away).'
+const DETAIL = 'target user message is no longer in session history'
+
+describe('toast titles', () => {
+  beforeEach(() => {
+    clearNotifications()
+  })
+
+  afterEach(() => {
+    cleanup()
+    clearNotifications()
+  })
+
+  it('drops the one-line clamp so a long error title can wrap', () => {
+    const className = toastTitleClassName()
+
+    expect(className).toMatch(/\bline-clamp-none\b/)
+    expect(className).not.toMatch(/\bline-clamp-1\b/)
+    expect(className).toMatch(/\bwhitespace-normal\b/)
+    expect(className).toContain('max-h-[4.5em]')
+    expect(className).toMatch(/\boverflow-y-auto\b/)
+  })
+
+  it('renders the full title and body instead of truncating them', () => {
+    notify({ kind: 'error', title: LONG_TITLE, message: DETAIL })
+
+    render(
+      <I18nProvider configClient={null} initialLocale="en">
+        <NotificationStack />
+      </I18nProvider>
+    )
+
+    const title = screen.getByText(LONG_TITLE)
+
+    expect(title.textContent).toBe(LONG_TITLE)
+    expect(title.getAttribute('title')).toBe(LONG_TITLE)
+    expect(title.className).toMatch(/\bline-clamp-none\b/)
+    expect(title.className).not.toMatch(/\bline-clamp-1\b/)
+    expect(title.className).toMatch(/\boverflow-y-auto\b/)
+    expect(screen.getByText(DETAIL)).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/components/notifications.tsx
+++ b/apps/desktop/src/components/notifications.tsx
@@ -119,7 +119,7 @@ function TopCenterStack({
       aria-label={copy.region}
       className={cn(
         REGION_BASE,
-        'left-1/2 top-[calc(var(--titlebar-height,34px)+0.75rem)] w-[min(32rem,calc(100%-2rem))] -translate-x-1/2 flex-col'
+        'left-1/2 top-[calc(var(--titlebar-height,34px)+0.75rem)] w-[min(40rem,calc(100%-2rem))] -translate-x-1/2 flex-col'
       )}
       role="region"
     >
@@ -187,6 +187,13 @@ function renderMessage(message: string, accent?: string): ReactNode {
   )
 }
 
+// AlertTitle defaults to a single-line clamp. Toast errors are often a full
+// sentence, so the toast wraps — then caps height and scrolls instead of
+// growing down the chat or clipping with an ellipsis.
+export function toastTitleClassName() {
+  return 'col-start-auto line-clamp-none max-h-[4.5em] overflow-y-auto overscroll-contain whitespace-normal wrap-break-word'
+}
+
 function NotificationItem({ notification }: { notification: AppNotification }) {
   const styles = tone[notification.kind]
   const Icon = styles.icon
@@ -213,9 +220,13 @@ function NotificationItem({ notification }: { notification: AppNotification }) {
         <Icon className={styles.iconClass} style={iconStyle} />
       )}
       <div className="col-start-2 min-w-0">
-        {notification.title && <AlertTitle className="col-start-auto">{notification.title}</AlertTitle>}
+        {notification.title && (
+          <AlertTitle className={toastTitleClassName()} title={notification.title}>
+            {notification.title}
+          </AlertTitle>
+        )}
         <AlertDescription className="col-start-auto">
-          <p className="m-0">{renderMessage(notification.message, accent)}</p>
+          <p className="m-0 wrap-break-word">{renderMessage(notification.message, accent)}</p>
           {notification.meta && <p className="m-0 text-xs text-muted-foreground tabular-nums">{notification.meta}</p>}
           {hasDetail && <NotificationDetail detail={notification.detail || ''} />}
           {notification.action && (


### PR DESCRIPTION
## Summary
- Desktop error toasts used `AlertTitle`'s one-line clamp, so messages like "This turn is no longer in server history (it may have been compressed away)." were cut off with an ellipsis and could not be read.
- Toast titles now wrap onto more lines, the toast is a bit wider, and the full title is also available as a hover tooltip.
- Adds a focused UI test so the clamp cannot come back unnoticed.

## Test plan
- [ ] In Desktop, trigger a long error toast (edit/rewind a turn that has been compressed away, or any error whose title is longer than the toast width).
- [ ] Confirm the full title wraps onto extra lines instead of ending in `...`.
- [ ] Confirm the gray subtitle/detail line still shows underneath.
- [ ] From `apps/desktop`: `npx vitest run --project ui src/components/notifications.test.tsx`