### PR TITLE
fix(desktop): send only the durable row_id on rewind, not the ordinal

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
@@ -485,7 +485,40 @@ describe('runRewindSubmit durable-address discipline (#87059)', () => {
     const submit = calls.find(call => call.method === 'prompt.submit')
 
     expect(submit?.params?.truncate_before_row_id).toBe(13)
-    expect(submit?.params?.truncate_before_user_ordinal).toBe(1)
+    expect(submit?.params?.truncate_before_user_ordinal).toBeUndefined()
+    expect(submit?.params?.truncate_before_message_id).toBeUndefined()
+    expect(submit?.params?.confirm_truncate).toBe(true)
+  })
+
+  it('sends ONLY the durable rowId when bound, dropping a divergent ordinal (#4030 false-refusal)', async () => {
+    // The renderer's visible-user ordinal can diverge from the gateway's durable
+    // ordinal space (here ordinal 5 vs the durable target's real ordinal) — the
+    // #87059 class that used to make the gateway refuse a legitimate rewind with
+    // 4030 because the row_id and ordinal disagreed. A bound row_id is
+    // authoritative and the cut is aimed by it alone, so it must be sent without
+    // the wasteful, mismatch-triggering ordinal / message-id.
+    const calls: Call[] = []
+
+    await runRewindSubmit(makeGateway(calls), 'sid', 'fixed prompt', 5, undefined, false, undefined, 13, 'typo prompt')
+
+    const submit = calls.find(call => call.method === 'prompt.submit')
+
+    expect(submit?.params?.truncate_before_row_id).toBe(13)
+    expect(submit?.params?.truncate_before_user_ordinal).toBeUndefined()
+    expect(submit?.params?.truncate_before_message_id).toBeUndefined()
+    expect(submit?.params?.confirm_truncate).toBe(true)
+  })
+
+  it('keeps confirm_empty_truncate for an ordinal-0 restore even with a bound rowId', async () => {
+    const calls: Call[] = []
+
+    await runRewindSubmit(makeGateway(calls), 'sid', 'restore to empty', 0, undefined, false, undefined, 13, 'typo prompt')
+
+    const submit = calls.find(call => call.method === 'prompt.submit')
+
+    expect(submit?.params?.truncate_before_row_id).toBe(13)
+    expect(submit?.params?.truncate_before_user_ordinal).toBeUndefined()
+    expect(submit?.params?.confirm_empty_truncate).toBe(true)
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
@@ -247,6 +247,18 @@ export async function runRewindSubmit(
   const hasDurableAddress =
     typeof truncateRowId === 'number' ||
     (typeof truncateMessageId === 'string' && truncateMessageId.length > 0 && !isSyntheticRendererId(truncateMessageId))
+  // A bound INTEGER row_id is the gateway's authoritative address — the cut is
+  // ALWAYS aimed by the resolved durable target, never the client ordinal
+  // (gateway `_reconcile_client_ordinal`: "The cut itself is always aimed by the
+  // resolved durable target, never by the client ordinal"). But the renderer's
+  // visible-user ordinal can diverge from the gateway's durable ordinal space by
+  // an arbitrary amount (#87059; observed 75 vs 102), and the gateway REFUSES a
+  // mismatch with 4030 even though the row_id resolved fine — turning a
+  // legitimate rewind/edit/regenerate into a false refusal. With a row_id in
+  // hand, send it alone and drop the redundant ordinal + message-id; the gateway
+  // already prefers row_id over both, and stale-row_id safety is unchanged (an
+  // unknown/dead id still fails closed with 4018).
+  const hasRowId = typeof truncateRowId === 'number' && Number.isInteger(truncateRowId)
 
   if (wantsTruncation && !hasDurableAddress) {
     resolvedRowId =
@@ -258,6 +270,14 @@ export async function runRewindSubmit(
     // diverge from the gateway's — the #87059 root). Resolved: the row id alone
     // is the address; sending the divergent ordinal too would trip the
     // gateway's 4030 cross-check. Unresolved: plain resubmit, no truncation.
+    resolvedOrdinal = undefined
+    resolvedMessageId = undefined
+  }
+
+  if (hasRowId) {
+    // Durable row_id in hand: drop the ordinal and message-id so the gateway
+    // aims purely by the row_id (see the note above) instead of tripping its
+    // 4030 cross-check on a divergent renderer ordinal.
     resolvedOrdinal = undefined
     resolvedMessageId = undefined
   }


### PR DESCRIPTION
## Problem

Rewinding, editing, or regenerating a turn on a long-lived desktop session fails server-side
with:

    truncate_before_user_ordinal (75) does not match truncate_before_row_id target turn (102)

(code `4030`, from `_reconcile_client_ordinal`). The desktop sent all three truncation
addresses at once (`truncate_before_user_ordinal`, `truncate_before_message_id`,
`truncate_before_row_id`). The gateway resolves the row_id to its own durable ordinal and
refuses any mismatch — but across a long session the renderer's visible-user ordinal drifts
from the gateway's active-durable ordinal (the #87059 drift class; observed 7 → 27 in one
day), so the ordinal is wrong even though the row_id is correct, and every legitimate rewind
gets refused. Reproducible on current main (9 refusals on one session), independent of
context compression (prefix_user_count=0).

## Fix

When a bound integer row_id is available, the desktop sends only `truncate_before_row_id` and
drops the redundant ordinal + message-id. This matches the gateway's documented contract —
prefer row_id over ordinals, and keep the ordinal only as a back-compat / optimistic-row path
when no durable id exists. Safety is unchanged: an unknown/dead row_id still fails closed with
`4018`, dropped turns are soft-archived (`active=0`) rather than deleted, and `confirm_truncate`
/ ordinal-0 `confirm_empty_truncate` gating is preserved.

## Tests

Updated `rewind.test.ts` so a bound rowId plus a divergent ordinal sends row_id alone, and an
ordinal-0 restore still carries `confirm_empty_truncate`. `rewind.test.ts` 32 + `index.test.tsx`
122 pass (216 in `use-prompt-actions/`).
