### PR TITLE
fix(agent): bridge Copilot ACP execute permissions

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -188,6 +188,51 @@ def _permission_denied(message_id: Any) -> dict[str, Any]:
     }
 
 
+def _permission_granted_once(message_id: Any, option_id: str) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": message_id,
+        "result": {
+            "outcome": {
+                "outcome": "selected",
+                "optionId": option_id,
+            }
+        },
+    }
+
+
+def _approved_execute_option(params: Any) -> str | None:
+    """Return an offered one-shot grant after Hermes approves the command."""
+    if not isinstance(params, dict):
+        return None
+    tool_call = params.get("toolCall") or {}
+    if not isinstance(tool_call, dict) or tool_call.get("kind") != "execute":
+        return None
+    raw_input = tool_call.get("rawInput") or {}
+    if not isinstance(raw_input, dict):
+        return None
+    command = raw_input.get("command")
+    if not isinstance(command, str) or not command.strip():
+        return None
+
+    try:
+        from tools.terminal_tool import _check_all_guards
+
+        decision = _check_all_guards(command.strip(), "local")
+    except Exception:
+        return None
+    if not isinstance(decision, dict) or decision.get("approved") is not True:
+        return None
+
+    for option in params.get("options") or []:
+        if not isinstance(option, dict) or option.get("kind") != "allow_once":
+            continue
+        option_id = option.get("optionId")
+        if isinstance(option_id, str) and option_id.strip():
+            return option_id
+    return None
+
+
 def _format_messages_as_prompt(
     messages: list[dict[str, Any]],
     model: str | None = None,
@@ -776,7 +821,12 @@ class CopilotACPClient:
         params = msg.get("params") or {}
 
         if method == "session/request_permission":
-            response = _permission_denied(message_id)
+            option_id = _approved_execute_option(params)
+            response = (
+                _permission_granted_once(message_id, option_id)
+                if option_id
+                else _permission_denied(message_id)
+            )
         elif method == "fs/read_text_file":
             try:
                 path = _ensure_path_within_cwd(str(params.get("path") or ""), cwd)

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -34,6 +34,15 @@ from tools.environments.local import hermes_subprocess_env
 ACP_MARKER_BASE_URL = "acp://copilot"
 _DEFAULT_TIMEOUT_SECONDS = 900.0
 
+_COPILOT_TOOLS_REPLACED_BY_HERMES_MCP = (
+    "bash",
+    "view",
+    "edit",
+    "create",
+    "grep",
+    "glob",
+)
+
 _TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
 _TOOL_CALL_JSON_RE = re.compile(r"\{\s*\"id\"\s*:\s*\"[^\"]+\"\s*,\s*\"type\"\s*:\s*\"function\"\s*,\s*\"function\"\s*:\s*\{.*?\}\s*\}", re.DOTALL)
 
@@ -234,6 +243,72 @@ def _approved_execute_option(params: Any) -> str | None:
     return None
 
 
+def _copilot_mcp_cli_config(
+    mcp_servers: list[dict[str, Any]] | None,
+) -> dict[str, Any] | None:
+    """Translate ACP MCP entries to Copilot CLI additional-MCP config."""
+    configured: dict[str, dict[str, Any]] = {}
+    for server in mcp_servers or []:
+        if not isinstance(server, dict):
+            continue
+        name = server.get("name")
+        command = server.get("command")
+        server_args = server.get("args")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        if not isinstance(command, str) or not command.strip():
+            continue
+        if not isinstance(server_args, list) or not all(
+            isinstance(arg, str) for arg in server_args
+        ):
+            continue
+        server_env: dict[str, str] = {}
+        for item in server.get("env") or []:
+            if not isinstance(item, dict):
+                continue
+            env_name = item.get("name")
+            env_value = item.get("value")
+            if isinstance(env_name, str) and isinstance(env_value, str):
+                server_env[env_name] = env_value
+        configured[name.strip()] = {
+            "type": "local",
+            "command": command.strip(),
+            "args": server_args,
+            "env": server_env,
+            "tools": ["*"],
+        }
+    if not configured:
+        return None
+    return {"mcpServers": configured}
+
+
+def _copilot_args_for_hermes_mcp(
+    args: list[str],
+    *,
+    mcp_servers: list[dict[str, Any]] | None,
+) -> list[str]:
+    """Inject Hermes MCP and route duplicate Copilot tools through Hermes."""
+    effective = list(args)
+    mcp_config = _copilot_mcp_cli_config(mcp_servers)
+    if mcp_config is None:
+        return effective
+    has_explicit_tool_filter = any(
+        arg == "--available-tools"
+        or arg.startswith("--available-tools=")
+        or arg == "--excluded-tools"
+        or arg.startswith("--excluded-tools=")
+        for arg in effective
+    )
+    if not has_explicit_tool_filter:
+        effective.extend(
+            ["--excluded-tools", *_COPILOT_TOOLS_REPLACED_BY_HERMES_MCP]
+        )
+    effective.extend(
+        ["--additional-mcp-config", json.dumps(mcp_config, ensure_ascii=False)]
+    )
+    return effective
+
+
 def _hermes_tools_mcp_bridge(
     tools: list[dict[str, Any]] | None,
 ) -> tuple[list[dict[str, Any]], set[str]]:
@@ -254,11 +329,11 @@ def _hermes_tools_mcp_bridge(
 
     from agent.transports.hermes_tools_mcp_server import (
         ALLOWED_TOOLS_ENV,
-        EXPOSED_TOOLS,
+        COPILOT_EXPOSED_TOOLS,
         TOOL_SCHEMAS_ENV,
     )
 
-    native_tool_names = set(requested).intersection(EXPOSED_TOOLS)
+    native_tool_names = set(requested).intersection(COPILOT_EXPOSED_TOOLS)
     if not native_tool_names:
         return [], set()
 
@@ -532,6 +607,18 @@ def _extract_tool_calls_from_text(text: str) -> tuple[list[ChatCompletionMessage
     return extracted, cleaned
 
 
+def _strip_copilot_tool_filter_notice(text: str) -> str:
+    """Remove the deterministic CLI notice produced by our tool filter."""
+    if not isinstance(text, str):
+        return text
+    notice = "Info: Disabled tools: " + ", ".join(
+        sorted(_COPILOT_TOOLS_REPLACED_BY_HERMES_MCP)
+    )
+    if text.startswith(notice):
+        return text[len(notice):].lstrip()
+    return text
+
+
 
 def _ensure_path_within_cwd(path_text: str, cwd: str) -> Path:
     candidate = Path(path_text)
@@ -644,6 +731,7 @@ class CopilotACPClient:
             mcp_servers=mcp_servers,
         )
 
+        response_text = _strip_copilot_tool_filter_notice(response_text)
         tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)
 
         usage = SimpleNamespace(
@@ -677,6 +765,10 @@ class CopilotACPClient:
         timeout_seconds: float,
         mcp_servers: list[dict[str, Any]] | None = None,
     ) -> tuple[str, str]:
+        effective_acp_args = _copilot_args_for_hermes_mcp(
+            self._acp_args,
+            mcp_servers=mcp_servers,
+        )
         # Fast-fail when the CLI doesn't support the ACP args we'd pass.
         # Without this guard, a CLI like Claude Code v2.x exits with
         # ``error: unknown option '--acp'`` immediately, then the parent
@@ -686,8 +778,8 @@ class CopilotACPClient:
         # ``None`` (inconclusive probe — e.g. binary missing) falls
         # through to the spawn below, which raises the established
         # "Could not start Copilot ACP command" error.
-        if _acp_supported(self._acp_command, self._acp_args) is False:
-            preview = " ".join(self._acp_args[:3]) if self._acp_args else "(none)"
+        if _acp_supported(self._acp_command, effective_acp_args) is False:
+            preview = " ".join(effective_acp_args[:3]) if effective_acp_args else "(none)"
             raise RuntimeError(
                 f"ACP transport not supported by '{self._acp_command}': "
                 f"`{preview}` is rejected as an unknown option. "
@@ -705,7 +797,7 @@ class CopilotACPClient:
             from hermes_cli._subprocess_compat import windows_hide_flags
 
             proc = subprocess.Popen(
-                [self._acp_command] + self._acp_args,
+                [self._acp_command] + effective_acp_args,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -836,7 +928,10 @@ class CopilotACPClient:
                 "session/new",
                 {
                     "cwd": self._acp_cwd,
-                    "mcpServers": mcp_servers or [],
+                    # Copilot CLI currently ignores ACP session-scoped MCP
+                    # entries, so they are injected at process startup via
+                    # --additional-mcp-config instead.
+                    "mcpServers": [],
                 },
             ) or {}
             session_id = str(session.get("sessionId") or "").strip()

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -14,6 +14,7 @@ import queue
 import re
 import shlex
 import subprocess
+import sys
 import threading
 import time
 from collections import deque
@@ -233,16 +234,71 @@ def _approved_execute_option(params: Any) -> str | None:
     return None
 
 
+def _hermes_tools_mcp_bridge(
+    tools: list[dict[str, Any]] | None,
+) -> tuple[list[dict[str, Any]], set[str]]:
+    """Build a turn-scoped ACP MCP server for supported Hermes tools."""
+    if not isinstance(tools, list) or not tools:
+        return [], set()
+
+    requested: dict[str, dict[str, Any]] = {}
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        function = tool.get("function") or {}
+        if not isinstance(function, dict):
+            continue
+        name = function.get("name")
+        if isinstance(name, str) and name.strip():
+            requested[name.strip()] = function
+
+    from agent.transports.hermes_tools_mcp_server import (
+        ALLOWED_TOOLS_ENV,
+        EXPOSED_TOOLS,
+        TOOL_SCHEMAS_ENV,
+    )
+
+    native_tool_names = set(requested).intersection(EXPOSED_TOOLS)
+    if not native_tool_names:
+        return [], set()
+
+    allowed = sorted(native_tool_names)
+    return [
+        {
+            "name": "hermes-tools",
+            "command": sys.executable,
+            "args": ["-m", "agent.transports.hermes_tools_mcp_server"],
+            "env": [
+                {
+                    "name": ALLOWED_TOOLS_ENV,
+                    "value": json.dumps(allowed),
+                },
+                {
+                    "name": TOOL_SCHEMAS_ENV,
+                    "value": json.dumps(
+                        {name: requested[name] for name in allowed},
+                        ensure_ascii=False,
+                    ),
+                }
+            ],
+        }
+    ], native_tool_names
+
+
 def _format_messages_as_prompt(
     messages: list[dict[str, Any]],
     model: str | None = None,
     tools: list[dict[str, Any]] | None = None,
     tool_choice: Any = None,
+    native_tool_names: set[str] | None = None,
 ) -> str:
+    native_tool_names = native_tool_names or set()
     sections: list[str] = [
         "You are being used as the active ACP agent backend for Hermes.",
         "Use ACP capabilities to complete tasks.",
-        "IMPORTANT: If you take an action with a tool, you MUST output tool calls using <tool_call>{...}</tool_call> blocks with JSON exactly in OpenAI function-call shape.",
+        "For native ACP/MCP tools, call the tool directly and continue from its result. "
+        "For prompt-described Hermes tools, output tool calls using "
+        "<tool_call>{...}</tool_call> blocks with JSON exactly in OpenAI function-call shape.",
         "If no tool is needed, answer normally.",
     ]
     if model:
@@ -259,6 +315,8 @@ def _format_messages_as_prompt(
             name = fn.get("name")
             if not isinstance(name, str) or not name.strip():
                 continue
+            if name.strip() in native_tool_names:
+                continue
             tool_specs.append(
                 {
                     "name": name.strip(),
@@ -273,6 +331,15 @@ def _format_messages_as_prompt(
                 "containing id/type/function{name,arguments}. arguments must be a JSON string.\n"
                 + json.dumps(tool_specs, ensure_ascii=False)
             )
+
+    if native_tool_names:
+        sections.append(
+            "Native Hermes MCP tools available in this ACP session: "
+            + ", ".join(sorted(native_tool_names))
+            + ". When one matches the user's request, you MUST use it instead of "
+            "substituting shell commands or filesystem inspection. Treat its result as "
+            "authoritative. Call it directly; do not print an XML tool_call for it."
+        )
 
     if tool_choice is not None:
         sections.append(f"Tool choice hint: {json.dumps(tool_choice, ensure_ascii=False)}")
@@ -547,11 +614,13 @@ class CopilotACPClient:
         stream: bool = False,
         **_: Any,
     ) -> Any:
+        mcp_servers, native_tool_names = _hermes_tools_mcp_bridge(tools)
         prompt_text = _format_messages_as_prompt(
             messages or [],
             model=model,
             tools=tools,
             tool_choice=tool_choice,
+            native_tool_names=native_tool_names,
         )
         # Normalise timeout: run_agent.py may pass an httpx.Timeout object
         # (used natively by the OpenAI SDK) rather than a plain float.
@@ -572,6 +641,7 @@ class CopilotACPClient:
         response_text, reasoning_text = self._run_prompt(
             prompt_text,
             timeout_seconds=_effective_timeout,
+            mcp_servers=mcp_servers,
         )
 
         tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)
@@ -600,7 +670,13 @@ class CopilotACPClient:
             return _completion_to_stream_chunks(completion)
         return completion
 
-    def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
+    def _run_prompt(
+        self,
+        prompt_text: str,
+        *,
+        timeout_seconds: float,
+        mcp_servers: list[dict[str, Any]] | None = None,
+    ) -> tuple[str, str]:
         # Fast-fail when the CLI doesn't support the ACP args we'd pass.
         # Without this guard, a CLI like Claude Code v2.x exits with
         # ``error: unknown option '--acp'`` immediately, then the parent
@@ -760,7 +836,7 @@ class CopilotACPClient:
                 "session/new",
                 {
                     "cwd": self._acp_cwd,
-                    "mcpServers": [],
+                    "mcpServers": mcp_servers or [],
                 },
             ) or {}
             session_id = str(session.get("sessionId") or "").strip()

--- a/agent/transports/hermes_tools_mcp_server.py
+++ b/agent/transports/hermes_tools_mcp_server.py
@@ -1,4 +1,4 @@
-"""Hermes-tools-as-MCP server for the codex_app_server runtime.
+"""Hermes-tools-as-MCP server for Codex and Copilot ACP runtimes.
 
 When the user runs `openai/*` turns through the codex app-server, codex
 owns the loop and builds its own tool list. By default, that means
@@ -38,8 +38,8 @@ What we DO NOT expose:
                                            comment on EXPOSED_TOOLS below.
 
 Run with: python -m agent.transports.hermes_tools_mcp_server
-Spawned by: CodexAppServerSession.ensure_started() when the runtime is
-            active and config opts in.
+Spawned by: CodexAppServerSession.ensure_started(), or by the Copilot ACP
+            client with a per-turn allowlist and schemas.
 """
 
 from __future__ import annotations
@@ -52,6 +52,9 @@ import sys
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
+
+ALLOWED_TOOLS_ENV = "HERMES_TOOLS_MCP_ALLOWED"
+TOOL_SCHEMAS_ENV = "HERMES_TOOLS_MCP_SCHEMAS"
 
 # JSON Schema type -> Python type mapping for signature generation
 _JSON_TO_PY = {
@@ -151,6 +154,47 @@ EXPOSED_TOOLS: tuple[str, ...] = (
 )
 
 
+def _configured_exposed_tools() -> tuple[str, ...]:
+    """Return the caller-scoped tool subset, preserving the legacy default."""
+    raw = os.getenv(ALLOWED_TOOLS_ENV)
+    if raw is None:
+        return EXPOSED_TOOLS
+    try:
+        requested = json.loads(raw)
+    except (TypeError, ValueError):
+        return ()
+    if not isinstance(requested, list):
+        return ()
+    allowed = {name for name in requested if isinstance(name, str)}
+    return tuple(name for name in EXPOSED_TOOLS if name in allowed)
+
+
+def _configured_tool_specs(
+    configured_tools: tuple[str, ...],
+) -> dict[str, dict[str, Any]] | None:
+    """Load caller-supplied schemas, or signal the legacy discovery path."""
+    raw = os.getenv(TOOL_SCHEMAS_ENV)
+    if raw is None:
+        return None
+    try:
+        supplied = json.loads(raw)
+    except (TypeError, ValueError):
+        return {}
+    if not isinstance(supplied, dict):
+        return {}
+
+    specs: dict[str, dict[str, Any]] = {}
+    for name in configured_tools:
+        spec = supplied.get(name)
+        if not isinstance(spec, dict) or spec.get("name") != name:
+            continue
+        parameters = spec.get("parameters")
+        if not isinstance(parameters, dict):
+            continue
+        specs[name] = spec
+    return specs
+
+
 def _build_server() -> Any:
     """Create the MCP server with Hermes tools attached. Lazy imports
     so the module can be imported without the mcp package installed
@@ -164,12 +208,6 @@ def _build_server() -> Any:
             f"hermes-tools MCP server requires the 'mcp' package: {exc}"
         ) from exc
 
-    # Discover Hermes tools so dispatch works.
-    from model_tools import (
-        get_tool_definitions,
-        handle_function_call,
-    )
-
     mcp = MCPServer(
         "hermes-tools",
         instructions=(
@@ -181,17 +219,22 @@ def _build_server() -> Any:
         ),
     )
 
-    # Pull authoritative Hermes tool schemas for the ones we expose, so
-    # MCP clients see the same parameter docs Hermes gives the model.
-    all_defs = {
-        td["function"]["name"]: td["function"]
-        for td in (get_tool_definitions(quiet_mode=True) or [])
-        if isinstance(td, dict) and td.get("type") == "function"
-    }
+    configured_tools = _configured_exposed_tools()
+    all_defs = _configured_tool_specs(configured_tools)
+    if all_defs is None:
+        # Legacy Codex app-server path: no turn-scoped schemas were supplied,
+        # so discover the authoritative Hermes registry as before.
+        from model_tools import get_tool_definitions
+
+        all_defs = {
+            td["function"]["name"]: td["function"]
+            for td in (get_tool_definitions(quiet_mode=True) or [])
+            if isinstance(td, dict) and td.get("type") == "function"
+        }
 
     exposed_count = 0
 
-    for name in EXPOSED_TOOLS:
+    for name in configured_tools:
         spec = all_defs.get(name)
         if spec is None:
             logger.debug(
@@ -216,6 +259,17 @@ def _build_server() -> Any:
                     # Filter out None values before dispatch so unset optionals
                     # aren't forwarded to the handler.
                     args = {k: v for k, v in kwargs.items() if v is not None}
+                    if tool_name == "skills_list":
+                        from tools.skills_tool import skills_list
+
+                        return skills_list(**args)
+                    if tool_name == "skill_view":
+                        from tools.skills_tool import skill_view
+
+                        return skill_view(**args)
+
+                    from model_tools import handle_function_call
+
                     return handle_function_call(tool_name, args or {})
                 except Exception as exc:
                     logger.exception("tool %s raised", tool_name)
@@ -245,7 +299,7 @@ def _build_server() -> Any:
     logger.info(
         "hermes-tools MCP server registered %d/%d tools",
         exposed_count,
-        len(EXPOSED_TOOLS),
+        len(configured_tools),
     )
     return mcp
 

--- a/agent/transports/hermes_tools_mcp_server.py
+++ b/agent/transports/hermes_tools_mcp_server.py
@@ -153,6 +153,19 @@ EXPOSED_TOOLS: tuple[str, ...] = (
     "kanban_link",
 )
 
+# Copilot ACP disables duplicate built-in tools when this bridge is active, so
+# the ordinary Hermes file/process tools must also be available through the
+# turn-scoped MCP server. Keep EXPOSED_TOOLS unchanged for the Codex runtime,
+# where Codex's native sandboxed equivalents remain preferable.
+COPILOT_EXPOSED_TOOLS: tuple[str, ...] = EXPOSED_TOOLS + (
+    "terminal",
+    "read_file",
+    "write_file",
+    "patch",
+    "search_files",
+    "process",
+)
+
 
 def _configured_exposed_tools() -> tuple[str, ...]:
     """Return the caller-scoped tool subset, preserving the legacy default."""
@@ -166,7 +179,12 @@ def _configured_exposed_tools() -> tuple[str, ...]:
     if not isinstance(requested, list):
         return ()
     allowed = {name for name in requested if isinstance(name, str)}
-    return tuple(name for name in EXPOSED_TOOLS if name in allowed)
+    available = (
+        COPILOT_EXPOSED_TOOLS
+        if os.getenv(TOOL_SCHEMAS_ENV) is not None
+        else EXPOSED_TOOLS
+    )
+    return tuple(name for name in available if name in allowed)
 
 
 def _configured_tool_specs(

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -22,8 +22,6 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
     def setUp(self) -> None:
         self.client = CopilotACPClient(acp_cwd="/tmp")
 
-
-
     def test_stream_true_preserves_tool_call_deltas(self) -> None:
         tool_response = (
             "<tool_call>"
@@ -54,7 +52,6 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
         )
         self.assertEqual(chunks[1].choices, [])
 
-
     def _dispatch(self, message: dict, *, cwd: str) -> dict:
         process = _FakeProcess()
         handled = self.client._handle_server_message(
@@ -69,7 +66,156 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
         self.assertTrue(payload)
         return json.loads(payload)
 
+    def test_execute_permission_uses_hermes_guard_and_selects_allow_once(self) -> None:
+        request = {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "session/request_permission",
+            "params": {
+                "toolCall": {
+                    "kind": "execute",
+                    "title": "Read project metadata",
+                    "rawInput": {"command": "head -n 1 pyproject.toml"},
+                },
+                "options": [
+                    {"optionId": "allow_once", "kind": "allow_once"},
+                    {"optionId": "allow_always", "kind": "allow_always"},
+                    {"optionId": "reject_once", "kind": "reject_once"},
+                ],
+            },
+        }
 
+        with patch(
+            "tools.terminal_tool._check_all_guards",
+            return_value={"approved": True, "message": None},
+        ) as guard:
+            response = self._dispatch(request, cwd="/tmp")
+
+        guard.assert_called_once_with("head -n 1 pyproject.toml", "local")
+        self.assertEqual(
+            response["result"]["outcome"],
+            {"outcome": "selected", "optionId": "allow_once"},
+        )
+
+    def test_execute_permission_denies_when_hermes_guard_blocks(self) -> None:
+        request = {
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "session/request_permission",
+            "params": {
+                "toolCall": {
+                    "kind": "execute",
+                    "rawInput": {"command": "rm -rf /"},
+                },
+                "options": [
+                    {"optionId": "allow_once", "kind": "allow_once"},
+                    {"optionId": "reject_once", "kind": "reject_once"},
+                ],
+            },
+        }
+
+        with patch(
+            "tools.terminal_tool._check_all_guards",
+            return_value={"approved": False, "message": "hardline block"},
+        ):
+            response = self._dispatch(request, cwd="/tmp")
+
+        self.assertEqual(
+            response["result"]["outcome"],
+            {"outcome": "cancelled"},
+        )
+
+    def test_execute_permission_never_upgrades_to_allow_always(self) -> None:
+        request = {
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "session/request_permission",
+            "params": {
+                "toolCall": {
+                    "kind": "execute",
+                    "rawInput": {"command": "head -n 1 pyproject.toml"},
+                },
+                "options": [
+                    {"optionId": "allow_always", "kind": "allow_always"},
+                    {"optionId": "reject_once", "kind": "reject_once"},
+                ],
+            },
+        }
+
+        with patch(
+            "tools.terminal_tool._check_all_guards",
+            return_value={"approved": True, "message": None},
+        ):
+            response = self._dispatch(request, cwd="/tmp")
+
+        self.assertEqual(
+            response["result"]["outcome"],
+            {"outcome": "cancelled"},
+        )
+
+    def test_permission_without_execute_command_fails_closed(self) -> None:
+        request = {
+            "jsonrpc": "2.0",
+            "id": 10,
+            "method": "session/request_permission",
+            "params": {
+                "toolCall": {"kind": "edit", "rawInput": {"path": "note.md"}},
+                "options": [
+                    {"optionId": "allow_once", "kind": "allow_once"},
+                ],
+            },
+        }
+
+        with patch("tools.terminal_tool._check_all_guards") as guard:
+            response = self._dispatch(request, cwd="/tmp")
+
+        guard.assert_not_called()
+        self.assertEqual(
+            response["result"]["outcome"],
+            {"outcome": "cancelled"},
+        )
+
+    def test_permission_guard_exception_fails_closed(self) -> None:
+        request = {
+            "jsonrpc": "2.0",
+            "id": 11,
+            "method": "session/request_permission",
+            "params": {
+                "toolCall": {
+                    "kind": "execute",
+                    "rawInput": {"command": "head -n 1 pyproject.toml"},
+                },
+                "options": [
+                    {"optionId": "allow_once", "kind": "allow_once"},
+                ],
+            },
+        }
+
+        with patch(
+            "tools.terminal_tool._check_all_guards",
+            side_effect=RuntimeError("guard unavailable"),
+        ):
+            response = self._dispatch(request, cwd="/tmp")
+
+        self.assertEqual(
+            response["result"]["outcome"],
+            {"outcome": "cancelled"},
+        )
+
+    def test_permission_with_malformed_params_fails_closed(self) -> None:
+        request = {
+            "jsonrpc": "2.0",
+            "id": 12,
+            "method": "session/request_permission",
+            "params": ["not", "an", "object"],
+        }
+
+        response = self._dispatch(request, cwd="/tmp")
+
+        self.assertEqual(
+            response["result"]["outcome"],
+            {"outcome": "cancelled"},
+        )
 
     def test_read_text_file_redacts_sensitive_content(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -10,7 +10,10 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from agent.copilot_acp_client import CopilotACPClient
+from agent.copilot_acp_client import (
+    CopilotACPClient,
+    _hermes_tools_mcp_bridge,
+)
 
 
 class _FakeProcess:
@@ -51,6 +54,84 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
             {"path": "README.md"},
         )
         self.assertEqual(chunks[1].choices, [])
+
+    def test_hermes_tools_mcp_bridge_exposes_only_requested_safe_tools(self) -> None:
+        tools = [
+            {
+                "type": "function",
+                "function": {"name": name, "description": "", "parameters": {}},
+            }
+            for name in ("skills_list", "web_search", "terminal", "unknown_tool")
+        ]
+
+        servers, native_tool_names = _hermes_tools_mcp_bridge(tools)
+
+        self.assertEqual(native_tool_names, {"skills_list", "web_search"})
+        self.assertEqual(len(servers), 1)
+        server = servers[0]
+        self.assertEqual(server["name"], "hermes-tools")
+        self.assertEqual(
+            server["args"],
+            ["-m", "agent.transports.hermes_tools_mcp_server"],
+        )
+        env = {item["name"]: item["value"] for item in server["env"]}
+        self.assertEqual(
+            json.loads(env["HERMES_TOOLS_MCP_ALLOWED"]),
+            ["skills_list", "web_search"],
+        )
+        schemas = json.loads(env["HERMES_TOOLS_MCP_SCHEMAS"])
+        self.assertEqual(set(schemas), {"skills_list", "web_search"})
+        self.assertNotIn("terminal", schemas)
+
+    def test_hermes_tools_mcp_bridge_is_absent_without_matching_tools(self) -> None:
+        servers, native_tool_names = _hermes_tools_mcp_bridge(
+            [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "terminal",
+                        "description": "",
+                        "parameters": {},
+                    },
+                }
+            ]
+        )
+
+        self.assertEqual(servers, [])
+        self.assertEqual(native_tool_names, set())
+
+    def test_native_mcp_tools_are_not_duplicated_as_xml_tool_specs(self) -> None:
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "skills_list",
+                    "description": "List Hermes skills",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+
+        with patch.object(
+            self.client,
+            "_run_prompt",
+            return_value=("260 skills", ""),
+        ) as run_prompt:
+            self.client._create_chat_completion(
+                model="copilot-acp",
+                messages=[{"role": "user", "content": "count skills"}],
+                tools=tools,
+            )
+
+        prompt_text = run_prompt.call_args.args[0]
+        self.assertIn("skills_list", prompt_text)
+        self.assertIn("MUST use it", prompt_text)
+        self.assertIn("authoritative", prompt_text)
+        self.assertNotIn('"name": "skills_list"', prompt_text)
+        self.assertEqual(
+            run_prompt.call_args.kwargs["mcp_servers"][0]["name"],
+            "hermes-tools",
+        )
 
     def _dispatch(self, message: dict, *, cwd: str) -> dict:
         process = _FakeProcess()

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -12,6 +12,8 @@ from unittest.mock import patch
 
 from agent.copilot_acp_client import (
     CopilotACPClient,
+    _copilot_args_for_hermes_mcp,
+    _copilot_mcp_cli_config,
     _hermes_tools_mcp_bridge,
 )
 
@@ -66,7 +68,10 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
 
         servers, native_tool_names = _hermes_tools_mcp_bridge(tools)
 
-        self.assertEqual(native_tool_names, {"skills_list", "web_search"})
+        self.assertEqual(
+            native_tool_names,
+            {"skills_list", "terminal", "web_search"},
+        )
         self.assertEqual(len(servers), 1)
         server = servers[0]
         self.assertEqual(server["name"], "hermes-tools")
@@ -77,11 +82,94 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
         env = {item["name"]: item["value"] for item in server["env"]}
         self.assertEqual(
             json.loads(env["HERMES_TOOLS_MCP_ALLOWED"]),
-            ["skills_list", "web_search"],
+            ["skills_list", "terminal", "web_search"],
         )
         schemas = json.loads(env["HERMES_TOOLS_MCP_SCHEMAS"])
-        self.assertEqual(set(schemas), {"skills_list", "web_search"})
-        self.assertNotIn("terminal", schemas)
+        self.assertEqual(set(schemas), {"skills_list", "terminal", "web_search"})
+
+    def test_hermes_mcp_disables_copilot_bash_by_default(self) -> None:
+        servers, _ = _hermes_tools_mcp_bridge(
+            [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "skills_list",
+                        "description": "List skills",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ]
+        )
+
+        effective = _copilot_args_for_hermes_mcp(
+            ["--acp", "--stdio"],
+            mcp_servers=servers,
+        )
+
+        self.assertEqual(effective[:3], ["--acp", "--stdio", "--excluded-tools"])
+        self.assertIn("bash", effective)
+        self.assertNotIn("apply_patch", effective)
+        config_index = effective.index("--additional-mcp-config") + 1
+        config = json.loads(effective[config_index])
+        self.assertEqual(
+            config["mcpServers"]["hermes-tools"]["tools"],
+            ["*"],
+        )
+        self.assertIn(
+            "HERMES_TOOLS_MCP_ALLOWED",
+            config["mcpServers"]["hermes-tools"]["env"],
+        )
+
+    def test_explicit_copilot_tool_filter_is_preserved(self) -> None:
+        args = ["--acp", "--stdio", "--excluded-tools", "shell"]
+
+        servers, _ = _hermes_tools_mcp_bridge(
+            [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "skills_list",
+                        "description": "List skills",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ]
+        )
+
+        effective = _copilot_args_for_hermes_mcp(args, mcp_servers=servers)
+
+        self.assertEqual(effective[: len(args)], args)
+        self.assertEqual(effective.count("--excluded-tools"), 1)
+        self.assertIn("--additional-mcp-config", effective)
+
+    def test_invalid_mcp_entries_do_not_change_copilot_args(self) -> None:
+        args = ["--acp", "--stdio"]
+
+        self.assertIsNone(_copilot_mcp_cli_config([{"name": "broken"}]))
+        self.assertEqual(
+            _copilot_args_for_hermes_mcp(
+                args,
+                mcp_servers=[{"name": "broken"}],
+            ),
+            args,
+        )
+
+    def test_copilot_tool_filter_notice_is_not_returned_to_user(self) -> None:
+        notice = "Info: Disabled tools: bash, create, edit, glob, grep, view"
+        with patch.object(
+            self.client,
+            "_run_prompt",
+            return_value=(notice + "Hermes has 260 skills.", ""),
+        ):
+            completion = self.client._create_chat_completion(
+                model="copilot-acp",
+                messages=[{"role": "user", "content": "count skills"}],
+            )
+
+        self.assertEqual(
+            completion.choices[0].message.content,
+            "Hermes has 260 skills.",
+        )
 
     def test_hermes_tools_mcp_bridge_is_absent_without_matching_tools(self) -> None:
         servers, native_tool_names = _hermes_tools_mcp_bridge(
@@ -89,7 +177,7 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
                 {
                     "type": "function",
                     "function": {
-                        "name": "terminal",
+                        "name": "delegate_task",
                         "description": "",
                         "parameters": {},
                     },

--- a/tests/agent/transports/test_hermes_tools_mcp_server.py
+++ b/tests/agent/transports/test_hermes_tools_mcp_server.py
@@ -118,6 +118,17 @@ class TestModuleSurface:
 
         assert m._configured_exposed_tools() == ("skills_list",)
 
+    def test_turn_scoped_schema_mode_can_expose_hermes_terminal(self, monkeypatch):
+        from agent.transports import hermes_tools_mcp_server as m
+
+        monkeypatch.setenv(
+            "HERMES_TOOLS_MCP_ALLOWED",
+            json.dumps(["skills_list", "terminal"]),
+        )
+        monkeypatch.setenv("HERMES_TOOLS_MCP_SCHEMAS", "{}")
+
+        assert m._configured_exposed_tools() == ("skills_list", "terminal")
+
     def test_missing_allowed_tools_env_preserves_existing_codex_contract(
         self, monkeypatch
     ):

--- a/tests/agent/transports/test_hermes_tools_mcp_server.py
+++ b/tests/agent/transports/test_hermes_tools_mcp_server.py
@@ -9,6 +9,7 @@ build helper assembles a server when the SDK is present.
 from __future__ import annotations
 
 import inspect
+import json
 from typing import get_args
 
 from agent.transports.hermes_tools_mcp_server import (
@@ -106,6 +107,51 @@ class TestModuleSurface:
             f"these tools must NOT be exposed via the codex callback "
             f"because codex has built-in equivalents: {leaked}"
         )
+
+    def test_allowed_tools_env_filters_exposed_tools(self, monkeypatch):
+        from agent.transports import hermes_tools_mcp_server as m
+
+        monkeypatch.setenv(
+            "HERMES_TOOLS_MCP_ALLOWED",
+            json.dumps(["skills_list", "terminal", "not_registered"]),
+        )
+
+        assert m._configured_exposed_tools() == ("skills_list",)
+
+    def test_missing_allowed_tools_env_preserves_existing_codex_contract(
+        self, monkeypatch
+    ):
+        from agent.transports import hermes_tools_mcp_server as m
+
+        monkeypatch.delenv("HERMES_TOOLS_MCP_ALLOWED", raising=False)
+
+        assert m._configured_exposed_tools() == m.EXPOSED_TOOLS
+
+    def test_supplied_schemas_are_filtered_to_configured_tools(self, monkeypatch):
+        from agent.transports import hermes_tools_mcp_server as m
+
+        monkeypatch.setenv(
+            "HERMES_TOOLS_MCP_SCHEMAS",
+            json.dumps(
+                {
+                    "skills_list": {
+                        "name": "skills_list",
+                        "description": "List skills",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                    "terminal": {
+                        "name": "terminal",
+                        "description": "Must not leak",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ),
+        )
+
+        specs = m._configured_tool_specs(("skills_list",))
+
+        assert specs is not None
+        assert set(specs) == {"skills_list"}
 
 
 


### PR DESCRIPTION
## Summary

- handle Copilot ACP session/request_permission execute requests through the existing Hermes terminal guard
- select only an offered one-shot permission; never grant allow-always
- fail closed for blocked, malformed, unsupported, or guard-error requests

## Root cause

The ACP client unconditionally returned a cancelled permission outcome. Copilot therefore emitted progress narration, had its native tool request cancelled, and ended without the requested result.

## Validation

- Real Hermes CLI with provider copilot-acp and model gpt-5.6-sol used a tool to read pyproject.toml and returned [project]
- Real Hermes terminal guard rejected rm -rf / without executing it
- scripts/run_tests.sh tests/agent/test_copilot_acp_client.py -q: 18 passed
- Related provider-routing and streaming tests: 4 passed
- Ruff and git diff checks passed