### PR TITLE
fix(timeouts): add GLM-5 family to reasoning stale-timeout floor (#89241)

### DIFF
--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -28,6 +28,15 @@ _REASONING_STALE_TIMEOUT_FLOORS: dict[int, tuple[str, ...]] = {
         # Mythos-class named models (claude-fable-5): 1M ctx + 128K output, a heavier thinking
         # phase than the numbered line — otherwise the stale detector trips the circuit breaker.
         "claude-fable",
+        # Z.AI GLM-5 family: always-thinking on the Coding endpoint
+        # (#89241, #85904) - the thinking toggle is silently ignored, so
+        # the pre-first-token phase routinely exceeds the 90s non-stream
+        # stale default on mid-size contexts (24 kills/day reported).
+        # The family slug covers glm-5.2 / glm-5.3 via the separator
+        # right-anchor, including 5.2 requests rerouted to the 5.3
+        # backend; over-match is accepted as a patience ceiling (the
+        # table already accepts this for qwen3).
+        "glm-5",
     ),
     300: (
         "nemotron-3-nano", "nemotron-3.5-lightning", "qwq-32b", "o3-mini", "o4-mini",

--- a/tests/agent/test_reasoning_stale_timeout_floor.py
+++ b/tests/agent/test_reasoning_stale_timeout_floor.py
@@ -89,6 +89,15 @@ import pytest
     ("x-ai/grok-4.5", 300.0),
     ("x-ai/grok-4.6", 300.0),
     ("x-ai/grok-4-fast-non-reasoning", 180.0),
+    # Z.AI GLM-5 family: always-thinking on the Coding endpoint
+    # (#89241, #85904).  glm-5-turbo matches the family prefix by
+    # design (separator right-anchor); that over-match is accepted
+    # as a patience ceiling, same trade-off as qwen3.
+    ("glm-5", 600.0),
+    ("glm-5.2", 600.0),
+    ("glm-5.3", 600.0),
+    ("zai/glm-5.3", 600.0),
+    ("glm-5-turbo", 600.0),
     # Thinking Machines Inkling — family entry covers -small and the
     # OpenRouter :free / :batch SKU suffixes (":" is a slug separator
     # in the right anchor, same as "-").
@@ -103,6 +112,19 @@ def test_reasoning_stale_timeout_floor_positive_cases(model, expected):
         f"{expected}; bare substrings and shared prefixes must not "
         f"over-match community derivatives."
     )
+
+
+@pytest.mark.parametrize("model", [
+    "glam-5",
+    "aglm-5",
+    "glm",
+    "glm-50",
+    "glm-4.5",
+    "glm-4.71",
+])
+def test_reasoning_stale_timeout_floor_negative_cases(model):
+    from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+    assert get_reasoning_stale_timeout_floor(model) is None
 
 
 
@@ -161,6 +183,39 @@ def test_non_reasoning_model_keeps_default(monkeypatch, tmp_path):
     base, implicit = agent._resolved_api_call_stale_timeout_base()
     assert base == 90.0
     assert implicit is True
+
+
+def test_glm5_non_stream_stale_timeout_floor(monkeypatch, tmp_path):
+    """zai/glm-5.2 (the requested, pre-reroute id) gets the 600s floor
+    in the non-stream resolver; a non-reasoning control keeps 90s."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    monkeypatch.delenv("HERMES_API_CALL_STALE_TIMEOUT", raising=False)
+    _write_config(tmp_path, "")
+
+    # No provider config, no env var -> floor decides (issue #89241).
+    import run_agent
+    monkeypatch.setattr(run_agent, "get_provider_stale_timeout", lambda *a, **k: None)
+
+    agent = _make_agent(
+        tmp_path,
+        provider="openai",
+        base_url="https://api.openai.com/v1",
+        model="zai/glm-5.2",
+    )
+    assert agent._compute_non_stream_stale_timeout(
+        {"messages": [{"role": "user", "content": "hi"}]}
+    ) == 600.0
+
+    control = _make_agent(
+        tmp_path,
+        provider="openai",
+        base_url="https://api.openai.com/v1",
+        model="gpt-5.5",
+    )
+    assert control._compute_non_stream_stale_timeout(
+        {"messages": [{"role": "user", "content": "hi"}]}
+    ) == 90.0
 
 
 # ── stream-side mirror (the real builder lives in a worker thread) ────────


### PR DESCRIPTION
## Summary

Fixes #89241. Refs #85904 and #52217.

Adds the GLM-5 family to the existing 600-second reasoning-model stale-timeout floor. This retains the original PR's intended patience budget for the requested GLM-5 model ID, including provider-prefixed IDs, without changing the matcher, timeout consumers, retry policy, or configuration surface.

## Rebase: PRD-HA-001

The existing `fix/glm-stale-timeout-floor` branch was force-updated after notice in the [rebase evidence comment](https://github.com/NousResearch/hermes-agent/pull/90024#issuecomment-5627983772).

- Previous head: `66b7a2244aa2cf52dbab7ebac6960bcef867d2da`.
- New head: `959c8fa49c86e0666ada7ea6973ceae302bc2ec3`.
- Single parent: upstream `main` at `45a6101f36576367359c171cd5820ee76a3d047b`, re-fetched immediately before publication.

Upstream regrouped the floor table by duration. Conflict resolution places `"glm-5"` in its existing `600` group rather than restoring the old tuple table. The original regression additions are retained. Comparison against the new parent remains exactly two files, +64/-0:

- `agent/reasoning_timeouts.py`: the GLM-5 family entry and original rationale.
- `tests/agent/test_reasoning_stale_timeout_floor.py`: five positive parameters, six negative parameters, and the existing GLM non-stream consumer regression.

All other upstream model entries and the current matcher are preserved. No workflow files or unrelated paths were edited.

## Validation on the new head

The tested production and test file blobs were verified against the published commit. Validation used a source-only snapshot, not a complete project checkout; full project configuration and inherited fixtures were not available.

```text
scripts/run_tests.sh tests/agent/test_reasoning_stale_timeout_floor.py -j 1 --file-retries 0 -k 'positive_cases or negative_cases' -q
exit 0: 49 passed

scripts/run_tests.sh tests/agent/test_reasoning_stale_timeout_floor.py -j 1 --file-retries 0 -q
exit 1: 49 passed, 3 failed

git diff --check
exit 0

python -m compileall -q agent/reasoning_timeouts.py tests/agent/test_reasoning_stale_timeout_floor.py
exit 0
```

The three full-file failures are missing imports: `run_agent` in the default/GLM consumer tests, and `agent.model_metadata` in the stream mirror. Those consumer/integration checks remain unverified; no substitutes were introduced to turn them green.

Red/green control: using the unchanged upstream production file with the same pure-case selection produces 44 passed and exactly five GLM-positive failures. Restoring the published source produces 49 passed. A separate structural scope check found the production AST identical to upstream after removing only the added GLM entry.

Earlier pass counts from the pre-rebase branch are historical, not validation of this head.

## Current state and open gates

Fork ref and PR head were re-fetched at `959c8fa49c86e0666ada7ea6973ceae302bc2ec3`. GitHub reports `mergeable: true`, `rebaseable: true`, and `mergeable_state: blocked`, rather than `dirty`.

- [x] Same branch updated; new head and two-file diff verified.
- [x] Pure resolver cases pass; red/green regression control captured.
- [ ] Full focused file passes in a complete checkout.
- [ ] Broader standard agent suite validated.
- [ ] CI green: CI, Nix flake check, and Docker Build, Test, and Publish currently report `action_required`; no CI jobs were returned.

No unanswered review request was present in the inspected discussion. The material rebase and exact evidence are recorded in the linked comment. This PR is conflict-free but is not being represented as fully validated or merge-ready. Nothing was merged.