### PR TITLE
fix(desktop): persist custom-endpoint model catalog on save

### DIFF
--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -60,6 +60,10 @@ class CustomEndpointUpdate(BaseModel):
     discover_models: bool = True
     make_default: bool = False
     models: Optional[List[str]] = None
+    # Optional wire-protocol hint. Desktop does not expose a field today;
+    # CLI / hand-written providers set ``anthropic_messages`` so catalog
+    # probes use x-api-key + anthropic-version instead of Bearer.
+    api_mode: Optional[str] = None
 
 
 class MessagingPlatformUpdate(BaseModel):

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7921,6 +7921,127 @@ def _parse_model_ids(resp: "Any") -> List[str]:
     return ids
 
 
+def _anthropic_compat_api_mode(api_mode: Optional[str] = None, base_url: str = "") -> bool:
+    """True when a custom endpoint speaks Anthropic native ``/models`` auth."""
+    mode = str(api_mode or "").strip().lower().replace("-", "_")
+    if mode in {"anthropic", "anthropic_messages"}:
+        return True
+    if not base_url:
+        return False
+    from hermes_cli.models import _base_url_looks_like_anthropic_messages
+    return _base_url_looks_like_anthropic_messages(base_url)
+
+
+def _custom_endpoint_probe_headers(
+    api_key: Optional[str] = None,
+    api_mode: Optional[str] = None,
+    base_url: str = "",
+) -> Dict[str, str]:
+    """Auth headers for GET ``{base_url}/models``.
+
+    Matches the CLI probe (``probe_api_models``): Anthropic-compat mode
+    uses ``x-api-key`` + ``anthropic-version`` instead of Bearer.
+    """
+    headers: Dict[str, str] = {"Accept": "application/json"}
+    key = (api_key or "").strip()
+    if not key:
+        return headers
+    if _anthropic_compat_api_mode(api_mode, base_url):
+        headers["x-api-key"] = key
+        headers["anthropic-version"] = "2023-06-01"
+    else:
+        headers["Authorization"] = f"Bearer {key}"
+    return headers
+
+
+def _resolve_custom_endpoint_probe_key(
+    entry: Dict[str, Any],
+    submitted_key: Optional[str],
+) -> Optional[str]:
+    """Key for a catalog probe: newly submitted, else the stored credential."""
+    if submitted_key:
+        return submitted_key
+    plaintext = str(entry.get("api_key") or "").strip()
+    if plaintext:
+        return plaintext
+    key_env = str(entry.get("key_env") or "").strip()
+    if not key_env:
+        return None
+    from hermes_cli.config import get_env_value
+    return (get_env_value(key_env) or "").strip() or None
+
+
+def _discover_custom_endpoint_models(
+    base_url: str,
+    api_key: Optional[str] = None,
+    api_mode: Optional[str] = None,
+    timeout: float = 8.0,
+) -> List[str]:
+    """GET ``{base_url}/models`` — the same catalog probe as Desktop Test.
+
+    Failures (timeout, DNS, HTTP error) return ``[]`` so Save still
+    persists the typed model and GET list still returns typed/stored ids.
+    """
+    import httpx
+
+    url = (base_url or "").strip().rstrip("/") + "/models"
+    if url == "/models":
+        return []
+    headers = _custom_endpoint_probe_headers(api_key, api_mode, base_url)
+    try:
+        with httpx.Client(timeout=httpx.Timeout(timeout)) as client:
+            resp = client.get(url, headers=headers)
+    except Exception:
+        return []
+    return _parse_model_ids(resp)
+
+
+def _merge_discovered_custom_models(stored: List[str], discovered: List[str]) -> List[str]:
+    """Append newly discovered ids while keeping typed/stored order first."""
+    seen = set(stored)
+    merged = list(stored)
+    for raw in discovered:
+        model_id = str(raw).strip()
+        if model_id and model_id not in seen:
+            merged.append(model_id)
+            seen.add(model_id)
+    return merged
+
+
+def _apply_live_custom_endpoint_catalogs(response: Dict[str, Any], cfg: Dict[str, Any]) -> None:
+    """Merge a live GET ``{base_url}/models`` into Settings list responses.
+
+    Picker-open used to show only stored models until Test/Save persisted a
+    catalog. When ``discover_models`` is on we probe here and return typed +
+    stored + discovered. Failures keep the stored list. GET does not write
+    config.
+    """
+    providers = cfg.get("providers") if isinstance(cfg.get("providers"), dict) else {}
+    model_cfg = cfg.get("model") if isinstance(cfg.get("model"), dict) else {}
+    for endpoint in response.get("endpoints") or []:
+        if not isinstance(endpoint, dict) or not bool(endpoint.get("discover_models", True)):
+            continue
+        if endpoint.get("source") == "direct-config":
+            entry = model_cfg
+        else:
+            entry = providers.get(str(endpoint.get("id") or ""))
+        if not isinstance(entry, dict):
+            continue
+        if endpoint.get("source") != "direct-config" and not bool(entry.get("discover_models", True)):
+            continue
+        discovered = _discover_custom_endpoint_models(
+            str(endpoint.get("base_url") or ""),
+            api_key=_resolve_custom_endpoint_probe_key(entry, None),
+            api_mode=str(entry.get("api_mode") or "").strip() or None,
+        )
+        if not discovered:
+            continue
+        endpoint["models"] = _merge_discovered_custom_models(
+            list(endpoint.get("models") or []),
+            discovered,
+        )
+
+
 def _custom_endpoint_id(raw: str, fallback: str = "custom") -> str:
     slug = re.sub(r"[^A-Za-z0-9_-]+", "-", (raw or "").strip()).strip("-_").lower()
     return slug or fallback
