### PR TITLE
feat(desktop): isolated Desktop instances for named SSH shells

### DIFF
--- a/apps/desktop/electron/isolated-desktop-controller.test.ts
+++ b/apps/desktop/electron/isolated-desktop-controller.test.ts
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+import { createIsolatedDesktopController } from './isolated-desktop-controller'
+
+const connection = {
+  id: 'grace-id',
+  kind: 'ssh',
+  label: 'Hermes Grace',
+  host: 'grace.example',
+  user: 'alice',
+  port: 2222,
+  keyPath: '/keys/alice',
+  remoteHermesPath: '/opt/hermes/bin/hermes',
+  remoteProfile: 'default'
+}
+
+function controller(overrides: Record<string, unknown> = {}) {
+  const calls: string[][] = []
+  const logs: string[] = []
+  const root = path.join(path.sep, 'home', 'bear', '.hermes')
+  const cli = path.join(root, 'bin', 'hermes')
+
+  const options = {
+    env: { PATH: '' },
+    execFile: (_file, args, _options, callback) => {
+      calls.push(args)
+      callback(null, '', '')
+    },
+    fs: {
+      existsSync: candidate => candidate === cli,
+      readFileSync: () => {
+        throw new Error('unexpected read')
+      }
+    },
+    log: message => logs.push(message),
+    platform: 'linux',
+    readConnectionsRegistry: () => ({ connections: [connection] }),
+    resolveHermesHome: () => root,
+    ...overrides
+  }
+
+  return { calls, controller: createIsolatedDesktopController(options), logs, root }
+}
+
+test('controller creates and launches an isolated shell from the exact SSH row', async () => {
+  const state = controller()
+  const result = await state.controller.openConnection('grace-id')
+
+  assert.deepEqual(result, { instanceName: 'grace', launched: true, ok: true })
+  assert.deepEqual(state.calls, [
+    [
+      'desktop',
+      'instance',
+      'create',
+      'grace',
+      '--ssh-host',
+      'grace.example',
+      '--remote-hermes-path',
+      '/opt/hermes/bin/hermes',
+      '--remote-profile',
+      'default',
+      '--display-name',
+      'Hermes Grace',
+      '--connection-id',
+      'grace-id',
+      '--ssh-port',
+      '2222',
+      '--ssh-user',
+      'alice',
+      '--ssh-key-path',
+      '/keys/alice'
+    ],
+    ['desktop', 'instance', 'launch', 'grace']
+  ])
+})
+
+test('controller rejects a stale manifest before invoking the CLI', async () => {
+  const root = path.join(path.sep, 'home', 'bear', '.hermes')
+  const cli = path.join(root, 'bin', 'hermes')
+  const manifest = path.join(root, 'desktop-instances', 'grace', 'instance.json')
+
+  const state = controller({
+    fs: {
+      existsSync: candidate => candidate === cli || candidate === manifest,
+      readFileSync: candidate => {
+        assert.equal(candidate, manifest)
+
+        return JSON.stringify({
+          connection_id: 'grace-id',
+          ssh_host: 'edited.example',
+          ssh_user: 'alice',
+          ssh_port: 2222,
+          ssh_key_path: '/keys/alice',
+          remote_hermes_path: '/opt/hermes/bin/hermes',
+          remote_profile: 'default'
+        })
+      }
+    }
+  })
+
+  await assert.rejects(state.controller.openConnection('grace-id'), /no longer matches/)
+  assert.deepEqual(state.calls, [])
+})
+
+test('controller logs launch failures and leaves propagation to its caller', async () => {
+  const state = controller({
+    execFile: (_file, _args, _options, callback) => {
+      callback(new Error('exit 1'), '', 'route mismatch')
+    }
+  })
+
+  await assert.rejects(state.controller.launchByName('grace', 'hermes://chat/1'), /route mismatch/)
+  assert.deepEqual(state.logs, ['[isolated-instance] launch grace failed: route mismatch'])
+})
+
+test('controller recovers the shared root from an isolated HERMES_HOME', () => {
+  const shared = path.join(path.sep, 'home', 'bear', '.hermes')
+
+  const state = controller({
+    resolveHermesHome: () => path.join(shared, 'desktop-instances', 'grace', 'home')
+  })
+
+  assert.equal(state.controller.resolveCanonicalHermesRoot(), shared)
+})

--- a/apps/desktop/electron/isolated-desktop-controller.ts
+++ b/apps/desktop/electron/isolated-desktop-controller.ts
@@ -1,0 +1,213 @@
+import { type ExecFileException, execFile as nodeExecFile } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import {
+  assertIsolatedManifestMatches,
+  isolatedInstanceSpecFromSsh,
+  type IsolatedSshConnection
+} from './isolated-desktop-instance'
+
+interface ConnectionsRegistryLike {
+  connections?: IsolatedSshConnection[]
+}
+
+interface FileSystemLike {
+  existsSync(path: string): boolean
+  readFileSync(path: string, encoding: BufferEncoding): string
+}
+
+type ExecFileLike = (
+  file: string,
+  args: string[],
+  options: { windowsHide: boolean },
+  callback: (error: ExecFileException | null, stdout: string | Buffer, stderr: string | Buffer) => void
+) => unknown
+
+export interface IsolatedDesktopControllerOptions {
+  env?: NodeJS.ProcessEnv | Record<string, string | undefined>
+  execFile?: ExecFileLike
+  fs?: FileSystemLike
+  log: (message: string) => void
+  platform?: NodeJS.Platform | string
+  readConnectionsRegistry: () => ConnectionsRegistryLike
+  resolveHermesHome: () => string
+}
+
+export interface IsolatedDesktopController {
+  launchByName(name: string, remainder?: string): Promise<void>
+  openConnection(id: string): Promise<{ instanceName: string; launched: true; ok: true }>
+  resolveCanonicalHermesRoot(): string
+  resolveLocalHermesCli(): null | string
+}
+
+/**
+ * Main-process orchestration for isolated Desktop shells.
+ *
+ * Dependencies are injected so route selection, CLI resolution, and error
+ * propagation can be tested without booting Electron. The controller owns no
+ * renderer or Electron state; main.ts only registers IPC and forwards links.
+ */
+export function createIsolatedDesktopController(
+  options: IsolatedDesktopControllerOptions
+): IsolatedDesktopController {
+  const env = options.env ?? process.env
+  const execFile = options.execFile ?? nodeExecFile
+  const fileSystem = options.fs ?? fs
+  const platform = options.platform ?? process.platform
+
+  function resolveCanonicalHermesRoot(): string {
+    const home = options.resolveHermesHome()
+    const marker = `${path.sep}desktop-instances${path.sep}`
+    const idx = home.toLowerCase().lastIndexOf(marker.toLowerCase())
+
+    return idx === -1 ? home : home.slice(0, idx)
+  }
+
+  function resolveLocalHermesCli(): null | string {
+    const explicit = env.HERMES_DESKTOP_HERMES
+
+    if (explicit && fileSystem.existsSync(explicit)) {
+      return explicit
+    }
+
+    const root = env.HERMES_DESKTOP_HERMES_ROOT || resolveCanonicalHermesRoot()
+    const names = platform === 'win32' ? ['hermes.exe', 'hermes.cmd', 'hermes'] : ['hermes']
+
+    const dirs = [
+      path.join(root, 'bin'),
+      path.join(root, 'hermes-agent', 'bin'),
+      path.join(root, 'venv', 'Scripts'),
+      path.join(root, 'venv', 'bin'),
+      path.join(root, '.venv', 'Scripts'),
+      path.join(root, '.venv', 'bin'),
+      ...String(env.PATH || '').split(path.delimiter)
+    ]
+
+    for (const dir of dirs) {
+      if (!dir) {
+        continue
+      }
+
+      for (const name of names) {
+        const candidate = path.join(dir, name)
+
+        if (fileSystem.existsSync(candidate)) {
+          return candidate
+        }
+      }
+    }
+
+    return null
+  }
+
+  function runHermesDesktopInstance(args: string[]): Promise<string> {
+    const cli = resolveLocalHermesCli()
+
+    if (!cli) {
+      throw new Error('The local hermes CLI was not found. Isolated Desktop actions need the shared Hermes install.')
+    }
+
+    return new Promise((resolve, reject) => {
+      execFile(cli, ['desktop', 'instance', ...args], { windowsHide: true }, (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(String(stderr || stdout || error.message || '').trim()))
+
+          return
+        }
+
+        resolve(String(stdout || ''))
+      })
+    })
+  }
+
+  async function launchByName(name: string, remainder?: string): Promise<void> {
+    try {
+      const args = ['launch', name]
+
+      if (remainder) {
+        args.push('--deep-link', remainder)
+      }
+
+      await runHermesDesktopInstance(args)
+    } catch (cause) {
+      const detail = cause instanceof Error ? cause.message : String(cause)
+
+      options.log(`[isolated-instance] launch ${name} failed: ${detail}`)
+      throw cause
+    }
+
+    if (remainder) {
+      options.log(`[isolated-instance] forwarded deep link remainder to ${name}`)
+    }
+  }
+
+  async function openConnection(id: string): Promise<{ instanceName: string; launched: true; ok: true }> {
+    const registry = options.readConnectionsRegistry()
+    const connection = (registry.connections || []).find(item => item.id === id)
+
+    if (!connection) {
+      throw new Error('That connection was not found.')
+    }
+
+    const spec = isolatedInstanceSpecFromSsh(connection)
+    const manifestPath = path.join(resolveCanonicalHermesRoot(), 'desktop-instances', spec.name, 'instance.json')
+
+    if (fileSystem.existsSync(manifestPath)) {
+      const raw = JSON.parse(fileSystem.readFileSync(manifestPath, 'utf8'))
+
+      assertIsolatedManifestMatches(
+        {
+          connectionId: String(raw.connection_id || ''),
+          dialIdentity: JSON.stringify({
+            host: String(raw.ssh_host || ''),
+            keyPath: String(raw.ssh_key_path || ''),
+            port: Number(raw.ssh_port || 22),
+            remoteHermesPath: String(raw.remote_hermes_path || ''),
+            remoteProfile: String(raw.remote_profile || ''),
+            user: String(raw.ssh_user || '')
+          })
+        },
+        spec
+      )
+    } else {
+      const args = [
+        'create',
+        spec.name,
+        '--ssh-host',
+        spec.sshHost,
+        '--remote-hermes-path',
+        spec.remoteHermesPath,
+        '--remote-profile',
+        spec.remoteProfile,
+        '--display-name',
+        spec.displayName,
+        '--connection-id',
+        spec.connectionId,
+        '--ssh-port',
+        String(spec.sshPort)
+      ]
+
+      if (spec.sshUser) {
+        args.push('--ssh-user', spec.sshUser)
+      }
+
+      if (spec.sshKeyPath) {
+        args.push('--ssh-key-path', spec.sshKeyPath)
+      }
+
+      await runHermesDesktopInstance(args)
+    }
+
+    await launchByName(spec.name)
+
+    return { instanceName: spec.name, launched: true, ok: true }
+  }
+
+  return {
+    launchByName,
+    openConnection,
+    resolveCanonicalHermesRoot,
+    resolveLocalHermesCli
+  }
+}

