### PR TITLE
fix(tools): coalesce read_file into two Git Bash execs

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -9,6 +9,10 @@ from unittest.mock import MagicMock
 
 from tools.file_operations import (
     _is_write_denied,
+    _decode_base64_sample,
+    _parse_page_header,
+    _parse_size_header,
+    _split_sentinel_payload,
     ReadResult,
     WriteResult,
     PatchResult,
@@ -20,6 +24,40 @@ from tools.file_operations import (
     normalize_read_pagination,
     normalize_search_pagination,
 )
+
+
+def _sentinel_in(command: str) -> str | None:
+    match = re.search(r"__HERMES_READ_[0-9a-f]+__", command)
+    return match.group(0) if match else None
+
+
+def _probe_ok(size: int, sample: bytes, sentinel: str) -> dict:
+    import base64 as b64
+    return {
+        "output": (
+            f"size={size}\nsize_rc=0\nsample_rc=0\n"
+            f"{sentinel}\n{b64.b64encode(sample).decode()}"
+        ),
+        "returncode": 0,
+    }
+
+
+def _page_ok(
+    content: str,
+    sentinel: str,
+    *,
+    total: int,
+    tail_ran: int = 1,
+    tail_nl: int = 1,
+) -> dict:
+    return {
+        "output": (
+            f"sed_rc=0\nwc_rc=0\ntotal={total}\n"
+            f"tail_ran={tail_ran}\ntail_nl={tail_nl}\n"
+            f"{sentinel}\n{content}"
+        ),
+        "returncode": 0,
+    }
 
 
 # =========================================================================
@@ -303,19 +341,12 @@ class TestShellFileOpsHelpers:
 
         def side_effect(command, **kwargs):
             commands.append(command)
-            # The size probe gates `wc -c` behind `[ -f ]` so a FIFO or device
-            # cannot block the read; it still reports a plain byte count.
-            if command.startswith("if [ -f ") or command.startswith("wc -c"):
-                return {"output": "5\n", "returncode": 0}
-            if command.startswith("head -c") and "| base64" in command:
-                import base64 as b64
-                return {"output": b64.b64encode(b"hello").decode(), "returncode": 0}
-            if command.startswith("head -c"):
-                return {"output": "hello", "returncode": 0}
-            if command.startswith("sed -n"):
-                return {"output": "hello\n", "returncode": 0}
-            if command.startswith("wc -l"):
-                return {"output": "1\n", "returncode": 0}
+            sentinel = _sentinel_in(command)
+            # Probe: [ -f ] size + sample. Page: sed|cut + wc -l + optional tail.
+            if command.startswith("if [ -f ") and sentinel:
+                return _probe_ok(5, b"hello", sentinel)
+            if "sed -n" in command and sentinel:
+                return _page_ok("hello\n", sentinel, total=1)
             return {"output": "", "returncode": 0}
 
         mock_env.execute.side_effect = side_effect
@@ -323,16 +354,13 @@ class TestShellFileOpsHelpers:
         result = ops.read_file(r"C:\Users\alice\notes.txt")
 
         assert result.error is None
-        assert commands[0] == (
-            "if [ -f '/c/Users/alice/notes.txt' ]; "
-            "then wc -c < '/c/Users/alice/notes.txt' 2>/dev/null; "
-            "elif [ -e '/c/Users/alice/notes.txt' ]; "
-            "then echo __hermes_not_regular__; "
-            "else exit 1; fi"
-        )
-        assert commands[1] == "head -c 1000 '/c/Users/alice/notes.txt' 2>/dev/null | base64"
-        assert commands[2] == "sed -n '1,2000p' '/c/Users/alice/notes.txt' | cut -b1-8001"
-        assert commands[3] == "wc -l < '/c/Users/alice/notes.txt'"
+        assert len(commands) == 2
+        assert "if [ -f '/c/Users/alice/notes.txt' ]" in commands[0]
+        assert "wc -c < '/c/Users/alice/notes.txt'" in commands[0]
+        assert "head -c 1000 '/c/Users/alice/notes.txt'" in commands[0]
+        assert "sed -n '1,2000p' '/c/Users/alice/notes.txt' | cut -b1-8001" in commands[1]
+        assert "wc -l < '/c/Users/alice/notes.txt'" in commands[1]
+        assert "tail -c 1" in commands[1]
 
     def test_is_likely_binary_by_extension(self, file_ops):
         assert file_ops._is_likely_binary("photo.png") is True
@@ -355,14 +383,11 @@ class TestShellFileOpsHelpers:
         )
 
         def side_effect(command, **kwargs):
-            if command.startswith("if [ -f ") or command.startswith("wc -c"):
-                return {"output": "12\n", "returncode": 0}
-            if command.startswith("head -c"):
-                return {"output": "print('ok')\n", "returncode": 0}
-            if command.startswith("sed -n"):
-                return {"output": leaked, "returncode": 0}
-            if command.startswith("wc -l"):
-                return {"output": "1\n", "returncode": 0}
+            sentinel = _sentinel_in(command)
+            if command.startswith("if [ -f ") and sentinel:
+                return _probe_ok(12, b"print('ok')\n", sentinel)
+            if "sed -n" in command and sentinel:
+                return _page_ok(leaked, sentinel, total=1)
             return {"output": "", "returncode": 0}
 
         mock_env.execute.side_effect = side_effect
@@ -776,14 +801,15 @@ class TestByteLayerBinaryDetection:
         import base64 as b64
 
         def side_effect(command, **kwargs):
-            if command.startswith("if [ -f ") or command.startswith("wc -c"):
-                return {"output": f"{len(cjk_bytes)}\n", "returncode": 0}
-            if command.startswith("head -c") and "| base64" in command:
-                return {"output": b64.b64encode(cjk_bytes[:1000]).decode(), "returncode": 0}
-            if command.startswith("sed -n"):
-                return {"output": cjk_bytes.decode("utf-8", errors="replace"), "returncode": 0}
-            if command.startswith("wc -l"):
-                return {"output": "1\n", "returncode": 0}
+            sentinel = _sentinel_in(command)
+            if command.startswith("if [ -f ") and sentinel:
+                return _probe_ok(len(cjk_bytes), cjk_bytes[:1000], sentinel)
+            if "sed -n" in command and sentinel:
+                return _page_ok(
+                    cjk_bytes.decode("utf-8", errors="replace"),
+                    sentinel,
+                    total=1,
+                )
             return {"output": "", "returncode": 0}
 
         return side_effect

