### PR TITLE
fix(browser): serialize shared npx cache warmup

### DIFF
--- a/tests/test_windows_subprocess_no_window_flags.py
+++ b/tests/test_windows_subprocess_no_window_flags.py
@@ -189,7 +189,7 @@ def test_shell_hooks_hide_hook_command_windows(monkeypatch):
     assert "process_group" not in captured[0][1]
 
 
-def test_agent_browser_npx_warmup_hides_npx_window(monkeypatch):
+def test_agent_browser_npx_warmup_hides_npx_window(monkeypatch, tmp_path):
     """warm_agent_browser_npx_cache spawns via subprocess.Popen (not .run,
     since the T3 security-hardening rewrite added process-tree containment
     via Popen + communicate()) — the console-hiding flag must still survive
@@ -200,6 +200,8 @@ def test_agent_browser_npx_warmup_hides_npx_window(monkeypatch):
     equality with the whole creationflags value."""
     from tools import browser_tool_install
 
+    # Keep the Popen fake scoped to npx while exercising the real cache lock.
+    monkeypatch.setenv("npm_config_cache", str(tmp_path / "npm-cache"))
     captured = []
 
     class _FakePopen:

--- a/tests/tools/test_browser_homebrew_paths.py
+++ b/tests/tools/test_browser_homebrew_paths.py
@@ -19,8 +19,9 @@ from tools import browser_tool_install as bt_install
 
 
 @pytest.fixture(autouse=True)
-def _clear_browser_caches():
+def _clear_browser_caches(monkeypatch):
     """Clear lru_cache and manual caches between tests."""
+    monkeypatch.setattr(bt_install, "warm_agent_browser_npx_cache", lambda: True)
     _discover_homebrew_node_dirs.cache_clear()
     _bt._cached_agent_browser = None
     _bt._agent_browser_resolved = False

--- a/tests/tools/test_browser_npx_warmup.py
+++ b/tests/tools/test_browser_npx_warmup.py
@@ -16,6 +16,7 @@ npx PID — on timeout.
 from __future__ import annotations
 
 import subprocess
+import pytest
 from unittest.mock import MagicMock, patch
 
 from tools.browser_tool import AGENT_BROWSER_NPX_SPEC
@@ -121,8 +122,8 @@ def test_merges_extended_path_so_managed_only_npx_can_find_sibling_node():
     assert kwargs["env"]["PATH"] == "/opt/hermes/node/bin:/usr/bin"
 
 
-def test_runs_in_its_own_process_group_on_posix(monkeypatch):
-    monkeypatch.setattr("os.name", "posix")
+@pytest.mark.linux_only
+def test_runs_in_its_own_process_group_on_posix():
     with patch("tools.browser_tool_install._resolve_npx_bin", return_value="/usr/bin/npx"), \
          patch("subprocess.Popen", return_value=_mock_proc()) as mock_popen:
         warm_agent_browser_npx_cache()
@@ -131,12 +132,12 @@ def test_runs_in_its_own_process_group_on_posix(monkeypatch):
     assert kwargs.get("start_new_session") is True
 
 
+@pytest.mark.windows_only
 def test_uses_new_process_group_creationflag_on_windows_instead_of_start_new_session():
     """start_new_session is a POSIX-only Popen kwarg (raises on Windows).
     The Windows equivalent for _kill_process_tree's taskkill /T to have a
     coherent tree to kill is CREATE_NEW_PROCESS_GROUP via creationflags."""
-    with patch("os.name", "nt"), \
-         patch("tools.browser_tool_install._resolve_npx_bin", return_value="C:\\npx.cmd"), \
+    with patch("tools.browser_tool_install._resolve_npx_bin", return_value="C:\\npx.cmd"), \
          patch("tools.browser_tool._build_browser_env", return_value={"PATH": "C:\\Windows"}), \
          patch("tools.browser_tool_install._merge_browser_path", side_effect=lambda p: p), \
          patch("subprocess.Popen", return_value=_mock_proc()) as mock_popen:

--- a/tests/tools/test_browser_npx_warmup.py
+++ b/tests/tools/test_browser_npx_warmup.py
@@ -24,6 +24,16 @@ from tools.browser_tool_install import warm_agent_browser_npx_cache
 from tools.browser_tool_lifecycle import _legacy_kill_process_tree
 
 
