### PR TITLE
feat(gateway): add per-chat-type display overrides

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1524,7 +1524,21 @@ display:
   # long_running_notifications STAY ON so the user has real signal between
   # turn start and final answer (mid-turn assistant commentary + a single
   # edit-in-place "⏳ Working — N min" heartbeat). Override under
-  # display.platforms.telegram.
+  # display.platforms.telegram. A chat-type override is more specific than its
+  # platform default, so one bot can stay verbose in DMs and quiet in groups:
+  #   display:
+  #     platforms:
+  #       telegram:
+  #         chat_types:
+  #           group:
+  #             tool_progress: off
+  #             interim_assistant_messages: false
+  #             long_running_notifications: false
+  #           dm:
+  #             tool_progress: all
+  # Canonical scopes are dm and group. direct/private resolve to dm;
+  # forum/supergroup/channel/thread resolve to group. Process-global knobs
+  # such as tool_preview_length are ignored inside chat_types.
 
   # Auto-cleanup of temporary progress bubbles after the final response lands.
   # On platforms that support message deletion (currently Telegram), this

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -1,7 +1,7 @@
-"""Per-platform display/verbosity configuration resolver.
+"""Per-chat-type and per-platform display configuration resolver.
 
 Provides ``resolve_display_setting()`` — the single entry-point for reading
-display settings with platform-specific overrides and sensible defaults.
+display settings with chat-type/platform overrides and sensible defaults.
 
 Resolution order (first non-None wins):
     1. ``display.platforms.<platform>.chat_types.<chat_type>.<key>``
@@ -185,6 +185,13 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
 # Canonical set of per-platform overrideable keys (for validation).
 OVERRIDEABLE_KEYS = frozenset(_GLOBAL_DEFAULTS.keys())
 
