### PR TITLE
fix(install): refuse ConstrainedLanguage with a reason instead of a .NET error

### DIFF
--- a/.github/workflows/installer-tests.yml
+++ b/.github/workflows/installer-tests.yml
@@ -36,3 +36,16 @@ jobs:
       - name: 8.3 short-path normalization (Windows PowerShell 5.1)
         shell: powershell
         run: powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-longpath.ps1
+
+      # The language mode preflight (#89857) is the one guard that must hold on a
+      # host where almost nothing else in install.ps1 can run, so it is worth
+      # asserting on both shells too: the child runspace is dropped into
+      # ConstrainedLanguage by the test itself, so no AppLocker/WDAC policy is
+      # needed on the runner.
+      - name: Language mode preflight (pwsh 7)
+        shell: pwsh
+        run: pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-language-mode.ps1
+
+      - name: Language mode preflight (Windows PowerShell 5.1)
+        shell: powershell
+        run: powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-language-mode.ps1

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -77,6 +77,63 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+# ============================================================================
+# PowerShell language mode preflight
+# ============================================================================
+# AppLocker and WDAC in enforcement mode drop PowerShell into
+# ConstrainedLanguage, which refuses method calls on anything but a short list
+# of core types: [Environment]::GetEnvironmentVariable, [Environment]::
+# GetFolderPath, [Console]::Error.WriteLine, New-Object on a .NET type and
+# [System.IO.File]::WriteAllText all throw
+# MethodInvocationNotSupportedInConstrainedLanguage. This installer makes more
+# than forty of those calls.
+#
+# The first one runs at SCRIPT scope in Set-LongProfileEnvVars a couple of
+# hundred lines below, so the script dies before any parameter is honored --
+# including -Manifest and -ProtocolVersion, which are read-only queries that
+# touch nothing. What the operator gets instead is a raw .NET error, localized
+# into the host language, naming a line number inside a cached copy of a
+# script they never wrote (#89857).
+#
+# Fail here instead, while we still can, and say what is wrong. This is a
+# refusal, not a workaround: there is no flag that makes the rest of the file
+# run, because the restriction is on the language, not on this script.
+#
+# Every construct below is legal under ConstrainedLanguage: a property read on
+# an automatic variable, string concatenation, Write-Host and Write-Error.
+# $host.UI.WriteErrorLine is NOT -- it is a method call on a non-core type and
+# throws the exact error this block exists to explain -- so the detail goes
+# out through Write-Error, whose cmdlet form is allowed.
+$DetectedLanguageMode = [string]$ExecutionContext.SessionState.LanguageMode
+if ($DetectedLanguageMode -and $DetectedLanguageMode -ne 'FullLanguage') {
+    Write-Host ""
+    Write-Host "[X] Hermes cannot install in PowerShell $DetectedLanguageMode mode." -ForegroundColor Red
+    Write-Host ""
+    Write-Host "    This session is restricted by an application control policy" -ForegroundColor Yellow
+    Write-Host "    (AppLocker, WDAC, or Windows Defender Application Control)." -ForegroundColor Yellow
+    Write-Host "    In this mode PowerShell refuses the .NET calls the installer" -ForegroundColor Yellow
+    Write-Host "    needs to read environment variables and locate profile folders." -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "    -ExecutionPolicy Bypass does not help. Execution policy and" -ForegroundColor Yellow
+    Write-Host "    language mode are separate controls; bypassing the first" -ForegroundColor Yellow
+    Write-Host "    leaves the second exactly as it was." -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "    PowerShell applies the restriction because this script sits in" -ForegroundColor Yellow
+    Write-Host "    a user-writable directory that the policy does not trust. Ask" -ForegroundColor Yellow
+    Write-Host "    whoever administers the policy to either:" -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "      * allow-list the installer's path, or" -ForegroundColor Yellow
+    Write-Host "      * let you run it from a directory the policy already trusts" -ForegroundColor Yellow
+    Write-Host "        (typically %ProgramFiles% or %SystemRoot%)." -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "    Confirm the fix worked before re-running:" -ForegroundColor Yellow
+    Write-Host "      `$ExecutionContext.SessionState.LanguageMode" -ForegroundColor Yellow
+    Write-Host "    must print FullLanguage." -ForegroundColor Yellow
+    Write-Host ""
+    Write-Error -Message ("install.ps1 requires FullLanguage; this session is " + $DetectedLanguageMode) -ErrorAction Continue
+    exit 1
+}
+
 # Suppress Invoke-WebRequest's per-chunk progress bar.  Windows PowerShell
 # 5.1's progress UI repaints synchronously on every received byte, which
 # pegs CPU on a single core and throttles downloads by 10-100x (a 57MB

