### PR TITLE
fix(image-gen): grok-imagine-image 2.0 must not default upscale on

### DIFF
--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -685,7 +685,10 @@ FAL_MODELS: Dict[str, Dict[str, Any]] = {
             "prompt", "aspect_ratio", "num_images", "output_format",
             "resolution", "quality", "sync_mode",
         },
-        "upscale": True,   # 1k native is sub-2MP
+        # Opt-in only, like every other catalog entry: default-on upscaling was
+        # removed globally (the sub-2MP rationale included) — a caller who wants
+        # the pass asks for it. Enforced by TestFalCatalog invariants.
+        "upscale": False,
         # Edit endpoint takes `image_urls` (max 3) + the same knobs;
         # aspect_ratio defaults to "auto" (follows the first input image),
         # so we don't send it on edits.


### PR DESCRIPTION
## What

One line: the `xai/grok-imagine-image/v2.0` FAL catalog entry defaults `"upscale": True`; this flips it to opt-in like every other entry.

## Why

`f06c41522e` removed default-on upscaling globally ("opt-in only"), including the sub-2MP rationale this entry's comment revives. `TestFalCatalog::test_upscale_defaults_are_all_off` enforces that invariant — so `Python tests / slice 12` has been red on main since the v2.0 entry landed in `ceabb030fb` (Aug 15). Every open PR currently inherits the failure.

Read the original intent before flipping the other way: the invariant commit is the later, deliberate decision — the upscale pass costs an extra model call per image, which is exactly why it was made opt-in per call. Callers who want it still get it by asking.

Tests: 0 added, 51 passing in `tests/tools/test_image_generation.py`