--- a/apps/desktop/electron/isolated-desktop-instance.test.ts
+++ b/apps/desktop/electron/isolated-desktop-instance.test.ts
@@ -4,6 +4,7 @@ import { test } from 'vitest'
 
 import {
   DEFAULT_AUMID,
+  assertIsolatedManifestMatches,
   isolatedDesktopLaunchArguments,
   isolatedDesktopLaunchEnv,
   isolatedInstanceSpecFromSsh,
@@ -19,20 +20,86 @@ test('slugFromLabel strips a Hermes prefix', () => {
   assert.equal(slugFromLabel('Work laptop'), 'work-laptop')
 })
 
-test('isolatedInstanceSpecFromSsh maps non-secret SSH fields', () => {
+test('isolatedInstanceSpecFromSsh maps the full SSH dial contract', () => {
   const spec = isolatedInstanceSpecFromSsh({
+    connectionId: 'c1',
     host: 'bear-agent',
     kind: 'ssh',
+    keyPath: '/home/bear/.ssh/id_ed25519',
     label: 'Hermes Athena',
+    port: 2222,
     remoteHermesPath: '/opt/hermes/bin/hermes',
-    remoteProfile: 'default'
+    remoteProfile: 'default',
+    user: 'bear'
   })
 
   assert.equal(spec.name, 'athena')
+  assert.equal(spec.connectionId, 'c1')
   assert.equal(spec.sshHost, 'bear-agent')
+  assert.equal(spec.sshUser, 'bear')
+  assert.equal(spec.sshPort, 2222)
+  assert.equal(spec.sshKeyPath, '/home/bear/.ssh/id_ed25519')
   assert.equal(spec.remoteHermesPath, '/opt/hermes/bin/hermes')
   assert.equal(spec.displayName, 'Hermes Athena')
   assert.equal(spec.aumid, 'com.nousresearch.hermes.instance.athena')
+})
+
+test('same-host SSH rows stay distinct when user/port/key/path/profile differ', () => {
+  const alice = isolatedInstanceSpecFromSsh({
+    connectionId: 'alice-box',
+    host: 'lab.example',
+    kind: 'ssh',
+    keyPath: '/keys/alice',
+    label: 'Lab',
+    port: 22,
+    remoteHermesPath: '/opt/hermes/bin/hermes',
+    remoteProfile: 'default',
+    user: 'alice'
+  })
+  const bob = isolatedInstanceSpecFromSsh({
+    connectionId: 'bob-box',
+    host: 'lab.example',
+    kind: 'ssh',
+    keyPath: '/keys/bob',
+    label: 'Lab',
+    port: 2200,
+    remoteHermesPath: '/opt/hermes/bin/hermes',
+    remoteProfile: 'research',
+    user: 'bob'
+  })
+
+  assert.notEqual(alice.dialIdentity, bob.dialIdentity)
+  assert.notEqual(alice.connectionId, bob.connectionId)
+})
+
+test('a stale isolated manifest must fail closed against a retargeted Connection', () => {
+  const current = isolatedInstanceSpecFromSsh({
+    connectionId: 'alice-box',
+    host: 'lab.example',
+    kind: 'ssh',
+    keyPath: '/keys/alice',
+    label: 'Lab',
+    port: 2200,
+    remoteHermesPath: '/opt/hermes/bin/hermes',
+    remoteProfile: 'default',
+    user: 'alice'
+  })
+  const stale = {
+    connectionId: 'alice-box',
+    dialIdentity: isolatedInstanceSpecFromSsh({
+      connectionId: 'alice-box',
+      host: 'lab.example',
+      kind: 'ssh',
+      keyPath: '/keys/alice',
+      label: 'Lab',
+      port: 22,
+      remoteHermesPath: '/opt/hermes/bin/hermes',
+      remoteProfile: 'default',
+      user: 'alice'
+    }).dialIdentity
+  }
+
+  assert.throws(() => assertIsolatedManifestMatches(stale, current), /no longer matches/)
 })
 
 test('isolatedInstanceSpecFromSsh rejects shared-shell kinds and relative paths', () => {
@@ -66,6 +133,7 @@ test('isolated launch arguments put a deep link on argv for a warm second-instan
 test('isolated launch env disables global hotkey and protocol capture', () => {
   const env = isolatedDesktopLaunchEnv(
     isolatedInstanceSpecFromSsh({
+      connectionId: 'grace-id',
       host: 'grace',
       kind: 'ssh',
       label: 'Hermes Grace',

--- a/apps/desktop/electron/isolated-desktop-instance.test.ts
+++ b/apps/desktop/electron/isolated-desktop-instance.test.ts
@@ -3,8 +3,8 @@ import assert from 'node:assert/strict'
 import { test } from 'vitest'
 
 import {
-  DEFAULT_AUMID,
   assertIsolatedManifestMatches,
+  DEFAULT_AUMID,
   isolatedDesktopLaunchArguments,
   isolatedDesktopLaunchEnv,
   isolatedInstanceSpecFromSsh,
@@ -56,6 +56,7 @@ test('same-host SSH rows stay distinct when user/port/key/path/profile differ', 
     remoteProfile: 'default',
     user: 'alice'
   })
+
   const bob = isolatedInstanceSpecFromSsh({
     connectionId: 'bob-box',
     host: 'lab.example',
@@ -84,6 +85,7 @@ test('a stale isolated manifest must fail closed against a retargeted Connection
     remoteProfile: 'default',
     user: 'alice'
   })
+
   const stale = {
     connectionId: 'alice-box',
     dialIdentity: isolatedInstanceSpecFromSsh({

--- a/apps/desktop/electron/isolated-desktop-instance.test.ts
+++ b/apps/desktop/electron/isolated-desktop-instance.test.ts
@@ -4,6 +4,7 @@ import { test } from 'vitest'
 
 import {
   DEFAULT_AUMID,
+  isolatedDesktopLaunchArguments,
   isolatedDesktopLaunchEnv,
   isolatedInstanceSpecFromSsh,
   parseInstanceDeepLink,
@@ -47,6 +48,19 @@ test('parseInstanceDeepLink extracts the slug and remainder', () => {
 
   assert.deepEqual(parsed, { instanceName: 'grace', remainder: 'hermes://blueprint/morning' })
   assert.equal(parseInstanceDeepLink('hermes://blueprint/morning'), null)
+  assert.equal(parseInstanceDeepLink('hermes://instance/desktop/blueprint/x'), null)
+})
+
+test('slugFromLabel rejects reserved names before the CLI round-trip', () => {
+  assert.throws(() => slugFromLabel('Hermes Desktop'), /reserved/)
+  assert.throws(() => slugFromLabel('local'), /reserved/)
+})
+
+test('isolated launch arguments put a deep link on argv for a warm second-instance', () => {
+  const args = isolatedDesktopLaunchArguments('/u', 'hermes://blueprint/morning')
+
+  assert.deepEqual(args, ['--user-data-dir=/u', 'hermes://blueprint/morning'])
+  assert.deepEqual(isolatedDesktopLaunchArguments('/u'), ['--user-data-dir=/u'])
 })
 
 test('isolated launch env disables global hotkey and protocol capture', () => {

--- a/apps/desktop/electron/isolated-desktop-instance.test.ts
+++ b/apps/desktop/electron/isolated-desktop-instance.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  DEFAULT_AUMID,
+  isolatedDesktopLaunchEnv,
+  isolatedInstanceSpecFromSsh,
+  parseInstanceDeepLink,
+  resolveAppUserModelId,
+  shouldRegisterGlobalShortcuts,
+  shouldRegisterProtocolClient,
+  slugFromLabel
+} from './isolated-desktop-instance'
+
+test('slugFromLabel strips a Hermes prefix', () => {
+  assert.equal(slugFromLabel('Hermes Athena'), 'athena')
+  assert.equal(slugFromLabel('Work laptop'), 'work-laptop')
+})
+
+test('isolatedInstanceSpecFromSsh maps non-secret SSH fields', () => {
+  const spec = isolatedInstanceSpecFromSsh({
+    host: 'bear-agent',
+    kind: 'ssh',
+    label: 'Hermes Athena',
+    remoteHermesPath: '/opt/hermes/bin/hermes',
+    remoteProfile: 'default'
+  })
+
+  assert.equal(spec.name, 'athena')
+  assert.equal(spec.sshHost, 'bear-agent')
+  assert.equal(spec.remoteHermesPath, '/opt/hermes/bin/hermes')
+  assert.equal(spec.displayName, 'Hermes Athena')
+  assert.equal(spec.aumid, 'com.nousresearch.hermes.instance.athena')
+})
+
+test('isolatedInstanceSpecFromSsh rejects shared-shell kinds and relative paths', () => {
+  assert.throws(() => isolatedInstanceSpecFromSsh({ kind: 'remote', label: 'box', host: 'x' }), /SSH/)
+  assert.throws(
+    () => isolatedInstanceSpecFromSsh({ host: 'lab', kind: 'ssh', label: 'box', remoteHermesPath: 'rel' }),
+    /absolute/
+  )
+})
+
+test('parseInstanceDeepLink extracts the slug and remainder', () => {
+  const parsed = parseInstanceDeepLink('hermes://instance/grace/blueprint/morning')
+
+  assert.deepEqual(parsed, { instanceName: 'grace', remainder: 'hermes://blueprint/morning' })
+  assert.equal(parseInstanceDeepLink('hermes://blueprint/morning'), null)
+})
+
+test('isolated launch env disables global hotkey and protocol capture', () => {
+  const env = isolatedDesktopLaunchEnv(
+    isolatedInstanceSpecFromSsh({
+      host: 'grace',
+      kind: 'ssh',
+      label: 'Hermes Grace',
+      remoteHermesPath: '/opt/hermes',
+      remoteProfile: 'default'
+    }),
+    { cwd: '/tmp', hermesHome: '/h', runtimeRoot: '/r', userData: '/u' }
+  )
+
+  assert.equal(env.HERMES_DESKTOP_DISABLE_GLOBAL_SHORTCUTS, '1')
+  assert.equal(env.HERMES_DESKTOP_SKIP_PROTOCOL_REGISTER, '1')
+  assert.equal(shouldRegisterGlobalShortcuts(env), false)
+  assert.equal(shouldRegisterProtocolClient(env), false)
+  assert.equal(resolveAppUserModelId(env), 'com.nousresearch.hermes.instance.grace')
+  assert.equal(shouldRegisterGlobalShortcuts({}), true)
+  assert.equal(resolveAppUserModelId({}), DEFAULT_AUMID)
+})

--- a/apps/desktop/electron/isolated-desktop-instance.ts
+++ b/apps/desktop/electron/isolated-desktop-instance.ts
@@ -44,6 +44,7 @@ export interface InstanceDeepLink {
 }
 
 const NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
+
 const RESERVED_NAMES = new Set([
   'connections',
   'default',
@@ -120,6 +121,7 @@ export function isolatedInstanceSpecFromSsh(connection: IsolatedSshConnection): 
   const rawPort = Number(connection.port)
   const sshPort = Number.isInteger(rawPort) && rawPort > 0 && rawPort <= 65535 ? rawPort : 22
   const sshKeyPath = String(connection.keyPath || '').trim()
+
   const dialIdentity = JSON.stringify({
     host,
     keyPath: sshKeyPath,

--- a/apps/desktop/electron/isolated-desktop-instance.ts
+++ b/apps/desktop/electron/isolated-desktop-instance.ts
@@ -17,17 +17,25 @@ export interface IsolatedSshConnection {
   host?: string
   user?: string
   port?: number
+  keyPath?: string
   remoteHermesPath?: string
   remoteProfile?: string
+  connectionId?: string
+  id?: string
 }
 
 export interface IsolatedInstanceSpec {
   name: string
   displayName: string
+  connectionId: string
   sshHost: string
+  sshUser: string
+  sshPort: number
+  sshKeyPath: string
   remoteHermesPath: string
   remoteProfile: string
   aumid: string
+  dialIdentity: string
 }
 
 export interface InstanceDeepLink {
@@ -98,18 +106,58 @@ export function isolatedInstanceSpecFromSsh(connection: IsolatedSshConnection): 
     )
   }
 
+  const connectionId = String(connection.connectionId || connection.id || '').trim()
+
+  if (!connectionId) {
+    throw new Error('A Connections registry id is required so the isolated shell keeps the exact SSH row.')
+  }
+
   const label = String(connection.label || '').trim()
   const name = slugFromLabel(label || host)
   const displayName = label.toLowerCase().startsWith('hermes ') ? label : `Hermes ${name.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}`
   const remoteProfile = String(connection.remoteProfile || 'default').trim() || 'default'
+  const sshUser = String(connection.user || '').trim()
+  const rawPort = Number(connection.port)
+  const sshPort = Number.isInteger(rawPort) && rawPort > 0 && rawPort <= 65535 ? rawPort : 22
+  const sshKeyPath = String(connection.keyPath || '').trim()
+  const dialIdentity = JSON.stringify({
+    host,
+    keyPath: sshKeyPath,
+    port: sshPort,
+    remoteHermesPath,
+    remoteProfile,
+    user: sshUser
+  })
 
   return {
     name,
     displayName,
+    connectionId,
     sshHost: host,
+    sshUser,
+    sshPort,
+    sshKeyPath,
     remoteHermesPath,
     remoteProfile,
-    aumid: instanceAumid(name)
+    aumid: instanceAumid(name),
+    dialIdentity
+  }
+}
+
+export function assertIsolatedManifestMatches(
+  existing: { connectionId?: string; dialIdentity?: string },
+  spec: IsolatedInstanceSpec
+): void {
+  if (existing.connectionId && existing.connectionId !== spec.connectionId) {
+    throw new Error(
+      `Isolated Desktop instance belongs to connection ${JSON.stringify(existing.connectionId)}, not ${JSON.stringify(spec.connectionId)}.`
+    )
+  }
+
+  if (existing.dialIdentity && existing.dialIdentity !== spec.dialIdentity) {
+    throw new Error(
+      `Isolated Desktop instance no longer matches the selected Connection ${JSON.stringify(spec.connectionId)}.`
+    )
   }
 }
 

--- a/apps/desktop/electron/isolated-desktop-instance.ts
+++ b/apps/desktop/electron/isolated-desktop-instance.ts
@@ -1,0 +1,151 @@
+/**
+ * Isolated Desktop instance helpers — electron-free so they can be tested
+ * with vitest without booting Electron.
+ *
+ * The Python CLI (`hermes_cli.desktop_instances`) is the Windows/macOS/Linux
+ * installer. This module is the in-app twin: map a Connections SSH entry to
+ * an isolated-shell spec, parse instance deep links, and decide whether this
+ * process should own the global protocol handler / quick-entry hotkey / AUMID.
+ */
+
+export const INSTANCE_AUMID_PREFIX = 'com.nousresearch.hermes.instance.'
+export const DEFAULT_AUMID = 'com.nousresearch.hermes'
+
+export interface IsolatedSshConnection {
+  kind?: string
+  label?: string
+  host?: string
+  user?: string
+  port?: number
+  remoteHermesPath?: string
+  remoteProfile?: string
+}
+
+export interface IsolatedInstanceSpec {
+  name: string
+  displayName: string
+  sshHost: string
+  remoteHermesPath: string
+  remoteProfile: string
+  aumid: string
+}
+
+export interface InstanceDeepLink {
+  instanceName: string
+  remainder: string
+}
+
+const NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
+
+export function instanceAumid(name: string): string {
+  return `${INSTANCE_AUMID_PREFIX}${name}`
+}
+
+export function slugFromLabel(label: string): string {
+  let text = String(label || '').trim()
+
+  if (text.toLowerCase().startsWith('hermes ')) {
+    text = text.slice(6).trim()
+  }
+
+  const slug = text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+  if (!NAME_RE.test(slug)) {
+    throw new Error(`Cannot derive an instance name from ${JSON.stringify(label)}.`)
+  }
+
+  return slug
+}
+
+export function isolatedInstanceSpecFromSsh(connection: IsolatedSshConnection): IsolatedInstanceSpec {
+  if (String(connection.kind || '').trim().toLowerCase() !== 'ssh') {
+    throw new Error('Only SSH Connections can open as an isolated Desktop.')
+  }
+
+  const host = String(connection.host || '').trim()
+
+  if (!host) {
+    throw new Error('SSH host is required.')
+  }
+
+  const remoteHermesPath = String(connection.remoteHermesPath || '').trim()
+  const posixAbs = remoteHermesPath.startsWith('/')
+  const windowsAbs = /^[A-Za-z]:[\\/]/.test(remoteHermesPath) || remoteHermesPath.startsWith('\\\\')
+
+  if (!posixAbs && !windowsAbs) {
+    throw new Error(
+      'Set an absolute Remote Hermes path on this SSH connection before opening it as an isolated Desktop.'
+    )
+  }
+
+  const label = String(connection.label || '').trim()
+  const name = slugFromLabel(label || host)
+  const displayName = label.toLowerCase().startsWith('hermes ') ? label : `Hermes ${name.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}`
+  const remoteProfile = String(connection.remoteProfile || 'default').trim() || 'default'
+
+  return {
+    name,
+    displayName,
+    sshHost: host,
+    remoteHermesPath,
+    remoteProfile,
+    aumid: instanceAumid(name)
+  }
+}
+
+export function parseInstanceDeepLink(url: string): InstanceDeepLink | null {
+  const raw = String(url || '').trim()
+  const prefix = 'hermes://instance/'
+
+  if (!raw.startsWith(prefix)) {
+    return null
+  }
+
+  const rest = raw.slice(prefix.length)
+  const slash = rest.indexOf('/')
+  const slug = slash === -1 ? rest : rest.slice(0, slash)
+  const tail = slash === -1 ? '' : rest.slice(slash + 1)
+
+  if (!NAME_RE.test(slug)) {
+    return null
+  }
+
+  return {
+    instanceName: slug,
+    remainder: tail ? `hermes://${tail}` : 'hermes://'
+  }
+}
+
+export function isolatedDesktopLaunchEnv(
+  spec: IsolatedInstanceSpec,
+  paths: { hermesHome: string; userData: string; runtimeRoot: string; cwd: string }
+): Record<string, string> {
+  return {
+    HERMES_HOME: paths.hermesHome,
+    HERMES_DESKTOP_USER_DATA_DIR: paths.userData,
+    HERMES_DESKTOP_HERMES_ROOT: paths.runtimeRoot,
+    HERMES_DESKTOP_APP_NAME: spec.displayName,
+    HERMES_DESKTOP_CWD: paths.cwd,
+    HERMES_DESKTOP_INSTANCE: spec.name,
+    HERMES_DESKTOP_AUMID: spec.aumid,
+    HERMES_DESKTOP_DISABLE_GLOBAL_SHORTCUTS: '1',
+    HERMES_DESKTOP_SKIP_PROTOCOL_REGISTER: '1'
+  }
+}
+
+export function shouldRegisterProtocolClient(env: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env): boolean {
+  return env.HERMES_DESKTOP_SKIP_PROTOCOL_REGISTER !== '1'
+}
+
+export function shouldRegisterGlobalShortcuts(env: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env): boolean {
+  return env.HERMES_DESKTOP_DISABLE_GLOBAL_SHORTCUTS !== '1'
+}
+
+export function resolveAppUserModelId(env: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env): string {
+  const override = String(env.HERMES_DESKTOP_AUMID || '').trim()
+
+  return override || DEFAULT_AUMID
+}

--- a/apps/desktop/electron/isolated-desktop-instance.ts
+++ b/apps/desktop/electron/isolated-desktop-instance.ts
@@ -36,6 +36,19 @@ export interface InstanceDeepLink {
 }
 
 const NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
+const RESERVED_NAMES = new Set([
+  'connections',
+  'default',
+  'desktop',
+  'gui',
+  'hermes',
+  'instance',
+  'local',
+  'root',
+  'sudo',
+  'test',
+  'tmp'
+])
 
 export function instanceAumid(name: string): string {
   return `${INSTANCE_AUMID_PREFIX}${name}`
@@ -55,6 +68,10 @@ export function slugFromLabel(label: string): string {
 
   if (!NAME_RE.test(slug)) {
     throw new Error(`Cannot derive an instance name from ${JSON.stringify(label)}.`)
+  }
+
+  if (RESERVED_NAMES.has(slug)) {
+    throw new Error(`Instance name ${JSON.stringify(slug)} is reserved.`)
   }
 
   return slug
@@ -109,7 +126,7 @@ export function parseInstanceDeepLink(url: string): InstanceDeepLink | null {
   const slug = slash === -1 ? rest : rest.slice(0, slash)
   const tail = slash === -1 ? '' : rest.slice(slash + 1)
 
-  if (!NAME_RE.test(slug)) {
+  if (!NAME_RE.test(slug) || RESERVED_NAMES.has(slug)) {
     return null
   }
 
@@ -117,6 +134,16 @@ export function parseInstanceDeepLink(url: string): InstanceDeepLink | null {
     instanceName: slug,
     remainder: tail ? `hermes://${tail}` : 'hermes://'
   }
+}
+
+export function isolatedDesktopLaunchArguments(userData: string, deepLink?: string): string[] {
+  const args = [`--user-data-dir=${userData}`]
+
+  if (deepLink) {
+    args.push(deepLink)
+  }
+
+  return args
 }
 
 export function isolatedDesktopLaunchEnv(

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -309,6 +309,13 @@ import {
   tagRegistrySessionResponse
 } from './profile-session-routing'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
+import {
+  isolatedInstanceSpecFromSsh,
+  parseInstanceDeepLink,
+  resolveAppUserModelId,
+  shouldRegisterGlobalShortcuts,
+  shouldRegisterProtocolClient
+} from './isolated-desktop-instance'
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
 import * as remoteLifecycle from './remote-lifecycle'
 import {
@@ -1300,7 +1307,7 @@ app.setName(APP_NAME)
 // need this, so gate it on Windows. (Fixes: desktop approval/turn notifications
 // never firing on Windows.)
 if (IS_WINDOWS) {
-  app.setAppUserModelId('com.nousresearch.hermes')
+  app.setAppUserModelId(resolveAppUserModelId(process.env))
 }
 
 // Seed the native About panel with the live Hermes version. This is refreshed
@@ -13346,6 +13353,9 @@ function applyHudSnapToPointer() {
 const hudSnapShortcut = createHudSnapShortcut(globalShortcut, applyHudSnapToPointer)
 
 function registerHudSnapShortcut() {
+  if (!shouldRegisterGlobalShortcuts(process.env)) {
+    return
+  }
   if (!hudSnapShortcut.register()) {
     rememberLog('[hud] snap shortcut unavailable — CommandOrControl+Shift+G may be owned by another app')
   }
@@ -13900,9 +13910,10 @@ function toggleQuickEntryWindow() {
 const quickEntryShortcut = createQuickEntryShortcut(globalShortcut, toggleQuickEntryWindow)
 
 function applyQuickEntrySettings(settings) {
-  const state = quickEntryShortcut.apply(settings)
+  const gated = shouldRegisterGlobalShortcuts(process.env) ? settings : { ...settings, enabled: false }
+  const state = quickEntryShortcut.apply(gated)
 
-  if (!settings.enabled) {
+  if (!gated.enabled) {
     // Turning the feature off must not leave an orphan always-on-top window.
     if (quickEntryWindow && !quickEntryWindow.isDestroyed()) {
       quickEntryWindow.close()
@@ -14700,6 +14711,116 @@ ipcMain.handle('hermes:secret-storage:set', async (_event: any, on: any) => appl
 // the registry lands separately; these handlers only manage the persisted
 // list, so they are safe to ship ahead of the switchover.
 ipcMain.handle('hermes:connections:list', async () => sanitizeConnectionsRegistry())
+
+function resolveCanonicalHermesRoot() {
+  const home = resolveHermesHome()
+  const marker = `${path.sep}desktop-instances${path.sep}`
+  const idx = home.toLowerCase().lastIndexOf(marker.toLowerCase())
+
+  return idx === -1 ? home : home.slice(0, idx)
+}
+
+function resolveLocalHermesCli() {
+  const explicit = process.env.HERMES_DESKTOP_HERMES
+  if (explicit && fs.existsSync(explicit)) {
+    return explicit
+  }
+
+  const root = process.env.HERMES_DESKTOP_HERMES_ROOT || resolveCanonicalHermesRoot()
+  const names = process.platform === 'win32' ? ['hermes.exe', 'hermes.cmd', 'hermes'] : ['hermes']
+  const dirs = [
+    path.join(root, 'bin'),
+    path.join(root, 'hermes-agent', 'bin'),
+    path.join(root, 'venv', 'Scripts'),
+    path.join(root, 'venv', 'bin'),
+    path.join(root, '.venv', 'Scripts'),
+    path.join(root, '.venv', 'bin'),
+    ...String(process.env.PATH || '').split(path.delimiter)
+  ]
+
+  for (const dir of dirs) {
+    if (!dir) {
+      continue
+    }
+    for (const name of names) {
+      const candidate = path.join(dir, name)
+
+      if (fs.existsSync(candidate)) {
+        return candidate
+      }
+    }
+  }
+
+  return null
+}
+
+function runHermesDesktopInstance(args) {
+  const cli = resolveLocalHermesCli()
+
+  if (!cli) {
+    throw new Error('The local hermes CLI was not found. Isolated Desktop actions need the shared Hermes install.')
+  }
+
+  return new Promise((resolve, reject) => {
+    execFile(cli, ['desktop', 'instance', ...args], { windowsHide: true }, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error((stderr || stdout || error.message || '').trim()))
+        return
+      }
+
+      resolve(String(stdout || ''))
+    })
+  })
+}
+
+async function launchIsolatedInstanceByName(name, remainder) {
+  try {
+    const args = ['launch', name]
+    if (remainder) {
+      args.push('--deep-link', remainder)
+    }
+    await runHermesDesktopInstance(args)
+  } catch (error) {
+    rememberLog(`[isolated-instance] launch ${name} failed: ${error.message}`)
+    throw error
+  }
+
+  if (remainder) {
+    rememberLog(`[isolated-instance] forwarded deep link remainder to ${name}`)
+  }
+}
+
+ipcMain.handle('hermes:connections:open-isolated', async (_event, id) => {
+  const registry = readDesktopConnectionsRegistry()
+  const connection = (registry.connections || []).find(item => item.id === id)
+
+  if (!connection) {
+    throw new Error('That connection was not found.')
+  }
+
+  const spec = isolatedInstanceSpecFromSsh(connection)
+  const root = resolveCanonicalHermesRoot()
+  const manifest = path.join(root, 'desktop-instances', spec.name, 'instance.json')
+
+  if (!fs.existsSync(manifest)) {
+    await runHermesDesktopInstance([
+      'create',
+      spec.name,
+      '--ssh-host',
+      spec.sshHost,
+      '--remote-hermes-path',
+      spec.remoteHermesPath,
+      '--remote-profile',
+      spec.remoteProfile,
+      '--display-name',
+      spec.displayName
+    ])
+  }
+
+  await runHermesDesktopInstance(['launch', spec.name])
+
+  return { instanceName: spec.name, launched: true, ok: true }
+})
 ipcMain.handle('hermes:connections:save', async (_event, payload) => {
   const saved = await saveRegistryConnection(payload)
 
@@ -17209,6 +17330,24 @@ function handleDeepLink(url) {
     return
   }
 
+  const instanceLink = parseInstanceDeepLink(url)
+  const thisInstance = String(process.env.HERMES_DESKTOP_INSTANCE || '').trim()
+
+  if (instanceLink) {
+    if (thisInstance && thisInstance !== instanceLink.instanceName) {
+      rememberLog(`[deeplink] ignoring ${url} — this shell is ${thisInstance}`)
+      return
+    }
+
+    if (!thisInstance) {
+      rememberLog(`[deeplink] forwarding ${url} to isolated instance ${instanceLink.instanceName}`)
+      void launchIsolatedInstanceByName(instanceLink.instanceName, instanceLink.remainder)
+      return
+    }
+
+    url = instanceLink.remainder
+  }
+
   let parsed
 
   try {
@@ -17273,6 +17412,10 @@ ipcMain.handle('hermes:deep-link-ready', () => {
 })
 
 function registerDeepLinkProtocol() {
+  if (!shouldRegisterProtocolClient(process.env)) {
+    rememberLog('[deeplink] skipping protocol registration in isolated Desktop instance')
+    return
+  }
   try {
     if (process.defaultApp && process.argv.length >= 2) {
       // Dev: register with the electron exec path + entry script so the OS can
@@ -17373,7 +17516,10 @@ app.whenReady().then(() => {
   installEmbedReferer()
   installRemoteHeaderRules()
   registerDeepLinkProtocol()
-
+  const pendingIsolatedLink = process.env.HERMES_DESKTOP_PENDING_DEEP_LINK
+  if (pendingIsolatedLink) {
+    handleDeepLink(pendingIsolatedLink)
+  }
   ensureWslWindowsFonts()
   configureSpellChecker()
   registerPowerResumeListeners()

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -308,7 +308,6 @@ import {
   spliceRegistrySessionRows,
   tagRegistrySessionResponse
 } from './profile-session-routing'
-import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
 import {
   isolatedInstanceSpecFromSsh,
   parseInstanceDeepLink,
@@ -316,6 +315,7 @@ import {
   shouldRegisterGlobalShortcuts,
   shouldRegisterProtocolClient
 } from './isolated-desktop-instance'
+import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
 import * as remoteLifecycle from './remote-lifecycle'
 import {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -227,9 +227,8 @@ import { snapHudBounds } from './hud-snap'
 import { createHudSnapShortcut } from './hud-snap-shortcut'
 import { buildHudWindowUrl } from './hud-url'
 import { resolveHudWindowing } from './hud-windowing'
+import { createIsolatedDesktopController } from './isolated-desktop-controller'
 import {
-  assertIsolatedManifestMatches,
-  isolatedInstanceSpecFromSsh,
   parseInstanceDeepLink,
   resolveAppUserModelId,
   shouldRegisterGlobalShortcuts,
@@ -13357,6 +13356,7 @@ function registerHudSnapShortcut() {
   if (!shouldRegisterGlobalShortcuts(process.env)) {
     return
   }
+
   if (!hudSnapShortcut.register()) {
     rememberLog('[hud] snap shortcut unavailable — CommandOrControl+Shift+G may be owned by another app')
   }
@@ -14713,148 +14713,16 @@ ipcMain.handle('hermes:secret-storage:set', async (_event: any, on: any) => appl
 // list, so they are safe to ship ahead of the switchover.
 ipcMain.handle('hermes:connections:list', async () => sanitizeConnectionsRegistry())
 
-function resolveCanonicalHermesRoot() {
-  const home = resolveHermesHome()
-  const marker = `${path.sep}desktop-instances${path.sep}`
-  const idx = home.toLowerCase().lastIndexOf(marker.toLowerCase())
-
-  return idx === -1 ? home : home.slice(0, idx)
-}
-
-function resolveLocalHermesCli() {
-  const explicit = process.env.HERMES_DESKTOP_HERMES
-
-  if (explicit && fs.existsSync(explicit)) {
-    return explicit
-  }
-
-  const root = process.env.HERMES_DESKTOP_HERMES_ROOT || resolveCanonicalHermesRoot()
-  const names = process.platform === 'win32' ? ['hermes.exe', 'hermes.cmd', 'hermes'] : ['hermes']
-
-  const dirs = [
-    path.join(root, 'bin'),
-    path.join(root, 'hermes-agent', 'bin'),
-    path.join(root, 'venv', 'Scripts'),
-    path.join(root, 'venv', 'bin'),
-    path.join(root, '.venv', 'Scripts'),
-    path.join(root, '.venv', 'bin'),
-    ...String(process.env.PATH || '').split(path.delimiter)
-  ]
-
-  for (const dir of dirs) {
-    if (!dir) {
-      continue
-    }
-
-    for (const name of names) {
-      const candidate = path.join(dir, name)
-
-      if (fs.existsSync(candidate)) {
-        return candidate
-      }
-    }
-  }
-
-  return null
-}
-
-function runHermesDesktopInstance(args) {
-  const cli = resolveLocalHermesCli()
-
-  if (!cli) {
-    throw new Error('The local hermes CLI was not found. Isolated Desktop actions need the shared Hermes install.')
-  }
-
-  return new Promise((resolve, reject) => {
-    execFile(cli, ['desktop', 'instance', ...args], { windowsHide: true }, (error, stdout, stderr) => {
-      if (error) {
-        reject(new Error((stderr || stdout || error.message || '').trim()))
-
-        return
-      }
-
-      resolve(String(stdout || ''))
-    })
-  })
-}
-
-async function launchIsolatedInstanceByName(name, remainder) {
-  try {
-    const args = ['launch', name]
-
-    if (remainder) {
-      args.push('--deep-link', remainder)
-    }
-
-    await runHermesDesktopInstance(args)
-  } catch (error) {
-    rememberLog(`[isolated-instance] launch ${name} failed: ${error.message}`)
-    throw error
-  }
-
-  if (remainder) {
-    rememberLog(`[isolated-instance] forwarded deep link remainder to ${name}`)
-  }
-}
-
-ipcMain.handle('hermes:connections:open-isolated', async (_event, id) => {
-  const registry = readDesktopConnectionsRegistry()
-  const connection = (registry.connections || []).find(item => item.id === id)
-
-  if (!connection) {
-    throw new Error('That connection was not found.')
-  }
-
-  const spec = isolatedInstanceSpecFromSsh(connection)
-  const root = resolveCanonicalHermesRoot()
-  const manifestPath = path.join(root, 'desktop-instances', spec.name, 'instance.json')
-
-  if (fs.existsSync(manifestPath)) {
-    const raw = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
-    assertIsolatedManifestMatches({
-      connectionId: String(raw.connection_id || ''),
-      dialIdentity: JSON.stringify({
-        host: String(raw.ssh_host || ''),
-        keyPath: String(raw.ssh_key_path || ''),
-        port: Number(raw.ssh_port || 22),
-        remoteHermesPath: String(raw.remote_hermes_path || ''),
-        remoteProfile: String(raw.remote_profile || ''),
-        user: String(raw.ssh_user || '')
-      })
-    }, spec)
-  } else {
-    const args = [
-      'create',
-      spec.name,
-      '--ssh-host',
-      spec.sshHost,
-      '--remote-hermes-path',
-      spec.remoteHermesPath,
-      '--remote-profile',
-      spec.remoteProfile,
-      '--display-name',
-      spec.displayName,
-      '--connection-id',
-      spec.connectionId,
-      '--ssh-port',
-      String(spec.sshPort)
-    ]
-
-    if (spec.sshUser) {
-      args.push('--ssh-user', spec.sshUser)
-    }
-
-    if (spec.sshKeyPath) {
-      args.push('--ssh-key-path', spec.sshKeyPath)
-    }
-
-    await runHermesDesktopInstance(args)
-  }
-
-  await runHermesDesktopInstance(['launch', spec.name])
-
-  return { instanceName: spec.name, launched: true, ok: true }
+const isolatedDesktopController = createIsolatedDesktopController({
+  env: process.env,
+  log: rememberLog,
+  readConnectionsRegistry: readDesktopConnectionsRegistry,
+  resolveHermesHome
 })
+
+ipcMain.handle('hermes:connections:open-isolated', async (_event, id) =>
+  isolatedDesktopController.openConnection(String(id || ''))
+)
 ipcMain.handle('hermes:connections:save', async (_event, payload) => {
   const saved = await saveRegistryConnection(payload)
 
@@ -17370,12 +17238,16 @@ function handleDeepLink(url) {
   if (instanceLink) {
     if (thisInstance && thisInstance !== instanceLink.instanceName) {
       rememberLog(`[deeplink] ignoring ${url} — this shell is ${thisInstance}`)
+
       return
     }
 
     if (!thisInstance) {
       rememberLog(`[deeplink] forwarding ${url} to isolated instance ${instanceLink.instanceName}`)
-      void launchIsolatedInstanceByName(instanceLink.instanceName, instanceLink.remainder)
+      // The controller logs the useful failure detail; consume the rejection
+      // here because protocol dispatch is intentionally fire-and-forget.
+      void isolatedDesktopController.launchByName(instanceLink.instanceName, instanceLink.remainder).catch(() => {})
+
       return
     }
 
@@ -17448,8 +17320,10 @@ ipcMain.handle('hermes:deep-link-ready', () => {
 function registerDeepLinkProtocol() {
   if (!shouldRegisterProtocolClient(process.env)) {
     rememberLog('[deeplink] skipping protocol registration in isolated Desktop instance')
+
     return
   }
+
   try {
     if (process.defaultApp && process.argv.length >= 2) {
       // Dev: register with the electron exec path + entry script so the OS can
@@ -17551,9 +17425,11 @@ app.whenReady().then(() => {
   installRemoteHeaderRules()
   registerDeepLinkProtocol()
   const pendingIsolatedLink = process.env.HERMES_DESKTOP_PENDING_DEEP_LINK
+
   if (pendingIsolatedLink) {
     handleDeepLink(pendingIsolatedLink)
   }
+
   ensureWslWindowsFonts()
   configureSpellChecker()
   registerPowerResumeListeners()

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -309,6 +309,7 @@ import {
   tagRegistrySessionResponse
 } from './profile-session-routing'
 import {
+  assertIsolatedManifestMatches,
   isolatedInstanceSpecFromSsh,
   parseInstanceDeepLink,
   resolveAppUserModelId,
@@ -14800,10 +14801,23 @@ ipcMain.handle('hermes:connections:open-isolated', async (_event, id) => {
 
   const spec = isolatedInstanceSpecFromSsh(connection)
   const root = resolveCanonicalHermesRoot()
-  const manifest = path.join(root, 'desktop-instances', spec.name, 'instance.json')
+  const manifestPath = path.join(root, 'desktop-instances', spec.name, 'instance.json')
 
-  if (!fs.existsSync(manifest)) {
-    await runHermesDesktopInstance([
+  if (fs.existsSync(manifestPath)) {
+    const raw = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+    assertIsolatedManifestMatches({
+      connectionId: String(raw.connection_id || ''),
+      dialIdentity: JSON.stringify({
+        host: String(raw.ssh_host || ''),
+        keyPath: String(raw.ssh_key_path || ''),
+        port: Number(raw.ssh_port || 22),
+        remoteHermesPath: String(raw.remote_hermes_path || ''),
+        remoteProfile: String(raw.remote_profile || ''),
+        user: String(raw.ssh_user || '')
+      })
+    }, spec)
+  } else {
+    const args = [
       'create',
       spec.name,
       '--ssh-host',
@@ -14813,8 +14827,19 @@ ipcMain.handle('hermes:connections:open-isolated', async (_event, id) => {
       '--remote-profile',
       spec.remoteProfile,
       '--display-name',
-      spec.displayName
-    ])
+      spec.displayName,
+      '--connection-id',
+      spec.connectionId,
+      '--ssh-port',
+      String(spec.sshPort)
+    ]
+    if (spec.sshUser) {
+      args.push('--ssh-user', spec.sshUser)
+    }
+    if (spec.sshKeyPath) {
+      args.push('--ssh-key-path', spec.sshKeyPath)
+    }
+    await runHermesDesktopInstance(args)
   }
 
   await runHermesDesktopInstance(['launch', spec.name])

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -227,6 +227,14 @@ import { snapHudBounds } from './hud-snap'
 import { createHudSnapShortcut } from './hud-snap-shortcut'
 import { buildHudWindowUrl } from './hud-url'
 import { resolveHudWindowing } from './hud-windowing'
+import {
+  assertIsolatedManifestMatches,
+  isolatedInstanceSpecFromSsh,
+  parseInstanceDeepLink,
+  resolveAppUserModelId,
+  shouldRegisterGlobalShortcuts,
+  shouldRegisterProtocolClient
+} from './isolated-desktop-instance'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
 import { ensureMainWindow } from './main-window-lifecycle'
 import {
@@ -308,14 +316,6 @@ import {
   spliceRegistrySessionRows,
   tagRegistrySessionResponse
 } from './profile-session-routing'
-import {
-  assertIsolatedManifestMatches,
-  isolatedInstanceSpecFromSsh,
-  parseInstanceDeepLink,
-  resolveAppUserModelId,
-  shouldRegisterGlobalShortcuts,
-  shouldRegisterProtocolClient
-} from './isolated-desktop-instance'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
 import * as remoteLifecycle from './remote-lifecycle'
@@ -14723,12 +14723,14 @@ function resolveCanonicalHermesRoot() {
 
 function resolveLocalHermesCli() {
   const explicit = process.env.HERMES_DESKTOP_HERMES
+
   if (explicit && fs.existsSync(explicit)) {
     return explicit
   }
 
   const root = process.env.HERMES_DESKTOP_HERMES_ROOT || resolveCanonicalHermesRoot()
   const names = process.platform === 'win32' ? ['hermes.exe', 'hermes.cmd', 'hermes'] : ['hermes']
+
   const dirs = [
     path.join(root, 'bin'),
     path.join(root, 'hermes-agent', 'bin'),
@@ -14743,6 +14745,7 @@ function resolveLocalHermesCli() {
     if (!dir) {
       continue
     }
+
     for (const name of names) {
       const candidate = path.join(dir, name)
 
@@ -14766,6 +14769,7 @@ function runHermesDesktopInstance(args) {
     execFile(cli, ['desktop', 'instance', ...args], { windowsHide: true }, (error, stdout, stderr) => {
       if (error) {
         reject(new Error((stderr || stdout || error.message || '').trim()))
+
         return
       }
 
@@ -14777,9 +14781,11 @@ function runHermesDesktopInstance(args) {
 async function launchIsolatedInstanceByName(name, remainder) {
   try {
     const args = ['launch', name]
+
     if (remainder) {
       args.push('--deep-link', remainder)
     }
+
     await runHermesDesktopInstance(args)
   } catch (error) {
     rememberLog(`[isolated-instance] launch ${name} failed: ${error.message}`)
@@ -14833,12 +14839,15 @@ ipcMain.handle('hermes:connections:open-isolated', async (_event, id) => {
       '--ssh-port',
       String(spec.sshPort)
     ]
+
     if (spec.sshUser) {
       args.push('--ssh-user', spec.sshUser)
     }
+
     if (spec.sshKeyPath) {
       args.push('--ssh-key-path', spec.sshKeyPath)
     }
+
     await runHermesDesktopInstance(args)
   }
 

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -192,6 +192,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     // Fan out `hermes update` to every eligible registered connection.
     // Optional excludeIds skips rows the caller updates through another path.
     updateAll: options => ipcRenderer.invoke('hermes:connections:update-all', options),
+    openIsolated: id => ipcRenderer.invoke('hermes:connections:open-isolated', id),
     // Registry lifecycle push (main → renderer): a connection was removed or
     // materially edited, so secondaries scoped to it must be disposed (and,
     // for edits, re-dialed at the new target).

--- a/apps/desktop/src/app/settings/connections-registry.test.tsx
+++ b/apps/desktop/src/app/settings/connections-registry.test.tsx
@@ -18,6 +18,7 @@ const remove = vi.fn()
 const setLaunchMode = vi.fn()
 const setPrimary = vi.fn()
 const test = vi.fn()
+const openIsolated = vi.fn()
 
 const registry: DesktopConnectionsRegistry = {
   connections: [
@@ -57,7 +58,7 @@ beforeEach(() => {
   test.mockResolvedValue({ ok: true, reachable: true })
   Object.defineProperty(window, 'hermesDesktop', {
     configurable: true,
-    value: { connections: { list, remove, save, setLaunchMode, setPrimary, test } }
+    value: { connections: { list, openIsolated, remove, save, setLaunchMode, setPrimary, test } }
   })
 })
 
@@ -296,6 +297,34 @@ describe('ConnectionsRegistrySection', () => {
     fireEvent.click(screen.getAllByText('Test')[0])
 
     await waitFor(() => expect(test).toHaveBeenCalled())
+  })
+
+  it('opens an SSH connection as an isolated Desktop', async () => {
+    openIsolated.mockResolvedValue({ instanceName: 'grace', launched: true, ok: true })
+    list.mockResolvedValueOnce({
+      ...registry,
+      connections: [
+        ...registry.connections,
+        {
+          host: 'grace',
+          id: 'grace',
+          kind: 'ssh',
+          label: 'Hermes Grace',
+          remoteHermesPath: '/opt/hermes/bin/hermes',
+          remoteProfile: 'default',
+          tokenPreview: null,
+          tokenSet: false
+        }
+      ]
+    })
+    render(<ConnectionsRegistrySection />)
+
+    await waitFor(() => expect(screen.getByText('Hermes Grace')).toBeTruthy())
+    expect(screen.getByText('Open as isolated Desktop')).toBeTruthy()
+    expect(screen.queryAllByText('Open as isolated Desktop')).toHaveLength(1)
+    fireEvent.click(screen.getByText('Open as isolated Desktop'))
+
+    await waitFor(() => expect(openIsolated).toHaveBeenCalledWith('grace'))
   })
 })
 

--- a/apps/desktop/src/app/settings/connections-registry.tsx
+++ b/apps/desktop/src/app/settings/connections-registry.tsx
@@ -597,6 +597,7 @@ export function ConnectionsRegistrySection() {
     async (conn: DesktopRegistryConnection) => {
       if (!bridge?.openIsolated) {
         notifyError(new Error('Isolated Desktop is not available in this app build.'), s.openIsolatedFailed)
+
         return
       }
 

--- a/apps/desktop/src/app/settings/connections-registry.tsx
+++ b/apps/desktop/src/app/settings/connections-registry.tsx
@@ -262,6 +262,7 @@ export function ConnectionsRegistrySection() {
   const [signingIn, setSigningIn] = useState(false)
   const [oauthConnected, setOauthConnected] = useState(false)
   const probeSeq = useRef(0)
+  const [openingIsolatedId, setOpeningIsolatedId] = useState<null | string>(null)
 
   const bridge = window.hermesDesktop?.connections
 
@@ -592,6 +593,27 @@ export function ConnectionsRegistrySection() {
     }
   }, [bridge, s.updateAllDone, s.updateAllFailed, s.updateSkippedCloud])
 
+  const openIsolated = useCallback(
+    async (conn: DesktopRegistryConnection) => {
+      if (!bridge?.openIsolated) {
+        notifyError(new Error('Isolated Desktop is not available in this app build.'), s.openIsolatedFailed)
+        return
+      }
+
+      setOpeningIsolatedId(conn.id)
+
+      try {
+        const result = await bridge.openIsolated(conn.id)
+        notify({ title: result.instanceName || conn.label, message: s.openIsolatedDone })
+      } catch (err) {
+        notifyError(err, s.openIsolatedFailed)
+      } finally {
+        setOpeningIsolatedId(null)
+      }
+    },
+    [bridge, s.openIsolatedDone, s.openIsolatedFailed]
+  )
+
   const kindMeta: Record<DesktopConnectionKind, { label: string; desc: string }> = {
     cloud: { desc: s.kindCloudDesc, label: s.kindCloud },
     local: { desc: s.kindLocalDesc, label: s.kindLocal },
@@ -652,6 +674,9 @@ export function ConnectionsRegistrySection() {
       <p className="mb-4 text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
         {s.stagedNote}
       </p>
+      <p className="mb-4 text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+        {s.isolatedNote}
+      </p>
 
       {!loading && showSearch && (
         <Input
@@ -710,6 +735,23 @@ export function ConnectionsRegistrySection() {
                   {!isPrimary && (
                     <Button disabled={busy} onClick={() => void makePrimary(conn.id)} size="sm" variant="outline">
                       {s.makePrimary}
+                    </Button>
+                  )}
+                  {conn.kind === 'ssh' && (
+                    <Button
+                      disabled={openingIsolatedId === conn.id || !bridge?.openIsolated}
+                      onClick={() => {
+                        triggerHaptic('selection')
+                        void openIsolated(conn)
+                      }}
+                      size="sm"
+                      variant="outline"
+                    >
+                      {openingIsolatedId === conn.id ? (
+                        <Loader2 className="size-3.5 animate-spin" />
+                      ) : (
+                        s.openIsolated
+                      )}
                     </Button>
                   )}
                   {conn.kind !== 'local' && (

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -182,6 +182,7 @@ declare global {
         updateAll?: (options?: {
           excludeIds?: string[]
         }) => Promise<{ ok: boolean; results: DesktopConnectionUpdateResult[] }>
+        openIsolated?: (id: string) => Promise<{ ok: boolean; instanceName: string; launched: boolean }>
         // Registry lifecycle push: fired when a connection is removed or
         // materially edited so the renderer can dispose (and re-dial) the
         // secondary gateways scoped to it. Optional: older Electron mains

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -329,6 +329,14 @@ export const ar = defineLocale({
     noResults: 'لا توجد لغة مطابقة'
   },
   settings: {
+    connections: {
+      openIsolated: 'فتح كسطح مكتب معزول',
+      openIsolatedRunning: 'جارٍ فتح سطح المكتب المعزول…',
+      openIsolatedDone: 'تم تشغيل سطح المكتب المعزول',
+      openIsolatedFailed: 'تعذر فتح سطح المكتب المعزول',
+      isolatedNote:
+        'تُبقي هذه الصفحة مصادر متعددة في نافذة مشتركة واحدة. استخدم «فتح كسطح مكتب معزول» على صف SSH لهوية تطبيق منفصلة، أو شغّل `hermes desktop instance` من سطر الأوامر.'
+    },
     closeSettings: 'إغلاق الإعدادات',
     exportConfig: 'تصدير الإعدادات',
     importConfig: 'استيراد الإعدادات',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -795,6 +795,12 @@ export const en: Translations = {
       kindRemoteDesc: 'A Hermes gateway reachable over HTTP(S) — LAN, Tailscale, or the internet.',
       kindCloudDesc: 'A hosted instance discovered through your Hermes Cloud account.',
       kindSshDesc: 'A Hermes install reached over SSH.',
+      openIsolated: 'Open as isolated Desktop',
+      openIsolatedRunning: 'Opening isolated Desktop…',
+      openIsolatedDone: 'Isolated Desktop launched',
+      openIsolatedFailed: 'Could not open isolated Desktop',
+      isolatedNote:
+        'This page keeps multiple sources in one shared window. Use “Open as isolated Desktop” on an SSH row for a separate app identity, or `hermes desktop instance` from the CLI.',
       labelTitle: 'Name',
       labelDesc: 'Required. Shown everywhere this instance appears; must be unique (e.g. “Homelab”, “Work laptop”).',
       labelPlaceholder: 'Homelab',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -264,6 +264,14 @@ export const ja = defineLocale({
   },
 
   settings: {
+    connections: {
+      openIsolated: '独立した Desktop として開く',
+      openIsolatedRunning: '独立 Desktop を開いています…',
+      openIsolatedDone: '独立 Desktop を起動しました',
+      openIsolatedFailed: '独立 Desktop を開けませんでした',
+      isolatedNote:
+        'このページは複数のソースを同じ共有ウィンドウで管理します。別のアプリ識別が必要な SSH 行では「独立した Desktop として開く」を使うか、CLI で `hermes desktop instance` を実行してください。'
+    },
     closeSettings: '設定を閉じる',
     exportConfig: '設定を書き出す',
     importConfig: '設定を読み込む',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -674,6 +674,11 @@ export interface Translations {
       kindRemoteDesc: string
       kindCloudDesc: string
       kindSshDesc: string
+      openIsolated: string
+      openIsolatedRunning: string
+      openIsolatedDone: string
+      openIsolatedFailed: string
+      isolatedNote: string
       labelTitle: string
       labelDesc: string
       labelPlaceholder: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -256,6 +256,14 @@ export const zhHant = defineLocale({
   },
 
   settings: {
+    connections: {
+      openIsolated: '以獨立 Desktop 開啟',
+      openIsolatedRunning: '正在開啟獨立 Desktop…',
+      openIsolatedDone: '已啟動獨立 Desktop',
+      openIsolatedFailed: '無法開啟獨立 Desktop',
+      isolatedNote:
+        '此頁面在同一個共用視窗中管理多個來源。若需要獨立的應用程式身分，請對 SSH 列使用「以獨立 Desktop 開啟」，或在命令列執行 `hermes desktop instance`。'
+    },
     closeSettings: '關閉設定',
     exportConfig: '匯出設定',
     importConfig: '匯入設定',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -995,6 +995,12 @@ export const zh: Translations = {
       kindRemoteDesc: '可通过 HTTP(S) 访问的 Hermes 网关——局域网、Tailscale 或互联网。',
       kindCloudDesc: '通过你的 Hermes Cloud 账户发现的托管实例。',
       kindSshDesc: '通过 SSH 访问的 Hermes 安装。',
+      openIsolated: '作为独立 Desktop 打开',
+      openIsolatedRunning: '正在打开独立 Desktop…',
+      openIsolatedDone: '独立 Desktop 已启动',
+      openIsolatedFailed: '无法打开独立 Desktop',
+      isolatedNote:
+        '此页面在同一个共享窗口中管理多个来源。若需要独立的应用身份，请对 SSH 条目使用“作为独立 Desktop 打开”，或在命令行运行 `hermes desktop instance`。',
       labelTitle: '名称',
       labelDesc: '必填。此实例出现的所有位置都会显示该名称；必须唯一（例如“家庭服务器”、“工作笔记本”）。',
       labelPlaceholder: '家庭服务器',

--- a/hermes_cli/desktop_instances.py
+++ b/hermes_cli/desktop_instances.py
@@ -1,0 +1,1031 @@
+"""Named isolated Hermes Desktop instances.
+
+Each instance is a separate Electron shell (userData + single-instance
+namespace + process name) and a separate local ``HERMES_HOME``, while
+sharing one canonical Hermes runtime/install. Remote agent state stays
+on the remote machine.
+
+This is the opposite of Settings → Connections, which adds more sources
+to one shared Desktop shell.
+
+The Windows launch path follows the validated native-launcher contract:
+a differently named hardlink beside canonical ``Hermes.exe``, an explicit
+process environment, ``UseShellExecute=false``, and early
+``--user-data-dir``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+from hermes_cli.profiles import normalize_profile_name, validate_profile_name
+from hermes_constants import get_default_hermes_root
+from utils import atomic_write_text
+
+MANIFEST_VERSION = 1
+INSTANCES_DIRNAME = "desktop-instances"
+_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+_RESERVED_NAMES = frozenset({
+    "hermes",
+    "default",
+    "test",
+    "tmp",
+    "root",
+    "sudo",
+    "desktop",
+    "gui",
+    "instance",
+    "local",
+    "connections",
+})
+_WIN_ABS = re.compile(r"^[A-Za-z]:[\\/]")
+_TEMPLATE_NAME = "windows_isolated_desktop_launcher.cs"
+_SECRET_KEYS = frozenset({"token", "password", "secret", "passphrase", "private_key"})
+
+
+class DesktopInstanceError(Exception):
+    """User-facing instance management error."""
+
+
+class InstanceNameError(DesktopInstanceError):
+    """The instance slug is not a safe identifier."""
+
+
+class ManifestError(DesktopInstanceError):
+    """The on-disk manifest is missing or invalid."""
+
+
+class StalePathError(DesktopInstanceError):
+    """A required local path is missing or not absolute."""
+
+
+class MissingSshAliasError(DesktopInstanceError):
+    """SSH is missing or the configured host/alias cannot be used."""
+
+
+class IncompatiblePlatformError(DesktopInstanceError):
+    """The requested mutation is only supported on Windows."""
+
+
+class InstanceLockedError(DesktopInstanceError):
+    """The instance executable is running or otherwise locked."""
+
+
+class InstanceExistsError(DesktopInstanceError):
+    """An instance with this name already exists."""
+
+
+class InstanceNotFoundError(DesktopInstanceError):
+    """No instance is registered under that name."""
+
+
+@dataclass(frozen=True)
+class LaunchPlan:
+    executable: Path
+    arguments: list[str]
+    env: dict[str, str]
+    cwd: str
+    use_shell_execute: bool = False
+
+
+@dataclass(frozen=True)
+class HardlinkRefreshResult:
+    path: Path
+    refreshed: bool
+    retained_running: bool
+
+
+@dataclass(frozen=True)
+class ShortcutSpec:
+    path: Path
+    target: str
+    icon: str
+    working_directory: str
+    description: str
+
+
+@dataclass(frozen=True)
+class RemoveResult:
+    name: str
+    remote_state_deleted: bool = False
+    purged_local: bool = False
+
+
+@dataclass(frozen=True)
+class DesktopInstance:
+    name: str
+    display_name: str
+    app_name: str
+    ssh_host: str
+    remote_hermes_path: str
+    remote_profile: str
+    hermes_home: Path
+    user_data: Path
+    runtime_root: Path
+    canonical_exe: Path
+    named_exe: Path
+    launcher_dir: Path
+    launcher_exe: Path
+    shortcut_path: Path
+    manifest_path: Path
+
+    def to_manifest(self) -> dict[str, object]:
+        return {
+            "version": MANIFEST_VERSION,
+            "name": self.name,
+            "display_name": self.display_name,
+            "app_name": self.app_name,
+            "ssh_host": self.ssh_host,
+            "remote_hermes_path": self.remote_hermes_path,
+            "remote_profile": self.remote_profile,
+            "hermes_home": str(self.hermes_home),
+            "user_data": str(self.user_data),
+            "runtime_root": str(self.runtime_root),
+            "canonical_exe": str(self.canonical_exe),
+            "named_exe": str(self.named_exe),
+            "launcher_dir": str(self.launcher_dir),
+            "launcher_exe": str(self.launcher_exe),
+            "shortcut_path": str(self.shortcut_path),
+        }
+
+
+def validate_instance_name(name: str) -> str:
+    """Return the canonical instance slug or raise ``InstanceNameError``."""
+    if not isinstance(name, str) or not name.strip():
+        raise InstanceNameError("Instance name cannot be empty.")
+    slug = name.strip().lower()
+    if not _NAME_RE.match(slug):
+        raise InstanceNameError(
+            f"Invalid instance name {name!r}. Use a slug matching "
+            f"[a-z0-9][a-z0-9_-]{{0,63}} (for example 'grace' or 'athena')."
+        )
+    if slug in _RESERVED_NAMES:
+        raise InstanceNameError(
+            f"Instance name {slug!r} is reserved. Pick a different name."
+        )
+    return slug
+
+
+def validate_remote_hermes_path(path: str) -> str:
+    """Require an absolute remote Hermes launcher path."""
+    value = (path or "").strip()
+    if not value:
+        raise StalePathError("Remote Hermes path is required and must be absolute.")
+    posix_abs = value.startswith("/")
+    windows_abs = bool(_WIN_ABS.match(value) or value.startswith("\\\\"))
+    if not posix_abs and not windows_abs:
+        raise StalePathError(
+            f"Remote Hermes path {path!r} is not absolute. "
+            "Pass the full remote launcher path (for example /home/you/.local/bin/hermes)."
+        )
+    return value
+
+
+def validate_ssh_host(host: str) -> str:
+    value = (host or "").strip()
+    if not value:
+        raise MissingSshAliasError("SSH host / alias is required.")
+    if any(sep in value for sep in ("\\", "/", "\x00")):
+        raise MissingSshAliasError(
+            f"SSH host {host!r} looks like a path. Pass an ssh config alias or hostname."
+        )
+    return value
+
+
+def validate_remote_profile(name: str) -> str:
+    canon = normalize_profile_name(name)
+    validate_profile_name(canon)
+    return canon
+
+
+def default_display_name(name: str) -> str:
+    words = validate_instance_name(name).replace("_", "-").replace("-", " ")
+    return "Hermes " + " ".join(part.capitalize() for part in words.split())
+
+
+def seed_connection_config(instance: DesktopInstance) -> dict[str, object]:
+    """Non-secret SSH seed for the isolated shell's ``connection.json``."""
+    return {
+        "mode": "ssh",
+        "remote": {
+            "mode": "ssh",
+            "host": instance.ssh_host,
+            "remoteHermesPath": instance.remote_hermes_path,
+            "remoteProfile": instance.remote_profile,
+        },
+        "profiles": {},
+    }
+
+
+def _csharp_verbatim(value: str) -> str:
+    """Escape a value for a C# verbatim string literal.
+
+    A trailing backslash would eat the closing quote (``@"C:\\"``).
+    Embedded quotes are doubled.
+    """
+    text = str(value).replace('"', '""')
+    if text.endswith("\\"):
+        text += "\\"
+    return text
+
+
+def launcher_template_path() -> Path:
+    return Path(__file__).resolve().parent / "templates" / _TEMPLATE_NAME
+
+
+def csharp_identifier(display_name: str) -> str:
+    parts = re.findall(r"[A-Za-z0-9]+", display_name)
+    ident = "".join(part[:1].upper() + part[1:] for part in parts) or "HermesInstance"
+    if ident[0].isdigit():
+        ident = "Hermes" + ident
+    return ident + "Launcher"
+
+
+def _safe_exe_stem(display_name: str) -> str:
+    cleaned = re.sub(r'[<>:"/\\|?*]', "", display_name).strip(" .")
+    return cleaned or "Hermes Instance"
+
+
+def resolve_packaged_desktop_executable(runtime_root: Path) -> Path | None:
+    """Locate the current platform's unpacked Desktop executable."""
+    release_dir = Path(runtime_root) / "apps" / "desktop" / "release"
+    if sys.platform == "darwin":
+        candidates = list(release_dir.glob("mac*/Hermes.app/Contents/MacOS/Hermes"))
+    elif sys.platform == "win32":
+        candidates = [
+            release_dir / "win-unpacked" / "Hermes.exe",
+            release_dir / "win-ia32-unpacked" / "Hermes.exe",
+            release_dir / "win-arm64-unpacked" / "Hermes.exe",
+        ]
+    else:
+        candidates = [
+            release_dir / "linux-unpacked" / "hermes",
+            release_dir / "linux-unpacked" / "Hermes",
+            release_dir / "linux-arm64-unpacked" / "hermes",
+            release_dir / "linux-arm64-unpacked" / "Hermes",
+        ]
+    existing = [path for path in candidates if path.exists()]
+    if not existing:
+        return None
+    return max(existing, key=lambda path: path.stat().st_mtime)
+
+
+def default_shortcut_dir() -> Path:
+    for key in ("USERPROFILE", "HOME"):
+        home = os.environ.get(key, "").strip()
+        if home:
+            desktop = Path(home) / "Desktop"
+            if desktop.is_dir():
+                return desktop
+    return Path.home() / "Desktop"
+
+
+def default_ssh_probe(host: str) -> None:
+    ssh = shutil.which("ssh")
+    if not ssh:
+        raise MissingSshAliasError(
+            "ssh was not found on PATH. Install OpenSSH or add it to PATH, "
+            f"then retry with host {host!r}."
+        )
+    try:
+        result = subprocess.run(
+            [ssh, "-G", host],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except OSError as exc:
+        raise MissingSshAliasError(
+            f"Could not invoke ssh to resolve {host!r}: {exc}"
+        ) from exc
+    if result.returncode != 0:
+        detail = (
+            result.stderr or result.stdout or ""
+        ).strip() or f"exit {result.returncode}"
+        raise MissingSshAliasError(
+            f"SSH alias or host {host!r} could not be resolved ({detail})."
+        )
+
+
+def default_is_locked(path: Path) -> bool:
+    candidate = Path(path)
+    if not candidate.exists():
+        return False
+    flags = os.O_RDWR
+    if hasattr(os, "O_BINARY"):
+        flags |= os.O_BINARY
+    try:
+        fd = os.open(str(candidate), flags)
+    except OSError:
+        return True
+    os.close(fd)
+    return False
+
+
+def default_compiler(source: str, output: Path) -> None:
+    csc = _find_csc()
+    if csc is None:
+        raise DesktopInstanceError(
+            "The .NET Framework C# compiler (csc.exe) was not found. "
+            "Isolated Desktop launchers need the in-box Framework compiler."
+        )
+    output = Path(output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    source_path = output.with_suffix(".cs")
+    atomic_write_text(source_path, source)
+    command = [
+        str(csc),
+        "/nologo",
+        "/target:winexe",
+        f"/out:{os.path.normpath(output)}",
+        "/r:System.Windows.Forms.dll",
+        os.path.normpath(source_path),
+    ]
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    if result.returncode != 0 or not output.exists():
+        detail = (
+            result.stderr or result.stdout or ""
+        ).strip() or f"exit {result.returncode}"
+        raise DesktopInstanceError(
+            f"Failed to compile the isolated Desktop launcher: {detail}"
+        )
+
+
+def default_shortcut_writer(spec: ShortcutSpec) -> None:
+    spec.path.parent.mkdir(parents=True, exist_ok=True)
+    script = (
+        "$ws = New-Object -ComObject WScript.Shell; "
+        f"$s = $ws.CreateShortcut({_ps_quote(str(spec.path))}); "
+        f"$s.TargetPath = {_ps_quote(spec.target)}; "
+        f"$s.IconLocation = {_ps_quote(spec.icon)}; "
+        f"$s.WorkingDirectory = {_ps_quote(spec.working_directory)}; "
+        f"$s.Description = {_ps_quote(spec.description)}; "
+        "$s.Save()"
+    )
+    result = subprocess.run(
+        ["powershell", "-NoProfile", "-NonInteractive", "-Command", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0 or not spec.path.exists():
+        detail = (
+            result.stderr or result.stdout or ""
+        ).strip() or f"exit {result.returncode}"
+        raise DesktopInstanceError(f"Failed to create the Desktop shortcut: {detail}")
+
+
+def default_process_starter(plan: LaunchPlan) -> int:
+    env = os.environ.copy()
+    env.update(plan.env)
+    proc = subprocess.Popen(
+        [str(plan.executable), *plan.arguments],
+        cwd=plan.cwd or None,
+        env=env,
+    )
+    return int(proc.pid)
+
+
+def _find_csc() -> Path | None:
+    windir = Path(os.environ.get("WINDIR", r"C:\Windows"))
+    candidates = [
+        windir / "Microsoft.NET" / "Framework64" / "v4.0.30319" / "csc.exe",
+        windir / "Microsoft.NET" / "Framework" / "v4.0.30319" / "csc.exe",
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _ps_quote(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def refresh_named_hardlink(
+    canonical_exe: Path,
+    named_exe: Path,
+    *,
+    is_locked: Callable[[Path], bool] = default_is_locked,
+) -> HardlinkRefreshResult:
+    canonical_exe = Path(canonical_exe)
+    named_exe = Path(named_exe)
+    if not canonical_exe.is_file():
+        raise StalePathError(
+            f"The canonical Hermes Desktop executable is missing: {canonical_exe}"
+        )
+    named_exe.parent.mkdir(parents=True, exist_ok=True)
+    if named_exe.exists():
+        if is_locked(named_exe):
+            return HardlinkRefreshResult(named_exe, False, True)
+        try:
+            named_exe.unlink()
+        except OSError:
+            return HardlinkRefreshResult(named_exe, False, True)
+    os.link(canonical_exe, named_exe)
+    return HardlinkRefreshResult(named_exe, True, False)
+
+
+class DesktopInstanceStore:
+    """Filesystem-backed registry of isolated Desktop instances."""
+
+    def __init__(
+        self,
+        *,
+        hermes_root: Path,
+        runtime_root: Path,
+        canonical_exe: Path,
+        shortcut_dir: Path,
+        platform: str | None = None,
+        ssh_probe: Callable[[str], None] = default_ssh_probe,
+        compiler: Callable[[str, Path], None] = default_compiler,
+        shortcut_writer: Callable[[ShortcutSpec], None] = default_shortcut_writer,
+        is_locked: Callable[[Path], bool] = default_is_locked,
+        process_starter: Callable[[LaunchPlan], int] = default_process_starter,
+        cwd: Path | None = None,
+    ) -> None:
+        self.hermes_root = Path(hermes_root)
+        self.runtime_root = Path(runtime_root)
+        self.canonical_exe = Path(canonical_exe)
+        self.shortcut_dir = Path(shortcut_dir)
+        self.platform = platform or sys.platform
+        self.ssh_probe = ssh_probe
+        self.compiler = compiler
+        self.shortcut_writer = shortcut_writer
+        self.is_locked = is_locked
+        self.process_starter = process_starter
+        self.cwd = Path(cwd) if cwd is not None else Path.cwd()
+
+    @classmethod
+    def from_defaults(
+        cls,
+        *,
+        runtime_root: Path,
+        canonical_exe: Path | None = None,
+        hermes_root: Path | None = None,
+        cwd: Path | None = None,
+    ) -> "DesktopInstanceStore":
+        resolved_runtime = Path(runtime_root)
+        exe = (
+            Path(canonical_exe)
+            if canonical_exe is not None
+            else resolve_packaged_desktop_executable(resolved_runtime)
+        )
+        if exe is None:
+            exe = (
+                resolved_runtime
+                / "apps"
+                / "desktop"
+                / "release"
+                / "win-unpacked"
+                / "Hermes.exe"
+            )
+        return cls(
+            hermes_root=Path(hermes_root)
+            if hermes_root is not None
+            else get_default_hermes_root(),
+            runtime_root=resolved_runtime,
+            canonical_exe=exe,
+            shortcut_dir=default_shortcut_dir(),
+            cwd=cwd,
+        )
+
+    @property
+    def registry_root(self) -> Path:
+        return self.hermes_root / INSTANCES_DIRNAME
+
+    def instance_root(self, name: str) -> Path:
+        return self.registry_root / validate_instance_name(name)
+
+    def _require_windows(self, action: str) -> None:
+        if self.platform != "win32":
+            raise IncompatiblePlatformError(
+                f"{action} is only supported on Windows. "
+                "macOS/Linux isolated Desktop shells are a follow-up."
+            )
+
+    def _require_runtime(self) -> None:
+        if not self.canonical_exe.is_file():
+            raise StalePathError(
+                "The canonical Hermes Desktop executable is missing: "
+                f"{self.canonical_exe}. Build it with `hermes desktop --build-only` "
+                "or pass a packaged tree that still contains Hermes.exe."
+            )
+        if not self.runtime_root.exists():
+            raise StalePathError(
+                f"The shared Hermes runtime was not found: {self.runtime_root}"
+            )
+
+    def build_instance(
+        self,
+        name: str,
+        *,
+        ssh_host: str,
+        remote_hermes_path: str,
+        remote_profile: str,
+        display_name: str | None = None,
+    ) -> DesktopInstance:
+        slug = validate_instance_name(name)
+        host = validate_ssh_host(ssh_host)
+        remote_path = validate_remote_hermes_path(remote_hermes_path)
+        profile = validate_remote_profile(remote_profile)
+        label = (display_name or "").strip() or default_display_name(slug)
+        app_name = label
+        root = self.instance_root(slug)
+        launcher_dir = root / "launcher"
+        stem = _safe_exe_stem(app_name)
+        named_exe = self.canonical_exe.with_name(f"{stem}.exe")
+        if (
+            named_exe.resolve() == self.canonical_exe.resolve()
+            or stem.lower() == "hermes"
+        ):
+            raise InstanceNameError(
+                f"Display name {label!r} would collide with the canonical Hermes.exe. "
+                "Use a distinct name such as 'Hermes Grace'."
+            )
+        return DesktopInstance(
+            name=slug,
+            display_name=label,
+            app_name=app_name,
+            ssh_host=host,
+            remote_hermes_path=remote_path,
+            remote_profile=profile,
+            hermes_home=root / "home",
+            user_data=root / "user-data",
+            runtime_root=self.runtime_root,
+            canonical_exe=self.canonical_exe,
+            named_exe=named_exe,
+            launcher_dir=launcher_dir,
+            launcher_exe=launcher_dir / f"{csharp_identifier(app_name)}.exe",
+            shortcut_path=self.shortcut_dir / f"{stem}.lnk",
+            manifest_path=root / "instance.json",
+        )
+
+    def build_launch_plan(self, instance: DesktopInstance) -> LaunchPlan:
+        return LaunchPlan(
+            executable=instance.named_exe,
+            arguments=[f"--user-data-dir={instance.user_data}"],
+            env={
+                "HERMES_HOME": str(instance.hermes_home),
+                "HERMES_DESKTOP_USER_DATA_DIR": str(instance.user_data),
+                "HERMES_DESKTOP_HERMES_ROOT": str(instance.runtime_root),
+                "HERMES_DESKTOP_APP_NAME": instance.app_name,
+                "HERMES_DESKTOP_CWD": str(self.cwd),
+            },
+            cwd=str(self.cwd),
+            use_shell_execute=False,
+        )
+
+    def render_launcher_source(self, instance: DesktopInstance) -> str:
+        template = launcher_template_path().read_text(encoding="utf-8")
+        replacements = {
+            "{{CLASS_NAME}}": csharp_identifier(instance.app_name),
+            "{{LAUNCHER_DIRECTORY}}": _csharp_verbatim(instance.launcher_dir),
+            "{{SHARED_HERMES_EXE}}": _csharp_verbatim(instance.canonical_exe),
+            "{{NAMED_HERMES_EXE}}": _csharp_verbatim(instance.named_exe),
+            "{{HERMES_ROOT}}": _csharp_verbatim(instance.runtime_root),
+            "{{HERMES_HOME}}": _csharp_verbatim(instance.hermes_home),
+            "{{USER_DATA}}": _csharp_verbatim(instance.user_data),
+            "{{WORKING_DIRECTORY}}": _csharp_verbatim(self.cwd),
+            "{{APP_NAME}}": _csharp_verbatim(instance.app_name),
+        }
+        source = template
+        for token, value in replacements.items():
+            source = source.replace(token, value)
+        if "{{" in source:
+            raise DesktopInstanceError(
+                "Launcher template still contains unreplaced placeholders."
+            )
+        return source
+
+    def create(
+        self,
+        name: str,
+        *,
+        ssh_host: str,
+        remote_hermes_path: str,
+        remote_profile: str,
+        display_name: str | None = None,
+        skip_ssh_check: bool = False,
+        install_shortcut: bool = True,
+    ) -> DesktopInstance:
+        self._require_windows("Creating an isolated Desktop instance")
+        self._require_runtime()
+        instance = self.build_instance(
+            name,
+            ssh_host=ssh_host,
+            remote_hermes_path=remote_hermes_path,
+            remote_profile=remote_profile,
+            display_name=display_name,
+        )
+        if instance.manifest_path.exists():
+            raise InstanceExistsError(
+                f"Isolated Desktop instance {instance.name!r} already exists at "
+                f"{instance.manifest_path}."
+            )
+        if not skip_ssh_check:
+            self.ssh_probe(instance.ssh_host)
+
+        instance.hermes_home.mkdir(parents=True, exist_ok=True)
+        instance.user_data.mkdir(parents=True, exist_ok=True)
+        instance.launcher_dir.mkdir(parents=True, exist_ok=True)
+        self._seed_connection(instance)
+        self._materialize_windows_bits(instance, install_shortcut=install_shortcut)
+        self._write_manifest(instance)
+        return instance
+
+    def list(self) -> list[DesktopInstance]:
+        root = self.registry_root
+        if not root.is_dir():
+            return []
+        found: list[DesktopInstance] = []
+        for entry in sorted(root.iterdir(), key=lambda path: path.name.lower()):
+            manifest = entry / "instance.json"
+            if not manifest.is_file():
+                continue
+            try:
+                found.append(self._load_manifest(manifest))
+            except ManifestError:
+                continue
+        return found
+
+    def get(self, name: str) -> DesktopInstance:
+        slug = validate_instance_name(name)
+        manifest = self.instance_root(slug) / "instance.json"
+        if not manifest.is_file():
+            raise InstanceNotFoundError(
+                f"Isolated Desktop instance {slug!r} was not found. "
+                "Run `hermes desktop instance list`."
+            )
+        return self._load_manifest(manifest)
+
+    def repair(self, name: str) -> HardlinkRefreshResult:
+        self._require_windows("Repairing an isolated Desktop instance")
+        self._require_runtime()
+        instance = self.get(name)
+        result = refresh_named_hardlink(
+            self.canonical_exe,
+            instance.named_exe,
+            is_locked=self.is_locked,
+        )
+        self._compile_launcher(instance)
+        return result
+
+    def repair_all(self) -> list[tuple[DesktopInstance, HardlinkRefreshResult]]:
+        self._require_windows("Repairing isolated Desktop instances")
+        self._require_runtime()
+        repaired: list[tuple[DesktopInstance, HardlinkRefreshResult]] = []
+        compile_errors: list[str] = []
+        for instance in self.list():
+            result = refresh_named_hardlink(
+                self.canonical_exe,
+                instance.named_exe,
+                is_locked=self.is_locked,
+            )
+            repaired.append((instance, result))
+        for instance, _result in repaired:
+            try:
+                self._compile_launcher(instance)
+            except DesktopInstanceError as exc:
+                compile_errors.append(f"{instance.name}: {exc}")
+        if compile_errors:
+            raise DesktopInstanceError(
+                "Hardlinks were refreshed, but some launchers failed to rebuild: "
+                + "; ".join(compile_errors)
+            )
+        return repaired
+
+    def launch(self, name: str) -> int:
+        self._require_windows("Launching an isolated Desktop instance")
+        self._require_runtime()
+        instance = self.get(name)
+        instance.hermes_home.mkdir(parents=True, exist_ok=True)
+        instance.user_data.mkdir(parents=True, exist_ok=True)
+        self.repair(name)
+        plan = self.build_launch_plan(instance)
+        if not plan.executable.is_file():
+            raise StalePathError(
+                f"Named Desktop executable is missing after repair: {plan.executable}"
+            )
+        return self.process_starter(plan)
+
+    def install_shortcut(self, name: str) -> ShortcutSpec:
+        self._require_windows("Installing an isolated Desktop shortcut")
+        self._require_runtime()
+        instance = self.get(name)
+        self._materialize_windows_bits(instance, install_shortcut=True)
+        return ShortcutSpec(
+            path=instance.shortcut_path,
+            target=str(instance.launcher_exe),
+            icon=str(self.canonical_exe),
+            working_directory=str(self.cwd),
+            description=f"{instance.app_name} isolated Desktop",
+        )
+
+    def remove(
+        self,
+        name: str,
+        *,
+        purge_local: bool = False,
+        force: bool = False,
+    ) -> RemoveResult:
+        instance = self.get(name)
+        if (
+            self.platform == "win32"
+            and instance.named_exe.exists()
+            and self.is_locked(instance.named_exe)
+        ):
+            if not force:
+                raise InstanceLockedError(
+                    f"{instance.app_name} appears to be running "
+                    f"({instance.named_exe}). Close that window, or pass --force "
+                    "to remove the launcher while leaving the process alone."
+                )
+        self._unlink_if_present(instance.shortcut_path)
+        self._unlink_if_present(instance.launcher_exe)
+        self._unlink_if_present(instance.launcher_exe.with_suffix(".cs"))
+        if instance.named_exe.exists() and not self.is_locked(instance.named_exe):
+            self._unlink_if_present(instance.named_exe)
+        self._unlink_if_present(instance.manifest_path)
+        if purge_local:
+            shutil.rmtree(instance.hermes_home, ignore_errors=True)
+            shutil.rmtree(instance.user_data, ignore_errors=True)
+            shutil.rmtree(instance.launcher_dir, ignore_errors=True)
+            root = self.instance_root(instance.name)
+            if root.is_dir() and not any(root.rglob("*")):
+                shutil.rmtree(root, ignore_errors=True)
+        return RemoveResult(
+            name=instance.name,
+            remote_state_deleted=False,
+            purged_local=purge_local,
+        )
+
+    def _materialize_windows_bits(
+        self, instance: DesktopInstance, *, install_shortcut: bool
+    ) -> None:
+        refresh_named_hardlink(
+            self.canonical_exe,
+            instance.named_exe,
+            is_locked=self.is_locked,
+        )
+        self._compile_launcher(instance)
+        if install_shortcut:
+            spec = ShortcutSpec(
+                path=instance.shortcut_path,
+                target=str(instance.launcher_exe),
+                icon=str(self.canonical_exe),
+                working_directory=str(self.cwd),
+                description=f"{instance.app_name} isolated Desktop",
+            )
+            self.shortcut_writer(spec)
+
+    def _compile_launcher(self, instance: DesktopInstance) -> None:
+        instance.launcher_dir.mkdir(parents=True, exist_ok=True)
+        self.compiler(self.render_launcher_source(instance), instance.launcher_exe)
+
+    def _write_manifest(self, instance: DesktopInstance) -> None:
+        payload = instance.to_manifest()
+        payload["updated_at"] = datetime.now(timezone.utc).isoformat()
+        if not instance.manifest_path.exists():
+            payload["created_at"] = payload["updated_at"]
+        self._assert_no_secrets(payload)
+        atomic_write_text(
+            instance.manifest_path,
+            json.dumps(payload, indent=2) + "\n",
+            create_mode=0o600,
+        )
+
+    def _seed_connection(self, instance: DesktopInstance) -> None:
+        seed_path = instance.user_data / "connection.json"
+        if seed_path.exists():
+            return
+        payload = seed_connection_config(instance)
+        self._assert_no_secrets(payload)
+        atomic_write_text(
+            seed_path,
+            json.dumps(payload, indent=2) + "\n",
+            create_mode=0o600,
+        )
+
+    def _load_manifest(self, path: Path) -> DesktopInstance:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ManifestError(
+                f"Could not read instance manifest {path}: {exc}"
+            ) from exc
+        if not isinstance(data, dict):
+            raise ManifestError(f"Instance manifest {path} is not an object.")
+        version = data.get("version")
+        if version != MANIFEST_VERSION:
+            raise ManifestError(
+                f"Unsupported isolated Desktop manifest version {version!r} in {path}."
+            )
+        required = (
+            "name",
+            "ssh_host",
+            "remote_hermes_path",
+            "remote_profile",
+            "display_name",
+            "app_name",
+        )
+        missing = [key for key in required if not data.get(key)]
+        if missing:
+            raise ManifestError(
+                f"Instance manifest {path} is missing: {', '.join(missing)}."
+            )
+        return self.build_instance(
+            str(data["name"]),
+            ssh_host=str(data["ssh_host"]),
+            remote_hermes_path=str(data["remote_hermes_path"]),
+            remote_profile=str(data["remote_profile"]),
+            display_name=str(data.get("display_name") or ""),
+        )
+
+    @staticmethod
+    def _assert_no_secrets(payload: object) -> None:
+        stack: list[object] = [payload]
+        while stack:
+            current = stack.pop()
+            if isinstance(current, dict):
+                for key, value in current.items():
+                    if str(key).lower() in _SECRET_KEYS:
+                        raise ManifestError(
+                            f"Refusing to persist secret field {key!r} in an isolated Desktop file."
+                        )
+                    stack.append(value)
+            elif isinstance(current, list):
+                stack.extend(current)
+
+    @staticmethod
+    def _unlink_if_present(path: Path) -> None:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            return
+        except OSError:
+            return
+
+
+def repair_instances_for_runtime(
+    runtime_root: Path, canonical_exe: Path | None
+) -> list[str]:
+    """Best-effort hardlink refresh after the canonical Desktop exe is replaced."""
+    if sys.platform != "win32" or canonical_exe is None:
+        return []
+    store = DesktopInstanceStore.from_defaults(
+        runtime_root=runtime_root,
+        canonical_exe=canonical_exe,
+    )
+    if not store.list():
+        return []
+    refreshed = []
+    for instance, result in store.repair_all():
+        state = "retained (running)" if result.retained_running else "refreshed"
+        refreshed.append(f"{instance.name} ({state})")
+    return refreshed
+
+
+def cmd_desktop_instance(args, *, runtime_root: Path) -> None:
+    """CLI handler for ``hermes desktop instance …``."""
+    action = getattr(args, "instance_action", None)
+    store = DesktopInstanceStore.from_defaults(
+        runtime_root=Path(runtime_root),
+        cwd=Path(args.cwd).expanduser().resolve()
+        if getattr(args, "cwd", None)
+        else None,
+    )
+    try:
+        _dispatch_instance_action(store, args, action)
+    except DesktopInstanceError as exc:
+        print(f"✗ {exc}")
+        sys.exit(1)
+    except ValueError as exc:
+        print(f"✗ {exc}")
+        sys.exit(1)
+
+
+def _dispatch_instance_action(
+    store: DesktopInstanceStore, args, action: str | None
+) -> None:
+    if not action:
+        print(
+            "Usage: hermes desktop instance {create,list,show,launch,shortcut,repair,remove}"
+        )
+        print(
+            "Isolated instances are a separate Desktop shell — not Settings → Connections."
+        )
+        sys.exit(2)
+
+    if action == "list":
+        instances = store.list()
+        if not instances:
+            print("No isolated Desktop instances are registered.")
+            print(
+                "Create one with: hermes desktop instance create NAME --ssh-host HOST "
+                "--remote-hermes-path PATH --remote-profile PROFILE"
+            )
+            return
+        print(
+            "Isolated Desktop instances (separate shells; remote state stays remote):\n"
+        )
+        for instance in instances:
+            print(
+                f"  {instance.name:16}  {instance.app_name}  "
+                f"ssh:{instance.ssh_host}  remote-profile:{instance.remote_profile}"
+            )
+        return
+
+    if action == "create":
+        instance = store.create(
+            args.instance_name,
+            ssh_host=args.ssh_host,
+            remote_hermes_path=args.remote_hermes_path,
+            remote_profile=args.remote_profile,
+            display_name=getattr(args, "display_name", None),
+            skip_ssh_check=bool(getattr(args, "skip_ssh_check", False)),
+            install_shortcut=not bool(getattr(args, "no_shortcut", False)),
+        )
+        print(f"✓ Isolated Desktop instance {instance.name!r} ready")
+        print(f"  App name:        {instance.app_name}")
+        print(f"  SSH host:        {instance.ssh_host}")
+        print(f"  Remote Hermes:   {instance.remote_hermes_path}")
+        print(f"  Remote profile:  {instance.remote_profile}")
+        print(f"  Local home:      {instance.hermes_home}")
+        print(f"  Electron data:   {instance.user_data}")
+        print(f"  Shared runtime:  {instance.runtime_root}")
+        print(f"  Shortcut:        {instance.shortcut_path}")
+        print("  Remote sessions, memory, skills, and credentials were not copied.")
+        print(f"Launch with: hermes desktop instance launch {instance.name}")
+        return
+
+    if action == "show":
+        instance = store.get(args.instance_name)
+        print(json.dumps(instance.to_manifest(), indent=2))
+        return
+
+    if action == "launch":
+        pid = store.launch(args.instance_name)
+        instance = store.get(args.instance_name)
+        print(f"→ Launched {instance.app_name} (pid {pid})")
+        return
+
+    if action == "shortcut":
+        spec = store.install_shortcut(args.instance_name)
+        print(f"✓ Shortcut installed: {spec.path}")
+        return
+
+    if action == "repair":
+        if getattr(args, "all_instances", False):
+            repaired = store.repair_all()
+            if not repaired:
+                print("No isolated Desktop instances to repair.")
+                return
+            for instance, result in repaired:
+                note = (
+                    "retained running image"
+                    if result.retained_running
+                    else "hardlink refreshed"
+                )
+                print(f"✓ {instance.name}: {note}")
+            return
+        if not getattr(args, "instance_name", None):
+            raise DesktopInstanceError("Pass an instance name or --all.")
+        result = store.repair(args.instance_name)
+        note = (
+            "retained running image"
+            if result.retained_running
+            else "hardlink refreshed"
+        )
+        print(f"✓ {args.instance_name}: {note}")
+        return
+
+    if action == "remove":
+        result = store.remove(
+            args.instance_name,
+            purge_local=bool(getattr(args, "purge_local", False)),
+            force=bool(getattr(args, "force", False)),
+        )
+        print(
+            f"✓ Removed launcher/shortcut for {result.name!r}. "
+            "Remote Hermes state was not deleted."
+        )
+        if result.purged_local:
+            print("  Local isolated home and Electron userData were deleted.")
+        else:
+            print(
+                "  Local isolated home/userData were kept. Pass --purge-local to delete them."
+            )
+        return
+
+    raise DesktopInstanceError(f"Unknown instance action {action!r}.")

--- a/hermes_cli/desktop_instances.py
+++ b/hermes_cli/desktop_instances.py
@@ -443,7 +443,14 @@ def default_compiler(source: str, output: Path) -> None:
         "/r:System.Windows.Forms.dll",
         os.path.normpath(source_path),
     ]
-    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
     if result.returncode != 0 or not output.exists():
         detail = (
             result.stderr or result.stdout or ""
@@ -468,6 +475,8 @@ def default_shortcut_writer(spec: ShortcutSpec) -> None:
         ["powershell", "-NoProfile", "-NonInteractive", "-Command", script],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         check=False,
     )
     if result.returncode != 0 or not spec.path.exists():
@@ -478,8 +487,13 @@ def default_shortcut_writer(spec: ShortcutSpec) -> None:
 
 
 def default_process_starter(plan: LaunchPlan) -> int:
-    env = os.environ.copy()
-    env.update(plan.env)
+    from tools.environments.local import build_subprocess_env
+
+    env = build_subprocess_env(
+        inherit_profile_home=False,
+        scrub_secrets=False,
+        extra=plan.env,
+    )
     proc = subprocess.Popen(
         [str(plan.executable), *plan.arguments],
         cwd=plan.cwd or None,

--- a/hermes_cli/desktop_instances.py
+++ b/hermes_cli/desktop_instances.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -54,6 +55,38 @@ _SECRET_KEYS = frozenset({"token", "password", "secret", "passphrase", "private_
 
 class DesktopInstanceError(Exception):
     """User-facing instance management error."""
+
+
+class IsolatedInstanceSpecError(DesktopInstanceError):
+    """A Connections entry cannot become an isolated Desktop instance."""
+
+
+@dataclass(frozen=True)
+class IsolatedInstanceSpec:
+    name: str
+    display_name: str
+    ssh_host: str
+    remote_hermes_path: str
+    remote_profile: str
+
+    def to_manifest(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "display_name": self.display_name,
+            "ssh_host": self.ssh_host,
+            "remote_hermes_path": self.remote_hermes_path,
+            "remote_profile": self.remote_profile,
+        }
+
+
+@dataclass(frozen=True)
+class InstanceDeepLink:
+    instance_name: str
+    remainder: str
+
+
+SUPPORTED_DESKTOP_PLATFORMS = frozenset({"win32", "linux", "darwin"})
+INSTANCE_AUMID_PREFIX = "com.nousresearch.hermes.instance."
 
 
 class InstanceNameError(DesktopInstanceError):
@@ -210,6 +243,62 @@ def validate_remote_profile(name: str) -> str:
 def default_display_name(name: str) -> str:
     words = validate_instance_name(name).replace("_", "-").replace("-", " ")
     return "Hermes " + " ".join(part.capitalize() for part in words.split())
+
+
+def instance_aumid(name: str) -> str:
+    return INSTANCE_AUMID_PREFIX + validate_instance_name(name)
+
+
+def slug_from_label(label: str) -> str:
+    text = (label or "").strip()
+    if text.lower().startswith("hermes "):
+        text = text[6:].strip()
+    slug = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+    return validate_instance_name(slug)
+
+
+def isolated_instance_spec_from_ssh(
+    connection: dict[str, object],
+) -> IsolatedInstanceSpec:
+    kind = str(connection.get("kind") or "").strip().lower()
+    if kind != "ssh":
+        raise IsolatedInstanceSpecError(
+            "Only SSH Connections can open as an isolated Desktop. "
+            "Remote-gateway and Cloud entries stay in the shared shell."
+        )
+    host = validate_ssh_host(str(connection.get("host") or ""))
+    try:
+        remote_path = validate_remote_hermes_path(
+            str(connection.get("remoteHermesPath") or "")
+        )
+    except StalePathError as exc:
+        raise IsolatedInstanceSpecError(str(exc)) from exc
+    profile_raw = str(connection.get("remoteProfile") or "default")
+    profile = validate_remote_profile(profile_raw)
+    label = str(connection.get("label") or "").strip()
+    name = slug_from_label(label or host)
+    display = (
+        label if label.lower().startswith("hermes ") else default_display_name(name)
+    )
+    return IsolatedInstanceSpec(
+        name=name,
+        display_name=display,
+        ssh_host=host,
+        remote_hermes_path=remote_path,
+        remote_profile=profile,
+    )
+
+
+def parse_instance_deep_link(url: str) -> InstanceDeepLink | None:
+    raw = (url or "").strip()
+    prefix = "hermes://instance/"
+    if not raw.startswith(prefix):
+        return None
+    rest = raw[len(prefix) :]
+    slug, sep, tail = rest.partition("/")
+    name = validate_instance_name(slug)
+    remainder = f"hermes://{tail}" if sep else "hermes://"
+    return InstanceDeepLink(instance_name=name, remainder=remainder)
 
 
 def seed_connection_config(instance: DesktopInstance) -> dict[str, object]:
@@ -424,6 +513,12 @@ def refresh_named_hardlink(
         raise StalePathError(
             f"The canonical Hermes Desktop executable is missing: {canonical_exe}"
         )
+    try:
+        if canonical_exe.resolve() == named_exe.resolve():
+            return HardlinkRefreshResult(named_exe, False, False)
+    except OSError:
+        if canonical_exe == named_exe:
+            return HardlinkRefreshResult(named_exe, False, False)
     named_exe.parent.mkdir(parents=True, exist_ok=True)
     if named_exe.exists():
         if is_locked(named_exe):
@@ -507,11 +602,11 @@ class DesktopInstanceStore:
     def instance_root(self, name: str) -> Path:
         return self.registry_root / validate_instance_name(name)
 
-    def _require_windows(self, action: str) -> None:
-        if self.platform != "win32":
+    def _require_desktop_platform(self, action: str) -> None:
+        if self.platform not in SUPPORTED_DESKTOP_PLATFORMS:
             raise IncompatiblePlatformError(
-                f"{action} is only supported on Windows. "
-                "macOS/Linux isolated Desktop shells are a follow-up."
+                f"{action} is not supported on {self.platform!r}. "
+                "Isolated Desktop instances run on Windows, macOS, and Linux."
             )
 
     def _require_runtime(self) -> None:
@@ -544,8 +639,10 @@ class DesktopInstanceStore:
         root = self.instance_root(slug)
         launcher_dir = root / "launcher"
         stem = _safe_exe_stem(app_name)
-        named_exe = self.canonical_exe.with_name(f"{stem}.exe")
-        if (
+        named_exe, launcher_exe, shortcut_path = self._platform_launch_paths(
+            slug, app_name, stem, launcher_dir
+        )
+        if self.platform == "win32" and (
             named_exe.resolve() == self.canonical_exe.resolve()
             or stem.lower() == "hermes"
         ):
@@ -566,22 +663,31 @@ class DesktopInstanceStore:
             canonical_exe=self.canonical_exe,
             named_exe=named_exe,
             launcher_dir=launcher_dir,
-            launcher_exe=launcher_dir / f"{csharp_identifier(app_name)}.exe",
-            shortcut_path=self.shortcut_dir / f"{stem}.lnk",
+            launcher_exe=launcher_exe,
+            shortcut_path=shortcut_path,
             manifest_path=root / "instance.json",
         )
 
-    def build_launch_plan(self, instance: DesktopInstance) -> LaunchPlan:
+    def build_launch_plan(
+        self, instance: DesktopInstance, *, deep_link: str | None = None
+    ) -> LaunchPlan:
+        env = {
+            "HERMES_HOME": str(instance.hermes_home),
+            "HERMES_DESKTOP_USER_DATA_DIR": str(instance.user_data),
+            "HERMES_DESKTOP_HERMES_ROOT": str(instance.runtime_root),
+            "HERMES_DESKTOP_APP_NAME": instance.app_name,
+            "HERMES_DESKTOP_CWD": str(self.cwd),
+            "HERMES_DESKTOP_INSTANCE": instance.name,
+            "HERMES_DESKTOP_AUMID": instance_aumid(instance.name),
+            "HERMES_DESKTOP_DISABLE_GLOBAL_SHORTCUTS": "1",
+            "HERMES_DESKTOP_SKIP_PROTOCOL_REGISTER": "1",
+        }
+        if deep_link:
+            env["HERMES_DESKTOP_PENDING_DEEP_LINK"] = deep_link
         return LaunchPlan(
             executable=instance.named_exe,
             arguments=[f"--user-data-dir={instance.user_data}"],
-            env={
-                "HERMES_HOME": str(instance.hermes_home),
-                "HERMES_DESKTOP_USER_DATA_DIR": str(instance.user_data),
-                "HERMES_DESKTOP_HERMES_ROOT": str(instance.runtime_root),
-                "HERMES_DESKTOP_APP_NAME": instance.app_name,
-                "HERMES_DESKTOP_CWD": str(self.cwd),
-            },
+            env=env,
             cwd=str(self.cwd),
             use_shell_execute=False,
         )
@@ -598,6 +704,8 @@ class DesktopInstanceStore:
             "{{USER_DATA}}": _csharp_verbatim(instance.user_data),
             "{{WORKING_DIRECTORY}}": _csharp_verbatim(self.cwd),
             "{{APP_NAME}}": _csharp_verbatim(instance.app_name),
+            "{{INSTANCE_NAME}}": _csharp_verbatim(instance.name),
+            "{{AUMID}}": _csharp_verbatim(instance_aumid(instance.name)),
         }
         source = template
         for token, value in replacements.items():
@@ -619,7 +727,7 @@ class DesktopInstanceStore:
         skip_ssh_check: bool = False,
         install_shortcut: bool = True,
     ) -> DesktopInstance:
-        self._require_windows("Creating an isolated Desktop instance")
+        self._require_desktop_platform("Creating an isolated Desktop instance")
         self._require_runtime()
         instance = self.build_instance(
             name,
@@ -670,7 +778,7 @@ class DesktopInstanceStore:
         return self._load_manifest(manifest)
 
     def repair(self, name: str) -> HardlinkRefreshResult:
-        self._require_windows("Repairing an isolated Desktop instance")
+        self._require_desktop_platform("Repairing an isolated Desktop instance")
         self._require_runtime()
         instance = self.get(name)
         result = refresh_named_hardlink(
@@ -678,11 +786,14 @@ class DesktopInstanceStore:
             instance.named_exe,
             is_locked=self.is_locked,
         )
-        self._compile_launcher(instance)
+        if self.platform == "win32":
+            self._compile_launcher(instance)
+        else:
+            self._write_posix_wrapper(instance)
         return result
 
     def repair_all(self) -> list[tuple[DesktopInstance, HardlinkRefreshResult]]:
-        self._require_windows("Repairing isolated Desktop instances")
+        self._require_desktop_platform("Repairing isolated Desktop instances")
         self._require_runtime()
         repaired: list[tuple[DesktopInstance, HardlinkRefreshResult]] = []
         compile_errors: list[str] = []
@@ -695,7 +806,10 @@ class DesktopInstanceStore:
             repaired.append((instance, result))
         for instance, _result in repaired:
             try:
-                self._compile_launcher(instance)
+                if self.platform == "win32":
+                    self._compile_launcher(instance)
+                else:
+                    self._write_posix_wrapper(instance)
             except DesktopInstanceError as exc:
                 compile_errors.append(f"{instance.name}: {exc}")
         if compile_errors:
@@ -705,14 +819,14 @@ class DesktopInstanceStore:
             )
         return repaired
 
-    def launch(self, name: str) -> int:
-        self._require_windows("Launching an isolated Desktop instance")
+    def launch(self, name: str, *, deep_link: str | None = None) -> int:
+        self._require_desktop_platform("Launching an isolated Desktop instance")
         self._require_runtime()
         instance = self.get(name)
         instance.hermes_home.mkdir(parents=True, exist_ok=True)
         instance.user_data.mkdir(parents=True, exist_ok=True)
         self.repair(name)
-        plan = self.build_launch_plan(instance)
+        plan = self.build_launch_plan(instance, deep_link=deep_link)
         if not plan.executable.is_file():
             raise StalePathError(
                 f"Named Desktop executable is missing after repair: {plan.executable}"
@@ -720,7 +834,7 @@ class DesktopInstanceStore:
         return self.process_starter(plan)
 
     def install_shortcut(self, name: str) -> ShortcutSpec:
-        self._require_windows("Installing an isolated Desktop shortcut")
+        self._require_desktop_platform("Installing an isolated Desktop shortcut")
         self._require_runtime()
         instance = self.get(name)
         self._materialize_windows_bits(instance, install_shortcut=True)
@@ -754,7 +868,11 @@ class DesktopInstanceStore:
         self._unlink_if_present(instance.shortcut_path)
         self._unlink_if_present(instance.launcher_exe)
         self._unlink_if_present(instance.launcher_exe.with_suffix(".cs"))
-        if instance.named_exe.exists() and not self.is_locked(instance.named_exe):
+        if (
+            instance.named_exe.exists()
+            and instance.named_exe.resolve() != instance.canonical_exe.resolve()
+            and not self.is_locked(instance.named_exe)
+        ):
             self._unlink_if_present(instance.named_exe)
         self._unlink_if_present(instance.manifest_path)
         if purge_local:
@@ -770,9 +888,34 @@ class DesktopInstanceStore:
             purged_local=purge_local,
         )
 
+    def _platform_launch_paths(
+        self, slug: str, app_name: str, stem: str, launcher_dir: Path
+    ) -> tuple[Path, Path, Path]:
+        if self.platform == "darwin":
+            script = launcher_dir / f"{slug}.command"
+            return self.canonical_exe, script, self.shortcut_dir / f"{stem}.command"
+        if self.platform == "linux":
+            script = launcher_dir / f"{slug}.sh"
+            return self.canonical_exe, script, self.shortcut_dir / f"{stem}.desktop"
+        return (
+            self.canonical_exe.with_name(f"{stem}.exe"),
+            launcher_dir / f"{csharp_identifier(app_name)}.exe",
+            self.shortcut_dir / f"{stem}.lnk",
+        )
+
     def _materialize_windows_bits(
         self, instance: DesktopInstance, *, install_shortcut: bool
     ) -> None:
+        if self.platform == "linux":
+            self._write_posix_wrapper(instance)
+            if install_shortcut:
+                self._write_linux_desktop_entry(instance)
+            return
+        if self.platform == "darwin":
+            self._write_posix_wrapper(instance)
+            if install_shortcut:
+                self._write_macos_command_shortcut(instance)
+            return
         refresh_named_hardlink(
             self.canonical_exe,
             instance.named_exe,
@@ -788,6 +931,52 @@ class DesktopInstanceStore:
                 description=f"{instance.app_name} isolated Desktop",
             )
             self.shortcut_writer(spec)
+
+    def _posix_wrapper_body(self, instance: DesktopInstance) -> str:
+        plan = self.build_launch_plan(instance)
+        exports = "\n".join(
+            f"export {key}={shlex.quote(value)}" for key, value in plan.env.items()
+        )
+        args = " ".join(shlex.quote(arg) for arg in plan.arguments)
+        return (
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            f"{exports}\n"
+            f'exec {shlex.quote(str(instance.named_exe))} {args} "$@"\n'
+        )
+
+    def _write_posix_wrapper(self, instance: DesktopInstance) -> None:
+        instance.launcher_dir.mkdir(parents=True, exist_ok=True)
+        atomic_write_text(instance.launcher_exe, self._posix_wrapper_body(instance))
+        try:
+            instance.launcher_exe.chmod(instance.launcher_exe.stat().st_mode | 0o111)
+        except OSError:
+            pass
+
+    def _write_linux_desktop_entry(self, instance: DesktopInstance) -> None:
+        self._write_posix_wrapper(instance)
+        body = (
+            "[Desktop Entry]\n"
+            "Type=Application\n"
+            f"Name={instance.app_name}\n"
+            f"Exec={shlex.quote(str(instance.launcher_exe))}\n"
+            f"Icon={instance.canonical_exe}\n"
+            "Terminal=false\n"
+            "Categories=Development;\n"
+        )
+        atomic_write_text(instance.shortcut_path, body)
+        try:
+            instance.shortcut_path.chmod(instance.shortcut_path.stat().st_mode | 0o111)
+        except OSError:
+            pass
+
+    def _write_macos_command_shortcut(self, instance: DesktopInstance) -> None:
+        self._write_posix_wrapper(instance)
+        atomic_write_text(instance.shortcut_path, self._posix_wrapper_body(instance))
+        try:
+            instance.shortcut_path.chmod(instance.shortcut_path.stat().st_mode | 0o111)
+        except OSError:
+            pass
 
     def _compile_launcher(self, instance: DesktopInstance) -> None:
         instance.launcher_dir.mkdir(parents=True, exist_ok=True)
@@ -975,7 +1164,10 @@ def _dispatch_instance_action(
         return
 
     if action == "launch":
-        pid = store.launch(args.instance_name)
+        pid = store.launch(
+            args.instance_name,
+            deep_link=getattr(args, "deep_link", None),
+        )
         instance = store.get(args.instance_name)
         print(f"→ Launched {instance.app_name} (pid {pid})")
         return

--- a/hermes_cli/desktop_instances.py
+++ b/hermes_cli/desktop_instances.py
@@ -65,15 +65,33 @@ class IsolatedInstanceSpecError(DesktopInstanceError):
 class IsolatedInstanceSpec:
     name: str
     display_name: str
+    connection_id: str
     ssh_host: str
+    ssh_user: str
+    ssh_port: int
+    ssh_key_path: str
     remote_hermes_path: str
     remote_profile: str
+
+    def dial_identity(self) -> dict[str, object]:
+        return {
+            "host": self.ssh_host,
+            "user": self.ssh_user,
+            "port": self.ssh_port,
+            "key_path": self.ssh_key_path,
+            "remote_hermes_path": self.remote_hermes_path,
+            "remote_profile": self.remote_profile,
+        }
 
     def to_manifest(self) -> dict[str, object]:
         return {
             "name": self.name,
             "display_name": self.display_name,
+            "connection_id": self.connection_id,
             "ssh_host": self.ssh_host,
+            "ssh_user": self.ssh_user,
+            "ssh_port": self.ssh_port,
+            "ssh_key_path": self.ssh_key_path,
             "remote_hermes_path": self.remote_hermes_path,
             "remote_profile": self.remote_profile,
         }
@@ -158,7 +176,11 @@ class DesktopInstance:
     name: str
     display_name: str
     app_name: str
+    connection_id: str
     ssh_host: str
+    ssh_user: str
+    ssh_port: int
+    ssh_key_path: str
     remote_hermes_path: str
     remote_profile: str
     hermes_home: Path
@@ -171,13 +193,30 @@ class DesktopInstance:
     shortcut_path: Path
     manifest_path: Path
 
+    def dial_identity(self) -> dict[str, object]:
+        return IsolatedInstanceSpec(
+            name=self.name,
+            display_name=self.display_name,
+            connection_id=self.connection_id,
+            ssh_host=self.ssh_host,
+            ssh_user=self.ssh_user,
+            ssh_port=self.ssh_port,
+            ssh_key_path=self.ssh_key_path,
+            remote_hermes_path=self.remote_hermes_path,
+            remote_profile=self.remote_profile,
+        ).dial_identity()
+
     def to_manifest(self) -> dict[str, object]:
         return {
             "version": MANIFEST_VERSION,
             "name": self.name,
             "display_name": self.display_name,
             "app_name": self.app_name,
+            "connection_id": self.connection_id,
             "ssh_host": self.ssh_host,
+            "ssh_user": self.ssh_user,
+            "ssh_port": self.ssh_port,
+            "ssh_key_path": self.ssh_key_path,
             "remote_hermes_path": self.remote_hermes_path,
             "remote_profile": self.remote_profile,
             "hermes_home": str(self.hermes_home),
@@ -234,6 +273,65 @@ def validate_ssh_host(host: str) -> str:
     return value
 
 
+def validate_connection_id(value: str) -> str:
+    ident = (value or "").strip()
+    if not ident:
+        raise IsolatedInstanceSpecError(
+            "A Connections registry id is required so the isolated shell keeps the exact SSH row."
+        )
+    if any(sep in ident for sep in ("\\", "/", "\x00")):
+        raise IsolatedInstanceSpecError(
+            f"Connection id {value!r} is not a safe registry identifier."
+        )
+    return ident
+
+
+def validate_ssh_user(user: str) -> str:
+    value = (user or "").strip()
+    if any(ch in value for ch in ("\\", "/", "\x00", " ", "@")):
+        raise IsolatedInstanceSpecError(f"SSH user {user!r} is not a safe username.")
+    return value
+
+
+def validate_ssh_port(port: object) -> int:
+    if port in (None, ""):
+        return 22
+    try:
+        value = int(port)
+    except (TypeError, ValueError) as exc:
+        raise IsolatedInstanceSpecError(
+            f"SSH port {port!r} is not an integer."
+        ) from exc
+    if value <= 0 or value > 65535:
+        raise IsolatedInstanceSpecError(f"SSH port {port!r} is out of range.")
+    return value
+
+
+def validate_ssh_key_path(path: str) -> str:
+    value = (path or "").strip()
+    if not value:
+        return ""
+    if "\x00" in value or value.startswith("-"):
+        raise IsolatedInstanceSpecError(f"SSH key path {path!r} is unsafe.")
+    return value
+
+
+def assert_isolated_manifest_matches(
+    instance: DesktopInstance, spec: IsolatedInstanceSpec
+) -> None:
+    if instance.connection_id and instance.connection_id != spec.connection_id:
+        raise IsolatedInstanceSpecError(
+            f"Isolated Desktop instance {instance.name!r} belongs to connection "
+            f"{instance.connection_id!r}, not the selected {spec.connection_id!r}."
+        )
+    if instance.dial_identity() != spec.dial_identity():
+        raise IsolatedInstanceSpecError(
+            f"Isolated Desktop instance {instance.name!r} no longer matches the "
+            f"selected Connection {spec.connection_id!r}. Recreate the instance "
+            "instead of launching a stale SSH route."
+        )
+
+
 def validate_remote_profile(name: str) -> str:
     canon = normalize_profile_name(name)
     validate_profile_name(canon)
@@ -283,7 +381,11 @@ def isolated_instance_spec_from_ssh(
     return IsolatedInstanceSpec(
         name=name,
         display_name=display,
+        connection_id=validate_connection_id(str(connection.get("id") or "")),
         ssh_host=host,
+        ssh_user=validate_ssh_user(str(connection.get("user") or "")),
+        ssh_port=validate_ssh_port(connection.get("port")),
+        ssh_key_path=validate_ssh_key_path(str(connection.get("keyPath") or "")),
         remote_hermes_path=remote_path,
         remote_profile=profile,
     )
@@ -306,14 +408,22 @@ def parse_instance_deep_link(url: str) -> InstanceDeepLink | None:
 
 def seed_connection_config(instance: DesktopInstance) -> dict[str, object]:
     """Non-secret SSH seed for the isolated shell's ``connection.json``."""
+    remote: dict[str, object] = {
+        "mode": "ssh",
+        "host": instance.ssh_host,
+        "remoteHermesPath": instance.remote_hermes_path,
+        "remoteProfile": instance.remote_profile,
+    }
+    if instance.ssh_user:
+        remote["user"] = instance.ssh_user
+    if instance.ssh_port and instance.ssh_port != 22:
+        remote["port"] = instance.ssh_port
+    if instance.ssh_key_path:
+        remote["keyPath"] = instance.ssh_key_path
     return {
         "mode": "ssh",
-        "remote": {
-            "mode": "ssh",
-            "host": instance.ssh_host,
-            "remoteHermesPath": instance.remote_hermes_path,
-            "remoteProfile": instance.remote_profile,
-        },
+        "connectionId": instance.connection_id,
+        "remote": remote,
         "profiles": {},
     }
 
@@ -393,6 +503,8 @@ def default_ssh_probe(host: str) -> None:
             [ssh, "-G", host],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=15,
             check=False,
         )
@@ -491,7 +603,6 @@ def default_process_starter(plan: LaunchPlan) -> int:
 
     env = build_subprocess_env(
         inherit_profile_home=False,
-        scrub_secrets=False,
         extra=plan.env,
     )
     proc = subprocess.Popen(
@@ -646,6 +757,10 @@ class DesktopInstanceStore:
         remote_hermes_path: str,
         remote_profile: str,
         display_name: str | None = None,
+        connection_id: str = "",
+        ssh_user: str = "",
+        ssh_port: int | object = 22,
+        ssh_key_path: str = "",
     ) -> DesktopInstance:
         slug = validate_instance_name(name)
         host = validate_ssh_host(ssh_host)
@@ -671,7 +786,13 @@ class DesktopInstanceStore:
             name=slug,
             display_name=label,
             app_name=app_name,
+            connection_id=validate_connection_id(connection_id)
+            if connection_id
+            else "",
             ssh_host=host,
+            ssh_user=validate_ssh_user(ssh_user),
+            ssh_port=validate_ssh_port(ssh_port),
+            ssh_key_path=validate_ssh_key_path(ssh_key_path),
             remote_hermes_path=remote_path,
             remote_profile=profile,
             hermes_home=root / "home",
@@ -746,6 +867,10 @@ class DesktopInstanceStore:
         display_name: str | None = None,
         skip_ssh_check: bool = False,
         install_shortcut: bool = True,
+        connection_id: str = "",
+        ssh_user: str = "",
+        ssh_port: int | object = 22,
+        ssh_key_path: str = "",
     ) -> DesktopInstance:
         self._require_desktop_platform("Creating an isolated Desktop instance")
         self._require_runtime()
@@ -755,6 +880,10 @@ class DesktopInstanceStore:
             remote_hermes_path=remote_hermes_path,
             remote_profile=remote_profile,
             display_name=display_name,
+            connection_id=connection_id,
+            ssh_user=ssh_user,
+            ssh_port=ssh_port,
+            ssh_key_path=ssh_key_path,
         )
         if instance.manifest_path.exists():
             raise InstanceExistsError(
@@ -771,6 +900,26 @@ class DesktopInstanceStore:
         self._materialize_windows_bits(instance, install_shortcut=install_shortcut)
         self._write_manifest(instance)
         return instance
+
+    def open_from_connection(self, connection: dict[str, object]) -> DesktopInstance:
+        """Create or reuse the isolated instance for one exact Connections row."""
+        spec = isolated_instance_spec_from_ssh(connection)
+        try:
+            existing = self.get(spec.name)
+        except InstanceNotFoundError:
+            return self.create(
+                spec.name,
+                connection_id=spec.connection_id,
+                ssh_host=spec.ssh_host,
+                ssh_user=spec.ssh_user,
+                ssh_port=spec.ssh_port,
+                ssh_key_path=spec.ssh_key_path,
+                remote_hermes_path=spec.remote_hermes_path,
+                remote_profile=spec.remote_profile,
+                display_name=spec.display_name,
+            )
+        assert_isolated_manifest_matches(existing, spec)
+        return existing
 
     def list(self) -> list[DesktopInstance]:
         root = self.registry_root
@@ -954,15 +1103,21 @@ class DesktopInstanceStore:
 
     def _posix_wrapper_body(self, instance: DesktopInstance) -> str:
         plan = self.build_launch_plan(instance)
-        exports = "\n".join(
-            f"export {key}={shlex.quote(value)}" for key, value in plan.env.items()
-        )
+        keep = [
+            f"HOME={shlex.quote(str(Path.home()))}",
+            f"PATH={shlex.quote(os.environ.get('PATH', '/usr/bin:/bin'))}",
+        ]
+        for key in ("DISPLAY", "WAYLAND_DISPLAY", "XDG_RUNTIME_DIR", "XAUTHORITY"):
+            value = os.environ.get(key)
+            if value:
+                keep.append(f"{key}={shlex.quote(value)}")
+        keep.extend(f"{key}={shlex.quote(value)}" for key, value in plan.env.items())
         args = " ".join(shlex.quote(arg) for arg in plan.arguments)
         return (
             "#!/usr/bin/env bash\n"
             "set -euo pipefail\n"
-            f"{exports}\n"
-            f'exec {shlex.quote(str(instance.named_exe))} {args} "$@"\n'
+            f"exec /usr/bin/env -i {' '.join(keep)} "
+            f'{shlex.quote(str(instance.named_exe))} {args} "$@"\n'
         )
 
     def _write_posix_wrapper(self, instance: DesktopInstance) -> None:
@@ -1059,6 +1214,10 @@ class DesktopInstanceStore:
             remote_hermes_path=str(data["remote_hermes_path"]),
             remote_profile=str(data["remote_profile"]),
             display_name=str(data.get("display_name") or ""),
+            connection_id=str(data.get("connection_id") or ""),
+            ssh_user=str(data.get("ssh_user") or ""),
+            ssh_port=data.get("ssh_port") or 22,
+            ssh_key_path=str(data.get("ssh_key_path") or ""),
         )
 
     @staticmethod
@@ -1164,10 +1323,22 @@ def _dispatch_instance_action(
             display_name=getattr(args, "display_name", None),
             skip_ssh_check=bool(getattr(args, "skip_ssh_check", False)),
             install_shortcut=not bool(getattr(args, "no_shortcut", False)),
+            connection_id=getattr(args, "connection_id", "") or "",
+            ssh_user=getattr(args, "ssh_user", "") or "",
+            ssh_port=getattr(args, "ssh_port", 22),
+            ssh_key_path=getattr(args, "ssh_key_path", "") or "",
         )
         print(f"✓ Isolated Desktop instance {instance.name!r} ready")
         print(f"  App name:        {instance.app_name}")
+        if instance.connection_id:
+            print(f"  Connection id:   {instance.connection_id}")
         print(f"  SSH host:        {instance.ssh_host}")
+        if instance.ssh_user:
+            print(f"  SSH user:        {instance.ssh_user}")
+        if instance.ssh_port and instance.ssh_port != 22:
+            print(f"  SSH port:        {instance.ssh_port}")
+        if instance.ssh_key_path:
+            print(f"  SSH key:         {instance.ssh_key_path}")
         print(f"  Remote Hermes:   {instance.remote_hermes_path}")
         print(f"  Remote profile:  {instance.remote_profile}")
         print(f"  Local home:      {instance.hermes_home}")

--- a/hermes_cli/desktop_instances.py
+++ b/hermes_cli/desktop_instances.py
@@ -296,7 +296,10 @@ def parse_instance_deep_link(url: str) -> InstanceDeepLink | None:
         return None
     rest = raw[len(prefix) :]
     slug, sep, tail = rest.partition("/")
-    name = validate_instance_name(slug)
+    try:
+        name = validate_instance_name(slug)
+    except InstanceNameError:
+        return None
     remainder = f"hermes://{tail}" if sep else "hermes://"
     return InstanceDeepLink(instance_name=name, remainder=remainder)
 
@@ -684,9 +687,12 @@ class DesktopInstanceStore:
         }
         if deep_link:
             env["HERMES_DESKTOP_PENDING_DEEP_LINK"] = deep_link
+        arguments = [f"--user-data-dir={instance.user_data}"]
+        if deep_link:
+            arguments.append(deep_link)
         return LaunchPlan(
             executable=instance.named_exe,
-            arguments=[f"--user-data-dir={instance.user_data}"],
+            arguments=arguments,
             env=env,
             cwd=str(self.cwd),
             use_shell_execute=False,
@@ -958,7 +964,7 @@ class DesktopInstanceStore:
         body = (
             "[Desktop Entry]\n"
             "Type=Application\n"
-            f"Name={instance.app_name}\n"
+            f"Name={instance.app_name.replace(chr(10), ' ').replace(chr(13), ' ')}\n"
             f"Exec={shlex.quote(str(instance.launcher_exe))}\n"
             f"Icon={instance.canonical_exe}\n"
             "Terminal=false\n"

--- a/hermes_cli/desktop_instances.py
+++ b/hermes_cli/desktop_instances.py
@@ -664,10 +664,15 @@ def default_process_starter(plan: LaunchPlan) -> int:
         inherit_profile_home=False,
         extra=plan.env,
     )
+    # The short-lived CLI may itself be captured by Electron's execFile().
+    # Keep the long-lived Desktop from retaining those parent pipes after the CLI exits.
     proc = subprocess.Popen(
         [str(plan.executable), *plan.arguments],
         cwd=plan.cwd or None,
         env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
     )
     return int(proc.pid)
 

--- a/hermes_cli/desktop_instances.py
+++ b/hermes_cli/desktop_instances.py
@@ -16,6 +16,7 @@ process environment, ``UseShellExecute=false``, and early
 
 from __future__ import annotations
 
+import builtins
 import json
 import os
 import re
@@ -26,13 +27,14 @@ import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable, cast, NoReturn
 
 from hermes_cli.profiles import normalize_profile_name, validate_profile_name
 from hermes_constants import get_default_hermes_root
 from utils import atomic_write_text
 
 MANIFEST_VERSION = 1
+CONNECTION_REGISTRY_VERSION = 2
 INSTANCES_DIRNAME = "desktop-instances"
 _NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 _RESERVED_NAMES = frozenset({
@@ -137,6 +139,10 @@ class InstanceExistsError(DesktopInstanceError):
 
 class InstanceNotFoundError(DesktopInstanceError):
     """No instance is registered under that name."""
+
+
+class InstanceRouteMismatchError(DesktopInstanceError):
+    """Retained Electron routing state no longer matches the instance manifest."""
 
 
 @dataclass(frozen=True)
@@ -297,7 +303,7 @@ def validate_ssh_port(port: object) -> int:
     if port in (None, ""):
         return 22
     try:
-        value = int(port)
+        value = int(cast(Any, port))
     except (TypeError, ValueError) as exc:
         raise IsolatedInstanceSpecError(
             f"SSH port {port!r} is not an integer."
@@ -406,6 +412,11 @@ def parse_instance_deep_link(url: str) -> InstanceDeepLink | None:
     return InstanceDeepLink(instance_name=name, remainder=remainder)
 
 
+def instance_route_connection_id(instance: DesktopInstance) -> str:
+    """Stable registry id for an isolated shell, including CLI-created shells."""
+    return instance.connection_id or f"isolated-{instance.name}"
+
+
 def seed_connection_config(instance: DesktopInstance) -> dict[str, object]:
     """Non-secret SSH seed for the isolated shell's ``connection.json``."""
     remote: dict[str, object] = {
@@ -422,13 +433,61 @@ def seed_connection_config(instance: DesktopInstance) -> dict[str, object]:
         remote["keyPath"] = instance.ssh_key_path
     return {
         "mode": "ssh",
-        "connectionId": instance.connection_id,
+        "connectionId": instance_route_connection_id(instance),
         "remote": remote,
         "profiles": {},
     }
 
 
-def _csharp_verbatim(value: str) -> str:
+def seed_connections_registry(instance: DesktopInstance) -> dict[str, object]:
+    """Non-secret v2 registry whose active row is the manifest's exact SSH route."""
+    connection_id = instance_route_connection_id(instance)
+    route: dict[str, object] = {
+        "id": connection_id,
+        "kind": "ssh",
+        "label": instance.display_name,
+        "host": instance.ssh_host,
+        "remoteHermesPath": instance.remote_hermes_path,
+        "remoteProfile": instance.remote_profile,
+    }
+    if instance.ssh_user:
+        route["user"] = instance.ssh_user
+    if instance.ssh_port and instance.ssh_port != 22:
+        route["port"] = instance.ssh_port
+    if instance.ssh_key_path:
+        route["keyPath"] = instance.ssh_key_path
+    return {
+        "version": CONNECTION_REGISTRY_VERSION,
+        "primary": connection_id,
+        "launchMode": "primary",
+        "lastUsed": connection_id,
+        "connections": [
+            {"id": "local", "kind": "local", "label": "This device"},
+            route,
+        ],
+    }
+
+
+def _stored_ssh_identity(route: object) -> dict[str, object] | None:
+    if not isinstance(route, dict):
+        return None
+    record = cast(dict[str, object], route)
+    try:
+        port = int(str(record.get("port") or 22))
+    except (TypeError, ValueError):
+        return None
+    return {
+        "host": str(record.get("host") or "").strip(),
+        "user": str(record.get("user") or "").strip(),
+        "port": port,
+        "key_path": str(record.get("keyPath") or "").strip(),
+        "remote_hermes_path": str(record.get("remoteHermesPath") or "").strip(),
+        "remote_profile": str(record.get("remoteProfile") or "default").strip()
+        or "default",
+    }
+
+
+def _csharp_verbatim(value: object) -> str:
     """Escape a value for a C# verbatim string literal.
 
     A trailing backslash would eat the closing quote (``@"C:\\"``).
@@ -919,9 +978,10 @@ class DesktopInstanceStore:
                 display_name=spec.display_name,
             )
         assert_isolated_manifest_matches(existing, spec)
+        self._seed_connection(existing)
         return existing
 
-    def list(self) -> list[DesktopInstance]:
+    def list(self) -> builtins.list[DesktopInstance]:
         root = self.registry_root
         if not root.is_dir():
             return []
@@ -961,7 +1021,9 @@ class DesktopInstanceStore:
             self._write_posix_wrapper(instance)
         return result
 
-    def repair_all(self) -> list[tuple[DesktopInstance, HardlinkRefreshResult]]:
+    def repair_all(
+        self,
+    ) -> builtins.list[tuple[DesktopInstance, HardlinkRefreshResult]]:
         self._require_desktop_platform("Repairing isolated Desktop instances")
         self._require_runtime()
         repaired: list[tuple[DesktopInstance, HardlinkRefreshResult]] = []
@@ -994,6 +1056,7 @@ class DesktopInstanceStore:
         instance = self.get(name)
         instance.hermes_home.mkdir(parents=True, exist_ok=True)
         instance.user_data.mkdir(parents=True, exist_ok=True)
+        self._seed_connection(instance)
         self.repair(name)
         plan = self.build_launch_plan(instance, deep_link=deep_link)
         if not plan.executable.is_file():
@@ -1171,14 +1234,99 @@ class DesktopInstanceStore:
 
     def _seed_connection(self, instance: DesktopInstance) -> None:
         seed_path = instance.user_data / "connection.json"
+        registry_path = instance.user_data / "connections.json"
+
+        # Validate every retained authority before writing either missing file.
+        # remove() intentionally keeps userData, and create() can fail after
+        # seeding it; neither path may silently retarget that state later.
         if seed_path.exists():
-            return
-        payload = seed_connection_config(instance)
-        self._assert_no_secrets(payload)
-        atomic_write_text(
-            seed_path,
-            json.dumps(payload, indent=2) + "\n",
-            create_mode=0o600,
+            self._assert_v1_route_matches(seed_path, instance)
+        if registry_path.exists():
+            self._assert_v2_route_matches(registry_path, instance)
+
+        for path, payload in (
+            (seed_path, seed_connection_config(instance)),
+            (registry_path, seed_connections_registry(instance)),
+        ):
+            if path.exists():
+                continue
+            self._assert_no_secrets(payload)
+            atomic_write_text(
+                path,
+                json.dumps(payload, indent=2) + "\n",
+                create_mode=0o600,
+            )
+
+    def _assert_v1_route_matches(
+        self, path: Path, instance: DesktopInstance
+    ) -> None:
+        payload = self._read_route_file(path)
+        stored_id = str(payload.get("connectionId") or "").strip()
+        allowed_ids = {instance_route_connection_id(instance)}
+        if not instance.connection_id:
+            # Compatibility with CLI-created instances from the pre-v2 branch.
+            allowed_ids.add("")
+        if (
+            payload.get("mode") != "ssh"
+            or stored_id not in allowed_ids
+            or _stored_ssh_identity(payload.get("remote"))
+            != instance.dial_identity()
+        ):
+            self._raise_route_mismatch(path, instance)
+
+    def _assert_v2_route_matches(
+        self, path: Path, instance: DesktopInstance
+    ) -> None:
+        payload = self._read_route_file(path)
+        connection_id = instance_route_connection_id(instance)
+        connections = payload.get("connections")
+        if not isinstance(connections, list):
+            self._raise_route_mismatch(path, instance)
+        matches: list[dict[str, object]] = []
+        for item in connections:
+            if not isinstance(item, dict):
+                continue
+            record = cast(dict[str, object], item)
+            if str(record.get("id") or "").strip() == connection_id:
+                matches.append(record)
+        launch_mode = payload.get("launchMode")
+        active_last_used = (
+            launch_mode != "last-used"
+            or str(payload.get("lastUsed") or "").strip() == connection_id
+        )
+        if (
+            payload.get("version") != CONNECTION_REGISTRY_VERSION
+            or str(payload.get("primary") or "").strip() != connection_id
+            or not active_last_used
+            or len(matches) != 1
+            or matches[0].get("kind") != "ssh"
+            or _stored_ssh_identity(matches[0]) != instance.dial_identity()
+        ):
+            self._raise_route_mismatch(path, instance)
+
+    @staticmethod
+    def _read_route_file(path: Path) -> dict[str, object]:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise InstanceRouteMismatchError(
+                f"Isolated Desktop routing file {path} is unreadable. "
+                "Remove the instance with --purge-local before recreating it."
+            ) from exc
+        if not isinstance(payload, dict):
+            raise InstanceRouteMismatchError(
+                f"Isolated Desktop routing file {path} is not an object. "
+                "Remove the instance with --purge-local before recreating it."
+            )
+        return payload
+
+    @staticmethod
+    def _raise_route_mismatch(path: Path, instance: DesktopInstance) -> NoReturn:
+        raise InstanceRouteMismatchError(
+            f"Retained {path.name} for isolated Desktop instance "
+            f"{instance.name!r} does not match its SSH route. Refusing to "
+            "launch or retarget it; remove the instance with --purge-local "
+            "before recreating it."
         )
 
     def _load_manifest(self, path: Path) -> DesktopInstance:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8343,8 +8343,29 @@ def _register_linux_desktop_entry() -> None:
         print(f"⚠ Could not install the desktop launcher entry: {exc}")
 
 
+def _refresh_isolated_desktop_instances(runtime_root: Path, packaged_executable: Path) -> None:
+    """Rebuild named hardlinks after the shared Desktop executable is replaced."""
+    try:
+        from hermes_cli.desktop_instances import repair_instances_for_runtime
+
+        refreshed = repair_instances_for_runtime(runtime_root, packaged_executable)
+    except Exception as exc:  # never block a build on instance plumbing
+        print(f"⚠ Could not refresh isolated Desktop instances: {exc}")
+        return
+    if refreshed:
+        print("✓ Refreshed isolated Desktop instance executables:")
+        for item in refreshed:
+            print(f"    - {item}")
+
+
 def cmd_gui(args: argparse.Namespace):
     """Build and launch the native Electron desktop GUI."""
+    if getattr(args, "desktop_action", None) == "instance":
+        from hermes_cli.desktop_instances import cmd_desktop_instance
+
+        cmd_desktop_instance(args, runtime_root=PROJECT_ROOT)
+        return
+
     desktop_dir = PROJECT_ROOT / "apps" / "desktop"
     if not (desktop_dir / "package.json").exists():
         print(f"Desktop GUI source not found at: {desktop_dir}")
@@ -8576,6 +8597,8 @@ def cmd_gui(args: argparse.Namespace):
 
             # Build succeeded — write the stamp so next run can skip
             _write_desktop_build_stamp(PROJECT_ROOT, source_mode=source_mode)
+            if not source_mode and packaged_executable is not None:
+                _refresh_isolated_desktop_instances(PROJECT_ROOT, packaged_executable)
 
     # Linux: register the app in the desktop launcher, so Hermes shows up
     # in the application menu with its icon. Best-effort and idempotent.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -500,7 +500,11 @@ from hermes_cli.subcommands.console import build_console_parser
 from hermes_cli.subcommands.update import build_update_parser
 from hermes_cli.subcommands.uninstall import build_uninstall_parser
 from hermes_cli.subcommands.dashboard import build_dashboard_parser
-from hermes_cli.subcommands.gui import build_gui_parser
+from hermes_cli.subcommands.gui import (
+    build_gui_parser,
+    dispatch_desktop_instance,
+    refresh_isolated_desktop_instances,
+)
 from hermes_cli.subcommands.logs import build_logs_parser
 from hermes_cli.subcommands.prompt_size import build_prompt_size_parser
 from hermes_cli.subcommands.memory import build_memory_parser
@@ -8343,27 +8347,9 @@ def _register_linux_desktop_entry() -> None:
         print(f"⚠ Could not install the desktop launcher entry: {exc}")
 
 
-def _refresh_isolated_desktop_instances(runtime_root: Path, packaged_executable: Path) -> None:
-    """Rebuild named hardlinks after the shared Desktop executable is replaced."""
-    try:
-        from hermes_cli.desktop_instances import repair_instances_for_runtime
-
-        refreshed = repair_instances_for_runtime(runtime_root, packaged_executable)
-    except Exception as exc:  # never block a build on instance plumbing
-        print(f"⚠ Could not refresh isolated Desktop instances: {exc}")
-        return
-    if refreshed:
-        print("✓ Refreshed isolated Desktop instance executables:")
-        for item in refreshed:
-            print(f"    - {item}")
-
-
 def cmd_gui(args: argparse.Namespace):
     """Build and launch the native Electron desktop GUI."""
-    if getattr(args, "desktop_action", None) == "instance":
-        from hermes_cli.desktop_instances import cmd_desktop_instance
-
-        cmd_desktop_instance(args, runtime_root=PROJECT_ROOT)
+    if dispatch_desktop_instance(args, runtime_root=PROJECT_ROOT):
         return
 
     desktop_dir = PROJECT_ROOT / "apps" / "desktop"
@@ -8598,7 +8584,7 @@ def cmd_gui(args: argparse.Namespace):
             # Build succeeded — write the stamp so next run can skip
             _write_desktop_build_stamp(PROJECT_ROOT, source_mode=source_mode)
             if not source_mode and packaged_executable is not None:
-                _refresh_isolated_desktop_instances(PROJECT_ROOT, packaged_executable)
+                refresh_isolated_desktop_instances(PROJECT_ROOT, packaged_executable)
 
     # Linux: register the app in the desktop launcher, so Hermes shows up
     # in the application menu with its icon. Best-effort and idempotent.

--- a/hermes_cli/subcommands/gui.py
+++ b/hermes_cli/subcommands/gui.py
@@ -6,7 +6,36 @@ Handler injected to avoid importing ``main``.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Callable
+
+
+def dispatch_desktop_instance(args, *, runtime_root: Path) -> bool:
+    """Dispatch ``desktop instance`` without growing the legacy GUI handler."""
+    if getattr(args, "desktop_action", None) != "instance":
+        return False
+
+    from hermes_cli.desktop_instances import cmd_desktop_instance
+
+    cmd_desktop_instance(args, runtime_root=runtime_root)
+    return True
+
+
+def refresh_isolated_desktop_instances(
+    runtime_root: Path, packaged_executable: Path
+) -> None:
+    """Best-effort refresh after the shared Desktop executable is replaced."""
+    try:
+        from hermes_cli.desktop_instances import repair_instances_for_runtime
+
+        refreshed = repair_instances_for_runtime(runtime_root, packaged_executable)
+    except Exception as exc:  # never block a build on instance plumbing
+        print(f"⚠ Could not refresh isolated Desktop instances: {exc}")
+        return
+    if refreshed:
+        print("✓ Refreshed isolated Desktop instance executables:")
+        for item in refreshed:
+            print(f"    - {item}")
 
 
 def build_gui_parser(subparsers, *, cmd_gui: Callable) -> None:

--- a/hermes_cli/subcommands/gui.py
+++ b/hermes_cli/subcommands/gui.py
@@ -146,6 +146,10 @@ def build_gui_parser(subparsers, *, cmd_gui: Callable) -> None:
         help="Launch or focus an isolated Desktop instance",
     )
     launch.add_argument("instance_name")
+    launch.add_argument(
+        "--deep-link",
+        help="Forward a hermes:// URL into the isolated shell after launch",
+    )
     launch.set_defaults(func=cmd_gui)
 
     shortcut = instance_sub.add_parser(

--- a/hermes_cli/subcommands/gui.py
+++ b/hermes_cli/subcommands/gui.py
@@ -121,6 +121,27 @@ def build_gui_parser(subparsers, *, cmd_gui: Callable) -> None:
         help="Window/app name (default: 'Hermes <Name>')",
     )
     create.add_argument(
+        "--connection-id",
+        default="",
+        help="Exact Connections registry id this isolated shell belongs to",
+    )
+    create.add_argument(
+        "--ssh-user",
+        default="",
+        help="SSH username for the selected Connection (omit to use ssh config)",
+    )
+    create.add_argument(
+        "--ssh-port",
+        type=int,
+        default=22,
+        help="SSH port for the selected Connection (default: 22)",
+    )
+    create.add_argument(
+        "--ssh-key-path",
+        default="",
+        help="Absolute local path to the SSH private key used by this Connection",
+    )
+    create.add_argument(
         "--skip-ssh-check",
         action="store_true",
         help="Do not probe ssh before writing the instance",

--- a/hermes_cli/subcommands/gui.py
+++ b/hermes_cli/subcommands/gui.py
@@ -1,4 +1,4 @@
-"""``hermes gui`` subcommand parser.
+"""``hermes gui`` / ``hermes desktop`` subcommand parser.
 
 Extracted verbatim from ``hermes_cli/main.py:main()`` (god-file Phase 2).
 Handler injected to avoid importing ``main``.
@@ -10,8 +10,7 @@ from typing import Callable
 
 
 def build_gui_parser(subparsers, *, cmd_gui: Callable) -> None:
-    """Attach the ``gui`` subcommand to ``subparsers``."""
-    # =========================================================================
+    """Attach the ``gui`` / ``desktop`` subcommand to ``subparsers``."""
     gui_parser = subparsers.add_parser(
         "desktop",
         aliases=["gui"],
@@ -19,7 +18,9 @@ def build_gui_parser(subparsers, *, cmd_gui: Callable) -> None:
         description=(
             "Launch the Hermes Electron desktop app. By default this installs "
             "workspace Node dependencies, builds the current OS's unpacked "
-            "Electron app, then launches that packaged artifact."
+            "Electron app, then launches that packaged artifact. "
+            "Use `hermes desktop instance` for a separate isolated Desktop "
+            "shell (distinct from Settings → Connections)."
         ),
     )
     gui_parser.add_argument(
@@ -77,4 +78,109 @@ def build_gui_parser(subparsers, *, cmd_gui: Callable) -> None:
         default="Hermes Local Signing",
         help="Certificate name to create/use for --setup-tcc-identity (default: Hermes Local Signing)",
     )
-    gui_parser.set_defaults(func=cmd_gui)
+    gui_parser.set_defaults(func=cmd_gui, desktop_action=None, instance_action=None)
+
+    desktop_sub = gui_parser.add_subparsers(dest="desktop_action", required=False)
+    instance = desktop_sub.add_parser(
+        "instance",
+        help="Manage isolated Desktop shells (separate userData/home; shared runtime)",
+        description=(
+            "Create and launch named isolated Desktop applications. Each "
+            "instance has its own Electron userData, HERMES_HOME, and "
+            "single-instance lock, but shares the canonical Hermes install. "
+            "This is not Settings → Connections (which keeps one shared shell)."
+        ),
+    )
+    instance.set_defaults(func=cmd_gui)
+    instance_sub = instance.add_subparsers(dest="instance_action", required=False)
+
+    create = instance_sub.add_parser(
+        "create",
+        help="Register a named isolated Desktop instance and install its shortcut",
+    )
+    create.add_argument(
+        "instance_name", help="Instance slug (for example grace or athena)"
+    )
+    create.add_argument(
+        "--ssh-host",
+        required=True,
+        help="SSH config alias or hostname (remote state stays on that machine)",
+    )
+    create.add_argument(
+        "--remote-hermes-path",
+        required=True,
+        help="Absolute path to hermes on the remote machine",
+    )
+    create.add_argument(
+        "--remote-profile",
+        required=True,
+        help="Remote Hermes profile to attach (for example default)",
+    )
+    create.add_argument(
+        "--display-name",
+        help="Window/app name (default: 'Hermes <Name>')",
+    )
+    create.add_argument(
+        "--skip-ssh-check",
+        action="store_true",
+        help="Do not probe ssh before writing the instance",
+    )
+    create.add_argument(
+        "--no-shortcut",
+        action="store_true",
+        help="Create the instance without writing a Desktop shortcut",
+    )
+    create.set_defaults(func=cmd_gui)
+
+    listed = instance_sub.add_parser("list", help="List isolated Desktop instances")
+    listed.set_defaults(func=cmd_gui)
+
+    show = instance_sub.add_parser(
+        "show", help="Print one instance manifest (non-secret)"
+    )
+    show.add_argument("instance_name")
+    show.set_defaults(func=cmd_gui)
+
+    launch = instance_sub.add_parser(
+        "launch",
+        help="Launch or focus an isolated Desktop instance",
+    )
+    launch.add_argument("instance_name")
+    launch.set_defaults(func=cmd_gui)
+
+    shortcut = instance_sub.add_parser(
+        "shortcut",
+        help="Recreate the OS shortcut for an isolated Desktop instance",
+    )
+    shortcut.add_argument("instance_name")
+    shortcut.set_defaults(func=cmd_gui)
+
+    repair = instance_sub.add_parser(
+        "repair",
+        help="Refresh named hardlinks after a Desktop update",
+    )
+    repair.add_argument("instance_name", nargs="?", default=None)
+    repair.add_argument(
+        "--all",
+        dest="all_instances",
+        action="store_true",
+        help="Repair every registered isolated instance",
+    )
+    repair.set_defaults(func=cmd_gui)
+
+    remove = instance_sub.add_parser(
+        "remove",
+        help="Remove the launcher and shortcut; never deletes remote state",
+    )
+    remove.add_argument("instance_name")
+    remove.add_argument(
+        "--purge-local",
+        action="store_true",
+        help="Also delete this instance's local HERMES_HOME and Electron userData",
+    )
+    remove.add_argument(
+        "--force",
+        action="store_true",
+        help="Remove the launcher even if the named executable appears locked",
+    )
+    remove.set_defaults(func=cmd_gui)

--- a/hermes_cli/templates/windows_isolated_desktop_launcher.cs
+++ b/hermes_cli/templates/windows_isolated_desktop_launcher.cs
@@ -16,6 +16,8 @@ internal static class {{CLASS_NAME}}
     private const string UserData = @"{{USER_DATA}}";
     private const string WorkingDirectory = @"{{WORKING_DIRECTORY}}";
     private const string AppName = @"{{APP_NAME}}";
+    private const string InstanceName = @"{{INSTANCE_NAME}}";
+    private const string Aumid = @"{{AUMID}}";
 
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
     private static extern bool CreateHardLink(
@@ -51,6 +53,10 @@ internal static class {{CLASS_NAME}}
             startInfo.EnvironmentVariables["HERMES_DESKTOP_HERMES_ROOT"] = HermesRoot;
             startInfo.EnvironmentVariables["HERMES_DESKTOP_APP_NAME"] = AppName;
             startInfo.EnvironmentVariables["HERMES_DESKTOP_CWD"] = WorkingDirectory;
+            startInfo.EnvironmentVariables["HERMES_DESKTOP_INSTANCE"] = InstanceName;
+            startInfo.EnvironmentVariables["HERMES_DESKTOP_AUMID"] = Aumid;
+            startInfo.EnvironmentVariables["HERMES_DESKTOP_DISABLE_GLOBAL_SHORTCUTS"] = "1";
+            startInfo.EnvironmentVariables["HERMES_DESKTOP_SKIP_PROTOCOL_REGISTER"] = "1";
 
             var process = Process.Start(startInfo);
             if (process == null)

--- a/hermes_cli/templates/windows_isolated_desktop_launcher.cs
+++ b/hermes_cli/templates/windows_isolated_desktop_launcher.cs
@@ -1,0 +1,136 @@
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Windows.Forms;
+
+internal static class {{CLASS_NAME}}
+{
+    private const string LauncherDirectory = @"{{LAUNCHER_DIRECTORY}}";
+    private const string SharedHermesExe = @"{{SHARED_HERMES_EXE}}";
+    private const string HermesExe = @"{{NAMED_HERMES_EXE}}";
+    private const string HermesRoot = @"{{HERMES_ROOT}}";
+    private const string HermesHome = @"{{HERMES_HOME}}";
+    private const string UserData = @"{{USER_DATA}}";
+    private const string WorkingDirectory = @"{{WORKING_DIRECTORY}}";
+    private const string AppName = @"{{APP_NAME}}";
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern bool CreateHardLink(
+        string newFileName,
+        string existingFileName,
+        IntPtr securityAttributes);
+
+    [STAThread]
+    private static int Main()
+    {
+        try
+        {
+            if (!File.Exists(SharedHermesExe))
+                throw new FileNotFoundException("The shared Hermes Desktop executable was not found.", SharedHermesExe);
+            if (!Directory.Exists(HermesRoot))
+                throw new DirectoryNotFoundException("The shared Hermes runtime was not found: " + HermesRoot);
+
+            EnsureSharedExecutableLink();
+            Directory.CreateDirectory(HermesHome);
+            Directory.CreateDirectory(UserData);
+
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = HermesExe,
+                Arguments = "--user-data-dir=\"" + UserData + "\"",
+                WorkingDirectory = WorkingDirectory,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            startInfo.EnvironmentVariables["HERMES_HOME"] = HermesHome;
+            startInfo.EnvironmentVariables["HERMES_DESKTOP_USER_DATA_DIR"] = UserData;
+            startInfo.EnvironmentVariables["HERMES_DESKTOP_HERMES_ROOT"] = HermesRoot;
+            startInfo.EnvironmentVariables["HERMES_DESKTOP_APP_NAME"] = AppName;
+            startInfo.EnvironmentVariables["HERMES_DESKTOP_CWD"] = WorkingDirectory;
+
+            var process = Process.Start(startInfo);
+            if (process == null)
+                throw new InvalidOperationException("Windows did not create the " + AppName + " process.");
+
+            WriteLaunchRecord(process.Id);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            WriteErrorRecord(ex);
+            MessageBox.Show(
+                ex.Message,
+                AppName + " launcher",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return 1;
+        }
+    }
+
+    private static void EnsureSharedExecutableLink()
+    {
+        // Rebuild the zero-copy hardlink on every clean launch so a local
+        // Hermes update cannot leave the named executable on an old inode.
+        // If the instance is already running, retain the in-use link and
+        // let Electron focus that single-instance namespace.
+        if (File.Exists(HermesExe))
+        {
+            try
+            {
+                File.Delete(HermesExe);
+            }
+            catch (IOException)
+            {
+                return;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return;
+            }
+        }
+
+        if (!CreateHardLink(HermesExe, SharedHermesExe, IntPtr.Zero))
+        {
+            throw new Win32Exception(
+                Marshal.GetLastWin32Error(),
+                "Windows could not create the shared " + AppName + " executable link.");
+        }
+    }
+
+    private static void WriteLaunchRecord(int pid)
+    {
+        var text = new StringBuilder();
+        text.AppendLine("{");
+        text.AppendLine("  \"launched_at\": \"" + DateTime.UtcNow.ToString("o") + "\",");
+        text.AppendLine("  \"pid\": " + pid + ",");
+        text.AppendLine("  \"hermes_home\": \"" + JsonEscape(HermesHome) + "\",");
+        text.AppendLine("  \"user_data\": \"" + JsonEscape(UserData) + "\",");
+        text.AppendLine("  \"executable\": \"" + JsonEscape(HermesExe) + "\"");
+        text.AppendLine("}");
+        File.WriteAllText(Path.Combine(LauncherDirectory, "last-launch-native.json"), text.ToString(), Encoding.UTF8);
+    }
+
+    private static void WriteErrorRecord(Exception ex)
+    {
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(LauncherDirectory, "last-launch-native-error.txt"),
+                DateTime.UtcNow.ToString("o") + Environment.NewLine + ex,
+                Encoding.UTF8);
+        }
+        catch
+        {
+            // Preserve the original launch error for the message box.
+        }
+    }
+
+    private static string JsonEscape(string value)
+    {
+        return value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+    }
+}

--- a/hermes_cli/templates/windows_isolated_desktop_launcher.cs
+++ b/hermes_cli/templates/windows_isolated_desktop_launcher.cs
@@ -48,6 +48,15 @@ internal static class {{CLASS_NAME}}
                 CreateNoWindow = true
             };
 
+            startInfo.EnvironmentVariables.Clear();
+            startInfo.EnvironmentVariables["SystemRoot"] = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+            startInfo.EnvironmentVariables["WINDIR"] = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+            startInfo.EnvironmentVariables["USERPROFILE"] = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            startInfo.EnvironmentVariables["APPDATA"] = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            startInfo.EnvironmentVariables["LOCALAPPDATA"] = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            startInfo.EnvironmentVariables["TEMP"] = Path.GetTempPath();
+            startInfo.EnvironmentVariables["TMP"] = Path.GetTempPath();
+            startInfo.EnvironmentVariables["PATH"] = Environment.GetEnvironmentVariable("PATH") ?? "";
             startInfo.EnvironmentVariables["HERMES_HOME"] = HermesHome;
             startInfo.EnvironmentVariables["HERMES_DESKTOP_USER_DATA_DIR"] = UserData;
             startInfo.EnvironmentVariables["HERMES_DESKTOP_HERMES_ROOT"] = HermesRoot;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -587,7 +587,7 @@ py-modules = [
 include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "cron.*", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
 
 [tool.setuptools.package-data]
-hermes_cli = ["observability/schemas/*.json", "data/*.json"]
+hermes_cli = ["observability/schemas/*.json", "data/*.json", "templates/*"]
 # gateway/assets/ ships status_phrases.yaml and the Telegram BotFather
 # screenshot. Without this, sealed venvs (uv2nix) silently lose both —
 # status phrases fall back to the tiny hardcoded set and the Telegram

--- a/tests/hermes_cli/test_desktop_instances.py
+++ b/tests/hermes_cli/test_desktop_instances.py
@@ -1,0 +1,536 @@
+"""Isolated Desktop instance resolver, manifest, and launcher contracts.
+
+These tests drive ``hermes_cli.desktop_instances`` against temp roots and
+injected adapters. They must never touch the developer's real APPDATA,
+LOCALAPPDATA, Desktop folder, SSH config, or running Hermes processes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hermes_cli import main as cli_main
+from hermes_cli.subcommands.gui import build_gui_parser
+
+
+def _gui_parser(*, cmd_gui=lambda args: args):
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    build_gui_parser(sub, cmd_gui=cmd_gui)
+    return parser
+
+
+def _touch(path: Path, text: str = "exe") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _store(tmp_path: Path, **overrides: Any):
+    from hermes_cli.desktop_instances import DesktopInstanceStore
+
+    hermes_root = tmp_path / "hermes-root"
+    runtime_root = tmp_path / "runtime"
+    canonical_exe = (
+        runtime_root / "apps" / "desktop" / "release" / "win-unpacked" / "Hermes.exe"
+    )
+    desktop_dir = tmp_path / "Desktop"
+    kwargs = dict(
+        hermes_root=hermes_root,
+        runtime_root=runtime_root,
+        canonical_exe=canonical_exe,
+        shortcut_dir=desktop_dir,
+        platform="win32",
+        ssh_probe=lambda host: None,
+        compiler=lambda source, output: _touch(output, "compiled-launcher"),
+        shortcut_writer=lambda spec: _touch(spec.path, f"shortcut->{spec.target}"),
+        is_locked=lambda path: False,
+        cwd=tmp_path / "cwd",
+    )
+    kwargs.update(overrides)
+    _touch(canonical_exe)
+    (runtime_root / "hermes_constants.py").write_text(
+        "# runtime marker\n", encoding="utf-8"
+    )
+    desktop_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "cwd").mkdir(parents=True, exist_ok=True)
+    return DesktopInstanceStore(**kwargs)
+
+
+def _create(store, name: str = "grace", **kwargs: Any):
+    defaults = dict(
+        ssh_host="grace",
+        remote_hermes_path="/opt/hermes/bin/hermes",
+        remote_profile="default",
+    )
+    defaults.update(kwargs)
+    return store.create(name, **defaults)
+
+
+# ── name / path validation ───────────────────────────────────────────────
+
+
+def test_csharp_verbatim_does_not_let_trailing_backslash_eat_the_quote():
+    from hermes_cli.desktop_instances import _csharp_verbatim
+
+    assert _csharp_verbatim("C:\\") == "C:\\\\"
+    assert _csharp_verbatim('Hermes "X"') == 'Hermes ""X""'
+
+
+def test_instance_name_must_be_a_safe_slug():
+    from hermes_cli.desktop_instances import InstanceNameError, validate_instance_name
+
+    assert validate_instance_name("grace") == "grace"
+    assert validate_instance_name("Bear-Agent") == "bear-agent"
+    with pytest.raises(InstanceNameError):
+        validate_instance_name("../etc")
+    with pytest.raises(InstanceNameError):
+        validate_instance_name("Hermes Grace")
+    with pytest.raises(InstanceNameError):
+        validate_instance_name("default")
+    with pytest.raises(InstanceNameError):
+        validate_instance_name("desktop")
+
+
+def test_remote_hermes_path_must_be_absolute():
+    from hermes_cli.desktop_instances import StalePathError, validate_remote_hermes_path
+
+    assert (
+        validate_remote_hermes_path("/opt/hermes/bin/hermes")
+        == "/opt/hermes/bin/hermes"
+    )
+    assert (
+        validate_remote_hermes_path("C:\\hermes\\hermes.exe")
+        == "C:\\hermes\\hermes.exe"
+    )
+    with pytest.raises(StalePathError):
+        validate_remote_hermes_path("bin/hermes")
+    with pytest.raises(StalePathError):
+        validate_remote_hermes_path("")
+
+
+def test_remote_profile_reuses_profile_identifier_rules():
+    from hermes_cli.desktop_instances import validate_remote_profile
+
+    assert validate_remote_profile("default") == "default"
+    assert validate_remote_profile("Research") == "research"
+    with pytest.raises(ValueError):
+        validate_remote_profile("root")
+    with pytest.raises(ValueError):
+        validate_remote_profile("bad profile")
+
+
+# ── layout and isolation env ─────────────────────────────────────────────
+
+
+def test_instance_paths_stay_under_injected_roots_not_profiles(tmp_path):
+    store = _store(tmp_path)
+    instance = _create(store, display_name="Hermes Grace")
+
+    assert (
+        instance.hermes_home
+        == store.hermes_root / "desktop-instances" / "grace" / "home"
+    )
+    assert (
+        instance.user_data
+        == store.hermes_root / "desktop-instances" / "grace" / "user-data"
+    )
+    assert (
+        instance.launcher_exe.parent
+        == store.hermes_root / "desktop-instances" / "grace" / "launcher"
+    )
+    assert "profiles" not in instance.hermes_home.parts
+    assert instance.named_exe == store.canonical_exe.with_name("Hermes Grace.exe")
+    assert instance.runtime_root == store.runtime_root
+    assert instance.app_name == "Hermes Grace"
+
+
+def test_launch_plan_uses_named_hardlink_early_user_data_and_no_shellexecute(tmp_path):
+    store = _store(tmp_path)
+    instance = _create(store)
+    plan = store.build_launch_plan(instance)
+
+    assert plan.executable == instance.named_exe
+    assert plan.arguments == [f"--user-data-dir={instance.user_data}"]
+    assert plan.use_shell_execute is False
+    assert plan.env["HERMES_HOME"] == str(instance.hermes_home)
+    assert plan.env["HERMES_DESKTOP_USER_DATA_DIR"] == str(instance.user_data)
+    assert plan.env["HERMES_DESKTOP_HERMES_ROOT"] == str(instance.runtime_root)
+    assert plan.env["HERMES_DESKTOP_APP_NAME"] == instance.app_name
+    assert plan.env["HERMES_DESKTOP_CWD"] == str(store.cwd)
+
+
+# ── atomic non-secret manifest ───────────────────────────────────────────
+
+
+def test_display_name_cannot_collide_with_canonical_exe(tmp_path):
+    from hermes_cli.desktop_instances import InstanceNameError
+
+    store = _store(tmp_path)
+    with pytest.raises(InstanceNameError, match="collide"):
+        _create(store, display_name="Hermes")
+
+
+def test_create_writes_atomic_manifest_without_secrets(tmp_path):
+    store = _store(tmp_path)
+    instance = _create(store)
+
+    raw = instance.manifest_path.read_text(encoding="utf-8")
+    data = json.loads(raw)
+    assert data["version"] == 1
+    assert data["name"] == "grace"
+    assert data["ssh_host"] == "grace"
+    assert data["remote_hermes_path"] == "/opt/hermes/bin/hermes"
+    assert data["remote_profile"] == "default"
+    blob = raw.lower()
+    assert "token" not in blob
+    assert "password" not in blob
+    assert "secret" not in blob
+    assert "-----begin" not in blob
+
+
+def test_create_is_atomic_and_rejects_duplicates(tmp_path):
+    store = _store(tmp_path)
+    _create(store)
+    from hermes_cli.desktop_instances import InstanceExistsError
+
+    with pytest.raises(InstanceExistsError):
+        _create(store)
+    listed = store.list()
+    assert [item.name for item in listed] == ["grace"]
+
+
+def test_create_seeds_nonsecret_ssh_connection_json(tmp_path):
+    store = _store(tmp_path)
+    instance = _create(store)
+    seed_path = instance.user_data / "connection.json"
+    payload = json.loads(seed_path.read_text(encoding="utf-8"))
+    assert payload["mode"] == "ssh"
+    assert payload["remote"]["mode"] == "ssh"
+    assert payload["remote"]["host"] == "grace"
+    assert payload["remote"]["remoteHermesPath"] == "/opt/hermes/bin/hermes"
+    assert payload["remote"]["remoteProfile"] == "default"
+    assert "token" not in payload
+    assert "token" not in payload["remote"]
+    assert payload.get("profiles") == {}
+
+
+def test_create_does_not_clone_remote_or_ordinary_local_state(tmp_path, monkeypatch):
+    ordinary = tmp_path / "ordinary-home"
+    ordinary.mkdir()
+    (ordinary / "auth.json").write_text('{"token": "do-not-copy"}', encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(ordinary))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "real-appdata"))
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "real-local"))
+    store = _store(tmp_path)
+    instance = _create(store)
+    assert not (instance.hermes_home / "auth.json").exists()
+    leftover = list(instance.hermes_home.rglob("*"))
+    assert all("auth.json" not in str(path) for path in leftover)
+    assert not (tmp_path / "real-appdata").exists() or not any(
+        (tmp_path / "real-appdata").rglob("*")
+    )
+
+
+# ── SSH / platform / stale errors ────────────────────────────────────────
+
+
+def test_create_reports_missing_ssh_alias(tmp_path):
+    from hermes_cli.desktop_instances import MissingSshAliasError
+
+    def boom(host):
+        raise MissingSshAliasError(f"SSH alias {host!r} was not found")
+
+    store = _store(tmp_path, ssh_probe=boom)
+    with pytest.raises(MissingSshAliasError, match="grace"):
+        _create(store)
+
+
+def test_create_skip_ssh_check_bypasses_probe(tmp_path):
+    def boom(host):
+        raise AssertionError(f"probe should not run for {host}")
+
+    store = _store(tmp_path, ssh_probe=boom)
+    instance = _create(store, skip_ssh_check=True)
+    assert instance.ssh_host == "grace"
+
+
+def test_create_rejects_missing_canonical_runtime(tmp_path):
+    from hermes_cli.desktop_instances import StalePathError
+
+    store = _store(tmp_path)
+    store.canonical_exe.unlink()
+    with pytest.raises(StalePathError, match="canonical"):
+        _create(store)
+
+
+def test_windows_only_mutations_fail_on_other_platforms(tmp_path):
+    from hermes_cli.desktop_instances import IncompatiblePlatformError
+
+    store = _store(tmp_path, platform="linux")
+    with pytest.raises(IncompatiblePlatformError):
+        _create(store)
+    with pytest.raises(IncompatiblePlatformError):
+        store.launch("grace")
+    with pytest.raises(IncompatiblePlatformError):
+        store.install_shortcut("grace")
+
+
+def test_list_and_show_work_on_non_windows(tmp_path):
+    win = _store(tmp_path)
+    _create(win)
+    linux = _store(tmp_path, platform="darwin")
+    names = [item.name for item in linux.list()]
+    assert names == ["grace"]
+    shown = linux.get("grace")
+    assert shown.ssh_host == "grace"
+
+
+# ── native launcher source ───────────────────────────────────────────────
+
+
+def test_generated_launcher_source_has_validated_windows_invariants(tmp_path):
+    store = _store(tmp_path)
+    instance = _create(store)
+    source = store.render_launcher_source(instance)
+    assert "UseShellExecute = false" in source
+    assert 'Arguments = "--user-data-dir=\\"" + UserData + "\\""' in source
+    assert 'EnvironmentVariables["HERMES_HOME"]' in source
+    assert 'EnvironmentVariables["HERMES_DESKTOP_USER_DATA_DIR"]' in source
+    assert 'EnvironmentVariables["HERMES_DESKTOP_HERMES_ROOT"]' in source
+    assert 'EnvironmentVariables["HERMES_DESKTOP_APP_NAME"]' in source
+    assert "CreateHardLink" in source
+    assert "File.Delete" in source
+    assert instance.app_name in source
+    assert str(instance.user_data) in source
+    assert str(instance.hermes_home) in source
+    assert str(instance.named_exe) in source
+    assert str(store.canonical_exe) in source
+    assert "RunAsInvoker" not in source
+    assert "--no-sandbox" not in source
+    # Generated launchers may live under the current user's home; they must
+    # not bake in the validated live-workaround paths from this machine.
+    assert r"AppData\Local\hermes-launchers" not in source
+    assert r"AppData\Local\hermes-instances" not in source
+
+
+# ── hardlink refresh / lock policy ───────────────────────────────────────
+
+
+def test_repair_refreshes_named_hardlink_to_canonical_bytes(tmp_path):
+    store = _store(tmp_path)
+    instance = _create(store)
+    assert instance.named_exe.exists()
+    store.canonical_exe.write_text("updated-canonical", encoding="utf-8")
+    result = store.repair(instance.name)
+    assert result.refreshed is True
+    assert result.retained_running is False
+    assert instance.named_exe.read_text(encoding="utf-8") == "updated-canonical"
+
+
+def test_repair_retains_named_exe_when_running_instance_locks_it(tmp_path):
+    store = _store(tmp_path)
+    instance = _create(store)
+    instance.named_exe.write_text("in-use", encoding="utf-8")
+
+    def locked(path):
+        return Path(path) == instance.named_exe
+
+    store.is_locked = locked
+    result = store.repair(instance.name)
+    assert result.retained_running is True
+    assert instance.named_exe.read_text(encoding="utf-8") == "in-use"
+
+
+def test_launch_refreshes_hardlink_then_starts_named_exe(tmp_path):
+    launched: list[Any] = []
+
+    def starter(plan):
+        launched.append(plan)
+        return 4242
+
+    store = _store(tmp_path, process_starter=starter)
+    instance = _create(store, install_shortcut=False)
+    store.canonical_exe.write_text("after-update", encoding="utf-8")
+    pid = store.launch(instance.name)
+    assert pid == 4242
+    assert len(launched) == 1
+    plan = launched[0]
+    assert plan.executable == instance.named_exe
+    assert plan.use_shell_execute is False
+    assert instance.named_exe.read_text(encoding="utf-8") == "after-update"
+
+
+# ── shortcut / remove ────────────────────────────────────────────────────
+
+
+def test_create_installs_shortcut_to_native_launcher(tmp_path):
+    written = []
+
+    def writer(spec):
+        written.append(spec)
+        _touch(spec.path, spec.target)
+
+    store = _store(tmp_path, shortcut_writer=writer)
+    instance = _create(store)
+    assert instance.shortcut_path.exists()
+    assert written[0].target == str(instance.launcher_exe)
+    assert written[0].icon == str(store.canonical_exe)
+    assert instance.launcher_exe.exists()
+
+
+def test_remove_drops_launcher_and_shortcut_but_not_remote_or_local_state(tmp_path):
+    store = _store(tmp_path)
+    instance = _create(store)
+    (instance.hermes_home / "notes.txt").write_text(
+        "keep local cache", encoding="utf-8"
+    )
+    store.remove(instance.name)
+    assert not instance.manifest_path.exists()
+    assert not instance.launcher_exe.exists()
+    assert not instance.shortcut_path.exists()
+    assert not instance.named_exe.exists()
+    assert (instance.hermes_home / "notes.txt").read_text(
+        encoding="utf-8"
+    ) == "keep local cache"
+    assert (instance.user_data / "connection.json").exists()
+
+
+def test_remove_purge_local_still_does_not_claim_remote_deletion(tmp_path):
+    store = _store(tmp_path)
+    instance = _create(store)
+    result = store.remove(instance.name, purge_local=True)
+    assert result.remote_state_deleted is False
+    assert not instance.hermes_home.exists()
+    assert not instance.user_data.exists()
+
+
+def test_remove_refuses_running_instance_unless_forced(tmp_path):
+    from hermes_cli.desktop_instances import InstanceLockedError
+
+    store = _store(tmp_path)
+    instance = _create(store)
+    store.is_locked = lambda path: Path(path) == instance.named_exe
+    with pytest.raises(InstanceLockedError):
+        store.remove(instance.name)
+    assert instance.manifest_path.exists()
+    store.remove(instance.name, force=True)
+    assert not instance.manifest_path.exists()
+
+
+def test_create_can_be_retried_if_launcher_materialize_fails(tmp_path):
+    calls = {"n": 0}
+
+    def flaky_compiler(source, output):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("csc unavailable")
+        _touch(output, "compiled-launcher")
+
+    store = _store(tmp_path, compiler=flaky_compiler)
+    with pytest.raises(RuntimeError, match="csc unavailable"):
+        _create(store)
+    assert store.list() == []
+    instance = _create(store)
+    assert instance.manifest_path.exists()
+    assert instance.launcher_exe.exists()
+
+
+def test_unknown_instance_has_a_useful_error(tmp_path):
+    from hermes_cli.desktop_instances import InstanceNotFoundError
+
+    store = _store(tmp_path)
+    with pytest.raises(InstanceNotFoundError, match="athena"):
+        store.get("athena")
+
+
+# ── CLI parser: existing desktop launch stays default ────────────────────
+
+
+def test_instance_list_does_not_require_desktop_source_tree(
+    tmp_path, monkeypatch, capsys
+):
+    from hermes_cli.desktop_instances import DesktopInstanceStore
+
+    root = tmp_path / "not-a-desktop-checkout"
+    root.mkdir()
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    store = DesktopInstanceStore.from_defaults(
+        runtime_root=root, hermes_root=tmp_path / "isolated-root"
+    )
+    assert store.list() == []
+
+    ns = argparse.Namespace(
+        desktop_action="instance",
+        instance_action="list",
+        cwd=None,
+    )
+    cli_main.cmd_gui(ns)
+    assert "No isolated Desktop instances" in capsys.readouterr().out
+
+
+def test_bare_desktop_command_still_dispatches_to_cmd_gui():
+    seen = {}
+
+    def cmd_gui(args):
+        seen["args"] = args
+        return "launched"
+
+    parser = _gui_parser(cmd_gui=cmd_gui)
+    ns = parser.parse_args(["desktop", "--skip-build"])
+    assert ns.func is cmd_gui
+    assert ns.skip_build is True
+    assert getattr(ns, "desktop_action", None) in (None, "")
+
+
+def test_instance_create_parser_collects_ssh_fields():
+    parser = _gui_parser()
+    ns = parser.parse_args([
+        "desktop",
+        "instance",
+        "create",
+        "athena",
+        "--ssh-host",
+        "bear-agent",
+        "--remote-hermes-path",
+        "/home/bear/.local/bin/hermes",
+        "--remote-profile",
+        "default",
+        "--display-name",
+        "Hermes Athena",
+    ])
+    assert ns.desktop_action == "instance"
+    assert ns.instance_action == "create"
+    assert ns.instance_name == "athena"
+    assert ns.ssh_host == "bear-agent"
+    assert ns.remote_hermes_path == "/home/bear/.local/bin/hermes"
+    assert ns.remote_profile == "default"
+    assert ns.display_name == "Hermes Athena"
+
+
+def test_instance_list_launch_shortcut_repair_remove_parsers():
+    parser = _gui_parser()
+    listed = parser.parse_args(["desktop", "instance", "list"])
+    assert listed.instance_action == "list"
+    launched = parser.parse_args(["desktop", "instance", "launch", "grace"])
+    assert launched.instance_action == "launch"
+    assert launched.instance_name == "grace"
+    shortcut = parser.parse_args(["gui", "instance", "shortcut", "grace"])
+    assert shortcut.instance_action == "shortcut"
+    repaired = parser.parse_args(["desktop", "instance", "repair", "--all"])
+    assert repaired.instance_action == "repair"
+    assert repaired.all_instances is True
+    removed = parser.parse_args([
+        "desktop",
+        "instance",
+        "remove",
+        "grace",
+        "--purge-local",
+    ])
+    assert removed.purge_local is True

--- a/tests/hermes_cli/test_desktop_instances.py
+++ b/tests/hermes_cli/test_desktop_instances.py
@@ -334,15 +334,155 @@ def test_instance_spec_from_ssh_connection_maps_nonsecret_fields():
         "kind": "ssh",
         "label": "Hermes Athena",
         "host": "bear-agent",
+        "user": "bear",
+        "port": 2222,
+        "keyPath": "/home/bear/.ssh/id_ed25519",
         "remoteHermesPath": "/opt/hermes/bin/hermes",
         "remoteProfile": "default",
     })
     assert spec.name == "athena"
+    assert spec.connection_id == "c1"
     assert spec.ssh_host == "bear-agent"
+    assert spec.ssh_user == "bear"
+    assert spec.ssh_port == 2222
+    assert spec.ssh_key_path == "/home/bear/.ssh/id_ed25519"
     assert spec.remote_hermes_path == "/opt/hermes/bin/hermes"
     assert spec.remote_profile == "default"
     assert spec.display_name == "Hermes Athena"
     assert "token" not in spec.to_manifest()
+
+
+def test_same_host_ssh_rows_are_distinct_when_user_port_or_key_differ():
+    from hermes_cli.desktop_instances import isolated_instance_spec_from_ssh
+
+    alice = isolated_instance_spec_from_ssh({
+        "id": "alice-box",
+        "kind": "ssh",
+        "label": "Lab",
+        "host": "lab.example",
+        "user": "alice",
+        "port": 22,
+        "keyPath": "/keys/alice",
+        "remoteHermesPath": "/opt/hermes/bin/hermes",
+        "remoteProfile": "default",
+    })
+    bob = isolated_instance_spec_from_ssh({
+        "id": "bob-box",
+        "kind": "ssh",
+        "label": "Lab",
+        "host": "lab.example",
+        "user": "bob",
+        "port": 2200,
+        "keyPath": "/keys/bob",
+        "remoteHermesPath": "/opt/hermes/bin/hermes",
+        "remoteProfile": "research",
+    })
+    assert alice.dial_identity() != bob.dial_identity()
+    assert alice.connection_id != bob.connection_id
+
+
+def test_open_isolated_fails_closed_when_existing_manifest_does_not_match_selected_row(
+    tmp_path,
+):
+    from hermes_cli.desktop_instances import IsolatedInstanceSpecError
+
+    store = _store(tmp_path)
+    store.create(
+        "lab",
+        connection_id="alice-box",
+        ssh_host="lab.example",
+        ssh_user="alice",
+        ssh_port=22,
+        ssh_key_path="/keys/alice",
+        remote_hermes_path="/opt/hermes/bin/hermes",
+        remote_profile="default",
+        skip_ssh_check=True,
+        install_shortcut=False,
+    )
+    with pytest.raises(IsolatedInstanceSpecError, match="no longer matches"):
+        store.open_from_connection({
+            "id": "alice-box",
+            "kind": "ssh",
+            "label": "Lab",
+            "host": "lab.example",
+            "user": "alice",
+            "port": 2200,
+            "keyPath": "/keys/alice",
+            "remoteHermesPath": "/opt/hermes/bin/hermes",
+            "remoteProfile": "default",
+        })
+
+
+def test_open_isolated_updates_matching_connection_when_only_display_name_changes(
+    tmp_path,
+):
+    store = _store(tmp_path)
+    store.create(
+        "lab",
+        connection_id="alice-box",
+        ssh_host="lab.example",
+        ssh_user="alice",
+        ssh_port=22,
+        ssh_key_path="/keys/alice",
+        remote_hermes_path="/opt/hermes/bin/hermes",
+        remote_profile="default",
+        display_name="Hermes Lab",
+        skip_ssh_check=True,
+        install_shortcut=False,
+    )
+    instance = store.open_from_connection({
+        "id": "alice-box",
+        "kind": "ssh",
+        "label": "Hermes Lab",
+        "host": "lab.example",
+        "user": "alice",
+        "port": 22,
+        "keyPath": "/keys/alice",
+        "remoteHermesPath": "/opt/hermes/bin/hermes",
+        "remoteProfile": "default",
+    })
+    assert instance.connection_id == "alice-box"
+    assert instance.ssh_user == "alice"
+    assert instance.ssh_port == 22
+
+
+def test_default_process_starter_scrubs_parent_provider_secrets(tmp_path, monkeypatch):
+    from hermes_cli.desktop_instances import (
+        LaunchPlan,
+        default_process_starter,
+    )
+
+    captured: dict[str, object] = {}
+
+    class FakePopen:
+        def __init__(self, args, cwd=None, env=None):
+            captured["args"] = args
+            captured["cwd"] = cwd
+            captured["env"] = env
+            self.pid = 4242
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-parent-secret")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-parent")
+    monkeypatch.setattr(
+        "hermes_cli.desktop_instances.subprocess.Popen",
+        FakePopen,
+    )
+    plan = LaunchPlan(
+        executable=tmp_path / "Hermes Grace.exe",
+        arguments=["--user-data-dir=/u"],
+        env={
+            "HERMES_HOME": str(tmp_path / "home"),
+            "HERMES_DESKTOP_INSTANCE": "grace",
+        },
+        cwd=str(tmp_path),
+    )
+    assert default_process_starter(plan) == 4242
+    env = captured["env"]
+    assert env["HERMES_HOME"] == str(tmp_path / "home")
+    assert env["HERMES_DESKTOP_INSTANCE"] == "grace"
+    assert "OPENAI_API_KEY" not in env
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "sk-parent-secret" not in " ".join(str(value) for value in env.values())
 
 
 def test_instance_spec_rejects_non_ssh_and_missing_remote_path():

--- a/tests/hermes_cli/test_desktop_instances.py
+++ b/tests/hermes_cli/test_desktop_instances.py
@@ -189,6 +189,15 @@ def test_launch_plan_can_forward_a_deep_link(tmp_path):
     instance = _create(store)
     plan = store.build_launch_plan(instance, deep_link="hermes://blueprint/morning")
     assert plan.env["HERMES_DESKTOP_PENDING_DEEP_LINK"] == "hermes://blueprint/morning"
+    assert "hermes://blueprint/morning" in plan.arguments
+
+
+def test_parse_instance_deep_link_returns_none_for_reserved_or_invalid():
+    from hermes_cli.desktop_instances import parse_instance_deep_link
+
+    assert parse_instance_deep_link("hermes://instance/desktop/blueprint/x") is None
+    assert parse_instance_deep_link("hermes://instance/Not Valid/blueprint/x") is None
+    assert parse_instance_deep_link("hermes://instance/") is None
 
 
 def test_create_writes_atomic_manifest_without_secrets(tmp_path):

--- a/tests/hermes_cli/test_desktop_instances.py
+++ b/tests/hermes_cli/test_desktop_instances.py
@@ -164,6 +164,13 @@ def test_launch_plan_uses_named_hardlink_early_user_data_and_no_shellexecute(tmp
     assert plan.env["HERMES_DESKTOP_HERMES_ROOT"] == str(instance.runtime_root)
     assert plan.env["HERMES_DESKTOP_APP_NAME"] == instance.app_name
     assert plan.env["HERMES_DESKTOP_CWD"] == str(store.cwd)
+    assert plan.env["HERMES_DESKTOP_INSTANCE"] == instance.name
+    assert (
+        plan.env["HERMES_DESKTOP_AUMID"]
+        == f"com.nousresearch.hermes.instance.{instance.name}"
+    )
+    assert plan.env["HERMES_DESKTOP_DISABLE_GLOBAL_SHORTCUTS"] == "1"
+    assert plan.env["HERMES_DESKTOP_SKIP_PROTOCOL_REGISTER"] == "1"
 
 
 # ── atomic non-secret manifest ───────────────────────────────────────────
@@ -175,6 +182,13 @@ def test_display_name_cannot_collide_with_canonical_exe(tmp_path):
     store = _store(tmp_path)
     with pytest.raises(InstanceNameError, match="collide"):
         _create(store, display_name="Hermes")
+
+
+def test_launch_plan_can_forward_a_deep_link(tmp_path):
+    store = _store(tmp_path)
+    instance = _create(store)
+    plan = store.build_launch_plan(instance, deep_link="hermes://blueprint/morning")
+    assert plan.env["HERMES_DESKTOP_PENDING_DEEP_LINK"] == "hermes://blueprint/morning"
 
 
 def test_create_writes_atomic_manifest_without_secrets(tmp_path):
@@ -270,16 +284,82 @@ def test_create_rejects_missing_canonical_runtime(tmp_path):
         _create(store)
 
 
-def test_windows_only_mutations_fail_on_other_platforms(tmp_path):
+def test_unknown_platform_mutations_fail(tmp_path):
     from hermes_cli.desktop_instances import IncompatiblePlatformError
 
-    store = _store(tmp_path, platform="linux")
+    store = _store(tmp_path, platform="aix")
     with pytest.raises(IncompatiblePlatformError):
         _create(store)
-    with pytest.raises(IncompatiblePlatformError):
-        store.launch("grace")
-    with pytest.raises(IncompatiblePlatformError):
-        store.install_shortcut("grace")
+
+
+def test_linux_create_writes_desktop_entry_and_wrapper(tmp_path):
+    store = _store(tmp_path, platform="linux")
+    instance = _create(store)
+    assert instance.shortcut_path.suffix == ".desktop"
+    assert instance.shortcut_path.exists()
+    desktop = instance.shortcut_path.read_text(encoding="utf-8")
+    assert f"Name={instance.app_name}" in desktop
+    assert str(instance.launcher_exe) in desktop
+    wrapper = instance.launcher_exe.read_text(encoding="utf-8")
+    assert "HERMES_HOME=" in wrapper
+    assert "--user-data-dir=" in wrapper
+    assert "UseShellExecute" not in wrapper
+    assert instance.named_exe == store.canonical_exe
+
+
+def test_macos_create_writes_command_wrapper(tmp_path):
+    store = _store(tmp_path, platform="darwin")
+    instance = _create(store)
+    assert instance.shortcut_path.suffix == ".command"
+    assert instance.shortcut_path.exists()
+    script = instance.shortcut_path.read_text(encoding="utf-8")
+    assert "HERMES_DESKTOP_USER_DATA_DIR=" in script
+    assert "--user-data-dir=" in script
+
+
+def test_instance_spec_from_ssh_connection_maps_nonsecret_fields():
+    from hermes_cli.desktop_instances import isolated_instance_spec_from_ssh
+
+    spec = isolated_instance_spec_from_ssh({
+        "id": "c1",
+        "kind": "ssh",
+        "label": "Hermes Athena",
+        "host": "bear-agent",
+        "remoteHermesPath": "/opt/hermes/bin/hermes",
+        "remoteProfile": "default",
+    })
+    assert spec.name == "athena"
+    assert spec.ssh_host == "bear-agent"
+    assert spec.remote_hermes_path == "/opt/hermes/bin/hermes"
+    assert spec.remote_profile == "default"
+    assert spec.display_name == "Hermes Athena"
+    assert "token" not in spec.to_manifest()
+
+
+def test_instance_spec_rejects_non_ssh_and_missing_remote_path():
+    from hermes_cli.desktop_instances import (
+        IsolatedInstanceSpecError,
+        isolated_instance_spec_from_ssh,
+    )
+
+    with pytest.raises(IsolatedInstanceSpecError, match="SSH"):
+        isolated_instance_spec_from_ssh({"kind": "remote", "label": "box", "host": "x"})
+    with pytest.raises(IsolatedInstanceSpecError, match="absolute"):
+        isolated_instance_spec_from_ssh({
+            "kind": "ssh",
+            "label": "box",
+            "host": "lab",
+            "remoteHermesPath": "rel",
+        })
+
+
+def test_parse_instance_deep_link_extracts_slug_and_remainder():
+    from hermes_cli.desktop_instances import parse_instance_deep_link
+
+    parsed = parse_instance_deep_link("hermes://instance/grace/blueprint/morning")
+    assert parsed.instance_name == "grace"
+    assert parsed.remainder == "hermes://blueprint/morning"
+    assert parse_instance_deep_link("hermes://blueprint/morning") is None
 
 
 def test_list_and_show_work_on_non_windows(tmp_path):
@@ -305,6 +385,9 @@ def test_generated_launcher_source_has_validated_windows_invariants(tmp_path):
     assert 'EnvironmentVariables["HERMES_DESKTOP_USER_DATA_DIR"]' in source
     assert 'EnvironmentVariables["HERMES_DESKTOP_HERMES_ROOT"]' in source
     assert 'EnvironmentVariables["HERMES_DESKTOP_APP_NAME"]' in source
+    assert 'EnvironmentVariables["HERMES_DESKTOP_INSTANCE"]' in source
+    assert 'EnvironmentVariables["HERMES_DESKTOP_AUMID"]' in source
+    assert 'EnvironmentVariables["HERMES_DESKTOP_DISABLE_GLOBAL_SHORTCUTS"]' in source
     assert "CreateHardLink" in source
     assert "File.Delete" in source
     assert instance.app_name in source

--- a/tests/hermes_cli/test_desktop_instances.py
+++ b/tests/hermes_cli/test_desktop_instances.py
@@ -41,7 +41,7 @@ def _store(tmp_path: Path, **overrides: Any):
         runtime_root / "apps" / "desktop" / "release" / "win-unpacked" / "Hermes.exe"
     )
     desktop_dir = tmp_path / "Desktop"
-    kwargs = dict(
+    kwargs: dict[str, Any] = dict(
         hermes_root=hermes_root,
         runtime_root=runtime_root,
         canonical_exe=canonical_exe,
@@ -452,7 +452,7 @@ def test_default_process_starter_scrubs_parent_provider_secrets(tmp_path, monkey
         default_process_starter,
     )
 
-    captured: dict[str, object] = {}
+    captured: dict[str, Any] = {}
 
     class FakePopen:
         def __init__(self, args, cwd=None, env=None):
@@ -506,6 +506,7 @@ def test_parse_instance_deep_link_extracts_slug_and_remainder():
     from hermes_cli.desktop_instances import parse_instance_deep_link
 
     parsed = parse_instance_deep_link("hermes://instance/grace/blueprint/morning")
+    assert parsed is not None
     assert parsed.instance_name == "grace"
     assert parsed.remainder == "hermes://blueprint/morning"
     assert parse_instance_deep_link("hermes://blueprint/morning") is None
@@ -672,6 +673,98 @@ def test_create_can_be_retried_if_launcher_materialize_fails(tmp_path):
     instance = _create(store)
     assert instance.manifest_path.exists()
     assert instance.launcher_exe.exists()
+
+
+def test_recreate_rejects_retained_user_data_for_another_route(tmp_path):
+    from hermes_cli.desktop_instances import InstanceRouteMismatchError
+
+    store = _store(tmp_path)
+    instance = _create(
+        store,
+        connection_id="grace-alice",
+        ssh_user="alice",
+    )
+    store.remove(instance.name)
+
+    with pytest.raises(InstanceRouteMismatchError, match="--purge-local"):
+        _create(
+            store,
+            connection_id="grace-bob",
+            ssh_host="other.example",
+            ssh_user="bob",
+        )
+
+    assert not instance.manifest_path.exists()
+
+
+def test_failed_create_cannot_retarget_its_seeded_user_data(tmp_path):
+    from hermes_cli.desktop_instances import InstanceRouteMismatchError
+
+    calls = {"n": 0}
+
+    def flaky_compiler(source, output):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("csc unavailable")
+        _touch(output, "compiled-launcher")
+
+    store = _store(tmp_path, compiler=flaky_compiler)
+    with pytest.raises(RuntimeError, match="csc unavailable"):
+        _create(store, connection_id="grace-alice", ssh_user="alice")
+
+    with pytest.raises(InstanceRouteMismatchError, match="--purge-local"):
+        _create(
+            store,
+            connection_id="grace-bob",
+            ssh_host="other.example",
+            ssh_user="bob",
+        )
+
+    assert store.list() == []
+
+
+def test_create_seeds_exact_v2_registry_and_launch_rejects_route_edits(tmp_path):
+    from hermes_cli.desktop_instances import InstanceRouteMismatchError
+
+    launched: list[Any] = []
+    store = _store(
+        tmp_path,
+        process_starter=lambda plan: launched.append(plan) or 4242,
+    )
+    instance = _create(
+        store,
+        connection_id="grace-alice",
+        ssh_user="alice",
+        ssh_port=2222,
+        ssh_key_path="/keys/alice",
+    )
+    registry_path = instance.user_data / "connections.json"
+    registry = json.loads(registry_path.read_text(encoding="utf-8"))
+
+    assert registry["version"] == 2
+    assert registry["primary"] == "grace-alice"
+    assert registry["launchMode"] == "primary"
+    assert registry["lastUsed"] == "grace-alice"
+    route = next(item for item in registry["connections"] if item["id"] == "grace-alice")
+    assert route == {
+        "id": "grace-alice",
+        "kind": "ssh",
+        "label": "Hermes Grace",
+        "host": "grace",
+        "user": "alice",
+        "port": 2222,
+        "keyPath": "/keys/alice",
+        "remoteHermesPath": "/opt/hermes/bin/hermes",
+        "remoteProfile": "default",
+    }
+
+    route["host"] = "edited.example"
+    registry_path.write_text(json.dumps(registry), encoding="utf-8")
+
+    with pytest.raises(InstanceRouteMismatchError, match="connections.json"):
+        store.launch(instance.name)
+
+    assert launched == []
 
 
 def test_unknown_instance_has_a_useful_error(tmp_path):

--- a/tests/hermes_cli/test_desktop_instances.py
+++ b/tests/hermes_cli/test_desktop_instances.py
@@ -10,9 +10,12 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
+import psutil
 import pytest
 
 from hermes_cli import main as cli_main
@@ -455,10 +458,11 @@ def test_default_process_starter_scrubs_parent_provider_secrets(tmp_path, monkey
     captured: dict[str, Any] = {}
 
     class FakePopen:
-        def __init__(self, args, cwd=None, env=None):
+        def __init__(self, args, cwd=None, env=None, **kwargs):
             captured["args"] = args
             captured["cwd"] = cwd
             captured["env"] = env
+            captured["options"] = kwargs
             self.pid = 4242
 
     monkeypatch.setenv("OPENAI_API_KEY", "sk-parent-secret")
@@ -483,6 +487,84 @@ def test_default_process_starter_scrubs_parent_provider_secrets(tmp_path, monkey
     assert "OPENAI_API_KEY" not in env
     assert "ANTHROPIC_API_KEY" not in env
     assert "sk-parent-secret" not in " ".join(str(value) for value in env.values())
+    assert captured["options"] == {
+        "stdin": subprocess.DEVNULL,
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+    }
+
+
+def test_default_process_starter_releases_capturing_parent_pipes(tmp_path):
+    """A short-lived CLI must not wait for its long-lived Desktop child's stdio."""
+    repo_root = Path(__file__).resolve().parents[2]
+    pid_path = tmp_path / "desktop.pid"
+    stop_path = tmp_path / "stop-desktop"
+    desktop_code = (
+        "import time\n"
+        "from pathlib import Path\n"
+        f"stop = Path({str(stop_path)!r})\n"
+        "deadline = time.monotonic() + 6\n"
+        "while not stop.exists() and time.monotonic() < deadline:\n"
+        "    time.sleep(0.05)\n"
+    )
+    launcher_code = (
+        "import sys\n"
+        "from pathlib import Path\n"
+        "from hermes_cli.desktop_instances import LaunchPlan, default_process_starter\n"
+        "pid = default_process_starter(LaunchPlan(\n"
+        "    executable=Path(sys.executable),\n"
+        f"    arguments=['-c', {desktop_code!r}],\n"
+        "    env={},\n"
+        f"    cwd={str(tmp_path)!r},\n"
+        "))\n"
+        f"Path({str(pid_path)!r}).write_text(str(pid), encoding='utf-8')\n"
+        "print(f'launched {pid}', flush=True)\n"
+    )
+    launcher = subprocess.Popen(
+        [sys.executable, "-c", launcher_code],
+        cwd=repo_root,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    desktop_pid: int | None = None
+
+    try:
+        assert launcher.wait(timeout=20) == 0
+        desktop_pid = int(pid_path.read_text(encoding="utf-8"))
+        assert psutil.Process(desktop_pid).is_running()
+
+        stdout, stderr = launcher.communicate(timeout=3)
+
+        assert stdout.strip() == f"launched {desktop_pid}"
+        assert stderr == ""
+    finally:
+        stop_path.touch()
+        if desktop_pid is not None:
+            try:
+                psutil.Process(desktop_pid).wait(timeout=5)
+            except psutil.NoSuchProcess:
+                pass
+        if launcher.poll() is None:
+            launcher.kill()
+        launcher.communicate(timeout=5)
+
+
+def test_default_process_starter_preserves_immediate_launch_errors(tmp_path):
+    from hermes_cli.desktop_instances import LaunchPlan, default_process_starter
+
+    plan = LaunchPlan(
+        executable=tmp_path / "missing-desktop-executable",
+        arguments=[],
+        env={},
+        cwd=str(tmp_path),
+    )
+
+    with pytest.raises(OSError):
+        default_process_starter(plan)
 
 
 def test_instance_spec_rejects_non_ssh_and_missing_remote_path():

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -94,7 +94,7 @@ hermes [global-options] <command> [subcommand/options]
 | `hermes import-agent` | Import a Claude Code (`~/.claude`) or Codex CLI (`~/.codex`) setup. |
 | `hermes dashboard` | Launch the web dashboard for managing config, API keys, and sessions. |
 | `hermes serve` | Start the Hermes backend server (headless; powers the desktop app and remote backends). |
-| `hermes desktop` (alias `gui`) | Build and launch the native Electron desktop app. |
+| `hermes desktop` (alias `gui`) | Build and launch the native Electron desktop app. `hermes desktop instance` manages isolated Windows Desktop shells. |
 | `hermes profile` | Manage profiles — multiple isolated Hermes instances. |
 | `hermes completion` | Print shell completion scripts (bash/zsh/fish). |
 | `hermes --version` | Show version information. |
@@ -1700,6 +1700,25 @@ hermes dashboard --port 8080 --no-open
 # profile preselected in the sidebar switcher (attach if running)
 worker dashboard
 ```
+
+## `hermes desktop`
+
+```bash
+hermes desktop [options]
+hermes desktop instance <subcommand>
+```
+
+Build and launch the native Electron desktop app. Bare `hermes desktop` is unchanged. On Windows, `instance` manages **isolated Desktop shells** — separate Electron `userData`, `HERMES_HOME`, and process identity, sharing the canonical install. This is not Settings → Connections. See [Isolated Desktop instances](/user-guide/isolated-desktop-instances).
+
+| Subcommand | Description |
+|------------|-------------|
+| `instance create <name> --ssh-host HOST --remote-hermes-path PATH --remote-profile PROFILE` | Register an isolated shell and install its Desktop shortcut. |
+| `instance list` | List registered isolated instances. |
+| `instance show <name>` | Print the non-secret manifest. |
+| `instance launch <name>` | Launch or focus that isolated Desktop. |
+| `instance shortcut <name>` | Recreate the OS shortcut. |
+| `instance repair [<name> \| --all]` | Refresh named hardlinks after a local Desktop update. |
+| `instance remove <name> [--purge-local] [--force]` | Remove launcher and shortcut. Never deletes remote state. |
 
 ## `hermes profile`
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -94,7 +94,7 @@ hermes [global-options] <command> [subcommand/options]
 | `hermes import-agent` | Import a Claude Code (`~/.claude`) or Codex CLI (`~/.codex`) setup. |
 | `hermes dashboard` | Launch the web dashboard for managing config, API keys, and sessions. |
 | `hermes serve` | Start the Hermes backend server (headless; powers the desktop app and remote backends). |
-| `hermes desktop` (alias `gui`) | Build and launch the native Electron desktop app. `hermes desktop instance` manages isolated Windows Desktop shells. |
+| `hermes desktop` (alias `gui`) | Build and launch the native Electron desktop app. `hermes desktop instance` manages isolated Desktop shells. |
 | `hermes profile` | Manage profiles — multiple isolated Hermes instances. |
 | `hermes completion` | Print shell completion scripts (bash/zsh/fish). |
 | `hermes --version` | Show version information. |
@@ -1708,14 +1708,14 @@ hermes desktop [options]
 hermes desktop instance <subcommand>
 ```
 
-Build and launch the native Electron desktop app. Bare `hermes desktop` is unchanged. On Windows, `instance` manages **isolated Desktop shells** — separate Electron `userData`, `HERMES_HOME`, and process identity, sharing the canonical install. This is not Settings → Connections. See [Isolated Desktop instances](/user-guide/isolated-desktop-instances).
+Build and launch the native Electron desktop app. Bare `hermes desktop` is unchanged. `instance` manages **isolated Desktop shells** — separate Electron `userData`, `HERMES_HOME`, and process identity, sharing the canonical install. This is not Settings → Connections. See [Isolated Desktop instances](/user-guide/isolated-desktop-instances).
 
 | Subcommand | Description |
 |------------|-------------|
 | `instance create <name> --ssh-host HOST --remote-hermes-path PATH --remote-profile PROFILE` | Register an isolated shell and install its Desktop shortcut. |
 | `instance list` | List registered isolated instances. |
 | `instance show <name>` | Print the non-secret manifest. |
-| `instance launch <name>` | Launch or focus that isolated Desktop. |
+| `instance launch <name> [--deep-link URL]` | Launch or focus that isolated Desktop. Optional `hermes://` remainder. |
 | `instance shortcut <name>` | Recreate the OS shortcut. |
 | `instance repair [<name> \| --all]` | Refresh named hardlinks after a local Desktop update. |
 | `instance remove <name> [--purge-local] [--force]` | Remove launcher and shortcut. Never deletes remote state. |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -567,6 +567,8 @@ Three dashboard-auth providers ship in the box. For a remote Hermes Desktop conn
 | `HERMES_DESKTOP_HERMES_ROOT` | Desktop source-checkout override used by `hermes desktop --hermes-root`; checked before the packaged first-launch install or an existing `hermes` on `PATH`. |
 | `HERMES_DESKTOP_IGNORE_EXISTING` | Set to `1` to make Desktop ignore an existing `hermes` on `PATH` during backend resolution. Equivalent to `hermes desktop --ignore-existing`. |
 | `HERMES_DESKTOP_CWD` | Initial project directory for Desktop chat sessions. Set by `hermes desktop --cwd`. |
+| `HERMES_DESKTOP_USER_DATA_DIR` | Isolated Electron `userData` root. Set by `hermes desktop instance` for a named shell; do not set this globally. |
+| `HERMES_DESKTOP_APP_NAME` | Isolated Desktop process / single-instance name. Set by `hermes desktop instance`; do not set this globally. |
 | `HERMES_DESKTOP_PYTHON` | Absolute path to a Python interpreter for the backend, checked before Electron auto-resolves one for the source checkout. Used by worktree dev helpers (see [TUI & Desktop from Worktrees](../developer-guide/worktree-ui-dev.md)) to reuse a shared venv. |
 | `HERMES_DESKTOP_DEV_SERVER` | Vite dev-server URL the Electron shell loads instead of the packaged bundle (e.g. `http://127.0.0.1:5174`). Set automatically by `npm run dev`; only relevant when hacking on the app. |
 | `HERMES_DESKTOP_CDP_PORT` | Overrides the Chrome DevTools Protocol port the renderer exposes on `127.0.0.1` for DOM/CSS inspection tooling (default `9222`). Dev-server runs (`npm run dev`, `hgui`) open it automatically; a packaged app never does, and no value here changes that. Set to `off` to disable it on a dev run. Anything that can reach the port can execute code in the renderer. |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -569,6 +569,11 @@ Three dashboard-auth providers ship in the box. For a remote Hermes Desktop conn
 | `HERMES_DESKTOP_CWD` | Initial project directory for Desktop chat sessions. Set by `hermes desktop --cwd`. |
 | `HERMES_DESKTOP_USER_DATA_DIR` | Isolated Electron `userData` root. Set by `hermes desktop instance` for a named shell; do not set this globally. |
 | `HERMES_DESKTOP_APP_NAME` | Isolated Desktop process / single-instance name. Set by `hermes desktop instance`; do not set this globally. |
+| `HERMES_DESKTOP_INSTANCE` | Isolated instance slug. Set by `hermes desktop instance`; do not set this globally. |
+| `HERMES_DESKTOP_AUMID` | Windows AppUserModelID override (`com.nousresearch.hermes.instance.<name>`). Set by `hermes desktop instance`. |
+| `HERMES_DESKTOP_DISABLE_GLOBAL_SHORTCUTS` | Set to `1` so this process does not register the quick-entry / HUD-snap hotkeys. Isolated shells set this automatically. |
+| `HERMES_DESKTOP_SKIP_PROTOCOL_REGISTER` | Set to `1` so this process does not claim the OS `hermes://` handler. Isolated shells set this automatically. |
+| `HERMES_DESKTOP_PENDING_DEEP_LINK` | One-shot `hermes://` URL delivered after an isolated shell starts. Set by `hermes desktop instance launch --deep-link`. |
 | `HERMES_DESKTOP_PYTHON` | Absolute path to a Python interpreter for the backend, checked before Electron auto-resolves one for the source checkout. Used by worktree dev helpers (see [TUI & Desktop from Worktrees](../developer-guide/worktree-ui-dev.md)) to reuse a shared venv. |
 | `HERMES_DESKTOP_DEV_SERVER` | Vite dev-server URL the Electron shell loads instead of the packaged bundle (e.g. `http://127.0.0.1:5174`). Set automatically by `npm run dev`; only relevant when hacking on the app. |
 | `HERMES_DESKTOP_CDP_PORT` | Overrides the Chrome DevTools Protocol port the renderer exposes on `127.0.0.1` for DOM/CSS inspection tooling (default `9222`). Dev-server runs (`npm run dev`, `hgui`) open it automatically; a packaged app never does, and no value here changes that. Set to `off` to disable it on a dev run. Anything that can reach the port can execute code in the renderer. |

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -300,6 +300,8 @@ To launch via the CLI, simply run `hermes desktop`. By default it installs works
 | `--ignore-existing`  | Force the app to ignore any `hermes` CLI already on `PATH` during backend resolution      |
 | `--fake-boot`        | Enable deterministic boot delays for validating the startup UI                            |
 
+`hermes desktop instance` manages **isolated Desktop shells** on Windows (separate `userData` + `HERMES_HOME`, shared runtime). See [Isolated Desktop instances](./isolated-desktop-instances.md). Bare `hermes desktop` still launches the ordinary local app.
+
 ## How it works
 
 The packaged app ships the Electron shell and a native React chat surface. On first launch it can install the Hermes Agent runtime into `HERMES_HOME` (`~/.hermes`, or `%LOCALAPPDATA%\hermes` on Windows) — **the same layout a CLI install uses**, which is why the two are interchangeable. Backend resolution first honours `HERMES_DESKTOP_HERMES_ROOT`, then a completed managed install, then a probed `hermes` on `PATH` (unless `--ignore-existing` / `HERMES_DESKTOP_IGNORE_EXISTING=1` is set), and finally an explicit `HERMES_DESKTOP_HERMES` command override for packagers such as Nix. The React renderer talks to a headless backend the app launches for you — a `hermes serve` process that serves the `tui_gateway` JSON-RPC/WebSocket API — and reuses the agent runtime rather than embedding `hermes --tui`. The desktop app is **self-contained**: it runs its own `hermes serve` backend and never opens or requires the [web dashboard](./features/web-dashboard.md). (Runtimes older than the `serve` command fall back to a headless `dashboard --no-open` automatically, so an app update never outruns its backend.) Install, backend-resolution, and self-update logic live in the Electron main process.
@@ -332,6 +334,7 @@ Further down the same **Settings → Gateways** page, **Registered gateways** ma
 
 Side-by-side routing is live: each registered gateway dials its own backends and sockets on demand (keyed per connection + profile), the plugin SDK exposes the union agent roster (`host.agents()` / `host.ensureAgent()`), and **Update all instances** on the Gateways page dispatches `hermes update` to every eligible gateway at once — Hermes Cloud entries are skipped (the platform updates them), and each instance reports its own result.
 
+Need a **separate Desktop window** with its own settings, Chromium profile, and dock/taskbar identity instead of another source in this shell? That is [Isolated Desktop instances](./isolated-desktop-instances.md) (`hermes desktop instance` on Windows) — not another Connections entry.
 
 :::info The remote backend is a running `hermes serve` process
 "Remote backend" means a **`hermes serve`** server running on the remote machine — that is the process the desktop app connects to. Nothing in this section works unless that backend is actually up and reachable. The desktop app does not start it for you; you (or a `systemd` service) keep `hermes serve` running on the remote host, and the app attaches to it. If you also use messaging channels (Telegram, Discord, etc.), the **gateway** is a *separate* long-running process you start independently — see the note after the setup steps.

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -300,7 +300,7 @@ To launch via the CLI, simply run `hermes desktop`. By default it installs works
 | `--ignore-existing`  | Force the app to ignore any `hermes` CLI already on `PATH` during backend resolution      |
 | `--fake-boot`        | Enable deterministic boot delays for validating the startup UI                            |
 
-`hermes desktop instance` manages **isolated Desktop shells** on Windows (separate `userData` + `HERMES_HOME`, shared runtime). See [Isolated Desktop instances](./isolated-desktop-instances.md). Bare `hermes desktop` still launches the ordinary local app.
+`hermes desktop instance` manages **isolated Desktop shells** (separate `userData` + `HERMES_HOME`, shared runtime) on Windows, macOS, and Linux. See [Isolated Desktop instances](./isolated-desktop-instances.md). Bare `hermes desktop` still launches the ordinary local app.
 
 ## How it works
 
@@ -334,7 +334,7 @@ Further down the same **Settings → Gateways** page, **Registered gateways** ma
 
 Side-by-side routing is live: each registered gateway dials its own backends and sockets on demand (keyed per connection + profile), the plugin SDK exposes the union agent roster (`host.agents()` / `host.ensureAgent()`), and **Update all instances** on the Gateways page dispatches `hermes update` to every eligible gateway at once — Hermes Cloud entries are skipped (the platform updates them), and each instance reports its own result.
 
-Need a **separate Desktop window** with its own settings, Chromium profile, and dock/taskbar identity instead of another source in this shell? That is [Isolated Desktop instances](./isolated-desktop-instances.md) (`hermes desktop instance` on Windows) — not another Connections entry.
+Need a **separate Desktop window** with its own settings, Chromium profile, and dock/taskbar identity instead of another source in this shell? That is [Isolated Desktop instances](./isolated-desktop-instances.md) (`hermes desktop instance`, or **Open as isolated Desktop** on an SSH Connections row) — not another Connections entry.
 
 :::info The remote backend is a running `hermes serve` process
 "Remote backend" means a **`hermes serve`** server running on the remote machine — that is the process the desktop app connects to. Nothing in this section works unless that backend is actually up and reachable. The desktop app does not start it for you; you (or a `systemd` service) keep `hermes serve` running on the remote host, and the app attaches to it. If you also use messaging channels (Telegram, Discord, etc.), the **gateway** is a *separate* long-running process you start independently — see the note after the setup steps.

--- a/website/docs/user-guide/isolated-desktop-instances.md
+++ b/website/docs/user-guide/isolated-desktop-instances.md
@@ -130,9 +130,11 @@ URLs look like:
 hermes://instance/<name>/blueprint/morning
 ```
 
-The ordinary shell forwards that to the named instance (creating nothing
-new). Isolated shells do not re-register the protocol. Inside the matching
-instance the remainder is delivered as `hermes://blueprint/morning`.
+The ordinary shell forwards that to the named instance by launching it with
+the remainder both in `HERMES_DESKTOP_PENDING_DEEP_LINK` and as a `hermes://`
+argv token. If that isolated window is already open, Electron's
+`second-instance` handler delivers the remainder the same way ordinary
+deep links work. Isolated shells do not re-register the protocol.
 
 ## Layout
 

--- a/website/docs/user-guide/isolated-desktop-instances.md
+++ b/website/docs/user-guide/isolated-desktop-instances.md
@@ -13,8 +13,7 @@ Connections keep one shared Electron shell and add more agent sources
 inside it. Isolated instances are for the case where you tried that and
 need a second, independent Desktop.
 
-Currently the create / launch / shortcut path is **Windows-only**. Listing
-and inspecting instances works on every platform.
+Create, launch, shortcut, and repair work on **Windows, macOS, and Linux**.
 
 ## When to use which
 
@@ -28,29 +27,17 @@ An explicit rejection of Connections after you have tried it is a workflow
 preference. Keep using isolated instances; do not migrate those remotes back
 into the shared-shell registry unless you ask to.
 
-## What is isolated vs shared
+## Open from Settings
 
-Each named instance gets:
+On an SSH row in **Settings → Connections**, click **Open as isolated
+Desktop**. Hermes maps the connection's non-secret fields (host, absolute
+remote Hermes path, remote profile, label) into an instance, creates it
+if needed, and launches the isolated shell. Remote-gateway and Cloud rows
+stay in the shared window.
 
-1. Its own Electron `userData` (`HERMES_DESKTOP_USER_DATA_DIR` plus early `--user-data-dir`)
-2. Its own local `HERMES_HOME`
-3. Its own app / process name and single-instance namespace
-4. A persisted SSH target, absolute remote Hermes path, and remote profile
-5. Its own clickable Desktop shortcut
+The SSH connection must already have an **absolute** Remote Hermes path.
 
-What stays shared:
-
-- The canonical local `Hermes.exe` / runtime / update path
-- Adjacent Electron resources (via a differently named **hardlink** next to `Hermes.exe`)
-
-What is **never** cloned locally:
-
-- Remote sessions, memory, skills, configuration, and credentials
-
-A copied, symlinked, or hardlinked executable is **not** isolation by itself.
-The two state-root overrides plus the distinct app name are the boundary.
-
-## Create an instance
+## CLI
 
 The remote machine must already have Hermes and a working SSH alias:
 
@@ -59,7 +46,7 @@ ssh -o BatchMode=yes -o ConnectTimeout=15 <alias> \
   "bash -lc 'command -v hermes; hermes --version; hermes profile list'"
 ```
 
-Then, on the Windows machine that runs Desktop:
+Then, on the machine that runs Desktop:
 
 ```bash
 hermes desktop instance create grace \
@@ -76,14 +63,14 @@ hermes desktop instance create athena \
 ```
 
 That writes a non-secret manifest, seeds isolated `connection.json` (SSH
-fields only — no token bytes), compiles a small native launcher, creates
-the named hardlink beside canonical `Hermes.exe`, and drops a Desktop
-shortcut that points at the launcher (icon from canonical `Hermes.exe`).
+fields only — no token bytes), and installs a platform launcher plus
+shortcut.
 
 ```bash
 hermes desktop instance list
 hermes desktop instance launch grace
-hermes desktop instance shortcut grace     # recreate the .lnk
+hermes desktop instance launch grace --deep-link hermes://blueprint/morning
+hermes desktop instance shortcut grace
 hermes desktop instance repair --all       # after a local Desktop update
 hermes desktop instance remove grace       # launcher + shortcut only
 hermes desktop instance remove grace --purge-local
@@ -96,29 +83,80 @@ userData so you can recreate the launcher later.
 Ordinary `hermes desktop` is unchanged and still opens the canonical
 local shell.
 
+## What is isolated vs shared
+
+Each named instance gets:
+
+1. Its own Electron `userData` (`HERMES_DESKTOP_USER_DATA_DIR` plus early `--user-data-dir`)
+2. Its own local `HERMES_HOME`
+3. Its own app / process name and single-instance namespace
+4. Its own Windows AppUserModelID (`com.nousresearch.hermes.instance.<name>`)
+5. A persisted SSH target, absolute remote Hermes path, and remote profile
+6. Its own clickable Desktop shortcut
+7. No global quick-entry / HUD-snap hotkey (those stay on the ordinary Desktop)
+8. No `hermes://` protocol capture (the ordinary Desktop remains the OS handler)
+
+What stays shared:
+
+- The canonical local Hermes executable / runtime / update path
+- On Windows, adjacent Electron resources (via a differently named **hardlink** next to `Hermes.exe`)
+
+What is **never** cloned locally:
+
+- Remote sessions, memory, skills, configuration, and credentials
+
+A copied, symlinked, or hardlinked executable is **not** isolation by itself.
+The two state-root overrides plus the distinct app name are the boundary.
+
+## Platform launchers
+
+| Platform | Launch artifact | Shortcut |
+|---|---|---|
+| Windows | Native `/target:winexe` launcher + named hardlink beside `Hermes.exe` | `.lnk` on the Desktop |
+| macOS | `bash` `.command` wrapper (env + `--user-data-dir`) | same `.command` on the Desktop |
+| Linux | `bash` wrapper plus a `.desktop` entry | `.desktop` on the Desktop |
+
+On Windows the named hardlink avoids a path-specific AppCompat
+`RUNASADMIN` layer on the canonical `Hermes.exe` while still sharing
+updates. macOS and Linux launch the shared binary directly with the
+isolation environment.
+
+## Deep links
+
+The ordinary Desktop remains the OS `hermes://` handler. Instance-scoped
+URLs look like:
+
+```text
+hermes://instance/<name>/blueprint/morning
+```
+
+The ordinary shell forwards that to the named instance (creating nothing
+new). Isolated shells do not re-register the protocol. Inside the matching
+instance the remainder is delivered as `hermes://blueprint/morning`.
+
 ## Layout
 
 Defaults (no hardcoded usernames or hosts):
 
 ```text
-%LOCALAPPDATA%\hermes\desktop-instances\<name>\
+<HERMES_HOME>/desktop-instances/<name>/
   instance.json          # non-secret manifest
-  home\                  # isolated HERMES_HOME
-  user-data\             # isolated Electron userData
-  launcher\              # compiled native winexe + generated .cs
+  home/                  # isolated HERMES_HOME
+  user-data/             # isolated Electron userData
+  launcher/              # platform launcher
 ```
 
-The named hardlink lives **beside** the shared executable, for example
-`…\release\win-unpacked\Hermes Grace.exe` → same bytes as `Hermes.exe`.
-That avoids a path-specific Windows AppCompat `RUNASADMIN` layer on the
-canonical exe while still sharing updates.
+On Windows the named hardlink lives **beside** the shared executable, for
+example `…/release/win-unpacked/Hermes Grace.exe` → same bytes as
+`Hermes.exe`.
 
 ## Updates
 
 Close isolated windows before rebuilding the shared Desktop artifact
 (`hermes desktop --force-build` or the in-app updater). A successful
-packaged rebuild then refreshes every instance hardlink it can; a running
-instance keeps its in-use image and is repaired on the next clean launch.
+packaged rebuild then refreshes every instance launcher it can; a running
+Windows instance keeps its in-use hardlink image and is repaired on the
+next clean launch.
 
 If a shortcut opens the ordinary Desktop after an update, run:
 
@@ -136,7 +174,8 @@ If you already have a working native launcher (the documented workaround):
 
 1. Leave those launchers and isolated roots in place.
 2. Create first-party instances with the same SSH alias, absolute remote
-   path, and remote profile. If a `connection.json` already exists in the
+   path, and remote profile — or use **Open as isolated Desktop** on the
+   matching SSH Connection. If a `connection.json` already exists in the
    new instance `user-data` directory, Hermes will not overwrite it.
 3. Launch from the new shortcut and confirm a visible renderer plus
    `SSH: <host>` in the status badge. A ready backend without a window is
@@ -151,14 +190,11 @@ until you pass `--purge-local`.
 
 ## Reverting / uninstalling the feature
 
-- `hermes desktop instance remove NAME` — drop launcher, named hardlink,
-  and shortcut.
+- `hermes desktop instance remove NAME` — drop launcher, named hardlink
+  (Windows), and shortcut.
 - `--purge-local` — also delete that instance's local home and userData.
-- Ordinary Desktop, `%LOCALAPPDATA%\hermes`, and every remote host are
+- Ordinary Desktop, the canonical Hermes home, and every remote host are
   left alone.
-- There is no first-party macOS/Linux launcher yet. On those platforms
-  `create` / `launch` / `shortcut` / `repair` fail with an explicit
-  incompatible-platform error; `list` / `show` / `remove` still work.
 
 ## Pitfalls
 
@@ -173,11 +209,5 @@ until you pass `--purge-local`.
   `--no-sandbox`.
 - **Backend-only false positive** — `Remote Hermes backend is ready` is
   not success. You need a visible window and the SSH status badge.
-- Only one shell can own the global quick-entry hotkey. That does not
-  invalidate SSH connectivity.
-
-## Follow-up
-
-A Settings → Connections action to “Open as isolated Desktop” and a
-native macOS/Linux launcher are intentionally out of this first cut.
-The Windows CLI (`hermes desktop instance`) is the supported surface.
+- Isolated shells do not take the global quick-entry hotkey. That does
+  not invalidate SSH connectivity.

--- a/website/docs/user-guide/isolated-desktop-instances.md
+++ b/website/docs/user-guide/isolated-desktop-instances.md
@@ -30,10 +30,12 @@ into the shared-shell registry unless you ask to.
 ## Open from Settings
 
 On an SSH row in **Settings → Connections**, click **Open as isolated
-Desktop**. Hermes maps the connection's non-secret fields (host, absolute
-remote Hermes path, remote profile, label) into an instance, creates it
-if needed, and launches the isolated shell. Remote-gateway and Cloud rows
-stay in the shared window.
+Desktop**. Hermes keeps the selected registry `connectionId` plus the
+full non-secret SSH dial contract (host, user, port, key path, absolute
+remote Hermes path, remote profile). If that instance already exists and
+the selected row was retargeted, the action **fails closed** instead of
+launching a stale route. Remote-gateway and Cloud rows stay in the
+shared window.
 
 The SSH connection must already have an **absolute** Remote Hermes path.
 

--- a/website/docs/user-guide/isolated-desktop-instances.md
+++ b/website/docs/user-guide/isolated-desktop-instances.md
@@ -1,0 +1,183 @@
+---
+sidebar_position: 6
+---
+
+# Isolated Desktop instances
+
+Give a remote Hermes agent its **own Desktop application** — its own window,
+settings, Chromium profile, and single-instance lock — while still sharing
+the one local Hermes installation you already update.
+
+This is **not** [Settings → Connections](./multi-connection-desktop.md).
+Connections keep one shared Electron shell and add more agent sources
+inside it. Isolated instances are for the case where you tried that and
+need a second, independent Desktop.
+
+Currently the create / launch / shortcut path is **Windows-only**. Listing
+and inspecting instances works on every platform.
+
+## When to use which
+
+| You want… | Use |
+|---|---|
+| Several remotes in **one** window, one Settings app, one dock icon | **Settings → Connections** |
+| Independent windows, caches, and shell identity (`Hermes Grace`, `Hermes Athena`, ordinary Hermes) | **Isolated Desktop instances** |
+| Separate agent state without a second Desktop | [`hermes profile`](./profiles.md) |
+
+An explicit rejection of Connections after you have tried it is a workflow
+preference. Keep using isolated instances; do not migrate those remotes back
+into the shared-shell registry unless you ask to.
+
+## What is isolated vs shared
+
+Each named instance gets:
+
+1. Its own Electron `userData` (`HERMES_DESKTOP_USER_DATA_DIR` plus early `--user-data-dir`)
+2. Its own local `HERMES_HOME`
+3. Its own app / process name and single-instance namespace
+4. A persisted SSH target, absolute remote Hermes path, and remote profile
+5. Its own clickable Desktop shortcut
+
+What stays shared:
+
+- The canonical local `Hermes.exe` / runtime / update path
+- Adjacent Electron resources (via a differently named **hardlink** next to `Hermes.exe`)
+
+What is **never** cloned locally:
+
+- Remote sessions, memory, skills, configuration, and credentials
+
+A copied, symlinked, or hardlinked executable is **not** isolation by itself.
+The two state-root overrides plus the distinct app name are the boundary.
+
+## Create an instance
+
+The remote machine must already have Hermes and a working SSH alias:
+
+```bash
+ssh -o BatchMode=yes -o ConnectTimeout=15 <alias> \
+  "bash -lc 'command -v hermes; hermes --version; hermes profile list'"
+```
+
+Then, on the Windows machine that runs Desktop:
+
+```bash
+hermes desktop instance create grace \
+  --ssh-host grace \
+  --remote-hermes-path /home/you/.local/bin/hermes \
+  --remote-profile default \
+  --display-name "Hermes Grace"
+
+hermes desktop instance create athena \
+  --ssh-host bear-agent \
+  --remote-hermes-path /home/you/.local/bin/hermes \
+  --remote-profile default \
+  --display-name "Hermes Athena"
+```
+
+That writes a non-secret manifest, seeds isolated `connection.json` (SSH
+fields only — no token bytes), compiles a small native launcher, creates
+the named hardlink beside canonical `Hermes.exe`, and drops a Desktop
+shortcut that points at the launcher (icon from canonical `Hermes.exe`).
+
+```bash
+hermes desktop instance list
+hermes desktop instance launch grace
+hermes desktop instance shortcut grace     # recreate the .lnk
+hermes desktop instance repair --all       # after a local Desktop update
+hermes desktop instance remove grace       # launcher + shortcut only
+hermes desktop instance remove grace --purge-local
+```
+
+`remove` never deletes anything on the remote machine. Without
+`--purge-local` it also keeps the isolated local home and Electron
+userData so you can recreate the launcher later.
+
+Ordinary `hermes desktop` is unchanged and still opens the canonical
+local shell.
+
+## Layout
+
+Defaults (no hardcoded usernames or hosts):
+
+```text
+%LOCALAPPDATA%\hermes\desktop-instances\<name>\
+  instance.json          # non-secret manifest
+  home\                  # isolated HERMES_HOME
+  user-data\             # isolated Electron userData
+  launcher\              # compiled native winexe + generated .cs
+```
+
+The named hardlink lives **beside** the shared executable, for example
+`…\release\win-unpacked\Hermes Grace.exe` → same bytes as `Hermes.exe`.
+That avoids a path-specific Windows AppCompat `RUNASADMIN` layer on the
+canonical exe while still sharing updates.
+
+## Updates
+
+Close isolated windows before rebuilding the shared Desktop artifact
+(`hermes desktop --force-build` or the in-app updater). A successful
+packaged rebuild then refreshes every instance hardlink it can; a running
+instance keeps its in-use image and is repaired on the next clean launch.
+
+If a shortcut opens the ordinary Desktop after an update, run:
+
+```bash
+hermes desktop instance repair --all
+hermes desktop instance shortcut <name>
+```
+
+Update each **remote** Hermes install separately. Isolated instances do
+not copy or pin the remote runtime.
+
+## Migrating from a hand-rolled launcher
+
+If you already have a working native launcher (the documented workaround):
+
+1. Leave those launchers and isolated roots in place.
+2. Create first-party instances with the same SSH alias, absolute remote
+   path, and remote profile. If a `connection.json` already exists in the
+   new instance `user-data` directory, Hermes will not overwrite it.
+3. Launch from the new shortcut and confirm a visible renderer plus
+   `SSH: <host>` in the status badge. A ready backend without a window is
+   a failure.
+4. Only then retire the old `.lnk` / compiled launcher. Do not delete
+   remote state.
+
+To go the other way — from isolated instances back to **one** shared
+shell — use Settings → Connections, then `hermes desktop instance remove`
+once the shared-shell route is verified. Isolated local roots can stay
+until you pass `--purge-local`.
+
+## Reverting / uninstalling the feature
+
+- `hermes desktop instance remove NAME` — drop launcher, named hardlink,
+  and shortcut.
+- `--purge-local` — also delete that instance's local home and userData.
+- Ordinary Desktop, `%LOCALAPPDATA%\hermes`, and every remote host are
+  left alone.
+- There is no first-party macOS/Linux launcher yet. On those platforms
+  `create` / `launch` / `shortcut` / `repair` fail with an explicit
+  incompatible-platform error; `list` / `show` / `remove` still work.
+
+## Pitfalls
+
+- **VBS / Python / `ShellExecute` wrappers** focus the ordinary Desktop
+  or lose process-local `HERMES_HOME`. Use the compiled launcher or
+  `hermes desktop instance launch`.
+- **Win32 error 740** — canonical `Hermes.exe` has a path-specific
+  AppCompat run-as-admin layer. The named hardlink is the supported
+  workaround; do not change the ordinary app's compatibility tab.
+- **`__COMPAT_LAYER=RunAsInvoker`** can start the backend while the
+  renderer dies (`render-process-gone`, `exitCode=18`). Do not add
+  `--no-sandbox`.
+- **Backend-only false positive** — `Remote Hermes backend is ready` is
+  not success. You need a visible window and the SSH status badge.
+- Only one shell can own the global quick-entry hotkey. That does not
+  invalidate SSH connectivity.
+
+## Follow-up
+
+A Settings → Connections action to “Open as isolated Desktop” and a
+native macOS/Linux launcher are intentionally out of this first cut.
+The Windows CLI (`hermes desktop instance`) is the supported surface.

--- a/website/docs/user-guide/multi-connection-desktop.md
+++ b/website/docs/user-guide/multi-connection-desktop.md
@@ -15,6 +15,11 @@ This is the desktop-side complement to
 about hosting several gateways on one machine; this one is about one desktop
 app talking to several machines.
 
+If you want a **second Desktop application** (separate window, settings,
+and Chromium profile) instead of more sources in this shell, see
+[Isolated Desktop instances](./isolated-desktop-instances.md). Isolated
+instances share the same local install; they do not replace this registry.
+
 ## Where to find it
 
 Everything lives on the unified **Settings → Gateways** page (older builds had

--- a/website/docs/user-guide/multi-connection-desktop.md
+++ b/website/docs/user-guide/multi-connection-desktop.md
@@ -19,6 +19,8 @@ If you want a **second Desktop application** (separate window, settings,
 and Chromium profile) instead of more sources in this shell, see
 [Isolated Desktop instances](./isolated-desktop-instances.md). Isolated
 instances share the same local install; they do not replace this registry.
+On an SSH row, **Open as isolated Desktop** creates or launches that
+independent shell from the connection's host, remote Hermes path, and profile.
 
 ## Where to find it
 

--- a/website/docs/user-guide/windows-native.md
+++ b/website/docs/user-guide/windows-native.md
@@ -49,6 +49,8 @@ A thin GUI installer is also available — useful if you'd rather double-click a
 
 Use the desktop installer when you want a familiar Windows install experience or you're handing Hermes to a non-developer; use the PowerShell one-liner when you're already in a terminal.
 
+To open a **second, independent Desktop window** for a remote SSH agent (separate settings and Chromium profile, same install), use [`hermes desktop instance`](./isolated-desktop-instances.md) rather than adding that host to Settings → Connections.
+
 ### Dependency bootstrap (`dep_ensure`)
 
 On first launch (and on demand when a missing tool is detected), Hermes runs a small Python bootstrapper — `hermes_cli/dep_ensure.py` — that checks for and lazily installs the non-Python dependencies it needs. On Windows, the relevant ones are:

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -25,6 +25,7 @@ const sidebars: SidebarsConfig = {
         'user-guide/cli',
         'user-guide/tui',
         'user-guide/desktop',
+        'user-guide/isolated-desktop-instances',
         'user-guide/bot-mode',
         'user-guide/windows-native',
         'user-guide/windows-wsl-quickstart',


### PR DESCRIPTION
## What does this PR do?

Add first-class **isolated Desktop instances**: named independent Desktop shells (own Electron `userData`, `HERMES_HOME`, process name, single-instance lock, and Windows AUMID) that share one canonical Hermes install.

This is a second product surface next to Settings → Connections. Connections stay a **shared Electron shell**. Isolated instances are for users who need a separate window/identity for an SSH agent (for example, Hermes Grace / Hermes Athena) without cloning remote sessions, memory, skills, or credentials.

Windows uses the validated native `/target:winexe` launcher plus a named hardlink beside `Hermes.exe`. macOS/Linux use bash wrappers and `.command` / `.desktop` shortcuts.

## Related Issue

Closes #98301.

This work extends the exact SSH route identity established in #88922 by @matsvarn, preserves the broader `(connectionId, profile)` propagation from #89719 by @dokterdok (salvaged by @teknium1), and complements the filesystem/Git resource ownership work in #89916 by @frizikk.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/desktop_instances.py` — instance resolver, atomic non-secret manifests, platform launchers, launch/repair/remove
- Isolated instances persist the selected registry `connectionId` plus the full non-secret SSH dial contract (`host`, `user`, `port`, `keyPath`, `remoteHermesPath`, `remoteProfile`)
- Both retained `connection.json` and v2 `connections.json` route authorities are validated before reuse or launch; removal/recreate, partial-create retry, and later route edits fail closed instead of silently retargeting a shell
- Isolated launch env is built through `build_subprocess_env()` (secrets scrubbed). Windows/POSIX launchers start from a clean environment
- `hermes_cli/templates/windows_isolated_desktop_launcher.cs` — native winexe template
- `hermes_cli/subcommands/gui.py` + `hermes_cli/main.py` — `hermes desktop instance` CLI and post-pack hardlink refresh, with dispatch extracted from the legacy main module
- `apps/desktop/electron/isolated-desktop-instance.ts` — Connections → spec mapper, deep-link parse, hotkey/protocol/AUMID policy
- `apps/desktop/electron/isolated-desktop-controller.ts` — testable CLI resolution, manifest validation, connection open, and launch orchestration extracted from `main.ts`
- `apps/desktop/electron/main.ts` + `preload.ts` — IPC `hermes:connections:open-isolated`, instance deep-link forwarding, skip protocol/hotkeys in isolated shells
- `apps/desktop/src/app/settings/connections-registry.tsx` — **Open as isolated Desktop** on SSH rows
- `tests/hermes_cli/test_desktop_instances.py` + desktop vitest coverage
- Docs: `website/docs/user-guide/isolated-desktop-instances.md` plus desktop / Connections / CLI / env-var updates

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_desktop_instances.py`
2. In `apps/desktop`: `npx vitest run --project electron electron/isolated-desktop-controller.test.ts electron/isolated-desktop-instance.test.ts`
3. In `apps/desktop`: `npx vitest run --project ui src/app/settings/connections-registry.test.tsx`
4. In `apps/desktop`: `npm run typecheck`
5. In `apps/desktop`: `npx eslint electron/main.ts electron/isolated-desktop-instance.ts electron/isolated-desktop-instance.test.ts electron/isolated-desktop-controller.ts electron/isolated-desktop-controller.test.ts`
6. On Windows/macOS/Linux with a working SSH alias and an **absolute** remote Hermes path:
   ```bash
   hermes desktop instance create grace --ssh-host <alias> --remote-hermes-path /abs/path --remote-profile default --display-name "Hermes Grace"
   hermes desktop instance launch grace
   ```
   Confirm a visible renderer and `SSH: <host>` in the status badge (backend-ready alone is a false positive).
7. Settings → Connections → SSH row → **Open as isolated Desktop**
8. Ordinary Desktop remains the `hermes://` handler. With an instance already running, `hermes://instance/grace/blueprint/morning` should land in that window (remainder is on argv for a warm `second-instance`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (repository policy requires `scripts/run_tests.sh`; the focused canonical suite is green)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 26.04 (focused canonical Python suite, desktop vitest, typecheck, ESLint, ruff, and Windows footgun scan)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused verification after the review fix and rebase onto `origin/main` at `58523f284ca52a162a213a7efd335b203e783706`:

- `scripts/run_tests.sh tests/hermes_cli/test_desktop_instances.py` → **44 passed**
- `npx vitest run --project electron electron/isolated-desktop-controller.test.ts electron/isolated-desktop-instance.test.ts` → **13 passed**
- `npx vitest run --project ui src/app/settings/connections-registry.test.tsx` → **17 passed**
- `npm run typecheck` (from `apps/desktop`) → **passed**
- targeted desktop ESLint and Python `ruff` → **passed**
- `scripts/check-windows-footguns.py --all` → **passed**

Not run: the full repository suite or a packaged Electron rebuild.

## Notes for reviewers

- Live user launchers under `%LOCALAPPDATA%\hermes-launchers` were not mutated. Tests use temp roots and injected adapters.
- Isolated route files are seeded with the selected `connectionId` plus the non-secret SSH dial contract — no token bytes.
- Retained route state fails closed; it does not silently win over the manifest or current selected registry row.
- Isolated process start uses the scrubbed subprocess factory. Windows winexe and POSIX wrappers start from a clean environment so parent provider keys are not inherited.
- Isolated shells skip `hermes://` protocol registration and global quick-entry / HUD-snap hotkeys.
- Linux `.desktop` `Exec=` uses `shlex.quote` (not Desktop Entry quoting).
- Authorship topology and closeout credit are tracked in #98301 and the review-fix commit: #88922/@matsvarn, #89719/@dokterdok salvaged by @teknium1, and #89916/@frizikk.
- The unrelated Grok Imagine Image catalog upscale default was dropped from this branch.
