### PR TITLE
fix(dashboard): don't fail /api/files listing on a dangling symlink

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2560,12 +2560,19 @@ async def list_managed_files(request: Request, path: Optional[str] = None):
         raise HTTPException(status_code=400, detail="Path is not a directory")
 
     try:
+        entries = []
         with os.scandir(target) as scan:
-            entries = [
-                _managed_file_entry(policy, Path(entry.path))
-                for entry in scan
-                if not _is_sensitive_path(Path(entry.path))
-            ]
+            for entry in scan:
+                entry_path = Path(entry.path)
+                if _is_sensitive_path(entry_path):
+                    continue
+                try:
+                    entries.append(_managed_file_entry(policy, entry_path))
+                except HTTPException:
+                    # A single unstat-able entry (typically a dangling symlink,
+                    # e.g. ~/cuttlefish_runtime after its /var/tmp target is
+                    # wiped) must not fail the whole directory listing.
+                    continue
     except PermissionError:
         raise HTTPException(status_code=403, detail="Directory is not readable")
     except OSError as exc:


### PR DESCRIPTION
## Problem

The dashboard Files page returns **500 `Could not stat path: [Errno 2] ...`** for an entire directory if it contains even one entry whose `stat()`/`resolve()` fails — most commonly a dangling symlink.

Real-world trigger: Cuttlefish (Android emulator) leaves `~/cuttlefish_runtime -> /var/tmp/cvd/<uid>/<ts>/...` symlinks in $HOME. `/var/tmp` is wiped on reboot/cleanup, the links dangle, and the Files page can no longer list the home directory at all.

## Fix

In `list_managed_files`, wrap the per-entry `_managed_file_entry` call and skip entries that raise — one broken symlink no longer takes down the whole listing. Single-file endpoints keep their existing error behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)