### PR TITLE
feat(skills): add SocialRobot MCP catalog entry and five workflow skills

### DIFF
--- a/optional-mcps/socialrobot/manifest.yaml
+++ b/optional-mcps/socialrobot/manifest.yaml
@@ -1,0 +1,59 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: socialrobot
+description: Schedule and manage multi-platform social posts from Hermes.
+source: https://socialrobot.io/mcp
+
+# SocialRobot ships a remote MCP server over Streamable HTTP with native
+# OAuth 2.1 + Dynamic Client Registration via Better Auth. Hermes's MCP client
+# + mcp_oauth_manager handle discovery, PKCE, token exchange, and refresh;
+# nothing to install locally. The same server also serves its own agent skills
+# (SEP-2640) over the connection: list with `skills/list`, read the create-post
+# workflow with `skills/get`.
+transport:
+  type: http
+  url: https://socialrobot.io/api/mcp
+
+auth:
+  type: oauth
+  # No `provider:`: this is native MCP OAuth (case 1), not a third-party
+  # provider like Google. The MCP client triggers the browser flow on the
+  # first probe / first connect.
+  #
+  # Alternative for headless clients: SocialRobot also accepts API keys
+  # (Scheduler → API Keys) as `x-api-key` or `Authorization: Bearer <key>`.
+  # OAuth remains the default because it issues scoped, refreshable tokens.
+
+# Tool selection at install time:
+# The server exposes 18 tools (account discovery, media upload, create/update/
+# reschedule/delete posts, analytics, and platform-specific lookup tools such
+# as Pinterest boards, TikTok creator info, and LinkedIn geo/mention search).
+# The mutating tools (create_post, delete_post, update_post, reschedule_post,
+# pinterest_create_board) are the core value of the product, so unlike the n8n
+# entry we do NOT prune them by default. `default_enabled` is left unset so the
+# install-time checklist starts with everything pre-checked and users prune
+# what they don't want.
+
+# Composer-suggestion triggers (desktop brand pills).
+suggest:
+  keywords:
+    - socialrobot
+    - social robot
+    - post-scheduler
+  hosts:
+    - socialrobot.io
+
+post_install: |
+  On first connection, Hermes will open a browser to authenticate with
+  SocialRobot. Approve the requested scopes (publishing, analytics, media).
+  Nothing publishes until you approve them.
+
+  No account yet? Get a free account at https://socialrobot.io and link the
+  social platforms you want to post to there first.
+
+  After auth, restart your Hermes session so the SocialRobot tools are loaded.
+
+  You can re-run the tool checklist any time with:
+    hermes mcp configure socialrobot

--- a/optional-mcps/socialrobot/manifest.yaml
+++ b/optional-mcps/socialrobot/manifest.yaml
@@ -41,7 +41,6 @@ suggest:
   keywords:
     - socialrobot
     - social robot
-    - post-scheduler
   hosts:
     - socialrobot.io
 

--- a/optional-skills/social-media/DESCRIPTION.md
+++ b/optional-skills/social-media/DESCRIPTION.md
@@ -1,0 +1,6 @@
+# Social Media
+
+Skills for managing social media through external tools and services: posting
+and scheduling across platforms, content repurposing, queue review, and
+performance analytics. Mirrors the bundled `skills/social-media/` category;
+skills here are official but not activated by default.

