### PR TITLE
fix(profiles): tombstone deleted named profiles so logging cannot resurrect them

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -913,17 +913,13 @@ def ensure_hermes_home():
     home = get_hermes_home()
     key = str(home)
 
+    # Named profiles must be created explicitly (e.g. ``hermes profile create``).
+    # Check tombstones before the memo so a stale empty shell cannot skip
+    # the deleted-profile guard.
+    from hermes_constants import assert_named_profile_home_live
+    assert_named_profile_home_live(home)
     if key in _HERMES_HOME_ENSURED and home.is_dir():
         return
-    # Named profiles must be created explicitly (e.g. ``hermes profile create``).
-    # If a stale process keeps running after the profile was renamed/deleted,
-    # silently mkdir-ing the old HERMES_HOME would resurrect an empty skeleton
-    # and make the deleted profile reappear in Desktop/profile lists.
-    if home.parent.name == "profiles" and not home.exists():
-        raise FileNotFoundError(
-            f"Named profile home does not exist: {home}. "
-            "Create the profile explicitly before using it."
-        )
     if is_managed():
         old_umask = os.umask(0o007)
         try:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -385,11 +385,12 @@ def get_profile_dir(name: str) -> Path:
 
 
 def profile_exists(name: str) -> bool:
-    """Check whether a profile directory exists."""
+    """Check whether a live (non-tombstoned) profile directory exists."""
     canon = normalize_profile_name(name)
     if canon == "default":
         return True
-    return get_profile_dir(canon).is_dir()
+    profile_dir = get_profile_dir(canon)
+    return profile_dir.is_dir() and not named_profile_is_deleted(profile_dir)
 
 
 # ---------------------------------------------------------------------------
