### PR TITLE
fix(desktop): fall back to user-namespace sandbox when SUID helper can't be configured

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7655,6 +7655,47 @@ def _desktop_linux_needs_no_sandbox() -> bool:
         return False
 
 
+def _desktop_linux_userns_available() -> bool:
+    """Return True when the kernel allows unprivileged user namespaces.
+
+    When True, Electron/Chromium can sandbox itself with the namespace
+    sandbox even without the root-owned SUID ``chrome-sandbox`` helper, so a
+    desktop launch does not require ``sudo``. Returns False (conservatively)
+    when running as root, when AppArmor or a sysctl clearly blocks user
+    namespaces, or on any read error.
+    """
+    if sys.platform != "linux":
+        return False
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        return False  # root picks its own path explicitly
+
+    # AppArmor hardening that explicitly blocks unprivileged user namespaces.
+    try:
+        with open("/proc/sys/kernel/apparmor_restrict_unprivileged_userns", encoding="utf-8") as f:
+            if f.read().strip() == "1":
+                return False
+    except OSError:
+        pass
+
+    # Older Debian/Ubuntu knob: "0" disallows unprivileged user namespaces.
+    try:
+        with open("/proc/sys/kernel/unprivileged_userns_clone", encoding="utf-8") as f:
+            if f.read().strip() == "0":
+                return False
+    except OSError:
+        pass
+
+    # No user namespaces permitted at all.
+    try:
+        with open("/proc/sys/user/max_user_namespaces", encoding="utf-8") as f:
+            if int((f.read().strip() or "0")) <= 0:
+                return False
+    except (OSError, ValueError):
+        pass
+
+    return True
+
+
 def _desktop_linux_sandbox_helper_is_regular_file(packaged_executable: Path) -> bool:
     """Return True when ``chrome-sandbox`` exists as a regular file."""
     if sys.platform != "linux":
@@ -8073,10 +8114,28 @@ def cmd_gui(args: argparse.Namespace):
 
     launch_command = [str(packaged_executable)]
     if not _desktop_linux_sandbox_fixup(packaged_executable):
-        if _desktop_linux_needs_no_sandbox() and _desktop_linux_sandbox_helper_is_regular_file(packaged_executable):
-            print("⚠ Falling back to --no-sandbox because this Linux host restricts unprivileged user namespaces and the Electron sandbox helper could not be configured.")
+        # The root-owned SUID chrome-sandbox helper could not be configured
+        # (no sudo / not root). Decide how to proceed without it:
+        #  - ELECTRON_DISABLE_SANDBOX=1  -> honour the explicit opt-out.
+        #  - unprivileged user namespaces available -> Electron sandboxes
+        #    itself via the namespace sandbox (no SUID helper, no sudo needed).
+        #  - otherwise -> fall back to --no-sandbox as a last resort.
+        #  - if none of those apply, hard-fail with actionable guidance.
+        if os.environ.get("ELECTRON_DISABLE_SANDBOX") == "1":
+            print("→ ELECTRON_DISABLE_SANDBOX=1 set: launching with --no-sandbox.")
+            launch_command.append("--no-sandbox")
+        elif _desktop_linux_userns_available():
+            print("→ Launching with the unprivileged user-namespace sandbox "
+                  "(SUID helper not configured; sudo not required).")
+        elif _desktop_linux_sandbox_helper_is_regular_file(packaged_executable):
+            print("⚠ Falling back to --no-sandbox: unprivileged user namespaces are "
+                  "blocked on this host and the Electron sandbox helper could not be configured.")
             launch_command.append("--no-sandbox")
         else:
+            print("✗ Hermes Desktop cannot establish a sandbox on this host and "
+                  "unprivileged user namespaces are unavailable.")
+            print("  Run once with sudo to set up the sandbox helper, or add "
+                  "desktop.electron_flags: ['--no-sandbox'] to config.yaml.")
             sys.exit(1)
 
     launch_command.extend(config_electron_flags)

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -779,3 +779,85 @@ def test_gui_password_store_bridge_is_linux_only(tmp_path, monkeypatch):
     mock_detect.assert_not_called()
     launch_env = mock_run.call_args_list[1].kwargs["env"]
     assert "HERMES_DESKTOP_PASSWORD_STORE" not in launch_env
