### PR TITLE
fix(image_gen): default Grok Imagine Image 2.0 upscale off

### DIFF
--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -685,7 +685,10 @@ FAL_MODELS: Dict[str, Dict[str, Any]] = {
             "prompt", "aspect_ratio", "num_images", "output_format",
             "resolution", "quality", "sync_mode",
         },
-        "upscale": False,  # opt-in only; default-on upscale degrades text/CJK/faces
+        # Opt-in only (policy: default-on upscaling was disabled everywhere
+        # Aug 2026; the upscaler is a creative enhancer that can alter fine
+        # detail). 1k native is sub-2MP — pass upscale=true when needed.
+        "upscale": False,
         # Edit endpoint takes `image_urls` (max 3) + the same knobs;
         # aspect_ratio defaults to "auto" (follows the first input image),
         # so we don't send it on edits.

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -685,7 +685,7 @@ FAL_MODELS: Dict[str, Dict[str, Any]] = {
             "prompt", "aspect_ratio", "num_images", "output_format",
             "resolution", "quality", "sync_mode",
         },
-        "upscale": True,   # 1k native is sub-2MP
+        "upscale": False,  # opt-in only; default-on upscale degrades text/CJK/faces
         # Edit endpoint takes `image_urls` (max 3) + the same knobs;
         # aspect_ratio defaults to "auto" (follows the first input image),
         # so we don't send it on edits.


### PR DESCRIPTION
## Summary
- Fixes #90013: `main` fails `test_upscale_defaults_are_all_off` because the Grok Imagine Image 2.0 FAL catalog entry defaults `upscale` to `True`.
- That entry landed after the opt-in-only sweep. Default-on upscaling is the quality footgun the catalog guard exists to prevent (text, CJK, faces). Callers can still pass `upscale=true` per request.