--- a/optional-skills/social-media/socialrobot-analytics/SKILL.md
+++ b/optional-skills/social-media/socialrobot-analytics/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: socialrobot-analytics
+description: Report SocialRobot post, account, and audience analytics.
+version: 0.1.0
+author: Nicolas Torres (ntgussoni), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Social-Media, Analytics, Audience, MCP]
+    related_skills: [socialrobot-scheduling, social-media-content-calendar]
+---
+
+# SocialRobot Analytics Skill
+
+Answers performance questions about the user's connected social accounts using
+the analytics tools on the SocialRobot MCP server. It produces reports on post
+and account performance, follower demographics, and analytics-derived best
+times to post. It reports the numbers the tools return; it does not invent
+metrics, extrapolate missing platforms, or turn data into marketing claims.
+
+## When to Use
+
+- "Which of my Instagram posts did best last month?"
+- "What are the best times to post for my audience?"
+- "How is my LinkedIn Company Page audience split by industry?"
+- "Summarize last week's performance across accounts."
+
+Don't use for: scheduling or creating posts (use `socialrobot-scheduling`), or
+platforms the user has not connected (the tools only cover linked accounts).
+
+## Prerequisites
+
+- The `socialrobot` MCP server is installed and connected: `hermes mcp install
+  socialrobot`. OAuth signs you in through a browser; an API key
+  (`x-api-key` header) works for headless setups. No account yet?
+  [Get a free account](https://socialrobot.io).
+- Scopes granted include `analytics:read` and `audience:read`.
+
+## How to Run
+
+Pick the tool that matches the question, call it, and report what it returns
+with the time range and account it covers. Tool signatures and fields live in
+`tools/list`; this skill covers choosing the right tool and reporting the
+results faithfully. All analytics tools require the account ID from
+`list_connected_accounts` first.
+
+## Quick Reference
+
+`tools/list` is the source of truth for signatures and fields. The mapping from
+question to tool:
+
+| Tool | Question it answers |
+|------|---------------------|
+| `get_account_analytics` | How did this account perform over a period? |
+| `get_post_analytics` | How did one post perform? |
+| `get_posts_with_analytics` | Which recent posts did well, in one call? |
+| `get_follower_demographics` | Who follows this account? |
+| `instagram_best_post_times` | When does this account's audience engage? |
+
+## Procedure
+
+1. **Discover accounts.** Call `list_connected_accounts` and use the returned
+   account IDs. Do not guess.
+2. **Scope the question.** Account-level: `get_account_analytics`. Single post:
+   `get_post_analytics`. Recent batch: `get_posts_with_analytics`. Audience:
+   `get_follower_demographics`. Best times: `instagram_best_post_times`.
+3. **Call the tool** with the account ID and, where supported, the time range
+   the user asked about. Keep the returned period explicit in your report.
+4. **Report faithfully.** Present the numbers the tool returned, the period,
+   and the account. Note when a metric is unavailable or zero; do not fill gaps
+   with estimates.
+5. **Interpret, do not inflate.** Frame best times as analytics-derived windows
+   for this account, not universal guarantees. Tie post-level numbers to the
+   content and date when useful.
+
+## Pitfalls
+
+- Never invent or round up metrics the tools did not return. If a field is
+  missing, say it is missing.
+- Coverage varies by platform: LinkedIn Company Pages expose demographics and
+  page analytics; TikTok account analytics plus `get_posts_with_analytics` cover
+  public videos (requires `video.list`). State the coverage for each account.
+- `instagram_best_post_times` reflects analytics for the connected account;
+  it is not a claim about other accounts or platforms.
+- Always attach the time range to the numbers you report. Bare numbers without
+  a period are unverifiable.
+- Do not use the analytics output to make forward-looking performance claims in
+  marketing copy; that is a separate editorial decision for the user.
+
+## Verification
+
+The response includes the account ID, the time range queried, and non-empty
+metric fields for at least the primary metric asked about. If the user asked
+for a comparison, the numbers must come from the same tool and same period so
+they are comparable.

--- a/optional-skills/social-media/socialrobot-calendar-review/SKILL.md
+++ b/optional-skills/social-media/socialrobot-calendar-review/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: socialrobot-calendar-review
+description: Audit the upcoming social queue and fix gaps or overlaps.
+version: 0.1.0
+author: Nicolas Torres (ntgussoni), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Social-Media, Calendar, Queue, MCP]
+    related_skills: [socialrobot-scheduling, social-media-content-calendar]
+---
+
+# SocialRobot Calendar Review Skill
+
+Audits the user's upcoming social media queue through the SocialRobot MCP
+server: what is scheduled, when, on which accounts, and whether the calendar is
+healthy (cadence, duplicates, gaps, stale drafts). It proposes concrete fixes
+and applies only the changes the user approves. It does not invent content;
+filling a gap means drafting a brief for the user or handing off to
+`socialrobot-scheduling` / `social-media-content-calendar`.
+
+## When to Use
+
+- "What's in my queue this week?"
+- "Why do I have two posts on the same day for the same account?"
+- "I have a hole in my calendar next week, what should I do?"
+- "Move everything scheduled for Thursday."
+- "Clean up my drafts."
+
+Don't use for: creating new content (that is
+`social-media-content-calendar` + `socialrobot-scheduling`), or measuring past
+performance (that is `socialrobot-analytics` / `socialrobot-campaign-report`).
+
+## Prerequisites
+
+- The `socialrobot` MCP server is installed and connected: `hermes mcp install
+  socialrobot`. OAuth signs you in through a browser; an API key
+  (`x-api-key` header) works for headless setups. No account yet?
+  [Get a free account](https://socialrobot.io).
+- Scopes granted include `publishing:read` (audit) and `publishing:write`
+  (applying changes).
+
+## How to Run
+
+1. Pull the queue with `list_posts` filtered to `SCHEDULED` (and `DRAFT` when
+   asked) for the window in question.
+2. Audit against the cadence and mix the user wants.
+3. Present findings with concrete proposals.
+4. Apply only approved changes, then re-verify.
+
+## Quick Reference
+
+| Tool | Role |
+|------|------|
+| `list_posts` | Queue source: filter by `status`, `platform`, `dateFrom`, `dateTo`, paginate with `limit`/`cursor`. |
+| `reschedule_post` | Move a post to a new future datetime. |
+| `update_post` | Change caption, media, or targets on a draft/scheduled post. |
+| `delete_post` | Remove a draft or scheduled post. Irreversible; confirm first. |
+| `create_post` | Fill an approved gap (or hand the gap to scheduling skills). |
+
+## Procedure
+
+1. **Pull the queue.** `list_posts` with `status: SCHEDULED` and the window
+   (`dateFrom`/`dateTo`). Paginate with `cursor` until the window is covered.
+   Include `DRAFT` when the user asks for a cleanup.
+2. **Audit.**
+   - Cadence: count posts per platform per day/week against the user's target.
+   - Overlaps: two or more posts to the same account within a short window.
+   - Gaps: days or platforms with no coverage in the window.
+   - Stale items: drafts past their relevance date, or posts with expired
+     claims or dead links.
+   - Mix: same content type repeated back to back (for example, three text-only
+     posts in a row on one account).
+3. **Propose.** Present findings as a short list: each issue, the item (post
+   id, platform, datetime), and the proposed fix (reschedule to X, update copy,
+   delete, or draft a new post). Get approval before executing anything.
+4. **Apply approved changes.** `reschedule_post` and `update_post` for edits,
+   `delete_post` only for explicitly approved deletions. For approved gaps,
+   hand the brief to `socialrobot-scheduling` rather than improvising content.
+5. **Re-verify.** `list_posts` over the same window: no duplicates remain,
+   cadence matches the target, and every slot has a purpose.
+
+## Pitfalls
+
+- Deleting without explicit approval; `delete_post` is irreversible.
+- Confusing timezones. Confirm the user's timezone; `scheduledFor` datetimes
+  are absolute ISO timestamps.
+- Over-posting one platform in a single day; platforms throttle or bury
+  repeated posts.
+- Treating drafts as approved content. Drafts go back to the editorial step,
+  not straight to scheduling.
+- Forgetting pagination: `limit` caps at 100, so large queues need `cursor`
+  continuation.
+
+## Verification
+
+A fresh `list_posts` over the audited window shows the approved changes:
+overlaps resolved, gaps filled or explicitly reported, and nothing deleted or
+moved that the user did not approve.

--- a/optional-skills/social-media/socialrobot-campaign-report/SKILL.md
+++ b/optional-skills/social-media/socialrobot-campaign-report/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: socialrobot-campaign-report
+description: Compare campaign performance across platforms and recap.
+version: 0.1.0
+author: Nicolas Torres (ntgussoni), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Social-Media, Analytics, Campaign, MCP]
+    related_skills: [socialrobot-analytics, social-media-content-calendar]
+---
+
+# SocialRobot Campaign Report Skill
+
+Builds a cross-platform performance report for a campaign or time window using
+the SocialRobot MCP analytics tools, and writes a structured recap: what was
+posted, how each platform performed, what stood out, and what to do next. It
+compares platforms honestly, using platform-native metrics, and never invents
+numbers or extrapolates beyond the window the tools returned.
+
+## When to Use
+
+- "How did the launch do across platforms?"
+- "Compare last month on Instagram vs LinkedIn vs X."
+- "Recap our Q3 social performance."
+- "Which platform should we double down on next quarter?"
+
+Don't use for: single-account metric questions (use `socialrobot-analytics`),
+or scheduling (use `socialrobot-scheduling`).
+
+## Prerequisites
+
+- The `socialrobot` MCP server is installed and connected: `hermes mcp install
+  socialrobot`. OAuth signs you in through a browser; an API key
+  (`x-api-key` header) works for headless setups. No account yet?
+  [Get a free account](https://socialrobot.io).
+- Scopes granted include `analytics:read` and `audience:read`.
+
+## How to Run
+
+1. Define the window and scope with the user (campaign, platform, account).
+2. Pull per-platform data with `get_posts_with_analytics` (needs `platform`
+   and `accountId` from `list_connected_accounts`).
+3. Aggregate, compare, and write the recap.
+
+## Quick Reference
+
+| Tool | Role in the report |
+|------|--------------------|
+| `list_connected_accounts` | Discover the account IDs to query. |
+| `get_posts_with_analytics` | Per-platform post list with metrics and history for the window. |
+| `get_account_analytics` | Account-level series over the window. |
+| `get_follower_demographics` | Audience context (who the platform reached). |
+
+## Procedure
+
+1. **Scope the report.** Confirm the campaign name or window (start and end
+   dates), and which platforms and accounts it covers. A report without an
+   explicit window is not verifiable.
+2. **Pull the data.** For each platform in scope: `get_posts_with_analytics`
+   with the account ID and `startDate`/`endDate`. Note the platforms it covers
+   (instagram, facebook, threads, pinterest, linkedin, tiktok) and state
+   clearly when a platform is not covered.
+3. **Aggregate honestly.** Sum or average only within comparable metric
+   families. Platforms report different native metrics (for example reach vs
+   impressions vs engagements); keep them labeled per platform instead of
+   forcing one cross-platform number.
+4. **Add context.** `get_account_analytics` for the window trend and
+   `get_follower_demographics` for who the posts reached, where supported.
+5. **Write the recap.** Structure: window and scope, per-platform performance,
+   top posts (with ids), what worked and what did not, and a recommendation
+   grounded in the numbers. Flag data gaps (platforms with no posts, metrics
+   the platform did not return).
+
+## Pitfalls
+
+- Comparing incompatible metrics across platforms as if they were the same
+  number. Label each metric with its platform.
+- Claiming causation ("this post caused signups") from engagement data alone.
+- Ignoring the window: numbers from outside the requested range do not belong
+  in the report.
+- Reporting for platforms with no posts in the window as if they underperformed;
+  report them as not covered.
+- Rounding or trimming outliers to make the story cleaner. Report what the
+  tools returned.
+
+## Verification
+
+Every number in the recap traces to a tool call with an explicit platform,
+account, and window. The report states per-platform coverage, and no metric is
+presented without its platform label and time range.

--- a/optional-skills/social-media/socialrobot-content-repurposing/SKILL.md
+++ b/optional-skills/social-media/socialrobot-content-repurposing/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: socialrobot-content-repurposing
+description: Repurpose long-form content into multi-platform posts.
+version: 0.1.0
+author: Nicolas Torres (ntgussoni), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Social-Media, Content, Repurposing, MCP]
+    related_skills: [socialrobot-scheduling, social-media-content-calendar, humanizer]
+---
+
+# SocialRobot Content Repurposing Skill
+
+Turn one long-form source (blog post, video, newsletter) into platform-adapted
+posts and schedule them through the SocialRobot MCP server. Read the server's
+`create-post` skill with MCP `skills/get` for media upload and per-platform
+fields; this skill covers the adaptation: one distinct post per platform,
+within each platform's length limits, with every claim traceable to the source.
+It does not write copy with no source; pair it with
+`social-media-content-calendar` and `humanizer` for that.
+
+## When to Use
+
+- "Repurpose this blog post into posts for LinkedIn, X, and Instagram."
+- "Turn this YouTube video into a TikTok, a Threads post, and a pin."
+- "Make a launch announcement for all my connected platforms."
+- "We published a newsletter, give me a week of posts from it."
+
+Don't use for: writing original posts with no source (use
+`social-media-content-calendar` plus `humanizer`), or posting one piece of copy
+to every platform unchanged (that is exactly what this skill is designed to
+avoid).
+
+## Prerequisites
+
+- The `socialrobot` MCP server is installed and connected: `hermes mcp install
+  socialrobot`. OAuth signs you in through a browser; an API key
+  (`x-api-key` header) works for headless setups. No account yet?
+  [Get a free account](https://socialrobot.io).
+- The target platforms are linked in the SocialRobot app. The MCP server only
+  schedules to accounts already connected there.
+- Scopes granted include `publishing:write` and `media:write` (media uploads).
+
+## How to Run
+
+1. Load the source with `read_file` (local file) or `web_extract` (URL).
+2. Call `list_connected_accounts` to see which platforms are available.
+3. Read the server's `create-post` skill via MCP `skills/get` for current
+   mechanics (media upload, per-platform fields).
+4. Build the adapted package below, then create and verify each post.
+
+## Quick Reference
+
+| Platform | Adapt as |
+|----------|----------|
+| X, Bluesky | Short hook, link, 1-3 key points, relevant media |
+| LinkedIn | Long-form post or article; mentions, geo, poll, visibility options |
+| Instagram | Visual first: carousel or image, caption with hashtags, first comment |
+| TikTok | Short vertical video; `postMode` decides publish vs inbox draft |
+| Pinterest | Pin with title, description, destination link |
+| Threads, Mastodon | Conversational take; poll, link attachment, topic tag where offered |
+| Facebook | Broad reach post; reel/story/slideshow variants where offered |
+
+## Procedure
+
+1. **Extract and verify the source.** Read the full source, note the core
+   message, facts, figures, quotes, and any links. Mark claims that are
+   unsupported or expired; do not carry them into posts.
+2. **Define the package.** One adapted post per platform, not the same copy
+   everywhere. Draft hooks that fit each platform's norms (short for X,
+   headline-first for LinkedIn, visual-led for Instagram).
+3. **Respect constraints.** Every target has `maxLength` limits in its input
+   schema; keep captions inside them. Include alt text for images and media
+   references from `get_media_upload_url` uploads before calling `create_post`.
+4. **Build platform specifics.** Instagram: carousel slides, first comment,
+   hashtags, optional location. LinkedIn: article variant for long content,
+   mentions via `linkedin_search_organizations` / `linkedin_search_people_mentions`,
+   geo via `linkedin_search_geo_locations`. Pinterest: board ID from
+   `pinterest_list_boards`, title and link. TikTok: `privacyLevel` from
+   `tiktok_get_creator_info`, `postMode` `DIRECT_POST` or `UPLOAD`.
+5. **Schedule or draft.** One `create_post` call with multiple targets when the
+   copy is shared; separate calls when platforms need different copy (the usual
+   case here). Use `SCHEDULE` with an explicit ISO datetime, `NOW` for
+   immediate publish, or `DRAFT` when the user wants to review first.
+6. **Verify.** `list_posts` read-back for every created item: scheduled time,
+   account, preview, and provider post/job ID. Report status honestly.
+
+## Pitfalls
+
+- Identical copy on every platform. Adaptation is the point of this skill.
+- Inventing or embellishing claims the source does not support. Every post
+  must trace to a verified source fact.
+- Forgetting to upload media before `create_post`; the media reference must
+  come from the upload response.
+- Mixing timezones. Ask for the user's timezone before picking `SCHEDULE`
+  datetimes.
+- Claiming "published" when the post is only scheduled or is a TikTok
+  `UPLOAD` inbox draft.
+
+## Verification
+
+Every post in the package has platform-adapted copy within its schema limits,
+media references from real uploads, and a `list_posts` entry with the scheduled
+time, account, and status. All claims in the posts trace back to the source
+material.