--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -5,6 +5,8 @@ Covers:
 - ``_check_lint()`` robustness against file paths containing curly braces
 """
 
+import re
+
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -205,14 +207,23 @@ class TestPaginationBounds:
 
         def fake_exec(command, *args, **kwargs):
             commands.append(command)
-            if command.startswith("if [ -f ") or command.startswith("wc -c"):
-                return MagicMock(exit_code=0, stdout="12")
-            if command.startswith("head -c"):
-                return MagicMock(exit_code=0, stdout="line1\nline2\n")
-            if command.startswith("sed -n"):
-                return MagicMock(exit_code=0, stdout="line1\n")
-            if command.startswith("wc -l"):
-                return MagicMock(exit_code=0, stdout="2")
+            match = re.search(r"__HERMES_READ_[0-9a-f]+__", command)
+            sentinel = match.group(0) if match else None
+            if command.startswith("if [ -f ") and sentinel:
+                import base64 as b64
+                sample = b64.b64encode(b"line1\n").decode()
+                return MagicMock(
+                    exit_code=0,
+                    stdout=f"size=12\nsize_rc=0\nsample_rc=0\n{sentinel}\n{sample}",
+                )
+            if "sed -n" in command and sentinel:
+                return MagicMock(
+                    exit_code=0,
+                    stdout=(
+                        f"sed_rc=0\nwc_rc=0\ntotal=2\ntail_ran=1\ntail_nl=1\n"
+                        f"{sentinel}\nline1\n"
+                    ),
+                )
             return MagicMock(exit_code=0, stdout="")
 
         with patch.object(ops, "_exec", side_effect=fake_exec):
@@ -220,8 +231,9 @@ class TestPaginationBounds:
 
         assert result.error is None
         assert "1|line1" in result.content
-        sed_commands = [cmd for cmd in commands if cmd.startswith("sed -n")]
-        assert sed_commands == ["sed -n '1,1p' 'notes.txt' | cut -b1-8001"]
+        page_commands = [cmd for cmd in commands if "sed -n" in cmd]
+        assert page_commands, commands
+        assert "sed -n '1,1p' 'notes.txt' | cut -b1-8001" in page_commands[0]
 
     def test_search_clamps_offset_and_limit_before_building_head_pipeline(self):
         env = MagicMock()

--- a/tests/tools/test_read_file_coalesce.py
+++ b/tests/tools/test_read_file_coalesce.py
@@ -1,0 +1,250 @@
+"""Coalesced read_file execs: probe + page, not 4–5 sequential shells.
+
+Live LocalEnvironment cases run wherever bash is available (Linux CI and
+native Windows with Git Bash). Parser tests pin the wire format so a
+dropped ``wc -l`` / ``tail -c 1`` cannot hide behind an updated fixture.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+
+import pytest
+
+from tools.environments.local import LocalEnvironment
+from tools.file_operations import (
+    IMAGE_EXTENSIONS,
+    ShellFileOperations,
+    _decode_base64_sample,
+    _new_read_sentinel,
+    _parse_page_header,
+    _parse_size_header,
+    _split_sentinel_payload,
+)
+
+
+@pytest.fixture
+def ops():
+    return ShellFileOperations(LocalEnvironment())
+
+
+class TestWireFormatParsers:
+    def test_split_keeps_body_after_first_sentinel(self):
+        token = _new_read_sentinel()
+        body = f"hello\n{token}\nstill body"
+        header, payload = _split_sentinel_payload(f"12\n{token}\n{body}", token)
+        assert header.strip() == "12"
+        assert payload == body
+
+    def test_parse_size_header_last_int_wins_junk_prefix(self):
+        assert _parse_size_header("noise\n42") == 42
+        assert _parse_size_header("5") == 5
+        assert _parse_size_header("") == 0
+
+    def test_parse_page_header_independent_statuses(self):
+        fields = _parse_page_header("sed_rc=0\nwc_rc=1\ntotal=\ntail_ran=0\ntail_nl=1\n")
+        assert fields["sed_rc"] == "0"
+        assert fields["wc_rc"] == "1"
+        assert fields["tail_ran"] == "0"
+
+    def test_decode_base64_sample_roundtrip(self):
+        import base64
+        payload = b"abc\x00def"
+        assert _decode_base64_sample(base64.b64encode(payload).decode()) == payload
+        assert _decode_base64_sample("") == b""
+        assert _decode_base64_sample("!!!!") is None
+
+
+class TestPageScriptShape:
+    def test_page_script_still_runs_wc_and_conditional_tail(self, ops):
+        script = ops._page_text_file_cmd(
+            "/tmp/notes.txt",
+            offset=1,
+            end_line=2000,
+            line_clamp_bytes=8001,
+            sentinel="__HERMES_READ_deadbeefdeadbeef__",
+        )
+        assert "sed -n '1,2000p'" in script
+        assert "wc -l <" in script
+        assert "tail -c 1" in script
+        assert "tail_ran=1" in script
+        assert "set -o pipefail" in script
+
+    def test_probe_script_does_not_head_not_regular_paths(self, ops):
+        script = ops._probe_regular_file_cmd(
+            "/tmp/notes.txt",
+            "__HERMES_READ_deadbeefdeadbeef__",
+        )
+        assert "[ -f " in script
+        assert "head -c 1000" in script
+        # head is inside the regular-file arm, after [ -f ]
+        regular_arm, _, rest = script.partition("elif [ -e ")
+        assert "head -c 1000" in regular_arm
+        assert "head -c" not in rest
+        assert "size_rc" in regular_arm
+        assert "sample_rc" in regular_arm
+        assert "exit 0" in regular_arm
+
+
+class TestProbeStatusIsolation:
+    def test_failed_sample_is_not_file_not_found(self):
+        from unittest.mock import MagicMock
+
+        from tools.file_operations import ShellFileOperations
+
+        env = MagicMock()
+        env.cwd = "/tmp"
+        calls = []
+
+        def execute(command, **kwargs):
+            calls.append(command)
+            sentinel = None
+            import re
+            match = re.search(r"__HERMES_READ_[0-9a-f]+__", command)
+            if match:
+                sentinel = match.group(0)
+            if command.startswith("if [ -f ") and sentinel:
+                return {
+                    "output": f"size=12\nsize_rc=0\nsample_rc=1\n{sentinel}\n",
+                    "returncode": 0,
+                }
+            if command.startswith("head -c") and "base64" in command:
+                import base64 as b64
+                return {
+                    "output": b64.b64encode(b"hello\n").decode(),
+                    "returncode": 0,
+                }
+            if "sed -n" in command and sentinel:
+                return {
+                    "output": (
+                        f"sed_rc=0\nwc_rc=0\ntotal=1\ntail_ran=1\ntail_nl=1\n"
+                        f"{sentinel}\nhello\n"
+                    ),
+                    "returncode": 0,
+                }
+            return {"output": "", "returncode": 0}
+
+        env.execute.side_effect = execute
+        result = ShellFileOperations(env).read_file("/tmp/notes.txt")
+        assert result.error is None
+        assert "File not found" not in (result.error or "")
+        assert any(c.startswith("head -c") and "base64" in c for c in calls)
+
+    def test_failed_size_is_read_error_not_empty_file(self):
+        from unittest.mock import MagicMock
+        import re
+
+        from tools.file_operations import ShellFileOperations
+
+        env = MagicMock()
+        env.cwd = "/tmp"
+
+        def execute(command, **kwargs):
+            match = re.search(r"__HERMES_READ_[0-9a-f]+__", command)
+            sentinel = match.group(0) if match else "x"
+            if command.startswith("if [ -f "):
+                return {
+                    "output": f"size=0\nsize_rc=1\nsample_rc=1\n{sentinel}\n",
+                    "returncode": 0,
+                }
+            return {"output": "", "returncode": 0}
+
+        env.execute.side_effect = execute
+        result = ShellFileOperations(env).read_file("/tmp/secret.txt")
+        assert result.error
+        assert "Failed to read file" in result.error
+        assert result.hint != "File is empty (0 bytes)."
+
+
+class TestLiveCoalescedRead:
+    def test_text_path_uses_two_execs(self, tmp_path, ops, monkeypatch):
+        target = tmp_path / "notes.txt"
+        target.write_text("alpha\nbeta\ngamma\n", encoding="utf-8")
+        calls = []
+        original = ops._exec
+
+        def counted(command, *args, **kwargs):
+            calls.append(command)
+            return original(command, *args, **kwargs)
+
+        monkeypatch.setattr(ops, "_exec", counted)
+        result = ops.read_file(str(target))
+        assert result.error is None
+        assert "1|alpha" in result.content
+        assert "3|gamma" in result.content
+        assert len(calls) == 2
+        assert "sed -n" in calls[1]
+        assert "wc -l <" in calls[1]
+
+    def test_no_trailing_newline_stripped(self, tmp_path, ops):
+        target = tmp_path / "nonl.txt"
+        target.write_text("a\nb", encoding="utf-8")
+        result = ops.read_file(str(target))
+        assert result.error is None
+        assert result.content == "1|a\n2|b"
+
+    def test_truncated_page_still_reports_total(self, tmp_path, ops, monkeypatch):
+        target = tmp_path / "long.txt"
+        target.write_text("".join(f"line {i}\n" for i in range(1, 30)), encoding="utf-8")
+        calls = []
+        original = ops._exec
+
+        def counted(command, *args, **kwargs):
+            calls.append(command)
+            return original(command, *args, **kwargs)
+
+        monkeypatch.setattr(ops, "_exec", counted)
+        result = ops.read_file(str(target), offset=1, limit=10)
+        assert result.error is None
+        assert result.truncated is True
+        assert result.total_lines == 29
+        assert "Use offset=11" in (result.hint or "")
+        # Skip condition lives in the page script; tail probe must be present
+        # as a command but gated on total <= end_line (here 10).
+        assert "tail -c 1" in calls[1]
+        assert "-le 10" in calls[1]
+
+    def test_image_never_runs_page_script(self, tmp_path, ops, monkeypatch):
+        ext = next(iter(IMAGE_EXTENSIONS))
+        target = tmp_path / f"pic{ext}"
+        target.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 32)
+        calls = []
+        original = ops._exec
+
+        def counted(command, *args, **kwargs):
+            calls.append(command)
+            return original(command, *args, **kwargs)
+
+        monkeypatch.setattr(ops, "_exec", counted)
+        result = ops.read_file(str(target))
+        assert result.is_image is True
+        assert len(calls) == 1
+        assert "sed -n" not in calls[0]
+        assert "wc -l <" not in calls[0]
+
+    def test_directory_errors_without_paging(self, tmp_path, ops, monkeypatch):
+        calls = []
+        original = ops._exec
+
+        def counted(command, *args, **kwargs):
+            calls.append(command)
+            return original(command, *args, **kwargs)
+
+        monkeypatch.setattr(ops, "_exec", counted)
+        result = ops.read_file(str(tmp_path))
+        assert result.error
+        assert "not a regular file" in result.error
+        assert len(calls) == 1
+        assert "sed -n" not in calls[0]
+
+    @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="no mkfifo on this host")
+    def test_fifo_errors_without_blocking(self, tmp_path, ops):
+        fifo = tmp_path / "pipe.fifo"
+        os.mkfifo(fifo)
+        # Drop write bit so a mistaken open cannot hang the test waiting
+        # for a writer. The size probe must not open it at all.
+        os.chmod(fifo, stat.S_IRUSR)
+        result = ops.read_file(str(fifo))
+        assert result.error
+        assert "not a regular file" in result.error

