### PR TITLE
feat(codex): add opt-in Hermes usage attribution

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1267,7 +1267,9 @@ def init_agent(
                 client_kwargs["default_headers"] = _ra()._qwen_portal_headers()
             elif base_url_host_matches(effective_base, "chatgpt.com"):
                 from agent.auxiliary_client import _codex_cloudflare_headers
-                client_kwargs["default_headers"] = _codex_cloudflare_headers(api_key)
+                client_kwargs["default_headers"] = _codex_cloudflare_headers(
+                    api_key, base_url=effective_base,
+                )
             elif base_url_host_matches(effective_base, "x.ai"):
                 from tools.xai_http import hermes_xai_default_headers
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1191,19 +1191,34 @@ _AUTH_JSON_PATH = get_hermes_home() / "auth.json"
 _CODEX_AUX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 
 
-def _codex_cloudflare_headers(access_token: str) -> Dict[str, str]:
-    """Headers required to avoid Cloudflare 403s on chatgpt.com/backend-api/codex.
+def _is_official_codex_base_url(base_url: str) -> bool:
+    """Keep optional attribution off custom proxies and unrelated endpoints."""
+    try:
+        parsed = urlparse(base_url)
+        path = parsed.path.rstrip("/")
+        return (
+            parsed.scheme == "https"
+            and parsed.hostname == "chatgpt.com"
+            and parsed.port in (None, 443)
+            and (path == "/backend-api/codex" or path.startswith("/backend-api/codex/"))
+        )
+    except (TypeError, ValueError):
+        return False
 
-    The Cloudflare layer in front of the Codex endpoint whitelists a small set of
-    first-party originators (``codex_cli_rs``, ``codex_vscode``, ``codex_sdk_ts``,
-    anything starting with ``Codex``). Requests from non-residential IPs (VPS,
-    server-hosted agents) that don't advertise an allowed originator are served
-    a 403 with ``cf-mitigated: challenge`` regardless of auth correctness.
 
-    We pin ``originator: codex_cli_rs`` to match the upstream codex-rs CLI, set
-    ``User-Agent`` to a codex_cli_rs-shaped string (beats SDK fingerprinting),
-    and extract ``ChatGPT-Account-ID`` (canonical casing, from codex-rs
-    ``auth.rs``) out of the OAuth JWT's ``chatgpt_account_id`` claim.
+def _codex_cloudflare_headers(
+    access_token: str, *, base_url: str = _CODEX_AUX_BASE_URL,
+) -> Dict[str, str]:
+    """Identity and account headers for chatgpt.com/backend-api/codex.
+
+    The Codex endpoint has historically challenged unrecognized originators on
+    some networks with a 403 and ``cf-mitigated: challenge``, even when the
+    credentials are valid.
+
+    Keep the existing compatibility identity by default. Users who opt into
+    provider usage attribution send Hermes' own originator and version instead. In
+    either case, preserve ``ChatGPT-Account-ID`` (canonical casing, from
+    codex-rs ``auth.rs``) from the OAuth JWT's ``chatgpt_account_id`` claim.
 
     Malformed tokens are tolerated — we drop the account-ID header rather than
     raise, so a bad token still surfaces as an auth error (401) instead of a
@@ -1213,6 +1228,15 @@ def _codex_cloudflare_headers(access_token: str) -> Dict[str, str]:
         "User-Agent": "codex_cli_rs/0.0.0 (Hermes Agent)",
         "originator": "codex_cli_rs",
     }
+    from hermes_cli.usage_attribution import usage_attribution_enabled
+
+    if _is_official_codex_base_url(base_url) and usage_attribution_enabled():
+        from hermes_cli import __version__
+
+        headers.update({
+            "User-Agent": f"HermesAgent/{__version__}",
+            "originator": "hermes-agent",
+        })
     if not isinstance(access_token, str) or not access_token.strip():
         return headers
     try:
@@ -3697,7 +3721,7 @@ def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
     real_client = _create_openai_client(
         api_key=codex_token,
         base_url=base_url,
-        default_headers=_codex_cloudflare_headers(codex_token),
+        default_headers=_codex_cloudflare_headers(codex_token, base_url=base_url),
     )
     return CodexAuxiliaryClient(real_client, model), model
 
