### PR TITLE
fix(cron): route scheduled audio through play_tts so it plays in a live voice channel

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2386,7 +2386,13 @@ def _send_media_via_adapter(
             ext = Path(media_path).suffix.lower()
             route_platform = platform if platform is not None else getattr(adapter, "platform", None)
             if should_send_media_as_audio(route_platform, ext, is_voice=_is_voice):
-                coro = adapter.send_voice(chat_id=chat_id, audio_path=media_path, metadata=metadata)
+                # Prefer play_tts: it plays into a live voice channel when the bot
+                # is connected to one mapped to this chat, and falls back to
+                # send_voice otherwise. Calling send_voice directly skipped that
+                # router, so a scheduled reminder always arrived as a file
+                # attachment even while the user was sitting in the channel.
+                _audio_send = getattr(adapter, "play_tts", None) or adapter.send_voice
+                coro = _audio_send(chat_id=chat_id, audio_path=media_path, metadata=metadata)
             elif ext in _VIDEO_EXTS:
                 coro = adapter.send_video(chat_id=chat_id, video_path=media_path, metadata=metadata)
             elif ext in _IMAGE_EXTS:


### PR DESCRIPTION
Scheduled cron messages that produce audio always arrive as a file attachment, even when the bot is sitting in the voice channel the job targets.

**Cause**

`cron/scheduler.py` calls `adapter.send_voice()` directly for anything `should_send_media_as_audio()` classifies as audio. `send_voice()` is the file-attachment sender.

`play_tts()` is the router that decides between the two:

```python
async def play_tts(self, chat_id, audio_path, **kwargs):
    for gid, text_ch_id in self._voice_text_channels.items():
        if str(text_ch_id) == str(chat_id) and self.is_in_voice_channel(gid):
            return SendResult(success=await self.play_in_voice_channel(gid, audio_path))
    return await self.send_voice(chat_id=chat_id, audio_path=audio_path, **kwargs)
```

Cron is the only audio caller that skips it, so live agent replies speak in the VC while scheduled ones silently attach — two behaviours for the same audio on the same chat.

**Fix**

Prefer `play_tts` when the adapter provides it:

```python
_audio_send = getattr(adapter, "play_tts", None) or adapter.send_voice
coro = _audio_send(chat_id=chat_id, audio_path=media_path, metadata=metadata)
```

**Compatibility**

- Adapters without `play_tts` (Telegram, Slack, Signal, ...) keep calling `send_voice`, unchanged, via `getattr`.
- When the bot is not in a mapped voice channel, `play_tts` falls through to `send_voice` itself, so behaviour is byte-identical.
- Only the case the router already exists to handle changes.

**Repro**

1. `/voice join` a Discord voice channel.
2. Schedule a cron job in that chat that synthesizes speech with `text_to_speech`.
3. Before: a tap-to-play attachment. After: it speaks in the channel.