### PR TITLE
Pin multiplex session cwd to the serving profile home

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25644,6 +25644,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _adapters = getattr(self, "adapters", None) or {}
         _adapter = _adapters.get(context.source.platform)
         _async_delivery = getattr(_adapter, "supports_async_delivery", True)
+        # Multiplex remaps get_hermes_home() per turn. TERMINAL_CWD is bridged
+        # once from the default profile at process start, so secondary-profile
+        # turns would otherwise inject that profile's AGENTS.md.
+        cwd = ""
+        if getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            try:
+                cwd = str(get_hermes_home())
+            except Exception:
+                cwd = ""
         return set_session_vars(
             platform=context.source.platform.value,
             chat_id=context.source.chat_id,
@@ -25659,6 +25668,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             session_key=context.session_key,
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",
+            cwd=cwd,
             async_delivery=_async_delivery,
             cron_session="",
         )

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -238,6 +238,71 @@ async def test_run_in_executor_with_context_preserves_session_env(monkeypatch):
     }
 
 
+def test_set_session_env_pins_cwd_to_profile_home_when_multiplexed(tmp_path, monkeypatch):
+    """Multiplex turns must use the serving profile home, not process TERMINAL_CWD."""
+    from types import SimpleNamespace
+
+    from agent.runtime_cwd import resolve_context_cwd
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = SimpleNamespace(multiplex_profiles=True)
+    runner.adapters = {}
+
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="2144471399",
+        chat_type="dm",
+        user_id="123456",
+        user_name="alice",
+        thread_id=None,
+    )
+    context = SessionContext(source=source, connected_platforms=[], home_channels={})
+
+    token = set_hermes_home_override(str(tmp_path))
+    try:
+        tokens = runner._set_session_env(context)
+        try:
+            assert resolve_context_cwd() == tmp_path
+        finally:
+            runner._clear_session_env(tokens)
+        assert resolve_context_cwd() is None
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_set_session_env_leaves_cwd_unset_without_multiplex(tmp_path, monkeypatch):
+    """Single-profile gateways keep falling through to TERMINAL_CWD / launch cwd."""
+    from types import SimpleNamespace
+
+    from agent.runtime_cwd import resolve_context_cwd
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = SimpleNamespace(multiplex_profiles=False)
+    runner.adapters = {}
+
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="2144471399",
+        chat_type="dm",
+        user_id="123456",
+        user_name="alice",
+        thread_id=None,
+    )
+    context = SessionContext(source=source, connected_platforms=[], home_channels={})
+
+    token = set_hermes_home_override(str(tmp_path))
+    try:
+        tokens = runner._set_session_env(context)
+        try:
+            assert resolve_context_cwd() is None
+        finally:
+            runner._clear_session_env(tokens)
+    finally:
+        reset_hermes_home_override(token)
 
 
 def test_cron_session_contextvar_preserves_legacy_env_fallback(monkeypatch):


### PR DESCRIPTION
## Summary
Under `gateway.multiplex_profiles`, `get_hermes_home()` already remaps to the serving profile for config, skills, memory, and SOUL. Session cwd did not. `TERMINAL_CWD` is bridged once from the default profile at process start, so a secondary-profile first prompt injects the default profile's project `AGENTS.md`.

`_set_session_env` now passes `cwd=str(get_hermes_home())` when multiplexing is on. Single-profile gateways are unchanged (cwd stays unset and still falls through to `TERMINAL_CWD` / launch cwd).

## Changes
- `gateway/run.py`: pin session cwd from `get_hermes_home()` under multiplex
- `tests/gateway/test_session_env.py`: multiplex pins to the override home; non-multiplex leaves cwd unset

## Tests
- [x] `pytest tests/gateway/test_session_env.py`