+# Chat-type overrides are resolved per turn. Process-global formatter knobs
+# must stay at platform/global scope or concurrent turns can overwrite each
+# other's renderer state.
+CHAT_TYPE_OVERRIDEABLE_KEYS = (
+    OVERRIDEABLE_KEYS - {"tool_preview_length"}
+) | {"thinking_progress"}
+
 
 def resolve_display_setting(
     user_config: dict,
@@ -194,7 +201,7 @@ def resolve_display_setting(
     *,
     chat_type: str | None = None,
 ) -> Any:
-    """Resolve a display setting with per-platform override support.
+    """Resolve a display setting with chat-type and platform overrides.
 
     Parameters
     ----------
@@ -225,7 +232,11 @@ def resolve_display_setting(
     if isinstance(plat_overrides, dict):
         chat_type_key = _normalise_chat_type(chat_type)
         chat_types = plat_overrides.get("chat_types")
-        if chat_type_key and isinstance(chat_types, dict):
+        if (
+            setting in CHAT_TYPE_OVERRIDEABLE_KEYS
+            and chat_type_key
+            and isinstance(chat_types, dict)
+        ):
             chat_overrides = chat_types.get(chat_type_key)
             if isinstance(chat_overrides, dict):
                 val = chat_overrides.get(setting)
@@ -339,5 +350,9 @@ def _normalise_chat_type(value: str | None) -> str | None:
     aliases = {
         "direct": "dm",
         "private": "dm",
+        "forum": "group",
+        "supergroup": "group",
+        "channel": "group",
+        "thread": "group",
     }
     return aliases.get(key, key)

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -4,10 +4,12 @@ Provides ``resolve_display_setting()`` — the single entry-point for reading
 display settings with platform-specific overrides and sensible defaults.
 
 Resolution order (first non-None wins):
-    1. ``display.platforms.<platform>.<key>``  — explicit per-platform user override
-    2. ``display.<key>``                       — global user setting
-    3. ``_PLATFORM_DEFAULTS[<platform>][<key>]``  — built-in sensible default
-    4. ``_GLOBAL_DEFAULTS[<key>]``              — built-in global default
+    1. ``display.platforms.<platform>.chat_types.<chat_type>.<key>``
+       — explicit per-chat-type user override
+    2. ``display.platforms.<platform>.<key>``  — explicit per-platform user override
+    3. ``display.<key>``                       — global user setting
+    4. ``_PLATFORM_DEFAULTS[<platform>][<key>]``  — built-in sensible default
+    5. ``_GLOBAL_DEFAULTS[<key>]``              — built-in global default
 
 Exception: ``display.streaming`` is CLI-only.  Gateway streaming follows the
 top-level ``streaming`` config unless ``display.platforms.<platform>.streaming``
@@ -189,6 +191,8 @@ def resolve_display_setting(
     platform_key: str,
     setting: str,
     fallback: Any = None,
+    *,
+    chat_type: str | None = None,
 ) -> Any:
     """Resolve a display setting with per-platform override support.
 
@@ -203,6 +207,10 @@ def resolve_display_setting(
         Display setting name (e.g. ``"tool_progress"``, ``"show_reasoning"``).
     fallback : Any
         Fallback value when the setting isn't found anywhere.
+    chat_type : str | None
+        Optional source chat type (e.g. ``"dm"``, ``"group"``,
+        ``"channel"``, ``"thread"``).  When provided, chat-type overrides
+        under ``display.platforms.<platform>.chat_types`` take precedence.
 
     Returns
     -------
@@ -210,15 +218,26 @@ def resolve_display_setting(
     """
     display_cfg = user_config.get("display") or {}
 
-    # 1. Explicit per-platform override (display.platforms.<platform>.<key>)
+    # 1. Explicit per-chat-type override
+    # (display.platforms.<platform>.chat_types.<chat_type>.<key>)
     platforms = display_cfg.get("platforms") or {}
     plat_overrides = platforms.get(platform_key)
     if isinstance(plat_overrides, dict):
+        chat_type_key = _normalise_chat_type(chat_type)
+        chat_types = plat_overrides.get("chat_types")
+        if chat_type_key and isinstance(chat_types, dict):
+            chat_overrides = chat_types.get(chat_type_key)
+            if isinstance(chat_overrides, dict):
+                val = chat_overrides.get(setting)
+                if val is not None:
+                    return _normalise(setting, val)
+
+        # 2. Explicit per-platform override (display.platforms.<platform>.<key>)
         val = plat_overrides.get(setting)
         if val is not None:
             return _normalise(setting, val)
 
-    # 1b. Backward compat: display.tool_progress_overrides.<platform>
+    # 2b. Backward compat: display.tool_progress_overrides.<platform>
     if setting == "tool_progress":
         legacy = display_cfg.get("tool_progress_overrides")
         if isinstance(legacy, dict):
@@ -226,7 +245,7 @@ def resolve_display_setting(
             if val is not None:
                 return _normalise(setting, val)
 
-    # 2. Global user setting (display.<key>).  Skip display.streaming because
+    # 3. Global user setting (display.<key>).  Skip display.streaming because
     # that key controls only CLI terminal streaming; gateway token streaming is
     # governed by the top-level streaming config plus per-platform overrides.
     if setting != "streaming":
@@ -234,14 +253,14 @@ def resolve_display_setting(
         if val is not None:
             return _normalise(setting, val)
 
-    # 3. Built-in platform default
+    # 4. Built-in platform default
     plat_defaults = _PLATFORM_DEFAULTS.get(platform_key)
     if plat_defaults:
         val = plat_defaults.get(setting)
         if val is not None:
             return val
 
-    # 4. Built-in global default
+    # 5. Built-in global default
     val = _GLOBAL_DEFAULTS.get(setting)
     if val is not None:
         return val
@@ -309,3 +328,16 @@ def _normalise(setting: str, value: Any) -> Any:
         except (TypeError, ValueError):
             return 0
     return value
+
+
+def _normalise_chat_type(value: str | None) -> str | None:
+    if value is None:
+        return None
+    key = str(value).strip().lower()
+    if not key:
+        return None
+    aliases = {
+        "direct": "dm",
+        "private": "dm",
+    }
+    return aliases.get(key, key)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -906,8 +906,14 @@ def _resolve_progress_thread_id(
     return None
 
 
-def _has_platform_display_override(user_config: dict, platform_key: str, setting: str) -> bool:
-    """Return True when display.platforms.<platform> explicitly sets setting."""
+def _has_platform_display_override(
+    user_config: dict,
+    platform_key: str,
+    setting: str,
+    *,
+    chat_type: str | None = None,
+) -> bool:
+    """Return True when the platform or current chat type sets ``setting``."""
     display = user_config.get("display") if isinstance(user_config, dict) else None
     if not isinstance(display, dict):
         return False
@@ -915,7 +921,21 @@ def _has_platform_display_override(user_config: dict, platform_key: str, setting
     if not isinstance(platforms, dict):
         return False
     platform_cfg = platforms.get(platform_key)
-    return isinstance(platform_cfg, dict) and setting in platform_cfg
+    if not isinstance(platform_cfg, dict):
+        return False
+    if chat_type:
+        from gateway.display_config import _normalise_chat_type
+
+        chat_types = platform_cfg.get("chat_types")
+        chat_type_key = _normalise_chat_type(chat_type)
+        chat_type_cfg = (
+            chat_types.get(chat_type_key)
+            if chat_type_key and isinstance(chat_types, dict)
+            else None
+        )
+        if isinstance(chat_type_cfg, dict) and chat_type_cfg.get(setting) is not None:
+            return True
+    return platform_cfg.get(setting) is not None
 
 
 def _resolve_gateway_display_bool(
@@ -926,6 +946,7 @@ def _resolve_gateway_display_bool(
     default: bool = False,
     platform: Any = None,
     require_platform_override_for: set[Any] | None = None,
+    chat_type: str | None = None,
 ) -> bool:
     """Resolve a boolean display setting with optional platform-only opt-in.
 
@@ -941,13 +962,24 @@ def _resolve_gateway_display_bool(
     }
     if (
         current_platform in platform_only
-        and not _has_platform_display_override(user_config, platform_key, setting)
+        and not _has_platform_display_override(
+            user_config,
+            platform_key,
+            setting,
+            chat_type=chat_type,
+        )
     ):
         return False
 
     from gateway.display_config import resolve_display_setting
 
-    value = resolve_display_setting(user_config, platform_key, setting, default)
+    value = resolve_display_setting(
+        user_config,
+        platform_key,
+        setting,
+        default,
+        chat_type=chat_type,
+    )
     if isinstance(value, bool):
         return value
     if isinstance(value, str):
@@ -5293,7 +5325,10 @@ class TurnRunner:
         # can disable streaming for specific platforms even when the global
         # streaming config is enabled.
         _plat_streaming = ctx.resolve_display_setting(
-            ctx.user_config, platform_key, "streaming"
+            ctx.user_config,
+            platform_key,
+            "streaming",
+            chat_type=getattr(ctx.source, "chat_type", None),
         )
         # None = no per-platform override → follow global config
         _streaming_enabled = (
@@ -10265,6 +10300,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         platform_key,
                         "busy_steer_ack_enabled",
                         True,
+                        chat_type=getattr(event.source, "chat_type", None),
                     )
                 )
             if not steer_ack_enabled:
@@ -10283,6 +10319,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _platform_config_key(event.source.platform),
                 "busy_ack_detail",
                 True,
+                chat_type=getattr(event.source, "chat_type", None),
             )
         )
 
@@ -20113,6 +20150,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     default=bool(getattr(self, "_show_reasoning", False)),
                     platform=source.platform,
                     require_platform_override_for={Platform.MATTERMOST},
+                    chat_type=getattr(source, "chat_type", None),
                 )
             except Exception:
                 _show_reasoning_effective = (
@@ -20141,6 +20179,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             _platform_config_key(source.platform),
                             "reasoning_style",
                             "code",
+                            chat_type=getattr(source, "chat_type", None),
                         )
                     except Exception:
                         _reasoning_style = "code"
@@ -27416,7 +27455,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         user_config = _load_gateway_config()
         from gateway.display_config import resolve_display_setting
         _plat_streaming = resolve_display_setting(
-            user_config, platform_key, "streaming"
+            user_config,
+            platform_key,
+            "streaming",
+            chat_type=getattr(source, "chat_type", None),
         )
         _streaming_enabled = (
             _scfg.enabled and _scfg.transport != "off"
@@ -27835,10 +27877,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not isinstance(display_config, dict):
             display_config = {}
 
-        # Per-platform display settings — resolve via display_config module
-        # which checks display.platforms.<platform>.<key> first, then
-        # display.<key> global, then built-in platform defaults.
-        from gateway.display_config import resolve_display_setting
+        # Per-chat-type/platform display settings — resolve via display_config,
+        # then fall back to global and built-in platform defaults.
+        from gateway.display_config import _normalise_chat_type, resolve_display_setting
 
         # Apply tool preview length config (0 = no limit)
         try:
@@ -27856,18 +27897,39 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             pass
 
-        # Tool progress mode — resolved per-platform with env var fallback
-        _resolved_tp = resolve_display_setting(user_config, platform_key, "tool_progress")
+        # Tool progress mode — resolved per-platform/chat-type with env var fallback
+        _source_chat_type = getattr(source, "chat_type", None)
+        _source_chat_type_key = _normalise_chat_type(_source_chat_type)
+        _resolved_tp = resolve_display_setting(
+            user_config,
+            platform_key,
+            "tool_progress",
+            chat_type=_source_chat_type,
+        )
         _env_tp = os.getenv("HERMES_TOOL_PROGRESS_MODE")
         _display_cfg = display_config if isinstance(display_config, dict) else {}
         _platforms_cfg = _display_cfg.get("platforms") or {}
         _platform_cfg = _platforms_cfg.get(platform_key) or {}
+        _chat_types_cfg = (
+            _platform_cfg.get("chat_types") or {}
+            if isinstance(_platform_cfg, dict)
+            else {}
+        )
+        _chat_type_cfg = (
+            _chat_types_cfg.get(_source_chat_type_key) or {}
+            if isinstance(_chat_types_cfg, dict)
+            else {}
+        )
         _legacy_tp_overrides = _display_cfg.get("tool_progress_overrides") or {}
         _tool_progress_configured = (
             "tool_progress" in _display_cfg
             or (
                 isinstance(_platform_cfg, dict)
                 and "tool_progress" in _platform_cfg
+            )
+            or (
+                isinstance(_chat_type_cfg, dict)
+                and "tool_progress" in _chat_type_cfg
             )
             or (
                 isinstance(_legacy_tp_overrides, dict)
@@ -27880,7 +27942,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             else (_resolved_tp or _env_tp or "all")
         )
         # Tool progress grouping: "accumulate" (edit one bubble) or "separate" (one msg per tool)
-        progress_grouping = resolve_display_setting(user_config, platform_key, "tool_progress_grouping") or "accumulate"
+        progress_grouping = resolve_display_setting(
+            user_config,
+            platform_key,
+            "tool_progress_grouping",
+            chat_type=_source_chat_type,
+        ) or "accumulate"
         from gateway.status_phrases import choose_status_phrase, resolve_status_phrase_catalog
         _generic_status_recent: List[str] = []
         _generic_status_catalog = resolve_status_phrase_catalog(user_config, platform_key)
@@ -27901,10 +27968,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 }
                 if (
                     current_platform in platform_only
-                    and not _has_platform_display_override(user_config, platform_key, setting)
+                    and not _has_platform_display_override(
+                        user_config,
+                        platform_key,
+                        setting,
+                        chat_type=_source_chat_type,
+                    )
                 ):
                     return "off"
-            value = resolve_display_setting(user_config, platform_key, setting, default)
+            value = resolve_display_setting(
+                user_config,
+                platform_key,
+                setting,
+                default,
+                chat_type=_source_chat_type,
+            )
             if isinstance(value, str) and value.strip().lower() == "generic":
                 return "generic" if allow_generic else "off"
             return "raw" if bool(value) else "off"
@@ -27934,7 +28012,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # callback only stores a phrase on the adapter, costing zero extra
         # platform API calls.
         _live_status_mode = resolve_display_setting(
-            user_config, platform_key, "live_status", "full"
+            user_config,
+            platform_key,
+            "live_status",
+            "full",
+            chat_type=_source_chat_type,
         )
         _live_status_adapter = self._adapter_for_source(source)
         if not getattr(_live_status_adapter, "supports_status_text", False):
@@ -28031,7 +28113,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # are collected here and deleted after the final response lands.
         # Failed runs skip cleanup so the bubbles remain as breadcrumbs.
         _cleanup_progress = bool(
-            resolve_display_setting(user_config, platform_key, "cleanup_progress")
+            resolve_display_setting(
+                user_config,
+                platform_key,
+                "cleanup_progress",
+                chat_type=_source_chat_type,
+            )
         )
         _cleanup_adapter = self._adapter_for_source(source) if _cleanup_progress else None
         # getattr, not attribute access — same duck-typed-adapter guard as the
@@ -28563,6 +28650,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         platform_key,
                         "busy_ack_detail",
                         True,
+                        chat_type=_source_chat_type,
                     )
                 )
                 if _agent_ref and hasattr(_agent_ref, "get_activity_summary"):

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -51,6 +51,109 @@ class TestResolveDisplaySetting:
         assert resolve_display_setting(config, "telegram", "tool_progress") == "all"
 
 
+class TestChatTypeOverrides:
+    """Per-chat-type display overrides refine platform settings."""
+
+    def test_chat_type_override_wins_over_platform_and_global(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "tool_progress": "all",
+                "platforms": {
+                    "telegram": {
+                        "tool_progress": "new",
+                        "chat_types": {
+                            "dm": {"tool_progress": "verbose"},
+                            "group": {"tool_progress": "off"},
+                        },
+                    },
+                },
+            }
+        }
+
+        assert (
+            resolve_display_setting(
+                config,
+                "telegram",
+                "tool_progress",
+                chat_type="dm",
+            )
+            == "verbose"
+        )
+        assert (
+            resolve_display_setting(
+                config,
+                "telegram",
+                "tool_progress",
+                chat_type="group",
+            )
+            == "off"
+        )
+
+    def test_missing_chat_type_override_falls_back_to_platform(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "tool_progress": "new",
+                        "chat_types": {"dm": {"tool_progress": "verbose"}},
+                    },
+                },
+            }
+        }
+
+        assert (
+            resolve_display_setting(
+                config,
+                "telegram",
+                "tool_progress",
+                chat_type="group",
+            )
+            == "new"
+        )
+        assert resolve_display_setting(config, "telegram", "tool_progress") == "new"
+
+    def test_chat_type_overrides_are_normalised(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "chat_types": {
+                            "dm": {
+                                "show_reasoning": "true",
+                                "tool_preview_length": "120",
+                            },
+                        },
+                    },
+                },
+            }
+        }
+
+        assert (
+            resolve_display_setting(
+                config,
+                "telegram",
+                "show_reasoning",
+                chat_type="private",
+            )
+            is True
+        )
+        assert (
+            resolve_display_setting(
+                config,
+                "telegram",
+                "tool_preview_length",
+                chat_type="Direct",
+            )
+            == 120
+        )
+
+
 # ---------------------------------------------------------------------------
 # Backward compatibility: tool_progress_overrides
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -123,10 +123,12 @@ class TestChatTypeOverrides:
             "display": {
                 "platforms": {
                     "telegram": {
+                        "thinking_progress": True,
                         "chat_types": {
                             "dm": {
                                 "show_reasoning": "true",
-                                "tool_preview_length": "120",
+                                "cleanup_progress": "true",
+                                "thinking_progress": "false",
                             },
                         },
                     },
@@ -147,10 +149,88 @@ class TestChatTypeOverrides:
             resolve_display_setting(
                 config,
                 "telegram",
-                "tool_preview_length",
+                "cleanup_progress",
                 chat_type="Direct",
             )
-            == 120
+            is True
+        )
+        assert (
+            resolve_display_setting(
+                config,
+                "telegram",
+                "thinking_progress",
+                chat_type="dm",
+            )
+            is False
+        )
+
+
+    def test_shared_chat_aliases_fall_back_to_group_override(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "tool_progress": "all",
+                        "chat_types": {
+                            "group": {"tool_progress": "off"},
+                        },
+                    },
+                },
+            }
+        }
+
+        for chat_type in ("forum", "supergroup", "channel", "thread"):
+            assert (
+                resolve_display_setting(
+                    config,
+                    "telegram",
+                    "tool_progress",
+                    chat_type=chat_type,
+                )
+                == "off"
+            ), chat_type
+
+
+    def test_process_global_formatter_settings_ignore_chat_type_overrides(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "tool_preview_length": 90,
+                        "friendly_tool_labels": True,
+                        "chat_types": {
+                            "group": {
+                                "tool_preview_length": 5,
+                                "friendly_tool_labels": False,
+                            },
+                        },
+                    },
+                },
+            }
+        }
+
+        assert (
+            resolve_display_setting(
+                config,
+                "telegram",
+                "tool_preview_length",
+                chat_type="group",
+            )
+            == 90
+        )
+        assert (
+            resolve_display_setting(
+                config,
+                "telegram",
+                "friendly_tool_labels",
+                True,
+                chat_type="group",
+            )
+            is True
         )
 
 

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -45,6 +45,55 @@ class TestMattermostDisplayHygiene:
         ) is True
 
 
+    def test_mattermost_chat_type_opt_in_can_enable_interim_messages(self):
+        """A chat-type override counts as an explicit Mattermost opt-in."""
+        user_config = {
+            "display": {
+                "platforms": {
+                    "mattermost": {
+                        "chat_types": {
+                            "group": {"interim_assistant_messages": True},
+                        },
+                    },
+                },
+            }
+        }
+
+        assert _resolve_gateway_display_bool(
+            user_config,
+            "mattermost",
+            "interim_assistant_messages",
+            default=False,
+            platform=Platform.MATTERMOST,
+            require_platform_override_for={Platform.MATTERMOST},
+            chat_type="group",
+        ) is True
+
+    def test_mattermost_null_chat_type_override_is_not_an_explicit_opt_in(self):
+        """A null scoped value must not expose scratch thinking via global fallback."""
+        user_config = {
+            "display": {
+                "thinking_progress": True,
+                "platforms": {
+                    "mattermost": {
+                        "chat_types": {
+                            "group": {"thinking_progress": None},
+                        },
+                    },
+                },
+            }
+        }
+
+        assert _resolve_gateway_display_bool(
+            user_config,
+            "mattermost",
+            "thinking_progress",
+            default=False,
+            platform=Platform.MATTERMOST,
+            require_platform_override_for={Platform.MATTERMOST},
+            chat_type="group",
+        ) is False
+
     def test_global_thinking_progress_still_applies_to_other_platforms(self):
         """The Mattermost guard must not silently neuter Telegram/other chats."""
         user_config = {"display": {"thinking_progress": True}}

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1163,6 +1163,99 @@ async def test_retryable_overflow_edit_keeps_editable_bubble_identity(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_group_chat_type_override_suppresses_interim_commentary(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        CommentaryAgent,
+        session_id="sess-quiet-telegram-group",
+        config_data={
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "interim_assistant_messages": True,
+                        "chat_types": {
+                            "group": {"interim_assistant_messages": False},
+                        },
+                    },
+                },
+            },
+            "streaming": {"enabled": False},
+        },
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.sent == []
+
+
+@pytest.mark.asyncio
+async def test_group_override_does_not_suppress_dm_commentary(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        CommentaryAgent,
+        session_id="sess-verbose-telegram-dm",
+        config_data={
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "interim_assistant_messages": True,
+                        "chat_types": {
+                            "group": {"interim_assistant_messages": False},
+                        },
+                    },
+                },
+            },
+            "streaming": {"enabled": False},
+        },
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    assert result["final_response"] == "done"
+    assert [call["content"] for call in adapter.sent] == ["I'll inspect the repo first."]
+
+
+@pytest.mark.asyncio
+async def test_chat_type_does_not_override_process_global_tool_preview_length(
+    monkeypatch, tmp_path
+):
+    """Concurrent chat scopes must not mutate the process-global preview cap."""
+    from agent import display as agent_display
+
+    applied = []
+    monkeypatch.setattr(agent_display, "set_tool_preview_max_len", applied.append)
+
+    _, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        CommentaryAgent,
+        session_id="sess-global-preview-length",
+        config_data={
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "tool_preview_length": 90,
+                        "chat_types": {
+                            "group": {"tool_preview_length": 5},
+                        },
+                    },
+                },
+            },
+            "streaming": {"enabled": False},
+        },
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+
+    assert result["final_response"] == "done"
+    assert applied == [90]
+
+
+@pytest.mark.asyncio
 async def test_display_streaming_does_not_enable_gateway_streaming(monkeypatch, tmp_path):
     adapter, result = await _run_with_agent(
         monkeypatch,

--- a/tests/gateway/test_turn_context.py
+++ b/tests/gateway/test_turn_context.py
@@ -132,7 +132,7 @@ class TestTurnRunner:
             session_key="test-session-key",
             user_config={},
             AIAgent=_ExhaustedAgent,
-            resolve_display_setting=lambda *_args: False,
+            resolve_display_setting=lambda *_args, **_kwargs: False,
             _run_still_current=lambda: True,
             _hooks_ref=SimpleNamespace(loaded_hooks=False),
         )

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1885,7 +1885,7 @@ Example footer appended to a Telegram/Discord/Slack reply:
 
 Only the **final** message of a turn gets the footer; interim updates stay clean.
 
-### Per-platform progress overrides
+### Per-platform and per-chat-type progress overrides
 
 Different platforms have different verbosity needs. Use `display.platforms` to set per-platform modes:
 
@@ -1896,10 +1896,26 @@ display:
     signal:
       tool_progress: 'off'    # Signal cannot currently display tool-progress bubbles
     telegram:
-      tool_progress: verbose  # detailed progress on Telegram
+      tool_progress: verbose  # detailed progress on Telegram by default
+      chat_types:
+        group:
+          tool_progress: 'off'
+          interim_assistant_messages: false
+          long_running_notifications: false
+        dm:
+          tool_progress: verbose
     slack:
       tool_progress: 'off'    # quiet in shared Slack workspace
 ```
+
+Chat-type overrides use two canonical scopes: `dm` and `group`. Gateway values `direct` and `private` normalize to `dm`; `forum`, `supergroup`, `channel`, and `thread` normalize to `group`. This makes a `group` override cover shared Telegram forums and other adapters that expose different shared-chat labels. Resolution is most-specific first:
+
+1. `display.platforms.<platform>.chat_types.<chat_type>.<setting>`
+2. `display.platforms.<platform>.<setting>`
+3. `display.<setting>`
+4. built-in platform and global defaults
+
+This lets one bot stay verbose in DMs while sending only final answers in shared groups. The gateway applies chat-type overrides to per-turn visibility and delivery settings such as `tool_progress`, `interim_assistant_messages`, `thinking_progress`, `long_running_notifications`, `show_reasoning`, `streaming`, `cleanup_progress`, and busy-status detail. Process-global formatter settings such as `tool_preview_length` are rejected inside `chat_types`; they retain their existing platform/global behavior so this feature does not add a finer-grained concurrent-state race.
 
 Platforms without an override fall back to the global `tool_progress` value. Valid platform keys: `telegram`, `discord`, `slack`, `signal`, `whatsapp`, `matrix`, `mattermost`, `email`, `sms`, `homeassistant`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`. The legacy `display.tool_progress_overrides` key still loads for backward compatibility but is deprecated and migrated into `display.platforms` on first load.
 


### PR DESCRIPTION
## Summary

- add `display.platforms.<platform>.chat_types.<chat_type>.<setting>` as the most-specific gateway display override
- preserve the existing platform, global, and built-in fallback order
- thread `chat_type` through current gateway visibility, streaming, reasoning, cleanup, busy-status, and heartbeat resolution paths
- keep process-global formatter state such as `tool_preview_length` out of chat-type scoping
- document the schema and add resolver plus runner-level coverage

Fixes #20533.

## Salvage of #20559

This PR salvages and updates #20559 against current `main`. The original commit by @LeonSGP43 was cherry-picked so its authorship is preserved, then the implementation was rebased at the current abstraction boundaries.

The original branch cannot be updated by this contributor account, and it now conflicts with `main`. This replacement addresses the keep-open review on #20559:

- **Process-global race:** chat-type resolution rejects process-global formatter settings such as `tool_preview_length` and `friendly_tool_labels`; resolver and runner-level regression tests verify a group override cannot mutate those global knobs.
- **Stale runtime paths:** `chat_type` is threaded through the current `TurnRunner`, `_display_surface_mode`, `_resolve_gateway_display_bool`, proxy/local streaming, reasoning, cleanup, live status, and busy/heartbeat detail paths.
- **Runtime coverage:** tests verify a Telegram group suppresses interim commentary while platform defaults remain available to DMs, and a chat-type override counts as an explicit Mattermost opt-in.
- **Documentation:** `cli-config.yaml.example` and the user configuration guide now document the schema, precedence, aliases, supported settings, and concurrency limitation.

## Related PRs reviewed

Before preparing this salvage, I reviewed the overlapping open implementations and the cross-PR triage on #20533:

- #48638 — same DM/group goal, but uses a different config shape and is stale against the current `_display_surface_mode` paths; its broader call-site coverage informed this update.
- #34240 — alternative `scopes`-based implementation.
- #31488 — related per-`chat_id` / per-thread overrides rather than chat-type defaults.

This PR keeps #20559's issue-aligned `chat_types` shape and consolidates the current-main runtime/documentation coverage requested by the triage, instead of introducing another unrelated design.

## Configuration

```yaml
display:
  platforms:
    telegram:
      tool_progress: all
      chat_types:
        group:
          tool_progress: off
          interim_assistant_messages: false
          long_running_notifications: false
        dm:
          tool_progress: all
```

Resolution order:

1. `display.platforms.<platform>.chat_types.<chat_type>.<setting>`
2. `display.platforms.<platform>.<setting>`
3. `display.<setting>`
4. built-in platform/global defaults

Canonical scopes are `dm` and `group`: `direct`/`private` normalize to `dm`, while `forum`/`supergroup`/`channel`/`thread` normalize to `group`.

## Verification

- `scripts/run_tests.sh tests/gateway/test_display_config.py tests/gateway/test_run_progress_topics.py tests/gateway/test_mattermost.py tests/gateway/test_turn_context.py tests/gateway/test_turn_lease.py -q` — **98 passed**
- `HERMES_TEST_WORKERS=4 scripts/run_tests.sh tests/gateway -q` — **5,837 passed, 0 failed, 29 skipped**
- `python -m py_compile gateway/display_config.py gateway/run.py`
- `python -m ruff check gateway/display_config.py gateway/run.py tests/gateway/test_display_config.py tests/gateway/test_mattermost.py tests/gateway/test_run_progress_topics.py tests/gateway/test_turn_context.py`
- `python scripts/check-windows-footguns.py --all`
- `git diff --check`
- `cd website && npm ci && npm run build:fast` — production build succeeded (only the repository's existing `/docs/llms*.txt` broken-link warnings)

## Backward compatibility

Existing callers that omit `chat_type` keep the previous behavior. Existing per-platform and global configuration remains unchanged. The legacy `display.tool_progress_overrides` fallback is preserved.
