### PR TITLE
fix(xai-oauth): route OAuth inference through the Grok Build proxy (SuperGrok quota)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2574,6 +2574,22 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             client_kwargs["default_headers"] = existing
     except Exception:
         _ra().logger.debug("Copilot default-header guard skipped", exc_info=True)
+    # xAI Grok Build proxy (cli-chat-proxy.grok.com) rejects requests without
+    # the grok-cli headers (HTTP 426). The xai-oauth bearer is the same one
+    # the official grok CLI sends there; inject the required headers whenever
+    # the target is that origin. Only ADD missing keys — never override
+    # headers a caller deliberately set (mirrors the Copilot guard above).
+    try:
+        from hermes_cli.auth import xai_grok_proxy_headers_for
+
+        _grok_headers = xai_grok_proxy_headers_for(str(client_kwargs.get("base_url", "")))
+        if _grok_headers:
+            _existing_headers = dict(client_kwargs.get("default_headers") or {})
+            for _hk, _hv in _grok_headers.items():
+                _existing_headers.setdefault(_hk, _hv)
+            client_kwargs["default_headers"] = _existing_headers
+    except Exception:
+        _ra().logger.debug("xAI Grok proxy default-header guard skipped", exc_info=True)
     # Uses the module-level `OpenAI` name, resolved lazily on first
     # access via __getattr__ below. Tests patch via `run_agent.OpenAI`.
     client = _ra().OpenAI(**client_kwargs)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -271,6 +271,21 @@ def _create_openai_client(*, api_key: str, base_url: str, **kwargs: Any) -> Any:
     # by default and let Hermes control the budget; explicit callers can still
     # override via kwargs.
     kwargs.setdefault("max_retries", 0)
+    # xAI Grok Build proxy (cli-chat-proxy.grok.com) rejects requests without
+    # the grok-cli headers (HTTP 426); aux clients use the same OAuth bearer
+    # as the primary. Only ADD missing keys.
+    if base_url:
+        try:
+            from hermes_cli.auth import xai_grok_proxy_headers_for
+
+            _grok_headers = xai_grok_proxy_headers_for(base_url)
+            if _grok_headers:
+                _aux_headers = dict(kwargs.get("default_headers") or {})
+                for _hk, _hv in _grok_headers.items():
+                    _aux_headers.setdefault(_hk, _hv)
+                kwargs["default_headers"] = _aux_headers
+        except Exception:
+            pass
     return OpenAI(api_key=api_key, base_url=base_url, **kwargs)
 
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -122,7 +122,13 @@ ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120       # refresh 2 min before expiry
 NOUS_INVOKE_JWT_MIN_TTL_SECONDS = ACCESS_TOKEN_REFRESH_SKEW_SECONDS
 DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS = 1     # poll at most every 1s
 DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
-DEFAULT_XAI_OAUTH_BASE_URL = "https://api.x.ai/v1"
+# xAI serves OAuth-token inference from two origins: api.x.ai (API-key /
+# pay-as-you-go billing; OAuth tokens only get the API free tier there —
+# "free-usage-exhausted" at 500K tokens/24h) and the Grok Build proxy
+# cli-chat-proxy.grok.com, where the SuperGrok subscription quota lives (the
+# official grok CLI uses this origin with the same OAuth bearer/scope).
+# OAuth == subscription auth, so default xai-oauth to the proxy.
+DEFAULT_XAI_OAUTH_BASE_URL = "https://cli-chat-proxy.grok.com/v1"
 MINIMAX_OAUTH_CLIENT_ID = "78257093-7e40-4613-99e0-527b14b39113"
 MINIMAX_OAUTH_SCOPE = "group_id profile model.completion"
 MINIMAX_OAUTH_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:user_code"
@@ -4881,16 +4887,47 @@ def _xai_validate_inference_base_url(value: str, *, fallback: str) -> str:
             candidate, fallback,
         )
         return fallback