@@ -6029,6 +6053,10 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
         async_kwargs["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
     elif base_url_host_matches(sync_base_url, "integrate.api.nvidia.com"):
         async_kwargs["default_headers"] = build_nvidia_nim_headers(sync_base_url)
+    elif _is_official_codex_base_url(sync_base_url):
+        async_kwargs["default_headers"] = _codex_cloudflare_headers(
+            sync_client.api_key, base_url=sync_base_url,
+        )
     elif base_url_host_matches(sync_base_url, "x.ai"):
         from tools.xai_http import hermes_xai_default_headers
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1744,6 +1744,12 @@ display:
 telemetry:
   shared_metrics:
     enabled: false
+  # Allow supported model providers to identify Hermes on existing requests.
+  # Currently applies to ChatGPT-authenticated Codex requests. No separate
+  # telemetry request is sent. Configure with `hermes setup telemetry` or
+  # `hermes tools`; restart running sessions/gateways after changing this.
+  usage_attribution:
+    enabled: false
 
 
 # =============================================================================

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3114,10 +3114,14 @@ DEFAULT_CONFIG = {
         "profile_build": "ask",
     },
 
-    # Privacy-safe aggregate metrics written only to this profile's local
-    # telemetry directory. Collection is opt-in and no remote sink exists.
+    # Profile-owned, opt-in telemetry and provider attribution settings.
     "telemetry": {
+        # Aggregate metrics stay local; no remote sink exists.
         "shared_metrics": {
+            "enabled": False,
+        },
+        # Identify Hermes on supported providers' existing inference requests.
+        "usage_attribution": {
             "enabled": False,
         },
     },

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2313,12 +2313,40 @@ def setup_tools(config: dict, first_install: bool = False):
 
 
 # =============================================================================
-# Shared Metrics
+# Telemetry and Usage Attribution
 # =============================================================================
 
 
+def setup_usage_attribution(config: dict):
+    """Ask before identifying Hermes to supported model providers."""
+    from hermes_cli.usage_attribution import usage_attribution_enabled
+
+    print_header("Provider Usage Attribution")
+    print_info("Allow supported model providers to recognize Hermes traffic.")
+    print_info("This adds the Hermes name and version to existing requests.")
+    print_info("It does not add prompt content or send a separate telemetry request.")
+
+    current = usage_attribution_enabled(config)
+    enabled = prompt_yes_no("Allow provider usage attribution?", default=current)
+    telemetry = config.get("telemetry")
+    if not isinstance(telemetry, dict):
+        telemetry = {}
+        config["telemetry"] = telemetry
+    attribution = telemetry.get("usage_attribution")
+    if not isinstance(attribution, dict):
+        attribution = {}
+        telemetry["usage_attribution"] = attribution
+    attribution["enabled"] = enabled
+
+    if enabled:
+        print_success("Provider usage attribution enabled for new clients.")
+    else:
+        print_info("Provider usage attribution disabled for new clients.")
+    print_info("Restart running Hermes sessions or gateways to apply the change.")
+
+
 def setup_telemetry(config: dict):
-    """Configure the local, privacy-safe shared-metrics subscriber."""
+    """Configure local shared metrics and optional provider attribution."""
     print_header("Shared Metrics")
     print_info("Shared metrics contain only bounded counters and histograms.")
     print_info("Packages stay under this Hermes profile and are not uploaded.")
@@ -2341,6 +2369,8 @@ def setup_telemetry(config: dict):
         print_success("Local shared metrics enabled.")
     else:
         print_info("Local shared metrics disabled.")
+
+    setup_usage_attribution(config)
 
 
 # =============================================================================
@@ -2751,7 +2781,7 @@ SETUP_SECTIONS = [
     ("terminal", "Terminal Backend", setup_terminal_backend),
     ("gateway", "Messaging Platforms (Gateway)", setup_gateway),
     ("tools", "Tools", setup_tools),
-    ("telemetry", "Shared Metrics", setup_telemetry),
+    ("telemetry", "Telemetry & Usage Attribution", setup_telemetry),
     ("agent", "Agent Settings", setup_agent_settings),
 ]
 
@@ -2850,7 +2880,7 @@ def run_setup_wizard(args):
       hermes setup terminal  — just terminal backend
       hermes setup gateway   — just messaging platforms
       hermes setup tools     — just tool configuration
-      hermes setup telemetry — just local shared metrics
+      hermes setup telemetry — local metrics and provider usage attribution
       hermes setup agent     — just agent settings
     """
     from hermes_cli.config import is_managed, managed_error
@@ -2994,7 +3024,7 @@ def run_setup_wizard(args):
         print_info("Press Enter to keep it, or type a new value to change it.")
         print_info("")
         print_info("Tip: jump straight to a section with 'hermes setup model|terminal|")
-        print_info("     gateway|tools|agent', or fill only missing items with --quick.")
+        print_info("     gateway|tools|telemetry|agent', or fill only missing items with --quick.")
         # Fall through to the "Full Setup — run all sections" block below.
         # --reconfigure is now the default on existing installs; the flag
         # is preserved for backwards compatibility but is a no-op here.
@@ -3071,6 +3101,9 @@ def run_setup_wizard(args):
     # Section 5: Tools
     if not (migration_ran and _skip_configured_section(config, "tools", "Tools")):
         setup_tools(config, first_install=not is_existing)
+
+    # Attribution is a separate, profile-owned opt-in, never a setup default.
+    setup_usage_attribution(config)
 
     # Save and show summary
     save_config(config)

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -5308,13 +5308,15 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
     if _has_mcp:
         platform_choices.append("Configure MCP server tools")
 
+    _attribution_idx = len(platform_choices)
+    platform_choices.append("Configure provider usage attribution")
+    _done_idx = len(platform_choices)
     platform_choices.append("Done")
 
     # Index offsets for the extra options after per-platform entries
     _global_idx = len(platform_keys) if len(platform_keys) > 1 else -1
     _reconfig_idx = len(platform_keys) + (1 if len(platform_keys) > 1 else 0)
     _mcp_idx = (_reconfig_idx + 1) if _has_mcp else -1
-    _done_idx = _reconfig_idx + (2 if _has_mcp else 1)
 
     while True:
         idx = _prompt_choice("Select an option:", platform_choices, default=0)
@@ -5322,6 +5324,14 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
         # "Done" selected
         if idx == _done_idx:
             break
+
+        if idx == _attribution_idx:
+            from hermes_cli.setup import setup_usage_attribution
+
+            setup_usage_attribution(config)
+            save_config(config)
+            print()
+            continue
 
         # "Reconfigure" selected
         if idx == _reconfig_idx:

--- a/hermes_cli/usage_attribution.py
+++ b/hermes_cli/usage_attribution.py
@@ -1,0 +1,31 @@
+"""Profile-owned consent for optional provider usage attribution."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def usage_attribution_enabled(config: Mapping[str, Any] | None = None) -> bool:
+    """Require an explicit opt-in before adding new provider attribution tags."""
+    if config is None:
+        try:
+            from hermes_cli.config import read_raw_config_readonly
+
+            # Like shared-metrics consent, this belongs to the active profile.
+            # Defaults and managed overlays must not opt a user in.
+            config = read_raw_config_readonly()
+        except Exception:
+            logger.debug("Unable to read usage-attribution policy", exc_info=True)
+            return False
+
+    telemetry = config.get("telemetry") if isinstance(config, Mapping) else None
+    attribution = (
+        telemetry.get("usage_attribution")
+        if isinstance(telemetry, Mapping)
+        else None
+    )
+    return isinstance(attribution, Mapping) and attribution.get("enabled") is True

--- a/run_agent.py
+++ b/run_agent.py
@@ -6275,7 +6275,7 @@ class AIAgent:
         elif base_url_host_matches(base_url, "chatgpt.com"):
             from agent.auxiliary_client import _codex_cloudflare_headers
             self._client_kwargs["default_headers"] = _codex_cloudflare_headers(
-                self._client_kwargs.get("api_key", "")
+                self._client_kwargs.get("api_key", ""), base_url=base_url,
             )
         elif base_url_host_matches(base_url, "x.ai"):
             # Cover both provider=xai and provider=xai-oauth (api.x.ai).

--- a/tests/agent/test_codex_cloudflare_headers.py
+++ b/tests/agent/test_codex_cloudflare_headers.py
@@ -13,9 +13,9 @@ header set so the primary chat client (``run_agent.AIAgent.__init__`` +
 (``_build_codex_client`` and the ``raw_codex`` branch of ``resolve_provider_client``)
 all emit the same headers.
 
-These tests pin:
-- the originator value (must be ``codex_cli_rs`` — the whitelisted one)
-- the User-Agent shape (codex_cli_rs-prefixed)
+These tests pin the default behavior when provider usage attribution is off:
+- the compatibility originator value (``codex_cli_rs``)
+- the compatibility User-Agent shape (codex_cli_rs-prefixed)
 - ``ChatGPT-Account-ID`` extraction from the OAuth JWT (canonical casing,
   from codex-rs ``auth.rs``)
 - graceful handling of malformed tokens (drop the account-ID header, don't

--- a/tests/agent/test_codex_usage_attribution.py
+++ b/tests/agent/test_codex_usage_attribution.py
@@ -1,0 +1,289 @@
+"""Exercise opt-in Codex attribution through real SDK request construction."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from types import SimpleNamespace
+
+import httpx
+import pytest
+import yaml
+
+from hermes_cli import __version__
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+CODEX_URL = "https://chatgpt.com/backend-api/codex"
+MODEL = "gpt-5.4"
+
+
+def _jwt(account_id="acct-attribution-test"):
+    payload = json.dumps({
+        "https://api.openai.com/auth": {"chatgpt_account_id": account_id},
+    }).encode()
+    encoded = base64.urlsafe_b64encode(payload).rstrip(b"=").decode()
+    return f"e30.{encoded}.test-signature"
+
+
+@pytest.fixture
+def configure_attribution(tmp_path, monkeypatch):
+    home = tmp_path / "profile"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    token = set_hermes_home_override(home)
+
+    def configure(enabled):
+        (home / "config.yaml").write_text(
+            yaml.safe_dump({
+                "telemetry": {"usage_attribution": {"enabled": enabled}},
+            }),
+            encoding="utf-8",
+        )
+
+    try:
+        yield configure
+    finally:
+        reset_hermes_home_override(token)
+
+
+@pytest.fixture
+def wire(configure_attribution, monkeypatch):
+    """Replace only HTTP transports; use Hermes routing and the real SDK."""
+    from agent import auxiliary_client
+    from run_agent import AIAgent
+
+    requests = []
+    response = {
+        "id": "resp_attribution_test",
+        "object": "response",
+        "created_at": 0,
+        "status": "completed",
+        "model": MODEL,
+        "output": [{
+            "type": "message",
+            "id": "msg_test",
+            "role": "assistant",
+            "status": "completed",
+            "content": [{"type": "output_text", "text": "ok", "annotations": []}],
+        }],
+    }
+
+    def respond(request):
+        requests.append(request)
+        if json.loads(request.content).get("stream"):
+            events = [
+                {
+                    "type": "response.output_item.done",
+                    "output_index": 0,
+                    "item": response["output"][0],
+                },
+                {"type": "response.completed", "response": response},
+            ]
+            content = "".join(f"data: {json.dumps(event)}\n\n" for event in events)
+            return httpx.Response(
+                200,
+                headers={"Content-Type": "text/event-stream"},
+                content=content + "data: [DONE]\n\n",
+            )
+        return httpx.Response(200, json=response)
+
+    def http_client(*_args, async_mode=False, **_kwargs):
+        cls = httpx.AsyncClient if async_mode else httpx.Client
+        return cls(transport=httpx.MockTransport(respond))
+
+    monkeypatch.setattr(
+        auxiliary_client, "_openai_http_client_kwargs",
+        lambda _url, *, async_mode=False: {
+            "http_client": http_client(async_mode=async_mode),
+        },
+    )
+    monkeypatch.setattr(AIAgent, "_build_keepalive_http_client", staticmethod(http_client))
+    return requests
+
+
+def _assert_identity(request, enabled, account_id="acct-attribution-test"):
+    assert request.headers["originator"] == ("hermes-agent" if enabled else "codex_cli_rs")
+    expected_ua = (
+        f"HermesAgent/{__version__}"
+        if enabled else "codex_cli_rs/0.0.0 (Hermes Agent)"
+    )
+    assert request.headers["user-agent"] == expected_ua
+    assert request.headers["chatgpt-account-id"] == account_id
+    assert "extra_headers" not in json.loads(request.content)
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_header_policy_preserves_account_id(configure_attribution, enabled):
+    from agent.auxiliary_client import _codex_cloudflare_headers
+
+    configure_attribution(enabled)
+    headers = _codex_cloudflare_headers(_jwt())
+
+    assert headers["originator"] == ("hermes-agent" if enabled else "codex_cli_rs")
+    assert headers["ChatGPT-Account-ID"] == "acct-attribution-test"
+    assert "ChatGPT-Account-ID" not in _codex_cloudflare_headers("not-a-jwt")
+
+
+@pytest.mark.parametrize(
+    ("base_url", "attributed"),
+    [
+        (CODEX_URL, True),
+        (CODEX_URL + "/", True),
+        (CODEX_URL + "/responses", True),
+        ("https://CHATGPT.COM:443/backend-api/codex", True),
+        ("http://chatgpt.com/backend-api/codex", False),
+        ("https://chatgpt.com:8443/backend-api/codex", False),
+        ("https://api.openai.com/v1", False),
+        ("https://proxy.example/backend-api/codex", False),
+        ("https://chatgpt.com.example/backend-api/codex", False),
+        ("https://subdomain.chatgpt.com/backend-api/codex", False),
+        ("https://chatgpt.com/backend-api/codex-other", False),
+        ("https://chatgpt.com/backend-api/other", False),
+        ("https://chatgpt.com:invalid/backend-api/codex", False),
+    ],
+)
+def test_new_identity_is_limited_to_the_official_endpoint(
+    configure_attribution, base_url, attributed,
+):
+    from agent.auxiliary_client import _codex_cloudflare_headers
+
+    configure_attribution(True)
+    headers = _codex_cloudflare_headers(_jwt(), base_url=base_url)
+
+    assert headers["originator"] == ("hermes-agent" if attributed else "codex_cli_rs")
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_primary_client_and_credential_rebuild_send_expected_headers(
+    configure_attribution, wire, enabled,
+):
+    from run_agent import AIAgent
+
+    configure_attribution(enabled)
+    agent = AIAgent(
+        api_key=_jwt(),
+        base_url=CODEX_URL,
+        provider="openai-codex",
+        model=MODEL,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    clients = [agent.client]
+    try:
+        agent.client.responses.create(model=MODEL, input="test")
+        _assert_identity(wire[-1], enabled)
+
+        agent._client_kwargs["api_key"] = _jwt("acct-rotated")
+        agent._apply_client_headers_for_base_url(CODEX_URL)
+        assert agent._replace_primary_openai_client(reason="attribution-test")
+        clients.append(agent.client)
+        agent.client.responses.create(model=MODEL, input="test")
+        _assert_identity(wire[-1], enabled, "acct-rotated")
+
+        direct_url = "https://api.openai.com/v1"
+        agent._client_kwargs.update(api_key="test-direct-key", base_url=direct_url)
+        agent._apply_client_headers_for_base_url(direct_url)
+        assert agent._replace_primary_openai_client(reason="attribution-route-change")
+        clients.append(agent.client)
+        agent.client.responses.create(model=MODEL, input="test")
+        assert "originator" not in wire[-1].headers
+        assert "chatgpt-account-id" not in wire[-1].headers
+        assert not wire[-1].headers["user-agent"].startswith("HermesAgent/")
+    finally:
+        for client in clients:
+            client.close()
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_auxiliary_raw_and_async_clients_send_expected_headers(
+    configure_attribution, wire, monkeypatch, enabled,
+):
+    from agent import auxiliary_client
+
+    configure_attribution(enabled)
+    monkeypatch.setattr(auxiliary_client, "_select_pool_entry", lambda _p: (False, None))
+    monkeypatch.setattr(auxiliary_client, "_read_codex_access_token", _jwt)
+
+    wrapped, model = auxiliary_client._build_codex_client(MODEL)
+    raw, raw_model = auxiliary_client.resolve_provider_client(
+        "openai-codex", model=MODEL, raw_codex=True,
+    )
+    try:
+        result = wrapped.chat.completions.create(
+            model=model, messages=[{"role": "user", "content": "test"}],
+        )
+        assert result.choices[0].message.content == "ok"
+        _assert_identity(wire[-1], enabled)
+
+        raw.responses.create(model=raw_model, input="test")
+        _assert_identity(wire[-1], enabled)
+
+        async def send_async():
+            async_wrapped, _ = auxiliary_client._to_async_client(wrapped, model)
+            result = await async_wrapped.chat.completions.create(
+                model=model, messages=[{"role": "user", "content": "test"}],
+            )
+            assert result.choices[0].message.content == "ok"
+            _assert_identity(wire[-1], enabled)
+
+            async_raw, _ = auxiliary_client._to_async_client(raw, raw_model)
+            try:
+                await async_raw.responses.create(model=raw_model, input="test")
+                _assert_identity(wire[-1], enabled)
+            finally:
+                await async_raw.close()
+
+        asyncio.run(send_async())
+    finally:
+        wrapped.close()
+        raw.close()
+
+
+def test_credential_pool_custom_endpoint_keeps_existing_identity(
+    configure_attribution, wire, monkeypatch,
+):
+    from agent import auxiliary_client
+
+    configure_attribution(True)
+    entry = SimpleNamespace(
+        runtime_api_key=_jwt(),
+        runtime_base_url="https://proxy.example/backend-api/codex",
+    )
+    monkeypatch.setattr(auxiliary_client, "_select_pool_entry", lambda _p: (True, entry))
+
+    client, model = auxiliary_client._build_codex_client(MODEL)
+    try:
+        client.chat.completions.create(
+            model=model, messages=[{"role": "user", "content": "test"}],
+        )
+        assert wire[-1].url.host == "proxy.example"
+        _assert_identity(wire[-1], False)
+    finally:
+        client.close()
+
+
+def test_disabling_attribution_restores_compatibility_for_new_clients(
+    configure_attribution, wire, monkeypatch,
+):
+    from agent import auxiliary_client
+
+    monkeypatch.setattr(auxiliary_client, "_read_codex_access_token", _jwt)
+    configure_attribution(True)
+    old, _ = auxiliary_client.resolve_provider_client(
+        "openai-codex", model=MODEL, raw_codex=True,
+    )
+    configure_attribution(False)
+    new, _ = auxiliary_client.resolve_provider_client(
+        "openai-codex", model=MODEL, raw_codex=True,
+    )
+    try:
+        old.responses.create(model=MODEL, input="test")
+        _assert_identity(wire[-1], True)
+        new.responses.create(model=MODEL, input="test")
+        _assert_identity(wire[-1], False)
+    finally:
+        old.close()
+        new.close()

--- a/tests/hermes_cli/test_setup_reconfigure.py
+++ b/tests/hermes_cli/test_setup_reconfigure.py
@@ -114,6 +114,7 @@ class TestExistingInstallDefault:
                 agent="hermes_cli.setup.setup_agent_settings",
                 gateway="hermes_cli.setup.setup_gateway",
                 tools="hermes_cli.setup.setup_tools",
+                attribution="hermes_cli.setup.setup_usage_attribution",
             )
             from hermes_cli.setup import run_setup_wizard
             run_setup_wizard(args)
@@ -129,6 +130,7 @@ class TestExistingInstallDefault:
         m["agent"].assert_not_called()
         m["gateway"].assert_called_once()
         m["tools"].assert_called_once()
+        m["attribution"].assert_called_once()
 
 
 class TestQuickFlag:
@@ -146,6 +148,7 @@ class TestQuickFlag:
                 agent="hermes_cli.setup.setup_agent_settings",
                 gateway="hermes_cli.setup.setup_gateway",
                 tools="hermes_cli.setup.setup_tools",
+                attribution="hermes_cli.setup.setup_usage_attribution",
             )
             from hermes_cli.setup import run_setup_wizard
             run_setup_wizard(args)
@@ -157,6 +160,7 @@ class TestQuickFlag:
         m["agent"].assert_not_called()
         m["gateway"].assert_not_called()
         m["tools"].assert_not_called()
+        m["attribution"].assert_not_called()
 
 
 class TestFreshInstall:
@@ -198,5 +202,4 @@ class TestArgparse:
             pass
         assert captured["args"].reconfigure is True
         assert captured["args"].quick is False
-
 

--- a/tests/hermes_cli/test_usage_attribution.py
+++ b/tests/hermes_cli/test_usage_attribution.py
@@ -1,0 +1,173 @@
+"""Provider attribution requires consent from the active Hermes profile."""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from hermes_cli import config, managed_scope
+from hermes_cli.usage_attribution import usage_attribution_enabled
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+@pytest.fixture
+def profile(tmp_path, monkeypatch):
+    home = tmp_path / "profile"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_MANAGED_DIR", raising=False)
+    token = set_hermes_home_override(home)
+    managed_scope.invalidate_managed_cache()
+    try:
+        yield home
+    finally:
+        reset_hermes_home_override(token)
+        managed_scope.invalidate_managed_cache()
+
+
+def _write_config(home, data):
+    (home / "config.yaml").write_text(yaml.safe_dump(data), encoding="utf-8")
+
+
+def _policy(enabled):
+    return {"telemetry": {"usage_attribution": {"enabled": enabled}}}
+
+
+def test_usage_attribution_is_disabled_by_default(profile):
+    assert config.DEFAULT_CONFIG["telemetry"]["usage_attribution"]["enabled"] is False
+    assert usage_attribution_enabled() is False
+
+
+@pytest.mark.parametrize("value", [False, None, 0, 1, "true", "false", [], {}])
+def test_only_a_yaml_boolean_true_is_consent(profile, value):
+    _write_config(profile, _policy(value))
+
+    assert usage_attribution_enabled() is False
+
+
+@pytest.mark.parametrize(
+    "data",
+    [{}, [], {"telemetry": None}, {"telemetry": True},
+     {"telemetry": {"usage_attribution": True}}],
+)
+def test_malformed_policy_is_disabled(profile, data):
+    _write_config(profile, data)
+
+    assert usage_attribution_enabled() is False
+
+
+def test_config_edits_are_seen_without_restarting_the_policy_reader(profile):
+    _write_config(profile, _policy(True))
+    assert usage_attribution_enabled() is True
+
+    _write_config(profile, _policy(False))
+    assert usage_attribution_enabled() is False
+
+    (profile / "config.yaml").write_text("telemetry: [\n", encoding="utf-8")
+    assert usage_attribution_enabled() is False
+
+
+def test_config_read_error_fails_closed(profile, monkeypatch):
+    def unreadable():
+        raise OSError("unreadable test config")
+
+    monkeypatch.setattr(config, "read_raw_config_readonly", unreadable)
+
+    assert usage_attribution_enabled() is False
+
+
+def test_consent_does_not_leak_between_profiles(profile, tmp_path):
+    _write_config(profile, _policy(True))
+    other = tmp_path / "other-profile"
+    other.mkdir()
+    _write_config(other, _policy(False))
+
+    assert usage_attribution_enabled() is True
+    token = set_hermes_home_override(other)
+    try:
+        assert usage_attribution_enabled() is False
+    finally:
+        reset_hermes_home_override(token)
+    assert usage_attribution_enabled() is True
+
+
+@pytest.mark.parametrize(
+    ("profile_enabled", "managed_enabled"),
+    [(None, True), (False, True), (True, False)],
+)
+def test_managed_overlay_cannot_supply_or_replace_consent(
+    profile, tmp_path, monkeypatch, profile_enabled, managed_enabled,
+):
+    managed = tmp_path / "managed"
+    managed.mkdir()
+    _write_config(profile, {} if profile_enabled is None else _policy(profile_enabled))
+    _write_config(managed, _policy(managed_enabled))
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed))
+    config._LOAD_CONFIG_CACHE.clear()
+    managed_scope.invalidate_managed_cache()
+
+    effective = config.load_config_readonly()
+    assert effective["telemetry"]["usage_attribution"]["enabled"] is managed_enabled
+    assert usage_attribution_enabled() is (profile_enabled is True)
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_setup_keeps_attribution_and_local_metrics_independent(
+    profile, monkeypatch, enabled,
+):
+    from hermes_cli.setup import setup_telemetry
+
+    data = {
+        "telemetry": {
+            "shared_metrics": {"enabled": True},
+            "usage_attribution": {"enabled": not enabled},
+            "unrelated_setting": "preserved",
+        },
+    }
+    questions = []
+    answers = iter([True, enabled])
+
+    def answer(question, default):
+        questions.append((question, default))
+        return next(answers)
+
+    monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", answer)
+    setup_telemetry(data)
+    config.save_config(data)
+
+    assert len(questions) == 2
+    assert questions[1] == ("Allow provider usage attribution?", not enabled)
+    assert data["telemetry"]["shared_metrics"]["enabled"] is True
+    assert data["telemetry"]["unrelated_setting"] == "preserved"
+    assert usage_attribution_enabled() is enabled
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+@pytest.mark.parametrize("has_extra_menus", [False, True])
+def test_tools_menu_persists_attribution_choice(
+    profile, monkeypatch, enabled, has_extra_menus,
+):
+    from hermes_cli import tools_config
+
+    data = _policy(not enabled)
+    data["telemetry"]["shared_metrics"] = {"enabled": True}
+    if has_extra_menus:
+        data["mcp_servers"] = {"test": {"command": "unused"}}
+    _write_config(profile, data)
+
+    platforms = ["cli", "telegram"] if has_extra_menus else ["cli"]
+    monkeypatch.setattr(tools_config, "_get_enabled_platforms", lambda: platforms)
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda *a, **kw: set())
+    monkeypatch.setattr(tools_config, "_get_effective_configurable_toolsets", lambda: [])
+    choices = iter(["Configure provider usage attribution", "Done"])
+    monkeypatch.setattr(
+        tools_config, "_prompt_choice",
+        lambda _question, options, default: options.index(next(choices)),
+    )
+    monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", lambda _q, default: enabled)
+
+    tools_config.tools_command()
+
+    assert usage_attribution_enabled() is enabled
+    saved = config.read_raw_config_readonly()
+    assert saved["telemetry"]["shared_metrics"]["enabled"] is True

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1930,6 +1930,30 @@ When `redact_pii` is `true`, the gateway redacts personally identifiable informa
 
 Hashes are deterministic — the same user always maps to the same hash, so the model can still distinguish between users in group chats. Routing and delivery use the original values internally.
 
+### Provider usage attribution
+
+You can allow supported model providers to recognize requests made by Hermes.
+This is off by default and separate from local shared metrics. Configure it in
+`hermes setup telemetry`, in `hermes tools` → **Configure provider usage
+attribution**, or in your profile's `config.yaml`:
+
+```yaml
+telemetry:
+  usage_attribution:
+    enabled: false
+```
+
+When enabled, ChatGPT-authenticated requests to the official Codex endpoint
+send `originator: hermes-agent` and `User-Agent: HermesAgent/<version>`. The
+existing ChatGPT account header is preserved. No prompt content or separate
+telemetry requests are added.
+Direct OpenAI API requests and custom proxy endpoints are unchanged.
+
+The setting applies when clients are created. Restart running Hermes sessions
+or gateways after changing it. If the new identity causes a Codex connection
+error, disable the setting and restart to restore the existing compatibility
+headers.
+
 ## Speech-to-Text (STT)
 
 ```yaml


### PR DESCRIPTION
## Summary

Let users identify Hermes on ChatGPT-authenticated Codex requests. This adds a generic, profile-owned `telemetry.usage_attribution.enabled` setting, defaulting to `false`, with a setup prompt and a toggle in `hermes tools`.

When explicitly enabled, requests to the official Codex endpoint use `originator: hermes-agent` and `User-Agent: HermesAgent/<version>`. The existing ChatGPT account header is preserved. Primary, auxiliary, raw Responses, and async clients use the same policy. Direct OpenAI API requests and custom proxy endpoints are unchanged.

The existing compatibility identity remains the default. No separate telemetry request is sent, and managed configuration cannot supply consent on a user's behalf. Restart running sessions or gateways after changing the setting.

Related: [Hermes direct-API attribution PR #38603](https://github.com/NousResearch/hermes-agent/pull/38603), [OpenCode #42959](https://github.com/anomalyco/opencode/pull/42959), and [Pi's Codex harness attribution change](https://github.com/earendil-works/pi/commit/6dcb64565a66de609413de6c98457ca7ab450da9). This PR covers the ChatGPT/Codex route, not the direct-API work in #38603.

## Verification

Tested on macOS with Python 3.12.12 and the locked development dependencies. The targeted suite passed **456 tests across 17 files**. The new request tests use the real OpenAI SDK with `httpx.MockTransport`; they do not use live credentials or contact the provider.

```sh
scripts/run_tests.sh \
  tests/hermes_cli/test_usage_attribution.py \
  tests/hermes_cli/test_setup_telemetry.py \
  tests/hermes_cli/test_setup_reconfigure.py \
  tests/hermes_cli/test_setup_noninteractive.py \
  tests/hermes_cli/test_setup_openclaw_migration.py \
  tests/hermes_cli/test_tools_config.py \
  tests/hermes_cli/test_mcp_tools_config.py \
  tests/hermes_cli/test_auth_codex_provider.py \
  tests/agent/test_codex_usage_attribution.py \
  tests/agent/test_codex_cloudflare_headers.py \
  tests/agent/test_auxiliary_client.py \
  tests/agent/test_auxiliary_user_default_headers.py \
  tests/agent/test_auxiliary_client_base_url_host_validation_52608.py \
  tests/agent/test_auxiliary_client_resolve_dedup.py \
  tests/agent/transports/test_codex_transport.py \
  tests/run_agent/test_create_openai_client_reuse.py \
  tests/plugins/image_gen/test_openai_codex_provider.py \
  -j 4
ruff check .
ty check hermes_cli/usage_attribution.py
```

For a manual-clone environment outside the checkout, set `HERMES_PYTHON` to that environment's Python before running the test script.

## Before rollout

Live Codex acceptance of `originator: hermes-agent` still needs a smoke test. The endpoint has previously challenged unrecognized originators on some networks. Keep attribution disabled until that compatibility check is complete; disabling it and restarting restores the existing headers.
