### PR TITLE
fix(desktop): preserve config on model settings save

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7324,8 +7324,58 @@ def _apply_model_assignment_sync(
                 # must never block saving the model assignment.
                 _log.debug("apply_nous_managed_defaults skipped", exc_info=True)
 
-        save_config(cfg)
+        # Desktop selection owns only the model subtree. `load_config()` returns
+        # a normalized whole-document snapshot; feeding it to `save_config()`
+        # rewrites unrelated user keys and strips comments. Re-open the current
+        # YAML and mutate its existing model map in one atomic round-trip write.
+        from hermes_cli.config import _secure_file, get_config_path, is_managed, managed_error
+        from hermes_cli import managed_scope
+        from utils import atomic_roundtrip_yaml_mutate
 
+        managed_keys = managed_scope.managed_config_keys()
+
+        def _persist_model(root):
+            existing_model = root.get("model")
+            if not isinstance(existing_model, dict):
+                existing_model = {}
+                root["model"] = existing_model
+            _apply_main_model_assignment(existing_model, provider, model, base_url, api_key)
+            if isinstance(provider_entry, dict) and provider_entry.get("api_key"):
+                existing_model["api_key"] = provider_entry["api_key"]
+            for key in ("provider", "default", "base_url", "api_key", "api", "api_mode"):
+                if f"model.{key}" in managed_keys:
+                    existing_model.pop(key, None)
+
+            # apply_nous_managed_defaults only changes these leaf settings.
+            # Apply the same leaves to the round-trip document rather than
+            # saving the normalized cfg snapshot, which would clobber user
+            # comments and unrelated configuration.
+            managed_gateway_keys = {
+                "web": ("backend",),
+                "tts": ("provider",),
+                "stt": ("provider",),
+                "browser": ("cloud_provider",),
+                "image_gen": ("use_gateway",),
+                "video_gen": ("provider", "use_gateway"),
+            }
+            for section in gateway_tools:
+                source = cfg.get(section)
+                if not isinstance(source, dict):
+                    continue
+                target = root.get(section)
+                if not isinstance(target, dict):
+                    target = {}
+                    root[section] = target
+                for key in managed_gateway_keys.get(section, ()):
+                    if key in source and f"{section}.{key}" not in managed_keys:
+                        target[key] = source[key]
+
+        config_path = get_config_path()
+        if is_managed():
+            managed_error("save configuration")
+        else:
+            atomic_roundtrip_yaml_mutate(config_path, _persist_model)
+            _secure_file(config_path)
         # Register a named ``custom_providers`` entry for a custom/local
         # endpoint, mirroring the ``hermes model`` custom flow
         # (_save_custom_provider). Without this the endpoint only lives in

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1318,6 +1318,174 @@ class TestWebServerEndpoints:
 
 
 
+    def test_model_set_preserves_unrelated_config_and_yaml_comments(self, monkeypatch):
+        """Desktop's model picker must update only model keys, leaving unrelated
+        user configuration and comments intact (#89184)."""
+        from hermes_constants import get_hermes_home
+
+        config_path = get_hermes_home() / "config.yaml"
+        config_path.write_text(
+            "# user-managed config\n"
+            "model:\n"
+            "  # retain this comment\n"
+            "  default: old-model\n"
+            "  provider: old-provider\n"
+            "  base_url: https://old.example/v1\n"
+            "fallback_providers:\n"
+            "  - provider: backup\n"
+            "    model: backup-model\n"
+            "agent:\n"
+            "  personalities:\n"
+            "    catgirl: 'nya (=^･ω･^=) 你好'\n"
+            "auxiliary:\n"
+            "  unchanged: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            "hermes_cli.model_cost_guard.expensive_model_warning",
+            lambda *_args, **_kwargs: None,
+        )
+
+        resp = self.client.post(
+            "/api/model/set",
+            json={
+                "scope": "main",
+                "provider": "openrouter",
+                "model": "new/model",
+                "confirm_expensive_model": True,
+            },
+        )
+
+        assert resp.status_code == 200
+        text = config_path.read_text(encoding="utf-8")
+        assert "# user-managed config" in text
+        assert "# retain this comment" in text
+        assert "nya (=^･ω･^=) 你好" in text
+        saved = yaml.safe_load(text)
+        assert saved["model"] == {
+            "default": "new/model",
+            "provider": "openrouter",
+            "base_url": "",
+        }
+        assert saved["fallback_providers"] == [{"provider": "backup", "model": "backup-model"}]
+        assert saved["agent"]["personalities"] == {"catgirl": "nya (=^･ω･^=) 你好"}
+        assert saved["auxiliary"] == {"unchanged": True}
+
+    def test_model_set_preserves_comments_when_nous_gateway_defaults_change(self, monkeypatch):
+        """Managed gateway defaults must not turn a targeted model save into a
+        whole-document rewrite (#89184)."""
+        from hermes_constants import get_hermes_home
+
+        config_path = get_hermes_home() / "config.yaml"
+        config_path.write_text(
+            "# user-managed config\n"
+            "model:\n"
+            "  # retain this comment\n"
+            "  default: old-model\n"
+            "  provider: old-provider\n"
+            "agent:\n"
+            "  personalities:\n"
+            "    catgirl: 'nya (=^･ω･^=) 你好'\n"
+            "web:\n"
+            "  # retain this tool comment\n"
+            "  custom_option: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            "hermes_cli.model_cost_guard.expensive_model_warning",
+            lambda *_args, **_kwargs: None,
+        )
+
+        def apply_managed_defaults(cfg, **_kwargs):
+            cfg.setdefault("web", {})["backend"] = "firecrawl"
+            return {"web"}
+
+        monkeypatch.setattr(
+            "hermes_cli.nous_subscription.apply_nous_managed_defaults",
+            apply_managed_defaults,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._get_platform_tools",
+            lambda *_args, **_kwargs: ["web"],
+        )
+
+        resp = self.client.post(
+            "/api/model/set",
+            json={
+                "scope": "main",
+                "provider": "nous",
+                "model": "new-model",
+                "confirm_expensive_model": True,
+            },
+        )
+
+        assert resp.status_code == 200
+        text = config_path.read_text(encoding="utf-8")
+        assert "# user-managed config" in text
+        assert "# retain this comment" in text
+        assert "# retain this tool comment" in text
+        saved = yaml.safe_load(text)
+        assert saved["model"]["provider"] == "nous"
+        assert saved["model"]["default"] == "new-model"
+        assert saved["web"] == {"custom_option": True, "backend": "firecrawl"}
+        assert saved["agent"]["personalities"] == {"catgirl": "nya (=^･ω･^=) 你好"}
+
+    def test_model_set_respects_managed_configuration(self, monkeypatch):
+        """The targeted persistence path must retain save_config's managed
+        installation write guard."""
+        from hermes_constants import get_hermes_home
+
+        config_path = get_hermes_home() / "config.yaml"
+        original = "model:\n  provider: old-provider\n  default: old-model\n"
+        config_path.write_text(original, encoding="utf-8")
+        monkeypatch.setattr("hermes_cli.config.is_managed", lambda: True)
+        monkeypatch.setattr("hermes_cli.config.ensure_hermes_home", lambda: None)
+        monkeypatch.setattr(
+            "hermes_cli.model_cost_guard.expensive_model_warning",
+            lambda *_args, **_kwargs: None,
+        )
+
+        resp = self.client.post(
+            "/api/model/set",
+            json={
+                "scope": "main",
+                "provider": "openrouter",
+                "model": "new/model",
+                "confirm_expensive_model": True,
+            },
+        )
+
+        assert resp.status_code == 200
+        assert config_path.read_text(encoding="utf-8") == original
+
+    @pytest.mark.linux_only
+    def test_model_set_secures_config_file_after_persisting_api_key(self, monkeypatch):
+        """Saving a model endpoint key must retain save_config's owner-only
+        config file permissions."""
+        from hermes_constants import get_hermes_home
+
+        config_path = get_hermes_home() / "config.yaml"
+        config_path.write_text("model:\n  default: old-model\n", encoding="utf-8")
+        os.chmod(config_path, 0o644)
+        monkeypatch.setattr(
+            "hermes_cli.model_cost_guard.expensive_model_warning",
+            lambda *_args, **_kwargs: None,
+        )
+
+        resp = self.client.post(
+            "/api/model/set",
+            json={
+                "scope": "main",
+                "provider": "openrouter",
+                "model": "new/model",
+                "api_key": "test-model-key",
+                "confirm_expensive_model": True,
+            },
+        )
+
+        assert resp.status_code == 200
+        assert (config_path.stat().st_mode & 0o777) == 0o600
+
     def test_model_set_maps_unknown_vendor_to_aggregator(self, monkeypatch):
         """A bare vendor name from analytics rows (no billing_provider) is not
         a Hermes provider — keep the user's aggregator instead of writing a

--- a/utils.py
+++ b/utils.py
@@ -9,7 +9,7 @@ import stat
 import tempfile
 import time
 from pathlib import Path
-from typing import Any, Union
+from typing import Any, Callable, Union
 from urllib.parse import urlparse
 
 import yaml
@@ -603,6 +603,61 @@ def atomic_roundtrip_yaml_update(
         prefix=f".{path.stem}_",
         suffix=".tmp",
     )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            yaml_rt.dump(config, f)
+            f.flush()
+            os.fsync(f.fileno())
+        real_path = atomic_replace(tmp_path, path)
+        real_path_obj = Path(real_path)
+        _restore_file_owner(real_path_obj, original_owner)
+        _restore_file_mode(real_path_obj, original_mode)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def atomic_roundtrip_yaml_mutate(path: Union[str, Path], mutate: Callable[[Any], None]) -> None:
+    """Atomically mutate a round-trip YAML document without replacing siblings.
+
+    The shared config lock covers the entire read-modify-write sequence, so a
+    concurrent ``save_config`` cannot overwrite a change between parsing the
+    existing document and atomically replacing it.
+    """
+    from hermes_cli.config import _CONFIG_LOCK
+
+    with _CONFIG_LOCK:
+        _atomic_roundtrip_yaml_mutate_unlocked(path, mutate)
+
+
+def _atomic_roundtrip_yaml_mutate_unlocked(path: Union[str, Path], mutate: Callable[[Any], None]) -> None:
+    """Implementation of :func:`atomic_roundtrip_yaml_mutate`; caller holds the config lock."""
+    from ruamel.yaml import YAML
+    from ruamel.yaml.comments import CommentedMap
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    yaml_rt = YAML(typ="rt")
+    yaml_rt.preserve_quotes = True
+    yaml_rt.allow_unicode = True
+    yaml_rt.default_flow_style = False
+    yaml_rt.indent(mapping=2, sequence=4, offset=2)
+
+    if path.exists():
+        with path.open("r", encoding="utf-8") as f:
+            config = yaml_rt.load(f) or CommentedMap()
+    else:
+        config = CommentedMap()
+    if not isinstance(config, CommentedMap):
+        config = CommentedMap(config)
+    mutate(config)
+
+    original_mode = _preserve_file_mode(path)
+    original_owner = _preserve_file_owner(path)
+    fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.stem}_", suffix=".tmp")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             yaml_rt.dump(config, f)


### PR DESCRIPTION
## Summary
- persist Desktop main-model changes through an atomic YAML round-trip instead of rewriting the normalized config snapshot
- preserve unrelated keys and comments, including when Nous gateway defaults add managed tool settings
- retain managed-install/config protections and secure config permissions

## Tests
- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py tests/test_utils_atomic_roundtrip_yaml_save.py -q`

Closes #89184