### PR TITLE
fix: unwrap OpenAI-wire `data` envelope for all non-streaming providers

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -923,6 +923,37 @@ def _bedrock_reasoning_stale_floor(model_id: object) -> "float | None":
     return None
 
 
+def _create_with_data_envelope_unwrap(request_client, api_kwargs: dict):
+    """Some OpenAI-wire providers (e.g. clinepass) wrap NON-streaming
+    chat-completion responses in a top-level ``data`` envelope --
+    ``{"data": {"choices": [...]}, "success": true}``. The OpenAI SDK does NOT
+    reject this outright: it tolerates the wrapped body by returning a
+    ``ChatCompletion`` whose required ``id``/``choices`` fields are empty,
+    which the agent loop then treats as an invalid/"empty" response. Fetch the
+    raw JSON, unwrap ``data`` when present, and rebuild a normal
+    ``ChatCompletion`` so downstream validation sees real choices. Streaming
+    responses are unaffected (SSE chunks already use the standard shape); for
+    providers that do NOT use an envelope the raw body parses as-is, so this
+    is a safe no-op for them.
+    """
+    import json
+
+    raw_response = request_client.chat.completions.with_raw_response.create(**api_kwargs)
+    try:
+        body = json.loads(getattr(raw_response, "text", ""))
+    except Exception:
+        body = {}
+    if (
+        isinstance(body, dict)
+        and "choices" not in body
+        and isinstance(body.get("data"), dict)
+    ):
+        body = body["data"]
+    from openai.types.chat import ChatCompletion
+
+    return ChatCompletion.model_validate(body)
+
+
 def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
     """Run one non-streaming LLM request for the active api_mode and return it.
 
@@ -996,7 +1027,12 @@ def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
             api_kwargs.pop("_moa_prepared_request", None)
         return agent.client.chat.completions.create(**api_kwargs)
     request_client = make_client("chat_completion_request")
-    return request_client.chat.completions.create(**api_kwargs)
+    # Some OpenAI-wire providers wrap NON-streaming responses in a top-level
+    # `data` envelope ({'data': {...}, 'success': true}); the SDK then returns
+    # a ChatCompletion with empty id/choices, which the agent loop rejects as
+    # "Invalid API response". Unwrap whenever the envelope is present so every
+    # provider round-trips cleanly (no-op for standard-shaped responses).
+    return _create_with_data_envelope_unwrap(request_client, api_kwargs)
 
 
 def should_use_direct_api_call(agent) -> bool:

--- a/tests/test_data_envelope_unwrap.py
+++ b/tests/test_data_envelope_unwrap.py
@@ -1,0 +1,129 @@
+"""Tests for data-envelope unwrapping in non-streaming chat-completion dispatch.
+
+Catches a provider quirk: some OpenAI-wire providers (e.g. clinepass) wrap
+non-streaming responses in a top-level ``{"data": {...}, "success": true}``
+envelope. The OpenAI SDK tolerates this by returning a ChatCompletion with
+empty id/choices, which the agent loop rejects. These tests pin the unwrap
+behaviour that keeps every OpenAI-wire provider round-tripping cleanly.
+"""
+
+from types import SimpleNamespace
+
+from openai.types.chat import ChatCompletion
+
+from agent.chat_completion_helpers import (
+    _create_with_data_envelope_unwrap,
+    _dispatch_nonstreaming_api_request,
+)
+
+
+WRAPPED = {
+    "data": {
+        "id": "gen_x",
+        "object": "chat.completion",
+        "created": 1700000000,
+        "model": "cline-pass/deepseek-v4-flash",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hello from envelope"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    },
+    "success": True,
+}
+
+STANDARD = {
+    "id": "gen_y",
+    "object": "chat.completion",
+    "created": 1700000000,
+    "model": "some/provider-model",
+    "choices": [
+        {
+            "index": 0,
+            "message": {"role": "assistant", "content": "hello standard"},
+            "finish_reason": "stop",
+        }
+    ],
+}
+
+
+class _FakeRawResponse:
+    def __init__(self, text):
+        self.text = text
+
+
+class _FakeRawAccessor:
+    def __init__(self, raw_text):
+        self._raw_text = raw_text
+
+    def create(self, *args, **kwargs):
+        return _FakeRawResponse(self._raw_text)
+
+
+class _FakeCompletions:
+    """Mimics the parts of an OpenAI client's chat.completions the code uses."""
+
+    def __init__(self, raw_text):
+        self.with_raw_response = _FakeRawAccessor(raw_text)
+
+    def create(self, *args, **kwargs):
+        raise AssertionError("plain create() should not be hit when unwrapping")
+
+
+class _FakeClient:
+    def __init__(self, raw_text, host="api.cline.bot"):
+        self.base_url = SimpleNamespace(host=host)
+        self.chat = SimpleNamespace(completions=_FakeCompletions(raw_text))
+
+
+class _FakeAgent:
+    api_mode = "chat_completions"
+    provider = "not-moa"
+
+
+def _import_fast_json_body(body):
+    import json
+
+    return json.dumps(body)
+
+
+def _make_client_factory(raw_text):
+    client = _FakeClient(raw_text)
+    return lambda reason, kind="openai": client
+
+
+def test_unwrap_envelope_returns_inner_choices():
+    raw = _import_fast_json_body(WRAPPED)
+    result = _create_with_data_envelope_unwrap(_FakeClient(raw), {})
+    assert isinstance(result, ChatCompletion)
+    assert result.id == "gen_x"
+    assert result.choices[0].message.content == "hello from envelope"
+
+
+def test_no_envelope_passes_standard_body_through():
+    raw = _import_fast_json_body(STANDARD)
+    result = _create_with_data_envelope_unwrap(_FakeClient(raw), {})
+    assert isinstance(result, ChatCompletion)
+    assert result.id == "gen_y"
+    assert result.choices[0].message.content == "hello standard"
+
+
+def test_dispatch_unwraps_envelope_through_make_client():
+    raw = _import_fast_json_body(WRAPPED)
+    result = _dispatch_nonstreaming_api_request(
+        _FakeAgent(), {}, make_client=_make_client_factory(raw)
+    )
+    assert isinstance(result, ChatCompletion)
+    assert result.choices[0].message.content == "hello from envelope"
+
+
+def test_dispatch_passes_standard_body_through():
+    raw = _import_fast_json_body(STANDARD)
+    result = _dispatch_nonstreaming_api_request(
+        _FakeAgent(), {}, make_client=_make_client_factory(raw)
+    )
+    assert isinstance(result, ChatCompletion)
+    assert result.choices[0].message.content == "hello standard"


### PR DESCRIPTION
## Problem

Some OpenAI-wire providers (e.g. clinepass) wrap NON-streaming chat-completion responses in a top-level `{"data": {"choices": [...]}, "success": true}` envelope. The OpenAI SDK does **not** reject this with a ValidationError — it tolerates the wrapped body by returning a `ChatCompletion` whose required `id`/`choices` fields are empty. The agent loop then treats that as an invalid/empty response and fails the turn.

This surfaces as intermittent "Invalid API response" failures against any provider that uses this wire shape.

## Fix

Fetch the raw JSON via `with_raw_response`, unwrap the nested `data` object when present (and only when `choices` is absent at top level), and rebuild a valid `ChatCompletion` via `model_validate`. The unwrap is applied to every OpenAI-wire provider in the non-streaming dispatch tail and is a **safe no-op** for standards-shaped responses (no envelope → body parses as-is).

## Tests

Adds `tests/test_data_envelope_unwrap.py` with four cases covering enclosed and standard-shaped responses at both the helper and dispatch level. All four pass.

## Notes

- Mirrors the interim Hermes plugin approach but is generalized to any provider using this envelope, rather than gating on `cline.bot`.