--- a/scripts/tests/test-install-ps1-language-mode.ps1
+++ b/scripts/tests/test-install-ps1-language-mode.ps1
@@ -1,0 +1,165 @@
+# Regression tests for install.ps1's PowerShell language mode preflight (#89857).
+#
+# Run from a PowerShell prompt:
+#
+#   powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-language-mode.ps1
+#
+# AppLocker / WDAC enforcement puts PowerShell in ConstrainedLanguage, where
+# method calls on non-core .NET types are refused. install.ps1 makes one at
+# script scope long before it looks at its own parameters, so without the
+# preflight even -ProtocolVersion -- a read-only query that touches nothing --
+# dies with a raw, host-localized .NET error pointing into a cached copy of a
+# script the operator never wrote.
+#
+# These tests run the installer as a real subprocess in a runspace that has
+# been put into ConstrainedLanguage, which is the same restriction the policy
+# applies. They do NOT need AppLocker configured on the runner.
+#
+# Nothing here installs anything: both invocations use -ProtocolVersion, which
+# returns before Main / Invoke-AllStages.
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path))
+$installScript = Join-Path $repoRoot "scripts\install.ps1"
+
+if (-not (Test-Path $installScript)) {
+    throw "Could not locate install.ps1 at $installScript"
+}
+
+$failures = 0
+function Assert-Equal {
+    param([Parameter(Mandatory=$true)] $Expected,
+          [Parameter(Mandatory=$true)] $Actual,
+          [Parameter(Mandatory=$true)] [string]$Label)
+    if ($Expected -ne $Actual) {
+        Write-Host "FAIL: $Label" -ForegroundColor Red
+        Write-Host "  expected: $Expected"
+        Write-Host "  actual:   $Actual"
+        $script:failures++
+    } else {
+        Write-Host "OK: $Label" -ForegroundColor Green
+    }
+}
+function Assert-True {
+    param([Parameter(Mandatory=$true)] $Condition,
+          [Parameter(Mandatory=$true)] [string]$Label)
+    if (-not $Condition) {
+        Write-Host "FAIL: $Label" -ForegroundColor Red
+        $script:failures++
+    } else {
+        Write-Host "OK: $Label" -ForegroundColor Green
+    }
+}
+
+# The shell that delivers install.ps1 is whatever the user already has, so the
+# child must be the SAME host this test is running under -- 5.1 and 7 differ in
+# how they surface a terminating error from a child script, and the CI job runs
+# this file under both.
+$psExe = (Get-Process -Id $PID).Path
+
+# Run a scriptblock's worth of PowerShell as a subprocess whose runspace has
+# been dropped into ConstrainedLanguage first. Streams go to files rather than
+# through the pipeline: Windows PowerShell 5.1 wraps a child's stderr in a
+# NativeCommandError and folds it into the caller's own error stream, which
+# would make an ordinary 2>&1 capture look like a failure of this test.
+function Invoke-Constrained {
+    param([Parameter(Mandatory=$true)] [string]$Body)
+
+    $dir = Join-Path ([System.IO.Path]::GetTempPath()) ("hermes-clm-" + [Guid]::NewGuid().ToString("N"))
+    New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    $wrapper = Join-Path $dir "wrapper.ps1"
+    $outFile = Join-Path $dir "out.txt"
+    $errFile = Join-Path $dir "err.txt"
+
+    # The mode assignment is one-way within a session, so it must happen in the
+    # child rather than here -- this test process stays FullLanguage.
+    $script = "`$ExecutionContext.SessionState.LanguageMode = 'ConstrainedLanguage'" + [Environment]::NewLine + $Body
+    Set-Content -LiteralPath $wrapper -Value $script -Encoding ascii
+
+    $proc = Start-Process -FilePath $psExe `
+        -ArgumentList @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $wrapper) `
+        -Wait -PassThru -NoNewWindow `
+        -RedirectStandardOutput $outFile -RedirectStandardError $errFile
+
+    $result = [pscustomobject]@{
+        ExitCode = $proc.ExitCode
+        Output   = ((Get-Content -LiteralPath $outFile -Raw -ErrorAction SilentlyContinue) + [Environment]::NewLine +
+                    (Get-Content -LiteralPath $errFile -Raw -ErrorAction SilentlyContinue))
+    }
+    Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue
+    return $result
+}
+
+# -----------------------------------------------------------------------------
+# Guardrail: the harness really is constrained.
+#
+# Without this the whole file passes vacuously on any host where the mode
+# assignment silently does not take -- every assertion below would be checking
+# FullLanguage behavior while claiming to check ConstrainedLanguage.
+# -----------------------------------------------------------------------------
+Write-Host ""
+Write-Host "-- harness --"
+$probe = Invoke-Constrained -Body @'
+Write-Output ("mode=" + $ExecutionContext.SessionState.LanguageMode)
+try { $null = [Environment]::GetEnvironmentVariable('TEMP'); Write-Output 'dotnet=ALLOWED' }
+catch { Write-Output ('dotnet=' + $_.FullyQualifiedErrorId) }
+'@
+Assert-True ($probe.Output -match 'mode=ConstrainedLanguage') `
+    -Label "harness runspace reports ConstrainedLanguage"
+Assert-True ($probe.Output -match 'dotnet=MethodInvocationNotSupportedInConstrainedLanguage') `
+    -Label "harness refuses [Environment]::GetEnvironmentVariable (the call install.ps1 dies on)"
+
+# -----------------------------------------------------------------------------
+# Test: the preflight fires before anything else can throw.
+#
+# -ProtocolVersion is the strongest form of this: it is a read-only query, so
+# the ONLY reason it can fail is the language mode.
+# -----------------------------------------------------------------------------
+Write-Host ""
+Write-Host "-- ConstrainedLanguage --"
+$constrained = Invoke-Constrained -Body ("& '" + $installScript + "' -ProtocolVersion" + [Environment]::NewLine + "exit `$LASTEXITCODE")
+
+Assert-Equal -Expected 1 -Actual $constrained.ExitCode `
+    -Label "-ProtocolVersion exits 1 under ConstrainedLanguage"
+Assert-True ($constrained.Output -match 'ConstrainedLanguage mode') `
+    -Label "the message names the language mode"
+Assert-True ($constrained.Output -match 'ExecutionPolicy Bypass does not help') `
+    -Label "the message pre-empts the -ExecutionPolicy Bypass attempt (#89857's step 2)"
+Assert-True ($constrained.Output -match 'allow-list') `
+    -Label "the message says what an administrator has to change"
+
+# This is the regression itself: before the preflight, the run died inside
+# Set-LongProfileEnvVars with a .NET error and no mention of why.
+Assert-True (-not ($constrained.Output -match 'MethodInvocationNotSupportedInConstrainedLanguage')) `
+    -Label "the raw .NET error never reaches the operator"
+Assert-True (-not ($constrained.Output -match 'GetEnvironmentVariable')) `
+    -Label "the failure does not surface an install.ps1 line number"
+
+# -----------------------------------------------------------------------------
+# Test: FullLanguage is untouched.
+#
+# The guard is a refusal, so the thing most worth pinning is that it does not
+# fire on the hosts every other user has.
+# -----------------------------------------------------------------------------
+Write-Host ""
+Write-Host "-- FullLanguage --"
+$version = & $psExe -NoProfile -ExecutionPolicy Bypass -File $installScript -ProtocolVersion
+Assert-Equal -Expected 0 -Actual $LASTEXITCODE -Label "-ProtocolVersion still exits 0 under FullLanguage"
+Assert-True ($version -match '^\d+$') -Label "-ProtocolVersion still emits an integer (got: $version)"
+
+$manifest = & $psExe -NoProfile -ExecutionPolicy Bypass -File $installScript -Manifest
+Assert-Equal -Expected 0 -Actual $LASTEXITCODE -Label "-Manifest still exits 0 under FullLanguage"
+Assert-True (($manifest -join '') -match '"protocol_version"') `
+    -Label "-Manifest still emits the manifest, so the guard did not pollute stdout"
+
+# -----------------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------------
+Write-Host ""
+if ($failures -gt 0) {
+    Write-Host "FAILED: $failures assertion(s) failed" -ForegroundColor Red
+    exit 1
+} else {
+    Write-Host "All language mode tests passed." -ForegroundColor Green
+    exit 0
+}


### PR DESCRIPTION
## Read this first: it does not make the install work

`Refs #89857`, not `Fixes`. This does not let anyone install under Constrained Language Mode. It makes the failure legible, and it stops the installer from dying in a way that points the operator at the wrong thing.

Whether Hermes should support CLM at all is a maintainer decision, and I have put the measurements for it at the bottom rather than deciding it in a PR.

## What does this PR do?

`install.ps1` makes more than forty method calls on non-core .NET types. Constrained Language Mode refuses every one of them. The first is at **script scope**, so it fires before the script has looked at a single parameter:

```powershell
$script:NormalizedProfilePaths = Set-LongProfileEnvVars   # line ~327, runs on load
    -> foreach ($name in @('TEMP','TMP','LOCALAPPDATA','APPDATA','USERPROFILE')) {
           $current = [Environment]::GetEnvironmentVariable($name)   # line 312 -- refused
```

That is why the report's log shows `stage=__manifest__`: `-Manifest` is a read-only query that touches nothing on disk, and it still cannot answer. Same for `-ProtocolVersion`. The bootstrap gets exit 1 and forwards a raw .NET error, localized into the host language, naming line 312 of a file in `AppData\Local\hermes\bootstrap-cache\` that the operator did not write. Nothing in that output contains the words "language mode".

This adds a preflight at the top of the script that detects the mode and says so. Every construct in it is CLM-legal: a property read on an automatic variable, string concatenation, `Write-Host`, and `Write-Error`. `$host.UI.WriteErrorLine` is **not** legal there, and neither is `[Console]::Error.WriteLine` (which `Write-PathDiag` uses) -- both are method calls on non-core types and would throw the exact error the block exists to explain.

## Related Issue

Refs #89857

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `scripts/install.ps1` - a language mode preflight immediately after `$ErrorActionPreference = "Stop"`, before the UTF-8 console block and well before the 8.3 normalization that currently kills the run. Fires on anything that is not `FullLanguage`, prints an explanation, and exits 1. **57 lines added, 0 changed** - no existing line is touched.
- `scripts/tests/test-install-ps1-language-mode.ps1` - new, following the `Assert-Equal`/`Assert-True` shape of the three tests already in that directory.
- `.github/workflows/installer-tests.yml` - runs the new file on pwsh 7 and Windows PowerShell 5.1, the same pair the 8.3 test already uses.

### What the operator sees now

```
[X] Hermes cannot install in PowerShell ConstrainedLanguage mode.

    This session is restricted by an application control policy
    (AppLocker, WDAC, or Windows Defender Application Control).
    In this mode PowerShell refuses the .NET calls the installer
    needs to read environment variables and locate profile folders.

    -ExecutionPolicy Bypass does not help. Execution policy and
    language mode are separate controls; bypassing the first
    leaves the second exactly as it was.

    PowerShell applies the restriction because this script sits in
    a user-writable directory that the policy does not trust. Ask
    whoever administers the policy to either:

      * allow-list the installer's path, or
      * let you run it from a directory the policy already trusts
        (typically %ProgramFiles% or %SystemRoot%).

    Confirm the fix worked before re-running:
      $ExecutionContext.SessionState.LanguageMode
    must print FullLanguage.
```

The `-ExecutionPolicy Bypass` sentence is there because it is the reporter's own step 2. They tried it, it did not help, and nothing told them why. It is the sentence I would most want kept if the message gets trimmed.

### Three decisions worth a maintainer's eye

**1. It refuses rather than degrades.** A partial port that made line 312 CLM-safe would move the crash to the next blocked call and leave a half-configured tree behind. I would rather the installer stop while it can still explain itself. If you would prefer best-effort-then-fail, the guard becomes a warning and the mutation table below tells you which test to expect to flip (M3).

**2. Exit code 1, not a new one.** The stage protocol documents `0` success, `1` generic failure, `2` unknown stage. A distinct code (say `3`) would let the Rust bootstrap render this specially instead of forwarding text, but that extends a documented contract and drivers would need to learn it. I used `1`. Say the word and I will add `3` plus the protocol doc entry.

**3. No override flag.** There is deliberately no `-IgnoreLanguageMode`. Anything that got past the guard would fail ~200 lines later with the original error, so the flag's only real effect would be to restore the confusing failure.

## How to Test

```powershell
powershell -NoProfile -ExecutionPolicy Bypass -File scripts\tests\test-install-ps1-language-mode.ps1   # 12/12
powershell -NoProfile -ExecutionPolicy Bypass -File scripts\tests\test-install-ps1-stage-protocol.ps1  # unchanged, passes
powershell -NoProfile -ExecutionPolicy Bypass -File scripts\tests\test-install-ps1-longpath.ps1        # unchanged, passes
```

No AppLocker or WDAC policy is needed on the runner: the test drops a **child** runspace into `ConstrainedLanguage` with `$ExecutionContext.SessionState.LanguageMode = 'ConstrainedLanguage'`, which is the same restriction the policy applies, and runs `install.ps1` inside it as a real subprocess.

To see the old behavior, revert `scripts/install.ps1` and re-run the first file: five assertions fail and the raw error comes back.

## Verification

**The failure reproduces exactly, on a real Windows 11 box.** Against pristine `upstream/main` in a constrained child:

```
Cannot invoke method. Method invocation is supported only on core types in this language mode.
At C:\Users\jackl\AppData\Local\Temp\install-pristine.ps1:312 char:9
+         $current = [Environment]::GetEnvironmentVariable($name)
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + FullyQualifiedErrorId : MethodInvocationNotSupportedInConstrainedLanguage
```

Same line, same character offset, same error id as the report -- in English rather than the reporter's Spanish, which is itself the point: the text an operator gets is host-localized, so it cannot be searched for.

**Mutation proof - 6 mutations, 6 caught:**

| # | Mutation | Caught by |
|---|---|---|
| 1 | guard removed entirely (the reported bug) | 5 assertions |
| 2 | condition inverted, fires on `FullLanguage` instead | 9 assertions, including every FullLanguage regression check |
| 3 | `exit 1` removed, so it warns and continues | 2 - the run reaches line 312 and the raw error resurfaces |
| 4 | stderr via `$host.UI.WriteErrorLine` instead of `Write-Error` | 1 - the guard itself throws under CLM |
| 5 | the `-ExecutionPolicy Bypass` sentence dropped | 1 |
| 6 | guard moved after the 8.3 normalization block | 5 - placement, not presence, is what makes it work |

Mutation 6 is the one worth looking at: the guard is only useful *before* `Set-LongProfileEnvVars` runs at script scope, and nothing about the code's appearance says so. That assertion is what stops a future reshuffle from silently reverting this.

**The test cannot pass vacuously.** Its first two assertions check the harness itself: that the child reports `ConstrainedLanguage`, and that `[Environment]::GetEnvironmentVariable` really is refused inside it. Without those, a host where the mode assignment silently did not take would run every remaining assertion against FullLanguage and report green.

**Platform:** Windows 11, Windows PowerShell 5.1. **I could not run pwsh 7 locally** - it is not installed on this machine - so the pwsh 7 job added to `installer-tests.yml` is the first real execution of this file under 7. Flagging that rather than implying I tested both.

`scripts/install.ps1` stays pure ASCII with CRLF endings, as its own header requires.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate: no open or merged PR names #89857, and a search for `ConstrainedLanguage` / `LanguageMode` across open PRs returns nothing
- [x] My PR contains **only** changes related to this fix (no unrelated commits): one commit, one added block, one new test, one workflow wiring
- [x] I've run the tests and all pass: all three installer suites above, on 5.1
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation or N/A: the block documents itself and names why each construct in it was chosen
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A: no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility): Windows-only file. On any host reporting `FullLanguage` (which includes every non-Windows PowerShell) the guard is a single string comparison and does nothing
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## What a real CLM port would cost, if you want one

