### PR TITLE
fix(desktop): stop re-entrant pin-sync reconcile from overflowing nanostores

### DIFF
--- a/apps/desktop/src/store/session-pin-sync.test.ts
+++ b/apps/desktop/src/store/session-pin-sync.test.ts
@@ -14,6 +14,7 @@ vi.mock('@/hermes', () => ({
 }))
 
 import { $pinnedSessionIds } from '@/store/layout'
+import { $activeGatewayProfile } from '@/store/profile'
 import { $sessions } from '@/store/session'
 
 import { resetSessionPinMirror, watchSessionPins } from './session-pin-sync'
@@ -289,5 +290,34 @@ describe('watchSessionPins remote pull', () => {
 
     expect($pinnedSessionIds.get()).toContain('failed')
     expect(patch).toHaveBeenCalledWith('failed', true, undefined)
+  })
+
+  it('does not oscillate when two profiles share a session id with conflicting pins', async () => {
+    // The cross-profile list can hold the same durable id twice with opposite
+    // `pinned` flags (copied/imported profile DBs). A profile-blind pull would
+    // pin then unpin the id in one pass and re-fire reconcile forever,
+    // overflowing nanostores' listenerQueue (RangeError: Invalid array length).
+    $sessions.set([
+      row('shared', { profile: 'default', pinned: true }),
+      row('shared', { profile: 'hcoder', pinned: false })
+    ])
+    await flush()
+
+    // Deterministic: exactly one row wins, so the local set settles and no
+    // runaway re-entrant reconcile occurs.
+    expect($pinnedSessionIds.get()).toEqual(['shared'])
+  })
+
+  it('prefers the active gateway profile when duplicate ids disagree', async () => {
+    $activeGatewayProfile.set('hcoder')
+    $sessions.set([
+      row('shared', { profile: 'default', pinned: true }),
+      row('shared', { profile: 'hcoder', pinned: false })
+    ])
+    await flush()
+
+    // The active profile's row is authoritative, so the pin is dropped.
+    expect($pinnedSessionIds.get()).toEqual([])
+    $activeGatewayProfile.set('default')
   })
 })

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -24,7 +24,9 @@
 import { setSessionPinnedRemote } from '@/hermes'
 import { onConnectionScopeChange } from '@/lib/connection-scoped'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { $sessions, sessionMatchesStoredId, sessionPinId } from '@/store/session'
+import type { SessionInfo } from '@/types/hermes'
 
 // pin ids we've successfully PATCHed pinned=true this session.
 const mirrored = new Set<string>()
@@ -44,6 +46,39 @@ const WRITE_GUARD_MS = 10_000
 
 function profileFor(pinId: string): null | string | undefined {
   return $sessions.get().find(row => sessionMatchesStoredId(row, pinId))?.profile
+}
+
+/**
+ * One authoritative row per durable pin id. Session ids are only unique inside
+ * a profile, so the cross-profile list can legitimately hold two rows with the
+ * same `sessionPinId` but different `pinned` flags (copied/imported profile
+ * databases). Iterating both would pin then unpin the same id in one pass and
+ * re-fire `reconcile` forever — the runaway that overflows nanostores'
+ * listenerQueue. Collapse to a single row per id, preferring the active
+ * gateway's profile (the same tie-break `resolveLoadedRow` uses), so the pull
+ * is deterministic and never oscillates.
+ */
+function rowsByPinId(rows: readonly SessionInfo[]): Map<string, SessionInfo> {
+  const byId = new Map<string, SessionInfo>()
+  const gateway = normalizeProfileKey($activeGatewayProfile.get())
+
+  for (const row of rows) {
+    const pinId = sessionPinId(row)
+    const existing = byId.get(pinId)
+
+    if (!existing) {
+      byId.set(pinId, row)
+
+      continue
+    }
+
+    // Prefer the active gateway's profile; otherwise keep the first seen.
+    if (normalizeProfileKey(row.profile) === gateway && normalizeProfileKey(existing.profile) !== gateway) {
+      byId.set(pinId, row)
+    }
+  }
+
+  return byId
 }
 
 /** PATCH the flag, guarding reads against pages that predate the write. */
