### PR TITLE
feat(plugins): carry token usage on the on_stream_end observer payload

### DIFF
--- a/agent/plugin_stream_hooks.py
+++ b/agent/plugin_stream_hooks.py
@@ -32,6 +32,19 @@ def _callback_name(callback: Callable[..., Any]) -> str:
     return getattr(callback, "__name__", repr(callback))
 
 
+def _invoke_callback(callback: Callable[..., Any], payload: dict[str, Any]) -> Any:
+    """Deliver ``payload`` the way synchronous plugin hooks do.
+
+    A callback declaring ``**kwargs`` sees every field; one with a fixed
+    signature receives only the fields it names. That is what lets a payload
+    grow (e.g. ``usage`` on ``on_stream_end``) without breaking an older
+    observer that never asked for the new field.
+    """
+    from hermes_cli.plugins import PluginManager
+
+    return PluginManager._invoke_hook_callback(callback, payload)
+
+
 def _worker(dispatcher: _ConsumerDispatcher) -> None:
     while True:
         item = dispatcher.events.get()
@@ -41,7 +54,7 @@ def _worker(dispatcher: _ConsumerDispatcher) -> None:
             payload = dict(item)
             payload.setdefault("telemetry_schema_version", OBSERVER_SCHEMA_VERSION)
             try:
-                dispatcher.callback(**payload)
+                _invoke_callback(dispatcher.callback, payload)
             except Exception as exc:
                 logger.warning(
                     "Hook '%s' callback %s raised: %s",

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -174,6 +174,13 @@ VALID_HOOKS: Set[str] = {
     # Streaming LLM output observer hooks. Fired asynchronously off the token
     # path by agent.plugin_stream_hooks; callbacks observe immutable normalized
     # text/lifecycle payloads and cannot transform the stream.
+    # on_stream_end additionally carries ``usage``: the turn's token counters in
+    # turn_finalizer's field vocabulary (prompt/completion/total/reasoning_tokens,
+    # api_calls) plus ``last_prompt_tokens`` (the final call's prompt size — the
+    # model's context occupancy at that request) and ``context_length`` — enough
+    # for an observer plugin to render a context meter without touching core.
+    # ``context_length == 0`` is the "unknown window" sentinel, never a real
+    # size: a meter must not divide by it.
     "on_stream_start",
     "on_stream_delta",
     "on_stream_end",

--- a/run_agent.py
+++ b/run_agent.py
@@ -7453,6 +7453,32 @@ class AIAgent:
         except Exception:
             logger.debug("on_stream_start plugin hook enqueue failed", exc_info=True)
 
+    def _stream_hook_usage_payload(self) -> Dict[str, Any]:
+        """Token usage for stream observer hooks, in turn_finalizer's field vocabulary.
+
+        Same names and sources as the ``run_conversation`` result dict built in
+        ``agent/turn_finalizer.py`` (session_* counters plus the compressor's
+        ``last_prompt_tokens``), so a plugin can read either without a mapping.
+        ``last_prompt_tokens`` is the final API call's prompt size — the model's
+        context occupancy as of that request — unlike the cumulative session_*
+        counters; paired with ``context_length`` it lets an observer render a
+        context meter without touching core. ``context_length == 0`` means the
+        window is unknown (no compressor yet, or an unresolved model), not a
+        zero-sized window: consumers must treat it as "no ratio available"
+        rather than divide by it. All reads are defensive: a partially
+        initialized agent yields zeros, never a raise.
+        """
+        compressor = getattr(self, "context_compressor", None)
+        return {
+            "prompt_tokens": int(getattr(self, "session_prompt_tokens", 0) or 0),
+            "completion_tokens": int(getattr(self, "session_completion_tokens", 0) or 0),
+            "total_tokens": int(getattr(self, "session_total_tokens", 0) or 0),
+            "reasoning_tokens": int(getattr(self, "session_reasoning_tokens", 0) or 0),
+            "api_calls": int(getattr(self, "session_api_calls", 0) or 0),
+            "last_prompt_tokens": int(getattr(compressor, "last_prompt_tokens", 0) or 0),
+            "context_length": int(getattr(compressor, "context_length", 0) or 0),
+        }
+
     def _emit_stream_end(self, *, final_text: str, finished: bool, error: str | None) -> None:
         try:
             from agent.plugin_stream_hooks import enqueue_plugin_stream_hook
@@ -7463,6 +7489,7 @@ class AIAgent:
                 final_text=final_text,
                 finished=finished,
                 error=error,
+                usage=self._stream_hook_usage_payload(),
             )
         except Exception:
             logger.debug("on_stream_end plugin hook enqueue failed", exc_info=True)

--- a/tests/run_agent/test_plugin_stream_hooks.py
+++ b/tests/run_agent/test_plugin_stream_hooks.py
@@ -262,6 +262,120 @@ def test_stream_lifecycle_plugin_hooks_are_queued(monkeypatch):
     assert end_call[1]["error"] is None
 
 
+def test_stream_end_plugin_hook_carries_usage(monkeypatch):
+    from agent.plugin_stream_hooks import shutdown_plugin_stream_hook_dispatcher
+
+    shutdown_plugin_stream_hook_dispatcher()
+    calls = []
+    monkeypatch.setattr(
+        "hermes_cli.plugins.iter_hook_callbacks",
+        _callbacks({"on_stream_end": [lambda **kwargs: calls.append(kwargs)]}),
+    )
+
+    agent = _agent()
+    agent.session_prompt_tokens = 1200
+    agent.session_completion_tokens = 300
+    agent.session_total_tokens = 1500
+    agent.session_reasoning_tokens = 45
+    agent.session_api_calls = 3
+    agent.context_compressor.last_prompt_tokens = 900
+    agent.context_compressor.context_length = 128000
+    agent._emit_stream_end(final_text="done", finished=True, error=None)
+    _wait_for(lambda: len(calls) == 1)
+    shutdown_plugin_stream_hook_dispatcher()
+
+    usage = calls[0]["usage"]
+    assert usage["prompt_tokens"] == 1200
+    assert usage["completion_tokens"] == 300
+    assert usage["total_tokens"] == 1500
+    assert usage["reasoning_tokens"] == 45
+    assert usage["api_calls"] == 3
+    assert usage["last_prompt_tokens"] == 900
+    assert usage["context_length"] == 128000
+
+
+def test_stream_end_usage_survives_missing_counters(monkeypatch):
+    """A partially initialized agent must yield zeroed usage, never a raise."""
+    from agent.plugin_stream_hooks import shutdown_plugin_stream_hook_dispatcher
+
+    shutdown_plugin_stream_hook_dispatcher()
+    calls = []
+    monkeypatch.setattr(
+        "hermes_cli.plugins.iter_hook_callbacks",
+        _callbacks({"on_stream_end": [lambda **kwargs: calls.append(kwargs)]}),
+    )
+
+    agent = _agent()
+    agent.context_compressor = None
+    agent._emit_stream_end(final_text="", finished=False, error="boom")
+    _wait_for(lambda: len(calls) == 1)
+    shutdown_plugin_stream_hook_dispatcher()
+
+    usage = calls[0]["usage"]
+    assert usage["last_prompt_tokens"] == 0
+    assert usage["context_length"] == 0
+
+
+def test_stream_end_usage_reports_unknown_window_as_zero(monkeypatch):
+    """An unresolved context window is the 0 sentinel, not a raise or a None."""
+    from agent.plugin_stream_hooks import shutdown_plugin_stream_hook_dispatcher
+
+    shutdown_plugin_stream_hook_dispatcher()
+    calls = []
+    monkeypatch.setattr(
+        "hermes_cli.plugins.iter_hook_callbacks",
+        _callbacks({"on_stream_end": [lambda **kwargs: calls.append(kwargs)]}),
+    )
+
+    agent = _agent()
+    # A context engine that never resolved a window (plugin engines, or an
+    # unresolved model) reports 0 — the payload must pass that through as an
+    # int 0, not None and not a guess.
+    agent.context_compressor = SimpleNamespace(context_length=0, last_prompt_tokens=900)
+    agent._emit_stream_end(final_text="done", finished=True, error=None)
+    _wait_for(lambda: len(calls) == 1)
+    shutdown_plugin_stream_hook_dispatcher()
+
+    usage = calls[0]["usage"]
+    assert usage["context_length"] == 0
+    assert isinstance(usage["context_length"], int)
+    assert usage["last_prompt_tokens"] == 900
+
+
+def test_stream_end_narrow_signature_callback_keeps_working(monkeypatch):
+    """An observer that only declares the original fields must not see ``usage``.
+
+    Stream observers are delivered through the same signature-aware path as
+    synchronous hooks: ``**kwargs`` callbacks get every field, fixed-signature
+    callbacks get only what they name. That is what makes ``usage`` additive.
+    """
+    from agent.plugin_stream_hooks import shutdown_plugin_stream_hook_dispatcher
+
+    shutdown_plugin_stream_hook_dispatcher()
+    narrow_calls = []
+    wide_calls = []
+
+    def narrow(final_text, finished, error):
+        narrow_calls.append((final_text, finished, error))
+
+    def wide(**kwargs):
+        wide_calls.append(kwargs)
+
+    monkeypatch.setattr(
+        "hermes_cli.plugins.iter_hook_callbacks",
+        _callbacks({"on_stream_end": [narrow, wide]}),
+    )
+
+    agent = _agent()
+    agent._emit_stream_end(final_text="done", finished=True, error=None)
+    _wait_for(lambda: len(narrow_calls) == 1 and len(wide_calls) == 1)
+    shutdown_plugin_stream_hook_dispatcher()
+
+    assert narrow_calls == [("done", True, None)]
+    assert "usage" in wide_calls[0]
+    assert wide_calls[0]["final_text"] == "done"
+
+
 @patch("run_agent.AIAgent._create_request_openai_client")
 @patch("run_agent.AIAgent._close_request_openai_client")
 def test_chat_completion_stream_emits_lifecycle_hooks(_mock_close, mock_create, monkeypatch):

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -452,7 +452,7 @@ Payload fields below are the exact event-specific fields supplied by each call s
 | `api_request_error` | Observer | On each failed provider attempt; return ignored. | `task_id`, `turn_id`, `api_request_id`, `session_id`, `platform`, `model`, `provider`, `base_url`, `api_mode`, `api_call_count`, `api_duration`, `started_at`, `ended_at`, `status_code`, `retry_count`, `max_retries`, `retryable`, `reason`, `error`, `request` | Error text may contain provider/user data; `request` is intended to be sanitized. |
 | `on_stream_start` | Observer | Dispatched when a streaming LLM response begins; delivered off the token path via a host-owned bounded queue with one worker per callback; return ignored. | `turn_id`, `iteration`, `session_id`, `model`, `provider`, `surface` | Identifiers and routing metadata only. |
 | `on_stream_delta` | Observer | Dispatched per normalized streaming text delta via the bounded observer queue; a stalled callback drops only its own oldest events; return ignored. | `delta`, `kind` (`text` or `reasoning`), `turn_id`, `iteration`, `session_id`, `model`, `provider`, `surface` | Delta text is raw model output; reasoning deltas require the `plugins.stream_reasoning_deltas` opt-in. |
-| `on_stream_end` | Observer | Dispatched when a streaming response finishes or errors, after the stream closes; return ignored. | `final_text`, `finished`, `error`, `turn_id`, `iteration`, `session_id`, `model`, `provider`, `surface` | Full assembled response text; error text may include provider data. |
+| `on_stream_end` | Observer | Dispatched when a streaming response finishes or errors, after the stream closes; return ignored. | `final_text`, `finished`, `error`, `usage`, `turn_id`, `iteration`, `session_id`, `model`, `provider`, `surface` | Full assembled response text; error text may include provider data; `usage` is accounting data. |
 | `on_interim_message` | Observer | Dispatched when a mid-loop assistant message is surfaced before the final answer (streaming or non-streaming); return ignored. | `text`, `already_streamed`, `turn_id`, `iteration`, `session_id`, `model`, `provider`, `surface` | Full interim assistant text. |
 | `transform_api_error_classification` | Transform | On each failed provider attempt, at the top of the built-in classifier; all callbacks run, then the first dict with a valid `reason` wins (run-all-then-pick-first), and skipped valid results log a runtime warning. Python plugins only. | `provider`, `model`, `status_code`, `error_type`, `error_code`, `error_message`, `error_body`, `error`, `approx_tokens`, `context_length`, `num_messages` | `error_message` and `error_body` may contain raw provider/user data. |
 | `on_session_start` | Observer | First turn of a new session; return ignored. | `session_id`, `model`, `platform` | Identifiers and routing metadata only. |
@@ -510,10 +510,12 @@ Additional fields:
 |------|--------------|
 | `on_stream_start` | none |
 | `on_stream_delta` | `delta: str`, `kind: "text" | "reasoning"` |
-| `on_stream_end` | `final_text: str`, `finished: bool`, `error: str | None` |
+| `on_stream_end` | `final_text: str`, `finished: bool`, `error: str | None`, `usage: dict` |
 | `on_interim_message` | `text: str`, `already_streamed: bool` |
 
 `on_interim_message` can also fire after a non-streaming response, so registering only that hook does not force a provider call onto streaming transport.
+
+`usage` on `on_stream_end` is a snapshot of the turn's token counters, using the same field names as the `run_conversation` result: `prompt_tokens`, `completion_tokens`, `total_tokens`, `reasoning_tokens`, and `api_calls` are cumulative for the session; `last_prompt_tokens` is the prompt size of the final API call (the model's context occupancy at that request); `context_length` is the model's context window. Every value is an `int`, and `context_length == 0` means the window is unknown (not yet resolved, or no compressor), so a context meter must treat `0` as "no ratio available" rather than divide by it.
 
 Reasoning deltas are not exposed to plugins by default. Opt in explicitly:
 


