### PR TITLE
fix(agent): serialize background review Relay handoff

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -893,6 +893,9 @@ def init_agent(
     # normal interrupt propagation available once the fork is constructed.
     agent._background_review_agent = None
     agent._background_review_run = None
+    # Prepared automatic post-turn review (thread + run token), held until the
+    # parent Relay task/turn has fully finalized. Manual /refine is immediate.
+    agent._deferred_background_review = None
     agent._background_review_lock = threading.Lock()
 
     # Store OpenRouter provider preferences

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -887,14 +887,12 @@ def init_agent(
     agent._active_children = []      # Running child AIAgents (for interrupt propagation)
     agent._active_children_lock = threading.Lock()
 
-    # Background memory/skill review state (agent/background_review.py). Holds
-    # the forked review AIAgent while its run_conversation() is in flight, so
-    # the NEXT live turn can proactively interrupt a still-running review
-    # instead of letting the two race concurrently against the same
-    # session_id/credentials (observed as doubled prompt-token counts and a
-    # Ctrl+C-proof lockup when a live turn started before a review fired at
-    # the end of the prior turn had finished).
+    # Background memory/skill review state (agent/background_review.py).
+    # ``_background_review_run`` is installed before the worker starts and
+    # fences its first provider-capable phase; the direct agent pointer keeps
+    # normal interrupt propagation available once the fork is constructed.
     agent._background_review_agent = None
+    agent._background_review_run = None
     agent._background_review_lock = threading.Lock()
 
     # Store OpenRouter provider preferences

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -23,11 +23,155 @@ import json
 import logging
 import os
 from pathlib import Path
+import threading
 from typing import Any, Dict, List, Optional
 
 from agent.thread_scoped_output import thread_scoped_silence
 
 logger = logging.getLogger(__name__)
+
+
+_BACKGROUND_REVIEW_CANCEL_TIMEOUT_SECONDS = 2.0
+
+
+class _BackgroundReviewRun:
+    """Per-review cancellation and request-completion handshake."""
+
+    def __init__(self) -> None:
+        self.cancel_requested = threading.Event()
+        self.request_done = threading.Event()
+        self._lock = threading.Lock()
+        self._review_agent = None
+        self._request_finished = False
+        self._cancel_dispatched = False
+
+    def begin_request(self, review_agent: Any) -> bool:
+        """Atomically admit the first provider-capable review phase."""
+        with self._lock:
+            if self.cancel_requested.is_set() or self._request_finished:
+                return False
+            self._review_agent = review_agent
+            return True
+
+    def cancel(self) -> Any:
+        """Fence startup and return the running fork, if one was admitted."""
+        with self._lock:
+            self.cancel_requested.set()
+            if self._review_agent is not None and not self._cancel_dispatched:
+                self._cancel_dispatched = True
+                return self._review_agent
+            return None
+
+    def mark_request_finished(self) -> bool:
+        """Latch request completion once; the caller publishes the event."""
+        with self._lock:
+            if self._request_finished:
+                return False
+            self._request_finished = True
+            self._review_agent = None
+            return True
+
+
+def prepare_background_review_run(agent: Any) -> Optional[_BackgroundReviewRun]:
+    """Install a unique run token on the parent before ``Thread.start()``."""
+    lock = getattr(agent, "_background_review_lock", None)
+    if lock is None:
+        try:
+            lock = threading.Lock()
+            agent._background_review_lock = lock
+        except (AttributeError, TypeError):
+            return None
+
+    run = _BackgroundReviewRun()
+    try:
+        with lock:
+            current = getattr(agent, "_background_review_run", None)
+            if current is not None and not current.request_done.is_set():
+                return None
+            agent._background_review_run = run
+    except (AttributeError, TypeError):
+        return None
+    return run
+
+
+def finish_background_review_run(
+    agent: Any,
+    run: Optional[_BackgroundReviewRun],
+) -> None:
+    """Publish one run's request exit without clearing a successor (ABA-safe)."""
+    if run is None or not run.mark_request_finished():
+        return
+
+    lock = getattr(agent, "_background_review_lock", None)
+    if lock is not None:
+        with lock:
+            if getattr(agent, "_background_review_run", None) is run:
+                agent._background_review_run = None
+    elif getattr(agent, "_background_review_run", None) is run:
+        agent._background_review_run = None
+    run.request_done.set()
+
+
+def _interrupt_background_review(review_agent: Any) -> None:
+    """Request abort off-thread so a broken abort hook cannot stall foreground."""
+
+    def _interrupt() -> None:
+        try:
+            review_agent.interrupt("superseded by a new live turn")
+        except Exception:
+            logger.debug(
+                "Failed to cancel in-flight background review for a new turn",
+                exc_info=True,
+            )
+
+    try:
+        threading.Thread(
+            target=_interrupt,
+            daemon=True,
+            name="bg-review-cancel",
+        ).start()
+    except Exception:
+        logger.debug(
+            "Failed to start background-review cancellation thread",
+            exc_info=True,
+        )
+
+
+def cancel_background_review_for_live_turn(agent: Any) -> bool:
+    """Cancel the current review and await its request-phase acknowledgement.
+
+    Returns ``False`` when acknowledgement is unavailable or misses the bounded
+    deadline.  Callers must then stop before same-session turn-context work.
+    """
+    lock = getattr(agent, "_background_review_lock", None)
+    if lock is not None:
+        with lock:
+            run = getattr(agent, "_background_review_run", None)
+            legacy_agent = getattr(agent, "_background_review_agent", None)
+    else:
+        run = getattr(agent, "_background_review_run", None)
+        legacy_agent = getattr(agent, "_background_review_agent", None)
+
+    if run is None:
+        if legacy_agent is None:
+            return True
+        _interrupt_background_review(legacy_agent)
+        return False
+
+    review_agent = run.cancel()
+    if review_agent is not None:
+        _interrupt_background_review(review_agent)
+
+    acknowledged = run.request_done.wait(
+        timeout=_BACKGROUND_REVIEW_CANCEL_TIMEOUT_SECONDS
+    )
+    if not acknowledged:
+        logger.error(
+            "Background review did not acknowledge cancellation within %.1fs; "
+            "refusing to start overlapping live turn",
+            _BACKGROUND_REVIEW_CANCEL_TIMEOUT_SECONDS,
+        )
+    return acknowledged
 
 
 # ---------------------------------------------------------------------------
@@ -862,6 +1006,7 @@ def _run_review_in_thread(
     messages_snapshot: List[Dict],
     prompt: str,
     task_cfg: Optional[Dict[str, Any]] = None,
+    review_run: Optional[_BackgroundReviewRun] = None,
 ) -> None:
     """Worker function executed in the background-review daemon thread.
 
@@ -869,6 +1014,10 @@ def _run_review_in_thread(
     review prompt, and surfaces a compact action summary back to the user
     via ``agent._safe_print`` and ``agent.background_review_callback``.
     """
+    if review_run is not None and review_run.cancel_requested.is_set():
+        finish_background_review_run(agent, review_run)
+        return
+
     # Local import to avoid a hard circular dep at module load.
     from run_agent import AIAgent
     from tools.terminal_tool import set_approval_callback as _set_approval_callback
@@ -917,6 +1066,10 @@ def _run_review_in_thread(
                     agent._active_children.remove(agent_ref)
             except (ValueError, AttributeError):
                 pass
+
+    def _finish_request_phase(agent_ref) -> None:
+        _unregister_review_agent(agent_ref)
+        finish_background_review_run(agent, review_run)
 
     try:
         # Silence stdout/stderr for THIS worker thread only.  A process-global
@@ -1117,12 +1270,10 @@ def _run_review_in_thread(
             # Register this fork on the PARENT's _active_children (the same
             # list interrupt() fans out to for subagent delegation) and
             # _background_review_agent (a direct pointer the next live turn
-            # uses to proactively cancel a still-running review). Without
-            # this, a review still streaming when the next turn starts races
-            # the live turn against the same session_id/credentials — producing
-            # doubled prompt-token accounting and a Ctrl+C-proof lockup.
-            # Best-effort: agents built without agent_init.py (test stubs)
-            # degrade to "no cross-cancellation" rather than aborting the review.
+            # uses to interrupt an admitted request). The per-review run token
+            # separately fences startup and acknowledges request-phase exit.
+            # The legacy pointer/list remain best-effort for direct test stubs;
+            # a prepared run token is the live-turn cancellation authority.
             if hasattr(agent, "_background_review_agent"):
                 _br_lock = getattr(agent, "_background_review_lock", None)
                 if _br_lock is not None:
@@ -1173,22 +1324,26 @@ def _run_review_in_thread(
                 pass
 
             try:
-                # Routed to a different model -> replay a digest (cache is cold
-                # on that model anyway, so minimise cold-written tokens). Same
-                # model -> replay the full snapshot (warm cache reads).
-                _review_history = (
-                    _digest_history(messages_snapshot) if _routed
-                    else messages_snapshot
+                request_admitted = (
+                    review_run is None or review_run.begin_request(review_agent)
                 )
-                review_agent.run_conversation(
-                    user_message=(
-                        prompt
-                        + "\n\nYou can only call memory and skill "
-                        "management tools. Other tools will be denied "
-                        "at runtime — do not attempt them."
-                    ),
-                    conversation_history=_review_history,
-                )
+                if request_admitted:
+                    # Routed to a different model -> replay a digest (cache is cold
+                    # on that model anyway, so minimise cold-written tokens). Same
+                    # model -> replay the full snapshot (warm cache reads).
+                    _review_history = (
+                        _digest_history(messages_snapshot) if _routed
+                        else messages_snapshot
+                    )
+                    review_agent.run_conversation(
+                        user_message=(
+                            prompt
+                            + "\n\nYou can only call memory and skill "
+                            "management tools. Other tools will be denied "
+                            "at runtime — do not attempt them."
+                        ),
+                        conversation_history=_review_history,
+                    )
             finally:
                 clear_thread_tool_whitelist()
                 # Attribute the review fork's usage to the PARENT session.
@@ -1199,12 +1354,9 @@ def _run_review_in_thread(
                 if review_agent is not None:
                     review_usage.update(_snapshot_review_usage(review_agent))
                     _record_review_usage_to_parent(agent, review_usage)
-                # Unregister as soon as run_conversation() itself has
-                # returned — that's the only phase making outbound API
-                # calls, i.e. the only phase that can race the parent's
-                # next live turn. Runs on both the success and exception
-                # path (this whole block is inside the try/finally above).
-                _unregister_review_agent(review_agent)
+                # Publish completion as soon as the provider-capable phase has
+                # returned or startup cancellation has fenced it out.
+                _finish_request_phase(review_agent)
 
             # Snapshot review actions before teardown. close() is allowed to
             # clean per-session state, but the user-visible self-improvement
@@ -1284,13 +1436,10 @@ def _run_review_in_thread(
         # thread-scoped silence here so teardown output (Honcho flush, Hindsight
         # sync, background thread joins) stays quiet even on the exception path,
         # without blanking other threads' streams.
-        # Also a safety-net unregister: covers exceptions raised during setup
-        # (between registration and the run_conversation try/finally above)
-        # that the primary _unregister_review_agent call site never reaches.
-        # _unregister_review_agent is idempotent (checks `is`/`in` membership),
-        # so calling it again here after the primary call site already ran is
-        # a harmless no-op.
-        _unregister_review_agent(review_agent)
+        # Also a safety-net completion: covers exceptions raised during setup
+        # before the request-phase finally. Both tracking cleanup and the
+        # per-run completion publication are identity-scoped and idempotent.
+        _finish_request_phase(review_agent)
         if review_agent is not None:
             try:
                 with thread_scoped_silence():
@@ -1319,6 +1468,7 @@ def spawn_background_review_thread(
     review_skills: bool = False,
     focus: Optional[str] = None,
     task_cfg: Optional[Dict[str, Any]] = None,
+    review_run: Optional[_BackgroundReviewRun] = None,
 ):
     """Build the review thread target and prompt for a background review.
 
@@ -1359,7 +1509,13 @@ def spawn_background_review_thread(
         )
 
     def _target() -> None:
-        _run_review_in_thread(agent, messages_snapshot, prompt, task_cfg)
+        _run_review_in_thread(
+            agent,
+            messages_snapshot,
+            prompt,
+            task_cfg=task_cfg,
+            review_run=review_run,
+        )
 
     return _target, prompt
 

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -72,8 +72,17 @@ class _BackgroundReviewRun:
             return True
 
 
-def prepare_background_review_run(agent: Any) -> Optional[_BackgroundReviewRun]:
-    """Install a unique run token on the parent before ``Thread.start()``."""
+def prepare_background_review_run(
+    agent: Any,
+    *,
+    deferred: bool = False,
+) -> Optional[_BackgroundReviewRun]:
+    """Install a unique run token before ``Thread.start()``.
+
+    A deferred automatic review also publishes a placeholder tuple under the
+    same parent lock. A concurrent live turn can therefore retire the prepared
+    run even while its target/thread object is still being constructed.
+    """
     lock = getattr(agent, "_background_review_lock", None)
     if lock is None:
         try:
@@ -89,6 +98,8 @@ def prepare_background_review_run(agent: Any) -> Optional[_BackgroundReviewRun]:
             if current is not None and not current.request_done.is_set():
                 return None
             agent._background_review_run = run
+            if deferred:
+                agent._deferred_background_review = (None, run)
     except (AttributeError, TypeError):
         return None
     return run
@@ -112,12 +123,12 @@ def finish_background_review_run(
     run.request_done.set()
 
 
-def _interrupt_background_review(review_agent: Any) -> None:
+def _interrupt_background_review(review_agent: Any, reason: str) -> None:
     """Request abort off-thread so a broken abort hook cannot stall foreground."""
 
     def _interrupt() -> None:
         try:
-            review_agent.interrupt("superseded by a new live turn")
+            review_agent.interrupt(reason)
         except Exception:
             logger.debug(
                 "Failed to cancel in-flight background review for a new turn",
@@ -137,7 +148,11 @@ def _interrupt_background_review(review_agent: Any) -> None:
         )
 
 
-def cancel_background_review_for_live_turn(agent: Any) -> bool:
+def cancel_background_review_for_live_turn(
+    agent: Any,
+    *,
+    reason: str = "superseded by a new live turn",
+) -> bool:
     """Cancel the current review and await its request-phase acknowledgement.
 
     Returns ``False`` when acknowledgement is unavailable or misses the bounded
@@ -166,7 +181,7 @@ def cancel_background_review_for_live_turn(agent: Any) -> bool:
     if run is None:
         if legacy_agent is None:
             return True
-        _interrupt_background_review(legacy_agent)
+        _interrupt_background_review(legacy_agent, reason)
         return False
 
     review_agent = run.cancel()
@@ -176,7 +191,7 @@ def cancel_background_review_for_live_turn(agent: Any) -> bool:
         # parent cleanup has not launched yet.
         finish_background_review_run(agent, run)
     if review_agent is not None:
-        _interrupt_background_review(review_agent)
+        _interrupt_background_review(review_agent, reason)
 
     acknowledged = run.request_done.wait(
         timeout=_BACKGROUND_REVIEW_CANCEL_TIMEOUT_SECONDS

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -141,13 +141,24 @@ def cancel_background_review_for_live_turn(agent: Any) -> bool:
     """Cancel the current review and await its request-phase acknowledgement.
 
     Returns ``False`` when acknowledgement is unavailable or misses the bounded
-    deadline.  Callers must then stop before same-session turn-context work.
+    deadline. The live turn retains foreground priority and may proceed after
+    the bounded wait; the warning remains actionable.
     """
     lock = getattr(agent, "_background_review_lock", None)
+    prepared_cancelled = False
     if lock is not None:
         with lock:
             run = getattr(agent, "_background_review_run", None)
             legacy_agent = getattr(agent, "_background_review_agent", None)
+            prepared = getattr(agent, "_deferred_background_review", None)
+            if (
+                run is not None
+                and isinstance(prepared, tuple)
+                and len(prepared) == 2
+                and prepared[1] is run
+            ):
+                agent._deferred_background_review = None
+                prepared_cancelled = True
     else:
         run = getattr(agent, "_background_review_run", None)
         legacy_agent = getattr(agent, "_background_review_agent", None)
@@ -159,6 +170,11 @@ def cancel_background_review_for_live_turn(agent: Any) -> bool:
         return False
 
     review_agent = run.cancel()
+    if prepared_cancelled:
+        # The automatic review was prepared but its daemon had not started.
+        # Retire it synchronously so foreground never waits for a worker that
+        # parent cleanup has not launched yet.
+        finish_background_review_run(agent, run)
     if review_agent is not None:
         _interrupt_background_review(review_agent)
 
@@ -166,9 +182,9 @@ def cancel_background_review_for_live_turn(agent: Any) -> bool:
         timeout=_BACKGROUND_REVIEW_CANCEL_TIMEOUT_SECONDS
     )
     if not acknowledged:
-        logger.error(
+        logger.warning(
             "Background review did not acknowledge cancellation within %.1fs; "
-            "refusing to start overlapping live turn",
+            "proceeding with foreground live turn",
             _BACKGROUND_REVIEW_CANCEL_TIMEOUT_SECONDS,
         )
     return acknowledged

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -917,6 +917,7 @@ def run_codex_app_server_turn(
                 messages_snapshot=list(messages),
                 review_memory=should_review_memory,
                 review_skills=should_review_skills,
+                defer_until_turn_complete=True,
             )
         except Exception:
             logger.debug("background review spawn raised", exc_info=True)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1762,31 +1762,6 @@ def run_conversation(
     agent._last_compression_attempt_recorded = False
     agent._last_compression_attempt_in_place = None
 
-    # If a background memory/skill review spawned at the end of a PRIOR turn
-    # (agent/background_review.py) is still running its own run_conversation()
-    # when THIS turn starts, cancel it now rather than letting both make
-    # outbound API calls concurrently against the same session_id/credentials.
-    # That concurrency can produce doubled prompt-token accounting on this
-    # turn's own calls and, because the review fork is a fully separate
-    # AIAgent with no route back to THIS agent's interrupt() by default, a
-    # lockup that survives a normal /stop and needs a hard Ctrl+C.
-    # ``review_agent.interrupt()`` is fire-and-forget here — it just flags
-    # cancellation and aborts the review's in-flight socket; it does not
-    # block waiting for the review's daemon thread to exit, so it can't add
-    # latency to this turn. Only ever set on the real owning agent (the
-    # review fork's own copy of this attribute stays None — reviews don't
-    # spawn nested reviews), so this is a no-op on every other run_conversation
-    # caller (subagents, the review fork itself, etc).
-    _pending_review = getattr(agent, "_background_review_agent", None)
-    if _pending_review is not None:
-        try:
-            _pending_review.interrupt("superseded by a new live turn")
-        except Exception:
-            logger.debug(
-                "Failed to cancel in-flight background review for a new turn",
-                exc_info=True,
-            )
-
     # Adopt any ~/.hermes/.env credential/base-url edits made since the last
     # turn — a Settings save updates .env but not this worker's client, which
     # was built at agent init (#67821). No-op when .env is unchanged.

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -783,8 +783,9 @@ def finalize_turn(
         messages=messages,
     )
 
-    # Background memory/skill review — runs AFTER the response is delivered
-    # so it never competes with the user's task for model attention.
+    # Queue the background memory/skill review. The outer AIAgent wrapper starts
+    # it only after parent Relay/task/session-lease cleanup has completed, so
+    # the fork cannot share a live physical scope stack with the finishing turn.
     # Suppressed when skip_background_review=True (e.g. cron) — review forks
     # spawn another AIAgent (~30K tokens / event) and cron sessions have no
     # human-in-the-loop benefit from the review.
@@ -799,6 +800,7 @@ def finalize_turn(
                 messages_snapshot=list(messages),
                 review_memory=_should_review_memory,
                 review_skills=_should_review_skills,
+                defer_until_turn_complete=True,
             )
         except Exception:
             pass  # Background review is best-effort

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2982,14 +2982,17 @@ class GatewaySlashCommandsMixin:
 
         review_skills = "skill_manage" in getattr(agent, "valid_tool_names", set())
         try:
-            agent._spawn_background_review(
+            started = agent._spawn_background_review(
                 messages_snapshot=snapshot,
                 review_memory=True,
                 review_skills=review_skills,
                 focus=args or None,
+                explicit_request=True,
             )
         except Exception as exc:
             return f"/refine failed to start: {exc}"
+        if not started:
+            return "A background review is already running — retry /refine shortly."
         tail = f" (focus: {args})" if args else ""
         return (
             f"⚗ Reviewing this conversation in the background{tail} — "

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2695,14 +2695,18 @@ class CLICommandsMixin:
 
         review_skills = "skill_manage" in getattr(agent, "valid_tool_names", set())
         try:
-            agent._spawn_background_review(
+            started = agent._spawn_background_review(
                 messages_snapshot=snapshot,
                 review_memory=True,
                 review_skills=review_skills,
                 focus=focus or None,
+                explicit_request=True,
             )
         except Exception as exc:
             _cprint(f"  /refine failed to start: {exc}")
+            return
+        if not started:
+            _cprint("  A background review is already running — retry /refine shortly.")
             return
         tail = f" (focus: {focus})" if focus else ""
         _cprint(

--- a/run_agent.py
+++ b/run_agent.py
@@ -1809,7 +1809,8 @@ class AIAgent:
         review_skills: bool = False,
         focus: Optional[str] = None,
         defer_until_turn_complete: bool = False,
-    ) -> None:
+        explicit_request: bool = False,
+    ) -> bool:
         """Spawn the background memory/skill review thread.
 
         Thin wrapper — the heavy lifting lives in
@@ -1820,7 +1821,8 @@ class AIAgent:
 
         ``focus`` is optional user-supplied steering (from ``/refine``)
         appended to the review prompt — e.g. "save the deploy workflow as a
-        skill". The automatic post-turn triggers never set it.
+        skill". ``explicit_request`` distinguishes a bare ``/refine`` from an
+        automatic trigger even when no focus text is supplied.
 
         Automatic reviews pass ``defer_until_turn_complete=True`` from the
         turn finalizer. They are started by the outer wrapper only after its
@@ -1833,31 +1835,64 @@ class AIAgent:
         # are spawned with ``skip_memory=True``, so a review here has little to
         # persist — yet it inherits the subagent's (often premium) delegation
         # model and replays the whole conversation at premium rates, silently
-        # inflating token cost (#85859). An explicit ``/refine`` (``focus`` set)
-        # is a deliberate user request and still runs.
-        if focus is None and getattr(self, "_delegate_depth", 0) > 0:
-            return
+        # inflating token cost (#85859). An explicit ``/refine`` is a deliberate
+        # user request and still runs, with or without focus text.
+        manual_request = explicit_request or focus is not None
+        if not manual_request and getattr(self, "_delegate_depth", 0) > 0:
+            return False
         # Explicit off-switch for automatic post-turn forks
         # (``auxiliary.background_review.enabled: false``). Manual ``/refine``
         # still works — same contract as zeroing the nudge intervals (#87250).
         # Load the task block once here and pass it into the spawn path so
         # aux routing does not re-read config.
         task_cfg = None
-        if focus is None:
+        if not manual_request:
             from agent.background_review import load_background_review_settings
             enabled, task_cfg = load_background_review_settings()
             if not enabled:
-                return
+                return False
         from agent.background_review import (
+            cancel_background_review_for_live_turn,
             finish_background_review_run,
             prepare_background_review_run,
             spawn_background_review_thread,
         )
         from tools.thread_context import propagate_context_to_thread
 
-        review_run = prepare_background_review_run(self)
+        review_run = prepare_background_review_run(
+            self,
+            deferred=defer_until_turn_complete,
+        )
+        if review_run is None and manual_request:
+            cancel_background_review_for_live_turn(
+                self,
+                reason="superseded by explicit /refine",
+            )
+            review_run = prepare_background_review_run(self)
         if review_run is None:
-            return
+            return False
+
+        def _clear_deferred_reservation() -> None:
+            if not defer_until_turn_complete:
+                return
+            lock = getattr(self, "_background_review_lock", None)
+            if lock is None:
+                prepared = getattr(self, "_deferred_background_review", None)
+                if (
+                    isinstance(prepared, tuple)
+                    and len(prepared) == 2
+                    and prepared[1] is review_run
+                ):
+                    self._deferred_background_review = None
+                return
+            with lock:
+                prepared = getattr(self, "_deferred_background_review", None)
+                if (
+                    isinstance(prepared, tuple)
+                    and len(prepared) == 2
+                    and prepared[1] is review_run
+                ):
+                    self._deferred_background_review = None
         try:
             target, _prompt = spawn_background_review_thread(
                 self,
@@ -1876,36 +1911,77 @@ class AIAgent:
                 name="bg-review",
             )
             if defer_until_turn_complete:
-                # The run token is already published, closing the gap between
-                # parent finalization and Thread.start(). A concurrent live turn
-                # can cancel this prepared review before it reaches a provider.
-                self._deferred_background_review = (t, review_run)
-                return
+                lock = getattr(self, "_background_review_lock", None)
+                installed = False
+                if lock is None:
+                    prepared = getattr(self, "_deferred_background_review", None)
+                    if (
+                        isinstance(prepared, tuple)
+                        and len(prepared) == 2
+                        and prepared[1] is review_run
+                        and not review_run.cancel_requested.is_set()
+                    ):
+                        self._deferred_background_review = (t, review_run)
+                        installed = True
+                else:
+                    with lock:
+                        prepared = getattr(self, "_deferred_background_review", None)
+                        if (
+                            getattr(self, "_background_review_run", None) is review_run
+                            and isinstance(prepared, tuple)
+                            and len(prepared) == 2
+                            and prepared[1] is review_run
+                            and not review_run.cancel_requested.is_set()
+                        ):
+                            self._deferred_background_review = (t, review_run)
+                            installed = True
+                if not installed:
+                    finish_background_review_run(self, review_run)
+                    return False
+                return True
             t.start()
+            return True
         except Exception:
+            _clear_deferred_reservation()
             finish_background_review_run(self, review_run)
             raise
 
     def _flush_deferred_background_review(self) -> None:
         """Start one queued automatic review after parent turn cleanup."""
         lock = getattr(self, "_background_review_lock", None)
+        start_error = None
+        review_run = None
         if lock is None:
             prepared = getattr(self, "_deferred_background_review", None)
             self._deferred_background_review = None
+            if isinstance(prepared, tuple) and len(prepared) == 2:
+                thread, review_run = prepared
+                if thread is not None:
+                    try:
+                        thread.start()
+                    except Exception as exc:
+                        start_error = exc
         else:
             with lock:
                 prepared = getattr(self, "_deferred_background_review", None)
-                self._deferred_background_review = None
-        if not isinstance(prepared, tuple) or len(prepared) != 2:
-            return
-        thread, review_run = prepared
-        try:
-            thread.start()
-        except Exception:
+                if isinstance(prepared, tuple) and len(prepared) == 2:
+                    thread, review_run = prepared
+                    if thread is not None:
+                        try:
+                            # Keep the synchronous-retire handle visible until
+                            # Thread.start() returns. The worker may block briefly
+                            # on this parent lock, but cannot enter a provider
+                            # before startup fencing has a concrete daemon.
+                            thread.start()
+                        except Exception as exc:
+                            start_error = exc
+                if getattr(self, "_deferred_background_review", None) is prepared:
+                    self._deferred_background_review = None
+        if start_error is not None:
             from agent.background_review import finish_background_review_run
 
             finish_background_review_run(self, review_run)
-            raise
+            raise start_error
 
     def _build_memory_write_metadata(
         self,

--- a/run_agent.py
+++ b/run_agent.py
@@ -1842,22 +1842,37 @@ class AIAgent:
             enabled, task_cfg = load_background_review_settings()
             if not enabled:
                 return
-        from agent.background_review import spawn_background_review_thread
+        from agent.background_review import (
+            finish_background_review_run,
+            prepare_background_review_run,
+            spawn_background_review_thread,
+        )
         from tools.thread_context import propagate_context_to_thread
-        target, _prompt = spawn_background_review_thread(
-            self,
-            messages_snapshot,
-            review_memory=review_memory,
-            review_skills=review_skills,
-            focus=focus,
-            task_cfg=task_cfg,
-        )
-        # Carry the active profile into the review thread so MEMORY.md / skill
-        # review writes land in the right profile (#54937).
-        t = threading.Thread(
-            target=propagate_context_to_thread(target), daemon=True, name="bg-review"
-        )
-        t.start()
+
+        review_run = prepare_background_review_run(self)
+        if review_run is None:
+            return
+        try:
+            target, _prompt = spawn_background_review_thread(
+                self,
+                messages_snapshot,
+                review_memory=review_memory,
+                review_skills=review_skills,
+                focus=focus,
+                task_cfg=task_cfg,
+                review_run=review_run,
+            )
+            # Carry the active profile into the review thread so MEMORY.md /
+            # skill review writes land in the right profile (#54937).
+            t = threading.Thread(
+                target=propagate_context_to_thread(target),
+                daemon=True,
+                name="bg-review",
+            )
+            t.start()
+        except Exception:
+            finish_background_review_run(self, review_run)
+            raise
 
     def _build_memory_write_metadata(
         self,
@@ -8350,6 +8365,32 @@ class AIAgent:
         moa_config: Optional[dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
+        # A review deliberately shares this agent's session_id for prompt-cache
+        # parity. Fence review startup or interrupt an admitted request, then
+        # await that request's exit before opening any live-turn Relay or task
+        # instrumentation for the same session.
+        from agent.background_review import cancel_background_review_for_live_turn
+
+        if not cancel_background_review_for_live_turn(self):
+            failure = (
+                "Live turn not started: the prior background review did not "
+                "acknowledge cancellation before the bounded safety deadline. "
+                "Retry after the review has stopped."
+            )
+            existing_messages = conversation_history
+            if existing_messages is None:
+                existing_messages = getattr(self, "_session_messages", None)
+            return {
+                "final_response": failure,
+                "messages": list(existing_messages or []),
+                "completed": False,
+                "api_calls": 0,
+                "error": failure,
+                "failed": True,
+                "retryable": True,
+                "background_review_cancellation_timeout": True,
+            }
+
         from agent.aux_accounting import (
             reset_accounting_context,
             set_accounting_context,

--- a/run_agent.py
+++ b/run_agent.py
@@ -1808,6 +1808,7 @@ class AIAgent:
         review_memory: bool = False,
         review_skills: bool = False,
         focus: Optional[str] = None,
+        defer_until_turn_complete: bool = False,
     ) -> None:
         """Spawn the background memory/skill review thread.
 
@@ -1820,6 +1821,11 @@ class AIAgent:
         ``focus`` is optional user-supplied steering (from ``/refine``)
         appended to the review prompt — e.g. "save the deploy workflow as a
         skill". The automatic post-turn triggers never set it.
+
+        Automatic reviews pass ``defer_until_turn_complete=True`` from the
+        turn finalizer. They are started by the outer wrapper only after its
+        Relay task/turn and durable session lease have closed. Explicit
+        ``/refine`` calls remain immediate.
         """
         # A delegation subagent (``_delegate_depth > 0``) must not run the
         # automatic post-turn review. Subagents are ephemeral workers already
@@ -1869,8 +1875,35 @@ class AIAgent:
                 daemon=True,
                 name="bg-review",
             )
+            if defer_until_turn_complete:
+                # The run token is already published, closing the gap between
+                # parent finalization and Thread.start(). A concurrent live turn
+                # can cancel this prepared review before it reaches a provider.
+                self._deferred_background_review = (t, review_run)
+                return
             t.start()
         except Exception:
+            finish_background_review_run(self, review_run)
+            raise
+
+    def _flush_deferred_background_review(self) -> None:
+        """Start one queued automatic review after parent turn cleanup."""
+        lock = getattr(self, "_background_review_lock", None)
+        if lock is None:
+            prepared = getattr(self, "_deferred_background_review", None)
+            self._deferred_background_review = None
+        else:
+            with lock:
+                prepared = getattr(self, "_deferred_background_review", None)
+                self._deferred_background_review = None
+        if not isinstance(prepared, tuple) or len(prepared) != 2:
+            return
+        thread, review_run = prepared
+        try:
+            thread.start()
+        except Exception:
+            from agent.background_review import finish_background_review_run
+
             finish_background_review_run(self, review_run)
             raise
 
@@ -8367,29 +8400,11 @@ class AIAgent:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         # A review deliberately shares this agent's session_id for prompt-cache
         # parity. Fence review startup or interrupt an admitted request, then
-        # await that request's exit before opening any live-turn Relay or task
-        # instrumentation for the same session.
+        # bounded-wait for request exit before opening live-turn Relay/task
+        # instrumentation. Foreground retains priority on a pathological abort.
         from agent.background_review import cancel_background_review_for_live_turn
 
-        if not cancel_background_review_for_live_turn(self):
-            failure = (
-                "Live turn not started: the prior background review did not "
-                "acknowledge cancellation before the bounded safety deadline. "
-                "Retry after the review has stopped."
-            )
-            existing_messages = conversation_history
-            if existing_messages is None:
-                existing_messages = getattr(self, "_session_messages", None)
-            return {
-                "final_response": failure,
-                "messages": list(existing_messages or []),
-                "completed": False,
-                "api_calls": 0,
-                "error": failure,
-                "failed": True,
-                "retryable": True,
-                "background_review_cancellation_timeout": True,
-            }
+        cancel_background_review_for_live_turn(self)
 
         from agent.aux_accounting import (
             reset_accounting_context,
@@ -8843,6 +8858,17 @@ class AIAgent:
                         pass
                     if getattr(self, "_relay_pending_turn_id", None) == relay_turn_id:
                         self._relay_pending_turn_id = None
+                    # Start an automatic review only after the parent Relay
+                    # task/turn and durable session lease are fully closed.
+                    # Keep the current profile/accounting ContextVars alive for
+                    # thread propagation, then reset them below.
+                    try:
+                        self._flush_deferred_background_review()
+                    except Exception:
+                        logger.warning(
+                            "Failed to start deferred background review",
+                            exc_info=True,
+                        )
                     if acct_token is not None:
                         reset_accounting_context(acct_token)
                     if token is not None:

--- a/tests/gateway/test_refine_background_review.py
+++ b/tests/gateway/test_refine_background_review.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from gateway.slash_commands import GatewaySlashCommandsMixin
+
+
+class _Event:
+    source = object()
+
+    def get_command_args(self) -> str:
+        return ""
+
+
+def test_refine_reports_busy_instead_of_false_started_message() -> None:
+    agent = SimpleNamespace(
+        _session_messages=[{"role": "user", "content": "hello"}],
+        valid_tool_names=set(),
+        _spawn_background_review=MagicMock(return_value=False),
+    )
+    runner = object.__new__(GatewaySlashCommandsMixin)
+    runner._session_key_for_source = lambda _source: "session"
+    runner._running_agents = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._agent_cache = {"session": (agent, None)}
+
+    result = asyncio.run(runner._handle_refine_command(_Event()))
+
+    assert result == "A background review is already running — retry /refine shortly."
+    agent._spawn_background_review.assert_called_once_with(
+        messages_snapshot=agent._session_messages,
+        review_memory=True,
+        review_skills=False,
+        focus=None,
+        explicit_request=True,
+    )

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -2,8 +2,64 @@
 
 from __future__ import annotations
 
+import threading
+
 import run_agent as run_agent_module
 from run_agent import AIAgent
+
+
+_REAL_THREAD = threading.Thread
+
+
+class _TurnBoundaryReached(Exception):
+    """Stop a live turn exactly when it reaches turn-context construction."""
+
+
+class CapturingThread:
+    targets = []
+
+    def __init__(self, *, target, daemon=None, name=None):
+        self.targets.append(target)
+
+    def start(self):
+        pass
+
+
+class ObservedEvent:
+    """A real Event that also exposes when a waiter starts waiting."""
+
+    def __init__(self):
+        self._event = threading.Event()
+        self.wait_started = threading.Event()
+        self.set_calls = 0
+
+    def set(self):
+        self.set_calls += 1
+        self._event.set()
+
+    def wait(self, timeout=None):
+        self.wait_started.set()
+        return self._event.wait(timeout)
+
+    def is_set(self):
+        return self._event.is_set()
+
+
+class FakeReviewAgent:
+    def __init__(self, **kwargs):
+        self._session_messages = []
+
+    def run_conversation(self, **kwargs):
+        pass
+
+    def interrupt(self, message=None):
+        pass
+
+    def shutdown_memory_provider(self):
+        pass
+
+    def close(self):
+        pass
 
 
 def _bare_agent() -> AIAgent:
@@ -31,6 +87,7 @@ def _bare_agent() -> AIAgent:
     agent._safe_print = lambda *_args, **_kwargs: None
     import threading as _threading
     agent._background_review_agent = None
+    agent._background_review_run = None
     agent._background_review_lock = _threading.Lock()
     agent._active_children = []
     agent._active_children_lock = _threading.Lock()
@@ -43,6 +100,89 @@ class ImmediateThread:
 
     def start(self):
         self._target()
+
+
+def _install_live_turn_boundary(monkeypatch, on_boundary=None):
+    import agent.conversation_loop as conversation_loop_module
+
+    def stop_at_boundary(*args, **kwargs):
+        if on_boundary is not None:
+            on_boundary()
+        raise _TurnBoundaryReached
+
+    monkeypatch.setattr(
+        conversation_loop_module,
+        "build_turn_context",
+        stop_at_boundary,
+    )
+
+
+def _run_wrapped_live_turn_to_boundary(agent, result):
+    try:
+        result["return"] = AIAgent.run_conversation(
+            agent,
+            "next turn",
+            task_id="live-task",
+        )
+    except _TurnBoundaryReached:
+        result["boundary_reached"] = True
+    except BaseException as exc:  # surfaced in the test thread for a useful failure
+        result["error"] = exc
+
+
+def _install_relay_recorder(monkeypatch, review_run=None):
+    from agent import relay_runtime
+    from hermes_cli.observability import relay_shared_metrics
+
+    calls = []
+
+    def review_acknowledged():
+        return bool(review_run and review_run.request_done.is_set())
+
+    class RelayTurn:
+        relay_enabled = True
+
+    class RecordingCoordinator:
+        def acquire_conversation(self, **kwargs):
+            calls.append(("acquire", review_acknowledged()))
+            return object()
+
+        def begin_turn(self, lease, **kwargs):
+            calls.append(("begin", review_acknowledged()))
+            return RelayTurn()
+
+        def finish_logical_calls(self, turn, **kwargs):
+            pass
+
+        def end_turn(self, turn, **kwargs):
+            pass
+
+        def release_conversation(self, lease):
+            pass
+
+    monkeypatch.setattr(
+        relay_runtime,
+        "SESSION_COORDINATOR",
+        RecordingCoordinator(),
+    )
+    monkeypatch.setattr(
+        relay_runtime,
+        "current_profile_key",
+        lambda: "/test-profile",
+    )
+    monkeypatch.setattr(
+        relay_shared_metrics,
+        "start_task_run",
+        lambda **kwargs: calls.append(
+            ("start_task_run", review_acknowledged())
+        ),
+    )
+    monkeypatch.setattr(
+        relay_shared_metrics,
+        "finish_task_run",
+        lambda **kwargs: None,
+    )
+    return calls
 
 
 def test_background_review_shuts_down_memory_provider_before_close(monkeypatch):
@@ -325,42 +465,339 @@ def test_background_review_registers_on_active_children_for_interrupt(monkeypatc
     assert agent._active_children == []
 
 
-def test_new_live_turn_cancels_still_running_background_review(monkeypatch):
-    """conversation_loop.run_conversation() must proactively interrupt a
-    background review still in flight from a prior turn, rather than let the
-    two race concurrently against the same session_id/credentials. This is
-    the other half of the fix: registration alone only enables interrupt()
-    propagation, it doesn't by itself stop the race — something has to
-    actually call interrupt() at the start of the next turn.
-    """
-    import agent.conversation_loop as conversation_loop_module
+def test_background_review_registers_before_start_runs_and_cleans_up(monkeypatch):
+    """The parent must own a unique review run before the worker can start."""
+    seen = {}
 
-    calls = []
+    class RecordingReviewAgent(FakeReviewAgent):
+        def run_conversation(self, **kwargs):
+            seen["run"] = agent._background_review_run
+            seen["active_children_during_run"] = list(agent._active_children)
+            seen["background_review_agent_during_run"] = agent._background_review_agent
 
-    class FakeReviewAgent:
-        def interrupt(self, message=None):
-            calls.append(message)
+    monkeypatch.setattr(run_agent_module, "AIAgent", RecordingReviewAgent)
+    CapturingThread.targets = []
+    monkeypatch.setattr(run_agent_module.threading, "Thread", CapturingThread)
 
     agent = _bare_agent()
-    agent._background_review_agent = FakeReviewAgent()
 
-    # Invoke just the cancellation snippet in isolation via the same
-    # attribute contract run_conversation() reads, to avoid dragging in the
-    # rest of the turn machinery (network calls, tool setup, etc.) that
-    # isn't relevant to this regression.
-    _pending_review = getattr(agent, "_background_review_agent", None)
-    assert _pending_review is not None
-    _pending_review.interrupt("superseded by a new live turn")
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
 
-    assert calls == ["superseded by a new live turn"]
+    run = agent._background_review_run
+    assert run is not None
+    assert len(CapturingThread.targets) == 1
+    assert not run.request_done.is_set()
+
+    observed_done = ObservedEvent()
+    run.request_done = observed_done
+    CapturingThread.targets[0]()
+
+    fork = seen["background_review_agent_during_run"]
+    assert fork is not None
+    assert seen["run"] is run
+    assert seen["active_children_during_run"] == [fork]
+    assert observed_done.is_set()
+    assert observed_done.set_calls == 1
+    assert agent._background_review_run is None
+    assert agent._background_review_agent is None
+    assert agent._active_children == []
 
 
+def test_live_turn_waits_for_review_exit_before_relay_and_turn_context(monkeypatch):
+    """The outer production wrapper waits before same-session instrumentation."""
+    review_entered = threading.Event()
+    review_returned = threading.Event()
+    allow_review_return = threading.Event()
+    interrupted = threading.Event()
+    boundary_reached = threading.Event()
+    seen = {}
+
+    class BlockingReviewAgent(FakeReviewAgent):
+        def interrupt(self, message=None):
+            seen["interrupt_message"] = message
+            interrupted.set()
+
+        def run_conversation(self, **kwargs):
+            review_entered.set()
+            assert allow_review_return.wait(2.0)
+            review_returned.set()
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", BlockingReviewAgent)
+    CapturingThread.targets = []
+    monkeypatch.setattr(run_agent_module.threading, "Thread", CapturingThread)
+
+    agent = _bare_agent()
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+    run = agent._background_review_run
+    assert run is not None
+    observed_done = ObservedEvent()
+    run.request_done = observed_done
+
+    monkeypatch.setattr(run_agent_module.threading, "Thread", _REAL_THREAD)
+    worker = _REAL_THREAD(target=CapturingThread.targets[0], daemon=True)
+    worker.start()
+    assert review_entered.wait(2.0)
+
+    def on_boundary():
+        seen["review_returned_at_boundary"] = review_returned.is_set()
+        boundary_reached.set()
+
+    _install_live_turn_boundary(monkeypatch, on_boundary)
+    relay_calls = _install_relay_recorder(monkeypatch, run)
+    live_result = {}
+    live = _REAL_THREAD(
+        target=_run_wrapped_live_turn_to_boundary,
+        args=(agent, live_result),
+        daemon=True,
+    )
+    live.start()
+
+    assert interrupted.wait(2.0)
+    wait_started = observed_done.wait_started.wait(2.0)
+    relay_calls_before_ack = list(relay_calls)
+    allow_review_return.set()
+    worker.join(timeout=2.0)
+    live.join(timeout=2.0)
+
+    assert not worker.is_alive()
+    assert not live.is_alive()
+    assert wait_started
+    assert relay_calls_before_ack == []
+    assert relay_calls == [
+        ("acquire", True),
+        ("begin", True),
+        ("start_task_run", True),
+    ]
+    assert boundary_reached.is_set()
+    assert seen["interrupt_message"] == "superseded by a new live turn"
+    assert seen["review_returned_at_boundary"] is True
+    assert live_result == {"boundary_reached": True}
 
 
+def test_live_turn_cancels_review_during_startup_before_provider(monkeypatch):
+    """A review cancelled before its worker runs must never call its provider."""
+    provider_calls = []
+    boundary_reached = threading.Event()
+
+    class RecordingReviewAgent(FakeReviewAgent):
+        def run_conversation(self, **kwargs):
+            provider_calls.append(kwargs)
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", RecordingReviewAgent)
+    CapturingThread.targets = []
+    monkeypatch.setattr(run_agent_module.threading, "Thread", CapturingThread)
+
+    agent = _bare_agent()
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+    run = agent._background_review_run
+    assert run is not None
+
+    _install_live_turn_boundary(monkeypatch, boundary_reached.set)
+    relay_calls = _install_relay_recorder(monkeypatch, run)
+    live_result = {}
+    live = _REAL_THREAD(
+        target=_run_wrapped_live_turn_to_boundary,
+        args=(agent, live_result),
+        daemon=True,
+    )
+    live.start()
+    assert run.cancel_requested.wait(2.0)
+
+    worker = _REAL_THREAD(target=CapturingThread.targets[0], daemon=True)
+    worker.start()
+    worker.join(timeout=2.0)
+    live.join(timeout=2.0)
+
+    assert not worker.is_alive()
+    assert not live.is_alive()
+    assert boundary_reached.is_set()
+    assert provider_calls == []
+    assert run.request_done.is_set()
+    assert relay_calls == [
+        ("acquire", True),
+        ("begin", True),
+        ("start_task_run", True),
+    ]
+    assert live_result == {"boundary_reached": True}
 
 
+def test_live_turn_stops_safely_when_review_acknowledgement_times_out(monkeypatch):
+    """A broken review abort path must not create an unbounded foreground wait."""
+    import time
+
+    import agent.background_review as background_review_module
+
+    review_entered = threading.Event()
+    interrupt_entered = threading.Event()
+    interrupt_returned = threading.Event()
+    allow_interrupt_return = threading.Event()
+    allow_review_return = threading.Event()
+
+    class WedgedReviewAgent(FakeReviewAgent):
+        def run_conversation(self, **kwargs):
+            review_entered.set()
+            allow_review_return.wait(5.0)
+
+        def interrupt(self, message=None):
+            interrupt_entered.set()
+            allow_interrupt_return.wait(5.0)
+            interrupt_returned.set()
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", WedgedReviewAgent)
+    CapturingThread.targets = []
+    monkeypatch.setattr(run_agent_module.threading, "Thread", CapturingThread)
+    monkeypatch.setattr(
+        background_review_module,
+        "_BACKGROUND_REVIEW_CANCEL_TIMEOUT_SECONDS",
+        0.01,
+        raising=False,
+    )
+
+    agent = _bare_agent()
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+    run = agent._background_review_run
+    assert run is not None
+    monkeypatch.setattr(run_agent_module.threading, "Thread", _REAL_THREAD)
+    worker = _REAL_THREAD(target=CapturingThread.targets[0], daemon=True)
+    worker.start()
+    assert review_entered.wait(2.0)
+
+    boundary_calls = []
+    _install_live_turn_boundary(
+        monkeypatch, lambda: boundary_calls.append(True)
+    )
+    relay_calls = _install_relay_recorder(monkeypatch, run)
+
+    started = time.monotonic()
+    result = AIAgent.run_conversation(
+        agent,
+        "next turn",
+        task_id="live-task",
+    )
+    elapsed = time.monotonic() - started
+
+    allow_interrupt_return.set()
+    allow_review_return.set()
+    worker.join(timeout=2.0)
+
+    assert elapsed < 2.0
+    assert interrupt_entered.is_set()
+    assert interrupt_returned.wait(2.0)
+    assert not worker.is_alive()
+    assert relay_calls == []
+    assert boundary_calls == []
+    assert result is not None
+    assert result["completed"] is False
+    assert result["failed"] is True
+    assert result["background_review_cancellation_timeout"] is True
+    assert "not started" in result["final_response"].lower()
+    assert agent.session_id == "test-session"
 
 
+def test_live_turn_fails_closed_for_untracked_legacy_review_stub(monkeypatch):
+    """Directly constructed agents without a handshake must not overlap turns."""
+    interrupts = []
+    interrupt_called = threading.Event()
+
+    class LegacyReviewAgent:
+        def interrupt(self, message=None):
+            interrupts.append(message)
+            interrupt_called.set()
+
+    agent = _bare_agent()
+    del agent._background_review_run
+    agent._background_review_agent = LegacyReviewAgent()
+    boundary_calls = []
+    _install_live_turn_boundary(
+        monkeypatch, lambda: boundary_calls.append(True)
+    )
+    relay_calls = _install_relay_recorder(monkeypatch)
+
+    result = AIAgent.run_conversation(
+        agent,
+        "next turn",
+        task_id="live-task",
+    )
+
+    assert interrupt_called.wait(2.0)
+    assert interrupts == ["superseded by a new live turn"]
+    assert relay_calls == []
+    assert boundary_calls == []
+    assert result["background_review_cancellation_timeout"] is True
+    assert result["failed"] is True
+    assert agent.session_id == "test-session"
+
+
+def test_stale_review_cleanup_cannot_clear_or_signal_newer_review(monkeypatch):
+    """A retired worker's late cleanup must be scoped to its own run identity."""
+    first_cleanup_entered = threading.Event()
+    allow_first_cleanup = threading.Event()
+    instance_count = 0
+
+    class BlockingCleanupReviewAgent(FakeReviewAgent):
+        def __init__(self, **kwargs):
+            nonlocal instance_count
+            super().__init__(**kwargs)
+            self.index = instance_count
+            instance_count += 1
+
+        def shutdown_memory_provider(self):
+            if self.index == 0:
+                first_cleanup_entered.set()
+                assert allow_first_cleanup.wait(2.0)
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", BlockingCleanupReviewAgent)
+    CapturingThread.targets = []
+    monkeypatch.setattr(run_agent_module.threading, "Thread", CapturingThread)
+
+    agent = _bare_agent()
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "first"}],
+        review_memory=True,
+    )
+    first_run = agent._background_review_run
+    first_worker = _REAL_THREAD(target=CapturingThread.targets[0], daemon=True)
+    first_worker.start()
+    assert first_cleanup_entered.wait(2.0)
+    assert first_run.request_done.is_set()
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "second"}],
+        review_memory=True,
+    )
+    second_run = agent._background_review_run
+    second_target = CapturingThread.targets[1]
+    assert second_run is not first_run
+    assert not second_run.request_done.is_set()
+
+    allow_first_cleanup.set()
+    first_worker.join(timeout=2.0)
+
+    assert not first_worker.is_alive()
+    assert agent._background_review_run is second_run
+    assert not second_run.request_done.is_set()
+
+    second_target()
+    assert second_run.request_done.is_set()
+    assert agent._background_review_run is None
 
 # ---------------------------------------------------------------------------
 # memory_notifications mode: off | on | verbose

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -88,10 +88,155 @@ def _bare_agent() -> AIAgent:
     import threading as _threading
     agent._background_review_agent = None
     agent._background_review_run = None
+    agent._deferred_background_review = None
     agent._background_review_lock = _threading.Lock()
     agent._active_children = []
     agent._active_children_lock = _threading.Lock()
     return agent
+
+
+def test_automatic_review_is_deferred_until_parent_cleanup_flush(monkeypatch):
+    events = []
+
+    class RecordingReviewAgent(FakeReviewAgent):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            events.append("init")
+
+        def run_conversation(self, **kwargs):
+            events.append("run")
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", RecordingReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+        defer_until_turn_complete=True,
+    )
+
+    assert events == []
+    assert agent._background_review_run is not None
+    assert agent._deferred_background_review is not None
+
+    AIAgent._flush_deferred_background_review(agent)
+
+    assert events == ["init", "run"]
+    assert agent._deferred_background_review is None
+    assert agent._background_review_run is None
+
+
+def test_prepared_review_is_cancelled_without_starting_worker(monkeypatch):
+    from agent.background_review import cancel_background_review_for_live_turn
+
+    provider_calls = []
+
+    class RecordingReviewAgent(FakeReviewAgent):
+        def run_conversation(self, **kwargs):
+            provider_calls.append(kwargs)
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", RecordingReviewAgent)
+    CapturingThread.targets = []
+    monkeypatch.setattr(run_agent_module.threading, "Thread", CapturingThread)
+
+    agent = _bare_agent()
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+        defer_until_turn_complete=True,
+    )
+    run = agent._background_review_run
+
+    assert run is not None
+    assert agent._deferred_background_review is not None
+    assert cancel_background_review_for_live_turn(agent) is True
+    assert run.request_done.is_set()
+    assert agent._background_review_run is None
+    assert agent._deferred_background_review is None
+    assert provider_calls == []
+
+    AIAgent._flush_deferred_background_review(agent)
+    assert provider_calls == []
+
+
+def test_deferred_review_flushes_after_parent_relay_cleanup(monkeypatch):
+    """The review starts only after task, turn, and lease cleanup complete."""
+    from agent import relay_runtime
+    import agent.conversation_loop as conversation_loop_module
+
+    events = []
+
+    class RelayTurn:
+        relay_enabled = False
+
+    class RecordingCoordinator:
+        def register_session_initializer(self, *args, **kwargs):
+            return None
+
+        def acquire_conversation(self, **kwargs):
+            events.append("acquire")
+            return object()
+
+        def begin_turn(self, lease, **kwargs):
+            events.append("begin")
+            return RelayTurn()
+
+        def finish_logical_calls(self, turn, **kwargs):
+            events.append("finish_logical")
+
+        def end_turn(self, turn, **kwargs):
+            events.append("end_turn")
+
+        def release_conversation(self, lease):
+            events.append("release_conversation")
+
+    def fake_inner_run(agent, *args, **kwargs):
+        events.append("inner_return")
+        agent._deferred_background_review = {
+            "messages_snapshot": [],
+            "review_memory": True,
+            "review_skills": False,
+            "focus": None,
+        }
+        return {
+            "final_response": "ok",
+            "messages": [],
+            "completed": True,
+            "failed": False,
+        }
+
+    agent = _bare_agent()
+    agent._delegate_depth = 0
+    agent._session_db = None
+    agent._flush_deferred_background_review = lambda: events.append("flush_review")
+
+    monkeypatch.setattr(
+        relay_runtime,
+        "SESSION_COORDINATOR",
+        RecordingCoordinator(),
+    )
+    monkeypatch.setattr(
+        relay_runtime,
+        "current_profile_key",
+        lambda: "/test-profile",
+    )
+    monkeypatch.setattr(conversation_loop_module, "run_conversation", fake_inner_run)
+
+    result = AIAgent.run_conversation(agent, "hello", task_id="parent-task")
+
+    assert result["final_response"] == "ok"
+    assert events == [
+        "acquire",
+        "begin",
+        "inner_return",
+        "finish_logical",
+        "end_turn",
+        "release_conversation",
+        "flush_review",
+    ]
 
 
 class ImmediateThread:
@@ -633,8 +778,8 @@ def test_live_turn_cancels_review_during_startup_before_provider(monkeypatch):
     assert live_result == {"boundary_reached": True}
 
 
-def test_live_turn_stops_safely_when_review_acknowledgement_times_out(monkeypatch):
-    """A broken review abort path must not create an unbounded foreground wait."""
+def test_live_turn_keeps_foreground_priority_when_review_ack_times_out(monkeypatch):
+    """A broken review abort path must not block the foreground indefinitely."""
     import time
 
     import agent.background_review as background_review_module
@@ -685,11 +830,15 @@ def test_live_turn_stops_safely_when_review_acknowledgement_times_out(monkeypatc
     relay_calls = _install_relay_recorder(monkeypatch, run)
 
     started = time.monotonic()
-    result = AIAgent.run_conversation(
-        agent,
-        "next turn",
-        task_id="live-task",
-    )
+    boundary_reached = False
+    try:
+        AIAgent.run_conversation(
+            agent,
+            "next turn",
+            task_id="live-task",
+        )
+    except _TurnBoundaryReached:
+        boundary_reached = True
     elapsed = time.monotonic() - started
 
     allow_interrupt_return.set()
@@ -700,18 +849,18 @@ def test_live_turn_stops_safely_when_review_acknowledgement_times_out(monkeypatc
     assert interrupt_entered.is_set()
     assert interrupt_returned.wait(2.0)
     assert not worker.is_alive()
-    assert relay_calls == []
-    assert boundary_calls == []
-    assert result is not None
-    assert result["completed"] is False
-    assert result["failed"] is True
-    assert result["background_review_cancellation_timeout"] is True
-    assert "not started" in result["final_response"].lower()
+    assert relay_calls == [
+        ("acquire", False),
+        ("begin", False),
+        ("start_task_run", False),
+    ]
+    assert boundary_calls == [True]
+    assert boundary_reached is True
     assert agent.session_id == "test-session"
 
 
-def test_live_turn_fails_closed_for_untracked_legacy_review_stub(monkeypatch):
-    """Directly constructed agents without a handshake must not overlap turns."""
+def test_live_turn_interrupts_legacy_review_but_keeps_foreground_priority(monkeypatch):
+    """Legacy stubs are interrupted without turning review into a user blocker."""
     interrupts = []
     interrupt_called = threading.Event()
 
@@ -729,18 +878,25 @@ def test_live_turn_fails_closed_for_untracked_legacy_review_stub(monkeypatch):
     )
     relay_calls = _install_relay_recorder(monkeypatch)
 
-    result = AIAgent.run_conversation(
-        agent,
-        "next turn",
-        task_id="live-task",
-    )
+    boundary_reached = False
+    try:
+        AIAgent.run_conversation(
+            agent,
+            "next turn",
+            task_id="live-task",
+        )
+    except _TurnBoundaryReached:
+        boundary_reached = True
 
     assert interrupt_called.wait(2.0)
     assert interrupts == ["superseded by a new live turn"]
-    assert relay_calls == []
-    assert boundary_calls == []
-    assert result["background_review_cancellation_timeout"] is True
-    assert result["failed"] is True
+    assert relay_calls == [
+        ("acquire", False),
+        ("begin", False),
+        ("start_task_run", False),
+    ]
+    assert boundary_calls == [True]
+    assert boundary_reached is True
     assert agent.session_id == "test-session"
 
 

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -107,21 +107,24 @@ def test_automatic_review_is_deferred_until_parent_cleanup_flush(monkeypatch):
             events.append("run")
 
     monkeypatch.setattr(run_agent_module, "AIAgent", RecordingReviewAgent)
-    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+    CapturingThread.targets = []
+    monkeypatch.setattr(run_agent_module.threading, "Thread", CapturingThread)
 
     agent = _bare_agent()
-    AIAgent._spawn_background_review(
+    assert AIAgent._spawn_background_review(
         agent,
         messages_snapshot=[{"role": "user", "content": "hello"}],
         review_memory=True,
         defer_until_turn_complete=True,
-    )
+    ) is True
 
     assert events == []
     assert agent._background_review_run is not None
     assert agent._deferred_background_review is not None
 
     AIAgent._flush_deferred_background_review(agent)
+    assert events == []
+    CapturingThread.targets[0]()
 
     assert events == ["init", "run"]
     assert agent._deferred_background_review is None
@@ -160,6 +163,93 @@ def test_prepared_review_is_cancelled_without_starting_worker(monkeypatch):
 
     AIAgent._flush_deferred_background_review(agent)
     assert provider_calls == []
+
+
+def test_live_turn_retires_deferred_reservation_during_thread_construction(monkeypatch):
+    import time
+    import agent.background_review as background_review_module
+
+    entered_construction = threading.Event()
+    allow_construction = threading.Event()
+    provider_calls = []
+    real_spawn = background_review_module.spawn_background_review_thread
+
+    def delayed_spawn(*args, **kwargs):
+        entered_construction.set()
+        assert allow_construction.wait(2.0)
+        return real_spawn(*args, **kwargs)
+
+    monkeypatch.setattr(
+        background_review_module,
+        "spawn_background_review_thread",
+        delayed_spawn,
+    )
+    CapturingThread.targets = []
+    monkeypatch.setattr(run_agent_module.threading, "Thread", CapturingThread)
+
+    agent = _bare_agent()
+    spawn_result = {}
+
+    def build_review():
+        spawn_result["started"] = AIAgent._spawn_background_review(
+            agent,
+            messages_snapshot=[{"role": "user", "content": "hello"}],
+            review_memory=True,
+            defer_until_turn_complete=True,
+        )
+
+    builder = _REAL_THREAD(target=build_review, daemon=True)
+    builder.start()
+    assert entered_construction.wait(2.0)
+    run = agent._background_review_run
+    assert run is not None
+    assert agent._deferred_background_review == (None, run)
+
+    started = time.monotonic()
+    from agent.background_review import cancel_background_review_for_live_turn
+
+    assert cancel_background_review_for_live_turn(agent) is True
+    elapsed = time.monotonic() - started
+    allow_construction.set()
+    builder.join(timeout=2.0)
+
+    assert elapsed < 0.5
+    assert not builder.is_alive()
+    assert spawn_result == {"started": False}
+    assert run.request_done.is_set()
+    assert agent._background_review_run is None
+    assert agent._deferred_background_review is None
+    assert provider_calls == []
+
+
+def test_explicit_refine_supersedes_prepared_automatic_review(monkeypatch):
+    CapturingThread.targets = []
+    monkeypatch.setattr(run_agent_module.threading, "Thread", CapturingThread)
+
+    agent = _bare_agent()
+    assert AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "automatic"}],
+        review_memory=True,
+        defer_until_turn_complete=True,
+    ) is True
+    automatic_run = agent._background_review_run
+
+    assert AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "manual"}],
+        review_memory=True,
+        explicit_request=True,
+    ) is True
+
+    assert automatic_run is not None
+    assert automatic_run.request_done.is_set()
+    assert agent._background_review_run is not automatic_run
+    assert agent._deferred_background_review is None
+    assert len(CapturingThread.targets) == 2
+
+    CapturingThread.targets[-1]()
+    assert agent._background_review_run is None
 
 
 def test_deferred_review_flushes_after_parent_relay_cleanup(monkeypatch):


