### PR TITLE
fix(gateway): decode Windows process-scan output with the machine code page

### DIFF
--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -28,6 +28,7 @@ guarantee.
 
 from __future__ import annotations
 
+import locale
 import os
 import shutil
 import subprocess
@@ -45,6 +46,7 @@ __all__ = [
     "windows_detach_popen_kwargs",
     "bounded_git_probe",
     "bounded_probe_run",
+    "windows_probe_encoding",
     "noninteractive_git_env",
 ]
 
@@ -443,11 +445,47 @@ def kill_process_tree(proc: "subprocess.Popen") -> None:
             pass
 
 
+def windows_probe_encoding() -> str:
+    """Codec for decoding output from Windows-native console probes.
+
+    ``wmic``, ``tasklist`` and Windows PowerShell write in the machine's code
+    page, not UTF-8 -- CP932 on a Japanese host, CP936 on a Chinese one.
+    Decoding that as UTF-8 does not raise at the probe call sites, because they
+    pass ``errors="ignore"``: the bytes are deleted silently, and a DBCS trail
+    byte in the 0x40-0x7E range survives as a literal ASCII character. A path
+    segment whose CP932 bytes are ``90 66 92 66 83 7E`` decodes to ``ff~``, so
+    a later match against the same path read from the filesystem never fires.
+
+    Resolution order: the OEM code page (what a console-mode child writes),
+    then the locale's ANSI code page, then UTF-8. ``locale.getencoding()`` is
+    used rather than ``locale.getpreferredencoding(False)`` because the latter
+    honours Python UTF-8 Mode, which Hermes turns on for its own processes and
+    which has no bearing on what the child emits.
+
+    Always ``"utf-8"`` off Windows.
+    """
+    if not IS_WINDOWS:
+        return "utf-8"
+    try:
+        import ctypes
+
+        code_page = int(ctypes.windll.kernel32.GetOEMCP())
+        if code_page:
+            return "cp%d" % code_page
+    except Exception:
+        pass
+    try:
+        return locale.getencoding() or "utf-8"
+    except Exception:
+        return "utf-8"
+
+
 def bounded_probe_run(
     argv: Sequence[str],
     *,
     timeout: float,
     errors: str = "replace",
+    encoding: str = "utf-8",
 ) -> "subprocess.CompletedProcess[str] | None":
     """Deadlock-safe ``subprocess.run(argv, capture_output=True, timeout=...)``
     for fail-open probe call sites. Returns a ``CompletedProcess`` when the
@@ -469,11 +507,12 @@ def bounded_probe_run(
     (the orphaned reader threads are daemonic and cost nothing).
 
     The spawn contract mirrors the ``run`` calls it replaces: PIPE/PIPE/DEVNULL,
-    ``text`` with UTF-8 decoding (*errors* configurable — the process scans use
-    ``"ignore"``), and the hidden-window ``creationflags`` on Windows only. On
-    POSIX the child is placed in its own process group (``process_group=0``,
-    Python ≥3.11) so timeout cleanup can take down descendants with the
-    launcher instead of orphaning them.
+    ``text`` decoding (*encoding* and *errors* configurable — the Windows-native
+    process scans pass :func:`windows_probe_encoding` and ``"ignore"``), and the
+    hidden-window ``creationflags`` on Windows only. On POSIX the child is
+    placed in its own process group (``process_group=0``, Python ≥3.11) so
+    timeout cleanup can take down descendants with the launcher instead of
+    orphaning them.
     """
     _popen_kwargs: dict = {"creationflags": windows_hide_flags()} if IS_WINDOWS else {"process_group": 0}
     try:
@@ -483,7 +522,7 @@ def bounded_probe_run(
             stderr=subprocess.PIPE,
             stdin=subprocess.DEVNULL,
             text=True,
-            encoding="utf-8",
+            encoding=encoding,
             errors=errors,
             **_popen_kwargs,
         )

--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -81,13 +81,17 @@ def _detect_openclaw_processes() -> list[str]:
         # forever on Windows in post-timeout cleanup when a conhost.exe
         # descendant holds duplicated pipe handles (#87134) — and a hang is
         # not an exception, so the try/except here can't save the caller.