I measured this before choosing to refuse, and the answer is not "impossible", it is "a decision with trade-offs":

| construct | count | CLM-legal replacement | cost |
|---|---|---|---|
| `[Environment]::GetEnvironmentVariable($n)` (process scope) | 5 | `(Get-Item "Env:$n").Value` or `$env:$n` | none - the file already uses `Set-Item "Env:$name"` for the *write* one line below the read that fails |
| `[Environment]::GetEnvironmentVariable("Path","User"\|"Machine")` and the matching `SetEnvironmentVariable` | 18 | `Get-ItemProperty`/`Set-ItemProperty` on `HKCU:\Environment` and the machine key | loses the `WM_SETTINGCHANGE` broadcast .NET does, so open shells keep a stale PATH |
| `[Environment]::GetFolderPath(...)` | 4 | no cmdlet equivalent | already fallback-only in `Get-LongProfileRoot`; the shortcut sites at ~4131 have no equivalent |
| `New-Object System.Diagnostics.Process` | 2 | `Start-Process` | changes stdout/stderr capture semantics |
| `[System.IO.File]::WriteAllText($p,$s,$utf8NoBom)` | 3 | `Set-Content -Encoding utf8` | **behavior change on 5.1**: it writes a BOM, and these sites pass `UTF8Encoding($false)` deliberately |
| `Add-Type` P/Invoke for `GetLongPathNameW` | 1 | none | already wrapped in try/catch with two fallbacks, so it degrades today |

I verified each replacement in a constrained runspace rather than reasoning about it -- `Get-Item Env:`, `$env:`, `Get-ItemProperty HKCU:\Environment` and `ConvertTo-Json` are all allowed; `[Environment]::*`, `[Console]::*` and `$host.UI.WriteErrorLine` are all refused.

The two rows that make it a decision rather than a chore are the PATH broadcast and the BOM. Both are silent behavior changes on hosts that are working fine today, in exchange for supporting a locked-down configuration. Happy to do the port as a follow-up if that trade is one you want to make, but it should be its own PR with its own argument, not smuggled in behind an error message.
