### PR TITLE
fix(desktop): skip notarization on unsigned local builds

### DIFF
--- a/apps/desktop/scripts/notarize.mjs
+++ b/apps/desktop/scripts/notarize.mjs
@@ -53,6 +53,23 @@ export default async function notarize(context) {
   const { electronPlatformName, appOutDir, packager } = context
   if (electronPlatformName !== 'darwin') return
 
+  // Skip when code signing is disabled — stapler has nothing valid to staple
+  // and will fail with CloudKit "Record not found" (error 65). This happens on
+  // ad-hoc-signed local builds (CSC_IDENTITY_AUTO_DISCOVERY=false, no explicit
+  // identity) where BWS still re-injects APPLE_* vars, so the creds-present
+  // guard below is bypassed. Mirrors _force_adhoc_macos_signing in main.py.
+  const autoDiscoveryOff =
+    String(process.env.CSC_IDENTITY_AUTO_DISCOVERY || '').toLowerCase() === 'false'
+  const hasExplicitIdentity = Boolean(
+    process.env.CSC_LINK || process.env.CSC_NAME || process.env.APPLE_SIGNING_IDENTITY
+  )
+  if (autoDiscoveryOff && !hasExplicitIdentity) {
+    console.log(
+      'Skipping notarization: code signing disabled (CSC_IDENTITY_AUTO_DISCOVERY=false, no explicit identity)'
+    )
+    return
+  }
+
   const appName = packager.appInfo.productFilename
   const appPath = path.join(appOutDir, `${appName}.app`)
   if (!fs.existsSync(appPath)) {


### PR DESCRIPTION
## Problem

`hermes desktop --build-only` (and `npm run pack` in `apps/desktop`) fails at the very end — after vite build, esbuild bundle, and electron packaging all succeed — with:

```
CloudKit query for Hermes.app (2/…) failed due to "Record not found".
Could not find base64 encoded ticket in response for 2/…
The staple and validate action failed! Error 65.
    at …/apps/desktop/scripts/notarize.mjs
✗ Desktop GUI build failed
```

Exit code 1, and `~/.hermes/desktop-build-stamp.json` is never updated.

## Root cause

`scripts/notarize.mjs` is wired as electron-builder's `afterSign` hook. It only skips notarization when the `APPLE_API_KEY` / `APPLE_API_KEY_ID` / `APPLE_API_ISSUER` env vars are unset. But on local `--dir` builds, electron-builder itself skips code signing (`CSC_IDENTITY_AUTO_DISCOVERY=false`, set by `_force_adhoc_macos_signing` in `hermes_cli/main.py`), producing an ad-hoc-signed app.

Two things compound:

1. `notarize.mjs` still runs `xcrun notarytool submit` + `xcrun stapler staple` on the ad-hoc bundle. An ad-hoc app has no notarization ticket in Apple's CloudKit, so `stapler` fails with "Record not found" / Error 65 — permanently, not transiently (three identical failures in one session).
2. On BWS (Bitwarden Secrets Manager)-managed installs, the `APPLE_*` vars are re-injected on every process start ("applied N secrets"), so the "credentials not configured" early-return never triggers and notarization runs against the unsigned app.

The build itself is fine — `release/mac-arm64/Hermes.app` is fully packaged before the hook runs. Only the exit code and the build-stamp update are casualties.

## Fix

Skip notarization when code signing is disabled and no explicit identity is configured, mirroring `_force_adhoc_macos_signing`:

```js
const autoDiscoveryOff =
  String(process.env.CSC_IDENTITY_AUTO_DISCOVERY || '').toLowerCase() === 'false'
const hasExplicitIdentity = Boolean(
  process.env.CSC_LINK || process.env.CSC_NAME || process.env.APPLE_SIGNING_IDENTITY
)
if (autoDiscoveryOff && !hasExplicitIdentity) {
  console.log('Skipping notarization: code signing disabled (CSC_IDENTITY_AUTO_DISCOVERY=false, no explicit identity)')
  return
}
```

The `!hasExplicitIdentity` guard preserves notarization for the edge case where a caller disables auto-discovery but still supplies a concrete identity via `CSC_LINK` / `CSC_NAME`.

## Test plan

- `hermes desktop --build-only` on macOS arm64 now exits 0, prints `Skipping notarization: code signing disabled …`, and updates `desktop-build-stamp.json`.
- Confirmed the failure reproduces without the patch (identical CloudKit "Record not found" / Error 65) and is resolved with it.
