### PR TITLE
fix(launchd): clean up transient reload jobs on exit

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4790,7 +4790,15 @@ def refresh_launchd_plist_if_needed() -> bool:
         # Label for the transient one-shot job (see `launchctl submit` below).
         # Unique per reload so concurrent/repeated reloads never collide.
         submit_label = f"{label}.reload.{os.getpid()}.{int(time.time())}"
+        cleanup_command = (
+            f"launchctl remove {shlex.quote(submit_label)} 2>/dev/null"
+        )
         reload_script = (
+            # `launchctl submit` jobs are inferred KeepAlive. Install cleanup
+            # before any work so normal exits and handled signals cannot leave
+            # a helper that launchd respawns indefinitely.
+            f"trap {shlex.quote(cleanup_command)} EXIT; "
+            f"trap 'exit 1' HUP INT TERM; "
             f"sleep 2; "
             f"launchctl bootout {shlex.quote(target)} 2>/dev/null; "
             # Wait for the OLD gateway to actually exit before bootstrapping.
@@ -4822,12 +4830,7 @@ def refresh_launchd_plist_if_needed() -> bool:
             f"done; "
             f"if ! launchctl list {shlex.quote(label)} 2>/dev/null | grep -qE '\\\"PID\\\" = [0-9]+;'; then "
             f"  echo \"[$(date '+%Y-%m-%d %H:%M:%S %z')] FAILED launchd reload for {shlex.quote(target)} — service NOT registered after {_reload_budget}s of retries\" >> {shlex.quote(str(reload_log_path))}; "
-            f"fi; "
-            # Submitted jobs stay registered with launchd after the script
-            # exits; without this, every reload leaks one dead label. Removing
-            # our own label is the documented way to end a one-shot submit job
-            # (it SIGTERMs the job, but this is the final statement anyway).
-            f"launchctl remove {shlex.quote(submit_label)} 2>/dev/null"
+            f"fi"
         )
         try:
             # Spawn the reload helper via `launchctl submit` (a transient

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -383,10 +383,15 @@ class TestLaunchdServiceRecovery:
         script = cmd[bash_idx + 2]
         assert "bootout" in script and "bootstrap" in script
         assert str(plist_path) in script
-        # The one-shot job must deregister its own transient label at the end,
-        # otherwise every reload leaks a dead label in launchd.
+        # The one-shot job must deregister its transient label on every shell
+        # exit path. A final cleanup command alone is skipped when launchd
+        # terminates the helper, leaving an inferred KeepAlive job behind.
         submit_label = cmd[cmd.index("-l") + 1]
-        assert f"launchctl remove {submit_label}" in script
+        cleanup_trap = (
+            f"trap 'launchctl remove {submit_label} 2>/dev/null' EXIT; "
+            "trap 'exit 1' HUP INT TERM; "
+        )
+        assert script.startswith(cleanup_trap)
 
     def test_refresh_defers_reload_even_when_not_a_posix_descendant(self, tmp_path, monkeypatch):
         """The detached helper is used even when the gateway is NOT an ancestor.

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -366,6 +366,18 @@ These are equivalent to `hermes -p coder gateway <action>` — useful if a
 profile alias is not on `PATH` or if you target profiles dynamically from a
 script.
 
+### Automating macOS restarts
+
+Use the profile-aware Hermes commands above instead of invoking `launchctl`
+directly. Hermes detects whether the service is registered in the
+`gui/<uid>` or `user/<uid>` domain; hard-coding either domain makes automation
+depend on how the user session was started.
+
+If an external wrapper must create a transient job with `launchctl submit`,
+remove that submitted label on every exit and handled signal. Submitted jobs
+are inferred KeepAlive jobs, so a failing helper that exits without removing
+itself will be launched again.
+
 ## Service files
 
 Each profile installs its own service with a unique name, so installations


### PR DESCRIPTION
## What does this PR do?

`launchctl submit` jobs are inferred KeepAlive jobs. The transient macOS gateway reload helper previously removed its submitted label only as its final shell statement. If the helper failed or received a signal before reaching that statement, the label remained registered and launchd could repeatedly respawn the supposedly one-shot helper.

This change installs an `EXIT` cleanup trap before any reload work and converts handled `HUP`, `INT`, and `TERM` signals into exits that trigger that cleanup. The existing bootout, drain, bootstrap, retry, verification, and fallback behavior is unchanged.

The multi-profile documentation also recommends using Hermes profile-aware gateway commands instead of hard-coding a `gui/<uid>` or `user/<uid>` launchd domain.

This intentionally does not add transport-wide Slack outbound deduplication: repeated outbound messages can be valid behavior, and Hermes already handles deduplication at the appropriate inbound and reply-delivery seams.

## Related Issue

No dedicated issue exists for this exact failure.

Related launchd behavior is documented in #62891 and #79519.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway.py`
  - Install transient-label cleanup before one-shot reload work starts.
  - Run cleanup on normal exit and handled `HUP`, `INT`, and `TERM`.
  - Remove reliance on a final cleanup statement that may never execute.
- `tests/hermes_cli/test_gateway_service.py`
  - Assert that the submitted shell script begins with the cleanup and signal traps.
- `website/docs/user-guide/multi-profile-gateways.md`
  - Document profile-aware macOS restart automation.
  - Warn external wrappers to remove submitted labels on every exit path.

## How to Test

1. Run the focused hermetic gateway suite:

   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py -q
   ```

   Expected: `83 passed, 1 skipped`.

2. Run the broader gateway CLI tests:

   ```bash
   python -m pytest -q tests/hermes_cli/test_gateway*.py
   ```

   Expected: `282 passed, 17 skipped`.

3. Submit harmless launchd jobs that exit nonzero or receive `HUP`, `INT`, or `TERM`. Confirm each job runs once and its label disappears.

4. Build the English documentation:

   ```bash
   cd website
   npm run build:fast
   ```

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs and found no open duplicate
- [x] This PR contains only changes related to this fix
- [ ] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for this change
- [x] Tested on macOS arm64

### Documentation & Housekeeping

- [x] Updated relevant documentation
- [x] `cli-config.yaml.example` update: N/A
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A
- [x] Considered cross-platform impact; the changed runtime path is macOS-only
- [x] Tool descriptions or schemas update: N/A

## Screenshots / Logs

### Regression evidence

The new assertion failed against `origin/main` because the generated reload script did not begin with cleanup traps. It passes with this change.

### Automated verification

- Hermetic affected suite: `83 passed, 1 skipped`
- Broader gateway suite: `282 passed, 17 skipped`
- Ruff lint on changed Python files: passed
- `git diff --check`: passed
- Docusaurus English build: passed
- Five independent review lanes: passed with no blockers

### Manual macOS verification

Harmless `launchctl submit` jobs were exercised for normal or nonzero exit, `SIGTERM`, `SIGHUP`, and `SIGINT`. Each helper ran exactly once, removed its submitted label, did not respawn across the throttle window, and left no residual QA labels.

### Full-suite note

A direct `pytest tests/ -q` run inherited the local Hermes user environment. It encountered interactive Tenor and Discord credential prompts, unrelated plugin and logging failures, and timed out after 30 minutes at 24%, so it did not produce a valid full-suite result.

The project-recommended hermetic wrapper was then used for the complete affected test file and passed: `83 passed, 1 skipped`.

Additional pre-existing checks outside this diff include existing `ty` diagnostics, formatting drift in the large gateway files, and nine existing Windows-footgun findings elsewhere in the changed test file.