@@ -1132,6 +1133,10 @@ def create_profile(
 
     profile_dir = get_profile_dir(canon)
     if profile_dir.exists() and named_profile_is_deleted(profile_dir):
+        # Empty shells left by post-delete mkdir may be replaced. Identity
+        # files mean the leftover is not a shell — fail closed, no rmtree.
+        if (profile_dir / "config.yaml").exists() or (profile_dir / ".env").exists():
+            raise FileExistsError(f"Profile '{canon}' already exists at {profile_dir}")
         shutil.rmtree(profile_dir)
     if profile_dir.exists():
         raise FileExistsError(f"Profile '{canon}' already exists at {profile_dir}")
@@ -1351,6 +1356,8 @@ def backfill_profile_envs(quiet: bool = False) -> List[str]:
         if not entry.is_dir() or not _PROFILE_ID_RE.match(entry.name):
             continue
         if entry.name == "default":
+            continue
+        if named_profile_is_deleted(entry):
             continue
         env_path = entry / ".env"
         if env_path.exists():
@@ -2499,7 +2506,7 @@ def resolve_profile_env(profile_name: str) -> str:
         return str(root)
     profile_dir = root / "profiles" / canon
 
-    if not profile_dir.is_dir():
+    if not profile_dir.is_dir() or named_profile_is_deleted(profile_dir):
         raise FileNotFoundError(
             f"Profile '{canon}' does not exist. "
             f"Create it with: hermes profile create {canon}"

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -34,6 +34,11 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Dict, List, Optional, Tuple
 
 from agent.skill_utils import is_excluded_skill_path
+from hermes_constants import (
+    clear_named_profile_deleted,
+    mark_named_profile_deleted,
+    named_profile_is_deleted,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -971,6 +976,8 @@ def list_profiles() -> List[ProfileInfo]:
                 continue  # already added as the built-in default above
             if not _PROFILE_ID_RE.match(name):
                 continue
+            if named_profile_is_deleted(entry):
+                continue
             model, provider = _read_config_model(entry)
             alias_name = alias_map.get(normalize_profile_name(name))
             if alias_name:
@@ -1056,6 +1063,8 @@ def profiles_to_serve(
                 continue  # default is the built-in entry already added above
             if not _PROFILE_ID_RE.match(name):
                 continue
+            if named_profile_is_deleted(entry):
+                continue
             if allowed is not None and name not in allowed:
                 continue
             serve.append((name, entry))
@@ -1122,8 +1131,11 @@ def create_profile(
         )
 
     profile_dir = get_profile_dir(canon)
+    if profile_dir.exists() and named_profile_is_deleted(profile_dir):
+        shutil.rmtree(profile_dir)
     if profile_dir.exists():
         raise FileExistsError(f"Profile '{canon}' already exists at {profile_dir}")
+    clear_named_profile_deleted(profile_dir)
 
     # Resolve clone source
     source_dir = None
@@ -1657,6 +1669,10 @@ def delete_profile(name: str, yes: bool = False) -> Path:
     # the rmtree below fail with ENOTEMPTY and — before the ensure_hermes_home
     # guard — resurrected the deleted tree.
     _stop_profile_backends(canon, profile_dir)
+
+    # Tombstone before rmtree so a stale serve/logging mkdir cannot relist
+    # this name as a live profile.
+    mark_named_profile_deleted(profile_dir)
 
     # 2c. Release this process's holographic memory-store connections into
     # the profile. The Desktop's *main* serve process opens memory_store.db

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -227,6 +227,62 @@ def get_default_hermes_root() -> Path:
     return result
 
 
+# Named-profile deletion must survive stale mkdir from live serve/logging.
+# The marker lives beside the profile dir, not inside it, so rmtree cannot
+# erase the fact that the profile was deleted.
+_DELETED_PROFILES_DIR = ".deleted"
+
+
+def named_profile_home(path: str | Path) -> Path | None:
+    """Return ``<root>/profiles/<name>`` when *path* is that home or under it."""
+    current = Path(path)
+    for candidate in (current, *current.parents):
+        if candidate.parent.name == "profiles" and not candidate.name.startswith("."):
+            return candidate
+    return None
+
+
+def profile_tombstone_path(profile_home: Path) -> Path:
+    return profile_home.parent / _DELETED_PROFILES_DIR / profile_home.name
+
+
+def named_profile_is_deleted(profile_home: str | Path) -> bool:
+    return profile_tombstone_path(Path(profile_home)).exists()
+
+
+def mark_named_profile_deleted(profile_home: str | Path) -> None:
+    marker = profile_tombstone_path(Path(profile_home))
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("deleted\n", encoding="utf-8")
+
+
+def clear_named_profile_deleted(profile_home: str | Path) -> None:
+    profile_tombstone_path(Path(profile_home)).unlink(missing_ok=True)
+
+
+def assert_named_profile_home_live(path: str | Path) -> None:
+    """Refuse missing or tombstoned named profile homes.
+
+    Default ``HERMES_HOME`` (not under ``profiles/``) is unchanged.
+    """
+    home = named_profile_home(path)
+    if home is None:
+        return
+    if named_profile_is_deleted(home) or not home.exists():
+        raise FileNotFoundError(
+            f"Named profile home does not exist: {home}. "
+            "Create the profile explicitly before using it."
+        )
+
+
+def mkdir_under_hermes_home(path: str | Path) -> Path:
+    """Create *path*, but never materialize a deleted/missing named profile."""
+    target = Path(path)
+    assert_named_profile_home_live(target)
+    target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
 def get_optional_skills_dir(default: Path | None = None) -> Path:
     """Return the optional-skills directory, honoring package-manager wrappers.
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -234,11 +234,22 @@ _DELETED_PROFILES_DIR = ".deleted"
 
 
 def named_profile_home(path: str | Path) -> Path | None:
-    """Return ``<root>/profiles/<name>`` when *path* is that home or under it."""
+    """Return ``<root>/profiles/<name>`` when *path* is that home or under it.
+
+    A named profile home is only ``.../profiles/<id>`` where ``<id>`` does
+    not start with ``.``. A default Hermes home whose path merely contains a
+    ``profiles`` segment (e.g. ``/tmp/foo/profiles/notahome/.hermes``) is not
+    a named profile. ``.../profiles/worker/logs`` still resolves to
+    ``.../profiles/worker``.
+    """
     current = Path(path)
     for candidate in (current, *current.parents):
         if candidate.parent.name == "profiles" and not candidate.name.startswith("."):
             return candidate
+        # Stop at a default Hermes home so a coincidental ``profiles/``
+        # ancestor is not treated as a named-profile root.
+        if candidate.name == ".hermes":
+            return None
     return None
 
 

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -301,8 +301,8 @@ def setup_logging(
     """
     global _logging_initialized
     home = hermes_home or get_hermes_home()
-    log_dir = home / "logs"
-    log_dir.mkdir(parents=True, exist_ok=True)
+    from hermes_constants import mkdir_under_hermes_home
+    log_dir = mkdir_under_hermes_home(home / "logs")
 
     # Read config defaults (best-effort — config may not be loaded yet).
     cfg_level, cfg_max_size, cfg_backup = _read_logging_config()
@@ -745,7 +745,8 @@ def _add_rotating_handler(
         ):
             return  # already attached
 
-    path.parent.mkdir(parents=True, exist_ok=True)
+    from hermes_constants import mkdir_under_hermes_home
+    mkdir_under_hermes_home(path.parent)
     handler = _ManagedRotatingFileHandler(
         str(path), maxBytes=max_bytes, backupCount=backup_count,
         encoding="utf-8",

--- a/tests/hermes_cli/test_deleted_profile_tombstone.py
+++ b/tests/hermes_cli/test_deleted_profile_tombstone.py
@@ -1,0 +1,95 @@
+"""Deleted named profiles must stay gone until explicitly recreated.
+
+A live serve/logging process can mkdir ``profiles/<name>/logs`` after
+``hermes profile delete`` removes the tree. That empty shell then
+reappears in ``hermes profile list`` and Desktop Bot Mode. These tests
+lock the tombstone + no-mkdir contract without depending on Desktop.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.config import ensure_hermes_home
+from hermes_cli.profiles import (
+    create_profile,
+    delete_profile,
+    list_profiles,
+    profiles_to_serve,
+)
+from hermes_logging import setup_logging
+
+
+@pytest.fixture()
+def profile_env(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    return tmp_path
+
+
+def _named_homes(tmp_path: Path) -> list[str]:
+    return [info.name for info in list_profiles() if not info.is_default]
+
+
+class TestDeletedProfileTombstone:
+    def test_delete_then_logging_setup_does_not_recreate_home(self, profile_env, monkeypatch):
+        profile_dir = create_profile("worker", no_alias=True, no_skills=True)
+        with patch("hermes_cli.profiles._cleanup_gateway_service"), patch(
+            "hermes_cli.profiles._stop_profile_backends"
+        ):
+            delete_profile("worker", yes=True)
+
+        assert not profile_dir.exists()
+        assert "worker" not in _named_homes(profile_env)
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        with pytest.raises(FileNotFoundError, match="Named profile home does not exist"):
+            setup_logging(hermes_home=profile_dir, force=True)
+
+        assert not profile_dir.exists()
+        monkeypatch.setenv("HERMES_HOME", str(profile_env / ".hermes"))
+        assert "worker" not in _named_homes(profile_env)
+
+    def test_empty_shell_after_delete_is_not_listed_or_served(self, profile_env):
+        profile_dir = create_profile("worker", no_alias=True, no_skills=True)
+        with patch("hermes_cli.profiles._cleanup_gateway_service"), patch(
+            "hermes_cli.profiles._stop_profile_backends"
+        ):
+            delete_profile("worker", yes=True)
+
+        # Simulate a stale mkdir that only rebuilds the directory itself.
+        profile_dir.mkdir(parents=True)
+        (profile_dir / "state.db").write_bytes(b"")
+
+        assert "worker" not in _named_homes(profile_env)
+        served = [name for name, _ in profiles_to_serve(True)]
+        assert "worker" not in served
+
+    def test_tombstoned_home_is_not_bootstrapped(self, profile_env, monkeypatch):
+        profile_dir = create_profile("worker", no_alias=True, no_skills=True)
+        with patch("hermes_cli.profiles._cleanup_gateway_service"), patch(
+            "hermes_cli.profiles._stop_profile_backends"
+        ):
+            delete_profile("worker", yes=True)
+        profile_dir.mkdir(parents=True)
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        with pytest.raises(FileNotFoundError, match="Named profile home does not exist"):
+            ensure_hermes_home()
+        assert not (profile_dir / "sessions").exists()
+
+    def test_create_after_delete_clears_tombstone(self, profile_env):
+        create_profile("worker", no_alias=True, no_skills=True)
+        with patch("hermes_cli.profiles._cleanup_gateway_service"), patch(
+            "hermes_cli.profiles._stop_profile_backends"
+        ):
+            delete_profile("worker", yes=True)
+
+        recreated = create_profile("worker", no_alias=True, no_skills=True)
+        assert recreated.is_dir()
+        assert "worker" in _named_homes(profile_env)

--- a/tests/hermes_cli/test_deleted_profile_tombstone.py
+++ b/tests/hermes_cli/test_deleted_profile_tombstone.py
@@ -15,11 +15,16 @@ import pytest
 
 from hermes_cli.config import ensure_hermes_home
 from hermes_cli.profiles import (
+    backfill_profile_envs,
     create_profile,
     delete_profile,
     list_profiles,
+    profile_exists,
     profiles_to_serve,
+    resolve_profile_env,
+    set_active_profile,
 )
+from hermes_constants import named_profile_home
 from hermes_logging import setup_logging
 
 
@@ -34,6 +39,13 @@ def profile_env(tmp_path, monkeypatch):
 
 def _named_homes(tmp_path: Path) -> list[str]:
     return [info.name for info in list_profiles() if not info.is_default]
+
+
+def _delete(name: str) -> None:
+    with patch("hermes_cli.profiles._cleanup_gateway_service"), patch(
+        "hermes_cli.profiles._stop_profile_backends"
+    ):
+        delete_profile(name, yes=True)
 
 
 class TestDeletedProfileTombstone:
@@ -93,3 +105,64 @@ class TestDeletedProfileTombstone:
         recreated = create_profile("worker", no_alias=True, no_skills=True)
         assert recreated.is_dir()
         assert "worker" in _named_homes(profile_env)
+
+    def test_profile_exists_is_false_for_tombstoned_shell(self, profile_env):
+        profile_dir = create_profile("worker", no_alias=True, no_skills=True)
+        assert profile_exists("worker") is True
+        _delete("worker")
+        profile_dir.mkdir(parents=True)
+
+        assert profile_exists("worker") is False
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            set_active_profile("worker")
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            resolve_profile_env("worker")
+
+    def test_backfill_skips_tombstoned_directory(self, profile_env):
+        profile_dir = create_profile("worker", no_alias=True, no_skills=True)
+        _delete("worker")
+        profile_dir.mkdir(parents=True)
+        (profile_env / ".hermes" / ".env").write_text("OPENROUTER_API_KEY=root-key\n")
+
+        backfilled = backfill_profile_envs(quiet=True)
+
+        assert "worker" not in backfilled
+        assert not (profile_dir / ".env").exists()
+
+    def test_create_after_delete_replaces_empty_shell(self, profile_env):
+        profile_dir = create_profile("worker", no_alias=True, no_skills=True)
+        _delete("worker")
+        profile_dir.mkdir(parents=True)
+        (profile_dir / "logs").mkdir()
+
+        recreated = create_profile("worker", no_alias=True, no_skills=True)
+        assert recreated.is_dir()
+        assert "worker" in _named_homes(profile_env)
+
+    @pytest.mark.parametrize("leftover", ["config.yaml", ".env"])
+    def test_create_after_delete_refuses_when_identity_files_remain(
+        self, profile_env, leftover
+    ):
+        profile_dir = create_profile("worker", no_alias=True, no_skills=True)
+        _delete("worker")
+        profile_dir.mkdir(parents=True)
+        leftover_path = profile_dir / leftover
+        leftover_path.write_text("keep-me\n", encoding="utf-8")
+
+        with pytest.raises(FileExistsError, match="already exists"):
+            create_profile("worker", no_alias=True, no_skills=True)
+
+        assert leftover_path.read_text(encoding="utf-8") == "keep-me\n"
+        assert leftover_path.exists()
+
+
+class TestNamedProfileHome:
+    def test_logs_under_named_profile_resolve_to_profile_home(self, tmp_path):
+        worker = tmp_path / "profiles" / "worker"
+        assert named_profile_home(worker / "logs") == worker
+        assert named_profile_home(worker) == worker
+
+    def test_default_home_with_profiles_in_path_is_not_named(self, tmp_path):
+        default_home = tmp_path / "foo" / "profiles" / "notahome" / ".hermes"
+        assert named_profile_home(default_home) is None
+        assert named_profile_home(default_home / "logs") is None


### PR DESCRIPTION
## Bug Description

After `hermes profile delete`, a still-running serve/logging process can `mkdir` `profiles/<name>/logs` (and `ensure_hermes_home` will then bootstrap an empty skeleton). That empty shell reappears in `hermes profile list` and Desktop Bot Mode even though the user already deleted the profile.

Related: #89438, #52279

## Root Cause

`setup_logging` / rotating-file setup used `Path.mkdir(parents=True)` under the named profile home. Combined with `list_profiles` treating any `profiles/<name>` directory as live, a post-delete log write resurrected the profile as an empty shell.

`ensure_hermes_home` already refused a *missing* named home, but not a tombstoned empty directory created by that mkdir.

## Fix

- Write a sibling tombstone at `profiles/.deleted/<name>` *before* rmtree
- Refuse mkdir/bootstrap for missing or tombstoned named profile homes
- Skip tombstoned names in `list_profiles` and `profiles_to_serve`
- `hermes profile create` clears the tombstone (and replaces a tombstoned empty shell)

## How to Verify

1. `hermes profile create worker --no-skills`
2. `hermes profile delete worker --yes`
3. Point `HERMES_HOME` at the deleted named home and call `setup_logging` / `ensure_hermes_home` — both must raise `FileNotFoundError` and must not recreate the tree
4. Manually mkdir an empty `profiles/worker` after delete — `hermes profile list` must not show `worker`
5. `hermes profile create worker --no-skills` must succeed again

## Test Plan

- [x] Added regression tests in `tests/hermes_cli/test_deleted_profile_tombstone.py`
- [x] Existing focused profile/config tests still pass (`21 passed`)
- [ ] Manual verification of the Desktop Bot Mode delete path

## Risk Assessment

Low — named-profile delete/create/list/logging only. Default `HERMES_HOME` (not under `profiles/`) is unchanged. Tombstones live beside profile dirs, so rmtree cannot erase the deletion record.
