### PR TITLE
fix(tts): make tts.provider the authoritative backend selector

### DIFF
--- a/tests/tools/test_tts_provider_authority.py
+++ b/tests/tools/test_tts_provider_authority.py
@@ -23,6 +23,11 @@ def _fake_key(tag: str) -> str:
 def clean_env(monkeypatch):
     for key in ("OPENAI_API_KEY", "HERMES_SESSION_PLATFORM"):
         monkeypatch.delenv(key, raising=False)
+    # The ignored-override warning is once-per-process per distinct value;
+    # reset it so one test's emission never masks the next test's assertion.
+    from tools import tts_tool as _tts_mod
+
+    _tts_mod._once_warnings.clear()
 
 
 class _OpenaiBackendStub:

--- a/tests/tools/test_tts_provider_authority.py
+++ b/tests/tools/test_tts_provider_authority.py
@@ -1,0 +1,202 @@
+"""Tests for config-authoritative TTS provider selection (#90109).
+
+``tts.provider`` in config.yaml is the only backend selector: the
+model-facing ``text_to_speech`` schema must not advertise a per-call
+``provider`` override, and a per-call value that disagrees with the
+configured provider is ignored (with a warning) instead of rerouting
+speech to another vendor.
+"""
+
+import json
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _fake_key(tag: str) -> str:
+    return "-".join(("tts", tag, "test", "key"))
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for key in ("OPENAI_API_KEY", "HERMES_SESSION_PLATFORM"):
+        monkeypatch.delenv(key, raising=False)
+
+
+class _OpenaiBackendStub:
+    """Patch set that routes the configured ``openai`` provider through a
+    mocked OpenAI client writing a tiny MP3 payload (same shape as
+    tests/tools/test_tts_instructions.py)."""
+
+    def __init__(self):
+        self.mock_client = MagicMock()
+
+        def fake_stream(path):
+            Path(path).write_bytes(b"ID3\x03\x00\x00\x00\x00\x00\x00")
+
+        response = MagicMock()
+        response.stream_to_file.side_effect = fake_stream
+        self.mock_client.audio.speech.create.return_value = response
+
+        mock_cls = MagicMock(return_value=self.mock_client)
+        self.xai_patch = patch("tools.tts_tool._generate_xai_tts")
+        self.xai_generator = self.xai_patch.start()
+        self._patches = [
+            patch("tools.tts_tool._import_openai_client", return_value=mock_cls),
+            patch(
+                "tools.tts_tool._resolve_openai_audio_client_config",
+                return_value=(_fake_key("openai"), None, False),
+            ),
+            patch(
+                "tools.tts_tool._load_tts_config",
+                return_value={"provider": "openai"},
+            ),
+        ]
+        for p in self._patches:
+            p.start()
+
+    @property
+    def create(self):
+        return self.mock_client.audio.speech.create
+
+    def stop(self):
+        for p in self._patches:
+            p.stop()
+        self.xai_patch.stop()
+
+
+@pytest.fixture
+def openai_backend():
+    stub = _OpenaiBackendStub()
+    yield stub
+    stub.stop()
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+class TestSchema:
+    def test_schema_does_not_advertise_provider(self):
+        from tools.tts_tool import TTS_SCHEMA
+        props = TTS_SCHEMA["parameters"]["properties"]
+        assert "provider" not in props, (
+            "The model-facing text_to_speech schema must not advertise a "
+            "provider override: tts.provider in config.yaml is the only "
+            "backend selector (#90109)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tool-level enforcement (text_to_speech_tool)
+# ---------------------------------------------------------------------------
+
+class TestToolLevelProviderAuthority:
+    def test_disagreeing_override_is_ignored(
+        self, tmp_path, monkeypatch, openai_backend
+    ):
+        """A per-call provider that disagrees with config is not honored:
+        the configured openai backend runs and xAI never fires."""
+        from tools.tts_tool import text_to_speech_tool
+
+        result = json.loads(
+            text_to_speech_tool(
+                "Hello world",
+                output_path=str(tmp_path / "out.mp3"),
+                provider="xai",
+            )
+        )
+        assert result.get("success") is True
+        assert result.get("provider") == "openai"
+        openai_backend.create.assert_called_once()
+        openai_backend.xai_generator.assert_not_called()
+
+    def test_disagreeing_override_logs_warning(
+        self, tmp_path, monkeypatch, openai_backend, caplog
+    ):
+        from tools.tts_tool import text_to_speech_tool
+
+        with caplog.at_level(logging.WARNING, logger="tools.tts_tool"):
+            text_to_speech_tool(
+                "Hello world",
+                output_path=str(tmp_path / "out.mp3"),
+                provider="xai",
+            )
+        assert any(
+            "Ignoring per-call TTS provider override" in rec.message
+            for rec in caplog.records
+        ), "An ignored provider override must be visible in the logs."
+
+    def test_matching_override_is_accepted(
+        self, tmp_path, monkeypatch, openai_backend, caplog
+    ):
+        """A per-call provider that agrees with config stays a no-op."""
+        from tools.tts_tool import text_to_speech_tool
+
+        with caplog.at_level(logging.WARNING, logger="tools.tts_tool"):
+            result = json.loads(
+                text_to_speech_tool(
+                    "Hello world",
+                    output_path=str(tmp_path / "out.mp3"),
+                    provider="openai",
+                )
+            )
+        assert result.get("success") is True
+        assert result.get("provider") == "openai"
+        assert not any(
+            "Ignoring per-call TTS provider override" in rec.message
+            for rec in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
+# Registered handler (the model-args path)
+# ---------------------------------------------------------------------------
+
+class TestRegisteredHandler:
+    def test_handler_does_not_forward_provider_arg(
+        self, tmp_path, monkeypatch, openai_backend
+    ):
+        """Even if a model (or a leaked platform hint) sends provider= in
+        its tool args, the registered handler must not forward it."""
+        from tools.registry import registry
+
+        entry = registry.get_entry("text_to_speech")
+        assert entry is not None
+        result = json.loads(
+            entry.handler(
+                {
+                    "text": "Hello world",
+                    "output_path": str(tmp_path / "out.mp3"),
+                    "provider": "xai",
+                }
+            )
+        )
+        assert result.get("success") is True
+        assert result.get("provider") == "openai"
+        openai_backend.xai_generator.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Inner single-chunk helper
+# ---------------------------------------------------------------------------
+
+class TestSingleChunkHelperAuthority:
+    def test_single_helper_ignores_disagreeing_provider(
+        self, tmp_path, monkeypatch, openai_backend
+    ):
+        from tools.tts_tool import _text_to_speech_single
+
+        result = json.loads(
+            _text_to_speech_single(
+                "Hello world",
+                str(tmp_path / "out.mp3"),
+                provider="xai",
+                tts_config_override={"provider": "openai"},
+            )
+        )
+        assert result.get("success") is True
+        assert result.get("provider") == "openai"
+        openai_backend.xai_generator.assert_not_called()

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -3130,6 +3130,28 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
 # ===========================================================================
 # Main tool function
 # ===========================================================================
+def _warn_ignored_tts_provider_override(requested: str, configured: str) -> None:
+    """Once-per-process (per distinct requested value) warning for ignored
+    per-call provider overrides — a stale session whose cached tool schema
+    still advertises the param would otherwise repeat it every call; and
+    callers with no tts config at all are silent (nothing to disagree
+    WITH — default resolution just runs). See #90109."""
+    if not configured:
+        return
+    key = ("tts_provider_override", requested)
+    if key in _once_warnings:
+        return
+    _once_warnings.add(key)
+    logger.warning(
+        "Ignoring per-call TTS provider override %r; tts.provider is %r",
+        requested,
+        configured,
+    )
+
+
+_once_warnings: set = set()
+
+
 def _text_to_speech_single(
     text: str,
     output_path: Optional[str] = None,
@@ -3172,11 +3194,7 @@ def _text_to_speech_single(
     if provider:
         requested = provider.lower().strip()
         if requested and requested != configured_provider:
-            logger.warning(
-                "Ignoring per-call TTS provider override %r; tts.provider is %r",
-                requested,
-                configured_provider,
-            )
+            _warn_ignored_tts_provider_override(requested, configured_provider)
         provider = configured_provider
     else:
         provider = configured_provider
@@ -3564,11 +3582,7 @@ def text_to_speech_tool(
     if provider:
         requested = provider.lower().strip()
         if requested and requested != configured_provider:
-            logger.warning(
-                "Ignoring per-call TTS provider override %r; tts.provider is %r",
-                requested,
-                configured_provider,
-            )
+            _warn_ignored_tts_provider_override(requested, configured_provider)
         provider = configured_provider
     else:
         provider = configured_provider

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -3162,11 +3162,24 @@ def _text_to_speech_single(
         tts_config = dict(tts_config)  # shallow copy to avoid mutating the cache
         tts_config["speed"] = clamped
 
-    # Allow per-call provider override; fall back to the configured default.
+    # tts.provider in config.yaml is the authoritative backend selector
+    # (#90109). The per-call argument stays for internal/test callers, but a
+    # value that disagrees with the configured provider is ignored — the
+    # model-facing schema no longer advertises the override, and a leaked
+    # platform hint passing one anyway must not reroute speech to another
+    # vendor behind the operator's back.
+    configured_provider = _get_provider(tts_config)
     if provider:
-        provider = provider.lower().strip()
+        requested = provider.lower().strip()
+        if requested and requested != configured_provider:
+            logger.warning(
+                "Ignoring per-call TTS provider override %r; tts.provider is %r",
+                requested,
+                configured_provider,
+            )
+        provider = configured_provider
     else:
-        provider = _get_provider(tts_config)
+        provider = configured_provider
 
     # User-declared command provider (type: command under tts.providers.<name>)
     # resolves BEFORE the built-in dispatch. Built-in names short-circuit here
@@ -3512,7 +3525,9 @@ def text_to_speech_tool(
         output_path: Optional custom save path.
         speed: Optional playback speed multiplier (0.25-4.0).
         instructions: Optional voice-design guidance (tone, emotion, pacing).
-        provider: Optional TTS provider override.
+        provider: Kept for internal/test callers. When it disagrees with the
+            configured ``tts.provider`` it is ignored with a warning — config
+            is the only backend selector (#90109).
 
     Returns:
         str: JSON result with success, file_path, file_paths, and MEDIA tag.
@@ -3539,11 +3554,24 @@ def text_to_speech_tool(
         tts_config = dict(tts_config)  # shallow copy to avoid mutating the cache
         tts_config["speed"] = clamped
 
-    # Allow per-call provider override; fall back to the configured default.
+    # tts.provider in config.yaml is the authoritative backend selector
+    # (#90109). The per-call argument stays for internal/test callers, but a
+    # value that disagrees with the configured provider is ignored — the
+    # model-facing schema no longer advertises the override, and a leaked
+    # platform hint passing one anyway must not reroute speech to another
+    # vendor behind the operator's back.
+    configured_provider = _get_provider(tts_config)
     if provider:
-        provider = provider.lower().strip()
+        requested = provider.lower().strip()
+        if requested and requested != configured_provider:
+            logger.warning(
+                "Ignoring per-call TTS provider override %r; tts.provider is %r",
+                requested,
+                configured_provider,
+            )
+        provider = configured_provider
     else:
-        provider = _get_provider(tts_config)
+        provider = configured_provider
 
     command_provider_config = _resolve_command_provider_config(provider, tts_config)
     max_len = _resolve_max_text_length(provider, tts_config)
@@ -4474,16 +4502,6 @@ TTS_SCHEMA = {
                     "Forwarded to the OpenAI backend (gpt-4o-mini-tts and OpenAI-compatible "
                     "voice-design servers). Silently ignored by backends that don't support it."
                 )
-            },
-            "provider": {
-                "type": "string",
-                "description": (
-                    "Optional TTS provider override. Accepts built-in names "
-                    "(edge, openai, elevenlabs, minimax, xai, mistral, gemini, "
-                    "neutts, kittentts, piper), user-declared command provider "
-                    "names from tts.providers.<name>, or plugin-registered names. "
-                    "When omitted, the configured tts.provider from config.yaml is used."
-                )
             }
         },
         "required": ["text"]
@@ -4498,8 +4516,7 @@ registry.register(
         text=args.get("text", ""),
         output_path=args.get("output_path"),
         speed=args.get("speed"),
-        instructions=args.get("instructions"),
-        provider=args.get("provider")),
+        instructions=args.get("instructions")),
     check_fn=check_tts_requirements,
     emoji="🔊",
 )


### PR DESCRIPTION
## What does this PR do?

Makes `tts.provider` in config.yaml the authoritative TTS backend selector. The per-call `provider` argument added via #73513 (closing #47459) let the model reroute speech to any configured backend — contradicting the tool schema's own header ("Voice and provider are user-configured ... not model-selected", which predates the parameter) and leaving compact channels (Discord, A2A) unable to keep a house voice without prompt-layer "never pass provider=" appendices.

Direction follows the issue author's field-tested salvage patch and the discussion in #90109: drop the model-facing surface entirely, keep the function argument for internal/test callers. Concretely:

- `TTS_SCHEMA` no longer advertises a `provider` property.
- The `registry.register` handler no longer forwards `args["provider"]`, so even a leaked platform hint sending it in tool args cannot reroute speech.
- `text_to_speech_tool` and `_text_to_speech_single` keep the `provider` parameter, but a value that disagrees with the configured `tts.provider` is ignored with a warning log (config wins); a matching value remains a no-op. This also covers future re-exposures through paths other than the schema.

## Related Issue

Fixes #90109

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/tts_tool.py` — `TTS_SCHEMA`: removed the `provider` property (the model no longer sees the override).
- `tools/tts_tool.py` — `registry.register` handler: stopped forwarding `provider=args.get("provider")`.
- `tools/tts_tool.py` — `text_to_speech_tool` / `_text_to_speech_single`: a per-call `provider` disagreeing with `_get_provider(tts_config)` is now ignored with a `logger.warning` instead of honored; docstring updated to state config is the only backend selector.
- `tests/tools/test_tts_provider_authority.py` — new: schema advertisement, tool-level enforcement (result provider, backend dispatch, warning log, matching-value no-op), registered-handler args path, and inner single-chunk helper.

## How to Test

1. `uv run --python 3.11 --with pytest --with pytest-asyncio --with pyyaml --with python-dotenv --with httpx --with pillow --with requests --with rich --with prompt_toolkit --with openai python -m pytest -q -o 'addopts=' tests/tools/test_tts_provider_authority.py`
2. Observed result: 6 passed on this branch; 5 of 6 fail on unmodified `main` (the schema still advertises `provider` and the xAI backend is dispatched on `provider="xai"`), confirming the regression tests pin the fix.
3. Baseline comparison: the full `tests/tools/test_tts_*.py` suites pass with an identical failure set to unmodified `main` (2 pre-existing environmental timeout failures in `test_tts_command_providers.py`, unchanged); 122 passed / 1 skipped across the remaining suites with no new failures.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstring + schema description updated in-place)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior
