### PR TITLE
fix(tui): retry kanban notifications when dispatch is rejected

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6139,6 +6139,115 @@ def test_notification_poller_delivers_owned_events(
             process_registry.completion_queue.get_nowait()
 
 
+def _delegation_delivery_row(home, delegation_id):
+    """Read one delegation's delivery columns out of *home*'s state.db."""
+    token = set_hermes_home_override(home)
+    try:
+        with ad._DB_LOCK, ad._transaction() as conn:
+            return conn.execute(
+                """SELECT delivery_state, delivery_attempts, delivered_at
+                   FROM async_delegations WHERE delegation_id=?""",
+                (delegation_id,),
+            ).fetchone()
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_notification_poller_thread_acks_routed_profile_db(monkeypatch, tmp_path):
+    """The real poller thread must claim and ack in the session's profile store.
+
+    The HERMES_HOME override is a ContextVar, so a bare poller thread resolves
+    async_delegation._db_path() against the LAUNCH profile — the claim finds no
+    row there, returns None, and the completion is silently never delivered.
+    """
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    launch_home = tmp_path / "launch"
+    profile_home = tmp_path / "profiles" / "routed"
+    launch_home.mkdir()
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(launch_home))
+
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg_profile_ack",
+        "session_key": "session-a",
+        "origin_ui_session_id": "sid-profile",
+        "origin_session_id": "",
+        "status": "success",
+        "summary": "done",
+    }
+    now = time.time()
+    token = set_hermes_home_override(profile_home)
+    try:
+        with ad._DB_LOCK, ad._transaction() as conn:
+            conn.execute(
+                """INSERT INTO async_delegations
+                   (delegation_id, origin_session, origin_ui_session_id, state,
+                    dispatched_at, completed_at, updated_at, event_json,
+                    delivery_state, delivery_attempts)
+                   VALUES (?, ?, ?, 'success', ?, ?, ?, ?, 'pending', 0)""",
+                (
+                    event["delegation_id"],
+                    event["session_key"],
+                    event["origin_ui_session_id"],
+                    now,
+                    now,
+                    now,
+                    json.dumps(event),
+                ),
+            )
+    finally:
+        reset_hermes_home_override(token)
+
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue.put(event)
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+    turns = []
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda _rid, _sid, _session, text, **kwargs: turns.append((text, kwargs)),
+    )
+    session = _session(
+        session_key="session-a",
+        profile_home=str(profile_home),
+    )
+    server._sessions["sid-profile"] = session
+
+    # Spawn through the real entry point so the registry/reap bookkeeping and
+    # the thread's home binding are both exercised as production wires them.
+    stop = server._start_notification_poller("sid-profile", session)
+    worker = server._notification_pollers[-1][1]
+    assert worker.name == "tui-notif-poller-sid-profile"
+    try:
+        deadline = time.time() + 5
+        row = _delegation_delivery_row(profile_home, event["delegation_id"])
+        while row[0] != "delivered" and time.time() < deadline:
+            time.sleep(0.01)
+            row = _delegation_delivery_row(profile_home, event["delegation_id"])
+
+        assert row[0] == "delivered"
+        assert row[1] == 1
+        assert row[2] is not None
+        # The launch profile must be untouched: a claim that landed there is
+        # the bug, and it would leave the session's own row pending forever.
+        assert _delegation_delivery_row(launch_home, event["delegation_id"]) is None
+        assert len(turns) == 1
+        assert turns[0][1]["display_kind"] == "async_delegation_complete"
+        assert isolated_queue.empty()
+    finally:
+        stop.set()
+        worker.join(timeout=2)
+        assert not worker.is_alive()
+        server._sessions.pop("sid-profile", None)
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
+
+
 def _configure_immediate_prompt_run(
     monkeypatch, tmp_path, *, immediate_threads=True
 ):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5963,6 +5963,76 @@ def test_completion_ownership_lineage_lookup_failure_fails_closed(monkeypatch):
     assert isolated_queue.get_nowait() is event
 
 
+@pytest.mark.parametrize("drain_only", [False, True])
+def test_notification_poller_releases_claim_when_dispatch_is_rejected(
+    monkeypatch, drain_only
+):
+    """A rejected turn must stay pending instead of being acknowledged.
+
+    ``_run_prompt_submit`` returns False without starting a turn when the
+    session is closing or has been re-registered. Calling
+    ``complete_event_delivery`` anyway consumes the only copy of the event, so
+    the notification is lost. Both the live loop and the shutdown drain must
+    release the claim and hand the event back to the queue instead.
+    """
+    import queue as _queue_mod
+
+    from tools import async_delegation
+    from tools.process_registry import process_registry
+
+    session = _session(session_key="closing-notification-owner")
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "delegation-close-race",
+        "session_key": "closing-notification-owner",
+        "goal": "return the completed result",
+        "summary": "done",
+        "status": "completed",
+    }
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue.put(event)
+    completed = []
+    released = []
+
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_run_prompt_submit", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(
+        async_delegation,
+        "claim_event_delivery",
+        lambda _event, _consumer: "close-race-claim",
+    )
+    monkeypatch.setattr(
+        async_delegation,
+        "complete_event_delivery",
+        lambda claimed_event, claim: completed.append((claimed_event, claim)),
+    )
+    monkeypatch.setattr(
+        async_delegation,
+        "release_event_delivery",
+        lambda claimed_event, claim: released.append((claimed_event, claim)),
+    )
+    server._sessions["sid-closing-notification"] = session
+    stop = threading.Event() if drain_only else _StopAfterOneNotificationPoll()
+    if drain_only:
+        stop.set()
+
+    try:
+        server._notification_poller_loop(stop, "sid-closing-notification", session)
+
+        assert completed == []
+        assert released == [(event, "close-race-claim")]
+        assert session["running"] is False
+        # Handed back to the queue exactly once, for a later delivery.
+        assert isolated_queue.qsize() == 1
+        assert isolated_queue.get_nowait() is event
+    finally:
+        server._sessions.pop("sid-closing-notification", None)
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
+
+
 @pytest.mark.parametrize(
     "routing",
     [

--- a/tests/tui_gateway/test_kanban_notify_poller.py
+++ b/tests/tui_gateway/test_kanban_notify_poller.py
@@ -360,3 +360,60 @@ class TestNotificationPollerLoopKanbanWiring:
         assert any(tid in text for text in submits), submits
         assert session["_kanban_pending"] == []
         assert session["running"] is True
+
+    def test_rejected_dispatch_keeps_batch_for_retry(self, monkeypatch):
+        """A rejected turn must not consume the batch.
+
+        ``_collect_kanban_notifications`` advances the subscription cursor when
+        it claims the events, so once they are buffered the batch is the only
+        remaining copy — the DB will never hand them out again. When
+        ``_run_prompt_submit`` returns False (session closing / queued-prompt
+        generation mismatch) without starting a turn, dropping the batch loses
+        the notification permanently.
+        """
+        import threading
+        import tui_gateway.server as server
+
+        tid = _create_subscribed_task()
+        _complete(tid, summary="rejected then retried")
+        session = self._poller_session(running=False)
+
+        submits: list = []
+        rejected = threading.Event()
+
+        def _submit(rid, sid, sess, text):
+            submits.append(text)
+            if len(submits) == 1:
+                # First dispatch is refused before any turn starts.
+                rejected.set()
+                return False
+            return True
+
+        monkeypatch.setattr(server, "_KANBAN_POLL_SECONDS", 0.01)
+        monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
+        monkeypatch.setattr(server, "_run_prompt_submit", _submit)
+
+        stop = threading.Event()
+        thread = threading.Thread(
+            target=server._notification_poller_loop,
+            args=(stop, "sid-kanban-reject", session),
+            daemon=True,
+        )
+        thread.start()
+        try:
+            assert self._wait_for(rejected.is_set), "dispatch was never attempted"
+            # Retained for retry, and the retry actually happens.
+            assert self._wait_for(lambda: len(submits) >= 2), (
+                f"rejected batch was never retried (pending="
+                f"{session.get('_kanban_pending')!r})"
+            )
+        finally:
+            stop.set()
+            thread.join(timeout=5)
+
+        # The retry carries the same notification — not a truncated or
+        # duplicated one — and the accepted dispatch clears the buffer.
+        assert tid in submits[0]
+        assert submits[1] == submits[0]
+        assert submits.count(submits[0]) == 2, submits
+        assert session["_kanban_pending"] == []

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -604,6 +604,11 @@ class ComputeHost:
                     cwd=str(frame.get("cwd") or "") or None,
                     session_db=session_db,
                     source=frame.get("source"),
+                    # _init_session starts the notification poller, which binds
+                    # its HERMES_HOME from the session's profile_home. Set it
+                    # here rather than only on the assignment below, which lands
+                    # after that thread is already running.
+                    profile_home=profile_home or None,
                 )
             finally:
                 reset_transport(token)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10023,6 +10023,10 @@ def _notification_poller_loop(
     from tools.process_registry import process_registry, format_process_notification
 
     _emitted = set()  # dedup re-queued events so same completion isn't emitted 50 times while session is busy
+    # Events dequeued here but not actually dispatched. Handed back to the
+    # shared queue when this poller exits, so a rejected dispatch (below) never
+    # loses the notification. Also used by the shutdown drain.
+    deferred: list = []
     _last_kanban_poll = 0.0
     _last_loop_poll = 0.0
     while not stop_event.is_set() and not session.get("_finalized"):
@@ -10068,16 +10072,33 @@ def _notification_poller_loop(
                         session["_kanban_pending"] = []
                 if _batch:
                     rid = f"__notif__{int(time.time() * 1000)}"
+                    # ``claim_unseen_events_for_sub`` advanced the subscription
+                    # cursor when these events were collected, so the buffer is
+                    # the only remaining copy. _run_prompt_submit returns False
+                    # without starting a turn when the session is closing or a
+                    # queued-prompt generation lost the race — dropping the
+                    # batch there loses the notification permanently. Put it
+                    # back (ahead of anything collected since, preserving
+                    # order) so the next poll retries it.
+                    _restore_batch = False
                     try:
                         _emit("message.start", sid)
-                        _run_prompt_submit(rid, sid, session, "\n".join(_batch))
+                        _restore_batch = (
+                            _run_prompt_submit(rid, sid, session, "\n".join(_batch))
+                            is False
+                        )
                     except Exception as exc:
                         print(
                             f"[tui_gateway] kanban notification dispatch failed: "
                             f"{type(exc).__name__}: {exc}",
                             file=sys.stderr,
                         )
+                        _restore_batch = True
+                    if _restore_batch:
                         with session["history_lock"]:
+                            session["_kanban_pending"] = _batch + list(
+                                session.get("_kanban_pending") or []
+                            )
                             session["running"] = False
         try:
             evt = process_registry.completion_queue.get(timeout=0.5)
@@ -10157,7 +10178,7 @@ def _notification_poller_loop(
         try:
             _emit("message.start", sid)
             if evt.get("type") == "async_delegation":
-                _run_prompt_submit(
+                _dispatch_started = _run_prompt_submit(
                     rid,
                     sid,
                     session,
@@ -10166,7 +10187,16 @@ def _notification_poller_loop(
                     display_metadata=_async_delegation_display_metadata(evt),
                 )
             else:
-                _run_prompt_submit(rid, sid, session, text)
+                _dispatch_started = _run_prompt_submit(rid, sid, session, text)
+            if _dispatch_started is False:
+                # No turn started (session closing or re-registered), so the
+                # event was never delivered. Acknowledging it here would
+                # consume the only copy — release the claim and hand it back.
+                release_event_delivery(evt, _claim)
+                deferred.append(evt)
+                with session["history_lock"]:
+                    session["running"] = False
+                break
             complete_event_delivery(evt, _claim)
         except Exception as exc:
             release_event_delivery(evt, _claim)
@@ -10182,7 +10212,6 @@ def _notification_poller_loop(
     # before exiting so nothing is lost on shutdown). Events owned by other
     # live sessions are set aside and re-queued so their poller still sees them.
     # Orphaned events (owner gone) are dropped — same guard as the main loop.
-    deferred: list = []
     while not process_registry.completion_queue.empty():
         try:
             evt = process_registry.completion_queue.get_nowait()
@@ -10235,7 +10264,7 @@ def _notification_poller_loop(
         try:
             _emit("message.start", sid)
             if evt.get("type") == "async_delegation":
-                _run_prompt_submit(
+                _dispatch_started = _run_prompt_submit(
                     rid,
                     sid,
                     session,
@@ -10244,7 +10273,16 @@ def _notification_poller_loop(
                     display_metadata=_async_delegation_display_metadata(evt),
                 )
             else:
-                _run_prompt_submit(rid, sid, session, text)
+                _dispatch_started = _run_prompt_submit(rid, sid, session, text)
+            if _dispatch_started is False:
+                # Same rule as the live loop: an unstarted turn means the
+                # event is still undelivered, so defer it rather than
+                # acknowledge it away on the way out.
+                release_event_delivery(evt, _claim)
+                deferred.append(evt)
+                with session["history_lock"]:
+                    session["running"] = False
+                continue
             complete_event_delivery(evt, _claim)
         except Exception as exc:
             release_event_delivery(evt, _claim)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10361,13 +10361,40 @@ def _wire_desktop_ui() -> None:
 _notification_pollers: list = []
 
 
+def _run_notification_poller_in_session_home(
+    stop_event: threading.Event, sid: str, session: dict
+) -> None:
+    """Run the poller bound to the profile that owns the session's durable state.
+
+    The poller claims and acknowledges delegation deliveries through
+    tools.async_delegation, whose _db_path() resolves get_hermes_home() — and
+    the HERMES_HOME override is a ContextVar, which a bare thread does not
+    inherit. Without this the poller marks events delivered in the LAUNCH
+    profile's state.db while the rows it is claiming live in the session's,
+    so a global-remote session re-delivers completions forever.
+
+    Anchored on _session_home(session) rather than on a snapshot of the
+    spawning thread's context (the propagate_context_to_thread idiom the
+    async-delegation worker uses for the same class of bug) because the spawn
+    sites do not all carry the session's override: compute_host resets it in
+    the finally that precedes its _init_session call, so a snapshot taken
+    there would capture the launch profile and reproduce the bug. The session
+    dict is authoritative on every path; read it here.
+    """
+    home_token = set_hermes_home_override(_session_home(session))
+    try:
+        _notification_poller_loop(stop_event, sid, session)
+    finally:
+        reset_hermes_home_override(home_token)
+
+
 def _start_notification_poller(sid: str, session: dict) -> threading.Event:
     """Start the background notification poller for a TUI session."""
     _wire_agent_terminal_output()
     _wire_desktop_ui()
     stop = threading.Event()
     t = threading.Thread(
-        target=_notification_poller_loop,
+        target=_run_notification_poller_in_session_home,
         args=(stop, sid, session),
         daemon=True,
         # Stable, greppable name for debuggers and test teardowns.


### PR DESCRIPTION
## What does this PR do?

Kanban notifications can be **permanently lost**. `claim_unseen_events_for_sub` advances `last_event_id` at claim time inside the write transaction; the poller then pops the batch into memory and calls `_run_prompt_submit(...)` while **ignoring its bool return**. When dispatch is rejected — the session is `_closing`, or the queued-prompt generation doesn't match — the batch is dropped and the cursor has already moved, so nothing can ever redeliver it. The completion-queue sites have the same shape: they call `complete_event_delivery` whether or not dispatch actually started.

This honors the return value: a rejected dispatch restores the batch for the next poll, and completion is only recorded when the turn actually started.

## Related Issue

No open issue — found while working on the notification poller.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` — restore `_kanban_pending` on a rejected/failed kanban dispatch (and on the exception path); guard both completion-queue sites on whether dispatch started. ~38 net production lines.
- Tests in `tests/test_tui_gateway_server.py` and `tests/tui_gateway/test_kanban_notify_poller.py`.

The rejection check is `is False` rather than truthiness, deliberately: an existing mock returns `None`, and retrying on an unknown outcome would risk duplicate delivery. The success path asserts no duplicate submit.

## How to Test

```text
bash scripts/run_tests.sh tests/test_tui_gateway_server.py tests/tui_gateway/test_kanban_notify_poller.py -q
```
Fail-before (production change reverted, tests applied): **3 failed** — `AssertionError: rejected batch was never retried (pending=[])`, and `complete_event_delivery` firing on a turn that never started. Pass-after: **603 passed, 0 failed**. Adjacent delegation/notify suites: 138 passed.

## Two things I deliberately left out — say the word and I'll add them

1. **A third same-class site**: the post-turn completion drain inside `_run_prompt_submit` (around `server.py:11566`) ignores the same bool. It's ~1300 lines from the poller and felt like separate scope, but it is the same bug — happy to fold it in here or send it separately, whichever you prefer.
2. **Durable claims**: this fixes loss from *rejected dispatch*, not from process death. If the poller dies between the cursor claim and a successful dispatch, the in-memory batch still evaporates. Covering that needs a durable claim/lease with a pending-event record — a much larger change, and I'd rather land this small fix first than bundle a subsystem.

## Stacking

Built on #78500 (poller profile-scoping) so the poller stays profile-home-scoped. Take that one first, or tell me and I'll rebase this onto plain `main`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched existing PRs
- [x] Only changes related to this fix
- [x] Ran the affected suites
- [x] Added tests (with a fail-before receipt)
- [x] Tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] Docs — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform — N/A
- [x] Tool descriptions/schemas — N/A
