### PR TITLE
feat(gateway): opt-in require_all_profiles_connected for multiplexed startup

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -973,6 +973,11 @@ class GatewayConfig:
     # Optional named-profile allowlist for multiplex mode. None preserves the
     # historical serve-all behavior; [] serves only the default profile.
     multiplex_profile_allowlist: Optional[List[str]] = None
+    # Refuse to finish startup when a served profile has no adapter online.
+    # Off by default: one flaky token should not stop a single-profile gateway.
+    # Operators serving several profiles from one process turn it on because
+    # "gateway healthy, one profile unreachable" looks identical to working.
+    require_all_profiles_connected: bool = False
 
     # Opt-in systemd event-loop watchdog. Zero preserves Type=simple and
     # disables sd_notify at runtime.
@@ -1122,6 +1127,7 @@ class GatewayConfig:
             "max_concurrent_sessions": self.max_concurrent_sessions,
             "multiplex_profiles": self.multiplex_profiles,
             "multiplex_profile_allowlist": self.multiplex_profile_allowlist,
+            "require_all_profiles_connected": self.require_all_profiles_connected,
             "systemd_watchdog_seconds": self.systemd_watchdog_seconds,
             "loop_watchdog": self.loop_watchdog,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
@@ -1193,6 +1199,10 @@ class GatewayConfig:
             multiplex_profile_allowlist = nested_gateway.get(
                 "multiplex_profile_allowlist"
             )
+        if "require_all_profiles_connected" in data:
+            require_all_raw = data.get("require_all_profiles_connected")
+        else:
+            require_all_raw = nested_gateway.get("require_all_profiles_connected")
         if "systemd_watchdog_seconds" in data:
             systemd_watchdog_raw = data.get("systemd_watchdog_seconds")
             systemd_watchdog_key = "systemd_watchdog_seconds"
@@ -1267,6 +1277,7 @@ class GatewayConfig:
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             multiplex_profiles=_coerce_bool(multiplex_profiles, False),
             multiplex_profile_allowlist=multiplex_profile_allowlist,
+            require_all_profiles_connected=_coerce_bool(require_all_raw, False),
             systemd_watchdog_seconds=systemd_watchdog_seconds,
             loop_watchdog=loop_watchdog,
             max_concurrent_sessions=max_concurrent_sessions,
@@ -1421,6 +1432,12 @@ def load_gateway_config() -> GatewayConfig:
                 gw_data["multiplex_profile_allowlist"] = gateway_section[
                     "multiplex_profile_allowlist"
                 ]
+
+            _rapc = yaml_cfg.get("require_all_profiles_connected")
+            if _rapc is None and isinstance(gateway_section, dict):
+                _rapc = gateway_section.get("require_all_profiles_connected")
+            if _rapc is not None:
+                gw_data["require_all_profiles_connected"] = _rapc
 
             # Profile-based routing rules: accept either top-level
             # ``profile_routes`` or the nested ``gateway.profile_routes`` form

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -45,7 +45,7 @@ from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
 from datetime import datetime, timedelta, timezone
-from typing import Awaitable, Callable, Dict, Optional, Any, List, Tuple, Union, cast
+from typing import Awaitable, Callable, Dict, Optional, Any, List, Set, Tuple, Union, cast
 
 from agent.async_utils import consume_detached_task_result, safe_schedule_threadsafe
 from agent.conversation_compression import (
@@ -2075,6 +2075,15 @@ class MultiplexConfigError(RuntimeError):
 
 class SecondaryPortBindingConfigError(MultiplexConfigError):
     """A secondary profile conflicts with the multiplexer's shared listener."""
+
+
+class ProfileConnectivityError(MultiplexConfigError):
+    """A served profile did not come online and the operator demanded it.
+
+    Only raised when ``gateway.require_all_profiles_connected`` is on: adapter
+    failures are otherwise logged and skipped, which is right for one profile
+    and wrong once one process serves several.
+    """
 
 
 def _multiplex_profile_homes(config: object) -> list[tuple[str, "Path"]]:
@@ -6687,6 +6696,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # sites are untouched when multiplexing is off (this dict is empty).
         # Populated by _start_secondary_profile_adapters().
         self._profile_adapters: Dict[str, Dict[Platform, BasePlatformAdapter]] = {}
+        # Per-profile startup failures, read only by
+        # _assert_all_profiles_connected(); empty unless something failed.
+        self._profile_startup_failures: Dict[str, List[str]] = {}
+        # Profiles served only through the shared Relay ingress, which end
+        # startup with zero adapters by design rather than by failure.
+        self._profile_relay_served: Set[str] = set()
         self._warn_if_docker_media_delivery_is_risky()
         _gateway_runner_ref = _weakref.ref(self)
 
@@ -14961,10 +14976,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if isinstance(retry_claim, tuple):
                     claimed[retry_claim] = active
 
+        self._profile_startup_failures = {}
         profile_homes = _multiplex_profile_homes(self.config)
+        served_secondaries: List[str] = []
         for profile_name, profile_home in profile_homes:
             if profile_name == active:
                 continue  # handled by the primary startup loop
+            served_secondaries.append(profile_name)
             try:
                 connected += await self._start_one_profile_adapters(
                     profile_name, profile_home, claimed
@@ -14975,6 +14993,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     profile_name,
                     e,
                 )
+                self._record_profile_startup_failure(
+                    profile_name, "*", f"port-binding config error: {e}"
+                )
             except MultiplexConfigError:
                 raise
             except Exception as e:
@@ -14982,6 +15003,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "Failed to start adapters for profile '%s': %s",
                     profile_name, e, exc_info=True,
                 )
