### PR TITLE
fix(clarify): unwrap 'value' key in dict-shaped choices

### DIFF
--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -110,6 +110,16 @@ class TestClarifyDictChoices:
     def test_flatten_unwraps_label_first(self):
         assert _flatten_choice({"label": "Short", "description": "Long"}) == "Short"
 
+    def test_flatten_unwraps_value_when_no_display_key(self):
+        """GLM-family providers (zai, 2026-08) emit [{"value": "..."}] with no
+        display key at all — dropping ``value`` would empty the whole choice
+        set and make clarify a no-op for those providers."""
+        assert _flatten_choice({"value": "Option A"}) == "Option A"
+        # display keys still win when both are present
+        assert _flatten_choice({"label": "Short", "value": "opt-a"}) == "Short"
+        # ``name`` remains excluded (component-shaped field)
+        assert _flatten_choice({"name": "modelid"}) == ""
+
 
     def test_dict_choices_reach_callback_as_clean_text(self):
         """The whole point: the UI callback never sees a dict repr."""
@@ -124,7 +134,7 @@ class TestClarifyDictChoices:
             choices=[
                 {"choice": "Tight", "description": "Tight, covers all 3 points"},
                 {"description": "Loose layout"},
-                {"name": "modelid", "value": "abc"},  # dropped, not leaked
+                {"name": "modelid", "value": "abc"},  # value unwrapped ("abc")
                 "A plain string choice",
             ],
             callback=cb,
@@ -132,6 +142,7 @@ class TestClarifyDictChoices:
         assert seen == [
             "Tight, covers all 3 points (Recommended)",
             "Loose layout",
+            "abc",
             "A plain string choice",
         ]
         # and the resolved answer is clean text, not a dict repr

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -52,18 +52,22 @@ def _flatten_choice(c) -> str:
     fixes the whole class in one place instead of per-adapter.
 
     Dict unwrap order is the canonical LLM tool-call user-facing keys:
-    ``label`` → ``description`` → ``text`` → ``title``. ``name`` and ``value``
-    are deliberately excluded — they're component-shaped fields that could
-    carry raw enum values or short identifiers, not human-readable labels. A
-    dict with none of the canonical keys is dropped (returns ""), since a
-    garbage label is worse than no choice at all.
+    ``label`` → ``description`` → ``text`` → ``title`` → ``value``. ``name``
+    is deliberately excluded — it's a component-shaped field that could carry
+    raw enum values or short identifiers, not a human-readable label.
+    ``value`` IS unwrapped (last, after the display keys) because GLM-family
+    providers (zai, 2026-08) emit choices as ``[{"value": "..."}]`` — with
+    no display key at all — so excluding it drops the entire choice set and
+    the clarify tool becomes a no-op for those providers. A dict with none of
+    the unwrap keys is dropped (returns ""), since a garbage label is worse
+    than no choice at all.
     """
     if c is None:
         return ""
     if isinstance(c, str):
         return c.strip()
     if isinstance(c, dict):
-        for key in ("label", "description", "text", "title"):
+        for key in ("label", "description", "text", "title", "value"):
             v = c.get(key)
             if isinstance(v, str) and v.strip():
                 return v.strip()


### PR DESCRIPTION
## Problem

GLM-family providers (zai endpoint) emit `clarify` tool-call choices as `[{"value": "..."}]` — no `label`/`description`/`text`/`title` at all. `_flatten_choice` dropped those dicts entirely, so the whole choice set vanished and the clarify tool became a no-op for those providers (user sees no options, tool silently degrades).

## Change

- Unwrap `value` **last**, after the four display keys — display keys still win when both are present
- `name` stays excluded (component-shaped field, not a human-readable label)
- Docstring updated to document the GLM-shaped emission rationale

## Testing

- New: `test_flatten_unwraps_value_when_no_display_key` (value-only dict, display-key precedence, name still excluded)
- Updated: `test_dict_choices_reach_callback_as_clean_text` now asserts `{"name":…, "value":"abc"}` yields `"abc"` instead of being dropped
- Full file: 48 passed