### PR TITLE
fix(gateway): do not auto-TTS A2A replies

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7343,7 +7343,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             _auto_tts_default = False
         if hasattr(adapter, "_auto_tts_default"):
-            adapter._auto_tts_default = _auto_tts_default
+            # A2A never inherits the global speak default. Desktop/wake-word
+            # may flip voice.auto_tts; agent peers still get text only.
+            if getattr(platform, "value", None) == "a2a":
+                adapter._auto_tts_default = False
+            else:
+                adapter._auto_tts_default = _auto_tts_default
 
         prefix = f"{platform.value}:"
         if isinstance(disabled_chats, set):
@@ -21804,6 +21809,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
           runner must handle it.
         """
         if not response or response.startswith("Error:"):
+            return False
+
+        # A2A is agent-to-agent text. The adapter has no native send_voice, so
+        # global voice.auto_tts (Desktop "Read replies aloud") would synthesize
+        # an MP3 and then fail delivery with "Couldn't deliver the audio
+        # attachment." Keep /voice scoped to human platforms.
+        if getattr(event.source.platform, "value", None) == "a2a":
             return False
 
         chat_id = event.source.chat_id

--- a/tests/gateway/test_auto_voice_reply_format.py
+++ b/tests/gateway/test_auto_voice_reply_format.py
@@ -93,6 +93,28 @@ class TestAutoVoiceReplyFormat:
         voice_event = _make_event(Platform.TELEGRAM, chat_id="123", message_type=MessageType.VOICE)
         assert runner._should_send_voice_reply(voice_event, "hello", [], already_sent=True) is True
 
+    def test_should_send_voice_reply_a2a_ignores_global_auto_tts(self):
+        """A2A text tasks must stay text even when voice.auto_tts is on.
+
+        Desktop Read-replies-aloud writes the global default. The runner used
+        that default for every adapter with no /voice mode, including A2A,
+        which cannot deliver native audio (#90103).
+        """
+        runner = _make_runner()
+        a2a = Platform("a2a")
+        adapter = _make_adapter(a2a)
+        adapter._should_auto_tts_for_chat = MagicMock(return_value=True)
+        runner.adapters[a2a] = adapter
+        event = _make_event(a2a, chat_id="ctx-peer")
+
+        assert runner._should_send_voice_reply(event, "audit findings", []) is False
+
+        telegram = _make_event(Platform.TELEGRAM, chat_id="999")
+        telegram_adapter = _make_adapter(Platform.TELEGRAM)
+        telegram_adapter._should_auto_tts_for_chat = MagicMock(return_value=True)
+        runner.adapters[Platform.TELEGRAM] = telegram_adapter
+        assert runner._should_send_voice_reply(telegram, "hello", []) is True
+
 def _make_runner() -> GatewayRunner:
     with patch("gateway.run.GatewayRunner._load_voice_modes", return_value={}):
         runner = GatewayRunner.__new__(GatewayRunner)


### PR DESCRIPTION
## Summary

Desktop **Read replies aloud** persists `voice.auto_tts` as a *global* gateway default. The runner then treats that default as “speak every reply on every platform that has no `/voice` mode.”

A2A inbound is `MessageType.TEXT`. The A2A adapter has no native `send_voice`. Result: a completed text reply is synthesized to `tts_reply_*.mp3`, then:

```
[A2A] send_voice fallback: native audio send unavailable
⚠️ Couldn't deliver the audio attachment.
```

The peer sees a failed audio attachment instead of the text. Observed on v0.20.4 after an update flipped `auto_tts` true; earlier A2A text deliveries on the same hosts were clean.

## Change

- `_should_send_voice_reply` returns `False` for platform `a2a`.
- `_sync_voice_mode_state_to_adapter` never copies the global default onto the A2A adapter.
- Regression: A2A + `adapter_auto_tts=True` stays text; Telegram with the same default still voices.

`/voice on` / `/voice tts` on Discord/Telegram are unchanged.

## Test plan

- [x] Isolated smoke: before patch, A2A text + global auto-TTS → `_should_send_voice_reply` **True**; after → **False**; Telegram still **True**.
- [x] `test_should_send_voice_reply_a2a_ignores_global_auto_tts` passes.
- [ ] CI gateway voice tests.

Field report + logs: #90103