--- a/optional-skills/social-media/socialrobot-scheduling/SKILL.md
+++ b/optional-skills/social-media/socialrobot-scheduling/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: socialrobot-scheduling
+description: Schedule multi-platform social posts via SocialRobot MCP.
+version: 0.1.0
+author: Nicolas Torres (ntgussoni), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Social-Media, Scheduling, Publishing, MCP]
+    related_skills: [social-media-content-calendar, xurl]
+---
+
+# SocialRobot Scheduling Skill
+
+Schedule approved posts to connected social accounts through the SocialRobot
+MCP server. Read the server's `create-post` skill with MCP `skills/get` first;
+it has the per-platform steps and the SocialRobot team keeps it current. This
+skill covers what that one does not: approval gating, timing, verification, and
+honest status reporting. It does not write copy; pair it with
+`social-media-content-calendar` for a brief-to-published flow.
+
+## When to Use
+
+- "Schedule this post for Tuesday 9am."
+- "Publish the approved draft to LinkedIn, X, and Instagram."
+- "Move my Monday post to Wednesday, or cancel it."
+- "Turn this campaign calendar into scheduled posts."
+
+Don't use for: writing the copy itself (pair with `social-media-content-calendar`
+or `humanizer`), or one-off posting without a SocialRobot account (use the
+platform skill directly, e.g. `xurl`).
+
+## Prerequisites
+
+- The `socialrobot` MCP server is installed and connected: `hermes mcp install
+  socialrobot` (or add `mcp_servers.socialrobot.url: https://socialrobot.io/api/mcp`
+  to `~/.hermes/config.yaml`). OAuth signs you in through a browser; an API key
+  (`x-api-key` header) works for headless setups. No account yet?
+  [Get a free account](https://socialrobot.io).
+- The user has linked the social accounts they want to post to inside the
+  SocialRobot app first. The MCP server cannot invent platform logins; it only
+  schedules to accounts already connected there.
+- Scopes granted include `publishing:write` (and `media:write` when the post
+  needs media).
+
+## How to Run
+
+1. Confirm the server is connected: `tools/list` returns the SocialRobot tools.
+2. Load the server's current workflow: MCP `skills/get` on `create-post` (or
+   `resources/read` on `skill://create-post/SKILL.md`). It documents the
+   account, media, and per-platform steps, and the SocialRobot team keeps it
+   current with the product.
+3. Execute the pipeline below, following the server skill for mechanics.
+
+## Quick Reference
+
+`tools/list` and `skills/get` are the source of truth for tool signatures and
+workflow details. The orchestration-relevant tools:
+
+| Tool | Role in this skill |
+|------|--------------------|
+| `list_connected_accounts` | Entry point: discover account IDs; never guess them. |
+| `create_post` / `list_posts` | Create, then verify with read-back. |
+| `update_post`, `reschedule_post`, `delete_post` | Post-run management. |
+
+## Procedure
+
+1. **Confirm approval state.** Only posts that are approved (never `draft` or
+   `needs review`) may be scheduled. If drafts are unapproved, hand them back.
+2. **Discover accounts.** `list_connected_accounts`, pick the account ID per
+   target platform.
+3. **Pick timing.** If the user left timing open or wants the best time, call
+   `instagram_best_post_times` for Instagram accounts and use
+   `get_account_analytics` trends for other platforms, then set `scheduledFor`
+   accordingly. Confirm the user's timezone before choosing datetimes.
+4. **Follow the server's `create-post` skill for mechanics**: media upload
+   before `create_post` (keep the returned media reference), Pinterest board
+   resolution, TikTok `privacyLevel` and `postMode` (`DIRECT_POST` publishes,
+   `UPLOAD` is an inbox draft), LinkedIn geo and @mention URN resolution.
+5. **Create.** One `create_post` call with multiple targets when the copy is
+   shared, rather than separate posts.
+6. **Verify with read-back.** `list_posts`: confirm scheduled time, account,
+   content preview, and provider post/job ID. Report `scheduled` or `published`
+   only per the status the tool returns.
+7. **Manage.** `update_post`, `reschedule_post`, or `delete_post` when the user
+   changes their mind; re-verify after any change.
+
+## Pitfalls
+
+- Never invent account IDs, board IDs, or TikTok `privacyLevel` values; always
+  read them from the tools or the server-served skill.
+- Upload media before `create_post`; keep the returned media reference.
+- `UPLOAD` mode on TikTok means an inbox draft, not a published post. Say so.
+- A queued post is not published. Do not claim publication for posts that only
+  show as scheduled or pending.
+- API key quota is one shared pool between the HTTP OpenAPI endpoints and MCP
+  `tools/call` + `tools/list` for that key. Handshake traffic (login, OAuth,
+  `initialize`, `get-session`) does not consume quota.
+- If `skills/get` fails, the connection may be stale; reconnect the MCP server
+  before proceeding.
+
+## Verification
+
+`list_posts` shows the post with its scheduled time, account, and status, and
+any provider post/job ID. Every scheduled slot must trace back to an approved
+draft, and every `scheduled`/`published` claim must match the status field the
+tool returned.

