### PR TITLE
fix(acp): recover named custom provider identity on session resume

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -546,6 +546,29 @@ class SessionManager:
 
         model = row.get("model") or None
 
+        # Persistence stores the *resolved* billing class, which for every
+        # named ``providers:`` / ``custom_providers:`` entry is the bare
+        # string "custom" — not a routable identity. Passing it straight to
+        # resolve_runtime_provider() misses the entry, so the rebuilt agent
+        # gets no key and the client falls back to OPENROUTER_API_KEY against
+        # the stored custom base_url (401 on every resumed turn). Recover the
+        # ``custom:<name>`` identity from the durable facts that survived.
+        if str(requested_provider or "").strip().lower() == "custom":
+            try:
+                from hermes_cli.runtime_provider import canonical_custom_identity
+
+                requested_provider = (
+                    canonical_custom_identity(
+                        base_url=restored_base_url, model=model
+                    )
+                    or requested_provider
+                )
+            except Exception:
+                logger.debug(
+                    "ACP restore: could not recover custom provider identity",
+                    exc_info=True,
+                )
+
         # Load conversation history. repair_alternation: this restore feeds
         # LIVE REPLAY — the loaded list becomes the resumed agent's working
         # conversation. A durable ``user;user`` violation left in state.db would

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -281,6 +281,31 @@ class TestPersistence:
 
 
 
+    def test_restore_recovers_named_custom_provider_identity(self, manager):
+        """A session persisted as bare provider "custom" must be rebuilt
+        through its named entry (recovered from billing_base_url), not handed
+        to the resolver as the unroutable "custom" string."""
+        db = manager._get_db()
+        db.create_session(session_id="acp-custom-1", source="acp", model="my-model")
+        db.update_session_billing_route(
+            "acp-custom-1", provider="custom", base_url="http://proxy.local/v1"
+        )
+        seen = {}
+
+        def fake_make_agent(**kw):
+            seen.update(kw)
+            return _mock_agent()
+
+        with patch(
+            "hermes_cli.runtime_provider.canonical_custom_identity",
+            return_value="custom:myproxy",
+        ) as ident, patch.object(manager, "_make_agent", side_effect=fake_make_agent):
+            assert manager._restore("acp-custom-1") is not None
+
+        ident.assert_called_once_with(base_url="http://proxy.local/v1", model="my-model")
+        assert seen["requested_provider"] == "custom:myproxy"
+        assert seen["base_url"] == "http://proxy.local/v1"
+
     def test_only_restores_acp_sessions(self, manager):
         """get_session should not restore non-ACP sessions from DB."""
         db = manager._get_db()


### PR DESCRIPTION
`SessionManager._restore` reads `billing_provider` from the persisted
row and passes it straight to `resolve_runtime_provider()`. For every
named `providers:` / `custom_providers:` entry the persisted value is
the bare billing class `"custom"`, which is not a routable identity:
the resolver misses the entry, the rebuilt agent gets no key, and the
client falls back to `OPENROUTER_API_KEY` against the stored custom
`base_url` — every turn of a resumed session 401s (fresh `session/new`
sessions are fine). Reproduced on v0.20.4 after a daemon restart with
a LiteLLM-style local proxy configured as a named custom provider.

`hermes_cli.runtime_provider.canonical_custom_identity()` already
exists for exactly this (recover `custom:<name>` from the durable
base_url / model), and its docstring names the persist/rebuild paths
as the intended callers — this just wires the ACP resume path to it.
No behavior change for non-custom providers or for sessions whose
identity cannot be recovered (falls through to today's behavior).

Adds `test_restore_recovers_named_custom_provider_identity`
(tests/acp/test_session.py). `tests/acp`: 136 passed.

Related: issue #90088 (also: when a `key_env` provider
resolves empty, falling back to `OPENROUTER_API_KEY` against a foreign
base_url is a credential-misdirection hazard — out of scope here).