+
+
+# ── Sandbox-helper fallback tests ──────────────────────────────────────
+# These exercise the launch path taken when the root-owned SUID
+# chrome-sandbox helper cannot be configured (no sudo / not root). The old
+# code hard-exited (sys.exit(1)); it must now fall back to the unprivileged
+# user-namespace sandbox when the kernel supports it, and only --no-sandbox as
+# a last resort, and only hard-fail when namespaces are truly unavailable.
+
+
+def test_gui_launches_via_userns_sandbox_when_suid_helper_unavailable(tmp_path, monkeypatch):
+    """Regression: on a host where the SUID chrome-sandbox helper can't be
+    chown'd (no sudo) but unprivileged user namespaces are permitted, the
+    launcher must NOT hard-exit — it should launch with the namespace sandbox
+    and without --no-sandbox."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    _make_packaged_executable(root, monkeypatch)
+
+    launch_ok = subprocess.CompletedProcess(["hermes"], 0)
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=False), \
+         patch("hermes_cli.main._register_linux_desktop_entry"), \
+         patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=False), \
+         patch("hermes_cli.main._desktop_linux_userns_available", return_value=True), \
+         patch("hermes_cli.main.subprocess.run", return_value=launch_ok) as mock_run, \
+         patch("hermes_cli.config.load_config", return_value={}), \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(skip_build=True))
+
+    assert exc.value.code == 0
+    launch_call = mock_run.call_args_list[-1]
+    assert launch_call.args[0][0].endswith("hermes")
+    # No --no-sandbox: the namespace sandbox is used instead.
+    assert "--no-sandbox" not in launch_call.args[0]
+
+
+def test_gui_hard_fails_only_when_userns_unavailable_and_no_helper(tmp_path, monkeypatch):
+    """When the SUID helper can't be configured AND unprivileged user
+    namespaces are unavailable, the launcher must hard-fail with a clear
+    actionable message rather than launching unsandboxed by default."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    _make_packaged_executable(root, monkeypatch)
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=False), \
+         patch("hermes_cli.main._register_linux_desktop_entry"), \
+         patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=False), \
+         patch("hermes_cli.main._desktop_linux_userns_available", return_value=False), \
+         patch("hermes_cli.main._desktop_linux_sandbox_helper_is_regular_file", return_value=False), \
+         patch("hermes_cli.config.load_config", return_value={}), \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(skip_build=True))
+
+    assert exc.value.code == 1
+
+
+def test_gui_explicit_disable_sandbox_flag_is_honoured(tmp_path, monkeypatch):
+    """ELECTRON_DISABLE_SANDBOX=1 must force --no-sandbox even when the userns
+    sandbox would otherwise be used."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    _make_packaged_executable(root, monkeypatch)
+    monkeypatch.setenv("ELECTRON_DISABLE_SANDBOX", "1")
+
+    launch_ok = subprocess.CompletedProcess(["hermes"], 0)
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=False), \
+         patch("hermes_cli.main._register_linux_desktop_entry"), \
+         patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=False), \
+         patch("hermes_cli.main._desktop_linux_userns_available", return_value=True), \
+         patch("hermes_cli.main.subprocess.run", return_value=launch_ok) as mock_run, \
+         patch("hermes_cli.config.load_config", return_value={}), \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(skip_build=True))
+
+    assert exc.value.code == 0
+    launch_call = mock_run.call_args_list[-1]
+    assert "--no-sandbox" in launch_call.args[0]


### PR DESCRIPTION
## What does this PR do?

On Linux hosts where the root-owned SUID `chrome-sandbox` helper can't be `chown`'d (no sudo / not root), `hermes desktop` (`hermes gui`) printed a sudo prompt and then `sys.exit(1)`, making the GUI unusable for unprivileged users. This happened even when the kernel supports unprivileged user namespaces (`unprivileged_userns_clone=1`), which Electron/Chromium can use to sandbox themselves **without** the SUID helper.

This PR adds `_desktop_linux_userns_available()` and reworks the launch fallback so that when the SUID helper can't be configured:
- `ELECTRON_DISABLE_SANDBOX=1` → forces `--no-sandbox` (explicit opt-out)
- unprivileged user namespaces available → launches with the **namespace sandbox** (no SUID helper, no sudo required)
- otherwise → falls back to `--no-sandbox` only as a last resort
- only hard-fails with actionable guidance when namespaces are truly blocked

## Related Issue

None (no existing issue; happy to file one if maintainers prefer).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`: new `_desktop_linux_userns_available()` helper; reworked the sandbox-fallback branch in `cmd_gui()`.
- `tests/hermes_cli/test_gui_command.py`: 3 regression tests (userns-sandbox path, hard-fail path, explicit opt-out flag).

## How to Test

1. On a no-sudo Linux host with `unprivileged_userns_clone=1`: `hermes desktop --skip-build` now launches instead of exiting 1.
2. `pytest tests/hermes_cli/test_gui_command.py -q` → all pass (29 passed, 5 skipped).

## Checklist

- [x] Commit messages follow Conventional Commits (`fix(desktop):`)
- [x] PR contains only changes related to this fix (the unrelated `tools/mcp_oauth.py` working-tree change was intentionally left uncommitted)
- [x] I've run `pytest tests/hermes_cli/test_gui_command.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] Tested on: Ubuntu/XFCE (no-sudo), `unprivileged_userns_clone=1`