--- a/tests/tools/test_read_file_coalesce.py
+++ b/tests/tools/test_read_file_coalesce.py
@@ -70,6 +70,12 @@ class TestPageScriptShape:
         assert "tail -c 1" in script
         assert "tail_ran=1" in script
         assert "set -o pipefail" in script
+        # Missing mktemp used to `exit 1`. Must degrade instead.
+        assert "then exit 1; fi" not in script
+        assert "hermes-read.$$" in script
+        assert "page=$(" not in script
+        assert "trap " in script
+        assert script.count("sed -n") == 2
 
     def test_probe_script_does_not_head_not_regular_paths(self, ops):
         script = ops._probe_regular_file_cmd(
@@ -157,6 +163,70 @@ class TestProbeStatusIsolation:
         assert result.hint != "File is empty (0 bytes)."
 
 
+class TestPageFailureReporting:
+    def test_empty_page_failure_includes_exit_code(self):
+        from unittest.mock import MagicMock
+        import re
+
+        from tools.file_operations import ShellFileOperations
+
+        env = MagicMock()
+        env.cwd = "/tmp"
+
+        def execute(command, **kwargs):
+            match = re.search(r"__HERMES_READ_[0-9a-f]+__", command)
+            sentinel = match.group(0) if match else "x"
+            if command.startswith("if [ -f "):
+                import base64 as b64
+                return {
+                    "output": (
+                        f"size=5\nsize_rc=0\nsample_rc=0\n{sentinel}\n"
+                        f"{b64.b64encode(b'hello').decode()}"
+                    ),
+                    "returncode": 0,
+                }
+            if "sed -n" in command:
+                return {"output": "", "returncode": 1}
+            return {"output": "", "returncode": 0}
+
+        env.execute.side_effect = execute
+        result = ShellFileOperations(env).read_file("/tmp/notes.txt")
+        assert result.error
+        assert result.error == "Failed to read file: exit 1"
+        assert not result.error.endswith(": ")
+
+    def test_missing_sentinel_names_the_reason(self):
+        from unittest.mock import MagicMock
+        import re
+
+        from tools.file_operations import ShellFileOperations
+
+        env = MagicMock()
+        env.cwd = "/tmp"
+
+        def execute(command, **kwargs):
+            match = re.search(r"__HERMES_READ_[0-9a-f]+__", command)
+            sentinel = match.group(0) if match else "x"
+            if command.startswith("if [ -f "):
+                import base64 as b64
+                return {
+                    "output": (
+                        f"size=5\nsize_rc=0\nsample_rc=0\n{sentinel}\n"
+                        f"{b64.b64encode(b'hello').decode()}"
+                    ),
+                    "returncode": 0,
+                }
+            if "sed -n" in command:
+                return {"output": "no fence here", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        env.execute.side_effect = execute
+        result = ShellFileOperations(env).read_file("/tmp/notes.txt")
+        assert result.error
+        assert "missing page sentinel" in result.error
+        assert "exit 0" in result.error
+
+
 class TestLiveCoalescedRead:
     def test_text_path_uses_two_execs(self, tmp_path, ops, monkeypatch):
         target = tmp_path / "notes.txt"
@@ -237,6 +307,76 @@ class TestLiveCoalescedRead:
         assert "not a regular file" in result.error
         assert len(calls) == 1
         assert "sed -n" not in calls[0]
+
+    def test_text_path_still_reads_when_mktemp_missing(self, tmp_path, ops, monkeypatch):
+        target = tmp_path / "notes.txt"
+        target.write_text("alpha\nbeta\ngamma\n", encoding="utf-8")
+        original = ops._exec
+
+        def without_mktemp(command, *args, **kwargs):
+            if "sed -n" in command:
+                command = "mktemp() { return 127; }; " + command
+            return original(command, *args, **kwargs)
+
+        monkeypatch.setattr(ops, "_exec", without_mktemp)
+        result = ops.read_file(str(target))
+        assert result.error is None
+        assert "1|alpha" in result.content
+        assert "3|gamma" in result.content
+
+    def test_text_path_still_reads_without_any_temp_file(self, tmp_path, ops, monkeypatch):
+        target = tmp_path / "notes.txt"
+        target.write_text("alpha\nbeta\ngamma\n", encoding="utf-8")
+        original = ops._exec
+
+        def without_temp(command, *args, **kwargs):
+            if "sed -n" in command:
+                command = (
+                    "mktemp() { return 127; }; "
+                    "TMPDIR=/this-dir-does-not-exist-hermes-read-test; "
+                    + command
+                )
+            return original(command, *args, **kwargs)
+
+        monkeypatch.setattr(ops, "_exec", without_temp)
+        result = ops.read_file(str(target))
+        assert result.error is None
+        assert "1|alpha" in result.content
+        assert "3|gamma" in result.content
+
+    def test_trailing_blank_line_without_any_temp_file(self, tmp_path, ops, monkeypatch):
+        target = tmp_path / "blank.txt"
+        target.write_text("a\n\n", encoding="utf-8")
+        original = ops._exec
+
+        def without_temp(command, *args, **kwargs):
+            if "sed -n" in command:
+                command = (
+                    "mktemp() { return 127; }; "
+                    "TMPDIR=/this-dir-does-not-exist-hermes-read-test; "
+                    + command
+                )
+            return original(command, *args, **kwargs)
+
+        monkeypatch.setattr(ops, "_exec", without_temp)
+        result = ops.read_file(str(target))
+        assert result.error is None
+        assert result.content == "1|a\n2|\n3|"
+
+    def test_no_trailing_newline_without_mktemp(self, tmp_path, ops, monkeypatch):
+        target = tmp_path / "nonl.txt"
+        target.write_text("a\nb", encoding="utf-8")
+        original = ops._exec
+
+        def without_mktemp(command, *args, **kwargs):
+            if "sed -n" in command:
+                command = "mktemp() { return 127; }; " + command
+            return original(command, *args, **kwargs)
+
+        monkeypatch.setattr(ops, "_exec", without_mktemp)
+        result = ops.read_file(str(target))
+        assert result.error is None
+        assert result.content == "1|a\n2|b"
 
     @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="no mkfifo on this host")
     def test_fifo_errors_without_blocking(self, tmp_path, ops):

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -29,6 +29,7 @@ import base64
 import binascii
 import os
 import re
+import secrets
 import difflib
 import hashlib
 import json
@@ -801,6 +802,72 @@ DEFAULT_SEARCH_LIMIT = 50
 # `wc -c` prints only digits, so this can never collide with a real size.
 NOT_REGULAR_SENTINEL = "__hermes_not_regular__"
 
+# Per-call fence between metadata and payload on the coalesced read scripts.
+# Hex suffix is random so a file that happens to contain the token cannot
+# collide with the first (only) occurrence we split on.
+_READ_SENTINEL_PREFIX = "__HERMES_READ_"
+
+
+def _new_read_sentinel() -> str:
+    return f"{_READ_SENTINEL_PREFIX}{secrets.token_hex(8)}__"
+
+
+def _split_sentinel_payload(stdout: str, sentinel: str) -> Optional[tuple[str, str]]:
+    """Split ``header + sentinel + body``. Body keeps every byte after the fence."""
+    raw = _strip_terminal_fence_leaks(stdout or "")
+    idx = raw.find(sentinel)
+    if idx < 0:
+        return None
+    header = raw[:idx]
+    body = raw[idx + len(sentinel):]
+    if body.startswith("\r\n"):
+        body = body[2:]
+    elif body.startswith("\n"):
+        body = body[1:]
+    return header, body
+
+
+def _parse_size_header(header: str) -> Optional[int]:
+    text = (header or "").strip()
+    if not text:
+        return 0
+    try:
+        return int(text)
+    except ValueError:
+        for line in reversed(text.splitlines()):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                return int(line)
+            except ValueError:
+                continue
+        return None
+
+
+def _parse_page_header(header: str) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    for line in (header or "").splitlines():
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        if key:
+            fields[key] = value.strip()
+    return fields
+
+
+def _decode_base64_sample(encoded: str) -> Optional[bytes]:
+    compact = "".join((encoded or "").split())
+    if not compact:
+        return b""
+    if not re.fullmatch(r"[A-Za-z0-9+/]+={0,2}", compact):
+        return None
+    try:
+        return base64.b64decode(compact, validate=True)
+    except (binascii.Error, ValueError):
+        return None
+
 
 def _coerce_int(value: Any, default: int) -> int:
     """Best-effort integer coercion for tool pagination inputs."""
@@ -985,16 +1052,7 @@ class ShellFileOperations(FileOperations):
         )
         if result.exit_code != 0:
             return None
-        encoded = _strip_terminal_fence_leaks(result.stdout)
-        encoded = "".join(encoded.split())
-        if not encoded:
-            return b""
-        if not re.fullmatch(r"[A-Za-z0-9+/]+={0,2}", encoded):
-            return None
-        try:
-            return base64.b64decode(encoded, validate=True)
-        except (binascii.Error, ValueError):
-            return None
+        return _decode_base64_sample(_strip_terminal_fence_leaks(result.stdout))
 
     @staticmethod
     def _is_likely_binary_bytes(sample: bytes) -> bool:
@@ -1341,6 +1399,73 @@ class ShellFileOperations(FileOperations):
             f"else exit 1; fi"
         )
 
+    def _probe_regular_file_cmd(self, path: str, sentinel: str) -> str:
+        """Size-probe a regular file, then sample its first 1000 bytes.
+
+        Missing and not-regular paths short-circuit *before* ``head``, so a
+        FIFO / socket / device is never opened. Image / binary / UTF-16
+        decisions stay in Python after this returns.
+        """
+        arg = self._escape_shell_arg(path)
+        # Regular-file arm always exits 0 so a failed ``head|base64`` cannot
+        # be mistaken for "file not found". Status lives in the header;
+        # the sample payload is after the sentinel.
+        return (
+            f"if [ -f {arg} ]; then "
+            f"size=$(wc -c < {arg} 2>/dev/null); size_rc=$?; "
+            f"set -o pipefail; "
+            f"sample=$(head -c 1000 {arg} 2>/dev/null | base64); sample_rc=$?; "
+            f"set +o pipefail; "
+            f"printf 'size=%s\\nsize_rc=%s\\nsample_rc=%s\\n' "
+            f"\"$size\" \"$size_rc\" \"$sample_rc\"; "
+            f"echo {sentinel}; "
+            f"printf '%s' \"$sample\"; "
+            f"exit 0; "
+            f"elif [ -e {arg} ]; then echo {NOT_REGULAR_SENTINEL}; exit 0; "
+            f"else exit 1; fi"
+        )
+
+    def _page_text_file_cmd(
+        self,
+        path: str,
+        *,
+        offset: int,
+        end_line: int,
+        line_clamp_bytes: int,
+        sentinel: str,
+    ) -> str:
+        """Page a text file, count lines, and optionally probe the last byte.
+
+        Metadata (status + ``wc -l`` + tail probe) is printed *before* a
+        per-call sentinel; the raw ``sed|cut`` page follows so a file that
+        contains the sentinel cannot steal the header. ``tail -c 1`` runs
+        only when the page is the last one *and* it ends in a newline —
+        the same skip the previous sequential path used.
+
+        ``mktemp`` assignment succeeds even when mktemp is missing (empty
+        tmp); refuse that so we never redirect onto a file named ``$tmp``.
+        """
+        arg = self._escape_shell_arg(path)
+        return (
+            f"tmp=$(mktemp -t hermes-read.XXXXXX 2>/dev/null || mktemp); "
+            f"if [ -z \"$tmp\" ] || [ ! -f \"$tmp\" ]; then exit 1; fi; "
+            f"set -o pipefail; "
+            f"sed -n '{offset},{end_line}p' {arg} "
+            f"| cut -b1-{line_clamp_bytes} > \"$tmp\"; "
+            f"sed_rc=$?; "
+            f"set +o pipefail; "
+            f"total=$(wc -l < {arg}); wc_rc=$?; "
+            f"tail_ran=0; tail_nl=1; "
+            f"if [ \"$wc_rc\" -eq 0 ] && [ \"${{total:-0}}\" -le {end_line} ] "
+            f"&& [ \"$(tail -c 1 \"$tmp\" | wc -l)\" -eq 1 ]; then "
+            f"tail_nl=$(tail -c 1 {arg} | wc -l); tail_ran=1; "
+            f"fi; "
+            f"printf 'sed_rc=%s\\nwc_rc=%s\\ntotal=%s\\ntail_ran=%s\\ntail_nl=%s\\n' "
+            f"\"$sed_rc\" \"$wc_rc\" \"$total\" \"$tail_ran\" \"$tail_nl\"; "
+            f"echo {sentinel}; "
+            f"cat \"$tmp\"; rm -f \"$tmp\""
+        )
+
     @staticmethod
     def _not_regular_error(path: str) -> ReadResult:
         """Error for a path that exists but would block if read."""
@@ -1473,11 +1598,13 @@ class ShellFileOperations(FileOperations):
         path = self._expand_path(path)
         
         offset, limit = normalize_read_pagination(offset, limit)
-        
-        # Check if file exists and get size (POSIX, works on Linux + macOS)
-        stat_result = self._exec(self._size_probe_cmd(path))
 
-        if stat_result.exit_code != 0:
+        # One exec: [ -f ] size probe, then sample. Missing / not-regular
+        # paths never reach ``head``, so FIFOs stay unopened.
+        probe_sentinel = _new_read_sentinel()
+        probe_result = self._exec(self._probe_regular_file_cmd(path, probe_sentinel))
+
+        if probe_result.exit_code != 0:
             # File not found. Before failing, try unicode-equivalent
             # spellings — NFC/NFD, narrow no-break space, curly quotes
             # render identically in a terminal, so the model retyping a
@@ -1497,19 +1624,43 @@ class ShellFileOperations(FileOperations):
             # No equivalent spelling — suggest similar files
             return self._suggest_similar_files(path)
 
-        stat_output = _strip_terminal_fence_leaks(stat_result.stdout)
-        if stat_output.strip() == NOT_REGULAR_SENTINEL:
+        probe_stdout = _strip_terminal_fence_leaks(probe_result.stdout)
+        if probe_stdout.strip() == NOT_REGULAR_SENTINEL:
             return self._not_regular_error(path)