### PR DESCRIPTION
## Summary

Fixes #84423 while preserving automatic background review, application session identity, and prompt-cache parity.

This rebases and combines the useful parts of:

- #84461 — identity-scoped per-review run token, startup fence, bounded acknowledgement, ABA-safe cleanup (authorship preserved in the first commit)
- #84450 — foreground-priority semantics on pathological abort timeout (credited in the follow-up commit)

It also closes the earlier parent-finalization race that neither open PR covers on current `main`: automatic review was started by `turn_finalizer` before the parent Relay task/turn and durable session lease had finished closing.

## What changes

- Publish the exact review run token before any worker can start.
- Prepare automatic review during turn finalization, but start its daemon only after parent Relay task/turn + session-lease cleanup.
- Cancel a prepared-but-not-started review synchronously if a new live turn arrives in the handoff window.
- Cancel and bounded-wait for an admitted review before opening foreground Relay/task instrumentation.
- Keep foreground priority if a pathological provider abort misses the bounded deadline; emit an actionable warning instead of blocking the user's turn.
- Keep cleanup identity-scoped so stale worker A cannot clear or release successor B.
- Publish the deferred placeholder atomically with the run token and keep it visible through `Thread.start()`, closing construction/start TOCTOU windows.
- Let explicit `/refine` supersede a prepared automatic review, or report busy honestly if an admitted provider request cannot retire within the bound.
- Apply the same deferred handoff to the Codex automatic-review path.
- Preserve the application `session_id`, cached system prompt bytes, accounting attribution, manual `/refine`, disabled-review behavior, and delegation guards.