+                self._record_profile_startup_failure(
+                    profile_name, "*", f"profile startup raised {e}"
+                )
+
+        self._assert_all_profiles_connected(served_secondaries, active)
 
         # Record the authoritative served set in runtime status for `hermes status`.
         # "Served" means eligible for shared routing, HTTP prefixes, cron, and
@@ -15010,11 +15036,99 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         return connected
 
+    def _assert_all_profiles_connected(
+        self, served_secondaries: List[str], active: str = ""
+    ) -> None:
+        """Refuse to finish startup with a served profile offline.
+
+        No-op unless ``gateway.require_all_profiles_connected`` is set; the
+        default log-and-continue behavior is kept for everyone else. A profile
+        fails the check when it recorded any adapter failure *or* ended startup
+        with zero connected adapters.
+
+        The *active* profile is covered too when its name is passed; its
+        adapters come up in the primary startup loop, so its state is read from
+        ``self.adapters`` and ``self._failed_platforms`` instead. Leaving it out
+        would let a multiplexed host pass this gate with the active profile
+        offline. A Relay-only profile is exempt from the zero-adapters rule:
+        multiplex mode skips its Relay adapter by design (see
+        ``_start_one_profile_adapters``), so an empty map is expected.
+        """
+        # Only a literal True arms this. Its effect is to ABORT startup, so it
+        # must not be armable by a config object whose attribute access returns
+        # a truthy sentinel rather than a stored value (duck-typed configs and
+        # MagicMock test runners both do). GatewayConfig stores a real bool
+        # here via _coerce_bool, so the strict check is free on that path.
+        if getattr(self.config, "require_all_profiles_connected", False) is not True:
+            return
+
+        recorded = getattr(self, "_profile_startup_failures", None) or {}
+        relay_served = getattr(self, "_profile_relay_served", None) or set()
+        no_adapter_reason = (
+            "no platform adapter connected (check that this profile's "
+            "config.yaml enables a platform and its credentials are present)"
+        )
+        offline: Dict[str, List[str]] = {}
+        for profile_name in served_secondaries:
+            reasons = list(recorded.get(profile_name, ()))
+            if (
+                not self._profile_adapters.get(profile_name)
+                and profile_name not in relay_served
+            ):
+                reasons.append(no_adapter_reason)
+            if reasons:
+                offline[profile_name] = reasons
+
+        checked = len(served_secondaries) + (1 if active else 0)
+        if active:
+            active_reasons = [
+                f"{platform.value}: queued for background reconnection"
+                for platform in getattr(self, "_failed_platforms", {})
+            ]
+            if not self.adapters and active not in relay_served:
+                active_reasons.append(no_adapter_reason)
+            if active_reasons:
+                offline[active] = active_reasons
+
+        if not offline:
+            logger.info(
+                "[MULTIPLEX] require_all_profiles_connected: all %d served "
+                "profile(s) connected",
+                checked,
+            )
+            return
+
+        detail = "; ".join(
+            f"{name} ({', '.join(reasons)})" for name, reasons in sorted(offline.items())
+        )
+        raise ProfileConnectivityError(
+            f"gateway.require_all_profiles_connected is on and "
+            f"{len(offline)} of {checked} served profile(s) did "
+            f"not come online: {detail}. Fix the profile(s) or turn the flag off."
+        )
+
+    def _record_profile_startup_failure(
+        self, profile_name: str, platform_value: str, reason: str
+    ) -> None:
+        """Note that one of *profile_name*'s platforms did not come online.
+
+        Recorded unconditionally so the log-and-continue path and the
+        assertion cannot drift apart; only consulted when the flag is on.
+        """
+        failures = getattr(self, "_profile_startup_failures", None)
+        if failures is None:
+            failures = {}
+            self._profile_startup_failures = failures
+        failures.setdefault(profile_name, []).append(f"{platform_value}: {reason}")
+
     async def _start_one_profile_adapters(
         self, profile_name: str, profile_home: "Path", claimed: Dict[tuple, str]
     ) -> int:
         """Create+connect one profile's adapters under its runtime scope."""
         from gateway.config import load_gateway_config
