### PR TITLE
fix(kanban): scope dispatcher policy to explicit board

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -9835,6 +9835,35 @@ def dispatch_once(
     boards tick in parallel. See :func:`_dispatch_tick_lock` for the
     cross-process / cross-platform mechanics.
     """
+    # Multi-board callers already resolved the authoritative board. Pin that
+    # identity for every nested policy lookup during this tick instead of
+    # allowing helpers to fall back to a stale process-global current board.
+    # Re-entering keeps the existing lock and observer paths single-shot while
+    # preserving compatibility for callers that omit ``board``.
+    if board is not None:
+        try:
+            normalized_board = _normalize_board_slug(board)
+        except ValueError:
+            # Preserve the pre-existing fail-soft dispatch path below. Invalid
+            # board input is handled by kanban_db_path() and its fallback;
+            # adding policy scoping must not turn it into an earlier crash.
+            normalized_board = None
+        if normalized_board and _CURRENT_BOARD_OVERRIDE.get() != normalized_board:
+            with scoped_current_board(normalized_board):
+                return dispatch_once(
+                    conn,
+                    spawn_fn=spawn_fn,
+                    ttl_seconds=ttl_seconds,
+                    dry_run=dry_run,
+                    max_spawn=max_spawn,
+                    max_in_progress=max_in_progress,
+                    failure_limit=failure_limit,
+                    stale_timeout_seconds=stale_timeout_seconds,
+                    board=normalized_board,
+                    default_assignee=default_assignee,
+                    max_in_progress_per_profile=max_in_progress_per_profile,
+                    reconcile_orphans=reconcile_orphans,
+                )
     try:
         db_path = kanban_db_path(board=board)
     except Exception:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import contextlib
 import os
 import sqlite3
 import subprocess
@@ -16,6 +17,97 @@ import pytest
 
 import hermes_state
 from hermes_cli import kanban_db as kb
+
+
+def test_dispatch_once_scopes_each_explicit_board_over_stale_global_selection(
+    kanban_home, monkeypatch, tmp_path
+):
+    """Alternating board ticks must not share ambient policy identity."""
+    boards = {"yibbles", "passive-income-engine"}
+    for slug in boards:
+        (kanban_home / "kanban" / "boards" / slug).mkdir(parents=True, exist_ok=True)
+    (kanban_home / "kanban" / "current").write_text(
+        "passive-income-engine\n", encoding="utf-8"
+    )
+
+    observed: list[tuple[str, bool]] = []
+
+    def fake_locked(conn, **kwargs):
+        observed.append((kb.get_current_board(), kwargs["reconcile_orphans"]))
+        return kb.DispatchResult()
+
+    monkeypatch.setattr(kb, "_dispatch_once_locked", fake_locked)
+    monkeypatch.setattr(kb, "board_exists", lambda slug: slug in boards)
+    monkeypatch.setattr(
+        kb, "kanban_db_path", lambda board=None: tmp_path / f"{board}.db"
+    )
+    monkeypatch.setattr(
+        kb, "_dispatch_tick_lock", lambda path: contextlib.nullcontext(True)
+    )
+    monkeypatch.setattr(kb, "_maybe_checkpoint_wal", lambda conn, path: None)
+    monkeypatch.setattr(kb, "_fire_dispatch_tick_hook", lambda *args, **kwargs: None)
+
+    with sqlite3.connect(":memory:") as conn:
+        kb.dispatch_once(conn, board="yibbles", reconcile_orphans=False)
+        kb.dispatch_once(conn, board="passive-income-engine")
+        kb.dispatch_once(conn, board="yibbles", reconcile_orphans=False)
+
+    assert observed == [
+        ("yibbles", False),
+        ("passive-income-engine", True),
+        ("yibbles", False),
+    ]
+    assert kb.get_current_board() == "passive-income-engine"
+
+
+def test_dispatch_once_preserves_fail_soft_malformed_board_handling(monkeypatch):
+    """Policy scoping must not preempt the existing invalid-path fallback."""
+    observed: list[str] = []
+
+    def fake_locked(conn, **kwargs):
+        observed.append(kwargs["board"])
+        return kb.DispatchResult()
+
+    monkeypatch.setattr(kb, "_dispatch_once_locked", fake_locked)
+    monkeypatch.setattr(
+        kb, "kanban_db_path", lambda board=None: (_ for _ in ()).throw(ValueError("bad board"))
+    )
+    monkeypatch.setattr(kb, "_fire_dispatch_tick_hook", lambda *args, **kwargs: None)
+
+    with sqlite3.connect(":memory:") as conn:
+        kb.dispatch_once(conn, board="not a valid board")
+
+    assert observed == ["not a valid board"]
+
+
+def test_dispatch_once_real_claim_hooks_keep_alternating_board_identity(
+    kanban_home, monkeypatch
+):
+    """Real claims must report the explicit board despite stale environment."""
+    from hermes_cli import profiles
+
+    for slug in ("yibbles", "passive-income-engine"):
+        kb.create_board(slug)
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "passive-income-engine")
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: True)
+    monkeypatch.setattr(kb, "_memory_pressure_level", lambda: "unknown")
+
+    claimed_boards: list[str] = []
+
+    def capture_hook(name, task_id, **kwargs):
+        if name == "kanban_task_claimed":
+            claimed_boards.append(kwargs["board"])
+
+    monkeypatch.setattr(kb, "_fire_kanban_lifecycle_hook", capture_hook)
+    monkeypatch.setattr(kb, "_fire_dispatch_tick_hook", lambda *args, **kwargs: None)
+
+    for index, slug in enumerate(("yibbles", "passive-income-engine", "yibbles")):
+        with kb.connect(board=slug) as conn:
+            kb.create_task(conn, title=f"claim-{index}", assignee="worker")
+            kb.dispatch_once(conn, board=slug, spawn_fn=lambda *args: 1000 + index)
+
+    assert claimed_boards == ["yibbles", "passive-income-engine", "yibbles"]
+    assert kb.get_current_board() == "passive-income-engine"
 
 
 @pytest.fixture


### PR DESCRIPTION
## What does this PR do?

Ensures an explicit `dispatch_once(board=...)` selection remains authoritative for every nested board lookup during that dispatcher tick.

Previously, nested helpers such as `claim_task()` could fall back to process-global current-board state. In a long-lived multi-board dispatcher, stale ambient state could therefore be reported or used as another board's identity. The dispatcher now enters `scoped_current_board()` for the explicit board and restores the ambient selection after the tick, including exception paths.

Malformed board input preserves the existing fail-soft dispatch behavior rather than raising earlier during scope setup.

## Related Issue

No existing issue or PR found after searching the repository for dispatcher board-isolation and `dispatch_once` board-scope terms.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Scope an explicit `dispatch_once(board=...)` tick to that normalized board.
- Preserve all current dispatch parameters, including `reconcile_orphans`.
- Preserve fail-soft handling for malformed board values.
- Add regression coverage for stale ambient selection, alternating explicit boards, real dispatch/claim lifecycle hooks, and malformed input.

## How to Test

```bash
PYTHONPATH=. python -m pytest \
  tests/hermes_cli/test_kanban_db.py::test_dispatch_once_scopes_each_explicit_board_over_stale_global_selection \
  tests/hermes_cli/test_kanban_db.py::test_dispatch_once_preserves_fail_soft_malformed_board_handling \
  tests/hermes_cli/test_kanban_db.py::test_dispatch_once_real_claim_hooks_keep_alternating_board_identity \
  -o 'addopts=' -q

PYTHONPATH=. python -m pytest tests/hermes_cli/test_kanban_db.py -o 'addopts=' -q
```

Observed on macOS:

- focused regressions: `3 passed`
- `tests/hermes_cli/test_kanban_db.py`: `33 passed, 1 skipped`
- `git diff --check`: clean

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and issues
- [x] My PR contains only changes related to this fix
- [ ] I've run the complete repository test suite — not run on this resource-constrained host; focused changed-surface tests are reported above
- [x] I've added tests for my changes
- [x] I've tested on macOS

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing API or config changed
- [x] `cli-config.yaml.example`: N/A; no config changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no workflow changed
- [x] Cross-platform impact considered; implementation uses existing `ContextVar`/context-manager infrastructure
- [x] Tool descriptions/schemas: N/A
