### PR TITLE
fix(email): suppress session reset notices

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -547,7 +547,7 @@ class SessionResetPolicy:
     at_hour: int = 4  # Hour for daily reset (0-23, local time)
     idle_minutes: int = 1440  # Minutes of inactivity before reset (24 hours)
     notify: bool = True  # Send a notification to the user when auto-reset occurs
-    notify_exclude_platforms: tuple = ("api_server", "webhook")  # Platforms that don't get reset notifications
+    notify_exclude_platforms: tuple = ("api_server", "webhook", "email")  # Platforms that don't get reset notifications
     # A background process this many hours old (or older) no longer blocks
     # session idle/daily reset. A forgotten preview server should not keep a
     # session alive forever (#29177). The process is NOT killed — only ignored
@@ -580,7 +580,7 @@ class SessionResetPolicy:
             at_hour=at_hour if at_hour is not None else 4,
             idle_minutes=idle_minutes if idle_minutes is not None else 1440,
             notify=_coerce_bool(notify, True),
-            notify_exclude_platforms=tuple(exclude) if exclude is not None else ("api_server", "webhook"),
+            notify_exclude_platforms=tuple(exclude) if exclude is not None else ("api_server", "webhook", "email"),
             bg_process_max_age_hours=bg_max_age if bg_max_age is not None else 24,
         )
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15740,6 +15740,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
 
 
+    @staticmethod
+    def _should_send_auto_reset_notice(
+        platform_name: str, reset_reason: str, policy, had_activity: bool
+    ) -> bool:
+        """Return whether reset policy allows a standalone platform notice."""
+        if platform_name in policy.notify_exclude_platforms:
+            return False
+        return reset_reason in {"suspended", "resume_pending_expired"} or (
+            policy.notify and had_activity
+        )
+
     async def _deliver_platform_notice(self, source, content: str) -> None:
         """Deliver a setup/operational notice using platform-specific privacy rules."""
         adapter = self._adapter_for_source(source)
@@ -18837,14 +18848,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 platform_name = source.platform.value if source.platform else ""
                 had_activity = getattr(session_entry, 'reset_had_activity', False)
-                # Suspended and restart-recovery-expired sessions always notify
-                # regardless of policy.notify — the user had an active session
-                # that was silently replaced, so they need to know they can
-                # /resume it.  Idle/daily resets respect the policy flag.
-                should_notify = reset_reason in {"suspended", "resume_pending_expired"} or (
-                    policy.notify
-                    and had_activity
-                    and platform_name not in policy.notify_exclude_platforms
+                # Suspended and restart-recovery-expired sessions ignore
+                # policy.notify because the user needs to know the active
+                # session was replaced. Transport exclusions still win.
+                should_notify = self._should_send_auto_reset_notice(
+                    platform_name, reset_reason, policy, had_activity
                 )
                 if should_notify:
                     adapter = self._adapter_for_source(source)

--- a/tests/gateway/test_notice_delivery.py
+++ b/tests/gateway/test_notice_delivery.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.config import GatewayConfig, Platform, PlatformConfig, SessionResetPolicy
 from gateway.platforms.base import SendResult
 from gateway.run import GatewayRunner
 from gateway.session import SessionSource
@@ -45,5 +45,28 @@ async def test_deliver_platform_notice_uses_private_delivery_when_configured():
         metadata={"thread_id": "111.222"},
     )
     adapter.send.assert_not_awaited()
+
+
+@pytest.mark.parametrize("reset_reason", ["suspended", "resume_pending_expired"])
+def test_reset_notice_platform_exclusion_is_absolute(reset_reason):
+    policy = SessionResetPolicy(
+        notify=True,
+        notify_exclude_platforms=("email",),
+    )
+
+    assert not GatewayRunner._should_send_auto_reset_notice(
+        "email", reset_reason, policy, had_activity=True
+    )
+
+
+def test_reset_notice_still_sends_on_included_chat_platform():
+    policy = SessionResetPolicy(
+        notify=True,
+        notify_exclude_platforms=("email",),
+    )
+
+    assert GatewayRunner._should_send_auto_reset_notice(
+        "telegram", "idle", policy, had_activity=True
+    )
 
 

--- a/tests/gateway/test_session_reset_notify.py
+++ b/tests/gateway/test_session_reset_notify.py
@@ -168,6 +168,15 @@ class TestResetPolicyNotify:
         policy = SessionResetPolicy()
         assert "api_server" in policy.notify_exclude_platforms
         assert "webhook" in policy.notify_exclude_platforms
+        assert "email" in policy.notify_exclude_platforms
+
+    def test_from_dict_uses_notify_exclude_defaults(self):
+        policy = SessionResetPolicy.from_dict({})
+        assert policy.notify_exclude_platforms == (
+            "api_server",
+            "webhook",
+            "email",
+        )
 
 
     def test_from_dict_with_custom_excludes(self):


### PR DESCRIPTION
## Summary

- Exclude Email from session auto-reset notices by default so gateway status text cannot become an unsolicited SMTP reply.
- Make `notify_exclude_platforms` an absolute transport boundary, including `suspended` and `resume_pending_expired` resets.
- Preserve reset notices on included chat platforms and preserve Email home-channel setup guidance.

## Problem

The gateway sends an auto-reset notice with `adapter.send()` before the agent runs. On chat platforms that is a useful status message. On Email it is a real reply in the external sender's current thread, so `[SILENT]` and final-response safeguards cannot suppress it.

The existing predicate also allowed forced recovery reset reasons to bypass `notify_exclude_platforms`, which made configured transport exclusions incomplete.

## Approach

- Add `email` to the default `SessionResetPolicy.notify_exclude_platforms` value and its `from_dict()` fallback.
- Centralize the send predicate so platform exclusions are checked before reset-reason overrides.
- Keep the change scoped to auto-reset notices. Unlike #76475, this does not suppress the separate home-channel onboarding prompt because Email remains a valid home target.

## Tests

- Added a default-policy regression test for Email.
- Added predicate coverage proving:
  - Email exclusions block forced recovery notices.
  - Included chat platforms still receive idle-reset notices.
- `scripts/run_tests.sh tests/gateway/ -q` — 5,834 passed, 37 platform-specific skips, 0 failed.
- Ruff and `git diff --check` pass.
- `ty` baseline comparison: 77 existing normalized diagnostics, 0 new diagnostics.

## Risk

Low. The change only affects standalone auto-reset notices on excluded transports. Agent replies, Email home-channel guidance, and notices on included chat platforms are unchanged.

Related: #27804, #76475
