### PR TITLE
fix(bedrock): sanitize tool names to the Converse pattern in specs and replayed history

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -485,6 +485,28 @@ def is_anthropic_bedrock_model(model_id: str) -> bool:
 # Message format conversion: OpenAI → Bedrock Converse
 # ---------------------------------------------------------------------------
 
+# Bedrock's Converse API validates toolUse.name / toolSpec.name against
+# ^[a-zA-Z0-9_-]{1,64}$ (ValidationException names the exact regex). Tool
+# names from MCP servers, plugins, or pet-mode aliases can carry dots,
+# slashes, or unicode, and one offending name in the conversation history
+# is replayed on EVERY subsequent request — wedging the session (#90008).
+_BEDROCK_TOOL_NAME_RE = re.compile(r"[^a-zA-Z0-9_]")
+
+
+def _sanitize_bedrock_tool_name(name: Any) -> str:
+    """Coerce a tool name into Bedrock's ``[a-zA-Z0-9_-]+`` pattern.
+
+    Non-conforming characters fold to ``_``; an empty result falls back to
+    ``tool``. The mapping is applied identically to the toolSpec definition
+    and to replayed toolUse history blocks, so the (possibly renamed) spec
+    the model sees matches the name its own earlier calls are recorded
+    under. toolResult blocks pair by toolUseId, not by name, so tool
+    results are unaffected by the rename.
+    """
+    cleaned = _BEDROCK_TOOL_NAME_RE.sub("_", str(name or ""))
+    return cleaned[:64] if cleaned else "tool"
+
+
 def convert_tools_to_converse(tools: List[Dict]) -> List[Dict]:
     """Convert OpenAI-format tool definitions to Bedrock Converse ``toolConfig``.
 
@@ -503,7 +525,7 @@ def convert_tools_to_converse(tools: List[Dict]) -> List[Dict]:
     result = []
     for t in tools:
         fn = t.get("function", {})
-        name = fn.get("name", "")
+        name = _sanitize_bedrock_tool_name(fn.get("name", ""))
         description = fn.get("description", "")
         parameters = fn.get("parameters", {"type": "object", "properties": {}})
         result.append({
@@ -680,7 +702,7 @@ def convert_messages_to_converse(
                 content_blocks.append({
                     "toolUse": {
                         "toolUseId": tc.get("id", ""),
-                        "name": fn.get("name", ""),
+                        "name": _sanitize_bedrock_tool_name(fn.get("name", "")),
                         "input": args_dict,
                     }
                 })

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -10,6 +10,7 @@ Covers:
 """
 
 import json
+import re
 from contextlib import contextmanager
 from types import ModuleType
 from unittest.mock import MagicMock, patch
@@ -182,6 +183,76 @@ class TestConvertMessagesToConverse:
         assert tool_use_blocks[0]["toolUse"]["name"] == "read_file"
         assert tool_use_blocks[0]["toolUse"]["toolUseId"] == "call_123"
         assert tool_use_blocks[0]["toolUse"]["input"] == {"path": "/tmp/test.txt"}