-        try:
-            file_size = int(stat_output.strip())
-        except ValueError:
-            file_size = 0
-        
+        probe_parts = _split_sentinel_payload(probe_stdout, probe_sentinel)
+        if probe_parts is None:
+            # Size-only output (or a transport that ate the fence): treat
+            # the whole stdout as the byte count and fall back to a
+            # separate sample, matching the old two-call path.
+            file_size = _parse_size_header(probe_stdout) or 0
+            sample_bytes = self._sample_file_bytes(path)
+        else:
+            size_header, sample_encoded = probe_parts
+            probe_fields = _parse_page_header(size_header)
+            if "size" in probe_fields:
+                try:
+                    file_size = int(probe_fields.get("size") or "0")
+                except ValueError:
+                    file_size = 0
+                if probe_fields.get("size_rc", "0") != "0":
+                    return ReadResult(
+                        error=f"Failed to read file: {path}",
+                        file_size=file_size,
+                    )
+                if probe_fields.get("sample_rc", "0") == "0":
+                    sample_bytes = _decode_base64_sample(sample_encoded)
+                else:
+                    sample_bytes = self._sample_file_bytes(path)
+            else:
+                parsed_size = _parse_size_header(size_header)
+                file_size = 0 if parsed_size is None else parsed_size
+                sample_bytes = _decode_base64_sample(sample_encoded)
+
         # Check if file is too large
         if file_size > MAX_FILE_SIZE:
             # Still try to read, but warn
             pass
-        
+
         # Images are never inlined — redirect to the vision tool
         if self._is_image(path):
             return ReadResult(
@@ -1521,10 +1672,9 @@ class ShellFileOperations(FileOperations):
                     "Use vision_analyze with this file path to inspect the image contents."
                 ),
             )
-        
-        # Read a sample to check for binary content — at the byte layer when
-        # the transport allows, falling back to the legacy text heuristic.
-        sample_bytes = self._sample_file_bytes(path)
+
+        # Byte-layer binary detection when the sample survived the
+        # transport; otherwise the legacy text heuristic (one extra exec).
         if sample_bytes is not None:
             ext_binary = os.path.splitext(path)[1].lower() in BINARY_EXTENSIONS
             is_binary = ext_binary or self._is_likely_binary_bytes(sample_bytes)
@@ -1550,13 +1700,8 @@ class ShellFileOperations(FileOperations):
                 file_size=file_size,
                 error=describe_binary_file(sample_bytes, file_size),
             )
-        
-        # Read with pagination using sed, clamping each line to a byte
-        # budget IN THE SHELL so a pathological single-line file (e.g. one
-        # 400MB minified line) never crosses the exec transport. The Python
-        # clamp in _add_line_numbers still runs afterwards; the shell clamp
-        # only bounds what reaches it.
-        #
+
+        # Second exec, text only: page + wc -l + optional last-byte probe.
         # Why 4*max_line_length + 1 bytes (not max_line_length + 1):
         # ``cut -c`` on GNU coreutils is byte-based despite its name, and a
         # byte clamp can split a multibyte UTF-8 codepoint at the boundary.
@@ -1578,31 +1723,42 @@ class ShellFileOperations(FileOperations):
         from tools.tool_output_limits import get_max_line_length
         line_clamp_bytes = 4 * get_max_line_length() + 1
         end_line = offset + limit - 1
