### PR TITLE
fix(tools): grok-imagine must not default upscale on (Aug 2026 policy)

### DIFF
--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -685,7 +685,7 @@ FAL_MODELS: Dict[str, Dict[str, Any]] = {
             "prompt", "aspect_ratio", "num_images", "output_format",
             "resolution", "quality", "sync_mode",
         },
-        "upscale": True,   # 1k native is sub-2MP
+        "upscale": False,  # opt-in per call (Aug 2026 policy); 1k native is sub-2MP
         # Edit endpoint takes `image_urls` (max 3) + the same knobs;
         # aspect_ratio defaults to "auto" (follows the first input image),
         # so we don't send it on edits.


### PR DESCRIPTION
## Summary

The FAL catalog entry `xai/grok-imagine-image/v2.0/text-to-image` is the only entry defaulting `upscale: True`, which violates the Aug 2026 opt-in-only upscaling policy. This fails `tests/tools/test_image_generation.py::TestFalCatalog::test_upscale_defaults_are_all_off` on **every** open PR right now (it's a pre-existing main bug, unrelated to the individual PRs that each hit it).

## Change

- `tools/image_generation_tool.py`: set the grok-imagine entry's `upscale` default to `False`. Per-call `upscale=True` still works via the explicit tool-schema path (`tools/image_generation_tool.py` honors an explicit `upscale` arg over the catalog default), so this only removes the *default-on* behavior.

## Tests

- `test_upscale_defaults_are_all_off` passes.

## Why this PR

Fixes the pre-existing main regression at its source so it stops blocking unrelated PRs' CI. The same one-line change was temporarily carried on #89252 / #88875 / #86419 to get those green; this is the standalone home so each routing/MCP/Discord PR can drop its copy and be reviewed independently.