### PR DESCRIPTION
## What

`on_stream_end` observer callbacks now receive a `usage` kwarg alongside `final_text`/`finished`/`error` — the turn's token counters in `turn_finalizer`'s existing field vocabulary:

```
usage = {
  prompt_tokens, completion_tokens, total_tokens, reasoning_tokens, api_calls,
  last_prompt_tokens,   # final API call's prompt size = current context occupancy
  context_length,       # the window that occupancy sits in
}
```

## Why

Stream observer hooks (added with the `on_stream_start/delta/end` family) let a plugin watch every token of a turn, but none of the numbers behind it — so anything usage-shaped (a context meter in a client, a token dashboard) still requires core patches, which the plugin policy forbids. `last_prompt_tokens` + `context_length` are exactly a context gauge; the session counters come along at zero extra cost since they're already on the agent.

Real consumer exists: a standalone gateway side-channel plugin that renders a per-turn context ring in a Matrix client. No behavior change for existing callbacks — the payload is additive, observer-only, and every read is a defensive `getattr` with a zero default (a partially initialized agent yields zeroed usage, never a raise).

## Changes

- `run_agent.py`: `_stream_hook_usage_payload()` + wired into `_emit_stream_end`
- `hermes_cli/plugins.py`: payload documented in the VALID_HOOKS comment block
- Tests: 2 added, 14 passing in `tests/run_agent/test_plugin_stream_hooks.py`