### PR TITLE
fix(image-gen): Grok Imagine 2.0 catalog entry must not default upscale on

### DIFF
--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -685,7 +685,11 @@ FAL_MODELS: Dict[str, Dict[str, Any]] = {
             "prompt", "aspect_ratio", "num_images", "output_format",
             "resolution", "quality", "sync_mode",
         },
-        "upscale": True,   # 1k native is sub-2MP
+        # Opt-in only (f06c41522e invariant: no catalog entry defaults
+        # upscale on — cost/latency surprise). 1k native is sub-2MP, so
+        # callers that need print-grade output should pass upscale
+        # explicitly, or bump `resolution` to 2k at +33%/image.
+        "upscale": False,
         # Edit endpoint takes `image_urls` (max 3) + the same knobs;
         # aspect_ratio defaults to "auto" (follows the first input image),
         # so we don't send it on edits.


### PR DESCRIPTION
## Summary

`test_upscale_defaults_are_all_off` is failing on main tip (`ceabb030fb`) and on every open PR whose test slice includes `tests/tools` — first noticed on #90038's slice 5/12, reproduced locally on a clean main worktree.

## Cause

`ceabb030fb` (Grok Imagine Image 2.0 FAL catalog entry) shipped with `"upscale": True`. The guard test added by `f06c41522e` pins the catalog invariant: no entry defaults upscaling on — it's opt-in per call because a default silently multiplies image cost and latency.

## Change

One line: `upscale: True` → `False` on the new entry, with the original rationale ('1k native is sub-2MP') kept as a comment steering callers to explicit `upscale` or the 2k `resolution` tier.

## Validation

`tests/tools/test_image_generation.py`: 51/51 locally on this branch; the single failing test reproduces on unmodified main tip.