+
+
+class TestBedrockToolNameSanitization:
+    """toolSpec/toolUse names must satisfy Bedrock's [a-zA-Z0-9_-]+ pattern.
+
+    One offending name in the replayed history is validated on EVERY
+    subsequent ConverseStream request, wedging the session after a single
+    bad tool call (#90008)."""
+    def test_spec_name_with_dots_slashes_and_unicode_folds_to_underscores(self):
+        from agent.bedrock_adapter import convert_tools_to_converse
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "mcp.github.search_repos/v2·x",
+                "description": "d",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }]
+        spec = convert_tools_to_converse(tools)[0]["toolSpec"]
+        assert re.fullmatch(r"[a-zA-Z0-9_-]+", spec["name"]) is not None
+        assert spec["name"] == "mcp_github_search_repos_v2_x"
+
+    def test_spec_name_over_64_chars_is_truncated(self):
+        from agent.bedrock_adapter import convert_tools_to_converse
+        name = "a" * 80
+        spec = convert_tools_to_converse([{
+            "type": "function",
+            "function": {"name": name, "description": "", "parameters": {}},
+        }])[0]["toolSpec"]
+        assert len(spec["name"]) == 64
+
+    def test_spec_empty_name_falls_back(self):
+        from agent.bedrock_adapter import convert_tools_to_converse, _sanitize_bedrock_tool_name
+        assert _sanitize_bedrock_tool_name("") == "tool"
+        assert _sanitize_bedrock_tool_name(None) == "tool"
+        # A name made purely of illegal characters still yields a
+        # pattern-conforming (if opaque) name, never an empty one.
+        assert _sanitize_bedrock_tool_name("///") == "___"
+
+    def test_replayed_tool_use_history_is_sanitized_the_same_way(self):
+        """The recorded toolUse block that Wedges every later request must be
+        sanitized identically to the spec the model is offered."""
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [
+            {"role": "user", "content": "go"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "pet.display/info",
+                        "arguments": "{}",
+                    },
+                }],
+            },
+        ]
+        _system, msgs = convert_messages_to_converse(messages)
+        tool_use = next(
+            b["toolUse"] for m in msgs for b in m["content"] if "toolUse" in b
+        )
+        assert tool_use["name"] == "pet_display_info"
+        assert re.fullmatch(r"[a-zA-Z0-9_-]+", tool_use["name"]) is not None
+
+    def test_conforming_names_pass_through_unchanged(self):
+        from agent.bedrock_adapter import convert_tools_to_converse, _sanitize_bedrock_tool_name
+        assert _sanitize_bedrock_tool_name("read_file") == "read_file"
+        assert _sanitize_bedrock_tool_name("mcp__server__tool") == "mcp__server__tool"
+        assert convert_tools_to_converse([]) == []
 
     def test_tool_result_becomes_user_message(self):
         from agent.bedrock_adapter import convert_messages_to_converse


### PR DESCRIPTION
## What does this PR do?

Fixes #90008: after a single tool call whose name violates Bedrock's Converse pattern, every subsequent ConverseStream request in the session fails with a ValidationException — including a plain "hi" — because the offending `toolUse` block sits in the replayed history and is re-validated on every request.

Bedrock validates `toolSpec.name` / `toolUse.name` against `^[a-zA-Z0-9_-]{1,64}$`. Tool names sourced from MCP servers, plugins, or aliases can carry dots, slashes, or unicode (the report's flow hits it after a tool-search invocation). The adapter passed both sites through verbatim.

This adds `_sanitize_bedrock_tool_name()`: non-conforming characters fold to underscores, the result is truncated to 64, and an empty result falls back to `tool`. It is applied identically at **both** emission sites — the `toolSpec` definitions (`convert_tools_to_converse`) and the replayed `toolUse` history blocks (`convert_messages_to_converse`) — so the name the model's earlier calls are recorded under matches the spec it is offered. `toolResult` blocks pair by `toolUseId`, not by name, so tool results are unaffected by the rename.

## Related Issue

Fixes #90008

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/bedrock_adapter.py`: new `_BEDROCK_TOOL_NAME_RE` + `_sanitize_bedrock_tool_name()`; applied at the toolSpec name and the replayed toolUse name.

## How to Test

1. `pytest tests/agent/test_bedrock_adapter.py -q` — 71 passed (5 new tests in `TestBedrockToolNameSanitization`).
2. Fail-on-main verified: with the source stashed, all 5 new tests fail on the unmodified tree.
3. Full Bedrock suites (`test_bedrock_adapter`, `test_bedrock_empty_text_blocks`, `test_bedrock_1m_context`): 76 passed.
4. Observed result: a tool named `mcp.github.search_repos/v2·x` becomes `mcp_github_search_repos_v2_x` in both the spec and the replayed history; conforming names (including `mcp__server__tool`) pass through unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
