### PR TITLE
fix: emit reasoning_effort for custom OpenAI-compatible providers

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -593,6 +593,25 @@ class ChatCompletionsTransport(ProviderTransport):
             if _lm_effort is not None:
                 api_kwargs["reasoning_effort"] = _lm_effort
 
+        # Custom OpenAI-compatible providers: top-level reasoning_effort,
+        # emitted only when the user explicitly set an effort (config.yaml
+        # or a session /reasoning override, both resolved into
+        # reasoning_config before this call). Custom providers do not
+        # advertise supports_reasoning, so the generic extra_body.reasoning
+        # arm below never fires and the effort was silently dropped, letting
+        # the server fall back to its model default (#90031). Identity
+        # pass-through of low|medium|high only: unset, disabled or a level
+        # outside the OpenAI wire set omits the field instead of inventing
+        # a value. Deliberately no supports_reasoning side effect.
+        if params.get("is_custom_provider", False):
+            _custom_effort = None
+            if reasoning_config and isinstance(reasoning_config, dict):
+                _e = str(reasoning_config.get("effort") or "").strip().lower()
+                if _e in {"low", "medium", "high"}:
+                    _custom_effort = _e
+            if _custom_effort is not None:
+                api_kwargs["reasoning_effort"] = _custom_effort
+
         # extra_body assembly
         extra_body: dict[str, Any] = {}
 

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -488,6 +488,100 @@ class TestChatCompletionsLmStudioReasoning:
 
 
 