-    if host != "x.ai" and not host.endswith(".x.ai"):
+    if host != "x.ai" and not host.endswith(".x.ai") and not host.endswith(".grok.com"):
         logger.warning(
             "Refusing xAI base_url override %r — host %r is not on the xAI origin "
-            "(expected x.ai or a *.x.ai subdomain). The xai-oauth bearer is only "
+            "(expected x.ai, a *.x.ai subdomain, or *.grok.com — the latter is "
+            "xAI's Grok Build proxy origin). The xai-oauth bearer is only "
             "valid against xAI's inference API; sending it elsewhere would leak "
             "the credential. Falling back to %s.",
             candidate, host, fallback,
         )
         return fallback
     return candidate
+
+
+# Headers the Grok Build proxy (cli-chat-proxy.grok.com) requires on every
+# inference request. Without them it rejects with HTTP 426 ("Grok CLI version
+# (none) is outdated"). The official grok CLI sends the same set with the
+# same OAuth bearer.
+XAI_GROK_PROXY_REQUIRED_HEADERS = {
+    "X-XAI-Token-Auth": "xai-grok-cli",
+    "x-authenticateresponse": "authenticate-response",
+    "x-grok-client-mode": "headless",
+    # Bump when xAI raises the Grok CLI minimum version (proxy replies 426).
+    "x-grok-client-version": "1.0.5",
+    "x-grok-client-identifier": "grok-shell",
+}
+
+
+def xai_grok_proxy_headers_for(base_url: str) -> dict:
+    """Return the required Grok Build proxy headers when *base_url* targets it.
+
+    Matches the cli-chat-proxy.grok.com origin exactly (host only, port
+    ignored); returns ``{}`` for any other origin so the headers never leak
+    onto third-party endpoints.
+    """
+    try:
+        host = (urlparse(base_url).hostname or "").lower()
+    except Exception:
+        return {}
+    if host == "cli-chat-proxy.grok.com":
+        return dict(XAI_GROK_PROXY_REQUIRED_HEADERS)
+    return {}
 
 
 def _xai_oauth_discovery(timeout_seconds: float = 15.0) -> Dict[str, str]:

--- a/tests/hermes_cli/test_auth_xai_oauth_provider.py
+++ b/tests/hermes_cli/test_auth_xai_oauth_provider.py
@@ -990,3 +990,44 @@ def test_pool_sync_back_preserves_active_provider(tmp_path, monkeypatch):
     state = raw_after["providers"]["xai-oauth"]["tokens"]
     assert state["access_token"] == new_access
     assert state["refresh_token"] == "rt-rotated"
+
+
+# ---------------------------------------------------------------------------
+# Grok Build proxy origin (SuperGrok subscription quota)
+#
+# The xai-oauth bearer carries the SuperGrok entitlement; xAI serves that
+# quota on the Grok Build proxy (cli-chat-proxy.grok.com), not on api.x.ai
+# (which applies the API free tier / pay-as-you-go billing). The env
+# override must be able to point at the proxy, and the proxy's required
+# headers must be injectable without leaking onto other origins.
+# ---------------------------------------------------------------------------
+
+
+def test_validate_inference_base_url_accepts_grok_build_proxy():
+    assert _xai_validate_inference_base_url(
+        "https://cli-chat-proxy.grok.com/v1", fallback="https://api.x.ai/v1"
+    ) == "https://cli-chat-proxy.grok.com/v1"
+    # Third-party hosts must still be rejected (bearer-leak protection).
+    assert _xai_validate_inference_base_url(
+        "https://evil.example.com/v1", fallback="https://api.x.ai/v1"
+    ) == "https://api.x.ai/v1"
+    assert _xai_validate_inference_base_url(
+        "http://cli-chat-proxy.grok.com/v1", fallback="https://api.x.ai/v1"
+    ) == "https://api.x.ai/v1"
+
+
+def test_xai_grok_proxy_headers_are_origin_scoped():
+    from hermes_cli.auth import XAI_GROK_PROXY_REQUIRED_HEADERS, xai_grok_proxy_headers_for
+
+    h = xai_grok_proxy_headers_for("https://cli-chat-proxy.grok.com/v1")
+    assert h["X-XAI-Token-Auth"] == "xai-grok-cli"
+    assert h["x-authenticateresponse"] == "authenticate-response"
+    assert h["x-grok-client-mode"] == "headless"
+    assert h["x-grok-client-identifier"] == "grok-shell"
+    assert h["x-grok-client-version"]
+    assert set(h) == set(XAI_GROK_PROXY_REQUIRED_HEADERS)
+    # Any other origin must get nothing — the headers must not leak onto
+    # api.x.ai, third-party endpoints, or empty values.
+    assert xai_grok_proxy_headers_for("https://api.x.ai/v1") == {}
+    assert xai_grok_proxy_headers_for("https://grok.com") == {}
+    assert xai_grok_proxy_headers_for("") == {}


