### PR TITLE
fix(providers): strip name/tool_name from NVIDIA NIM tool messages

### DIFF
--- a/contributors/emails/rroveri@nvidia.com
+++ b/contributors/emails/rroveri@nvidia.com
@@ -1,0 +1,1 @@
+rroverin

--- a/plugins/model-providers/nvidia/__init__.py
+++ b/plugins/model-providers/nvidia/__init__.py
@@ -1,9 +1,34 @@
 """NVIDIA NIM provider profile."""
 
+import copy
+from typing import Any
+
 from providers import register_provider
 from providers.base import ProviderProfile
 
-nvidia = ProviderProfile(
+
+class NvidiaProviderProfile(ProviderProfile):
+    """NVIDIA NIM accepts a stricter ToolMessage schema than most OpenAI-compatible APIs."""
+
+    def prepare_messages(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        needs_sanitize = any(
+            isinstance(msg, dict)
+            and msg.get("role") == "tool"
+            and ("name" in msg or "tool_name" in msg)
+            for msg in messages
+        )
+        if not needs_sanitize:
+            return messages
+
+        sanitized = copy.deepcopy(messages)
+        for msg in sanitized:
+            if isinstance(msg, dict) and msg.get("role") == "tool":
+                msg.pop("name", None)
+                msg.pop("tool_name", None)
+        return sanitized
+
+
+nvidia = NvidiaProviderProfile(
     name="nvidia",
     aliases=("nvidia-nim",),
     env_vars=("NVIDIA_API_KEY",),

--- a/plugins/model-providers/nvidia/__init__.py
+++ b/plugins/model-providers/nvidia/__init__.py
@@ -1,6 +1,5 @@
 """NVIDIA NIM provider profile."""
 
-import copy
 from typing import Any
 
 from providers import register_provider
@@ -20,11 +19,25 @@ class NvidiaProviderProfile(ProviderProfile):
         if not needs_sanitize:
             return messages
 
-        sanitized = copy.deepcopy(messages)
-        for msg in sanitized:
-            if isinstance(msg, dict) and msg.get("role") == "tool":
-                msg.pop("name", None)
-                msg.pop("tool_name", None)
+        # Copy-on-write: shallow outer-list copy, then a shallow dict copy
+        # only for the role:"tool" messages that actually need a field
+        # dropped. Avoids recursively deep-copying every message's content
+        # (including large tool outputs and attachments) for a turn that
+        # only ever needs to touch two top-level keys on a handful of
+        # messages. Matches the pattern already used by the shared
+        # sanitizer in agent/transports/chat_completions.py and by
+        # QwenProfile.prepare_messages().
+        sanitized = list(messages)
+        for idx, msg in enumerate(messages):
+            if (
+                isinstance(msg, dict)
+                and msg.get("role") == "tool"
+                and ("name" in msg or "tool_name" in msg)
+            ):
+                msg_copy = dict(msg)
+                msg_copy.pop("name", None)
+                msg_copy.pop("tool_name", None)
+                sanitized[idx] = msg_copy
         return sanitized
 
 

--- a/tests/providers/test_e2e_wiring.py
+++ b/tests/providers/test_e2e_wiring.py
@@ -39,6 +39,51 @@ class TestNvidiaProfileWiring:
         assert kwargs["model"] == "nvidia/test-model"
 
 
+    def test_nvidia_tool_messages_drop_name_fields(self, transport):
+        profile = get_provider_profile("nvidia")
+        msgs = [
+            {"role": "user", "content": "run a command"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "name": "terminal",
+                "tool_name": "terminal",
+                "tool_call_id": "call_1",
+                "content": "ok",
+            },
+        ]
+        kwargs = transport.build_kwargs(
+            model="mistralai/mistral-large-3-675b-instruct-2512",
+            messages=msgs,
+            tools=None,
+            provider_profile=profile,
+            max_tokens=None,
+            max_tokens_param_fn=lambda x: {"max_tokens": x} if x else {},
+            timeout=300,
+            reasoning_config=None,
+            request_overrides=None,
+            session_id="test",
+            ollama_num_ctx=None,
+        )
+
+        assert kwargs["messages"][2] == {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": "ok",
+        }
+        assert msgs[2]["name"] == "terminal"
+        assert msgs[2]["tool_name"] == "terminal"
+
 
 class TestDeepSeekProfileWiring:
     def test_deepseek_no_forced_max_tokens(self, transport):

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -25,6 +25,47 @@ class TestNvidiaProfile:
         assert "nvidia.com" in p.base_url
 
 
+    def test_prepare_messages_strips_tool_result_names(self):
+        p = get_provider_profile("nvidia")
+        msgs = [
+            {"role": "user", "content": "run a command"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "name": "terminal",
+                "tool_name": "terminal",
+                "tool_call_id": "call_1",
+                "content": "ok",
+            },
+        ]
+
+        result = p.prepare_messages(msgs)
+
+        assert "name" not in result[2]
+        assert "tool_name" not in result[2]
+        assert result[2] == {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": "ok",
+        }
+        assert msgs[2]["name"] == "terminal"
+        assert msgs[2]["tool_name"] == "terminal"
+
+    def test_prepare_messages_passthrough_without_tool_result_names(self):
+        p = get_provider_profile("nvidia")
+        msgs = [{"role": "tool", "tool_call_id": "call_1", "content": "ok"}]
+        assert p.prepare_messages(msgs) is msgs
+
 
 class TestKimiProfile:
     def test_temperature_omit(self):


### PR DESCRIPTION
## What does this PR do?

Finishes #30674 (originally by @pmos69, who diagnosed and fixed the root
cause). This PR:

- Cherry-picks @pmos69's original fix as-is (commit preserved with their
  authorship) — an NVIDIA-specific `prepare_messages()` hook that strips
  `name` and `tool_name` from `role: "tool"` messages before they reach
  NVIDIA NIM's stricter ToolMessage schema.
- Adds a follow-up commit addressing @teknium1's unresolved review comment
  on #30674: switches from `copy.deepcopy()` of the whole conversation to
  the copy-on-write pattern already used elsewhere in the codebase
  (`agent/transports/chat_completions.py`'s shared sanitizer,
  `QwenProfile.prepare_messages()`) — avoids deep-copying every message's
  content/attachments to sanitize two keys on a handful of messages.

Closes #30662. Supersedes #30674 (same fix, review comment addressed).

## Root cause

Confirmed still present on current `main`: `make_tool_result_message()`
(`agent/tool_dispatch_helpers.py`) builds every tool-result message with
both `name` and `tool_name`. The shared transport-level sanitizer in
`agent/transports/chat_completions.py` already strips `tool_name` for all
providers, but never touches `name` — so `name` still reaches NVIDIA NIM's
schema.

## Related Issue

Fixes #30662

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/model-providers/nvidia/__init__.py`: new `NvidiaProviderProfile`
  subclass with `prepare_messages()` that strips `name`/`tool_name` from
  `role: "tool"` messages using copy-on-write (not deepcopy)

## How to Test

```
scripts/run_tests.sh tests/providers/test_provider_profiles.py tests/providers/test_e2e_wiring.py tests/agent/transports/test_chat_completions.py
```

## Checklist

- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs — this directly continues #30674
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` — will run on test machine once PR is open
- [x] I've added tests for my changes — tests from #30674 are included via cherry-pick
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
- [x] I've considered cross-platform impact — pure Python dict operations, no platform dependency

## Credit

All original diagnosis and the core fix design are @pmos69's (#30674).
This PR only addresses the outstanding review comment and finishes what
they started.