@@ -78,7 +113,7 @@ function writePin(id: string, pinned: boolean, profile?: null | string): Promise
 function pullRemotePins(): void {
   const local = new Set($pinnedSessionIds.get())
 
-  for (const row of $sessions.get()) {
+  for (const row of rowsByPinId($sessions.get()).values()) {
     // A backend without the flag has no opinion; never act on `undefined`.
     if (typeof row.pinned !== 'boolean') {
       continue
@@ -128,7 +163,31 @@ function pullRemotePins(): void {
   }
 }
 
+// Re-entrancy guard: reconcile() is subscribed to BOTH $sessions and
+// $pinnedSessionIds, and pullRemotePins() mutates $pinnedSessionIds (via
+// pinSession/unpinSession), which fires reconcile() again synchronously.
+// Without this guard, a session whose pin state oscillates — two rows with the
+// same durable id but conflicting `pinned` flags, possible when profile
+// databases share session ids — drives an unbounded re-entrant loop that
+// overflows nanostores' shared listenerQueue and crashes the renderer with
+// `RangeError: Invalid array length`.
+let reconciling = false
+
 function reconcile(): void {
+  if (reconciling) {
+    return
+  }
+
+  reconciling = true
+
+  try {
+    reconcileInner()
+  } finally {
+    reconciling = false
+  }
+}
+
+function reconcileInner(): void {
   // Config/session REST is only reachable through the Electron bridge.
   if (!window.hermesDesktop) {
     return

--- a/apps/desktop/src/store/session-unread.ts
+++ b/apps/desktop/src/store/session-unread.ts
@@ -64,6 +64,9 @@ type SeenCounts = Record<string, Record<string, number>>
 /** profile key → durable ids flagged by the live busy→idle edge. */
 type Markers = Record<string, string[]>
 
+const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+
 export const $sessionSeenCounts = persistentAtom<SeenCounts>(
   'hermes.desktop.sessionSeenCounts',
   {},
@@ -75,9 +78,6 @@ export const $unreadFinishedMarkers = persistentAtom<Markers>(
   {},
   Codecs.json(sanitizeMarkers)
 )
-
-const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
-  Boolean(value) && typeof value === 'object' && !Array.isArray(value)
 
 // Also the migration: a pre-profile-scoping flat record (durable id → number)
 // has non-object values, so it drops wholesale rather than mis-attributing


### PR DESCRIPTION
## Problem

The Desktop renderer crashes with `RangeError: Invalid array length`, thrown from `Array.push` inside nanostores' `notify()`. The shared `listenerQueue` grows without bound because `reconcile()` is subscribed to **both** `$sessions` and `$pinnedSessionIds`, and `pullRemotePins()` mutates `$pinnedSessionIds` (via `pinSession`/`unpinSession`), which fires `reconcile()` again synchronously.

The existing `mirrored`/`pending`/`unconfirmed` fences only cover a *bounded* single-toggle echo. They do not cover the *unbounded* oscillation that occurs when two profiles share a session id with conflicting `pinned` flags (copied or imported profile databases). A profile-blind pull then pins and unpins the same durable id in one pass, re-firing `reconcile` forever until the queue overflows and the renderer dies.

## Root cause (source-mapped CDP, pause-on-exceptions)

```
RangeError: Invalid array length
  at Array.push (<anonymous>)
  at Object.notify (nanostores:91:19)
  at Object.set (nanostores:100:11)
  at notifySessionsChanged (live-sync.ts:34:22)
  at gateway-event.ts:283:6
```

The re-entrant cycle:

```
setSessions → $sessions.set → notify → drainQueue
  → reconcile (subscribed to $sessions)
    → pullRemotePins → pinSession/unpinSession → $pinnedSessionIds.set → notify
      → reconcile (subscribed to $pinnedSessionIds) → pullRemotePins → …  (infinite)
```

## Fix

1. **`rowsByPinId()`** collapses the cross-profile session list to one authoritative row per durable pin id, preferring the active gateway's profile (the same tie-break `resolveLoadedRow` uses). `pullRemotePins()` iterates the deduped rows, so a conflicting duplicate can no longer pin then unpin the same id in a single pass.

2. **Re-entrancy guard** on `reconcile()` so a synchronous re-entry (from the `$pinnedSessionIds` listener firing during `pullRemotePins`) returns immediately instead of recursing.

3. **TDZ fix** in `session-unread.ts`: `isPlainRecord` was declared after its first use through `persistentAtom`, so decoding a persisted value could throw `Cannot access 'isPlainRecord' before initialization`.

## Verification

- Typecheck clean.
- 20/20 `session-pin-sync` tests (2 new regression tests for the duplicate-id oscillation and the active-profile tie-break).
- 14/14 `session-unread` tests.
- Packaged production build ran 150s with **zero** new `Invalid array length` lines (baseline reproduced within ~10–60s of every startup before the fix).

## Notes

- Related open PRs #82128 (virtualizer clamp) and #83492 (grid-model validation) describe the same symptom but target different allocation sites; both were tested against this reproduction and did not resolve it. This PR addresses the actual re-entrant store-notification cycle.
