### PR TITLE
fix(bot-mode): unwrap connections registry object so 'Create on' picker renders

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -6158,7 +6158,7 @@ function CreateAgentDialog({ open, onClose, roster }) {
 
     host
       .connections()
-      .then(value => setConnections(Array.isArray(value) ? value : []))
+      .then(value => setConnections(Array.isArray(value?.connections) ? value.connections : []))
       .catch(() => setConnections([]))
   }, [open, connections])
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/cross-connection-bots.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/cross-connection-bots.test.mjs
@@ -162,3 +162,18 @@ test('source contract: group chat turns route through requestForBot on the membe
   // Room records persist remote member descriptors.
   assert.match(pluginSource, /members: Array\.isArray\(room\.members\) \? room\.members : \[\]/)
 })
+
+test('regression: host.connections() registry object is unwrapped before the picker gate', () => {
+  // host.connections() resolves the IPC handler hermes:connections:list, which
+  // returns the registry OBJECT ({version, primary, connections: [...]}) — not
+  // a bare array. The picker gate (Array.isArray(connections) && length > 1)
+  // never fired, so the "Create on" picker stayed hidden on multi-connection
+  // desktops. The plugin must unwrap .connections before storing.
+  assert.match(
+    pluginSource,
+    /setConnections\(Array\.isArray\(value\?\.connections\) \? value\.connections : \[\]\)/
+  )
+  // The built-in Connections UI consumes the registry object, so the IPC
+  // handler contract must NOT change to a bare array.
+  assert.doesNotMatch(pluginSource, /setConnections\(Array\.isArray\(value\) \? value : \[\]\)/)
+})


### PR DESCRIPTION
## Summary

Fixes #89823 — the Bot Mode **"Create on"** picker in the New Agent dialog never appears, even with multiple connections registered. The docs promise it: [bot-mode.md](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/bot-mode.md) — *"With more than one connection registered in Settings → Connections, the New Agent dialog grows a **Create on** picker."*

## Root cause

`host.connections()` resolves the IPC handler `hermes:connections:list`, which returns the **registry object** — not a bare array:

```js
// apps/desktop/electron/main.ts
ipcMain.handle('hermes:connections:list', async () => sanitizeConnectionsRegistry())
// →
{ version, primary, launchMode, lastUsed, secureTokenStorage, connections: [ ... ] }
```

The plugin stored it directly and the picker gated on `Array.isArray(...)`:

```js
// apps/desktop/src/plugins/hermes-bots/plugin.js
.then(value => setConnections(Array.isArray(value) ? value : []))
...
Array.isArray(connections) && connections.length > 1 ? labeled('Create on', ...) : null
```

So `connections` was always `[]`, the gate never fired, and the picker stayed hidden on multi-connection desktops.

## Fix

Unwrap the registry object in the plugin:

```js
.then(value => setConnections(Array.isArray(value?.connections) ? value.connections : []))
```

The IPC handler is deliberately **untouched**: the built-in Connections UI (`refreshConnectionsRegistry` in `apps/desktop/src/store/connections.ts`) consumes the same registry object (`registry.connections.some(...)`, `registry.primary`, `registry.lastUsed`), so changing the handler to a bare array would break that surface. The plugin is the only caller that misinterprets the shape.

## Test

Adds a regression test in `cross-connection-bots.test.mjs` asserting:
- the plugin unwraps `value.connections` before the picker gate, and
- the IPC contract (registry object) must not change to a bare array.

Plugin suite: **309/309 pass** (`npm run check:test:plugins`).

## Notes

Docs-only companion PR for the local "This device" connect-on-demand roster behaviour: #89790.