--- a/tests/skills/test_socialrobot_analytics_skill.py
+++ b/tests/skills/test_socialrobot_analytics_skill.py
@@ -1,0 +1,91 @@
+"""HARDLINE checks for the socialrobot-analytics optional skill."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / "optional-skills" / "social-media" / "socialrobot-analytics"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+
+ANALYTICS_TOOLS = {
+    "get_account_analytics",
+    "get_post_analytics",
+    "get_posts_with_analytics",
+    "get_follower_demographics",
+    "instagram_best_post_times",
+    "list_connected_accounts",
+}
+
+REQUIRED_SECTIONS = [
+    "## When to Use",
+    "## Prerequisites",
+    "## How to Run",
+    "## Quick Reference",
+    "## Procedure",
+    "## Pitfalls",
+    "## Verification",
+]
+
+BANNED_MARKETING_WORDS = ["powerful", "comprehensive", "seamless", "advanced"]
+
+
+def _frontmatter(text):
+    match = re.search(r"^---\n(.*?)\n---", text, re.DOTALL)
+    assert match, "no YAML frontmatter block found"
+    fields = {}
+    for line in match.group(1).splitlines():
+        if ":" in line and not line.startswith(" "):
+            key, _, value = line.partition(":")
+            fields[key.strip()] = value.strip()
+    return fields
+
+
+@pytest.fixture(scope="module")
+def skill_text():
+    assert SKILL_MD.exists(), f"missing {SKILL_MD}"
+    return SKILL_MD.read_text()
+
+
+def test_description_harline(skill_text):
+    fields = _frontmatter(skill_text)
+    desc = fields["description"]
+    assert len(desc) <= 60, f"description too long: {len(desc)} chars"
+    assert desc.endswith("."), "description must end with a period"
+    assert desc.count(". ") == 0, "description must be one sentence"
+    lower = desc.lower()
+    for word in BANNED_MARKETING_WORDS:
+        assert word not in lower, f"banned marketing word: {word}"
+    assert "socialrobot-analytics" not in lower, "description repeats the skill name"
+
+
+def test_frontmatter_required_fields(skill_text):
+    fields = _frontmatter(skill_text)
+    assert fields["name"] == "socialrobot-analytics"
+    assert fields.get("version") == "0.1.0", "new skills start at 0.1.0"
+    assert fields.get("author", "").startswith("Nicolas Torres"), "author must credit the human first"
+    assert fields.get("author") != "Hermes Agent", "author must not be Hermes Agent alone"
+    assert fields.get("license") == "MIT"
+    assert fields.get("platforms") == "[linux, macos, windows]", "platforms must be declared"
+
+
+def test_modern_section_order(skill_text):
+    positions = [skill_text.find(section) for section in REQUIRED_SECTIONS]
+    assert all(p >= 0 for p in positions), "a required section is missing"
+    assert positions == sorted(positions), "sections must appear in canonical order"
+
+
+def test_analytics_tools_are_referenced(skill_text):
+    for tool in ANALYTICS_TOOLS:
+        assert tool in skill_text, f"missing reference to {tool}"
+
+
+def test_no_secrets_in_skill(skill_text):
+    assert "sk-" not in skill_text
+    assert "ghp_" not in skill_text
+    assert re.search(r"Bearer\s+[A-Za-z0-9._~+/=-]{20,}", skill_text) is None
+
+
+def test_reporting_discipline_mentioned(skill_text):
+    verification = skill_text.split("## Verification", 1)[1]
+    assert "time range" in verification or "period" in verification

--- a/tests/skills/test_socialrobot_calendar_review_skill.py
+++ b/tests/skills/test_socialrobot_calendar_review_skill.py
@@ -1,0 +1,89 @@
+"""HARDLINE checks for the socialrobot-calendar-review optional skill."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / "optional-skills" / "social-media" / "socialrobot-calendar-review"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+
+QUEUE_TOOLS = {
+    "list_posts",
+    "reschedule_post",
+    "update_post",
+    "delete_post",
+    "create_post",
+}
+
+REQUIRED_SECTIONS = [
+    "## When to Use",
+    "## Prerequisites",
+    "## How to Run",
+    "## Quick Reference",
+    "## Procedure",
+    "## Pitfalls",
+    "## Verification",
+]
+
+BANNED_MARKETING_WORDS = ["powerful", "comprehensive", "seamless", "advanced"]
+
+
+def _frontmatter(text):
+    match = re.search(r"^---\n(.*?)\n---", text, re.DOTALL)
+    assert match, "no YAML frontmatter block found"
+    fields = {}
+    for line in match.group(1).splitlines():
+        if ":" in line and not line.startswith(" "):
+            key, _, value = line.partition(":")
+            fields[key.strip()] = value.strip()
+    return fields
+
+
+@pytest.fixture(scope="module")
+def skill_text():
+    assert SKILL_MD.exists(), f"missing {SKILL_MD}"
+    return SKILL_MD.read_text()
+
+
+def test_description_harline(skill_text):
+    fields = _frontmatter(skill_text)
+    desc = fields["description"]
+    assert len(desc) <= 60, f"description too long: {len(desc)} chars"
+    assert desc.endswith("."), "description must end with a period"
+    assert desc.count(". ") == 0, "description must be one sentence"
+    lower = desc.lower()
+    for word in BANNED_MARKETING_WORDS:
+        assert word not in lower, f"banned marketing word: {word}"
+    assert "socialrobot-calendar-review" not in lower, "description repeats the skill name"
+
+
+def test_frontmatter_required_fields(skill_text):
+    fields = _frontmatter(skill_text)
+    assert fields["name"] == "socialrobot-calendar-review"
+    assert fields.get("version") == "0.1.0", "new skills start at 0.1.0"
+    assert fields.get("author", "").startswith("Nicolas Torres"), "author must credit the human first"
+    assert fields.get("author") != "Hermes Agent", "author must not be Hermes Agent alone"
+    assert fields.get("license") == "MIT"
+    assert fields.get("platforms") == "[linux, macos, windows]", "platforms must be declared"
+
+
+def test_modern_section_order(skill_text):
+    positions = [skill_text.find(section) for section in REQUIRED_SECTIONS]
+    assert all(p >= 0 for p in positions), "a required section is missing"
+    assert positions == sorted(positions), "sections must appear in canonical order"
+
+
+def test_queue_tools_are_referenced(skill_text):
+    for tool in QUEUE_TOOLS:
+        assert tool in skill_text, f"missing reference to {tool}"
+
+
+def test_delete_requires_approval(skill_text):
+    assert "approval" in skill_text.split("## Pitfalls", 1)[1].lower()
+
+
+def test_no_secrets_in_skill(skill_text):
+    assert "sk-" not in skill_text
+    assert "ghp_" not in skill_text
+    assert re.search(r"Bearer\s+[A-Za-z0-9._~+/=-]{20,}", skill_text) is None

--- a/tests/skills/test_socialrobot_campaign_report_skill.py
+++ b/tests/skills/test_socialrobot_campaign_report_skill.py
@@ -1,0 +1,89 @@
+"""HARDLINE checks for the socialrobot-campaign-report optional skill."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / "optional-skills" / "social-media" / "socialrobot-campaign-report"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+
+REPORT_TOOLS = {
+    "list_connected_accounts",
+    "get_posts_with_analytics",
+    "get_account_analytics",
+    "get_follower_demographics",
+}
+
+REQUIRED_SECTIONS = [
+    "## When to Use",
+    "## Prerequisites",
+    "## How to Run",
+    "## Quick Reference",
+    "## Procedure",
+    "## Pitfalls",
+    "## Verification",
+]
+
+BANNED_MARKETING_WORDS = ["powerful", "comprehensive", "seamless", "advanced"]
+
+
+def _frontmatter(text):
+    match = re.search(r"^---\n(.*?)\n---", text, re.DOTALL)
+    assert match, "no YAML frontmatter block found"
+    fields = {}
+    for line in match.group(1).splitlines():
+        if ":" in line and not line.startswith(" "):
+            key, _, value = line.partition(":")
+            fields[key.strip()] = value.strip()
+    return fields
+
+
+@pytest.fixture(scope="module")
+def skill_text():
+    assert SKILL_MD.exists(), f"missing {SKILL_MD}"
+    return SKILL_MD.read_text()
+
+
+def test_description_harline(skill_text):
+    fields = _frontmatter(skill_text)
+    desc = fields["description"]
+    assert len(desc) <= 60, f"description too long: {len(desc)} chars"
+    assert desc.endswith("."), "description must end with a period"
+    assert desc.count(". ") == 0, "description must be one sentence"
+    lower = desc.lower()
+    for word in BANNED_MARKETING_WORDS:
+        assert word not in lower, f"banned marketing word: {word}"
+    assert "socialrobot-campaign-report" not in lower, "description repeats the skill name"
+
+
+def test_frontmatter_required_fields(skill_text):
+    fields = _frontmatter(skill_text)
+    assert fields["name"] == "socialrobot-campaign-report"
+    assert fields.get("version") == "0.1.0", "new skills start at 0.1.0"
+    assert fields.get("author", "").startswith("Nicolas Torres"), "author must credit the human first"
+    assert fields.get("author") != "Hermes Agent", "author must not be Hermes Agent alone"
+    assert fields.get("license") == "MIT"
+    assert fields.get("platforms") == "[linux, macos, windows]", "platforms must be declared"
+
+
+def test_modern_section_order(skill_text):
+    positions = [skill_text.find(section) for section in REQUIRED_SECTIONS]
+    assert all(p >= 0 for p in positions), "a required section is missing"
+    assert positions == sorted(positions), "sections must appear in canonical order"
+
+
+def test_report_tools_are_referenced(skill_text):
+    for tool in REPORT_TOOLS:
+        assert tool in skill_text, f"missing reference to {tool}"
+
+
+def test_explicit_window_required(skill_text):
+    assert "window" in skill_text
+    assert "start" in skill_text.lower() and "end" in skill_text.lower()
+
+
+def test_no_secrets_in_skill(skill_text):
+    assert "sk-" not in skill_text
+    assert "ghp_" not in skill_text
+    assert re.search(r"Bearer\s+[A-Za-z0-9._~+/=-]{20,}", skill_text) is None

--- a/tests/skills/test_socialrobot_content_repurposing_skill.py
+++ b/tests/skills/test_socialrobot_content_repurposing_skill.py
@@ -1,0 +1,110 @@
+"""HARDLINE checks for the socialrobot-content-repurposing optional skill."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / "optional-skills" / "social-media" / "socialrobot-content-repurposing"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+
+KNOWN_MCP_TOOLS = {
+    "list_connected_accounts",
+    "get_media_upload_url",
+    "create_post",
+    "list_posts",
+    "delete_post",
+    "update_post",
+    "reschedule_post",
+    "get_account_analytics",
+    "get_post_analytics",
+    "get_posts_with_analytics",
+    "get_follower_demographics",
+    "instagram_best_post_times",
+    "pinterest_list_boards",
+    "pinterest_create_board",
+    "tiktok_get_creator_info",
+    "linkedin_search_geo_locations",
+    "linkedin_search_people_mentions",
+    "linkedin_search_organizations",
+}
+
+ALLOWED_PROTOCOL_METHODS = {"skills/get", "skills/list", "resources/read"}
+
+ALLOWED_HERMES_TOOLS = {"read_file", "web_extract", "image_generate"}
+
+REQUIRED_SECTIONS = [
+    "## When to Use",
+    "## Prerequisites",
+    "## How to Run",
+    "## Quick Reference",
+    "## Procedure",
+    "## Pitfalls",
+    "## Verification",
+]
+
+BANNED_MARKETING_WORDS = ["powerful", "comprehensive", "seamless", "advanced"]
+
+
+def _frontmatter(text):
+    match = re.search(r"^---\n(.*?)\n---", text, re.DOTALL)
+    assert match, "no YAML frontmatter block found"
+    fields = {}
+    for line in match.group(1).splitlines():
+        if ":" in line and not line.startswith(" "):
+            key, _, value = line.partition(":")
+            fields[key.strip()] = value.strip()
+    return fields
+
+
+@pytest.fixture(scope="module")
+def skill_text():
+    assert SKILL_MD.exists(), f"missing {SKILL_MD}"
+    return SKILL_MD.read_text()
+
+
+def test_description_harline(skill_text):
+    fields = _frontmatter(skill_text)
+    desc = fields["description"]
+    assert len(desc) <= 60, f"description too long: {len(desc)} chars"
+    assert desc.endswith("."), "description must end with a period"
+    assert desc.count(". ") == 0, "description must be one sentence"
+    lower = desc.lower()
+    for word in BANNED_MARKETING_WORDS:
+        assert word not in lower, f"banned marketing word: {word}"
+    assert "socialrobot-content-repurposing" not in lower, "description repeats the skill name"
+
+
+def test_frontmatter_required_fields(skill_text):
+    fields = _frontmatter(skill_text)
+    assert fields["name"] == "socialrobot-content-repurposing"
+    assert fields.get("version") == "0.1.0", "new skills start at 0.1.0"
+    assert fields.get("author", "").startswith("Nicolas Torres"), "author must credit the human first"
+    assert fields.get("author") != "Hermes Agent", "author must not be Hermes Agent alone"
+    assert fields.get("license") == "MIT"
+    assert fields.get("platforms") == "[linux, macos, windows]", "platforms must be declared"
+
+
+def test_modern_section_order(skill_text):
+    positions = [skill_text.find(section) for section in REQUIRED_SECTIONS]
+    assert all(p >= 0 for p in positions), "a required section is missing"
+    assert positions == sorted(positions), "sections must appear in canonical order"
+
+
+def test_referenced_tools_exist(skill_text):
+    referenced = set()
+    for token in re.findall(r"`([^`]+)`", skill_text):
+        if re.fullmatch(r"[a-z]+(?:_[a-z0-9]+)+", token):
+            referenced.add(token)
+    unknown = referenced - KNOWN_MCP_TOOLS - ALLOWED_PROTOCOL_METHODS - ALLOWED_HERMES_TOOLS
+    assert not unknown, f"referenced tools not allowed: {sorted(unknown)}"
+
+
+def test_adaptation_is_mandatory(skill_text):
+    assert "not the same copy" in skill_text or "Identical copy" in skill_text
+
+
+def test_no_secrets_in_skill(skill_text):
+    assert "sk-" not in skill_text
+    assert "ghp_" not in skill_text
+    assert re.search(r"Bearer\s+[A-Za-z0-9._~+/=-]{20,}", skill_text) is None

--- a/tests/skills/test_socialrobot_manifest.py
+++ b/tests/skills/test_socialrobot_manifest.py
@@ -1,0 +1,47 @@
+"""Checks for the optional-mcps/socialrobot catalog entry manifest."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+MANIFEST = (
+    Path(__file__).resolve().parents[2] / "optional-mcps" / "socialrobot" / "manifest.yaml"
+)
+
+
+@pytest.fixture(scope="module")
+def manifest_text():
+    assert MANIFEST.exists(), f"missing {MANIFEST}"
+    return MANIFEST.read_text()
+
+
+def test_manifest_required_fields(manifest_text):
+    assert re.search(r"^manifest_version:\s*1\s*$", manifest_text, re.MULTILINE)
+    assert re.search(r"^name:\s*socialrobot\s*$", manifest_text, re.MULTILINE)
+    assert re.search(r"^description:\s*.+\.\s*$", manifest_text, re.MULTILINE)
+    assert re.search(r"^source:\s*https://socialrobot\.io/mcp\s*$", manifest_text, re.MULTILINE)
+
+
+def test_transport_is_remote_http(manifest_text):
+    assert re.search(r"^transport:\s*$", manifest_text, re.MULTILINE)
+    assert re.search(r"^\s+type:\s*http\s*$", manifest_text, re.MULTILINE)
+    assert re.search(
+        r"^\s+url:\s*https://socialrobot\.io/api/mcp\s*$", manifest_text, re.MULTILINE
+    )
+
+
+def test_auth_is_native_oauth(manifest_text):
+    assert re.search(r"^auth:\s*$", manifest_text, re.MULTILINE)
+    assert re.search(r"^\s+type:\s*oauth\s*$", manifest_text, re.MULTILINE)
+
+
+def test_no_secrets_in_manifest(manifest_text):
+    assert "sk-" not in manifest_text
+    assert "api_key:" not in manifest_text
+    assert re.search(r"Bearer\s+[A-Za-z0-9._~+/=-]{20,}", manifest_text) is None
+
+
+def test_post_install_present(manifest_text):
+    assert "post_install:" in manifest_text
+    assert "hermes mcp configure socialrobot" in manifest_text

--- a/tests/skills/test_socialrobot_scheduling_skill.py
+++ b/tests/skills/test_socialrobot_scheduling_skill.py
@@ -1,0 +1,108 @@
+"""HARDLINE checks for the socialrobot-scheduling optional skill."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / "optional-skills" / "social-media" / "socialrobot-scheduling"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+
+KNOWN_MCP_TOOLS = {
+    "list_connected_accounts",
+    "get_media_upload_url",
+    "create_post",
+    "list_posts",
+    "delete_post",
+    "update_post",
+    "reschedule_post",
+    "get_account_analytics",
+    "get_post_analytics",
+    "get_posts_with_analytics",
+    "get_follower_demographics",
+    "instagram_best_post_times",
+    "pinterest_list_boards",
+    "pinterest_create_board",
+    "tiktok_get_creator_info",
+    "linkedin_search_geo_locations",
+    "linkedin_search_people_mentions",
+    "linkedin_search_organizations",
+}
+
+ALLOWED_PROTOCOL_METHODS = {"skills/get", "skills/list", "resources/read"}
+
+REQUIRED_SECTIONS = [
+    "## When to Use",
+    "## Prerequisites",
+    "## How to Run",
+    "## Quick Reference",
+    "## Procedure",
+    "## Pitfalls",
+    "## Verification",
+]
+
+BANNED_MARKETING_WORDS = ["powerful", "comprehensive", "seamless", "advanced"]
+
+
+def _frontmatter(text):
+    match = re.search(r"^---\n(.*?)\n---", text, re.DOTALL)
+    assert match, "no YAML frontmatter block found"
+    fields = {}
+    for line in match.group(1).splitlines():
+        if ":" in line and not line.startswith(" "):
+            key, _, value = line.partition(":")
+            fields[key.strip()] = value.strip()
+    return fields
+
+
+@pytest.fixture(scope="module")
+def skill_text():
+    assert SKILL_MD.exists(), f"missing {SKILL_MD}"
+    return SKILL_MD.read_text()
+
+
+def test_description_harline(skill_text):
+    fields = _frontmatter(skill_text)
+    desc = fields["description"]
+    assert len(desc) <= 60, f"description too long: {len(desc)} chars"
+    assert desc.endswith("."), "description must end with a period"
+    assert desc.count(". ") == 0, "description must be one sentence"
+    lower = desc.lower()
+    for word in BANNED_MARKETING_WORDS:
+        assert word not in lower, f"banned marketing word: {word}"
+    assert "socialrobot-scheduling" not in lower, "description repeats the skill name"
+
+
+def test_frontmatter_required_fields(skill_text):
+    fields = _frontmatter(skill_text)
+    assert fields["name"] == "socialrobot-scheduling"
+    assert fields.get("version") == "0.1.0", "new skills start at 0.1.0"
+    assert fields.get("author", "").startswith("Nicolas Torres"), "author must credit the human first"
+    assert fields.get("author") != "Hermes Agent", "author must not be Hermes Agent alone"
+    assert fields.get("license") == "MIT"
+    assert fields.get("platforms") == "[linux, macos, windows]", "platforms must be declared"
+
+
+def test_modern_section_order(skill_text):
+    positions = [skill_text.find(section) for section in REQUIRED_SECTIONS]
+    assert all(p >= 0 for p in positions), "a required section is missing"
+    assert positions == sorted(positions), "sections must appear in canonical order"
+
+
+def test_referenced_tools_exist(skill_text):
+    referenced = set()
+    for token in re.findall(r"`([^`]+)`", skill_text):
+        if re.fullmatch(r"[a-z]+(?:_[a-z0-9]+)+", token):
+            referenced.add(token)
+    unknown = referenced - KNOWN_MCP_TOOLS - ALLOWED_PROTOCOL_METHODS
+    assert not unknown, f"referenced tools not in the SocialRobot MCP surface: {sorted(unknown)}"
+
+
+def test_no_secrets_in_skill(skill_text):
+    assert "sk-" not in skill_text
+    assert "ghp_" not in skill_text
+    assert re.search(r"Bearer\s+[A-Za-z0-9._~+/=-]{20,}", skill_text) is None
+
+
+def test_verification_section_mentions_list_posts(skill_text):
+    assert "list_posts" in skill_text.split("## Verification", 1)[1]

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -255,6 +255,11 @@ hermes skills uninstall <skill-name>
 | Skill | Description |
 |-------|-------------|
 | [**reddit-reading**](/docs/user-guide/skills/optional/social-media/social-media-reddit-reading) | Read Reddit: subreddits, search, threads, users. No browser. |
+| [**socialrobot-analytics**](/docs/user-guide/skills/optional/social-media/social-media-socialrobot-analytics) | Report SocialRobot post, account, and audience analytics. |
+| [**socialrobot-calendar-review**](/docs/user-guide/skills/optional/social-media/social-media-socialrobot-calendar-review) | Audit the upcoming social queue and fix gaps or overlaps. |
+| [**socialrobot-campaign-report**](/docs/user-guide/skills/optional/social-media/social-media-socialrobot-campaign-report) | Compare campaign performance across platforms and recap. |
+| [**socialrobot-content-repurposing**](/docs/user-guide/skills/optional/social-media/social-media-socialrobot-content-repurposing) | Repurpose long-form content into multi-platform posts. |
+| [**socialrobot-scheduling**](/docs/user-guide/skills/optional/social-media/social-media-socialrobot-scheduling) | Schedule multi-platform social posts via SocialRobot MCP. |
 
 ## software-development
 