+
+        def _record_failure(platform_value: str, reason: str) -> None:
+            self._record_profile_startup_failure(profile_name, platform_value, reason)
 
         with _profile_runtime_scope(profile_home):
             profile_runtime_cfg = _load_gateway_runtime_config()
@@ -15061,6 +15175,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 getattr(self.config, "multiplex_profiles", False)
                 and platform is Platform.RELAY
             ):
+                # Note the skip: a Relay-only profile ends this loop with zero
+                # adapters by design, which the connectivity assertion must
+                # tell apart from "everything failed".
+                self._profile_relay_served = (
+                    getattr(self, "_profile_relay_served", None) or set()
+                )
+                self._profile_relay_served.add(profile_name)
                 continue
             try:
                 with _profile_runtime_scope(profile_home):
@@ -15073,6 +15194,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     e,
                     exc_info=True,
                 )
+                _record_failure(platform.value, f"adapter creation raised {e}")
                 continue
             if not adapter:
                 logger.warning(
@@ -15080,6 +15202,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     profile_name,
                     platform.value,
                 )
+                _record_failure(platform.value, "adapter creation returned None")
                 continue
 
             # Same-token conflict detection — refuse a duplicate poll.
@@ -15109,6 +15232,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # resources to clean up. Calling disconnect here can mutate
                     # the shared platform state and, for a same-credential Photon
                     # adapter, shut down the primary profile's live sidecar.
+                    _record_failure(
+                        platform.value,
+                        f"same credential already claimed by profile '{owner}'",
+                    )
                     continue
 
             listener_claim = self._adapter_listener_claim(platform, adapter)
@@ -15142,6 +15269,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                     # Like credential conflicts, this adapter never connected
                     # and owns no resources that should be disconnected.
+                    _record_failure(
+                        platform.value,
+                        f"sidecar {bind}:{port} already claimed by profile '{owner}'",
+                    )
                     continue
 
             self._configure_profile_adapter(adapter, profile_name, platform)
@@ -15161,9 +15292,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     logger.info("✓ %s connected (profile: %s)", platform.value, profile_name)
                 else:
                     logger.warning("✗ %s failed to connect (profile: %s)", platform.value, profile_name)
+                    _record_failure(platform.value, "failed to connect")
                     await self._safe_adapter_disconnect(adapter, platform)
             except Exception as e:
                 logger.error("✗ %s error (profile: %s): %s", platform.value, profile_name, e)
+                _record_failure(platform.value, f"connect raised {e}")
                 await self._safe_adapter_disconnect(adapter, platform)
         return connected
 

