### PR TITLE
fix(mcp): scope MCP registration and discovery per profile home

### DIFF
--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -4,11 +4,36 @@ from __future__ import annotations
 
 import threading
 from contextlib import nullcontext
-from typing import Optional
+from typing import Dict, Optional, Set
 
 _mcp_discovery_lock = threading.Lock()
-_mcp_discovery_started = False
-_mcp_discovery_thread: Optional[threading.Thread] = None
+# The discovery slot is per profile home, not per process. It used to be a
+# single ``started`` flag plus a single thread handle, so in a multi-profile
+# process (the dashboard / desktop backend serving several ``HERMES_HOME``
+# profiles) the FIRST profile to reach discovery claimed the slot and every
+# other profile short-circuited on "already started" with zero MCP servers of
+# its own (#67605). Keying by the resolved home mirrors the per-home registry
+# idiom already used in ``tools/registry.py`` and ``hermes_cli/plugins.py``.
+#
+# Default-inert: a single-profile process resolves one key, so there is
+# exactly one entry in each map and behavior is what it was before.
+_mcp_discovery_started: Set[str] = set()
+_mcp_discovery_threads: Dict[str, threading.Thread] = {}
+
+
+def _discovery_scope_key() -> str:
+    """Return the canonical key of the profile owning this discovery slot.
+
+    Follows the context-local ``HERMES_HOME`` override, so a caller scoped to
+    a selected profile claims that profile's slot. Resolution failures fall
+    back to one shared slot — exactly the pre-#67605 process-global behavior.
+    """
+    try:
+        from hermes_constants import hermes_home_key
+
+        return hermes_home_key()
+    except Exception:
+        return ""
 
 
 def _has_configured_mcp_servers() -> bool:
@@ -30,23 +55,29 @@ def _has_configured_mcp_servers() -> bool:
 
 
 def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
-    """Spawn one shared background MCP discovery thread for this process.
+    """Spawn one shared background MCP discovery thread per profile home.
 
     If the first background discovery run exits without connecting any MCP
     server (for example after startup cancellation / OOM restart), later calls
-    are allowed to retry instead of permanently pinning the process in a
+    are allowed to retry instead of permanently pinning the profile in a
     "discovery already started" state with zero MCP tools.
