### PR TITLE
fix(approvals): honor class-key approvals in dry-run

### DIFF
--- a/hermes_cli/approvals_test.py
+++ b/hermes_cli/approvals_test.py
@@ -130,9 +130,17 @@ def evaluate_command(command: str, env_type: str = "local") -> dict:
                    "(permanently approved)",
         )
 
-    # 7. Dangerous-pattern detection → would prompt.
+    # 7. Dangerous-pattern detection → class-key allowlist or prompt.
     is_dangerous, pattern_key, description = approval.detect_dangerous_command(command)
     if is_dangerous:
+        session_key = approval.get_current_session_key()
+        if approval.is_approved(session_key, pattern_key):
+            return result(
+                "allow",
+                detail=f"dangerous-pattern class key {pattern_key!r} (or a "
+                       "legacy alias) is already approved for this session or "
+                       "in command_allowlist",
+            )
         return result(
             "ask-approval", rule=description,
             detail="matches a dangerous-command pattern; the runtime would "

--- a/tests/hermes_cli/test_approvals_test.py
+++ b/tests/hermes_cli/test_approvals_test.py
@@ -35,7 +35,9 @@ def isolated_approvals(monkeypatch):
     monkeypatch.setattr(A, "is_current_session_yolo_enabled", lambda: False)
     monkeypatch.setattr(A, "load_permanent_allowlist", lambda: set())
     saved = set(A._permanent_approved)
+    saved_sessions = {key: set(value) for key, value in A._session_approved.items()}
     A._permanent_approved.clear()
+    A._session_approved.clear()
     # The tester must NEVER prompt or persist — make any attempt explode.
     def _boom(*_a, **_kw):  # pragma: no cover - failure path
         raise AssertionError("read-only tester touched a prompt/persistence path")
@@ -45,6 +47,8 @@ def isolated_approvals(monkeypatch):
     yield A
     A._permanent_approved.clear()
     A._permanent_approved.update(saved)
+    A._session_approved.clear()
+    A._session_approved.update(saved_sessions)
 
 
 class TestVerdicts:
@@ -67,6 +71,63 @@ class TestVerdicts:
         assert rc == 2
         assert "ask-approval" in out
         assert "recursive delete" in out
+
+    def test_permanent_class_key_allows_like_runtime(self, isolated_approvals,
+                                                     capsys):
+        isolated_approvals._permanent_approved.add("recursive delete")
+
+        rc = at.approvals_test_command(_args(["rm", "-rf", "~/project/build"]))
+        out = capsys.readouterr().out
+
+        assert rc == 0
+        assert "recursive delete" in out
+        assert "already approved" in out
+
+    def test_session_class_key_allows_like_runtime(self, isolated_approvals,
+                                                   capsys):
+        session_key = isolated_approvals.get_current_session_key()
+        isolated_approvals._session_approved[session_key] = {"recursive delete"}
+
+        rc = at.approvals_test_command(_args(["rm", "-rf", "~/project/build"]))
+        out = capsys.readouterr().out
+
+        assert rc == 0
+        assert "already approved" in out
+
+    def test_other_session_class_key_does_not_allow(self, isolated_approvals,
+                                                    capsys):
+        isolated_approvals._session_approved["some-other-session"] = {
+            "recursive delete"}
+
+        rc = at.approvals_test_command(_args(["rm", "-rf", "~/project/build"]))
+        out = capsys.readouterr().out
+
+        assert rc == 2
+        assert "ask-approval" in out
+
+    def test_hardline_beats_permanent_class_key(self, isolated_approvals, capsys):
+        _dangerous, pattern_key, _description = (
+            isolated_approvals.detect_dangerous_command("rm -rf /"))
+        isolated_approvals._permanent_approved.add(pattern_key)
+
+        rc = at.approvals_test_command(_args(["rm", "-rf", "/"]))
+        out = capsys.readouterr().out
+
+        assert rc == 3
+        assert "hardline-deny" in out
+
+    def test_user_deny_beats_permanent_class_key(self, isolated_approvals, capsys,
+                                                 monkeypatch):
+        isolated_approvals._permanent_approved.add("recursive delete")
+        monkeypatch.setattr(
+            isolated_approvals, "_get_approval_config",
+            lambda: {"mode": "manual", "deny": ["rm -rf *"]})
+
+        rc = at.approvals_test_command(_args(["rm", "-rf", "~/project/build"]))
+        out = capsys.readouterr().out
+
+        assert rc == 3
+        assert "user-deny" in out
 
     def test_user_deny_rule_from_config_honored(self, isolated_approvals, capsys,
                                                 monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Aligns `hermes approvals test` with the runtime approval path for dangerous-pattern class keys stored as permanent or session approvals.

Before this change, command-text/glob allowlist entries were modeled, but a class-key approval such as `recursive delete` still produced `ask-approval` in the dry-run even though runtime `is_approved(session_key, pattern_key)` allowed it.

The fix reuses the runtime helper after dangerous-pattern detection while preserving hardline, sudo-stdin, user-deny, bypass, and command-text/glob ordering.

## Related Issue

Fixes #90136

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `hermes_cli/approvals_test.py` to check the detected dangerous-pattern class key with runtime `is_approved()` before returning `ask-approval`.
- Cover permanent and current-session class approvals.
- Prove that another session cannot leak its approval.
- Preserve hardline and user-defined deny precedence over approved class keys.
- Restore isolated session approval state in the test fixture.

## How to Test

```bash
python -m pytest -q \
  tests/hermes_cli/test_approvals_test.py \
  tests/hermes_cli/test_approvals_suggest.py \
  tests/hermes_cli/test_approvals_command.py \
  tests/tools/test_approval_deny_rules.py \
  tests/tools/test_approval_mode_parity.py

ruff check hermes_cli/approvals_test.py tests/hermes_cli/test_approvals_test.py
git diff --check
```

Observed locally:

- `55 passed`
- ruff: `All checks passed!`
- `git diff --check`: clean

The repository-wide pytest suite was not run locally; CI remains the source for the full matrix.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing open/closed issues and PRs for this exact parity defect.
- [x] My PR contains only changes related to this fix.
- [ ] I've run `pytest tests/ -q` locally. (Focused and adjacent approval suites were run; full matrix delegated to CI.)
- [x] I've added tests for the bug.
- [x] Tested on Ubuntu Linux / Python 3.11.

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing command or config key changed.
- [x] `cli-config.yaml.example`: N/A.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture or workflow change.
- [x] Cross-platform impact considered: pure Python approval ordering, no platform-specific path handling added.
- [x] Tool descriptions/schemas: N/A; existing dry-run behavior is corrected to match runtime.