--- a/website/docs/user-guide/skills/optional/social-media/social-media-socialrobot-analytics.md
+++ b/website/docs/user-guide/skills/optional/social-media/social-media-socialrobot-analytics.md
@@ -1,0 +1,114 @@
+---
+title: "Socialrobot Analytics — Report SocialRobot post, account, and audience analytics"
+sidebar_label: "Socialrobot Analytics"
+description: "Report SocialRobot post, account, and audience analytics"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Socialrobot Analytics
+
+Report SocialRobot post, account, and audience analytics.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/social-media/socialrobot-analytics` |
+| Path | `optional-skills/social-media/socialrobot-analytics` |
+| Version | `0.1.0` |
+| Author | Nicolas Torres (ntgussoni), Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `Social-Media`, `Analytics`, `Audience`, `MCP` |
+| Related skills | [`socialrobot-scheduling`](/docs/user-guide/skills/optional/social-media/social-media-socialrobot-scheduling), [`social-media-content-calendar`](/docs/user-guide/skills/optional/creative/creative-social-media-content-calendar) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# SocialRobot Analytics Skill
+
+Answers performance questions about the user's connected social accounts using
+the analytics tools on the SocialRobot MCP server. It produces reports on post
+and account performance, follower demographics, and analytics-derived best
+times to post. It reports the numbers the tools return; it does not invent
+metrics, extrapolate missing platforms, or turn data into marketing claims.
+
+## When to Use
+
+- "Which of my Instagram posts did best last month?"
+- "What are the best times to post for my audience?"
+- "How is my LinkedIn Company Page audience split by industry?"
+- "Summarize last week's performance across accounts."
+
+Don't use for: scheduling or creating posts (use `socialrobot-scheduling`), or
+platforms the user has not connected (the tools only cover linked accounts).
+
+## Prerequisites
+
+- The `socialrobot` MCP server is installed and connected: `hermes mcp install
+  socialrobot`. OAuth signs you in through a browser; an API key
+  (`x-api-key` header) works for headless setups. No account yet?
+  [Get a free account](https://socialrobot.io).
+- Scopes granted include `analytics:read` and `audience:read`.
+
+## How to Run
+
+Pick the tool that matches the question, call it, and report what it returns
+with the time range and account it covers. Tool signatures and fields live in
+`tools/list`; this skill covers choosing the right tool and reporting the
+results faithfully. All analytics tools require the account ID from
+`list_connected_accounts` first.
+
+## Quick Reference
+
+`tools/list` is the source of truth for signatures and fields. The mapping from
+question to tool:
+
+| Tool | Question it answers |
+|------|---------------------|
+| `get_account_analytics` | How did this account perform over a period? |
+| `get_post_analytics` | How did one post perform? |
+| `get_posts_with_analytics` | Which recent posts did well, in one call? |
+| `get_follower_demographics` | Who follows this account? |
+| `instagram_best_post_times` | When does this account's audience engage? |
+
+## Procedure
+
+1. **Discover accounts.** Call `list_connected_accounts` and use the returned
+   account IDs. Do not guess.
+2. **Scope the question.** Account-level: `get_account_analytics`. Single post:
+   `get_post_analytics`. Recent batch: `get_posts_with_analytics`. Audience:
+   `get_follower_demographics`. Best times: `instagram_best_post_times`.
+3. **Call the tool** with the account ID and, where supported, the time range
+   the user asked about. Keep the returned period explicit in your report.
+4. **Report faithfully.** Present the numbers the tool returned, the period,
+   and the account. Note when a metric is unavailable or zero; do not fill gaps
+   with estimates.
+5. **Interpret, do not inflate.** Frame best times as analytics-derived windows
+   for this account, not universal guarantees. Tie post-level numbers to the
+   content and date when useful.
+
+## Pitfalls
+
+- Never invent or round up metrics the tools did not return. If a field is
+  missing, say it is missing.
+- Coverage varies by platform: LinkedIn Company Pages expose demographics and
+  page analytics; TikTok account analytics plus `get_posts_with_analytics` cover
+  public videos (requires `video.list`). State the coverage for each account.
+- `instagram_best_post_times` reflects analytics for the connected account;
+  it is not a claim about other accounts or platforms.
+- Always attach the time range to the numbers you report. Bare numbers without
+  a period are unverifiable.
+- Do not use the analytics output to make forward-looking performance claims in
+  marketing copy; that is a separate editorial decision for the user.
+
+## Verification
+
+The response includes the account ID, the time range queried, and non-empty
+metric fields for at least the primary metric asked about. If the user asked
+for a comparison, the numbers must come from the same tool and same period so
+they are comparable.

--- a/website/docs/user-guide/skills/optional/social-media/social-media-socialrobot-calendar-review.md
+++ b/website/docs/user-guide/skills/optional/social-media/social-media-socialrobot-calendar-review.md
@@ -1,0 +1,118 @@
+---
+title: "Socialrobot Calendar Review — Audit the upcoming social queue and fix gaps or overlaps"
+sidebar_label: "Socialrobot Calendar Review"
+description: "Audit the upcoming social queue and fix gaps or overlaps"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Socialrobot Calendar Review
+
+Audit the upcoming social queue and fix gaps or overlaps.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/social-media/socialrobot-calendar-review` |
+| Path | `optional-skills/social-media/socialrobot-calendar-review` |
+| Version | `0.1.0` |
+| Author | Nicolas Torres (ntgussoni), Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `Social-Media`, `Calendar`, `Queue`, `MCP` |
+| Related skills | [`socialrobot-scheduling`](/docs/user-guide/skills/optional/social-media/social-media-socialrobot-scheduling), [`social-media-content-calendar`](/docs/user-guide/skills/optional/creative/creative-social-media-content-calendar) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# SocialRobot Calendar Review Skill
+
+Audits the user's upcoming social media queue through the SocialRobot MCP
+server: what is scheduled, when, on which accounts, and whether the calendar is
+healthy (cadence, duplicates, gaps, stale drafts). It proposes concrete fixes
+and applies only the changes the user approves. It does not invent content;
+filling a gap means drafting a brief for the user or handing off to
+`socialrobot-scheduling` / `social-media-content-calendar`.
+
+## When to Use
+
+- "What's in my queue this week?"
+- "Why do I have two posts on the same day for the same account?"
+- "I have a hole in my calendar next week, what should I do?"
+- "Move everything scheduled for Thursday."
+- "Clean up my drafts."
+
+Don't use for: creating new content (that is
+`social-media-content-calendar` + `socialrobot-scheduling`), or measuring past
+performance (that is `socialrobot-analytics` / `socialrobot-campaign-report`).
+
+## Prerequisites
+
+- The `socialrobot` MCP server is installed and connected: `hermes mcp install
+  socialrobot`. OAuth signs you in through a browser; an API key
+  (`x-api-key` header) works for headless setups. No account yet?
+  [Get a free account](https://socialrobot.io).
+- Scopes granted include `publishing:read` (audit) and `publishing:write`
+  (applying changes).
+
+## How to Run
+
+1. Pull the queue with `list_posts` filtered to `SCHEDULED` (and `DRAFT` when
+   asked) for the window in question.
+2. Audit against the cadence and mix the user wants.
+3. Present findings with concrete proposals.
+4. Apply only approved changes, then re-verify.
+
+## Quick Reference
+
+| Tool | Role |
+|------|------|
+| `list_posts` | Queue source: filter by `status`, `platform`, `dateFrom`, `dateTo`, paginate with `limit`/`cursor`. |
+| `reschedule_post` | Move a post to a new future datetime. |
+| `update_post` | Change caption, media, or targets on a draft/scheduled post. |
+| `delete_post` | Remove a draft or scheduled post. Irreversible; confirm first. |
+| `create_post` | Fill an approved gap (or hand the gap to scheduling skills). |
+
+## Procedure
+
+1. **Pull the queue.** `list_posts` with `status: SCHEDULED` and the window
+   (`dateFrom`/`dateTo`). Paginate with `cursor` until the window is covered.
+   Include `DRAFT` when the user asks for a cleanup.
+2. **Audit.**
+   - Cadence: count posts per platform per day/week against the user's target.
+   - Overlaps: two or more posts to the same account within a short window.
+   - Gaps: days or platforms with no coverage in the window.
+   - Stale items: drafts past their relevance date, or posts with expired
+     claims or dead links.
+   - Mix: same content type repeated back to back (for example, three text-only
+     posts in a row on one account).
+3. **Propose.** Present findings as a short list: each issue, the item (post
+   id, platform, datetime), and the proposed fix (reschedule to X, update copy,
+   delete, or draft a new post). Get approval before executing anything.
+4. **Apply approved changes.** `reschedule_post` and `update_post` for edits,
+   `delete_post` only for explicitly approved deletions. For approved gaps,
+   hand the brief to `socialrobot-scheduling` rather than improvising content.
+5. **Re-verify.** `list_posts` over the same window: no duplicates remain,
+   cadence matches the target, and every slot has a purpose.
+
+## Pitfalls
+
+- Deleting without explicit approval; `delete_post` is irreversible.
+- Confusing timezones. Confirm the user's timezone; `scheduledFor` datetimes
+  are absolute ISO timestamps.
+- Over-posting one platform in a single day; platforms throttle or bury
+  repeated posts.
+- Treating drafts as approved content. Drafts go back to the editorial step,
+  not straight to scheduling.
+- Forgetting pagination: `limit` caps at 100, so large queues need `cursor`
+  continuation.
+
+## Verification
+
+A fresh `list_posts` over the audited window shows the approved changes:
+overlaps resolved, gaps filled or explicitly reported, and nothing deleted or
+moved that the user did not approve.

--- a/website/docs/user-guide/skills/optional/social-media/social-media-socialrobot-campaign-report.md
+++ b/website/docs/user-guide/skills/optional/social-media/social-media-socialrobot-campaign-report.md
@@ -1,0 +1,110 @@
+---
+title: "Socialrobot Campaign Report — Compare campaign performance across platforms and recap"
+sidebar_label: "Socialrobot Campaign Report"
+description: "Compare campaign performance across platforms and recap"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Socialrobot Campaign Report
+
+Compare campaign performance across platforms and recap.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/social-media/socialrobot-campaign-report` |
+| Path | `optional-skills/social-media/socialrobot-campaign-report` |
+| Version | `0.1.0` |
+| Author | Nicolas Torres (ntgussoni), Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `Social-Media`, `Analytics`, `Campaign`, `MCP` |
+| Related skills | [`socialrobot-analytics`](/docs/user-guide/skills/optional/social-media/social-media-socialrobot-analytics), [`social-media-content-calendar`](/docs/user-guide/skills/optional/creative/creative-social-media-content-calendar) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# SocialRobot Campaign Report Skill
+
+Builds a cross-platform performance report for a campaign or time window using
+the SocialRobot MCP analytics tools, and writes a structured recap: what was
+posted, how each platform performed, what stood out, and what to do next. It
+compares platforms honestly, using platform-native metrics, and never invents
+numbers or extrapolates beyond the window the tools returned.
+
+## When to Use
+
+- "How did the launch do across platforms?"
+- "Compare last month on Instagram vs LinkedIn vs X."
+- "Recap our Q3 social performance."
+- "Which platform should we double down on next quarter?"
+
+Don't use for: single-account metric questions (use `socialrobot-analytics`),
+or scheduling (use `socialrobot-scheduling`).
+
+## Prerequisites
+
+- The `socialrobot` MCP server is installed and connected: `hermes mcp install
+  socialrobot`. OAuth signs you in through a browser; an API key
+  (`x-api-key` header) works for headless setups. No account yet?
+  [Get a free account](https://socialrobot.io).
+- Scopes granted include `analytics:read` and `audience:read`.
+
+## How to Run
+
+1. Define the window and scope with the user (campaign, platform, account).
+2. Pull per-platform data with `get_posts_with_analytics` (needs `platform`
+   and `accountId` from `list_connected_accounts`).
+3. Aggregate, compare, and write the recap.
+
+## Quick Reference
+
+| Tool | Role in the report |
+|------|--------------------|
+| `list_connected_accounts` | Discover the account IDs to query. |
+| `get_posts_with_analytics` | Per-platform post list with metrics and history for the window. |
+| `get_account_analytics` | Account-level series over the window. |
+| `get_follower_demographics` | Audience context (who the platform reached). |
+
+## Procedure
+
+1. **Scope the report.** Confirm the campaign name or window (start and end
+   dates), and which platforms and accounts it covers. A report without an
+   explicit window is not verifiable.
+2. **Pull the data.** For each platform in scope: `get_posts_with_analytics`
+   with the account ID and `startDate`/`endDate`. Note the platforms it covers
+   (instagram, facebook, threads, pinterest, linkedin, tiktok) and state
+   clearly when a platform is not covered.
+3. **Aggregate honestly.** Sum or average only within comparable metric
+   families. Platforms report different native metrics (for example reach vs
+   impressions vs engagements); keep them labeled per platform instead of
+   forcing one cross-platform number.
+4. **Add context.** `get_account_analytics` for the window trend and
+   `get_follower_demographics` for who the posts reached, where supported.
+5. **Write the recap.** Structure: window and scope, per-platform performance,
+   top posts (with ids), what worked and what did not, and a recommendation
+   grounded in the numbers. Flag data gaps (platforms with no posts, metrics
+   the platform did not return).
+
+## Pitfalls
+
+- Comparing incompatible metrics across platforms as if they were the same
+  number. Label each metric with its platform.
+- Claiming causation ("this post caused signups") from engagement data alone.
+- Ignoring the window: numbers from outside the requested range do not belong
+  in the report.
+- Reporting for platforms with no posts in the window as if they underperformed;
+  report them as not covered.
+- Rounding or trimming outliers to make the story cleaner. Report what the
+  tools returned.
+
+## Verification
+
+Every number in the recap traces to a tool call with an explicit platform,
+account, and window. The report states per-platform coverage, and no metric is
+presented without its platform label and time range.

--- a/website/docs/user-guide/skills/optional/social-media/social-media-socialrobot-content-repurposing.md
+++ b/website/docs/user-guide/skills/optional/social-media/social-media-socialrobot-content-repurposing.md
@@ -1,0 +1,125 @@
+---
+title: "Socialrobot Content Repurposing — Repurpose long-form content into multi-platform posts"
+sidebar_label: "Socialrobot Content Repurposing"
+description: "Repurpose long-form content into multi-platform posts"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Socialrobot Content Repurposing
+
+Repurpose long-form content into multi-platform posts.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/social-media/socialrobot-content-repurposing` |
+| Path | `optional-skills/social-media/socialrobot-content-repurposing` |
+| Version | `0.1.0` |
+| Author | Nicolas Torres (ntgussoni), Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `Social-Media`, `Content`, `Repurposing`, `MCP` |
+| Related skills | [`socialrobot-scheduling`](/docs/user-guide/skills/optional/social-media/social-media-socialrobot-scheduling), [`social-media-content-calendar`](/docs/user-guide/skills/optional/creative/creative-social-media-content-calendar), [`humanizer`](/docs/user-guide/skills/bundled/creative/creative-humanizer) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# SocialRobot Content Repurposing Skill
+
+Turn one long-form source (blog post, video, newsletter) into platform-adapted
+posts and schedule them through the SocialRobot MCP server. Read the server's
+`create-post` skill with MCP `skills/get` for media upload and per-platform
+fields; this skill covers the adaptation: one distinct post per platform,
+within each platform's length limits, with every claim traceable to the source.
+It does not write copy with no source; pair it with
+`social-media-content-calendar` and `humanizer` for that.
+
+## When to Use
+
+- "Repurpose this blog post into posts for LinkedIn, X, and Instagram."
+- "Turn this YouTube video into a TikTok, a Threads post, and a pin."
+- "Make a launch announcement for all my connected platforms."
+- "We published a newsletter, give me a week of posts from it."
+
+Don't use for: writing original posts with no source (use
+`social-media-content-calendar` plus `humanizer`), or posting one piece of copy
+to every platform unchanged (that is exactly what this skill is designed to
+avoid).
+
+## Prerequisites
+
+- The `socialrobot` MCP server is installed and connected: `hermes mcp install
+  socialrobot`. OAuth signs you in through a browser; an API key
+  (`x-api-key` header) works for headless setups. No account yet?
+  [Get a free account](https://socialrobot.io).
+- The target platforms are linked in the SocialRobot app. The MCP server only
+  schedules to accounts already connected there.
+- Scopes granted include `publishing:write` and `media:write` (media uploads).
+
+## How to Run
+
+1. Load the source with `read_file` (local file) or `web_extract` (URL).
+2. Call `list_connected_accounts` to see which platforms are available.
+3. Read the server's `create-post` skill via MCP `skills/get` for current
+   mechanics (media upload, per-platform fields).
+4. Build the adapted package below, then create and verify each post.
+
+## Quick Reference
+
+| Platform | Adapt as |
+|----------|----------|
+| X, Bluesky | Short hook, link, 1-3 key points, relevant media |
+| LinkedIn | Long-form post or article; mentions, geo, poll, visibility options |
+| Instagram | Visual first: carousel or image, caption with hashtags, first comment |
+| TikTok | Short vertical video; `postMode` decides publish vs inbox draft |
+| Pinterest | Pin with title, description, destination link |
+| Threads, Mastodon | Conversational take; poll, link attachment, topic tag where offered |
+| Facebook | Broad reach post; reel/story/slideshow variants where offered |
+
+## Procedure
+
+1. **Extract and verify the source.** Read the full source, note the core
+   message, facts, figures, quotes, and any links. Mark claims that are
+   unsupported or expired; do not carry them into posts.
+2. **Define the package.** One adapted post per platform, not the same copy
+   everywhere. Draft hooks that fit each platform's norms (short for X,
+   headline-first for LinkedIn, visual-led for Instagram).
+3. **Respect constraints.** Every target has `maxLength` limits in its input
+   schema; keep captions inside them. Include alt text for images and media
+   references from `get_media_upload_url` uploads before calling `create_post`.
+4. **Build platform specifics.** Instagram: carousel slides, first comment,
+   hashtags, optional location. LinkedIn: article variant for long content,
+   mentions via `linkedin_search_organizations` / `linkedin_search_people_mentions`,
+   geo via `linkedin_search_geo_locations`. Pinterest: board ID from
+   `pinterest_list_boards`, title and link. TikTok: `privacyLevel` from
+   `tiktok_get_creator_info`, `postMode` `DIRECT_POST` or `UPLOAD`.
+5. **Schedule or draft.** One `create_post` call with multiple targets when the
+   copy is shared; separate calls when platforms need different copy (the usual
+   case here). Use `SCHEDULE` with an explicit ISO datetime, `NOW` for
+   immediate publish, or `DRAFT` when the user wants to review first.
+6. **Verify.** `list_posts` read-back for every created item: scheduled time,
+   account, preview, and provider post/job ID. Report status honestly.
+
+## Pitfalls
+
+- Identical copy on every platform. Adaptation is the point of this skill.
+- Inventing or embellishing claims the source does not support. Every post
+  must trace to a verified source fact.
+- Forgetting to upload media before `create_post`; the media reference must
+  come from the upload response.
+- Mixing timezones. Ask for the user's timezone before picking `SCHEDULE`
+  datetimes.
+- Claiming "published" when the post is only scheduled or is a TikTok
+  `UPLOAD` inbox draft.
+
+## Verification
+
+Every post in the package has platform-adapted copy within its schema limits,
+media references from real uploads, and a `list_posts` entry with the scheduled
+time, account, and status. All claims in the posts trace back to the source
+material.