@@ -8093,15 +8214,27 @@ def _write_custom_endpoint(cfg: Dict[str, Any], body: CustomEndpointUpdate) -> T
         "model": model,
         "discover_models": bool(body.discover_models),
     })
+    submitted_key = body.api_key.strip() if body.api_key is not None else None
+    api_mode = (body.api_mode or "").strip() or str(entry.get("api_mode") or "").strip() or None
+    if api_mode:
+        entry["api_mode"] = api_mode
     # Same for the model map: merge rather than replace, so existing models
     # keep their context lengths. ``body.models`` is the catalogue the panel's
     # Test button already discovered — without it only the one hand-typed
     # model survived Save, and every picker showed a single-entry list for a
-    # provider serving dozens (#69988). A payload with no ``models`` (older
-    # UI) still just ensures the named default is present.
+    # provider serving dozens (#69988). Save-without-Test used to skip the
+    # live catalog entirely; when discover_models is on we fetch
+    # GET {base_url}/models here and merge it in.
     existing_models = entry.get("models")
     models_map: Dict[str, Any] = dict(existing_models) if isinstance(existing_models, dict) else {}
-    for candidate in (*(body.models or ()), model):
+    discovered: List[str] = []
+    if body.discover_models:
+        discovered = _discover_custom_endpoint_models(
+            base_url,
+            api_key=_resolve_custom_endpoint_probe_key(entry, submitted_key),
+            api_mode=api_mode,
+        )
+    for candidate in (*(body.models or ()), *discovered, model):
         model_id = str(candidate).strip()
         if not model_id:
             continue
@@ -8116,7 +8249,6 @@ def _write_custom_endpoint(cfg: Dict[str, Any], body: CustomEndpointUpdate) -> T
     # reference it via ``key_env`` — the same indirection built-in providers
     # use and that runtime_provider.py already resolves at load time.
     env_var = custom_endpoint_key_env(endpoint_id)
-    submitted_key = body.api_key.strip() if body.api_key is not None else None
     if submitted_key:
         save_env_value(env_var, submitted_key)
         entry["key_env"] = env_var
