### PR TITLE
fix(disk-cleanup): protect durable runtime trees

### DIFF
--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -144,6 +144,14 @@ ALLOWED_CATEGORIES = {
     "chrome-profile", "cron-output", "other",
 }
 
+_DURABLE_RUNTIME_TOP_LEVEL = frozenset({
+    # Authored runtime/control-plane trees. The post-tool hook sees paths from
+    # patch/terminal results, not whether a file was newly created; a name such
+    # as scripts/test_guard.py must therefore never make it disposable.
+    "scripts", "hooks", "bin", "guardrails", "services", "state",
+    "kanban", "workspace", "platforms", "gateway", "control-room",
+})
+
 _EMPTY_DIR_PROTECTED_TOP_LEVEL = frozenset({
     "logs", "memories", "sessions", "cron", "cronjobs",
     "cache", "skills", "plugins", "disk-cleanup", "optional-skills",
@@ -151,7 +159,7 @@ _EMPTY_DIR_PROTECTED_TOP_LEVEL = frozenset({
     # User-authored project trees — never sweep empty directories
     # inside these (#75403).
     "patches", "projects", "skins", "themes", "contributors",
-})
+}) | _DURABLE_RUNTIME_TOP_LEVEL
 
 _EMPTY_DIR_SWEEP_PRUNE_DIRS = frozenset({
     ".git", "node_modules", "venv", ".venv",
@@ -586,7 +594,7 @@ def guess_category(path: Path) -> Optional[str]:
             # tmp_* (#75403, also #32164, #37721).
             "patches", "projects", "skins", "themes", "contributors",
             "profiles", "backups", "optional-skills",
-        }:
+        } | _DURABLE_RUNTIME_TOP_LEVEL:
             return None
         if top == "cron" or top == "cronjobs":
             # Only files under the disposable ``output/`` subtree are

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -115,6 +115,27 @@ class TestGuessCategory:
         # Even though it matches test_* pattern, logs/ is excluded.
         assert dg.guess_category(p) is None
 
+    @pytest.mark.parametrize(
+        "top",
+        [
+            "scripts", "hooks", "bin", "guardrails", "services", "state",
+            "kanban", "workspace", "platforms", "gateway", "control-room",
+        ],
+    )
+    def test_skips_durable_runtime_trees(self, _isolate_env, top):
+        """Regression: edited, versioned test guards under scripts/ were deleted.
+
+        The cleanup hook sees paths from patch/terminal results, not whether a file was
+        newly created. Durable runtime trees must therefore never be auto-categorised
+        solely because a filename starts with ``test_`` or ``tmp_``.
+        """
+        dg = _load_lib()
+        durable = _isolate_env / top
+        durable.mkdir()
+        p = durable / "test_durable_guard.py"
+        p.write_text("assert True")
+        assert dg.guess_category(p) is None
+
     def test_cron_subtree_categorised(self, _isolate_env):
         dg = _load_lib()
         # Only files under ``cron/output/`` are disposable run artifacts.
@@ -223,6 +244,38 @@ class TestStaleCronEntryMigration:
         summary = dg.quick()
         assert summary["deleted"] == 1, "valid old cron-output should be deleted"
         assert not run_md.exists()
+
+
+class TestDurableRuntimeTreeMigration:
+    def test_quick_does_not_delete_stale_test_entry_under_scripts(self, _isolate_env):
+        """A stale tracker entry must not delete an authored regression test."""
+        dg = _load_lib()
+        scripts = _isolate_env / "scripts"
+        scripts.mkdir()
+        guard = scripts / "test_cron_failure_watch.py"
+        guard.write_text("assert True")
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        tracked_file.parent.mkdir(parents=True)
+        tracked_file.write_text(json.dumps([{
+            "path": str(guard),
+            "category": "test",
+            "timestamp": "2025-01-01T00:00:00+00:00",
+            "size": guard.stat().st_size,
+        }]))
+
+        summary = dg.quick()
+        assert summary["deleted"] == 0
+        assert guard.exists(), "durable scripts/test_*.py must never be deleted"
+        assert json.loads(tracked_file.read_text()) == []
+
+    def test_quick_preserves_empty_directories_under_scripts(self, _isolate_env):
+        dg = _load_lib()
+        placeholder = _isolate_env / "scripts" / "health"
+        placeholder.mkdir(parents=True)
+
+        summary = dg.quick()
+        assert summary["empty_dirs"] == 0
+        assert placeholder.exists()
 
 
 class TestTrackForgetQuick:


### PR DESCRIPTION
## Summary

- protect authored runtime/control-plane trees from filename-based `test` auto-tracking
- prevent the empty-directory sweep from removing placeholders inside those trees
- migrate stale `tracked.json` entries without deleting durable files

## Root cause

The post-tool hook receives paths mentioned by `patch` and `terminal`, but cannot know whether a path was newly created. A versioned file such as `~/.hermes/scripts/test_cron_failure_watch.py` was therefore classified as ephemeral solely from its basename and deleted by `quick()` at session end.

On the reporting host, the cleanup audit recorded 10 authored `scripts/test_*.py` deletions over three days. It also removed empty control-plane directories under `scripts/`, `kanban/`, `state/`, `services/`, and `workspace/`.

## Verification

- new targeted regression cases: 13 failed before the fix, 13 passed after
- complete isolated plugin suite: 40 passed
- live rollout: gateway restarted onto this commit; stale tracked entry removed; restored durable test remained present after `quick()`

Command:

```bash
python -m pytest -q --confcutdir=tests/plugins tests/plugins/test_disk_cleanup_plugin.py
```