+@pytest.fixture(autouse=True)
+def isolated_cache_lock_path(tmp_path, monkeypatch):
+    # These tests isolate process/env handling; real cache resolution and
+    # contention are covered by test_browser_shared_warmup.py.
+    monkeypatch.setattr(
+        "tools.browser_tool_install._agent_browser_npx_lock_path",
+        lambda env, **kwargs: tmp_path / "warmup.lock",
+    )
+
+
 def _mock_proc(returncode=0, communicate_side_effect=None, pid=4242):
     proc = MagicMock()
     proc.pid = pid

--- a/tests/tools/test_browser_shared_warmup.py
+++ b/tests/tools/test_browser_shared_warmup.py
@@ -17,7 +17,7 @@ def test_shared_cache_contention_is_bounded_and_releases_after_warmup(tmp_path, 
     fake = tmp_path / 'fake_npx.py'
     fake.write_text(
         'from pathlib import Path\nimport time, sys\n'
-        f'if sys.argv[1:4] == ["config", "get", "cache"]:\n print(Path({str(tmp_path / ".npmrc")!r}).read_text().split("=", 1)[1].strip()); sys.exit(0)\n'
+        f'if sys.argv[1:4] == ["config", "get", "cache"]:\n print(Path({str(tmp_path / ".npmrc")!r}).read_text(encoding="utf-8").split("=", 1)[1].strip()); sys.exit(0)\n'
         f'trace=Path({str(trace)!r}); release=Path({str(release)!r})\n'
         "with trace.open('a') as f: f.write('enter\\n')\n"
         'while not release.exists(): time.sleep(0.01)\n'
@@ -64,7 +64,7 @@ print(json.dumps(install.warm_agent_browser_npx_cache(float(sys.argv[2]))))
         out, err = second.communicate(timeout=10)
         assert second.returncode == 0, err
         assert json.loads(out) is False
-        assert trace.read_text().splitlines() == ['enter']
+        assert trace.read_text(encoding="utf-8").splitlines() == ['enter']
         release.touch()
         out, err = first.communicate(timeout=10)
         assert first.returncode == 0, err
@@ -73,7 +73,7 @@ print(json.dumps(install.warm_agent_browser_npx_cache(float(sys.argv[2]))))
         out, err = third.communicate(timeout=10)
         assert third.returncode == 0, err
         assert json.loads(out) is True
-        assert trace.read_text().splitlines() == ['enter', 'exit', 'enter', 'exit']
+        assert trace.read_text(encoding="utf-8").splitlines() == ['enter', 'exit', 'enter', 'exit']
         assert (tmp_path / 'shared-cache' / '.hermes-agent-browser-warmup.lock').exists()
     finally:
         release.touch()

--- a/tests/tools/test_browser_shared_warmup.py
+++ b/tests/tools/test_browser_shared_warmup.py
@@ -5,28 +5,35 @@ import subprocess
 import sys
 import time
 
+import pytest
+
 from tools import browser_tool as browser
 from tools import browser_tool_install as install
 
 
-def test_shared_cache_contention_is_bounded_and_releases_after_warmup(tmp_path):
+@pytest.mark.parametrize("cache_source", ["environment", "npmrc"])
+def test_shared_cache_contention_is_bounded_and_releases_after_warmup(tmp_path, cache_source):
     trace, release = tmp_path / 'trace', tmp_path / 'release'
     fake = tmp_path / 'fake_npx.py'
     fake.write_text(
-        'from pathlib import Path\nimport time\n'
+        'from pathlib import Path\nimport time, sys\n'
+        f'if sys.argv[1:4] == ["config", "get", "cache"]:\n print(Path({str(tmp_path / ".npmrc")!r}).read_text().split("=", 1)[1].strip()); sys.exit(0)\n'
         f'trace=Path({str(trace)!r}); release=Path({str(release)!r})\n'
         "with trace.open('a') as f: f.write('enter\\n')\n"
         'while not release.exists(): time.sleep(0.01)\n'
         "with trace.open('a') as f: f.write('exit\\n')\n",
         encoding='utf-8',
     )
+    (tmp_path / '.npmrc').write_text(f'cache={tmp_path / "shared-cache"}\n', encoding='utf-8')
     worker = '''
 import json, subprocess, sys
 from tools import browser_tool_install as install
 real_popen = subprocess.Popen
+real_which = install.shutil.which
+install.shutil.which = lambda name, *a, **kw: 'fake-npm' if name == 'npm' else real_which(name, *a, **kw)
 install._resolve_npx_bin = lambda: 'fake-npx'
 def spawn(cmd, **kwargs):
-    assert cmd[0] == 'fake-npx'
+    assert cmd[0] in {'fake-npx', 'fake-npm'}
     return real_popen([sys.executable, sys.argv[1], *cmd[1:]], **kwargs)
 install.subprocess.Popen = spawn
 print(json.dumps(install.warm_agent_browser_npx_cache(float(sys.argv[2]))))
@@ -34,8 +41,11 @@ print(json.dumps(install.warm_agent_browser_npx_cache(float(sys.argv[2]))))
     processes = []
 
     def start(profile, timeout):
-        env = dict(os.environ, HERMES_HOME=str(tmp_path / profile),
-                   NPM_CONFIG_CACHE=str(tmp_path / 'shared-cache'))
+        env = dict(os.environ, HERMES_HOME=str(tmp_path / profile))
+        env.pop('npm_config_cache', None)
+        env.pop('NPM_CONFIG_CACHE', None)
+        if cache_source == 'environment':
+            env['NPM_CONFIG_CACHE'] = str(tmp_path / 'shared-cache')
         proc = subprocess.Popen([sys.executable, '-c', worker, str(fake), str(timeout)],
                                 env=env, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE, text=True)
@@ -79,6 +89,7 @@ def test_validated_fallback_warms_before_publishing_cached_sentinel(monkeypatch)
     monkeypatch.setattr(install, '_agent_browser_candidates', lambda path: ())
     monkeypatch.setattr(install, '_resolve_npx_bin', lambda: 'fake-npx')
     calls = []
+    real_warm = install.warm_agent_browser_npx_cache
 
     def warm():
         assert not browser._agent_browser_resolved
@@ -92,3 +103,11 @@ def test_validated_fallback_warms_before_publishing_cached_sentinel(monkeypatch)
     assert install._find_agent_browser() == browser.NPX_AGENT_BROWSER_SENTINEL
     assert calls == ['warm']
     assert browser._agent_browser_resolved
+
+    monkeypatch.setattr(install, '_agent_browser_npx_lock_path', lambda env, **kwargs: None)
+
+    def unexpected_spawn(*args, **kwargs):
+        raise AssertionError('Unknown cache ownership must not spawn npx')
+
+    monkeypatch.setattr(subprocess, 'Popen', unexpected_spawn)
+    assert real_warm() is False

--- a/tests/tools/test_browser_shared_warmup.py
+++ b/tests/tools/test_browser_shared_warmup.py
@@ -1,0 +1,94 @@
+"""Exercise cache contention through the real warmup subprocess path."""
+import json
+import os
+import subprocess
+import sys
+import time
+
+from tools import browser_tool as browser
+from tools import browser_tool_install as install
+
+
+def test_shared_cache_contention_is_bounded_and_releases_after_warmup(tmp_path):
+    trace, release = tmp_path / 'trace', tmp_path / 'release'
+    fake = tmp_path / 'fake_npx.py'
+    fake.write_text(
+        'from pathlib import Path\nimport time\n'
+        f'trace=Path({str(trace)!r}); release=Path({str(release)!r})\n'
+        "with trace.open('a') as f: f.write('enter\\n')\n"
+        'while not release.exists(): time.sleep(0.01)\n'
+        "with trace.open('a') as f: f.write('exit\\n')\n",
+        encoding='utf-8',
+    )
+    worker = '''
+import json, subprocess, sys
+from tools import browser_tool_install as install
+real_popen = subprocess.Popen
+install._resolve_npx_bin = lambda: 'fake-npx'
+def spawn(cmd, **kwargs):
+    assert cmd[0] == 'fake-npx'
+    return real_popen([sys.executable, sys.argv[1], *cmd[1:]], **kwargs)
+install.subprocess.Popen = spawn
+print(json.dumps(install.warm_agent_browser_npx_cache(float(sys.argv[2]))))
+'''
+    processes = []
+
+    def start(profile, timeout):
+        env = dict(os.environ, HERMES_HOME=str(tmp_path / profile),
+                   NPM_CONFIG_CACHE=str(tmp_path / 'shared-cache'))
+        proc = subprocess.Popen([sys.executable, '-c', worker, str(fake), str(timeout)],
+                                env=env, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE, text=True)
+        processes.append(proc)
+        return proc
+
+    first = start('profile-a', 15)
+    try:
+        deadline = time.monotonic() + 10
+        while not trace.exists() and first.poll() is None and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert trace.exists(), first.communicate(timeout=2)
+        # The first real subprocess holds the cache lock. Another profile must
+        # exhaust its own budget without launching a competing npm writer.
+        second = start('profile-b', 0.25)
+        out, err = second.communicate(timeout=10)
+        assert second.returncode == 0, err
+        assert json.loads(out) is False
+        assert trace.read_text().splitlines() == ['enter']
+        release.touch()
+        out, err = first.communicate(timeout=10)
+        assert first.returncode == 0, err
+        assert json.loads(out) is True
+        third = start('profile-b', 5)
+        out, err = third.communicate(timeout=10)
+        assert third.returncode == 0, err
+        assert json.loads(out) is True
+        assert trace.read_text().splitlines() == ['enter', 'exit', 'enter', 'exit']
+        assert (tmp_path / 'shared-cache' / '.hermes-agent-browser-warmup.lock').exists()
+    finally:
+        release.touch()
+        for proc in processes:
+            if proc.poll() is None:
+                proc.kill()
+            proc.communicate(timeout=10)
+
+
+def test_validated_fallback_warms_before_publishing_cached_sentinel(monkeypatch):
+    monkeypatch.setattr(browser, '_agent_browser_resolved', False)
+    monkeypatch.setattr(browser, '_cached_agent_browser', None)
+    monkeypatch.setattr(install, '_agent_browser_candidates', lambda path: ())
+    monkeypatch.setattr(install, '_resolve_npx_bin', lambda: 'fake-npx')
+    calls = []
+
+    def warm():
+        assert not browser._agent_browser_resolved
+        assert browser._cached_agent_browser is None
+        calls.append('warm')
+        return False  # Best-effort failure preserves the existing fallback.
+
+    monkeypatch.setattr(install, 'warm_agent_browser_npx_cache', warm)
+    assert install._find_agent_browser(validate=False) == browser.NPX_AGENT_BROWSER_SENTINEL
+    assert calls == []
+    assert install._find_agent_browser() == browser.NPX_AGENT_BROWSER_SENTINEL
+    assert calls == ['warm']
+    assert browser._agent_browser_resolved

--- a/tests/tools/test_browser_shared_warmup.py
+++ b/tests/tools/test_browser_shared_warmup.py
@@ -29,8 +29,8 @@ def test_shared_cache_contention_is_bounded_and_releases_after_warmup(tmp_path, 
 import json, subprocess, sys
 from tools import browser_tool_install as install
 real_popen = subprocess.Popen
-real_which = install.shutil.which
-install.shutil.which = lambda name, *a, **kw: 'fake-npm' if name == 'npm' else real_which(name, *a, **kw)
+real_find_node = install.find_node_executable
+install.find_node_executable = lambda name: 'fake-npm' if name == 'npm' else real_find_node(name)
 install._resolve_npx_bin = lambda: 'fake-npx'
 def spawn(cmd, **kwargs):
     assert cmd[0] in {'fake-npx', 'fake-npm'}

--- a/tools/browser_tool_install.py
+++ b/tools/browser_tool_install.py
@@ -3,6 +3,8 @@
 Split out of ``tools/browser_tool.py``. Facade-owned state is read through ``_bt`` (``tools.browser_tool``, resolved per call) — no import cycle."""
 
 import contextlib
+import errno
+import time
 import functools
 import os
 import shutil
@@ -106,6 +108,21 @@ def _agent_browser_candidates(extended_path: str):
         yield shutil.which("agent-browser", path=str(local_bin_dir))
 
 
+def _agent_browser_npx_lock_path(env: dict[str, str]) -> Path:
+    """Return a lock path shared by every process using the same npm cache."""
+    configured = env.get("NPM_CONFIG_CACHE") or env.get("npm_config_cache")
+    if configured:
+        cache_dir = Path(os.path.expandvars(configured)).expanduser()
+    elif os.name == "nt":
+        local_appdata = env.get("LOCALAPPDATA") or os.environ.get("LOCALAPPDATA")
+        base = local_appdata or env.get("HOME") or str(Path.home())
+        cache_dir = Path(base).expanduser() / "npm-cache"
+    else:
+        home = env.get("HOME") or str(Path.home())
+        cache_dir = Path(home).expanduser() / ".npm"
+    return cache_dir / ".hermes-agent-browser-warmup.lock"
+
+
 def _find_agent_browser(*, validate: bool = True) -> str:
     """Find the agent-browser CLI: PATH, Homebrew/managed dirs, local node_modules/.bin, npx fallback, lazy install.
 
@@ -140,6 +157,8 @@ def _find_agent_browser(*, validate: bool = True) -> str:
             return _accept(candidate)
     # npx fallback (also searches the extended PATH)
     if _resolve_npx_bin():
+        if validate:
+            warm_agent_browser_npx_cache()
         return _accept(_bt.NPX_AGENT_BROWSER_SENTINEL)
     if not validate:
         raise FileNotFoundError("agent-browser CLI not found")
@@ -179,6 +198,17 @@ def warm_agent_browser_npx_cache(timeout: float = 60.0) -> bool:
         return False
     env = _bt._build_browser_env()
     env["PATH"] = _merge_browser_path(env.get("PATH", ""))
+    deadline = time.monotonic() + timeout
+    with _agent_browser_npx_cache_lock(env, timeout=timeout) as acquired:
+        if not acquired:
+            return False
+        remaining = deadline - time.monotonic()
+        return remaining > 0 and _run_agent_browser_npx_warmup(npx_bin, env, remaining)
+
+
+def _run_agent_browser_npx_warmup(npx_bin: str, env: dict, timeout: float) -> bool:
+    """Run under the shared-cache lock, retaining process-tree timeout cleanup."""
+    _bt = _origin()
     popen_kwargs: dict = {"stdout": subprocess.PIPE, "stderr": subprocess.PIPE, "text": True, "env": env}
     if os.name == "posix":
         popen_kwargs.update(creationflags=windows_hide_flags(), start_new_session=True)
@@ -340,3 +370,52 @@ def check_browser_vision_requirements() -> bool:
     except ImportError:
         return False
     return check_vision_requirements()
+
+
+@contextlib.contextmanager
+def _agent_browser_npx_cache_lock(env: dict[str, str], *, timeout: float = 60.0):
+    """Serialize cold writers sharing npm's cache, with a bounded contention wait.
+
+    The lock and npx execution share the caller's timeout budget. Acquisition
+    failure skips warming. Kernel locks release on process death; deleting the
+    npm cache while it is held can replace its inode and defeat serialization.
+    """
+    handle = None
+    acquired = False
+    try:
+        path = _agent_browser_npx_lock_path(env)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        handle = path.open('a+b')
+        if os.name == 'nt':
+            import msvcrt
+            handle.seek(0, os.SEEK_END)
+            if handle.tell() == 0:
+                handle.write(b'\0')
+                handle.flush()
+            handle.seek(0)
+            lock = lambda: msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+            lock = lambda: fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        deadline = time.monotonic() + timeout
+        while True:
+            try:
+                lock()
+                acquired = True
+                break
+            except OSError as exc:
+                if exc.errno not in {errno.EACCES, errno.EAGAIN, errno.EDEADLK}:
+                    raise
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    _origin().logger.debug('Skipping npx warmup: shared cache lock remained contended')
+                    break
+                time.sleep(min(0.1, remaining))
+    except OSError:
+        _origin().logger.debug('Skipping npx warmup: shared cache lock unavailable', exc_info=True)
+    try:
+        yield acquired
+    finally:
+        if handle is not None:
+            # Closing releases flock and Windows byte locks, including on exceptions.
+            handle.close()

--- a/tools/browser_tool_install.py
+++ b/tools/browser_tool_install.py
@@ -108,19 +108,27 @@ def _agent_browser_candidates(extended_path: str):
         yield shutil.which("agent-browser", path=str(local_bin_dir))
 
 
-def _agent_browser_npx_lock_path(env: dict[str, str]) -> Path:
-    """Return a lock path shared by every process using the same npm cache."""
-    configured = env.get("NPM_CONFIG_CACHE") or env.get("npm_config_cache")
-    if configured:
-        cache_dir = Path(os.path.expandvars(configured)).expanduser()
-    elif os.name == "nt":
-        local_appdata = env.get("LOCALAPPDATA") or os.environ.get("LOCALAPPDATA")
-        base = local_appdata or env.get("HOME") or str(Path.home())
-        cache_dir = Path(base).expanduser() / "npm-cache"
-    else:
-        home = env.get("HOME") or str(Path.home())
-        cache_dir = Path(home).expanduser() / ".npm"
-    return cache_dir / ".hermes-agent-browser-warmup.lock"
+def _agent_browser_npx_lock_path(env: dict[str, str], *, timeout: float = 5.0) -> Optional[Path]:
+    """Use npm's effective cache, including project/user npmrc configuration."""
+    configured = env.get("npm_config_cache") or env.get("NPM_CONFIG_CACHE")
+    if not configured:
+        npm = shutil.which("npm", path=env.get("PATH"))
+        if not npm:
+            return None
+        try:
+            result = subprocess.run(
+                [npm, "config", "get", "cache"], env=env, stdin=subprocess.DEVNULL,
+                capture_output=True, text=True, timeout=max(0.0, timeout),
+                creationflags=windows_hide_flags(),
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+        if result.returncode != 0:
+            return None
+        configured = result.stdout.strip()
+        if not configured:
+            return None
+    return Path(configured).expanduser() / ".hermes-agent-browser-warmup.lock"
 
 
 def _find_agent_browser(*, validate: bool = True) -> str:
@@ -380,10 +388,15 @@ def _agent_browser_npx_cache_lock(env: dict[str, str], *, timeout: float = 60.0)
     failure skips warming. Kernel locks release on process death; deleting the
     npm cache while it is held can replace its inode and defeat serialization.
     """
+    deadline = time.monotonic() + timeout
+    path = _agent_browser_npx_lock_path(env, timeout=min(5.0, timeout))
+    if path is None:
+        _origin().logger.debug('Skipping npx warmup: effective npm cache unavailable')
+        yield False
+        return
     handle = None
     acquired = False
     try:
-        path = _agent_browser_npx_lock_path(env)
         path.parent.mkdir(parents=True, exist_ok=True)
         handle = path.open('a+b')
         if os.name == 'nt':
@@ -397,7 +410,6 @@ def _agent_browser_npx_cache_lock(env: dict[str, str], *, timeout: float = 60.0)
         else:
             import fcntl
             lock = lambda: fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        deadline = time.monotonic() + timeout
         while True:
             try:
                 lock()

--- a/tools/browser_tool_install.py
+++ b/tools/browser_tool_install.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from hermes_cli._subprocess_compat import windows_hide_flags
-from hermes_constants import agent_browser_runnable, get_hermes_home, is_termux as _is_termux_environment, node_tool_runnable
+from hermes_constants import agent_browser_runnable, find_node_executable, get_hermes_home, is_termux as _is_termux_environment, node_tool_runnable
 from tools.browser_tool_origin import origin_module as _origin
 from tools import browser_tool_cdp as _cdp
 from tools import browser_tool_cloud as _cloud
@@ -112,7 +112,7 @@ def _agent_browser_npx_lock_path(env: dict[str, str], *, timeout: float = 5.0) -
     """Use npm's effective cache, including project/user npmrc configuration."""
     configured = env.get("npm_config_cache") or env.get("NPM_CONFIG_CACHE")
     if not configured:
-        npm = shutil.which("npm", path=env.get("PATH"))
+        npm = find_node_executable("npm")
         if not npm:
             return None
         try:


### PR DESCRIPTION
## Summary

- serialize cold `npx agent-browser` warm-ups across Hermes processes that share the same npm cache
- use cache-scoped POSIX/Windows file locking, including retrying transient Windows byte-lock contention beyond `msvcrt.LK_LOCK`'s short retry window
- warm before caching the validated `npx agent-browser` fallback sentinel, while preserving the existing best-effort/no-raise contract and credential-scrubbed subprocess environment

## Why

Parallel cold `npx agent-browser` invocations can mutate the same npm `_npx/<hash>` tree and race during package-directory rename, producing intermittent `ENOTEMPTY` failures. Separate Hermes profiles may share one npm cache, so a process-local or profile-local lock is insufficient.

## 2026-09-03 refresh

Rebased onto current `main` (`b9dc790332`). The cache-scoped locking behavior and current pinned/credential-scrubbed npx invocation are both preserved. Focused browser warm-up/path suites pass 56/56; Ruff, `compileall`, and `git diff --check` pass on head `0c9b9064b5`.

## Verification

- `pytest -q -o addopts= tests/tools/test_browser_npx_warmup.py tests/tools/test_browser_homebrew_paths.py` — 56 passed
- related Windows/autoinstall/update selection — 15 passed, 3 skipped
- doctor warm-up call-path selection — 6 passed
- dependency-ensure selection — 4 passed
- subscription capability selection — 6 passed
- Ruff, `compileall`, and `git diff --check` — passed
- independent exact-snapshot review — GO

The regression coverage includes a real two-process POSIX serialization test, Windows contention retry/unlock behavior, fail-closed lock acquisition, shared-cache path selection, and warm-before-sentinel ordering.