-        read_cmd = (
-            f"sed -n '{offset},{end_line}p' {self._escape_shell_arg(path)}"
-            f" | cut -b1-{line_clamp_bytes}"
+        page_sentinel = _new_read_sentinel()
+        page_result = self._exec(
+            self._page_text_file_cmd(
+                path,
+                offset=offset,
+                end_line=end_line,
+                line_clamp_bytes=line_clamp_bytes,
+                sentinel=page_sentinel,
+            )
         )
-        read_result = self._exec(read_cmd)
-        
-        if read_result.exit_code != 0:
-            return ReadResult(error=f"Failed to read file: {read_result.stdout}")
-        read_output = _strip_terminal_fence_leaks(read_result.stdout)
+        if page_result.exit_code != 0:
+            return ReadResult(error=f"Failed to read file: {page_result.stdout}")
+        page_parts = _split_sentinel_payload(page_result.stdout, page_sentinel)
+        if page_parts is None:
+            return ReadResult(error=f"Failed to read file: {page_result.stdout}")
+        page_header, read_output = page_parts
+        fields = _parse_page_header(page_header)
+        try:
+            sed_rc = int(fields.get("sed_rc", "1"))
+        except ValueError:
+            sed_rc = 1
+        if sed_rc != 0:
+            return ReadResult(error=f"Failed to read file: {read_output}")
+        try:
+            total_lines = int(fields.get("total", "0"))
+        except ValueError:
+            total_lines = 0
+        if fields.get("wc_rc", "1") != "0":
+            total_lines = 0
+
         # Strip a leading UTF-8 BOM so the model never sees a phantom U+FEFF
         # before the first real character. Only meaningful on the first
         # chunk (the marker lives at byte 0); later pages can't carry it.
         if offset == 1:
             read_output, _ = _strip_bom(read_output)
-        
-        # Get total line count
-        wc_cmd = f"wc -l < {self._escape_shell_arg(path)}"
-        wc_result = self._exec(wc_cmd)
-        wc_output = _strip_terminal_fence_leaks(wc_result.stdout)
-        try:
-            total_lines = int(wc_output.strip())
-        except ValueError:
-            total_lines = 0
-        
-        # Check if truncated
+
         truncated = total_lines > end_line
         hint = None
         if truncated:
@@ -1610,14 +1766,12 @@ class ShellFileOperations(FileOperations):
 
         # ``cut`` (unlike sed -n p) always newline-terminates its output,
         # so a file whose final line has no trailing newline would grow a
-        # phantom empty last line. Only possible when this page reaches the
-        # file's final line; probe the last byte and strip the artifact.
-        if not truncated and read_output.endswith('\n'):
-            tail_cmd = f"tail -c 1 {self._escape_shell_arg(path)} | wc -l"
-            tail_result = self._exec(tail_cmd)
-            tail_output = _strip_terminal_fence_leaks(tail_result.stdout)
-            if tail_result.exit_code == 0 and tail_output.strip() == "0":
-                read_output = read_output[:-1]
+        # phantom empty last line. The page script already skipped the
+        # last-byte probe unless this is the final page *and* the page
+        # ends in a newline; apply the strip only when that probe ran
+        # and reported no trailing newline on disk.
+        if fields.get("tail_ran") == "1" and fields.get("tail_nl") == "0" and read_output.endswith("\n"):
+            read_output = read_output[:-1]
 
         # Ambiguous-silence guards: an empty content string is
         # indistinguishable, from inside the model, from a broken tool —

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1405,6 +1405,10 @@ class ShellFileOperations(FileOperations):
         Missing and not-regular paths short-circuit *before* ``head``, so a
         FIFO / socket / device is never opened. Image / binary / UTF-16
         decisions stay in Python after this returns.
+
+        ``[ -f ]`` then ``wc -c <`` is a TOCTOU window: a replacement
+        between the test and the redirect is accepted and reported via
+        ``size_rc``, not retried.
         """
         arg = self._escape_shell_arg(path)
         # Regular-file arm always exits 0 so a failed ``head|base64`` cannot
@@ -1442,16 +1446,38 @@ class ShellFileOperations(FileOperations):
         only when the page is the last one *and* it ends in a newline —
         the same skip the previous sequential path used.
 
-        ``mktemp`` assignment succeeds even when mktemp is missing (empty
-        tmp); refuse that so we never redirect onto a file named ``$tmp``.
+        Prefers ``mktemp`` so the page lives on disk (header before body,
+        sentinel cannot appear in the payload until after it). When mktemp
+        is missing, fall back to a PID-stamped file under ``$TMPDIR`` —
+        the same degradation ``write_file`` already uses — so a busybox
+        without mktemp still reads. Only if that create fails too do we
+        stream ``sed|cut`` after the header (the last-page ``tail -c 1``
+        of the page itself is skipped; the file's last byte is still
+        probed). Streaming, not ``page=$(...)``: command substitution
+        strips trailing newlines and would drop a blank last line.
+        A missing mktemp must not fail the read.
         """
         arg = self._escape_shell_arg(path)
-        return (
-            f"tmp=$(mktemp -t hermes-read.XXXXXX 2>/dev/null || mktemp); "
-            f"if [ -z \"$tmp\" ] || [ ! -f \"$tmp\" ]; then exit 1; fi; "
-            f"set -o pipefail; "
+        page_pipe = (
             f"sed -n '{offset},{end_line}p' {arg} "
-            f"| cut -b1-{line_clamp_bytes} > \"$tmp\"; "
+            f"| cut -b1-{line_clamp_bytes}"
+        )
+        header_printf = (
+            "printf 'sed_rc=%s\\nwc_rc=%s\\ntotal=%s\\ntail_ran=%s\\ntail_nl=%s\\n' "
+            "\"$sed_rc\" \"$wc_rc\" \"$total\" \"$tail_ran\" \"$tail_nl\"; "
+            f"echo {sentinel}; "
+        )
+        return (
+            f"tmp=$(mktemp -t hermes-read.XXXXXX 2>/dev/null "
+            f"|| mktemp 2>/dev/null || true); "
+            f"if [ -z \"$tmp\" ] || [ ! -f \"$tmp\" ]; then "
+            f"tmp=\"${{TMPDIR:-/tmp}}/hermes-read.$$\"; "
+            f": > \"$tmp\" 2>/dev/null || tmp=; "
+            f"fi; "
+            f"set -o pipefail; "
+            f"if [ -n \"$tmp\" ] && [ -f \"$tmp\" ]; then "
+            f"trap 'rm -f \"$tmp\"' EXIT; "
+            f"{page_pipe} > \"$tmp\"; "
             f"sed_rc=$?; "
             f"set +o pipefail; "
             f"total=$(wc -l < {arg}); wc_rc=$?; "
@@ -1460,10 +1486,20 @@ class ShellFileOperations(FileOperations):
             f"&& [ \"$(tail -c 1 \"$tmp\" | wc -l)\" -eq 1 ]; then "
             f"tail_nl=$(tail -c 1 {arg} | wc -l); tail_ran=1; "
             f"fi; "
-            f"printf 'sed_rc=%s\\nwc_rc=%s\\ntotal=%s\\ntail_ran=%s\\ntail_nl=%s\\n' "
-            f"\"$sed_rc\" \"$wc_rc\" \"$total\" \"$tail_ran\" \"$tail_nl\"; "
-            f"echo {sentinel}; "
-            f"cat \"$tmp\"; rm -f \"$tmp\""
+            f"{header_printf}"
+            f"cat \"$tmp\"; rm -f \"$tmp\"; "
+            f"else "
+            f"set +o pipefail; "
+            f"total=$(wc -l < {arg}); wc_rc=$?; "
+            f"sed_rc=0; tail_ran=0; tail_nl=1; "
+            f"if [ \"$wc_rc\" -eq 0 ] && [ \"${{total:-0}}\" -le {end_line} ]; then "
+            f"tail_nl=$(tail -c 1 {arg} | wc -l); tail_ran=1; "
+            f"fi; "
+            f"{header_printf}"
+            f"set -o pipefail; "
+            f"{page_pipe}; "
+            f"exit $?; "
+            f"fi"
         )
 
     @staticmethod
@@ -1475,6 +1511,25 @@ class ShellFileOperations(FileOperations):
                 "socket, or device). Reading it could block indefinitely."
             )
         )