-        from hermes_cli._subprocess_compat import bounded_probe_run
+        from hermes_cli._subprocess_compat import (
+            bounded_probe_run,
+            windows_probe_encoding,
+        )
 
         try:
             for exe in ("openclaw.exe", "clawd.exe"):
                 result = bounded_probe_run(
                     ["tasklist", "/FI", f"IMAGENAME eq {exe}"],
                     timeout=5,
+                    encoding=windows_probe_encoding(),
                 )
                 if result is not None and exe in (result.stdout or "").lower():
                     found.append(f"process: {exe}")
@@ -102,6 +106,7 @@ def _detect_openclaw_processes() -> list[str]:
             result = bounded_probe_run(
                 ["powershell", "-NoProfile", "-Command", ps_cmd],
                 timeout=5,
+                encoding=windows_probe_encoding(),
             )
             if result is not None and (result.stdout or "").strip():
                 found.append(f"node.exe process with openclaw in command line (PID {result.stdout.strip()})")

--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -84,11 +84,15 @@ def _scan_dashboard_processes(
             # CREATE_NO_WINDOW: this scan can run from the windowless
             # pythonw.exe desktop/gateway backend during an update, where a
             # bare wmic spawn would pop a console window.
-            from hermes_cli._subprocess_compat import bounded_probe_run
+            from hermes_cli._subprocess_compat import (
+                bounded_probe_run,
+                windows_probe_encoding,
+            )
 
             result = bounded_probe_run(
                 ["wmic", "process", "get", "ProcessId,CommandLine", "/FORMAT:LIST"],
                 timeout=10,
+                encoding=windows_probe_encoding(),
                 errors="ignore",
             )
             if result is None or result.returncode != 0 or result.stdout is None:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -542,7 +542,10 @@ def _scan_gateway_pids(
             # inside the windowless pythonw.exe gateway/desktop backend, so a
             # bare wmic/powershell spawn would flash a conhost window on every
             # watchdog probe.
-            from hermes_cli._subprocess_compat import bounded_probe_run
+            from hermes_cli._subprocess_compat import (
+                bounded_probe_run,
+                windows_probe_encoding,
+            )
 
             wmic_path = shutil.which("wmic")
             result = None
@@ -556,6 +559,7 @@ def _scan_gateway_pids(
                         "/FORMAT:LIST",
                     ],
                     timeout=10,
+                    encoding=windows_probe_encoding(),
                     errors="ignore",
                 )
             if result is None or result.returncode != 0 or not (result.stdout or ""):
@@ -575,6 +579,7 @@ def _scan_gateway_pids(
                 result = bounded_probe_run(
                     [powershell, "-NoProfile", "-Command", ps_cmd],
                     timeout=15,
+                    encoding=windows_probe_encoding(),
                     errors="ignore",
                 )
                 if result is None:

--- a/tests/hermes_cli/test_bounded_probe_run.py
+++ b/tests/hermes_cli/test_bounded_probe_run.py
@@ -110,3 +110,92 @@ def test_posix_child_gets_own_process_group():
     )
     assert result is not None
     assert result.stdout.strip() == "True"
+
+
+# --------------------------------------------------------------------------
+# Decoding contract (#90017 follow-up): the Windows-native probes -- wmic,
+# tasklist, Windows PowerShell -- emit the machine's code page, not UTF-8.
+# ``bounded_probe_run`` used to hardcode ``encoding="utf-8"``, so on a CP932
+# host the process scans decoded CJK path segments to garbage before matching
+# them against a path read from the filesystem.
+# --------------------------------------------------------------------------
+
+
+class _FakeProc:
+    def __init__(self):
+        self.returncode = 0
+
+    def communicate(self, timeout=None):
+        return "", ""
+
+
+def _capture_popen(monkeypatch, captured):
+    import hermes_cli._subprocess_compat as sc
+
+    def fake_popen(argv, **kwargs):
+        captured.update(kwargs)
+        captured["argv"] = list(argv)
+        return _FakeProc()
+
+    monkeypatch.setattr(sc.subprocess, "Popen", fake_popen)
+
+
+def test_bounded_probe_run_defaults_to_utf8(monkeypatch):
+    """Existing callers (git probes, POSIX probes) keep UTF-8 decoding."""
+    captured: dict = {}
+    _capture_popen(monkeypatch, captured)
+
+    bounded_probe_run(["anything"], timeout=5)
+
+    assert captured["encoding"] == "utf-8"
+    assert captured["errors"] == "replace"
+
+
+def test_bounded_probe_run_forwards_an_explicit_encoding(monkeypatch):
+    captured: dict = {}
+    _capture_popen(monkeypatch, captured)
+
+    bounded_probe_run(["anything"], timeout=5, encoding="cp932", errors="ignore")
+
+    assert captured["encoding"] == "cp932"
+    assert captured["errors"] == "ignore"
+
+
+def test_windows_probe_encoding_is_utf8_off_windows(monkeypatch):
+    import hermes_cli._subprocess_compat as sc
+
+    monkeypatch.setattr(sc, "IS_WINDOWS", False)
+    assert sc.windows_probe_encoding() == "utf-8"
+
+
+def test_windows_probe_encoding_falls_back_to_the_locale_code_page(monkeypatch):
+    """When the OEM code page can't be read, use the ANSI one -- never
+    ``getpreferredencoding(False)``, which follows Python UTF-8 Mode and would
+    answer ``utf-8`` on a CP932 host that Hermes started in UTF-8 Mode."""
+    import hermes_cli._subprocess_compat as sc
+
+    monkeypatch.setattr(sc, "IS_WINDOWS", True)
+    monkeypatch.setattr(sc.locale, "getencoding", lambda: "cp932")
+    monkeypatch.setattr(sc.locale, "getpreferredencoding", lambda *a, **k: "utf-8")
+
+    # ``ctypes.windll`` does not exist off Windows, so the OEM probe raises and
+    # the locale fallback is what this asserts.
+    assert sc.windows_probe_encoding() == "cp932"
+
+
+def test_utf8_ignore_keeps_dbcs_trail_bytes_as_ascii():
+    """Why the wrong codec is worse than a crash here.
+
+    Measured on a ja-JP host: a real ``wmic`` scan returned a path segment
+    whose CP932 bytes are ``90 66 92 66 83 7E``. Under ``utf-8`` with
+    ``errors="ignore"`` each lead byte is dropped and each trail byte in the
+    0x40-0x7E range survives as a literal ASCII character, so five characters
+    became ``ff~`` -- no U+FFFD, nothing to notice, and every later
+    ``in``-match against the real path fails.
+    """
+    segment = "診断ミレル"
+    raw = segment.encode("cp932")
+
+    assert raw == b"\x90\x66\x92\x66\x83\x7e\x83\x8c\x83\x8b"
+    assert raw.decode("cp932") == segment
+    assert raw.decode("utf-8", errors="ignore") == "ff~"

--- a/tests/hermes_cli/test_bounded_probe_run.py
+++ b/tests/hermes_cli/test_bounded_probe_run.py
@@ -23,6 +23,7 @@ exercise the same code path through the ``bounded_git_probe`` delegation.
 import subprocess
 import sys
 import time
+import types
 
 import pytest
 
@@ -168,18 +169,63 @@ def test_windows_probe_encoding_is_utf8_off_windows(monkeypatch):
     assert sc.windows_probe_encoding() == "utf-8"
 
 
+def _windows_host(monkeypatch, *, oem, ansi):
+    """Put ``windows_probe_encoding`` on a Windows host whose ``GetOEMCP`` answers *oem*.
+
+    *oem* is the code page the call returns, or an exception it raises.  Faking
+    ``ctypes.windll`` is what makes these tests platform-independent: off Windows
+    the attribute does not exist, so the OEM branch raises for a reason that has
+    nothing to do with the case under test, and a Windows runner takes the OEM
+    branch for real and never reaches the fallback at all.
+    """
+    import ctypes
+
+    import hermes_cli._subprocess_compat as sc
+
+    def get_oem_cp():
+        if isinstance(oem, BaseException):
+            raise oem
+        return oem
+
+    monkeypatch.setattr(sc, "IS_WINDOWS", True)
+    monkeypatch.setattr(
+        ctypes,
+        "windll",
+        types.SimpleNamespace(kernel32=types.SimpleNamespace(GetOEMCP=get_oem_cp)),
+        raising=False,
+    )
+    monkeypatch.setattr(sc.locale, "getencoding", lambda: ansi)
+    monkeypatch.setattr(sc.locale, "getpreferredencoding", lambda *a, **k: "utf-8")
+    return sc
+
+
+def test_windows_probe_encoding_prefers_the_oem_code_page(monkeypatch):
+    """A console-mode child writes in the OEM code page, not the ANSI one.
+
+    Measured on a us-EN Win11 host: ``GetOEMCP()`` is 437 while ``GetACP()`` is
+    1252, and a spawned command line carrying an e-acute came back as the byte
+    ``0x82``, which is where cp437 keeps that letter.  cp1252 reads ``0x82`` as a
+    low quotation mark instead, so resolving the ANSI page first would corrupt
+    the very scan this codec exists to decode.
+    """
+    sc = _windows_host(monkeypatch, oem=437, ansi="cp1252")
+
+    assert sc.windows_probe_encoding() == "cp437"
+
+
 def test_windows_probe_encoding_falls_back_to_the_locale_code_page(monkeypatch):
     """When the OEM code page can't be read, use the ANSI one -- never
     ``getpreferredencoding(False)``, which follows Python UTF-8 Mode and would
     answer ``utf-8`` on a CP932 host that Hermes started in UTF-8 Mode."""
-    import hermes_cli._subprocess_compat as sc
+    sc = _windows_host(monkeypatch, oem=OSError(1, "GetOEMCP unavailable"), ansi="cp932")
 
-    monkeypatch.setattr(sc, "IS_WINDOWS", True)
-    monkeypatch.setattr(sc.locale, "getencoding", lambda: "cp932")
-    monkeypatch.setattr(sc.locale, "getpreferredencoding", lambda *a, **k: "utf-8")
+    assert sc.windows_probe_encoding() == "cp932"
 
-    # ``ctypes.windll`` does not exist off Windows, so the OEM probe raises and
-    # the locale fallback is what this asserts.
+
+def test_windows_probe_encoding_falls_back_when_the_oem_page_is_zero(monkeypatch):
+    """``GetOEMCP`` answers 0 when it fails, and ``cp0`` is not a codec."""
+    sc = _windows_host(monkeypatch, oem=0, ansi="cp932")
+
     assert sc.windows_probe_encoding() == "cp932"
 
 


### PR DESCRIPTION
## What does this PR do?

`bounded_probe_run` hardcoded `encoding="utf-8"`. It is the shared entry point for the Windows-native process scans -- `wmic process get ProcessId,CommandLine /FORMAT:LIST`, its PowerShell `Get-CimInstance` fallback, and `tasklist` -- and those write in the machine's code page, not UTF-8.

The call sites pass `errors="ignore"`, so nothing raises. The bytes are deleted, and a DBCS trail byte in the 0x40-0x7E range survives as a literal ASCII character.

Measured on ja-JP Windows (ACP=932), Python 3.12.10, **with UTF-8 Mode off** -- the codec was hardcoded, so unlike #89878 this does not depend on `PYTHONUTF8`:

```
wmic                : C:\Windows\System32\Wbem\wmic.EXE
raw output          : 172,061 bytes, 7 non-ASCII
CommandLine rows    : 386
rows changed by the utf-8 + errors="ignore" decode : 1

  machine code page : ...\I-O DATA\診断ミレル for HDD\HDDMireru.exe
  utf-8 + ignore    : ...\I-O DATA\ff~ for HDD\HDDMireru.exe
```

Byte level:

```
診断ミレル  cp932 = 90 66  92 66  83 7E  83 8C  83 8B

  90 -> invalid UTF-8 lead byte, dropped   66 -> survives as 'f'
  92 -> dropped                            66 -> survives as 'f'
  83 -> dropped                            7E -> survives as '~'
  83 -> dropped                            8C -> dropped
  83 -> dropped                            8B -> dropped
```

Five characters become `ff~`. No `U+FFFD`, no exception, nothing above debug level.

**What that costs.** `_scan_gateway_pids` matches the decoded command line against a path it read from the filesystem:

```python
current_home = str(get_hermes_home().resolve())        # correct, from the OS
...
return (... or f"hermes_home={current_home_lc}" in command_lc)   # haystack came from wmic
```

On an account whose profile path contains non-ASCII, the needle is `c:/users/ヨギー/.hermes` and the haystack is `c:/users/m[/.hermes`. Those can never match, so the scan does not find the gateway it is looking for. The default-profile branch is affected in the other direction: a command line carrying a non-matching `hermes_home=` is actively disqualified.

**To be exact about what I did and did not observe.** My own profile path is ASCII, so the scan still matched on this host, and the corrupted row above is an unrelated third-party path. The gateway consequence is read off the matcher, not observed on my machine. What is measured is the decode.

`dashboard_procs.py` already carries a comment saying wmic *"may emit text in the system code page (for example cp936 on zh-CN systems), not UTF-8"* -- the code knows; it just never resolves that code page.

**The fix.** `bounded_probe_run` gains an `encoding` parameter defaulting to `"utf-8"`, so the git and POSIX probes are byte-for-byte unchanged. The five Windows-native call sites pass a new `windows_probe_encoding()`, which resolves the OEM code page, then the locale's ANSI code page, then UTF-8. `locale.getencoding()` is used rather than `getpreferredencoding(False)` for the reason established in #89907.

**One thing I could not settle here.** On a Japanese host the ANSI and OEM code pages are both 932, so my measurement cannot distinguish them. They differ on Western hosts (1252 vs 850/437). I put `GetOEMCP()` first because these are console-mode children, but I have no measurement behind that ordering -- a check from a cp1252 host would settle it, and I am happy to flip the order or drop to `locale.getencoding()` alone if you prefer.



## Related Issue

No separate issue -- reporting it here with the measurement. Same class as #89878 / #89907 / #90017, but a different decoding path: this one hardcodes the codec inside a shared helper rather than resolving it from the locale, so UTF-8 Mode never enters into it.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/_subprocess_compat.py` -- added `windows_probe_encoding()`: OEM code page, then `locale.getencoding()`, then `utf-8`; always `utf-8` off Windows.
- `hermes_cli/_subprocess_compat.py` -- `bounded_probe_run()` takes `encoding: str = "utf-8"` and forwards it to `Popen`. The default keeps `bounded_git_probe` and every POSIX probe unchanged.
- `hermes_cli/gateway.py` -- the wmic and PowerShell scans in `_scan_gateway_pids` pass `encoding=windows_probe_encoding()`.
- `hermes_cli/dashboard_procs.py` -- same for the wmic scan.
- `hermes_cli/claw.py` -- same for the `tasklist` and PowerShell probes.
- `tests/hermes_cli/test_bounded_probe_run.py` -- five tests covering the default, the forwarded value, the off-Windows answer, the locale fallback, and the byte-level behaviour above.

## How to Test

1. On a CP932 host, capture the same scan the gateway runs, as bytes, and decode it both ways:

```
> python -c "import subprocess; print(len(subprocess.run(['wmic','process','get','ProcessId,CommandLine','/FORMAT:LIST'],capture_output=True).stdout))"
172061
```

Decoding that with `cp932` gives 386 `CommandLine=` rows intact. Decoding with `utf-8` and `errors="ignore"` changes one of them on my machine, as shown above. A host whose user profile path contains non-ASCII will see every Hermes row change.

2. `scripts/run_tests.sh tests/hermes_cli/test_bounded_probe_run.py -q` -- 13 pass.

3. To confirm the new tests are not vacuous, run them against the pre-patch source: 3 failed / 10 passed (`TypeError` for the unknown `encoding` kwarg, `AttributeError` for the missing helper). Two of the five pass either way on purpose -- one pins that the default stays `"utf-8"` so the git probes cannot regress, the other asserts a stdlib fact about the CP932 bytes and does not depend on this change.

Note on the checklist below: I ran `tests/hermes_cli/test_bounded_probe_run.py` and the pre-patch comparison, not the full `pytest tests/ -q`, so I left that box unchecked rather than claiming it.

I have a ja-JP (ACP=932) Windows host and can measure anything else on that locale.

*(Measured on my host. Drafted with Claude.)*

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, ja-JP (ACP=932), Python 3.12.10

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

