### PR TITLE
fix(gitlock): resolve the tasklist codec with locale.getencoding()

### DIFF
--- a/hermes_cli/gitlock.py
+++ b/hermes_cli/gitlock.py
@@ -22,6 +22,7 @@ This module provides two small, defensive helpers used by the update paths:
 
 from __future__ import annotations
 
+import locale
 import logging
 import os
 import subprocess
@@ -45,6 +46,23 @@ STALE_LOCK_MIN_AGE_SECONDS = 10 * 60
 LOCK_NAMES = ("shallow.lock", "index.lock", "HEAD.lock", "MERGE_HEAD.lock")
 
 
+def _tasklist_encoding() -> str:
+    """Codec for decoding ``tasklist.exe`` output on Windows.
+
+    ``tasklist`` emits the console/ANSI code page, not UTF-8 -- CP932 on a
+    Japanese host. ``locale.getpreferredencoding(False)`` is the wrong probe
+    here because it honours Python UTF-8 Mode, which Hermes turns on for its
+    own processes, so it reports ``utf-8`` while the child is still emitting
+    CP932. ``locale.getencoding()`` ignores UTF-8 Mode and returns the real
+    code page. Same resolution as ``_schtasks_encoding()`` in
+    :mod:`hermes_cli.gateway_windows` (#89907).
+    """
+    try:
+        return locale.getencoding() or "utf-8"
+    except Exception:
+        return "utf-8"
+
+
 def _git_proc_running() -> bool:
     """True when a ``git`` process is currently running.
 
@@ -54,13 +72,16 @@ def _git_proc_running() -> bool:
     """
     try:
         if os.name == "nt":
-            out = subprocess.run(
+            probe = subprocess.run(
                 ["tasklist", "/FI", "IMAGENAME eq git.exe", "/FO", "CSV"],
-                capture_output=True, text=True, timeout=10,
-            ).stdout.lower()
+                capture_output=True, timeout=10,
+                text=True, encoding=_tasklist_encoding(), errors="replace",
+            )
+            out = (probe.stdout or "").lower()
             return "git.exe" in out
         out = subprocess.run(
-            ["pgrep", "-x", "git"], capture_output=True, text=True, timeout=10,
+            ["pgrep", "-x", "git"], capture_output=True, timeout=10,
+            text=True, encoding="utf-8", errors="replace",
         )
         return out.returncode == 0
     except Exception:
@@ -119,7 +140,8 @@ def is_ancestor_of_head(repo_root: Path, rev: str) -> bool:
         result = subprocess.run(
             ["git", "merge-base", "--is-ancestor", rev, "HEAD"],
             cwd=str(repo_root),
-            capture_output=True, text=True, timeout=10,
+            capture_output=True, timeout=10,
+            text=True, encoding="utf-8", errors="replace",
         )
         return result.returncode == 0
     except Exception:

--- a/tests/test_gitlock.py
+++ b/tests/test_gitlock.py
@@ -137,3 +137,71 @@ def test_is_ancestor_false_for_unknown_rev(repo: Path) -> None:
 
 def test_is_ancestor_false_for_nonexistent_repo(tmp_path: Path) -> None:
     assert is_ancestor_of_head(tmp_path / "missing", "HEAD") is False
+
+
+def test_windows_probe_uses_the_ansi_codec_not_utf8_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The tasklist probe must resolve its codec with ``locale.getencoding()``.
+
+    ``tasklist`` emits the console/ANSI code page.  Under Python UTF-8 Mode --
+    which Hermes turns on for its own processes -- ``getpreferredencoding(False)``
+    reports ``utf-8``, so a bare ``text=True`` decodes CP932 bytes as UTF-8.
+    That failure lands in ``subprocess``' reader thread, not at the call site:
+    ``run()`` returns normally with ``stdout`` set to ``None``, ``.lower()``
+    raises ``AttributeError``, the blanket ``except`` swallows it, and the probe
+    answers "no git running" -- silently disabling the guard that stops
+    :func:`clear_stale_git_locks` from yanking a lock a live fetch is holding.
+    """
+    import hermes_cli.gitlock as gitlock
+
+    captured: dict = {}
+    payload = '"\u30a4\u30e1\u30fc\u30b8\u540d","PID"\n"git.exe","4321"\n'.encode("cp932")
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        captured.update(kwargs)
+        codec = kwargs.get("encoding")
+        text = payload.decode(codec, kwargs.get("errors", "replace")) if codec else None
+        return subprocess.CompletedProcess(cmd, 0, stdout=text, stderr="")
+
+    monkeypatch.setattr(gitlock.subprocess, "run", fake_run)
+    monkeypatch.setattr(gitlock.locale, "getencoding", lambda: "cp932")
+    monkeypatch.setattr(gitlock.locale, "getpreferredencoding", lambda *a, **k: "utf-8")
+
+    # ``os.name`` is restored before the assertions run: leaving it flipped
+    # would make pytest build a path object for the wrong OS while rendering
+    # a failure, turning a readable assertion error into an INTERNALERROR.
+    with monkeypatch.context() as ctx:
+        ctx.setattr(gitlock.os, "name", "nt")
+        running = gitlock._git_proc_running()
+
+    assert running is True
+    assert captured["cmd"][0] == "tasklist"
+    assert captured["encoding"] == "cp932"
+    assert captured["errors"] == "replace"
+
+
+def test_posix_probe_passes_an_explicit_codec(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The pgrep branch must not fall back to the locale default either."""
+    import hermes_cli.gitlock as gitlock
+
+    captured: dict = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="")
+
+    monkeypatch.setattr(gitlock.subprocess, "run", fake_run)
+
+    with monkeypatch.context() as ctx:
+        ctx.setattr(gitlock.os, "name", "posix")
+        running = gitlock._git_proc_running()
+
+    assert running is False
+    assert captured["cmd"][0] == "pgrep"
+    assert captured["encoding"] == "utf-8"
+    assert captured["errors"] == "replace"


