### PR TITLE
fix(image): make Grok upscaling opt-in by default

### DIFF
--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -685,7 +685,7 @@ FAL_MODELS: Dict[str, Dict[str, Any]] = {
             "prompt", "aspect_ratio", "num_images", "output_format",
             "resolution", "quality", "sync_mode",
         },
-        "upscale": True,   # 1k native is sub-2MP
+        "upscale": False,  # opt-in only; preserve native model output by default
         # Edit endpoint takes `image_urls` (max 3) + the same knobs;
         # aspect_ratio defaults to "auto" (follows the first input image),
         # so we don't send it on edits.


### PR DESCRIPTION
## Summary
- make Grok Imagine 2.0 automatic upscaling opt-in
- align the catalog entry with the repository's existing all-off default policy

## Why
Current `main` sets this model's `upscale` default to `True`, while `TestFalCatalog::test_upscale_defaults_are_all_off` requires automatic upscaling to remain off for every model. That contradiction makes unrelated PRs fail the shared test slice.

## Test plan
- `pytest -q tests/tools/test_image_generation.py::TestFalCatalog` — 5 passed