## Why this placement

On current `main`, Relay/task instrumentation is opened by the outer `AIAgent.run_conversation` wrapper before `agent.conversation_loop.run_conversation` executes. The cancellation fence therefore belongs at that outer boundary. Starting the automatic daemon is deferred to the opposite boundary, after parent instrumentation has closed.

## Verification

All commands exit 0 on exact tree `83f7f9c867cc5cc8235631dfb26cb722569c3d53`:

- background-review/cache/refine/Codex/gateway matrix — **85 passed**
- Relay/conversation/stream/interrupt matrix — **69 passed**
- `pytest tests/run_agent/test_run_agent.py` — **262 passed**
- `ruff check` on changed Python files
- `python -m py_compile` on changed Python files
- `git diff --check`

Regression sabotage against untouched current `main`:

- automatic review deferred until parent cleanup — **fails on main, passes here**
- prepared review cancelled without worker/provider start — **fails on main, passes here**
- daemon flush ordered after parent Relay turn/lease cleanup — **fails on main, passes here**
- cancellation during deferred target/thread construction retires synchronously — **fails on main, passes here**

## Risk / rollback

The change is limited to background-review lifecycle and its outer turn boundary. No config schema, session ID, prompt content, tool surface, or memory format changes. Revert the three commits to restore prior behavior.