+
+    @staticmethod
+    def _read_failed(result: ExecuteResult, *, why: str = "") -> ReadResult:
+        """Page/read failure with exit status. Never ``Failed to read file: ``.
+
+        ``_exec`` folds stderr into stdout (``stderr=subprocess.STDOUT``),
+        so there is no separate stderr field. Empty stdout is the case
+        this exists for — a dangling colon with no reason.
+        """
+        bits: list[str] = []
+        if why:
+            bits.append(why)
+        stdout = (result.stdout or "").strip()
+        if stdout:
+            if len(stdout) > 400:
+                stdout = stdout[:400] + "..."
+            bits.append(stdout)
+        bits.append(f"exit {result.exit_code}")
+        return ReadResult(error="Failed to read file: " + "; ".join(bits))
 
     # UTF-16 rescue constants (ported from MoonshotAI/kimi-code#2647,
     # detection derived from VS Code's encoding sniffer): sample the leading
@@ -1734,10 +1789,10 @@ class ShellFileOperations(FileOperations):
             )
         )
         if page_result.exit_code != 0:
-            return ReadResult(error=f"Failed to read file: {page_result.stdout}")
+            return self._read_failed(page_result)
         page_parts = _split_sentinel_payload(page_result.stdout, page_sentinel)
         if page_parts is None:
-            return ReadResult(error=f"Failed to read file: {page_result.stdout}")
+            return self._read_failed(page_result, why="missing page sentinel")
         page_header, read_output = page_parts
         fields = _parse_page_header(page_header)
         try:
@@ -1745,7 +1800,7 @@ class ShellFileOperations(FileOperations):
         except ValueError:
             sed_rc = 1
         if sed_rc != 0:
-            return ReadResult(error=f"Failed to read file: {read_output}")
+            return self._read_failed(page_result, why=f"sed_rc={sed_rc}")
         try:
             total_lines = int(fields.get("total", "0"))
         except ValueError:


### PR DESCRIPTION
## What does this PR do?

`read_file` started Git Bash (or the remote shell) once per probe: size, byte sample, `sed|cut`, `wc -l`, and on the last page `tail -c 1`. On native Windows each start is ~53ms. A 160-line source file on this host paid 546ms of sequential process starts.

This keeps the existing decision tree and cuts the text path to two `_exec`s:

1. Probe: `[ -f ]` then size + `head|base64`. Missing / not-regular paths never reach `head`, so FIFOs stay unopened. Python still decides image / binary / UTF-16.
2. Page (text only): `sed|cut` + `wc -l` + the same last-page `tail` skip as before.

`wc -l` still returns whatever it returned before (trailing-newline undercount is a separate discussion). Pipeline status is isolated with `set -o pipefail` and explicit `size_rc` / `sample_rc` / `sed_rc` so a failed sample is not "file not found" and a failed `sed` is not `total_lines=0`.

Honest save on this Windows host: about 150–190ms per text read (the three avoided Git Bash starts). Docker/SSH save the extra RTTs. Linux local spawn is noise.

## Related Issue

Fixes #90039

Adjacent: #86964 (timeout for stalled cloud reads) touches `read_file` from the wrapper side. Different bug. I will rebase if that lands first.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `tools/file_operations.py`: `_probe_regular_file_cmd` / `_page_text_file_cmd` + wire-format helpers; `read_file` uses them.
- `tests/tools/test_read_file_coalesce.py`: parser, script-shape, live LocalEnvironment (2 execs on text, 1 on image/dir, phantom newline, truncated total).
- `tests/tools/test_file_operations.py` and `test_file_operations_edge_cases.py`: mocks now return the probe/page payload. Prefix-dispatch tests now assert `sed -n` / `wc -l` **inside** the page script instead of as standalone commands — the commands moved, the paths they carry did not.

## How to Test

1. `uv run --locked --with pytest pytest tests/tools/test_read_file_coalesce.py tests/tools/test_read_shell_line_clamp.py tests/tools/test_file_operations.py tests/tools/test_file_operations_edge_cases.py -k "read_file and not raw and not search" -q`
2. On native Windows, time a `read_file` of a small source file before/after if you want the spawn tax in your own numbers.

Without the source change, a 3-line file still does 5 `_exec`s. With it, 2. Dropping `wc -l` from the page script turns `test_page_script_still_runs_wc_and_conditional_tail` and `test_truncated_page_still_reports_total` red.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(tools):`)
- [x] I searched for existing PRs (nearest is #86964, timeout, not spawn count; several open PRs about `wc -l` *correctness* — this does not change that number)
- [x] My PR contains only changes related to this fix
- [x] Scoped pytest as above: 18 passed, 1 skipped (no `mkfifo` on Windows). I did not run `pytest tests/ -q`.
- [x] I've added tests
- [x] I've tested on Windows 11 + Git for Windows bash

### Documentation & Housekeeping

- [x] Docs: N/A
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform: shell-only, same as the rest of `file_operations.py`. Linux local win is small; Windows and docker/ssh are the point.
- [x] Tool schemas: N/A

## Not validated

- Full `pytest tests/` suite
- Live docker/ssh backends (the `_exec` count is what they would save in RTTs)
- Linux CI lane (tests are host-native; the live ones should run there)

## Screenshots / Logs

```
without fix: 5 execs (size, sample, sed, wc -l, tail)
with fix:    2 execs (probe, page)
isolated bash -c true on this host: 53ms
```
