### PR TITLE
feat(kanban): Remoko keep-alive on iteration-budget burn [LS-2777]

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -61,44 +61,30 @@ def _record_kanban_budget_exhausted(
     api_call_count: int,
     max_iterations: int,
     logger: logging.Logger,
+    agent=None,
 ) -> None:
-    """Record a terminal ``timed_out`` outcome for a kanban worker that
-    exhausted its iteration budget.
+    """Keep a live objective alive when the iteration budget burns (LS-2777).
 
-    This is a bounded fallback (#87096): the CAS invariant in ``_end_run``
-    (``WHERE ended_at IS NULL``) guarantees idempotence — if another path
-    already closed the run this is a no-op — so it is safe to call from
-    multiple exit paths.
+    This is not a spawn/crash failure and must not increment
+    ``consecutive_failures``. The keep-alive recorder parks the card
+    (or a sidecar for delegate_task / Bot Chat) and sends one Remoko
+    ``ask_question``. Wall-clock ``max_runtime_seconds`` still uses
+    ``_record_task_failure(outcome="timed_out")``.
     """
     try:
-        from hermes_cli import kanban_db as _kb
-        _conn = _kb.connect()
-        try:
-            _kb._record_task_failure(
-                _conn,
-                kanban_task,
-                error=(
-                    f"Iteration budget exhausted "
-                    f"({api_call_count}/{max_iterations}) — "
-                    "task could not complete within the allowed "
-                    "iterations"
-                ),
-                outcome="timed_out",
-                release_claim=True,
-                end_run=True,
-                event_payload_extra={
-                    "budget_used": api_call_count,
-                    "budget_max": max_iterations,
-                },
-            )
-        finally:
-            try:
-                _conn.close()
-            except Exception:
-                pass
+        from hermes_cli.kanban_budget_keepalive import (
+            record_iteration_budget_exhausted,
+        )
+
+        record_iteration_budget_exhausted(
+            task_id=kanban_task,
+            budget_used=api_call_count,
+            budget_max=max_iterations,
+            agent=agent,
+        )
     except Exception:
         logger.warning(
-            "Failed to record budget-exhausted failure for task %s",
+            "Failed to record budget-exhausted keep-alive for task %s",
             kanban_task,
             exc_info=True,
         )
@@ -193,34 +179,30 @@ def finalize_turn(
         iteration_limit_fallback = True
 
     if iteration_limit_fallback:
-        # If running as a kanban worker, signal the dispatcher that the
-        # worker could not complete (rather than treating it as a
-        # protocol violation). This applies whether the user-facing fallback
-        # came from the summary call or an explicitly pending continuation;
-        # both exhausted the task budget and must advance the failure circuit.
-        #
-        # We route through ``_record_task_failure(outcome="timed_out")``
-        # rather than ``kanban_block`` so this counts toward the dispatcher's
-        # consecutive-failure circuit breaker (#29747 gap 2).
-        _kanban_task = os.environ.get("HERMES_KANBAN_TASK")
-        if _kanban_task:
-            _record_kanban_budget_exhausted(
-                _kanban_task, api_call_count, agent.max_iterations, logger,
-            )
+        # Iteration-budget burn is an owner fork (LS-2777), not a spawn
+        # failure. Keep-alive parks a live Kanban / delegate / Bot Chat
+        # objective and asks Remoko; regular CLI chats no-op. Wall-clock
+        # ``max_runtime_seconds`` still uses ``_record_task_failure``.
+        _record_kanban_budget_exhausted(
+            os.environ.get("HERMES_KANBAN_TASK") or "",
+            api_call_count,
+            agent.max_iterations,
+            logger,
+            agent=agent,
+        )
     elif budget_exhausted:
         # Bounded fallback (#87096): budget was exhausted but none of the
         # normal fallback paths were eligible (interrupted / failed /
-        # anomalous exit_reason). If running as a kanban worker we must
-        # still record a terminal outcome so the task does not remain in
-        # an ambiguous lifecycle state. The worker's run is closed via
-        # ``_record_task_failure`` (compare-and-swap receipt path) which
-        # is a no-op if another path closed it — the CAS invariant in
-        # ``_end_run`` (``WHERE ended_at IS NULL``) guarantees idempotence.
-        _kanban_task = os.environ.get("HERMES_KANBAN_TASK")
-        if _kanban_task:
-            _record_kanban_budget_exhausted(
-                _kanban_task, api_call_count, agent.max_iterations, logger,
-            )
+        # anomalous exit_reason). Keep-alive still records a typed
+        # ``budget_exhausted`` outcome so a live objective does not sit
+        # ambiguous and does not count toward ``gave_up``.
+        _record_kanban_budget_exhausted(
+            os.environ.get("HERMES_KANBAN_TASK") or "",
+            api_call_count,
+            agent.max_iterations,
+            logger,
+            agent=agent,
+        )
 
     # Determine if conversation completed successfully
     normal_text_response = str(_turn_exit_reason).startswith("text_response(")

--- a/cli.py
+++ b/cli.py
@@ -5105,9 +5105,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self.api_key = api_key or os.getenv("OPENROUTER_API_KEY") or os.getenv("OPENAI_API_KEY")
         else:
             self.api_key = api_key or os.getenv("OPENAI_API_KEY") or os.getenv("OPENROUTER_API_KEY")
-        # Max turns priority: CLI arg > config file > env var > default
+        # Max turns priority: CLI arg > kanban keep-alive env (LS-2777) >
+        # config file > HERMES_MAX_ITERATIONS > default.
+        # HERMES_KANBAN_MAX_ITERATIONS must beat agent.max_turns so a
+        # granted +90 survives restart. HERMES_MAX_ITERATIONS still loses
+        # to config (historical); the kanban-specific env is the lock.
+        from hermes_cli.kanban_budget_keepalive import (
+            effective_kanban_max_iterations,
+        )
+
+        _kanban_iter = effective_kanban_max_iterations()
         if max_turns is not None:  # CLI arg was explicitly set
             self.max_turns = max_turns
+        elif _kanban_iter is not None:
+            self.max_turns = _kanban_iter
         elif CLI_CONFIG["agent"].get("max_turns"):
             self.max_turns = CLI_CONFIG["agent"]["max_turns"]
         elif CLI_CONFIG.get("max_turns"):  # Backwards compat: root-level max_turns

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -217,7 +217,7 @@ class GatewayKanbanWatchersMixin:
         # but is not a block (see kanban_db.request_review); the task is not
         # archived, so the subscription stays alive and later review
         # cycles keep notifying.
-        TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out", "status", "archived", "unblocked", "block_loop_detected", "review_requested")
+        TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out", "budget_exhausted", "status", "archived", "unblocked", "block_loop_detected", "review_requested")
         # Subscriptions are removed only when the task reaches the irreversible
         # archived status. ``done`` is reversible in review/controller flows,
         # so removing its subscription would silence a later reopen. We used
@@ -759,7 +759,7 @@ class GatewayKanbanWatchersMixin:
                         #   claim exactly like a failed send() above, so the
                         #   next tick retries.
                         task_terminal = task and task.status == "archived"
-                        _WAKE_KINDS = ("completed", "gave_up", "crashed", "timed_out", "blocked")
+                        _WAKE_KINDS = ("completed", "gave_up", "crashed", "timed_out", "blocked", "budget_exhausted")
                         _wake_kinds = (
                             {ev.kind for ev in d["events"] if ev.kind in _WAKE_KINDS}
                             if wake_agent
@@ -796,6 +796,11 @@ class GatewayKanbanWatchersMixin:
                             if "crashed" in _wake_kinds: _parts.append(t("gateway.kanban.wake.crashed"))
                             if "timed_out" in _wake_kinds: _parts.append(t("gateway.kanban.wake.timed_out"))
                             if "blocked" in _wake_kinds: _parts.append(t("gateway.kanban.wake.blocked"))
+                            if "budget_exhausted" in _wake_kinds:
+                                _budget_label = t("gateway.kanban.wake.budget_exhausted")
+                                if _budget_label == "gateway.kanban.wake.budget_exhausted":
+                                    _budget_label = "ran out of turns"
+                                _parts.append(_budget_label)
                             _status = t("gateway.kanban.wake.status_joiner").join(_parts) or t("gateway.kanban.wake.status_default")
                             _synth = t(
                                 "gateway.kanban.wake.message",

--- a/hermes_cli/kanban_budget_keepalive.py
+++ b/hermes_cli/kanban_budget_keepalive.py
@@ -1,0 +1,1316 @@
+"""Remoko keep-alive when a worker burns its iteration budget (LS-2777).
+
+Budget exhaustion is an owner fork, not a spawn/crash failure. A live
+Kanban card (or a delegate_task / Bot Chat sidecar) stays parked until
+one Remoko tap grants +90 turns, parks, or stops the work.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import sqlite3
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional, Protocol
+
+logger = logging.getLogger(__name__)
+
+CHOICE_GIVE_MORE = "Give 90 more"
+CHOICE_GIVE_ONCE = "Give 90 once"
+CHOICE_PARK = "Park it"
+CHOICE_STOP = "Stop this"
+CHOICES = (CHOICE_GIVE_MORE, CHOICE_GIVE_ONCE, CHOICE_PARK, CHOICE_STOP)
+
+STATUS_PENDING = "pending"
+STATUS_GRANTED = "granted"
+STATUS_PARKED = "parked"
+STATUS_STOPPED = "stopped"
+
+POLICY_EXTEND_REPEAT = "extend_repeat"
+POLICY_EXTEND_ONCE = "extend_once"
+POLICY_PARK = "park"
+POLICY_STOP = "stop"
+
+EXTENSION_TURNS = 90
+MAX_RECOMMENDED_GRANTS = 3
+BUDGET_EXHAUST_NEEDLE = "Iteration budget exhausted"
+DEFAULT_BASE_MAX_TURNS = 90
+HEADLINE = "Keep this work going?"
+
+DECISION_STATUSES = frozenset(
+    {STATUS_PENDING, STATUS_GRANTED, STATUS_PARKED, STATUS_STOPPED}
+)
+BLOCKING_DECISION_STATUSES = frozenset(
+    {STATUS_PENDING, STATUS_PARKED, STATUS_STOPPED}
+)
+
+BUDGET_DECISIONS_DDL = """
+CREATE TABLE IF NOT EXISTS kanban_budget_decisions (
+    task_id              TEXT PRIMARY KEY,
+    request_id           TEXT,
+    external_id          TEXT,
+    status               TEXT NOT NULL,
+    policy               TEXT,
+    extensions_count     INTEGER NOT NULL DEFAULT 0,
+    extra_turns          INTEGER NOT NULL DEFAULT 0,
+    last_budget_burn_at  INTEGER,
+    created_at           INTEGER NOT NULL,
+    updated_at           INTEGER NOT NULL
+)
+"""
+
+_SAFE_ID_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+class RemokoClient(Protocol):
+    def ask_question(self, **kwargs: Any) -> Mapping[str, Any]: ...
+    def report_execution(self, **kwargs: Any) -> Mapping[str, Any]: ...
+    def mark_processed(self, **kwargs: Any) -> Mapping[str, Any]: ...
+    def get_response(self, **kwargs: Any) -> Mapping[str, Any]: ...
+
+
+@dataclass
+class BudgetDecision:
+    task_id: str
+    request_id: Optional[str] = None
+    external_id: Optional[str] = None
+    status: str = STATUS_PENDING
+    policy: Optional[str] = None
+    extensions_count: int = 0
+    extra_turns: int = 0
+    last_budget_burn_at: Optional[int] = None
+    created_at: int = 0
+    updated_at: int = 0
+    store: str = "kanban"  # "kanban" | "sidecar"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "request_id": self.request_id or "",
+            "external_id": self.external_id or "",
+            "status": self.status,
+            "policy": self.policy or "",
+            "extensions_count": int(self.extensions_count),
+            "extra_turns": int(self.extra_turns),
+            "last_budget_burn_at": self.last_budget_burn_at,
+            "created_at": int(self.created_at),
+            "updated_at": int(self.updated_at),
+        }
+
+
+class NullRemokoClient:
+    """No network. Used under pytest when a test did not inject a client."""
+
+    def ask_question(self, **kwargs: Any) -> dict[str, Any]:
+        return {"ok": False, "error": "remoko disabled (inject remoko_client)"}
+
+    def report_execution(self, **kwargs: Any) -> dict[str, Any]:
+        return {"ok": False, "error": "remoko disabled (inject remoko_client)"}
+
+    def mark_processed(self, **kwargs: Any) -> dict[str, Any]:
+        return {"ok": False, "error": "remoko disabled (inject remoko_client)"}
+
+    def get_response(self, **kwargs: Any) -> dict[str, Any]:
+        return {"status": "pending"}
+
+
+class RecordingRemokoClient:
+    """In-memory Remoko double for unit tests. Never hits the live inbox."""
+
+    def __init__(self) -> None:
+        self.ask_calls: list[dict[str, Any]] = []
+        self.report_calls: list[dict[str, Any]] = []
+        self.mark_calls: list[dict[str, Any]] = []
+        self.get_calls: list[dict[str, Any]] = []
+        self._n = 0
+        self.fail_ask = False
+        self.answers: dict[str, str] = {}
+
+    def ask_question(self, **kwargs: Any) -> dict[str, Any]:
+        self.ask_calls.append(dict(kwargs))
+        if self.fail_ask:
+            raise RuntimeError("remoko send failed")
+        self._n += 1
+        request_id = f"req-budget-{self._n}"
+        return {"ok": True, "request_id": request_id, "external_id": kwargs.get("external_id")}
+
+    def report_execution(self, **kwargs: Any) -> dict[str, Any]:
+        self.report_calls.append(dict(kwargs))
+        return {"ok": True}
+
+    def mark_processed(self, **kwargs: Any) -> dict[str, Any]:
+        self.mark_calls.append(dict(kwargs))
+        return {"ok": True}
+
+    def get_response(self, **kwargs: Any) -> dict[str, Any]:
+        self.get_calls.append(dict(kwargs))
+        request_id = str(kwargs.get("request_id") or "")
+        choice = self.answers.get(request_id)
+        if not choice:
+            return {"status": "pending", "request_id": request_id}
+        return {
+            "status": "answered",
+            "request_id": request_id,
+            "response": {"choice": choice},
+        }
+
+
+class LiveRemokoClient:
+    """Best-effort live Remoko MCP caller. Never used under pytest."""
+
+    def ask_question(self, **kwargs: Any) -> dict[str, Any]:
+        return _invoke_remoko_tool("ask_question", kwargs)
+
+    def report_execution(self, **kwargs: Any) -> dict[str, Any]:
+        return _invoke_remoko_tool("report_execution", kwargs)
+
+    def mark_processed(self, **kwargs: Any) -> dict[str, Any]:
+        return _invoke_remoko_tool("mark_processed", kwargs)
+
+    def get_response(self, **kwargs: Any) -> dict[str, Any]:
+        return _invoke_remoko_tool("get_response", kwargs)
+
+
+def default_remoko_client() -> RemokoClient:
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        return NullRemokoClient()
+    return LiveRemokoClient()
+
+
+def _invoke_remoko_tool(suffix: str, args: Mapping[str, Any]) -> dict[str, Any]:
+    name = f"mcp__remoko__{suffix}"
+    try:
+        from tools.registry import registry
+
+        handler = None
+        get = getattr(registry, "get_handler", None) or getattr(registry, "get", None)
+        if callable(get):
+            handler = get(name)
+        if handler is None:
+            tools = getattr(registry, "tools", None) or getattr(registry, "_tools", None)
+            if isinstance(tools, dict):
+                entry = tools.get(name) or {}
+                handler = entry.get("handler") if isinstance(entry, dict) else None
+        if handler is None:
+            return {"ok": False, "error": f"{name} not registered"}
+        raw = handler(dict(args))
+        if isinstance(raw, dict):
+            return raw
+        if isinstance(raw, str):
+            try:
+                parsed = json.loads(raw)
+            except json.JSONDecodeError:
+                return {"ok": False, "error": raw[:300], "raw": raw}
+            return parsed if isinstance(parsed, dict) else {"ok": True, "result": parsed}
+        return {"ok": True, "result": raw}
+    except Exception as exc:
+        logger.warning("remoko %s failed: %s", suffix, exc, exc_info=True)
+        return {"ok": False, "error": str(exc)}
+
+
+def effective_kanban_max_iterations(
+    env: Optional[Mapping[str, str]] = None,
+) -> Optional[int]:
+    """Return HERMES_KANBAN_MAX_ITERATIONS when this process is a kanban worker.
+
+    Honoured ahead of ``agent.max_turns`` so a granted +90 survives restart.
+    """
+    source = env if env is not None else os.environ
+    if not str(source.get("HERMES_KANBAN_TASK") or "").strip():
+        return None
+    raw = source.get("HERMES_KANBAN_MAX_ITERATIONS")
+    if raw is None or str(raw).strip() == "":
+        return None
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
+def resolve_base_max_turns(hermes_home: Optional[str] = None) -> int:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg: Mapping[str, Any]
+        if hermes_home:
+            from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+            token = set_hermes_home_override(hermes_home)
+            try:
+                cfg = load_config() or {}
+            finally:
+                reset_hermes_home_override(token)
+        else:
+            cfg = load_config() or {}
+        agent_cfg = cfg.get("agent") if isinstance(cfg.get("agent"), dict) else {}
+        raw = (agent_cfg or {}).get("max_turns") or cfg.get("max_turns") or DEFAULT_BASE_MAX_TURNS
+        value = int(raw)
+        return value if value > 0 else DEFAULT_BASE_MAX_TURNS
+    except Exception:
+        return DEFAULT_BASE_MAX_TURNS
+
+
+def worker_max_iterations_value(
+    extra_turns: int,
+    *,
+    hermes_home: Optional[str] = None,
+    base_max_turns: Optional[int] = None,
+) -> int:
+    base = (
+        int(base_max_turns)
+        if base_max_turns is not None
+        else resolve_base_max_turns(hermes_home)
+    )
+    extra = max(0, int(extra_turns or 0))
+    return max(1, base + extra)
+
+
+def ensure_budget_decisions_table(conn: sqlite3.Connection) -> None:
+    conn.execute(BUDGET_DECISIONS_DDL)
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_budget_decisions_status "
+        "ON kanban_budget_decisions(status)"
+    )
+
+
+def external_id_for(task_id: str, extensions_count: int) -> str:
+    return f"obj-{task_id}-budget-{int(extensions_count) + 1}"
+
+
+def recommended_choice(extensions_count: int) -> str:
+    return CHOICE_PARK if int(extensions_count) >= MAX_RECOMMENDED_GRANTS else CHOICE_GIVE_MORE
+
+
+def build_remoko_card(
+    *,
+    task_id: str,
+    extensions_count: int,
+    budget_used: int,
+    budget_max: int,
+    extra_turns: int = 0,
+) -> dict[str, Any]:
+    recommend = recommended_choice(extensions_count)
+    after_three = int(extensions_count) >= MAX_RECOMMENDED_GRANTS
+    if after_three:
+        purpose_extra = (
+            " This card has already been given three extra bursts, so the "
+            "recommended tap is now Park it — do not silently grant a fourth."
+        )
+        why = "Three extra bursts already landed; parking keeps the work without burning more turns."
+        next_step = "If you tap Park it, the same card stays paused until a later tap."
+    else:
+        purpose_extra = ""
+        why = "The work already started; killing it wastes the progress."
+        next_step = "If you tap Give 90 more, I add 90 turns and restart the same card."
+
+    context = (
+        f"This job ran out of turns mid-pipeline ({budget_used}/{budget_max}). "
+        f"Without a tap it will sit dead.{purpose_extra}\n\n"
+        f"{next_step}\n\n"
+        f"{CHOICE_GIVE_MORE} — plus: the same job keeps going. minus: it can ask again later.\n"
+        f"{CHOICE_GIVE_ONCE} — plus: one more burst, then it stops asking. minus: the next burn parks with no new card.\n"
+        f"{CHOICE_PARK} — plus: nothing more runs until you come back. minus: the work stays paused.\n"
+        f"{CHOICE_STOP} — plus: no more auto-runs. minus: the started work stays unfinished.\n\n"
+        f"Why: {why}"
+    )
+    if extra_turns:
+        context += f"\n\nAlready added: {extra_turns} extra turns."
+    context += f"\nCard: {task_id}"
+
+    consequence = (
+        "The same card stays paused. No merge, deploy, or restart."
+        if recommend == CHOICE_PARK
+        else "The same card gets 90 more turns and starts again. No merge, deploy, or restart."
+    )
+    return {
+        "question": HEADLINE,
+        "context": context[:2000],
+        "choices": list(CHOICES),
+        "allow_freeform": False,
+        "priority": "high",
+        "agent_name": "Hermes",
+        "wait_seconds": 0,
+        "external_id": external_id_for(task_id, extensions_count),
+        "project": task_id,
+        "risk": "medium",
+        "recommendation": f"{recommend} — {why}"[:1000],
+        "consequence": consequence[:1000],
+        "prohibitions": [
+            "No merge from this tap",
+            "No deploy from this tap",
+            "No gateway or dispatcher restart from this tap",
+            "No second Remoko card for this same burn",
+        ],
+    }
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+def _row_to_decision(row: sqlite3.Row, *, store: str = "kanban") -> BudgetDecision:
+    return BudgetDecision(
+        task_id=row["task_id"],
+        request_id=(row["request_id"] or None) or None,
+        external_id=(row["external_id"] or None) or None,
+        status=row["status"],
+        policy=(row["policy"] or None) or None,
+        extensions_count=int(row["extensions_count"] or 0),
+        extra_turns=int(row["extra_turns"] or 0),
+        last_budget_burn_at=row["last_budget_burn_at"],
+        created_at=int(row["created_at"] or 0),
+        updated_at=int(row["updated_at"] or 0),
+        store=store,
+    )
+
+
+def get_decision(conn: sqlite3.Connection, task_id: str) -> Optional[BudgetDecision]:
+    ensure_budget_decisions_table(conn)
+    row = conn.execute(
+        "SELECT * FROM kanban_budget_decisions WHERE task_id = ?",
+        (task_id,),
+    ).fetchone()
+    return _row_to_decision(row) if row else None
+
+
+def extra_turns_for_task(task_id: str, conn: Optional[sqlite3.Connection] = None) -> int:
+    owns = conn is None
+    if owns:
+        from hermes_cli import kanban_db as kb
+
+        conn = kb.connect()
+    try:
+        decision = get_decision(conn, task_id)
+        return int(decision.extra_turns) if decision else 0
+    except Exception:
+        return 0
+    finally:
+        if owns:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
+def budget_decision_blocks_dispatch(
+    conn: sqlite3.Connection, task_id: str
+) -> bool:
+    decision = get_decision(conn, task_id)
+    return bool(decision and decision.status in BLOCKING_DECISION_STATUSES)
+
+
+def _upsert_decision(conn: sqlite3.Connection, decision: BudgetDecision) -> None:
+    ensure_budget_decisions_table(conn)
+    now = _now()
+    decision.updated_at = now
+    if not decision.created_at:
+        decision.created_at = now
+    conn.execute(
+        """
+        INSERT INTO kanban_budget_decisions (
+            task_id, request_id, external_id, status, policy,
+            extensions_count, extra_turns, last_budget_burn_at,
+            created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(task_id) DO UPDATE SET
+            request_id = excluded.request_id,
+            external_id = excluded.external_id,
+            status = excluded.status,
+            policy = excluded.policy,
+            extensions_count = excluded.extensions_count,
+            extra_turns = excluded.extra_turns,
+            last_budget_burn_at = excluded.last_budget_burn_at,
+            updated_at = excluded.updated_at
+        """,
+        (
+            decision.task_id,
+            decision.request_id or "",
+            decision.external_id or "",
+            decision.status,
+            decision.policy or "",
+            int(decision.extensions_count),
+            int(decision.extra_turns),
+            decision.last_budget_burn_at,
+            int(decision.created_at),
+            int(decision.updated_at),
+        ),
+    )
+
+
+def sidecar_dir() -> Path:
+    try:
+        from hermes_constants import get_hermes_home
+
+        home = Path(get_hermes_home())
+    except Exception:
+        raw = os.environ.get("HERMES_HOME")
+        home = Path(raw).expanduser() if raw else Path.home() / ".hermes"
+    return home / "state" / "budget-keepalive"
+
+
+def _safe_sidecar_name(subject_id: str) -> str:
+    cleaned = _SAFE_ID_RE.sub("-", str(subject_id or "").strip())
+    return cleaned[:180] or "unknown"
+
+
+def _sidecar_path(subject_id: str) -> Path:
+    return sidecar_dir() / f"{_safe_sidecar_name(subject_id)}.json"
+
+
+def load_sidecar(subject_id: str) -> Optional[BudgetDecision]:
+    path = _sidecar_path(subject_id)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("unreadable budget sidecar %s: %s", path, exc)
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return BudgetDecision(
+        task_id=str(payload.get("task_id") or subject_id),
+        request_id=str(payload.get("request_id") or "") or None,
+        external_id=str(payload.get("external_id") or "") or None,
+        status=str(payload.get("status") or STATUS_PENDING),
+        policy=str(payload.get("policy") or "") or None,
+        extensions_count=int(payload.get("extensions_count") or 0),
+        extra_turns=int(payload.get("extra_turns") or 0),
+        last_budget_burn_at=payload.get("last_budget_burn_at"),
+        created_at=int(payload.get("created_at") or 0),
+        updated_at=int(payload.get("updated_at") or 0),
+        store="sidecar",
+    )
+
+
+def save_sidecar(decision: BudgetDecision) -> None:
+    path = _sidecar_path(decision.task_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(path.parent, 0o700)
+    except OSError:
+        pass
+    decision.updated_at = _now()
+    if not decision.created_at:
+        decision.created_at = decision.updated_at
+    payload = decision.to_dict()
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            try:
+                os.fchmod(handle.fileno(), 0o600)
+            except OSError:
+                pass
+            json.dump(payload, handle, sort_keys=True, indent=2)
+            handle.write("\n")
+        os.replace(tmp_name, path)
+    finally:
+        try:
+            os.unlink(tmp_name)
+        except FileNotFoundError:
+            pass
+
+
+def is_bot_chat_agent(agent: Any) -> bool:
+    try:
+        from tools.bot_mode_probe import BOT_CHAT_TITLE
+    except Exception:
+        BOT_CHAT_TITLE = "Bot Chat"
+    title = str(getattr(agent, "_session_title_hint", "") or "").strip()
+    if not title:
+        session_db = getattr(agent, "_session_db", None)
+        session_id = getattr(agent, "session_id", None)
+        getter = getattr(session_db, "get_session_title", None) if session_db else None
+        if callable(getter) and session_id:
+            try:
+                title = str(getter(session_id) or "").strip()
+            except Exception:
+                title = ""
+    return title == BOT_CHAT_TITLE
+
+
+def sidecar_subject_id(agent: Any = None) -> Optional[str]:
+    """Id for the sidecar store, or None when this burn belongs on the board."""
+    if agent is not None:
+        sub = getattr(agent, "_subagent_id", None)
+        if isinstance(sub, str) and sub.strip():
+            return sub.strip()
+    try:
+        from agent.delegation_context import is_delegated_child_process_context
+
+        delegated = is_delegated_child_process_context()
+    except Exception:
+        delegated = bool(os.environ.get("HERMES_DELEGATED_CHILD_CONTEXT"))
+    if delegated:
+        return (
+            str(os.environ.get("HERMES_DELEGATE_ID") or "").strip()
+            or str(getattr(agent, "session_id", "") or "").strip()
+            or "delegated-child"
+        )
+    if agent is not None and is_bot_chat_agent(agent):
+        return str(getattr(agent, "session_id", "") or "").strip() or "bot-chat"
+    return None
+
+
+def _attest_origin(
+    args: Mapping[str, Any],
+    *,
+    task_id: str,
+    run_id: Any,
+    session_id: str,
+) -> dict[str, Any]:
+    """Reuse remoko-approval-delivery origin attestation when the lib is present."""
+    out = dict(args)
+    try:
+        import sys
+
+        lib = Path.home() / ".hermes" / "lib"
+        if lib.is_dir():
+            value = str(lib)
+            if value in sys.path:
+                sys.path.remove(value)
+            sys.path.insert(0, value)
+        import remoko_approval_delivery as rad
+
+        turn_id = f"budget-{out.get('external_id') or task_id}"
+        tool_call_id = f"keepalive-{out.get('external_id') or task_id}"
+        run_token = str(run_id or os.environ.get("HERMES_KANBAN_RUN_ID") or "0")
+        session_token = (
+            session_id
+            or str(os.environ.get("HERMES_SESSION_ID") or "").strip()
+            or f"kanban-{task_id}"
+        )
+        origin = {
+            "task_id": task_id,
+            "run_id": run_token,
+            "session_id": session_token,
+            "turn_id": turn_id,
+            "tool_call_id": tool_call_id,
+        }
+        origin["source_thread"] = rad._origin_token(
+            task_id=task_id,
+            run_id=run_token,
+            session_id=session_token,
+            turn_id=turn_id,
+            tool_call_id=tool_call_id,
+        )
+        board_row = {
+            "id": task_id,
+            "task_id": task_id,
+            "run_id": run_token,
+        }
+        rad.attest_origin_against_board(origin, board_row)
+        out = rad.augment_request_args(out, origin)
+        rad.ensure_request(out, origin)
+    except Exception as exc:
+        logger.debug("remoko origin attestation skipped: %s", exc)
+        out.setdefault("project", task_id)
+        out.setdefault("source_thread", f"hermes:kanban:{task_id}:budget")
+    return out
+
+
+def _extract_request_id(result: Mapping[str, Any]) -> str:
+    for key in ("request_id", "id"):
+        value = result.get(key)
+        if value:
+            return str(value)
+    nested = result.get("result")
+    if isinstance(nested, dict):
+        for key in ("request_id", "id"):
+            value = nested.get(key)
+            if value:
+                return str(value)
+    return ""
+
+
+def _send_card(
+    remoko_client: RemokoClient,
+    card: Mapping[str, Any],
+    *,
+    task_id: str,
+    run_id: Any = None,
+    session_id: str = "",
+) -> str:
+    enriched = _attest_origin(
+        card, task_id=task_id, run_id=run_id, session_id=session_id
+    )
+    result = remoko_client.ask_question(**enriched)
+    if not isinstance(result, Mapping):
+        return ""
+    return _extract_request_id(result)
+
+
+def _park_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    budget_used: int,
+    budget_max: int,
+    reason: str,
+    payload: Optional[dict[str, Any]] = None,
+) -> Optional[int]:
+    from hermes_cli import kanban_db as kb
+
+    run_id = kb._end_run(
+        conn,
+        task_id,
+        outcome="budget_exhausted",
+        status="budget_exhausted",
+        error=reason[:500],
+        metadata={
+            "budget_used": budget_used,
+            "budget_max": budget_max,
+            **(payload or {}),
+        },
+    )
+    conn.execute(
+        """
+        UPDATE tasks
+           SET status = 'blocked',
+               claim_lock = NULL,
+               claim_expires = NULL,
+               worker_pid = NULL,
+               block_kind = 'needs_input'
+         WHERE id = ?
+           AND status IN ('running', 'ready', 'blocked')
+        """,
+        (task_id,),
+    )
+    event_payload = {
+        "budget_used": budget_used,
+        "budget_max": budget_max,
+        "error": reason[:500],
+        **(payload or {}),
+    }
+    kb._append_event(
+        conn, task_id, "budget_exhausted", event_payload, run_id=run_id
+    )
+    return run_id
+
+
+def _consecutive_failures(conn: sqlite3.Connection, task_id: str) -> int:
+    row = conn.execute(
+        "SELECT consecutive_failures FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if row is None:
+        return 0
+    return int(row["consecutive_failures"] or 0)
+
+
+def record_kanban_budget_exhausted(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    budget_used: int,
+    budget_max: int,
+    remoko_client: Optional[RemokoClient] = None,
+    session_id: str = "",
+) -> BudgetDecision:
+    """First-class keep-alive for a live Kanban task."""
+    from hermes_cli import kanban_db as kb
+
+    client = remoko_client or default_remoko_client()
+    ensure_budget_decisions_table(conn)
+    existing = get_decision(conn, task_id)
+    failures_before = _consecutive_failures(conn, task_id)
+    now = _now()
+    reason = (
+        f"{BUDGET_EXHAUST_NEEDLE} ({budget_used}/{budget_max}) — "
+        "task could not complete within the allowed iterations"
+    )
+
+    if existing and existing.status in (
+        STATUS_PENDING,
+        STATUS_PARKED,
+        STATUS_STOPPED,
+    ):
+        if existing.status == STATUS_PENDING and not existing.request_id:
+            card = build_remoko_card(
+                task_id=task_id,
+                extensions_count=existing.extensions_count,
+                budget_used=budget_used,
+                budget_max=budget_max,
+                extra_turns=existing.extra_turns,
+            )
+            try:
+                request_id = _send_card(
+                    client,
+                    card,
+                    task_id=task_id,
+                    session_id=session_id,
+                )
+            except Exception as exc:
+                logger.warning("remoko retry on pending burn failed: %s", exc)
+                request_id = ""
+            if request_id:
+                existing.request_id = request_id
+                existing.external_id = existing.external_id or card["external_id"]
+                with kb.write_txn(conn):
+                    _upsert_decision(conn, existing)
+        return existing
+
+    if (
+        existing
+        and existing.status == STATUS_GRANTED
+        and existing.policy == POLICY_EXTEND_ONCE
+    ):
+        existing.status = STATUS_PARKED
+        existing.policy = POLICY_PARK
+        existing.last_budget_burn_at = now
+        existing.external_id = existing.external_id or external_id_for(
+            task_id, existing.extensions_count
+        )
+        with kb.write_txn(conn):
+            _park_task(
+                conn,
+                task_id,
+                budget_used=budget_used,
+                budget_max=budget_max,
+                reason=reason,
+                payload={
+                    "auto_parked": True,
+                    "policy": POLICY_EXTEND_ONCE,
+                    "external_id": existing.external_id,
+                    "consecutive_failures": failures_before,
+                },
+            )
+            _upsert_decision(conn, existing)
+            if _consecutive_failures(conn, task_id) != failures_before:
+                conn.execute(
+                    "UPDATE tasks SET consecutive_failures = ? WHERE id = ?",
+                    (failures_before, task_id),
+                )
+        return existing
+
+    extensions_count = existing.extensions_count if existing else 0
+    extra_turns = existing.extra_turns if existing else 0
+    created_at = existing.created_at if existing else now
+    card = build_remoko_card(
+        task_id=task_id,
+        extensions_count=extensions_count,
+        budget_used=budget_used,
+        budget_max=budget_max,
+        extra_turns=extra_turns,
+    )
+    decision = BudgetDecision(
+        task_id=task_id,
+        request_id="",
+        external_id=card["external_id"],
+        status=STATUS_PENDING,
+        policy="",
+        extensions_count=extensions_count,
+        extra_turns=extra_turns,
+        last_budget_burn_at=now,
+        created_at=created_at,
+        updated_at=now,
+    )
+    with kb.write_txn(conn):
+        _park_task(
+            conn,
+            task_id,
+            budget_used=budget_used,
+            budget_max=budget_max,
+            reason=reason,
+            payload={
+                "external_id": decision.external_id,
+                "consecutive_failures": failures_before,
+            },
+        )
+        _upsert_decision(conn, decision)
+        if _consecutive_failures(conn, task_id) != failures_before:
+            conn.execute(
+                "UPDATE tasks SET consecutive_failures = ? WHERE id = ?",
+                (failures_before, task_id),
+            )
+
+    try:
+        request_id = _send_card(
+            client, card, task_id=task_id, session_id=session_id
+        )
+    except Exception as exc:
+        logger.warning("remoko ask_question failed for %s: %s", task_id, exc)
+        request_id = ""
+    if request_id:
+        decision.request_id = request_id
+        with kb.write_txn(conn):
+            _upsert_decision(conn, decision)
+    return decision
+
+
+def record_sidecar_budget_exhausted(
+    subject_id: str,
+    *,
+    budget_used: int,
+    budget_max: int,
+    remoko_client: Optional[RemokoClient] = None,
+    session_id: str = "",
+) -> BudgetDecision:
+    client = remoko_client or default_remoko_client()
+    existing = load_sidecar(subject_id)
+    now = _now()
+    if existing and existing.status in (
+        STATUS_PENDING,
+        STATUS_PARKED,
+        STATUS_STOPPED,
+    ):
+        if existing.status == STATUS_PENDING and not existing.request_id:
+            card = build_remoko_card(
+                task_id=subject_id,
+                extensions_count=existing.extensions_count,
+                budget_used=budget_used,
+                budget_max=budget_max,
+                extra_turns=existing.extra_turns,
+            )
+            try:
+                request_id = _send_card(
+                    client, card, task_id=subject_id, session_id=session_id
+                )
+            except Exception as exc:
+                logger.warning("sidecar remoko retry failed: %s", exc)
+                request_id = ""
+            if request_id:
+                existing.request_id = request_id
+                existing.external_id = existing.external_id or card["external_id"]
+                save_sidecar(existing)
+        return existing
+
+    if (
+        existing
+        and existing.status == STATUS_GRANTED
+        and existing.policy == POLICY_EXTEND_ONCE
+    ):
+        existing.status = STATUS_PARKED
+        existing.policy = POLICY_PARK
+        existing.last_budget_burn_at = now
+        save_sidecar(existing)
+        return existing
+
+    extensions_count = existing.extensions_count if existing else 0
+    extra_turns = existing.extra_turns if existing else 0
+    card = build_remoko_card(
+        task_id=subject_id,
+        extensions_count=extensions_count,
+        budget_used=budget_used,
+        budget_max=budget_max,
+        extra_turns=extra_turns,
+    )
+    decision = BudgetDecision(
+        task_id=subject_id,
+        request_id="",
+        external_id=card["external_id"],
+        status=STATUS_PENDING,
+        policy="",
+        extensions_count=extensions_count,
+        extra_turns=extra_turns,
+        last_budget_burn_at=now,
+        created_at=existing.created_at if existing else now,
+        store="sidecar",
+    )
+    save_sidecar(decision)
+    try:
+        request_id = _send_card(
+            client, card, task_id=subject_id, session_id=session_id
+        )
+    except Exception as exc:
+        logger.warning("sidecar remoko ask_question failed: %s", exc)
+        request_id = ""
+    if request_id:
+        decision.request_id = request_id
+        save_sidecar(decision)
+    return decision
+
+
+def record_iteration_budget_exhausted(
+    *,
+    task_id: Optional[str] = None,
+    budget_used: int,
+    budget_max: int,
+    agent: Any = None,
+    remoko_client: Optional[RemokoClient] = None,
+    conn: Optional[sqlite3.Connection] = None,
+) -> Optional[BudgetDecision]:
+    """Route a budget burn to the board table or a sidecar. Never a death count."""
+    sidecar_id = sidecar_subject_id(agent)
+    if sidecar_id:
+        return record_sidecar_budget_exhausted(
+            sidecar_id,
+            budget_used=budget_used,
+            budget_max=budget_max,
+            remoko_client=remoko_client,
+            session_id=str(getattr(agent, "session_id", "") or ""),
+        )
+
+    live_task = (
+        str(task_id or "").strip()
+        or str(os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+    )
+    if not live_task:
+        return None
+
+    owns = conn is None
+    if owns:
+        from hermes_cli import kanban_db as kb
+
+        conn = kb.connect()
+    try:
+        return record_kanban_budget_exhausted(
+            conn,
+            live_task,
+            budget_used=budget_used,
+            budget_max=budget_max,
+            remoko_client=remoko_client,
+            session_id=str(getattr(agent, "session_id", "") or ""),
+        )
+    finally:
+        if owns:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
+def _normalize_answer(answer: Any) -> str:
+    if isinstance(answer, Mapping):
+        for key in ("choice", "answer", "text", "value"):
+            if answer.get(key):
+                return str(answer[key]).strip()
+    return str(answer or "").strip()
+
+
+def _stale_reason(conn: sqlite3.Connection, task_id: str, decision: BudgetDecision) -> Optional[str]:
+    from hermes_cli import kanban_db as kb
+
+    task = kb.get_task(conn, task_id)
+    if task is None:
+        return "task missing"
+    if task.status in {"done", "archived"}:
+        return f"task already {task.status}"
+    burned_at = int(decision.last_budget_burn_at or 0)
+    if burned_at:
+        newer = conn.execute(
+            """
+            SELECT 1 FROM task_runs
+             WHERE task_id = ?
+               AND outcome = 'completed'
+               AND ended_at IS NOT NULL
+               AND ended_at >= ?
+             LIMIT 1
+            """,
+            (task_id, burned_at),
+        ).fetchone()
+        if newer:
+            return "a newer run already completed"
+    return None
+
+
+def consume_budget_decision(
+    conn: sqlite3.Connection,
+    task_id: str,
+    answer: Any,
+    *,
+    remoko_client: Optional[RemokoClient] = None,
+) -> dict[str, Any]:
+    """Apply one Remoko tap after revalidation. Never increment the death counter."""
+    from hermes_cli import kanban_db as kb
+
+    client = remoko_client or default_remoko_client()
+    decision = get_decision(conn, task_id)
+    if decision is None:
+        return {"ok": False, "reason": "no budget decision", "applied": False}
+
+    choice = _normalize_answer(answer)
+    request_id = decision.request_id or ""
+
+    def _report(outcome: str, note: str) -> None:
+        if not request_id:
+            return
+        try:
+            client.report_execution(
+                request_id=request_id,
+                outcome=outcome,
+                note=note[:1000],
+            )
+        except Exception as exc:
+            logger.warning("report_execution failed for %s: %s", task_id, exc)
+
+    def _mark() -> None:
+        if not request_id:
+            return
+        try:
+            client.mark_processed(request_id=request_id)
+        except Exception as exc:
+            logger.warning("mark_processed failed for %s: %s", task_id, exc)
+
+    if decision.status == STATUS_STOPPED and choice != CHOICE_STOP:
+        _report("failed", "This card was already stopped.")
+        _mark()
+        return {"ok": False, "reason": "stopped", "applied": False, "stale": True}
+
+    if decision.status == STATUS_GRANTED:
+        _report("failed", "This tap was already used.")
+        _mark()
+        return {"ok": False, "reason": "already granted", "applied": False, "stale": True}
+
+    stale = _stale_reason(conn, task_id, decision)
+    if stale:
+        _report("failed", f"Stale tap: {stale}. No extra turns applied.")
+        _mark()
+        return {"ok": False, "reason": stale, "applied": False, "stale": True}
+
+    if choice == CHOICE_GIVE_MORE:
+        with kb.write_txn(conn):
+            # unblock_task opens its own txn; apply grant fields first, then unblock.
+            decision.extra_turns = int(decision.extra_turns) + EXTENSION_TURNS
+            decision.extensions_count = int(decision.extensions_count) + 1
+            decision.status = STATUS_GRANTED
+            decision.policy = POLICY_EXTEND_REPEAT
+            _upsert_decision(conn, decision)
+        task = kb.get_task(conn, task_id)
+        if task and task.status == "blocked":
+            kb.unblock_task(conn, task_id)
+        _report("completed", "Added 90 turns and restarted the same card.")
+        _mark()
+        return {
+            "ok": True,
+            "applied": True,
+            "choice": choice,
+            "extra_turns": decision.extra_turns,
+            "policy": decision.policy,
+            "max_iterations": worker_max_iterations_value(decision.extra_turns),
+        }
+
+    if choice == CHOICE_GIVE_ONCE:
+        with kb.write_txn(conn):
+            decision.extra_turns = int(decision.extra_turns) + EXTENSION_TURNS
+            decision.extensions_count = int(decision.extensions_count) + 1
+            decision.status = STATUS_GRANTED
+            decision.policy = POLICY_EXTEND_ONCE
+            _upsert_decision(conn, decision)
+        task = kb.get_task(conn, task_id)
+        if task and task.status == "blocked":
+            kb.unblock_task(conn, task_id)
+        _report("completed", "Added 90 turns once. The next burn will park with no new card.")
+        _mark()
+        return {
+            "ok": True,
+            "applied": True,
+            "choice": choice,
+            "extra_turns": decision.extra_turns,
+            "policy": decision.policy,
+            "max_iterations": worker_max_iterations_value(decision.extra_turns),
+        }
+
+    if choice == CHOICE_PARK:
+        with kb.write_txn(conn):
+            decision.status = STATUS_PARKED
+            decision.policy = POLICY_PARK
+            _upsert_decision(conn, decision)
+            conn.execute(
+                """
+                UPDATE tasks
+                   SET status = 'blocked',
+                       block_kind = 'needs_input'
+                 WHERE id = ?
+                   AND status IN ('blocked', 'ready', 'running')
+                """,
+                (task_id,),
+            )
+        _report("completed", "Parked. The card waits for a later tap.")
+        _mark()
+        return {"ok": True, "applied": True, "choice": choice, "status": STATUS_PARKED}
+
+    if choice == CHOICE_STOP:
+        with kb.write_txn(conn):
+            decision.status = STATUS_STOPPED
+            decision.policy = POLICY_STOP
+            _upsert_decision(conn, decision)
+            conn.execute(
+                """
+                UPDATE tasks
+                   SET status = 'blocked',
+                       block_kind = 'needs_input'
+                 WHERE id = ?
+                   AND status IN ('blocked', 'ready', 'running')
+                """,
+                (task_id,),
+            )
+        _report("completed", "Stopped. This card will not be dispatched.")
+        _mark()
+        return {"ok": True, "applied": True, "choice": choice, "status": STATUS_STOPPED}
+
+    _report("failed", f"Unknown tap {choice!r}.")
+    return {"ok": False, "reason": f"unknown choice {choice!r}", "applied": False}
+
+
+def consume_sidecar_budget_decision(
+    subject_id: str,
+    answer: Any,
+    *,
+    remoko_client: Optional[RemokoClient] = None,
+) -> dict[str, Any]:
+    client = remoko_client or default_remoko_client()
+    decision = load_sidecar(subject_id)
+    if decision is None:
+        return {"ok": False, "reason": "no budget decision", "applied": False}
+    choice = _normalize_answer(answer)
+    request_id = decision.request_id or ""
+
+    def _report(outcome: str, note: str) -> None:
+        if not request_id:
+            return
+        try:
+            client.report_execution(request_id=request_id, outcome=outcome, note=note[:1000])
+        except Exception as exc:
+            logger.warning("sidecar report_execution failed: %s", exc)
+
+    def _mark() -> None:
+        if not request_id:
+            return
+        try:
+            client.mark_processed(request_id=request_id)
+        except Exception as exc:
+            logger.warning("sidecar mark_processed failed: %s", exc)
+
+    if decision.status == STATUS_STOPPED and choice != CHOICE_STOP:
+        _report("failed", "This work was already stopped.")
+        _mark()
+        return {"ok": False, "reason": "stopped", "applied": False, "stale": True}
+    if decision.status == STATUS_GRANTED:
+        _report("failed", "This tap was already used.")
+        _mark()
+        return {"ok": False, "reason": "already granted", "applied": False, "stale": True}
+
+    if choice == CHOICE_GIVE_MORE:
+        decision.extra_turns += EXTENSION_TURNS
+        decision.extensions_count += 1
+        decision.status = STATUS_GRANTED
+        decision.policy = POLICY_EXTEND_REPEAT
+        save_sidecar(decision)
+        _report("completed", "Added 90 turns.")
+        _mark()
+        return {"ok": True, "applied": True, "choice": choice, "extra_turns": decision.extra_turns}
+    if choice == CHOICE_GIVE_ONCE:
+        decision.extra_turns += EXTENSION_TURNS
+        decision.extensions_count += 1
+        decision.status = STATUS_GRANTED
+        decision.policy = POLICY_EXTEND_ONCE
+        save_sidecar(decision)
+        _report("completed", "Added 90 turns once.")
+        _mark()
+        return {"ok": True, "applied": True, "choice": choice, "extra_turns": decision.extra_turns}
+    if choice == CHOICE_PARK:
+        decision.status = STATUS_PARKED
+        decision.policy = POLICY_PARK
+        save_sidecar(decision)
+        _report("completed", "Parked.")
+        _mark()
+        return {"ok": True, "applied": True, "choice": choice, "status": STATUS_PARKED}
+    if choice == CHOICE_STOP:
+        decision.status = STATUS_STOPPED
+        decision.policy = POLICY_STOP
+        save_sidecar(decision)
+        _report("completed", "Stopped.")
+        _mark()
+        return {"ok": True, "applied": True, "choice": choice, "status": STATUS_STOPPED}
+    return {"ok": False, "reason": f"unknown choice {choice!r}", "applied": False}
+
+
+def reconcile_budget_keepalive(
+    conn: sqlite3.Connection,
+    *,
+    remoko_client: Optional[RemokoClient] = None,
+) -> dict[str, Any]:
+    """Retry unsent pending cards. Never auto-resumes a pending/parked/stopped row."""
+    client = remoko_client or default_remoko_client()
+    ensure_budget_decisions_table(conn)
+    retried = 0
+    consumed = 0
+    rows = conn.execute(
+        "SELECT * FROM kanban_budget_decisions WHERE status = ?",
+        (STATUS_PENDING,),
+    ).fetchall()
+    for row in rows:
+        decision = _row_to_decision(row)
+        if not decision.request_id:
+            card = build_remoko_card(
+                task_id=decision.task_id,
+                extensions_count=decision.extensions_count,
+                budget_used=0,
+                budget_max=0,
+                extra_turns=decision.extra_turns,
+            )
+            card["external_id"] = decision.external_id or card["external_id"]
+            try:
+                request_id = _send_card(client, card, task_id=decision.task_id)
+            except Exception as exc:
+                logger.warning("reconcile remoko send failed for %s: %s", decision.task_id, exc)
+                request_id = ""
+            if request_id:
+                decision.request_id = request_id
+                from hermes_cli import kanban_db as kb
+
+                with kb.write_txn(conn):
+                    _upsert_decision(conn, decision)
+                retried += 1
+            continue
+        try:
+            payload = client.get_response(request_id=decision.request_id)
+        except Exception:
+            continue
+        if not isinstance(payload, Mapping) or payload.get("status") != "answered":
+            continue
+        response = payload.get("response") if isinstance(payload.get("response"), Mapping) else payload
+        choice = _normalize_answer(response)
+        if not choice:
+            continue
+        result = consume_budget_decision(
+            conn, decision.task_id, choice, remoko_client=client
+        )
+        if result.get("ok"):
+            consumed += 1
+
+    sidecar_retried = _reconcile_sidecars(client)
+    return {"retried": retried, "consumed": consumed, "sidecar_retried": sidecar_retried}
+
+
+def _reconcile_sidecars(client: RemokoClient) -> int:
+    root = sidecar_dir()
+    if not root.is_dir():
+        return 0
+    retried = 0
+    for path in root.glob("*.json"):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict) or payload.get("status") != STATUS_PENDING:
+            continue
+        if payload.get("request_id"):
+            continue
+        subject_id = str(payload.get("task_id") or path.stem)
+        card = build_remoko_card(
+            task_id=subject_id,
+            extensions_count=int(payload.get("extensions_count") or 0),
+            budget_used=0,
+            budget_max=0,
+            extra_turns=int(payload.get("extra_turns") or 0),
+        )
+        card["external_id"] = payload.get("external_id") or card["external_id"]
+        try:
+            request_id = _send_card(client, card, task_id=subject_id)
+        except Exception:
+            request_id = ""
+        if request_id:
+            decision = load_sidecar(subject_id)
+            if decision:
+                decision.request_id = request_id
+                save_sidecar(decision)
+                retried += 1
+    return retried

--- a/hermes_cli/kanban_budget_keepalive.py
+++ b/hermes_cli/kanban_budget_keepalive.py
@@ -7,16 +7,24 @@ one Remoko tap grants +90 turns, parks, or stops the work.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
 import re
+import secrets
 import sqlite3
 import tempfile
+import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Mapping, Optional, Protocol
+from typing import Any, Iterator, Mapping, Optional, Protocol
+
+try:
+    import fcntl as _fcntl
+except ImportError:  # Windows — sidecar claim still serializes in-process.
+    _fcntl = None
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +49,9 @@ MAX_RECOMMENDED_GRANTS = 3
 BUDGET_EXHAUST_NEEDLE = "Iteration budget exhausted"
 DEFAULT_BASE_MAX_TURNS = 90
 HEADLINE = "Keep this work going?"
+SEND_CLAIM_PREFIX = "sending:"
+SEND_CLAIM_TTL_SECONDS = 30.0
+_SIDECAR_THREAD_LOCK = threading.Lock()
 
 DECISION_STATUSES = frozenset(
     {STATUS_PENDING, STATUS_GRANTED, STATUS_PARKED, STATUS_STOPPED}
@@ -646,6 +657,144 @@ def _send_card(
     return _extract_request_id(result)
 
 
+def _new_send_claim() -> str:
+    return f"{SEND_CLAIM_PREFIX}{os.getpid()}:{time.time_ns()}:{secrets.token_hex(8)}"
+
+
+def _send_claim_age_seconds(request_id: Optional[str]) -> Optional[float]:
+    rid = str(request_id or "").strip()
+    if not rid.startswith(SEND_CLAIM_PREFIX):
+        return None
+    parts = rid.split(":")
+    if len(parts) < 4:
+        return float("inf")
+    try:
+        minted_ns = int(parts[2])
+    except ValueError:
+        return float("inf")
+    return max(0.0, (time.time_ns() - minted_ns) / 1e9)
+
+
+def _has_live_request_id(request_id: Optional[str]) -> bool:
+    rid = str(request_id or "").strip()
+    return bool(rid) and _send_claim_age_seconds(rid) is None
+
+
+def _request_is_claimable(request_id: Optional[str]) -> bool:
+    """Empty or a stale sending token may be claimed. A live Remoko id may not."""
+    rid = str(request_id or "").strip()
+    if not rid:
+        return True
+    age = _send_claim_age_seconds(rid)
+    if age is None:
+        return False
+    return age >= SEND_CLAIM_TTL_SECONDS
+
+
+def _send_claimed_card(
+    remoko_client: RemokoClient,
+    card: Mapping[str, Any],
+    *,
+    task_id: str,
+    session_id: str = "",
+) -> str:
+    try:
+        return _send_card(
+            remoko_client, card, task_id=task_id, session_id=session_id
+        )
+    except Exception as exc:
+        logger.warning("remoko ask_question failed for %s: %s", task_id, exc)
+        return ""
+
+
+def _complete_or_clear_kanban_claim(
+    conn: sqlite3.Connection,
+    decision: BudgetDecision,
+    claim: str,
+    request_id: str,
+) -> None:
+    from hermes_cli import kanban_db as kb
+
+    now = _now()
+    persisted = request_id or ""
+    with kb.write_txn(conn):
+        cur = conn.execute(
+            """
+            UPDATE kanban_budget_decisions
+               SET request_id = ?, updated_at = ?
+             WHERE task_id = ?
+               AND request_id = ?
+            """,
+            (persisted, now, decision.task_id, claim),
+        )
+        if cur.rowcount == 1:
+            decision.request_id = persisted or None
+            decision.updated_at = now
+            return
+        live = get_decision(conn, decision.task_id)
+        if live is not None:
+            decision.request_id = live.request_id
+            decision.status = live.status
+            decision.extra_turns = live.extra_turns
+            decision.updated_at = live.updated_at
+
+
+@contextlib.contextmanager
+def _sidecar_lock(subject_id: str) -> Iterator[None]:
+    path = _sidecar_path(subject_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_name(path.name + ".lock")
+    handle = open(lock_path, "a+b")
+    _SIDECAR_THREAD_LOCK.acquire()
+    try:
+        try:
+            os.chmod(lock_path, 0o600)
+        except OSError:
+            pass
+        if _fcntl is not None:
+            _fcntl.flock(handle.fileno(), _fcntl.LOCK_EX)
+        yield
+    finally:
+        if _fcntl is not None:
+            try:
+                _fcntl.flock(handle.fileno(), _fcntl.LOCK_UN)
+            except OSError:
+                pass
+        handle.close()
+        _SIDECAR_THREAD_LOCK.release()
+
+
+def _complete_or_clear_sidecar_claim(
+    subject_id: str,
+    decision: BudgetDecision,
+    claim: str,
+    request_id: str,
+) -> None:
+    with _sidecar_lock(subject_id):
+        live = load_sidecar(subject_id)
+        if live is None or live.request_id != claim:
+            if live is not None:
+                decision.request_id = live.request_id
+                decision.status = live.status
+                decision.extra_turns = live.extra_turns
+                decision.updated_at = live.updated_at
+            return
+        live.request_id = request_id or None
+        save_sidecar(live)
+        decision.request_id = live.request_id
+        decision.status = live.status
+        decision.updated_at = live.updated_at
+
+
+def _answered_choice(payload: Any) -> str:
+    if not isinstance(payload, Mapping) or payload.get("status") != "answered":
+        return ""
+    response = payload.get("response")
+    if not isinstance(response, Mapping):
+        response = payload
+    return _normalize_answer(response)
+
+
 def _park_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -718,56 +867,49 @@ def record_kanban_budget_exhausted(
 
     client = remoko_client or default_remoko_client()
     ensure_budget_decisions_table(conn)
-    existing = get_decision(conn, task_id)
     failures_before = _consecutive_failures(conn, task_id)
     now = _now()
     reason = (
         f"{BUDGET_EXHAUST_NEEDLE} ({budget_used}/{budget_max}) — "
         "task could not complete within the allowed iterations"
     )
+    claim = _new_send_claim()
+    send_card: Optional[dict[str, Any]] = None
+    decision: Optional[BudgetDecision] = None
 
-    if existing and existing.status in (
-        STATUS_PENDING,
-        STATUS_PARKED,
-        STATUS_STOPPED,
-    ):
-        if existing.status == STATUS_PENDING and not existing.request_id:
-            card = build_remoko_card(
-                task_id=task_id,
-                extensions_count=existing.extensions_count,
-                budget_used=budget_used,
-                budget_max=budget_max,
-                extra_turns=existing.extra_turns,
-            )
-            try:
-                request_id = _send_card(
-                    client,
-                    card,
+    with kb.write_txn(conn):
+        existing = get_decision(conn, task_id)
+
+        if existing and existing.status in (
+            STATUS_PENDING,
+            STATUS_PARKED,
+            STATUS_STOPPED,
+        ):
+            if existing.status == STATUS_PENDING and _request_is_claimable(
+                existing.request_id
+            ):
+                send_card = build_remoko_card(
                     task_id=task_id,
-                    session_id=session_id,
+                    extensions_count=existing.extensions_count,
+                    budget_used=budget_used,
+                    budget_max=budget_max,
+                    extra_turns=existing.extra_turns,
                 )
-            except Exception as exc:
-                logger.warning("remoko retry on pending burn failed: %s", exc)
-                request_id = ""
-            if request_id:
-                existing.request_id = request_id
-                existing.external_id = existing.external_id or card["external_id"]
-                with kb.write_txn(conn):
-                    _upsert_decision(conn, existing)
-        return existing
-
-    if (
-        existing
-        and existing.status == STATUS_GRANTED
-        and existing.policy == POLICY_EXTEND_ONCE
-    ):
-        existing.status = STATUS_PARKED
-        existing.policy = POLICY_PARK
-        existing.last_budget_burn_at = now
-        existing.external_id = existing.external_id or external_id_for(
-            task_id, existing.extensions_count
-        )
-        with kb.write_txn(conn):
+                existing.request_id = claim
+                existing.external_id = existing.external_id or send_card["external_id"]
+                _upsert_decision(conn, existing)
+            decision = existing
+        elif (
+            existing
+            and existing.status == STATUS_GRANTED
+            and existing.policy == POLICY_EXTEND_ONCE
+        ):
+            existing.status = STATUS_PARKED
+            existing.policy = POLICY_PARK
+            existing.last_budget_burn_at = now
+            existing.external_id = existing.external_id or external_id_for(
+                task_id, existing.extensions_count
+            )
             _park_task(
                 conn,
                 task_id,
@@ -787,60 +929,56 @@ def record_kanban_budget_exhausted(
                     "UPDATE tasks SET consecutive_failures = ? WHERE id = ?",
                     (failures_before, task_id),
                 )
-        return existing
-
-    extensions_count = existing.extensions_count if existing else 0
-    extra_turns = existing.extra_turns if existing else 0
-    created_at = existing.created_at if existing else now
-    card = build_remoko_card(
-        task_id=task_id,
-        extensions_count=extensions_count,
-        budget_used=budget_used,
-        budget_max=budget_max,
-        extra_turns=extra_turns,
-    )
-    decision = BudgetDecision(
-        task_id=task_id,
-        request_id="",
-        external_id=card["external_id"],
-        status=STATUS_PENDING,
-        policy="",
-        extensions_count=extensions_count,
-        extra_turns=extra_turns,
-        last_budget_burn_at=now,
-        created_at=created_at,
-        updated_at=now,
-    )
-    with kb.write_txn(conn):
-        _park_task(
-            conn,
-            task_id,
-            budget_used=budget_used,
-            budget_max=budget_max,
-            reason=reason,
-            payload={
-                "external_id": decision.external_id,
-                "consecutive_failures": failures_before,
-            },
-        )
-        _upsert_decision(conn, decision)
-        if _consecutive_failures(conn, task_id) != failures_before:
-            conn.execute(
-                "UPDATE tasks SET consecutive_failures = ? WHERE id = ?",
-                (failures_before, task_id),
+            decision = existing
+        else:
+            extensions_count = existing.extensions_count if existing else 0
+            extra_turns = existing.extra_turns if existing else 0
+            created_at = existing.created_at if existing else now
+            send_card = build_remoko_card(
+                task_id=task_id,
+                extensions_count=extensions_count,
+                budget_used=budget_used,
+                budget_max=budget_max,
+                extra_turns=extra_turns,
             )
-
-    try:
-        request_id = _send_card(
-            client, card, task_id=task_id, session_id=session_id
-        )
-    except Exception as exc:
-        logger.warning("remoko ask_question failed for %s: %s", task_id, exc)
-        request_id = ""
-    if request_id:
-        decision.request_id = request_id
-        with kb.write_txn(conn):
+            decision = BudgetDecision(
+                task_id=task_id,
+                request_id=claim,
+                external_id=send_card["external_id"],
+                status=STATUS_PENDING,
+                policy="",
+                extensions_count=extensions_count,
+                extra_turns=extra_turns,
+                last_budget_burn_at=now,
+                created_at=created_at,
+                updated_at=now,
+            )
+            _park_task(
+                conn,
+                task_id,
+                budget_used=budget_used,
+                budget_max=budget_max,
+                reason=reason,
+                payload={
+                    "external_id": decision.external_id,
+                    "consecutive_failures": failures_before,
+                },
+            )
             _upsert_decision(conn, decision)
+            if _consecutive_failures(conn, task_id) != failures_before:
+                conn.execute(
+                    "UPDATE tasks SET consecutive_failures = ? WHERE id = ?",
+                    (failures_before, task_id),
+                )
+
+    assert decision is not None
+    if send_card is None:
+        return decision
+
+    request_id = _send_claimed_card(
+        client, send_card, task_id=task_id, session_id=session_id
+    )
+    _complete_or_clear_kanban_claim(conn, decision, claim, request_id)
     return decision
 
 
@@ -853,77 +991,74 @@ def record_sidecar_budget_exhausted(
     session_id: str = "",
 ) -> BudgetDecision:
     client = remoko_client or default_remoko_client()
-    existing = load_sidecar(subject_id)
     now = _now()
-    if existing and existing.status in (
-        STATUS_PENDING,
-        STATUS_PARKED,
-        STATUS_STOPPED,
-    ):
-        if existing.status == STATUS_PENDING and not existing.request_id:
-            card = build_remoko_card(
+    claim = _new_send_claim()
+    send_card: Optional[dict[str, Any]] = None
+    decision: Optional[BudgetDecision] = None
+
+    with _sidecar_lock(subject_id):
+        existing = load_sidecar(subject_id)
+        if existing and existing.status in (
+            STATUS_PENDING,
+            STATUS_PARKED,
+            STATUS_STOPPED,
+        ):
+            if existing.status == STATUS_PENDING and _request_is_claimable(
+                existing.request_id
+            ):
+                send_card = build_remoko_card(
+                    task_id=subject_id,
+                    extensions_count=existing.extensions_count,
+                    budget_used=budget_used,
+                    budget_max=budget_max,
+                    extra_turns=existing.extra_turns,
+                )
+                existing.request_id = claim
+                existing.external_id = existing.external_id or send_card["external_id"]
+                save_sidecar(existing)
+            decision = existing
+        elif (
+            existing
+            and existing.status == STATUS_GRANTED
+            and existing.policy == POLICY_EXTEND_ONCE
+        ):
+            existing.status = STATUS_PARKED
+            existing.policy = POLICY_PARK
+            existing.last_budget_burn_at = now
+            save_sidecar(existing)
+            decision = existing
+        else:
+            extensions_count = existing.extensions_count if existing else 0
+            extra_turns = existing.extra_turns if existing else 0
+            send_card = build_remoko_card(
                 task_id=subject_id,
-                extensions_count=existing.extensions_count,
+                extensions_count=extensions_count,
                 budget_used=budget_used,
                 budget_max=budget_max,
-                extra_turns=existing.extra_turns,
+                extra_turns=extra_turns,
             )
-            try:
-                request_id = _send_card(
-                    client, card, task_id=subject_id, session_id=session_id
-                )
-            except Exception as exc:
-                logger.warning("sidecar remoko retry failed: %s", exc)
-                request_id = ""
-            if request_id:
-                existing.request_id = request_id
-                existing.external_id = existing.external_id or card["external_id"]
-                save_sidecar(existing)
-        return existing
+            decision = BudgetDecision(
+                task_id=subject_id,
+                request_id=claim,
+                external_id=send_card["external_id"],
+                status=STATUS_PENDING,
+                policy="",
+                extensions_count=extensions_count,
+                extra_turns=extra_turns,
+                last_budget_burn_at=now,
+                created_at=existing.created_at if existing else now,
+                store="sidecar",
+            )
+            save_sidecar(decision)
 
-    if (
-        existing
-        and existing.status == STATUS_GRANTED
-        and existing.policy == POLICY_EXTEND_ONCE
-    ):
-        existing.status = STATUS_PARKED
-        existing.policy = POLICY_PARK
-        existing.last_budget_burn_at = now
-        save_sidecar(existing)
-        return existing
+    assert decision is not None
+    if send_card is None:
+        return decision
 
-    extensions_count = existing.extensions_count if existing else 0
-    extra_turns = existing.extra_turns if existing else 0
-    card = build_remoko_card(
-        task_id=subject_id,
-        extensions_count=extensions_count,
-        budget_used=budget_used,
-        budget_max=budget_max,
-        extra_turns=extra_turns,
+    request_id = _send_claimed_card(
+        client, send_card, task_id=subject_id, session_id=session_id
     )
-    decision = BudgetDecision(
-        task_id=subject_id,
-        request_id="",
-        external_id=card["external_id"],
-        status=STATUS_PENDING,
-        policy="",
-        extensions_count=extensions_count,
-        extra_turns=extra_turns,
-        last_budget_burn_at=now,
-        created_at=existing.created_at if existing else now,
-        store="sidecar",
-    )
-    save_sidecar(decision)
-    try:
-        request_id = _send_card(
-            client, card, task_id=subject_id, session_id=session_id
-        )
-    except Exception as exc:
-        logger.warning("sidecar remoko ask_question failed: %s", exc)
-        request_id = ""
-    if request_id:
-        decision.request_id = request_id
-        save_sidecar(decision)
+    _complete_or_clear_sidecar_claim(subject_id, decision, claim, request_id)
     return decision
 
 
@@ -1227,7 +1362,9 @@ def reconcile_budget_keepalive(
     *,
     remoko_client: Optional[RemokoClient] = None,
 ) -> dict[str, Any]:
-    """Retry unsent pending cards. Never auto-resumes a pending/parked/stopped row."""
+    """Retry unsent pending cards and apply answered taps. Never auto-resumes."""
+    from hermes_cli import kanban_db as kb
+
     client = remoko_client or default_remoko_client()
     ensure_budget_decisions_table(conn)
     retried = 0
@@ -1238,7 +1375,9 @@ def reconcile_budget_keepalive(
     ).fetchall()
     for row in rows:
         decision = _row_to_decision(row)
-        if not decision.request_id:
+        if not _has_live_request_id(decision.request_id):
+            if not _request_is_claimable(decision.request_id):
+                continue
             card = build_remoko_card(
                 task_id=decision.task_id,
                 extensions_count=decision.extensions_count,
@@ -1247,27 +1386,28 @@ def reconcile_budget_keepalive(
                 extra_turns=decision.extra_turns,
             )
             card["external_id"] = decision.external_id or card["external_id"]
-            try:
-                request_id = _send_card(client, card, task_id=decision.task_id)
-            except Exception as exc:
-                logger.warning("reconcile remoko send failed for %s: %s", decision.task_id, exc)
-                request_id = ""
+            claim = _new_send_claim()
+            with kb.write_txn(conn):
+                live = get_decision(conn, decision.task_id)
+                if (
+                    live is None
+                    or live.status != STATUS_PENDING
+                    or not _request_is_claimable(live.request_id)
+                ):
+                    continue
+                live.request_id = claim
+                live.external_id = live.external_id or card["external_id"]
+                _upsert_decision(conn, live)
+            request_id = _send_claimed_card(client, card, task_id=decision.task_id)
+            _complete_or_clear_kanban_claim(conn, decision, claim, request_id)
             if request_id:
-                decision.request_id = request_id
-                from hermes_cli import kanban_db as kb
-
-                with kb.write_txn(conn):
-                    _upsert_decision(conn, decision)
                 retried += 1
             continue
         try:
             payload = client.get_response(request_id=decision.request_id)
         except Exception:
             continue
-        if not isinstance(payload, Mapping) or payload.get("status") != "answered":
-            continue
-        response = payload.get("response") if isinstance(payload.get("response"), Mapping) else payload
-        choice = _normalize_answer(response)
+        choice = _answered_choice(payload)
         if not choice:
             continue
         result = consume_budget_decision(
@@ -1276,15 +1416,21 @@ def reconcile_budget_keepalive(
         if result.get("ok"):
             consumed += 1
 
-    sidecar_retried = _reconcile_sidecars(client)
-    return {"retried": retried, "consumed": consumed, "sidecar_retried": sidecar_retried}
+    sidecar_retried, sidecar_consumed = _reconcile_sidecars(client)
+    return {
+        "retried": retried,
+        "consumed": consumed,
+        "sidecar_retried": sidecar_retried,
+        "sidecar_consumed": sidecar_consumed,
+    }
 
 
-def _reconcile_sidecars(client: RemokoClient) -> int:
+def _reconcile_sidecars(client: RemokoClient) -> tuple[int, int]:
     root = sidecar_dir()
     if not root.is_dir():
-        return 0
+        return 0, 0
     retried = 0
+    consumed = 0
     for path in root.glob("*.json"):
         try:
             payload = json.loads(path.read_text(encoding="utf-8"))
@@ -1292,9 +1438,24 @@ def _reconcile_sidecars(client: RemokoClient) -> int:
             continue
         if not isinstance(payload, dict) or payload.get("status") != STATUS_PENDING:
             continue
-        if payload.get("request_id"):
-            continue
         subject_id = str(payload.get("task_id") or path.stem)
+        request_id = str(payload.get("request_id") or "") or None
+        if _has_live_request_id(request_id):
+            try:
+                response = client.get_response(request_id=request_id)
+            except Exception:
+                continue
+            choice = _answered_choice(response)
+            if not choice:
+                continue
+            result = consume_sidecar_budget_decision(
+                subject_id, choice, remoko_client=client
+            )
+            if result.get("ok"):
+                consumed += 1
+            continue
+        if not _request_is_claimable(request_id):
+            continue
         card = build_remoko_card(
             task_id=subject_id,
             extensions_count=int(payload.get("extensions_count") or 0),
@@ -1303,14 +1464,21 @@ def _reconcile_sidecars(client: RemokoClient) -> int:
             extra_turns=int(payload.get("extra_turns") or 0),
         )
         card["external_id"] = payload.get("external_id") or card["external_id"]
-        try:
-            request_id = _send_card(client, card, task_id=subject_id)
-        except Exception:
-            request_id = ""
-        if request_id:
-            decision = load_sidecar(subject_id)
-            if decision:
-                decision.request_id = request_id
-                save_sidecar(decision)
-                retried += 1
-    return retried
+        claim = _new_send_claim()
+        with _sidecar_lock(subject_id):
+            live = load_sidecar(subject_id)
+            if (
+                live is None
+                or live.status != STATUS_PENDING
+                or not _request_is_claimable(live.request_id)
+            ):
+                continue
+            live.request_id = claim
+            live.external_id = live.external_id or card["external_id"]
+            save_sidecar(live)
+        sent = _send_claimed_card(client, card, task_id=subject_id)
+        scratch = live if live is not None else BudgetDecision(task_id=subject_id)
+        _complete_or_clear_sidecar_claim(subject_id, scratch, claim, sent)
+        if sent:
+            retried += 1
+    return retried, consumed

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1514,7 +1514,24 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     PRIMARY KEY (task_id, platform, chat_id, thread_id)
 );
 
+-- Iteration-budget Remoko keep-alive (LS-2777). Board-local; not the
+-- LS-2776 objective tables. A burn parks here until one owner tap.
+CREATE TABLE IF NOT EXISTS kanban_budget_decisions (
+    task_id              TEXT PRIMARY KEY,
+    request_id           TEXT,
+    external_id          TEXT,
+    status               TEXT NOT NULL,
+    policy               TEXT,
+    extensions_count     INTEGER NOT NULL DEFAULT 0,
+    extra_turns          INTEGER NOT NULL DEFAULT 0,
+    last_budget_burn_at  INTEGER,
+    created_at           INTEGER NOT NULL,
+    updated_at           INTEGER NOT NULL
+);
+
 CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
+CREATE INDEX IF NOT EXISTS idx_budget_decisions_status
+    ON kanban_budget_decisions(status);
 CREATE INDEX IF NOT EXISTS idx_tasks_status          ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_links_child           ON task_links(child_id);
 CREATE INDEX IF NOT EXISTS idx_links_parent          ON task_links(parent_id);
@@ -2833,6 +2850,30 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "UPDATE task_events SET kind = ? WHERE kind = ?",
             (new, old),
         )
+
+    # LS-2777 keep-alive table. SCHEMA_SQL creates it on fresh DBs;
+    # CREATE TABLE IF NOT EXISTS here covers boards that opened before
+    # the table existed without forcing a full SCHEMA_SQL re-run.
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS kanban_budget_decisions (
+            task_id              TEXT PRIMARY KEY,
+            request_id           TEXT,
+            external_id          TEXT,
+            status               TEXT NOT NULL,
+            policy               TEXT,
+            extensions_count     INTEGER NOT NULL DEFAULT 0,
+            extra_turns          INTEGER NOT NULL DEFAULT 0,
+            last_budget_burn_at  INTEGER,
+            created_at           INTEGER NOT NULL,
+            updated_at           INTEGER NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_budget_decisions_status "
+        "ON kanban_budget_decisions(status)"
+    )
 
     _rebuild_drifted_tables(conn)
 
@@ -9970,6 +10011,12 @@ def _dispatch_once_locked(
         result.rate_limited.extend(_crash_rate_limited)
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
+    try:
+        from hermes_cli.kanban_budget_keepalive import reconcile_budget_keepalive
+
+        reconcile_budget_keepalive(conn)
+    except Exception:
+        _log.warning("kanban dispatch: budget keep-alive reconcile failed", exc_info=True)
 
     # Count tasks already running so max_spawn enforces concurrency rather
     # than a per-tick spawn budget. See the docstring above for the full
@@ -10215,6 +10262,19 @@ def _dispatch_once_locked(
                         {"reason": guard_reason},
                     )
             continue
+        try:
+            from hermes_cli.kanban_budget_keepalive import (
+                budget_decision_blocks_dispatch,
+            )
+
+            if budget_decision_blocks_dispatch(conn, row["id"]):
+                continue
+        except Exception:
+            _log.debug(
+                "kanban dispatch: budget keep-alive gate failed for %s",
+                row["id"],
+                exc_info=True,
+            )
         if dry_run:
             result.spawned.append((row["id"], row_assignee, ""))
             spawned += 1
@@ -10829,6 +10889,23 @@ def _default_spawn(
     # what the tool reads — set it explicitly here so comments are
     # attributed correctly regardless of how the child loads config.
     env["HERMES_PROFILE"] = profile_arg
+
+    try:
+        from hermes_cli.kanban_budget_keepalive import (
+            extra_turns_for_task,
+            worker_max_iterations_value,
+        )
+
+        extra = extra_turns_for_task(task.id)
+        env["HERMES_KANBAN_MAX_ITERATIONS"] = str(
+            worker_max_iterations_value(extra, hermes_home=env.get("HERMES_HOME"))
+        )
+    except Exception:
+        _log.debug(
+            "kanban worker: could not resolve HERMES_KANBAN_MAX_ITERATIONS for %s",
+            task.id,
+            exc_info=True,
+        )
 
     # A worker must NEVER boot the interactive TUI: an inherited HERMES_TUI=1
     # or a `display.interface: tui` in the profile's config would send the

--- a/tests/agent/test_turn_finalizer_iteration_limit_exit.py
+++ b/tests/agent/test_turn_finalizer_iteration_limit_exit.py
@@ -165,13 +165,16 @@ def test_pending_response_does_not_mask_later_terminal_exit(
     assert agent._handle_max_iterations_called is False
 
 
-def test_pending_response_records_kanban_timeout(monkeypatch):
+def test_pending_response_records_kanban_keepalive(monkeypatch):
     monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
     monkeypatch.setenv("HERMES_KANBAN_TASK", "task-123")
-    record = MagicMock(name="record_task_failure")
-    conn = SimpleNamespace(close=lambda: None)
-    monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: conn)
-    monkeypatch.setattr("hermes_cli.kanban_db._record_task_failure", record)
+    record = MagicMock(name="record_iteration_budget_exhausted")
+    monkeypatch.setattr(
+        "hermes_cli.kanban_budget_keepalive.record_iteration_budget_exhausted",
+        record,
+    )
+    fail = MagicMock(name="record_task_failure")
+    monkeypatch.setattr("hermes_cli.kanban_db._record_task_failure", fail)
     agent = _LimitAgent()
 
     result = _finalize(
@@ -182,18 +185,12 @@ def test_pending_response_records_kanban_timeout(monkeypatch):
     )
 
     assert result["turn_exit_reason"] == "max_iterations_reached(60/60)"
-    record.assert_called_once_with(
-        conn,
-        "task-123",
-        error=(
-            "Iteration budget exhausted (60/60) — task could not complete "
-            "within the allowed iterations"
-        ),
-        outcome="timed_out",
-        release_claim=True,
-        end_run=True,
-        event_payload_extra={"budget_used": 60, "budget_max": 60},
-    )
+    record.assert_called_once()
+    kwargs = record.call_args.kwargs
+    assert kwargs["task_id"] == "task-123"
+    assert kwargs["budget_used"] == 60
+    assert kwargs["budget_max"] == 60
+    fail.assert_not_called()
 
 
 def test_published_pending_candidate_is_not_duplicated_by_finalizer(monkeypatch):
@@ -235,21 +232,22 @@ def test_published_pending_candidate_is_not_duplicated_by_finalizer(monkeypatch)
     assert persisted_roles == ["user", "assistant"]
 
 
-def test_bounded_fallback_records_kanban_failure_when_interrupted(monkeypatch):
+def test_bounded_fallback_records_kanban_keepalive_when_interrupted(monkeypatch):
     """When budget is exhausted and the turn was interrupted,
-    ``finalize_turn`` must still record a terminal kanban failure via
-    the bounded fallback path (#87096).
+    ``finalize_turn`` still records keep-alive, not a timed_out failure.
     """
     monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
     monkeypatch.setenv("HERMES_KANBAN_TASK", "task-456")
-    record = MagicMock(name="record_task_failure")
-    conn = SimpleNamespace(close=lambda: None)
-    monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: conn)
-    monkeypatch.setattr("hermes_cli.kanban_db._record_task_failure", record)
+    record = MagicMock(name="record_iteration_budget_exhausted")
+    monkeypatch.setattr(
+        "hermes_cli.kanban_budget_keepalive.record_iteration_budget_exhausted",
+        record,
+    )
+    fail = MagicMock(name="record_task_failure")
+    monkeypatch.setattr("hermes_cli.kanban_db._record_task_failure", fail)
     agent = _LimitAgent()
 
-    # Budget exhausted (60/60), interrupted, no fallback-eligible exit_reason
-    result = finalize_turn(
+    finalize_turn(
         agent,
         final_response=None,
         api_call_count=60,
@@ -265,31 +263,28 @@ def test_bounded_fallback_records_kanban_failure_when_interrupted(monkeypatch):
         _turn_exit_reason="interrupted_by_user",
     )
 
-    # The bounded fallback must fire even though interrupted=True
-    # makes budget_fallback_eligible=False.
     record.assert_called_once()
-    args, kwargs = record.call_args
-    assert args[1] == "task-456"
-    assert kwargs["outcome"] == "timed_out"
-    assert kwargs["release_claim"] is True
-    assert kwargs["end_run"] is True
-    assert kwargs["event_payload_extra"]["budget_used"] == 60
-    assert kwargs["event_payload_extra"]["budget_max"] == 60
+    assert record.call_args.kwargs["task_id"] == "task-456"
+    assert record.call_args.kwargs["budget_used"] == 60
+    fail.assert_not_called()
 
 
-def test_bounded_fallback_records_kanban_failure_when_failed(monkeypatch):
+def test_bounded_fallback_records_kanban_keepalive_when_failed(monkeypatch):
     """When budget is exhausted and the turn failed,
-    the bounded fallback must still record a terminal kanban failure (#87096).
+    keep-alive still records a typed budget burn (#87096 / LS-2777).
     """
     monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
     monkeypatch.setenv("HERMES_KANBAN_TASK", "task-789")
-    record = MagicMock(name="record_task_failure")
-    conn = SimpleNamespace(close=lambda: None)
-    monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: conn)
-    monkeypatch.setattr("hermes_cli.kanban_db._record_task_failure", record)
+    record = MagicMock(name="record_iteration_budget_exhausted")
+    monkeypatch.setattr(
+        "hermes_cli.kanban_budget_keepalive.record_iteration_budget_exhausted",
+        record,
+    )
+    fail = MagicMock(name="record_task_failure")
+    monkeypatch.setattr("hermes_cli.kanban_db._record_task_failure", fail)
     agent = _LimitAgent()
 
-    result = finalize_turn(
+    finalize_turn(
         agent,
         final_response=None,
         api_call_count=60,
@@ -306,23 +301,24 @@ def test_bounded_fallback_records_kanban_failure_when_failed(monkeypatch):
     )
 
     record.assert_called_once()
-    args, kwargs = record.call_args
-    assert args[1] == "task-789"
-    assert kwargs["outcome"] == "timed_out"
+    assert record.call_args.kwargs["task_id"] == "task-789"
+    fail.assert_not_called()
 
 
-def test_bounded_fallback_does_not_fire_without_kanban_task(monkeypatch):
-    """When budget is exhausted and interrupted but no kanban task is
-    active, the bounded fallback must NOT fire (#87096).
-    """
+def test_bounded_fallback_keepalive_noops_without_live_objective(monkeypatch):
+    """Regular CLI budget exhaust must not trip ``_record_task_failure``."""
     monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
-    record = MagicMock(name="record_task_failure")
-    conn = SimpleNamespace(close=lambda: None)
-    monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: conn)
-    monkeypatch.setattr("hermes_cli.kanban_db._record_task_failure", record)
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    record = MagicMock(name="record_iteration_budget_exhausted", return_value=None)
+    monkeypatch.setattr(
+        "hermes_cli.kanban_budget_keepalive.record_iteration_budget_exhausted",
+        record,
+    )
+    fail = MagicMock(name="record_task_failure")
+    monkeypatch.setattr("hermes_cli.kanban_db._record_task_failure", fail)
     agent = _LimitAgent()
 
-    result = finalize_turn(
+    finalize_turn(
         agent,
         final_response=None,
         api_call_count=60,
@@ -338,7 +334,9 @@ def test_bounded_fallback_does_not_fire_without_kanban_task(monkeypatch):
         _turn_exit_reason="interrupted_by_user",
     )
 
-    record.assert_not_called()
+    fail.assert_not_called()
+    record.assert_called_once()
+    assert record.call_args.kwargs["task_id"] == ""
 
 
 def test_bounded_fallback_does_not_fire_when_budget_not_exhausted(monkeypatch):
@@ -347,14 +345,17 @@ def test_bounded_fallback_does_not_fire_when_budget_not_exhausted(monkeypatch):
     """
     monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
     monkeypatch.setenv("HERMES_KANBAN_TASK", "task-999")
-    record = MagicMock(name="record_task_failure")
-    conn = SimpleNamespace(close=lambda: None)
-    monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: conn)
-    monkeypatch.setattr("hermes_cli.kanban_db._record_task_failure", record)
+    record = MagicMock(name="record_iteration_budget_exhausted")
+    monkeypatch.setattr(
+        "hermes_cli.kanban_budget_keepalive.record_iteration_budget_exhausted",
+        record,
+    )
+    fail = MagicMock(name="record_task_failure")
+    monkeypatch.setattr("hermes_cli.kanban_db._record_task_failure", fail)
     agent = _LimitAgent(budget_remaining=60)
 
     # api_call_count=10, max_iterations=60 — budget NOT exhausted
-    result = finalize_turn(
+    finalize_turn(
         agent,
         final_response=None,
         api_call_count=10,
@@ -371,5 +372,6 @@ def test_bounded_fallback_does_not_fire_when_budget_not_exhausted(monkeypatch):
     )
 
     record.assert_not_called()
+    fail.assert_not_called()
 
 

--- a/tests/hermes_cli/test_kanban_budget_keepalive.py
+++ b/tests/hermes_cli/test_kanban_budget_keepalive.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -498,3 +499,142 @@ def test_blocking_decision_skips_dispatch(kanban_home):
 
 def test_pytest_default_client_does_not_send():
     assert isinstance(keepalive.default_remoko_client(), keepalive.NullRemokoClient)
+
+
+def test_reconcile_consumes_answered_sidecar(kanban_home):
+    client = keepalive.RecordingRemokoClient()
+    subject = "child-sidecar-90"
+    keepalive.save_sidecar(
+        keepalive.BudgetDecision(
+            task_id=subject,
+            request_id="req-sidecar-90",
+            external_id="obj-child-sidecar-90-budget-1",
+            status=keepalive.STATUS_PENDING,
+            extra_turns=0,
+            store="sidecar",
+        )
+    )
+    client.answers["req-sidecar-90"] = "Give 90 more"
+    conn = kb.connect()
+    try:
+        result = keepalive.reconcile_budget_keepalive(conn, remoko_client=client)
+        assert result["sidecar_consumed"] == 1
+        assert result["sidecar_retried"] == 0
+        assert result["consumed"] == 0
+    finally:
+        conn.close()
+    refreshed = keepalive.load_sidecar(subject)
+    assert refreshed is not None
+    assert refreshed.extra_turns == 90
+    assert refreshed.status == "granted"
+    assert client.get_calls
+    assert client.get_calls[0]["request_id"] == "req-sidecar-90"
+
+
+def test_overlapping_kanban_burns_send_one_remoko(kanban_home):
+    conn = kb.connect()
+    try:
+        task = _running_task(conn)
+        tid = task.id
+    finally:
+        conn.close()
+
+    in_ask = threading.Event()
+    release_send = threading.Event()
+
+    class SlowClient(keepalive.RecordingRemokoClient):
+        def ask_question(self, **kwargs):
+            in_ask.set()
+            assert release_send.wait(timeout=5)
+            return super().ask_question(**kwargs)
+
+    client = SlowClient()
+    first_result: list[keepalive.BudgetDecision] = []
+    errors: list[BaseException] = []
+
+    def first_burn():
+        c = kb.connect()
+        try:
+            first_result.append(
+                keepalive.record_kanban_budget_exhausted(
+                    c, tid, budget_used=90, budget_max=90, remoko_client=client
+                )
+            )
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            c.close()
+
+    worker = threading.Thread(target=first_burn)
+    worker.start()
+    assert in_ask.wait(timeout=5)
+
+    c2 = kb.connect()
+    try:
+        second = keepalive.record_kanban_budget_exhausted(
+            c2, tid, budget_used=90, budget_max=90, remoko_client=client
+        )
+    finally:
+        c2.close()
+
+    release_send.set()
+    worker.join(timeout=5)
+    assert not worker.is_alive()
+    assert errors == []
+    assert len(client.ask_calls) == 1
+    assert first_result[0].request_id == "req-budget-1"
+    assert second.status == "pending"
+    conn = kb.connect()
+    try:
+        live = keepalive.get_decision(conn, tid)
+        assert live is not None
+        assert live.request_id == "req-budget-1"
+        assert live.status == "pending"
+        assert live.external_id == f"obj-{tid}-budget-1"
+    finally:
+        conn.close()
+
+
+def test_overlapping_sidecar_burns_send_one_remoko(kanban_home):
+    in_ask = threading.Event()
+    release_send = threading.Event()
+
+    class SlowClient(keepalive.RecordingRemokoClient):
+        def ask_question(self, **kwargs):
+            in_ask.set()
+            assert release_send.wait(timeout=5)
+            return super().ask_question(**kwargs)
+
+    client = SlowClient()
+    subject = "child-race-1"
+    first_result: list[keepalive.BudgetDecision] = []
+    errors: list[BaseException] = []
+
+    def first_burn():
+        try:
+            first_result.append(
+                keepalive.record_sidecar_budget_exhausted(
+                    subject, budget_used=50, budget_max=50, remoko_client=client
+                )
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    worker = threading.Thread(target=first_burn)
+    worker.start()
+    assert in_ask.wait(timeout=5)
+    second = keepalive.record_sidecar_budget_exhausted(
+        subject, budget_used=50, budget_max=50, remoko_client=client
+    )
+    release_send.set()
+    worker.join(timeout=5)
+    assert not worker.is_alive()
+    assert errors == []
+    assert len(client.ask_calls) == 1
+    assert first_result[0].request_id == "req-budget-1"
+    assert second.status == "pending"
+    live = keepalive.load_sidecar(subject)
+    assert live is not None
+    assert live.request_id == "req-budget-1"
+    assert live.status == "pending"
+    assert live.external_id == "obj-child-race-1-budget-1"

--- a/tests/hermes_cli/test_kanban_budget_keepalive.py
+++ b/tests/hermes_cli/test_kanban_budget_keepalive.py
@@ -1,0 +1,500 @@
+"""LS-2777: iteration-budget Remoko keep-alive."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import kanban_budget_keepalive as keepalive
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _running_task(conn, title="keep alive", assignee="cole"):
+    tid = kb.create_task(conn, title=title, assignee=assignee)
+    task = kb.get_task(conn, tid)
+    if task.status != "ready":
+        conn.execute(
+            "UPDATE tasks SET status='ready', claim_lock=NULL WHERE id=?",
+            (tid,),
+        )
+        conn.commit()
+    claimed = kb.claim_task(conn, tid)
+    assert claimed is not None
+    return claimed
+
+
+def _events(conn, task_id, kind=None):
+    if kind:
+        rows = conn.execute(
+            "SELECT kind, payload FROM task_events WHERE task_id=? AND kind=? ORDER BY id",
+            (task_id, kind),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT kind, payload FROM task_events WHERE task_id=? ORDER BY id",
+            (task_id,),
+        ).fetchall()
+    return [row["kind"] for row in rows]
+
+
+def _failures(conn, task_id):
+    row = conn.execute(
+        "SELECT consecutive_failures, status, block_kind, last_failure_error "
+        "FROM tasks WHERE id=?",
+        (task_id,),
+    ).fetchone()
+    return row
+
+
+def test_schema_creates_budget_decisions_table(kanban_home):
+    conn = kb.connect()
+    try:
+        names = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+        assert "kanban_budget_decisions" in names
+        assert "kanban_objectives" not in names
+        assert "kanban_objective_units" not in names
+    finally:
+        conn.close()
+
+
+def test_first_burn_parks_without_death_counter(kanban_home):
+    conn = kb.connect()
+    client = keepalive.RecordingRemokoClient()
+    try:
+        task = _running_task(conn)
+        before = _failures(conn, task.id)
+        decision = keepalive.record_kanban_budget_exhausted(
+            conn, task.id, budget_used=90, budget_max=90, remoko_client=client
+        )
+        after = _failures(conn, task.id)
+        assert after["consecutive_failures"] == before["consecutive_failures"] == 0
+        assert after["status"] == "blocked"
+        assert after["block_kind"] == "needs_input"
+        assert _events(conn, task.id, "budget_exhausted") == ["budget_exhausted"]
+        assert "gave_up" not in _events(conn, task.id)
+        assert "timed_out" not in _events(conn, task.id)
+        assert len(client.ask_calls) == 1
+        card = client.ask_calls[0]
+        assert card["question"] == "Keep this work going?"
+        assert card["choices"] == list(keepalive.CHOICES)
+        assert card["choices"][0] == "Give 90 more"
+        assert card["risk"] == "medium"
+        assert card["external_id"] == f"obj-{task.id}-budget-1"
+        assert decision.request_id == "req-budget-1"
+        assert decision.status == "pending"
+        run = conn.execute(
+            "SELECT outcome, status FROM task_runs WHERE task_id=? ORDER BY id DESC LIMIT 1",
+            (task.id,),
+        ).fetchone()
+        assert run["outcome"] == "budget_exhausted"
+        assert run["status"] == "budget_exhausted"
+    finally:
+        conn.close()
+
+
+def test_second_burn_while_pending_is_noop(kanban_home):
+    conn = kb.connect()
+    client = keepalive.RecordingRemokoClient()
+    try:
+        task = _running_task(conn)
+        first = keepalive.record_kanban_budget_exhausted(
+            conn, task.id, budget_used=90, budget_max=90, remoko_client=client
+        )
+        # Simulate another worker finishing the same burn.
+        conn.execute(
+            "UPDATE tasks SET status='running' WHERE id=?",
+            (task.id,),
+        )
+        conn.commit()
+        second = keepalive.record_kanban_budget_exhausted(
+            conn, task.id, budget_used=90, budget_max=90, remoko_client=client
+        )
+        assert second.request_id == first.request_id == "req-budget-1"
+        assert second.external_id == first.external_id
+        assert len(client.ask_calls) == 1
+        assert _events(conn, task.id, "budget_exhausted") == ["budget_exhausted"]
+        assert _failures(conn, task.id)["consecutive_failures"] == 0
+    finally:
+        conn.close()
+
+
+def test_give_90_more_requeues_and_adds_turns(kanban_home):
+    conn = kb.connect()
+    client = keepalive.RecordingRemokoClient()
+    try:
+        task = _running_task(conn)
+        keepalive.record_kanban_budget_exhausted(
+            conn, task.id, budget_used=90, budget_max=90, remoko_client=client
+        )
+        result = keepalive.consume_budget_decision(
+            conn, task.id, "Give 90 more", remoko_client=client
+        )
+        assert result["ok"] is True
+        assert result["extra_turns"] == 90
+        assert keepalive.worker_max_iterations_value(90, base_max_turns=90) == 180
+        assert result["max_iterations"] == keepalive.worker_max_iterations_value(90)
+        decision = keepalive.get_decision(conn, task.id)
+        assert decision.status == "granted"
+        assert decision.policy == "extend_repeat"
+        assert decision.extra_turns == 90
+        row = _failures(conn, task.id)
+        assert row["status"] == "ready"
+        assert row["consecutive_failures"] == 0
+        assert keepalive.worker_max_iterations_value(decision.extra_turns, base_max_turns=90) == 180
+        assert client.report_calls[-1]["outcome"] == "completed"
+        assert client.mark_calls
+    finally:
+        conn.close()
+
+
+def test_park_it_keeps_blocked_needs_input(kanban_home):
+    conn = kb.connect()
+    client = keepalive.RecordingRemokoClient()
+    try:
+        task = _running_task(conn)
+        first = keepalive.record_kanban_budget_exhausted(
+            conn, task.id, budget_used=90, budget_max=90, remoko_client=client
+        )
+        result = keepalive.consume_budget_decision(
+            conn, task.id, "Park it", remoko_client=client
+        )
+        assert result["ok"] is True
+        row = _failures(conn, task.id)
+        assert row["status"] == "blocked"
+        assert row["block_kind"] == "needs_input"
+        decision = keepalive.get_decision(conn, task.id)
+        assert decision.status == "parked"
+        assert decision.request_id == first.request_id
+        keepalive.record_kanban_budget_exhausted(
+            conn, task.id, budget_used=90, budget_max=90, remoko_client=client
+        )
+        assert len(client.ask_calls) == 1
+    finally:
+        conn.close()
+
+
+def test_duplicate_exhaustion_does_not_create_second_remoko(kanban_home):
+    conn = kb.connect()
+    client = keepalive.RecordingRemokoClient()
+    try:
+        task = _running_task(conn)
+        keepalive.record_kanban_budget_exhausted(
+            conn, task.id, budget_used=90, budget_max=90, remoko_client=client
+        )
+        keepalive.record_kanban_budget_exhausted(
+            conn, task.id, budget_used=90, budget_max=90, remoko_client=client
+        )
+        keepalive.record_kanban_budget_exhausted(
+            conn, task.id, budget_used=90, budget_max=90, remoko_client=client
+        )
+        assert len(client.ask_calls) == 1
+        assert len({call["external_id"] for call in client.ask_calls}) == 1
+    finally:
+        conn.close()
+
+
+def test_pending_survives_reconnect_and_does_not_autoresume(kanban_home):
+    conn = kb.connect()
+    client = keepalive.RecordingRemokoClient()
+    try:
+        task = _running_task(conn)
+        keepalive.record_kanban_budget_exhausted(
+            conn, task.id, budget_used=90, budget_max=90, remoko_client=client
+        )
+        tid = task.id
+    finally:
+        conn.close()
+
+    # Simulated gateway restart: new connection, same board file.
+    conn = kb.connect()
+    try:
+        decision = keepalive.get_decision(conn, tid)
+        assert decision is not None
+        assert decision.status == "pending"
+        assert decision.request_id == "req-budget-1"
+        row = _failures(conn, tid)
+        assert row["status"] == "blocked"
+        assert row["block_kind"] == "needs_input"
+        # Reconcile must not flip pending → ready.
+        keepalive.reconcile_budget_keepalive(conn, remoko_client=client)
+        assert keepalive.get_decision(conn, tid).status == "pending"
+        assert _failures(conn, tid)["status"] == "blocked"
+        # Consume still revalidates.
+        result = keepalive.consume_budget_decision(
+            conn, tid, "Give 90 more", remoko_client=client
+        )
+        assert result["ok"] is True
+        assert _failures(conn, tid)["status"] == "ready"
+    finally:
+        conn.close()
+
+
+def test_failure_limit_does_not_autokill_first_budget_burn(kanban_home):
+    conn = kb.connect()
+    client = keepalive.RecordingRemokoClient()
+    try:
+        task = _running_task(conn)
+        conn.execute("UPDATE tasks SET max_retries = 1 WHERE id=?", (task.id,))
+        conn.commit()
+        keepalive.record_kanban_budget_exhausted(
+            conn, task.id, budget_used=90, budget_max=90, remoko_client=client
+        )
+        assert "gave_up" not in _events(conn, task.id)
+        assert _failures(conn, task.id)["consecutive_failures"] == 0
+        assert keepalive.get_decision(conn, task.id).status == "pending"
+    finally:
+        conn.close()
+
+
+def test_wall_clock_timeout_does_not_enter_keepalive(kanban_home, monkeypatch):
+    conn = kb.connect()
+    try:
+        task = _running_task(conn)
+        now_minus = 10_000
+        conn.execute(
+            "UPDATE tasks SET worker_pid=4242, max_runtime_seconds=1, "
+            "started_at=? WHERE id=?",
+            (now_minus, task.id),
+        )
+        conn.execute(
+            "UPDATE task_runs SET worker_pid=4242, started_at=? WHERE id=?",
+            (now_minus, task.current_run_id),
+        )
+        conn.commit()
+        monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+        timed = kb.enforce_max_runtime(conn, signal_fn=lambda *_a, **_k: None)
+        assert task.id in timed
+        assert keepalive.get_decision(conn, task.id) is None
+        assert "budget_exhausted" not in _events(conn, task.id)
+        assert "timed_out" in _events(conn, task.id)
+        assert _failures(conn, task.id)["consecutive_failures"] == 1
+    finally:
+        conn.close()
+
+
+def test_stale_tap_rejected_when_task_completed(kanban_home):
+    conn = kb.connect()
+    client = keepalive.RecordingRemokoClient()
+    try:
+        task = _running_task(conn)
+        keepalive.record_kanban_budget_exhausted(
+            conn, task.id, budget_used=90, budget_max=90, remoko_client=client
+        )
+        # complete_task requires a non-blocked path; force done after the burn.
+        conn.execute(
+            "UPDATE tasks SET status='done', completed_at=strftime('%s','now') WHERE id=?",
+            (task.id,),
+        )
+        conn.commit()
+        result = keepalive.consume_budget_decision(
+            conn, task.id, "Give 90 more", remoko_client=client
+        )
+        assert result["ok"] is False
+        assert result.get("stale") is True
+        decision = keepalive.get_decision(conn, task.id)
+        assert decision.extra_turns == 0
+        assert decision.status == "pending"
+        assert client.report_calls[-1]["outcome"] == "failed"
+    finally:
+        conn.close()
+
+
+def test_after_three_grants_next_card_recommends_park(kanban_home):
+    conn = kb.connect()
+    client = keepalive.RecordingRemokoClient()
+    try:
+        task = _running_task(conn)
+        keepalive.record_kanban_budget_exhausted(
+            conn, task.id, budget_used=90, budget_max=90, remoko_client=client
+        )
+        for _ in range(3):
+            keepalive.consume_budget_decision(
+                conn, task.id, "Give 90 more", remoko_client=client
+            )
+            # Reclaim so the next burn can park a running card.
+            conn.execute(
+                "UPDATE tasks SET status='ready', claim_lock=NULL WHERE id=?",
+                (task.id,),
+            )
+            conn.commit()
+            kb.claim_task(conn, task.id)
+            keepalive.record_kanban_budget_exhausted(
+                conn, task.id, budget_used=90, budget_max=90, remoko_client=client
+            )
+        last = client.ask_calls[-1]
+        assert last["recommendation"].startswith("Park it")
+        assert "three extra bursts" in last["context"].lower()
+        assert last["choices"][0] == "Give 90 more"
+        assert last["external_id"] == f"obj-{task.id}-budget-4"
+        assert keepalive.recommended_choice(3) == "Park it"
+    finally:
+        conn.close()
+
+
+def test_give_90_once_then_next_burn_autoparks(kanban_home):
+    conn = kb.connect()
+    client = keepalive.RecordingRemokoClient()
+    try:
+        task = _running_task(conn)
+        keepalive.record_kanban_budget_exhausted(
+            conn, task.id, budget_used=90, budget_max=90, remoko_client=client
+        )
+        keepalive.consume_budget_decision(
+            conn, task.id, "Give 90 once", remoko_client=client
+        )
+        asks_after_grant = len(client.ask_calls)
+        conn.execute(
+            "UPDATE tasks SET status='ready', claim_lock=NULL WHERE id=?",
+            (task.id,),
+        )
+        conn.commit()
+        kb.claim_task(conn, task.id)
+        decision = keepalive.record_kanban_budget_exhausted(
+            conn, task.id, budget_used=180, budget_max=180, remoko_client=client
+        )
+        assert decision.status == "parked"
+        assert decision.policy == "park"
+        assert len(client.ask_calls) == asks_after_grant
+        row = _failures(conn, task.id)
+        assert row["status"] == "blocked"
+        assert row["block_kind"] == "needs_input"
+    finally:
+        conn.close()
+
+
+def test_send_failure_leaves_pending_empty_request_and_reconcile_retries(kanban_home):
+    conn = kb.connect()
+    failing = keepalive.RecordingRemokoClient()
+    failing.fail_ask = True
+    try:
+        task = _running_task(conn)
+        decision = keepalive.record_kanban_budget_exhausted(
+            conn, task.id, budget_used=90, budget_max=90, remoko_client=failing
+        )
+        assert decision.status == "pending"
+        assert not decision.request_id
+        retry = keepalive.RecordingRemokoClient()
+        keepalive.reconcile_budget_keepalive(conn, remoko_client=retry)
+        refreshed = keepalive.get_decision(conn, task.id)
+        assert refreshed.status == "pending"
+        assert refreshed.request_id == "req-budget-1"
+        assert _failures(conn, task.id)["status"] == "blocked"
+    finally:
+        conn.close()
+
+
+def test_cli_lock_honors_kanban_env_ahead_of_config():
+    env = {
+        "HERMES_KANBAN_TASK": "t_abc",
+        "HERMES_KANBAN_MAX_ITERATIONS": "180",
+        "HERMES_MAX_ITERATIONS": "40",
+    }
+    assert keepalive.effective_kanban_max_iterations(env) == 180
+    assert keepalive.effective_kanban_max_iterations({"HERMES_MAX_ITERATIONS": "40"}) is None
+    assert keepalive.effective_kanban_max_iterations(
+        {"HERMES_KANBAN_TASK": "t_abc"}
+    ) is None
+
+
+def test_sidecar_used_for_subagent_even_with_kanban_env(kanban_home, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_parent")
+    client = keepalive.RecordingRemokoClient()
+    agent = SimpleNamespace(_subagent_id="child-99", session_id="sess-child")
+    decision = keepalive.record_iteration_budget_exhausted(
+        task_id="t_parent",
+        budget_used=50,
+        budget_max=50,
+        agent=agent,
+        remoko_client=client,
+    )
+    assert decision is not None
+    assert decision.store == "sidecar"
+    assert decision.task_id == "child-99"
+    assert decision.external_id == "obj-child-99-budget-1"
+    assert len(client.ask_calls) == 1
+    conn = kb.connect()
+    try:
+        assert keepalive.get_decision(conn, "t_parent") is None
+    finally:
+        conn.close()
+
+
+def test_bot_chat_uses_sidecar(kanban_home):
+    client = keepalive.RecordingRemokoClient()
+    agent = SimpleNamespace(
+        _subagent_id=None,
+        session_id="sess-bot",
+        _session_title_hint="Bot Chat",
+        _session_db=None,
+    )
+    decision = keepalive.record_iteration_budget_exhausted(
+        budget_used=90,
+        budget_max=90,
+        agent=agent,
+        remoko_client=client,
+    )
+    assert decision.store == "sidecar"
+    assert decision.task_id == "sess-bot"
+    again = keepalive.record_iteration_budget_exhausted(
+        budget_used=90,
+        budget_max=90,
+        agent=agent,
+        remoko_client=client,
+    )
+    assert again.request_id == decision.request_id
+    assert len(client.ask_calls) == 1
+
+
+def test_regular_cli_does_not_open_keepalive(kanban_home):
+    agent = SimpleNamespace(
+        _subagent_id=None,
+        session_id="sess-cli",
+        _session_title_hint="something else",
+        _session_db=None,
+    )
+    assert (
+        keepalive.record_iteration_budget_exhausted(
+            budget_used=90, budget_max=90, agent=agent
+        )
+        is None
+    )
+
+
+def test_blocking_decision_skips_dispatch(kanban_home):
+    conn = kb.connect()
+    client = keepalive.RecordingRemokoClient()
+    try:
+        task = _running_task(conn)
+        keepalive.record_kanban_budget_exhausted(
+            conn, task.id, budget_used=90, budget_max=90, remoko_client=client
+        )
+        # A stray unblock must not let the dispatcher spawn.
+        conn.execute(
+            "UPDATE tasks SET status='ready', claim_lock=NULL WHERE id=?",
+            (task.id,),
+        )
+        conn.commit()
+        assert keepalive.budget_decision_blocks_dispatch(conn, task.id) is True
+    finally:
+        conn.close()
+
+
+def test_pytest_default_client_does_not_send():
+    assert isinstance(keepalive.default_remoko_client(), keepalive.NullRemokoClient)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9644,6 +9644,7 @@ def _notification_event_dedup_key(evt: dict) -> tuple:
 # event behind an unclaimed row.
 _KANBAN_NOTIFY_KINDS = (
     "completed", "blocked", "gave_up", "crashed", "timed_out",
+    "budget_exhausted",
     "status", "archived", "unblocked",
 )
 _KANBAN_SILENT_KINDS = frozenset({"archived", "unblocked"})


### PR DESCRIPTION
## Why

A Kanban worker that burns `Iteration budget exhausted (N/N)` was recorded as `timed_out` via `_record_task_failure`. After `kanban.failure_limit` that became `gave_up` with no owner tap. Live incident: `t_f2d215c2` runs 167 + 173.

This is LS-2777. Not LS-2776 (`active_pr` / PR 90033). Wall-clock `max_runtime_seconds` stays on the breaker.

## What

Budget burn is now an owner fork:

1. Do not increment `consecutive_failures`.
2. Close the run with outcome `budget_exhausted`.
3. Emit one `budget_exhausted` event.
4. Persist `kanban_budget_decisions` (board-local; not LS-2776 tables).
5. Send exactly one Remoko `ask_question`.
6. Park the card `blocked` / `needs_input` until a revalidated tap.

Taps: `Give 90 more` (recommended until 3 grants) / `Give 90 once` / `Park it` / `Stop this`.

`HERMES_KANBAN_MAX_ITERATIONS` is set to `agent.max_turns + extra_turns` and, when `HERMES_KANBAN_TASK` is set, wins over `agent.max_turns`. `delegate_task` children and Bot Chat use a sidecar store.

## Tests

```
HERMES_PYTHON=/home/ubuntu/.hermes/hermes-agent/.venv/bin/python scripts/run_tests.sh \
  tests/hermes_cli/test_kanban_budget_keepalive.py \
  tests/agent/test_turn_finalizer_iteration_limit_exit.py
# 28 passed

HERMES_PYTHON=/home/ubuntu/.hermes/hermes-agent/.venv/bin/python scripts/run_tests.sh \
  tests/hermes_cli/test_kanban_db.py \
  tests/hermes_cli/test_kanban_review_lifecycle.py \
  tests/gateway/test_kanban_notifier.py
```

No OpenRouter. Do not merge. Do not restart the gateway. Do not enable production config.