### PR DESCRIPTION
## What does this PR do?

`_git_proc_running()` runs `tasklist` with `text=True` and no `encoding=`, so the child's output is decoded with `locale.getpreferredencoding(False)`. Hermes starts its own processes in Python UTF-8 Mode, and under UTF-8 Mode that call reports `utf-8` while `tasklist` is still emitting the ANSI code page.

The decode then fails inside `subprocess`' reader thread rather than at the call site: `run()` returns normally with `stdout` set to `None`, `.stdout.lower()` raises `AttributeError`, the blanket `except Exception` catches it, logs at debug level, and returns `False`.

`False` means "no git process is running", so `clear_stale_git_locks()` proceeds to the unlink loop. The function's own docstring states the opposite intent:

> The conservative answer on any platform we can't probe: if we can't tell, treat a lock as possibly-live and don't remove it. This is the safety check that stops us from yanking a lock a real fetch is holding.

On a CP932 host the guard is therefore dead in the always-permissive direction, and silently -- nothing above debug level is emitted. Only the 10-minute age check still applies.

`scripts/check-windows-footguns.py` does not flag this. Its `text=True` rule requires `_is_likely_subprocess_call(line)`, which looks for `subprocess.run` on the *same* line; here the call opener is on line 57 and `text=True` on line 59. That is the documented "acceptable false negative" for a line-based scanner -- this is one instance that escaped through it.

**The fix** resolves the codec with `locale.getencoding()`, which ignores UTF-8 Mode and returns the real ANSI code page -- the same resolution `_schtasks_encoding()` uses after #89907. `pgrep` and the `git merge-base` probe get an explicit `encoding="utf-8", errors="replace"` for the same reason. `text=True` and `encoding=` are kept on one line so the footgun checker can see them together.

**One thing I did not change.** `except Exception: ... return False` sends a probe failure toward *removing* locks, which reads as the inverse of the docstring's stated intent. Flipping it to `True` would change behaviour on every platform (a host without `pgrep` would stop self-healing entirely), so it seemed wrong to fold into this PR. Happy to send it as a follow-up if you want it changed.



## Related Issue

No separate issue -- reporting it here with the measurement rather than filing a duplicate-shaped issue first. Same root cause as #89878 and the same resolution as #89907, but a different call site that neither touches.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gitlock.py` -- added `_tasklist_encoding()`, which resolves the console codec with `locale.getencoding()` and falls back to `utf-8`.
- `hermes_cli/gitlock.py` -- `_git_proc_running()` now passes `encoding=_tasklist_encoding(), errors="replace"` to the `tasklist` call, and reads `(probe.stdout or "")`.
- `hermes_cli/gitlock.py` -- the `pgrep` branch and `is_ancestor_of_head()`'s `git merge-base` call get `encoding="utf-8", errors="replace"`.
- `tests/test_gitlock.py` -- two tests pinning that each branch passes an explicit codec, and that the Windows one comes from `getencoding()` rather than `getpreferredencoding()`.

## How to Test

1. On a CP932 host (ja-JP Windows, `chcp` reports 932), reproduce the decode failure directly:

```
> python -c "import subprocess; r=subprocess.run(['tasklist','/FI','IMAGENAME eq nosuchprocess.exe','/FO','CSV'],capture_output=True,text=True,timeout=10); print(repr(r.stdout))"
'\u60c5\u5831: \u6307\u5b9a\u3055\u308c\u305f\u6761\u4ef6\u306b\u4e00\u81f4\u3059\u308b\u30bf\u30b9\u30af\u306f\u5b9f\u884c\u3055\u308c\u3066\u3044\u307e\u305b\u3093\u3002\n'

> $env:PYTHONUTF8=1
> python -c "...same command..."
Exception in thread Thread-1 (_readerthread):
  File "...\subprocess.py", line 1599, in _readerthread
    buffer.append(fh.read())
  File "<frozen codecs>", line 322, in decode
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8f in position 0: invalid start byte
None
```

The trailing `None` is the failure this PR fixes -- that is what reaches `.stdout.lower()`.

2. `scripts/run_tests.sh tests/test_gitlock.py -q` -- 12 pass.

3. To confirm the two new tests are not vacuous, run them against the pre-patch source: they fail with `KeyError: 'encoding'` (2 failed / 10 passed). `os.name` is patched inside `monkeypatch.context()` so it is restored before the assertions run -- left flipped, a failing assertion makes pytest build a path object for the wrong OS and the run dies with `INTERNALERROR` instead of a readable failure.

Note on the checklist below: I ran `tests/test_gitlock.py` and the pre-patch comparison, not the full `pytest tests/ -q`, so I left that box unchecked rather than claiming it.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, ja-JP (ACP=932), Python 3.12.10

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