@@ -8160,7 +8292,10 @@ def list_custom_endpoints(profile: Optional[str] = None):
     """
     try:
         with _config_profile_scope(profile):
-            return _custom_endpoint_response(load_config())
+            cfg = load_config()
+            response = _custom_endpoint_response(cfg)
+            _apply_live_custom_endpoint_catalogs(response, cfg)
+            return response
     except HTTPException:
         raise
     except Exception:
@@ -8256,9 +8391,7 @@ async def validate_custom_endpoint(body: CustomEndpointUpdate):
         return {"ok": False, "reachable": True, "message": "Enter an endpoint URL first.", "models": []}
 
     url = base_url + "/models"
-    headers = {"Accept": "application/json"}
-    if body.api_key and body.api_key.strip():
-        headers["Authorization"] = f"Bearer {body.api_key.strip()}"
+    headers = _custom_endpoint_probe_headers(body.api_key, body.api_mode, base_url)
 
     try:
         async with httpx.AsyncClient(timeout=httpx.Timeout(8.0)) as client:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -255,6 +255,12 @@ class TestWebServerEndpoints:
         from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
 
         monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
+        # Save and GET list now probe GET {base_url}/models. Existing tests
+        # use fake hosts and must not pay a real DNS timeout.
+        monkeypatch.setattr(
+            "hermes_cli.web_server._discover_custom_endpoint_models",
+            lambda *a, **k: [],
+        )
 
         self.client = TestClient(app)
         self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
@@ -4647,6 +4653,286 @@ class TestValidateProviderCredential:
                 "Authorization": "Bearer local-secret",
             },
         }
+
+    def test_named_custom_endpoint_probe_uses_anthropic_headers(self, monkeypatch):
+        """Anthropic-compat Test must send x-api-key + anthropic-version."""
+        captured = {}
+
+        class _Resp:
+            status_code = 200
+            is_success = True
+
+            def json(self):
+                return {"data": [{"id": "alpha"}, {"id": "beta"}, {"id": "gamma"}]}
+
+        class _Client:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            async def get(self, url, *args, headers=None, **kwargs):
+                captured["url"] = url
+                captured["headers"] = headers
+                return _Resp()
+
+        monkeypatch.setattr("httpx.AsyncClient", _Client)
+
+        response = self.client.post(
+            "/api/providers/custom-endpoints/validate",
+            json={
+                "name": "Claude Proxy",
+                "base_url": "https://proxy.example/anthropic/v1",
+                "model": "only-typed",
+                "api_key": "sk-ant-secret",
+                "api_mode": "anthropic_messages",
+            },
+        )
+
+        assert response.json()["models"] == ["alpha", "beta", "gamma"]
+        assert captured == {
+            "url": "https://proxy.example/anthropic/v1/models",
+            "headers": {
+                "Accept": "application/json",
+                "x-api-key": "sk-ant-secret",
+                "anthropic-version": "2023-06-01",
+            },
+        }
+
+
+class TestCustomEndpointCatalogSave:
+    """Save and list must surface the live GET {base_url}/models catalog."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_test_client(self, monkeypatch, _isolate_hermes_home):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+        self.client = TestClient(app)
+        self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+        self.captured = []
+
+        class _BlockingAsync:
+            def __init__(self, *args, **kwargs):
+                raise AssertionError("save-time catalog probe used AsyncClient")
+
+        monkeypatch.setattr("httpx.AsyncClient", _BlockingAsync)
+
+    def _mock_models_get(self, monkeypatch, ids, *, status=200):
+        captured = self.captured
+
+        class _Resp:
+            status_code = status
+            is_success = 200 <= status < 300
+
+            def json(self):
+                return {"data": [{"id": mid} for mid in ids]}
+
+        class _Client:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def get(self, url, *args, headers=None, **kwargs):
+                captured.append({"url": url, "headers": dict(headers or {})})
+                return _Resp()
+
+        monkeypatch.setattr("httpx.Client", _Client)
+
+    def _payload(self, **overrides):
+        body = {
+            "id": "proxy",
+            "name": "Proxy",
+            "base_url": "https://llm.example.com/v1",
+            "model": "only-typed",
+            "api_key": "sk-secret",
+        }
+        body.update(overrides)
+        return body
+
+    def test_save_without_models_array_persists_discovered_catalog(self, monkeypatch):
+        """POST {model: only-typed} and no models[] must still store the catalog."""
+        self._mock_models_get(monkeypatch, ["alpha", "beta", "gamma"])
+
+        resp = self.client.post(
+            "/api/providers/custom-endpoints",
+            json=self._payload(),
+        )
+        assert resp.status_code == 200
+        endpoint = next(e for e in resp.json()["endpoints"] if e["id"] == "proxy")
+        assert endpoint["model"] == "only-typed"
+        assert endpoint["models"] == ["only-typed", "alpha", "beta", "gamma"]
+
+        listed = self.client.get("/api/providers/custom-endpoints").json()
+        endpoint = next(e for e in listed["endpoints"] if e["id"] == "proxy")
+        assert endpoint["models"] == ["only-typed", "alpha", "beta", "gamma"]
+
+        from hermes_cli.config import load_config
+        stored = load_config()["providers"]["proxy"]["models"]
+        assert set(stored) == {"only-typed", "alpha", "beta", "gamma"}
+        assert self.captured[0]["url"] == "https://llm.example.com/v1/models"
+        assert self.captured[0]["headers"]["Authorization"] == "Bearer sk-secret"
+
+    def test_save_skips_catalog_probe_when_discover_models_is_false(self, monkeypatch):
+        self._mock_models_get(monkeypatch, ["alpha"])
+
+        resp = self.client.post(
+            "/api/providers/custom-endpoints",
+            json=self._payload(discover_models=False),
+        )
+        assert resp.status_code == 200
+        endpoint = next(e for e in resp.json()["endpoints"] if e["id"] == "proxy")
+        assert endpoint["models"] == ["only-typed"]
+        assert self.captured == []
+
+    def test_save_anthropic_compat_uses_cli_headers(self, monkeypatch):
+        self._mock_models_get(monkeypatch, ["alpha", "beta", "gamma"])
+
+        resp = self.client.post(
+            "/api/providers/custom-endpoints",
+            json=self._payload(
+                base_url="https://proxy.example/anthropic/v1",
+                api_mode="anthropic_messages",
+                api_key="sk-ant-secret",
+            ),
+        )
+        assert resp.status_code == 200
+        endpoint = next(e for e in resp.json()["endpoints"] if e["id"] == "proxy")
+        assert endpoint["models"] == ["only-typed", "alpha", "beta", "gamma"]
+        assert self.captured[0]["url"] == "https://proxy.example/anthropic/v1/models"
+        assert self.captured[0]["headers"] == {
+            "Accept": "application/json",
+            "x-api-key": "sk-ant-secret",
+            "anthropic-version": "2023-06-01",
+        }
+        assert "Authorization" not in self.captured[0]["headers"]
+
+        from hermes_cli.config import load_config
+        assert load_config()["providers"]["proxy"]["api_mode"] == "anthropic_messages"
+
+    def test_save_infers_anthropic_headers_from_base_url(self, monkeypatch):
+        self._mock_models_get(monkeypatch, ["claude-sonnet"])
+
+        resp = self.client.post(
+            "/api/providers/custom-endpoints",
+            json=self._payload(
+                base_url="https://gateway.example/anthropic/v1",
+                api_key="sk-ant-url",
+            ),
+        )
+        assert resp.status_code == 200
+        assert self.captured[0]["headers"]["x-api-key"] == "sk-ant-url"
+        assert self.captured[0]["headers"]["anthropic-version"] == "2023-06-01"
+
+    def test_save_still_persists_typed_model_when_catalog_is_unreachable(self, monkeypatch):
+        class _Client:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def get(self, *args, **kwargs):
+                raise RuntimeError("connection refused")
+
+        monkeypatch.setattr("httpx.Client", _Client)
+
+        resp = self.client.post(
+            "/api/providers/custom-endpoints",
+            json=self._payload(),
+        )
+        assert resp.status_code == 200
+        endpoint = next(e for e in resp.json()["endpoints"] if e["id"] == "proxy")
+        assert endpoint["models"] == ["only-typed"]
+
+    def _seed_typed_only_endpoint(self, **overrides):
+        """Pre-save-discover era: config has only the typed model, no Test/Save catalog."""
+        from hermes_cli.config import custom_endpoint_key_env, load_config, save_config, save_env_value
+
+        env_var = custom_endpoint_key_env("proxy")
+        save_env_value(env_var, "sk-secret")
+        entry = {
+            "name": "Proxy",
+            "base_url": "https://llm.example.com/v1",
+            "model": "only-typed",
+            "discover_models": True,
+            "key_env": env_var,
+            "models": {"only-typed": {}},
+        }
+        entry.update(overrides)
+        cfg = load_config()
+        providers = cfg.get("providers")
+        if not isinstance(providers, dict):
+            providers = {}
+        providers["proxy"] = entry
+        cfg["providers"] = providers
+        save_config(cfg)
+
+    def test_list_live_probes_catalog_when_only_typed_model_is_stored(self, monkeypatch):
+        """GET must return typed + discovered without a prior Test/Save models[]."""
+        self._mock_models_get(monkeypatch, ["alpha", "beta", "gamma"])
+        self._seed_typed_only_endpoint()
+
+        listed = self.client.get("/api/providers/custom-endpoints").json()
+        endpoint = next(e for e in listed["endpoints"] if e["id"] == "proxy")
+        assert endpoint["models"] == ["only-typed", "alpha", "beta", "gamma"]
+        assert self.captured == [{
+            "url": "https://llm.example.com/v1/models",
+            "headers": {
+                "Accept": "application/json",
+                "Authorization": "Bearer sk-secret",
+            },
+        }]
+
+        from hermes_cli.config import load_config
+        stored = load_config()["providers"]["proxy"]["models"]
+        assert set(stored) == {"only-typed"}
+
+    def test_list_skips_catalog_probe_when_discover_models_is_false(self, monkeypatch):
+        self._mock_models_get(monkeypatch, ["alpha", "beta"])
+        self._seed_typed_only_endpoint(discover_models=False)
+
+        listed = self.client.get("/api/providers/custom-endpoints").json()
+        endpoint = next(e for e in listed["endpoints"] if e["id"] == "proxy")
+        assert endpoint["models"] == ["only-typed"]
+        assert self.captured == []
+
+    def test_list_returns_typed_models_when_catalog_is_unreachable(self, monkeypatch):
+        class _Client:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def get(self, *args, **kwargs):
+                raise RuntimeError("connection refused")
+
+        monkeypatch.setattr("httpx.Client", _Client)
+        self._seed_typed_only_endpoint()
+
+        listed = self.client.get("/api/providers/custom-endpoints").json()
+        endpoint = next(e for e in listed["endpoints"] if e["id"] == "proxy")
+        assert endpoint["models"] == ["only-typed"]
 
 
 class TestDesktopCronTicker:


### PR DESCRIPTION
## What does this PR do?

Custom endpoint Save in Settings → Providers only persisted the one typed model unless the user had already clicked Test. Opening the Settings list also returned that stored list, so the picker showed a single entry even when `{base_url}/models` served many models.

Save now probes `GET {base_url}/models` when `discover_models` is on, and merges the typed model, any Test results, and the discovered ids. Opening Settings (`GET /api/providers/custom-endpoints`) live-probes the same catalog and returns the merge without writing config. Anthropic-compatible endpoints use `x-api-key` + `anthropic-version` instead of Bearer, matching the CLI probe. A failed probe still keeps the typed/stored models.

## Related Issue

Fixes #90010

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_server.py` — save-time catalog fetch; GET list live-probe; shared `_custom_endpoint_probe_headers` for save and validate
- `hermes_cli/web_models.py` — optional `api_mode` on `CustomEndpointUpdate`
- `tests/hermes_cli/test_web_server.py` — mocked save-without-`models[]`, GET live-probe, `discover_models: false`, Anthropic headers, URL heuristic, unreachable catalog

## How to Test

1. Add a custom provider whose `base_url` serves several models on `GET /models`. Type only one model name. Save without clicking Test.
2. Open Settings → Providers (or GET `/api/providers/custom-endpoints`). The list should include the typed model plus the catalog, not only the typed name.
3. Repeat with an Anthropic-compatible endpoint (`api_mode: anthropic_messages` or a `/anthropic` URL) and confirm the probe uses `x-api-key`.
4. `scripts/run_tests.sh tests/hermes_cli/test_web_server.py -k "custom_endpoint or CustomEndpoint or named_custom_endpoint or local_endpoint or ValidateProvider or parse_model_ids"`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Settings API + CLI; Electron UI not re-run)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

CLI `hermes model` already listed the mock catalog (`Found 3 model(s)`). Desktop Settings save-without-Test previously persisted only the typed model; Test/validate already returned the full catalog. GET list now live-probes the same catalog when `discover_models` is on.
