### PR TITLE
fix(desktop): route /rollback through the native rollback RPCs instead of the slash worker

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -309,6 +309,93 @@ describe('usePromptActions /title', () => {
   })
 })
 
+describe('usePromptActions /rollback', () => {
+  beforeEach(() => {
+    setSessions(() => [sessionInfo()])
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('lists checkpoints via the rollback.list RPC — never the slash worker', async () => {
+    const requestGateway = vi.fn(
+      async (method: string) => (method === 'rollback.list' ? { checkpoints: [], enabled: true } : {}) as never
+    )
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+
+    await handle!.submitText('/rollback')
+
+    expect(requestGateway).toHaveBeenCalledWith('rollback.list', { session_id: RUNTIME_SESSION_ID })
+    expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
+    expect(requestGateway).not.toHaveBeenCalledWith('command.dispatch', expect.anything())
+  })
+
+  it('previews a checkpoint via the rollback.diff RPC', async () => {
+    const requestGateway = vi.fn(
+      async (method: string) => (method === 'rollback.diff' ? { diff: '- a\n+ b', stat: '1 file changed' } : {}) as never
+    )
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+
+    await handle!.submitText('/rollback diff 2')
+
+    expect(requestGateway).toHaveBeenCalledWith('rollback.diff', { hash: '2', session_id: RUNTIME_SESSION_ID })
+    expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
+  })
+
+  it('restores via the rollback.restore RPC (live session history) — never slash.exec', async () => {
+    // This is the bug: slash.exec runs /rollback in a throwaway HermesCLI
+    // subprocess with no agent attached — on remote/Cloud gateways it dead-ends
+    // with "No active agent session.", and where it works it restores the file
+    // while only undoing ITS OWN history copy, so the live gateway session
+    // diverges from the restored files. rollback.restore mutates the real
+    // session["history"].
+    const requestGateway = vi.fn(
+      async (method: string) =>
+        (method === 'rollback.restore' ? { history_removed: 2, restored_to: 'abc123', success: true } : {}) as never
+    )
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+
+    await handle!.submitText('/rollback 2')
+
+    expect(requestGateway).toHaveBeenCalledWith('rollback.restore', { hash: '2', session_id: RUNTIME_SESSION_ID })
+    expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
+  })
+
+  it('passes the file path through for a file-scoped restore', async () => {
+    const requestGateway = vi.fn(
+      async (method: string) =>
+        (method === 'rollback.restore' ? { reason: 'ok', restored_to: 'abc123', success: true } : {}) as never
+    )
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+
+    await handle!.submitText('/rollback 2 src/foo.py')
+
+    expect(requestGateway).toHaveBeenCalledWith('rollback.restore', {
+      file_path: 'src/foo.py',
+      hash: '2',
+      session_id: RUNTIME_SESSION_ID
+    })
+  })
+})
+
 // Helper: extract rendered text parts from captured updateSessionState seeds.
 function renderedSeedTexts(seeds: Record<string, unknown>[]): string[] {
   return seeds.flatMap(state => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -14,6 +14,16 @@ import {
   resolveDesktopCommand
 } from '@/lib/desktop-slash-commands'
 import { isMissingRpcMethod } from '@/lib/gateway-rpc'
+import {
+  formatCheckpointList,
+  formatRollbackDiff,
+  formatRollbackRestore,
+  parseRollbackCommand,
+  type RollbackDiffResponse,
+  type RollbackListResponse,
+  type RollbackRestoreResponse,
+  trimLastExchange
+} from '@/lib/desktop-rollback'
 import { setSessionYolo } from '@/lib/yolo-session'
 import { openCommandPalettePage } from '@/store/command-palette'
 import { setComposerDraft } from '@/store/composer'
@@ -684,6 +694,77 @@ export function useSlashCommand(deps: SlashCommandDeps) {
                 ? `Session title set: ${finalTitle}${queued ? ' (queued while session initializes)' : ''}`
                 : 'Session title cleared.'
             )
+          } catch (err) {
+            renderSlashOutput(`error: ${err instanceof Error ? err.message : String(err)}`)
+          }
+        },
+        // /rollback routes through the native rollback.list/diff/restore RPCs —
+        // the same path the TUI uses (ui-tui/src/app/slash/commands/ops.ts) —
+        // NOT the slash worker. The worker is a throwaway HermesCLI subprocess
+        // with no agent attached: on remote/Cloud gateways its CLI handler
+        // dead-ends with "No active agent session.", and even where it works it
+        // restores files while only undoing its OWN in-memory history copy, so
+        // the live gateway session (the agent's next-turn context) silently
+        // diverges from the restored files. rollback.restore mutates the live
+        // session["history"] and reports how many messages it dropped via
+        // history_removed; we mirror that drop in the visible transcript.
+        rollback: async ctx => {
+          const resolved = await withSlashOutput(ctx)
+
+          if (!resolved) {
+            return
+          }
+
+          const { render: renderSlashOutput, sessionId, storedSessionId } = resolved
+          const plan = parseRollbackCommand(ctx.arg)
+
+          if (plan.kind === 'usage') {
+            renderSlashOutput(plan.message)
+
+            return
+          }
+
+          try {
+            if (plan.kind === 'list') {
+              const result = await requestGateway<RollbackListResponse>('rollback.list', { session_id: sessionId })
+
+              renderSlashOutput(formatCheckpointList(result))
+
+              return
+            }
+
+            if (plan.kind === 'diff') {
+              const result = await requestGateway<RollbackDiffResponse>('rollback.diff', {
+                hash: plan.hash,
+                session_id: sessionId
+              })
+
+              renderSlashOutput(formatRollbackDiff(result))
+
+              return
+            }
+
+            const result = await requestGateway<RollbackRestoreResponse>('rollback.restore', {
+              hash: plan.hash,
+              session_id: sessionId,
+              ...(plan.filePath ? { file_path: plan.filePath } : {})
+            })
+
+            // A full restore also dropped the last exchange from the live
+            // session history server-side (history_removed) — trim the visible
+            // transcript to match so the rolled-back exchange doesn't linger on
+            // screen. updateSessionState only publishes for the active runtime,
+            // so a late result after a session switch updates its own cache
+            // without clobbering the foreground transcript.
+            if (result?.success && !plan.filePath && (result.history_removed ?? 0) > 0) {
+              updateSessionState(
+                sessionId,
+                state => ({ ...state, messages: trimLastExchange(state.messages) }),
+                storedSessionId
+              )
+            }
+
+            renderSlashOutput(formatRollbackRestore(result, plan.filePath))
           } catch (err) {
             renderSlashOutput(`error: ${err instanceof Error ? err.message : String(err)}`)
           }

--- a/apps/desktop/src/lib/desktop-rollback.test.ts
+++ b/apps/desktop/src/lib/desktop-rollback.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ChatMessage } from '@/lib/chat-messages'
+
+import {
+  formatCheckpointList,
+  formatRollbackDiff,
+  formatRollbackRestore,
+  parseRollbackCommand,
+  ROLLBACK_DIFF_LINE_LIMIT,
+  trimLastExchange
+} from './desktop-rollback'
+
+const msg = (role: ChatMessage['role'], id: string = role): ChatMessage => ({ id, parts: [], role })
+
+describe('parseRollbackCommand', () => {
+  it('routes a bare command (and list/ls aliases) to rollback.list', () => {
+    expect(parseRollbackCommand('')).toEqual({ kind: 'list' })
+    expect(parseRollbackCommand('   ')).toEqual({ kind: 'list' })
+    expect(parseRollbackCommand('list')).toEqual({ kind: 'list' })
+    expect(parseRollbackCommand('ls')).toEqual({ kind: 'list' })
+    expect(parseRollbackCommand('LIST')).toEqual({ kind: 'list' })
+  })
+
+  it('routes diff to rollback.diff and demands a checkpoint', () => {
+    expect(parseRollbackCommand('diff 2')).toEqual({ hash: '2', kind: 'diff' })
+    expect(parseRollbackCommand('DIFF abc123')).toEqual({ hash: 'abc123', kind: 'diff' })
+    expect(parseRollbackCommand('diff')).toEqual({
+      kind: 'usage',
+      message: 'usage: /rollback diff <checkpoint>'
+    })
+  })
+
+  it('routes a checkpoint ref to rollback.restore, with optional file path', () => {
+    expect(parseRollbackCommand('2')).toEqual({ filePath: '', hash: '2', kind: 'restore' })
+    expect(parseRollbackCommand('abc123')).toEqual({ filePath: '', hash: 'abc123', kind: 'restore' })
+    expect(parseRollbackCommand('2 src/foo.py')).toEqual({ filePath: 'src/foo.py', hash: '2', kind: 'restore' })
+    expect(parseRollbackCommand('  3   path/with space.txt  ')).toEqual({
+      filePath: 'path/with space.txt',
+      hash: '3',
+      kind: 'restore'
+    })
+  })
+
+  it('never resolves to a slash.exec / unknown plan — every input maps to an RPC or a usage hint', () => {
+    const kinds = ['', 'list', 'ls', 'diff', 'diff 2', '2', 'abc123', '2 file.py'].map(a => parseRollbackCommand(a).kind)
+
+    expect(kinds.every(kind => ['diff', 'list', 'restore', 'usage'].includes(kind))).toBe(true)
+  })
+})
+
+describe('formatCheckpointList', () => {
+  it('reports when checkpoints are disabled', () => {
+    expect(formatCheckpointList({ enabled: false })).toBe('checkpoints are not enabled')
+  })
+
+  it('reports an empty checkpoint set', () => {
+    expect(formatCheckpointList({ checkpoints: [], enabled: true })).toBe('no checkpoints found')
+  })
+
+  it('numbers checkpoints and shows short hash + metadata', () => {
+    const out = formatCheckpointList({
+      checkpoints: [
+        { hash: '0123456789abcdef', message: 'edited config', timestamp: '2026-06-07T12:00:00Z' },
+        { hash: 'fedcba9876543210' }
+      ],
+      enabled: true
+    })
+
+    expect(out).toBe(
+      ['Rollback checkpoints', '1. 0123456789  2026-06-07T12:00:00Z · edited config', '2. fedcba9876  (no metadata)'].join(
+        '\n'
+      )
+    )
+  })
+})
+
+describe('formatRollbackDiff', () => {
+  it('reports no changes when stat and diff are both empty', () => {
+    expect(formatRollbackDiff({})).toBe('no changes since this checkpoint')
+    expect(formatRollbackDiff({ diff: '', stat: '  ' })).toBe('no changes since this checkpoint')
+  })
+
+  it('combines stat and the plain diff (ignoring the ANSI rendered field)', () => {
+    const out = formatRollbackDiff({ diff: '- old\n+ new', rendered: '[31m- old[0m', stat: '1 file changed' })
+
+    expect(out).toBe('1 file changed\n\n- old\n+ new')
+  })
+
+  it('caps long diffs at the line limit and notes the remainder', () => {
+    const lines = Array.from({ length: ROLLBACK_DIFF_LINE_LIMIT + 5 }, (_, i) => `+ line ${i}`)
+    const out = formatRollbackDiff({ diff: lines.join('\n') })
+    const outLines = out.split('\n')
+
+    expect(outLines).toHaveLength(ROLLBACK_DIFF_LINE_LIMIT + 1)
+    expect(outLines.at(-1)).toBe(`… 5 more lines (showing first ${ROLLBACK_DIFF_LINE_LIMIT})`)
+  })
+})
+
+describe('formatRollbackRestore', () => {
+  it('surfaces failures with the best available reason', () => {
+    expect(formatRollbackRestore({ error: 'bad hash', success: false }, '')).toBe('rollback failed: bad hash')
+    expect(formatRollbackRestore({ success: false }, '')).toBe('rollback failed: unknown error')
+  })
+
+  it('reports a full-workspace restore', () => {
+    expect(formatRollbackRestore({ reason: 'reset to abc123', success: true }, '')).toBe(
+      'rollback restored workspace: reset to abc123'
+    )
+  })
+
+  it('reports a file-scoped restore', () => {
+    expect(formatRollbackRestore({ restored_to: 'abc123', success: true }, 'src/foo.py')).toBe(
+      'rollback restored src/foo.py: abc123'
+    )
+  })
+})
+
+describe('trimLastExchange', () => {
+  it('drops trailing assistant/tool messages plus the user turn that started them', () => {
+    const messages = [
+      msg('user', 'u1'),
+      msg('assistant', 'a1'),
+      msg('user', 'u2'),
+      msg('tool', 't1'),
+      msg('assistant', 'a2')
+    ]
+
+    expect(trimLastExchange(messages).map(m => m.id)).toEqual(['u1', 'a1'])
+  })
+
+  it('leaves a trailing system message (e.g. a prior slash note) and its turn intact', () => {
+    const messages = [msg('user', 'u1'), msg('assistant', 'a1'), msg('system', 's1')]
+
+    expect(trimLastExchange(messages).map(m => m.id)).toEqual(['u1', 'a1', 's1'])
+  })
+
+  it('does not mutate the input and tolerates an empty transcript', () => {
+    const messages = [msg('user'), msg('assistant')]
+    const result = trimLastExchange(messages)
+
+    expect(messages).toHaveLength(2)
+    expect(result).toHaveLength(0)
+    expect(trimLastExchange([])).toEqual([])
+  })
+})

--- a/apps/desktop/src/lib/desktop-rollback.ts
+++ b/apps/desktop/src/lib/desktop-rollback.ts
@@ -1,0 +1,150 @@
+import type { ChatMessage } from '@/lib/chat-messages'
+
+export interface RollbackCheckpoint {
+  hash: string
+  message?: string
+  timestamp?: string
+}
+
+export interface RollbackListResponse {
+  checkpoints?: RollbackCheckpoint[]
+  enabled?: boolean
+}
+
+export interface RollbackDiffResponse {
+  diff?: string
+  rendered?: string
+  stat?: string
+}
+
+export interface RollbackRestoreResponse {
+  error?: string
+  history_removed?: number
+  message?: string
+  reason?: string
+  restored_to?: string
+  success?: boolean
+}
+
+/**
+ * Parsed intent of a `/rollback …` invocation. Each variant maps 1:1 to the
+ * native gateway RPC the desktop must call — `list` → `rollback.list`,
+ * `diff` → `rollback.diff`, `restore` → `rollback.restore`. `usage` short-circuits
+ * with a help line and hits no RPC.
+ *
+ * Routing through these RPCs (instead of `slash.exec`) is the whole point: the
+ * slash worker is a throwaway HermesCLI subprocess with no agent attached, so
+ * on remote/Cloud gateways `/rollback` dead-ends with "No active agent
+ * session." — and even where the worker path nominally works it restores the
+ * file but only undoes its OWN in-memory history copy, leaving the live
+ * gateway session (and therefore the agent's next-turn context) out of sync
+ * with the restored files. `rollback.restore` mutates the live
+ * `session["history"]` and reports how many messages it dropped via
+ * `history_removed`.
+ */
+export type RollbackPlan =
+  | { kind: 'diff'; hash: string }
+  | { kind: 'list' }
+  | { kind: 'restore'; filePath: string; hash: string }
+  | { kind: 'usage'; message: string }
+
+// Mirror the CLI's `/rollback diff` cap (cli_commands_mixin.py) so a large
+// diff doesn't flood the transcript with one giant system bubble.
+export const ROLLBACK_DIFF_LINE_LIMIT = 80
+
+export function parseRollbackCommand(arg: string): RollbackPlan {
+  const trimmed = arg.trim()
+  const [first = '', ...rest] = trimmed.split(/\s+/).filter(Boolean)
+  const lower = first.toLowerCase()
+
+  if (!trimmed || lower === 'list' || lower === 'ls') {
+    return { kind: 'list' }
+  }
+
+  if (lower === 'diff') {
+    const hash = rest[0]
+
+    if (!hash) {
+      return { kind: 'usage', message: 'usage: /rollback diff <checkpoint>' }
+    }
+
+    return { hash, kind: 'diff' }
+  }
+
+  return { filePath: rest.join(' ').trim(), hash: first, kind: 'restore' }
+}
+
+export function formatCheckpointList(r: RollbackListResponse): string {
+  if (!r.enabled) {
+    return 'checkpoints are not enabled'
+  }
+
+  const checkpoints = r.checkpoints ?? []
+
+  if (!checkpoints.length) {
+    return 'no checkpoints found'
+  }
+
+  return [
+    'Rollback checkpoints',
+    ...checkpoints.map((c, idx) => {
+      const meta = [c.timestamp, c.message].filter(Boolean).join(' · ') || '(no metadata)'
+
+      return `${idx + 1}. ${c.hash.slice(0, 10)}  ${meta}`
+    })
+  ].join('\n')
+}
+
+export function formatRollbackDiff(r: RollbackDiffResponse): string {
+  const stat = (r.stat || '').trim()
+  // Use the plain unified diff, not the ANSI-coloured `rendered` field (that is
+  // for the TUI pager and would render as escape-code noise in the transcript).
+  const diff = (r.diff || '').trim()
+
+  if (!stat && !diff) {
+    return 'no changes since this checkpoint'
+  }
+
+  const lines = diff ? diff.split('\n') : []
+
+  const shown =
+    lines.length > ROLLBACK_DIFF_LINE_LIMIT
+      ? [
+          ...lines.slice(0, ROLLBACK_DIFF_LINE_LIMIT),
+          `… ${lines.length - ROLLBACK_DIFF_LINE_LIMIT} more lines (showing first ${ROLLBACK_DIFF_LINE_LIMIT})`
+        ]
+      : lines
+
+  return [stat, shown.join('\n')].filter(Boolean).join('\n\n')
+}
+
+export function formatRollbackRestore(r: RollbackRestoreResponse, filePath: string): string {
+  if (!r.success) {
+    return `rollback failed: ${r.error || r.message || 'unknown error'}`
+  }
+
+  const target = filePath || 'workspace'
+  const detail = r.reason || r.message || r.restored_to || 'restored'
+
+  return `rollback restored ${target}: ${detail}`
+}
+
+/**
+ * Drop the last user/assistant exchange from the visible transcript, matching
+ * what a full `rollback.restore` removed from the live session history server-side
+ * (and the TUI's behaviour): pop trailing assistant/tool messages, then the
+ * user turn that started the exchange.
+ */
+export function trimLastExchange(messages: ChatMessage[]): ChatMessage[] {
+  const next = [...messages]
+
+  while (next.length && (next.at(-1)?.role === 'assistant' || next.at(-1)?.role === 'tool')) {
+    next.pop()
+  }
+
+  if (next.at(-1)?.role === 'user') {
+    next.pop()
+  }
+
+  return next
+}

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -39,6 +39,7 @@ export type DesktopActionId =
   | 'new'
   | 'pet'
   | 'profile'
+  | 'rollback'
   | 'skin'
   | 'title'
   | 'yolo'
@@ -225,7 +226,12 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
   },
   { name: '/queue', description: 'Queue a prompt for the next turn', aliases: ['/q'], surface: exec() },
   { name: '/retry', description: 'Retry the last user message', surface: exec() },
-  { name: '/rollback', description: 'List or restore filesystem checkpoints', surface: exec() },
+  {
+    name: '/rollback',
+    description: 'List or restore filesystem checkpoints',
+    surface: action('rollback'),
+    argumentMode: 'text'
+  },
   {
     name: '/save',
     description: 'Save the current transcript to JSON',


### PR DESCRIPTION
## What does this PR do?

Makes `/rollback` work from Hermes Desktop. Today the desktop registry marks it `exec`, so it runs in the slash worker — a headless `HermesCLI` subprocess with no agent attached. Two user-facing failures result:

1. **On remote/Cloud gateways it dead-ends immediately**: the worker's CLI handler prints `No active agent session.` no matter what the user does (reproduced today on a Desktop → Hermes Cloud setup, gateway v0.20.1/2026.8.13: fresh project-bound chat, message sent first, checkpoints enabled and populated — `/rollback` still fails, while the same store lists and restores correctly through the native RPC layer).
2. **Where the worker path nominally works, it desyncs state** (as #40987 diagnosed): the worker restores files on disk but only undoes its *own* in-memory history copy, so the live gateway session — the agent's next-turn context — silently diverges from the restored files.

The fix routes `/rollback` to the native `rollback.list` / `rollback.diff` / `rollback.restore` RPCs (`tui_gateway/methods_tools.py`), the same path the TUI already uses (`ui-tui/src/app/slash/commands/ops.ts`). Those handlers build/wait for the agent correctly and `rollback.restore` mutates the real `session["history"]`, reporting `history_removed`.

Implementation follows the registry architecture:

- `apps/desktop/src/lib/desktop-slash-commands.ts`: `/rollback` becomes a native `action` row (was `exec`).
- `apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts`: new `rollback` action handler — parses list/diff/restore intent, calls the RPCs, and on a successful full restore trims the last exchange from the visible transcript via the existing `updateSessionState` updater so the renderer matches what the server dropped from history (guarded to the active runtime, same pattern as `/compress`).
- `apps/desktop/src/lib/desktop-rollback.ts` (+ tests): parsing/formatting helpers — checkpoint list, diff (plain `diff` field, ANSI `rendered` ignored, 80-line cap), restore result, and `trimLastExchange`.
- `apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx`: four regression tests asserting each subcommand hits its RPC and that `slash.exec` / `command.dispatch` are never called for `/rollback`.

Credit: the state-divergence diagnosis and the original fix are @Frowtek's (#40987). This PR ports that work to the current registry-driven dispatcher per the review feedback there (the pre-split `use-prompt-actions.ts` target no longer exists on main). Supersedes #40987.

## Related Issue

Supersedes #40987.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `npx vitest run src/lib/desktop-rollback.test.ts src/app/session/hooks/use-prompt-actions/index.test.tsx` — 142 passed (2 files), including the 4 new `/rollback` routing tests.
- Live repro of failure mode 1 on a Desktop → Hermes Cloud setup (gateway v0.20.1): `/rollback` returns `No active agent session.` via the worker path while the same checkpoint store lists/restores correctly through `CheckpointManager` directly.
- The native RPC surface exercised end to end on the same box: checkpoint taken before a destructive op, list rendered, full restore returned all files byte-intact.
