### PR TITLE
skills hub: don't abort installs on missing referenced support files

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -28,6 +28,7 @@ from tools.skills_hub import (
     unified_search,
     append_audit_log,
     quarantine_bundle,
+    _referenced_support_paths,
 )
 
 
@@ -1804,3 +1805,70 @@ class TestLoadHermesIndex:
 
         data = hub._load_hermes_index()
         assert data == {"skills": [{"name": "stale"}]}
+
+
+# ---------------------------------------------------------------------------
+# Referenced-path extraction & missing support files (regression: a prose
+# glob or a repo-only dev tool referenced in SKILL.md must not abort install)
+# ---------------------------------------------------------------------------
+
+
+class TestReferencedSupportPaths:
+    def test_ignores_globs_placeholders_and_truncated_tokens(self):
+        md = (
+            "Load `references/type-*.md` before drawing, and "
+            "`references/type-<name>.md` for the matching type.\n"
+            "Real files: [flowchart](references/type-flowchart.md) and "
+            "`references/type-architecture.md`.\n"
+        )
+        assert _referenced_support_paths(md) == {
+            "references/type-flowchart.md",
+            "references/type-architecture.md",
+        }
+
+    def test_keeps_real_backtick_references(self):
+        md = "Run `python3 scripts/self_check.py <file>` and see `references/guide.md`.\n"
+        assert _referenced_support_paths(md) == {
+            "scripts/self_check.py",
+            "references/guide.md",
+        }
+
+
+class TestGitHubSourceFetchMissingReferencedFile:
+    def _source(self):
+        auth = MagicMock(spec=GitHubAuth)
+        return GitHubSource(auth=auth)
+
+    def test_fetch_skips_missing_referenced_file_and_keeps_the_rest(self):
+        md = (
+            "---\nname: demo\ndescription: demo\n---\n\n"
+            "See [guide](references/guide.md) and `references/missing.md`.\n"
+        )
+        tree_entries = [
+            {"path": "skills/demo/references/guide.md", "type": "blob", "mode": "100644"},
+        ]
+        source = self._source()
+        with patch.object(source, "_fetch_file_content", return_value=md), \
+             patch.object(source, "_get_repo_tree", return_value=("main", tree_entries)), \
+             patch.object(source, "_fetch_file_bytes", return_value=b"# guide"):
+            bundle = source.fetch("owner/repo/skills/demo")
+
+        assert bundle is not None
+        assert bundle.name == "demo"
+        # The present referenced file is bundled…
+        assert bundle.files["references/guide.md"] == b"# guide"
+        # …and the missing one is warned about and skipped, not fatal.
+        assert "references/missing.md" not in bundle.files
+
+
+class TestUrlSourceFetchMissingReferencedFile:
+    def test_fetch_skips_missing_referenced_file(self):
+        md = "---\nname: demo\ndescription: demo\n---\n\nSee `references/missing.md`.\n"
+        source = UrlSource()
+        with patch.object(source, "_fetch_text", return_value=md), \
+             patch.object(source, "_fetch_bytes", return_value=None):
+            bundle = source.fetch("https://example.com/skills/demo/SKILL.md")
+
+        assert bundle is not None
+        assert bundle.name == "demo"
+        assert "references/missing.md" not in bundle.files

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -175,6 +175,12 @@ def _referenced_support_paths(skill_md: str) -> Optional[set[str]]:
         except ValueError:
             return None
         if safe.split("/", 1)[0] in _ALLOWED_SUPPORT_DIRS:
+            # Prose globs/placeholders — e.g. ``references/type-*.md`` or
+            # ``references/type-<name>.md`` (which the regex truncates to the
+            # bare prefix ``references/type-``) — are agent instructions, not
+            # files. Only tokens that can name an actual file are references.
+            if re.search(r"[*?<>]", safe) or "." not in safe.rsplit("/", 1)[-1]:
+                continue
             paths.add(safe)
     return paths
 
@@ -676,22 +682,30 @@ class GitHubSource(SkillSource):
             for rel_path in sorted(referenced):
                 item_path = f"{prefix}{rel_path}"
                 item = entries_by_path.get(item_path)
+                # A missing or unfetchable support file (a repo-only dev tool,
+                # a prose mention, a transient API miss) must not abort the
+                # whole install — bundle what exists and warn about the rest.
                 if item is None:
-                    logger.warning("Referenced skill support file is missing: %s", item_path)
-                    return None
+                    logger.warning("Referenced skill support file is missing; "
+                                   "continuing without it: %s", item_path)
+                    continue
                 if item.get("type") != "blob" or item.get("mode") == "120000":
                     logger.warning("Rejected non-regular file in skill bundle: %s", item_path)
                     return None
                 content = self._fetch_file_bytes(repo, item_path)
                 if content is None:
-                    return None
+                    logger.warning("Failed to fetch referenced skill support "
+                                   "file; continuing without it: %s", item_path)
+                    continue
                 files[rel_path] = content
             revision = self._tree_revisions.get(repo) or branch
         else:
             for rel_path in referenced:
                 content = self._fetch_file_bytes(repo, f"{skill_path.rstrip('/')}/{rel_path}")
                 if content is None:
-                    return None
+                    logger.warning("Failed to fetch referenced skill support "
+                                   "file; continuing without it: %s", rel_path)
+                    continue
                 files[rel_path] = content
             revision = ""
 
@@ -1524,7 +1538,9 @@ class UrlSource(SkillSource):
                 return None
             content = self._fetch_bytes(support_url)
             if content is None:
-                return None
+                logger.warning("Failed to fetch referenced skill support "
+                               "file; continuing without it: %s", rel_path)
+                continue
             files[rel_path] = content
 
         # When auto-resolution fails, return a bundle with an empty name and


### PR DESCRIPTION
## Summary

A `SKILL.md` that merely *mentions* a support-path token which doesn't exist in the repo currently makes the whole install fail with `Error: Could not fetch ... from any source`. Two legitimate causes:

1. **Prose globs / placeholders** — e.g. `` `references/type-*.md` `` or `` `references/type-<name>.md` `` (the regex truncates the second to the bare prefix `references/type-`). These are agent instructions, not files.
2. **Repo-only dev tools** — skills that reference e.g. `scripts/verify-geometry.py` which the author documents as *not* shipped with the skill ("from an installed skill, manually check …").

Repro: `hermes skills install skills-sh/cathrynlavery/diagram-design/diagram-design` fails with "Could not fetch … from any source" even though all 44 real referenced files fetch fine.

## Changes

- **`_referenced_support_paths`**: skip glob/placeholder tokens (`* ? < >`) and bare prefix matches without a file extension — they can't name a real file.
- **`GitHubSource.fetch` / `UrlSource.fetch`**: when a referenced support file is missing or unfetchable, log a warning and continue bundling what exists instead of returning `None` for the whole bundle. Non-regular tree entries (git symlinks etc.) are still rejected as before.

## Tests

Added regression tests: reference-token filtering (globs/placeholders kept out, real backtick refs kept in) and missing-file behavior for both `GitHubSource` and `UrlSource` fetch loops.

`PYTHONPATH=. python -m pytest tests/tools/test_skills_hub.py` → **74 passed** (70 existing + 4 new). E2E verified: the `skills-sh/cathrynlavery/diagram-design/diagram-design` fetch now completes and reaches the security scan (previously died at fetch).

Relates to #90081.