### PR DESCRIPTION
## Problem

`xai-oauth` (SuperGrok OAuth) sends inference to `https://api.x.ai/v1`, where xAI applies the **API free tier** to OAuth tokens: `subscription:free-usage-exhausted` at 500K tokens / rolling 24h. Active SuperGrok ($30/mo) subscribers hit this even with the subscription quota (weekly Grok Build bucket) almost untouched, because the subscription quota lives on a **different origin**.

## Root cause

xAI serves OAuth-token inference from two origins:

| Origin | What it bills |
|---|---|
| `api.x.ai/v1` | API free tier (500K tokens/24h) or pay-as-you-go API credits |
| `cli-chat-proxy.grok.com/v1` | SuperGrok subscription quota (Grok Build weekly bucket) — **what the official `grok` CLI uses** with the same OAuth identity/scope (`openid profile email offline_access grok-cli:access api:access`) |

Verified empirically (Aug 2026): the same OAuth bearer against `api.x.ai` → `free-usage-exhausted`; against `cli-chat-proxy.grok.com` with the grok-cli headers → HTTP 200, model `grok-4.6-build`, subscription quota consumed.

## Fix

1. **`DEFAULT_XAI_OAUTH_BASE_URL` → `https://cli-chat-proxy.grok.com/v1`** — OAuth == subscription auth, so default xai-oauth to the quota origin.
2. **Host guard allows `*.grok.com`** — `grok.com` is xAI-owned; the env override (`HERMES_XAI_BASE_URL` / `XAI_BASE_URL`) must be able to point at the proxy without weakening the bearer-leak protection (third-party hosts still rejected).
3. **Proxy-required headers injected at both client chokepoints** — the proxy rejects requests without the grok-cli headers with HTTP 426 (`Your Grok CLI version (none) is outdated`). New origin-scoped helper `xai_grok_proxy_headers_for()` (exact host match, `{}` elsewhere) is applied:
   - in the primary client builder (`agent_runtime_helpers._build_client`), next to the existing Copilot header guard;
   - in the auxiliary client factory (`auxiliary_client._create_openai_client`), so title generation / compression / vision don't 426 on the proxy.
   Headers are only **added** (`setdefault`), never overriding caller-set values.

## Tests

- `test_validate_inference_base_url_accepts_grok_build_proxy` — proxy accepted, third-party host and non-HTTPS still rejected.
- `test_xai_grok_proxy_headers_are_origin_scoped` — headers returned for the proxy origin only; never for `api.x.ai`, `grok.com`, or empty.
- Both regression tests proven to FAIL on pre-fix code (sabotage run).
- `tests/hermes_cli/test_auth_xai_oauth_provider.py` + `tests/agent/test_auxiliary_client.py`: **209 passed**.

## Verification (live)

- `hermes chat -q "Reply exactly: XAI_OAUTH_TEST_OK"` → `XAI_OAUTH_TEST_OK`, endpoint shown as `https://cli-chat-proxy.grok.com/v1`.
- Tool-use roundtrip (terminal tool via grok-4.6) succeeded.
- End-to-end HTTP 200; no more `free-usage-exhausted` on an active SuperGrok account.

## Risks / follow-ups

- **`x-grok-client-version: 1.0.5`** is pinned; xAI may raise the CLI minimum version (proxy replies 426) — bump the constant then. Consider reading it from the installed `grok` CLI if one is present.
- Free-tier (non-subscriber) behavior on the proxy was not verified — the official CLI routes all users there, but quota semantics for non-subscribers should be confirmed.
- This is a provider-default change: users who relied on the OAuth token consuming the api.x.ai free tier will now route to the proxy (same bearer, no data change).
