### PR TITLE
fix(image): keep Grok Imagine upscale opt-in

### DIFF
--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -685,7 +685,8 @@ FAL_MODELS: Dict[str, Dict[str, Any]] = {
             "prompt", "aspect_ratio", "num_images", "output_format",
             "resolution", "quality", "sync_mode",
         },
-        "upscale": True,   # 1k native is sub-2MP
+        # Upscaling is opt-in only; default-on enhancement degrades text/CJK/faces.
+        "upscale": False,
         # Edit endpoint takes `image_urls` (max 3) + the same knobs;
         # aspect_ratio defaults to "auto" (follows the first input image),
         # so we don't send it on edits.


### PR DESCRIPTION
## Summary
- turn off the Grok Imagine 2.0 FAL catalog default upscale flag
- keep upscaling opt-in only, matching the August 2026 catalog invariant

## Tests
- PYTHONPATH=$PWD /root/.hermes/hermes-agent/venv/bin/ruff check tools/image_generation_tool.py tests/tools/test_image_generation.py
- PYTHONPATH=$PWD /root/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_image_generation.py -q

## Context
This fixes the current mainline CI blocker reproduced on origin/main:
`tests/tools/test_image_generation.py::TestFalCatalog::test_upscale_defaults_are_all_off`.