### PR TITLE
fix(skills): honor Managed Scope for skills.external_dirs discovery

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -551,7 +551,10 @@ def get_external_skills_dirs() -> List[Path]:
                 _mstat = _managed_path.stat()
                 managed_sig = (_mstat.st_mtime_ns, _mstat.st_size)
                 managed_cfg = managed_scope.load_managed_config() or {}
-    except Exception:
+    except Exception as e:
+        # Fail-open is right for discovery, but leave a breadcrumb so a
+        # misconfigured managed scope shows up as more than mystery absence.
+        logger.debug("Managed Scope config unavailable, using profile-only discovery: %s", e)
         managed_cfg = {}
 
     if not config_path.exists() and not managed_cfg:

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -526,20 +526,53 @@ def get_external_skills_dirs() -> List[Path]:
     path.  Only directories that actually exist are returned.  Duplicates and
     paths that resolve to the local ``~/.hermes/skills/`` are silently skipped.
 
-    Cached in-process, keyed on ``config.yaml`` mtime — the function is
-    called once per skill during banner / tool-registry scans, and YAML
-    parsing a non-trivial config dominates ``hermes`` cold-start time
-    when the cache is absent.
+    Cached in-process, keyed on the profile AND managed config.yaml
+    signatures — the function is called once per skill during banner /
+    tool-registry scans, and YAML parsing a non-trivial config dominates
+    ``hermes`` cold-start time when the cache is absent.
     """
     config_path = get_config_path()
-    if not config_path.exists():
+
+    # Managed Scope must be honored here too (#90040): the managed config's
+    # ``skills.external_dirs`` replaces the profile's list, exactly as the
+    # effective-config contract promises, so an administrator can publish
+    # one shared skill directory without duplicating the key into every
+    # profile. The managed signature also keys the cache below — editing
+    # /etc/hermes/config.yaml mid-run must invalidate discovery.
+    managed_cfg: Dict[str, Any] = {}
+    managed_sig: Tuple[int, int] = (0, 0)
+    try:
+        from hermes_cli import managed_scope
+
+        _managed_dir = managed_scope.get_managed_dir()
+        if _managed_dir is not None:
+            _managed_path = _managed_dir / "config.yaml"
+            if _managed_path.exists():
+                _mstat = _managed_path.stat()
+                managed_sig = (_mstat.st_mtime_ns, _mstat.st_size)
+                managed_cfg = managed_scope.load_managed_config() or {}
+    except Exception:
+        managed_cfg = {}
+
+    if not config_path.exists() and not managed_cfg:
         return []
 
-    # Cache key: (absolute path, mtime_ns).  stat() is ~2us vs ~85ms for
-    # the full YAML parse, so the fast path is nearly free.
+    # Cache key: (profile path, mtime_ns, managed mtime, managed size).
+    # stat() is ~2us vs ~85ms for the full YAML parse, so the fast path
+    # is nearly free. A missing profile config still participates via a
+    # zero signature so managed-only discovery caches too.
     try:
-        stat = config_path.stat()
-        cache_key: Tuple[str, int] = (str(config_path), stat.st_mtime_ns)
+        stat = (
+            config_path.stat()
+            if config_path.exists()
+            else None
+        )
+        cache_key: Tuple[str, int, int, int] = (
+            str(config_path),
+            stat.st_mtime_ns if stat is not None else 0,
+            managed_sig[0],
+            managed_sig[1],
+        )
     except OSError:
         cache_key = None  # type: ignore[assignment]
 
@@ -550,6 +583,11 @@ def get_external_skills_dirs() -> List[Path]:
             return list(cached)
 
     parsed = _load_raw_config()
+    managed_skills = managed_cfg.get("skills")
+    if isinstance(managed_skills, dict) and "external_dirs" in managed_skills:
+        # Managed Scope replaces the profile's list (same overlay semantics
+        # as apply_managed_overlay for list-valued leaves).
+        parsed = {**parsed, "skills": managed_skills}
     if not parsed:
         return []
 

--- a/tests/agent/test_external_skills_dirs_cache.py
+++ b/tests/agent/test_external_skills_dirs_cache.py
@@ -110,3 +110,88 @@ def test_cache_key_is_per_config_path(tmp_path, monkeypatch):
     # And switching back still works — both entries coexist in the cache.
     monkeypatch.setenv("HERMES_HOME", str(home_a))
     assert get_external_skills_dirs() == [ext_a.resolve()]
+
+
+# ---------------------------------------------------------------------------
+# Managed Scope (#90040): skills.external_dirs declared in the managed config
+# replaces the profile's list and must be discovered, with the managed file's
+# signature keying the cache.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def managed_scope_home(tmp_path, monkeypatch):
+    """Isolated profile home + managed dir with a shared skill directory."""
+    home = tmp_path / "home"
+    home.mkdir()
+    shared = tmp_path / "shared"
+    (shared / "demo").mkdir(parents=True)
+    managed = tmp_path / "managed"
+    managed.mkdir()
+    (managed / "config.yaml").write_text(
+        "skills:\n"
+        f"  external_dirs:\n"
+        f"    - {shared}\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    _external_dirs_cache_clear()
+    yield home, shared, managed
+    _external_dirs_cache_clear()
+
+
+def test_managed_only_external_dirs_discovered(managed_scope_home):
+    """A managed-only skills.external_dirs is discovered even when the
+    profile config declares no dirs."""
+    _home, shared, _managed = managed_scope_home
+    assert get_external_skills_dirs() == [shared.resolve()]
+
+
+def test_managed_only_works_without_profile_config_file(managed_scope_home):
+    """The profile home has NO config.yaml; managed scope alone drives it."""
+    _home, shared, _managed = managed_scope_home
+    from agent.skill_utils import get_config_path
+
+    assert not get_config_path().exists()
+    assert get_external_skills_dirs() == [shared.resolve()]
+
+
+def test_managed_list_replaces_profile_list(managed_scope_home):
+    """Managed Scope semantics: the managed list replaces the profile's
+    list (same overlay rule as apply_managed_overlay for list leaves)."""
+    home, shared, _managed = managed_scope_home
+    profile_only = home / "profile_only"
+    profile_only.mkdir()
+    (home / "config.yaml").write_text(
+        "skills:\n"
+        f"  external_dirs:\n"
+        f"    - {profile_only}\n",
+        encoding="utf-8",
+    )
+    dirs = get_external_skills_dirs()
+    assert dirs == [shared.resolve()]
+    assert profile_only.resolve() not in dirs
+
+
+def test_managed_edit_invalidates_cache(managed_scope_home):
+    """Editing the managed config.yaml invalidates the discovery cache."""
+    _home, shared, managed = managed_scope_home
+    assert get_external_skills_dirs() == [shared.resolve()]
+
+    other = managed.parent / "other_shared"
+    other.mkdir()
+    cfg = managed / "config.yaml"
+    cfg.write_text(
+        "skills:\n"
+        f"  external_dirs:\n"
+        f"    - {other}\n",
+        encoding="utf-8",
+    )
+    stat = cfg.stat()
+    future = stat.st_atime + 10
+    os.utime(cfg, (future, future))
+
+    assert get_external_skills_dirs() == [other.resolve()]

--- a/tests/agent/test_external_skills_dirs_cache.py
+++ b/tests/agent/test_external_skills_dirs_cache.py
@@ -176,6 +176,28 @@ def test_managed_list_replaces_profile_list(managed_scope_home):
     assert profile_only.resolve() not in dirs
 
 
+def test_managed_without_external_dirs_leaf_keeps_profile_list(managed_scope_home):
+    """A managed ``skills`` section without an ``external_dirs`` leaf must
+    leave the profile's list untouched — replacement only happens when the
+    leaf itself exists."""
+    home, _shared, managed = managed_scope_home
+    profile_only = home / "profile_only"
+    profile_only.mkdir()
+    (home / "config.yaml").write_text(
+        "skills:\n"
+        f"  external_dirs:\n"
+        f"    - {profile_only}\n",
+        encoding="utf-8",
+    )
+    (managed / "config.yaml").write_text(
+        "skills:\n"
+        "  auto_sync: true\n",
+        encoding="utf-8",
+    )
+
+    assert get_external_skills_dirs() == [profile_only.resolve()]
+
+
 def test_managed_edit_invalidates_cache(managed_scope_home):
     """Editing the managed config.yaml invalidates the discovery cache."""
     _home, shared, managed = managed_scope_home


### PR DESCRIPTION
## What does this PR do?

Fixes #90040: `skills.external_dirs` declared in Managed Scope was present in the effective configuration but never discovered — external skill discovery (`get_external_skills_dirs`) read only the active profile's raw `config.yaml`. An administrator publishing one shared skill directory through `/etc/hermes/config.yaml` had to duplicate the key into every profile, breaking the managed-config-overrides-user contract.

The discovery path now loads the managed config (`HERMES_MANAGED_DIR`, falling back to `/etc/hermes`) and, when the managed config declares `skills.external_dirs`, the managed list **replaces** the profile's list — the same overlay semantics `apply_managed_overlay` gives list-valued leaves. Managed-only discovery also works with no profile `config.yaml` at all (a zero profile signature still participates in the cache key).

The memo key grows the managed file's `(mtime_ns, size)` so editing the managed config mid-run invalidates the discovery cache exactly like a profile edit already did — the cache-correctness concern the report flagged alongside the main bug.

## Related Issue

Fixes #90040

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/skill_utils.py`: `get_external_skills_dirs` loads the managed config up front, applies its `skills.external_dirs` as a replacement overlay on the profile config, and keys the in-process cache on the profile **and** managed file signatures; missing profile config no longer short-circuits when a managed scope is present.

## How to Test

1. `pytest tests/agent/test_external_skills_dirs_cache.py -q` — 6 passed (4 new tests covering the report's suggested regression matrix).
2. Fail-on-main verified: with the source change stashed, all 4 new managed-scope tests fail on the unmodified tree.
3. Adjacent suites (`test_skill_utils`, `test_external_skills`): 29 passed — profile-local discovery and the pre-existing mtime cache behavior are unchanged.
4. Observed result: with `HERMES_MANAGED_DIR` pointing at a managed config that declares `external_dirs: [/shared]` and a profile that declares a different directory, discovery returns `[/shared]`; deleting the profile `config.yaml` entirely still discovers `[/shared]`; editing the managed file's list is picked up on the next call.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
