### PR TITLE
feat(delegation): add durable lifecycle control on delegate_task

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -861,7 +861,11 @@ def init_agent(
     # iteration. Message-role alternation is preserved (we modify an
     # existing tool message rather than inserting a new user turn).
     agent._pending_steer: Optional[str] = None
+    agent._pending_steer_envelopes: list = []
     agent._pending_steer_lock = threading.Lock()
+    from tools.foreground_wait import ForegroundWaitRegistry
+
+    agent._foreground_waits = ForegroundWaitRegistry()
 
     # Active-turn redirect mechanism. A regular follow-up sent while the model
     # is generating is different from a hard /stop: preserve the valid turn

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1317,7 +1317,12 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         try:
             try:
                 def _execute(next_args: dict[str, Any]) -> Any:
-                    return agent._invoke_tool(
+                    from tools.foreground_wait import track_foreground_wait
+
+                    with track_foreground_wait(
+                        agent, str(tool_call.id), function_name, next_args
+                    ):
+                        return agent._invoke_tool(
                         function_name,
                         next_args,
                         effective_task_id,
@@ -2348,7 +2353,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     from model_tools import suppress_post_tool_call_hook
 
                     with suppress_post_tool_call_hook():
-                        return _ra().handle_function_call(
+                        from tools.foreground_wait import track_foreground_wait
+
+                        with track_foreground_wait(
+                            agent, str(tool_call.id), function_name, next_args
+                        ):
+                            return _ra().handle_function_call(
                             function_name,
                             next_args,
                             effective_task_id,
@@ -2430,7 +2440,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     from model_tools import suppress_post_tool_call_hook
 
                     with suppress_post_tool_call_hook():
-                        return _ra().handle_function_call(
+                        from tools.foreground_wait import track_foreground_wait
+
+                        with track_foreground_wait(
+                            agent, str(tool_call.id), function_name, next_args
+                        ):
+                            return _ra().handle_function_call(
                             function_name,
                             next_args,
                             effective_task_id,

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -626,7 +626,17 @@ def _subagent_spawn_count(args: Mapping[str, Any]) -> int:
     """
     if isinstance(args, Mapping):
         action = str(args.get("action") or "").strip().lower()
-        if action in ("list", "steer", "stop"):
+        if action in (
+            "list",
+            "steer",
+            "stop",
+            "status",
+            "tail",
+            "wait",
+            "resume",
+            "interrupt",
+            "abandon",
+        ):
             return 0
     tasks = args.get("tasks") if isinstance(args, Mapping) else None
     if isinstance(tasks, list) and tasks:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -95,6 +95,37 @@ MAX_SAFE_RESUME_MESSAGES = 20_000
 MAX_SAFE_EXPORT_MESSAGES = 20_000
 
 
+def ensure_state_schema(conn: sqlite3.Connection) -> None:
+    """Apply the shared session schema to an already-open connection.
+
+    Used by auxiliary stores (delegation repository, etc.) that share the
+    session schema helpers but do not construct a SessionDB.
+    """
+    helper = SessionSchemaMixin.__new__(SessionSchemaMixin)
+    owns_transaction = not conn.in_transaction
+    if owns_transaction:
+        conn.execute("BEGIN IMMEDIATE")
+    try:
+        cursor = conn.cursor()
+        cursor.executescript(SCHEMA_SQL)
+        helper._reconcile_columns(cursor)
+        try:
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_messages_platform_msg_id "
+                "ON messages(session_id, platform_message_id) "
+                "WHERE platform_message_id IS NOT NULL"
+            )
+        except sqlite3.OperationalError:
+            pass
+        cursor.executescript(DEFERRED_INDEX_SQL)
+        if owns_transaction:
+            conn.commit()
+    except BaseException:
+        if owns_transaction:
+            conn.rollback()
+        raise
+
+
 def _configured_transcript_limit(key: str, fallback: int) -> int:
     """Resolve a transcript safety limit from config at call time.
 
@@ -8542,6 +8573,187 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 max_num = max(max_num, int(m.group(1)))
 
         return f"{base} #{max_num + 1}"
+
+    @staticmethod
+    def _session_model_config(row: Any) -> Dict[str, Any]:
+        """Decode one session row's model_config without trusting its shape."""
+        raw = row["model_config"] if row is not None else None
+        if isinstance(raw, dict):
+            return dict(raw)
+        if not isinstance(raw, str) or not raw:
+            return {}
+        try:
+            value = json.loads(raw)
+        except (TypeError, ValueError):
+            return {}
+        return value if isinstance(value, dict) else {}
+
+    def control_session_candidates(self, session_id: str) -> List[str]:
+        """Return exact session plus proven compression ancestors, newest first.
+
+        Branches, delegates, and arbitrary sessions sharing a conversation root
+        are deliberately excluded. This is the ownership seam used by durable
+        delegation controls when the originating parent was compressed after it
+        spawned a child.
+        """
+        if not session_id:
+            return []
+        candidates: List[str] = []
+        current = session_id
+        seen: set[str] = set()
+        with self._lock:
+            for _ in range(100):
+                if not current or current in seen:
+                    break
+                seen.add(current)
+                candidates.append(current)
+                row = self._conn.execute(
+                    """SELECT child.parent_session_id, child.source,
+                              child.model_config, parent.end_reason
+                       FROM sessions child
+                       LEFT JOIN sessions parent ON parent.id=child.parent_session_id
+                       WHERE child.id=?""",
+                    (current,),
+                ).fetchone()
+                config = self._session_model_config(row) if row is not None else {}
+                if (
+                    row is None
+                    or row["end_reason"] != "compression"
+                    or row["source"] in {"subagent", "tool"}
+                    or config.get("_delegate_from") is not None
+                    or config.get("_branched_from") is not None
+                ):
+                    break
+                current = row["parent_session_id"]
+        return candidates
+
+    def is_authorized_control_session(
+        self, origin_session_id: str, candidate_session_id: str
+    ) -> bool:
+        """Whether candidate is the origin or its proven compression tip."""
+        return bool(
+            origin_session_id
+            and origin_session_id
+            in self.control_session_candidates(candidate_session_id)
+        )
+
+    def get_subagent_resume_bundle(
+        self,
+        child_session_id: str,
+        reconstruction_metadata: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Return validated provider-facing history for one durable child.
+
+        The walk is child-only and fail-closed: every included segment must be a
+        ``source='subagent'`` row carrying the same stable ``_delegate_from``
+        owner marker. Parent-agent rows are never queried into the replay. A
+        compression continuation is followed only when its parent ended for
+        compression and it carries that same marker.
+        """
+        if not isinstance(reconstruction_metadata, dict):
+            raise ValueError("missing reconstruction metadata")
+        try:
+            metadata = json.loads(json.dumps(reconstruction_metadata))
+        except (TypeError, ValueError) as exc:
+            raise ValueError("corrupt reconstruction metadata") from exc
+        expected_child = metadata.get("child_session_id")
+        delegate_from = metadata.get("parent_session_id")
+        if (
+            not isinstance(child_session_id, str)
+            or not child_session_id
+            or expected_child != child_session_id
+            or not isinstance(delegate_from, str)
+            or not delegate_from
+        ):
+            raise ValueError("incomplete reconstruction metadata")
+
+        with self._lock:
+            start = self._conn.execute(
+                "SELECT id,parent_session_id,source,model_config,end_reason "
+                "FROM sessions WHERE id=?",
+                (child_session_id,),
+            ).fetchone()
+            if start is None:
+                raise ValueError("missing subagent transcript")
+
+            tip = child_session_id
+            seen_forward = {tip}
+            for _ in range(100):
+                row = self._conn.execute(
+                    """SELECT child.id
+                       FROM sessions parent
+                       JOIN sessions child ON child.parent_session_id=parent.id
+                       WHERE parent.id=? AND parent.end_reason='compression'
+                         AND child.source='subagent'
+                         AND json_extract(COALESCE(child.model_config, '{}'),
+                                          '$._delegate_from')=?
+                       ORDER BY child.started_at DESC, child.id DESC LIMIT 1""",
+                    (tip, delegate_from),
+                ).fetchone()
+                if row is None or not row["id"] or row["id"] in seen_forward:
+                    break
+                tip = row["id"]
+                seen_forward.add(tip)
+
+            child_ids_tip_to_root: List[str] = []
+            current = tip
+            seen: set[str] = set()
+            owner_parent = None
+            for _ in range(100):
+                if not current or current in seen:
+                    raise ValueError("corrupt subagent lineage")
+                seen.add(current)
+                row = self._conn.execute(
+                    "SELECT id,parent_session_id,source,model_config "
+                    "FROM sessions WHERE id=?",
+                    (current,),
+                ).fetchone()
+                if row is None:
+                    raise ValueError("missing subagent lineage segment")
+                config = self._session_model_config(row)
+                if row["source"] != "subagent" or config.get("_delegate_from") != delegate_from:
+                    owner_parent = current
+                    break
+                child_ids_tip_to_root.append(current)
+                current = row["parent_session_id"]
+            else:
+                raise ValueError("subagent lineage exceeds safety bound")
+
+            if owner_parent is None:
+                owner_parent = current
+            if child_session_id not in child_ids_tip_to_root:
+                raise ValueError("foreign subagent lineage")
+
+            child_ids = list(reversed(child_ids_tip_to_root))
+            placeholders = ",".join("?" for _ in child_ids)
+            rows = self._conn.execute(
+                f"SELECT session_id, {self._CONVERSATION_ROW_COLUMNS} "
+                f"FROM messages WHERE session_id IN ({placeholders}) AND active=1 "
+                "ORDER BY id",
+                tuple(child_ids),
+            ).fetchall()
+
+        if not self.is_authorized_control_session(delegate_from, owner_parent):
+            raise ValueError("foreign subagent lineage")
+        history = self._rows_to_conversation(
+            rows,
+            session_id=tip,
+            include_ancestors=False,
+            repair_alternation=True,
+        )
+        from agent.replay_cleanup import sanitize_replay_history
+
+        history = sanitize_replay_history(history)
+        if not history:
+            raise ValueError("missing subagent transcript")
+        return {
+            "history": history,
+            "prior_child_session_id": tip,
+            "initial_child_session_id": child_session_id,
+            "parent_session_id": delegate_from,
+            "child_lineage": child_ids,
+            "reconstruction_metadata": metadata,
+        }
 
     def get_compression_tip(self, session_id: str) -> Optional[str]:
         """Walk the compression-continuation chain forward and return the tip.

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -415,7 +415,76 @@ CREATE TABLE IF NOT EXISTS async_delegations (
     owner_started_at INTEGER,
     task_json TEXT,
     delivery_claim TEXT,
-    delivery_claimed_at REAL
+    delivery_claimed_at REAL,
+    root_subagent_ids_json TEXT NOT NULL DEFAULT '[]',
+    children_json TEXT NOT NULL DEFAULT '{}',
+    interrupt_requests_json TEXT NOT NULL DEFAULT '{}',
+    interrupt_reason TEXT,
+    abandon_reason TEXT,
+    lifecycle_version INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE TABLE IF NOT EXISTS delegation_logical_subagents (
+    logical_id TEXT PRIMARY KEY,
+    delegation_id TEXT NOT NULL REFERENCES async_delegations(delegation_id) ON DELETE CASCADE,
+    parent_logical_id TEXT REFERENCES delegation_logical_subagents(logical_id),
+    root_ordinal INTEGER,
+    spec_json TEXT NOT NULL DEFAULT '{}',
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    UNIQUE (delegation_id, root_ordinal)
+);
+
+CREATE TABLE IF NOT EXISTS delegation_runs (
+    run_id TEXT PRIMARY KEY,
+    delegation_id TEXT NOT NULL REFERENCES async_delegations(delegation_id) ON DELETE CASCADE,
+    run_number INTEGER NOT NULL,
+    kind TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    completed_at REAL,
+    event_json TEXT,
+    result_json TEXT,
+    delivery_state TEXT NOT NULL DEFAULT 'pending',
+    delivery_claim TEXT,
+    delivery_claimed_at REAL,
+    delivery_attempts INTEGER NOT NULL DEFAULT 0,
+    delivered_at REAL,
+    UNIQUE (delegation_id, run_number)
+);
+
+CREATE TABLE IF NOT EXISTS delegation_attempts (
+    attempt_id TEXT PRIMARY KEY,
+    logical_id TEXT NOT NULL REFERENCES delegation_logical_subagents(logical_id) ON DELETE CASCADE,
+    run_id TEXT NOT NULL REFERENCES delegation_runs(run_id) ON DELETE CASCADE,
+    attempt_number INTEGER NOT NULL,
+    physical_worker_id TEXT,
+    state TEXT NOT NULL,
+    owner_pid INTEGER,
+    owner_started_at INTEGER,
+    created_at REAL NOT NULL,
+    started_at REAL,
+    completed_at REAL,
+    updated_at REAL NOT NULL,
+    metadata_json TEXT NOT NULL DEFAULT '{}',
+    interrupt_reason TEXT,
+    interrupt_requested_at REAL,
+    interrupt_taken_at REAL,
+    UNIQUE (logical_id, attempt_number)
+);
+
+CREATE TABLE IF NOT EXISTS delegation_steer_mailbox (
+    mailbox_id TEXT PRIMARY KEY,
+    delegation_id TEXT NOT NULL REFERENCES async_delegations(delegation_id) ON DELETE CASCADE,
+    logical_id TEXT NOT NULL REFERENCES delegation_logical_subagents(logical_id) ON DELETE CASCADE,
+    attempt_id TEXT NOT NULL REFERENCES delegation_attempts(attempt_id) ON DELETE CASCADE,
+    sequence_number INTEGER NOT NULL,
+    message TEXT NOT NULL,
+    force INTEGER NOT NULL DEFAULT 0,
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at REAL NOT NULL,
+    forwarded_at REAL,
+    resolved_at REAL,
+    UNIQUE (attempt_id, sequence_number)
 );
 
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
@@ -458,6 +527,17 @@ CREATE INDEX IF NOT EXISTS idx_sessions_handoff_state
     ON sessions(handoff_state, started_at);
 CREATE INDEX IF NOT EXISTS idx_sessions_system_prompt_hash
     ON sessions(system_prompt_hash);
+CREATE INDEX IF NOT EXISTS idx_async_delegations_owner_updated
+    ON async_delegations(origin_session, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_delegation_attempts_run
+    ON delegation_attempts(run_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_delegation_one_active_attempt
+    ON delegation_attempts(logical_id)
+    WHERE state IN ('starting','running','finalizing','interrupt_requested');
+CREATE INDEX IF NOT EXISTS idx_delegation_runs_delivery
+    ON delegation_runs(delivery_state, completed_at);
+CREATE INDEX IF NOT EXISTS idx_delegation_steer_attempt
+    ON delegation_steer_mailbox(attempt_id, sequence_number);
 """
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -3376,7 +3376,27 @@ class AIAgent:
                 self._pending_steer = None
         return True
 
-    def steer(self, text: str) -> bool:
+    def _steer_queue_unlocked(self) -> list:
+        queue = getattr(self, "_pending_steer_envelopes", None)
+        if isinstance(queue, list):
+            return queue
+        text = getattr(self, "_pending_steer", None)
+        queue = [{"text": text, "mailbox_id": None, "outcome_callback": None}] if text else []
+        self._pending_steer_envelopes = queue
+        return queue
+
+    def _sync_pending_steer_text_unlocked(self, queue: list) -> None:
+        self._pending_steer = "\n".join(
+            str(item.get("text") or "") for item in queue if item.get("text")
+        ) or None
+
+    def steer(
+        self,
+        text: str,
+        *,
+        mailbox_id: Optional[str] = None,
+        outcome_callback=None,
+    ) -> bool:
         """
         Inject a user message into the next tool result without interrupting.
 
@@ -3393,24 +3413,121 @@ class AIAgent:
 
         Returns:
             True if the steer was accepted, False if the text was empty.
+        
+        Optional mailbox_id / outcome_callback track a durable steer envelope.
         """
-        if not text or not text.strip():
+        if not isinstance(text, str) or not text.strip():
             return False
         cleaned = text.strip()
-        _lock = getattr(self, "_pending_steer_lock", None)
-        if _lock is None:
-            # Test stubs that built AIAgent via object.__new__ skip __init__.
-            # Fall back to direct attribute set; no concurrent callers expected
-            # in those stubs.
-            existing = getattr(self, "_pending_steer", None)
-            self._pending_steer = (existing + "\n" + cleaned) if existing else cleaned
+        envelope = {
+            "text": cleaned,
+            "mailbox_id": mailbox_id if isinstance(mailbox_id, str) else None,
+            "outcome_callback": outcome_callback if callable(outcome_callback) else None,
+        }
+        lock = getattr(self, "_pending_steer_lock", None)
+        if lock is None:
+            if envelope["mailbox_id"] and getattr(self, "_interrupt_requested", False):
+                self._ack_steer_envelopes([envelope], "superseded_by_interrupt")
+                return False
+            queue = self._steer_queue_unlocked()
+            queue.append(envelope)
+            self._sync_pending_steer_text_unlocked(queue)
             return True
-        with _lock:
-            if self._pending_steer:
-                self._pending_steer = self._pending_steer + "\n" + cleaned
-            else:
-                self._pending_steer = cleaned
+        with lock:
+            if envelope["mailbox_id"] and getattr(self, "_interrupt_requested", False):
+                self._ack_steer_envelopes([envelope], "superseded_by_interrupt")
+                return False
+            queue = self._steer_queue_unlocked()
+            queue.append(envelope)
+            self._sync_pending_steer_text_unlocked(queue)
         return True
+
+    def request_durable_steer(
+        self,
+        text: str,
+        *,
+        mailbox_id: str,
+        outcome_callback,
+        force: bool = False,
+    ) -> dict:
+        """Queue a tracked steer, optionally handing foreground waits off first."""
+        waits = getattr(self, "_foreground_waits", None)
+        active = waits.snapshot() if waits is not None else []
+        wait_kinds = sorted({slot.kind for slot in active})
+        if active and not force:
+            if callable(outcome_callback):
+                outcome_callback("foreground_wait")
+            return {"status": "foreground_wait", "wait_kinds": wait_kinds}
+
+        accepted = self.steer(
+            text,
+            mailbox_id=mailbox_id,
+            outcome_callback=outcome_callback,
+        )
+        if not accepted:
+            return {"status": "too_late_after_completion", "wait_kinds": wait_kinds}
+        if not active:
+            return {"status": "accepted", "wait_kinds": []}
+
+        result = waits.request_background(active)
+        if result.get("status") != "backgrounded":
+            self._remove_pending_steer_envelope(mailbox_id)
+            if callable(outcome_callback):
+                outcome_callback("force_background_failed")
+            return {
+                "status": "force_background_failed",
+                "wait_kinds": result.get("wait_kinds") or wait_kinds,
+                "errors": result.get("errors") or ["foreground handoff failed"],
+            }
+        return {
+            "status": "accepted",
+            "wait_kinds": result.get("wait_kinds") or wait_kinds,
+        }
+
+    def _remove_pending_steer_envelope(self, mailbox_id: str) -> None:
+        lock = getattr(self, "_pending_steer_lock", None)
+
+        def _remove() -> None:
+            queue = self._steer_queue_unlocked()
+            self._pending_steer_envelopes = [
+                item for item in queue if item.get("mailbox_id") != mailbox_id
+            ]
+            self._sync_pending_steer_text_unlocked(self._pending_steer_envelopes)
+
+        if lock is None:
+            _remove()
+        else:
+            with lock:
+                _remove()
+
+    def _drain_pending_steer_envelopes(self) -> list:
+        lock = getattr(self, "_pending_steer_lock", None)
+        if lock is None:
+            queue = list(self._steer_queue_unlocked())
+            self._pending_steer_envelopes = []
+            self._pending_steer = None
+            return queue
+        with lock:
+            queue = list(self._steer_queue_unlocked())
+            self._pending_steer_envelopes = []
+            self._pending_steer = None
+        return queue
+
+    @staticmethod
+    def _steer_envelope_text(envelopes: list) -> Optional[str]:
+        return "\n".join(
+            str(item.get("text") or "") for item in envelopes if item.get("text")
+        ) or None
+
+    @staticmethod
+    def _ack_steer_envelopes(envelopes: list, outcome: str) -> None:
+        for envelope in envelopes:
+            callback = envelope.get("outcome_callback")
+            if callable(callback):
+                try:
+                    callback(outcome)
+                except Exception:
+                    logger.debug("steer outcome callback failed", exc_info=True)
 
     def redirect(self, text: str) -> bool:
         """Redirect the active turn without converting it into a new task.
@@ -3530,15 +3647,7 @@ class AIAgent:
         Safe to call from the agent execution thread after appending tool
         results. Returns None when no steer is pending.
         """
-        _lock = getattr(self, "_pending_steer_lock", None)
-        if _lock is None:
-            text = getattr(self, "_pending_steer", None)
-            self._pending_steer = None
-            return text
-        with _lock:
-            text = self._pending_steer
-            self._pending_steer = None
-        return text
+        return self._steer_envelope_text(self._drain_pending_steer_envelopes())
 
     def _record_file_mutation_result(
         self,
@@ -8241,6 +8350,14 @@ class AIAgent:
             action=function_args.get("action"),
             subagent_id=function_args.get("subagent_id"),
             message=function_args.get("message"),
+            delegation_id=function_args.get("delegation_id"),
+            attempt_id=function_args.get("attempt_id"),
+            run_id=function_args.get("run_id"),
+            timeout_seconds=function_args.get("timeout_seconds"),
+            limit=function_args.get("limit"),
+            cascade=function_args.get("cascade"),
+            reason=function_args.get("reason"),
+            force=function_args.get("force"),
             parent_agent=self,
         )
 

--- a/tests/tools/test_delegation_control.py
+++ b/tests/tools/test_delegation_control.py
@@ -1,0 +1,1117 @@
+"""Focused tests for model-facing delegation lifecycle control."""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+import os
+import threading
+import time
+import uuid
+from collections import OrderedDict
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tools import async_delegation as ad
+from tools import delegate_tool as dt
+from tools.process_registry import process_registry
+
+def _observe_interrupt(home, delegation_id, output):
+    os.environ["HERMES_HOME"] = home
+    output.put(ad.interrupt_async_delegation(delegation_id, session_key="owner", reason="observer"))
+
+@pytest.fixture(autouse=True)
+def isolated_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    ad._reset_for_tests()
+    with dt._active_subagents_lock:
+        dt._active_subagents.clear()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+    yield
+    ad._reset_for_tests()
+    with dt._active_subagents_lock:
+        dt._active_subagents.clear()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+def _dispatch(runner, *, session_key="owner", roots=None, interrupt_fn=None):
+    return ad.dispatch_async_delegation(
+        goal="controlled task",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="test",
+        session_key=session_key,
+        parent_session_id="parent-owner",
+        origin_ui_session_id="ui-owner",
+        runner=runner,
+        interrupt_fn=interrupt_fn,
+        root_subagent_ids=roots,
+        max_async_children=4,
+    )
+
+def _wait_terminal(delegation_id, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        row = ad.get_durable_delegation(delegation_id)
+        if row and row["state"] not in ad._ACTIVE_STATES:
+            return row
+        time.sleep(0.005)
+    raise AssertionError("delegation did not become terminal")
+
+def _interrupt_twice(monkeypatch, delegation_id, while_running=None):
+    barrier = threading.Barrier(2)
+    real_get = ad.get_async_delegation
+    synchronized = threading.local()
+
+    def synchronized_initial_snapshot(*args, **kwargs):
+        snapshot = real_get(*args, **kwargs)
+        if not getattr(synchronized, "done", False):
+            synchronized.done = True
+            barrier.wait(timeout=2)
+        return snapshot
+
+    monkeypatch.setattr(ad, "get_async_delegation", synchronized_initial_snapshot)
+    outcomes, returned = [], threading.Event()
+
+    def request(reason):
+        outcomes.append(ad.interrupt_async_delegation(
+            delegation_id, session_key="owner", reason=reason
+        ))
+        returned.set()
+
+    threads = [threading.Thread(target=request, args=(reason,)) for reason in ("one", "two")]
+    for thread in threads:
+        thread.start()
+    if while_running:
+        while_running(outcomes, returned)
+    for thread in threads:
+        thread.join(4)
+        assert not thread.is_alive()
+    return outcomes
+
+
+
+def test_standalone_delegation_tool_is_not_registered():
+    import tools.delegate_tool  # noqa: F401
+    import tools.delegation_control  # noqa: F401
+    from tools.registry import registry
+
+    definitions = registry.get_definitions({"delegate_task", "delegation"})
+    names = {item["function"]["name"] for item in definitions}
+    assert "delegate_task" in names
+    assert "delegation" not in names
+
+
+def test_tool_schema_and_runtime_validation_are_strict():
+    import tools.delegate_tool  # noqa: F401
+    from tools.delegation_control import _handle_delegation_args, delegation_control
+    from tools.registry import registry
+
+    definitions = registry.get_definitions({"delegate_task"})
+    control = next(item for item in definitions if item["function"]["name"] == "delegate_task")
+    action_enum = control["function"]["parameters"]["properties"]["action"]["enum"]
+    assert "resume" in action_enum
+    assert "wait" in action_enum
+
+    cases = [
+        _handle_delegation_args({"action": "list", "unexpected": True}),
+        _handle_delegation_args({"action": "status", "delegation_id": "d", "force": True}),
+        _handle_delegation_args(
+            {"action": "interrupt", "delegation_id": "d", "cascade": "false"}
+        ),
+        _handle_delegation_args(
+            {"action": "wait", "delegation_id": "d", "timeout_seconds": "1"}
+        ),
+        _handle_delegation_args(
+            {"action": "tail", "delegation_id": "d", "limit": 1.5}
+        ),
+        delegation_control(action="tail", delegation_id="d", limit=65),
+    ]
+    for output in cases:
+        payload = json.loads(output)
+        assert payload["status"] == "invalid_arguments"
+        assert payload["error"]
+
+    force_schema = control["function"]["parameters"]["properties"]["force"]
+    assert force_schema["type"] == "boolean"
+
+
+def test_resume_control_is_strict_and_forwards_live_parent(monkeypatch):
+    import tools.delegate_tool  # noqa: F401
+    from tools.delegation_control import _handle_delegation_args, delegation_control
+    from tools.registry import registry
+
+    definitions = registry.get_definitions({"delegate_task"})
+    control = next(item for item in definitions if item["function"]["name"] == "delegate_task")
+    assert "resume" in control["function"]["parameters"]["properties"]["action"]["enum"]
+    for args in (
+        {"action": "resume", "delegation_id": "d", "message": "next"},
+        {"action": "resume", "delegation_id": "d", "subagent_id": "sa"},
+        {
+            "action": "resume",
+            "delegation_id": "d",
+            "subagent_id": "sa",
+            "message": "next",
+            "reason": "not allowed",
+        },
+    ):
+        assert json.loads(_handle_delegation_args(args))["status"] == "invalid_arguments"
+
+    repository, initial, attempt = _starting_steer_attempt(
+        "deleg-resume-control", "sa-resume-control"
+    )
+    repository.transition_attempt(
+        attempt["attempt_id"], {"starting"}, "completed"
+    )
+    captured = {}
+
+    def fake_dispatch(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return {
+            "status": "dispatched",
+            "delegation_id": args[0],
+            "subagent_id": args[1],
+            "run_id": "run-new",
+            "attempt_id": "attempt-new",
+            "attempt_number": 2,
+            "child_session_id": "child-new",
+            "bundle": {"history": [{"reasoning": "never expose"}]},
+        }
+
+    monkeypatch.setattr(ad, "dispatch_resumed_subagent", fake_dispatch)
+    parent = object()
+    payload = json.loads(
+        delegation_control(
+            action="resume",
+            delegation_id="deleg-resume-control",
+            subagent_id="sa-resume-control",
+            message=" continue now ",
+            session_key="owner",
+            parent_agent=parent,
+        )
+    )
+    assert payload == {
+        "action": "resume",
+        "status": "dispatched",
+        "delegation_id": "deleg-resume-control",
+        "subagent_id": "sa-resume-control",
+        "run_id": "run-new",
+        "attempt_id": "attempt-new",
+        "attempt_number": 2,
+        "child_session_id": "child-new",
+    }
+    assert captured["kwargs"] == {
+        "session_key": "owner",
+        "message": "continue now",
+        "parent_agent": parent,
+    }
+    assert "reasoning" not in repr(payload)
+
+
+def _two_terminal_runs():
+    suffix = uuid.uuid4().hex
+    delegation_id = f"deleg-two-runs-{suffix}"
+    child_id = f"sa-two-runs-{suffix}"
+    record = {
+        "delegation_id": delegation_id,
+        "goal": "two runs",
+        "goals": ["two runs"],
+        "session_key": "owner",
+        "origin_ui_session_id": "ui-owner",
+        "parent_session_id": "owner",
+        "status": "running",
+        "dispatched_at": time.time(),
+        "root_subagent_ids": [child_id],
+        "is_batch": False,
+    }
+    ad._persist_dispatch(record)
+    repo = ad._repository()
+    first_run = record["run_id"]
+    first_attempt = record["attempt_ids"][0]
+    old_metadata = {
+        "child_session_id": f"child-old-{suffix}",
+        "assistant_text_tail": "old tail",
+        "events": [{"type": "tool.started", "name": "old-tool"}],
+    }
+    assert repo.transition_attempt(
+        first_attempt, {"starting"}, "completed", metadata=old_metadata
+    )["status"] == "updated"
+    assert repo.complete_run(
+        first_run,
+        {"type": "async_delegation", "delegation_id": delegation_id,
+         "run_id": first_run, "status": "completed"},
+        {"status": "completed", "summary": "old result"},
+    )["status"] == "completed"
+
+    reserved = repo.reserve_resumed_attempt(
+        child_id,
+        physical_worker_id=child_id,
+        owner_pid=os.getpid(),
+        metadata={"child_session_id": f"child-new-{suffix}"},
+    )
+    assert reserved["status"] == "reserved"
+    second_run = reserved["run_id"]
+    second_attempt = reserved["attempt_id"]
+    assert repo.transition_attempt(
+        second_attempt,
+        {"starting"},
+        "completed",
+        metadata={
+            "child_session_id": f"child-new-{suffix}",
+            "assistant_text_tail": "new tail",
+            "events": [{"type": "tool.completed", "name": "new-tool"}],
+        },
+    )["status"] == "updated"
+    assert repo.complete_run(
+        second_run,
+        {"type": "async_delegation", "delegation_id": delegation_id,
+         "run_id": second_run, "status": "completed"},
+        {"status": "completed", "summary": "new result"},
+    )["status"] == "completed"
+    return delegation_id, child_id, first_run, first_attempt, second_run, second_attempt
+
+
+def test_status_and_tail_project_exact_resumed_attempts(monkeypatch):
+    from tools.delegation_control import delegation_control
+
+    monkeypatch.setattr(dt, "list_active_subagents", lambda: [])
+    delegation_id, child_id, first_run, first_attempt, second_run, second_attempt = (
+        _two_terminal_runs()
+    )
+
+    status = json.loads(delegation_control(
+        action="status", delegation_id=delegation_id, session_key="owner"
+    ))
+    assert status["run_id"] == second_run
+    assert status["latest_run_id"] == second_run
+    assert status["active_run_id"] is None
+    assert status["pending_run_count"] == 2
+    assert status["subagents"][0]["attempt_id"] == second_attempt
+    assert status["subagents"][0]["resume_available"] is True
+
+    old_tail = json.loads(delegation_control(
+        action="tail",
+        delegation_id=delegation_id,
+        attempt_id=first_attempt,
+        session_key="owner",
+    ))
+    assert old_tail["run_id"] == first_run
+    assert old_tail["subagents"][0]["attempt_id"] == first_attempt
+    assert old_tail["subagents"][0]["assistant_text_tail"] == "old tail"
+    assert old_tail["subagents"][0]["events"][0]["name"] == "old-tool"
+
+    mismatch = json.loads(delegation_control(
+        action="tail",
+        delegation_id=delegation_id,
+        subagent_id=f"other-{child_id}",
+        attempt_id=first_attempt,
+        session_key="owner",
+    ))
+    assert mismatch["status"] == "not_found"
+
+
+def test_wait_is_fifo_by_default_and_exact_by_run(monkeypatch):
+    monkeypatch.setattr(dt, "list_active_subagents", lambda: [])
+    delegation_id, _child, first_run, _first_attempt, second_run, _second_attempt = (
+        _two_terminal_runs()
+    )
+    first = ad.wait_for_delegation(
+        delegation_id, session_key="owner", timeout_seconds=0
+    )
+    second = ad.wait_for_delegation(
+        delegation_id, session_key="owner", timeout_seconds=0
+    )
+    assert first["run_id"] == first_run and first["claimed_delivery"] is True
+    assert second["run_id"] == second_run and second["claimed_delivery"] is True
+
+    exact_id, _child, old_run, _old_attempt, new_run, _new_attempt = _two_terminal_runs()
+    exact = ad.wait_for_delegation(
+        exact_id, session_key="owner", timeout_seconds=0, run_id=new_run
+    )
+    assert exact["run_id"] == new_run and exact["claimed_delivery"] is True
+    assert ad._repository().inspect_delivery(exact_id, old_run)["delivery_state"] == "pending"
+
+
+def test_abandon_suppresses_every_pending_run(monkeypatch):
+    monkeypatch.setattr(dt, "list_active_subagents", lambda: [])
+    delegation_id, _child, first_run, _first_attempt, second_run, _second_attempt = (
+        _two_terminal_runs()
+    )
+    abandoned = ad.abandon_async_delegation(
+        delegation_id, session_key="owner", reason="obsolete"
+    )
+    assert abandoned["status"] == "abandoned"
+    assert ad._repository().inspect_delivery(
+        delegation_id, first_run
+    )["delivery_state"] == "suppressed"
+    assert ad._repository().inspect_delivery(
+        delegation_id, second_run
+    )["delivery_state"] == "suppressed"
+
+
+def _starting_steer_attempt(delegation_id: str, subagent_id: str):
+    repository = ad._repository()
+    initial = repository.register_initial_dispatch(
+        {
+            "delegation_id": delegation_id,
+            "session_key": "owner",
+            "dispatched_at": time.time(),
+            "root_subagent_ids": [subagent_id],
+        }
+    )
+    return repository, initial, initial["attempts"][0]
+
+
+def test_deterministic_dispatch_steer_complete_resume_interrupt_smoke():
+    suffix = uuid.uuid4().hex
+    delegation_id = f"deleg-lifecycle-smoke-{suffix}"
+    child_id = f"sa-lifecycle-smoke-{suffix}"
+    repository, initial, first = _starting_steer_attempt(
+        delegation_id, child_id
+    )
+    steered = repository.enqueue_steer(
+        delegation_id, child_id, "owner", "finish with the latest constraint"
+    )
+    assert steered["status"] == "accepted"
+
+    assert repository.transition_attempt(
+        first["attempt_id"],
+        {"starting"},
+        "completed",
+        metadata={"child_session_id": f"child-smoke-{suffix}"},
+    )["status"] == "updated"
+    assert repository.complete_run(
+        initial["run_id"],
+        {"type": "async_delegation", "delegation_id": delegation_id,
+         "run_id": initial["run_id"], "status": "completed"},
+        {"status": "completed", "summary": "first completion"},
+    )["status"] == "completed"
+
+    resumed = repository.reserve_resumed_attempt(
+        child_id,
+        physical_worker_id=child_id,
+        owner_pid=os.getpid(),
+        metadata={"child_session_id": f"child-smoke-{suffix}"},
+    )
+    assert resumed["status"] == "reserved"
+    assert resumed["attempt_number"] == 2
+    assert resumed["attempt_id"] != first["attempt_id"]
+    assert resumed["run_id"] != initial["run_id"]
+    current = repository.find_attempt(
+        child_id, delegation_id=delegation_id, session_key="owner"
+    )
+    assert current["attempt_id"] == resumed["attempt_id"]
+    assert current["logical_id"] == child_id
+
+    interrupted = repository.request_interrupt(
+        resumed["attempt_id"], "stop resumed attempt"
+    )
+    assert interrupted["status"] == "interrupt_requested"
+    snapshot = repository.snapshot(delegation_id, session_key="owner")
+    assert snapshot["children"][child_id]["attempt_id"] == resumed["attempt_id"]
+    assert snapshot["children"][child_id]["status"] == "interrupt_requested"
+
+
+def test_steer_queues_while_starting_then_forwards_in_order_and_acks_injection():
+    from tools.delegation_control import delegation_control
+
+    repository, initial, attempt = _starting_steer_attempt(
+        "deleg-steer-starting", "sa-steer"
+    )
+
+    responses = [
+        json.loads(
+            delegation_control(
+                action="steer",
+                delegation_id="deleg-steer-starting",
+                subagent_id="sa-steer",
+                message=text,
+                session_key="owner",
+            )
+        )
+        for text in ("first guidance", "second guidance")
+    ]
+    assert [item["status"] for item in responses] == ["accepted", "accepted"]
+    assert [item["steer_status"] for item in responses] == ["pending", "pending"]
+
+    delivered = []
+    agent = MagicMock()
+
+    def accept(text, **kwargs):
+        delivered.append((text, kwargs["mailbox_id"], kwargs["outcome_callback"]))
+        return True
+
+    agent.steer.side_effect = accept
+    dt._register_subagent(
+        {
+            "subagent_id": "sa-steer",
+            "delegation_attempt_id": attempt["attempt_id"],
+            "delegation_run_id": initial["run_id"],
+            "status": "running",
+            "events": [],
+            "assistant_text_tail": "",
+            "agent": agent,
+        }
+    )
+
+    assert [item[0] for item in delivered] == ["first guidance", "second guidance"]
+    assert [repository.inspect_steer(item[1])["status"] for item in delivered] == [
+        "forwarded",
+        "forwarded",
+    ]
+    for _, _, callback in delivered:
+        callback("injected")
+    assert [repository.inspect_steer(item[1])["status"] for item in delivered] == [
+        "injected",
+        "injected",
+    ]
+    observed = json.loads(
+        delegation_control(
+            action="status",
+            delegation_id="deleg-steer-starting",
+            subagent_id="sa-steer",
+            session_key="owner",
+        )
+    )["subagents"][0]["steers"]
+    assert [item["status"] for item in observed] == ["injected", "injected"]
+    assert all("message" not in item for item in observed)
+
+
+def test_live_foreground_wait_rejects_normal_steer_with_force_hint():
+    from tools.delegation_control import delegation_control
+
+    repository, initial, attempt = _starting_steer_attempt(
+        "deleg-steer-foreground", "sa-foreground"
+    )
+
+    class WaitingAgent:
+        def request_durable_steer(
+            self, _text, *, outcome_callback, force, **_kwargs
+        ):
+            assert force is False
+            outcome_callback("foreground_wait")
+            return {"status": "foreground_wait", "wait_kinds": ["terminal"]}
+
+    dt._register_subagent(
+        {
+            "subagent_id": "sa-foreground",
+            "delegation_attempt_id": attempt["attempt_id"],
+            "delegation_run_id": initial["run_id"],
+            "status": "running",
+            "events": [],
+            "assistant_text_tail": "",
+            "agent": WaitingAgent(),
+        }
+    )
+
+    result = json.loads(
+        delegation_control(
+            action="steer",
+            delegation_id="deleg-steer-foreground",
+            subagent_id="sa-foreground",
+            message="change direction",
+            force=False,
+            session_key="owner",
+        )
+    )
+
+    assert result["status"] == "foreground_wait"
+    assert result["steer_status"] == "foreground_wait"
+    assert result["wait_kinds"] == ["terminal"]
+    assert "force=true" in result["hint"]
+    assert repository.inspect_steer(result["mailbox_id"])["status"] == "foreground_wait"
+
+
+
+def test_steer_rejects_foreign_terminal_and_interrupt_wins_startup_race():
+    from tools.delegation_control import delegation_control
+
+    repository, initial, attempt = _starting_steer_attempt(
+        "deleg-steer-races", "sa-race"
+    )
+    foreign = json.loads(
+        delegation_control(
+            action="steer",
+            delegation_id="deleg-steer-races",
+            subagent_id="sa-race",
+            message="foreign",
+            session_key="foreign",
+        )
+    )
+    assert foreign["status"] == "not_found"
+
+    queued = json.loads(
+        delegation_control(
+            action="steer",
+            delegation_id="deleg-steer-races",
+            subagent_id="sa-race",
+            message="must lose to interrupt",
+            session_key="owner",
+        )
+    )
+    assert ad.request_pending_subagent_interrupt(
+        "deleg-steer-races", "sa-race", session_key="owner", reason="stop"
+    ) == "interrupt_requested"
+    assert repository.inspect_steer(queued["mailbox_id"])["status"] == (
+        "superseded_by_interrupt"
+    )
+
+    agent = MagicMock()
+    dt._register_subagent(
+        {
+            "subagent_id": "sa-race",
+            "delegation_attempt_id": attempt["attempt_id"],
+            "delegation_run_id": initial["run_id"],
+            "status": "running",
+            "events": [],
+            "assistant_text_tail": "",
+            "agent": agent,
+        }
+    )
+    agent.interrupt.assert_called_once()
+    agent.steer.assert_not_called()
+
+    terminal_repo, _, terminal_attempt = _starting_steer_attempt(
+        "deleg-steer-terminal", "sa-terminal"
+    )
+    assert terminal_repo.transition_attempt(
+        terminal_attempt["attempt_id"], {"starting"}, "completed"
+    )["status"] == "updated"
+    terminal = json.loads(
+        delegation_control(
+            action="steer",
+            delegation_id="deleg-steer-terminal",
+            subagent_id="sa-terminal",
+            message="too late",
+            session_key="owner",
+        )
+    )
+    assert terminal["status"] == "already_terminal"
+    assert terminal["terminal_status"] == "completed"
+
+
+@pytest.mark.parametrize(
+    ("winner", "expected"),
+    [
+        ("interrupt", "superseded_by_interrupt"),
+        ("completion", "too_late_after_completion"),
+    ],
+)
+def test_claimed_steer_reports_honest_race_outcome(monkeypatch, winner, expected):
+    from tools.delegation_control import delegation_control
+
+    repository, initial, attempt = _starting_steer_attempt(
+        f"deleg-steer-{winner}", f"sa-{winner}"
+    )
+    claim_started = threading.Event()
+    release_claim = threading.Event()
+    real_claim = type(repository).claim_steer
+
+    def blocked_claim(self, attempt_id, mailbox_id):
+        outcome = real_claim(self, attempt_id, mailbox_id)
+        claim_started.set()
+        assert release_claim.wait(2)
+        return outcome
+
+    monkeypatch.setattr(type(repository), "claim_steer", blocked_claim)
+
+    class RaceAgent:
+        def __init__(self):
+            self.interrupted = False
+
+        def interrupt(self, _reason):
+            self.interrupted = True
+
+        def steer(self, _text, *, outcome_callback, **_kwargs):
+            if self.interrupted:
+                outcome_callback("superseded_by_interrupt")
+                return False
+            return True
+
+    agent = RaceAgent()
+    child_id = f"sa-{winner}"
+    dt._register_subagent(
+        {
+            "subagent_id": child_id,
+            "delegation_attempt_id": attempt["attempt_id"],
+            "delegation_run_id": initial["run_id"],
+            "status": "running",
+            "events": [],
+            "assistant_text_tail": "",
+            "agent": agent,
+        }
+    )
+    responses = []
+
+    def request_steer():
+        responses.append(
+            json.loads(
+                delegation_control(
+                    action="steer",
+                    delegation_id=f"deleg-steer-{winner}",
+                    subagent_id=child_id,
+                    message="race guidance",
+                    session_key="owner",
+                )
+            )
+        )
+
+    thread = threading.Thread(target=request_steer)
+    thread.start()
+    assert claim_started.wait(2)
+    if winner == "interrupt":
+        interrupted = json.loads(
+            delegation_control(
+                action="interrupt",
+                delegation_id="deleg-steer-interrupt",
+                subagent_id=child_id,
+                session_key="owner",
+            )
+        )
+        assert interrupted["status"] == "interrupt_requested"
+    else:
+        repository.complete_run(
+            initial["run_id"],
+            {
+                "completed_at": time.time(),
+                "status": "completed",
+                "children": [
+                    {
+                        "subagent_id": child_id,
+                        "attempt_id": attempt["attempt_id"],
+                        "status": "completed",
+                    }
+                ],
+            },
+            {"status": "completed"},
+        )
+    release_claim.set()
+    thread.join(2)
+
+    assert not thread.is_alive()
+    assert responses[0]["status"] == expected
+    assert responses[0]["steer_status"] == expected
+
+
+def test_compressed_parent_session_retains_control_without_root_scope_leak():
+    from hermes_state import SessionDB
+    from tools.delegation_control import delegation_control
+
+    session_db = SessionDB()
+    session_db.create_session("owner", source="discord")
+    session_db.end_session("owner", "compression")
+    session_db.create_session(
+        "owner-tip", source="discord", parent_session_id="owner"
+    )
+    session_db.create_session(
+        "owner-branch",
+        source="discord",
+        parent_session_id="owner",
+        model_config={"_branched_from": "owner"},
+    )
+    dispatched = _dispatch(lambda: {"status": "completed", "summary": "ok"})
+    delegation_id = dispatched["delegation_id"]
+    _wait_terminal(delegation_id)
+
+    status = json.loads(
+        delegation_control(
+            action="status", delegation_id=delegation_id, session_key="owner-tip"
+        )
+    )
+    listed = json.loads(delegation_control(action="list", session_key="owner-tip"))
+    branch = json.loads(
+        delegation_control(
+            action="status",
+            delegation_id=delegation_id,
+            session_key="owner-branch",
+        )
+    )
+
+    assert status["delegation_id"] == delegation_id
+    assert [item["delegation_id"] for item in listed["delegations"]] == [
+        delegation_id
+    ]
+    assert branch["status"] == "not_found"
+
+
+def test_list_and_status_hide_foreign_session_like_unknown():
+    release = threading.Event()
+    dispatched = _dispatch(
+        lambda: (release.wait(2), {"status": "completed", "summary": "done"})[1],
+        roots=["sa-owner"],
+    )
+    from tools.delegation_control import delegation_control
+
+    try:
+        own = json.loads(delegation_control(action="list", session_key="owner"))
+        foreign = json.loads(delegation_control(action="list", session_key="foreign"))
+        hidden = json.loads(
+            delegation_control(
+                action="status",
+                delegation_id=dispatched["delegation_id"],
+                session_key="foreign",
+            )
+        )
+        unknown = json.loads(
+            delegation_control(
+                action="status", delegation_id="deleg_unknown", session_key="foreign"
+            )
+        )
+        assert [item["delegation_id"] for item in own["delegations"]] == [
+            dispatched["delegation_id"]
+        ]
+        assert foreign["delegations"] == []
+        assert hidden == unknown | {"delegation_id": dispatched["delegation_id"]}
+    finally:
+        release.set()
+
+
+def test_force_flag_survives_starting_mailbox_until_live_forwarding():
+    from tools.delegation_control import delegation_control
+
+    repository, initial, attempt = _starting_steer_attempt(
+        "deleg-steer-force-starting", "sa-force-starting"
+    )
+    queued = json.loads(
+        delegation_control(
+            action="steer",
+            delegation_id="deleg-steer-force-starting",
+            subagent_id="sa-force-starting",
+            message="persist force",
+            force=True,
+            session_key="owner",
+        )
+    )
+    assert queued["status"] == "accepted"
+    assert repository.inspect_steer(queued["mailbox_id"])["force"] == 1
+
+    class RecordingAgent:
+        def __init__(self):
+            self.interrupt_event = threading.Event()
+            self.calls = []
+
+        def request_durable_steer(
+            self, text, *, mailbox_id, outcome_callback, force=False
+        ):
+            self.calls.append((text, mailbox_id, force))
+            return {"status": "accepted", "wait_kinds": []}
+
+    agent = RecordingAgent()
+    dt._register_subagent(
+        {
+            "subagent_id": "sa-force-starting",
+            "delegation_attempt_id": attempt["attempt_id"],
+            "delegation_run_id": initial["run_id"],
+            "status": "running",
+            "events": [],
+            "assistant_text_tail": "",
+            "agent": agent,
+        }
+    )
+    try:
+        assert agent.calls == [("persist force", queued["mailbox_id"], True)]
+        assert repository.inspect_steer(queued["mailbox_id"])["status"] == "forwarded"
+    finally:
+        dt._unregister_subagent(
+            "sa-force-starting", str(attempt["attempt_id"])
+        )
+
+def test_starting_child_interrupt_is_queued_then_applied_once():
+    runner_started = threading.Event()
+    allow_registration = threading.Event()
+    allow_finish = threading.Event()
+    registered = threading.Event()
+    agent = MagicMock()
+
+    def runner():
+        runner_started.set()
+        assert allow_registration.wait(2)
+        dt._register_subagent(
+            {
+                "subagent_id": "sa-starting",
+                "parent_id": None,
+                "depth": 0,
+                "goal": "controlled task",
+                "status": "running",
+                "started_at": time.time(),
+                "agent": agent,
+            }
+        )
+        registered.set()
+        assert allow_finish.wait(2)
+        dt._unregister_subagent("sa-starting")
+        return {"status": "interrupted", "summary": "stopped"}
+
+    dispatched = _dispatch(runner, roots=["sa-starting"])
+    assert runner_started.wait(2)
+    from tools.delegation_control import delegation_control
+
+    try:
+        payload = json.loads(
+            delegation_control(
+                action="interrupt",
+                delegation_id=dispatched["delegation_id"],
+                subagent_id="sa-starting",
+                session_key="owner",
+                reason="stop before startup",
+            )
+        )
+        assert payload["status"] == "interrupt_requested"
+        agent.interrupt.assert_not_called()
+        allow_registration.set()
+        assert registered.wait(2)
+        agent.interrupt.assert_called_once_with("stop before startup")
+    finally:
+        allow_registration.set()
+        allow_finish.set()
+
+@pytest.mark.parametrize("supplied_attempt", ["stale", None, "", 17, "attempt_missing"])
+def test_invalid_attempt_registration_and_archive_fail_closed(supplied_attempt):
+    repository = ad._repository()
+    initial = repository.register_initial_dispatch(
+        {
+            "delegation_id": "deleg-exact-attempt",
+            "session_key": "owner",
+            "origin_ui_session_id": "ui-owner",
+            "parent_session_id": "parent-owner",
+            "dispatched_at": 1.0,
+            "goal": "original",
+            "root_subagent_ids": ["sa-exact"],
+        }
+    )
+    stale_attempt_id = initial["attempts"][0]["attempt_id"]
+    assert repository.transition_attempt(
+        stale_attempt_id, {"starting"}, "completed"
+    )["status"] == "updated"
+    resumed = repository.reserve_resumed_attempt(
+        "sa-exact", physical_worker_id="worker-current"
+    )
+
+    invalid_record = {
+        "subagent_id": "sa-exact",
+        "delegation_attempt_id": (
+            stale_attempt_id if supplied_attempt == "stale" else supplied_attempt
+        ),
+        "delegation_run_id": initial["run_id"],
+        "parent_id": None,
+        "goal": "invalid callback",
+        "status": "running",
+        "started_at": time.time(),
+        "agent": MagicMock(),
+    }
+    dt._register_subagent(invalid_record)
+    invalid_record["status"] = "error"
+    dt._unregister_subagent("sa-exact")
+
+    current = repository.snapshot("deleg-exact-attempt")["children"]["sa-exact"]
+    assert current["attempt_id"] == resumed["attempt_id"]
+    assert current["run_id"] == resumed["run_id"]
+    assert current["status"] == "starting"
+    assert current.get("goal") == "original"
+
+
+def test_stale_attempt_callbacks_cannot_replace_mutate_or_remove_live_resume():
+    repository = ad._repository()
+    initial = repository.register_initial_dispatch(
+        {
+            "delegation_id": "deleg-live-resume",
+            "session_key": "owner",
+            "dispatched_at": 1.0,
+            "root_subagent_ids": ["sa-resumed"],
+        }
+    )
+    old_attempt = initial["attempts"][0]["attempt_id"]
+    assert repository.transition_attempt(
+        old_attempt, {"starting"}, "completed"
+    )["status"] == "updated"
+    resumed = repository.reserve_resumed_attempt(
+        "sa-resumed", physical_worker_id="sa-resumed"
+    )
+    current_record = {
+        "subagent_id": "sa-resumed",
+        "delegation_attempt_id": resumed["attempt_id"],
+        "delegation_run_id": resumed["run_id"],
+        "status": "running",
+        "events": [],
+        "assistant_text_tail": "current",
+        "agent": MagicMock(),
+    }
+    dt._register_subagent(current_record)
+
+    stale_record = {
+        "subagent_id": "sa-resumed",
+        "delegation_attempt_id": old_attempt,
+        "delegation_run_id": initial["run_id"],
+        "status": "running",
+        "agent": MagicMock(),
+    }
+    dt._register_subagent(stale_record)
+    dt._unregister_subagent("sa-resumed", old_attempt)
+
+    with dt._active_subagents_lock:
+        assert dt._active_subagents["sa-resumed"] is current_record
+        assert current_record["events"] == []
+        assert current_record["assistant_text_tail"] == "current"
+
+
+def test_nested_child_without_attempt_id_allocates_propagates_and_archives_exact_id():
+    repository = ad._repository()
+    repository.register_initial_dispatch(
+        {
+            "delegation_id": "deleg-nested-attempt",
+            "session_key": "owner",
+            "dispatched_at": 1.0,
+            "root_subagent_ids": ["sa-parent"],
+        }
+    )
+    parent = dict(
+        subagent_id="sa-parent", parent_id=None, status="running", agent=MagicMock()
+    )
+    child = {
+        "subagent_id": "sa-child",
+        "parent_id": "sa-parent",
+        "goal": "nested",
+        "status": "running",
+        "agent": MagicMock(),
+    }
+    dt._register_subagent(parent)
+    dt._register_subagent(child)
+    attempt_id = child.get("delegation_attempt_id")
+    assert isinstance(attempt_id, str) and attempt_id
+    child.update(status="completed", tool_count=3)
+    dt._unregister_subagent("sa-child")
+    archived = repository.snapshot("deleg-nested-attempt")["children"]["sa-child"]
+    assert (archived["attempt_id"], archived["status"], archived["tool_count"]) == (
+        attempt_id, "completed", 3
+    )
+
+def test_cross_process_interrupt_cannot_claim_owner_callback_success():
+    release = threading.Event()
+    callback_entered, release_callback = threading.Event(), threading.Event()
+    successful_calls = []
+
+    def failed_interrupt():
+        callback_entered.set()
+        assert release_callback.wait(5)
+        raise RuntimeError("signal failed")
+
+    dispatched = _dispatch(
+        lambda: (release.wait(10), {"status": "completed", "summary": "done"})[1],
+        roots=["sa-interrupt-retry"],
+        interrupt_fn=failed_interrupt,
+    )
+    delegation_id = dispatched["delegation_id"]
+    try:
+        owner_outcome = []
+        owner = threading.Thread(target=lambda: owner_outcome.append(
+            ad.interrupt_async_delegation(delegation_id, session_key="owner", reason="first")
+        ))
+        owner.start()
+        assert callback_entered.wait(2)
+        ctx = multiprocessing.get_context("spawn"); output = ctx.Queue()
+        observer = ctx.Process(target=_observe_interrupt, args=(os.environ["HERMES_HOME"], delegation_id, output))
+        observer.start()
+        observer.join(10)
+        assert observer.exitcode == 0
+        assert output.get(timeout=1)["status"] == "interrupt_unavailable"
+        release_callback.set()
+        owner.join(2)
+        assert owner_outcome[0]["status"] == "interrupt_failed"
+        snapshot = ad.get_durable_delegation(delegation_id)
+        assert (snapshot["state"], snapshot["interrupt_requests"]) == ("running", {})
+
+        with ad._records_lock:
+            ad._records[delegation_id]["interrupt_fn"] = lambda: successful_calls.append(True)
+        assert ad.interrupt_async_delegation(
+            delegation_id, session_key="owner", reason="second"
+        )["status"] == "interrupt_requested"
+        assert successful_calls == [True]
+        assert ad.take_pending_subagent_interrupt("sa-interrupt-retry") == (True, "second")
+    finally:
+        release_callback.set()
+        release.set()
+
+def test_concurrent_interrupt_callbacks_serialize_failure_then_success(monkeypatch):
+    release = threading.Event()
+    callback_rendezvous, successful_callback = threading.Barrier(2), threading.Event()
+    callback_guard, counts = threading.Lock(), [0, 0, 0]  # calls, active, peak
+
+    def interrupt_callback():
+        with callback_guard:
+            counts[0] += 1
+            call_number = counts[0]
+            counts[1] += 1
+            counts[2] = max(counts[2], counts[1])
+        try:
+            try:
+                callback_rendezvous.wait(timeout=0.5)
+                if call_number == 1:
+                    assert successful_callback.wait(2)
+            except threading.BrokenBarrierError:
+                pass
+            if call_number == 1:
+                raise RuntimeError("first signal failed")
+            successful_callback.set()
+        finally:
+            with callback_guard:
+                counts[1] -= 1
+
+    dispatched = _dispatch(
+        lambda: (release.wait(10), {"status": "completed", "summary": "done"})[1],
+        roots=["sa-concurrent-interrupt"],
+        interrupt_fn=interrupt_callback,
+    )
+    delegation_id = dispatched["delegation_id"]
+    try:
+        outcomes = _interrupt_twice(monkeypatch, delegation_id)
+        statuses = sorted(item["status"] for item in outcomes)
+        assert statuses == ["interrupt_failed", "interrupt_requested"]
+        assert counts == [2, 0, 1]
+        snapshot = ad.get_durable_delegation(delegation_id)
+        assert snapshot["state"] == "interrupt_requested"
+        assert list(snapshot["interrupt_requests"]) == ["sa-concurrent-interrupt"]
+        pending_reason = snapshot["interrupt_requests"]["sa-concurrent-interrupt"]
+        assert ad.take_pending_subagent_interrupt("sa-concurrent-interrupt") == (
+            True, pending_reason
+        )
+        assert ad.take_pending_subagent_interrupt("sa-concurrent-interrupt") == (False, "")
+    finally:
+        release.set()
+
+def test_concurrent_idempotent_interrupt_waits_for_callback_owner(monkeypatch):
+    release = threading.Event()
+    callback_entered, release_callback = threading.Event(), threading.Event()
+    callback_calls = []
+
+    def successful_interrupt():
+        callback_calls.append(True)
+        callback_entered.set()
+        assert release_callback.wait(2)
+
+    dispatched = _dispatch(
+        lambda: (release.wait(10), {"status": "completed", "summary": "done"})[1],
+        roots=["sa-idempotent-interrupt"],
+        interrupt_fn=successful_interrupt,
+    )
+    delegation_id = dispatched["delegation_id"]
+
+    def release_owner(outcomes, returned):
+        assert callback_entered.wait(2)
+        assert not returned.wait(0.2)
+        assert outcomes == []
+        release_callback.set()
+
+    try:
+        outcomes = _interrupt_twice(monkeypatch, delegation_id, release_owner)
+        assert [item["status"] for item in outcomes] == ["interrupt_requested"] * 2
+        assert callback_calls == [True]
+        assert ad.take_pending_subagent_interrupt("sa-idempotent-interrupt")[0] is True
+        assert ad.take_pending_subagent_interrupt("sa-idempotent-interrupt") == (False, "")
+    finally:
+        release_callback.set()
+        release.set()
+

--- a/tests/tools/test_delegation_durable_lifecycle.py
+++ b/tests/tools/test_delegation_durable_lifecycle.py
@@ -1,0 +1,432 @@
+"""Durable delegation delivery/control invariants.
+
+These tests intentionally exercise SQLite state rather than installing a second
+in-memory lifecycle registry.
+"""
+
+import queue
+import threading
+import time
+
+import pytest
+
+from tools import async_delegation as ad
+from tools.process_registry import process_registry
+
+
+@pytest.fixture(autouse=True)
+def isolated_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    ad._reset_for_tests()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+    yield
+    ad._reset_for_tests()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+
+def _dispatch(runner, *, session_key="owner", interrupt_fn=None, roots=None):
+    return ad.dispatch_async_delegation(
+        goal="durable control",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="test",
+        session_key=session_key,
+        parent_session_id="parent-owner",
+        origin_ui_session_id="ui-owner",
+        runner=runner,
+        interrupt_fn=interrupt_fn,
+        root_subagent_ids=roots,
+        max_async_children=8,
+    )
+
+
+def _wait_terminal(delegation_id, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        row = ad.get_durable_delegation(delegation_id)
+        if row and row["state"] not in {"running", "finalizing", "interrupt_requested"}:
+            return row
+        time.sleep(0.005)
+    raise AssertionError("delegation did not become terminal")
+
+
+def _set_delivery(delegation_id, state, *, claimed_at=None):
+    repository = ad._repository()
+    token = "test-claim"
+    if state == "pending":
+        return
+    if state in {"held_by_wait", "consumed"}:
+        if repository.inspect_delivery(delegation_id).get("delivery_state") == "held_by_wait":
+            assert repository.release_wait_hold(
+                delegation_id, "owner", token
+            )["status"] == "released"
+        assert repository.hold_for_wait(
+            delegation_id, "owner", token, now=claimed_at
+        )["status"] == "held"
+        if state == "consumed":
+            assert repository.consume_wait_hold(
+                delegation_id, "owner", token
+            )["status"] == "consumed"
+        return
+    if state == "suppressed":
+        assert repository.suppress_delivery(
+            delegation_id, "owner"
+        )["status"] == "suppressed"
+        return
+    assert repository.claim_run_delivery(
+        delegation_id, None, token, now=claimed_at
+    )["status"] == "claimed"
+    if state == "delivered":
+        assert repository.commit_run_delivery(
+            repository.resolve_run_id(delegation_id)["run_id"], token
+        )["status"] == "delivered"
+
+
+def test_terminal_wait_consumes_once_and_auto_delivery_drops_it():
+    dispatched = _dispatch(
+        lambda: {"status": "completed", "summary": "one result"}
+    )
+    _wait_terminal(dispatched["delegation_id"])
+
+    first = ad.wait_for_delegation(
+        dispatched["delegation_id"], session_key="owner", timeout_seconds=1
+    )
+    second = ad.wait_for_delegation(
+        dispatched["delegation_id"], session_key="owner", timeout_seconds=0
+    )
+
+    assert first["claimed_delivery"] is True
+    assert first["result"]["summary"] == "one result"
+    assert first["delivery_disposition"] == "consumed"
+    assert second["claimed_delivery"] is False
+    assert second["delivery_disposition"] == "consumed"
+    assert not ad.claim_completion_delivery(dispatched["delegation_id"], "auto")
+
+
+def test_wait_timeout_releases_hold_without_consuming_late_completion():
+    release = threading.Event()
+    dispatched = _dispatch(
+        lambda: release.wait(2) or {"status": "completed", "summary": "late"}
+    )
+
+    timed_out = ad.wait_for_delegation(
+        dispatched["delegation_id"], session_key="owner", timeout_seconds=0.02
+    )
+    assert timed_out["status"] == "timeout"
+    assert timed_out["claimed_delivery"] is False
+    row = ad.get_durable_delegation(dispatched["delegation_id"])
+    assert row["delivery_state"] == "pending"
+    assert row["delivery_claim"] is None
+
+    release.set()
+    _wait_terminal(dispatched["delegation_id"])
+    assert ad.claim_completion_delivery(dispatched["delegation_id"], "auto")
+    assert ad.release_completion_delivery(dispatched["delegation_id"], "auto")
+
+
+def test_forced_delegation_wait_returns_recoverable_running_handoff():
+    from tools.foreground_wait import ForegroundWaitSlot, set_current_foreground_wait
+
+    release = threading.Event()
+    dispatched = _dispatch(
+        lambda: release.wait(2) or {"status": "completed", "summary": "later"}
+    )
+    slot = ForegroundWaitSlot("call-wait", "delegation")
+    outcome = {}
+
+    def wait():
+        set_current_foreground_wait(slot)
+        try:
+            outcome.update(
+                ad.wait_for_delegation(
+                    dispatched["delegation_id"],
+                    session_key="owner",
+                    timeout_seconds=1,
+                )
+            )
+        finally:
+            set_current_foreground_wait(None)
+
+    thread = threading.Thread(target=wait)
+    thread.start()
+    deadline = time.monotonic() + 1
+    while time.monotonic() < deadline:
+        row = ad.get_durable_delegation(dispatched["delegation_id"])
+        if row and row["delivery_state"] == "held_by_wait":
+            break
+        time.sleep(0.002)
+    else:
+        raise AssertionError("wait never registered its durable hold")
+
+    slot.background_requested.set()
+    thread.join(1)
+
+    assert not thread.is_alive()
+    assert outcome["status"] == "backgrounded"
+    assert outcome["claimed_delivery"] is False
+    handoff = outcome["foreground_handoff"]
+    assert handoff["kind"] == "delegation"
+    assert handoff["delegation_id"] == dispatched["delegation_id"]
+    durable = ad.get_durable_delegation(dispatched["delegation_id"])
+    assert handoff["run_id"] == durable["active_run_id"]
+    assert 'action="wait"' in handoff["continue"]
+    assert 'action="interrupt"' in handoff["stop"]
+    assert ad.get_durable_delegation(dispatched["delegation_id"])["delivery_state"] == "pending"
+    assert slot.wait_for_resolution(0)["handoff"] == handoff
+
+    release.set()
+    _wait_terminal(dispatched["delegation_id"])
+    assert ad.claim_completion_delivery(dispatched["delegation_id"], "auto")
+    assert ad.release_completion_delivery(dispatched["delegation_id"], "auto")
+
+
+def test_completion_while_wait_hold_is_registered_is_consumed_by_waiter():
+    release = threading.Event()
+    dispatched = _dispatch(
+        lambda: (release.wait(2), {"status": "completed", "summary": "at edge"})[1]
+    )
+    outcome = {}
+
+    def wait():
+        outcome.update(
+            ad.wait_for_delegation(
+                dispatched["delegation_id"],
+                session_key="owner",
+                timeout_seconds=1,
+            )
+        )
+
+    thread = threading.Thread(target=wait)
+    thread.start()
+    deadline = time.monotonic() + 1
+    while time.monotonic() < deadline:
+        row = ad.get_durable_delegation(dispatched["delegation_id"])
+        if row and row["delivery_state"] == "held_by_wait":
+            break
+        time.sleep(0.002)
+    else:
+        raise AssertionError("wait never registered its durable hold")
+
+    release.set()
+    thread.join(2)
+    assert not thread.is_alive()
+    assert outcome["claimed_delivery"] is True
+    assert outcome["delivery_disposition"] == "consumed"
+    assert outcome["result"]["summary"] == "at edge"
+
+
+def test_multiple_waiters_have_exactly_one_result_owner():
+    release = threading.Event()
+    start = threading.Barrier(3)
+    dispatched = _dispatch(
+        lambda: release.wait(2) or {"status": "completed", "summary": "single owner"}
+    )
+    outcomes = []
+
+    def wait():
+        start.wait()
+        outcomes.append(
+            ad.wait_for_delegation(
+                dispatched["delegation_id"],
+                session_key="owner",
+                timeout_seconds=1,
+            )
+        )
+
+    threads = [threading.Thread(target=wait) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    start.wait()
+
+    deadline = time.monotonic() + 1
+    while time.monotonic() < deadline:
+        if ad.get_durable_delegation(dispatched["delegation_id"])["delivery_state"] == "held_by_wait":
+            break
+        time.sleep(0.002)
+    release.set()
+    for thread in threads:
+        thread.join(2)
+
+    assert len(outcomes) == 2
+    assert sum(result["claimed_delivery"] is True for result in outcomes) == 1
+    assert ad.get_durable_delegation(dispatched["delegation_id"])["delivery_state"] == "consumed"
+
+
+def test_abandon_suppresses_before_delivery_and_is_too_late_after_claim():
+    release = threading.Event()
+    interrupted = threading.Event()
+    first = _dispatch(
+        lambda: release.wait(2) or {"status": "interrupted", "summary": "stopped"},
+        interrupt_fn=interrupted.set,
+    )
+
+    abandoned = ad.abandon_async_delegation(
+        first["delegation_id"], session_key="owner", reason="obsolete"
+    )
+    assert abandoned["suppression"] == "applied"
+    assert interrupted.wait(1)
+    assert ad.get_durable_delegation(first["delegation_id"])["delivery_state"] == "suppressed"
+    release.set()
+    _wait_terminal(first["delegation_id"])
+    assert not ad.claim_completion_delivery(first["delegation_id"], "auto")
+
+    second = _dispatch(lambda: {"status": "completed", "summary": "accepted"})
+    _wait_terminal(second["delegation_id"])
+    assert ad.claim_completion_delivery(second["delegation_id"], "gateway")
+    too_late = ad.abandon_async_delegation(
+        second["delegation_id"], session_key="owner", reason="too late"
+    )
+    assert too_late["suppression"] == "too_late"
+    assert ad.get_durable_delegation(second["delegation_id"])["delivery_state"] == "delivering"
+
+
+def test_foreign_session_is_indistinguishable_from_unknown():
+    release = threading.Event()
+    dispatched = _dispatch(
+        lambda: release.wait(2) or {"status": "completed", "summary": "private"}
+    )
+    try:
+        foreign = ad.get_async_delegation(
+            dispatched["delegation_id"], session_key="foreign"
+        )
+        unknown = ad.get_async_delegation("deleg_unknown", session_key="foreign")
+        assert foreign is None
+        assert unknown is None
+        assert ad.list_durable_delegations(session_keys=["foreign"]) == []
+    finally:
+        release.set()
+
+
+def test_exact_run_wrappers_preserve_missing_and_ambiguous_shapes():
+    assert ad.claim_async_delivery("missing") == {"status": "legacy"}
+    assert ad.claim_async_delivery("missing", managed=True) == {"status": "stale"}
+    assert ad.claim_completion_delivery("missing", "claim") is True
+    assert ad.inspect_async_delivery_claim("missing", "claim") == "not_found"
+    assert ad.mark_completion_delivered("missing") is False
+    assert ad.release_completion_delivery("missing", "claim") is False
+    assert ad.complete_completion_delivery("missing", "claim") is False
+
+    repository = ad._repository()
+    created = repository.register_initial_dispatch(
+        {
+            "delegation_id": "deleg-ambiguous", "session_key": "owner",
+            "dispatched_at": 1.0, "root_subagent_ids": ["sa-ambiguous"],
+        }
+    )
+    repository.transition_attempt(
+        created["attempts"][0]["attempt_id"], {"starting"}, "completed"
+    )
+    assert repository.reserve_resumed_attempt("sa-ambiguous")["status"] == "reserved"
+    assert ad.claim_async_delivery("deleg-ambiguous", managed=True) == {
+        "status": "stale", "reason": "ambiguous_run"
+    }
+    assert ad.claim_completion_delivery("deleg-ambiguous", "claim") is False
+    assert ad.inspect_async_delivery_claim("deleg-ambiguous", "claim") == "stale"
+    assert ad.mark_completion_delivered("deleg-ambiguous") is False
+    assert ad.release_completion_delivery("deleg-ambiguous", "claim") is False
+    assert ad.complete_completion_delivery("deleg-ambiguous", "claim") is False
+
+
+def test_pruning_keeps_all_undelivered_and_held_terminal_results(monkeypatch):
+    monkeypatch.setattr(ad, "_MAX_RETAINED_COMPLETED", 1)
+    states = ["pending", "held_by_wait", "delivering", "delivered", "consumed", "suppressed"]
+    for index, delivery_state in enumerate(states):
+        delegation_id = f"deleg_retention_{index}"
+        ad._persist_dispatch(
+            {
+                "delegation_id": delegation_id,
+                "session_key": "owner",
+                "origin_ui_session_id": "ui-owner",
+                "parent_session_id": "parent-owner",
+                "dispatched_at": float(index + 1),
+                "root_subagent_ids": [],
+            }
+        )
+        ad._persist_completion(
+            {
+                "delegation_id": delegation_id,
+                "status": "completed",
+                "completed_at": float(index + 1),
+            },
+            {"status": "completed", "summary": delivery_state},
+        )
+        _set_delivery(delegation_id, delivery_state)
+
+    ad._prune_durable_records()
+
+    for index, delivery_state in enumerate(states[:3]):
+        row = ad.get_durable_delegation(f"deleg_retention_{index}")
+        assert row is not None, delivery_state
+        assert row["delivery_state"] == delivery_state
+
+
+def test_restore_only_enqueues_pending_terminal_results():
+    for index, state in enumerate(("pending", "consumed", "suppressed")):
+        delegation_id = f"deleg_restore_{index}"
+        ad._persist_dispatch(
+            {
+                "delegation_id": delegation_id,
+                "session_key": "owner",
+                "origin_ui_session_id": "",
+                "parent_session_id": None,
+                "dispatched_at": float(index + 1),
+                "root_subagent_ids": [],
+            }
+        )
+        ad._persist_completion(
+            {"delegation_id": delegation_id, "status": "completed", "completed_at": float(index + 1)},
+            {"status": "completed", "summary": state},
+        )
+        _set_delivery(delegation_id, state)
+
+    restored = queue.Queue()
+    assert ad.restore_undelivered_completions(restored) == 1
+    assert restored.get_nowait()["delegation_id"] == "deleg_restore_0"
+
+
+def _age_wait_hold(delegation_id, *, seconds):
+    _set_delivery(delegation_id, "held_by_wait", claimed_at=time.time() - seconds)
+
+
+def test_stale_wait_hold_is_reclaimed_but_live_hold_is_not():
+    stale = _dispatch(lambda: {"status": "completed", "summary": "stale"})
+    _wait_terminal(stale["delegation_id"])
+    _age_wait_hold(
+        stale["delegation_id"], seconds=ad._WAIT_HOLD_STALE_SECONDS + 1
+    )
+
+    claimed = ad.claim_async_delivery(stale["delegation_id"], managed=True)
+    assert claimed["status"] == "claimed"
+    assert ad.release_completion_delivery(stale["delegation_id"], claimed["token"])
+
+    live = _dispatch(lambda: {"status": "completed", "summary": "live"})
+    _wait_terminal(live["delegation_id"])
+    _age_wait_hold(live["delegation_id"], seconds=1)
+    assert ad.claim_async_delivery(live["delegation_id"], managed=True) == {
+        "status": "held"
+    }
+
+
+def test_owner_requeues_completion_after_stale_waiter_crash():
+    dispatched = _dispatch(lambda: {"status": "completed", "summary": "recover"})
+    _wait_terminal(dispatched["delegation_id"])
+    _age_wait_hold(
+        dispatched["delegation_id"], seconds=ad._WAIT_HOLD_STALE_SECONDS + 1
+    )
+
+    restored = queue.Queue()
+    assert ad.restore_stale_wait_completions(restored, session_key="owner") == 1
+    event = restored.get_nowait()
+    assert event["delegation_id"] == dispatched["delegation_id"]
+    assert event["restored"] is True
+    assert event["_async_delivery_claim_token"]
+    row = ad.get_durable_delegation(dispatched["delegation_id"])
+    assert row is not None
+    assert row["delivery_state"] == "delivering"
+    assert row["delivery_claim"] == event["_async_delivery_claim_token"]
+
+
+

--- a/tests/tools/test_delegation_repository.py
+++ b/tests/tools/test_delegation_repository.py
@@ -1,0 +1,662 @@
+"""Behavior contracts for normalized delegation persistence."""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+import sqlite3
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from tools.delegation_repository import DelegationRepository
+
+def _released_schema(path: str) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """CREATE TABLE async_delegations (
+            delegation_id TEXT PRIMARY KEY,
+            origin_session TEXT NOT NULL,
+            origin_ui_session_id TEXT NOT NULL DEFAULT '',
+            parent_session_id TEXT,
+            state TEXT NOT NULL,
+            dispatched_at REAL NOT NULL,
+            completed_at REAL,
+            updated_at REAL NOT NULL,
+            event_json TEXT,
+            result_json TEXT,
+            delivery_state TEXT NOT NULL DEFAULT 'pending',
+            delivery_attempts INTEGER NOT NULL DEFAULT 0,
+            delivered_at REAL,
+            owner_pid INTEGER,
+            owner_started_at INTEGER,
+            task_json TEXT,
+            delivery_claim TEXT,
+            delivery_claimed_at REAL,
+            root_subagent_ids_json TEXT NOT NULL DEFAULT '[]',
+            children_json TEXT NOT NULL DEFAULT '{}',
+            interrupt_requests_json TEXT NOT NULL DEFAULT '{}',
+            interrupt_reason TEXT,
+            abandon_reason TEXT
+        )"""
+    )
+    conn.commit()
+    conn.close()
+
+def _open_snapshot(path: str, delegation_id: str, start, output) -> None:
+    start.wait()
+    try:
+        snap = DelegationRepository(Path(path)).snapshot(delegation_id)
+        output.put(("ok", snap["lifecycle_version"] if snap else None))
+    except BaseException as exc:  # pragma: no cover - asserted in parent
+        output.put(("error", f"{type(exc).__name__}: {exc}"))
+
+def _reserve_attempt(path: str, logical_id: str, worker_id: str, start, output) -> None:
+    start.wait()
+    try:
+        outcome = DelegationRepository(Path(path)).reserve_resumed_attempt(
+            logical_id, physical_worker_id=worker_id
+        )
+        output.put(outcome)
+    except BaseException as exc:  # pragma: no cover - asserted in parent
+        output.put({"status": "error", "error": f"{type(exc).__name__}: {exc}"})
+
+@pytest.fixture
+def repo(tmp_path: Path) -> DelegationRepository:
+    return DelegationRepository(tmp_path / "state.db")
+
+def _record(delegation_id="deleg-1", roots=None, dispatched_at=10.0):
+    roots = ["sa-root"] if roots is None else roots
+    return {
+        "delegation_id": delegation_id,
+        "session_key": "owner",
+        "origin_ui_session_id": "ui-owner",
+        "parent_session_id": "parent-owner",
+        "dispatched_at": dispatched_at,
+        "goal": "do work",
+        "context": "context",
+        "role": "leaf",
+        "model": "test",
+        "root_subagent_ids": roots,
+    }
+
+def test_initial_dispatch_persists_supplied_attempt_mapping_atomically(repo):
+    record = _record("deleg-protected", ["sa-a", "sa-b"])
+    record["attempt_ids_by_logical_id"] = {
+        "sa-a": "attempt-physical-a",
+        "sa-b": "attempt-physical-b",
+    }
+
+    created = repo.register_initial_dispatch(record)
+
+    assert created["status"] == "registered"
+    assert [item["attempt_id"] for item in created["attempts"]] == [
+        "attempt-physical-a",
+        "attempt-physical-b",
+    ]
+    with sqlite3.connect(repo.db_path) as conn:
+        rows = conn.execute(
+            "SELECT attempt_id, logical_id, physical_worker_id "
+            "FROM delegation_attempts ORDER BY logical_id"
+        ).fetchall()
+    assert rows == [
+        ("attempt-physical-a", "sa-a", "attempt-physical-a"),
+        ("attempt-physical-b", "sa-b", "attempt-physical-b"),
+    ]
+
+
+def test_initial_dispatch_persists_authority_inside_immutable_logical_spec(repo):
+    authority = {
+        "version": 1,
+        "profile": {"name": "isolated", "hash": "hash", "snapshot": {}},
+        "state": {"revoked": False, "cleaned": False},
+    }
+    record = _record("deleg-authority", ["sa-root"])
+    record["authority_by_logical_id"] = {"sa-root": authority}
+
+    created = repo.register_initial_dispatch(record)
+    repo.transition_attempt(
+        created["attempts"][0]["attempt_id"],
+        {"starting"},
+        "completed",
+        metadata={"status_observation": "mutable"},
+    )
+
+    with sqlite3.connect(repo.db_path) as conn:
+        raw_spec = conn.execute(
+            "SELECT spec_json FROM delegation_logical_subagents WHERE logical_id=?",
+            ("sa-root",),
+        ).fetchone()[0]
+    assert json.loads(raw_spec)["authority"] == authority
+
+
+
+def test_authority_revocation_tombstone_preserves_immutable_snapshot(repo):
+    authority = {
+        "version": 1,
+        "authority_hash": "immutable-hash",
+        "profile": {"name": "isolated"},
+        "state": {"revoked": False, "cleaned": False},
+    }
+    record = _record("deleg-authority-tombstone", ["sa-authority"])
+    record["attempt_ids_by_logical_id"] = {
+        "sa-authority": "attempt-authority"
+    }
+    record["authority_by_logical_id"] = {"sa-authority": authority}
+    repo.register_initial_dispatch(record)
+
+    outcome = repo.tombstone_logical_authority(
+        "sa-authority", revoked=True, cleaned=True
+    )
+
+    assert outcome == {"status": "tombstoned"}
+    with sqlite3.connect(repo.db_path) as conn:
+        spec = json.loads(
+            conn.execute(
+                "SELECT spec_json FROM delegation_logical_subagents WHERE logical_id = ?",
+                ("sa-authority",),
+            ).fetchone()[0]
+        )
+    assert spec["authority"] == {
+        **authority,
+        "state": {"revoked": True, "cleaned": True},
+    }
+
+
+def test_tombstoned_authority_denies_late_steer_and_interrupt(repo):
+    authority = {
+        "version": 1,
+        "authority_hash": "immutable-hash",
+        "profile": {"name": "isolated"},
+        "state": {"revoked": False, "cleaned": False},
+    }
+    record = _record("deleg-authority-denial", ["sa-authority-denial"])
+    record["attempt_ids_by_logical_id"] = {
+        "sa-authority-denial": "attempt-authority-denial"
+    }
+    record["authority_by_logical_id"] = {
+        "sa-authority-denial": authority
+    }
+    repo.register_initial_dispatch(record)
+    repo.tombstone_logical_authority("sa-authority-denial", revoked=True)
+
+    assert repo.enqueue_steer(
+        "deleg-authority-denial", "sa-authority-denial", "owner", "late"
+    ) == {"status": "authority_revoked"}
+    assert repo.request_interrupt("attempt-authority-denial", "late") == {
+        "status": "authority_revoked"
+    }
+
+
+def test_fresh_resumed_attempt_preserves_immutable_logical_authority(repo):
+    authority = {
+        "version": 1,
+        "authority_hash": "immutable-hash",
+        "lineage": {
+            "scope_id": "scope-original",
+            "attempt_id": "attempt-original",
+            "parent_attempt_id": None,
+        },
+        "state": {"revoked": False, "cleaned": False},
+    }
+    record = _record("deleg-authority-resume", ["sa-authority-resume"])
+    record["attempt_ids_by_logical_id"] = {
+        "sa-authority-resume": "attempt-original"
+    }
+    record["authority_by_logical_id"] = {
+        "sa-authority-resume": authority
+    }
+    repo.register_initial_dispatch(record)
+    repo.transition_attempt("attempt-original", {"starting"}, "completed")
+
+    resumed = repo.reserve_resumed_attempt("sa-authority-resume")
+
+    with sqlite3.connect(repo.db_path) as conn:
+        stored = json.loads(
+            conn.execute(
+                "SELECT spec_json FROM delegation_logical_subagents WHERE logical_id=?",
+                ("sa-authority-resume",),
+            ).fetchone()[0]
+        )["authority"]
+        physical_worker_id = conn.execute(
+            "SELECT physical_worker_id FROM delegation_attempts WHERE attempt_id=?",
+            (resumed["attempt_id"],),
+        ).fetchone()[0]
+    assert resumed["status"] == "reserved"
+    assert resumed["attempt_id"] != "attempt-original"
+    assert physical_worker_id == resumed["attempt_id"]
+    assert stored == authority
+
+
+def test_retry_replacement_and_resume_allocate_fresh_physical_attempt_ids(repo):
+    record = _record("deleg-retry", ["sa-a"])
+    record["attempt_ids_by_logical_id"] = {"sa-a": "attempt-initial"}
+    initial = repo.register_initial_dispatch(record)
+    assert initial["status"] == "registered"
+    assert repo.transition_attempt(
+        "attempt-initial", {"starting"}, "completed"
+    )["status"] == "updated"
+
+    resumed = repo.reserve_resumed_attempt("sa-a")
+    assert resumed["status"] == "reserved"
+    assert repo.transition_attempt(
+        resumed["attempt_id"], {"starting"}, "completed"
+    )["status"] == "updated"
+    replacement = repo.reserve_resumed_attempt("sa-a")
+    assert replacement["status"] == "reserved"
+
+    ids = {"attempt-initial", resumed["attempt_id"], replacement["attempt_id"]}
+    assert len(ids) == 3
+    conn = repo._connect()
+    try:
+        rows = conn.execute(
+            "SELECT attempt_id,physical_worker_id FROM delegation_attempts "
+            "WHERE logical_id=? ORDER BY attempt_number",
+            ("sa-a",),
+        ).fetchall()
+    finally:
+        conn.close()
+    assert {
+        str(row["attempt_id"]): str(row["physical_worker_id"]) for row in rows
+    } == {attempt_id: attempt_id for attempt_id in ids}
+
+
+def test_initial_single_and_batch_shape_preserves_root_order(repo):
+    single = repo.register_initial_dispatch(_record())
+    batch = repo.register_initial_dispatch(
+        _record("deleg-batch", ["sa-z", "sa-a"], dispatched_at=20.0)
+    )
+
+    assert single["status"] == "registered"
+    assert single["run_id"]
+    assert [(a["logical_id"], a["attempt_number"]) for a in single["attempts"]] == [
+        ("sa-root", 1)
+    ]
+    assert [a["logical_id"] for a in batch["attempts"]] == ["sa-z", "sa-a"]
+    snap = repo.snapshot("deleg-batch")
+    assert snap["lifecycle_version"] == 2
+    assert snap["root_subagent_ids"] == ["sa-z", "sa-a"]
+    assert list(snap["children"]) == ["sa-z", "sa-a"]
+    assert snap["state"] == "running"
+    assert snap["children"]["sa-z"]["status"] == "starting"
+
+def test_batch_result_mapping_is_ordinal_not_uuid_order(repo):
+    created = repo.register_initial_dispatch(_record(roots=["sa-z", "sa-a"]))
+    result = {
+        "results": [
+            {"status": "completed", "summary": "first"},
+            {"status": "error", "error": "second"},
+        ]
+    }
+    event = {"status": "completed", "completed_at": 30.0, "results": result["results"]}
+
+    assert repo.complete_run(created["run_id"], event, result)["status"] == "completed"
+    children = repo.snapshot("deleg-1")["children"]
+    assert children["sa-z"]["status"] == "completed"
+    assert children["sa-z"]["summary"] == "first"
+    assert children["sa-a"]["status"] == "error"
+    assert children["sa-a"]["error"] == "second"
+
+def test_concurrent_resume_has_one_winner(repo):
+    initial = repo.register_initial_dispatch(_record())
+    attempt_id = initial["attempts"][0]["attempt_id"]
+    assert repo.transition_attempt(
+        attempt_id, {"starting"}, "completed", completed_at=11.0
+    )["status"] == "updated"
+    barrier = threading.Barrier(9)
+    outcomes = []
+
+    def reserve(index):
+        barrier.wait()
+        outcomes.append(
+            repo.reserve_resumed_attempt("sa-root", physical_worker_id=f"worker-{index}")
+        )
+
+    threads = [threading.Thread(target=reserve, args=(i,)) for i in range(8)]
+    for thread in threads:
+        thread.start()
+    barrier.wait()
+    for thread in threads:
+        thread.join()
+
+    assert [outcome["status"] for outcome in outcomes].count("reserved") == 1
+    assert [outcome["status"] for outcome in outcomes].count("already_running") == 7
+
+def test_stale_attempt_and_interrupt_cannot_poison_new_attempt(repo):
+    initial = repo.register_initial_dispatch(_record())
+    old_id = initial["attempts"][0]["attempt_id"]
+    repo.transition_attempt(old_id, {"starting"}, "completed", completed_at=11.0)
+    current = repo.reserve_resumed_attempt("sa-root", physical_worker_id="worker-new")
+
+    assert repo.transition_attempt(old_id, {"completed"}, "error")["status"] == "stale"
+    assert repo.request_interrupt(old_id, "too late")["status"] == "already_terminal"
+    requested = repo.request_interrupt(current["attempt_id"], "stop")
+    assert requested["status"] == "interrupt_requested"
+    assert repo.request_interrupt(current["attempt_id"], "again")["status"] == "already_requested"
+    assert repo.take_interrupt(current["attempt_id"]) == {"status": "taken", "reason": "stop"}
+    assert repo.take_interrupt(current["attempt_id"])["status"] == "not_pending"
+    assert repo.snapshot("deleg-1")["children"]["sa-root"]["status"] == "interrupt_requested"
+
+def test_exact_run_completion_is_independent_of_newer_reserved_run(repo):
+    initial = repo.register_initial_dispatch(_record())
+    old_attempt = initial["attempts"][0]["attempt_id"]
+    repo.transition_attempt(old_attempt, {"starting"}, "completed")
+    resumed = repo.reserve_resumed_attempt("sa-root")
+    initial_event = {"status": "error", "summary": "initial", "completed_at": 19.0}
+    assert repo.complete_run(initial["run_id"], initial_event, initial_event)["status"] == "completed"
+    assert repo.pending_events() == [{"run_id": initial["run_id"], "event": initial_event}]
+    current = repo.snapshot("deleg-1")["children"]["sa-root"]
+    assert current["attempt_id"] == resumed["attempt_id"]
+    assert current["status"] == "starting"
+    assert repo.inspect_delivery("deleg-1", resumed["run_id"])["completed_at"] is None
+
+    duplicate = {"status": "error", "summary": "duplicate", "completed_at": 20.0}
+    assert repo.complete_run(initial["run_id"], duplicate, duplicate)["status"] == "stale"
+    assert len(repo.pending_events()) == 1
+
+    fresh_event = {"status": "completed", "summary": "fresh", "completed_at": 20.0}
+    assert repo.complete_run(resumed["run_id"], fresh_event, fresh_event)["status"] == "completed"
+    assert len(repo.pending_events()) == 2
+    snap = repo.snapshot("deleg-1")
+    assert snap["event"]["summary"] == "fresh"
+    assert snap["result"]["summary"] == "fresh"
+
+def test_owner_recovery_is_exact_and_allows_later_reserve(repo):
+    initial = repo.register_initial_dispatch(
+        _record(), owner_pid=999999, owner_started_at=1
+    )
+    attempt_id = initial["attempts"][0]["attempt_id"]
+
+    recovered = repo.recover_orphaned_attempts(lambda _pid, _started: False)
+    assert recovered["attempts"] == [{"attempt_id": attempt_id, "run_id": initial["run_id"], "delegation_id": "deleg-1"}]
+    assert repo.snapshot("deleg-1")["children"]["sa-root"]["status"] == "unknown"
+    resumed = repo.reserve_resumed_attempt("sa-root", owner_pid=123, owner_started_at=2)
+    assert resumed["status"] == "reserved"
+    assert resumed["attempt_number"] == 2
+
+def test_initial_registration_logical_conflict_rolls_back_every_row(repo):
+    repo.register_initial_dispatch(_record("deleg-existing", ["sa-collision"]))
+    rejected = _record("deleg-rejected", ["sa-collision"])
+    rejected.update(run_id="run-rejected", attempt_ids=["attempt-rejected"])
+    outcome = repo.register_initial_dispatch(rejected)
+    assert outcome["status"] == "conflict"
+    assert repo.register_initial_dispatch(_record("deleg-existing", ["sa-other"]))["status"] == "already_exists"
+    with sqlite3.connect(repo.db_path) as conn:
+        counts = conn.execute("""SELECT
+            (SELECT COUNT(*) FROM async_delegations WHERE delegation_id='deleg-rejected'),
+            (SELECT COUNT(*) FROM delegation_runs WHERE run_id='run-rejected'),
+            (SELECT COUNT(*) FROM delegation_logical_subagents WHERE delegation_id='deleg-rejected'),
+            (SELECT COUNT(*) FROM delegation_attempts WHERE attempt_id='attempt-rejected')""").fetchone()
+        assert counts == (0, 0, 0, 0)
+
+def test_legacy_migration_is_idempotent_and_preserves_disposition(tmp_path):
+    path = tmp_path / "state.db"
+    _released_schema(str(path))
+    children = {
+        "sa-z": {"subagent_id": "sa-z", "status": "success", "summary": "z"},
+        "sa-a": {"subagent_id": "sa-a", "status": "failed", "error": "a"},
+        "sa-child": {
+            "subagent_id": "sa-child",
+            "parent_id": "sa-z",
+            "status": "running",
+            "goal": "nested",
+        },
+    }
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """INSERT INTO async_delegations
+           (delegation_id, origin_session, state, dispatched_at, completed_at,
+            updated_at, event_json, result_json, delivery_state,
+            delivery_attempts, delivery_claim, delivery_claimed_at,
+            delivered_at, owner_pid, owner_started_at, task_json,
+            root_subagent_ids_json, children_json)
+           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+        (
+            "deleg-old", "owner", "completed", 1.0, 2.0, 2.0,
+            json.dumps({"status": "completed", "summary": "event"}),
+            json.dumps({"status": "completed", "summary": "result"}),
+            "pending", 3, "claim-old", 1.5, None, 4321, 99,
+            json.dumps({"goal": "legacy"}),
+            json.dumps(["sa-z", "sa-a"]), json.dumps(children),
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    repository = DelegationRepository(path)
+    first = repository.snapshot("deleg-old")
+    second = repository.snapshot("deleg-old")
+    assert first == second
+    assert first["lifecycle_version"] == 2
+    assert first["root_subagent_ids"] == ["sa-z", "sa-a"]
+    assert first["children"]["sa-child"]["parent_id"] == "sa-z"
+    assert first["children"]["sa-child"]["status"] == "running"
+    assert first["children"]["sa-z"]["status"] == "completed"
+    assert first["children"]["sa-a"]["status"] == "error"
+    assert first["delivery_state"] == "delivering"
+    assert first["delivery_claim"] == "claim-old"
+    assert first["delivery_attempts"] == 3
+    assert first["owner_pid"] == 4321
+
+    with sqlite3.connect(path) as check:
+        assert check.execute(
+            "SELECT COUNT(*) FROM delegation_runs WHERE delegation_id='deleg-old'"
+        ).fetchone()[0] == 1
+        assert check.execute(
+            "SELECT lifecycle_version FROM async_delegations WHERE delegation_id='deleg-old'"
+        ).fetchone()[0] == 2
+
+def test_released_schema_migrates_under_concurrent_process_open(tmp_path):
+    path = tmp_path / "state.db"
+    _released_schema(str(path))
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """INSERT INTO async_delegations
+           (delegation_id, origin_session, state, dispatched_at, updated_at,
+            root_subagent_ids_json, children_json)
+           VALUES ('deleg-mp','owner','running',1,1,'["sa-root"]',
+                   '{"sa-root":{"status":"running"}}')"""
+    )
+    conn.commit()
+    conn.close()
+
+    ctx = multiprocessing.get_context("spawn")
+    start = ctx.Event()
+    output = ctx.Queue()
+    workers = [ctx.Process(target=_open_snapshot, args=(str(path), "deleg-mp", start, output)) for _ in range(6)]
+    for worker in workers:
+        worker.start()
+    start.set()
+    outcomes = [output.get(timeout=20) for _ in workers]
+    for worker in workers:
+        worker.join(20)
+        assert worker.exitcode == 0
+
+    assert outcomes == [("ok", 2)] * 6
+
+def test_run_delivery_is_exact_and_omitted_run_fails_ambiguous(repo):
+    initial = repo.register_initial_dispatch(_record())
+    repo.complete_run(initial["run_id"], {"status": "completed"}, {"summary": "initial"})
+    repo.transition_attempt(initial["attempts"][0]["attempt_id"], {"completed"}, "completed")
+    resumed = repo.reserve_resumed_attempt("sa-root")
+    repo.complete_run(resumed["run_id"], {"status": "completed"}, {"summary": "resumed"})
+
+    first = repo.claim_run_delivery("deleg-1", initial["run_id"], "claim-1")
+    second = repo.claim_run_delivery("deleg-1", resumed["run_id"], "claim-2")
+    assert first["status"] == second["status"] == "claimed"
+    assert repo.commit_run_delivery(initial["run_id"], "claim-1")["status"] == "delivered"
+    assert repo.release_run_delivery(resumed["run_id"], "claim-2")["status"] == "released"
+    assert repo.claim_run_delivery("deleg-1", None, "claim-3") == {
+        "status": "ambiguous_run"
+    }
+
+def test_retention_protects_active_attempts_and_nonterminal_delivery(repo):
+    repo.register_initial_dispatch(_record("deleg-active", ["sa-active"], 1.0))
+    protected = {}
+    for index, state in enumerate(("pending", "held_by_wait", "delivering"), 2):
+        delegation_id = f"deleg-{state}"
+        created = repo.register_initial_dispatch(
+            _record(delegation_id, [f"sa-{state}"], float(index))
+        )
+        repo.complete_run(created["run_id"], {"status": "completed"}, {"summary": state})
+        if state == "held_by_wait":
+            repo.hold_for_wait(delegation_id, "owner", "hold")
+        elif state == "delivering":
+            repo.claim_run_delivery(delegation_id, created["run_id"], "claim")
+        protected[delegation_id] = state
+    for index, state in enumerate(("delivered", "consumed", "suppressed"), 5):
+        delegation_id = f"deleg-{state}"
+        created = repo.register_initial_dispatch(
+            _record(delegation_id, [f"sa-{state}"], float(index))
+        )
+        repo.complete_run(created["run_id"], {"status": "completed"}, {"summary": state})
+        if state == "delivered":
+            repo.acknowledge_pending(delegation_id)
+        elif state == "consumed":
+            repo.hold_for_wait(delegation_id, "owner", "hold")
+            repo.consume_wait_hold(delegation_id, "owner", "hold")
+        else:
+            repo.suppress_delivery(delegation_id, "owner")
+    outcome = repo.prune(cutoff=time.time() + 100.0, max_terminal=0)
+    assert outcome["deleted"] == 3
+    assert repo.snapshot("deleg-active") is not None
+    for delegation_id, state in protected.items():
+        assert repo.snapshot(delegation_id)["delivery_state"] == state
+    for state in ("delivered", "consumed", "suppressed"):
+        assert repo.snapshot(f"deleg-{state}") is None
+
+def test_authorized_snapshot_derives_compatibility_fields(repo):
+    created = repo.register_initial_dispatch(_record())
+    attempt_id = created["attempts"][0]["attempt_id"]
+    repo.transition_attempt(
+        attempt_id,
+        {"starting"},
+        "running",
+        metadata={"goal": "updated", "tool_count": 2, "last_tool": "terminal"},
+    )
+    own = repo.snapshot("deleg-1", session_key="owner")
+
+    assert own["worker_status"] == own["state"] == "running"
+    assert own["delivery_disposition"] == own["delivery_state"] == "pending"
+    assert own["children"]["sa-root"]["goal"] == "updated"
+    assert own["children"]["sa-root"]["tool_count"] == 2
+    assert own["owner_pid"] is None
+    assert repo.snapshot("deleg-1", session_key="foreign") is None
+
+def test_list_snapshots_hydrates_one_hundred_records_with_one_connection(repo):
+    for index in range(100):
+        repo.register_initial_dispatch(_record(f"deleg-{index}", [f"sa-{index}"]))
+    opened, connect = 0, repo._connect
+    def counted_connect():
+        nonlocal opened
+        opened += 1; return connect()
+    repo._connect = counted_connect
+    assert len(repo.list_snapshots(limit=100)) == 100
+    assert opened == 1
+
+@pytest.mark.parametrize(("legacy_state", "expected"), [
+    ("starting", "starting"), ("running", "running"), ("finalizing", "finalizing"),
+    ("interrupt_requested", "interrupt_requested"), ("completed", "completed"),
+    ("success", "completed"), ("error", "error"), ("failed", "error"),
+    ("budget_exhausted", "error"), ("interrupted", "interrupted"),
+    ("cancelled", "interrupted"), ("timeout", "timeout"), ("mystery", "unknown"),
+])
+@pytest.mark.parametrize("delivery", [
+    "pending", "held_by_wait", "delivering", "delivered", "consumed", "suppressed"
+])
+def test_released_migration_matrix_and_frozen_legacy_fields(tmp_path, legacy_state, expected, delivery):
+    path = tmp_path / "state.db"
+    _released_schema(str(path))
+    claim = "legacy-claim" if delivery in {"held_by_wait", "delivering"} else None
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            """INSERT INTO async_delegations
+               (delegation_id,origin_session,state,dispatched_at,updated_at,
+                completed_at,event_json,result_json,delivery_state,delivery_claim,
+                root_subagent_ids_json,children_json)
+               VALUES (?,?,?,?,?,?,?,?,?,?,?,?)""",
+            (
+                "deleg-matrix", "owner", legacy_state, 1.0, 2.0,
+                None if legacy_state in {"starting", "running", "finalizing", "interrupt_requested"} else 2.0,
+                json.dumps({"status": legacy_state}), json.dumps({"status": legacy_state}),
+                delivery, claim, '["sa-root"]',
+                json.dumps({"sa-root": {"status": legacy_state}}),
+            ),
+        )
+    repository = DelegationRepository(path)
+    before = repository.snapshot("deleg-matrix")
+    assert before["children"]["sa-root"]["status"] == expected
+    assert before["delivery_state"] == delivery
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            """UPDATE async_delegations SET state='failed',delivery_state='suppressed',
+               children_json='{}',event_json='{}' WHERE delegation_id='deleg-matrix'"""
+        )
+    after = repository.snapshot("deleg-matrix")
+    assert after["children"] == before["children"]
+    assert after["delivery_state"] == delivery
+    assert after["event"] == before["event"]
+
+@pytest.mark.parametrize("repository_first", [True, False])
+def test_repository_and_session_db_bootstrap_in_either_order(tmp_path, repository_first):
+    from hermes_state import SessionDB
+
+    path = tmp_path / "state.db"
+    repository = DelegationRepository(path)
+    if repository_first:
+        assert repository.snapshot("missing") is None
+    database = SessionDB(db_path=path)
+    database.close()
+    if not repository_first:
+        assert repository.snapshot("missing") is None
+    assert repository.register_initial_dispatch(_record())["status"] == "registered"
+    assert repository.snapshot("deleg-1")["lifecycle_version"] == 2
+
+def test_preallocated_ids_survive_registration_archive_completion_and_event(repo):
+    record = _record()
+    record.update(run_id="run-preallocated", attempt_ids=["attempt-preallocated"])
+    created = repo.register_initial_dispatch(record)
+    assert created["run_id"] == "run-preallocated"
+    assert created["attempts"][0]["attempt_id"] == "attempt-preallocated"
+    registered = repo.register_subagent(
+        {"subagent_id": "sa-root", "status": "running", "tool_count": 1}
+    )
+    assert registered["attempt_id"] == "attempt-preallocated"
+    repo.transition_attempt(
+        "attempt-preallocated", {"running"}, "completed", metadata={"summary": "archived"}
+    )
+    event = {"status": "completed", "run_id": "run-preallocated", "completed_at": 5.0}
+    assert repo.complete_run("run-preallocated", event, {"summary": "done"})["status"] == "completed"
+    snapshot = repo.snapshot("deleg-1")
+    assert snapshot["children"]["sa-root"]["attempt_id"] == "attempt-preallocated"
+    assert snapshot["children"]["sa-root"]["summary"] == "archived"
+    assert repo.pending_events()[0] == {"run_id": "run-preallocated", "event": event}
+
+def test_repeated_multiprocess_resume_has_one_winner(tmp_path):
+    path = tmp_path / "state.db"
+    repository = DelegationRepository(path)
+    created = repository.register_initial_dispatch(_record())
+    repository.transition_attempt(created["attempts"][0]["attempt_id"], {"starting"}, "completed")
+    ctx = multiprocessing.get_context("spawn")
+    for round_number in range(3):
+        start, output = ctx.Event(), ctx.Queue()
+        workers = [
+            ctx.Process(
+                target=_reserve_attempt,
+                args=(str(path), "sa-root", f"worker-{round_number}-{index}", start, output),
+            )
+            for index in range(6)
+        ]
+        for worker in workers:
+            worker.start()
+        start.set()
+        outcomes = [output.get(timeout=20) for _ in workers]
+        for worker in workers:
+            worker.join(20)
+            assert worker.exitcode == 0
+        winners = [outcome for outcome in outcomes if outcome["status"] == "reserved"]
+        assert len(winners) == 1
+        assert [outcome["status"] for outcome in outcomes].count("already_running") == 5
+        repository.transition_attempt(winners[0]["attempt_id"], {"starting"}, "completed")

--- a/tests/tools/test_delegation_transcript_resume.py
+++ b/tests/tools/test_delegation_transcript_resume.py
@@ -1,0 +1,301 @@
+"""Provider-safe, child-only transcript hydration for resumed delegations."""
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+def test_sessiondb_defines_get_subagent_resume_bundle():
+    """Fail closed if rebase drops the live resume hydration method again."""
+    import inspect
+
+    method = getattr(SessionDB, "get_subagent_resume_bundle", None)
+    assert callable(method)
+    params = inspect.signature(method).parameters
+    assert "child_session_id" in params
+    assert "reconstruction_metadata" in params
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SessionDB(tmp_path / "state.db")
+
+
+def _session(db, sid, *, parent=None, source="subagent", owner="parent"):
+    config = {"_delegate_from": owner} if source == "subagent" else None
+    db.create_session(
+        sid,
+        source=source,
+        parent_session_id=parent,
+        model_config=config,
+    )
+
+
+def _metadata(child="child-1", parent="parent"):
+    return {
+        "child_session_id": child,
+        "parent_session_id": parent,
+        "model": "provider/model",
+        "provider": "provider",
+        "role": "leaf",
+        "depth": 1,
+    }
+
+
+def test_hydrates_child_only_resume_chain_and_preserves_provider_fields(db):
+    _session(db, "parent", source="discord", owner=None)
+    db.append_message("parent", "user", "PARENT PRIVATE TRANSCRIPT")
+    _session(db, "child-1", parent="parent")
+    db.append_message("child-1", "user", "initial child goal")
+    tool_calls = [
+        {
+            "id": "call-1",
+            "type": "function",
+            "function": {"name": "read_file", "arguments": '{"path":"x"}'},
+        }
+    ]
+    db.append_message(
+        "child-1",
+        "assistant",
+        "working",
+        tool_calls=tool_calls,
+        reasoning="private reasoning",
+        reasoning_content="provider reasoning",
+        reasoning_details=[{"type": "reasoning.text", "text": "detail"}],
+        codex_reasoning_items=[{"type": "reasoning", "id": "r1"}],
+        codex_message_items=[{"type": "message", "id": "m1"}],
+        api_content="exact provider payload ",
+    )
+    db.append_message(
+        "child-1", "tool", "file data", tool_call_id="call-1", tool_name="read_file"
+    )
+    db.append_message("child-1", "assistant", "attempt one done")
+
+    # A resumed attempt is a new child segment linked to the prior segment.
+    _session(db, "child-2", parent="child-1")
+    db.append_message("child-2", "user", "continue with the result")
+    db.append_message("child-2", "assistant", "attempt two done")
+
+    bundle = db.get_subagent_resume_bundle("child-2", _metadata(child="child-2"))
+
+    assert bundle["child_lineage"] == ["child-1", "child-2"]
+    assert bundle["prior_child_session_id"] == "child-2"
+    assert "PARENT PRIVATE TRANSCRIPT" not in repr(bundle["history"])
+    assert [m["content"] for m in bundle["history"] if m["role"] == "user"] == [
+        "initial child goal",
+        "continue with the result",
+    ]
+    replayed = next(m for m in bundle["history"] if m.get("content") == "working")
+    assert replayed["tool_calls"] == tool_calls
+    assert replayed["reasoning"] == "private reasoning"
+    assert replayed["reasoning_content"] == "provider reasoning"
+    assert replayed["reasoning_details"] == [
+        {"type": "reasoning.text", "text": "detail"}
+    ]
+    assert replayed["codex_reasoning_items"] == [{"type": "reasoning", "id": "r1"}]
+    assert replayed["codex_message_items"] == [{"type": "message", "id": "m1"}]
+    assert replayed["api_content"] == "exact provider payload "
+
+    from tools.delegate_tool import prepare_resumed_child_session
+
+    continuation_a = prepare_resumed_child_session(bundle)
+    continuation_b = prepare_resumed_child_session(bundle)
+    assert continuation_a["session_id"] != continuation_b["session_id"]
+    assert continuation_a["parent_session_id"] == "child-2"
+    assert continuation_a["delegate_from"] == "parent"
+
+
+def test_follows_marked_child_compression_and_sanitizes_dangling_tool_tail(db):
+    _session(db, "parent", source="discord", owner=None)
+    _session(db, "child-1", parent="parent")
+    db.append_message("child-1", "user", "goal")
+    db.append_message("child-1", "assistant", "pre-compression")
+    db.end_session("child-1", "compression")
+    _session(db, "child-compressed", parent="child-1")
+    db.append_message("child-compressed", "user", "after compression")
+    db.append_message(
+        "child-compressed",
+        "assistant",
+        "",
+        tool_calls=[
+            {
+                "id": "dangling",
+                "type": "function",
+                "function": {"name": "read_file", "arguments": "{}"},
+            }
+        ],
+    )
+
+    bundle = db.get_subagent_resume_bundle("child-1", _metadata())
+
+    assert bundle["prior_child_session_id"] == "child-compressed"
+    assert bundle["child_lineage"] == ["child-1", "child-compressed"]
+    assert bundle["history"][-1]["role"] == "user"
+    assert bundle["history"][-1]["content"] == "after compression"
+
+
+
+
+def test_async_loader_is_authorized_and_keeps_provider_history_internal(
+    tmp_path, monkeypatch
+):
+    from tools import async_delegation as ad
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    ad._reset_for_tests()
+    db = SessionDB()
+    _session(db, "parent", source="discord", owner=None)
+    _session(db, "child-1", parent="parent")
+    db.append_message("child-1", "user", "goal")
+    db.append_message(
+        "child-1", "assistant", "answer", reasoning="private chain"
+    )
+    repository = ad._repository()
+    initial = repository.register_initial_dispatch(
+        {
+            "delegation_id": "deleg-hydrate",
+            "session_key": "parent",
+            "dispatched_at": 1.0,
+            "root_subagent_ids": ["logical-child"],
+        }
+    )
+    attempt = initial["attempts"][0]
+    assert repository.transition_attempt(
+        attempt["attempt_id"],
+        {"starting"},
+        "completed",
+        metadata=_metadata(),
+        completed_at=2.0,
+    )["status"] == "updated"
+
+    loaded = ad.load_subagent_resume_bundle(
+        "deleg-hydrate", "logical-child", session_key="parent"
+    )
+    foreign = ad.load_subagent_resume_bundle(
+        "deleg-hydrate", "logical-child", session_key="foreign"
+    )
+    projected = ad.get_async_delegation("deleg-hydrate", session_key="parent")
+
+    assert loaded["status"] == "ready"
+    assert loaded["bundle"]["history"][-1]["reasoning"] == "private chain"
+    assert foreign == {"status": "not_found"}
+    assert "history" not in repr(projected)
+    assert "private chain" not in repr(projected)
+    ad._reset_for_tests()
+
+
+def test_protected_resume_missing_immutable_authority_fails_closed(tmp_path, monkeypatch):
+    from tools import async_delegation as ad
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    ad._reset_for_tests()
+    db = SessionDB()
+    _session(db, "parent", source="discord", owner=None)
+    _session(db, "child-1", parent="parent")
+    db.append_message("child-1", "user", "goal")
+    repository = ad._repository()
+    initial = repository.register_initial_dispatch(
+        {
+            "delegation_id": "deleg-protected-missing-authority",
+            "session_key": "parent",
+            "dispatched_at": 1.0,
+            "root_subagent_ids": ["logical-child"],
+            "attempt_ids_by_logical_id": {"logical-child": "attempt-protected"},
+        }
+    )
+    repository.transition_attempt(
+        initial["attempts"][0]["attempt_id"],
+        {"starting"},
+        "completed",
+        metadata=_metadata(),
+        completed_at=2.0,
+    )
+
+    loaded = ad.load_subagent_resume_bundle(
+        "deleg-protected-missing-authority", "logical-child", session_key="parent"
+    )
+
+    assert loaded == {
+        "status": "resume_unavailable",
+        "reason": "protected authority is missing",
+    }
+    ad._reset_for_tests()
+
+
+def test_async_loader_falls_back_from_missing_completed_segment(tmp_path, monkeypatch):
+    from tools import async_delegation as ad
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    ad._reset_for_tests()
+    db = SessionDB()
+    _session(db, "parent", source="discord", owner=None)
+    _session(db, "child-valid", parent="parent")
+    db.append_message("child-valid", "user", "original goal")
+    db.append_message("child-valid", "assistant", "valid prior answer")
+
+    repository = ad._repository()
+    initial = repository.register_initial_dispatch(
+        {
+            "delegation_id": "deleg-missing-latest",
+            "session_key": "parent",
+            "dispatched_at": 1.0,
+            "root_subagent_ids": ["logical-child"],
+        }
+    )
+    first = initial["attempts"][0]
+    repository.transition_attempt(
+        first["attempt_id"],
+        {"starting"},
+        "completed",
+        metadata=_metadata(child="child-valid"),
+        completed_at=2.0,
+    )
+    second = repository.reserve_resumed_attempt(
+        "logical-child",
+        metadata=_metadata(child="child-valid"),
+    )
+    repository.transition_attempt(
+        second["attempt_id"],
+        {"starting"},
+        "completed",
+        metadata=_metadata(child="child-never-persisted"),
+        completed_at=3.0,
+    )
+
+    loaded = ad.load_subagent_resume_bundle(
+        "deleg-missing-latest", "logical-child", session_key="parent"
+    )
+
+    assert loaded["status"] == "ready"
+    assert loaded["bundle"]["prior_child_session_id"] == "child-valid"
+    assert loaded["bundle"]["history"][-1]["content"] == "valid prior answer"
+    ad._reset_for_tests()
+
+
+@pytest.mark.parametrize(
+    "mutation, error",
+    [
+        ("missing", "missing subagent transcript"),
+        ("wrong-source", "foreign subagent lineage"),
+        ("wrong-marker", "foreign subagent lineage"),
+        ("foreign-parent", "foreign subagent lineage"),
+        ("missing-metadata", "incomplete reconstruction metadata"),
+    ],
+)
+def test_resume_bundle_fails_closed(db, mutation, error):
+    _session(db, "parent", source="discord", owner=None)
+    child = "missing" if mutation == "missing" else "child-1"
+    if mutation != "missing":
+        source = "cli" if mutation == "wrong-source" else "subagent"
+        owner = "other-parent" if mutation in {"wrong-marker", "foreign-parent"} else "parent"
+        parent = "other-parent" if mutation == "foreign-parent" else "parent"
+        if parent == "other-parent":
+            _session(db, "other-parent", source="discord", owner=None)
+        _session(db, child, parent=parent, source=source, owner=owner)
+        db.append_message(child, "user", "goal")
+    metadata = _metadata(child=child)
+    if mutation == "missing-metadata":
+        metadata.pop("parent_session_id")
+
+    with pytest.raises(ValueError, match=error):
+        db.get_subagent_resume_bundle(child, metadata)

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -38,11 +38,13 @@ from __future__ import annotations
 
 import logging
 import os
+import sqlite3
 import threading
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Callable, Dict, List, Mapping, Optional
+from contextlib import contextmanager
+from typing import Any, Callable, Dict, Iterator, List, Mapping, Optional
 
 from hermes_constants import get_hermes_home
 from tools.daemon_pool import DaemonThreadPoolExecutor
@@ -100,6 +102,83 @@ def _notify_state_change() -> None:
 
 def _db_path():
     return get_hermes_home() / "state.db"
+
+
+def _connect() -> sqlite3.Connection:
+    path = _db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path, timeout=10)
+    try:
+        _initialize_schema(conn)
+    except Exception:
+        # A PRAGMA/DDL failure after a successful connect() must not leak the
+        # just-opened connection back to the caller.
+        conn.close()
+        raise
+    return conn
+
+
+def _initialize_schema(conn: sqlite3.Connection) -> None:
+    from hermes_state import apply_wal_with_fallback
+
+    apply_wal_with_fallback(conn, db_label="state.db (async_delegation)")
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS async_delegations (
+            delegation_id TEXT PRIMARY KEY,
+            origin_session TEXT NOT NULL,
+            origin_ui_session_id TEXT NOT NULL DEFAULT '',
+            parent_session_id TEXT,
+            state TEXT NOT NULL,
+            dispatched_at REAL NOT NULL,
+            completed_at REAL,
+            updated_at REAL NOT NULL,
+            event_json TEXT,
+            result_json TEXT,
+            delivery_state TEXT NOT NULL DEFAULT 'pending',
+            delivery_attempts INTEGER NOT NULL DEFAULT 0,
+            delivered_at REAL,
+            owner_pid INTEGER,
+            owner_started_at INTEGER,
+            task_json TEXT,
+            delivery_claim TEXT,
+            delivery_claimed_at REAL,
+            origin_session_id TEXT NOT NULL DEFAULT ''
+        )"""
+    )
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(async_delegations)")}
+    for name, sql_type in (
+        ("owner_pid", "INTEGER"),
+        ("owner_started_at", "INTEGER"),
+        ("task_json", "TEXT"),
+        ("delivery_claim", "TEXT"),
+        ("delivery_claimed_at", "REAL"),
+        # Raw api_server session id (X-Hermes-Session-Id) of the ORIGINATING
+        # request — the wake self-post target. Without persisting it,
+        # completions recovered after a process restart are unroutable on
+        # api_server (the in-memory record that carried it is gone).
+        ("origin_session_id", "TEXT"),
+    ):
+        if name not in columns:
+            conn.execute(f"ALTER TABLE async_delegations ADD COLUMN {name} {sql_type}")
+
+
+@contextmanager
+def _transaction() -> Iterator[sqlite3.Connection]:
+    """Open a connection, commit/rollback on exit, and ALWAYS close it.
+
+    ``sqlite3.Connection.__enter__``/``__exit__`` only commit or roll back the
+    transaction; they do not close the connection. Using ``with _connect()``
+    alone therefore leaks a connection — and its WAL/SHM file descriptors — on
+    every durable dispatch, completion, and delivery-claim, deferring the close
+    to the garbage collector. On a long-running gateway that exhausts
+    ``RLIMIT_NOFILE`` (the cron-ledger sibling of this bug was #69567 / PR #69594).
+    """
+    conn = _connect()
+    try:
+        with conn:
+            yield conn
+    finally:
+        conn.close()
 
 
 def _repository() -> DelegationRepository:

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -36,18 +36,22 @@ logic stays in one place.
 
 from __future__ import annotations
 
-import json
 import logging
-import sqlite3
+import os
 import threading
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import contextmanager
-from typing import Any, Callable, Dict, Iterator, List, Optional
+from typing import Any, Callable, Dict, List, Mapping, Optional
 
 from hermes_constants import get_hermes_home
 from tools.daemon_pool import DaemonThreadPoolExecutor
+from tools.delegation_repository import (
+    DelegationRepository,
+    _ACTIVE_STATES,
+    _TERMINAL_DELIVERY_STATES,
+    _attempt_state,
+)
 from tools.thread_context import propagate_context_to_thread
 
 logger = logging.getLogger(__name__)
@@ -77,259 +81,82 @@ _DEFAULT_MAX_ASYNC_CHILDREN = 3
 # How many completed records to retain for status queries before pruning.
 _MAX_RETAINED_COMPLETED = 50
 _DURABLE_RETENTION_SECONDS = 7 * 24 * 60 * 60
-_MAX_DURABLE_PENDING = 1000
-# A pending completion whose delivery keeps failing is retried across claim
-# cycles (and across restarts via restore_undelivered_completions). Cap the
-# attempts so an unroutable row converges to a terminal 'dropped' state
-# instead of replaying on every restart forever.
-_MAX_DELIVERY_ATTEMPTS = 8
-# Staleness cap for restart replay: a pending completion older than this is
-# terminally dropped instead of re-run as a fresh full-context turn (see
-# restore_undelivered_completions). 48h keeps overnight/weekend results
-# deliverable while stopping weeks-old sessions from replaying after upgrades.
-_MAX_COMPLETION_REPLAY_AGE_S = 48 * 3600.0
-_DB_LOCK = threading.Lock()
+_MAX_DURABLE_PENDING = 1000  # legacy compatibility; undelivered rows are never pruned
+_MAX_DURABLE_LIST = 100
+_STATE_CONDITION = threading.Condition()
+_NONTERMINAL_DELIVERY_STATES = {"pending", "held_by_wait", "delivering"}
+_WAIT_POLL_SECONDS = 0.05
+# Public lifecycle waits are capped at 300 seconds. Keep the durable hold lease
+# longer than that bound so a live waiter cannot be pre-empted, while a process
+# that dies mid-wait cannot strand the result forever.
+_WAIT_HOLD_STALE_SECONDS = 360.0
 
-# ---------------------------------------------------------------------------
-# Stale-delegation detection (progress-based, on by default)
-# ---------------------------------------------------------------------------
-# A detached runner that wedges before returning (e.g. stuck inside its first
-# model API call — #60203) never reaches its ``finally`` finalizer, so no
-# completion event is ever published: the delegation shows "dispatched"
-# forever and the owning session looks silent until a process restart. We do
-# NOT fix this with a wall-clock timeout — legitimate heavy subagent work
-# (deep reviews, research fan-outs, slow reasoning models) must never be
-# killed for taking long (see delegate_tool.DEFAULT_CHILD_TIMEOUT rationale).
-# Instead a single monitor thread watches per-dispatch PROGRESS (api-call
-# count + current tool, via an injected ``progress_fn``): a child that is
-# advancing is left alone forever; a child with NO progress past the stale
-# threshold is interrupted, given a grace window to unwind and deliver its
-# partial results through the normal finalize path, and only force-finalized
-# with a terminal ``stalled`` event if it never returns.
-#
-# Thresholds mirror the sync-path heartbeat staleness monitor in
-# delegate_tool: idle (not inside a tool) stays tight so a wedged first API
-# call is caught quickly; in-tool is much higher so legitimately slow tools
-# (long terminal commands, big fetches) get time to finish.
-_STALE_CHECK_INTERVAL = 30.0  # seconds between monitor sweeps
-_STALE_IDLE_SECONDS = 450.0  # no progress, no current tool → stalled
-_STALE_IN_TOOL_SECONDS = 1200.0  # no progress while inside a tool → stalled
-_STALL_GRACE_SECONDS = 120.0  # after interrupt, time for the runner to return
 
-_monitor_lock = threading.Lock()
-_monitor_thread: Optional[threading.Thread] = None
-_monitor_stop = threading.Event()
+def _notify_state_change() -> None:
+    """Wake local waiters; SQLite remains the lifecycle authority."""
+    with _STATE_CONDITION:
+        _STATE_CONDITION.notify_all()
 
 
 def _db_path():
     return get_hermes_home() / "state.db"
 
 
-def _connect() -> sqlite3.Connection:
-    path = _db_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(path, timeout=10)
-    try:
-        _initialize_schema(conn)
-    except Exception:
-        # A PRAGMA/DDL failure after a successful connect() must not leak the
-        # just-opened connection back to the caller.
-        conn.close()
-        raise
-    return conn
+def _repository() -> DelegationRepository:
+    return DelegationRepository(_db_path())
 
 
-def _initialize_schema(conn: sqlite3.Connection) -> None:
-    from hermes_state import apply_wal_with_fallback
-
-    apply_wal_with_fallback(conn, db_label="state.db (async_delegation)")
-    conn.execute(
-        """CREATE TABLE IF NOT EXISTS async_delegations (
-            delegation_id TEXT PRIMARY KEY,
-            origin_session TEXT NOT NULL,
-            origin_ui_session_id TEXT NOT NULL DEFAULT '',
-            parent_session_id TEXT,
-            state TEXT NOT NULL,
-            dispatched_at REAL NOT NULL,
-            completed_at REAL,
-            updated_at REAL NOT NULL,
-            event_json TEXT,
-            result_json TEXT,
-            delivery_state TEXT NOT NULL DEFAULT 'pending',
-            delivery_attempts INTEGER NOT NULL DEFAULT 0,
-            delivered_at REAL,
-            owner_pid INTEGER,
-            owner_started_at INTEGER,
-            task_json TEXT,
-            delivery_claim TEXT,
-            delivery_claimed_at REAL,
-            origin_session_id TEXT NOT NULL DEFAULT ''
-        )"""
-    )
-    columns = {row[1] for row in conn.execute("PRAGMA table_info(async_delegations)")}
-    for name, sql_type in (
-        ("owner_pid", "INTEGER"),
-        ("owner_started_at", "INTEGER"),
-        ("task_json", "TEXT"),
-        ("delivery_claim", "TEXT"),
-        ("delivery_claimed_at", "REAL"),
-        # Raw api_server session id (X-Hermes-Session-Id) of the ORIGINATING
-        # request — the wake self-post target. Without persisting it,
-        # completions recovered after a process restart are unroutable on
-        # api_server (the in-memory record that carried it is gone).
-        ("origin_session_id", "TEXT"),
-    ):
-        if name not in columns:
-            conn.execute(f"ALTER TABLE async_delegations ADD COLUMN {name} {sql_type}")
-
-
-@contextmanager
-def _transaction() -> Iterator[sqlite3.Connection]:
-    """Open a connection, commit/rollback on exit, and ALWAYS close it.
-
-    ``sqlite3.Connection.__enter__``/``__exit__`` only commit or roll back the
-    transaction; they do not close the connection. Using ``with _connect()``
-    alone therefore leaks a connection — and its WAL/SHM file descriptors — on
-    every durable dispatch, completion, and delivery-claim, deferring the close
-    to the garbage collector. On a long-running gateway that exhausts
-    ``RLIMIT_NOFILE`` (the cron-ledger sibling of this bug was #69567 / PR #69594).
-    """
-    conn = _connect()
-    try:
-        with conn:
-            yield conn
-    finally:
-        conn.close()
-
-
-def _capture_routing_origin() -> Dict[str, Any]:
-    """Snapshot the dispatching turn's routing origin for the completion event.
-
-    Captured on the PARENT thread at dispatch time (the daemon worker doesn't
-    carry the contextvars) and persisted with the durable record, so a
-    completion replayed after a restart can reconstruct a full SessionSource
-    even when the session-store origin and in-memory source cache are gone.
-    scope_id matters most: on a relay-fronted deployment the connector's
-    fail-closed egress guard needs the tenant discriminator (or a user
-    binding) to route a scoped reply; without it, post-restart scoped
-    completions bounce with "target not routed to an onboarded tenant"
-    (staging 2026-08-09 defect #4). Best-effort — empty values are simply
-    omitted so CLI/contextvar-unaware paths persist nothing new.
-    """
-    origin: Dict[str, Any] = {}
-    try:
-        from gateway.session_context import get_session_env
-
-        for evt_key, env_name in (
-            ("scope_id", "HERMES_SESSION_SCOPE_ID"),
-            ("user_id", "HERMES_SESSION_USER_ID"),
-            ("user_name", "HERMES_SESSION_USER_NAME"),
-        ):
-            value = get_session_env(env_name, "")
-            if value:
-                origin[evt_key] = value
-    except Exception:  # noqa: BLE001 - routing origin is additive, never fatal
-        pass
-    return origin
+def _changed(outcome: Dict[str, Any], *success: str) -> bool:
+    changed = outcome.get("status") in success
+    if changed:
+        _notify_state_change()
+    return changed
 
 
 def _persist_dispatch(record: Dict[str, Any]) -> None:
-    now = time.time()
     try:
         from gateway.status import get_process_start_time
-        owner_started_at = get_process_start_time(__import__("os").getpid())
+
+        owner_started_at = get_process_start_time(os.getpid())
     except Exception:
         owner_started_at = None
-    task_payload = {
-        key: record.get(key)
-        for key in (
-            "goal", "goals", "context", "toolsets", "role", "model", "is_batch",
-            # Routing origin (scope_id/user_id/user_name): persisted so a
-            # restart-recovered completion can reconstruct a full
-            # SessionSource — see _capture_routing_origin.
-            "scope_id", "user_id", "user_name",
-        )
-        if key in record
-    }
-    with _DB_LOCK, _transaction() as conn:
-        conn.execute(
-            """INSERT OR REPLACE INTO async_delegations
-               (delegation_id, origin_session, origin_ui_session_id,
-                parent_session_id, state, dispatched_at, updated_at,
-                delivery_state, delivery_attempts, owner_pid,
-                owner_started_at, task_json, origin_session_id)
-               VALUES (?, ?, ?, ?, 'running', ?, ?, 'pending', 0, ?, ?, ?, ?)""",
-            (record["delegation_id"], record.get("session_key", ""),
-             record.get("origin_ui_session_id", ""), record.get("parent_session_id"),
-             record["dispatched_at"], now, __import__("os").getpid(),
-             owner_started_at, json.dumps(task_payload),
-             record.get("origin_session_id", "")),
-        )
+    if not record.get("root_subagent_ids"):
+        record["root_subagent_ids"] = [f"sa-{record['delegation_id']}"]
+    outcome = _repository().register_initial_dispatch(
+        record, owner_pid=os.getpid(), owner_started_at=owner_started_at
+    )
+    if outcome.get("status") != "registered":
+        raise RuntimeError(f"durable delegation registration failed: {outcome}")
+    record["run_id"] = outcome["run_id"]
+    record["attempt_ids"] = [item["attempt_id"] for item in outcome["attempts"]]
+    _notify_state_change()
     _prune_durable_records()
 
 
 def _delete_durable_delegation(delegation_id: str) -> None:
-    with _DB_LOCK, _transaction() as conn:
-        conn.execute("DELETE FROM async_delegations WHERE delegation_id=?", (delegation_id,))
+    if _repository().delete(delegation_id):
+        _notify_state_change()
 
 
 def _prune_durable_records() -> None:
-    """Bound terminal history, preferring delivered records for deletion."""
-    now = time.time()
-    cutoff = now - _DURABLE_RETENTION_SECONDS
-    with _DB_LOCK, _transaction() as conn:
-        conn.execute(
-            "DELETE FROM async_delegations WHERE delivery_state='delivered' AND updated_at < ?",
-            (cutoff,),
-        )
-        terminal_count = conn.execute(
-            "SELECT COUNT(*) FROM async_delegations WHERE state NOT IN ('running','finalizing')"
-        ).fetchone()[0]
-        excess = max(0, terminal_count - _MAX_RETAINED_COMPLETED)
-        if excess:
-            conn.execute(
-                """DELETE FROM async_delegations WHERE delegation_id IN (
-                     SELECT delegation_id FROM async_delegations
-                     WHERE state NOT IN ('running','finalizing')
-                     ORDER BY CASE delivery_state WHEN 'delivered' THEN 0 ELSE 1 END,
-                              updated_at ASC LIMIT ?
-                   )""",
-                (excess,),
-            )
-        pending_count = conn.execute(
-            """SELECT COUNT(*) FROM async_delegations
-               WHERE state NOT IN ('running','finalizing') AND delivery_state='pending'"""
-        ).fetchone()[0]
-        overflow = max(0, pending_count - _MAX_DURABLE_PENDING)
-        if overflow:
-            conn.execute(
-                """DELETE FROM async_delegations WHERE delegation_id IN (
-                     SELECT delegation_id FROM async_delegations
-                     WHERE state NOT IN ('running','finalizing') AND delivery_state='pending'
-                     ORDER BY updated_at ASC LIMIT ?
-                   )""",
-                (overflow,),
-            )
+    """Bound safely terminal history; never prune an undelivered result."""
+    _repository().prune(
+        cutoff=time.time() - _DURABLE_RETENTION_SECONDS,
+        max_terminal=_MAX_RETAINED_COMPLETED,
+    )
 
 
-def _persist_completion(event: Dict[str, Any], result: Dict[str, Any]) -> None:
-    now = time.time()
-    with _DB_LOCK, _transaction() as conn:
-        conn.execute(
-            """UPDATE async_delegations SET state=?, completed_at=?, updated_at=?,
-               event_json=?, result_json=?, delivery_state='pending'
-               WHERE delegation_id=?""",
-            (event.get("status", "completed"), event.get("completed_at", now), now,
-             json.dumps(event), json.dumps(result), event["delegation_id"]),
-        )
-
-
-def _note_delivery_attempt(delegation_id: str) -> None:
-    with _DB_LOCK, _transaction() as conn:
-        conn.execute(
-            "UPDATE async_delegations SET delivery_attempts=delivery_attempts+1, updated_at=? WHERE delegation_id=?",
-            (time.time(), delegation_id),
-        )
+def _persist_completion(event: Dict[str, Any], result: Dict[str, Any]) -> bool:
+    """Persist worker completion without stealing an existing delivery hold."""
+    run_id = event.get("run_id")
+    if not run_id:
+        resolved = _repository().resolve_run_id(event["delegation_id"])
+        if resolved.get("status") != "found":
+            return False
+        run_id = resolved["run_id"]
+    return _changed(
+        _repository().complete_run(str(run_id), event, result), "completed"
+    )
 
 
 def recover_abandoned_delegations() -> int:
@@ -338,55 +165,54 @@ def recover_abandoned_delegations() -> int:
         from gateway.status import _pid_exists, get_process_start_time
     except Exception:
         return 0
-    now = time.time()
-    recovered = 0
-    with _DB_LOCK, _transaction() as conn:
-        rows = conn.execute(
-            """SELECT delegation_id, origin_session, origin_ui_session_id,
-                      parent_session_id, dispatched_at, owner_pid,
-                      owner_started_at, task_json, origin_session_id
-               FROM async_delegations WHERE state IN ('running','finalizing')"""
-        ).fetchall()
-        for row in rows:
-            (delegation_id, session_key, origin_ui, parent_id, dispatched_at,
-             pid, started, task_json, origin_session_id) = row
-            live = False
-            if pid:
-                live = _pid_exists(int(pid))
-                if live and started is not None:
-                    live = get_process_start_time(int(pid)) == int(started)
-            if live:
-                continue
-            task = json.loads(task_json or "{}")
-            event = {
-                "type": "async_delegation", "delegation_id": delegation_id,
-                "session_key": session_key, "origin_ui_session_id": origin_ui,
-                # Restore the durable wake target so completions recovered
-                # after a restart remain routable to api_server sessions.
-                "origin_session_id": origin_session_id or "",
-                "parent_session_id": parent_id, "goal": task.get("goal", ""),
-                "goals": task.get("goals"), "context": task.get("context"),
-                "toolsets": task.get("toolsets"), "role": task.get("role"),
-                "model": task.get("model"), "is_batch": bool(task.get("is_batch")),
-                "status": "unknown", "summary": None,
-                "error": "Delegation owner exited before recording a terminal result; outcome unknown.",
-                "dispatched_at": dispatched_at, "completed_at": now,
-            }
-            # Routing origin persisted at dispatch (see _capture_routing_origin):
-            # restores scope_id/user_id for the reconstructed SessionSource so
-            # relay egress priming works after a restart.
-            for _k in ("scope_id", "user_id", "user_name"):
-                if task.get(_k):
-                    event[_k] = task[_k]
-            result = {"status": "unknown", "summary": None, "error": event["error"]}
-            conn.execute(
-                """UPDATE async_delegations SET state='unknown', completed_at=?,
-                   updated_at=?, event_json=?, result_json=?, delivery_state='pending'
-                   WHERE delegation_id=?""",
-                (now, now, json.dumps(event), json.dumps(result), delegation_id),
-            )
-            recovered += 1
-    return recovered
+
+    def owner_alive(pid: int, started: Optional[int]) -> bool:
+        if not _pid_exists(pid):
+            return False
+        return started is None or get_process_start_time(pid) == int(started)
+
+    repository = _repository()
+    recovered = repository.recover_orphaned_attempts(owner_alive)["attempts"]
+    if not recovered:
+        return 0
+    affected = 0
+    runs = {(item["delegation_id"], item["run_id"]) for item in recovered}
+    for delegation_id, run_id in runs:
+        current = repository.snapshot(delegation_id, run_id=run_id)
+        if (
+            not current or current["completed_at"] is not None
+            or any(child["status"] in _ACTIVE_STATES for child in current["children"].values())
+        ):
+            continue
+        now = time.time()
+        error = "Delegation owner exited before recording a terminal result; outcome unknown."
+        event = {
+            "type": "async_delegation",
+            "delivery_managed": True,
+            "delegation_id": delegation_id,
+            "run_id": run_id,
+            "session_key": current["session_key"],
+            "origin_ui_session_id": current["origin_ui_session_id"],
+            "parent_session_id": current["parent_session_id"],
+            "goal": current.get("goal", ""),
+            "goals": current.get("goals"),
+            "context": current.get("context"),
+            "toolsets": current.get("toolsets"),
+            "role": current.get("role"),
+            "model": current.get("model"),
+            "is_batch": bool(current.get("is_batch")),
+            "status": "unknown",
+            "summary": None,
+            "error": error,
+            "dispatched_at": current["dispatched_at"],
+            "completed_at": now,
+        }
+        result = {"status": "unknown", "summary": None, "error": error}
+        if repository.complete_run(run_id, event, result).get("status") == "completed":
+            affected += 1
+    if affected:
+        _notify_state_change()
+    return affected
 
 
 def restore_undelivered_completions(target_queue) -> int:
@@ -409,85 +235,565 @@ def restore_undelivered_completions(target_queue) -> int:
     on anymore; the payload stays queryable on the dropped row.
     """
     recover_abandoned_delegations()
-    now = time.time()
+    rows = _repository().pending_events()
+    for row in rows:
+        event = dict(row["event"])
+        event.update(restored=True, delivery_managed=True, run_id=row["run_id"])
+        target_queue.put(event)
+    return len(rows)
+
+
+def restore_stale_wait_completions(
+    target_queue,
+    *,
+    session_key: str = "",
+    owns_event: Optional[Callable[[Dict[str, Any]], bool]] = None,
+) -> int:
+    """Requeue expired wait holds only for a consumer that can own them.
+
+    Foreign consumers leave the durable row untouched. An authorised consumer
+    atomically claims the expired hold before enqueueing it, so another process
+    cannot publish the same result and a busy local queue cannot grow duplicate
+    restored copies.
+    """
     restored = 0
-    with _DB_LOCK, _transaction() as conn:
-        rows = conn.execute(
-            """SELECT delegation_id, event_json, completed_at, dispatched_at
-               FROM async_delegations
-               WHERE state != 'running' AND delivery_state='pending' AND event_json IS NOT NULL
-               ORDER BY completed_at, delegation_id"""
-        ).fetchall()
-        for delegation_id, payload, completed_at, dispatched_at in rows:
-            age_basis = completed_at or dispatched_at
-            if age_basis and (now - age_basis) > _MAX_COMPLETION_REPLAY_AGE_S:
-                conn.execute(
-                    """UPDATE async_delegations SET delivery_state='dropped',
-                              delivery_claim=NULL, delivery_claimed_at=NULL,
-                              updated_at=?
-                       WHERE delegation_id=? AND delivery_state='pending'""",
-                    (now, delegation_id),
-                )
-                logger.warning(
-                    "Async delegation %s: pending completion is %.1fh old "
-                    "(cap %.1fh); terminally dropping the replay (result "
-                    "remains queryable).",
-                    delegation_id, (now - age_basis) / 3600.0,
-                    _MAX_COMPLETION_REPLAY_AGE_S / 3600.0,
-                )
-                continue
-            evt = json.loads(payload)
-            if isinstance(evt, dict):
-                evt["restored"] = True
-            target_queue.put(evt)
-            restored += 1
+    cutoff = time.time() - _WAIT_HOLD_STALE_SECONDS
+    for row in _repository().pending_events(delivery_state="held_by_wait"):
+        event = dict(row["event"])
+        inspected = _repository().inspect_delivery(
+            str(event.get("delegation_id") or ""), row["run_id"]
+        )
+        claimed_at = inspected.get("delivery_claimed_at")
+        if claimed_at is not None and claimed_at >= cutoff:
+            continue
+        try:
+            owned = bool(owns_event(event)) if owns_event else bool(
+                session_key and str(event.get("session_key") or "") == session_key
+            )
+        except Exception:
+            owned = False
+        if not owned:
+            continue
+        token = f"stale-restore:{os.getpid()}:{uuid.uuid4().hex}"
+        outcome = _repository().claim_run_delivery(
+            str(event.get("delegation_id") or ""),
+            row["run_id"],
+            token,
+            wait_stale_seconds=_WAIT_HOLD_STALE_SECONDS,
+        )
+        if outcome.get("status") != "claimed":
+            continue
+        event.update(
+            restored=True,
+            delivery_managed=True,
+            run_id=row["run_id"],
+            _async_delivery_claim_token=token,
+        )
+        try:
+            target_queue.put(event)
+        except Exception:
+            _repository().release_run_delivery(row["run_id"], token)
+            raise
+        restored += 1
     return restored
+
+
+def _terminal(snapshot: Dict[str, Any]) -> bool:
+    return str(snapshot.get("state") or "") not in _ACTIVE_STATES
+
+
+def get_durable_delegation(delegation_id: str) -> Optional[Dict[str, Any]]:
+    """Internal durable lookup. Model-facing callers must use the authorised view."""
+    return _repository().trusted_snapshot(delegation_id)
+
+
+def get_async_delegation(
+    delegation_id: str, *, session_key: str, run_id: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
+    """Read one session-authorised lifecycle record without claiming delivery."""
+    return _repository().snapshot(
+        delegation_id, session_key=session_key, run_id=run_id
+    )
+
+
+def get_async_delegation_attempt(
+    delegation_id: str, attempt_id: str, *, session_key: str
+) -> Optional[Dict[str, Any]]:
+    return _repository().snapshot_for_attempt(
+        delegation_id, attempt_id, session_key=session_key
+    )
+
+
+def list_durable_delegations(
+    *, session_keys: Optional[List[str]] = None, limit: int = _MAX_DURABLE_LIST
+) -> List[Dict[str, Any]]:
+    """Read a bounded stable snapshot, optionally restricted to session owners."""
+    return _repository().list_snapshots(session_keys=session_keys, limit=limit)
+
+
+_RESUME_METADATA_FIELDS = frozenset(
+    {
+        "child_session_id",
+        "parent_session_id",
+        "parent_logical_id",
+        "depth",
+        "role",
+        "model",
+        "provider",
+        "api_mode",
+        "reasoning_config",
+        "enabled_toolsets",
+        "disabled_toolsets",
+        "workdir",
+        "max_iterations",
+        "max_tokens",
+        "fallback_routes",
+        "provider_preferences",
+    }
+)
+
+
+def load_subagent_resume_bundle(
+    delegation_id: str,
+    logical_id: str,
+    *,
+    session_key: str,
+) -> Dict[str, Any]:
+    """Load one authorized child's validated provider-facing replay bundle."""
+    # Resume reconstruction is the sole consumer of canonical authority.  It
+    # remains owner-authorized but bypasses the ordinary audit projection so
+    # backing identity/revision can be revalidated before use.
+    snapshot = _repository().trusted_snapshot(
+        delegation_id, session_key=session_key
+    )
+    if snapshot is None:
+        return {"status": "not_found"}
+    child = (snapshot.get("children") or {}).get(logical_id)
+    if not isinstance(child, dict):
+        return {"status": "not_found"}
+    protected = bool(child.get("protected_execution"))
+    authority = child.get("authority")
+    if protected and not isinstance(authority, dict):
+        return {
+            "status": "resume_unavailable",
+            "reason": "protected authority is missing",
+        }
+    if authority is not None and not isinstance(authority, dict):
+        return {
+            "status": "resume_unavailable",
+            "reason": "protected authority is malformed",
+        }
+    metadata = {
+        key: child.get(key)
+        for key in _RESUME_METADATA_FIELDS
+        if key in child
+    }
+    candidates = [metadata]
+    latest_attempt_id = child.get("attempt_id")
+    for prior in _repository().resume_metadata_candidates(delegation_id, logical_id):
+        if prior.get("attempt_id") == latest_attempt_id:
+            continue
+        raw = prior.get("metadata")
+        if not isinstance(raw, dict):
+            continue
+        candidate = {
+            key: raw.get(key)
+            for key in _RESUME_METADATA_FIELDS
+            if key in raw
+        }
+        if candidate:
+            candidates.append(candidate)
+
+    from hermes_state import SessionDB
+
+    bundle = None
+    last_missing_error = "missing subagent transcript"
+    for candidate in candidates:
+        child_session_id = str(candidate.get("child_session_id") or "")
+        try:
+            bundle = SessionDB().get_subagent_resume_bundle(
+                child_session_id, candidate
+            )
+            break
+        except ValueError as exc:
+            # A completed legacy attempt could advance its durable anchor before
+            # the continuation row was actually persisted. Recover from the
+            # newest older valid segment, but never bypass ownership/lineage
+            # failures by trying a different attempt.
+            if str(exc) != "missing subagent transcript":
+                return {"status": "resume_unavailable", "reason": str(exc)}
+            last_missing_error = str(exc)
+        except (OSError, RuntimeError, TypeError) as exc:
+            return {"status": "resume_unavailable", "reason": str(exc)}
+    if bundle is None:
+        return {"status": "resume_unavailable", "reason": last_missing_error}
+    return {
+        "status": "ready",
+        "delegation_id": delegation_id,
+        "subagent_id": logical_id,
+        "attempt_id": child.get("attempt_id"),
+        "attempt_number": child.get("attempt_number"),
+        "run_id": child.get("run_id"),
+        "authority": dict(authority) if isinstance(authority, dict) else None,
+        "protected": protected,
+        "bundle": bundle,
+    }
+
+
+def dispatch_resumed_subagent(
+    delegation_id: str,
+    logical_id: str,
+    *,
+    session_key: str,
+    message: str,
+    parent_agent,
+    max_async_children: int = _DEFAULT_MAX_ASYNC_CHILDREN,
+    **_compat,
+) -> Dict[str, Any]:
+    """Reserve, reconstruct, and dispatch one persisted logical child."""
+    snapshot = get_async_delegation(delegation_id, session_key=session_key)
+    if snapshot is None:
+        return {"status": "not_found"}
+    child_snapshot = ((snapshot or {}).get("children") or {}).get(logical_id) or {}
+    if not child_snapshot:
+        return {"status": "not_found"}
+    if child_snapshot.get("status") in _ACTIVE_STATES:
+        return {
+            "status": "already_running",
+            "attempt_id": child_snapshot.get("attempt_id"),
+            "run_id": child_snapshot.get("run_id"),
+        }
+    loaded = load_subagent_resume_bundle(
+        delegation_id, logical_id, session_key=session_key
+    )
+    if loaded.get("status") != "ready":
+        return loaded
+
+    restored_scope = None
+    expected_policy = None
+    if loaded.get("protected"):
+        return {
+            "status": "resume_unavailable",
+            "reason": "protected resume is unavailable",
+        }
+
+    bundle = loaded["bundle"]
+    from tools import delegate_tool as _delegate
+
+    continuation = _delegate.prepare_resumed_child_session(bundle)
+    # Keep the last persisted segment as the durable anchor while this attempt
+    # is starting/running. The loader follows marked child continuations, so it
+    # still discovers a partially persisted new segment after process loss,
+    # without ever pointing durable state at a session that may not yet exist.
+    metadata = {
+        **dict(bundle["reconstruction_metadata"]),
+        "child_session_id": bundle["prior_child_session_id"],
+    }
+    authority_tools = None
+    if loaded.get("protected"):
+        authority_tools = dict(loaded["authority"]["tools"])
+        metadata["enabled_toolsets"] = list(authority_tools["enabled_toolsets"])
+        metadata["disabled_toolsets"] = list(authority_tools["disabled_toolsets"])
+    try:
+        from gateway.status import get_process_start_time
+
+        owner_started_at = get_process_start_time(os.getpid())
+    except Exception:
+        owner_started_at = None
+    reserved = _repository().reserve_resumed_attempt(
+        logical_id,
+        physical_worker_id=None if loaded.get("protected") else logical_id,
+        owner_pid=os.getpid(),
+        owner_started_at=owner_started_at,
+        metadata=metadata,
+    )
+    if reserved.get("status") != "reserved":
+        return reserved
+    _notify_state_change()
+
+    run_id = str(reserved["run_id"])
+    attempt_id = str(reserved["attempt_id"])
+    dispatched_at = time.time()
+    protected_attempt_registry = None
+    protected_attempt_authority = None
+    event_record = {
+        "delegation_id": delegation_id,
+        "run_id": run_id,
+        "session_key": snapshot.get("session_key", ""),
+        "origin_ui_session_id": snapshot.get("origin_ui_session_id", ""),
+        "parent_session_id": snapshot.get("parent_session_id"),
+        "goal": child_snapshot.get("goal") or snapshot.get("goal", ""),
+        "context": snapshot.get("context"),
+        "toolsets": metadata.get("enabled_toolsets"),
+        "role": metadata.get("role"),
+        "model": metadata.get("model"),
+        "dispatched_at": dispatched_at,
+        "subagent_id": logical_id,
+        "attempt_id": attempt_id,
+        "attempt_number": reserved["attempt_number"],
+    }
+
+    def finish(result: Dict[str, Any], status: str) -> None:
+        completed = {**event_record, "completed_at": time.time()}
+        result.setdefault("subagent_id", logical_id)
+        result.setdefault("attempt_id", attempt_id)
+        result.setdefault("run_id", run_id)
+        _push_completion_event(completed, result, status)
+
+    def fail_before_execution(exc: Exception) -> Dict[str, Any]:
+        cleanup_errors: tuple[Exception, ...] = ()
+        if protected_attempt_registry is not None:
+            try:
+                cleanup_errors = tuple(
+                    protected_attempt_registry.cleanup(attempt_id)
+                )
+            except Exception as cleanup_exc:
+                cleanup_errors = (cleanup_exc,)
+        error = f"{type(exc).__name__}: {exc}"
+        exit_reason = "dispatch_failed"
+        if cleanup_errors:
+            cleanup_detail = "; ".join(
+                f"{type(item).__name__}: {item}" for item in cleanup_errors
+            )
+            error = f"{error}; cleanup failed: {cleanup_detail}"
+            exit_reason = "cleanup_error"
+        result = {
+            "status": "error",
+            "summary": None,
+            "error": error,
+            "exit_reason": exit_reason,
+            # Failure occurred before the continuation session ran; keep the
+            # last persisted child segment as the retry anchor.
+            "child_session_id": bundle["prior_child_session_id"],
+            "api_calls": 0,
+            "duration_seconds": round(time.time() - dispatched_at, 2),
+        }
+        finish(result, "error")
+        return {
+            "status": "dispatch_failed",
+            "delegation_id": delegation_id,
+            "subagent_id": logical_id,
+            "run_id": run_id,
+            "attempt_id": attempt_id,
+            "attempt_number": reserved["attempt_number"],
+            "error": error,
+            "exit_reason": exit_reason,
+        }
+
+    try:
+        child = _delegate.build_resumed_child_agent(
+            bundle=bundle,
+            logical_id=logical_id,
+            goal=str(event_record["goal"] or "resumed subagent"),
+            parent_agent=parent_agent,
+            continuation=continuation,
+        )
+        child._delegation_run_id = run_id
+        child._delegation_attempt_id = attempt_id
+        child._delegation_session_ref.update(
+            {"run_id": run_id, "attempt_id": attempt_id}
+        )
+        child_metadata = dict(child._delegation_runtime_metadata)
+        # Keep the prior segment only in durable in-flight metadata.  The
+        # reconstructed child must retain its newly allocated session ID so a
+        # successful completion can advance the replay anchor.
+        metadata = {
+            **child_metadata,
+            "child_session_id": bundle["prior_child_session_id"],
+        }
+    except Exception as exc:
+        return fail_before_execution(exc)
+
+    try:
+        executor = _get_executor(max_async_children)
+    except Exception as exc:
+        try:
+            child.close()
+        except Exception:
+            pass
+        return fail_before_execution(exc)
+
+    def worker() -> None:
+        result: Dict[str, Any]
+        status = "error"
+        try:
+            _repository().transition_attempt(
+                attempt_id, {"starting"}, "running", metadata=metadata
+            )
+            result = _delegate._run_single_child(
+                0,
+                str(event_record["goal"] or "resumed subagent"),
+                child=child,
+                parent_agent=parent_agent,
+                conversation_history=bundle["history"],
+                resume_message=message,
+                resume_workdir=metadata.get("workdir"),
+            )
+            status = str(result.get("status") or "error")
+            if status == "completed":
+                # The standard conversation runner has now persisted the new
+                # child segment.  Completing the exact attempt with this field
+                # atomically advances the anchor used by the next resume.
+                result["child_session_id"] = continuation["session_id"]
+        except Exception as exc:
+            logger.exception("Resumed delegation %s/%s crashed", delegation_id, logical_id)
+            result = {
+                "status": "error",
+                "summary": None,
+                "error": f"{type(exc).__name__}: {exc}",
+                "api_calls": 0,
+                "duration_seconds": round(time.time() - dispatched_at, 2),
+            }
+            status = "error"
+        finish(result, status)
+
+    try:
+        if protected_attempt_registry is not None:
+            protected_attempt_registry.activate(
+                attempt_id, delegation_id=delegation_id, run_id=run_id
+            )
+        executor.submit(propagate_context_to_thread(worker))
+    except Exception as exc:
+        try:
+            child.close()
+        except Exception:
+            pass
+        return fail_before_execution(exc)
+
+    return {
+        "status": "dispatched",
+        "delegation_id": delegation_id,
+        "subagent_id": logical_id,
+        "run_id": run_id,
+        "attempt_id": attempt_id,
+        "attempt_number": reserved["attempt_number"],
+        "child_session_id": continuation["session_id"],
+    }
 
 
 def mark_completion_delivered(delegation_id: str) -> bool:
     """Atomically acknowledge successful injection of a durable completion."""
-    now = time.time()
-    with _DB_LOCK, _transaction() as conn:
-        cur = conn.execute(
-            """UPDATE async_delegations SET delivery_state='delivered', delivered_at=?, updated_at=?
-               WHERE delegation_id=? AND delivery_state!='delivered'""",
-            (now, now, delegation_id),
-        )
-        return cur.rowcount == 1
+    return _changed(_repository().acknowledge_pending(delegation_id), "delivered")
 
 
-def claim_completion_delivery(delegation_id: str, claim_id: str) -> bool:
+def claim_completion_delivery(
+    delegation_id: str, claim_id: str, *, run_id: Optional[str] = None
+) -> bool:
     """Claim one pending completion across competing consumers/processes."""
-    now = time.time()
-    with _DB_LOCK, _transaction() as conn:
-        row = conn.execute(
-            "SELECT delivery_state FROM async_delegations WHERE delegation_id=?",
-            (delegation_id,),
-        ).fetchone()
-        if row is None:
-            return True  # legacy event created before durable dispatch
-        cur = conn.execute(
-            """UPDATE async_delegations SET delivery_claim=?, delivery_claimed_at=?,
-                      delivery_attempts=delivery_attempts+1, updated_at=?
-               WHERE delegation_id=? AND delivery_state='pending'
-                 AND (delivery_claim IS NULL OR delivery_claimed_at < ?)""",
-            (claim_id, now, now, delegation_id, now - 300),
-        )
-        return cur.rowcount == 1
+    inspected = _repository().inspect_delivery(delegation_id, run_id)
+    if inspected.get("status") == "not_found":
+        return True
+    if inspected.get("status") != "found":
+        return False
+    return _changed(
+        _repository().claim_run_delivery(
+            delegation_id,
+            run_id,
+            claim_id,
+            wait_stale_seconds=_WAIT_HOLD_STALE_SECONDS,
+        ),
+        "claimed",
+    )
+
+
+def recover_stale_wait_holds(delegation_id: Optional[str] = None) -> int:
+    """Release wait holds whose owning process can no longer be trusted alive."""
+    changed = _repository().recover_stale_wait_holds(
+        cutoff=time.time() - _WAIT_HOLD_STALE_SECONDS,
+        delegation_id=delegation_id,
+    )
+    if changed:
+        _notify_state_change()
+    return changed
 
 
 def claim_event_delivery(evt: Dict[str, Any], consumer: str) -> Optional[str]:
     """Claim a durable delegation event; non-durable events need no token."""
     if evt.get("type") != "async_delegation":
         return ""
+    if evt.get("_async_delivery_claim_token"):
+        return str(evt["_async_delivery_claim_token"])
     delegation_id = str(evt.get("delegation_id") or "")
     if not delegation_id:
         return ""
-    claim_id = f"{consumer}:{__import__('os').getpid()}:{uuid.uuid4().hex}"
-    return claim_id if claim_completion_delivery(delegation_id, claim_id) else None
+    claim_id = f"{consumer}:{os.getpid()}:{uuid.uuid4().hex}"
+    run_id = evt.get("run_id")
+    return claim_id if claim_completion_delivery(
+        delegation_id,
+        claim_id,
+        run_id=str(run_id) if run_id else None,
+    ) else None
 
 
-def release_completion_delivery(delegation_id: str, claim_id: str) -> bool:
+def claim_async_delivery(
+    delegation_id: str,
+    *,
+    managed: bool = False,
+    run_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Atomically claim a queued terminal result for any automatic consumer.
+
+    Unknown events are legacy pass-through unless the producer explicitly
+    marked them managed. Durable dispositions are authoritative across threads
+    and processes; a wait hold, consumption, suppression, or prior delivery
+    can never be bypassed by an in-memory queue copy.
+    """
+    recover_stale_wait_holds(delegation_id)
+    inspected = _repository().inspect_delivery(delegation_id, run_id)
+    status = inspected.get("status")
+    if status == "not_found":
+        return {"status": "stale" if managed else "legacy"}
+    if status == "ambiguous_run":
+        return {"status": "stale", "reason": "ambiguous_run"}
+    if inspected.get("completed_at") is None or inspected.get("event_json") is None:
+        return {"status": "not_ready"}
+    disposition = inspected.get("delivery_state")
+    if disposition == "held_by_wait":
+        return {"status": "held"}
+    if disposition in _TERMINAL_DELIVERY_STATES:
+        return {"status": "stale"}
+    token = f"auto:{os.getpid()}:{uuid.uuid4().hex}"
+    outcome = _repository().claim_run_delivery(delegation_id, run_id, token)
+    if outcome.get("status") == "claimed":
+        _notify_state_change()
+        return {"status": "claimed", "token": token}
+    return {"status": "held" if outcome.get("status") == "held" else "stale"}
+
+
+def inspect_async_delivery_claim(
+    delegation_id: str, token: str, *, run_id: Optional[str] = None
+) -> str:
+    """Inspect a token retained on a requeued delivery event."""
+    inspected = _repository().inspect_delivery(delegation_id, run_id)
+    if inspected.get("status") != "found":
+        return "not_found" if inspected.get("status") == "not_found" else "stale"
+    if inspected.get("delivery_state") == "delivering" and inspected.get("delivery_claim") == token:
+        return "current"
+    return str(inspected.get("delivery_state") or "pending")
+
+
+def _delivery_claim_action(
+    delegation_id: str,
+    claim_id: str,
+    *,
+    delivered: bool,
+    run_id: Optional[str] = None,
+) -> bool:
+    inspected = _repository().inspect_delivery(delegation_id, run_id)
+    if inspected.get("status") != "found":
+        return False
+    run_id = str(inspected["run_id"])
+    outcome = (
+        _repository().commit_run_delivery(run_id, claim_id)
+        if delivered
+        else _repository().release_run_delivery(run_id, claim_id)
+    )
+    return _changed(outcome, "delivered" if delivered else "released")
+
+
+def release_completion_delivery(
+    delegation_id: str, claim_id: str, *, run_id: Optional[str] = None
+) -> bool:
     """Release a failed delivery claim so another consumer may retry.
 
     Attempts are counted at claim time, so a row that keeps being claimed and
@@ -497,96 +803,532 @@ def release_completion_delivery(delegation_id: str, claim_id: str) -> bool:
     gateway restart forever (restore_undelivered_completions only restores
     pending rows).
     """
-    now = time.time()
-    with _DB_LOCK, _transaction() as conn:
-        capped = conn.execute(
-            """UPDATE async_delegations SET delivery_state='dropped',
-                      delivery_claim=NULL, delivery_claimed_at=NULL, updated_at=?
-               WHERE delegation_id=? AND delivery_state='pending'
-                 AND delivery_claim=? AND delivery_attempts>=?""",
-            (now, delegation_id, claim_id, _MAX_DELIVERY_ATTEMPTS),
-        )
-        if capped.rowcount == 1:
-            logger.warning(
-                "Async delegation %s exhausted its %d delivery attempts; "
-                "marking terminally dropped (result remains queryable).",
-                delegation_id, _MAX_DELIVERY_ATTEMPTS,
-            )
-            return True
-        cur = conn.execute(
-            """UPDATE async_delegations SET delivery_claim=NULL,
-                      delivery_claimed_at=NULL, updated_at=?
-               WHERE delegation_id=? AND delivery_state='pending'
-                 AND delivery_claim=?""",
-            (now, delegation_id, claim_id),
-        )
-        return cur.rowcount == 1
+    return _delivery_claim_action(
+        delegation_id, claim_id, delivered=False, run_id=run_id
+    )
 
 
-def drop_completion_delivery(delegation_id: str, claim_id: str) -> bool:
-    """Terminally drop a claimed completion that can never be delivered.
-
-    Used when the delivery target is permanently gone — the spawning session
-    ended at an explicit user boundary (/new, reset) rather than a compression
-    rotation. Marking the row ``dropped`` (not ``delivered``) keeps the ack
-    honest, and (not ``pending``) keeps restart recovery from replaying a
-    completion that will be fail-closed dropped again every time.
-    """
-    now = time.time()
-    with _DB_LOCK, _transaction() as conn:
-        cur = conn.execute(
-            """UPDATE async_delegations SET delivery_state='dropped',
-                      updated_at=?, delivery_claim=NULL,
-                      delivery_claimed_at=NULL
-               WHERE delegation_id=? AND delivery_state='pending'
-                 AND delivery_claim=?""",
-            (now, delegation_id, claim_id),
-        )
-        return cur.rowcount == 1
-
-
-def complete_completion_delivery(delegation_id: str, claim_id: str) -> bool:
+def complete_completion_delivery(
+    delegation_id: str, claim_id: str, *, run_id: Optional[str] = None
+) -> bool:
     """Acknowledge acceptance for the consumer holding this claim."""
-    now = time.time()
-    with _DB_LOCK, _transaction() as conn:
-        cur = conn.execute(
-            """UPDATE async_delegations SET delivery_state='delivered',
-                      delivered_at=?, updated_at=?, delivery_claim=NULL,
-                      delivery_claimed_at=NULL
-               WHERE delegation_id=? AND delivery_state='pending'
-                 AND delivery_claim=?""",
-            (now, now, delegation_id, claim_id),
-        )
-        return cur.rowcount == 1
+    return _delivery_claim_action(
+        delegation_id, claim_id, delivered=True, run_id=run_id
+    )
 
 
-def complete_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
-    if claim_id and evt.get("type") == "async_delegation":
-        complete_completion_delivery(str(evt.get("delegation_id") or ""), claim_id)
+def finish_async_delivery(
+    delegation_id: str,
+    token: str,
+    *,
+    delivered: bool,
+    run_id: Optional[str] = None,
+) -> bool:
+    """Commit or release exactly the automatic claim identified by ``token``."""
+    return _delivery_claim_action(
+        delegation_id, token, delivered=delivered, run_id=run_id
+    )
+
+
+def complete_event_delivery(evt: Dict[str, Any], claim_id: str) -> bool:
+    if not claim_id or evt.get("type") != "async_delegation":
+        return True
+    if evt.get("_async_delivery_claim_token"):
+        from tools.process_registry import commit_notification_delivery, process_registry
+
+        return commit_notification_delivery(evt, process_registry.completion_queue)
+    run_id = evt.get("run_id")
+    return _delivery_claim_action(
+        str(evt.get("delegation_id") or ""),
+        claim_id,
+        delivered=True,
+        run_id=str(run_id) if run_id else None,
+    )
 
 
 def release_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
-    if claim_id and evt.get("type") == "async_delegation":
-        release_completion_delivery(str(evt.get("delegation_id") or ""), claim_id)
+    if not claim_id or evt.get("type") != "async_delegation":
+        return
+    if evt.get("_async_delivery_claim_token"):
+        from tools.process_registry import process_registry, requeue_notification_delivery
+
+        requeue_notification_delivery(evt, process_registry.completion_queue)
+        return
+    run_id = evt.get("run_id")
+    _delivery_claim_action(
+        str(evt.get("delegation_id") or ""),
+        claim_id,
+        delivered=False,
+        run_id=str(run_id) if run_id else None,
+    )
 
 
-def get_durable_delegation(delegation_id: str) -> Optional[Dict[str, Any]]:
-    with _DB_LOCK, _transaction() as conn:
-        row = conn.execute(
-            """SELECT origin_session, state, dispatched_at, completed_at,
-                      result_json, delivery_state, delivery_attempts,
-                      origin_session_id
-               FROM async_delegations WHERE delegation_id=?""", (delegation_id,),
-        ).fetchone()
-    if row is None:
-        return None
+def hold_completion_for_wait(
+    delegation_id: str, claim_id: str, *, session_key: str,
+    run_id: Optional[str] = None,
+) -> bool:
+    """Atomically reserve pending delivery for one authorised waiter."""
+    return _changed(
+        _repository().hold_for_wait(
+            delegation_id, session_key, claim_id, run_id=run_id
+        ),
+        "held",
+    )
+
+
+def consume_waited_completion(
+    delegation_id: str, claim_id: str, *, session_key: str,
+    run_id: Optional[str] = None,
+) -> bool:
+    """Consume a terminal completion only for the waiter owning its hold."""
+    return _changed(
+        _repository().consume_wait_hold(
+            delegation_id, session_key, claim_id, run_id=run_id
+        ),
+        "consumed",
+    )
+
+
+def release_wait_hold(
+    delegation_id: str, claim_id: str, *, session_key: str,
+    run_id: Optional[str] = None,
+) -> bool:
+    """Release only this waiter's hold; timeout never consumes a result."""
+    return _changed(
+        _repository().release_wait_hold(
+            delegation_id, session_key, claim_id, run_id=run_id
+        ),
+        "released",
+    )
+
+
+def wait_for_delegation(
+    delegation_id: str, *, session_key: str, timeout_seconds: float = 30.0,
+    run_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Wait on the exact run selected at call start and consume it at most once."""
+    timeout_seconds = max(0.0, float(timeout_seconds))
+    deadline = time.monotonic() + timeout_seconds
+    claim_id = f"wait:{os.getpid()}:{uuid.uuid4().hex}"
+
+    recover_stale_wait_holds(delegation_id)
+    binding = _repository().hold_for_wait(
+        delegation_id, session_key, claim_id, run_id=run_id
+    )
+    if binding.get("status") == "not_found":
+        return {"status": "not_found", "delegation_id": delegation_id}
+    bound_run_id = binding.get("run_id")
+    if not isinstance(bound_run_id, str) or not bound_run_id:
+        return {"status": "not_found", "delegation_id": delegation_id}
+    owns_hold = binding.get("status") == "held"
+
+    def _wait_bound() -> Dict[str, Any]:
+        while True:
+            snapshot = get_async_delegation(
+                delegation_id, session_key=session_key, run_id=bound_run_id
+            )
+            if snapshot is None:
+                if owns_hold:
+                    release_wait_hold(
+                        delegation_id, claim_id, session_key=session_key,
+                        run_id=bound_run_id,
+                    )
+                return {"status": "not_found", "delegation_id": delegation_id}
+            if _terminal(snapshot):
+                claimed = owns_hold and consume_waited_completion(
+                    delegation_id, claim_id, session_key=session_key,
+                    run_id=bound_run_id,
+                )
+                current = get_async_delegation(
+                    delegation_id, session_key=session_key, run_id=bound_run_id
+                ) or snapshot
+                current["claimed_delivery"] = bool(claimed)
+                return current
+
+            from tools.foreground_wait import current_foreground_wait
+
+            wait_slot = current_foreground_wait()
+            if (
+                wait_slot is not None
+                and wait_slot.kind == "delegation"
+                and wait_slot.background_requested.is_set()
+            ):
+                if owns_hold:
+                    release_wait_hold(
+                        delegation_id,
+                        claim_id,
+                        session_key=session_key,
+                        run_id=bound_run_id,
+                    )
+                current = get_async_delegation(
+                    delegation_id, session_key=session_key, run_id=bound_run_id
+                ) or snapshot
+                handoff = {
+                    "kind": "delegation",
+                    "delegation_id": delegation_id,
+                    "run_id": bound_run_id,
+                    "continue": (
+                        'delegate_task(action="wait", delegation_id='
+                        f'"{delegation_id}", run_id="{bound_run_id}")'
+                    ),
+                    "inspect": (
+                        'delegate_task(action="status", delegation_id='
+                        f'"{delegation_id}")'
+                    ),
+                    "stop": (
+                        'delegate_task(action="interrupt", delegation_id='
+                        f'"{delegation_id}", cascade=true)'
+                    ),
+                }
+                current["status"] = "backgrounded"
+                current["claimed_delivery"] = False
+                current["foreground_handoff"] = handoff
+                wait_slot.complete_background(handoff)
+                return current
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                latest = get_async_delegation(
+                    delegation_id, session_key=session_key, run_id=bound_run_id
+                ) or snapshot
+                if _terminal(latest):
+                    claimed = owns_hold and consume_waited_completion(
+                        delegation_id, claim_id, session_key=session_key,
+                        run_id=bound_run_id,
+                    )
+                    current = get_async_delegation(
+                        delegation_id, session_key=session_key, run_id=bound_run_id
+                    ) or latest
+                    current["claimed_delivery"] = bool(claimed)
+                    return current
+                if owns_hold:
+                    release_wait_hold(
+                        delegation_id, claim_id, session_key=session_key,
+                        run_id=bound_run_id,
+                    )
+                current = get_async_delegation(
+                    delegation_id, session_key=session_key, run_id=bound_run_id
+                ) or latest
+                current["status"] = "timeout"
+                current["claimed_delivery"] = False
+                return current
+            with _STATE_CONDITION:
+                _STATE_CONDITION.wait(timeout=min(remaining, _WAIT_POLL_SECONDS))
+
+    try:
+        return _wait_bound()
+    except BaseException:
+        # A transient DB/read failure after acquisition must never strand a
+        # held_by_wait run. Preserve the original exception if cleanup also
+        # encounters the same transient lock.
+        if owns_hold:
+            for retry_index in range(3):
+                try:
+                    release_wait_hold(
+                        delegation_id, claim_id, session_key=session_key,
+                        run_id=bound_run_id,
+                    )
+                    break
+                except Exception:
+                    if retry_index < 2:
+                        time.sleep(0.05)
+        raise
+
+
+def suppress_completion_delivery(
+    delegation_id: str, *, session_key: str, reason: str = ""
+) -> str:
+    """Atomically suppress pending/held delivery with an explicit race outcome."""
+    status = _repository().suppress_delivery(
+        delegation_id, session_key, reason
+    ).get("status")
+    if status == "suppressed":
+        _notify_state_change()
+        return "applied"
+    if status in {"not_found", "already_suppressed", "too_late"}:
+        return str(status)
+    return "too_late"
+
+
+def interrupt_async_delegation(
+    delegation_id: str, *, session_key: str, reason: str = ""
+) -> Dict[str, Any]:
+    """Idempotently request cooperative interruption without suppressing delivery."""
+    snapshot = get_async_delegation(delegation_id, session_key=session_key)
+    if snapshot is None:
+        return {"status": "not_found", "delegation_id": delegation_id}
+    if _terminal(snapshot):
+        return {
+            "status": "already_terminal",
+            "delegation_id": delegation_id,
+            "worker_status": snapshot["state"],
+        }
+    with _records_lock:
+        record = _records.get(delegation_id)
+        if record is None or record.get("session_key", "") != session_key:
+            record = None
+        interrupt_lock = (
+            record.setdefault("_interrupt_lock", threading.Lock())
+            if record is not None
+            else threading.Lock()
+        )
+
+    # Durable request ownership and the live callback form one per-delegation
+    # transaction. Never wait for this lock while holding _records_lock.
+    with interrupt_lock:
+        snapshot = get_async_delegation(delegation_id, session_key=session_key)
+        if snapshot is None:
+            return {"status": "not_found", "delegation_id": delegation_id}
+        if _terminal(snapshot):
+            return {
+                "status": "already_terminal",
+                "delegation_id": delegation_id,
+                "worker_status": snapshot["state"],
+            }
+        fn = None
+        if record is not None:
+            with _records_lock:
+                current = _records.get(delegation_id)
+                if current is record and current.get("session_key", "") == session_key:
+                    fn = current.get("interrupt_fn")
+
+        requested_attempt_ids = []
+        for child in snapshot["children"].values():
+            if child["status"] not in _ACTIVE_STATES:
+                continue
+            attempt_id = child.get("attempt_id")
+            if not isinstance(attempt_id, str) or not attempt_id:
+                continue
+            outcome = _repository().request_interrupt(attempt_id, reason)
+            if outcome.get("status") == "interrupt_requested":
+                requested_attempt_ids.append(attempt_id)
+
+        # A caller that owns no transition is idempotent. It observes the
+        # prior owner's completed transaction and never invokes or rolls back.
+        if not requested_attempt_ids:
+            current_snapshot = get_async_delegation(
+                delegation_id, session_key=session_key
+            )
+            if current_snapshot is None:
+                return {"status": "not_found", "delegation_id": delegation_id}
+            if _terminal(current_snapshot):
+                return {
+                    "status": "already_terminal",
+                    "delegation_id": delegation_id,
+                    "worker_status": current_snapshot["state"],
+                }
+            status = (
+                "interrupt_unavailable"
+                if record is None
+                else (
+                    "interrupt_requested"
+                    if current_snapshot["state"] == "interrupt_requested"
+                    else "interrupt_unavailable"
+                )
+            )
+            return {"status": status, "delegation_id": delegation_id}
+
+        if not callable(fn):
+            # Resumed runs are not represented by the legacy per-delegation
+            # closure. Their durable exact-attempt requests are authoritative;
+            # best-effort the live child registry when construction has finished.
+            from tools import delegate_tool as _delegate_tool
+
+            for child in snapshot["children"].values():
+                child_id = child.get("subagent_id")
+                if isinstance(child_id, str) and child_id:
+                    _delegate_tool.interrupt_subagent_status(child_id, reason=reason)
+            _notify_state_change()
+            return {
+                "status": "interrupt_requested",
+                "delegation_id": delegation_id,
+                "attempt_ids": requested_attempt_ids,
+            }
+
+        with _records_lock:
+            current = _records.get(delegation_id)
+            if record is not None and current is not None and current is record:
+                current["status"] = "interrupt_requested"
+        _notify_state_change()
+        try:
+            fn()
+        except Exception as exc:
+            for attempt_id in requested_attempt_ids:
+                _repository().rollback_interrupt_request(attempt_id)
+            current_snapshot = get_async_delegation(
+                delegation_id, session_key=session_key
+            )
+            with _records_lock:
+                current = _records.get(delegation_id)
+                if (
+                    record is not None
+                    and current is not None
+                    and current is record
+                    and current.get("status") == "interrupt_requested"
+                ):
+                    if current_snapshot and current_snapshot["state"] in _ACTIVE_STATES:
+                        current["status"] = current_snapshot["state"]
+            _notify_state_change()
+            return {
+                "status": "interrupt_failed",
+                "delegation_id": delegation_id,
+                "error": f"{type(exc).__name__}: {exc}",
+            }
+        return {
+            "status": "interrupt_requested",
+            "delegation_id": delegation_id,
+            "attempt_ids": requested_attempt_ids,
+            "run_id": snapshot.get("active_run_id") or snapshot.get("run_id"),
+        }
+
+
+def abandon_async_delegation(
+    delegation_id: str, *, session_key: str, reason: str = ""
+) -> Dict[str, Any]:
+    """Suppress future delivery first, then best-effort interrupt the worker."""
+    suppression = suppress_completion_delivery(
+        delegation_id, session_key=session_key, reason=reason
+    )
+    if suppression == "not_found":
+        return {
+            "status": "not_found",
+            "delegation_id": delegation_id,
+            "suppression": "not_found",
+            "worker": "not_found",
+        }
+    interrupted = interrupt_async_delegation(
+        delegation_id, session_key=session_key, reason=reason
+    )
+    # Physical interruption happens first so durable revocation cannot prevent
+    # the best-effort worker stop. The logical tombstone is retained in
+    # spec_json and closes every later resume/steer/interrupt path.
+    _repository().tombstone_delegation_authorities(
+        delegation_id, revoked=True, cleaned=True
+    )
+    worker = str(interrupted.get("status") or "interrupt_unavailable")
     return {
-        "delegation_id": delegation_id, "origin_session": row[0], "state": row[1],
-        "dispatched_at": row[2], "completed_at": row[3],
-        "result": json.loads(row[4]) if row[4] else None,
-        "delivery_state": row[5], "delivery_attempts": row[6],
-        "origin_session_id": row[7] or "",
+        "status": "delivery_too_late" if suppression == "too_late" else "abandoned",
+        "delegation_id": delegation_id,
+        "suppression": suppression,
+        "worker": worker,
     }
+
+
+def register_subagent_lifecycle(record: Dict[str, Any]) -> Optional[str]:
+    """Associate a live child with its durable delegation and refresh metadata.
+
+    Root IDs are written before executor submission. Descendants are associated
+    through their already-associated parent, so no process-local authority is
+    needed for model-facing authorization.
+    """
+    outcome = _repository().register_subagent(record)
+    if not outcome:
+        return None
+    record["delegation_attempt_id"] = outcome["attempt_id"]
+    _notify_state_change()
+    return outcome["delegation_id"]
+
+
+def delegation_contains_subagent(
+    delegation_id: str, subagent_id: str, *, session_key: str
+) -> bool:
+    """Return membership only when both delegation and session are authorized."""
+    return _repository().find_attempt(
+        subagent_id, delegation_id=delegation_id, session_key=session_key
+    ) is not None
+
+
+def enqueue_subagent_steer(
+    delegation_id: str,
+    subagent_id: str,
+    *,
+    session_key: str,
+    message: str,
+    force: bool = False,
+) -> Dict[str, Any]:
+    outcome = _repository().enqueue_steer(
+        delegation_id, subagent_id, session_key, message, force=force
+    )
+    if outcome.get("status") == "accepted":
+        _notify_state_change()
+    return outcome
+
+
+def inspect_subagent_steer(mailbox_id: str) -> Dict[str, Any]:
+    return _repository().inspect_steer(mailbox_id)
+
+
+def request_pending_subagent_interrupt(
+    delegation_id: str,
+    subagent_id: str,
+    *,
+    session_key: str,
+    reason: str = "",
+) -> str:
+    """Durably queue an interrupt for an authorized child still starting."""
+    attempt = _repository().find_attempt(
+        subagent_id, delegation_id=delegation_id, session_key=session_key
+    )
+    if attempt is None:
+        return "not_found"
+    status = str(
+        _repository().request_interrupt(attempt["attempt_id"], reason).get("status")
+    )
+    if status == "already_requested":
+        status = "interrupt_requested"
+    if status == "interrupt_requested":
+        _notify_state_change()
+    return status
+
+
+def take_pending_subagent_interrupt(subagent_id: str) -> tuple[bool, str]:
+    """Consume a queued startup interrupt immediately after live registration."""
+    attempt = _repository().find_attempt(subagent_id)
+    if attempt is None:
+        return False, ""
+    outcome = _repository().take_interrupt(attempt["attempt_id"])
+    if outcome.get("status") != "taken":
+        return False, ""
+    _notify_state_change()
+    return True, str(outcome.get("reason") or "")
+
+
+def pending_subagent_interrupt_ids(
+    delegation_id: str, *, session_key: str
+) -> set[str]:
+    snapshot = get_async_delegation(delegation_id, session_key=session_key)
+    return set(snapshot.get("interrupt_requests", {})) if snapshot else set()
+
+
+def archive_subagent_tail(subagent_id: str, tail: Dict[str, Any]) -> None:
+    """Persist a bounded, already-redacted child tail before live removal."""
+    supplied_attempt = tail.get("delegation_attempt_id")
+    if "delegation_attempt_id" in tail and (
+        not isinstance(supplied_attempt, str) or not supplied_attempt
+    ):
+        return
+    supplied_run = tail.get("delegation_run_id")
+    if supplied_run is not None and (
+        not isinstance(supplied_run, str) or not supplied_run
+    ):
+        return
+    attempt = _repository().find_attempt(
+        subagent_id,
+        attempt_id=supplied_attempt,
+        run_id=supplied_run,
+    )
+    if attempt is None or attempt["state"] not in _ACTIVE_STATES:
+        return
+    state = _attempt_state(tail.get("status"))
+    outcome = _repository().transition_attempt(
+        attempt["attempt_id"],
+        {attempt["state"]},
+        state,
+        metadata=tail,
+        completed_at=None if state in _ACTIVE_STATES else time.time(),
+    )
+    if outcome.get("status") == "updated":
+        _notify_state_change()
 
 
 def _get_executor(max_workers: int) -> ThreadPoolExecutor:
@@ -608,6 +1350,9 @@ def _get_executor(max_workers: int) -> ThreadPoolExecutor:
         return _executor
 
 
+_LIVE_RECORD_STATES = {"running", "stalling", "finalizing"}
+
+
 def active_count() -> int:
     """Number of async delegation UNITS currently running.
 
@@ -618,10 +1363,7 @@ def active_count() -> int:
     ``active_task_count()``.
     """
     with _records_lock:
-        return sum(
-            1 for r in _records.values()
-            if r.get("status") in {"running", "stalling", "finalizing"}
-        )
+        return sum(1 for r in _records.values() if r.get("status") in _LIVE_RECORD_STATES)
 
 
 def active_for_session(origin_ui_session_id: str) -> int:
@@ -632,9 +1374,8 @@ def active_for_session(origin_ui_session_id: str) -> int:
         return sum(
             1
             for r in _records.values()
-            if r.get("status") in {"running", "stalling", "finalizing"}
-            and str(r.get("origin_ui_session_id") or "")
-            == origin_ui_session_id
+            if r.get("status") in _LIVE_RECORD_STATES
+            and str(r.get("origin_ui_session_id") or "") == origin_ui_session_id
         )
 
 
@@ -651,7 +1392,7 @@ def active_task_count() -> int:
     with _records_lock:
         total = 0
         for r in _records.values():
-            if r.get("status") not in {"running", "finalizing"}:
+            if r.get("status") not in _LIVE_RECORD_STATES:
                 continue
             if r.get("is_batch"):
                 goals = r.get("goals")
@@ -689,7 +1430,7 @@ def has_live_for_session(
         return False
     with _records_lock:
         return any(
-            r.get("status") in {"running", "stalling", "finalizing"}
+            r.get("status") in _LIVE_RECORD_STATES
             and _matches_session_selectors(
                 r,
                 session_key=session_key,
@@ -698,6 +1439,69 @@ def has_live_for_session(
             )
             for r in _records.values()
         )
+
+
+def _capture_routing_origin() -> Dict[str, Any]:
+    """Snapshot the dispatching turn's routing origin for the completion event.
+
+    Captured on the PARENT thread at dispatch time (the daemon worker doesn't
+    carry the contextvars) and persisted with the durable record, so a
+    completion replayed after a restart can reconstruct a full SessionSource
+    even when the session-store origin and in-memory source cache are gone.
+    scope_id matters most: on a relay-fronted deployment the connector's
+    fail-closed egress guard needs the tenant discriminator (or a user
+    binding) to route a scoped reply; without it, post-restart scoped
+    completions bounce with "target not routed to an onboarded tenant"
+    (staging 2026-08-09 defect #4). Best-effort — empty values are simply
+    omitted so CLI/contextvar-unaware paths persist nothing new.
+    """
+    origin: Dict[str, Any] = {}
+    try:
+        from gateway.session_context import get_session_env
+
+        for evt_key, env_name in (
+            ("scope_id", "HERMES_SESSION_SCOPE_ID"),
+            ("user_id", "HERMES_SESSION_USER_ID"),
+            ("user_name", "HERMES_SESSION_USER_NAME"),
+        ):
+            value = get_session_env(env_name, "")
+            if value:
+                origin[evt_key] = value
+    except Exception:
+        pass
+    return origin
+
+
+def drop_completion_delivery(
+    delegation_id: str, claim_id: str, *, run_id: Optional[str] = None
+) -> bool:
+    """Terminally drop a claimed completion that can never be delivered.
+
+    Used when the delivery target is permanently gone — the spawning session
+    ended at an explicit user boundary (/new, reset) rather than a compression
+    rotation. Marking the row ``dropped`` (not ``delivered``) keeps the ack
+    honest, and (not ``pending``) keeps restart recovery from replaying a
+    completion that will be fail-closed dropped again every time.
+    """
+    repo = _repository()
+    with repo.write_txn() as conn:
+        if run_id:
+            cur = conn.execute(
+                """UPDATE delegation_runs SET delivery_state='dropped',
+                   delivery_claim=NULL, delivery_claimed_at=NULL
+                   WHERE delegation_id=? AND run_id=? AND delivery_claim=?
+                     AND delivery_state IN ('pending','held_by_wait')""",
+                (delegation_id, run_id, claim_id),
+            )
+        else:
+            cur = conn.execute(
+                """UPDATE delegation_runs SET delivery_state='dropped',
+                   delivery_claim=NULL, delivery_claimed_at=NULL
+                   WHERE delegation_id=? AND delivery_claim=?
+                     AND delivery_state IN ('pending','held_by_wait')""",
+                (delegation_id, claim_id),
+            )
+        return cur.rowcount == 1
 
 
 def _new_delegation_id() -> str:
@@ -712,7 +1516,7 @@ def _prune_completed_locked() -> None:
     completed = [
         (rid, r)
         for rid, r in _records.items()
-        if r.get("status") != "running"
+        if r.get("status") not in _ACTIVE_STATES
     ]
     if len(completed) <= _MAX_RETAINED_COMPLETED:
         return
@@ -720,34 +1524,6 @@ def _prune_completed_locked() -> None:
     completed.sort(key=lambda kv: kv[1].get("completed_at") or kv[1].get("dispatched_at") or 0)
     for rid, _ in completed[: len(completed) - _MAX_RETAINED_COMPLETED]:
         _records.pop(rid, None)
-
-
-def _current_origin_session_id() -> str:
-    """Raw session id of the ORIGINATING api_server request, or ``""``.
-
-    The obvious source — ``HERMES_SESSION_ID`` via ``get_session_env`` — is
-    NOT safe to read at dispatch time: constructing a child agent
-    (``agent/agent_init.py``) calls ``set_current_session_id(child.session_id)``,
-    clobbering that ContextVar *and* ``os.environ`` with the subagent's
-    internal ``{timestamp}_{uuid}`` id moments before the dispatch code reads
-    it, so the completion wake would self-post into the subagent's own
-    (unread) session instead of the spawner's.
-
-    The request-scoped ``HERMES_SESSION_CHAT_ID`` binding survives child
-    construction: ``_bind_api_server_session`` binds ``chat_id`` to the raw
-    ``X-Hermes-Session-Id``, and its only writer is ``set_session_vars`` —
-    ``set_current_session_id`` never touches it. Gate on the platform: on
-    push platforms ``chat_id`` is a chat, not a session, so yield ``""``
-    there.
-    """
-    try:
-        from gateway.session_context import get_session_env
-
-        if get_session_env("HERMES_SESSION_PLATFORM", "") != "api_server":
-            return ""
-        return get_session_env("HERMES_SESSION_CHAT_ID", "") or ""
-    except Exception:
-        return ""
 
 
 def dispatch_async_delegation(
@@ -759,12 +1535,13 @@ def dispatch_async_delegation(
     model: Optional[str],
     session_key: str,
     parent_session_id: Optional[str] = None,
+    origin_session_id: Optional[str] = None,
     runner: Callable[[], Dict[str, Any]],
     origin_ui_session_id: str = "",
-    origin_session_id: str = "",
     interrupt_fn: Optional[Callable[[], None]] = None,
+    root_subagent_ids: Optional[List[str]] = None,
     max_async_children: int = _DEFAULT_MAX_ASYNC_CHILDREN,
-    progress_fn: Optional[Callable[[], tuple]] = None,
+    **_compat,
 ) -> Dict[str, Any]:
     """Spawn ``runner`` on the daemon executor and return a handle immediately.
 
@@ -808,6 +1585,7 @@ def dispatch_async_delegation(
         ``{"status": "dispatched", "delegation_id": ...}`` on success, or
         ``{"status": "rejected", "error": ...}`` when at capacity.
     """
+    parent_session_id = parent_session_id or origin_session_id
     delegation_id = _new_delegation_id()
     dispatched_at = time.time()
     record: Dict[str, Any] = {
@@ -819,26 +1597,21 @@ def dispatch_async_delegation(
         "model": model,
         "session_key": session_key,
         "origin_ui_session_id": origin_ui_session_id,
-        "origin_session_id": origin_session_id,
         "parent_session_id": parent_session_id,
-        **_capture_routing_origin(),
+        "routing_origin": _capture_routing_origin(),
         "status": "running",
         "dispatched_at": dispatched_at,
         "completed_at": None,
         "interrupt_fn": interrupt_fn,
-        "progress_fn": progress_fn,
-        # Stale-monitor bookkeeping (see _stale_monitor_loop).
-        "_progress_token": None,
-        "_progress_ts": dispatched_at,
-        "_interrupted_at": None,
+        "_interrupt_lock": threading.Lock(),
+        "root_subagent_ids": list(root_subagent_ids or []),
     }
     # Capacity check and record insert under ONE lock hold — checking
     # active_count() separately would let two concurrent dispatches (e.g.
     # from different gateway sessions) both pass the check and exceed the cap.
     with _records_lock:
         running = sum(
-            1 for r in _records.values()
-            if r.get("status") in ("running", "stalling")
+            1 for r in _records.values() if r.get("status") in _ACTIVE_STATES
         )
         if running >= max_async_children:
             return {
@@ -887,8 +1660,6 @@ def dispatch_async_delegation(
             "status": "rejected",
             "error": f"Failed to schedule async delegation: {exc}",
         }
-    if progress_fn is not None:
-        _ensure_stale_monitor()
 
     logger.info(
         "Dispatched async delegation %s (session_key=%s): %s",
@@ -899,37 +1670,21 @@ def dispatch_async_delegation(
 
 def _finalize(delegation_id: str, result: Dict[str, Any], status: str) -> None:
     """Mark a record complete and push the completion event onto the queue."""
-    claimed = _begin_finalization(delegation_id)
-    if claimed is None:
-        return
-    event_record, _interrupt_fn = claimed
-
-    _push_completion_event(event_record, result, status)
-    _finish_finalization(delegation_id, status)
-
-
-def _begin_finalization(
-    delegation_id: str,
-) -> Optional[tuple[Dict[str, Any], Optional[Callable[[], None]]]]:
-    """Atomically claim terminal delivery while keeping the record active."""
     with _records_lock:
         record = _records.get(delegation_id)
-        if record is None or record.get("status") not in ("running", "stalling"):
+        if record is None:
             return
         # Stay active until durable persistence and queue publication finish;
         # otherwise process shutdown can kill this daemon worker in the narrow
         # gap after status flips but before SQLite is committed.
         record["status"] = "finalizing"
         record["completed_at"] = time.time()
-        interrupt_fn = record.get("interrupt_fn")
         record["interrupt_fn"] = None  # drop the closure; child is done
-        record["progress_fn"] = None  # stop stale-monitor sampling
-        event_record = dict(record)
+        event_record = {
+            k: v for k, v in record.items() if k != "_interrupt_lock"
+        }
 
-    return event_record, interrupt_fn
-
-
-def _finish_finalization(delegation_id: str, status: str) -> None:
+    _push_completion_event(event_record, result, status)
     with _records_lock:
         record = _records.get(delegation_id)
         if record is not None:
@@ -962,12 +1717,13 @@ def _push_completion_event(
 
     evt = {
         "type": "async_delegation",
+        "delivery_managed": True,
         "delegation_id": record.get("delegation_id"),
+        "run_id": record.get("run_id"),
         # session_key routes the completion back to the originating gateway
         # session; empty string => CLI (single-session) path.
         "session_key": record.get("session_key", ""),
         "origin_ui_session_id": record.get("origin_ui_session_id", ""),
-        "origin_session_id": record.get("origin_session_id", ""),
         "parent_session_id": record.get("parent_session_id"),
         "goal": record.get("goal", ""),
         "context": record.get("context"),
@@ -985,23 +1741,12 @@ def _push_completion_event(
         "completed_at": completed_at,
         "exit_reason": result.get("exit_reason"),
     }
-    # Routing origin captured at dispatch (see _capture_routing_origin):
-    # additive, lets the gateway reconstruct a full SessionSource (incl.
-    # scope_id for relay tenant egress) when its own caches are cold.
-    for _k in ("scope_id", "user_id", "user_name"):
-        if record.get(_k):
-            evt[_k] = record[_k]
-    # Structured stall metadata (#51690) — additive, present only on
-    # stall-monitor finalizations.
-    for _k in (
-        "stalled_after_quiet_seconds",
-        "stall_threshold_seconds",
-        "stall_phase",
-        "stall_grace_seconds",
-    ):
-        if _k in result:
-            evt[_k] = result[_k]
-    _persist_completion(evt, result)
+    if not _persist_completion(evt, result):
+        logger.warning(
+            "Async delegation %s rejected stale completion for run %s",
+            record.get("delegation_id"), record.get("run_id"),
+        )
+        return
     try:
         process_registry.completion_queue.put(evt)
     except Exception as exc:  # pragma: no cover
@@ -1021,13 +1766,17 @@ def dispatch_async_delegation_batch(
     model: Optional[str],
     session_key: str,
     parent_session_id: Optional[str] = None,
+    origin_session_id: Optional[str] = None,
     runner: Callable[[], Dict[str, Any]],
     origin_ui_session_id: str = "",
-    origin_session_id: str = "",
     interrupt_fn: Optional[Callable[[], None]] = None,
+    root_subagent_ids: Optional[List[str]] = None,
+    attempt_ids_by_logical_id: Optional[Dict[str, str]] = None,
+    authority_by_logical_id: Optional[Dict[str, Dict[str, Any]]] = None,
     max_async_children: int = _DEFAULT_MAX_ASYNC_CHILDREN,
     delegation_id: Optional[str] = None,
-    progress_fn: Optional[Callable[[], tuple]] = None,
+    _bind_attempts: Optional[Callable[[str, Dict[str, str]], None]] = None,
+    **_compat,
 ) -> Dict[str, Any]:
     """Dispatch a WHOLE fan-out batch as ONE background unit.
 
@@ -1049,6 +1798,7 @@ def dispatch_async_delegation_batch(
     ``{"status": "rejected", "error": ...}`` when the async pool is at
     capacity.
     """
+    parent_session_id = parent_session_id or origin_session_id
     delegation_id = delegation_id or _new_delegation_id()
     dispatched_at = time.time()
     n = len(goals)
@@ -1066,23 +1816,26 @@ def dispatch_async_delegation_batch(
         "model": model,
         "session_key": session_key,
         "origin_ui_session_id": origin_ui_session_id,
-        "origin_session_id": origin_session_id,
         "parent_session_id": parent_session_id,
-        **_capture_routing_origin(),
+        "routing_origin": _capture_routing_origin(),
         "status": "running",
         "dispatched_at": dispatched_at,
         "completed_at": None,
         "interrupt_fn": interrupt_fn,
+        "_interrupt_lock": threading.Lock(),
+        "root_subagent_ids": list(root_subagent_ids or []),
         "is_batch": True,
-        "progress_fn": progress_fn,
-        "_progress_token": None,
-        "_progress_ts": dispatched_at,
-        "_interrupted_at": None,
     }
+    if attempt_ids_by_logical_id is not None:
+        record["attempt_ids_by_logical_id"] = dict(attempt_ids_by_logical_id)
+    if authority_by_logical_id is not None:
+        record["authority_by_logical_id"] = {
+            logical_id: dict(authority)
+            for logical_id, authority in authority_by_logical_id.items()
+        }
     with _records_lock:
         running = sum(
-            1 for r in _records.values()
-            if r.get("status") in ("running", "stalling")
+            1 for r in _records.values() if r.get("status") in _ACTIVE_STATES
         )
         if running >= max_async_children:
             return {
@@ -1096,7 +1849,22 @@ def dispatch_async_delegation_batch(
             }
         _records[delegation_id] = record
 
-    _persist_dispatch(record)
+    try:
+        _persist_dispatch(record)
+        if _bind_attempts is not None:
+            _bind_attempts(
+                str(record["run_id"]),
+                dict(zip(record["root_subagent_ids"], record["attempt_ids"])),
+            )
+    except Exception as exc:
+        with _records_lock:
+            _records.pop(delegation_id, None)
+        _delete_durable_delegation(delegation_id)
+        return {
+            "status": "rejected",
+            "reason": "dispatch_setup_failed",
+            "error": f"Failed to establish durable async delegation: {exc}",
+        }
     executor = _get_executor(max_async_children)
 
     def _worker() -> None:
@@ -1135,8 +1903,6 @@ def dispatch_async_delegation_batch(
             "status": "rejected",
             "error": f"Failed to schedule async delegation batch: {exc}",
         }
-    if progress_fn is not None:
-        _ensure_stale_monitor()
 
     logger.info(
         "Dispatched async delegation batch %s (%d task(s), session_key=%s)",
@@ -1149,26 +1915,24 @@ def _finalize_batch(
     delegation_id: str, combined: Dict[str, Any], status: str
 ) -> None:
     """Mark a batch record complete and push ONE combined completion event."""
-    claimed = _begin_finalization(delegation_id)
-    if claimed is None:
-        return
-    event_record, _interrupt_fn = claimed
+    with _records_lock:
+        record = _records.get(delegation_id)
+        if record is None:
+            return
+        record["status"] = "finalizing"
+        record["completed_at"] = time.time()
+        record["interrupt_fn"] = None
+        event_record = {
+            k: v for k, v in record.items() if k != "_interrupt_lock"
+        }
 
-    _push_batch_completion_event(event_record, combined, status)
-    _finish_finalization(delegation_id, status)
-
-
-def _push_batch_completion_event(
-    event_record: Dict[str, Any], combined: Dict[str, Any], status: str
-) -> None:
-    """Push a combined async-delegation batch completion event."""
     try:
         from tools.process_registry import process_registry
     except Exception as exc:  # pragma: no cover
         logger.error(
             "Async delegation batch %s finished but process_registry import "
             "failed; result lost: %s",
-            event_record.get("delegation_id"), exc,
+            delegation_id, exc,
         )
         return
 
@@ -1176,10 +1940,11 @@ def _push_batch_completion_event(
     completed_at = event_record.get("completed_at") or time.time()
     evt = {
         "type": "async_delegation",
-        "delegation_id": event_record.get("delegation_id"),
+        "delivery_managed": True,
+        "delegation_id": delegation_id,
+        "run_id": event_record.get("run_id"),
         "session_key": event_record.get("session_key", ""),
         "origin_ui_session_id": event_record.get("origin_ui_session_id", ""),
-        "origin_session_id": event_record.get("origin_session_id", ""),
         "parent_session_id": event_record.get("parent_session_id"),
         "goal": event_record.get("goal", ""),
         "goals": event_record.get("goals"),
@@ -1201,243 +1966,31 @@ def _push_batch_completion_event(
         "dispatched_at": dispatched_at,
         "completed_at": completed_at,
     }
-    # Routing origin captured at dispatch (see _capture_routing_origin).
-    for _k in ("scope_id", "user_id", "user_name"):
-        if event_record.get(_k):
-            evt[_k] = event_record[_k]
-    # Structured stall metadata (#51690) — additive, present only on
-    # stall-monitor finalizations.
-    for _k in (
-        "stalled_after_quiet_seconds",
-        "stall_threshold_seconds",
-        "stall_phase",
-        "stall_grace_seconds",
-    ):
-        if _k in combined:
-            evt[_k] = combined[_k]
-    _persist_completion(evt, combined)
+    if not _persist_completion(evt, combined):
+        logger.warning(
+            "Async delegation batch %s rejected stale completion for run %s",
+            delegation_id, event_record.get("run_id"),
+        )
+        return
     try:
         process_registry.completion_queue.put(evt)
     except Exception as exc:  # pragma: no cover
         logger.error(
             "Async delegation batch %s: failed to enqueue completion event; "
             "result lost: %s",
-            event_record.get("delegation_id"), exc,
+            delegation_id, exc,
         )
-
-
-def _ensure_stale_monitor() -> None:
-    """Start (once) the module-level stale-delegation monitor thread.
-
-    One daemon thread serves every dispatch; it exits on its own when no
-    monitorable records remain, and is restarted by the next dispatch that
-    carries a ``progress_fn``.
-    """
-    global _monitor_thread
-    with _monitor_lock:
-        if _monitor_thread is not None and _monitor_thread.is_alive():
-            return
-        _monitor_stop.clear()
-        _monitor_thread = threading.Thread(
-            target=_stale_monitor_loop,
-            name="async-delegate-stale-monitor",
-            daemon=True,
-        )
-        _monitor_thread.start()
-
-
-def _stale_monitor_loop() -> None:
-    """Sweep running delegations for stalled progress.
-
-    Per sweep, for every running record with a ``progress_fn``:
-
-    - Sample ``(token, in_tool)``. A changed token refreshes the record's
-      progress timestamp — a child that keeps advancing is never touched, no
-      matter how long it runs.
-    - A frozen token past the idle/in-tool threshold marks the record
-      ``stalling``: we call ``interrupt_fn`` so a responsive-but-slow child
-      can unwind and deliver its (partial) result through the normal
-      ``_finalize`` path with full fidelity.
-    - A ``stalling`` record whose runner still hasn't returned after the
-      grace window is force-finalized with one terminal ``stalled`` event so
-      the owning session hears an outcome and the async slot frees. A late
-      runner return after that is ignored by ``_begin_finalization``.
-    """
-    while not _monitor_stop.wait(_STALE_CHECK_INTERVAL):
-        now = time.time()
-        stalled: List[tuple] = []  # (delegation_id, is_batch, quiet_for, in_tool)
-        expired: List[str] = []  # stalling past grace → force-finalize
-        any_monitorable = False
+    finally:
         with _records_lock:
-            for record in _records.values():
-                status = record.get("status")
-                if status == "stalling":
-                    any_monitorable = True
-                    interrupted_at = record.get("_interrupted_at") or now
-                    if now - interrupted_at >= _STALL_GRACE_SECONDS:
-                        expired.append(record["delegation_id"])
-                    continue
-                if status != "running":
-                    continue
-                progress_fn = record.get("progress_fn")
-                if progress_fn is None:
-                    continue
-                any_monitorable = True
-                try:
-                    token, in_tool = progress_fn()
-                except Exception:
-                    # An unreadable child must not look permanently healthy —
-                    # keep the last timestamp running instead of refreshing it.
-                    token, in_tool = record.get("_progress_token"), False
-                if token != record.get("_progress_token"):
-                    record["_progress_token"] = token
-                    record["_progress_ts"] = now
-                    continue
-                quiet_for = now - (record.get("_progress_ts") or now)
-                limit = (
-                    _STALE_IN_TOOL_SECONDS if in_tool else _STALE_IDLE_SECONDS
-                )
-                if quiet_for >= limit:
-                    record["status"] = "stalling"
-                    record["_interrupted_at"] = now
-                    # Structured stall context for the terminal event and
-                    # status listings (#51690): how long progress was frozen,
-                    # which threshold applied, and whether the child was
-                    # inside a tool when it went quiet.
-                    record["_stall_quiet_seconds"] = round(quiet_for, 2)
-                    record["_stall_threshold_seconds"] = limit
-                    record["_stall_in_tool"] = bool(in_tool)
-                    stalled.append(
-                        (
-                            record["delegation_id"],
-                            bool(record.get("is_batch")),
-                            quiet_for,
-                            in_tool,
-                        )
-                    )
-        for delegation_id, _is_batch, quiet_for, in_tool in stalled:
-            logger.warning(
-                "Async delegation %s made no progress for %.0fs "
-                "(in_tool=%s) — interrupting; grace window %.0fs",
-                delegation_id, quiet_for, in_tool, _STALL_GRACE_SECONDS,
-            )
-            with _records_lock:
-                record = _records.get(delegation_id)
-                fn = record.get("interrupt_fn") if record else None
-            if callable(fn):
-                try:
-                    fn()
-                except Exception as exc:
-                    logger.debug(
-                        "Async delegation %s stall interrupt failed: %s",
-                        delegation_id, exc,
-                    )
-        for delegation_id in expired:
-            _finalize_stalled(delegation_id)
-        if not any_monitorable:
-            return
+            record = _records.get(delegation_id)
+            if record is not None:
+                record["status"] = status
+            _prune_completed_locked()
 
 
-def _finalize_stalled(delegation_id: str) -> None:
-    """Force-finalize a stalling delegation whose runner never returned."""
-    claimed = _begin_finalization(delegation_id)
-    if claimed is None:
-        return
-    event_record, _interrupt_fn = claimed
-
-    completed_at = event_record.get("completed_at") or time.time()
-    duration = round(
-        completed_at - (event_record.get("dispatched_at") or completed_at),
-        2,
-    )
-    quiet_seconds = event_record.get("_stall_quiet_seconds")
-    threshold_seconds = event_record.get("_stall_threshold_seconds")
-    stall_in_tool = event_record.get("_stall_in_tool")
-    error = (
-        f"Async delegation {delegation_id} stalled: the detached subagent "
-        "stopped making progress (no new API calls, tool activity, or "
-        "streamed tokens), did not respond to interruption, and never "
-        "produced a completion event. The worker may be wedged inside a "
-        "model API call — this is a known failure mode of long-lived "
-        "gateway processes (#60203). Re-dispatch the task if it is still "
-        "needed."
-    )
-    logger.error(
-        "Async delegation %s force-finalized as stalled after %.0fs",
-        delegation_id, duration,
-    )
-    # Structured stall metadata (#51690): lets parents and UIs distinguish
-    # a stall-monitor kill from other failures without parsing the error
-    # string, mirroring the sync path's timeout_seconds/timed_out_after_
-    # seconds/timeout_phase fields.
-    stall_meta = {
-        "stalled_after_quiet_seconds": quiet_seconds,
-        "stall_threshold_seconds": threshold_seconds,
-        "stall_phase": (
-            "in_tool" if stall_in_tool
-            else "idle" if stall_in_tool is not None
-            else None
-        ),
-        "stall_grace_seconds": _STALL_GRACE_SECONDS,
-    }
-    if event_record.get("is_batch"):
-        _push_batch_completion_event(
-            event_record,
-            {
-                "results": [],
-                "error": error,
-                "total_duration_seconds": duration,
-                **stall_meta,
-            },
-            "stalled",
-        )
-    else:
-        _push_completion_event(
-            event_record,
-            {
-                "status": "stalled",
-                "summary": None,
-                "error": error,
-                "api_calls": 0,
-                "duration_seconds": duration,
-                "exit_reason": "stalled",
-                **stall_meta,
-            },
-            "stalled",
-        )
-    _finish_finalization(delegation_id, "stalled")
-
-
-def _children_activity_from_token(token: Any, now: float) -> Optional[List]:
-    """Parse a progress token into per-child activity dicts (best-effort).
-
-    delegate_tool's ``_batch_progress`` emits one ``(api_call_count,
-    current_tool, last_activity_ts)`` tuple per child. Foreign token shapes
-    (custom dispatchers) degrade to ``None`` entries rather than raising —
-    the token contract is intentionally opaque to the registry.
-    """
-    try:
-        parts = list(token)
-    except TypeError:
-        return None
-    out: List[Optional[Dict[str, Any]]] = []
-    for part in parts:
-        if isinstance(part, (list, tuple)) and len(part) >= 2:
-            entry: Dict[str, Any] = {
-                "api_calls": part[0],
-                "current_tool": part[1],
-            }
-            if len(part) >= 3 and isinstance(part[2], (int, float)):
-                entry["seconds_since_activity"] = round(
-                    max(0.0, now - float(part[2])), 1
-                )
-            out.append(entry)
-        else:
-            out.append(None)
-    return out
-
-
-def list_async_delegations() -> List[Dict[str, Any]]:
+def list_async_delegations(
+    session_key: Optional[str] = None,
+) -> List[Dict[str, Any]]:
     """Snapshot of async delegations (running + recently completed).
 
     Safe to call from any thread. Excludes the non-serialisable callables
@@ -1451,52 +2004,20 @@ def list_async_delegations() -> List[Dict[str, Any]]:
       ``progress_fn``.
     - ``stalled_after_quiet_seconds`` / ``stall_threshold_seconds`` /
       ``stall_in_tool``: stall context once the monitor has tripped.
+    
+    Optional session_key restricts the snapshot to one authorised session.
     """
-    now = time.time()
-    samplers: Dict[str, Callable] = {}
+    if session_key is not None:
+        return list_durable_delegations(session_keys=[session_key])
     with _records_lock:
-        items = []
-        for r in _records.values():
-            item = {
+        return [
+            {
                 k: v
                 for k, v in r.items()
-                if k not in {"interrupt_fn", "progress_fn"}
-                and not k.startswith("_")
+                if k not in {"interrupt_fn", "_interrupt_lock"}
             }
-            status = r.get("status")
-            if status in ("running", "stalling"):
-                ts = r.get("_progress_ts")
-                if ts:
-                    item["seconds_since_progress"] = round(now - ts, 1)
-                fn = r.get("progress_fn")
-                if callable(fn):
-                    samplers[r["delegation_id"]] = fn
-            if status in ("stalling", "stalled"):
-                for src, dst in (
-                    ("_stall_quiet_seconds", "stalled_after_quiet_seconds"),
-                    ("_stall_threshold_seconds", "stall_threshold_seconds"),
-                    ("_stall_in_tool", "stall_in_tool"),
-                ):
-                    if r.get(src) is not None:
-                        item[dst] = r.get(src)
-            items.append(item)
-
-    # Sample live activity OUTSIDE the lock — progress_fn reads child-agent
-    # attributes and must never run under _records_lock (a slow or broken
-    # sampler would block every dispatch/finalize in the process).
-    for item in items:
-        fn = samplers.get(item.get("delegation_id"))
-        if fn is None:
-            continue
-        try:
-            token, in_tool = fn()
-        except Exception:
-            continue
-        activity = _children_activity_from_token(token, now)
-        if activity is not None:
-            item["children_activity"] = activity
-        item["in_tool"] = bool(in_tool)
-    return items
+            for r in _records.values()
+        ]
 
 
 def interrupt_all(reason: str = "shutdown") -> int:
@@ -1509,8 +2030,7 @@ def interrupt_all(reason: str = "shutdown") -> int:
     count = 0
     with _records_lock:
         targets = [
-            r for r in _records.values()
-            if r.get("status") in ("running", "stalling")
+            r for r in _records.values() if r.get("status") == "running"
         ]
     for r in targets:
         fn = r.get("interrupt_fn")
@@ -1558,12 +2078,11 @@ def interrupt_for_session(
     with _records_lock:
         targets = [
             r for r in _records.values()
-            if r.get("status") in ("running", "stalling")
-            and _matches_session_selectors(
-                r,
-                session_key=session_key,
-                origin_ui_session_id=origin_ui_session_id,
-                parent_session_id=parent_session_id,
+            if r.get("status") == "running"
+            and (
+                (origin_ui_session_id and str(r.get("origin_ui_session_id") or "") == origin_ui_session_id)
+                or (session_key and str(r.get("session_key") or "") == session_key)
+                or (parent_session_id and str(r.get("parent_session_id") or "") == parent_session_id)
             )
         ]
     for r in targets:
@@ -1586,18 +2105,41 @@ def interrupt_for_session(
 
 
 def _reset_for_tests() -> None:
-    """Test-only: clear all state and tear down the executor + monitor."""
-    global _executor, _executor_max_workers, _monitor_thread
+    """Test-only: clear all state and tear down the executor."""
+    global _executor, _executor_max_workers
     with _executor_lock:
         if _executor is not None:
             _executor.shutdown(wait=False)
         _executor = None
         _executor_max_workers = 0
-    _monitor_stop.set()
-    with _monitor_lock:
-        thread = _monitor_thread
-        _monitor_thread = None
-    if thread is not None and thread.is_alive():
-        thread.join(timeout=2)
     with _records_lock:
         _records.clear()
+
+
+def _current_origin_session_id() -> str:
+    """Raw session id of the ORIGINATING api_server request, or ``""``.
+
+    The obvious source — ``HERMES_SESSION_ID`` via ``get_session_env`` — is
+    NOT safe to read at dispatch time: constructing a child agent
+    (``agent/agent_init.py``) calls ``set_current_session_id(child.session_id)``,
+    clobbering that ContextVar *and* ``os.environ`` with the subagent's
+    internal ``{timestamp}_{uuid}`` id moments before the dispatch code reads
+    it, so the completion wake would self-post into the subagent's own
+    (unread) session instead of the spawner's.
+
+    The request-scoped ``HERMES_SESSION_CHAT_ID`` binding survives child
+    construction: ``_bind_api_server_session`` binds ``chat_id`` to the raw
+    ``X-Hermes-Session-Id``, and its only writer is ``set_session_vars`` —
+    ``set_current_session_id`` never touches it. Gate on the platform: on
+    push platforms ``chat_id`` is a chat, not a session, so yield ``""``
+    there.
+    """
+    try:
+        from gateway.session_context import get_session_env
+
+        if get_session_env("HERMES_SESSION_PLATFORM", "") != "api_server":
+            return ""
+        return get_session_env("HERMES_SESSION_CHAT_ID", "") or ""
+    except Exception:
+        return ""
+

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -19,9 +19,12 @@ never the child's intermediate tool calls or reasoning.
 
 import enum
 import contextvars
+import copy
 import json
 import logging
 import re
+import uuid
+from types import SimpleNamespace
 
 logger = logging.getLogger(__name__)
 import os
@@ -151,6 +154,15 @@ _active_subagents_lock = threading.Lock()
 # subagent_id -> mutable record tracking the live child agent.  Stays only
 # for the lifetime of the run; _run_single_child is the owner.
 _active_subagents: Dict[str, Dict[str, Any]] = {}
+_TERMINAL_SUBAGENT_STATUSES = {
+    "completed",
+    "success",
+    "error",
+    "failed",
+    "interrupted",
+    "timeout",
+}
+_LIVE_BEARER_TOKEN_RE = re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]+")
 
 # subagent_id -> {goal, delegation_id, parent_session_id} retained AFTER the
 # child finishes (bounded FIFO). Child-started background processes routinely
@@ -212,9 +224,87 @@ def _register_subagent(record: Dict[str, Any]) -> None:
     sid = record.get("subagent_id")
     if not sid:
         return
+    record.setdefault("events", [])
+    record.setdefault("assistant_text_tail", "")
+    record.setdefault("assistant_text_raw_tail", "")
     record.setdefault("accepting_steer", True)
+    durable_expected = (
+        "delegation_attempt_id" in record or "delegation_run_id" in record
+    )
+    delegation_id = None
+    try:
+        from tools.async_delegation import (
+            register_subagent_lifecycle,
+            take_pending_subagent_interrupt,
+        )
+
+        delegation_id = register_subagent_lifecycle(record)
+        if durable_expected and delegation_id is None:
+            return
+    except Exception:
+        logger.debug("subagent/delegation association failed", exc_info=True)
+        if durable_expected:
+            return
+
     with _active_subagents_lock:
         _active_subagents[sid] = record
+    if delegation_id is not None:
+        pending, reason = take_pending_subagent_interrupt(sid)
+        if pending:
+            outcome = interrupt_subagent_status(sid, reason=reason)
+            if outcome != "interrupt_requested":
+                logger.warning(
+                    "queued interrupt for starting subagent %s resolved as %s",
+                    sid,
+                    outcome,
+                )
+        attempt_id = record.get("delegation_attempt_id")
+        if isinstance(attempt_id, str):
+            forward_pending_subagent_steers(sid, attempt_id)
+
+
+def _unregister_subagent(
+    subagent_id: str, attempt_id: Optional[str] = None, *, agent: Any = None
+) -> None:
+    """Drop a live child, optionally only if it still matches one attempt."""
+    with _active_subagents_lock:
+        record = _active_subagents.get(subagent_id)
+        if record is None:
+            return
+        if agent is not None and record.get("agent") is not agent:
+            return
+        if (
+            attempt_id is not None
+            and record.get("delegation_attempt_id") != attempt_id
+        ):
+            return
+        _active_subagents.pop(subagent_id, None)
+        _retain_recent_subagent(record)
+
+    tail = {
+        "subagent_id": subagent_id,
+        "parent_id": record.get("parent_id"),
+        "depth": record.get("depth"),
+        "goal": record.get("goal"),
+        "model": record.get("model"),
+        "started_at": record.get("started_at"),
+        "status": record.get("status"),
+        "interrupt_reason": record.get("interrupt_reason"),
+        "tool_count": record.get("tool_count", 0),
+        "last_tool": record.get("last_tool", ""),
+        "events": copy.deepcopy(record.get("events") or []),
+        "assistant_text_tail": str(record.get("assistant_text_tail") or ""),
+        "last_activity_at": record.get("last_activity_at"),
+    }
+    for lifecycle_id in ("delegation_attempt_id", "delegation_run_id"):
+        if lifecycle_id in record:
+            tail[lifecycle_id] = record[lifecycle_id]
+    try:
+        from tools.async_delegation import archive_subagent_tail
+
+        archive_subagent_tail(subagent_id, tail)
+    except Exception:
+        logger.debug("subagent tail archival failed", exc_info=True)
 
 
 def _retain_recent_subagent(record: Dict[str, Any]) -> None:
@@ -229,14 +319,6 @@ def _retain_recent_subagent(record: Dict[str, Any]) -> None:
     }
     while len(_recent_subagents) > _RECENT_SUBAGENTS_CAP:
         _recent_subagents.pop(next(iter(_recent_subagents)), None)
-
-
-def _unregister_subagent(subagent_id: str, *, agent: Any = None) -> None:
-    with _active_subagents_lock:
-        record = _active_subagents.get(subagent_id)
-        if record is not None and (agent is None or record.get("agent") is agent):
-            _active_subagents.pop(subagent_id, None)
-            _retain_recent_subagent(record)
 
 
 def _close_subagent_steering(subagent_id: str, agent: Any) -> Optional[str]:
@@ -398,9 +480,24 @@ def _is_descendant_of(child_agent: Any, parent_agent: Any, max_hops: int = 8) ->
     return False
 
 
-# Model-facing control actions accepted by delegate_task(action=...).
-# "spawn" (or omitted) keeps the historical spawn semantics.
-_CONTROL_ACTIONS = frozenset({"list", "steer", "stop"})
+# Live-tree actions accepted by delegate_task(action=...) without a
+# durable delegation_id. Durable wait/resume/interrupt/abandon/status/tail
+# route through the merged control plane below.
+_LIVE_CONTROL_ACTIONS = frozenset({"list", "steer", "stop"})
+_MERGED_CONTROL_ACTIONS = frozenset(
+    {
+        "list",
+        "status",
+        "tail",
+        "wait",
+        "steer",
+        "resume",
+        "interrupt",
+        "stop",
+        "abandon",
+    }
+)
+_CONTROL_ACTIONS = _LIVE_CONTROL_ACTIONS
 
 
 def _resolve_session_lineage(session_id: Optional[str], parent_agent: Any) -> str:
@@ -580,6 +677,64 @@ def _handle_control_action(
         )
 
     return tool_error(f"Unknown action '{action}'. Use spawn, list, steer, or stop.")
+
+
+def _route_delegate_control_action(
+    action: str,
+    *,
+    parent_agent: Any,
+    subagent_id: Optional[str] = None,
+    message: Optional[str] = None,
+    delegation_id: Optional[str] = None,
+    attempt_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    timeout_seconds: Optional[float] = None,
+    limit: Optional[int] = None,
+    cascade: Optional[bool] = None,
+    reason: Optional[str] = None,
+    force: Optional[bool] = None,
+) -> str:
+    """Route a control action to the live tree or the durable lifecycle plane."""
+    has_delegation_id = bool(str(delegation_id or "").strip())
+    live_compatible = action in _LIVE_CONTROL_ACTIONS or (
+        action == "interrupt" and not has_delegation_id and bool(str(subagent_id or "").strip())
+    )
+    if live_compatible and not has_delegation_id:
+        live_action = "stop" if action == "interrupt" else action
+        live = _handle_control_action(live_action, subagent_id, message, parent_agent)
+        if action != "list":
+            return live
+        live_payload = json.loads(live)
+        try:
+            from tools.delegation_control import delegation_control
+
+            durable = json.loads(
+                delegation_control(action="list", parent_agent=parent_agent)
+            )
+            live_payload["delegations"] = durable.get("delegations") or []
+            live_payload["status"] = durable.get("status") or "ok"
+        except Exception:
+            live_payload["delegations"] = []
+            live_payload["status"] = "ok"
+        return json.dumps(live_payload, ensure_ascii=False)
+
+    from tools.delegation_control import delegation_control
+
+    durable_action = "interrupt" if action == "stop" else action
+    return delegation_control(
+        action=durable_action,
+        delegation_id=delegation_id,
+        subagent_id=subagent_id,
+        attempt_id=attempt_id,
+        run_id=run_id,
+        timeout_seconds=timeout_seconds,
+        limit=limit,
+        cascade=cascade,
+        reason=reason,
+        message=message,
+        force=force,
+        parent_agent=parent_agent,
+    )
 
 
 def _extract_output_tail(
@@ -3606,6 +3761,14 @@ def delegate_task(
     subagent_id: Optional[str] = None,
     message: Optional[str] = None,
     parent_agent=None,
+    delegation_id: Optional[str] = None,
+    attempt_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    timeout_seconds: Optional[float] = None,
+    limit: Optional[int] = None,
+    cascade: Optional[bool] = None,
+    reason: Optional[str] = None,
+    force: Optional[bool] = None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks, or control
@@ -3620,6 +3783,9 @@ def delegate_task(
       - action='steer' -> queue course-correction text into a running child
                           (subagent_id + message)
       - action='stop'  -> interrupt a running child early (subagent_id)
+      - action='status' / 'tail' / 'wait' / 'resume' / 'interrupt' /
+        'abandon' require the handle returned by spawn. action='stop'
+        with a delegation_id is an alias for interrupt.
 
     The 'role' parameter controls whether a child can further delegate:
     'leaf' (default) cannot; 'orchestrator' retains the delegation
@@ -3635,13 +3801,25 @@ def delegate_task(
     # They never spawn, so they bypass the pause gate, depth limit, and the
     # async dispatch machinery entirely.
     normalized_action = (action or "").strip().lower()
-    if normalized_action in _CONTROL_ACTIONS:
-        return _handle_control_action(
-            normalized_action, subagent_id, message, parent_agent
+    if normalized_action in _MERGED_CONTROL_ACTIONS:
+        return _route_delegate_control_action(
+            normalized_action,
+            parent_agent=parent_agent,
+            subagent_id=subagent_id,
+            message=message,
+            delegation_id=delegation_id,
+            attempt_id=attempt_id,
+            run_id=run_id,
+            timeout_seconds=timeout_seconds,
+            limit=limit,
+            cascade=cascade,
+            reason=reason,
+            force=force,
         )
     if normalized_action and normalized_action != "spawn":
         return tool_error(
-            f"Unknown action '{action}'. Use spawn (default), list, steer, or stop."
+            f"Unknown action '{action}'. Use spawn (default), list, status, "
+            "tail, wait, steer, resume, interrupt, stop, or abandon."
         )
 
     # Operator-controlled kill switch — lets the TUI freeze new fan-out
@@ -4824,34 +5002,83 @@ DELEGATE_TASK_SCHEMA = {
             },
             "action": {
                 "type": "string",
-                "enum": ["spawn", "list", "steer", "stop"],
+                "enum": [
+                    "spawn",
+                    "list",
+                    "status",
+                    "tail",
+                    "wait",
+                    "steer",
+                    "resume",
+                    "interrupt",
+                    "stop",
+                    "abandon",
+                ],
                 "description": (
                     "Default 'spawn' (omit for normal delegation). Live "
-                    "orchestration of running subagents: 'list' shows this "
-                    "conversation's live children (ids, goals, status, "
-                    "transcript paths); 'steer' queues course-correction text "
-                    "into one child (requires subagent_id + message) without "
-                    "stopping it; 'stop' ends one child early (requires "
-                    "subagent_id) — its partial result still returns as a "
-                    "completion message. Control actions return immediately; "
-                    "goal/tasks are ignored when action is not 'spawn'."
+                    "orchestration: 'list' shows this conversation's live "
+                    "children; 'steer' queues course-correction text "
+                    "(subagent_id + message); 'stop' ends one live child. "
+                    "Durable lifecycle on the same tool: 'status', 'tail', "
+                    "'wait', 'resume', 'interrupt', 'abandon' require the "
+                    "handle returned by spawn. 'stop' with a delegation_id "
+                    "is an alias for interrupt. Control actions return "
+                    "immediately; goal/tasks are ignored when action is "
+                    "not 'spawn'."
                 ),
             },
             "subagent_id": {
                 "type": "string",
                 "description": (
-                    "Target for action='steer'/'stop'. Ids are returned in the "
-                    "spawn dispatch response (subagent_ids) and by "
-                    "action='list'."
+                    "Target child. Required for live steer/stop and for "
+                    "durable steer/resume. Returned in the spawn dispatch "
+                    "response and by action='list'."
                 ),
             },
             "message": {
                 "type": "string",
                 "description": (
-                    "For action='steer': the course correction. Be directive "
-                    "and specific — the child sees it appended to its next "
-                    "tool result mid-run (e.g. \"Stop exploring X; focus on Y "
-                    "and return early results\")."
+                    "For action='steer'/'resume': the course correction or "
+                    "next user instruction. Be directive and specific."
+                ),
+            },
+            "delegation_id": {
+                "type": "string",
+                "description": (
+                    "Handle returned by a spawn. Required for status/tail/"
+                    "wait/resume/interrupt/abandon; omitted for live list/"
+                    "steer/stop."
+                ),
+            },
+            "attempt_id": {
+                "type": "string",
+                "description": "Exact historical attempt selector; accepted only by tail.",
+            },
+            "run_id": {
+                "type": "string",
+                "description": "Exact execution run selector; accepted only by wait.",
+            },
+            "timeout_seconds": {
+                "type": "number",
+                "description": "Bounded wait duration; default 30 seconds. Zero checks immediately.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Recent events returned by tail; default 20.",
+            },
+            "cascade": {
+                "type": "boolean",
+                "description": "Interrupt descendants of the delegation or selected child branch. Defaults true.",
+            },
+            "reason": {
+                "type": "string",
+                "description": "Optional audit reason for interrupt or abandon.",
+            },
+            "force": {
+                "type": "boolean",
+                "description": (
+                    "For steer only: move supported foreground waits to "
+                    "background before delivering the guidance."
                 ),
             },
         },
@@ -4924,3 +5151,293 @@ registry.register(
     emoji="🔀",
     dynamic_schema_overrides=_build_dynamic_schema_overrides,
 )
+
+def build_resumed_child_agent(
+    *,
+    bundle: Dict[str, Any],
+    logical_id: str,
+    goal: str,
+    parent_agent,
+    continuation: Optional[Dict[str, str]] = None,
+):
+    """Reconstruct a child using persisted non-secret policy and live credentials."""
+    metadata = dict(bundle.get("reconstruction_metadata") or {})
+    model = str(metadata.get("model") or "").strip()
+    provider = str(metadata.get("provider") or "").strip()
+    if not model or not provider:
+        raise ValueError("saved child provider/model is unavailable")
+    continuation = continuation or prepare_resumed_child_session(bundle)
+    # Re-resolve credentials and approval policy from current authorized config;
+    # no persisted secret is ever accepted from the resume bundle.
+    credentials = _resolve_delegation_credentials(
+        {"provider": provider, "model": model}, parent_agent
+    )
+    runtime_parent = parent_agent
+    if runtime_parent is None:
+        from hermes_state import SessionDB
+
+        # Durable resume must work after a gateway restart, where the original
+        # parent AIAgent object no longer exists and native tool adapters may not
+        # expose the newly-created controller object. Rebuild only the non-secret
+        # policy surface consumed by _build_child_agent; credentials above were
+        # resolved fresh from the active provider configuration.
+        runtime_parent = SimpleNamespace(
+            session_id=continuation["delegate_from"],
+            _session_db=SessionDB(),
+            model=model,
+            provider=credentials.get("provider") or provider,
+            base_url=credentials.get("base_url"),
+            api_key=credentials.get("api_key"),
+            api_mode=credentials.get("api_mode"),
+            _client_kwargs={
+                key: value
+                for key, value in {
+                    "base_url": credentials.get("base_url"),
+                    "api_key": credentials.get("api_key"),
+                }.items()
+                if value
+            },
+            _delegate_depth=max(0, int(metadata.get("depth") or 1) - 1),
+            _subagent_id=metadata.get("parent_logical_id"),
+            enabled_toolsets=list(metadata.get("enabled_toolsets") or []),
+            disabled_toolsets=list(metadata.get("disabled_toolsets") or []),
+            valid_tool_names=[],
+            reasoning_config=_json_safe_copy(metadata.get("reasoning_config")),
+            _fallback_chain=_json_safe_copy(metadata.get("fallback_routes")) or [],
+            acp_command=credentials.get("command"),
+            acp_args=list(credentials.get("args") or []),
+        )
+    child = _build_child_agent(
+        task_index=0,
+        goal=goal,
+        context=None,
+        toolsets=list(metadata.get("enabled_toolsets") or []),
+        model=model,
+        max_iterations=int(metadata.get("max_iterations") or 50),
+        task_count=1,
+        parent_agent=runtime_parent,
+        override_provider=credentials.get("provider"),
+        override_base_url=credentials.get("base_url"),
+        override_api_key=credentials.get("api_key"),
+        override_api_mode=credentials.get("api_mode"),
+        override_request_overrides=credentials.get("request_overrides"),
+        override_max_tokens=(
+            metadata.get("max_tokens")
+            if isinstance(metadata.get("max_tokens"), int)
+            else credentials.get("max_output_tokens")
+        ),
+        override_acp_command=credentials.get("command"),
+        override_acp_args=credentials.get("args"),
+        role=str(metadata.get("role") or "leaf"),
+    )
+
+    owner = continuation["delegate_from"]
+    prior = continuation["parent_session_id"]
+    session_id = continuation["session_id"]
+    parent_logical_id = metadata.get("parent_logical_id")
+    child.session_id = session_id
+    child._parent_session_id = prior
+    child._subagent_id = logical_id
+    child._parent_subagent_id = (
+        parent_logical_id if isinstance(parent_logical_id, str) else None
+    )
+    if isinstance(metadata.get("depth"), int):
+        child._delegate_depth = metadata["depth"]
+    child._delegate_role = str(metadata.get("role") or "leaf")
+    child._subagent_goal = goal
+    session_ref = {"session_id": session_id}
+    child._delegation_session_ref = session_ref
+    child._delegation_runtime_metadata = {
+        **metadata,
+        "child_session_id": session_id,
+        "parent_session_id": owner,
+        "enabled_toolsets": list(getattr(child, "enabled_toolsets", None) or []),
+        "disabled_toolsets": list(getattr(child, "disabled_toolsets", None) or []),
+        "reasoning_config": _json_safe_copy(
+            getattr(child, "reasoning_config", metadata.get("reasoning_config"))
+        ),
+        "fallback_routes": _json_safe_copy(
+            getattr(child, "_fallback_chain", metadata.get("fallback_routes"))
+        ),
+    }
+    if getattr(child, "_session_init_model_config", None) is not None:
+        child._session_init_model_config["_delegate_from"] = owner
+
+    # Rebuild the callback because the initial builder generated a throwaway
+    # logical/session identity before this exact resumed identity was known.
+    child_progress_cb = _build_child_progress_callback(
+        0,
+        goal,
+        runtime_parent,
+        1,
+        subagent_id=logical_id,
+        parent_id=child._parent_subagent_id,
+        depth=max(0, int(getattr(child, "_delegate_depth", 1)) - 1),
+        model=model,
+        toolsets=list(getattr(child, "enabled_toolsets", None) or []),
+        session_ref=session_ref,
+    )
+    child.tool_progress_callback = child_progress_cb
+    if child_progress_cb:
+        def _resumed_thinking(text: str) -> None:
+            if text:
+                child_progress_cb("_thinking", text)
+
+        child.thinking_callback = _resumed_thinking
+    return child
+
+
+def prepare_resumed_child_session(bundle: Dict[str, Any]) -> Dict[str, str]:
+    """Validate a hydration bundle and allocate a distinct child segment.
+
+    This deliberately does not create the SQLite row. The standard AIAgent
+    persistence path creates/enriches it with the effective current runtime
+    configuration before the first resumed turn is stored.
+    """
+    if not isinstance(bundle, dict):
+        raise ValueError("missing subagent resume bundle")
+    prior = bundle.get("prior_child_session_id")
+    owner = bundle.get("parent_session_id")
+    history = bundle.get("history")
+    metadata = bundle.get("reconstruction_metadata")
+    if (
+        not isinstance(prior, str)
+        or not prior
+        or not isinstance(owner, str)
+        or not owner
+        or not isinstance(history, list)
+        or not history
+        or not isinstance(metadata, dict)
+        or metadata.get("parent_session_id") != owner
+    ):
+        raise ValueError("incomplete subagent resume bundle")
+    return {
+        "session_id": f"{time.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}",
+        "parent_session_id": prior,
+        "delegate_from": owner,
+    }
+
+
+def interrupt_subagent_status(subagent_id: str, reason: str = "") -> str:
+    """Request a cooperative stop and return an honest lifecycle outcome."""
+    with _active_subagents_lock:
+        record = _active_subagents.get(subagent_id)
+        if not record:
+            return "not_live"
+        current_status = str(record.get("status") or "").lower()
+        if current_status in _TERMINAL_SUBAGENT_STATUSES:
+            return "already_terminal"
+        if current_status == "interrupt_requested":
+            return "interrupt_requested"
+        agent = record.get("agent")
+        if agent is None:
+            return "interrupt_failed"
+        record["status"] = "interrupt_requested"
+        if reason:
+            record["interrupt_reason"] = reason
+    try:
+        agent.interrupt(reason or f"Interrupted via TUI ({subagent_id})")
+    except Exception as exc:
+        with _active_subagents_lock:
+            current = _active_subagents.get(subagent_id)
+            if current is not None and current.get("status") == "interrupt_requested":
+                current["status"] = "running"
+        logger.debug("interrupt_subagent(%s) failed: %s", subagent_id, exc)
+        return "interrupt_failed"
+    return "interrupt_requested"
+
+
+def forward_pending_subagent_steers(
+    subagent_id: str,
+    attempt_id: str,
+    *,
+    outcome_sink: Optional[Dict[str, Any]] = None,
+) -> int:
+    """Forward ordered durable mailbox items to one exact live attempt."""
+    if not subagent_id or not attempt_id:
+        return 0
+    with _active_subagents_lock:
+        record = _active_subagents.get(subagent_id)
+        if not record or record.get("delegation_attempt_id") != attempt_id:
+            return 0
+        agent = record.get("agent")
+    steer = getattr(agent, "steer", None)
+    request_durable = getattr(agent, "request_durable_steer", None)
+    request_defined = callable(getattr(type(agent), "request_durable_steer", None)) or callable(
+        getattr(agent, "__dict__", {}).get("request_durable_steer")
+    )
+    if not callable(steer) and not (request_defined and callable(request_durable)):
+        return 0
+
+    try:
+        from tools.async_delegation import _repository
+
+        repository = _repository()
+    except Exception:
+        return 0
+
+    forwarded = 0
+    while True:
+        pending = repository.pending_steers(attempt_id)
+        if not pending:
+            break
+        mailbox_id = str(pending[0]["mailbox_id"])
+        claimed = repository.claim_steer(attempt_id, mailbox_id)
+        if claimed.get("status") != "claimed":
+            break
+
+        def _ack(outcome: str, *, _mailbox_id: str = mailbox_id) -> None:
+            repository.resolve_steer(_mailbox_id, outcome)
+
+        if request_defined and callable(request_durable):
+            outcome = request_durable(
+                str(claimed.get("message") or ""),
+                mailbox_id=mailbox_id,
+                outcome_callback=_ack,
+                force=bool(claimed.get("force")),
+            )
+            outcome = outcome if isinstance(outcome, dict) else {"status": "rejected"}
+            if outcome_sink is not None:
+                outcome_sink[mailbox_id] = dict(outcome)
+            status = str(outcome.get("status") or "rejected")
+            accepted = status == "accepted"
+        else:
+            accepted = bool(
+                steer(
+                    str(claimed.get("message") or ""),
+                    mailbox_id=mailbox_id,
+                    outcome_callback=_ack,
+                )
+            )
+            status = "accepted" if accepted else "too_late_after_completion"
+        if not accepted:
+            if status in {"foreground_wait", "force_background_failed"}:
+                repository.resolve_steer(mailbox_id, status)
+                continue
+            repository.resolve_steer(mailbox_id, "too_late_after_completion")
+            break
+        repository.mark_steer_forwarded(mailbox_id)
+        forwarded += 1
+    return forwarded
+
+
+def redact_observable_text(value: Any) -> str:
+    """Force-redact model-facing delegation observations, failing closed."""
+    text = _stringify_tool_content(value)
+    try:
+        from agent.redact import redact_sensitive_text
+
+        redacted = redact_sensitive_text(text, force=True)
+        return _LIVE_BEARER_TOKEN_RE.sub("Bearer [REDACTED]", redacted)
+    except Exception:
+        logger.debug("observable text secret redaction failed", exc_info=True)
+        return "[REDACTION UNAVAILABLE]"
+
+
+def _json_safe_copy(value: Any) -> Any:
+    """Return a detached JSON value or ``None`` for runtime-only objects."""
+    try:
+        return json.loads(json.dumps(value))
+    except (TypeError, ValueError, OverflowError):
+        return None
+

--- a/tools/delegation_control.py
+++ b/tools/delegation_control.py
@@ -1,0 +1,646 @@
+#!/usr/bin/env python3
+"""Internal durable lifecycle controls used by delegate_task(action=...)."""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Any, Dict, List, Optional
+
+from tools import async_delegation as _async
+from tools import delegate_tool as _delegate
+from tools.approval import get_current_session_key
+
+_ACTIONS = {"list", "status", "tail", "wait", "steer", "resume", "interrupt", "abandon"}
+_TOOL_FIELDS = {
+    "action",
+    "delegation_id",
+    "subagent_id",
+    "attempt_id",
+    "run_id",
+    "timeout_seconds",
+    "limit",
+    "cascade",
+    "reason",
+    "message",
+    "force",
+}
+_ACTION_FIELDS = {
+    "list": set(),
+    "status": {"delegation_id", "subagent_id"},
+    "tail": {"delegation_id", "subagent_id", "attempt_id", "limit"},
+    "wait": {"delegation_id", "run_id", "timeout_seconds"},
+    "steer": {"delegation_id", "subagent_id", "message", "force"},
+    "resume": {"delegation_id", "subagent_id", "message"},
+    "interrupt": {"delegation_id", "subagent_id", "cascade", "reason"},
+    "abandon": {"delegation_id", "cascade", "reason"},
+}
+_MAX_WAIT_SECONDS = 300.0
+_MAX_TAIL_EVENTS = 64
+_MAX_REASON_CHARS = 1000
+_MAX_STEER_CHARS = 12000
+_MAX_ID_CHARS = 200
+
+
+def _invalid(action: str, error: str) -> str:
+    return json.dumps(
+        {"action": action or "delegation", "status": "invalid_arguments", "error": error},
+        ensure_ascii=False,
+    )
+
+
+def _resolve_session_key(session_key: Optional[str]) -> str:
+    if session_key is not None:
+        return session_key
+    return get_current_session_key(default="")
+
+
+def _control_session_candidates(session_key: str) -> List[str]:
+    """Exact controller plus proven compression ancestors, fail-closed."""
+    if not session_key:
+        return [session_key]
+    try:
+        from hermes_state import SessionDB
+
+        candidates = SessionDB().control_session_candidates(session_key)
+    except Exception:
+        candidates = []
+    return candidates or [session_key]
+
+
+def _redact_reason(reason: Optional[str]) -> str:
+    text = str(reason or "")
+    return _delegate.redact_observable_text(text) if text else ""
+
+
+def _validate(
+    *,
+    action: str,
+    delegation_id: Optional[str],
+    subagent_id: Optional[str],
+    attempt_id: Optional[str],
+    run_id: Optional[str],
+    timeout_seconds: Optional[float],
+    limit: Optional[int],
+    cascade: Optional[bool],
+    reason: Optional[str],
+    message: Optional[str],
+    force: Optional[bool],
+) -> Optional[str]:
+    if action not in _ACTIONS:
+        return f"Unknown action {action!r}; expected one of {sorted(_ACTIONS)}."
+    supplied = {
+        key
+        for key, value in {
+            "delegation_id": delegation_id,
+            "subagent_id": subagent_id,
+            "attempt_id": attempt_id,
+            "run_id": run_id,
+            "timeout_seconds": timeout_seconds,
+            "limit": limit,
+            "cascade": cascade,
+            "reason": reason,
+            "message": message,
+            "force": force,
+        }.items()
+        if value is not None
+    }
+    disallowed = sorted(supplied - _ACTION_FIELDS[action])
+    if disallowed:
+        return f"Action {action!r} does not accept: {', '.join(disallowed)}."
+    for name, value in (
+        ("delegation_id", delegation_id),
+        ("subagent_id", subagent_id),
+        ("attempt_id", attempt_id),
+        ("run_id", run_id),
+    ):
+        if value is not None and not isinstance(value, str):
+            return f"{name} must be a string."
+        if isinstance(value, str) and len(value) > _MAX_ID_CHARS:
+            return f"{name} must not exceed {_MAX_ID_CHARS} characters."
+    if action != "list" and not str(delegation_id or "").strip():
+        return f"Action {action!r} requires delegation_id."
+    if subagent_id is not None and not subagent_id.strip():
+        return "subagent_id must not be empty."
+    if attempt_id is not None and not attempt_id.strip():
+        return "attempt_id must not be empty."
+    if run_id is not None and not run_id.strip():
+        return "run_id must not be empty."
+    if action in {"steer", "resume"} and not str(subagent_id or "").strip():
+        return f"Action {action!r} requires subagent_id."
+    if message is not None and not isinstance(message, str):
+        return "message must be a string."
+    if action in {"steer", "resume"} and not str(message or "").strip():
+        return f"Action {action!r} requires a non-empty message."
+    if isinstance(message, str) and len(message) > _MAX_STEER_CHARS:
+        return f"message must not exceed {_MAX_STEER_CHARS} characters."
+    if timeout_seconds is not None:
+        if isinstance(timeout_seconds, bool) or not isinstance(timeout_seconds, (int, float)):
+            return "timeout_seconds must be a number."
+        timeout_value = float(timeout_seconds)
+        if not math.isfinite(timeout_value):
+            return "timeout_seconds must be finite."
+        if timeout_value < 0:
+            return "timeout_seconds must be non-negative."
+        if timeout_value > _MAX_WAIT_SECONDS:
+            return f"timeout_seconds must not exceed {int(_MAX_WAIT_SECONDS)}."
+    if limit is not None:
+        if isinstance(limit, bool) or not isinstance(limit, int):
+            return "limit must be an integer."
+        if limit < 1:
+            return "limit must be at least 1."
+        if limit > _MAX_TAIL_EVENTS:
+            return f"limit must not exceed {_MAX_TAIL_EVENTS}."
+    if cascade is not None and not isinstance(cascade, bool):
+        return "cascade must be a boolean."
+    if force is not None and not isinstance(force, bool):
+        return "force must be a boolean."
+    if reason is not None and not isinstance(reason, str):
+        return "reason must be a string."
+    if reason is not None and len(reason) > _MAX_REASON_CHARS:
+        return f"reason must not exceed {_MAX_REASON_CHARS} characters."
+    return None
+
+
+def _active_children(delegation_id: str, *, session_key: str) -> List[Dict[str, Any]]:
+    children = []
+    for child in _delegate.list_active_subagents():
+        child_id = str(child.get("subagent_id") or "")
+        if child_id and _async.delegation_contains_subagent(
+            delegation_id, child_id, session_key=session_key
+        ):
+            children.append(child)
+    return children
+
+
+def _safe_activity(value: Any) -> Optional[Dict[str, Any]]:
+    """Expose operational counters only; never provider reasoning payloads."""
+    if not isinstance(value, dict):
+        return None
+    allowed = {
+        "last_activity_ts",
+        "last_activity_desc",
+        "seconds_since_activity",
+        "current_tool",
+        "api_call_count",
+        "max_iterations",
+        "budget_used",
+        "budget_max",
+    }
+    return {key: value.get(key) for key in allowed if value.get(key) is not None}
+
+
+def _children_for_record(
+    record: Dict[str, Any],
+    *,
+    session_key: str,
+    subagent_id: Optional[str] = None,
+    include_tail: bool = False,
+    include_live: bool = True,
+    limit: int = 20,
+) -> List[Dict[str, Any]]:
+    delegation_id = str(record.get("delegation_id") or "")
+    pending_interrupt_ids = _async.pending_subagent_interrupt_ids(
+        delegation_id, session_key=session_key
+    )
+    by_id: Dict[str, Dict[str, Any]] = {}
+
+    for child_id, archived in (record.get("children") or {}).items():
+        if not isinstance(child_id, str):
+            continue
+        item = dict(archived) if isinstance(archived, dict) else {}
+        item["subagent_id"] = child_id
+        item["live"] = False
+        by_id[child_id] = item
+
+    if include_live:
+        for active in _active_children(delegation_id, session_key=session_key):
+            child_id = str(active.get("subagent_id") or "")
+            active = dict(active)
+            active["live"] = True
+            by_id[child_id] = {**by_id.get(child_id, {}), **active}
+
+    roots = list(record.get("root_subagent_ids") or [])
+    for child_id in roots:
+        by_id.setdefault(
+            child_id,
+            {
+                "subagent_id": child_id,
+                "status": (
+                    "interrupt_requested"
+                    if child_id in pending_interrupt_ids
+                    else (
+                        "starting"
+                        if record.get("worker_status") in _async._ACTIVE_STATES
+                        else record.get("worker_status")
+                    )
+                ),
+                "live": False,
+            },
+        )
+
+    if subagent_id:
+        branch_ids = {subagent_id}
+        changed = True
+        while changed:
+            changed = False
+            for child_id, child in by_id.items():
+                if child_id not in branch_ids and child.get("parent_id") in branch_ids:
+                    branch_ids.add(child_id)
+                    changed = True
+        by_id = {child_id: child for child_id, child in by_id.items() if child_id in branch_ids}
+
+    root_order = {child_id: index for index, child_id in enumerate(roots)}
+    children = sorted(
+        by_id.values(),
+        key=lambda item: (
+            int(item.get("depth") or 0),
+            root_order.get(item.get("subagent_id"), len(root_order)),
+            float(item.get("started_at") or item.get("last_activity_at") or 0),
+            str(item.get("subagent_id") or ""),
+        ),
+    )
+
+    output = []
+    for child in children:
+        item = {
+            key: child.get(key)
+            for key in (
+                "subagent_id",
+                "parent_id",
+                "depth",
+                "goal",
+                "model",
+                "started_at",
+                "status",
+                "attempt_id",
+                "attempt_number",
+                "run_id",
+                "resume_available",
+                "suggested_action",
+                "interrupt_reason",
+                "tool_count",
+                "last_tool",
+                "last_activity_at",
+                "live",
+            )
+            if child.get(key) is not None
+        }
+        activity = _safe_activity(child.get("activity"))
+        if activity:
+            item["activity"] = activity
+        authority_audit = child.get("authority_audit")
+        if isinstance(authority_audit, dict):
+            item["authority_audit"] = dict(authority_audit)
+        steers = child.get("steers")
+        if isinstance(steers, list) and steers:
+            item["steers"] = [dict(steer) for steer in steers[-20:] if isinstance(steer, dict)]
+        if include_tail:
+            item["assistant_text_tail"] = _delegate.redact_observable_text(
+                child.get("assistant_text_tail") or ""
+            )
+            raw_events = child.get("events")
+            events: List[Any] = raw_events if isinstance(raw_events, list) else []
+            # The producer only stores tool.started/tool.completed. Re-filter the
+            # archive so legacy reasoning records can never cross this boundary.
+            item["events"] = [
+                event
+                for event in events
+                if isinstance(event, dict)
+                and event.get("type") in {"tool.started", "tool.completed"}
+            ][-limit:]
+        output.append(item)
+    return output
+
+
+def _not_found(action: str, delegation_id: str) -> str:
+    return json.dumps(
+        {"action": action, "status": "not_found", "delegation_id": delegation_id},
+        ensure_ascii=False,
+    )
+
+
+def delegation_control(
+    *,
+    action: str,
+    delegation_id: Optional[str] = None,
+    subagent_id: Optional[str] = None,
+    attempt_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    timeout_seconds: Optional[float] = None,
+    limit: Optional[int] = None,
+    cascade: Optional[bool] = None,
+    reason: Optional[str] = None,
+    message: Optional[str] = None,
+    force: Optional[bool] = None,
+    session_key: Optional[str] = None,
+    parent_agent=None,
+) -> str:
+    """Execute one session-scoped delegation lifecycle action."""
+    if not isinstance(action, str):
+        return _invalid("delegation", "action must be a string.")
+    action = action.strip().lower()
+    error = _validate(
+        action=action,
+        delegation_id=delegation_id,
+        subagent_id=subagent_id,
+        attempt_id=attempt_id,
+        run_id=run_id,
+        timeout_seconds=timeout_seconds,
+        limit=limit,
+        cascade=cascade,
+        reason=reason,
+        message=message,
+        force=force,
+    )
+    if error:
+        return _invalid(action, error)
+
+    caller_session = _resolve_session_key(session_key)
+    owner_candidates = _control_session_candidates(caller_session)
+    origin = caller_session
+    audit_reason = _redact_reason(reason)
+
+    if action == "list":
+        delegations = []
+        for record in _async.list_durable_delegations(session_keys=owner_candidates):
+            record_origin = str(record.get("session_key") or "")
+            delegations.append(
+                {
+                    "delegation_id": record.get("delegation_id"),
+                    "goal": record.get("goal"),
+                    "count": len(record.get("goals") or [record.get("goal")]),
+                    "worker_status": record.get("worker_status"),
+                    "delivery_disposition": record.get("delivery_disposition"),
+                    "dispatched_at": record.get("dispatched_at"),
+                    "completed_at": record.get("completed_at"),
+                    "subagents": _children_for_record(
+                        record, session_key=record_origin, include_tail=False
+                    ),
+                }
+            )
+        return json.dumps(
+            {"action": action, "status": "ok", "delegations": delegations},
+            ensure_ascii=False,
+        )
+
+    target = str(delegation_id or "").strip()
+    child_target = subagent_id.strip() if isinstance(subagent_id, str) else None
+    record = None
+    for owner_candidate in owner_candidates:
+        record = _async.get_async_delegation(target, session_key=owner_candidate)
+        if record is not None:
+            origin = owner_candidate
+            break
+    if record is None:
+        return _not_found(action, target)
+    if child_target and not _async.delegation_contains_subagent(
+        target, child_target, session_key=origin
+    ):
+        return _not_found(action, target)
+
+    selected_attempt = (
+        attempt_id.strip() if isinstance(attempt_id, str) else None
+    )
+    if action == "tail" and selected_attempt:
+        historical = _async.get_async_delegation_attempt(
+            target, selected_attempt, session_key=origin
+        )
+        if historical is None:
+            return _not_found(action, target)
+        historical_child_ids = list((historical.get("children") or {}).keys())
+        if child_target and child_target not in historical_child_ids:
+            return _not_found(action, target)
+        record = historical
+        if not child_target and historical_child_ids:
+            child_target = historical_child_ids[0]
+
+    if action in {"status", "tail"}:
+        include_tail = action == "tail"
+        event_limit = min(_MAX_TAIL_EVENTS, int(limit or 20))
+        payload = {
+            "action": action,
+            "status": record.get("worker_status"),
+            "delegation_id": target,
+            "worker_status": record.get("worker_status"),
+            "delivery_disposition": record.get("delivery_disposition"),
+            "goal": record.get("goal"),
+            "dispatched_at": record.get("dispatched_at"),
+            "completed_at": record.get("completed_at"),
+            "result_available": record.get("result") is not None,
+            "run_id": record.get("run_id"),
+            "latest_run_id": record.get("latest_run_id"),
+            "active_run_id": record.get("active_run_id"),
+            "pending_run_count": record.get("pending_run_count", 0),
+            "interrupt_reason": record.get("interrupt_reason"),
+            "abandon_reason": record.get("abandon_reason"),
+            "subagents": _children_for_record(
+                record,
+                session_key=origin,
+                subagent_id=child_target,
+                include_tail=include_tail,
+                include_live=not bool(selected_attempt),
+                limit=event_limit,
+            ),
+        }
+        return json.dumps(payload, ensure_ascii=False)
+
+    if action == "wait":
+        waited = _async.wait_for_delegation(
+            target,
+            session_key=origin,
+            timeout_seconds=30.0 if timeout_seconds is None else float(timeout_seconds),
+            run_id=run_id.strip() if isinstance(run_id, str) else None,
+        )
+        if waited.get("status") == "not_found":
+            return _not_found(action, target)
+        payload = {
+            "action": action,
+            "status": waited.get("status"),
+            "delegation_id": target,
+            "worker_status": waited.get("worker_status"),
+            "delivery_disposition": waited.get("delivery_disposition"),
+            "claimed_delivery": bool(waited.get("claimed_delivery", False)),
+            "run_id": waited.get("run_id"),
+            "latest_run_id": waited.get("latest_run_id"),
+            "active_run_id": waited.get("active_run_id"),
+            "pending_run_count": waited.get("pending_run_count", 0),
+            "result": waited.get("result"),
+            "subagents": _children_for_record(
+                waited, session_key=origin, include_tail=True, limit=20
+            ),
+        }
+        if isinstance(waited.get("foreground_handoff"), dict):
+            payload["foreground_handoff"] = waited["foreground_handoff"]
+        return json.dumps(payload, ensure_ascii=False)
+
+    if action == "steer":
+        queued = _async.enqueue_subagent_steer(
+            target,
+            str(child_target),
+            session_key=origin,
+            message=str(message).strip(),
+            force=bool(force),
+        )
+        if queued.get("status") != "accepted":
+            payload = {
+                "action": action,
+                "status": queued.get("status"),
+                "delegation_id": target,
+                "subagent_id": child_target,
+            }
+            if queued.get("terminal_status"):
+                payload["terminal_status"] = queued.get("terminal_status")
+            return json.dumps(payload, ensure_ascii=False)
+
+        steer_outcomes: Dict[str, Any] = {}
+        _delegate.forward_pending_subagent_steers(
+            str(child_target),
+            str(queued["attempt_id"]),
+            outcome_sink=steer_outcomes,
+        )
+        mailbox = _async.inspect_subagent_steer(str(queued["mailbox_id"]))
+        mailbox_status = str(mailbox.get("status") or "pending")
+        honest_status = (
+            mailbox_status
+            if mailbox_status in {
+                "superseded_by_interrupt",
+                "too_late_after_completion",
+                "foreground_wait",
+                "force_background_failed",
+            }
+            else "accepted"
+        )
+        payload = {
+            "action": action,
+            "status": honest_status,
+            "delegation_id": target,
+            "subagent_id": child_target,
+            "attempt_id": queued.get("attempt_id"),
+            "mailbox_id": queued.get("mailbox_id"),
+            "steer_status": mailbox_status,
+            "force": bool(force),
+        }
+        exact_outcome = steer_outcomes.get(str(queued["mailbox_id"])) or {}
+        if exact_outcome.get("wait_kinds"):
+            payload["wait_kinds"] = exact_outcome["wait_kinds"]
+        if exact_outcome.get("errors"):
+            payload["errors"] = exact_outcome["errors"]
+        if mailbox_status == "foreground_wait":
+            payload["hint"] = (
+                "Retry this steer with force=true to move the foreground wait "
+                "to background."
+            )
+        return json.dumps(payload, ensure_ascii=False)
+
+    if action == "resume":
+        resumed = _async.dispatch_resumed_subagent(
+            target,
+            str(child_target),
+            session_key=origin,
+            message=str(message).strip(),
+            parent_agent=parent_agent,
+        )
+        payload = {
+            "action": action,
+            **{
+                key: value
+                for key, value in resumed.items()
+                if key not in {"bundle", "error"}
+            },
+        }
+        if resumed.get("error"):
+            payload["error"] = _redact_reason(str(resumed["error"]))
+        return json.dumps(payload, ensure_ascii=False)
+
+    use_cascade = True if cascade is None else cascade
+    if not use_cascade:
+        return json.dumps(
+            {
+                "action": action,
+                "status": "unsupported_mode",
+                "delegation_id": target,
+                "error": (
+                    "cascade=false is unsupported: AIAgent.interrupt() is "
+                    "cooperative and necessarily propagates through the targeted branch."
+                ),
+            },
+            ensure_ascii=False,
+        )
+
+    if action == "interrupt":
+        if child_target:
+            # Persist the exact-attempt interrupt first so it wins races with
+            # pending/forwarding steer mailboxes and survives process loss.
+            durable_outcome = _async.request_pending_subagent_interrupt(
+                target,
+                child_target,
+                session_key=origin,
+                reason=audit_reason,
+            )
+            if durable_outcome == "not_found":
+                return _not_found(action, target)
+            live_outcome = _delegate.interrupt_subagent_status(
+                child_target, reason=audit_reason
+            )
+            outcome = (
+                live_outcome
+                if live_outcome not in {"not_live", "already_terminal"}
+                else durable_outcome
+            )
+            current = _async.get_async_delegation(target, session_key=origin) or record
+            current_child = (current.get("children") or {}).get(child_target, {})
+            payload = {
+                "action": action,
+                "status": outcome,
+                "delegation_id": target,
+                "subagent_id": child_target,
+                "attempt_id": current_child.get("attempt_id"),
+                "run_id": current_child.get("run_id"),
+                "cascade": True,
+                "delivery_disposition": current.get("delivery_disposition"),
+                "reason": audit_reason,
+            }
+        else:
+            payload = _async.interrupt_async_delegation(
+                target, session_key=origin, reason=audit_reason
+            )
+            payload["action"] = action
+            payload["cascade"] = True
+            payload["reason"] = audit_reason
+            current = _async.get_async_delegation(target, session_key=origin)
+            if current is not None:
+                payload["delivery_disposition"] = current.get("delivery_disposition")
+        return json.dumps(payload, ensure_ascii=False)
+
+    payload = _async.abandon_async_delegation(
+        target, session_key=origin, reason=audit_reason
+    )
+    payload["action"] = action
+    payload["cascade"] = True
+    payload["reason"] = audit_reason
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _handle_delegation_args(args: Dict[str, Any], *, parent_agent=None) -> str:
+    if not isinstance(args, dict):
+        return _invalid("delegation", "arguments must be an object.")
+    unknown = sorted(set(args) - _TOOL_FIELDS)
+    if unknown:
+        raw_action = args.get("action")
+        action = raw_action.strip().lower() if isinstance(raw_action, str) else "delegation"
+        return _invalid(action, f"Unknown argument(s): {', '.join(unknown)}.")
+    return delegation_control(
+        action=args.get("action", ""),
+        delegation_id=args.get("delegation_id"),
+        subagent_id=args.get("subagent_id"),
+        attempt_id=args.get("attempt_id"),
+        run_id=args.get("run_id"),
+        timeout_seconds=args.get("timeout_seconds"),
+        limit=args.get("limit"),
+        cascade=args.get("cascade"),
+        reason=args.get("reason"),
+        message=args.get("message"),
+        force=args.get("force"),
+        parent_agent=parent_agent,
+    )

--- a/tools/delegation_repository.py
+++ b/tools/delegation_repository.py
@@ -1,0 +1,1486 @@
+"""Normalized durable authority for asynchronous delegation lifecycle state."""
+
+from __future__ import annotations
+import json
+import sqlite3
+import threading
+import time
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Mapping, Optional
+from hermes_state import apply_wal_with_fallback, ensure_state_schema
+
+_ACTIVE_STATES = {"starting", "running", "finalizing", "interrupt_requested"}
+_TERMINAL_DELIVERY_STATES = {"delivered", "consumed", "suppressed"}
+_DELIVERY_STATES = _TERMINAL_DELIVERY_STATES | {"pending", "held_by_wait", "delivering"}
+_TERMINAL_ATTEMPT_STATES = {"completed", "error", "interrupted", "timeout"}
+_SCHEMA_READY: set[str] = set()
+_MATERIALIZED_READY: set[str] = set()
+_BOOTSTRAP_LOCK = threading.Lock()
+
+
+def _json(raw: Any, default: Any) -> Any:
+    try:
+        value = json.loads(raw) if isinstance(raw, str) else raw
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return default
+    return value if isinstance(value, type(default)) else default
+
+
+def _dump(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+
+def _authority_is_tombstoned(spec_json: Any) -> bool:
+    spec = _json(spec_json, {})
+    authority = spec.get("authority")
+    if authority is None:
+        return False
+    if not isinstance(authority, dict):
+        return True
+    state = authority.get("state")
+    if not isinstance(state, dict):
+        return True
+    return bool(state.get("revoked")) or bool(state.get("cleaned"))
+
+
+def _attempt_state(value: Any) -> str:
+    state = str(value or "").lower()
+    if state in _ACTIVE_STATES:
+        return state
+    if state in {"completed", "success"}:
+        return "completed"
+    if state in {"error", "failed", "budget_exhausted"}:
+        return "error"
+    if state in {"interrupted", "cancelled"}:
+        return "interrupted"
+    if state == "timeout":
+        return "timeout"
+    return "unknown"
+
+
+def _external_authority_projection(snapshot: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove canonical authority from a lifecycle snapshot.
+
+    Repository storage remains the trusted resume authority.  Every ordinary
+    snapshot is instead shaped into an audit-only view whose cleanup state is
+    derived from the current durable attempt, not from the immutable logical
+    spec captured when the child was admitted.
+    """
+
+    def delegation_authority_audit_view(raw):
+        return {"outcome": {}, "state": {}}
+
+    children = snapshot.get("children")
+    if not isinstance(children, dict):
+        return snapshot
+    for child in children.values():
+        if not isinstance(child, dict) or "authority" not in child:
+            continue
+        raw = child.pop("authority")
+        if isinstance(raw, Mapping):
+            audit = delegation_authority_audit_view(raw)
+        else:
+            audit = {"outcome": {}, "state": {}}
+        status = str(child.get("status") or "unknown")
+        terminal = status in _TERMINAL_ATTEMPT_STATES
+        cleanup_failed = child.get("exit_reason") == "cleanup_error"
+        raw_state = raw.get("state") if isinstance(raw, Mapping) else None
+        raw_state = raw_state if isinstance(raw_state, Mapping) else {}
+        effective_revoked = bool(raw_state.get("revoked")) or terminal
+        effective_cleaned = bool(raw_state.get("cleaned")) or (
+            terminal and not cleanup_failed
+        )
+        if cleanup_failed:
+            cleanup_outcome = "failed"
+        elif effective_cleaned:
+            cleanup_outcome = "succeeded"
+        elif effective_revoked:
+            cleanup_outcome = "revoked_pending"
+        else:
+            cleanup_outcome = "pending"
+        outcome = audit.get("outcome")
+        outcome = dict(outcome) if isinstance(outcome, Mapping) else {}
+        outcome.update(execution=status, cleanup=cleanup_outcome)
+        audit["outcome"] = outcome
+        audit["state"] = {
+            "revoked": effective_revoked,
+            "cleaned": effective_cleaned,
+        }
+        child["authority_audit"] = audit
+    return snapshot
+
+
+def _new_id(kind: str) -> str:
+    return f"{kind}_{uuid.uuid4().hex}"
+
+
+class DelegationRepository:
+    """Own connections, migration, lifecycle CAS operations, and projection."""
+
+    def __init__(self, db_path: Path):
+        self.db_path = Path(db_path)
+
+    def _connect(self) -> sqlite3.Connection:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        key = str(self.db_path.resolve())
+        for attempt in range(20):
+            conn = sqlite3.connect(str(self.db_path), timeout=10, isolation_level=None, check_same_thread=False)
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA busy_timeout=10000")
+            try:
+                apply_wal_with_fallback(conn, db_label=str(self.db_path))
+                conn.execute("PRAGMA foreign_keys=ON")
+                if key not in _SCHEMA_READY or key not in _MATERIALIZED_READY:
+                    with _BOOTSTRAP_LOCK:
+                        if key not in _SCHEMA_READY:
+                            ensure_state_schema(conn)
+                            _SCHEMA_READY.add(key)
+                        if key not in _MATERIALIZED_READY:
+                            conn.execute("BEGIN IMMEDIATE")
+                            try:
+                                ids = conn.execute("SELECT delegation_id FROM async_delegations WHERE lifecycle_version=1").fetchall()
+                                for row in ids:
+                                    self._materialize(conn, str(row[0]))
+                                conn.commit()
+                                _MATERIALIZED_READY.add(key)
+                            except BaseException:
+                                conn.rollback()
+                                raise
+                return conn
+            except sqlite3.OperationalError as exc:
+                conn.close()
+                if "locked" not in str(exc).lower() or attempt == 19:
+                    raise
+                time.sleep(0.02 * (attempt + 1))
+        raise AssertionError("unreachable")
+
+    @contextmanager
+    def write_txn(self) -> Iterator[sqlite3.Connection]:
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            yield conn
+            conn.commit()
+        except BaseException:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def _materialize(self, conn: sqlite3.Connection, delegation_id: str) -> str:
+        row = conn.execute("SELECT * FROM async_delegations WHERE delegation_id=?", (delegation_id,)).fetchone()
+        if row is None:
+            return "not_found"
+        if int(row["lifecycle_version"] or 1) == 2:
+            return "already_materialized"
+        run_id = _new_id("run")
+        delivery = str(row["delivery_state"] or "pending")
+        if delivery not in _DELIVERY_STATES:
+            delivery = "pending"
+        if delivery == "pending" and row["delivery_claim"] is not None:
+            delivery = "delivering"
+        conn.execute(
+            "INSERT INTO delegation_runs\n               (run_id,delegation_id,run_number,kind,created_at,completed_at,\n                event_json,result_json,delivery_state,delivery_claim,\n                delivery_claimed_at,delivery_attempts,delivered_at)\n               VALUES (?,?,1,'initial',?,?,?,?,?,?,?,?,?)",
+            (
+                run_id,
+                delegation_id,
+                float(row["dispatched_at"]),
+                row["completed_at"],
+                row["event_json"],
+                row["result_json"],
+                delivery,
+                row["delivery_claim"],
+                row["delivery_claimed_at"],
+                int(row["delivery_attempts"] or 0),
+                row["delivered_at"],
+            ),
+        )
+        roots = [v for v in _json(row["root_subagent_ids_json"], []) if isinstance(v, str)]
+        children = _json(row["children_json"], {})
+        logical_ids = list(dict.fromkeys(roots + list(children)))
+        for logical_id in logical_ids:
+            child = children.get(logical_id) if isinstance(children.get(logical_id), dict) else {}
+            conn.execute(
+                "INSERT INTO delegation_logical_subagents\n                   (logical_id,delegation_id,parent_logical_id,root_ordinal,\n                    spec_json,created_at,updated_at) VALUES (?,?,NULL,?,?,?,?)",
+                (
+                    logical_id,
+                    delegation_id,
+                    roots.index(logical_id) if logical_id in roots else None,
+                    _dump(child),
+                    float(row["dispatched_at"]),
+                    float(row["updated_at"]),
+                ),
+            )
+            state = _attempt_state(child.get("status"))
+            active = state in _ACTIVE_STATES
+            conn.execute(
+                "INSERT INTO delegation_attempts\n                   (attempt_id,logical_id,run_id,attempt_number,physical_worker_id,\n                    state,owner_pid,owner_started_at,created_at,started_at,\n                    completed_at,updated_at,metadata_json,interrupt_reason,\n                    interrupt_requested_at)\n                   VALUES (?,?,?,1,?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    _new_id("attempt"),
+                    logical_id,
+                    run_id,
+                    logical_id,
+                    state,
+                    row["owner_pid"] if active else None,
+                    row["owner_started_at"] if active else None,
+                    float(row["dispatched_at"]),
+                    child.get("started_at"),
+                    None if active else row["completed_at"] or row["updated_at"],
+                    float(row["updated_at"]),
+                    "{}",
+                    child.get("interrupt_reason"),
+                    row["updated_at"] if state == "interrupt_requested" else None,
+                ),
+            )
+        known = set(logical_ids)
+        for logical_id in logical_ids:
+            child = children.get(logical_id) if isinstance(children.get(logical_id), dict) else {}
+            parent = child.get("parent_id")
+            if parent in known:
+                conn.execute("UPDATE delegation_logical_subagents SET parent_logical_id=? WHERE logical_id=?", (parent, logical_id))
+        conn.execute("UPDATE async_delegations SET lifecycle_version=2 WHERE delegation_id=? AND lifecycle_version=1", (delegation_id,))
+        return "materialized"
+
+    def register_initial_dispatch(
+        self, record: Dict[str, Any], *, owner_pid: Optional[int] = None, owner_started_at: Optional[int] = None
+    ) -> Dict[str, Any]:
+        roots = [v for v in record.get("root_subagent_ids", []) if isinstance(v, str) and v]
+        run_id = str(record.get("run_id") or _new_id("run"))
+        supplied_mapping = record.get("attempt_ids_by_logical_id")
+        if supplied_mapping is not None:
+            if (
+                not isinstance(supplied_mapping, dict)
+                or set(supplied_mapping) != set(roots)
+                or not all(
+                    isinstance(value, str) and value
+                    for value in supplied_mapping.values()
+                )
+                or len(set(supplied_mapping.values())) != len(roots)
+            ):
+                raise ValueError(
+                    "attempt_ids_by_logical_id must contain one unique physical attempt ID per root"
+                )
+            attempt_ids = [supplied_mapping[root] for root in roots]
+            physical_worker_ids = list(attempt_ids)
+        else:
+            supplied_attempts = record.get("attempt_ids")
+            attempt_ids = (
+                [str(value) for value in supplied_attempts]
+                if isinstance(supplied_attempts, list)
+                and len(supplied_attempts) == len(roots)
+                else [_new_id("attempt") for _ in roots]
+            )
+            # Legacy/ordinary dispatch keeps its conversational worker identity.
+            physical_worker_ids = list(roots)
+        authority_by_logical_id = record.get("authority_by_logical_id")
+        if authority_by_logical_id is not None and (
+            not isinstance(authority_by_logical_id, dict)
+            or set(authority_by_logical_id) != set(roots)
+            or not all(isinstance(value, dict) for value in authority_by_logical_id.values())
+        ):
+            raise ValueError(
+                "authority_by_logical_id must contain one immutable authority object per root"
+            )
+        now = time.time()
+        dispatched = float(record.get("dispatched_at") or now)
+        task = {key: record.get(key) for key in ("goal", "goals", "context", "toolsets", "role", "model", "is_batch") if key in record}
+        try:
+            with self.write_txn() as conn:
+                conn.execute(
+                    "INSERT INTO async_delegations\n                       (delegation_id,origin_session,origin_ui_session_id,\n                        parent_session_id,state,dispatched_at,updated_at,\n                        delivery_state,delivery_attempts,task_json,lifecycle_version)\n                       VALUES (?,?,?,?,'running',?,?,'pending',0,?,2)",
+                    (
+                        record["delegation_id"],
+                        record.get("session_key", ""),
+                        record.get("origin_ui_session_id", ""),
+                        record.get("parent_session_id"),
+                        dispatched,
+                        now,
+                        _dump(task),
+                    ),
+                )
+                conn.execute(
+                    "INSERT INTO delegation_runs (run_id,delegation_id,run_number,kind,created_at) VALUES (?,?,1,'initial',?)",
+                    (run_id, record["delegation_id"], dispatched),
+                )
+                raw_goals = task.get("goals")
+                goals: List[Any] = raw_goals if isinstance(raw_goals, list) else []
+                for ordinal, (logical_id, attempt_id, physical_worker_id) in enumerate(
+                    zip(roots, attempt_ids, physical_worker_ids)
+                ):
+                    spec = dict(task)
+                    if ordinal < len(goals):
+                        spec["goal"] = goals[ordinal]
+                    if authority_by_logical_id is not None:
+                        spec["authority"] = dict(authority_by_logical_id[logical_id])
+                    conn.execute(
+                        "INSERT INTO delegation_logical_subagents\n                           (logical_id,delegation_id,root_ordinal,spec_json,created_at,updated_at)\n                           VALUES (?,?,?,?,?,?)",
+                        (logical_id, record["delegation_id"], ordinal, _dump(spec), dispatched, now),
+                    )
+                    conn.execute(
+                        "INSERT INTO delegation_attempts\n                           (attempt_id,logical_id,run_id,attempt_number,physical_worker_id,\n                            state,owner_pid,owner_started_at,created_at,updated_at,metadata_json)\n                           VALUES (?,?,?,1,?,'starting',?,?,?,?,'{}')",
+                        (attempt_id, logical_id, run_id, physical_worker_id, owner_pid, owner_started_at, dispatched, now),
+                    )
+        except sqlite3.IntegrityError:
+            conn = self._connect()
+            try:
+                exists = conn.execute(
+                    "SELECT 1 FROM async_delegations WHERE delegation_id=?",
+                    (record["delegation_id"],),
+                ).fetchone()
+            finally:
+                conn.close()
+            return {"status": "already_exists" if exists else "conflict"}
+        attempts = [
+            {"attempt_id": attempt_id, "logical_id": logical_id, "attempt_number": 1} for logical_id, attempt_id in zip(roots, attempt_ids)
+        ]
+        return {"status": "registered", "run_id": run_id, "attempts": attempts}
+
+    def reserve_resumed_attempt(
+        self,
+        logical_id: str,
+        *,
+        physical_worker_id: Optional[str] = None,
+        owner_pid: Optional[int] = None,
+        owner_started_at: Optional[int] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        attempt_id: Optional[str] = None,
+        run_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        attempt_id = attempt_id or _new_id("attempt")
+        run_id = run_id or _new_id("run")
+        now = time.time()
+        with self.write_txn() as conn:
+            logical = conn.execute(
+                "SELECT delegation_id,spec_json FROM delegation_logical_subagents "
+                "WHERE logical_id=?",
+                (logical_id,),
+            ).fetchone()
+            if logical is None:
+                return {"status": "not_found"}
+            if _authority_is_tombstoned(logical["spec_json"]):
+                return {"status": "authority_revoked"}
+            active = conn.execute(
+                "SELECT attempt_id FROM delegation_attempts WHERE logical_id=? AND state IN ('starting','running','finalizing','interrupt_requested')",
+                (logical_id,),
+            ).fetchone()
+            if active is not None:
+                return {"status": "already_running", "attempt_id": active[0]}
+            delegation_id = str(logical[0])
+            run_number = int(
+                conn.execute(
+                    "SELECT COALESCE(MAX(run_number),0)+1 FROM delegation_runs WHERE delegation_id=?", (delegation_id,)
+                ).fetchone()[0]
+            )
+            attempt_number = int(
+                conn.execute(
+                    "SELECT COALESCE(MAX(attempt_number),0)+1 FROM delegation_attempts WHERE logical_id=?", (logical_id,)
+                ).fetchone()[0]
+            )
+            conn.execute(
+                "INSERT INTO delegation_runs (run_id,delegation_id,run_number,kind,created_at) VALUES (?,?,?,'resumed',?)",
+                (run_id, delegation_id, run_number, now),
+            )
+            conn.execute(
+                "INSERT INTO delegation_attempts\n                   (attempt_id,logical_id,run_id,attempt_number,physical_worker_id,\n                    state,owner_pid,owner_started_at,created_at,updated_at,metadata_json)\n                   VALUES (?,?,?,?,?,'starting',?,?,?,?,?)",
+                (
+                    attempt_id,
+                    logical_id,
+                    run_id,
+                    attempt_number,
+                    physical_worker_id or attempt_id,
+                    owner_pid,
+                    owner_started_at,
+                    now,
+                    now,
+                    _dump(metadata or {}),
+                ),
+            )
+        return {
+            "status": "reserved",
+            "delegation_id": delegation_id,
+            "run_id": run_id,
+            "run_number": run_number,
+            "attempt_id": attempt_id,
+            "attempt_number": attempt_number,
+        }
+
+    def enqueue_steer(
+        self,
+        delegation_id: str,
+        logical_id: str,
+        session_key: str,
+        message: str,
+        force: bool = False,
+    ) -> Dict[str, Any]:
+        """Append one ordered steer to the current authorized attempt."""
+        now = time.time()
+        mailbox_id = _new_id("steer")
+        with self.write_txn() as conn:
+            attempt = conn.execute(
+                "SELECT a.attempt_id,a.run_id,a.state,a.attempt_number,l.spec_json "
+                "FROM delegation_attempts a "
+                "JOIN delegation_logical_subagents l ON l.logical_id=a.logical_id "
+                "JOIN async_delegations d ON d.delegation_id=l.delegation_id "
+                "WHERE d.delegation_id=? AND d.origin_session=? AND l.logical_id=? "
+                "ORDER BY a.attempt_number DESC LIMIT 1",
+                (delegation_id, session_key, logical_id),
+            ).fetchone()
+            if attempt is None:
+                return {"status": "not_found"}
+            if _authority_is_tombstoned(attempt["spec_json"]):
+                return {"status": "authority_revoked"}
+            if attempt["state"] not in _ACTIVE_STATES:
+                return {
+                    "status": "already_terminal",
+                    "terminal_status": str(attempt["state"]),
+                    "attempt_id": str(attempt["attempt_id"]),
+                    "run_id": str(attempt["run_id"]),
+                }
+            sequence = int(
+                conn.execute(
+                    "SELECT COALESCE(MAX(sequence_number),0)+1 "
+                    "FROM delegation_steer_mailbox WHERE attempt_id=?",
+                    (attempt["attempt_id"],),
+                ).fetchone()[0]
+            )
+            conn.execute(
+                "INSERT INTO delegation_steer_mailbox "
+                "(mailbox_id,delegation_id,logical_id,attempt_id,sequence_number,"
+                "message,force,status,created_at) VALUES (?,?,?,?,?,?,?,'pending',?)",
+                (
+                    mailbox_id,
+                    delegation_id,
+                    logical_id,
+                    attempt["attempt_id"],
+                    sequence,
+                    message,
+                    1 if force else 0,
+                    now,
+                ),
+            )
+        return {
+            "status": "accepted",
+            "mailbox_id": mailbox_id,
+            "attempt_id": str(attempt["attempt_id"]),
+            "run_id": str(attempt["run_id"]),
+            "attempt_state": str(attempt["state"]),
+            "sequence_number": sequence,
+            "force": bool(force),
+        }
+
+    def pending_steers(self, attempt_id: str) -> List[Dict[str, Any]]:
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT mailbox_id,message,sequence_number,force FROM delegation_steer_mailbox "
+                "WHERE attempt_id=? AND status='pending' ORDER BY sequence_number",
+                (attempt_id,),
+            ).fetchall()
+            return [dict(row) for row in rows]
+        finally:
+            conn.close()
+
+    def claim_steer(self, attempt_id: str, mailbox_id: str) -> Dict[str, Any]:
+        """Claim only the oldest unresolved item for one still-current attempt."""
+        now = time.time()
+        with self.write_txn() as conn:
+            row = conn.execute(
+                "SELECT m.*,a.state FROM delegation_steer_mailbox m "
+                "JOIN delegation_attempts a ON a.attempt_id=m.attempt_id "
+                "WHERE m.mailbox_id=? AND m.attempt_id=?",
+                (mailbox_id, attempt_id),
+            ).fetchone()
+            if row is None:
+                return {"status": "not_found"}
+            if row["state"] not in _ACTIVE_STATES:
+                conn.execute(
+                    "UPDATE delegation_steer_mailbox SET status='too_late_after_completion',resolved_at=? "
+                    "WHERE mailbox_id=? AND status IN ('pending','forwarding','forwarded')",
+                    (now, mailbox_id),
+                )
+                return {"status": "too_late_after_completion"}
+            if row["status"] != "pending":
+                return {"status": str(row["status"])}
+            earlier = conn.execute(
+                "SELECT 1 FROM delegation_steer_mailbox WHERE attempt_id=? "
+                "AND sequence_number<? AND status IN ('pending','forwarding') LIMIT 1",
+                (attempt_id, row["sequence_number"]),
+            ).fetchone()
+            if earlier is not None:
+                return {"status": "blocked"}
+            changed = conn.execute(
+                "UPDATE delegation_steer_mailbox SET status='forwarding' "
+                "WHERE mailbox_id=? AND status='pending'",
+                (mailbox_id,),
+            ).rowcount
+        return (
+            {
+                "status": "claimed",
+                "message": str(row["message"]),
+                "force": bool(row["force"]),
+            }
+            if changed == 1
+            else {"status": "stale"}
+        )
+
+    def mark_steer_forwarded(self, mailbox_id: str) -> Dict[str, Any]:
+        now = time.time()
+        with self.write_txn() as conn:
+            changed = conn.execute(
+                "UPDATE delegation_steer_mailbox SET status='forwarded',forwarded_at=? "
+                "WHERE mailbox_id=? AND status='forwarding'",
+                (now, mailbox_id),
+            ).rowcount
+            row = conn.execute(
+                "SELECT status FROM delegation_steer_mailbox WHERE mailbox_id=?",
+                (mailbox_id,),
+            ).fetchone()
+        return {
+            "status": "forwarded" if changed == 1 else str(row[0] if row else "not_found")
+        }
+
+    def resolve_steer(self, mailbox_id: str, outcome: str) -> Dict[str, Any]:
+        if outcome not in {
+            "injected",
+            "superseded_by_interrupt",
+            "too_late_after_completion",
+            "foreground_wait",
+            "force_background_failed",
+        }:
+            raise ValueError("invalid steer outcome")
+        now = time.time()
+        with self.write_txn() as conn:
+            changed = conn.execute(
+                "UPDATE delegation_steer_mailbox SET status=?,resolved_at=? "
+                "WHERE mailbox_id=? AND status IN ('pending','forwarding','forwarded')",
+                (outcome, now, mailbox_id),
+            ).rowcount
+            row = conn.execute(
+                "SELECT status FROM delegation_steer_mailbox WHERE mailbox_id=?",
+                (mailbox_id,),
+            ).fetchone()
+        return {"status": outcome if changed == 1 else str(row[0] if row else "not_found")}
+
+    def inspect_steer(self, mailbox_id: str) -> Dict[str, Any]:
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT * FROM delegation_steer_mailbox WHERE mailbox_id=?",
+                (mailbox_id,),
+            ).fetchone()
+            return {"status": "not_found"} if row is None else dict(row)
+        finally:
+            conn.close()
+
+    def transition_attempt(
+        self,
+        attempt_id: str,
+        expected_states: Iterable[str],
+        new_state: str,
+        *,
+        metadata: Optional[Dict[str, Any]] = None,
+        started_at: Optional[float] = None,
+        completed_at: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        expected = set(expected_states)
+        now = time.time()
+        with self.write_txn() as conn:
+            row = conn.execute("SELECT state,metadata_json FROM delegation_attempts WHERE attempt_id=?", (attempt_id,)).fetchone()
+            if row is None:
+                return {"status": "not_found"}
+            if row[0] not in expected or row[0] not in _ACTIVE_STATES:
+                return {"status": "stale", "state": row[0]}
+            merged = _json(row[1], {})
+            if metadata:
+                merged.update(metadata)
+            terminal_at = completed_at
+            if new_state not in _ACTIVE_STATES and terminal_at is None:
+                terminal_at = now
+            changed = conn.execute(
+                "UPDATE delegation_attempts SET state=?,metadata_json=?,\n                   started_at=COALESCE(?,started_at),completed_at=?,updated_at=?\n                   WHERE attempt_id=? AND state=?",
+                (new_state, _dump(merged), started_at, terminal_at, now, attempt_id, row[0]),
+            ).rowcount
+            if changed == 1 and new_state not in _ACTIVE_STATES:
+                mailbox_outcome = (
+                    "superseded_by_interrupt"
+                    if new_state in {"interrupted", "abandoned"}
+                    else "too_late_after_completion"
+                )
+                conn.execute(
+                    "UPDATE delegation_steer_mailbox SET status=?,resolved_at=? "
+                    "WHERE attempt_id=? AND status IN ('pending','forwarding','forwarded')",
+                    (mailbox_outcome, terminal_at or now, attempt_id),
+                )
+        return {"status": "updated" if changed == 1 else "stale"}
+
+    def request_interrupt(self, attempt_id: str, reason: str = "") -> Dict[str, Any]:
+        now = time.time()
+        with self.write_txn() as conn:
+            row = conn.execute(
+                "SELECT a.state,a.interrupt_requested_at,l.spec_json "
+                "FROM delegation_attempts a JOIN delegation_logical_subagents l "
+                "ON l.logical_id=a.logical_id WHERE a.attempt_id=?",
+                (attempt_id,),
+            ).fetchone()
+            if row is None:
+                return {"status": "not_found"}
+            if _authority_is_tombstoned(row["spec_json"]):
+                return {"status": "authority_revoked"}
+            if row[0] == "interrupt_requested" or row[1] is not None:
+                return {"status": "already_requested"}
+            if row[0] not in _ACTIVE_STATES:
+                return {"status": "already_terminal"}
+            changed = conn.execute(
+                "UPDATE delegation_attempts SET state='interrupt_requested',\n                   interrupt_reason=?,interrupt_requested_at=?,updated_at=?\n                   WHERE attempt_id=? AND state=? AND interrupt_requested_at IS NULL",
+                (reason or None, now, now, attempt_id, row[0]),
+            ).rowcount
+            if changed == 1:
+                conn.execute(
+                    "UPDATE delegation_steer_mailbox "
+                    "SET status='superseded_by_interrupt',resolved_at=? "
+                    "WHERE attempt_id=? AND status='pending'",
+                    (now, attempt_id),
+                )
+        return {"status": "interrupt_requested" if changed == 1 else "stale"}
+
+    def tombstone_logical_authority(
+        self,
+        logical_id: str,
+        *,
+        revoked: bool = False,
+        cleaned: bool = False,
+    ) -> Dict[str, Any]:
+        """Durably narrow protected authority without rewriting immutable fields."""
+
+        if not revoked and not cleaned:
+            return {"status": "unchanged"}
+        now = time.time()
+        with self.write_txn() as conn:
+            row = conn.execute(
+                "SELECT spec_json FROM delegation_logical_subagents WHERE logical_id=?",
+                (logical_id,),
+            ).fetchone()
+            if row is None:
+                return {"status": "not_found"}
+            spec = _json(row["spec_json"], {})
+            authority = spec.get("authority")
+            if not isinstance(authority, dict):
+                return {"status": "ordinary"}
+            state = authority.get("state")
+            if not isinstance(state, dict):
+                return {"status": "malformed"}
+            immutable_before = {
+                key: value for key, value in authority.items() if key != "state"
+            }
+            authority_after = {
+                **authority,
+                "state": {
+                    "revoked": bool(state.get("revoked")) or bool(revoked),
+                    "cleaned": bool(state.get("cleaned")) or bool(cleaned),
+                },
+            }
+            if {
+                key: value for key, value in authority_after.items() if key != "state"
+            } != immutable_before:
+                raise RuntimeError("protected authority immutable snapshot changed")
+            spec["authority"] = authority_after
+            conn.execute(
+                "UPDATE delegation_logical_subagents SET spec_json=?,updated_at=? "
+                "WHERE logical_id=?",
+                (_dump(spec), now, logical_id),
+            )
+        return {"status": "tombstoned"}
+
+    def tombstone_delegation_authorities(
+        self,
+        delegation_id: str,
+        *,
+        revoked: bool = False,
+        cleaned: bool = False,
+    ) -> Dict[str, Any]:
+        """Retain protected tombstones with the logical delegation records."""
+
+        conn = self._connect()
+        try:
+            logical_ids = [
+                str(row[0])
+                for row in conn.execute(
+                    "SELECT logical_id FROM delegation_logical_subagents "
+                    "WHERE delegation_id=? ORDER BY logical_id",
+                    (delegation_id,),
+                ).fetchall()
+            ]
+        finally:
+            conn.close()
+        outcomes = {
+            logical_id: self.tombstone_logical_authority(
+                logical_id, revoked=revoked, cleaned=cleaned
+            )["status"]
+            for logical_id in logical_ids
+        }
+        return {"status": "tombstoned", "children": outcomes}
+
+    def take_interrupt(self, attempt_id: str) -> Dict[str, Any]:
+        now = time.time()
+        with self.write_txn() as conn:
+            row = conn.execute("SELECT interrupt_reason FROM delegation_attempts WHERE attempt_id=?", (attempt_id,)).fetchone()
+            if row is None:
+                return {"status": "not_found"}
+            changed = conn.execute(
+                "UPDATE delegation_attempts SET interrupt_taken_at=?,updated_at=?\n                   WHERE attempt_id=? AND state='interrupt_requested'\n                     AND interrupt_requested_at IS NOT NULL AND interrupt_taken_at IS NULL",
+                (now, now, attempt_id),
+            ).rowcount
+        return {"status": "taken", "reason": str(row[0] or "")} if changed == 1 else {"status": "not_pending"}
+
+    def rollback_interrupt_request(self, attempt_id: str) -> Dict[str, Any]:
+        """Roll back an exact interrupt marker only if no worker consumed it."""
+        now = time.time()
+        with self.write_txn() as conn:
+            changed = conn.execute(
+                "UPDATE delegation_attempts SET state='running',interrupt_reason=NULL,\n                   interrupt_requested_at=NULL,interrupt_taken_at=NULL,updated_at=?\n                   WHERE attempt_id=? AND state='interrupt_requested'\n                     AND interrupt_requested_at IS NOT NULL AND interrupt_taken_at IS NULL",
+                (now, attempt_id),
+            ).rowcount
+            if changed == 1:
+                conn.execute(
+                    "UPDATE delegation_steer_mailbox SET status='pending',resolved_at=NULL "
+                    "WHERE attempt_id=? AND status='superseded_by_interrupt'",
+                    (attempt_id,),
+                )
+        return {"status": "rolled_back" if changed == 1 else "stale"}
+
+    def complete_run(self, run_id: str, event: Dict[str, Any], result: Dict[str, Any]) -> Dict[str, Any]:
+        completed_at = float(event.get("completed_at") or time.time())
+        with self.write_txn() as conn:
+            run = conn.execute(
+                "SELECT delegation_id,completed_at FROM delegation_runs WHERE run_id=?",
+                (run_id,),
+            ).fetchone()
+            if run is None:
+                return {"status": "not_found"}
+            if run[1] is not None:
+                return {"status": "stale"}
+            changed = conn.execute(
+                "UPDATE delegation_runs SET completed_at=?,event_json=?,result_json=?\n                   WHERE run_id=? AND completed_at IS NULL",
+                (completed_at, _dump(event), _dump(result), run_id),
+            ).rowcount
+            if changed != 1:
+                return {"status": "stale"}
+            attempts = conn.execute(
+                "SELECT a.attempt_id,a.metadata_json,l.root_ordinal\n                   FROM delegation_attempts a JOIN delegation_logical_subagents l\n                     ON l.logical_id=a.logical_id WHERE a.run_id=?\n                   ORDER BY l.root_ordinal IS NULL,l.root_ordinal,a.attempt_number",
+                (run_id,),
+            ).fetchall()
+            raw_results = result.get("results")
+            child_results: List[Any] = raw_results if isinstance(raw_results, list) else []
+            for index, attempt in enumerate(attempts):
+                child = child_results[index] if index < len(child_results) and isinstance(child_results[index], dict) else result
+                metadata = _json(attempt[1], {})
+                metadata.update(child)
+                conn.execute(
+                    "UPDATE delegation_attempts SET state=?,completed_at=?,updated_at=?,metadata_json=?\n                       WHERE attempt_id=? AND state IN\n                         ('starting','running','finalizing','interrupt_requested')",
+                    (_attempt_state(child.get("status") or event.get("status")), completed_at, completed_at, _dump(metadata), attempt[0]),
+                )
+                conn.execute(
+                    "UPDATE delegation_steer_mailbox "
+                    "SET status='too_late_after_completion',resolved_at=? "
+                    "WHERE attempt_id=? AND status IN ('pending','forwarding','forwarded')",
+                    (completed_at, attempt[0]),
+                )
+        return {"status": "completed", "delegation_id": run[0], "run_id": run_id}
+
+    @staticmethod
+    def _resolve_run(conn: sqlite3.Connection, delegation_id: str, run_id: Optional[str]) -> Dict[str, Any]:
+        if run_id:
+            row = conn.execute("SELECT * FROM delegation_runs WHERE run_id=? AND delegation_id=?", (run_id, delegation_id)).fetchone()
+            return {"status": "found", "row": row} if row else {"status": "not_found"}
+        rows = conn.execute("SELECT * FROM delegation_runs WHERE delegation_id=? LIMIT 2", (delegation_id,)).fetchall()
+        if not rows:
+            return {"status": "not_found"}
+        if len(rows) != 1:
+            return {"status": "ambiguous_run"}
+        return {"status": "found", "row": rows[0]}
+
+    def inspect_delivery(self, delegation_id: str, run_id: Optional[str] = None) -> Dict[str, Any]:
+        conn = self._connect()
+        try:
+            resolved = self._resolve_run(conn, delegation_id, run_id)
+            return {"status": "found", **dict(resolved["row"])} if resolved["status"] == "found" else {"status": resolved["status"]}
+        finally:
+            conn.close()
+
+    def resolve_run_id(self, delegation_id: str, run_id: Optional[str] = None) -> Dict[str, Any]:
+        outcome = self.inspect_delivery(delegation_id, run_id)
+        return {"status": "found", "run_id": outcome["run_id"]} if outcome["status"] == "found" else outcome
+
+    def claim_run_delivery(
+        self,
+        delegation_id: str,
+        run_id: Optional[str],
+        token: str,
+        *,
+        now: Optional[float] = None,
+        delivering_stale_seconds: float = 300,
+        wait_stale_seconds: float = 360,
+    ) -> Dict[str, Any]:
+        claimed_at = float(time.time() if now is None else now)
+        with self.write_txn() as conn:
+            resolved = self._resolve_run(conn, delegation_id, run_id)
+            if resolved["status"] != "found":
+                return {"status": resolved["status"]}
+            row = resolved["row"]
+            if row["completed_at"] is None or row["event_json"] is None:
+                return {"status": "not_ready"}
+            disposition = str(row["delivery_state"])
+            stale_before = claimed_at - delivering_stale_seconds
+            wait_stale_before = claimed_at - wait_stale_seconds
+            claimable = (
+                disposition == "pending"
+                or (disposition == "delivering" and (row["delivery_claimed_at"] is None or row["delivery_claimed_at"] < stale_before))
+                or (
+                    disposition == "held_by_wait" and (row["delivery_claimed_at"] is None or row["delivery_claimed_at"] < wait_stale_before)
+                )
+            )
+            if not claimable:
+                return {"status": "held" if disposition in {"delivering", "held_by_wait"} else "stale"}
+            changed = conn.execute(
+                "UPDATE delegation_runs SET delivery_state='delivering',delivery_claim=?,\n                   delivery_claimed_at=?,delivery_attempts=delivery_attempts+1\n                   WHERE run_id=? AND delivery_state=?",
+                (token, claimed_at, row["run_id"], disposition),
+            ).rowcount
+        return {"status": "claimed", "token": token, "run_id": row["run_id"]} if changed == 1 else {"status": "held"}
+
+    def release_run_delivery(self, run_id: str, token: str) -> Dict[str, Any]:
+        with self.write_txn() as conn:
+            changed = conn.execute(
+                "UPDATE delegation_runs SET delivery_state='pending',delivery_claim=NULL,\n                   delivery_claimed_at=NULL WHERE run_id=? AND delivery_state='delivering'\n                   AND delivery_claim=?",
+                (run_id, token),
+            ).rowcount
+        return {"status": "released" if changed == 1 else "stale"}
+
+    def commit_run_delivery(
+        self, run_id: str, token: str, *, disposition: str = "delivered", now: Optional[float] = None
+    ) -> Dict[str, Any]:
+        if disposition not in _TERMINAL_DELIVERY_STATES:
+            raise ValueError("terminal delivery disposition required")
+        completed = float(time.time() if now is None else now)
+        with self.write_txn() as conn:
+            changed = conn.execute(
+                "UPDATE delegation_runs SET delivery_state=?,delivered_at=?,\n                   delivery_claim=NULL,delivery_claimed_at=NULL\n                   WHERE run_id=? AND delivery_state IN ('delivering','held_by_wait')\n                     AND delivery_claim=?",
+                (disposition, completed, run_id, token),
+            ).rowcount
+        return {"status": disposition if changed == 1 else "stale"}
+
+    def acknowledge_pending(self, delegation_id: str, *, now: Optional[float] = None) -> Dict[str, Any]:
+        completed = float(time.time() if now is None else now)
+        with self.write_txn() as conn:
+            resolved = self._resolve_run(conn, delegation_id, None)
+            if resolved["status"] != "found":
+                return {"status": resolved["status"]}
+            changed = conn.execute(
+                "UPDATE delegation_runs SET delivery_state='delivered',delivered_at=?\n                   WHERE run_id=? AND delivery_state='pending'",
+                (completed, resolved["row"]["run_id"]),
+            ).rowcount
+        return {"status": "delivered" if changed == 1 else "stale"}
+
+    def hold_for_wait(
+        self,
+        delegation_id: str,
+        session_key: str,
+        token: str,
+        *,
+        run_id: Optional[str] = None,
+        now: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Bind one waiter to an exact run without later retargeting it."""
+        claimed = float(time.time() if now is None else now)
+        with self.write_txn() as conn:
+            owner = conn.execute(
+                "SELECT 1 FROM async_delegations WHERE delegation_id=? AND origin_session=?",
+                (delegation_id, session_key),
+            ).fetchone()
+            if owner is None:
+                return {"status": "not_found"}
+            if run_id:
+                row = conn.execute(
+                    "SELECT * FROM delegation_runs WHERE delegation_id=? AND run_id=?",
+                    (delegation_id, run_id),
+                ).fetchone()
+            else:
+                # FIFO terminal delivery wins. With none available, bind to the
+                # latest active run at call start and never jump to a later run.
+                row = conn.execute(
+                    """SELECT * FROM delegation_runs WHERE delegation_id=?
+                       AND completed_at IS NOT NULL AND delivery_state='pending'
+                       ORDER BY completed_at,run_number LIMIT 1""",
+                    (delegation_id,),
+                ).fetchone()
+                if row is None:
+                    row = conn.execute(
+                        """SELECT r.* FROM delegation_runs r
+                           WHERE r.delegation_id=? AND EXISTS (
+                             SELECT 1 FROM delegation_attempts a WHERE a.run_id=r.run_id
+                               AND a.state IN ('starting','running','finalizing','interrupt_requested'))
+                           ORDER BY r.run_number DESC LIMIT 1""",
+                        (delegation_id,),
+                    ).fetchone()
+                if row is None:
+                    row = conn.execute(
+                        "SELECT * FROM delegation_runs WHERE delegation_id=? ORDER BY run_number DESC LIMIT 1",
+                        (delegation_id,),
+                    ).fetchone()
+            if row is None:
+                return {"status": "not_found"}
+            if row["delivery_state"] == "held_by_wait" and row["delivery_claim"] == token:
+                return {"status": "held", "run_id": row["run_id"]}
+            changed = conn.execute(
+                "UPDATE delegation_runs SET delivery_state='held_by_wait',delivery_claim=?,\n                   delivery_claimed_at=? WHERE run_id=? AND delivery_state='pending'",
+                (token, claimed, row["run_id"]),
+            ).rowcount
+            if changed == 1:
+                return {"status": "held", "run_id": row["run_id"]}
+            return {
+                "status": "bound",
+                "run_id": row["run_id"],
+                "delivery_state": row["delivery_state"],
+            }
+
+    def consume_wait_hold(
+        self, delegation_id: str, session_key: str, token: str, *,
+        run_id: Optional[str] = None, now: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        completed = float(time.time() if now is None else now)
+        with self.write_txn() as conn:
+            owner = conn.execute(
+                "SELECT 1 FROM async_delegations WHERE delegation_id=? AND origin_session=?", (delegation_id, session_key)
+            ).fetchone()
+            if owner is None:
+                return {"status": "not_found"}
+            row = conn.execute(
+                "SELECT run_id FROM delegation_runs WHERE delegation_id=? AND delivery_claim=?"
+                + (" AND run_id=?" if run_id else ""),
+                (delegation_id, token, run_id) if run_id else (delegation_id, token),
+            ).fetchone()
+            if row is None:
+                return {"status": "stale"}
+            changed = conn.execute(
+                "UPDATE delegation_runs SET delivery_state='consumed',delivered_at=?,\n                   delivery_claim=NULL,delivery_claimed_at=NULL\n                   WHERE run_id=? AND completed_at IS NOT NULL AND event_json IS NOT NULL\n                     AND delivery_state='held_by_wait' AND delivery_claim=?",
+                (completed, row["run_id"], token),
+            ).rowcount
+        return {"status": "consumed" if changed == 1 else "stale"}
+
+    def release_wait_hold(
+        self, delegation_id: str, session_key: str, token: str, *,
+        run_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        with self.write_txn() as conn:
+            owner = conn.execute(
+                "SELECT 1 FROM async_delegations WHERE delegation_id=? AND origin_session=?", (delegation_id, session_key)
+            ).fetchone()
+            if owner is None:
+                return {"status": "not_found"}
+            row = conn.execute(
+                "SELECT run_id FROM delegation_runs WHERE delegation_id=? AND delivery_claim=?"
+                + (" AND run_id=?" if run_id else ""),
+                (delegation_id, token, run_id) if run_id else (delegation_id, token),
+            ).fetchone()
+            if row is None:
+                return {"status": "stale"}
+            changed = conn.execute(
+                "UPDATE delegation_runs SET delivery_state='pending',delivery_claim=NULL,\n                   delivery_claimed_at=NULL WHERE run_id=? AND delivery_state='held_by_wait'\n                     AND delivery_claim=?",
+                (row["run_id"], token),
+            ).rowcount
+        return {"status": "released" if changed == 1 else "stale"}
+
+    def suppress_delivery(self, delegation_id: str, session_key: str, reason: str = "") -> Dict[str, Any]:
+        """Suppress every still-pending run delivery for one logical delegation."""
+        with self.write_txn() as conn:
+            container = conn.execute(
+                "SELECT abandon_reason FROM async_delegations WHERE delegation_id=? AND origin_session=?",
+                (delegation_id, session_key),
+            ).fetchone()
+            if container is None:
+                return {"status": "not_found"}
+            now = time.time()
+            changed = conn.execute(
+                """UPDATE delegation_runs SET delivery_state='suppressed',delivered_at=?,
+                     delivery_claim=NULL,delivery_claimed_at=NULL
+                   WHERE delegation_id=? AND delivery_state IN ('pending','held_by_wait')""",
+                (now, delegation_id),
+            ).rowcount
+            remaining = conn.execute(
+                """SELECT
+                     SUM(CASE WHEN delivery_state='suppressed' THEN 1 ELSE 0 END) AS suppressed,
+                     SUM(CASE WHEN delivery_state IN ('pending','held_by_wait') THEN 1 ELSE 0 END) AS pending
+                   FROM delegation_runs WHERE delegation_id=?""",
+                (delegation_id,),
+            ).fetchone()
+            conn.execute(
+                "UPDATE async_delegations SET abandon_reason=? WHERE delegation_id=?",
+                (reason or container["abandon_reason"], delegation_id),
+            )
+            if changed:
+                return {"status": "suppressed", "count": int(changed)}
+            if int(remaining["suppressed"] or 0) > 0 and int(remaining["pending"] or 0) == 0:
+                return {"status": "already_suppressed", "count": 0}
+            return {"status": "too_late", "count": 0}
+
+    def recover_stale_wait_holds(self, *, cutoff: float, delegation_id: Optional[str] = None) -> int:
+        where = " AND delegation_id=?" if delegation_id else ""
+        params: List[Any] = [cutoff]
+        if delegation_id:
+            params.append(delegation_id)
+        with self.write_txn() as conn:
+            changed = conn.execute(
+                "UPDATE delegation_runs SET delivery_state='pending',delivery_claim=NULL,\n                   delivery_claimed_at=NULL WHERE delivery_state='held_by_wait'\n                     AND (delivery_claimed_at IS NULL OR delivery_claimed_at < ?)"
+                + where,
+                params,
+            ).rowcount
+        return changed
+
+    def recover_orphaned_attempts(self, owner_alive: Callable[[int, Optional[int]], bool]) -> Dict[str, Any]:
+        recovered: List[Dict[str, str]] = []
+        now = time.time()
+        with self.write_txn() as conn:
+            rows = conn.execute(
+                "SELECT a.*,l.delegation_id FROM delegation_attempts a\n                   JOIN delegation_logical_subagents l ON l.logical_id=a.logical_id\n                   WHERE a.state IN ('starting','running','finalizing','interrupt_requested')\n                     AND a.attempt_number=(SELECT MAX(x.attempt_number)\n                         FROM delegation_attempts x WHERE x.logical_id=a.logical_id)"
+            ).fetchall()
+            for row in rows:
+                pid = row["owner_pid"]
+                if pid and owner_alive(int(pid), row["owner_started_at"]):
+                    continue
+                changed = conn.execute(
+                    "UPDATE delegation_attempts SET state='unknown',completed_at=?,updated_at=?\n                       WHERE attempt_id=? AND state=? AND owner_pid IS ? AND owner_started_at IS ?",
+                    (now, now, row["attempt_id"], row["state"], pid, row["owner_started_at"]),
+                ).rowcount
+                if changed == 1:
+                    recovered.append({key: str(row[key]) for key in (
+                        "attempt_id", "run_id", "delegation_id"
+                    )})
+        return {"status": "recovered", "attempts": recovered}
+
+    def snapshot_for_attempt(
+        self,
+        delegation_id: str,
+        attempt_id: str,
+        *,
+        session_key: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Return one authorized historical attempt projected through its run."""
+        conn = self._connect()
+        try:
+            params: List[Any] = [delegation_id, attempt_id]
+            owner_clause = ""
+            if session_key is not None:
+                owner_clause = " AND d.origin_session=?"
+                params.append(session_key)
+            row = conn.execute(
+                """SELECT a.run_id,a.logical_id FROM delegation_attempts a
+                   JOIN delegation_logical_subagents l ON l.logical_id=a.logical_id
+                   JOIN async_delegations d ON d.delegation_id=l.delegation_id
+                   WHERE d.delegation_id=? AND a.attempt_id=?"""
+                + owner_clause,
+                params,
+            ).fetchone()
+            if row is None:
+                return None
+            snapshot = self._snapshot_with_conn(
+                conn,
+                delegation_id,
+                session_key=session_key,
+                run_id=str(row["run_id"]),
+            )
+            if snapshot is None:
+                return None
+            logical_id = str(row["logical_id"])
+            child = snapshot.get("children", {}).get(logical_id)
+            if child is None:
+                return None
+            snapshot["children"] = {logical_id: child}
+            snapshot["root_subagent_ids"] = [logical_id]
+            return _external_authority_projection(snapshot)
+        finally:
+            conn.close()
+
+    def resume_metadata_candidates(
+        self, delegation_id: str, logical_id: str
+    ) -> List[Dict[str, Any]]:
+        """Return newest-first durable attempt metadata for transcript recovery."""
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT a.attempt_id,a.attempt_number,a.state,a.metadata_json "
+                "FROM delegation_attempts a "
+                "JOIN delegation_logical_subagents l ON l.logical_id=a.logical_id "
+                "WHERE a.logical_id=? AND l.delegation_id=? "
+                "ORDER BY a.attempt_number DESC",
+                (logical_id, delegation_id),
+            ).fetchall()
+            return [
+                {
+                    "attempt_id": str(row["attempt_id"]),
+                    "attempt_number": int(row["attempt_number"]),
+                    "state": str(row["state"]),
+                    "metadata": _json(row["metadata_json"], {}),
+                }
+                for row in rows
+            ]
+        finally:
+            conn.close()
+
+    def snapshot(
+        self, delegation_id: str, *, session_key: Optional[str] = None,
+        run_id: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Return a backing-redacted lifecycle projection."""
+        conn = self._connect()
+        try:
+            snapshot = self._snapshot_with_conn(
+                conn, delegation_id, session_key=session_key, run_id=run_id
+            )
+            return (
+                _external_authority_projection(snapshot)
+                if snapshot is not None
+                else None
+            )
+        finally:
+            conn.close()
+
+    def trusted_snapshot(
+        self, delegation_id: str, *, session_key: Optional[str] = None,
+        run_id: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Return canonical authority for internal resume and recovery only."""
+        conn = self._connect()
+        try:
+            return self._snapshot_with_conn(
+                conn, delegation_id, session_key=session_key, run_id=run_id
+            )
+        finally:
+            conn.close()
+
+    def _snapshot_with_conn(
+        self, conn: sqlite3.Connection, delegation_id: str, *,
+        session_key: Optional[str] = None, run_id: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        params: List[Any] = [delegation_id]
+        owner_clause = ""
+        if session_key is not None:
+            owner_clause = " AND origin_session=?"
+            params.append(session_key)
+        container = conn.execute(
+            "SELECT * FROM async_delegations WHERE delegation_id=?" + owner_clause, params
+        ).fetchone()
+        if container is None:
+            return None
+        run = conn.execute(
+            "SELECT * FROM delegation_runs WHERE delegation_id=?"
+            + (" AND run_id=?" if run_id else " ORDER BY run_number DESC LIMIT 1"),
+            (delegation_id, run_id) if run_id else (delegation_id,),
+        ).fetchone()
+        run_summary = conn.execute(
+            """SELECT
+                 SUM(CASE WHEN completed_at IS NOT NULL AND delivery_state IN
+                   ('pending','held_by_wait','delivering') THEN 1 ELSE 0 END)
+                   AS pending_count,
+                 MAX(run_number) AS latest_number
+               FROM delegation_runs WHERE delegation_id=?""",
+            (delegation_id,),
+        ).fetchone()
+        active_run = conn.execute(
+            """SELECT r.run_id FROM delegation_runs r
+               WHERE r.delegation_id=? AND EXISTS (
+                 SELECT 1 FROM delegation_attempts a WHERE a.run_id=r.run_id
+                   AND a.state IN ('starting','running','finalizing','interrupt_requested'))
+               ORDER BY r.run_number DESC LIMIT 1""",
+            (delegation_id,),
+        ).fetchone()
+        if run_id and run is None:
+            return None
+        attempt_clause = (
+            "a.run_id=?" if run_id else
+            "a.attempt_number=(SELECT MAX(x.attempt_number) FROM delegation_attempts x WHERE x.logical_id=a.logical_id)"
+        )
+        attempts = conn.execute(
+            "SELECT a.*,l.parent_logical_id,l.root_ordinal,l.spec_json,\n"
+            "  (SELECT CASE WHEN first.physical_worker_id != first.logical_id "
+            "    THEN 1 ELSE 0 END FROM delegation_attempts first "
+            "    WHERE first.logical_id=a.logical_id "
+            "    ORDER BY first.attempt_number LIMIT 1) AS protected_origin\n"
+            "  FROM delegation_attempts a JOIN delegation_logical_subagents l\n"
+            "    ON l.logical_id=a.logical_id\n"
+            "  WHERE l.delegation_id=? AND " + attempt_clause +
+            " ORDER BY l.root_ordinal IS NULL,l.root_ordinal,l.created_at,l.logical_id",
+            (delegation_id, run_id) if run_id else (delegation_id,),
+        ).fetchall()
+        steer_rows = conn.execute(
+            "SELECT m.mailbox_id,m.logical_id,m.attempt_id,m.sequence_number,"
+            "m.status,m.created_at,m.forwarded_at,m.resolved_at "
+            "FROM delegation_steer_mailbox m "
+            "JOIN delegation_attempts a ON a.attempt_id=m.attempt_id "
+            "WHERE m.delegation_id=?" + (" AND a.run_id=?" if run_id else "") +
+            " ORDER BY m.logical_id,m.sequence_number",
+            (delegation_id, run_id) if run_id else (delegation_id,),
+        ).fetchall()
+        steers_by_child: Dict[str, List[Dict[str, Any]]] = {}
+        for steer_row in steer_rows:
+            steers_by_child.setdefault(str(steer_row["logical_id"]), []).append(
+                {
+                    key: steer_row[key]
+                    for key in (
+                        "mailbox_id",
+                        "attempt_id",
+                        "sequence_number",
+                        "status",
+                        "created_at",
+                        "forwarded_at",
+                        "resolved_at",
+                    )
+                    if steer_row[key] is not None
+                }
+            )
+        children: Dict[str, Dict[str, Any]] = {}
+        roots: List[str] = []
+        active_states: List[str] = []
+        owner_pid = owner_started_at = None
+        interrupts: Dict[str, str] = {}
+        for attempt in attempts:
+            child = {
+                **_json(attempt["spec_json"], {}),
+                **_json(attempt["metadata_json"], {}),
+                "subagent_id": attempt["logical_id"],
+                "parent_id": attempt["parent_logical_id"],
+                "status": attempt["state"],
+                "attempt_id": attempt["attempt_id"],
+                "physical_worker_id": attempt["physical_worker_id"],
+                "protected_execution": bool(attempt["protected_origin"]),
+                "attempt_number": attempt["attempt_number"],
+                "run_id": attempt["run_id"],
+                "steers": steers_by_child.get(str(attempt["logical_id"]), []),
+            }
+            child["resume_available"] = (
+                attempt["state"] not in _ACTIVE_STATES
+                and isinstance(child.get("child_session_id"), str)
+                and bool(child.get("child_session_id"))
+            )
+            if child["resume_available"]:
+                child["suggested_action"] = "resume"
+            children[attempt["logical_id"]] = child
+            if attempt["root_ordinal"] is not None:
+                roots.append(attempt["logical_id"])
+            if attempt["state"] in _ACTIVE_STATES:
+                active_states.append(attempt["state"])
+                if owner_pid is None:
+                    owner_pid, owner_started_at = (attempt["owner_pid"], attempt["owner_started_at"])
+            if attempt["interrupt_requested_at"] is not None and attempt["interrupt_taken_at"] is None:
+                interrupts[attempt["logical_id"]] = str(attempt["interrupt_reason"] or "")
+        if active_states:
+            state = next(
+                (candidate for candidate in ("interrupt_requested", "finalizing", "running", "starting") if candidate in active_states)
+            )
+        elif run and run["completed_at"] is not None:
+            state = _attempt_state(_json(run["event_json"], {}).get("status"))
+        elif attempts:
+            state = attempts[0]["state"]
+        else:
+            state = "running" if run and run["completed_at"] is None else "unknown"
+        aggregate_state = "running" if state == "starting" else state
+        event = _json(run["event_json"], {}) if run and run["event_json"] else None
+        result = _json(run["result_json"], {}) if run and run["result_json"] else None
+        delivery = str(run["delivery_state"] if run else "pending")
+        return {
+            **_json(container["task_json"], {}),
+            "delegation_id": delegation_id,
+            "origin_session": container["origin_session"],
+            "session_key": container["origin_session"],
+            "origin_ui_session_id": container["origin_ui_session_id"],
+            "parent_session_id": container["parent_session_id"],
+            "lifecycle_version": 2,
+            "state": aggregate_state,
+            "worker_status": aggregate_state,
+            "status": aggregate_state,
+            "dispatched_at": container["dispatched_at"],
+            "completed_at": run["completed_at"] if run else None,
+            "updated_at": max(
+                [float(container["updated_at"])]
+                + [float(a["updated_at"]) for a in attempts]
+                + ([float(run["completed_at"] or run["created_at"])] if run else [])
+            ),
+            "event": event,
+            "result": result,
+            "delivery_state": delivery,
+            "delivery_disposition": delivery,
+            "delivery_attempts": int(run["delivery_attempts"] if run else 0),
+            "delivered_at": run["delivered_at"] if run else None,
+            "delivery_claim": run["delivery_claim"] if run else None,
+            "delivery_claimed_at": run["delivery_claimed_at"] if run else None,
+            "run_id": run["run_id"] if run else None,
+            "latest_run_id": run["run_id"] if run else None,
+            "active_run_id": active_run["run_id"] if active_run else None,
+            "pending_run_count": int(run_summary["pending_count"] or 0),
+            "root_subagent_ids": roots,
+            "children": children,
+            "interrupt_requests": interrupts,
+            "interrupt_reason": container["interrupt_reason"],
+            "abandon_reason": container["abandon_reason"],
+            "owner_pid": owner_pid,
+            "owner_started_at": owner_started_at,
+        }
+
+    def list_snapshots(self, *, session_keys: Optional[List[str]] = None, limit: int = 100) -> List[Dict[str, Any]]:
+        if session_keys == [] or limit <= 0:
+            return []
+        conn = self._connect()
+        try:
+            params: List[Any] = []
+            where = ""
+            if session_keys is not None:
+                owners = list(dict.fromkeys(session_keys))
+                where = f"WHERE origin_session IN ({','.join(('?' for _ in owners))})"
+                params.extend(owners)
+            params.append(max(0, min(int(limit), 100)))
+            ids = [
+                str(row[0])
+                for row in conn.execute(
+                    f"SELECT delegation_id FROM async_delegations {where} ORDER BY dispatched_at DESC,delegation_id LIMIT ?", params
+                )
+            ]
+            return [
+                _external_authority_projection(snap) for item in ids
+                if (snap := self._snapshot_with_conn(conn, item)) is not None
+            ]
+        finally:
+            conn.close()
+
+    def prune(self, *, cutoff: float, max_terminal: int) -> Dict[str, Any]:
+        with self.write_txn() as conn:
+            candidates = conn.execute(
+                "SELECT d.delegation_id,d.updated_at FROM async_delegations d\n                   WHERE NOT EXISTS (SELECT 1 FROM delegation_attempts a\n                       JOIN delegation_logical_subagents l ON l.logical_id=a.logical_id\n                       WHERE l.delegation_id=d.delegation_id\n                         AND a.state IN ('starting','running','finalizing','interrupt_requested'))\n                     AND NOT EXISTS (SELECT 1 FROM delegation_runs r\n                       WHERE r.delegation_id=d.delegation_id\n                         AND (r.completed_at IS NULL OR r.delivery_state NOT IN\n                           ('delivered','consumed','suppressed')))\n                   ORDER BY d.updated_at DESC"
+            ).fetchall()
+            keep = max(0, int(max_terminal))
+            delete_ids = [str(row[0]) for index, row in enumerate(candidates) if float(row[1]) < cutoff or index >= keep]
+            if delete_ids:
+                conn.executemany("DELETE FROM async_delegations WHERE delegation_id=?", [(delegation_id,) for delegation_id in delete_ids])
+        return {"status": "pruned", "deleted": len(delete_ids)}
+
+    def delete(self, delegation_id: str) -> bool:
+        with self.write_txn() as conn:
+            return conn.execute("DELETE FROM async_delegations WHERE delegation_id=?", (delegation_id,)).rowcount == 1
+
+    def pending_events(self, *, delivery_state: str = "pending") -> List[Dict[str, Any]]:
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT run_id,event_json FROM delegation_runs\n                   WHERE completed_at IS NOT NULL AND delivery_state=? AND event_json IS NOT NULL\n                   ORDER BY completed_at,run_id",
+                (delivery_state,),
+            ).fetchall()
+            return [{"run_id": row["run_id"], "event": _json(row["event_json"], {})} for row in rows]
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _attempt_for_worker(conn: sqlite3.Connection, worker_id: str) -> Optional[sqlite3.Row]:
+        return conn.execute(
+            "SELECT a.*,l.delegation_id,l.logical_id AS stable_id,l.spec_json\n               FROM delegation_attempts a JOIN delegation_logical_subagents l\n                 ON l.logical_id=a.logical_id\n               WHERE a.physical_worker_id=? OR a.logical_id=?\n               ORDER BY a.attempt_number DESC LIMIT 1",
+            (worker_id, worker_id),
+        ).fetchone()
+
+    def register_subagent(self, record: Dict[str, Any]) -> Optional[Dict[str, str]]:
+        worker_id = record.get("subagent_id")
+        if not isinstance(worker_id, str) or not worker_id:
+            return None
+        parent_id = record.get("parent_id")
+        supplied_attempt_id = record.get("delegation_attempt_id")
+        has_supplied_attempt = "delegation_attempt_id" in record
+        now = time.time()
+        with self.write_txn() as conn:
+            if has_supplied_attempt:
+                if not isinstance(supplied_attempt_id, str) or not supplied_attempt_id:
+                    return None
+                attempt = conn.execute(
+                    "SELECT a.*,l.delegation_id,l.logical_id AS stable_id,l.spec_json\n                       FROM delegation_attempts a JOIN delegation_logical_subagents l\n                         ON l.logical_id=a.logical_id\n                       WHERE a.attempt_id=?\n                         AND (a.physical_worker_id=? OR a.logical_id=?)",
+                    (supplied_attempt_id, worker_id, worker_id),
+                ).fetchone()
+                supplied_run_id = record.get("delegation_run_id")
+                if attempt is not None and supplied_run_id is not None and (
+                    not isinstance(supplied_run_id, str)
+                    or supplied_run_id != attempt["run_id"]
+                ):
+                    attempt = None
+            else:
+                attempt = self._attempt_for_worker(conn, worker_id)
+            if attempt is None and not has_supplied_attempt and isinstance(parent_id, str) and parent_id:
+                parent = self._attempt_for_worker(conn, parent_id)
+                if parent is None:
+                    return None
+                stable = {key: record.get(key) for key in ("parent_id", "depth", "goal", "model") if key in record}
+                conn.execute(
+                    "INSERT INTO delegation_logical_subagents\n                       (logical_id,delegation_id,parent_logical_id,spec_json,created_at,updated_at)\n                       VALUES (?,?,?,?,?,?)",
+                    (worker_id, parent["delegation_id"], parent["stable_id"], _dump(stable), now, now),
+                )
+                attempt_id = str(record.get("delegation_attempt_id") or _new_id("attempt"))
+                runtime = {key: value for key, value in record.items() if key != "agent" and key not in stable}
+                conn.execute(
+                    "INSERT INTO delegation_attempts\n                       (attempt_id,logical_id,run_id,attempt_number,physical_worker_id,state,\n                        owner_pid,owner_started_at,created_at,updated_at,metadata_json)\n                       VALUES (?,?,?,1,?,'starting',?,?,?,?,?)",
+                    (
+                        attempt_id,
+                        worker_id,
+                        parent["run_id"],
+                        worker_id,
+                        parent["owner_pid"],
+                        parent["owner_started_at"],
+                        now,
+                        now,
+                        _dump(runtime),
+                    ),
+                )
+                attempt = self._attempt_for_worker(conn, worker_id)
+            if attempt is None:
+                return None
+            if attempt["state"] not in _ACTIVE_STATES:
+                return None
+            metadata = _json(attempt["metadata_json"], {})
+            spec = _json(attempt["spec_json"], {})
+            metadata.update({key: value for key, value in record.items() if key != "agent" and (key not in spec or spec[key] != value)})
+            requested = attempt["interrupt_requested_at"] is not None
+            requested_state = "interrupt_requested" if requested else _attempt_state(record.get("status") or attempt["state"])
+            if attempt["state"] in _ACTIVE_STATES:
+                conn.execute(
+                    "UPDATE delegation_attempts SET state=?,metadata_json=?,updated_at=? WHERE attempt_id=?",
+                    (requested_state, _dump(metadata), now, attempt["attempt_id"]),
+                )
+            return {"delegation_id": str(attempt["delegation_id"]), "attempt_id": str(attempt["attempt_id"])}
+
+    def find_attempt(
+        self,
+        worker_id: str,
+        *,
+        attempt_id: Optional[str] = None,
+        run_id: Optional[str] = None,
+        delegation_id: Optional[str] = None,
+        session_key: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        conn = self._connect()
+        try:
+            clauses = ["(a.physical_worker_id=? OR a.logical_id=?)"]
+            params: List[Any] = [worker_id, worker_id]
+            if attempt_id is not None:
+                clauses.append("a.attempt_id=?")
+                params.append(attempt_id)
+            if run_id is not None:
+                clauses.append("a.run_id=?")
+                params.append(run_id)
+            if delegation_id is not None:
+                clauses.append("l.delegation_id=?")
+                params.append(delegation_id)
+            if session_key is not None:
+                clauses.append("d.origin_session=?")
+                params.append(session_key)
+            row = conn.execute(
+                "SELECT a.*,l.delegation_id FROM delegation_attempts a\n                   JOIN delegation_logical_subagents l ON l.logical_id=a.logical_id\n                   JOIN async_delegations d ON d.delegation_id=l.delegation_id WHERE "
+                + " AND ".join(clauses)
+                + " ORDER BY a.attempt_number DESC LIMIT 1",
+                params,
+            ).fetchone()
+            return dict(row) if row else None
+        finally:
+            conn.close()

--- a/tools/delegation_repository.py
+++ b/tools/delegation_repository.py
@@ -767,6 +767,18 @@ class DelegationRepository:
             ).rowcount
             if changed != 1:
                 return {"status": "stale"}
+            conn.execute(
+                "UPDATE async_delegations SET completed_at=?,event_json=?,result_json=?,"
+                "state=?,updated_at=? WHERE delegation_id=?",
+                (
+                    completed_at,
+                    _dump(event),
+                    _dump(result),
+                    _attempt_state(event.get("status")),
+                    completed_at,
+                    run[0],
+                ),
+            )
             attempts = conn.execute(
                 "SELECT a.attempt_id,a.metadata_json,l.root_ordinal\n                   FROM delegation_attempts a JOIN delegation_logical_subagents l\n                     ON l.logical_id=a.logical_id WHERE a.run_id=?\n                   ORDER BY l.root_ordinal IS NULL,l.root_ordinal,a.attempt_number",
                 (run_id,),

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -14,8 +14,8 @@ import re
 import select
 import shlex
 import subprocess
-import threading
 import time
+import threading
 import uuid
 from abc import ABC, abstractmethod
 from collections import deque
@@ -974,7 +974,8 @@ class BaseEnvironment(ABC):
     # ------------------------------------------------------------------
 
     def _wait_for_process(
-        self, proc: ProcessHandle, timeout: int = 120, *, bounded_capture: bool = False
+        self, proc: ProcessHandle, timeout: int = 120, *, bounded_capture: bool = False,
+        foreground_handoff: dict | None = None,
     ) -> dict:
         """Poll-based wait with interrupt checking and stdout draining.
 
@@ -1031,6 +1032,9 @@ class BaseEnvironment(ABC):
             except Exception:
                 spill_path = None
         output = _BoundedOutputCollector(capture_limit, spill_path=spill_path)
+        adoption_lock = threading.Lock()
+        adopted_session = None
+        handoff_failed = False
 
         # Non-blocking drain via select().
         #
@@ -1188,6 +1192,113 @@ class BaseEnvironment(ABC):
             _poll_sleep = 0.005
             while proc.poll() is None:
                 _iter_count += 1
+                from tools.foreground_wait import (
+                    current_foreground_wait,
+                    process_handoff,
+                )
+
+                wait_slot = current_foreground_wait()
+                if (
+                    not handoff_failed
+                    and wait_slot is not None
+                    and wait_slot.kind == "terminal"
+                    and wait_slot.background_requested.is_set()
+                ):
+                    metadata = foreground_handoff or {}
+                    command = metadata.get("command")
+                    if not isinstance(command, str) or not command:
+                        handoff_failed = True
+                        wait_slot.fail_background(
+                            "foreground terminal handoff metadata is unavailable"
+                        )
+                    else:
+                        from tools.process_registry import process_registry
+
+                        try:
+                            with adoption_lock:
+                                session = process_registry.adopt_foreground_process(
+                                    proc,
+                                    command=command,
+                                    task_id=str(metadata.get("task_id") or ""),
+                                    session_key=str(metadata.get("session_key") or ""),
+                                    cwd=str(metadata.get("cwd") or self.cwd or ""),
+                                    env_ref=self,
+                                    initial_output=output.render(),
+                                    kill_callback=lambda: self._kill_process(proc),
+                                    notify_on_complete=True,
+                                )
+                                adopted_session = session
+                        except Exception as exc:
+                            handoff_failed = True
+                            wait_slot.fail_background(
+                                f"Could not adopt the foreground process: {exc}"
+                            )
+                            continue
+
+                        on_adopted = metadata.get("on_adopted")
+                        if callable(on_adopted):
+                            try:
+                                on_adopted(session)
+                            except Exception:
+                                logger.debug(
+                                    "foreground process routing setup failed",
+                                    exc_info=True,
+                                )
+
+                        def _finish_adopted() -> None:
+                            timed_out = False
+                            while proc.poll() is None:
+                                if time.monotonic() > deadline:
+                                    timed_out = True
+                                    self._kill_process(proc)
+                                    break
+                                time.sleep(0.1)
+                            drain_thread.join(timeout=2)
+                            try:
+                                proc.stdout.close()
+                            except Exception:
+                                pass
+                            final_result = {
+                                "output": output.render(),
+                                "returncode": 124 if timed_out else proc.returncode,
+                            }
+                            self._update_cwd(final_result)
+                            on_complete = metadata.get("on_complete")
+                            if callable(on_complete):
+                                try:
+                                    on_complete(self.cwd)
+                                except Exception:
+                                    logger.debug(
+                                        "foreground process cwd update failed",
+                                        exc_info=True,
+                                    )
+                            process_registry.finish_adopted_process(
+                                session,
+                                output=final_result["output"],
+                                exit_code=final_result["returncode"],
+                                completion_reason=(
+                                    "timed_out" if timed_out else "exited"
+                                ),
+                                termination_source=(
+                                    "foreground_timeout" if timed_out else ""
+                                ),
+                            )
+
+                        finalizer = threading.Thread(
+                            target=_finish_adopted,
+                            daemon=True,
+                            name=f"proc-adopted-{session.id}",
+                        )
+                        session._reader_thread = finalizer
+                        finalizer.start()
+                        handoff = process_handoff(session.id)
+                        wait_slot.complete_background(handoff)
+                        return {
+                            "status": "backgrounded",
+                            "output": output.render(),
+                            "returncode": None,
+                            "foreground_handoff": handoff,
+                        }
                 if is_interrupted():
                     if _DEBUG_INTERRUPT:
                         logger.info(
@@ -1404,6 +1515,7 @@ class BaseEnvironment(ABC):
         stdin_data: str | None = None,
         rewrite_compound_background: bool = True,
         bounded_capture: bool = False,
+        foreground_handoff: dict | None = None,
     ) -> dict:
         """Execute a command, return {"output": str, "returncode": int}.
 
@@ -1451,7 +1563,8 @@ class BaseEnvironment(ABC):
             wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin
         )
         result = self._wait_for_process(
-            proc, timeout=effective_timeout, bounded_capture=bounded_capture
+            proc, timeout=effective_timeout, bounded_capture=bounded_capture,
+            foreground_handoff=foreground_handoff,
         )
         self._update_cwd(result)
 

--- a/tools/foreground_wait.py
+++ b/tools/foreground_wait.py
@@ -1,0 +1,179 @@
+"""Cooperative handoff for tool calls that can leave foreground waits running.
+
+The agent owns a registry; the tool executor binds one slot to the worker thread
+before invoking a supported blocking tool.  A forced durable steer requests a
+handoff through that slot instead of interrupting or killing the underlying
+work.
+"""
+
+from __future__ import annotations
+
+import threading
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+_current = threading.local()
+
+
+@dataclass
+class ForegroundWaitSlot:
+    tool_call_id: str
+    kind: str
+    background_requested: threading.Event = field(default_factory=threading.Event)
+    _resolved: threading.Event = field(default_factory=threading.Event, repr=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+    _status: str = "waiting"
+    _handoff: Optional[Dict[str, Any]] = None
+    _error: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def complete_background(self, handoff: Dict[str, Any]) -> None:
+        """Resolve this wait as successfully moved to background."""
+        with self._lock:
+            if self._resolved.is_set():
+                return
+            self._status = "backgrounded"
+            self._handoff = dict(handoff)
+            self._resolved.set()
+
+    def complete_naturally(self) -> None:
+        """Resolve a force/completion race where the foreground work finished."""
+        with self._lock:
+            if self._resolved.is_set():
+                return
+            self._status = "completed"
+            self._resolved.set()
+
+    def fail_background(self, error: str) -> None:
+        with self._lock:
+            if self._resolved.is_set():
+                return
+            self._status = "failed"
+            self._error = str(error or "foreground handoff failed")
+            self._resolved.set()
+
+    def wait_for_resolution(self, timeout: float) -> Dict[str, Any]:
+        if not self._resolved.wait(timeout):
+            return {
+                "status": "failed",
+                "error": "timed out while moving foreground wait to background",
+            }
+        with self._lock:
+            result: Dict[str, Any] = {"status": self._status}
+            if self._handoff is not None:
+                result["handoff"] = dict(self._handoff)
+            if self._error:
+                result["error"] = self._error
+            return result
+
+
+class ForegroundWaitRegistry:
+    """Thread-safe set of supported foreground waits owned by one agent."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._slots: Dict[str, ForegroundWaitSlot] = {}
+
+    def register(self, tool_call_id: str, kind: str) -> ForegroundWaitSlot:
+        slot = ForegroundWaitSlot(str(tool_call_id), str(kind))
+        with self._lock:
+            self._slots[slot.tool_call_id] = slot
+        return slot
+
+    def unregister(self, slot: ForegroundWaitSlot) -> None:
+        with self._lock:
+            if self._slots.get(slot.tool_call_id) is slot:
+                self._slots.pop(slot.tool_call_id, None)
+        slot.complete_naturally()
+
+    def snapshot(self) -> List[ForegroundWaitSlot]:
+        with self._lock:
+            return list(self._slots.values())
+
+    def request_background(
+        self,
+        slots: Optional[List[ForegroundWaitSlot]] = None,
+        timeout: float = 5.0,
+    ) -> Dict[str, Any]:
+        slots = list(slots) if slots is not None else self.snapshot()
+        kinds = sorted({slot.kind for slot in slots})
+        if not slots:
+            return {"status": "no_wait", "wait_kinds": []}
+
+        for slot in slots:
+            slot.background_requested.set()
+
+        handoffs: List[Dict[str, Any]] = []
+        failures: List[str] = []
+        for slot in slots:
+            outcome = slot.wait_for_resolution(timeout)
+            if outcome["status"] == "backgrounded":
+                handoff = outcome.get("handoff")
+                if isinstance(handoff, dict):
+                    handoffs.append(handoff)
+            elif outcome["status"] != "completed":
+                failures.append(str(outcome.get("error") or "foreground handoff failed"))
+
+        if failures:
+            return {
+                "status": "failed",
+                "wait_kinds": kinds,
+                "errors": failures,
+                "handoffs": handoffs,
+            }
+        return {
+            "status": "backgrounded",
+            "wait_kinds": kinds,
+            "handoffs": handoffs,
+        }
+
+
+def set_current_foreground_wait(slot: Optional[ForegroundWaitSlot]) -> None:
+    _current.slot = slot
+
+
+def current_foreground_wait() -> Optional[ForegroundWaitSlot]:
+    slot = getattr(_current, "slot", None)
+    return slot if isinstance(slot, ForegroundWaitSlot) else None
+
+
+def process_handoff(session_id: str) -> Dict[str, str]:
+    """Return the canonical recovery contract for one adopted process."""
+    return {
+        "kind": "process",
+        "session_id": session_id,
+        "continue": f'process(action="wait", session_id="{session_id}")',
+        "inspect": f'process(action="log", session_id="{session_id}")',
+        "stop": f'process(action="kill", session_id="{session_id}")',
+    }
+
+
+def supported_wait_kind(tool_name: str, args: Dict[str, Any]) -> Optional[str]:
+    if tool_name == "terminal" and not bool(args.get("background", False)):
+        return "terminal"
+    if tool_name == "delegate_task" and str(args.get("action") or "").lower() == "wait":
+        return "delegation"
+    return None
+
+
+@contextmanager
+def track_foreground_wait(
+    agent, tool_call_id: str, tool_name: str, args: Dict[str, Any]
+):
+    """Bind a supported wait slot around one registry-dispatched tool call."""
+    kind = supported_wait_kind(tool_name, args)
+    registry = getattr(agent, "_foreground_waits", None)
+    if not kind or registry is None:
+        yield None
+        return
+
+    slot = registry.register(tool_call_id, kind)
+    previous = current_foreground_wait()
+    set_current_foreground_wait(slot)
+    try:
+        yield slot
+    finally:
+        set_current_foreground_wait(previous)
+        registry.unregister(slot)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -419,6 +419,7 @@ class ProcessSession:
     _lock: threading.Lock = field(default_factory=threading.Lock)
     _reader_thread: Optional[threading.Thread] = field(default=None, repr=False)
     _pty: Any = field(default=None, repr=False)  # ptyprocess handle (when use_pty=True)
+    kill_callback: Any = field(default=None, repr=False)
 
 
 class ProcessRegistry:
@@ -970,6 +971,72 @@ class ProcessRegistry:
             except Exception as exc:
                 logger.debug("Could not resolve environment temp dir: %s", exc)
         return "/tmp"
+
+    def adopt_foreground_process(
+        self,
+        process,
+        *,
+        command: str,
+        task_id: str = "",
+        session_key: str = "",
+        cwd=None,
+        env_ref=None,
+        initial_output: str = "",
+        kill_callback=None,
+        notify_on_complete: bool = True,
+    ):
+        """Take ownership of an already-running foreground process handle."""
+        pid = getattr(process, "pid", None)
+        session = ProcessSession(
+            id=f"proc_{uuid.uuid4().hex[:12]}",
+            command=command,
+            task_id=task_id,
+            session_key=session_key,
+            pid=pid if isinstance(pid, int) else None,
+            process=process,
+            env_ref=env_ref,
+            kill_callback=kill_callback,
+            cwd=cwd,
+            started_at=time.time(),
+            host_start_time=(
+                self._safe_host_start_time(pid) if isinstance(pid, int) else None
+            ),
+            output_buffer=str(initial_output or "")[-MAX_OUTPUT_CHARS:],
+            notify_on_complete=bool(notify_on_complete),
+        )
+        with self._lock:
+            self._prune_if_needed()
+            self._running[session.id] = session
+        self._write_checkpoint()
+        return session
+
+    def update_adopted_output(self, session, output: str, chunk: str = "") -> None:
+        with session._lock:
+            if session.exited:
+                return
+            session.output_buffer = str(output or "")[-session.max_output_chars :]
+        if chunk:
+            self._check_watch_patterns(session, chunk)
+            self._emit_output(session, chunk)
+
+    def finish_adopted_process(
+        self,
+        session,
+        *,
+        output: str,
+        exit_code=None,
+        completion_reason: str = "exited",
+        termination_source: str = "",
+    ) -> None:
+        with session._lock:
+            if session.exited:
+                return
+            session.output_buffer = str(output or "")[-session.max_output_chars :]
+            session.exit_code = exit_code
+            session.completion_reason = completion_reason
+            session.termination_source = termination_source
+            session.exited = True
+        self._move_to_finished(session)
 
     def spawn_local(
         self,

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1213,6 +1213,41 @@ def record_session_cwd(session_key: Optional[str], cwd: Optional[str]) -> None:
             _session_cwd[key] = cwd
 
 
+def _configure_forced_handoff_session(proc_session, session_key: str) -> None:
+    """Route completion for a foreground process that was adopted mid-wait."""
+    from tools.process_registry import process_registry
+    from gateway.session_context import (
+        async_delivery_supported,
+        get_session_env,
+    )
+
+    if not async_delivery_supported():
+        proc_session.notify_on_complete = False
+        return
+    platform = get_session_env("HERMES_SESSION_PLATFORM", "")
+    if not platform:
+        return
+    proc_session.watcher_platform = platform
+    proc_session.watcher_chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "")
+    proc_session.watcher_user_id = get_session_env("HERMES_SESSION_USER_ID", "")
+    proc_session.watcher_user_name = get_session_env("HERMES_SESSION_USER_NAME", "")
+    proc_session.watcher_thread_id = get_session_env("HERMES_SESSION_THREAD_ID", "")
+    proc_session.watcher_message_id = get_session_env("HERMES_SESSION_MESSAGE_ID", "")
+    proc_session.watcher_interval = 5
+    process_registry.pending_watchers.append({
+        "session_id": proc_session.id,
+        "check_interval": 5,
+        "session_key": session_key,
+        "platform": proc_session.watcher_platform,
+        "chat_id": proc_session.watcher_chat_id,
+        "user_id": proc_session.watcher_user_id,
+        "user_name": proc_session.watcher_user_name,
+        "thread_id": proc_session.watcher_thread_id,
+        "message_id": proc_session.watcher_message_id,
+        "notify_on_complete": True,
+    })
+
+
 def get_session_cwd(session_key: Optional[str]) -> Optional[str]:
     """Return the recorded working directory for *session_key*, if any.
 
@@ -3356,6 +3391,24 @@ def terminal_tool(
                         # reads, RPC reads) intentionally stay unbounded.
                         "bounded_capture": True,
                     }
+                    from tools.foreground_wait import current_foreground_wait
+
+                    wait_slot = current_foreground_wait()
+                    if wait_slot is not None and wait_slot.kind == "terminal":
+                        execute_kwargs["foreground_handoff"] = {
+                            "command": command,
+                            "task_id": effective_task_id or "",
+                            "session_key": session_key,
+                            "cwd": command_cwd,
+                            "on_adopted": lambda proc_session: (
+                                _configure_forced_handoff_session(
+                                    proc_session, session_key
+                                )
+                            ),
+                            "on_complete": lambda final_cwd: record_session_cwd(
+                                session_key, final_cwd
+                            ),
+                        }
                     result = env.execute(command, **execute_kwargs)
                 except Exception as e:
                     error_str = str(e).lower()


### PR DESCRIPTION
## What does this PR do?

**Intent:** bring Hermes `delegate_task` up to the child-agent lifecycle
capability of the Codex harness. Codex can spawn a subagent and then inspect,
wait on, steer, interrupt, and resume it after the parent process restarts.
On current Hermes main, background `delegate_task` only returns a handle plus
live `list` / `steer` / `stop`; after a restart those children are gone from
the in-memory registry.

This is capability parity, not a Codex clone. It folds durable
`status` / `tail` / `wait` / `resume` / `interrupt` / `abandon` onto the
existing `delegate_task(action=...)` tool instead of adding a second
model-facing tool. Live `list` / `steer` / `stop` stay as they are. `stop`
with a `delegation_id` aliases interrupt. `force=true` on steer can hand a
registered foreground wait (terminal / `action=wait`) to the process
registry.

A follow-up commit keeps the origin `_connect()` ledger helper and writes
completion `event_json` back onto `async_delegations`, so
`restore_undelivered_completions` still stamps `restored=True` in memory only.

## Related Issue

No dedicated upstream issue. Searched open PRs/issues for
`delegate_task` lifecycle / resume / durable control; nothing covers this
surface.

Related but not fixed here:
- #71453 (`hermes chat -q` still kills async children on exit)
- #66804 (native persisted workflow runtime)

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/delegate_tool.py` — extend `delegate_task` schema/docstring with
  durable `status` / `tail` / `wait` / `resume` / `interrupt` / `abandon`;
  `stop` + `delegation_id` aliases interrupt.
- `tools/delegation_control.py` — route those actions.
- `tools/delegation_repository.py` + `hermes_state.py` /
  `hermes_state_common.py` — persist attempts/runs/events in `state.db`;
  `SessionDB.get_subagent_resume_bundle` for reconstructed resume.
- `tools/async_delegation.py` — repository-backed wait/resume/interrupt;
  restore origin `_connect()` / `_transaction()` for ledger inspect and
  FD-leak close.
- `tools/foreground_wait.py`, `run_agent.py`, `agent/agent_init.py`,
  `agent/tool_executor.py`, `tools/terminal_tool.py`,
  `tools/environments/base.py`, `tools/process_registry.py` — register
  foreground waits and implement `force=true` handoff.
- `agent/tool_guardrails.py` — allow the new control actions.
- Tests: `tests/tools/test_delegation_control.py`,
  `test_delegation_durable_lifecycle.py`, `test_delegation_repository.py`,
  `test_delegation_transcript_resume.py`.

## How to Test

1. Fresh `HERMES_HOME` on this tree (`bc0a4fa37c`, based on `5d3c15aaa7`).
2. Focused suite actually re-run on current HEAD:

   ```
   PYTHONPATH=. python -m pytest -o addopts= -q \
     tests/tools/test_restored_delegation_ownership.py \
     tests/tools/test_async_delegation_fd_leak.py \
     tests/tui_gateway/test_delegation_session_lifecycle.py \
     tests/tui_gateway/test_subagent_child_mirror.py::test_prompt_submit_rejected_while_child_run_active \
     tests/tools/test_delegation_repository.py \
     tests/tools/test_delegation_durable_lifecycle.py \
     tests/tools/test_delegation_control.py \
     tests/tools/test_delegation_transcript_resume.py
   ```

   Result: 167 passed. Full `pytest tests/ -q` / `scripts/run_tests.sh` was
   **not** completed, so that checklist item stays unchecked.

3. Manual: spawn `delegate_task(goal=...)`, then
   `action=status|tail|wait|steer|interrupt` with the returned
   `delegation_id`. For `force=true`, steer while the child is inside
   `terminal` or `action=wait` and confirm the wait backgrounds instead of
   returning `foreground_wait`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux (`7.0.10-arch1-1`); not tested on macOS/Windows

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
      Tool schema + `delegate_task` docstring updated. `AGENTS.md` and
      `website/docs/user-guide/features/delegation.md` still say background
      delegation is process-local only.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
      Process adoption / wait handoff is POSIX-oriented; not verified on Windows.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Re-run on current HEAD: 167 passed in ~83s.
Branch: `feat/delegate-task-lifecycle-control` @ `bc0a4fa37c`
(`0953da1e5e` feat + `bc0a4fa37c` restore `_connect`).
Full `pytest tests/ -q` has not completed.