### PR TITLE
fix(desktop): paint prefetched history during cold resume

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -772,6 +772,67 @@ describe('resumeSession failure recovery', () => {
     expect($messages.get().length).toBeGreaterThan(0)
   })
 
+  it('paints the REST transcript while a cold runtime resume is still pending', async () => {
+    const runtimeResume = deferred<SessionResumeResponse>()
+
+    const requestGateway = vi.fn((method: string) => {
+      if (method === 'session.resume') {
+        return runtimeResume.promise
+      }
+
+      return Promise.resolve({})
+    })
+
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({
+      messages: [
+        { content: 'older question', role: 'user', timestamp: 1 },
+        { content: 'older answer', role: 'assistant', timestamp: 2 },
+        { content: 'history visible before runtime', role: 'user', timestamp: 3 }
+      ],
+      session_id: 'stored-1'
+    } as never)
+
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+    render(<ResumeHarness onReady={ready => (resume = ready)} requestGateway={requestGateway as never} />)
+    await waitFor(() => expect(resume).not.toBeNull())
+
+    let settled = false
+
+    const pending = resume!('stored-1', true).then(() => {
+      settled = true
+    })
+
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('session.resume', expect.anything()))
+    await waitFor(() => expect(JSON.stringify($messages.get())).toContain('history visible before runtime'))
+    expect(settled).toBe(false)
+
+    await act(async () => {
+      runtimeResume.resolve({
+        session_id: 'runtime-1',
+        session_key: 'stored-1',
+        resumed: 'stored-1',
+        message_count: 3,
+        messages: [],
+        messages_omitted: true,
+        running: true,
+        inflight: {
+          user: 'history visible before runtime',
+          assistant: 'partial runtime tail',
+          streaming: true
+        },
+        info: {}
+      } as never)
+      await pending
+    })
+
+    const promptRows = $messages
+      .get()
+      .filter(message => JSON.stringify(message).includes('history visible before runtime'))
+
+    expect(promptRows).toHaveLength(1)
+    expect(JSON.stringify($messages.get())).toContain('partial runtime tail')
+  })
+
   it('preserves an optimistic user message during a same-session reconnect', async () => {
     setMessages([
       {
@@ -1744,7 +1805,7 @@ describe('resumeSession warm-cache mapping integrity', () => {
     expect(sessionStateByRuntimeIdRef.current.has('rt-recycled')).toBe(false)
   })
 
-  it('paints the bounded latest transcript after the deferred resume acknowledgement', async () => {
+  it('paints the bounded latest transcript before the deferred resume acknowledgement without rebuilding it', async () => {
     const latestPage = Array.from({ length: 500 }, (_, index) => ({
       content: `message-${index}`,
       role: index % 2 === 0 ? ('user' as const) : ('assistant' as const),
@@ -1779,7 +1840,8 @@ describe('resumeSession warm-cache mapping integrity', () => {
 
     await waitFor(() => expect(getLatestSessionMessages).toHaveBeenCalledTimes(1))
     expect(getLatestSessionMessages).toHaveBeenCalledWith('stored-A', undefined)
-    expect($messages.get()).toHaveLength(0)
+    await waitFor(() => expect($messages.get()).toHaveLength(500))
+    const paintedTranscript = $messages.get()
     expect(requestGatewayMock).toHaveBeenCalledWith(
       'session.resume',
       expect.objectContaining({
@@ -1797,7 +1859,7 @@ describe('resumeSession warm-cache mapping integrity', () => {
       info: {}
     })
     await resumePromise
-    expect($messages.get()).toHaveLength(500)
+    expect($messages.get()).toBe(paintedTranscript)
   })
 
   it('honours a warm cache entry whose stored id matches and refreshes its persisted transcript', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -1130,9 +1130,9 @@ export function useSessionActions({
         // keeps it from surfacing as unhandled while the prefetch settles.
         resumePromise.catch(() => undefined)
 
-        // Keep both requests concurrent, but do not paint the REST result until
-        // the runtime resume has also settled. An eager prefetch paint followed
-        // by the runtime projection rebuilds large transcripts during resume.
+        // Capture the REST result independently from the runtime acknowledgement.
+        // It is painted below as soon as it resolves; the later runtime response
+        // contributes only live state/projection that is not in persisted history.
         let prefetchedResult: { messages: SessionMessage[]; session_id?: string } | null = null
 
         try {
@@ -1143,13 +1143,15 @@ export function useSessionActions({
           // Non-fatal: gateway resume below can still hydrate the session.
         }
 
-        const resumed = await resumePromise
-
-        if (!isCurrentResume()) {
-          return
-        }
-
-        if (prefetchedResult) {
+        // Paint the persisted transcript as soon as REST returns. Runtime
+        // resume can legitimately stay pending while a cold profile builds its
+        // agent (skills, MCP, memory); holding this result until that build
+        // settles strands Bot Chats behind the hydration timeout even though
+        // their complete history is already available. Reconcile against the
+        // current view once here, then the runtime path below grafts only its
+        // live projection onto this same snapshot — no second authoritative
+        // transcript rebuild and no duplicate in-flight user row.
+        if (prefetchedResult && isCurrentResume()) {
           const previousMessages = resumedSameSelectedSession
             ? preserveLocalPendingTurnMessages(viewMessagesForReconcile(), resumeStartMessages)
             : viewMessagesForReconcile()
@@ -1164,6 +1166,16 @@ export function useSessionActions({
           localSnapshot = reconcileAuthoritativeChatMessages(graftedPrefetch, previousMessages)
           prefetchApplied = true
           prefetchedStoredSessionId = prefetchedResult.session_id || storedSessionId
+
+          if (!chatMessageArraysEquivalent($messages.get(), localSnapshot)) {
+            setMessages(localSnapshot)
+          }
+        }
+
+        const resumed = await resumePromise
+
+        if (!isCurrentResume()) {
+          return
         }
 
         const currentMessages = viewMessagesForReconcile()
@@ -1332,9 +1344,9 @@ export function useSessionActions({
         )
 
         // updateSessionState stages its view sync through requestAnimationFrame.
-        // Commit the final, already-reconciled transcript now so resume has one
-        // additive DOM build instead of an eager prefetch build plus a later
-        // runtime projection build.
+        // Commit only when runtime reconciliation changed the eagerly-painted
+        // transcript; an unchanged acknowledgement preserves reference identity
+        // and avoids a second large DOM build.
         if (!chatMessageArraysEquivalent($messages.get(), messagesForView)) {
           setMessages(messagesForView)
         }


### PR DESCRIPTION
## Bug Description

Opening a persisted Bot Chat against a cold profile backend could remain on the loading state and eventually show “Couldn’t load this session,” even though the complete transcript was already available through the REST history endpoint.

This was easiest to reproduce with profiles that have a large capability surface: the runtime `session.resume` remained pending while the agent initialized skills, MCP servers, and memory, while the visible chat stayed empty.

## Root Cause

The REST transcript prefetch and `session.resume` RPC already ran concurrently, but the prefetch result was held until the runtime resume settled. That ordering was introduced to avoid rebuilding large transcripts and duplicating in-flight rows.

Bot Chat hydration now treats transcript paint as sufficient to complete the wake, but the renderer could not observe that condition because it deliberately withheld the prefetched transcript. A slow runtime build therefore exhausted the hydration and retry budgets despite having readable history in hand.

## Fix

- Reconcile and paint the current REST transcript as soon as the prefetch resolves.
- Keep the existing current-resume guard so stale async results cannot paint after navigation.
- Continue the runtime resume in parallel and graft only its live projection when it settles.
- Preserve reference identity when the runtime acknowledgement does not change the prefetched transcript, avoiding a second large render.
- Preserve the existing in-flight prompt deduplication behavior.

## How to Verify

1. Open a persisted Bot Chat whose profile backend is cold and whose runtime initialization is intentionally slow.
2. Confirm that the stored transcript appears as soon as REST history resolves, before `session.resume` completes.
3. Switch to another chat and open the Bot Chat again.
4. Confirm that the transcript appears immediately and the session does not reach the exhausted-retry error surface.
5. Resolve the deferred runtime resume and confirm that an unchanged transcript retains the same array reference and in-flight user rows are not duplicated.

## Test Plan

- [x] Added a cold-resume regression proving history paints while `session.resume` is still pending, then preserves the live assistant tail without duplicating a persisted in-flight user prompt.
- [x] Updated the 500-message deferred-resume test to require pre-acknowledgement paint and stable reference identity after acknowledgement.
- [x] Full Desktop Vitest suite: 6,519 passed, 2 skipped.
- [x] Bot Mode and other Desktop plugin tests: 308 passed.
- [x] TypeScript typecheck passed.
- [x] ESLint passed on both touched files.
- [x] Production Desktop build passed.
- [x] Manual validation completed with two consecutive cold Bot Chat opens.

### Local Python runner note

The canonical Python runner was also attempted in an isolated `[dev]` environment. It was not green because that environment intentionally omits lazy optional backends used by the full repository matrix (171 failures and 40 collection/import failures across Daytona, ACP, messaging, voice/video, and web-provider tests). This PR changes no Python files; the Desktop suites above are the relevant local gates, and CI remains authoritative for the optional Python matrix.

## Risk Assessment

**Medium-low.** The change affects the cold-resume display order for all persisted Desktop sessions, not only Bot Chats. The runtime binding and reconciliation path are unchanged; the difference is that an already-authoritative REST transcript becomes visible earlier. Existing tests cover large transcripts, live projections, pending prompts, stale resume guards, and duplicate in-flight rows, and the full Desktop suite passes.
