### PR TITLE
fix(title): retry without response_format when upstream rejects it (#83390)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8678,6 +8678,26 @@ def _build_call_kwargs(
                 sticky_key = None
             if sticky_key:
                 merged_extra["session_id"] = sticky_key
+    # Providers whose wire is Anthropic Messages have no ``response_format``
+    # field. The native adapter translates it into ``output_config.format`` on
+    # the direct path (build_anthropic_kwargs), but retry / fallback routes
+    # that rebuild their request through this shared builder would otherwise
+    # forward the raw field verbatim and get a hard 400 ("Extra inputs are not
+    # permitted") the moment a payment/auth fallback fires. Strip it here so a
+    # fallback onto an Anthropic-compatible endpoint can't 400 #83390.
+    if merged_extra and "response_format" in merged_extra:
+        _is_anthropic_wire = (
+            _provider_for_portal == "anthropic"
+            or _endpoint_speaks_anthropic_messages(effective_base)
+            or _is_anthropic_compat_endpoint(_provider_for_portal, effective_base)
+        )
+        if _is_anthropic_wire:
+            merged_extra.pop("response_format", None)
+            logger.debug(
+                "_build_call_kwargs: stripped response_format for Anthropic wire "
+                "(provider=%s base_url=%s)",
+                provider, effective_base,
+            )
     if merged_extra:
         kwargs["extra_body"] = merged_extra
 

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -282,6 +282,19 @@ def derive_title(user_message: str) -> Optional[str]:
     return line or None
 
 
+def _is_response_format_unsupported(exc: BaseException) -> bool:
+    """True when the upstream rejected the structured-output format itself.
+
+    Some OpenAI-compatible upstreams (Console Go / opencode-go) answer any
+    ``response_format`` with a 400 (``This response_format type is unavailable
+    now``) before the model is even called. Retrying without it is safe
+    because title extraction already falls back to a loose JSON scan of the
+    plain ``{"title": ...}`` response; any other error must not be swallowed.
+    """
+    message = str(exc)
+    return "response_format" in message and "unavailable" in message
+
+
 def _extract_title_text(content: str) -> str:
     """Pull the title out of a model response.
 
@@ -400,17 +413,38 @@ def generate_title(
     ]
 
     try:
-        response = call_llm(
-            task="title_generation",
-            messages=messages,
-            # A title is a handful of tokens. The old 500-token ceiling let a
-            # chatty model burn seconds generating prose we then threw away.
-            max_tokens=64,
-            temperature=0.3,
-            timeout=timeout,
-            main_runtime=main_runtime,
-            extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
-        )
+        try:
+            response = call_llm(
+                task="title_generation",
+                messages=messages,
+                # A title is a handful of tokens. The old 500-token ceiling let a
+                # chatty model burn seconds generating prose we then threw away.
+                max_tokens=64,
+                temperature=0.3,
+                timeout=timeout,
+                main_runtime=main_runtime,
+                extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
+            )
+        except Exception as first_error:
+            # Some OpenAI-compatible upstreams (e.g. Console Go / opencode-go)
+            # reject json_schema response_format outright with a 400 before the
+            # model is ever called. Retry once without it: extraction already
+            # falls back to a loose JSON scan, so the structured-output
+            # constraint is a nicety, not a requirement.
+            if not _is_response_format_unsupported(first_error):
+                raise
+            logger.debug(
+                "Title upstream rejected response_format; retrying without it: %s",
+                first_error,
+            )
+            response = call_llm(
+                task="title_generation",
+                messages=messages,
+                max_tokens=64,
+                temperature=0.3,
+                timeout=timeout,
+                main_runtime=main_runtime,
+            )
         content = response.choices[0].message.content or ""
         title = _clean_title(_extract_title_text(content))
         # Answer-shaped output guard: titling is a 3-7 word task, so a title

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2721,6 +2721,38 @@ class TestAnthropicAuxiliaryReasoningTranslation:
         )
         assert "_reasoning_config" not in openai_wire_kwargs
 
+    def test_build_call_kwargs_strips_response_format_on_anthropic_wire(self):
+        """Anthropic Messages has no ``response_format``; a retry/fallback rebuilt
+        through this shared builder must not forward it verbatim (#83390)."""
+        rf = {"type": "json_schema", "json_schema": {"name": "t"}}
+
+        anthropic_kwargs = _build_call_kwargs(
+            "anthropic",
+            "claude-fable-5",
+            [{"role": "user", "content": "hi"}],
+            extra_body={"response_format": rf},
+            base_url="https://api.anthropic.com/v1",
+        )
+        assert "response_format" not in anthropic_kwargs.get("extra_body", {})
+
+        proxy_kwargs = _build_call_kwargs(
+            "custom",
+            "claude-fable-5",
+            [{"role": "user", "content": "hi"}],
+            extra_body={"response_format": rf},
+            base_url="https://example.test/anthropic/v1",
+        )
+        assert "response_format" not in proxy_kwargs.get("extra_body", {})
+
+        openai_kwargs = _build_call_kwargs(
+            "custom",
+            "gpt-compatible",
+            [{"role": "user", "content": "hi"}],
+            extra_body={"response_format": rf},
+            base_url="https://example.test/v1",
+        )
+        assert openai_kwargs["extra_body"]["response_format"] == rf
+
 
 class TestAuxiliaryProviderProfileReasoning:
     """Auxiliary calls must reuse provider-profile reasoning wire shapes."""


### PR DESCRIPTION
Addresses #83390 — title_generation 400s on providers that reject the structured-output format.

**What:**
- `agent/title_generator.py`: retry the title call **once without** `response_format` when the upstream rejects the `json_schema` shape (`This response_format type is unavailable now`) — which several OpenAI-compatible upstreams (Console Go / opencode-go / DeepSeek) do _before_ the model is even called. Extraction already falls back to a loose JSON scan, so the constraint is a nicety, not a requirement. Any other error is re-raised untouched.
- `agent/auxiliary_client.py` `_build_call_kwargs`: strip `response_format` when the wire is Anthropic Messages. The direct path translates it to `output_config.format`, but retry/fallback routes rebuilt through this shared builder would otherwise forward it verbatim and 400 the moment a payment/auth fallback fires.

**Why in the shared builder:** the direct Anthropic path uses `build_anthropic_kwargs` (correct translation); the retry path reconstructs through `_build_call_kwargs` and leaked the raw field. Guard is scoped to anthropic wire detection (provider=anthropic / base_url contains /anthropic / known compat provider).

**Tests:** `tests/agent/test_title_generator.py` + `tests/agent/test_auxiliary_client.py` — 219 passed locally.