+class TestChatCompletionsCustomProviderReasoning:
+    """Custom OpenAI-compatible providers (provider == "custom", e.g. local
+    llama.cpp) do not advertise supports_reasoning, so the generic
+    extra_body.reasoning arm never fires and the user's reasoning_effort was
+    silently dropped, letting the server fall back to its model default
+    (#90031). The custom arm emits top-level reasoning_effort only when the
+    user explicitly set an effort (config.yaml or a session /reasoning
+    override, both resolved into reasoning_config before build_kwargs).
+    """
+
+    def test_custom_medium_emits_top_level(self, transport):
+        kw = transport.build_kwargs(
+            model="qwen3-coder", messages=[{"role": "user", "content": "Hi"}],
+            is_custom_provider=True,
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        assert kw["reasoning_effort"] == "medium"
+        # No extra_body.reasoning: the generic arm is gated on
+        # supports_reasoning, which custom providers do not advertise.
+        assert "reasoning" not in kw.get("extra_body", {})
+
+    @pytest.mark.parametrize("level", ["low", "high"])
+    def test_custom_identity_pass_through(self, transport, level):
+        # Session /reasoning override and config.yaml both arrive in the
+        # same reasoning_config slot, so this covers "runtime override
+        # beats config" too: the caller-resolved value wins untouched.
+        kw = transport.build_kwargs(
+            model="qwen3-coder", messages=[{"role": "user", "content": "Hi"}],
+            is_custom_provider=True,
+            reasoning_config={"enabled": True, "effort": level},
+        )
+        assert kw["reasoning_effort"] == level
+
+    def test_custom_unset_omits_effort(self, transport):
+        # Untouched installs have no reasoning_effort configured: resolve
+        # returns None and the field must stay absent so the server keeps
+        # its model default (no surprise flip for existing users).
+        kw = transport.build_kwargs(
+            model="qwen3-coder", messages=[{"role": "user", "content": "Hi"}],
+            is_custom_provider=True,
+            reasoning_config=None,
+        )
+        assert "reasoning_effort" not in kw
+        assert "reasoning" not in kw.get("extra_body", {})
+
+    def test_custom_disabled_omits_effort(self, transport):
+        # reasoning_effort: false means thinking disabled; never re-enable.
+        kw = transport.build_kwargs(
+            model="qwen3-coder", messages=[{"role": "user", "content": "Hi"}],
+            is_custom_provider=True,
+            reasoning_config={"enabled": False},
+        )
+        assert "reasoning_effort" not in kw
+
+    def test_custom_unsupported_level_omits_effort(self, transport):
+        # xhigh/ultra/minimal/max are not in the OpenAI low|medium|high
+        # wire set for custom servers; omit rather than invent a value.
+        kw = transport.build_kwargs(
+            model="qwen3-coder", messages=[{"role": "user", "content": "Hi"}],
+            is_custom_provider=True,
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+        )
+        assert "reasoning_effort" not in kw
+
+    def test_custom_messages_untouched_by_arm(self, transport):
+        # The arm must not mutate the request; messages are byte-identical
+        # with the branch firing and not firing for the same inputs.
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw_on = transport.build_kwargs(
+            model="qwen3-coder", messages=msgs,
+            is_custom_provider=True,
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        kw_off = transport.build_kwargs(
+            model="qwen3-coder", messages=msgs,
+            is_custom_provider=False,
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        assert kw_on["messages"] == msgs == kw_off["messages"]
+
+    def test_kimi_takes_its_own_arm_no_double_emission(self, transport):
+        # Negative: a Kimi provider has is_custom_provider False (the
+        # flags are mutually exclusive upstream), so exactly one
+        # reasoning_effort is emitted and no extra_body.reasoning.
+        kw = transport.build_kwargs(
+            model="kimi-k3", messages=[{"role": "user", "content": "Hi"}],
+            is_kimi=True,
+            is_custom_provider=False,
+            reasoning_config={"enabled": True, "effort": "low"},
+        )
+        assert kw["reasoning_effort"] == "low"
+        assert "reasoning" not in kw.get("extra_body", {})
+
+
 class TestChatCompletionsValidate:
 
     def test_none(self, transport):


### PR DESCRIPTION
## Why

Issue #90031: for custom OpenAI-compatible providers (`provider: custom`, e.g. a local llama.cpp server via `base_url`), `reasoning_effort` was silently dropped. Custom providers do not advertise `supports_reasoning`, so the generic `extra_body.reasoning` arm never fires, and the server falls back to its model default (usually no reasoning or default effort), ignoring what the user configured.

## What

Added a custom-scoped arm in `ChatCompletionsTransport.build_kwargs()` (agent/transports/chat_completions.py), after the LM Studio arm, that emits top-level `reasoning_effort` for custom providers **only when the user explicitly set an effort** (config.yaml `agent.reasoning_effort` or a session `/reasoning` override; both arrive resolved in the same `reasoning_config` slot). Levels are passed through identically for `low`/`medium`/`high`; unset, disabled (`reasoning_effort: false`), or levels outside the OpenAI wire set (`xhigh`, `ultra`, etc.) omit the field instead of inventing a value. No new config keys, no env vars, no `supports_reasoning` side effect, no `extra_body` usage. The existing Kimi / TokenHub / LM Studio arms and the generic `extra_body.reasoning` arm are untouched.

`xhigh` and friends remain reachable for users who need them via the existing `extra_body` route; the new arm deliberately stays within the OpenAI `low|medium|high` wire set.

## Verification

Tests-first in `tests/agent/transports/test_chat_completions.py` (new class `TestChatCompletionsCustomProviderReasoning`):

- Red run (tests only, no arm yet): `1 failed, 51 deselected` with `KeyError: 'reasoning_effort'` on the first emission test.
- After adding the arm: `8 passed` (targeted), `59 passed` (full transport file).
- Sabotage check: temporarily removed only the new arm, targeted run went red again (`1 failed`, same missing-key error), restored byte-identically, both runs green again (`8 passed`, `59 passed`).
- Independent re-run (driver, separate from the drone): `59 passed in 2.57s`.

Covered by the tests: custom+medium emits top-level; low/high identity pass-through (covers the session override slot, runtime beats config); unset omits (no `reasoning_effort`, no `extra_body.reasoning`); disabled omits; unsupported level omits; messages list byte-identical with the branch firing and not firing; negative: Kimi takes its own arm with no double emission.

## Scope notes

This is complementary to #83566 (Ollama gate fix in `run_agent.py`, which does not cover `provider: custom` endpoints) and rebases cleanly either way. #87413 (reasoning_format surface) is still unmerged; if that design lands, the per-vendor arms are the natural seam to fold into it.

One known residual: the summary/compaction path in agent/chat_completion_helpers.py calls `chat.completions.create()` directly and mirrors only the LM Studio top-level emission and the `supports_reasoning` extra_body shape. For custom providers it never emitted `reasoning_effort` before this change and still does not; extending it is a separate, larger change and is deliberately out of scope here. Unknown-field residual risk on strict OpenAI-compatible gateways is unchanged from the existing Kimi/TokenHub top-level arms (the field is part of the OpenAI Chat Completions schema).

Fixes #90031
Refs #83566
Refs #87413
