### PR TITLE
fix(gateway): refuse startup when a session key is aliased across profiles

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2514,6 +2514,7 @@ from gateway.config import (
 )
 from gateway.session import (
     AsyncSessionStore,
+    MultiplexSessionCollisionError,
     SessionEntry,
     SessionStore,
     SessionSource,
@@ -12317,7 +12318,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
         if await self._abort_startup_if_shutdown_requested():
             return True
-        
+
+        # Multiplexed adapters must not connect while two profile namespaces
+        # point at one session: from the first inbound message the two share a
+        # cache, a transcript, and a turn lease. Load the routing index and
+        # fail closed with a redacted operator error before any platform can
+        # receive traffic. Covers the root/legacy routing scope — see
+        # SessionStore.assert_no_cross_profile_session_aliases.
+        if getattr(self.config, "multiplex_profiles", False):
+            try:
+                await (
+                    self.async_session_store
+                    .assert_no_cross_profile_session_aliases()
+                )
+            except MultiplexSessionCollisionError as exc:
+                reason = str(exc)
+                logger.error("Gateway multiplex session collision: %s", reason)
+                try:
+                    from gateway.status import write_runtime_status
+                    write_runtime_status(
+                        gateway_state="startup_failed",
+                        exit_reason="multiplex_session_collision",
+                    )
+                except Exception:
+                    pass
+                self._exit_code = GATEWAY_FATAL_CONFIG_EXIT_CODE
+                self._request_clean_exit(reason)
+                return True
+
         # Warn if no user allowlists are configured and open access is not opted in
         _builtin_allowed_vars = (
             "TELEGRAM_ALLOWED_USERS", "DISCORD_ALLOWED_USERS",

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1242,6 +1242,10 @@ class AsyncSessionStore:
 _DB_UNPINNED = object()
 
 
+class MultiplexSessionCollisionError(RuntimeError):
+    """Active gateway routing aliases one session across profile namespaces."""
+
+
 class SessionStore:
     """
     Manages session storage and retrieval.
@@ -1427,6 +1431,51 @@ class SessionStore:
         """Load sessions index from disk if not already loaded."""
         with self._lock:
             self._ensure_loaded_locked()
+
+    def assert_no_cross_profile_session_aliases(self) -> None:
+        """Reject root routing that aliases one session across profiles.
+
+        Duplicate keys within one normalized profile are legitimate aliases,
+        but a session ID reachable from two distinct profile namespaces would
+        merge that session's cache, transcript, and turn lease between two
+        people. Startup is the only safe place to notice: once adapters accept
+        traffic the merge has already happened.
+
+        Scope — this reads ONE routing index, not every profile's. ``_db``
+        resolves per active profile scope and ``_ensure_loaded`` runs once, so
+        a store checked at startup sees the root/legacy scope that was active
+        then (the same limitation ``close_all_db_handles`` documents). That is
+        deliberately where it is useful: un-migrated aliases predating
+        per-profile state.db live in exactly that index. A profile whose rows
+        were written to its own state.db is NOT covered by this call.
+
+        No-op unless ``gateway.multiplex_profiles`` is on — a single-profile
+        gateway has one namespace and cannot alias across two.
+
+        The raised error deliberately omits routing keys and session IDs: it
+        reaches operator logs and runtime status, which are not the place for
+        chat identifiers.
+        """
+        if not getattr(self.config, "multiplex_profiles", False):
+            return
+
+        self._ensure_loaded()
+        profiles_by_session: Dict[str, set] = {}
+        with self._lock:
+            for session_key, entry in self._entries.items():
+                profile = self._profile_from_session_key(session_key)
+                if profile is None:
+                    continue
+                profiles_by_session.setdefault(entry.session_id, set()).add(profile)
+
+        collisions = sum(
+            1 for profiles in profiles_by_session.values() if len(profiles) > 1
+        )
+        if collisions:
+            raise MultiplexSessionCollisionError(
+                "multiplex routing contains "
+                f"{collisions} cross-profile session collision(s)"
+            )
 
     def _routing_scope(self) -> str:
         """Namespace for this store's rows in the gateway_routing table.

--- a/tests/gateway/test_multiplex_session_alias_guard.py
+++ b/tests/gateway/test_multiplex_session_alias_guard.py
@@ -1,0 +1,221 @@
+"""Startup invariant: no session ID reachable from two profile namespaces.
+
+The corruption precondition for a multiplexed gateway is one session ID
+aliased across profiles — from the first inbound message the two namespaces
+share that session's cache, transcript, and turn lease. These pin the guard
+that refuses startup when the root routing index is already in that state.
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig
+from gateway.session import (
+    MultiplexSessionCollisionError,
+    SessionEntry,
+    SessionStore,
+)
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+def _entry(session_key: str, session_id: str) -> SessionEntry:
+    now = datetime.now()
+    return SessionEntry(
+        session_key=session_key,
+        session_id=session_id,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _store(tmp_path, entries, **config_kwargs) -> SessionStore:
+    """A loaded store whose routing index is exactly *entries*."""
+    with patch("gateway.session.SessionStore._ensure_loaded"):
+        store = SessionStore(
+            sessions_dir=tmp_path / "sessions",
+            config=GatewayConfig(**config_kwargs),
+        )
+    store._loaded = True
+    store._entries = {e.session_key: e for e in entries}
+    return store
+
+
+class TestAliasGuard:
+    def test_two_namespaces_on_one_session_trips_the_guard(self, tmp_path):
+        store = _store(
+            tmp_path,
+            [
+                _entry("agent:main:telegram:111", "sess-shared"),
+                _entry("agent:reviewer:telegram:222", "sess-shared"),
+            ],
+            multiplex_profiles=True,
+        )
+
+        with pytest.raises(MultiplexSessionCollisionError) as excinfo:
+            store.assert_no_cross_profile_session_aliases()
+
+        assert "1 cross-profile session collision(s)" in str(excinfo.value)
+
+    def test_error_leaks_no_routing_keys_or_session_ids(self, tmp_path):
+        """This message reaches operator logs and runtime status."""
+        store = _store(
+            tmp_path,
+            [
+                _entry("agent:main:telegram:private-chat-111", "sess-secret"),
+                _entry("agent:reviewer:telegram:private-chat-222", "sess-secret"),
+            ],
+            multiplex_profiles=True,
+        )
+
+        with pytest.raises(MultiplexSessionCollisionError) as excinfo:
+            store.assert_no_cross_profile_session_aliases()
+
+        message = str(excinfo.value)
+        assert "sess-secret" not in message
+        assert "private-chat" not in message
+        assert "reviewer" not in message
+
+    def test_clean_index_passes(self, tmp_path):
+        store = _store(
+            tmp_path,
+            [
+                _entry("agent:main:telegram:111", "sess-default"),
+                _entry("agent:reviewer:telegram:222", "sess-reviewer"),
+                _entry("agent:ops:discord:333", "sess-ops"),
+            ],
+            multiplex_profiles=True,
+        )
+
+        store.assert_no_cross_profile_session_aliases()
+
+    def test_aliases_within_one_profile_are_legitimate(self, tmp_path):
+        """Several routing keys may point at one session inside a namespace."""
+        store = _store(
+            tmp_path,
+            [
+                _entry("agent:reviewer:telegram:111", "sess-reviewer"),
+                _entry("agent:reviewer:telegram:111:thread:7", "sess-reviewer"),
+            ],
+            multiplex_profiles=True,
+        )
+
+        store.assert_no_cross_profile_session_aliases()
+
+    def test_main_and_default_are_the_same_namespace(self, tmp_path):
+        """`agent:main:` is the default profile's on-disk spelling."""
+        store = _store(
+            tmp_path,
+            [
+                _entry("agent:main:telegram:111", "sess-default"),
+                _entry("agent:default:telegram:222", "sess-default"),
+            ],
+            multiplex_profiles=True,
+        )
+
+        store.assert_no_cross_profile_session_aliases()
+
+    def test_unprofiled_keys_are_ignored(self, tmp_path):
+        """Legacy keys carry no namespace and cannot prove a collision."""
+        store = _store(
+            tmp_path,
+            [
+                _entry("telegram:111", "sess-shared"),
+                _entry("agent:reviewer:telegram:222", "sess-shared"),
+            ],
+            multiplex_profiles=True,
+        )
+
+        store.assert_no_cross_profile_session_aliases()
+
+    def test_counts_each_colliding_session_once(self, tmp_path):
+        store = _store(
+            tmp_path,
+            [
+                _entry("agent:main:telegram:111", "sess-a"),
+                _entry("agent:reviewer:telegram:222", "sess-a"),
+                _entry("agent:ops:telegram:333", "sess-a"),
+                _entry("agent:main:discord:444", "sess-b"),
+                _entry("agent:reviewer:discord:555", "sess-b"),
+            ],
+            multiplex_profiles=True,
+        )
+
+        with pytest.raises(MultiplexSessionCollisionError, match="2 cross-profile"):
+            store.assert_no_cross_profile_session_aliases()
+
+    def test_multiplex_off_is_a_no_op(self, tmp_path):
+        """One namespace cannot alias across two, so the check does not apply."""
+        store = _store(
+            tmp_path,
+            [
+                _entry("agent:main:telegram:111", "sess-shared"),
+                _entry("agent:reviewer:telegram:222", "sess-shared"),
+            ],
+        )
+
+        store.assert_no_cross_profile_session_aliases()
+
+    def test_multiplex_off_does_not_load_the_index(self, tmp_path):
+        """Cheap enough to sit on every startup path, multiplexed or not."""
+        store = _store(tmp_path, [])
+        calls = []
+        store._ensure_loaded = lambda: calls.append(1)
+
+        store.assert_no_cross_profile_session_aliases()
+
+        assert calls == []
+
+    def test_empty_index_passes(self, tmp_path):
+        store = _store(tmp_path, [], multiplex_profiles=True)
+
+        store.assert_no_cross_profile_session_aliases()
+
+
+class TestStartupAbort:
+    @pytest.mark.asyncio
+    async def test_gateway_aborts_before_connecting_adapters(self, tmp_path):
+        """A collision must be caught while no platform can deliver a message."""
+        from gateway.run import GATEWAY_FATAL_CONFIG_EXIT_CODE, GatewayRunner
+
+        home_token = set_hermes_home_override(tmp_path)
+        try:
+            runner = GatewayRunner(GatewayConfig(multiplex_profiles=True))
+            collision_check = AsyncMock(
+                side_effect=MultiplexSessionCollisionError(
+                    "multiplex routing contains 1 cross-profile session collision(s)"
+                )
+            )
+            runner._async_session_store = SimpleNamespace(
+                _store=runner.session_store,
+                assert_no_cross_profile_session_aliases=collision_check,
+            )
+            runner._abort_startup_if_shutdown_requested = AsyncMock(return_value=False)
+            runner._start_loop_liveness_guards = Mock()
+            runner._request_clean_exit = Mock()
+            runner._create_adapter = Mock()
+
+            with (
+                patch("gateway.run.faulthandler.enable"),
+                patch("gateway.status.write_runtime_status"),
+                patch(
+                    "agent.monitoring.gateway_health_export."
+                    "start_gateway_health_export",
+                    return_value=SimpleNamespace(enabled=False),
+                ),
+                patch(
+                    "hermes_cli.security_advisories.detect_compromised",
+                    return_value=[],
+                ),
+            ):
+                result = await runner.start()
+
+            assert result is True
+            collision_check.assert_awaited_once()
+            runner._create_adapter.assert_not_called()
+            runner._request_clean_exit.assert_called_once()
+            assert runner._exit_code == GATEWAY_FATAL_CONFIG_EXIT_CODE
+        finally:
+            reset_hermes_home_override(home_token)


### PR DESCRIPTION
## What does this PR do?

Adds a startup check that refuses to boot when the routing index shows one session key aliased across two profile namespaces. That aliasing is the precondition for cross-profile session bleed — two profiles sharing a session means sharing its persona, tools, credentials and filesystem scope — and today it's silent until a user notices their bot answering as someone else.

## Related Issue

This is the follow-up I promised in #81295, whose body says the startup-invariant half "is a separable follow-up and is not in this diff." It complements whichever recovery fix lands (#81295 or #74593) rather than competing with either: they stop a bad recovery happening, this reports that the corrupting state already exists.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Scope — please read, it's narrower than it sounds

The guard inspects **one** routing index, not every profile's. Since per-profile session stores landed (#88532), `_db` resolves against the active profile scope and `_ensure_loaded` runs once, so what this actually sees is the routing table of the scope active at startup — in practice the root/legacy one. That's deliberately where it's useful: the un-migrated aliases from before that change live in exactly that store, because the migration is forward-only.

I've stated the same limitation in the docstring and the commit body. It is the same constraint `close_all_db_handles()` already documents, so it's not a new wrinkle — but I'd rather you read "guards the root/legacy routing index" than assume gateway-wide coverage.

## Changes Made

- `gateway/session.py` — the alias assertion and its error type.
- `gateway/run.py` — call it at startup.
- Test file: two aliased namespaces in one index trip the guard; a clean index doesn't; single-profile and multiplex-off are unaffected.

## How to Test

```text
bash scripts/run_tests.sh tests/gateway/ -q
→ 5829 passed, 3 failed, 38 skipped   (new file: 11/11)
```
Same 3 load-flaky timeout tests as noted in #90034 — unrelated code, pass under light load, and reproduced against an unmodified pin on this machine.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched existing PRs
- [x] Only changes related to this fix
- [x] Ran `tests/gateway/` with a same-machine pin baseline
- [x] Added tests
- [x] Tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] Docs — N/A
- [x] `cli-config.yaml.example` — N/A (no new config key)
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform — N/A
- [x] Tool descriptions/schemas — N/A

---

Salvage-friendly: single commit on current main (`13ce0c5c67`), no dependencies — cherry-pick welcome, authorship preservation appreciated but optional.
