### PR TITLE
fix(dashboard): spawn detached actions from the install's venv interpreter

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4421,13 +4421,38 @@ def _record_completed_action(name: str, message: str, exit_code: int = 1) -> Non
 def _dashboard_spawn_executable() -> str:
     """Interpreter for detached dashboard actions.
 
-    Returns ``sys.executable`` on every platform.  On Windows the spawn
-    below carries ``windows_detach_flags()`` (CREATE_NO_WINDOW), so the
-    console python owns a single hidden console that its own subprocess
+    Prefers the install's own venv interpreter over ``sys.executable`` when
+    they differ. Under an SSH remote backend the web server is launched by
+    running the **uv base interpreter** with the venv's site-packages
+    injected into ``sys.path`` at startup (``-c "sys.path[:0]=[...];
+    runpy.run_module('hermes_cli.main', ...)"``) — so ``sys.executable`` is
+    the dependency-less base python and a detached action spawned from it
+    dies on the first third-party import (``ModuleNotFoundError: yaml``),
+    because the injected path is a startup artifact of the parent and is
+    not inherited (#90026). The venv launcher resolves the same dependency
+    set on its own.
+
+    Falls back to ``sys.executable`` when no venv interpreter exists next
+    to the install (in-process dev runs, exotic layouts). On Windows the
+    spawn below carries ``windows_detach_flags()`` (CREATE_NO_WINDOW), so
+    the console python owns a single hidden console that its own subprocess
     spawns inherit — the action stays invisible without resorting to
     console-less pythonw.exe, which would make every console-subsystem
     descendant flash its own conhost (#54220/#56747).
     """
+    exe = Path(sys.executable)
+    try:
+        for rel in ("venv/bin/python", "venv/Scripts/python.exe"):
+            candidate = PROJECT_ROOT / rel
+            if candidate.is_file():
+                resolved = candidate.resolve()
+                # Same interpreter → keep sys.executable (preserves the
+                # docstring's console-ownership behavior verbatim).
+                if resolved == exe.resolve():
+                    return sys.executable
+                return str(resolved)
+    except OSError:
+        pass
     return sys.executable
 
 

--- a/tests/hermes_cli/test_dashboard_spawn_executable.py
+++ b/tests/hermes_cli/test_dashboard_spawn_executable.py
@@ -1,0 +1,69 @@
+"""Tests for the detached-dashboard-action interpreter choice (#90026).
+
+Under an SSH remote backend the web server runs on the **uv base
+interpreter** with the venv's site-packages injected into ``sys.path`` at
+startup. A detached action spawned from ``sys.executable`` (the base
+interpreter) inherits no injected path and no PYTHONPATH, so it dies on the
+first third-party import. The spawner must prefer the install's own venv
+interpreter when it differs from ``sys.executable``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import hermes_cli.web_server as web_server
+
+
+class TestDashboardSpawnExecutable:
+    def test_same_interpreter_returns_sys_executable(self, tmp_path):
+        """When sys.executable IS the venv python (normal launch), the
+        behavior is unchanged — same path back, verbatim."""
+        fake_venv = tmp_path / "venv" / "bin" / "python"
+        fake_venv.parent.mkdir(parents=True)
+        fake_venv.touch()
+        with (
+            patch.object(web_server, "PROJECT_ROOT", tmp_path),
+            patch.object(sys, "executable", str(fake_venv)),
+        ):
+            assert web_server._dashboard_spawn_executable() == str(fake_venv)
+
+    def test_base_interpreter_replaced_by_venv_python(self, tmp_path):
+        """sys.executable pointing at the dependency-less uv base
+        interpreter (SSH remote backend) resolves to the install's venv
+        python instead (#90026)."""
+        fake_venv = tmp_path / "venv" / "bin" / "python"
+        fake_venv.parent.mkdir(parents=True)
+        fake_venv.touch()
+        base_interp = tmp_path / "uv-base" / "python"
+        with (
+            patch.object(web_server, "PROJECT_ROOT", tmp_path),
+            patch.object(sys, "executable", str(base_interp)),
+        ):
+            chosen = web_server._dashboard_spawn_executable()
+        assert chosen == str(fake_venv)
+
+    def test_windows_layout_resolved(self, tmp_path):
+        """The Windows venv layout (Scripts/python.exe) is honored."""
+        fake_venv = tmp_path / "venv" / "Scripts" / "python.exe"
+        fake_venv.parent.mkdir(parents=True)
+        fake_venv.touch()
+        base_interp = tmp_path / "uv-base" / "python.exe"
+        with (
+            patch.object(web_server, "PROJECT_ROOT", tmp_path),
+            patch.object(sys, "executable", str(base_interp)),
+        ):
+            chosen = web_server._dashboard_spawn_executable()
+        assert Path(chosen).name == "python.exe"
+        assert "Scripts" in chosen
+
+    def test_no_venv_falls_back_to_sys_executable(self, tmp_path):
+        """Exotic layouts without an install venv keep the old behavior."""
+        base_interp = tmp_path / "uv-base" / "python"
+        with (
+            patch.object(web_server, "PROJECT_ROOT", tmp_path),
+            patch.object(sys, "executable", str(base_interp)),
+        ):
+            assert web_server._dashboard_spawn_executable() == str(base_interp)


### PR DESCRIPTION
## What does this PR do?

Fixes #90026: the dashboard's "Update now" (and every detached action routed through `_spawn_hermes_action`) failed instantly with `ModuleNotFoundError: No module named 'yaml'` when the desktop app used an SSH remote backend, while `hermes update` from the venv on the same machine worked.

**Mechanism.** The SSH backend is launched by running the **uv base interpreter** with the venv's site-packages injected into `sys.path` at startup — so `sys.executable` is a dependency-less python and the web server only imports fine because of the injection. `_dashboard_spawn_executable()` returned bare `sys.executable`, and the detached child inherited neither the injected path (a startup artifact of the parent) nor a `PYTHONPATH` — it died on the first third-party import. The docstring's claim ("inherits the same venv/PYTHONPATH the web server is using") was true for the normal launch path but not this one.

**Fix.** `_dashboard_spawn_executable()` now prefers the install's own venv interpreter (`venv/bin/python`, `venv/Scripts/python.exe` resolved against `PROJECT_ROOT`) when it differs from `sys.executable` — the venv launcher resolves the same dependency set on its own. Same-interpreter launches return `sys.executable` unchanged (the Windows console-ownership behavior from #54220/#56747 is preserved verbatim), and layouts without an install venv keep the old fallback.

## Related Issue

Fixes #90026

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py`: `_dashboard_spawn_executable` resolves the install's venv interpreter and prefers it over `sys.executable` when the two differ; docstring documents the SSH-base-interpreter trap.

## How to Test

1. `pytest tests/hermes_cli/test_dashboard_spawn_executable.py -q` — 4 passed.
2. Fail-on-main verified: with the source change stashed, the base-interpreter and Windows-layout tests fail on the unmodified tree (both returned `sys.executable`); the same-interpreter and no-venv fallback tests pin the unchanged behavior and pass on both.
3. Adjacent suites (`test_spawn_gateway_restart_reap`, `test_web_server_fs`): 7 passed — the restart-spawn flow that also goes through the action spawner is unaffected.
4. Observed result: with `sys.executable` patched to a base-interpreter path and a venv python present under the install root, `_dashboard_spawn_executable()` returns the venv python.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
