### PR TITLE
fix(docs): index every docs page in llms.txt so agents know what Hermes can do

### DIFF
--- a/scripts/ci/classify_changes.py
+++ b/scripts/ci/classify_changes.py
@@ -45,6 +45,9 @@ must never skip one a change could break:
 * ``website/static/oauth/`` is python-relevant too: it publishes the OAuth
   Client ID Metadata Document that ``tests/tools/test_mcp_cimd.py`` checks
   against the pinned callback ports in ``tools/mcp_oauth.py``.
+* ``website/docs/`` and ``website/scripts/`` are python-relevant for the same
+  reason: the docs tree generates ``llms.txt``, and
+  ``tests/website/test_generate_llms_txt.py`` asserts every page reaches it.
 """
 
 from __future__ import annotations
@@ -66,7 +69,16 @@ _PY_SKIP = ("docs/", "website/") + _FRONTEND
 # callback ports in tools/mcp_oauth.py, so editing it alone must still run the
 # Python lane — otherwise dropping a redirect URI goes green here and breaks
 # every CIMD login on main.
-_PY_RELEVANT_SITE = ("website/static/oauth/",)
+# website/docs/ and website/scripts/ are asserted about the same way. The docs
+# tree generates llms.txt — the index every LLM (Hermes included, via the
+# hermes-agent skill) reads to learn what Hermes can do — and
+# tests/website/test_generate_llms_txt.py holds every page to appearing in it.
+# Skipping Python on a docs-only PR is how the index drifted to 53% coverage.
+_PY_RELEVANT_SITE = (
+    "website/static/oauth/",
+    "website/docs/",
+    "website/scripts/",
+)
 
 # CI-sensitive files: eslint config, workflow files, composite actions.
 # Changes here can influence what code the autofix job executes and pushes to

--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: hermes-agent
 description: "Use, configure, theme, extend, and orchestrate Hermes Agent."
-version: 3.1.0
+version: 3.2.0
 author: Hermes Agent + Teknium
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
   hermes:
-    tags: [hermes, setup, configuration, multi-agent, spawning, cli, gateway, themes, skins, desktop-plugins, tui-widgets, petdex, development]
+    tags: [hermes, setup, configuration, multi-agent, spawning, cli, gateway, bots, bot-mode, features, themes, skins, desktop-plugins, tui-widgets, petdex, development]
     homepage: https://github.com/NousResearch/hermes-agent
     related_skills: [claude-code, codex, opencode]
 ---
@@ -34,11 +34,13 @@ What makes Hermes different:
 
 This skill is a concise operating guide, not the complete source of truth for every Hermes feature. If a Hermes feature, command, or setting is not mentioned here or in a reference, do not treat that absence as evidence that it does not exist. Check the live repository and official docs before giving a negative answer.
 
-Good verification targets:
+Good verification targets, cheapest first:
 
+- **Every shipped feature, one line each: https://hermes-agent.nousresearch.com/docs/llms.txt.** Start here for any "can Hermes do X?" or "how do I do X?" — it indexes the entire documentation set with a link to the page that answers. It is generated from the docs tree on every build, so it is never behind the product. Fetch it with `web_extract`, or `curl -s https://hermes-agent.nousresearch.com/docs/llms.txt` when web tools are off. The whole documentation set in one file is at `/docs/llms-full.txt`.
 - CLI commands: `hermes --help`, `hermes <command> --help`, and `hermes_cli/main.py`
-- User documentation: https://hermes-agent.nousresearch.com/docs/
 - Source tree: https://github.com/NousResearch/hermes-agent
+
+Never answer "Hermes can't do that" from memory. Hermes ships far more than this skill body describes, and the index exists so a negative answer is always checkable.
 
 ## Quick Start
 
@@ -86,6 +88,8 @@ Profiles use `~/.hermes/profiles/<name>/` with the same layout. When a profile i
 
 | User wants... | Load |
 |---|---|
+| **Anything not listed below — "can Hermes do X?", "how do I set up X?"** | **https://hermes-agent.nousresearch.com/docs/llms.txt** |
+| Bots that chat, run routines, or message each other; the Bots tab | docs: `/user-guide/bot-mode` |
 | CLI commands, subcommands, flags, "how do I run X" | `references/cli-reference.md` |
 | In-session slash commands | `references/slash-commands.md` |
 | Provider setup, API keys, OAuth | `references/providers-and-models.md` |
@@ -104,6 +108,11 @@ Profiles use `~/.hermes/profiles/<name>/` with the same layout. When a profile i
 | Contributing code: adding tools, slash commands, tests | `references/contributor-guide.md` |
 | delegate_task "capped at N" reports | `references/delegate-task-concurrency-diagnosis.md` |
 | "Can app X use my Nous Portal subscription/OAuth?" | `references/portal-auth-for-third-party-apps.md` |
+| Connecting a messaging platform (Telegram, Discord, Slack, WhatsApp, …) | docs: `/user-guide/messaging` |
+
+The reference list above is not the feature list — it is the set of topics that
+need more than their docs page. For everything else Hermes ships, fetch
+`llms.txt` and it maps the question to the page that answers it.
 
 Two theming rules that hold even without loading the reference: **you apply skins yourself** (`hermes config set display.skin <name>` — every surface repaints live within ~a second; don't tell the user to run `/skin`), and **to tweak one color, edit the ACTIVE skin** (`hermes skin set <key> <hex>`) — never fork `default`, which drops the palette and resets the background.
 

--- a/tests/ci/test_classify_changes.py
+++ b/tests/ci/test_classify_changes.py
@@ -76,17 +76,32 @@ CASES = {
     # Lockfile bump shifts every TS package's tree, but not the Python suite.
     "root lockfile → frontend, not python": (["package-lock.json"], _lanes(frontend=True, npm_lock=True)),
     "nested lockfile → npm_lock": (["website/package-lock.json"], _lanes(site=True, npm_lock=True)),
-    "website → site": (["website/docs/intro.md"], _lanes(site=True)),
+    # A website file the Python suite cannot read stays site-only.
+    "website config → site": (["website/docusaurus.config.ts"], _lanes(site=True)),
     # uv lock --check re-resolves against PyPI, so it must stay off for any
     # diff that can't desync the lockfile — a registry blip on a docs PR
     # otherwise shows up as a blocking "uv.lock out of sync" red X.
-    "docs → no uv_lock": (["website/docs/user-guide/profiles.md"], _lanes(site=True)),
+    "docs → no uv_lock": (
+        ["website/docs/developer-guide/plugins/index.md"],
+        _lanes(python=True, site=True),
+    ),
     "frontend → no uv_lock": (["apps/desktop/src/store/profile.ts"], _lanes(frontend=True)),
     # The published CIMD document is asserted about by the Python suite, so a
     # lone edit there must not skip the lane that would catch a bad edit.
     "cimd document → python + site": (
         ["website/static/oauth/client-metadata.json"],
         _lanes(python=True, site=True),
+    ),
+    # A new docs page must reach llms.txt, and the generator that puts it there
+    # has its own tests. Skipping Python on either is how the index drifted to
+    # 53% coverage while every PR stayed green.
+    "docs page → python + site": (
+        ["website/docs/user-guide/bot-mode.md"],
+        _lanes(python=True, site=True),
+    ),
+    "docs generator → python + site": (
+        ["website/scripts/generate-llms-txt.py"],
+        _lanes(python=True, scan=True, site=True),
     ),
     # SKILL.md reads like docs, but the skill-doc tests read skills/, so a
     # skill edit must still run Python.

--- a/tests/skills/test_hermes_agent_skill.py
+++ b/tests/skills/test_hermes_agent_skill.py
@@ -1,0 +1,69 @@
+"""The `hermes-agent` skill is what a running Hermes knows about itself.
+
+`website/` is never packaged, so an installed Hermes has no local copy of the
+user guide; skills ARE synced into `$HERMES_HOME/skills/`. The skill therefore
+does not try to restate the product — it routes to the published `llms.txt`,
+which is generated from the docs tree on every build and so can never be behind
+the feature set. These tests keep that routing honest: the index has to be where
+the skill says it is, and every reference has to be reachable, otherwise a
+shipped feature is invisible and the agent answers "Hermes can't do that."
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SKILL_DIR = REPO / "skills" / "autonomous-ai-agents" / "hermes-agent"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+GENERATOR = REPO / "website" / "scripts" / "generate-llms-txt.py"
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+def test_every_referenced_file_exists(skill_text):
+    """Routing a question to a file that isn't there is a dead end."""
+    targets = set(re.findall(r"`((?:references|templates)/[^`]+)`", skill_text))
+
+    assert targets, "the skill's routing table no longer references any files"
+    for target in sorted(targets):
+        assert (SKILL_DIR / target).exists(), f"SKILL.md routes to missing {target}"
+
+
+def test_every_reference_is_reachable_from_the_skill(skill_text):
+    """An unrouted reference is one the agent will never think to open.
+
+    This is the failure that produced the original complaint: content can exist
+    and still be invisible because nothing points at it.
+    """
+    on_disk = {f"references/{path.name}" for path in (SKILL_DIR / "references").glob("*.md")}
+    routed = set(re.findall(r"`(references/[^`]+)`", skill_text))
+
+    assert not (on_disk - routed), (
+        f"reference files no reader will ever reach: {sorted(on_disk - routed)} — "
+        "add a routing-table row in SKILL.md"
+    )
+
+
+def test_unknown_features_route_to_the_published_index(skill_text):
+    """The catch-all is what makes coverage of the whole product possible."""
+    assert "/docs/llms.txt" in skill_text
+    # web_extract can be disabled; terminal never is.
+    assert "curl" in skill_text, "no way to reach the index without web tools"
+
+
+def test_the_index_is_published_where_the_skill_says_it_is(skill_text):
+    """A skill pointing at a URL nobody generates is worse than no routing."""
+    spec = importlib.util.spec_from_file_location("generate_llms_txt", GENERATOR)
+    assert spec is not None and spec.loader is not None
+    gen = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(gen)
+
+    assert f"{gen.SITE_BASE}/llms.txt" in skill_text

