### PR TITLE
fix(cron): reclaim stale executions + preserve model pin across fallback (#90089)

### DIFF
--- a/contributors/emails/paula@smfworks.com
+++ b/contributors/emails/paula@smfworks.com
@@ -1,0 +1,2 @@
+smfworks
+# SMF Works contributor

--- a/cron/executions.py
+++ b/cron/executions.py
@@ -201,7 +201,44 @@ def finish_execution(
 
 
 def recover_interrupted_executions() -> int:
-    """Mark provably abandoned attempts unknown without scheduling retries."""
+    """Mark provably abandoned attempts unknown without scheduling retries.
+
+    Called from the long-lived gateway scheduler tick loop (throttled every
+    300 s).  Only rows owned by a *different* process are considered — this
+    process's own in-flight rows are left alone.  See
+    :func:`reclaim_stale_executions` for a context-agnostic variant.
+    """
+    return _reap_dead_owner_executions(skip_self_owned=True)
+
+
+def reclaim_stale_executions() -> int:
+    """Context-agnostic variant of :func:`recover_interrupted_executions`.
+
+    Identical semantics — mark ``claimed``/``running`` executions whose owner
+    process is provably dead as ``unknown`` — but callable from any context:
+    a one-shot CLI ``hermes cron run`` invocation, a test harness, or any
+    other entry point that does not have the gateway tick loop running.
+
+    This is the self-heal that issue #90089 requires: when a manual cron run
+    spawns a worker that dies silently (segfault, SIGKILL, OOM), the
+    execution row stays ``running`` forever because the dead-owner reaper in
+    the gateway tick never fires without a gateway.  Calling this before
+    dispatching a new run clears zombie records from previous crashed runs.
+    """
+    return _reap_dead_owner_executions(skip_self_owned=False)
+
+
+def _reap_dead_owner_executions(*, skip_self_owned: bool) -> int:
+    """Shared reaper body for :func:`recover_interrupted_executions` and
+    :func:`reclaim_stale_executions`.
+
+    When ``skip_self_owned`` is True, rows owned by this process are skipped
+    (the gateway tick must not reap its own in-flight rows).  When False,
+    even this process's rows are considered — a CLI one-shot invocation
+    calling ``reclaim_stale_executions`` *before* dispatching a new run has
+    no in-flight rows of its own, but if it does (e.g. a re-entrant call),
+    a provably-dead PID check still protects them.
+    """
     now = _hermes_now().isoformat()
     changed = 0
     recovered: List[Dict[str, Any]] = []
@@ -211,7 +248,7 @@ def recover_interrupted_executions() -> int:
                WHERE status IN ('claimed','running')"""
         ).fetchall()
         for row in rows:
-            if row["process_id"] == _PROCESS_ID:
+            if skip_self_owned and row["process_id"] == _PROCESS_ID:
                 continue
             if _owner_is_live(int(row["pid"]), row["process_started_at"]):
                 continue

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -5397,12 +5397,21 @@ def run_job(
                     if fb_api_key:
                         fb_kwargs["explicit_api_key"] = fb_api_key
                     runtime = resolve_runtime_provider(**fb_kwargs)
-                    model = fb_model
+                    # #90089: preserve the job's explicit model pin across a
+                    # fallback provider switch.  Previously the fallback chain
+                    # unconditionally overwrote ``model = fb_model``, silently
+                    # discarding a pinned model (e.g. glm-4.5-air) when the
+                    # primary provider (e.g. zai) failed transiently.  Only
+                    # swap the model when the job does NOT have an explicit
+                    # model pin — unpinned jobs should follow the fallback
+                    # entry's model as before.
+                    if not job.get("model"):
+                        model = fb_model
                     logger.info(
                         "Job '%s': fallback resolved to %s model %s",
                         job_id,
                         runtime.get("provider"),
-                        fb_model,
+                        model,
                     )
                     break
                 except Exception as fb_exc:
@@ -6654,6 +6663,41 @@ def _run_one_job_body(
         if not isinstance(e, Exception):
             raise
         return False
+    finally:
+        # Safety net (#90089): if the execution row is still 'running' or
+        # 'claimed' after _run_one_job_body completes (normal return OR
+        # exception), some code path bypassed the terminal write — e.g. an
+        # exception that escaped before finish_execution was called, or a
+        # logic error in a new branch.  Without this net the row stays
+        # 'running' forever (the dead-owner reaper only fires from the
+        # gateway tick, which may not be running for a manual CLI run).
+        # Mark it 'failed' so the job is unblocked for its next run.
+        # Terminal states (completed/failed/unknown) are never rewritten.
+        try:
+            from cron.executions import latest_execution
+
+            _safety_record = latest_execution(job["id"])
+            if (
+                _safety_record is not None
+                and _safety_record["id"] == execution_id
+                and _safety_record["status"] in ("running", "claimed")
+            ):
+                logger.error(
+                    "Job '%s': execution %s still in '%s' state after "
+                    "run_one_job body completed — safety net marking failed",
+                    job["id"], execution_id, _safety_record["status"],
+                )
+                finish_execution(
+                    execution_id,
+                    success=False,
+                    error=(
+                        "Execution was left in a non-terminal state after "
+                        "the job body completed; safety net marked it failed. "
+                        "See #90089."
+                    ),
+                )
+        except Exception:
+            pass
 
 
 def _notify_provider_jobs_changed() -> None:

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -520,6 +520,27 @@ def _job_action(action: str, job_id: str, success_verb: str) -> int:
                 _SESSION_ASYNC_DELIVERY.reset(_stateless_token)
         except Exception:
             _stateless_reset = None
+
+        # Pre-dispatch stale execution sweep (#90089): the background dispatch
+        # path's own ``recover_interrupted_executions`` call is gated behind
+        # ``async_delivery_supported()`` — which we just disabled above — so
+        # it never runs for a one-shot CLI invocation.  Without a gateway tick
+        # loop running, a zombie 'running'/'claimed' row from a *previous*
+        # crashed manual run would block this run forever.  Call the
+        # context-agnostic reaper before dispatching so dead-owner rows are
+        # cleared.  Best-effort: a failure here must not block the run.
+        try:
+            from cron.executions import reclaim_stale_executions
+
+            _reclaimed = reclaim_stale_executions()
+            if _reclaimed:
+                print(color(
+                    f"Reclaimed {_reclaimed} stale cron execution(s) from "
+                    f"dead owner process(es) before running job '{job_id}'.",
+                    Colors.YELLOW,
+                ))
+        except Exception:
+            pass
     try:
         result = _cron_api(action=action, job_id=job_id)
     finally:

--- a/tests/cron/test_model_pin_fallback_90089.py
+++ b/tests/cron/test_model_pin_fallback_90089.py
@@ -1,0 +1,199 @@
+"""Regression for #90089 Part 2 — pinned model/provider intermittently
+ignored on manual cron runs.
+
+Root cause: when the primary provider resolution fails transiently (auth
+blip, network hiccup), the fallback chain in ``run_job`` unconditionally
+overwrites ``model = fb_model`` (line ~5400) — even when the job has an
+explicit ``model`` pin.  This means a job pinned to ``glm-4.5-air`` /
+``zai`` that hits a transient zai auth failure falls back to a different
+provider AND model, silently ignoring the pin.  The intermittent nature
+matches: only the runs where the primary provider resolution failed
+exhibited the bug.
+
+Fix: the fallback chain must not swap the model when the job has an
+explicit ``job["model"]`` pin.  The provider can still fall back (the
+credentials are gone), but the model pin is preserved so the operator's
+intent is respected — the fallback provider simply receives the pinned
+model name (which may or may not be available there, but at least the pin
+is not silently discarded).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from cron.scheduler import run_job
+
+
+def _base_job(**overrides):
+    job = {
+        "id": "pin-90089",
+        "name": "pin test 90089",
+        "prompt": "hello",
+        "model": None,
+        "provider": None,
+        "provider_snapshot": None,
+        "model_snapshot": None,
+        "base_url": None,
+    }
+    job.update(overrides)
+    return job
+
+
+def _run_with_fallback(
+    job,
+    *,
+    primary_provider,
+    primary_raises,
+    fallback_provider,
+    fallback_model,
+    tmp_path,
+    config_model="global-default-model",
+):
+    """Drive run_job where the primary provider resolution raises and the
+    fallback chain is walked.  Returns (success, output, error, model_used).
+
+    ``model_used`` is the model string passed to AIAgent — the thing that
+    actually determines which model the run uses.
+    """
+    config_yaml = f"model:\n  default: {config_model}\n  provider: {primary_provider}\n"
+    config_yaml += (
+        "fallback_providers:\n"
+        f"  - provider: {fallback_provider}\n"
+        f"    model: {fallback_model}\n"
+    )
+    (tmp_path / "config.yaml").write_text(config_yaml)
+
+    captured_agent_kwargs: dict = {}
+
+    class _FakeAgent:
+        def __init__(self, **kwargs):
+            captured_agent_kwargs.update(kwargs)
+            self.session_id = None
+
+        def run_conversation(self, *a, **kw):
+            return {"final_response": "ok"}
+
+        def close(self):
+            pass
+
+    fake_db = MagicMock()
+
+    call_count = [0]
+
+    def _resolve(**kwargs):
+        call_count[0] += 1
+        # First call (primary resolution) always raises to trigger the
+        # fallback chain.  Subsequent calls (fallback entries) succeed.
+        if call_count[0] == 1 and primary_raises:
+            raise primary_raises
+        return {
+            "api_key": "test-key",
+            "base_url": "https://example.invalid/v1",
+            "provider": fallback_provider,
+            "api_mode": "chat_completions",
+        }
+
+    with patch("cron.scheduler._hermes_home", tmp_path), \
+         patch("cron.scheduler._get_hermes_home", return_value=tmp_path), \
+         patch("cron.scheduler._resolve_origin", return_value=None), \
+         patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+         patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+         patch("hermes_state.SessionDB", return_value=fake_db), \
+         patch(
+             "hermes_cli.runtime_provider.resolve_runtime_provider",
+             side_effect=_resolve,
+         ), \
+         patch("run_agent.AIAgent", _FakeAgent):
+        try:
+            success, output, final_response, error = run_job(job)
+        except Exception as exc:
+            return False, "", str(exc), captured_agent_kwargs.get("model", "")
+
+    return success, output, error, captured_agent_kwargs.get("model", "")
+
+
+class TestPinnedModelNotOverwrittenByFallback:
+    """When the job has an explicit ``model`` pin, the fallback chain must
+    NOT replace it with the fallback entry's model."""
+
+    def test_pinned_model_survives_primary_provider_failure(self, tmp_path):
+        """Job pinned to glm-4.5-air/zai.  Primary (zai) auth fails →
+        fallback chain fires.  The model passed to AIAgent must still be
+        the pinned model, not the fallback's model."""
+        from hermes_cli.auth import AuthError
+
+        job = _base_job(
+            model="glm-4.5-air",
+            provider="zai",
+        )
+
+        success, _output, _error, model_used = _run_with_fallback(
+            job,
+            primary_provider="zai",
+            primary_raises=AuthError("zai token expired"),
+            fallback_provider="lmstudio",
+            fallback_model="qwen3.8",
+            tmp_path=tmp_path,
+        )
+
+        assert success is True, f"run should succeed via fallback, got error: {_error}"
+        assert model_used == "glm-4.5-air", (
+            f"pinned model 'glm-4.5-air' must survive fallback, "
+            f"got '{model_used}'"
+        )
+
+    def test_unpinned_model_is_replaced_by_fallback(self, tmp_path):
+        """Without a model pin, the fallback chain SHOULD replace the model
+        — this is the existing, correct behavior for unpinned jobs."""
+        from hermes_cli.auth import AuthError
+
+        # No snapshots → drift guard never engages, so the fallback path
+        # is exercised end-to-end.
+        job = _base_job(
+            model=None,
+            provider=None,
+            provider_snapshot=None,
+            model_snapshot=None,
+        )
+
+        success, _output, _error, model_used = _run_with_fallback(
+            job,
+            primary_provider="zai",
+            primary_raises=AuthError("zai token expired"),
+            fallback_provider="lmstudio",
+            fallback_model="qwen3.8",
+            tmp_path=tmp_path,
+        )
+
+        # Unpinned job: fallback model is used (existing behavior).
+        assert model_used == "qwen3.8"
+
+    def test_pinned_model_with_pinned_provider_survives_transient_network_error(
+        self, tmp_path
+    ):
+        """Same as above but with a transient network error instead of auth."""
+        import httpx
+
+        job = _base_job(
+            model="glm-4.5-air",
+            provider="zai",
+        )
+
+        success, _output, _error, model_used = _run_with_fallback(
+            job,
+            primary_provider="zai",
+            primary_raises=httpx.ConnectError("DNS resolution failed"),
+            fallback_provider="lmstudio",
+            fallback_model="qwen3.8",
+            tmp_path=tmp_path,
+        )
+
+        assert success is True
+        assert model_used == "glm-4.5-air"

--- a/tests/cron/test_silent_worker_death_90089.py
+++ b/tests/cron/test_silent_worker_death_90089.py
@@ -1,0 +1,288 @@
+"""Regression for #90089 — Windows manual cron run worker subprocess dies
+silently, execution stuck 'running' forever.
+
+Two related failure modes under test:
+
+1. ``reclaim_stale_executions()`` — a context-agnostic version of
+   ``recover_interrupted_executions`` that can be called from any context
+   (not just the gateway tick loop).  When a manual CLI ``hermes cron run``
+   spawns a worker that dies without reaching the finally block that calls
+   ``finish_execution``, the execution row stays ``running`` forever because
+   the dead-owner reaper only fires from the gateway tick every 300 s — and
+   if the gateway isn't running, it never fires.
+
+2. ``_job_action("run", ...)`` in the CLI must call
+   ``reclaim_stale_executions()`` before dispatching a new run so zombie
+   records from previous crashed runs are cleaned up.  The existing recovery
+   call inside ``_try_dispatch_background_run`` is gated behind the
+   ``async_delivery_supported()`` check, which the CLI path explicitly
+   disables (stateless channel) — so the recovery never runs for one-shot
+   CLI invocations.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _point_ledger(monkeypatch, tmp_path):
+    """Point the execution ledger at a temp DB."""
+    import cron.executions as executions
+
+    monkeypatch.setattr(
+        executions, "EXECUTIONS_FILE", tmp_path / "cron" / "executions.db"
+    )
+    return executions
+
+
+def _dead_pid() -> int:
+    """PID of a real process that has already exited."""
+    proc = subprocess.run(
+        [sys.executable, "-c", "import os; print(os.getpid())"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return int(proc.stdout.strip())
+
+
+def _orphan_running_row(executions, job_id: str) -> str:
+    """Persist a *running* execution owned by a process that no longer exists.
+
+    Mirrors what a dead worker leaves behind: a row stuck in ``running``
+    whose owner PID is dead — the exact symptom from issue #90089.
+    """
+    record = executions.create_execution(job_id, source="direct")
+    executions.mark_execution_running(record["id"])
+    with executions._transaction() as conn:
+        conn.execute(
+            "UPDATE executions SET process_id='dead-worker-process', pid=?, "
+            "process_started_at=NULL WHERE id=?",
+            (_dead_pid(), record["id"]),
+        )
+    return record["id"]
+
+
+# ---------------------------------------------------------------------------
+# reclaim_stale_executions — callable from any context
+# ---------------------------------------------------------------------------
+
+class TestReclaimStaleExecutions:
+    """``reclaim_stale_executions`` is the context-agnostic variant of
+    ``recover_interrupted_executions``: same semantics (mark provably-dead
+    owner rows ``unknown``), callable from the CLI path without a gateway.
+    """
+
+    def test_reclaims_running_row_from_dead_owner(self, monkeypatch, tmp_path):
+        executions = _point_ledger(monkeypatch, tmp_path)
+        execution_id = _orphan_running_row(executions, "stale-running-job")
+
+        reclaimed = executions.reclaim_stale_executions()
+
+        assert reclaimed >= 1
+        record = executions.latest_execution("stale-running-job")
+        assert record["id"] == execution_id
+        assert record["status"] == "unknown"
+        assert record["finished_at"] is not None
+
+    def test_reclaims_claimed_row_from_dead_owner(self, monkeypatch, tmp_path):
+        executions = _point_ledger(monkeypatch, tmp_path)
+        record = executions.create_execution("stale-claimed-job", source="direct")
+        with executions._transaction() as conn:
+            conn.execute(
+                "UPDATE executions SET process_id='dead-cli-process', pid=?, "
+                "process_started_at=NULL WHERE id=?",
+                (_dead_pid(), record["id"]),
+            )
+
+        assert executions.reclaim_stale_executions() >= 1
+        assert executions.latest_execution("stale-claimed-job")["status"] == "unknown"
+
+    def test_does_not_touch_live_owner_row(self, monkeypatch, tmp_path):
+        executions = _point_ledger(monkeypatch, tmp_path)
+        record = executions.create_execution("live-job", source="builtin")
+        executions.mark_execution_running(record["id"])
+
+        assert executions.reclaim_stale_executions() == 0
+        assert executions.latest_execution("live-job")["status"] == "running"
+
+    def test_does_not_touch_terminal_rows(self, monkeypatch, tmp_path):
+        executions = _point_ledger(monkeypatch, tmp_path)
+        record = executions.create_execution("done-job", source="builtin")
+        executions.finish_execution(record["id"], success=True)
+
+        assert executions.reclaim_stale_executions() == 0
+        assert executions.latest_execution("done-job")["status"] == "completed"
+
+    def test_returns_count_of_reclaimed_rows(self, monkeypatch, tmp_path):
+        executions = _point_ledger(monkeypatch, tmp_path)
+        _orphan_running_row(executions, "stale-1")
+        _orphan_running_row(executions, "stale-2")
+
+        reclaimed = executions.reclaim_stale_executions()
+        assert reclaimed == 2
+
+    def test_real_subprocess_stale_running_is_reclaimed(self, tmp_path):
+        """End-to-end: a subprocess creates a running row and exits; a fresh
+        process calls ``reclaim_stale_executions`` and clears it."""
+        home = tmp_path / "home"
+        repo = Path(__file__).resolve().parents[2]
+        env = os.environ.copy()
+        env["HERMES_HOME"] = str(home)
+        env["PYTHONPATH"] = str(repo)
+
+        create = subprocess.run(
+            [
+                sys.executable, "-c",
+                "from cron.executions import create_execution, mark_execution_running; "
+                "r=create_execution('e2e-stale', source='direct'); "
+                "mark_execution_running(r['id']); print(r['id'])",
+            ],
+            cwd=repo, env=env, text=True, capture_output=True, check=True,
+        )
+        execution_id = create.stdout.strip()
+
+        recover = subprocess.run(
+            [
+                sys.executable, "-c",
+                "import json; "
+                "from cron.executions import reclaim_stale_executions, list_executions; "
+                "print(reclaim_stale_executions()); "
+                "print(json.dumps(list_executions(job_id='e2e-stale')))",
+            ],
+            cwd=repo, env=env, text=True, capture_output=True, check=True,
+        )
+        lines = recover.stdout.strip().splitlines()
+        assert lines[0] == "1"
+        records = json.loads(lines[1])
+        assert records[0]["id"] == execution_id
+        assert records[0]["status"] == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# CLI _job_action sweep — reclaim before dispatch
+# ---------------------------------------------------------------------------
+
+class TestCliRunReclaimsBeforeDispatch:
+    """The CLI ``hermes cron run`` path must call
+    ``reclaim_stale_executions`` before dispatching a new run, because the
+    background-dispatch path's own recovery call is gated behind
+    ``async_delivery_supported()`` — which the CLI explicitly disables.
+    """
+
+    def test_run_action_calls_reclaim_before_cron_api(self, monkeypatch):
+        from hermes_cli import cron as cron_cli
+
+        calls: list[str] = []
+
+        def _fake_reclaim():
+            calls.append("reclaim")
+            return 0
+
+        monkeypatch.setattr(
+            "cron.executions.reclaim_stale_executions", _fake_reclaim,
+        )
+
+        def _fake_cron_api(**kwargs):
+            calls.append("cron_api")
+            return {"success": True, "job": {"executed": True, "execution_success": True}}
+
+        monkeypatch.setattr(cron_cli, "_cron_api", _fake_cron_api)
+
+        assert cron_cli._job_action("run", "job-123", "Triggered") == 0
+        assert calls[0] == "reclaim", "reclaim must run before cron_api dispatch"
+        assert "cron_api" in calls
+
+    def test_non_run_actions_do_not_call_reclaim(self, monkeypatch):
+        from hermes_cli import cron as cron_cli
+
+        calls: list[str] = []
+
+        monkeypatch.setattr(
+            "cron.executions.reclaim_stale_executions",
+            lambda: calls.append("reclaim") or 0,
+        )
+
+        def _fake_cron_api(**kwargs):
+            calls.append("cron_api")
+            return {"success": True, "job": {"name": "j"}}
+
+        monkeypatch.setattr(cron_cli, "_cron_api", _fake_cron_api)
+
+        cron_cli._job_action("pause", "job-123", "Paused")
+        assert "reclaim" not in calls, "pause must not trigger stale reclaim"
+
+    def test_reclaim_failure_does_not_block_run(self, monkeypatch):
+        from hermes_cli import cron as cron_cli
+
+        def _boom():
+            raise RuntimeError("ledger unavailable")
+
+        monkeypatch.setattr("cron.executions.reclaim_stale_executions", _boom)
+
+        def _fake_cron_api(**kwargs):
+            return {"success": True, "job": {"executed": True, "execution_success": True}}
+
+        monkeypatch.setattr(cron_cli, "_cron_api", _fake_cron_api)
+
+        # Must not raise — best-effort self-heal.
+        assert cron_cli._job_action("run", "job-456", "Triggered") == 0
+
+
+# ---------------------------------------------------------------------------
+# run_one_job safety net — execution still 'running' after job body
+# ---------------------------------------------------------------------------
+
+class TestRunOneJobSafetyNet:
+    """If ``_run_one_job_body`` completes without calling
+    ``finish_execution`` (e.g. an exception path that bypassed the terminal
+    write), the execution row must not be left ``running`` forever.
+
+    The safety net in ``_run_one_job_body``'s outer scope checks the
+    execution status after the body returns and marks it ``failed`` if it
+    is still ``running``.
+    """
+
+    def test_safety_net_marks_still_running_as_failed(self, monkeypatch, tmp_path):
+        """Simulate a code path where the body returns without finishing the
+        execution — the safety net must catch it."""
+        import cron.scheduler as scheduler
+        import cron.executions as executions
+
+        monkeypatch.setattr(
+            executions, "EXECUTIONS_FILE", tmp_path / "cron" / "executions.db"
+        )
+
+        # Create a real execution row in 'running' state.
+        record = executions.create_execution("safety-net-job", source="direct")
+        executions.mark_execution_running(record["id"])
+        execution_id = record["id"]
+
+        # Patch run_job to return successfully but WITHOUT finish_execution
+        # having been called (simulates a bypassed terminal write).
+        monkeypatch.setattr(
+            scheduler, "run_job",
+            lambda job, **kw: (True, "output", "response", None),
+        )
+        monkeypatch.setattr(scheduler, "claim_dispatch", lambda _jid: True)
+        monkeypatch.setattr(scheduler, "save_job_output", lambda *_a, **_k: "/tmp/fake")
+        monkeypatch.setattr(scheduler, "_deliver_result", lambda *_a, **_k: None)
+        monkeypatch.setattr(scheduler, "mark_job_run", lambda *_a, **_k: True)
+
+        job = {"id": "safety-net-job", "execution_id": execution_id, "prompt": "test"}
+        scheduler.run_one_job(job)
+
+        final = executions.latest_execution("safety-net-job")
+        assert final["status"] != "running", (
+            "safety net must not leave execution 'running' after run_one_job returns"
+        )


### PR DESCRIPTION
## Summary

Fixes #90089 — two bugs affecting Windows manual cron runs.

### Part 1: Silent worker death — execution stuck `running` forever

**Problem:** When a manual `hermes cron run` spawns a worker that dies silently (segfault, SIGKILL, OOM on Windows), the execution row stays `running` forever. The dead-owner reaper (`recover_interrupted_executions`) only fires from the gateway tick loop every 300s — without a gateway running, zombie records are never cleared. The existing recovery call in `_try_dispatch_background_run` is gated behind `async_delivery_supported()`, which the CLI path explicitly disables, so it never runs for one-shot CLI invocations.

**Fix (3 changes):**

1. **`cron/executions.py`** — Added `reclaim_stale_executions()`: a context-agnostic variant of `recover_interrupted_executions` that does NOT skip self-owned rows. Both functions now share a `_reap_dead_owner_executions(skip_self_owned=...)` helper. Callable from any entry point (CLI, test, etc.) without a gateway tick.

2. **`hermes_cli/cron.py`** — Added pre-dispatch stale execution sweep in `_job_action("run", ...)` that calls `reclaim_stale_executions()` before `_cron_api()`. Prints a warning if any zombie records were reclaimed. Best-effort: failure does not block the run.

3. **`cron/scheduler.py`** — Added a safety net in `_run_one_job_body`'s `finally` block: if the execution row is still `running` or `claimed` after the job body completes (normal return OR exception), mark it `failed` with an error message. This catches any code path that bypasses the terminal write — e.g., an exception that escaped before `finish_execution` was called.

### Part 2: Model pin intermittently ignored across fallback

**Problem:** The fallback chain in `run_job` unconditionally overwrote `model = fb_model` when the primary provider failed transiently — even when the job had an explicit `model` pin. This means a job pinned to `glm-4.5-air` / `zai` that hit a transient zai auth failure silently fell back to a different provider AND model. The intermittent nature matches: only runs where the primary provider resolution failed exhibited the bug.

**Fix:** Changed `model = fb_model` to `if not job.get("model"): model = fb_model` — the provider can still fall back (credentials are gone), but the model pin is preserved. Unpinned jobs continue to follow the fallback entry's model as before.

## Test Plan

- [x] 13 new tests written (TDD — tests first, then implementation)
  - `test_silent_worker_death_90089.py` — 10 tests: `reclaim_stale_executions()` reclaims dead-owner rows, doesn't touch live/terminal rows, returns count, CLI sweep calls reclaim before dispatch, safety net marks still-running executions
  - `test_model_pin_fallback_90089.py` — 3 tests: pinned model survives auth failure, unpinned model is replaced as before, pinned model survives transient network error
- [x] All 13 new tests pass
- [x] Existing cron test suite: 241 passed, 13 skipped, 1 pre-existing Windows failure (`test_tilde_expands` — verified on base commit, unrelated to this change)

## Files Changed

| File | Changes |
|------|---------|
| `cron/executions.py` | +41/-2 — `reclaim_stale_executions()` + shared `_reap_dead_owner_executions` helper |
| `cron/scheduler.py` | +48/-2 — safety net in `_run_one_job_body` finally + fallback model pin fix |
| `hermes_cli/cron.py` | +23 — pre-dispatch stale execution sweep |
| `tests/cron/test_silent_worker_death_90089.py` | New — 10 tests |
| `tests/cron/test_model_pin_fallback_90089.py` | New — 3 tests |
| `contributors/emails/paula@smfworks.com` | Contributor attribution mapping |