--- a/website/docs/user-guide/skills/optional/social-media/social-media-socialrobot-scheduling.md
+++ b/website/docs/user-guide/skills/optional/social-media/social-media-socialrobot-scheduling.md
@@ -1,0 +1,126 @@
+---
+title: "Socialrobot Scheduling — Schedule multi-platform social posts via SocialRobot MCP"
+sidebar_label: "Socialrobot Scheduling"
+description: "Schedule multi-platform social posts via SocialRobot MCP"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Socialrobot Scheduling
+
+Schedule multi-platform social posts via SocialRobot MCP.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/social-media/socialrobot-scheduling` |
+| Path | `optional-skills/social-media/socialrobot-scheduling` |
+| Version | `0.1.0` |
+| Author | Nicolas Torres (ntgussoni), Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `Social-Media`, `Scheduling`, `Publishing`, `MCP` |
+| Related skills | [`social-media-content-calendar`](/docs/user-guide/skills/optional/creative/creative-social-media-content-calendar), [`xurl`](/docs/user-guide/skills/bundled/social-media/social-media-xurl) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# SocialRobot Scheduling Skill
+
+Schedule approved posts to connected social accounts through the SocialRobot
+MCP server. Read the server's `create-post` skill with MCP `skills/get` first;
+it has the per-platform steps and the SocialRobot team keeps it current. This
+skill covers what that one does not: approval gating, timing, verification, and
+honest status reporting. It does not write copy; pair it with
+`social-media-content-calendar` for a brief-to-published flow.
+
+## When to Use
+
+- "Schedule this post for Tuesday 9am."
+- "Publish the approved draft to LinkedIn, X, and Instagram."
+- "Move my Monday post to Wednesday, or cancel it."
+- "Turn this campaign calendar into scheduled posts."
+
+Don't use for: writing the copy itself (pair with `social-media-content-calendar`
+or `humanizer`), or one-off posting without a SocialRobot account (use the
+platform skill directly, e.g. `xurl`).
+
+## Prerequisites
+
+- The `socialrobot` MCP server is installed and connected: `hermes mcp install
+  socialrobot` (or add `mcp_servers.socialrobot.url: https://socialrobot.io/api/mcp`
+  to `~/.hermes/config.yaml`). OAuth signs you in through a browser; an API key
+  (`x-api-key` header) works for headless setups. No account yet?
+  [Get a free account](https://socialrobot.io).
+- The user has linked the social accounts they want to post to inside the
+  SocialRobot app first. The MCP server cannot invent platform logins; it only
+  schedules to accounts already connected there.
+- Scopes granted include `publishing:write` (and `media:write` when the post
+  needs media).
+
+## How to Run
+
+1. Confirm the server is connected: `tools/list` returns the SocialRobot tools.
+2. Load the server's current workflow: MCP `skills/get` on `create-post` (or
+   `resources/read` on `skill://create-post/SKILL.md`). It documents the
+   account, media, and per-platform steps, and the SocialRobot team keeps it
+   current with the product.
+3. Execute the pipeline below, following the server skill for mechanics.
+
+## Quick Reference
+
+`tools/list` and `skills/get` are the source of truth for tool signatures and
+workflow details. The orchestration-relevant tools:
+
+| Tool | Role in this skill |
+|------|--------------------|
+| `list_connected_accounts` | Entry point: discover account IDs; never guess them. |
+| `create_post` / `list_posts` | Create, then verify with read-back. |
+| `update_post`, `reschedule_post`, `delete_post` | Post-run management. |
+
+## Procedure
+
+1. **Confirm approval state.** Only posts that are approved (never `draft` or
+   `needs review`) may be scheduled. If drafts are unapproved, hand them back.
+2. **Discover accounts.** `list_connected_accounts`, pick the account ID per
+   target platform.
+3. **Pick timing.** If the user left timing open or wants the best time, call
+   `instagram_best_post_times` for Instagram accounts and use
+   `get_account_analytics` trends for other platforms, then set `scheduledFor`
+   accordingly. Confirm the user's timezone before choosing datetimes.
+4. **Follow the server's `create-post` skill for mechanics**: media upload
+   before `create_post` (keep the returned media reference), Pinterest board
+   resolution, TikTok `privacyLevel` and `postMode` (`DIRECT_POST` publishes,
+   `UPLOAD` is an inbox draft), LinkedIn geo and @mention URN resolution.
+5. **Create.** One `create_post` call with multiple targets when the copy is
+   shared, rather than separate posts.
+6. **Verify with read-back.** `list_posts`: confirm scheduled time, account,
+   content preview, and provider post/job ID. Report `scheduled` or `published`
+   only per the status the tool returns.
+7. **Manage.** `update_post`, `reschedule_post`, or `delete_post` when the user
+   changes their mind; re-verify after any change.
+
+## Pitfalls
+
+- Never invent account IDs, board IDs, or TikTok `privacyLevel` values; always
+  read them from the tools or the server-served skill.
+- Upload media before `create_post`; keep the returned media reference.
+- `UPLOAD` mode on TikTok means an inbox draft, not a published post. Say so.
+- A queued post is not published. Do not claim publication for posts that only
+  show as scheduled or pending.
+- API key quota is one shared pool between the HTTP OpenAPI endpoints and MCP
+  `tools/call` + `tools/list` for that key. Handshake traffic (login, OAuth,
+  `initialize`, `get-session`) does not consume quota.
+- If `skills/get` fails, the connection may be stale; reconnect the MCP server
+  before proceeding.
+
+## Verification
+
+`list_posts` shows the post with its scheduled time, account, and status, and
+any provider post/job ID. Every scheduled slot must trace back to an approved
+draft, and every `scheduled`/`published` claim must match the status field the
+tool returned.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -599,6 +599,11 @@ const sidebars: SidebarsConfig = {
                   collapsed: true,
                   items: [
                     'user-guide/skills/optional/social-media/social-media-reddit-reading',
+                    'user-guide/skills/optional/social-media/social-media-socialrobot-analytics',
+                    'user-guide/skills/optional/social-media/social-media-socialrobot-calendar-review',
+                    'user-guide/skills/optional/social-media/social-media-socialrobot-campaign-report',
+                    'user-guide/skills/optional/social-media/social-media-socialrobot-content-repurposing',
+                    'user-guide/skills/optional/social-media/social-media-socialrobot-scheduling',
                   ],
                 },
                 {


### PR DESCRIPTION
Hi guys! I've been using hermes throughout this time, and we recently opened free registrations on our project so I thought it was time to add some optional skills to the repo. 

Let me know if there's anything you guys want me to change or adapt! 

hermes is awesome, btw. Can't live without it

## Summary

Adds the SocialRobot (socialrobot.io) remote MCP server to the official MCP
catalog, plus a new `optional-skills/social-media/` category with five workflow
skills built around its 18 tools. Together they cover the create, schedule,
manage, and measure loop, closing the handoff gap left by
`social-media-content-calendar` (which ends at "approved drafts for the user's
scheduler" for platforms without a connector).

## What's included

**MCP catalog entry**

- `optional-mcps/socialrobot/manifest.yaml`: remote HTTP MCP server at
  `https://socialrobot.io/api/mcp`, native OAuth (PKCE + dynamic client
  registration), mirroring the `linear` entry.

**Optional skills** (new `social-media` category, mirroring the bundled
`skills/social-media/` that holds `xurl`)

- `socialrobot-scheduling`: approved drafts to scheduled multi-platform posts,
  including best-time picking.
- `socialrobot-content-repurposing`: one long-form source into platform-adapted
  posts, scheduled per platform.
- `socialrobot-calendar-review`: queue audit (cadence, overlaps, gaps) with
  approval-gated fixes.
- `socialrobot-analytics`: question-driven post, account, and audience
  reporting.
- `socialrobot-campaign-report`: cross-platform campaign comparison over an
  explicit window.

## Design note

The SocialRobot server serves its own `create-post` agent skill over MCP
(SEP-2640). Each contributed skill instructs the agent to read it via
`skills/get` first and defer to it on conflicts, so per-platform mechanics stay
current with the product instead of going stale in this repo. The skills own
the layers the raw tools do not: approval gating, adaptation judgment, honest
status reporting, and verification discipline.

## Tests

- `tests/skills/test_socialrobot_*_skill.py` (6 files): stdlib + pytest +
  `unittest.mock`, no network.
- Validated with `scripts/run_tests.sh` (all pass), including the repo's
  `test_authoring_standards.py` over the new skills (1226 checks).
- Docs regenerated with scope discipline: one catalog row, one sidebar entry,
  five per-skill pages.

## Live surface (verified)

- `GET https://socialrobot.io/api/mcp` returns 401 unauthenticated (auth is
  enforced).
- `/.well-known/oauth-authorization-server` returns the full scope set.
- Public docs page: https://socialrobot.io/mcp