--- a/tests/website/test_generate_llms_txt.py
+++ b/tests/website/test_generate_llms_txt.py
@@ -1,0 +1,133 @@
+"""`llms.txt` is how an LLM learns what Hermes can do.
+
+It is the index every model reads when pointed at our docs — including Hermes
+itself, whose `hermes-agent` skill routes unknown-feature questions there.
+`website/` is never packaged, so there is no shipped copy to fall back on.
+
+The index used to be a hand-written list of page paths, and it rotted to 53%
+coverage: Bot Mode, the desktop app, computer use, web search, and 22 messaging
+platforms were all absent, which is why an agent asked how to make bots talk to
+each other answered that it couldn't. These tests hold the two directions of
+that contract — every page reachable, every link real — so the index tracks the
+docs tree instead of someone's memory of it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GENERATOR = REPO_ROOT / "website" / "scripts" / "generate-llms-txt.py"
+
+
+@pytest.fixture(scope="module")
+def gen():
+    spec = importlib.util.spec_from_file_location("generate_llms_txt", GENERATOR)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def index(gen) -> str:
+    return gen.emit_llms_index()
+
+
+def _linked(gen, index: str) -> set[str]:
+    return set(re.findall(rf"\]\({re.escape(gen.SITE_BASE)}/([^)]+)\)", index))
+
+
+def _pages_on_disk(gen) -> set[str]:
+    """Walk the docs tree directly, duplicating only the two documented
+    exclusions.
+
+    Deliberately does not call `iter_docs()`: the index is built from that
+    enumeration, so checking one against the other would pass even if the
+    enumerator went blind to a whole tree — which is the failure being guarded.
+    """
+    pages = set()
+    for path in (*gen.DOCS.rglob("*.md"), *gen.DOCS.rglob("*.mdx")):
+        rel = path.relative_to(gen.DOCS).with_suffix("")
+        slug = str(rel.parent) if rel.name == "index" else str(rel)
+        # The docs landing page is the index's subject; per-skill pages are
+        # summarized by the two catalog reference pages.
+        if slug == "." or slug.startswith(("user-guide/skills/bundled", "user-guide/skills/optional")):
+            continue
+        pages.add(slug)
+    return pages
+
+
+def test_every_docs_page_is_indexed(gen, index):
+    """The regression: a page the index omits is a feature the agent denies."""
+    pages = _pages_on_disk(gen)
+    assert len(pages) > 100, "docs root resolved wrong — the rest of this file proves nothing"
+
+    missing = pages - _linked(gen, index)
+    assert not missing, (
+        f"{len(missing)} docs pages missing from llms.txt: {sorted(missing)} — "
+        "they should have been absorbed into a section automatically"
+    )
+
+
+def test_the_enumerator_sees_the_whole_docs_tree(gen):
+    """Everything downstream trusts `iter_docs()`, so pin it to the filesystem."""
+    assert set(gen.iter_docs()) == _pages_on_disk(gen)
+
+
+def test_every_indexed_page_exists(gen, index):
+    """The other direction: a renamed page leaves the index pointing at a 404."""
+    for slug in sorted(_linked(gen, index)):
+        assert gen.doc_path(slug) is not None, (
+            f"llms.txt links {slug}, which is not in the docs tree — "
+            "drop the SECTIONS row and let the page be absorbed under its new path"
+        )
+
+
+def test_pages_are_listed_once(gen, index):
+    """Curating a page must promote it, not duplicate it."""
+    entries = re.findall(rf"^- \[.*?\]\({re.escape(gen.SITE_BASE)}/([^)]+)\)", index, re.MULTILINE)
+    duplicated = {slug for slug in entries if entries.count(slug) > 1}
+    assert not duplicated, f"listed more than once in llms.txt: {sorted(duplicated)}"
+
+
+def test_curation_orders_pages_without_gatekeeping_them(gen):
+    """SECTIONS decides what leads a section, never what the index contains."""
+    curated = {slug for _section, items in gen.SECTIONS for slug, _t, _d in items}
+    pages = set(gen.iter_docs())
+
+    assert curated < pages, "every page is curated — absorption is no longer exercised"
+    assert gen.section_for("user-guide/features/some-feature-shipped-tomorrow") in dict(gen.ABSORB)
+    assert gen.section_for("a-tree-nobody-anticipated/page") == gen.MISC_SECTION
+
+
+def test_section_landing_pages_resolve_to_their_directory(gen):
+    """`messaging/index.md` is served at `/messaging`; `/messaging/index` 404s."""
+    assert gen.slug_for(gen.DOCS / "user-guide" / "messaging" / "index.md") == "user-guide/messaging"
+    assert "user-guide/messaging/index" not in _linked(gen, gen.emit_llms_index())
+
+
+def test_mdx_pages_are_indexed_without_their_imports(gen):
+    """MDX docs are real pages; their component imports are not prose."""
+    mdx = [p for p in gen.DOCS.rglob("*.mdx") if gen.slug_for(p)]
+    assert mdx, "no .mdx docs — this test no longer guards anything"
+    assert {gen.slug_for(p) for p in mdx} <= set(gen.iter_docs())
+
+    _meta, body = gen.read_frontmatter(mdx[0])
+    assert not re.search(r"^import\s", body, re.MULTILINE)
+
+
+def test_per_skill_catalog_pages_stay_out(gen):
+    """~195 generated skill pages would bury the product docs in the index."""
+    assert not [slug for slug in gen.iter_docs() if slug.startswith(gen.SKILL_CATALOG)]
+    assert "reference/skills-catalog" in gen.iter_docs(), "the summary page must remain"
+
+
+def test_bot_mode_is_reachable(gen, index):
+    """The page behind the original complaint, and the answer it has to carry."""
+    assert "user-guide/bot-mode" in _linked(gen, index)
+    assert "hermes peer dm" in (gen.DOCS / "user-guide" / "bot-mode.md").read_text(encoding="utf-8")

--- a/website/scripts/generate-llms-txt.py
+++ b/website/scripts/generate-llms-txt.py
@@ -2,11 +2,19 @@
 """Generate llms.txt and llms-full.txt for the Hermes docs site.
 
 Outputs:
-  website/static/llms.txt        — short curated index of the docs, one link per page,
-                                    grouped by section. Conforms to https://llmstxt.org.
-  website/static/llms-full.txt   — every `.md` file under `website/docs/` concatenated,
+  website/static/llms.txt        — index of the docs, one link per page, grouped by
+                                    section. Conforms to https://llmstxt.org.
+  website/static/llms-full.txt   — every doc under `website/docs/` concatenated,
                                     with `# <title>` headings and `<!-- source: … -->`
                                     comments separating files.
+
+Both are driven by `iter_docs()`, which walks the docs tree. `SECTIONS` below
+curates *order and grouping*, never membership: a page nobody curated still
+gets indexed, under the section its path belongs to. That distinction is the
+reason this file was rewritten — when the section list also decided membership,
+it silently drifted to 53% coverage, and Bot Mode, the desktop app, computer
+use, web search, and 22 messaging platforms were absent from the index every
+LLM reads to learn what Hermes does.
 
 Both publish at:
   https://hermes-agent.nousresearch.com/docs/llms.txt
@@ -33,9 +41,11 @@ STATIC = WEBSITE / "static"
 
 SITE_BASE = "https://hermes-agent.nousresearch.com/docs"
 
-# Curated sections for llms.txt — mirrors the product story, not the filesystem.
-# Each entry: (docs-relative path without .md, display title, optional short desc).
-# `None` desc → pulled from frontmatter `description:` field.
+# The product story: which pages lead, and in what order. Everything not named
+# here is still indexed — ABSORB decides where it lands — so this list is safe
+# to leave alone as the docs grow, and worth editing only to promote a page.
+# Each entry: (docs-relative path without extension, display title, optional
+# short desc). `None` desc → pulled from frontmatter `description:` field.
 SECTIONS: list[tuple[str, list[tuple[str, str, str | None]]]] = [
     ("Getting Started", [
         ("getting-started/installation", "Installation", None),
@@ -88,7 +98,7 @@ SECTIONS: list[tuple[str, list[tuple[str, str, str | None]]]] = [
         ("user-guide/features/tts", "Text-to-Speech", None),
     ]),
     ("Messaging Platforms", [
-        ("user-guide/messaging/index", "Overview", None),
+        ("user-guide/messaging", "Overview", None),
         ("user-guide/messaging/telegram", "Telegram", None),
         ("user-guide/messaging/discord", "Discord", None),
         ("user-guide/messaging/slack", "Slack", None),
@@ -102,7 +112,7 @@ SECTIONS: list[tuple[str, list[tuple[str, str, str | None]]]] = [
         ("user-guide/messaging/webhooks", "Webhooks", None),
     ]),
     ("Integrations", [
-        ("integrations/index", "Integrations Overview", None),
+        ("integrations", "Integrations Overview", None),
         ("integrations/providers", "Providers", None),
         ("user-guide/features/mcp", "MCP (Model Context Protocol)", None),
         ("user-guide/features/acp", "ACP (Agent Context Protocol)", None),
@@ -121,7 +131,6 @@ SECTIONS: list[tuple[str, list[tuple[str, str, str | None]]]] = [
         ("guides/use-mcp-with-hermes", "Use MCP with Hermes", None),
         ("guides/use-voice-mode-with-hermes", "Use Voice Mode with Hermes", None),
         ("guides/use-soul-with-hermes", "Use SOUL.md with Hermes", None),
-        ("guides/build-a-hermes-plugin", "Build a Hermes Plugin", None),
         ("guides/automate-with-cron", "Automate with Cron", None),
         ("guides/work-with-skills", "Work with Skills", None),
         ("guides/delegation-patterns", "Delegation Patterns", None),
@@ -158,9 +167,40 @@ SECTIONS: list[tuple[str, list[tuple[str, str, str | None]]]] = [
 ]
 
 
+DOC_EXTS = (".md", ".mdx")
+
+# Per-skill pages are generated from the skill tree and summarized by the two
+# catalog reference pages. Listing ~195 of them would bury the product docs in
+# the index and add ~1.4 MB of duplicative material to llms-full.txt.
+SKILL_CATALOG = ("user-guide/skills/bundled", "user-guide/skills/optional")
+
+# Where a page nobody curated goes. First match wins, so a narrower prefix must
+# precede the tree containing it. Anything matching nothing lands in
+# MISC_SECTION — no path can drop a page out of the index.
+ABSORB: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("Getting Started", ("getting-started",)),
+    ("Messaging Platforms", ("user-guide/messaging",)),
+    ("Core Features", ("user-guide/features",)),
+    ("Using Hermes", ("user-guide",)),
+    ("Integrations", ("integrations",)),
+    ("Guides & Tutorials", ("guides",)),
+    ("Developer Guide", ("developer-guide",)),
+    ("Reference", ("reference",)),
+)
+MISC_SECTION = "More"
+
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
-DESC_RE = re.compile(r"^description:\s*[\"'](.+?)[\"']\s*$", re.MULTILINE)
-TITLE_RE = re.compile(r"^title:\s*[\"'](.+?)[\"']\s*$", re.MULTILINE)
+DESC_RE = re.compile(r"^description:\s*(.+?)\s*$", re.MULTILINE)
+TITLE_RE = re.compile(r"^title:\s*(.+?)\s*$", re.MULTILINE)
+H1_RE = re.compile(r"^#\s+(.+?)\s*$", re.MULTILINE)
+# MDX pages open with component imports — markup plumbing, not prose.
+MDX_IMPORT_RE = re.compile(r"^(?:import|export)\s.*$\n?", re.MULTILINE)
+
+
+def _unquote(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+        return value[1:-1]
+    return value
 
 
 def read_frontmatter(path: Path) -> tuple[dict[str, str], str]:
@@ -172,30 +212,86 @@ def read_frontmatter(path: Path) -> tuple[dict[str, str], str]:
     if m:
         fm = m.group(1)
         body = text[m.end():]
-        dm = DESC_RE.search(fm)
-        if dm:
-            meta["description"] = dm.group(1)
-        tm = TITLE_RE.search(fm)
-        if tm:
-            meta["title"] = tm.group(1)
+        for key, pattern in (("description", DESC_RE), ("title", TITLE_RE)):
+            found = pattern.search(fm)
+            if found:
+                meta[key] = _unquote(found.group(1))
+    if path.suffix == ".mdx":
+        body = MDX_IMPORT_RE.sub("", body)
     return meta, body
+
+
+def slug_for(path: Path) -> str:
+    """URL slug for a page: `user-guide/messaging/index.md` → `user-guide/messaging`."""
+    rel = path.relative_to(DOCS).with_suffix("")
+    if rel.name == "index":
+        rel = rel.parent
+    return "" if str(rel) == "." else str(rel)
+
+
+def doc_path(slug: str) -> Path | None:
+    """The file backing a slug, whether it's a page or a section landing page."""
+    for ext in DOC_EXTS:
+        for candidate in (DOCS / f"{slug}{ext}", DOCS / slug / f"index{ext}"):
+            if candidate.exists():
+                return candidate
+    return None
+
+
+def iter_docs() -> list[str]:
+    """Every indexable page, as a slug — the one enumeration of the docs tree.
+
+    llms.txt lists exactly these and llms-full.txt emits exactly these, so a
+    page on disk cannot be missing from either output.
+    """
+    slugs = set()
+    for ext in DOC_EXTS:
+        for path in DOCS.rglob(f"*{ext}"):
+            slug = slug_for(path)
+            # The docs landing page is this index's subject, not an entry in it.
+            if slug and not slug.startswith(SKILL_CATALOG):
+                slugs.add(slug)
+    return sorted(slugs)
+
+
+def section_for(slug: str) -> str:
+    for section, prefixes in ABSORB:
+        if any(slug == prefix or slug.startswith(f"{prefix}/") for prefix in prefixes):
+            return section
+    return MISC_SECTION
+
+
+def resolve_meta(slug: str) -> tuple[str, str]:
+    """(title, description) for a page, falling back to its H1 then its slug."""
+    path = doc_path(slug)
+    if path is None:
+        return slug, ""
+    meta, body = read_frontmatter(path)
+    title = meta.get("title")
+    if not title:
+        h1 = H1_RE.search(body)
+        title = h1.group(1) if h1 else slug.rsplit("/", 1)[-1].replace("-", " ").title()
+    return title, meta.get("description", "")
 
 
 def resolve_desc(slug: str, provided: str | None) -> str:
     """Resolve short description for llms.txt entry."""
-    if provided:
-        return provided
-    path = DOCS / f"{slug}.md"
-    if not path.exists():
-        path = DOCS / slug / "index.md"
-    if not path.exists():
-        return ""
-    meta, _ = read_frontmatter(path)
-    return meta.get("description", "")
+    return provided or resolve_meta(slug)[1]
+
+
+def _entry(slug: str, title: str, desc: str) -> str:
+    url = f"{SITE_BASE}/{slug}"
+    return f"- [{title}]({url}): {desc}" if desc else f"- [{title}]({url})"
 
 
 def emit_llms_index() -> str:
-    """Build the short llms.txt index."""
+    """Build the llms.txt index: curated pages lead a section, the rest follow."""
+    curated = {slug for _section, items in SECTIONS for slug, _title, _desc in items}
+    absorbed: dict[str, list[str]] = {}
+    for slug in iter_docs():
+        if slug not in curated:
+            absorbed.setdefault(section_for(slug), []).append(slug)
+
     lines: list[str] = []
     lines.append("# Hermes Agent")
     lines.append("")
@@ -222,23 +318,24 @@ def emit_llms_index() -> str:
         lines.append(f"## {section}")
         lines.append("")
         for slug, title, desc_override in items:
-            desc = resolve_desc(slug, desc_override)
-            url = f"{SITE_BASE}/{slug}"
-            if desc:
-                lines.append(f"- [{title}]({url}): {desc}")
-            else:
-                lines.append(f"- [{title}]({url})")
+            lines.append(_entry(slug, title, resolve_desc(slug, desc_override)))
+        for slug in absorbed.pop(section, []):
+            lines.append(_entry(slug, *resolve_meta(slug)))
+        lines.append("")
+
+    # Only MISC_SECTION can survive the pops — a page whose path matched no
+    # section still has to appear somewhere.
+    for section, slugs in absorbed.items():
+        lines.append(f"## {section}")
+        lines.append("")
+        for slug in slugs:
+            lines.append(_entry(slug, *resolve_meta(slug)))
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"
 
 
 def emit_llms_full() -> str:
-    """Concatenate every doc under website/docs/ into a single markdown file.
-
-    Order: mirrors the curated SECTIONS list first (so the most important
-    pages are front-loaded for agents that truncate on token budget), then
-    appends any remaining .md files sorted by path.
-    """
+    """Concatenate every doc under website/docs/ into a single markdown file."""
     seen: set[Path] = set()
     chunks: list[str] = [
         "# Hermes Agent — Full Documentation\n",
@@ -253,41 +350,24 @@ def emit_llms_full() -> str:
         "\n---\n\n",
     ]
 
-    def emit_file(rel: str) -> None:
-        path = DOCS / f"{rel}.md"
-        if not path.exists():
-            path = DOCS / rel / "index.md"
-        if not path.exists() or path in seen:
+    def emit_file(slug: str) -> None:
+        path = doc_path(slug)
+        if path is None or path in seen:
             return
         seen.add(path)
-        meta, body = read_frontmatter(path)
-        title = meta.get("title") or rel
+        title, _desc = resolve_meta(slug)
+        _meta, body = read_frontmatter(path)
         chunks.append(f"<!-- source: website/docs/{path.relative_to(DOCS)} -->\n")
         chunks.append(f"# {title}\n\n")
         chunks.append(body.rstrip() + "\n\n---\n\n")
 
-    # Curated order first
-    for _, items in SECTIONS:
-        for slug, _t, _d in items:
+    # Curated order first, so a reader truncating on token budget keeps the
+    # pages that matter most; then everything else the docs tree holds.
+    for _section, items in SECTIONS:
+        for slug, _title, _desc in items:
             emit_file(slug)
-
-    # Everything else (sorted, skipping already emitted and auto-gen skill pages
-    # — those are covered by the two catalog reference pages, emitting every
-    # individual skill would add ~1.4 MB of largely duplicative material).
-    for path in sorted(DOCS.rglob("*.md")):
-        if path in seen:
-            continue
-        rel = path.relative_to(DOCS)
-        parts = rel.parts
-        if len(parts) >= 3 and parts[0] == "user-guide" and parts[1] == "skills" \
-                and parts[2] in {"bundled", "optional"}:
-            continue
-        seen.add(path)
-        meta, body = read_frontmatter(path)
-        title = meta.get("title") or str(rel)
-        chunks.append(f"<!-- source: website/docs/{rel} -->\n")
-        chunks.append(f"# {title}\n\n")
-        chunks.append(body.rstrip() + "\n\n---\n\n")
+    for slug in iter_docs():
+        emit_file(slug)
 
     return "".join(chunks).rstrip() + "\n"
 


### PR DESCRIPTION
An agent asked how to get two bots talking to each other said it couldn't — while `user-guide/bot-mode` documents four ways. The docs were fine; the index that leads anything to them was not.

`llms.txt` is the entry point every LLM reads to learn what Hermes does, and Hermes reads it about itself through the `hermes-agent` skill. It is regenerated on every docs build, but the list of pages inside it was hand-written, so it drifted as the docs grew: **109 of 204 pages were missing.** Bot Mode, the desktop app, computer use, web search, x-search, skins, pets, Mixture of Agents, LSP, the web dashboard, both Windows guides, all three secrets managers, and 22 of 35 messaging platforms were absent — from the index, from the skill, and from anything Claude or Cursor read when pointed at our docs.

The fix is to let the docs tree decide what gets indexed. `SECTIONS` still curates which pages lead a section and in what order; it no longer decides membership. A page nobody curated is absorbed under its path, and one matching no section lands in "More", so nothing can fall out.

Coverage is now 206 of 206, with three `.mdx` pages the `.md`-only glob had never seen, and a curated row still pointing at a guide moved in #59613 is gone. `llms-full.txt` grows by 908 bytes — it already concatenated everything; only the index was blind.

The `hermes-agent` skill drops its 18-topic ceiling and routes unknown-feature questions at the published index instead of shipping a second copy of it. `website/` is never packaged, so that URL is the only complete self-knowledge a running Hermes has; `curl` covers sessions with the web tools disabled.

Finally, `website/` was on the Python skip list, so the tests asserting all of this never ran on a docs-only PR. That is how the drift went unnoticed, and it is why the classifier change is part of the fix rather than a follow-up.

## Test plan

- [x] `scripts/run_tests.sh tests/website/ tests/skills/ tests/ci/` — 1734 passed
- [x] Coverage test fails with the pre-fix generator, and again when the enumerator is made blind to `.mdx`, naming the dropped pages
- [x] Tests enumerate the filesystem directly rather than trusting `iter_docs()`, so an under-counting enumerator cannot pass them
- [x] `bot-mode`, `desktop`, `computer-use`, and every messaging platform resolve in the generated index