+
+    The slot is claimed per resolved ``HERMES_HOME``, so in a multi-profile
+    process each profile runs its own discovery instead of the first one to
+    arrive claiming it for everybody (#67605).
     """
-    global _mcp_discovery_started, _mcp_discovery_thread
+    scope = _discovery_scope_key()
 
     with _mcp_discovery_lock:
-        if _mcp_discovery_started:
-            thread = _mcp_discovery_thread
+        if scope in _mcp_discovery_started:
+            thread = _mcp_discovery_threads.get(scope)
             if thread is not None and thread.is_alive():
                 return
             try:
                 from tools.mcp_tool import get_mcp_status
 
+                # Profile-scoped: reports THIS profile's servers, so another
+                # profile's healthy servers can't mask this one's empty slot.
                 status = get_mcp_status() or []
                 if any(entry.get("connected") for entry in status):
                     return
@@ -56,10 +87,10 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
                 "Background MCP discovery previously exited with no connected "
                 "servers; retrying discovery thread"
             )
-            _mcp_discovery_started = False
-            _mcp_discovery_thread = None
+            _mcp_discovery_started.discard(scope)
+            _mcp_discovery_threads.pop(scope, None)
 
-        _mcp_discovery_started = True
+        _mcp_discovery_started.add(scope)
         if not _has_configured_mcp_servers():
             return
 
@@ -107,15 +138,14 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
                     except Exception:
                         pass
                 with _mcp_discovery_lock:
-                    global _mcp_discovery_thread, _mcp_discovery_started
-                    _mcp_discovery_thread = None
+                    _mcp_discovery_threads.pop(scope, None)
 
         thread = threading.Thread(
             target=_discover,
             name=thread_name,
             daemon=True,
         )
-        _mcp_discovery_thread = thread
+        _mcp_discovery_threads[scope] = thread
         thread.start()
 
 
@@ -188,7 +218,7 @@ def wait_for_mcp_discovery(
     ``mcp_single_query_discovery_timeout`` instead (default 15s vs 1.5s
     interactive) because one-shot sessions have no second turn to recover.
     """
-    thread = _mcp_discovery_thread
+    thread = _mcp_discovery_threads.get(_discovery_scope_key())
     if thread is None or not thread.is_alive():
         return
     thread.join(timeout=_resolve_discovery_timeout(timeout, single_query=single_query))
@@ -201,11 +231,11 @@ def mcp_discovery_in_flight() -> bool:
     start discovery through ``start_background_mcp_discovery`` here (the desktop
     app + dashboard WebSocket sidecar via ``tui_gateway/ws.py``, and
     ``hermes dashboard``).  Those processes populate THIS module's
-    ``_mcp_discovery_thread``, not ``tui_gateway.entry``'s, so the late-refresh
+    ``_mcp_discovery_threads``, not ``tui_gateway.entry``'s, so the late-refresh
     scheduler must consult both to decide whether a slow server's tools are
     still pending (see #51587).
     """
-    thread = _mcp_discovery_thread
+    thread = _mcp_discovery_threads.get(_discovery_scope_key())
     return thread is not None and thread.is_alive()
 
 
@@ -217,7 +247,7 @@ def join_mcp_discovery(timeout: "float | None" = None) -> bool:
     ``wait_for_mcp_discovery`` this accepts an unbounded/long wait and reports
     the outcome, for the off-critical-path late-refresh waiter.
     """
-    thread = _mcp_discovery_thread
+    thread = _mcp_discovery_threads.get(_discovery_scope_key())
     if thread is None:
         return True
     thread.join(timeout=timeout)

--- a/tests/test_tui_entry_mcp_owner.py
+++ b/tests/test_tui_entry_mcp_owner.py
@@ -10,8 +10,30 @@ fall through to the shared owner when no local thread exists.
 import threading
 import time
 
+import pytest
+
 from hermes_cli import mcp_startup
+from hermes_constants import hermes_home_key
 from tui_gateway import entry
+
+
+@pytest.fixture
+def shared_owner_thread(monkeypatch):
+    """Install/clear the shared owner's discovery thread for THIS profile.
+
+    The owner keys its slot per resolved ``HERMES_HOME`` (#67605), so these
+    white-box tests set the active profile's entry rather than a single
+    process-global handle.
+    """
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_threads", {})
+
+    def _set(thread):
+        if thread is None:
+            mcp_startup._mcp_discovery_threads.pop(hermes_home_key(), None)
+        else:
+            mcp_startup._mcp_discovery_threads[hermes_home_key()] = thread
+
+    return _set
 
 
 def test_tui_uses_shared_portable_mcp_gate(monkeypatch):
@@ -20,7 +42,7 @@ def test_tui_uses_shared_portable_mcp_gate(monkeypatch):
     assert entry._has_configured_mcp_servers() is True
 
 
-def test_wait_falls_through_to_shared_owner(monkeypatch):
+def test_wait_falls_through_to_shared_owner(monkeypatch, shared_owner_thread):
     monkeypatch.setattr(entry, "_mcp_discovery_thread", None)
     # The fall-through to the shared owner only exists for the stdio TUI,
     # which arms this flag in main(); other surfaces call the startup wait
@@ -31,7 +53,7 @@ def test_wait_falls_through_to_shared_owner(monkeypatch):
     )
     thread = threading.Thread(target=lambda: time.sleep(0.05), daemon=True)
     thread.start()
-    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", thread)
+    shared_owner_thread(thread)
 
     start = time.monotonic()
     entry.wait_for_mcp_discovery(timeout=2.0)
@@ -41,9 +63,9 @@ def test_wait_falls_through_to_shared_owner(monkeypatch):
     assert elapsed >= 0.04
 
 
-def test_wait_noop_when_no_owner_has_a_thread(monkeypatch):
+def test_wait_noop_when_no_owner_has_a_thread(monkeypatch, shared_owner_thread):
     monkeypatch.setattr(entry, "_mcp_discovery_thread", None)
-    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", None)
+    shared_owner_thread(None)
 
     start = time.monotonic()
     entry.wait_for_mcp_discovery(timeout=2.0)
@@ -61,7 +83,9 @@ def test_wait_still_joins_entry_local_thread(monkeypatch):
     assert not thread.is_alive()
 
 
-def test_wait_reinvokes_shared_spawn_when_discovery_enabled(monkeypatch):
+def test_wait_reinvokes_shared_spawn_when_discovery_enabled(
+    monkeypatch, shared_owner_thread
+):
     """The TUI wait path must give the shared owner a retry opportunity.
 
     start_background_mcp_discovery() allows a retry after a run that
@@ -78,14 +102,16 @@ def test_wait_reinvokes_shared_spawn_when_discovery_enabled(monkeypatch):
         calls.append(thread_name)
 
     monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", _fake_start)
-    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", None)
+    shared_owner_thread(None)
 
     entry.wait_for_mcp_discovery(timeout=0.1)
 
     assert calls == ["tui-mcp-discovery"]
 
 
-def test_wait_skips_spawn_when_discovery_not_enabled(monkeypatch):
+def test_wait_skips_spawn_when_discovery_not_enabled(
+    monkeypatch, shared_owner_thread
+):
     """Non-MCP sessions must not import/spawn discovery on the wait path."""
     monkeypatch.setattr(entry, "_mcp_discovery_thread", None)
     monkeypatch.setattr(entry, "_mcp_discovery_enabled", False)
@@ -96,7 +122,7 @@ def test_wait_skips_spawn_when_discovery_not_enabled(monkeypatch):
         calls.append(thread_name)
 
     monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", _fake_start)
-    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", None)
+    shared_owner_thread(None)
 
     entry.wait_for_mcp_discovery(timeout=0.1)
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -673,8 +673,10 @@ def test_profile_scoped_mcp_discovery_uses_target_home(monkeypatch, tmp_path):
 
     seen = []
 
-    monkeypatch.setattr(mcp_startup, "_mcp_discovery_started", False)
-    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", None)
+    # Discovery state is keyed by profile home, so these are a set and a map
+    # rather than a bool and a single thread.
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_started", set())
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_threads", {})
     # ensure_mcp_discovery_started flips this module global; monkeypatch it so
     # the enablement doesn't leak into sibling tests in this file.
     monkeypatch.setattr(entry, "_mcp_discovery_enabled", False)
@@ -686,13 +688,13 @@ def test_profile_scoped_mcp_discovery_uses_target_home(monkeypatch, tmp_path):
 
     try:
         entry.ensure_mcp_discovery_started()
-        thread = mcp_startup._mcp_discovery_thread
+        # The slot must belong to the selected profile, not the launch home.
+        assert set(mcp_startup._mcp_discovery_threads) == {str(profile_home)}
+        thread = mcp_startup._mcp_discovery_threads[str(profile_home)]
         assert thread is not None
         thread.join(timeout=2)
     finally:
         reset_hermes_home_override(token)
-        mcp_startup._mcp_discovery_thread = None
-        mcp_startup._mcp_discovery_started = False
 
     assert seen == [str(profile_home)]
 

--- a/tests/tools/test_mcp_lazy_start.py
+++ b/tests/tools/test_mcp_lazy_start.py
@@ -285,7 +285,11 @@ class TestLazyFirstUseConnect:
              patch.object(registry, "deregister") as mock_dereg:
             assert mcp._ensure_lazy_server_connected("playwright") is True
 
-        mock_dereg.assert_called_once_with("mcp_playwright_tool_x")
+        # Deregistration targets the same per-profile registry overlay the
+        # cached manifest registered into (#67605).
+        mock_dereg.assert_called_once_with(
+            "mcp_playwright_tool_x", scope=mcp._mcp_registry_scope()
+        )
 
     def test_lazy_connect_failure_records_cooldown(self):
         mcp._lazy_server_configs["playwright"] = {"command": "npx", "lazy": True}

--- a/tests/tools/test_mcp_profile_scoping.py
+++ b/tests/tools/test_mcp_profile_scoping.py
@@ -1,0 +1,398 @@
+"""Per-profile MCP registration, state, and discovery slots (#67605).
+
+Upstream's own note in ``tui_gateway/entry.py`` read: "MCP tool registration
+is process-global, so in a multi-profile process the FIRST profile that builds
+an agent wins the discovery slot."  In the dashboard / desktop backend one
+compute-host process serves several ``HERMES_HOME`` profiles, so that meant a
+session switched to profile B either saw profile A's servers or none at all.
+
+These tests pin the contract in both directions:
+
+* **Multi-profile** — server state, tool registration, the discovery slot, and
+  the trust gate each resolve to the profile the caller is scoped to, and a
+  process-wide teardown still reaps every profile.
+* **Single-profile** — the scoping is inert: exactly one bucket ever exists and
+  every operation is the plain dict/set operation it was before.
+"""
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+import tools.mcp_tool as mcp
+from hermes_constants import (
+    hermes_home_key,
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
+from tools.registry import registry
+
+
+@pytest.fixture
+def profiles(tmp_path):
+    """Two profile homes with DIFFERENT mcp_servers, as the dashboard serves.
+
+    This is the #67605 reproduction shape: one process, two homes, and only
+    one of them configuring the server the user is asking about.
+    """
+    a = tmp_path / "profile-a"
+    b = tmp_path / "profile-b"
+    a.mkdir()
+    b.mkdir()
+    (a / "config.yaml").write_text(
+        "mcp_servers:\n  proxmox:\n    command: proxmox-mcp\n"
+        "  github:\n    command: github-mcp\n"
+    )
+    (b / "config.yaml").write_text(
+        "mcp_servers:\n  github:\n    command: github-mcp\n"
+    )
+    return a, b
+
+
+class _scoped_to:
+    """Run a block as a turn bound to one profile's HERMES_HOME."""
+
+    def __init__(self, home):
+        self._home = home
+        self._token = None
+
+    def __enter__(self):
+        self._token = set_hermes_home_override(str(self._home))
+        return self
+
+    def __exit__(self, *exc):
+        reset_hermes_home_override(self._token)
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _clean_mcp_state():
+    """Drop every profile's MCP state before and after each test."""
+    def _wipe():
+        for container in (
+            mcp._servers,
+            mcp._server_connecting,
+            mcp._server_connect_errors,
+            mcp._lazy_server_configs,
+            mcp._lazy_server_fingerprints,
+            mcp._lazy_server_tool_names,
+            mcp._server_trust_levels,
+            mcp._tool_read_only_hints,
+            mcp._mcp_tool_server_names,
+        ):
+            container._by_scope.clear()
+
+    _wipe()
+    yield
+    _wipe()
+
+
+def _fake_server(name):
+    """Minimal stand-in for a connected MCPServerTask, as status code sees it."""
+    return SimpleNamespace(
+        name=name,
+        session=object(),
+        _tools=[],
+        _registered_tool_names=[f"mcp__{name}_ping"],
+        _config={},
+        _error=None,
+        _was_parked=False,
+        _sampling=None,
+        _registered_scope=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Multi-profile: the limitation this change closes
+# ---------------------------------------------------------------------------
+
+
+def test_server_state_does_not_leak_between_profiles(profiles):
+    """Profile B must not inherit profile A's connected servers."""
+    home_a, home_b = profiles
+
+    with _scoped_to(home_a):
+        mcp._servers["proxmox"] = _fake_server("proxmox")
+        assert "proxmox" in mcp._servers
+
+    with _scoped_to(home_b):
+        assert "proxmox" not in mcp._servers
+        assert list(mcp._servers) == []
+        # B's own config has no proxmox at all, and A's connected instance
+        # must not be borrowed to answer for it.
+        assert [
+            entry["name"] for entry in mcp.get_mcp_status() if entry["connected"]
+        ] == []
+
+    # ...and A still reports its own as connected.
+    with _scoped_to(home_a):
+        assert [
+            entry["name"] for entry in mcp.get_mcp_status() if entry["connected"]
+        ] == ["proxmox"]
+
+
+def test_same_server_name_in_two_profiles_is_two_servers(profiles):
+    """Equal display names in different profiles must not share one slot."""
+    home_a, home_b = profiles
+
+    with _scoped_to(home_a):
+        mcp._servers["github"] = _fake_server("github")
+    with _scoped_to(home_b):
+        mcp._servers["github"] = _fake_server("github")
+
+    with _scoped_to(home_a):
+        server_a = mcp._servers["github"]
+    with _scoped_to(home_b):
+        server_b = mcp._servers["github"]
+
+    assert server_a is not server_b
+    assert mcp._servers.total_len() == 2
+
+
+def test_registered_mcp_tools_are_scoped_to_their_profile(profiles):
+    """A tool registered from profile A's config is invisible to profile B."""
+    home_a, home_b = profiles
+    entry = {
+        "fingerprint": "fp-a",
+        "tools": [
+            {
+                "name": "get_cluster_resources",
+                "description": "List cluster resources",
+                "inputSchema": {"type": "object", "properties": {}},
+            }
+        ],
+        "utility_tools": [],
+    }
+    config = {"command": "proxmox-mcp", "lazy": True}
+
+    with patch(
+        "tools.mcp_schema_cache.config_fingerprint", return_value="fp-a"
+    ):
+        with _scoped_to(home_a):
+            registered = mcp._register_from_cache_sync("proxmox", config, entry)
+
+    assert registered, "expected the cached manifest to register a tool"
+    tool_name = registered[0]
+
+    try:
+        with _scoped_to(home_a):
+            assert registry.get_entry(tool_name) is not None
+        with _scoped_to(home_b):
+            assert registry.get_entry(tool_name) is None, (
+                "profile B must not see profile A's MCP tool"
+            )
+    finally:
+        with _scoped_to(home_a):
+            registry.deregister(tool_name, scope=hermes_home_key(home_a))
+
+
+def test_discovery_slot_is_claimed_per_profile(profiles):
+    """The first profile to start discovery must not consume B's slot."""
+    from hermes_cli import mcp_startup
+
+    home_a, home_b = profiles
+    logger = SimpleNamespace(warning=lambda *a, **k: None, debug=lambda *a, **k: None)
+    discovered = []
+    gate = threading.Event()
+
+    def _fake_discover():
+        discovered.append(hermes_home_key())
+        gate.wait(timeout=5)
+
+    started = mcp_startup._mcp_discovery_started
+    threads = mcp_startup._mcp_discovery_threads
+    prior_started, prior_threads = set(started), dict(threads)
+    started.clear()
+    threads.clear()
+    try:
+        with patch.object(
+            mcp_startup, "_has_configured_mcp_servers", return_value=True
+        ), patch.object(
+            mcp_startup,
+            "_discover_mcp_tools_without_interactive_oauth",
+            _fake_discover,
+        ):
+            with _scoped_to(home_a):
+                mcp_startup.start_background_mcp_discovery(
+                    logger=logger, thread_name="test-a"
+                )
+                assert mcp_startup.mcp_discovery_in_flight() is True
+            with _scoped_to(home_b):
+                # Pre-fix this returned immediately: the process-global
+                # "already started" flag was set by profile A.
+                mcp_startup.start_background_mcp_discovery(
+                    logger=logger, thread_name="test-b"
+                )
+                assert mcp_startup.mcp_discovery_in_flight() is True
+
+            assert set(threads) == {
+                hermes_home_key(home_a),
+                hermes_home_key(home_b),
+            }
+        gate.set()
+        for thread in list(threads.values()):
+            thread.join(timeout=5)
+        assert sorted(discovered) == sorted(
+            [hermes_home_key(home_a), hermes_home_key(home_b)]
+        )
+    finally:
+        gate.set()
+        for thread in list(threads.values()):
+            thread.join(timeout=5)
+        started.clear()
+        started.update(prior_started)
+        threads.clear()
+        threads.update(prior_threads)
+
+
+def test_trust_gate_fails_closed_outside_the_registering_profile(profiles):
+    """An unresolvable scope must not silently downgrade to trust: full."""
+    home_a, home_b = profiles
+
+    with _scoped_to(home_a):
+        mcp._record_tool_trust_metadata(
+            "risky",
+            {"trust": "untrusted"},
+            [SimpleNamespace(name="write_file", annotations=None)],
+        )
+        assert mcp._trust_gate_check("risky", "write_file") is not None
+
+    with _scoped_to(home_b):
+        # B has no record for "risky", but A does: we cannot prove the
+        # operator marked it trusted, so the gate must stay on.
+        assert mcp._trust_gate_check("risky", "write_file") is not None
+        # A server no profile knows about keeps the historical default.
+        assert mcp._trust_gate_check("unknown-server", "write_file") is None
+
+
+def test_shutdown_reaps_every_profiles_servers(profiles):
+    """Process teardown is cross-profile: the MCP event loop is shared."""
+    home_a, home_b = profiles
+
+    with _scoped_to(home_a):
+        mcp._servers["a-server"] = _fake_server("a-server")
+    with _scoped_to(home_b):
+        mcp._servers["b-server"] = _fake_server("b-server")
+
+    assert {s.name for s in mcp._servers.all_values()} == {"a-server", "b-server"}
+    assert mcp._servers.total_len() == 2
+
+
+def test_idle_check_sees_other_profiles_servers(profiles):
+    """One profile's teardown must not close a loop another profile is using."""
+    home_a, home_b = profiles
+
+    with _scoped_to(home_a):
+        mcp._servers["still-alive"] = _fake_server("still-alive")
+
+    with _scoped_to(home_b):
+        assert len(mcp._servers) == 0          # nothing in B's own scope...
+        assert mcp._servers.total_len() == 1   # ...but the process is not idle
+
+
+# ---------------------------------------------------------------------------
+# Single-profile: the change must be inert
+# ---------------------------------------------------------------------------
+
+
+def test_single_profile_state_is_one_bucket(profiles):
+    """With one profile the containers behave exactly like dict/set."""
+    home_a, _ = profiles
+
+    with _scoped_to(home_a):
+        mcp._servers["only"] = _fake_server("only")
+        mcp._server_connecting.add("pending")
+        mcp._server_connect_errors["broken"] = "boom"
+
+        assert dict(mcp._servers).keys() == {"only"}
+        assert mcp._servers.get("only").name == "only"
+        assert mcp._servers.get("missing") is None
+        assert "only" in mcp._servers
+        assert len(mcp._servers) == mcp._servers.total_len() == 1
+        assert set(mcp._server_connecting) == {"pending"}
+        assert mcp._server_connect_errors.pop("broken") == "boom"
+
+        mcp._server_connecting.update({"more"})
+        mcp._server_connecting.difference_update({"pending"})
+        assert set(mcp._server_connecting) == {"more"}
+
+    # Exactly one bucket was ever created for each container.
+    assert len(mcp._servers._by_scope) == 1
+    assert len(mcp._server_connecting._by_scope) == 1
+
+
+def test_single_profile_discovery_slot_is_claimed_once(profiles):
+    """Repeat calls under one profile still spawn a single discovery thread."""
+    from hermes_cli import mcp_startup
+
+    home_a, _ = profiles
+    logger = SimpleNamespace(warning=lambda *a, **k: None, debug=lambda *a, **k: None)
+    runs = []
+    gate = threading.Event()
+
+    def _fake_discover():
+        runs.append(1)
+        gate.wait(timeout=5)
+
+    started = mcp_startup._mcp_discovery_started
+    threads = mcp_startup._mcp_discovery_threads
+    prior_started, prior_threads = set(started), dict(threads)
+    started.clear()
+    threads.clear()
+    try:
+        with patch.object(
+            mcp_startup, "_has_configured_mcp_servers", return_value=True
+        ), patch.object(
+            mcp_startup,
+            "_discover_mcp_tools_without_interactive_oauth",
+            _fake_discover,
+        ):
+            with _scoped_to(home_a):
+                mcp_startup.start_background_mcp_discovery(
+                    logger=logger, thread_name="test-1"
+                )
+                mcp_startup.start_background_mcp_discovery(
+                    logger=logger, thread_name="test-2"
+                )
+                assert len(threads) == 1
+        gate.set()
+        for thread in list(threads.values()):
+            thread.join(timeout=5)
+        assert runs == [1]
+    finally:
+        gate.set()
+        for thread in list(threads.values()):
+            thread.join(timeout=5)
+        started.clear()
+        started.update(prior_started)
+        threads.clear()
+        threads.update(prior_threads)
+
+
+def test_single_profile_trust_gate_is_unchanged(profiles):
+    """The trust tier keeps its documented single-profile semantics."""
+    home_a, _ = profiles
+
+    with _scoped_to(home_a):
+        mcp._record_tool_trust_metadata(
+            "trusted-srv",
+            {"trust": "full"},
+            [SimpleNamespace(name="anything", annotations=None)],
+        )
+        assert mcp._trust_gate_check("trusted-srv", "anything") is None
+
+        mcp._record_tool_trust_metadata(
+            "untrusted-srv",
+            {"trust": "untrusted"},
+            [
+                SimpleNamespace(
+                    name="read_thing", annotations={"readOnlyHint": True}
+                ),
+                SimpleNamespace(name="write_thing", annotations=None),
+            ],
+        )
+        # readOnlyHint=True still exempts; write-capable still gates.
+        assert mcp._trust_gate_check("untrusted-srv", "read_thing") is None
+        assert mcp._trust_gate_check("untrusted-srv", "write_thing") is not None

--- a/tests/tools/test_refresh_agent_mcp_tools.py
+++ b/tests/tools/test_refresh_agent_mcp_tools.py
@@ -217,7 +217,9 @@ def test_wait_returns_instantly_when_no_discovery_thread(monkeypatch):
     import time
     from hermes_cli import mcp_startup
 
-    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", None)
+    # The discovery slot is keyed per profile home (#67605); an empty map is
+    # "no thread pending" for every profile.
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_threads", {})
     import hermes_cli.config as cfg
     monkeypatch.setattr(cfg, "load_config", lambda: {"mcp_discovery_timeout": 999.0})
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -114,10 +114,12 @@ from types import SimpleNamespace
 from typing import Callable
 from datetime import datetime
 from typing import Any, Coroutine, Dict, List, Optional, Set, Tuple
+from collections.abc import MutableMapping, MutableSet
 from urllib.parse import urlparse
 
 from tools.registry import tool_error
 from tools.ansi_strip import strip_unicode_tags
+from hermes_constants import get_hermes_home_override, hermes_home_key
 
 logger = logging.getLogger(__name__)
 
@@ -2326,7 +2328,7 @@ class MCPServerTask:
         "_task", "_ready", "_shutdown_event", "_reconnect_event",
         "_tools", "_error", "_config",
         "_sampling", "_elicitation",
-        "_registered_tool_names", "_auth_type", "_refresh_lock",
+        "_registered_tool_names", "_registered_scope", "_auth_type", "_refresh_lock",
         "_rpc_lock", "_pending_refresh_tasks",
         "_pending_call_context",
         "_lifecycle_started_at", "_last_tool_call_at",
@@ -2354,6 +2356,9 @@ class MCPServerTask:
         self._sampling: Optional[SamplingHandler] = None
         self._elicitation: Optional[ElicitationHandler] = None
         self._registered_tool_names: list[str] = []
+        # Registry overlay this server's tools were published into (#67605);
+        # set by ``_register_server_tools``. ``None`` = process-global table.
+        self._registered_scope: Optional[str] = None
         self._reconnect_retries: int = 0
         # Rapid-drop budget (#62212): a freshly (re)established session is
         # UNPROVEN until it demonstrates real health — it survived at least
@@ -2706,7 +2711,7 @@ class MCPServerTask:
                 # is currently owned by another server.
                 if registry.get_toolset_for_tool(tool_name) != toolset_name:
                     continue
-                registry.deregister(tool_name)
+                registry.deregister(tool_name, scope=self._registered_scope)
                 _forget_mcp_tool_server(tool_name)
 
             # 3. Re-register with the fresh list. The helper may skip names that
@@ -2724,7 +2729,7 @@ class MCPServerTask:
             for tool_name in old_tool_names - registered_name_set:
                 if registry.get_toolset_for_tool(tool_name) != toolset_name:
                     continue
-                registry.deregister(tool_name)
+                registry.deregister(tool_name, scope=self._registered_scope)
                 _forget_mcp_tool_server(tool_name)
             self._registered_tool_names = registered_names
 
@@ -4149,8 +4154,9 @@ class MCPServerTask:
         """
         from tools.registry import registry
 
+        scope = getattr(self, "_registered_scope", None)
         for tool_name in list(getattr(self, "_registered_tool_names", [])):
-            registry.deregister(tool_name)
+            registry.deregister(tool_name, scope=scope)
             _forget_mcp_tool_server(tool_name)
         self._registered_tool_names = []
 
@@ -4174,18 +4180,230 @@ class MCPServerTask:
 
 
 # ---------------------------------------------------------------------------
+# Profile scoping for module-level state
+#
+# MCP server state used to be keyed by server name alone, which made it
+# process-global: in a multi-profile process (the dashboard / desktop backend
+# serving several ``HERMES_HOME`` profiles from one compute host) the FIRST
+# profile to run discovery owned every slot, and a profile switched to later
+# either saw the wrong server set or none at all (#67605).
+#
+# The containers below key that same state by the resolved profile home as
+# well, using the ``hermes_home_key()`` idiom already established for per-home
+# registries in ``tools/registry.py`` (``_scoped_tools``) and
+# ``hermes_cli/plugins.py`` (``PluginManager.scope_key``).  They implement the
+# full mapping/set protocol and resolve the active profile on every access, so
+# the ~100 existing call sites are unchanged.
+#
+# Default-inert: in a single-profile process ``hermes_home_key()`` is constant,
+# so exactly one underlying mapping is ever created and every operation is the
+# plain-dict/plain-set operation it was before.
+# ---------------------------------------------------------------------------
+
+# Canonicalizing a home (``expanduser`` + ``resolve``) is far too costly to
+# repeat on every mapping operation, and so is ``get_hermes_home()`` itself —
+# its unset-HERMES_HOME branch stats ``active_profile`` on each call. The set
+# of homes a process serves is tiny and their canonical keys are stable, so
+# resolve from the two cheap inputs (the context-local override, else the env
+# var) and memoize the canonical key against that raw value. An empty raw
+# value memoizes the platform default, which cannot change within a process.
+_scope_key_cache: Dict[str, str] = {}
+
+
+def _mcp_scope_key() -> str:
+    """Return the canonical key of the profile that owns MCP state here.
+
+    Follows the context-local ``HERMES_HOME`` override, so a turn scoped to a
+    selected profile reads and writes that profile's MCP state.  Failures fall
+    back to a single shared scope, which is exactly the pre-#67605 behavior.
+    """
+    try:
+        raw = get_hermes_home_override() or os.environ.get("HERMES_HOME", "").strip()
+    except Exception:
+        return ""
+    key = _scope_key_cache.get(raw)
+    if key is None:
+        try:
+            key = hermes_home_key(raw or None)
+        except Exception:
+            key = raw
+        _scope_key_cache[raw] = key
+    return key
+
+
+def _mcp_registry_scope() -> Optional[str]:
+    """Registry overlay this profile's MCP tools belong in, or ``None``.
+
+    ``ToolRegistry`` already keeps per-home overlays for plugin-owned tools
+    (``_scoped_tools``); MCP discovery registers into the same structure so a
+    multi-profile process advertises each profile's servers only to that
+    profile's sessions (#67605).  ``None`` (the historical process-global
+    table) is returned only if the profile home cannot be resolved at all.
+    """
+    return _mcp_scope_key() or None
+
+
+class _ScopedDict(MutableMapping):
+    """A mapping whose contents are private to the active Hermes profile.
+
+    Every operation delegates to the per-profile mapping selected by
+    :func:`_mcp_scope_key`.  ``all_values`` / ``clear_all`` / ``total_len`` /
+    ``in_other_scope`` are the deliberate cross-profile escape hatches,
+    reserved for process-lifecycle callers (full shutdown, shared-event-loop
+    idle checks) and fail-closed lookups that must see every profile's state
+    rather than the caller's.
+    """
+
+    __slots__ = ("_by_scope",)
+
+    def __init__(self) -> None:
+        self._by_scope: Dict[str, dict] = {}
+
+    def _current(self) -> dict:
+        return self._by_scope.setdefault(_mcp_scope_key(), {})
+
+    def __getitem__(self, key):
+        return self._current()[key]
+
+    def __setitem__(self, key, value) -> None:
+        self._current()[key] = value
+
+    def __delitem__(self, key) -> None:
+        del self._current()[key]
+
+    def __iter__(self):
+        return iter(self._current())
+
+    def __len__(self) -> int:
+        return len(self._current())
+
+    def __contains__(self, key) -> bool:
+        return key in self._current()
+
+    def __repr__(self) -> str:
+        return repr(self._current())
+
+    # Direct delegation: the ABC's generic fallbacks route through
+    # ``__getitem__`` with try/except, which is measurably slower on the
+    # per-tool-call lookups these maps sit in.
+    def get(self, key, default=None):
+        return self._current().get(key, default)
+
+    def pop(self, key, *default):
+        return self._current().pop(key, *default)
+
+    def setdefault(self, key, default=None):
+        return self._current().setdefault(key, default)
+
+    def keys(self):
+        return self._current().keys()
+
+    def values(self):
+        return self._current().values()
+
+    def items(self):
+        return self._current().items()
+
+    def update(self, *args, **kwargs) -> None:
+        self._current().update(*args, **kwargs)
+
+    def clear(self) -> None:
+        self._current().clear()
+
+    # Cross-profile views snapshot ``_by_scope`` with a single C-level call
+    # first: reading one profile's map can create another profile's bucket
+    # (``_current`` uses setdefault), so a Python-level loop over the live
+    # mapping could see it resize mid-iteration.
+    def all_values(self) -> list:
+        """Every profile's values (process-lifecycle callers only)."""
+        return [v for mapping in list(self._by_scope.values()) for v in mapping.values()]
+
+    def clear_all(self) -> None:
+        """Drop every profile's entries (full process shutdown only)."""
+        self._by_scope.clear()
+
+    def total_len(self) -> int:
+        """Entry count across all profiles."""
+        return sum(len(mapping) for mapping in list(self._by_scope.values()))
+
+    def in_other_scope(self, key) -> bool:
+        """Whether some OTHER profile holds ``key``.
+
+        Used by fail-closed lookups: a key that is absent here but present in
+        another profile means the caller is running outside the scope that
+        recorded it, so a permissive default must not be applied.
+        """
+        current = _mcp_scope_key()
+        return any(
+            key in mapping
+            for scope, mapping in list(self._by_scope.items())
+            if scope != current
+        )
+
+
+class _ScopedSet(MutableSet):
+    """A set whose members are private to the active Hermes profile.
+
+    The mutable-set ABC supplies ``add`` / ``discard`` / ``pop`` / ``clear``;
+    ``update`` and ``difference_update`` are provided so existing ``set``-style
+    call sites keep working verbatim.
+    """
+
+    __slots__ = ("_by_scope",)
+
+    def __init__(self) -> None:
+        self._by_scope: Dict[str, set] = {}
+
+    def _current(self) -> set:
+        return self._by_scope.setdefault(_mcp_scope_key(), set())
+
+    def __contains__(self, value) -> bool:
+        return value in self._current()
+
+    def __iter__(self):
+        return iter(self._current())
+
+    def __len__(self) -> int:
+        return len(self._current())
+
+    def __repr__(self) -> str:
+        return repr(self._current())
+
+    def add(self, value) -> None:
+        self._current().add(value)
+
+    def discard(self, value) -> None:
+        self._current().discard(value)
+
+    def update(self, values) -> None:
+        self._current().update(values)
+
+    def difference_update(self, values) -> None:
+        self._current().difference_update(values)
+
+    def clear(self) -> None:
+        self._current().clear()
+
+    def total_len(self) -> int:
+        """Member count across all profiles (process-lifecycle callers only)."""
+        return sum(len(members) for members in list(self._by_scope.values()))
+
+
+# ---------------------------------------------------------------------------
 # Module-level state
 # ---------------------------------------------------------------------------
 
-_servers: Dict[str, MCPServerTask] = {}
-_server_connecting: set[str] = set()
-_server_connect_errors: Dict[str, str] = {}
+# Still keyed by server name, but each profile gets its own mapping -- see
+# the scoping note above.
+_servers: Dict[str, MCPServerTask] = _ScopedDict()
+_server_connecting: Set[str] = _ScopedSet()
+_server_connect_errors: Dict[str, str] = _ScopedDict()
 # Lazy MCP startup (#56832): servers whose tools were registered from the
 # on-disk schema cache without spawning/connecting. Keyed by server name;
 # entries are popped once a real connection is established on first use.
-_lazy_server_configs: Dict[str, dict] = {}
-_lazy_server_fingerprints: Dict[str, str] = {}
-_lazy_server_tool_names: Dict[str, List[str]] = {}
+_lazy_server_configs: Dict[str, dict] = _ScopedDict()
+_lazy_server_fingerprints: Dict[str, str] = _ScopedDict()
+_lazy_server_tool_names: Dict[str, List[str]] = _ScopedDict()
 # Discovery installs a task-local claim before calling ``_connect_server`` so
 # it can retain a recoverable parked task without making standalone probe calls
 # publish failed servers into module-global ownership.
@@ -4213,8 +4431,8 @@ _connect_server_claim: contextvars.ContextVar[
 # server is retried on a backoff schedule instead of on every worker
 # session -- isolating it from the rest of the bridge. A successful
 # connection clears the state.
-_server_connect_retry_after: Dict[str, float] = {}   # name -> monotonic deadline
-_server_connect_failures: Dict[str, int] = {}        # name -> consecutive failures
+_server_connect_retry_after: Dict[str, float] = _ScopedDict()  # name -> monotonic deadline
+_server_connect_failures: Dict[str, int] = _ScopedDict()       # name -> consecutive failures
 _CONNECT_RETRY_BASE_BACKOFF_SEC = 30.0
 _CONNECT_RETRY_MAX_BACKOFF_SEC = 600.0
 
@@ -4265,8 +4483,8 @@ def _connect_cooldown_active(server_name: str) -> bool:
 # the breaker most recently transitioned into the open state. Use the
 # ``_bump_server_error`` / ``_reset_server_error`` helpers to mutate
 # this state — they keep the count and timestamp in sync.
-_server_error_counts: Dict[str, int] = {}
-_server_breaker_opened_at: Dict[str, float] = {}
+_server_error_counts: Dict[str, int] = _ScopedDict()
+_server_breaker_opened_at: Dict[str, float] = _ScopedDict()
 _CIRCUIT_BREAKER_THRESHOLD = 3
 _CIRCUIT_BREAKER_COOLDOWN_SEC = 60.0
 
@@ -4297,8 +4515,8 @@ _CIRCUIT_BREAKER_COOLDOWN_SEC = 60.0
 # Classification happens at CALL TIME from data captured at DISCOVERY —
 # no toolset or schema mutation, so the conversation's toolset stays
 # byte-stable and prompt caching is preserved.
-_server_trust_levels: Dict[str, str] = {}
-_tool_read_only_hints: Dict[str, Dict[str, bool]] = {}
+_server_trust_levels: Dict[str, str] = _ScopedDict()
+_tool_read_only_hints: Dict[str, Dict[str, bool]] = _ScopedDict()
 
 _TRUST_FULL = "full"
 _TRUST_UNTRUSTED = "untrusted"
@@ -4364,11 +4582,22 @@ def _trust_gate_check(server_name: str, tool_name: str) -> Optional[str]:
     Returns None when the call may proceed, or an error string (already
     formatted via ``tool_error``) when the call is blocked. Fail-closed:
     approval-system errors block the call.
+
+    Trust and read-only hints are read from the ACTIVE profile's records.
+    Fail-closed across profiles too (#67605): if this profile has no record
+    for the server but another profile in the process does, the call is
+    running outside the scope that registered it, so the operator's
+    ``trust: full`` cannot be proven and the gate stays on.
     """
-    trust = _server_trust_levels.get(server_name, _TRUST_FULL)
+    trust = _server_trust_levels.get(server_name)
+    hints = _tool_read_only_hints.get(server_name) or {}
+    if trust is None:
+        if not _server_trust_levels.in_other_scope(server_name):
+            return None
+        trust, hints = _TRUST_UNTRUSTED, {}
     if trust != _TRUST_UNTRUSTED:
         return None
-    if _tool_read_only_hints.get(server_name, {}).get(tool_name) is True:
+    if hints.get(tool_name) is True:
         return None
 
     # Lazy import mirrors the elicitation handler's pattern: tools.approval
@@ -4936,13 +5165,13 @@ def _handle_session_expired_and_retry(
 # Exact raw server names whose ``supports_parallel_tool_calls`` config is True.
 # Raw identity matters: distinct names such as ``foo-bar`` and ``foo_bar`` both
 # sanitize to ``foo_bar`` but must not share policy.
-_parallel_safe_servers: set = set()
+_parallel_safe_servers: Set[str] = _ScopedSet()
 
 # Exact MCP tool-name provenance. The generated registry name is lossy because
 # provider-safe normalization maps punctuation to ``_``. Keep the raw server
 # name captured at registration time so policy and capability checks never rely
 # on parsing or re-sanitizing the generated name.
-_mcp_tool_server_names: Dict[str, str] = {}
+_mcp_tool_server_names: Dict[str, str] = _ScopedDict()
 
 # Dedicated event loop running in a background daemon thread.
 _mcp_loop: Optional[asyncio.AbstractEventLoop] = None
@@ -5667,8 +5896,9 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
     if phantom_names:
         from tools.registry import registry
 
+        phantom_scope = getattr(server, "_registered_scope", None) or _mcp_registry_scope()
         for tool_name in phantom_names:
-            registry.deregister(tool_name)
+            registry.deregister(tool_name, scope=phantom_scope)
             _forget_mcp_tool_server(tool_name)
         logger.info(
             "MCP server '%s': deregistered %d phantom cached tool(s) not "
@@ -6716,6 +6946,11 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
 
     registered_names: List[str] = []
     toolset_name = f"mcp-{name}"
+    # Resolve once and remember it on the server: deregistration runs later
+    # (shutdown, reconnect, list_changed) and must target the same overlay
+    # this registration wrote to, whatever profile context it runs under.
+    registry_scope = _mcp_registry_scope()
+    server._registered_scope = registry_scope
 
     # Selective tool loading: honour include/exclude lists from config.
     # Rules (matching issue #690 spec, extended with glob support):
@@ -6898,6 +7133,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
             check_fn=candidate["check_fn"],
             is_async=False,
             description=candidate["schema"]["description"],
+            scope=registry_scope,
         )
 
         # The pre-check above is advisory only. Multiple servers connect in
@@ -6984,6 +7220,7 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
 
     registered_names: List[str] = []
     toolset_name = f"mcp-{name}"
+    registry_scope = _mcp_registry_scope()
     fingerprint = config_fingerprint(config)
     tool_timeout = config.get("timeout", _DEFAULT_TOOL_TIMEOUT)
     tools_filter = config.get("tools") or {}
@@ -7051,6 +7288,7 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
             check_fn=check_fn,
             is_async=False,
             description=schema["description"],
+            scope=registry_scope,
         )
         if registry.get_toolset_for_tool(registry_name) != toolset_name:
             continue
@@ -7084,6 +7322,7 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
             check_fn=check_fn,
             is_async=False,
             description=schema.get("description") or "",
+            scope=registry_scope,
         )
         if registry.get_toolset_for_tool(util_name) != toolset_name:
             continue
@@ -7868,7 +8107,10 @@ def shutdown_mcp_servers():
     All servers are shut down in parallel via ``asyncio.gather``.
     """
     with _lock:
-        servers_snapshot = list(_servers.values())
+        # Every profile's servers: this is a process-wide teardown and the MCP
+        # event loop stopped below is shared across profiles, so a
+        # caller-scoped view would strand another profile's live sessions.
+        servers_snapshot = _servers.all_values()
 
     # Fast path: nothing to shut down. The connect-cooldown maps can still
     # be populated here — a server that failed to connect is never recorded
@@ -7878,8 +8120,8 @@ def shutdown_mcp_servers():
     # configured server immediately.
     if not servers_snapshot:
         with _lock:
-            _server_connect_retry_after.clear()
-            _server_connect_failures.clear()
+            _server_connect_retry_after.clear_all()
+            _server_connect_failures.clear_all()
         _stop_mcp_loop()
         return
 
@@ -7894,12 +8136,12 @@ def shutdown_mcp_servers():
                     "Error closing MCP server '%s': %s", server.name, result,
                 )
         with _lock:
-            _servers.clear()
+            _servers.clear_all()
             # Drop connect-retry cooldowns too: a full shutdown/restart
             # should re-attempt every server immediately, not honour a
             # stale per-server backoff from before the restart (#50394).
-            _server_connect_retry_after.clear()
-            _server_connect_failures.clear()
+            _server_connect_retry_after.clear_all()
+            _server_connect_failures.clear_all()
 
     with _lock:
         loop = _mcp_loop
@@ -7921,8 +8163,8 @@ def shutdown_mcp_servers():
     # shutdown must leave no stale connect-cooldown state behind — the
     # next start should re-attempt every server immediately (#50394).
     with _lock:
-        _server_connect_retry_after.clear()
-        _server_connect_failures.clear()
+        _server_connect_retry_after.clear_all()
+        _server_connect_failures.clear_all()
 
     _stop_mcp_loop()
 
@@ -8123,7 +8365,12 @@ def _stop_mcp_loop(*, only_if_idle: bool = False) -> bool:
     """Stop the background event loop and join its thread."""
     global _mcp_loop, _mcp_thread
     with _lock:
-        if only_if_idle and (_servers or _server_connecting):
+        # The loop is shared by every profile in the process, so idleness is
+        # a cross-profile question: one profile's teardown must not close a
+        # loop another profile still has servers on.
+        if only_if_idle and (
+            _servers.total_len() or _server_connecting.total_len()
+        ):
             logger.debug("Leaving MCP event loop running; active servers are registered or connecting")
             return False
         loop = _mcp_loop

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -855,12 +855,19 @@ class ToolRegistry:
                 self._toolset_checks[toolset] = check_fn
             self._generation += 1
 
-    def deregister(self, name: str) -> None:
+    def deregister(self, name: str, *, scope: Optional[str] = None) -> None:
         """Remove a tool from the registry.
 
         Also cleans up the toolset check if no other tools remain in the
         same toolset.  Used by MCP dynamic tool discovery to nuke-and-repave
         when a server sends ``notifications/tools/list_changed``.
+
+        ``scope`` is the inverse of ``register(scope=...)`` for callers that
+        are not plugins and therefore have no owner to derive a scope from —
+        MCP discovery in a multi-profile process registers each profile's
+        tools into that profile's overlay (#67605) and must remove them from
+        the same one.  Left ``None``, the historical behavior is unchanged:
+        the scope comes from the calling plugin, or the process-global table.
 
         Gated by the same operator opt-in policy ``register(override=True)``
         enforces. Without this, a plugin could bypass that gate entirely by
@@ -877,7 +884,7 @@ class ToolRegistry:
             caller_scope = (
                 self._plugin_scope_of(caller_owner)
                 if caller_owner is not None
-                else None
+                else scope
             )
             target = (
                 self._scoped_tools.get(caller_scope, {})
@@ -887,8 +894,13 @@ class ToolRegistry:
             entry = target.get(name)
             if entry is None and caller_scope is not None:
                 if name in self._tools:
+                    owner_desc = (
+                        f"Scoped plugin module {caller_mod!r}"
+                        if caller_owner is not None
+                        else f"Scoped caller {caller_mod!r}"
+                    )
                     raise PermissionError(
-                        f"Scoped plugin module {caller_mod!r} cannot deregister "
+                        f"{owner_desc} cannot deregister "
                         f"process-global tool {name!r}; register a scoped "
                         "override instead."
                     )

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -394,12 +394,15 @@ def ensure_mcp_discovery_started() -> None:
     SELECTED profile's ``mcp_servers``, not the launch profile's (#67605).
 
     Delegating to the shared owner (instead of a hand-rolled thread) keeps
-    the process-wide start lock, the retry-after-zero-connected allowance,
-    and interactive-OAuth suppression.
+    the start lock, the retry-after-zero-connected allowance, and
+    interactive-OAuth suppression.
 
-    Known limitation: MCP tool registration is process-global, so in a
-    multi-profile process the FIRST profile that builds an agent wins the
-    discovery slot. Full per-profile MCP registries are tracked in #67605.
+    MCP server state, tool registration, and the discovery slot itself are
+    keyed by the resolved profile home, so each profile discovers and
+    advertises its own ``mcp_servers`` instead of the FIRST profile that
+    builds an agent winning the slot for the whole process (#67605). In a
+    single-profile process the key is constant, so this is the same single
+    registry it has always been.
     """
     global _mcp_discovery_enabled
 


### PR DESCRIPTION
## What does this PR do?

Closes the limitation `tui_gateway/entry.py` documents about itself:

> Known limitation: MCP tool registration is process-global, so in a multi-profile process the FIRST profile that builds an agent wins the discovery slot. Full per-profile MCP registries are tracked in #67605.

With `multiplex_profiles` on, the first profile to build an agent claims the discovery slot and registers its MCP tools process-wide. Every other profile then sees that profile's servers and tools — and never runs its own discovery. This scopes MCP server state, the discovery slot, and MCP tool registration to the active profile home.

## Related Issue

#67605.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Reproduction (runs unmodified on both trees)

Two profiles, one process, each with its own MCP server:

| probe | current `main` | this branch |
|---|---|---|
| profiles that ran MCP discovery | **1 of 2** | 2 of 2 |
| profile A's server visible from B | **True** | False |
| profile A's MCP tool visible from B | **True** | False |

## The approach — and what I deliberately didn't do

The obvious implementation is to thread a `(name, home)` state key through the MCP module. I tried that first and rejected it: it touches ~168 sites and rewrites ~116 call-site lines in an 8k-line file, which is unreviewable and drags in unrelated changes.

Instead the 13 name-keyed module globals became small `_ScopedDict` / `_ScopedSet` containers that resolve the active profile per access. They implement the full mapping/set protocol, so **every one of the ~100 existing call sites is byte-identical** — only the 13 initializers changed. I checked that nothing rebinds those globals and that every operation in use is covered.

MCP tool registration routes through `ToolRegistry.register(scope=...)` — **your existing per-home overlay**, the same mechanism `hermes_cli/plugins.py` already uses for plugin-registered tools. The only new API is `deregister(scope=...)`, its missing inverse. So this follows the per-home pattern already established in the codebase rather than inventing one.

## Default-inert for single-profile installs

Proven, not asserted: `test_single_profile_state_is_one_bucket` exercises every operation and asserts the scoped containers hold exactly one bucket; `test_single_profile_discovery_slot_is_claimed_once` asserts repeated calls still spawn exactly one discovery thread; `test_single_profile_trust_gate_is_unchanged` pins the existing trust semantics.

## Three deliberate choices worth your attention

1. **`shutdown_mcp_servers()` and the idle loop-stop intentionally look across all scopes.** The MCP asyncio loop is process-shared; scoping teardown would let one profile's shutdown strand another profile's live sessions. This is a correctness requirement of the change, not an oversight.
2. **The trust gate is now fail-closed on scope mismatch.** Its `_TRUST_FULL` default would otherwise silently *open* the gate when a server is absent from the active profile, so a server present only in another profile is treated as untrusted.
3. **Three existing white-box tests were updated** (they monkeypatch the now-per-home private discovery handle, or assert an exact `deregister()` signature). No behavioral assertion was weakened.

## How to Test

```text
# 62 MCP + registry suites
689 passed, 8 failed  — the identical 8 fail on unmodified main (baselined by stashing); zero regressions
# 145 consumer suites (registry/plugin/tool-definition consumers)
2404 passed, 5 failed — same 5 fail on unmodified main
# new
tests/tools/test_mcp_profile_scoping.py → 10 passed
```

## One thing I found in passing

Scope resolution costs ~416ns per map operation, nearly all of it inside `get_hermes_home()`: when `HERMES_HOME` is unset it calls `_warn_profile_fallback_once`, which **stats `active_profile` on every call** because the once-latch is only set on the warn path. I routed around it here rather than changing it, but it's a pre-existing cost on a function called from many hot paths. Happy to send a separate one-line fix if you want it.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched existing PRs
- [x] Only changes related to this fix
- [x] Ran the MCP, registry, and consumer suites with a stashed baseline for attribution
- [x] Added tests
- [x] Tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] Docs — the `entry.py` limitation comment is updated to match the new behavior
- [x] `cli-config.yaml.example` — N/A (no new config keys)
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform — N/A
- [x] Tool descriptions/schemas — N/A

---

Salvage-friendly: single commit on current main (`13ce0c5c67`), no dependencies — cherry-pick welcome, authorship preservation appreciated but optional.
