### PR TITLE
fix(constants): engage the warn-once latch on the first check, not only on the warning branch

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -83,6 +83,16 @@ def _warn_profile_fallback_once() -> None:
     global _profile_fallback_warned
     if _profile_fallback_warned:
         return
+    # Latch unconditionally, on the FIRST check regardless of outcome --
+    # matching the "one-shot" contract this function's own name/docstring
+    # already promise. Previously the latch was only set on the warning
+    # branch, so in the common case (no active_profile file, or it reads
+    # "default") the check silently re-ran on every single call: a fresh
+    # _get_platform_default_hermes_home() + exists() + possible read_text()
+    # from a function called at module-import time from 30+ sites (issue
+    # #90065). A profile activated mid-process after the first call is out
+    # of scope for a one-shot startup-time check either way.
+    _profile_fallback_warned = True
     try:
         fallback_home = _get_platform_default_hermes_home()
         active_path = fallback_home / "active_profile"
@@ -90,7 +100,6 @@ def _warn_profile_fallback_once() -> None:
     except (UnicodeDecodeError, OSError):
         active = ""
     if active and active != "default":
-        _profile_fallback_warned = True
         # Write directly to stderr.  We intentionally do NOT route this
         # through ``logging`` because (a) this function is called at
         # module-import time from 30+ sites, often before logging is

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -138,6 +138,90 @@ class TestGetHermesHome:
 
         assert get_hermes_home() == local_appdata / "hermes"
 
+    def test_warn_once_latch_engages_on_first_check_even_without_warning(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression for issue #90065: the latch was only set on the
+        WARNING branch, so in the common case (no active_profile file, or
+        it reads "default") the one-shot check the function's own name
+        and docstring promise never actually engaged -- every subsequent
+        get_hermes_home() call re-did the platform-default resolution,
+        an exists() stat, and a possible read_text(), from a function
+        called at module-import time from 30+ sites."""
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(hermes_constants, "_profile_fallback_warned", False)
+        # No active_profile file at all -- the common, non-warning case.
+        monkeypatch.setattr(
+            hermes_constants, "_get_platform_default_hermes_home", lambda: tmp_path
+        )
+
+        get_hermes_home()
+        assert hermes_constants._profile_fallback_warned is True, (
+            "the one-shot latch must engage on the first check, "
+            "regardless of whether it found anything to warn about"
+        )
+
+    def test_expensive_resolution_only_happens_once_across_many_calls(
+        self, tmp_path, monkeypatch
+    ):
+        """Direct behavioral proof of the fix's actual performance claim:
+        _get_platform_default_hermes_home() (the expensive path inside
+        _warn_profile_fallback_once) must be invoked at most once across
+        many get_hermes_home() calls when HERMES_HOME stays unset --
+        not once per call."""
+        from unittest.mock import patch
+
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(hermes_constants, "_profile_fallback_warned", False)
+
+        real = hermes_constants._get_platform_default_hermes_home
+        calls = []
+
+        def counting(*a, **kw):
+            calls.append(1)
+            return real(*a, **kw)
+
+        with patch.object(
+            hermes_constants, "_get_platform_default_hermes_home", counting
+        ):
+            for _ in range(50):
+                get_hermes_home()
+
+        # One EXTRA call comes from _warn_profile_fallback_once (now
+        # latched after its first invocation); the rest come from
+        # _hermes_home_from_env()'s own, separate, always-needed
+        # resolution of the actual return value, once per
+        # get_hermes_home() call -- that part is unaffected by this fix
+        # and correctly still runs every time.
+        assert len(calls) == 51, (
+            f"expected exactly 51 calls (50 from the always-needed path "
+            f"resolution, once per get_hermes_home() call, + 1 from the "
+            f"now-latched warn check firing only on the first call), got "
+            f"{len(calls)} -- if this is 100 the warn-check latch "
+            f"regressed back to firing on every call"
+        )
+
+    def test_warn_still_fires_correctly_when_a_non_default_profile_is_active(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Sanity: the fix must not break the actual warning it exists
+        to produce -- when a non-default profile genuinely is active,
+        the warning still fires (on the first check, matching the
+        one-shot contract)."""
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(hermes_constants, "_profile_fallback_warned", False)
+        (tmp_path / "active_profile").write_text("work", encoding="utf-8")
+        monkeypatch.setattr(
+            hermes_constants, "_get_platform_default_hermes_home", lambda: tmp_path
+        )
+
+        get_hermes_home()
+
+        assert hermes_constants._profile_fallback_warned is True
+        captured = capsys.readouterr()
+        assert "HERMES_HOME fallback" in captured.err
+        assert "'work'" in captured.err
+
 
 class TestGetProcessHermesHome:
     """Tests for get_process_hermes_home() — process launch scope.


### PR DESCRIPTION
Fixes #90065.

## Root cause

`_warn_profile_fallback_once()`'s own name and docstring promise a one-shot check, but the implementation only set the `_profile_fallback_warned` latch inside the warning branch. In the common case (no `active_profile` file, or it reads `"default"`), the latch never engaged, so every subsequent `get_hermes_home()` call (called from 30+ sites, often at module-import time) silently redid the platform-default resolution, an `exists()` stat, and a possible `read_text()`.

## Why this is a bug fix, not a new tradeoff

The issue's own option 1 ("latch after the first check") matches what the function's name and docstring already promise -- this is the implementation catching up to documented intent, not a new behavioral decision. A profile activated mid-process after the first call is out of scope for a one-shot startup-time check either way.

## Verification

Wall-clock timing proved noisy/environment-dependent in this sandbox, so verified directly via call counting instead: mocked the expensive resolution function and counted invocations across 100 calls. Before: 200 calls. After: 101 calls (99 fewer -- the extra 1 is the now-correctly-latched first invocation of the warn check).

Added 3 regression tests to the existing `TestGetHermesHome` class. Verified as genuine regressions by reverting just the latch placement and confirming 2/3 new tests fail with the exact call-count/latch-state symptoms.

64/69 pass in the modified test file (5 pre-existing Windows-only skips); 7/7 in the related profile-fallback suite (no regression).