--- a/tests/gateway/test_multiplex_require_all_profiles_connected.py
+++ b/tests/gateway/test_multiplex_require_all_profiles_connected.py
@@ -1,0 +1,197 @@
+"""gateway.require_all_profiles_connected: fail startup on an offline profile."""
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.run import GatewayRunner, ProfileConnectivityError
+
+
+def _runner(**config_kwargs) -> GatewayRunner:
+    """A GatewayRunner with just the attributes the startup path reads."""
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True, **config_kwargs)
+    runner.adapters = {}
+    runner._profile_adapters = {}
+    runner._profile_startup_failures = {}
+    runner._profile_relay_served = set()
+    runner._failed_platforms = {}
+    return runner
+
+
+class TestAssertAllProfilesConnected:
+    def test_default_off_tolerates_offline_profile(self):
+        runner = _runner()
+        runner._profile_startup_failures = {"reviewer": ["telegram: failed to connect"]}
+
+        runner._assert_all_profiles_connected(["reviewer"], "default")
+
+    def test_opt_in_raises_naming_the_failed_profile(self):
+        runner = _runner(require_all_profiles_connected=True)
+        runner.adapters = {Platform.TELEGRAM: object()}
+        runner._profile_adapters = {"ops": {Platform.DISCORD: object()}}
+        runner._profile_startup_failures = {"reviewer": ["telegram: failed to connect"]}
+
+        with pytest.raises(ProfileConnectivityError) as excinfo:
+            runner._assert_all_profiles_connected(["reviewer", "ops"], "default")
+
+        message = str(excinfo.value)
+        assert "reviewer" in message
+        assert "telegram: failed to connect" in message
+        assert "1 of 3 served profile(s)" in message
+        # The remedy has to be in the message: this aborts the gateway.
+        assert "require_all_profiles_connected" in message
+        # A profile that came up must not be blamed.
+        assert "ops (" not in message
+
+    def test_opt_in_passes_when_every_profile_connected(self, caplog):
+        runner = _runner(require_all_profiles_connected=True)
+        runner.adapters = {Platform.TELEGRAM: object()}
+        runner._profile_adapters = {"reviewer": {Platform.DISCORD: object()}}
+
+        caplog.set_level(logging.INFO, logger="gateway.run")
+        runner._assert_all_profiles_connected(["reviewer"], "default")
+
+        assert "all 2 served profile(s) connected" in caplog.text
+
+    def test_opt_in_flags_profile_with_zero_adapters(self):
+        runner = _runner(require_all_profiles_connected=True)
+        runner.adapters = {Platform.TELEGRAM: object()}
+
+        with pytest.raises(ProfileConnectivityError, match="no platform adapter"):
+            runner._assert_all_profiles_connected(["reviewer"], "default")
+
+    def test_relay_only_profile_is_not_offline(self):
+        """Multiplex skips a secondary's Relay adapter by design, not by failure."""
+        runner = _runner(require_all_profiles_connected=True)
+        runner.adapters = {Platform.TELEGRAM: object()}
+        runner._profile_relay_served = {"reviewer"}
+
+        runner._assert_all_profiles_connected(["reviewer"], "default")
+
+    def test_offline_active_profile_is_caught(self):
+        """The active profile is served too; its adapters start elsewhere."""
+        runner = _runner(require_all_profiles_connected=True)
+        runner._profile_adapters = {"reviewer": {Platform.DISCORD: object()}}
+
+        with pytest.raises(ProfileConnectivityError) as excinfo:
+            runner._assert_all_profiles_connected(["reviewer"], "default")
+
+        assert "default (no platform adapter" in str(excinfo.value)
+
+    def test_active_profile_queued_for_retry_counts_as_offline(self):
+        runner = _runner(require_all_profiles_connected=True)
+        runner.adapters = {Platform.TELEGRAM: object()}
+        runner._failed_platforms = {Platform.DISCORD: {}}
+
+        with pytest.raises(ProfileConnectivityError, match="queued for background"):
+            runner._assert_all_profiles_connected([], "default")
+
+    def test_truthy_non_bool_does_not_arm_the_abort(self):
+        """A MagicMock config must not abort a gateway it never opted in."""
+        runner = _runner()
+        runner.config = MagicMock()
+
+        runner._assert_all_profiles_connected(["reviewer"], "default")
+
+
+class TestSecondaryStartupIntegration:
+    @pytest.mark.asyncio
+    async def test_default_off_still_skips_and_warns(self, monkeypatch, caplog):
+        """The pre-existing log-and-continue path is byte-identical when off."""
+        from gateway.run import SecondaryPortBindingConfigError
+
+        runner = _runner()
+        runner.pairing_stores = {"default": MagicMock(), "bad": MagicMock()}
+        runner.pairing_store = runner.pairing_stores["default"]
+
+        async def fake_start_one(profile_name, profile_home, claimed):
+            raise SecondaryPortBindingConfigError("bad enables webhook")
+
+        monkeypatch.setattr(
+            "hermes_cli.profiles.profiles_to_serve",
+            lambda multiplex, profile_allowlist=None: [
+                ("default", Path("/tmp/default")),
+                ("bad", Path("/tmp/bad")),
+            ],
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "default"
+        )
+        monkeypatch.setattr(runner, "_start_one_profile_adapters", fake_start_one)
+        monkeypatch.setattr(
+            "gateway.status.write_runtime_status", lambda **kwargs: None
+        )
+
+        caplog.set_level(logging.WARNING, logger="gateway.run")
+        assert await runner._start_secondary_profile_adapters() == 0
+        assert "Skipping secondary profile 'bad'" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_opt_in_turns_the_same_skip_into_a_fatal(self, monkeypatch):
+        from gateway.run import SecondaryPortBindingConfigError
+
+        runner = _runner(require_all_profiles_connected=True)
+        runner.adapters = {Platform.TELEGRAM: object()}
+        runner.pairing_stores = {"default": MagicMock(), "bad": MagicMock()}
+        runner.pairing_store = runner.pairing_stores["default"]
+
+        async def fake_start_one(profile_name, profile_home, claimed):
+            raise SecondaryPortBindingConfigError("bad enables webhook")
+
+        monkeypatch.setattr(
+            "hermes_cli.profiles.profiles_to_serve",
+            lambda multiplex, profile_allowlist=None: [
+                ("default", Path("/tmp/default")),
+                ("bad", Path("/tmp/bad")),
+            ],
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "default"
+        )
+        monkeypatch.setattr(runner, "_start_one_profile_adapters", fake_start_one)
+
+        with pytest.raises(ProfileConnectivityError, match="port-binding config error"):
+            await runner._start_secondary_profile_adapters()
+
+
+class TestConfigRoundTrip:
+    def test_defaults_off(self):
+        assert GatewayConfig().require_all_profiles_connected is False
+        assert (
+            GatewayConfig.from_dict({}).require_all_profiles_connected is False
+        )
+
+    def test_top_level_key(self):
+        cfg = GatewayConfig.from_dict({"require_all_profiles_connected": True})
+        assert cfg.require_all_profiles_connected is True
+
+    def test_nested_gateway_key(self):
+        """`hermes config set gateway.<key> true` writes the nested form."""
+        cfg = GatewayConfig.from_dict(
+            {"gateway": {"require_all_profiles_connected": True}}
+        )
+        assert cfg.require_all_profiles_connected is True
+
+    def test_top_level_wins_over_nested(self):
+        cfg = GatewayConfig.from_dict(
+            {
+                "require_all_profiles_connected": False,
+                "gateway": {"require_all_profiles_connected": True},
+            }
+        )
+        assert cfg.require_all_profiles_connected is False
+
+    def test_yaml_string_is_coerced(self):
+        cfg = GatewayConfig.from_dict({"require_all_profiles_connected": "true"})
+        assert cfg.require_all_profiles_connected is True
+
+    def test_to_dict_round_trip(self):
+        cfg = GatewayConfig(require_all_profiles_connected=True)
+        assert cfg.to_dict()["require_all_profiles_connected"] is True
+        assert (
+            GatewayConfig.from_dict(cfg.to_dict()).require_all_profiles_connected
+            is True
+        )


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in `gateway.require_all_profiles_connected` (default `false`). When a multiplexed gateway starts and a profile it is meant to serve has no working adapter, boot fails with an error naming the profile, instead of coming up and quietly serving a partial roster.

Today every adapter failure on the multiplex startup path is warn-or-log-and-continue: a raised adapter, a `None` adapter, a duplicate credential, a duplicate listener, a `connect()` returning false, a `connect()` that raised, and the port-binding config error. None of them is recorded anywhere. `served_profiles` is then written from the *configured* set — the code comment says this is "intentionally broader than profiles with a successfully connected secondary adapter" — so `hermes status` reports a profile as served when nothing is actually listening for it. For an unattended deployment the first sign is a user wondering why their bot never answers.

## Related Issue

No open issue — found while running multiplexed gateways.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/config.py` — the flag, parsed with the same idiom as `multiplex_profiles` (env override, nested and top-level acceptance, `to_dict` round-trip).
- `gateway/run.py` — record per-profile startup failures, and assert the served set is fully connected when the flag is on. The check covers the **active** profile as well as secondaries, since it's served too and leaving it out would be a hole in the thing the flag exists to close.
- Test file covering: opt-in produces a fatal error naming the failed profile; default-off preserves today's skip-with-warning byte-for-byte; config round-trip.

## Default is off

Nothing changes for anyone who doesn't set the flag — that's what the default-off test pins. It's opt-in because failing closed is right for an unattended fleet and wrong for someone debugging one profile locally.

## How to Test

```text
bash scripts/run_tests.sh tests/gateway/ -q
→ 5834 passed, 3 failed, 38 skipped   (new file: 16/16)
```
The 3 are timeout assertions in code this doesn't touch (`test_slow_push_is_waited_for` and two sandbox timeout tests); they fail under parallel load and pass 14/14 when those files are re-run under light load. A same-machine baseline at the unmodified pin reproduces the wider failure set, so none of it is attributable here.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched existing PRs
- [x] Only changes related to this feature
- [x] Ran `tests/gateway/` with a same-machine pin baseline for attribution
- [x] Added tests
- [x] Tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] Docs — N/A (config key documented inline)
- [ ] `cli-config.yaml.example` — happy to add the key there if you want it advertised; left out to keep the diff to the mechanism
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform — N/A
- [x] Tool descriptions/schemas — N/A

---

Salvage-friendly: single commit on current main (`13ce0c5c67`), no dependencies — cherry-pick welcome, authorship preservation appreciated but optional.
